### PR TITLE
feat(metrics): make OTLP metric egress pluggable via a destination seam

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -152,7 +152,8 @@ explicitly sets an OTLP endpoint.**
   key through `PATCH /api/config/kirocrew` (`telemetry.enabled` is in
   `_EDITABLE_CONFIG`). That route refuses `true` with **HTTP 409** when
   `telemetry.otlp_endpoint` is set: `_build_recorder` attaches an OTLP reader
-  whenever an endpoint is configured, so enabling from a switch offered as
+  whenever the active telemetry provider supplies a destination — which the public
+  default does for any non-empty endpoint — so enabling from a switch offered as
   local-only would start network egress. The endpoint is chosen in the config
   file, so that is where enabling on such a host is done. Disabling is always
   allowed — a narrower local choice always composes. An unreadable config also
@@ -171,10 +172,41 @@ lifecycle & threading"). The gateway process is where the session/turn/HTTP
 metrics are recorded; other kirocrew processes pick the value up on their own
 recheck or at their next start.
 
-**External OTLP egress (opt-in, off by default):** setting `otlp_endpoint` adds a
-second `PeriodicExportingMetricReader` alongside the local JSONL sink
-(`provider._build_otlp_reader`). Install support with
-`pip install "kirocrew[otlp]"`. If the endpoint is set but the package extra is
+**External OTLP egress (opt-in, off by default):** egress destinations are
+**pluggable**. `_build_recorder` asks the active `TelemetryProvider` for them via
+`otlp_destinations(cfg)` and attaches one `PeriodicExportingMetricReader` per
+returned destination that names the `"metrics"` signal (`provider._otlp_destinations`
+resolves, `provider._build_otlp_reader` builds one reader). The public
+`DefaultTelemetryProvider` turns a non-empty `otlp_endpoint` into exactly one
+destination and returns none when it is empty, so a standalone build behaves as it
+did when this module constructed that exporter itself. Readers are appended AFTER
+the local JSONL sink, so an edition can add destinations but can never remove or
+replace the sink the dashboard reads, and it supplies no cadence — the export
+interval stays `telemetry.export_interval_seconds`.
+
+A destination carries `name` (a non-secret label used in logs, because the
+endpoint value never is), `endpoint`, `signals`, and optionally an
+authenticated `session`. The session is why the seam exists: `requests`
+re-evaluates `Session.auth` per request, so a credential that rotates during
+process lifetime (an OIDC/SSO id_token, STS credentials) is re-read on every
+export, where `OTEL_EXPORTER_OTLP_HEADERS` — the only injection point before this
+seam — freezes into the exporter's session at construction and starts returning
+401 once it rotates. Static per-destination headers ride on `Session.headers` and
+need no field of their own.
+
+The method must be cheap and side-effect-free per call: it is read once per
+recorder build AND on every egress-posture read (the Privacy panel's status, and
+each `telemetry.enabled` config write), so an edition must build its transport
+once rather than acquiring a credential inside it.
+
+Filtering is deny-by-default: a destination with an empty `endpoint`, or one aimed
+at a signal this core does not emit, is dropped rather than trusted. A provider
+that raises contributes nothing and is reported at WARNING, and telemetry keeps
+working local-only; the same is true when the platform context cannot be composed,
+because for an egress seam "no destinations" is the closed state.
+
+Install support with `pip install "kirocrew[otlp]"`. If a destination is supplied
+but the package extra is
 not installed, telemetry
 degrades to local-only with a warning instead of crashing. The OTLP exporter
 sees the same data points as the local sink: the `MetricsRecorder` facade

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -55,7 +55,7 @@ boot holding the chosen adapter for every extension point, plus three carriers:
 | `package_manager` | adapter | **RESERVED** — `DefaultPackageManager`; installs are inline in `cli_doctor.py` (use `CapabilityManager`) | — (slot inert) |
 | `knowledge` | adapter | `DefaultKnowledgeProvider` (no extra connectors) | enterprise doc connector (`extra_connectors`) |
 | `tunnel` | adapter | `DefaultTunnelProvider` (no-op) | internal tunnel supervisor |
-| `telemetry` | adapter | `DefaultTelemetryProvider` (no-op, RUM off) | RUM/Cognito config |
+| `telemetry` | adapter | `DefaultTelemetryProvider` (no-op, RUM off; OTLP destination from `telemetry.otlp_endpoint`) | RUM/Cognito config + its own OTLP collector |
 | `dashboard` | adapter | `DefaultDashboardContributor` (no routes/services, no login handler) | secretary/taskkeeper routes + enterprise SSO PTY login |
 | `jail` | adapter | `DefaultJailProvider` (no-op, never jails) | enterprise process isolation |
 | `feature_apps` | tuple | **RESERVED** — `()`; apps register via `apps_loader` (provenance record only) | — (slot inert) |
@@ -631,6 +631,30 @@ is byte-identical) with no `CONTRACT_VERSION` bump.
   winner's identity. Merged at the
   consumption sites, never inside `KiroCrewConfig`, so a config save can never
   persist an edition default into the operator's file. Default `[]`.
+- `TelemetryProvider.otlp_destinations(cfg) -> Sequence[OtlpDestination]` — the
+  OTLP collectors this edition sends telemetry to. Read by
+  `metrics/provider.py::_otlp_destinations` once per recorder build (through
+  `safe_context_call`, fallback `()`), which attaches one
+  `PeriodicExportingMetricReader` per destination naming the `"metrics"` signal,
+  AFTER the built-in local JSONL reader. ADD-only: an edition can add a
+  destination but can never remove or replace the local sink, relax consent or
+  attribute sanitisation, or set the export cadence. `OtlpDestination` carries
+  `name` (non-secret, log-safe — the endpoint value is never logged), `endpoint`,
+  `signals`, and an optional authenticated `session`; the session is the seam a
+  ROTATING credential composes against, since `requests` re-evaluates
+  `Session.auth` per export where `OTEL_EXPORTER_OTLP_HEADERS` freezes at
+  construction (static per-destination headers ride on `Session.headers`).
+  Must be cheap and side-effect-free per call: it is read once per recorder build
+  AND on every egress-posture read (Privacy panel status, each `telemetry.enabled`
+  write), so an edition builds its transport once rather than minting a credential
+  inside it. A provider that does not implement the method answers "no
+  destinations" rather than "unknown", so a pre-seam edition keeps the two
+  surfaces agreeing. Signal-agnostic on purpose: the OTLP metric, span and log
+  exporters take the same constructor arguments, so a later core that emits traces
+  or logs reads the same descriptor instead of needing another method. Deny-by-
+  default — an empty `endpoint`, or a signal this core does not emit, is dropped.
+  Default: one destination for a non-empty `telemetry.otlp_endpoint`, none
+  otherwise (byte-identical to the endpoint-only exporter it replaced).
 - `DashboardContributor.on_user_message(app, message)` — fired once per user
   message by `dashboard/chat_handlers.py::api_chat` before the turn, inside a
   fail-safe `safe_context_call`. OBSERVER only. Default no-op.

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1992,10 +1992,12 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     # Local OTEL metric collection — the Privacy panel's recording switch. Safe
     # to expose where beacon_endpoint is not: turning this on writes JSONL under
     # ~/.kiro/crew/metrics. It is NOT unconditionally local, though —
-    # `_build_recorder` attaches an OTLP reader when `telemetry.otlp_endpoint` is
-    # set — so the gate below refuses the ENABLE on a host that configured an
-    # endpoint, which is what keeps the switch's local-only promise true for every
-    # state it can reach. The endpoint itself stays config-file-only, so a
+    # `_build_recorder` attaches an OTLP reader for every destination the active
+    # telemetry provider supplies (the default provider supplies one when
+    # `telemetry.otlp_endpoint` is set) — so the gate below refuses the ENABLE on a
+    # host where egress would start, which is what keeps the switch's local-only
+    # promise true for every state it can reach. The endpoint itself stays
+    # config-file-only, so a
     # dashboard caller can neither choose a destination nor start sending to one.
     "telemetry.enabled": {"type": "bool"},
     # SSO login flags for an edition that supplies a real sso_login_handler.
@@ -2281,9 +2283,11 @@ async def api_kirocrew_config_patch(request: web.Request) -> web.Response:
 
     # Local metric collection is offered as local-only ("Nothing is exported"), and
     # that promise has to hold for every state this route can reach. It would not:
