### PR TITLE
fix(embeddings): stop cp1252 null sinks killing the gateway mid-load

### DIFF
--- a/src/kiro_crew/embeddings.py
+++ b/src/kiro_crew/embeddings.py
@@ -432,10 +432,56 @@ def _load_llama_class():
     try:
         from llama_cpp import Llama  # noqa: F811
 
+        _rebind_null_sinks_utf8()
         return Llama
     except Exception:
         logger.warning("Vendored llama-cpp-python failed to import", exc_info=True)
         return None
+
+
+def _rebind_null_sinks_utf8() -> None:
+    """Rebind the vendored suppressor's devnull sinks to UTF-8 handles.
+
+    ``llama_cpp._utils`` opens ``outnull_file``/``errnull_file`` at import time
+    with the locale encoding — cp1252 on a stock Windows — and
+    ``suppress_stdout_stderr.__enter__`` assigns them to the process-global
+    ``sys.stdout``/``sys.stderr`` for the whole model-load window. The load runs
+    on a background thread (``kc-embed-load``), so any non-ASCII ``print()``
+    from an unrelated thread inside that window writes to a cp1252 handle,
+    raises ``UnicodeEncodeError``, and takes the gateway down (#6342).
+    ``ensure_utf8_console()`` cannot help: the stream is *replaced*, not
+    reconfigured.
+
+    ``__enter__`` resolves the sinks as module globals at call time, so
+    rebinding them here — from our own code, after the vendored import — covers
+    every future suppression window without editing the manifest-pinned
+    ``_vendor`` tree. ``errors="backslashreplace"`` means a stray glyph written
+    into a suppression window degrades into an escape sequence bound for
+    ``os.devnull`` instead of an exception. Never raises: on failure the
+    original sinks stay in place, which is exactly the pre-fix behaviour.
+    """
+    try:
+        import llama_cpp._utils as _llama_utils
+
+        for name in ("outnull_file", "errnull_file"):
+            old = getattr(_llama_utils, name, None)
+            if (
+                old is None
+                or (getattr(old, "encoding", "") or "").lower().replace("-", "") == "utf8"
+            ):
+                continue
+            replacement = open(  # noqa: SIM115 - deliberately module-lifetime
+                os.devnull, "w", encoding="utf-8", errors="backslashreplace"
+            )
+            setattr(_llama_utils, name, replacement)
+            # The displaced handle is deliberately NOT closed: if a suppression
+            # window were ever active during the rebind, sys.stdout/stderr would
+            # still reference the old object until __exit__, and closing it would
+            # turn every concurrent print() into ValueError -- worse than the
+            # UnicodeEncodeError being fixed. Two leaked devnull descriptors,
+            # at most once per process, is the cheap safe trade.
+    except Exception:  # pragma: no cover - defensive: keep the load path alive
+        logger.debug("Could not rebind vendored null sinks to UTF-8", exc_info=True)
 
 
 # ── Model paths ──

