### PR TITLE
fix(embeddings): harden suppressed streams for Windows

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -407,6 +407,13 @@ The backend `POST /api/memory/migrate` endpoint and the `kirocrew memory migrate
 
 macOS (Apple Silicon and Intel), Linux (x86_64, arm64/Graviton), and Windows supported. All paths use `pathlib.Path`. GGUF model downloaded over sha256-pinned HTTPS from the Kiro Crew CDN. No runtime install step — native llama.cpp libraries are vendored per platform in `_vendor/llama_cpp_libs/` and selected via `LLAMA_CPP_LIB_PATH` (the old Docker fallback is gone).
 
+Before the vendored runtime becomes usable, `embeddings._load_llama_class()`
+reconfigures llama-cpp-python's import-time stdout/stderr null streams to UTF-8
+with backslash replacement. The upstream suppressor temporarily installs those
+streams process-wide while the GGUF loads on `kc-embed-load`; keeping the same
+handles preserves its native fd suppression while preventing unrelated Unicode
+gateway output from failing under a locale encoding such as Windows cp1252.
+
 | Platform | Vendored libs | GPU | Notes |
 |----------|--------------|-----|-------|
 | macOS (Apple Silicon) | `macos_arm64/` | Metal (shader embedded in dylib) | Fastest |

--- a/src/kiro_crew/embeddings.py
+++ b/src/kiro_crew/embeddings.py
@@ -345,6 +345,25 @@ def _install_diskcache_stub() -> None:
     sys.modules["diskcache"] = stub
 
 
+def _harden_llama_null_streams() -> None:
+    """Make llama-cpp-python's process-global suppression streams Unicode-safe.
+
+    The vendored suppressor temporarily assigns its import-time ``os.devnull``
+    handles to ``sys.stdout`` and ``sys.stderr`` while a model loads. That load
+    runs on a background thread, so unrelated gateway output can reach those
+    handles. Reconfiguring the existing wrappers preserves the native ``dup2``
+    suppression while removing the host locale from that process-wide window.
+    """
+    llama_utils = sys.modules.get("llama_cpp._utils")
+    if llama_utils is None:
+        return
+    for name in ("outnull_file", "errnull_file"):
+        stream = getattr(llama_utils, name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+
+
 @functools.lru_cache(maxsize=1)
 def _load_llama_class():
     """Import the vendored llama-cpp-python runtime. Returns the Llama class or None.
@@ -432,6 +451,7 @@ def _load_llama_class():
     try:
         from llama_cpp import Llama  # noqa: F811
 
+        _harden_llama_null_streams()
         return Llama
     except Exception:
         logger.warning("Vendored llama-cpp-python failed to import", exc_info=True)

--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import io
 import os
 import sys
 import threading
@@ -236,6 +237,35 @@ class TestBundledLinuxX86CpuGate:
         assert active_lib_path is not None
         assert Path(active_lib_path).parts[-2:] == ("llama_cpp_libs", "linux_x86_64")
         assert embeddings_mod._LIB_PATH_ENV not in os.environ
+
+    def test_runtime_import_hardens_locale_encoded_null_streams(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.delenv(embeddings_mod._LIB_PATH_ENV, raising=False)
+        _stub_bundled_linux_libs(tmp_path)
+        fake_llama_cpp = ModuleType("llama_cpp")
+        expected = object()
+        setattr(fake_llama_cpp, "Llama", expected)
+        monkeypatch.setitem(sys.modules, "llama_cpp", fake_llama_cpp)
+
+        fake_utils = ModuleType("llama_cpp._utils")
+        stdout_sink = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+        stderr_sink = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+        setattr(fake_utils, "outnull_file", stdout_sink)
+        setattr(fake_utils, "errnull_file", stderr_sink)
+        monkeypatch.setitem(sys.modules, "llama_cpp._utils", fake_utils)
+
+        result, _active_lib_path = _load_bundled_linux_llama(
+            monkeypatch,
+            tmp_path,
+            lambda: embeddings_mod._LINUX_X86_64_REQUIRED_CPU_FLAGS,
+        )
+
+        assert result is expected
+        assert stdout_sink.encoding == "utf-8"
+        assert stderr_sink.encoding == "utf-8"
+        stdout_sink.write("👻")
+        stderr_sink.write("👻")
 
     def test_missing_cpu_features_refuse_before_native_import(
         self, tmp_path: Path, monkeypatch, caplog


### PR DESCRIPTION
## Problem / Motivation

On Windows hosts using a legacy console locale, llama-cpp's quiet-mode suppressor can replace process-global stdout/stderr with a locale-encoded devnull stream while the embedding model loads on a background thread. An unrelated emoji or other unencodable write can then raise UnicodeEncodeError and terminate the gateway.

## Why it matters

Embedding-model startup should not make unrelated gateway logging depend on the Windows ANSI code page. The failure is timing-dependent and can kill an otherwise healthy gateway during normal Unicode output.

## What changed (motivation → approach → change)

The bundled llama-cpp suppressor relies on its module-level null streams and their native file descriptors, so replacing the suppressor would widen the behavioral change. Instead, the KiroCrew-owned lazy loader now reconfigures those two text wrappers to UTF-8 with backslash replacement immediately after importing llama_cpp and before any Llama constructor can enter the suppressor. This preserves the vendor's native fd redirection and avoids editing the vendored tree.

The memory/embeddings system spec now records the stream-encoding invariant.

## Tests

- Added a deterministic regression that supplies CP1252-backed llama_cpp null streams, loads the runtime through the real lazy-loader path, and proves both streams accept emoji before construction.
- `test/test_embeddings.py`: 81 passed.
- isort, flake8, mypy, docs lint, and `git diff --check`: passed.
- Full repository pytest reached 99% before an unrelated existing global timeout left an xdist worker un-terminated; the focused embeddings suite completed cleanly.

## Manual verification

Ran the regression on Windows with the host's real CP950 preferred encoding; red-before raised UnicodeEncodeError and the fixed loader completed with UTF-8 streams.

## Related Issues

Fixes #6342

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template currently contains only an OSPO placeholder and supplies no CLA text to acknowledge.