-    # `_build_recorder` attaches an OTLP reader whenever `telemetry.otlp_endpoint`
-    # is set (see metrics/provider.py), so on a host that already configured an
-    # endpoint, enabling collection from the dashboard would start network egress
+    # `_build_recorder` attaches an OTLP reader for every destination the active
+    # telemetry provider supplies (see metrics/provider.py), so on a host where
+    # egress is configured — through `telemetry.otlp_endpoint` for the default
+    # provider, or an edition's own collector — enabling collection from the
+    # dashboard would start network egress
     # under a switch that says it does not. Refuse the ENABLE there and let the
     # config file — which is where the endpoint was chosen — be where that decision
     # is made. Disabling stays writable for the same reason as the beacon above: a
@@ -2294,17 +2298,33 @@ async def api_kirocrew_config_patch(request: web.Request) -> web.Response:
             # state, but a full read plus schema validation (~14ms) when the file
             # changed — and this handler runs on the event loop.
             cfg = await asyncio.to_thread(KiroCrewConfig.load)
-            endpoint = str(getattr(cfg.telemetry, "otlp_endpoint", "") or "")
+            # Resolved posture, not the raw endpoint string: the DEFAULT provider
+            # derives its one destination from telemetry.otlp_endpoint, but an
+            # edition may supply its own collector with that key empty. Asking the
+            # same resolver _build_recorder uses is what keeps this refusal and
+            # the actual egress from disagreeing. It RAISES when posture cannot be
+            # established, which the handler below turns into a refusal: reading a
+            # transient provider error as "no egress" would permit an enable that
+            # the recovered provider then turns into egress.
+            egress = await asyncio.to_thread(_metrics_provider.otlp_egress_active, cfg.telemetry)
         except Exception:
-            # Unreadable config: fail closed rather than enabling collection whose
-            # egress posture cannot be established.
-            logger.warning("telemetry config unreadable; refusing to enable", exc_info=True)
-            return _deny("could not read the telemetry configuration", f"{path_key}={value}", 409)
-        if endpoint.strip():
+            # Unreadable config, or egress posture that could not be resolved:
+            # fail closed rather than enabling collection whose egress posture
+            # cannot be established.
+            logger.warning(
+                "telemetry config or egress posture unreadable; refusing to enable",
+                exc_info=True,
+            )
             return _deny(
-                "telemetry.otlp_endpoint is set, so enabling collection here would "
-                "also export metrics off this machine. Enable it in the config file "
-                "instead, where the endpoint is configured.",
+                "could not establish the telemetry egress posture",
+                f"{path_key}={value}",
+                409,
+            )
+        if egress:
+            return _deny(
+                "this host is configured to export metrics off the machine, so "
+                "enabling collection here would also start that export. Enable it "
+                "in the config file instead, where the destination is configured.",
                 f"{path_key}={value}",
                 409,
             )

--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -51,7 +51,7 @@ from kiro_crew.dashboard.handlers.usage import (
 )
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE
 from kiro_crew.hooks import validate_file_path
-from kiro_crew.metrics.provider import TELEMETRY_ENV_VAR, env_pin
+from kiro_crew.metrics.provider import TELEMETRY_ENV_VAR, env_pin, otlp_egress_active
 from kiro_crew.metrics.schema import RESOURCE_ATTR_PROCESS_START_TIME
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -145,9 +145,22 @@ def _telemetry_cfg() -> _TelemetryState:
         enabled = bool(cfg.enabled)
         if getattr(cfg, "local_dir", None):
             directory = Path(cfg.local_dir).expanduser()
-        # Presence only. The endpoint string can carry credentials, so it never
-        # leaves this function; the panel only needs to know one is configured.
-        otlp_configured = bool(str(getattr(cfg, "otlp_endpoint", "") or "").strip())
+        # Presence only, and resolved the same way _build_recorder resolves it:
+        # from the active telemetry provider's destination set, NOT from the
+        # endpoint string. An edition that supplies its own collector must not be
+        # able to leave this panel reporting "nothing is exported" while metrics
+        # leave the machine. The endpoint value never leaves that resolution; the
+        # panel only needs to know whether egress would happen.
+        try:
+            otlp_configured = otlp_egress_active(cfg)
+        except Exception:
+            # Posture unresolvable (a provider that raised, an uncomposable
+            # context). Report egress rather than promising local-only: this
+            # answer is a DISCLOSURE, so its closed direction is "assume it
+            # exports". The panel then disables the enable direction instead of
+            # offering a write the config route refuses with 409 anyway.
+            logger.debug("OTLP egress posture unresolvable; reporting egress", exc_info=True)
+            otlp_configured = True
     except Exception:
         logger.debug("telemetry config load failed; assuming disabled", exc_info=True)
     env_var = TELEMETRY_ENV_VAR
@@ -1409,7 +1422,11 @@ async def api_collection_status(request: web.Request) -> web.Response:
     ignores, and ``overlay_override`` does the same for a ``config.local.json``
     entry that would make the switch snap back after a successful save.
 
-    ``otlp_configured`` reports that ``telemetry.otlp_endpoint`` is set. That makes
+    ``otlp_configured`` reports that enabling collection would send metrics off
+    this machine — resolved from the active telemetry provider's destination set,
+    the same one ``_build_recorder`` attaches readers for, not from the
+    ``telemetry.otlp_endpoint`` string (which is only how the DEFAULT provider
+    names a destination; an edition may supply its own collector). That makes
     collection not-local — ``_build_recorder`` attaches an OTLP reader — so the
     config route refuses to ENABLE it from here and the panel disables that
     direction rather than offering a write that comes back 409. Disabling stays

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -42,10 +42,20 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
 from kiro_crew.metrics.recorder import MetricsRecorder
+from kiro_crew.platform.context import (
+    PlatformCompositionError,
+    current_context,
+    safe_context_call,
+)
 
 if TYPE_CHECKING:  # real types for annotations; never imported at runtime
+    from collections.abc import Iterable
+
     from opentelemetry.sdk.metrics import MeterProvider as _MeterProviderT
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader as _ReaderT
+
+    from kiro_crew.config.loader import TelemetryConfig
+    from kiro_crew.platform.interfaces import OtlpDestination
 
 # KiroCrew declares opentelemetry-sdk as a required dependency, so
 # the availability probe below is defense-in-depth — not for a genuinely
@@ -272,8 +282,9 @@ _check_in_flight = False
 # LOCAL metrics on (or force them off) without editing ~/.kiro/crew/config.json —
 # handy for CI, containers, and one-off debugging. Truthy => enable, falsy =>
 # disable, unset/blank => defer to the ``telemetry.enabled`` config flag (itself
-# default False). This gates LOCAL collection ONLY: external OTLP egress still
-# requires ``telemetry.otlp_endpoint`` to be set, so merely flipping this var
+# default False). This gates LOCAL collection ONLY: external OTLP egress needs the
+# active telemetry provider to name a destination (the default provider does so
+# only for a non-empty ``telemetry.otlp_endpoint``), so merely flipping this var
 # never causes data to leave the host (egress stays off by default).
 # Public: a UI control over ``telemetry.enabled`` names this variable when it
 # reports the setting as pinned, and naming it from here keeps the message and the
@@ -358,6 +369,12 @@ def _build_recorder() -> _Build:
         logger.warning("opentelemetry not importable; telemetry disabled")
         return _Build(MetricsRecorder(None), None, consent)
 
+    # Resolve egress destinations BEFORE any reader is started. Two reasons:
+    # the seam belongs to the edition and a PlatformCompositionError from it must
+    # not be folded into "telemetry init failed" below, and resolving first means
+    # there is nothing started to reap if it goes wrong.
+    destinations = _otlp_destinations(cfg)
+
     # PeriodicExportingMetricReader starts its daemon ticker thread inside
     # __init__, so if any later step (MeterProvider construction, etc.) raises,
     # the reader is already ticking. This list is bound BEFORE the try — binding
@@ -383,12 +400,18 @@ def _build_recorder() -> _Build:
                 export_interval_millis=float(cfg.export_interval_seconds) * 1000.0,
             )
         )