--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -295,6 +295,121 @@ class TestBundledLinuxX86CpuGate:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# UTF-8 null-sink rebind (#6342)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _load_real_vendored_utils() -> ModuleType:
+    """Load a private copy of the REAL vendored ``llama_cpp._utils``.
+
+    Loaded standalone via a file spec so the test never installs the vendored
+    package under the public ``llama_cpp`` name (other tests stub that name).
+    ``_utils`` imports only ``os``/``sys``/``typing``, so this touches no
+    native code.
+    """
+    import importlib.util
+
+    path = embeddings_mod._VENDOR_DIR / "llama_cpp" / "_utils.py"
+    spec = importlib.util.spec_from_file_location("_test_llama_utils", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestRebindNullSinksUtf8:
+    """The vendored devnull sinks must not keep a locale (cp1252) encoding.
+
+    ``suppress_stdout_stderr`` swaps them into the process-global
+    ``sys.stdout``/``sys.stderr`` for the whole model-load window, so a
+    locale-encoded sink turns any concurrent emoji ``print()`` into a
+    gateway-killing ``UnicodeEncodeError`` (#6342).
+    """
+
+    def _install(self, monkeypatch, utils_mod: ModuleType) -> None:
+        pkg = ModuleType("llama_cpp")
+        setattr(pkg, "_utils", utils_mod)
+        monkeypatch.setitem(sys.modules, "llama_cpp", pkg)
+        monkeypatch.setitem(sys.modules, "llama_cpp._utils", utils_mod)
+
+    def test_locale_encoded_sinks_are_rebound_to_utf8(self, monkeypatch) -> None:
+        utils_mod = _load_real_vendored_utils()
+        # Simulate the stock-Windows locale default the issue measured.
+        utils_mod.outnull_file = open(os.devnull, "w", encoding="cp1252")
+        utils_mod.errnull_file = open(os.devnull, "w", encoding="cp1252")
+        # Prove the failure mode first -- the pre-fix sink raises.
+        with pytest.raises(UnicodeEncodeError):
+            utils_mod.outnull_file.write("\U0001f47b")
+        old_out, old_err = utils_mod.outnull_file, utils_mod.errnull_file
+        self._install(monkeypatch, utils_mod)
+
+        embeddings_mod._rebind_null_sinks_utf8()
+
+        for sink in (utils_mod.outnull_file, utils_mod.errnull_file):
+            assert (sink.encoding or "").lower().replace("-", "") == "utf8"
+            sink.write("\U0001f47b")  # must not raise
+        # The displaced locale handles are deliberately kept OPEN: an active
+        # suppression window could still hold them in sys.stdout/stderr, and
+        # closing them would turn concurrent print() into ValueError.
+        assert not old_out.closed and not old_err.closed
+
+    def test_rebind_during_an_active_suppression_window_is_safe(self, monkeypatch) -> None:
+        """Rebinding mid-window must not close the handle sys.stdout still holds."""
+        utils_mod = _load_real_vendored_utils()
+        utils_mod.outnull_file = open(os.devnull, "w", encoding="cp1252")
+        utils_mod.errnull_file = open(os.devnull, "w", encoding="cp1252")
+        self._install(monkeypatch, utils_mod)
+
+        with utils_mod.suppress_stdout_stderr(disable=False):
+            embeddings_mod._rebind_null_sinks_utf8()
+            # sys.stdout still references the DISPLACED handle until __exit__;
+            # ASCII writes through it must keep working (no ValueError).
+            print("plain ascii still fine")
+            print("plain ascii still fine", file=sys.stderr)
+
+    def test_emoji_print_inside_a_suppression_window_no_longer_raises(self, monkeypatch) -> None:
+        """End-to-end: the exact #6342 sequence through the real suppressor."""
+        utils_mod = _load_real_vendored_utils()
+        utils_mod.outnull_file = open(os.devnull, "w", encoding="cp1252")
+        utils_mod.errnull_file = open(os.devnull, "w", encoding="cp1252")
+        self._install(monkeypatch, utils_mod)
+
+        embeddings_mod._rebind_null_sinks_utf8()
+
+        # __enter__ resolves the sinks as module globals at call time, so the
+        # rebound handles are the ones swapped into sys.stdout/stderr.
+        with utils_mod.suppress_stdout_stderr(disable=False):
+            # What the update check does from the main loop mid-load.
+            print("\U0001f47b Checking for updates…")
+            print("stderr glyph \U0001f47b", file=sys.stderr)
+
+    def test_already_utf8_sinks_are_left_alone(self, monkeypatch) -> None:
+        utils_mod = _load_real_vendored_utils()
+        utils_mod.outnull_file = open(
+            os.devnull, "w", encoding="utf-8", errors="backslashreplace"
+        )
+        utils_mod.errnull_file = open(
+            os.devnull, "w", encoding="utf-8", errors="backslashreplace"
+        )
+        same_out, same_err = utils_mod.outnull_file, utils_mod.errnull_file
+        self._install(monkeypatch, utils_mod)
+
+        embeddings_mod._rebind_null_sinks_utf8()
+        embeddings_mod._rebind_null_sinks_utf8()  # idempotent
+
+        assert utils_mod.outnull_file is same_out
+        assert utils_mod.errnull_file is same_err
+        assert not same_out.closed and not same_err.closed
+
+    def test_missing_vendored_module_never_raises(self, monkeypatch) -> None:
+        """The rebind is defensive: an import failure keeps the load path alive."""
+        monkeypatch.setitem(sys.modules, "llama_cpp", ModuleType("llama_cpp"))
+        monkeypatch.delitem(sys.modules, "llama_cpp._utils", raising=False)
+
+        embeddings_mod._rebind_null_sinks_utf8()  # must not raise
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Model paths / file presence
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
<!-- no-visual-delta -->

## Problem / Motivation

On Windows the gateway dies intermittently -- minutes to hours after start -- with:

```
File "kiro_crew\slack\gateway.py", line 9905, in run
    print("👻 Checking for updates…")
File "...\Lib\encodings\cp1252.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f47b'
```

The vendored `llama_cpp/_utils.py` opens its devnull sinks at import time with the locale encoding (`open(os.devnull, "w")` == cp1252 on stock Windows), and `suppress_stdout_stderr.__enter__` assigns them to the process-global `sys.stdout`/`sys.stderr` for the whole model-load window. The load runs on a background thread (`kc-embed-load`), so any non-ASCII `print()` from the main event loop inside that window writes to a cp1252 handle and raises. `platform_compat.ensure_utf8_console()` cannot prevent it: the stream is **replaced**, not reconfigured. (Full diagnosis with measured repro tables in #6342.)

## Why it matters

With always-on in-process embeddings the load window exists on **every** start, `slack/gateway.py` alone contains 26 emoji prints, the crash timing looks random (it depends on the periodic update check landing inside a load window), and `kirocrew service` is Linux/macOS-only so there is no supervisor to restart the dead Windows gateway.

## What changed (motivation → approach → change)

Symptom → root cause: the sinks carry the locale encoding, and the suppressor publishes them process-globally from a background thread. The `_vendor/` tree is checksum-manifest-pinned (CI's `vendor-manifest` job fails any PR whose vendored contents differ), so the fix must live in first-party code.

`suppress_stdout_stderr.__enter__` resolves `outnull_file`/`errnull_file` as **module globals at call time**, so a new `_rebind_null_sinks_utf8()` in `embeddings.py` -- called from `_load_llama_class()` right after the vendored import succeeds, before any `Llama` construction can open a suppression window -- rebinds them to UTF-8 handles with `errors="backslashreplace"`. A stray glyph printed into a suppression window now degrades into an escape sequence bound for `os.devnull` instead of an exception.

Design points:
- Never raises; on any failure the original sinks stay in place (exactly the pre-fix behaviour).
- Idempotent: already-UTF-8 sinks are left untouched.
- The displaced locale handles are deliberately **not closed**: if a suppression window were ever active during a rebind, `sys.stdout`/`sys.stderr` would still reference the old object until `__exit__`, and closing it would turn every concurrent `print()` into `ValueError` -- worse than the bug being fixed. Two leaked devnull descriptors at most once per process is the safe trade. (Raised by pre-push adversarial review; fixed with a regression test.)
- The alternative from the issue -- opening the vendored sinks with an explicit encoding -- would edit the manifest-pinned `_vendor/` tree; the not-mutate-`sys.stdout` redesign would be a larger vendored behaviour change. The rebind gets the same protection from first-party code.

## Tests

Four new tests in `TestRebindNullSinksUtf8` (`test/test_embeddings.py`), running against the **real** vendored `_utils.py` loaded standalone (touches no native code, cross-platform -- the failure is reproduced by forcing cp1252 handles, so the suite proves the fix on any OS):

- `test_locale_encoded_sinks_are_rebound_to_utf8` -- proves the failure mode first (cp1252 sink raises on `\U0001f47b`), then that rebound sinks accept it and displaced handles stay open.
- `test_emoji_print_inside_a_suppression_window_no_longer_raises` -- end-to-end #6342 sequence: enters the real `suppress_stdout_stderr`, prints the ghost emoji to stdout and stderr inside the window.
- `test_rebind_during_an_active_suppression_window_is_safe` -- rebinding mid-window must not invalidate the handle `sys.stdout` still holds.
- `test_already_utf8_sinks_are_left_alone` -- idempotence, no churn.
- `test_missing_vendored_module_never_raises` -- the defensive path keeps the load alive.

Full `test/test_embeddings.py` suite: 85 passed. flake8 7.1.0, isort 6.0.0 clean; new code black-26.3.1-clean (both files are baselined).

## Manual verification

N/A beyond unit coverage -- the failure is an encoding property of the sink handles, fully reproduced in tests by constructing cp1252 handles; no Windows host is required to validate the mechanism. The end-to-end test drives the real vendored suppressor.

## Screenshots / video

N/A -- backend-only, no user-visible UI change.

## Related Issues

Fixes #6342

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no doc surface for this internal fix
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