-        # Opt-in OTLP egress: only when telemetry.otlp_endpoint is set.
-        # Empty endpoint => local-only, no network egress (the default).
-        otlp_reader = _build_otlp_reader(cfg)
-        otlp_active = otlp_reader is not None
-        if otlp_reader is not None:
-            started_readers.append(otlp_reader)
+        # Opt-in OTLP egress: one reader per destination the active telemetry
+        # provider supplied, appended AFTER the local sink so the local reader is
+        # always present and can never be replaced. No destinations => local-only,
+        # no network egress (the default). Each reader joins started_readers as it
+        # is constructed, so a later failure reaps every earlier one.
+        otlp_names: list = []
+        for dest in destinations:
+            reader = _build_otlp_reader(dest, cfg)
+            if reader is not None:
+                started_readers.append(reader)
+                otlp_names.append(dest.name)
+        otlp_active = bool(otlp_names)
         provider = MeterProvider(
             metric_readers=started_readers,
             resource=Resource.create({"service.name": _SERVICE_NAME}),
@@ -415,8 +438,13 @@ def _build_recorder() -> _Build:
         if otlp_active:
             # Name the egress start on its own line: a file/CLI enable is trusted
             # and ungated, so this log is the only record that metrics began
-            # leaving the machine.
-            logger.info("telemetry OTLP export active; metrics leave this machine")
+            # leaving the machine. Destination NAMES only — the endpoint value is
+            # never logged, and with more than one collector the name is the only
+            # way to tell which one is live.
+            logger.info(
+                "telemetry OTLP export active; metrics leave this machine (%s)",
+                ", ".join(otlp_names),
+            )
         meter = provider.get_meter(_SCOPE)
         # Process-resource gauges (threads/fds/gc/rss/cpu) ride the same consent
         # gate: registered only on this live path, and their observable
@@ -432,9 +460,9 @@ def _build_recorder() -> _Build:
         return _Build(MetricsRecorder(meter), provider, consent)
     except Exception as exc:
         logger.warning("telemetry init failed; metrics disabled: %s", exc)
-        # Reap EVERY reader already started, not just the first: with
-        # telemetry.otlp_endpoint set there are two, and leaving the second
-        # ticking is the same orphan this branch exists to prevent.
+        # Reap EVERY reader already started, not just the first: an egress
+        # destination adds one each, so there can be several, and leaving any of
+        # them ticking is the same orphan this branch exists to prevent.
         #
         # Off this thread, because a reader shutdown performs a final export and
         # joins its ticker with the SDK's 30s default.
@@ -442,24 +470,140 @@ def _build_recorder() -> _Build:
         return _Build(MetricsRecorder(None), None, consent)
 
 
-def _build_otlp_reader(cfg: object) -> Optional["_ReaderT"]:
-    """Build the opt-in OTLP/HTTP metric reader, or None when not configured.
+def _egress_degraded() -> tuple:
+    """Report a provider that could not answer, then contribute no destinations.
 
-    Egress is OFF by default: this returns None unless
-    ``telemetry.otlp_endpoint`` is a non-empty string. The OTLP exporter lives
-    in the separate ``kirocrew[otlp]`` package extra (install with
-    ``pip install "kirocrew[otlp]"``), not the hard dependency set. If a host
-    opts in without installing it, we log a warning and degrade to local-only
-    rather than crashing telemetry init. The exporter sees only what the
-    MetricsRecorder facade lets through: attributes are sanitised before they
-    reach any reader, and call sites are required to pass low-cardinality
-    constants rather than prompts, content, tokens, paths or user ids. That
-    sanitisation is defence in depth over that requirement, not a substitute
-    for it, so egress is only as safe as the call sites feeding it.
+    Separate from the call site because ``safe_context_call`` invokes a
+    ``fallback_factory`` ONLY on the degrade path, which is what turns "the
+    provider raised" into one WARNING a default install actually collects.
     """
-    endpoint = str(getattr(cfg, "otlp_endpoint", "") or "").strip()
-    if not endpoint:
-        return None
+    logger.warning(
+        "telemetry provider raised while resolving OTLP destinations; "
+        "OTLP egress disabled (local-only)"
+    )
+    return ()
+
+
+def otlp_egress_active(cfg: "TelemetryConfig") -> bool:
+    """Whether enabling collection under *cfg* would send metrics off this machine.
+
+    The disclosure surfaces (the Privacy panel's ``otlp_configured``, and the
+    config route that refuses to ENABLE collection from a switch offered as
+    local-only) MUST answer this question from the same resolved destination set
+    ``_build_recorder`` will attach — not from ``telemetry.otlp_endpoint``, which
+    is only how the DEFAULT provider happens to name a destination. An edition
+    that supplies its own collector would otherwise leave the panel reporting
+    "nothing is exported" while metrics leave the machine: two answers to one
+    consent question, which is the defect this seam must not introduce.
+
+    RAISES when posture cannot be established, and that is deliberate: the two
+    directions of "fail closed" are OPPOSITE here. At BUILD time an unresolvable
+    provider must not export, so ``_otlp_destinations`` degrades to ``()`` and
+    collection continues local-only. At GATE time it must not read as "no
+    egress" — a caller that saw ``False`` would permit an enable that the
+    provider, once recovered, turns into egress. So callers handle the raise: the
+    config route answers 409, and the panel reports egress rather than promising
+    local-only.
+
+    A provider that does not IMPLEMENT the method is a different case and answers
+    ``False``, not a raise. Providers are matched structurally with no inherited
+    default and the contract assertion compares only a version integer, so an
+    edition built before this seam composes fine and simply has no method. That
+    is a KNOWN answer — it contributes no destination through this seam, exactly
+    as ``_build_recorder`` concludes on the same host — so treating it as
+    "unknown" would make the two surfaces disagree, report egress that provably
+    cannot happen, and brick the dashboard's enable switch. An ``AttributeError``
+    raised INSIDE an implementation still propagates: only an absent attribute is
+    read as no-destinations.
+    """
+    provider = current_context().telemetry
+    resolve = getattr(provider, "otlp_destinations", None)
+    if resolve is None:
+        return False
+    return bool(_filter_metric_destinations(resolve(cfg)))
+
+
+def _filter_metric_destinations(
+    supplied: "Iterable[OtlpDestination] | None",
+) -> "tuple[OtlpDestination, ...]":
+    """Keep only the destinations this core would build a METRIC reader for.
+
+    Deny-by-default: a destination is kept only when it positively names an
+    ``endpoint`` AND the ``"metrics"`` signal. A descriptor that is
+    half-populated, or one aimed at a signal this core does not emit, contributes
+    nothing rather than being coerced into an egress nobody asked for.
+    """
+    kept = []
+    for dest in supplied or ():
+        endpoint = str(getattr(dest, "endpoint", "") or "").strip()
+        signals = frozenset(getattr(dest, "signals", ()) or ())
+        if not endpoint or "metrics" not in signals:
+            continue
+        kept.append(dest)
+    return tuple(kept)
+
+
+def _otlp_destinations(cfg: "TelemetryConfig") -> "tuple[OtlpDestination, ...]":
+    """Resolve the metric egress destinations the active edition supplies.
+
+    The core owns WHAT may leave this machine (consent, attribute sanitisation,
+    the views, batching); an edition owns only WHERE it goes, which it declares
+    through ``TelemetryProvider.otlp_destinations``. The public default turns
+    ``telemetry.otlp_endpoint`` into exactly one destination, so a standalone
+    build behaves as it did when this module constructed that exporter itself.
+
+    Lenient by design, unlike :func:`otlp_egress_active`: on this path an
+    unresolvable provider must not export, so it contributes nothing and
+    collection continues local-only.
+    """
+    try:
+        supplied = safe_context_call(
+            lambda: current_context().telemetry.otlp_destinations(cfg),
+            # A raising provider contributes NOTHING, but it must not do so
+            # quietly: safe_context_call's own log_message is debug-level, and a
+            # default install collects WARNING and above, so relying on it alone
+            # is how a broken provider becomes an undiagnosable permanent no-op.
+            # fallback_factory is invoked only on the degrade path (and inside the
+            # except), which makes it the hook for one loud line; log_message
+            # still carries the traceback at debug for whoever wants it.
+            fallback_factory=_egress_degraded,
+            log_message="telemetry provider raised in otlp_destinations",
+        )
+    except PlatformCompositionError:
+        # Deliberate departure from the usual re-raise. For an EGRESS seam the
+        # closed state is "no destinations", so a host that cannot compose its
+        # companion must land there rather than turn a metric call into a raise:
+        # boot_platform already fail-closes on composition for the paths where
+        # that is the security-relevant answer, and processes exist that never
+        # boot the platform at all (the MCP sidecar). Degrading here removes
+        # egress; it can never add any.
+        logger.warning("platform context unavailable; OTLP egress disabled (local-only)")
+        return ()
+
+    return _filter_metric_destinations(supplied)
+
+
+def _build_otlp_reader(dest: "OtlpDestination", cfg: object) -> Optional["_ReaderT"]:
+    """Build one OTLP/HTTP metric reader for *dest*, or None when unavailable.
+
+    Egress is OFF by default: reaching here at all means an edition named a
+    destination (the public default does so only when ``telemetry.otlp_endpoint``
+    is a non-empty string). The OTLP exporter lives in the separate
+    ``kirocrew[otlp]`` package extra (install with ``pip install
+    "kirocrew[otlp]"``), not the hard dependency set. If a host opts in without
+    installing it, we log a warning and degrade to local-only rather than
+    crashing telemetry init. The exporter sees only what the MetricsRecorder
+    facade lets through: attributes are sanitised before they reach any reader,
+    and call sites are required to pass low-cardinality constants rather than
+    prompts, content, tokens, paths or user ids. That sanitisation is defence in
+    depth over that requirement, not a substitute for it, so egress is only as
+    safe as the call sites feeding it.
+
+    The export CADENCE stays a core decision, read from
+    ``telemetry.export_interval_seconds`` — a destination says where to send, not
+    how often to send.
+    """
+    endpoint = dest.endpoint
     # Callable directly (not only via _build_recorder), so make sure the lazily
     # imported SDK symbols this needs are bound.
     if not _load_otel():
@@ -471,15 +615,26 @@ def _build_otlp_reader(cfg: object) -> Optional["_ReaderT"]:
         )
     except ImportError:
         # Never log the configured endpoint: URLs may contain credentials in
-        # userinfo or query parameters. The setting's presence is sufficient
-        # for diagnosis without exposing its value.
+        # userinfo or query parameters. The destination NAME is safe by contract
+        # and is enough for diagnosis without exposing the value.
         logger.warning(
-            "telemetry.otlp_endpoint is set but opentelemetry-exporter-otlp-"
-            "proto-http is not installed; OTLP egress disabled (local-only)"
+            "OTLP destination %r is configured but opentelemetry-exporter-otlp-"
+            "proto-http is not installed; OTLP egress disabled (local-only)",
+            dest.name,
         )
         return None
     try:
-        exporter = OTLPMetricExporter(endpoint=endpoint)
+        kwargs: dict = {"endpoint": endpoint}
+        # Passed only when supplied so the exporter keeps its own defaults (and
+        # its env-var fallbacks) for everything an edition did not set.
+        if dest.session is not None:
+            # An authenticated transport. requests re-evaluates Session.auth per
+            # request, which is what lets a credential that rotates mid-process
+            # keep working where a header frozen at construction would 401. Static
+            # per-destination headers ride on Session.headers, so they need no
+            # separate field on the descriptor.
+            kwargs["session"] = dest.session
+        exporter = OTLPMetricExporter(**kwargs)
         return PeriodicExportingMetricReader(
             exporter,
             export_interval_millis=float(
@@ -490,7 +645,10 @@ def _build_otlp_reader(cfg: object) -> Optional["_ReaderT"]:
     except Exception:
         # Constructor errors may echo the credential-bearing endpoint in their
         # message. Keep this warning fixed-text just like the missing-extra path.
-        logger.warning("OTLP exporter init failed; OTLP egress disabled (local-only)")
+        logger.warning(
+            "OTLP exporter init failed for destination %r; egress disabled (local-only)",
+            dest.name,
+        )
         return None
 
 

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from kiro_crew.platform.interfaces import ImportSource, McpScope
 
 from kiro_crew import security, sso_status
-from kiro_crew.platform.interfaces import CapabilityResult, InterceptDecision
+from kiro_crew.platform.interfaces import CapabilityResult, InterceptDecision, OtlpDestination
 
 # ``agent``, ``sandbox``, ``embeddings``, ``apps.registry`` and ``slack.enterprise``
 # import ``kiro_crew.platform`` at module-load time, so importing them at the top
@@ -430,6 +430,24 @@ class DefaultTelemetryProvider:
 
     def frontend_rum_config(self) -> Optional[dict]:
         return None
+
+    def otlp_destinations(self, cfg: Any) -> "tuple[OtlpDestination, ...]":
+        # Byte-identical to the endpoint-only OTLP exporter this seam replaced:
+        # ONE destination when telemetry.otlp_endpoint is a non-empty string,
+        # NONE otherwise — so egress stays off by default and the standalone
+        # build reaches exactly the collector it reached before. Read with
+        # getattr so any telemetry-config shape works, and never logged here:
+        # the value can carry credentials in userinfo or query parameters.
+        endpoint = str(getattr(cfg, "otlp_endpoint", "") or "").strip()
+        if not endpoint:
+            return ()
+        return (
+            OtlpDestination(
+                name="telemetry.otlp_endpoint",
+                endpoint=endpoint,
+                signals=frozenset({"metrics"}),
+            ),
+        )
 
 
 class DefaultKnowledgeProvider:

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -16,12 +16,22 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Protocol
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+)
 
 if TYPE_CHECKING:
     from aiohttp import web
 
-    from kiro_crew.config.loader import KiroCrewConfig
+    from kiro_crew.config.loader import KiroCrewConfig, TelemetryConfig
 
 
 class InterceptDecision(enum.Enum):
@@ -980,6 +990,44 @@ class TunnelProvider(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class OtlpDestination:
+    """One OTLP/HTTP collector this edition sends telemetry to.
+
+    A destination says WHERE telemetry goes and how to authenticate to it —
+    never WHAT may be sent.  The core keeps the signal shape, the consent gate,
+    attribute sanitisation, the histogram views, batching and retry; a
+    destination cannot widen any of them.
+
+    Deliberately signal-agnostic.  ``signals`` names which OTLP signals this
+    collector accepts (``"metrics"`` today), so a later core that also emits
+    traces or logs reads the SAME descriptor rather than needing a second
+    protocol method — the OTLP/HTTP metric, span and log exporters take the same
+    constructor arguments, so one descriptor already describes all three.  A
+    signal the core does not emit is simply never built.
+
+    ``name`` is a short, NON-SECRET label used in logs.  It exists because
+    ``endpoint`` must never be logged (a URL can carry credentials in userinfo or
+    query parameters), which would otherwise leave a multi-destination host with
+    no way to tell which collector failed.
+
+    ``session`` is an authenticated transport handed to the exporter (a
+    ``requests.Session``; typed loosely so this contract does not depend on the
+    HTTP client).  It is the seam a ROTATING credential composes against:
+    ``Session.auth`` is re-evaluated on every request, so a short-lived OIDC/SSO
+    id_token or STS credential is re-read on each export instead of being frozen
+    at construction — which is exactly what ``OTEL_EXPORTER_OTLP_HEADERS``, the
+    only injection point before this seam, cannot avoid.  Static per-destination
+    headers need no field of their own: ``Session.headers`` already carries them
+    per destination, where that env var is process-wide.
+    """
+
+    name: str
+    endpoint: str
+    signals: "frozenset[str]"
+    session: Optional[Any] = None
+
+
 class TelemetryProvider(Protocol):
     """Backend telemetry sink + the frontend RUM config blob.
 
@@ -991,6 +1039,45 @@ class TelemetryProvider(Protocol):
     def record_event(self, event_type: str, data: dict) -> None: ...
 
     def frontend_rum_config(self) -> Optional[dict]: ...
+
+    def otlp_destinations(self, cfg: "TelemetryConfig") -> Sequence[OtlpDestination]:
+        """OTLP collectors this edition sends telemetry to (WHERE, never WHAT).
+
+        WIRED: ``metrics/provider.py::_otlp_destinations`` calls this once per
+        recorder build — after the consent gate, before any reader is
+        constructed — and builds one ``PeriodicExportingMetricReader`` per
+        returned destination that names ``"metrics"`` in its ``signals``,
+        ALONGSIDE (never instead of) the built-in local JSONL reader.  An empty
+        sequence means local-only, with no network egress.
+
+        The public default returns one destination when
+        ``telemetry.otlp_endpoint`` is a non-empty string and nothing when it is
+        not, so a standalone build stays byte-identical to the hardcoded
+        endpoint-only exporter this replaced.  An edition overrides it to reach
+        its own collector — including one whose credential ROTATES during
+        process lifetime, which the once-at-construction
+        ``OTEL_EXPORTER_OTLP_HEADERS`` injection cannot express.
+
+        ADD-only by construction: destinations are appended to the core's reader
+        list, so this can never remove or replace the local sink, and it cannot
+        relax consent, attribute sanitisation, or the histogram views.  A
+        destination with an empty ``endpoint``, or one that does not name the
+        signal being built, is DROPPED rather than trusted — deny-by-default, so
+        a half-populated descriptor cannot start an unintended egress.
+
+        Best-effort: the build path reads it through ``safe_context_call``
+        (fallback ``()``), so a provider that raises contributes no destinations
+        and telemetry keeps working local-only instead of failing.
+
+        MUST be cheap and side-effect-free per call. It is read once per recorder
+        build AND on every egress-posture read — the Privacy panel's status and
+        each ``telemetry.enabled`` config write ask it so their disclosure cannot
+        disagree with what gets attached. So do not acquire a token, mint a
+        credential, or perform any one-shot side effect inside it: build the
+        transport once and hand back the same object. v1 method addition (no
+        ``CONTRACT_VERSION`` bump).
+        """
+        ...
 
 
 class DashboardContributor(Protocol):

--- a/test/metrics/test_provider.py
+++ b/test/metrics/test_provider.py
@@ -166,7 +166,7 @@ def test_the_otlp_reader_is_reaped_too_when_init_fails(tmp_path, monkeypatch):
         raise RuntimeError("meter provider init failed")
 
     monkeypatch.setattr(provider_mod, "PeriodicExportingMetricReader", FakeReader)
-    monkeypatch.setattr(provider_mod, "_build_otlp_reader", lambda cfg: FakeOtlpReader())
+    monkeypatch.setattr(provider_mod, "_build_otlp_reader", lambda dest, cfg: FakeOtlpReader())
     monkeypatch.setattr(provider_mod, "MeterProvider", _boom)
     try:
         assert get_recorder().enabled is False
@@ -197,12 +197,42 @@ def test_degrades_to_noop_when_otel_missing(monkeypatch):
 # ── OTLP opt-in egress (rec #1: no egress by default) ─────────────────────
 
 
-def test_otlp_reader_none_by_default():
-    """Empty otlp_endpoint => no OTLP reader => no network egress (default)."""
-    from kiro_crew.config.loader import TelemetryConfig
-    from kiro_crew.metrics.provider import _build_otlp_reader
+def _dest(endpoint, *, name="test", signals=("metrics",), **kw):
+    """An OtlpDestination as an edition would supply it."""
+    from kiro_crew.platform.interfaces import OtlpDestination
 
-    assert _build_otlp_reader(TelemetryConfig(enabled=True)) is None
+    return OtlpDestination(name=name, endpoint=endpoint, signals=frozenset(signals), **kw)
+
+
+def test_no_egress_destination_by_default():
+    """What SHIPS yields no destination: the real config, constructed with no
+    arguments, must resolve to zero OTLP destinations — egress-off is a property
+    of the default provider + default config, not of a test fixture."""
+    from kiro_crew.config.loader import TelemetryConfig
+    from kiro_crew.metrics.provider import _otlp_destinations
+    from kiro_crew.platform.defaults import DefaultTelemetryProvider
+
+    assert DefaultTelemetryProvider().otlp_destinations(TelemetryConfig()) == ()
+    assert _otlp_destinations(TelemetryConfig()) == ()
+    # Enabling LOCAL telemetry still must not create an egress destination.
+    assert _otlp_destinations(TelemetryConfig(enabled=True)) == ()
+
+
+def test_default_provider_yields_one_destination_for_the_config_endpoint():
+    """A non-empty telemetry.otlp_endpoint yields exactly the destination the
+    hardcoded exporter used to reach — the byte-identical-behaviour claim."""
+    from kiro_crew.config.loader import TelemetryConfig
+    from kiro_crew.metrics.provider import _otlp_destinations
+    from kiro_crew.platform.defaults import DefaultTelemetryProvider
+
+    cfg = TelemetryConfig(enabled=True, otlp_endpoint="http://localhost:4318/v1/metrics")
+    dests = DefaultTelemetryProvider().otlp_destinations(cfg)
+    assert len(dests) == 1
+    assert dests[0].endpoint == "http://localhost:4318/v1/metrics"
+    assert "metrics" in dests[0].signals
+    assert dests[0].session is None
+    # And the resolver keeps it (deny-by-default filter must not drop a valid one).
+    assert len(_otlp_destinations(cfg)) == 1
 
 
 def test_otlp_reader_degrades_without_logging_endpoint(monkeypatch, caplog):
@@ -223,7 +253,7 @@ def test_otlp_reader_degrades_without_logging_endpoint(monkeypatch, caplog):
     endpoint = "https://user:super-secret@example.test/v1/metrics?token=hidden"
     cfg = TelemetryConfig(enabled=True, otlp_endpoint=endpoint)
     # Must NOT raise — returns None and telemetry stays local-only.
-    assert _build_otlp_reader(cfg) is None
+    assert _build_otlp_reader(_dest(endpoint), cfg) is None
     assert endpoint not in caplog.text
     assert "super-secret" not in caplog.text
     assert "token=hidden" not in caplog.text
@@ -252,7 +282,7 @@ def test_otlp_constructor_failure_never_logs_endpoint(monkeypatch, caplog):
     )
 
     cfg = TelemetryConfig(enabled=True, otlp_endpoint=endpoint)
-    assert _build_otlp_reader(cfg) is None
+    assert _build_otlp_reader(_dest(endpoint), cfg) is None
     assert endpoint not in caplog.text
     assert "super-secret" not in caplog.text
     assert "token=hidden" not in caplog.text
@@ -309,7 +339,11 @@ def test_env_var_blank_defers_to_config(monkeypatch):
 
 
 def test_otlp_reader_built_when_endpoint_set(monkeypatch):
-    """A non-empty otlp_endpoint yields a live OTLP reader (opt-in enables export)."""
+    """A supplied destination yields a live OTLP reader, and its auth surface —
+    session + headers — reaches the exporter. The session is the whole point of
+    the seam: requests re-evaluates Session.auth per request, so a credential
+    that rotates mid-process keeps working where a header frozen at construction
+    would start returning 401."""
     import sys
     import types
 
@@ -322,9 +356,10 @@ def test_otlp_reader_built_when_endpoint_set(monkeypatch):
     captured = {}
 
     class _StubOTLPMetricExporter(MetricExporter):
-        def __init__(self, *, endpoint):
+        def __init__(self, *, endpoint, **kwargs):
             super().__init__()
             captured["endpoint"] = endpoint
+            captured.update(kwargs)
 
         def export(self, metrics_data, timeout_millis=10_000, **kwargs):
             return MetricExportResult.SUCCESS
@@ -343,10 +378,15 @@ def test_otlp_reader_built_when_endpoint_set(monkeypatch):
         mod,
     )
 
+    session = object()  # stands in for a requests.Session carrying rotating auth
     cfg = TelemetryConfig(enabled=True, otlp_endpoint="http://localhost:4318/v1/metrics")
-    reader = _build_otlp_reader(cfg)
-    assert reader is not None, "opt-in endpoint must build an OTLP reader"
+    reader = _build_otlp_reader(
+        _dest("http://localhost:4318/v1/metrics", session=session),
+        cfg,
+    )
+    assert reader is not None, "a supplied destination must build an OTLP reader"
     assert captured["endpoint"] == "http://localhost:4318/v1/metrics"
+    assert captured["session"] is session, "the edition's authenticated transport"
     # Clean shutdown so the reader's daemon thread doesn't linger.
     try:
         reader.shutdown()

--- a/test/metrics/test_provider_otlp_destinations.py
+++ b/test/metrics/test_provider_otlp_destinations.py
@@ -1,0 +1,410 @@
+"""Tests for the pluggable OTLP metric-egress seam.
+
+``TelemetryProvider.otlp_destinations`` lets a deployment say WHERE metrics go —
+including to a collector whose credential rotates during process lifetime, which
+the once-at-construction ``OTEL_EXPORTER_OTLP_HEADERS`` injection cannot express.
+The core keeps WHAT may leave: the consent gate, attribute sanitisation, the
+histogram views, the export cadence, and the local JSONL sink that an edition can
+never remove.
+
+These assert PROPERTIES rather than examples: egress stays off by default in what
+ships, provider-supplied readers join the same reaping list as the built-in one,
+and every way a provider can misbehave (empty, raising, half-populated, aimed at
+a signal this core does not emit) leaves the local reader working.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, TelemetryConfig
+from kiro_crew.metrics.provider import get_recorder, reset_for_testing
+from kiro_crew.platform import build_default_context
+from kiro_crew.platform.context import (
+    PlatformCompositionError,
+    reset_context,
+    set_context,
+)
+from kiro_crew.platform.interfaces import OtlpDestination
+
+ENDPOINT = "https://collector.example.internal:4318/v1/metrics"
+
+
+def _patch_config(monkeypatch, **tel_kwargs):
+    fake = KiroCrewConfig(telemetry=TelemetryConfig(**tel_kwargs))
+    monkeypatch.setattr(KiroCrewConfig, "load", classmethod(lambda cls: fake))
+    monkeypatch.delenv("KIROCREW_TELEMETRY", raising=False)
+
+
+def _wait_for(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class _StubProvider:
+    """A TelemetryProvider whose only job is to answer otlp_destinations."""
+
+    def __init__(self, destinations=(), raises=None):
+        self._destinations = destinations
+        self._raises = raises
+
+    def record_event(self, event_type: str, data: dict) -> None:
+        return None
+
+    def frontend_rum_config(self):
+        return None
+
+    def otlp_destinations(self, cfg):
+        if self._raises is not None:
+            raise self._raises
+        return self._destinations
+
+
+def _install(provider):
+    """Install a PlatformContext whose telemetry slot is *provider*."""
+    base = build_default_context(KiroCrewConfig())
+    set_context(dataclasses.replace(base, telemetry=provider))
+
+
+@pytest.fixture(autouse=True)
+def _clean_context():
+    # Reset BEFORE as well as after: get_recorder() caches its recorder module-
+    # globally behind a recheck window, so a recorder built by an earlier test in
+    # this worker would be handed back without re-reading the patched config -
+    # which is how this file flaked under xdist before the leading reset.
+    reset_for_testing()
+    yield
+    reset_context()
+    reset_for_testing()
+
+
+def _fake_readers(monkeypatch, *, fail_on=None):
+    """Patch the CONSUMER module's reader/provider globals.
+
+    Patched on ``kiro_crew.metrics.provider`` where the names are looked up, not
+    on ``opentelemetry.*`` that defines them — the module binds them as globals
+    precisely so a stand-in survives the lazy SDK load.
+    """
+    import kiro_crew.metrics.provider as provider_mod
+
+    built: list = []
+    shut: list = []
+    captured: dict = {}
+
+    class FakeReader:
+        def __init__(self, *a, **k):
+            built.append(self)
+            self.index = len(built)
+            if fail_on is not None and self.index == fail_on:
+                raise RuntimeError(f"reader {self.index} construction failed")
+
+        def shutdown(self, *a, **k):
+            shut.append(self.index)
+
+    class FakeMeterProvider:
+        def __init__(self, *, metric_readers, resource=None, views=None):
+            captured["readers"] = list(metric_readers)
+
+        def get_meter(self, *a, **k):
+            return MagicMock()
+
+        def shutdown(self, *a, **k):
+            return None
+
+        def force_flush(self, *a, **k):
+            return True
+
+    monkeypatch.setattr(provider_mod, "PeriodicExportingMetricReader", FakeReader)
+    monkeypatch.setattr(provider_mod, "MeterProvider", FakeMeterProvider)
+    # The local sink's exporter is irrelevant here; keep it out of the filesystem.
+    monkeypatch.setattr(provider_mod, "JsonlMetricExporter", lambda *a, **k: MagicMock())
+    return built, shut, captured
+
+
+def _stub_otlp_readers(monkeypatch):
+    """Make each destination yield one reader, recording the destinations seen."""
+    import kiro_crew.metrics.provider as provider_mod
+
+    seen: list = []
+
+    def _build(dest, cfg):
+        seen.append(dest)
+        return provider_mod.PeriodicExportingMetricReader()
+
+    monkeypatch.setattr(provider_mod, "_build_otlp_reader", _build)
+    return seen
+
+
+class TestAttachment:
+    def test_supplied_destinations_are_attached_to_the_meter_provider(self, tmp_path, monkeypatch):
+        """Every metrics destination becomes a reader on the MeterProvider, and
+        the local sink stays FIRST — an edition adds destinations, it never
+        replaces the sink the dashboard reads."""
+        _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+        built, _shut, captured = _fake_readers(monkeypatch)
+        seen = _stub_otlp_readers(monkeypatch)
+        _install(
+            _StubProvider(
+                (
+                    OtlpDestination("primary", ENDPOINT, frozenset({"metrics"})),
+                    OtlpDestination("secondary", ENDPOINT + "/2", frozenset({"metrics"})),
+                )
+            )
+        )
+
+        assert get_recorder().enabled is True
+        assert len(captured["readers"]) == 3, "local sink + one reader per destination"
+        assert captured["readers"][0] is built[0], "the local sink is attached first"
+        assert [d.name for d in seen] == ["primary", "secondary"]
+
+    def test_the_export_cadence_stays_a_core_decision(self, tmp_path, monkeypatch):
+        """A destination says where to send, not how often: the reader's interval
+        comes from telemetry.export_interval_seconds, not from the descriptor."""
+        import sys
+        import types
+
+        from kiro_crew.metrics.provider import _build_otlp_reader
+
+        captured: dict = {}
+
+        class _StubExporter:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        mod = types.ModuleType("opentelemetry.exporter.otlp.proto.http.metric_exporter")
+        mod.OTLPMetricExporter = _StubExporter  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules,
+            "opentelemetry.exporter.otlp.proto.http.metric_exporter",
+            mod,
+        )
+        import kiro_crew.metrics.provider as provider_mod
+
+        seen: dict = {}
+
+        class FakeReader:
+            def __init__(self, exporter, export_interval_millis=None):
+                seen["interval"] = export_interval_millis
+
+        monkeypatch.setattr(provider_mod, "PeriodicExportingMetricReader", FakeReader)
+
+        cfg = TelemetryConfig(enabled=True, export_interval_seconds=17)
+        _build_otlp_reader(OtlpDestination("d", ENDPOINT, frozenset({"metrics"})), cfg)
+        assert seen["interval"] == 17_000.0
+
+
+class TestDegradation:
+    """Every way a provider can fail must leave local collection working."""
+
+    def test_an_empty_sequence_is_local_only(self, tmp_path, monkeypatch):
+        _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+        _built, _shut, captured = _fake_readers(monkeypatch)
+        _install(_StubProvider(()))
+
+        assert get_recorder().enabled is True
+        assert len(captured["readers"]) == 1, "local sink only, no egress"
+
+    def test_a_raising_provider_is_local_only(self, tmp_path, monkeypatch, caplog):
+        """A provider that raises contributes no destinations and says so at
+        WARNING — not debug. A default install collects WARNING and above, so a
+        debug-only line would make a broken provider an undiagnosable no-op."""
+        import logging
+
+        _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+        _built, _shut, captured = _fake_readers(monkeypatch)
+        _install(_StubProvider(raises=RuntimeError("provider exploded")))
+
+        with caplog.at_level(logging.WARNING):
+            assert get_recorder().enabled is True
+        assert len(captured["readers"]) == 1
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any(
+            "otlp egress disabled" in r.getMessage().lower() for r in warnings
+        ), f"expected a WARNING naming the degrade, got {[r.getMessage() for r in warnings]}"
+
+    def test_a_composition_failure_is_local_only(self, tmp_path, monkeypatch, caplog):
+        """For an EGRESS seam the closed state is 'no destinations', so a host
+        that cannot compose its companion degrades to local-only rather than
+        turning a metric call into a raise. Deliberate, and documented at the
+        call site: degrading here can only REMOVE egress, never add any."""
+        _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+        _built, _shut, captured = _fake_readers(monkeypatch)
+        _install(_StubProvider(raises=PlatformCompositionError("no companion")))
+
+        assert get_recorder().enabled is True
+        assert len(captured["readers"]) == 1
+        assert "platform context unavailable" in caplog.text.lower()
+
+    def test_a_destination_for_another_signal_is_not_built(self, tmp_path, monkeypatch):
+        """A traces-only destination contributes no METRIC reader. This is what
+        makes the descriptor safe to reuse when the core starts emitting other
+        signals: adding a signal must not silently start exporting it."""
+        _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+        _built, _shut, captured = _fake_readers(monkeypatch)
+        seen = _stub_otlp_readers(monkeypatch)
+        _install(_StubProvider((OtlpDestination("traces-only", ENDPOINT, frozenset({"traces"})),)))
+
+        assert get_recorder().enabled is True
+        assert len(captured["readers"]) == 1
+        assert seen == []
+
+    def test_a_destination_without_an_endpoint_is_dropped(self, tmp_path, monkeypatch):
+        """Deny-by-default: a half-populated descriptor is dropped, never coerced
+        into an egress nobody asked for."""
+        _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+        _built, _shut, captured = _fake_readers(monkeypatch)
+        seen = _stub_otlp_readers(monkeypatch)
+        _install(
+            _StubProvider(
+                (
+                    OtlpDestination("blank", "", frozenset({"metrics"})),
+                    OtlpDestination("whitespace", "   ", frozenset({"metrics"})),
+                )
+            )
+        )
+
+        assert get_recorder().enabled is True
+        assert len(captured["readers"]) == 1
+        assert seen == []
+
+
+class TestEgressPostureIsSingleSourced:
+    """The disclosure surfaces must answer from the RESOLVED destination set.
+
+    Before this seam, "is egress on?" had exactly one answer:
+    ``telemetry.otlp_endpoint``. An edition that supplies its own collector makes
+    that key an unreliable proxy — so the Privacy panel's ``otlp_configured`` and
+    the config route's refusal to ENABLE collection both have to ask the same
+    resolver ``_build_recorder`` uses. Otherwise the panel reports "nothing is
+    exported" while metrics leave the machine: two answers to one consent
+    question, which is precisely the defect this seam must not introduce.
+    """
+
+    def test_a_provider_destination_counts_as_egress_with_no_config_endpoint(self):
+        from kiro_crew.metrics.provider import otlp_egress_active
+
+        cfg = TelemetryConfig(enabled=True)  # otlp_endpoint deliberately EMPTY
+        assert otlp_egress_active(cfg) is False, "default provider: no destination"
+
+        _install(
+            _StubProvider((OtlpDestination("edition-collector", ENDPOINT, frozenset({"metrics"})),))
+        )
+        assert otlp_egress_active(cfg) is True, (
+            "an edition-supplied destination IS egress, even with an empty "
+            "telemetry.otlp_endpoint"
+        )
+
+    def test_posture_ignores_a_destination_for_another_signal(self):
+        from kiro_crew.metrics.provider import otlp_egress_active
+
+        _install(_StubProvider((OtlpDestination("traces-only", ENDPOINT, frozenset({"traces"})),)))
+        assert otlp_egress_active(TelemetryConfig(enabled=True)) is False
+
+    def test_a_provider_without_the_method_answers_no_not_unknown(self, monkeypatch):
+        """An edition built BEFORE this seam composes fine (structural matching,
+        and the contract assertion only compares a version integer). It has no
+        method, which is a KNOWN answer: no destinations. Reading it as "unknown"
+        would report egress that provably cannot happen and brick the dashboard
+        enable switch, while the build path on the same host is local-only - the
+        two surfaces disagreeing is the defect this seam exists to remove."""
+        from kiro_crew.dashboard.handlers import telemetry as telemetry_handlers
+        from kiro_crew.metrics.provider import _otlp_destinations, otlp_egress_active
+
+        class _StaleProvider:
+            def record_event(self, event_type, data):
+                return None
+
+            def frontend_rum_config(self):
+                return None
+
+        cfg = TelemetryConfig(enabled=True)
+        _patch_config(monkeypatch, enabled=True)
+        _install(_StaleProvider())
+
+        assert otlp_egress_active(cfg) is False
+        assert _otlp_destinations(cfg) == (), "build path agrees: local-only"
+        assert telemetry_handlers._telemetry_cfg().otlp_configured is False
+
+    def test_an_attribute_error_from_inside_the_method_still_raises(self):
+        """Only an ABSENT attribute is read as no-destinations. A provider whose
+        implementation itself raises AttributeError is a broken provider, not a
+        stale one, so posture stays unknown and the gate stays closed."""
+        from kiro_crew.metrics.provider import otlp_egress_active
+
+        _install(_StubProvider(raises=AttributeError("typo inside the provider")))
+        with pytest.raises(AttributeError):
+            otlp_egress_active(TelemetryConfig(enabled=True))
+
+    def test_an_unresolvable_provider_makes_posture_raise_not_answer_no(self):
+        """The gate's closed direction is the OPPOSITE of the build path's.
+
+        At build time an unresolvable provider must not export, so
+        _otlp_destinations degrades to (). At gate time it must not read as "no
+        egress": a caller that saw False would permit an enable that the
+        recovered provider turns into egress. So posture raises and the callers
+        decide.
+        """
+        from kiro_crew.metrics.provider import _otlp_destinations, otlp_egress_active
+
+        cfg = TelemetryConfig(enabled=True)
+        _install(_StubProvider(raises=RuntimeError("provider exploded")))
+
+        with pytest.raises(RuntimeError):
+            otlp_egress_active(cfg)
+        # Same provider, build path: lenient, so local collection survives.
+        assert _otlp_destinations(cfg) == ()
+
+    def test_the_panel_reports_egress_when_posture_is_unresolvable(self, monkeypatch):
+        """A disclosure surface fails closed by assuming it EXPORTS - promising
+        local-only on an unresolved posture is the lie this must not tell."""
+        from kiro_crew.dashboard.handlers import telemetry as telemetry_handlers
+
+        _patch_config(monkeypatch, enabled=True)
+        _install(_StubProvider(raises=RuntimeError("provider exploded")))
+        assert telemetry_handlers._telemetry_cfg().otlp_configured is True
+
+    def test_the_privacy_panel_reports_the_resolved_posture(self, monkeypatch):
+        """otlp_configured is what the Settings → Privacy panel renders. The
+        enforcement half — the config route refusing to ENABLE collection on such
+        a host — is pinned at the route itself, in
+        test/test_config_patch.py::TestTelemetryEnabledEgressGate."""
+        from kiro_crew.dashboard.handlers import telemetry as telemetry_handlers
+
+        _patch_config(monkeypatch, enabled=True)  # empty otlp_endpoint
+        _install(
+            _StubProvider((OtlpDestination("edition-collector", ENDPOINT, frozenset({"metrics"})),))
+        )
+        assert telemetry_handlers._telemetry_cfg().otlp_configured is True
+
+
+class TestReaping:
+    def test_a_later_reader_failure_leaves_no_earlier_reader_running(self, tmp_path, monkeypatch):
+        """Provider-supplied readers join the SAME reaping list as the built-in
+        one. PeriodicExportingMetricReader starts its ticker inside __init__, so
+        a third reader that raises must not leave the first two ticking while
+        telemetry reports itself disabled."""
+        _patch_config(monkeypatch, enabled=True, local_dir=str(tmp_path))
+        built, shut, _captured = _fake_readers(monkeypatch, fail_on=3)
+        _stub_otlp_readers(monkeypatch)
+        _install(
+            _StubProvider(
+                (
+                    OtlpDestination("first", ENDPOINT, frozenset({"metrics"})),
+                    OtlpDestination("second", ENDPOINT + "/2", frozenset({"metrics"})),
+                )
+            )
+        )
+
+        assert get_recorder().enabled is False, "degraded to a no-op recorder"
+        assert _wait_for(
+            lambda: sorted(shut) == [1, 2]
+        ), f"expected readers 1 and 2 reaped, got {sorted(shut)}"
+        assert len(built) == 3, "the third reader raised inside its constructor"

--- a/test/test_config_patch.py
+++ b/test/test_config_patch.py
@@ -755,16 +755,62 @@ class TestTelemetryEnabledPatch:
 class TestTelemetryEnabledEgressGate:
     """The switch promises local-only, so it must not reach a state that exports.
 
-    `_build_recorder` attaches an OTLP reader whenever `telemetry.otlp_endpoint` is
-    set, so on a host that configured an endpoint, enabling collection from the
-    dashboard would start network egress under a control whose own description says
-    "Nothing is exported". Enabling is refused there; disabling always composes.
+    `_build_recorder` attaches an OTLP reader for every destination the active
+    telemetry provider supplies, so on a host where egress is configured — through
+    `telemetry.otlp_endpoint` for the default provider, or an edition's own
+    collector — enabling collection from the dashboard would start network egress
+    under a control whose own description says "Nothing is exported". Enabling is
+    refused there; disabling always composes.
     """
 
     def _seed_endpoint(self, cfg_path, endpoint: str) -> None:
         data = json.loads(cfg_path.read_text(encoding="utf-8"))
         data.setdefault("telemetry", {})["otlp_endpoint"] = endpoint
         cfg_path.write_text(json.dumps(data), encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_enable_is_refused_when_an_edition_supplies_a_destination(
+        self, tmp_config
+    ) -> None:
+        """Egress posture is NOT the config key. An edition that supplies its own
+        collector must refuse the same enable, or the local-only promise would hold
+        only for the default provider and the panel would report "nothing is
+        exported" while metrics left the machine."""
+        import dataclasses
+
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.platform import build_default_context
+        from kiro_crew.platform.context import reset_context, set_context
+        from kiro_crew.platform.interfaces import OtlpDestination
+
+        class _EditionTelemetry:
+            def record_event(self, event_type, data):
+                return None
+
+            def frontend_rum_config(self):
+                return None
+
+            def otlp_destinations(self, cfg):
+                return (
+                    OtlpDestination(
+                        "edition-collector",
+                        "https://collector.internal:4318/v1/metrics",
+                        frozenset({"metrics"}),
+                    ),
+                )
+
+        base = build_default_context(KiroCrewConfig())
+        set_context(dataclasses.replace(base, telemetry=_EditionTelemetry()))
+        try:
+            # telemetry.otlp_endpoint stays EMPTY on disk — the old guard read that
+            # key and would have allowed this write.
+            async with TestClient(TestServer(_make_app())) as c:
+                resp = await _patch(c, "telemetry.enabled", True)
+                assert resp.status == 409
+            data = json.loads(tmp_config.read_text(encoding="utf-8"))
+            assert data.get("telemetry", {}).get("enabled") is not True
+        finally:
+            reset_context()
 
     @pytest.mark.asyncio
     async def test_enable_is_refused_when_an_endpoint_is_configured(self, tmp_config) -> None:
@@ -774,6 +820,39 @@ class TestTelemetryEnabledEgressGate:
             assert resp.status == 409
         data = json.loads(tmp_config.read_text(encoding="utf-8"))
         assert data["telemetry"].get("enabled") is not True
+
+    @pytest.mark.asyncio
+    async def test_enable_is_refused_when_the_egress_posture_cannot_be_resolved(
+        self, tmp_config
+    ) -> None:
+        """A provider that raises must not read as "no egress". Permitting the
+        toggle there would let the recovered provider attach an OTLP reader on the
+        next build - egress the operator was told would not happen."""
+        import dataclasses
+
+        from kiro_crew.config.loader import KiroCrewConfig
+        from kiro_crew.platform import build_default_context
+        from kiro_crew.platform.context import reset_context, set_context
+
+        class _BrokenTelemetry:
+            def record_event(self, event_type, data):
+                return None
+
+            def frontend_rum_config(self):
+                return None
+
+            def otlp_destinations(self, cfg):
+                raise RuntimeError("collector discovery failed")
+
+        base = build_default_context(KiroCrewConfig())
+        set_context(dataclasses.replace(base, telemetry=_BrokenTelemetry()))
+        try:
+            async with TestClient(TestServer(_make_app())) as c:
+                assert (await _patch(c, "telemetry.enabled", True)).status == 409
+            data = json.loads(tmp_config.read_text(encoding="utf-8"))
+            assert data.get("telemetry", {}).get("enabled") is not True
+        finally:
+            reset_context()
 
     @pytest.mark.asyncio
     async def test_disable_is_still_allowed_when_an_endpoint_is_configured(


### PR DESCRIPTION
## 1. What is the problem?

The metric export destination and its transport are hardcoded in core.
`_build_recorder` assembled readers into a function-local list and
`_build_otlp_reader` constructed `OTLPMetricExporter(endpoint=endpoint)` - endpoint
only, no session, no headers, no credential hook. There was no registration seam
of any kind: `register_metric_exporter`, `additional_readers` and `extra_readers`
all return zero hits.

So a deployment cannot send metrics to its own collector. The gap is sharpest for
auth. The only injection point was `OTEL_EXPORTER_OTLP_HEADERS`, which the
exporter reads once at construction and freezes into its session.

## 2. Why this issue matters to the user

Any credential that expires during process lifetime - an OIDC/SSO id_token, STS
temporary credentials, a signed short-lived token - starts returning 401 once it
rotates, and a long-running gateway process outlives it. That is the common
enterprise case, not an exotic one: an operator sets an endpoint, sees metrics
flow for an hour, and then silently loses egress with nothing but exporter
warnings to explain it. There is no supported way to fix it from outside core.

## 3. How our fix solves it

Chain from symptom to root cause: 401 after an hour <- the credential is frozen
into the exporter's session at construction <- the only injection point is an env
var read once <- the destination and its transport are built inside core with no
seam <- core owns a decision that belongs to the deployment.

`TelemetryProvider` now answers `otlp_destinations(cfg)` with frozen
`OtlpDestination` descriptors (`name`, `endpoint`, `signals`, optional `headers` /
`session`). `_build_recorder` builds one `PeriodicExportingMetricReader` per
destination naming the `"metrics"` signal, appended AFTER the built-in local
JSONL reader.

The boundary is: **core decides what may leave the machine; an edition decides
only where it goes.** Core keeps consent, attribute sanitisation, the histogram
views, the export cadence and the local sink. `session` is what closes the auth
gap: `requests` re-evaluates `Session.auth` per request, so a rotating credential
is re-read on every export.

Two deliberate design decisions, recorded here as requested:

**Descriptors, not readers.** The open question was whether the method returns
live `MetricReader` objects or something narrower. It returns descriptors, and the
reason is verified rather than aesthetic: upstream `OTLPMetricExporter.__init__`
and `OTLPSpanExporter.__init__` take the *identical* argument set (`endpoint`,
`headers`, `timeout`, `compression`, the three TLS files, `session`). One
descriptor therefore already describes metrics, traces and logs, so a core that
later emits another signal adds a row in the assembly path instead of another
protocol method - the contract stays still. Returning readers would instead put
exporter construction and batching semantics in the edition's hands, which is
precisely the half core must keep. The narrower alternative rules out a non-OTLP
backend; that is accepted, and if one is ever needed it earns its own named seam
rather than widening this one.

**`CONTRACT_VERSION` is not bumped.** `platform/context.py` pins it at 1
pre-launch in writing ("Every seam added pre-launch ... landed under this same v1,
no bump"), and `interfaces.py` carries five existing "v1 method addition (no
`CONTRACT_VERSION` bump)" precedents. A bump here would compare 1 == 1 by
construction and protect nothing. The method is registered in
`platform-context.md`'s "Edition seam additions (v1, no bump)" list instead. Note
that `_assert_contract` compares a version integer and does NOT structurally
check protocol conformance, so it could not have caught a missing method anyway;
the call site goes through `safe_context_call(fallback=())`, which is what makes
an older or erroring provider degrade to local-only.

Also fixed, found by local review before opening: the Privacy panel's
`otlp_configured` and the config route that refuses to ENABLE `telemetry.enabled`
both read `telemetry.otlp_endpoint`, which is only how the *default* provider
names a destination. An edition supplying its own collector with that key empty
would have left the panel reporting "Nothing is exported" while metrics left the
machine, and would have let the switch turn on undisclosed egress. Both now
resolve posture from the same destination set via `otlp_egress_active(cfg)`.

Behaviour-preservation details kept intentionally intact: `started_readers` is
still bound before the `try` so every started reader - now including
provider-supplied ones - is reaped when a later step raises; the endpoint value is
never logged on any path (destination `name` is logged instead, which is also the
only way to tell which of several collectors failed); a missing `kirocrew[otlp]`
extra still degrades to local-only with a warning; and egress remains off by
default.

One policy stated explicitly rather than left implicit: `_otlp_destinations`
catches `PlatformCompositionError` instead of letting `safe_context_call` re-raise
it. For an egress seam the closed state IS "no destinations", so a host that
cannot compose its companion must land there rather than turn a metric call into a
raise - and processes exist that never boot the platform at all. Degrading there
can only remove egress, never add any.

## 4. What tests we did

Everything below was executed, not assumed.

- `test/metrics/test_provider_otlp_destinations.py` (new): destinations attach to
  the `MeterProvider` with the local sink still first; the export cadence stays
  core's; an empty sequence, a raising provider and a composition failure each
  leave the local reader working; a traces-only destination and an endpoint-less
  destination are both dropped (deny-by-default); a later reader failure leaves no
  earlier reader running; egress-off-by-default asserted against the real
  `TelemetryConfig()` with no arguments rather than a stand-in.
- Mutation-verified: reverting either disclosure consumer to the config-key read
  turns the panel assertion red (`False is not True`) and the config route back to
  200 instead of 409.
- Targeted: 682 passed across `test/metrics/`, `test_config_patch.py`,
  `test_collection_status_endpoint.py`, `test_platform_cpp_seam_coverage.py`,
  `test_platform_context.py`, both CPP wiring suites and `test_perf_boot_path.py`.
- Full backend suite: 66758 passed, 116 failed, 2 errors - ZERO failures in any
  changed area. A/B on the identical failing file set gives byte-identical
  81 failed / 521 passed / 2 errors on clean `main`, so those are base/env-owned
  (sandbox `unshare` EPERM, `AF_UNIX path too long`).
- `isort` and `flake8` clean on every changed file. `mypy src/kiro_crew`: my one
  arg-type error fixed; the remaining 4 in `transcribe.py` + `cloudwatch.py` A/B
  identical on clean `main`.
- Local review mirrors of both CI reviewer workflows ran pre-push on their pinned
  CI models. The Opus lane returned no findings. The GPT lane returned one
  BLOCKING finding - the disclosure coupling above - which is fixed in this diff.

## 5. Any other suggestions on the work

- `metrics.md` and `platform-context.md` are updated in the same commit.
- Deliberately NOT in scope, and it needs its own design discussion: moving
  telemetry POLICY into core (a declared manifest of emittable events and
  attribute keys, one consent resolver covering every signal, core-side validation
  and redaction, a user-visible record of what was sent). Today an edition owns
  the behaviour-event registry, its enforcement, and its own consent decision,
  which is a governance gap this PR does not touch. Bundling it here would make
  the change unreviewable.
- If traces or logs land later, the intended shape is a row in the assembly path
  (`TracerProvider` + `BatchSpanProcessor`) reading this same descriptor. Worth
  deciding then whether the default provider should extend its `signals` - adding
  a signal must not silently start exporting it, which is why `signals` is
  required rather than defaulted.
