### PR TITLE
fix(dev-fleet): reap run subprocess spawned during shutdown

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1282,37 +1282,72 @@ async def _start_run(
 
     async def worker() -> None:
         proc: Any = None
+        spawn_task: asyncio.Task | None = None
         try:
             try:
-                proc = await create_subprocess_limited(
-                    *cmd,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.STDOUT,
-                    cwd=cwd,
-                    env=env,
-                    # Kernel RLIMIT ceilings: sync/provision execute
-                    # worktree-controlled pip/npm code; on hosts without
-                    # delegated cgroup v2 the scope limiter is a no-op, so
-                    # the per-process rlimit backstop must be present. Build
-                    # variant: vite/npm need thousands of descriptors — the
-                    # default 1024 NOFILE hard cap EMFILEs the SPA build.
-                    profile=RLIMIT_PROFILE_BUILD,
-                    # Own process group so a timeout kill reaps descendants
-                    # (pip/npm children), not just the immediate CLI process.
-                    start_new_session=platform_compat.IS_POSIX,
-                    creationflags=(
-                        subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
-                        if platform_compat.IS_WINDOWS else 0
-                    ),
+                # Spawn on a child task and shield the await. A CancelledError
+                # (gateway shutdown cancels in-flight run tasks) that arrives
+                # WHILE asyncio is mid-exec would otherwise abandon the child:
+                # the OS process is already forked+exec'd but the Process handle
+                # is never returned, so nothing can reap it and it outlives the
+                # gateway, still mutating the shared checkout. The spawn runs to
+                # completion on its own task regardless of our cancellation; the
+                # handler below retrieves the handle from ``spawn_task`` and
+                # reaps it even when the shielded await itself raised.
+                spawn_task = asyncio.ensure_future(
+                    create_subprocess_limited(
+                        *cmd,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                        cwd=cwd,
+                        env=env,
+                        # Kernel RLIMIT ceilings: sync/provision execute
+                        # worktree-controlled pip/npm code; on hosts without
+                        # delegated cgroup v2 the scope limiter is a no-op, so
+                        # the per-process rlimit backstop must be present. Build
+                        # variant: vite/npm need thousands of descriptors — the
+                        # default 1024 NOFILE hard cap EMFILEs the SPA build.
+                        profile=RLIMIT_PROFILE_BUILD,
+                        # Own process group so a timeout kill reaps descendants
+                        # (pip/npm children), not just the immediate CLI process.
+                        start_new_session=platform_compat.IS_POSIX,
+                        creationflags=(
+                            subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+                            if platform_compat.IS_WINDOWS else 0
+                        ),
+                    )
                 )
+                proc = await asyncio.shield(spawn_task)
             except OSError as exc:
                 async with _RUNS_LOCK:
                     _RUNS[rid]["status"] = "done"
                     _RUNS[rid]["exit_code"] = -1
                     _RUNS[rid]["output"].append(f"[error] spawn failed: {exc}")
                 return
-            if rid in _ACTIVE_RUNS:
-                _ACTIVE_RUNS[rid] = (_ACTIVE_RUNS[rid][0], proc)
+            # Stamp the live process handle under the admission lock and
+            # re-check the shutdown flag in the SAME critical section. The
+            # parent registered this run as ``(task, None)`` before the child
+            # existed; cleanup snapshots ``(task, proc)`` tuples and only kills
+            # a proc it can SEE. Without this guard a child spawned in the
+            # window between registration and this stamp is invisible to a
+            # cleanup that already snapshotted -- it skips _kill_tree (proc was
+            # None) and only cancels the task, orphaning the child to keep
+            # mutating the shared checkout after the gateway exits. If shutdown
+            # already snapshotted, reap the just-spawned child ourselves and
+            # abort, since our cancellation may not have arrived yet.
+            async with _SHUTDOWN_ADMISSION_LOCK:
+                if _SHUTDOWN_IN_PROGRESS:
+                    await _kill_tree(proc.pid)
+                    await platform_compat.kill_and_reap(proc)
+                    async with _RUNS_LOCK:
+                        _RUNS[rid]["status"] = "done"
+                        _RUNS[rid]["exit_code"] = -1
+                        _RUNS[rid]["output"].append(
+                            "[shutdown] run aborted: gateway stopping"
+                        )
+                    return
+                if rid in _ACTIVE_RUNS:
+                    _ACTIVE_RUNS[rid] = (_ACTIVE_RUNS[rid][0], proc)
             assert proc.stdout is not None
             timed_out = False
             deadline = asyncio.get_event_loop().time() + _RUN_DEADLINE_S
@@ -1356,6 +1391,39 @@ async def _start_run(
                 else:
                     _RUNS[rid]["status"] = "done"
                     _RUNS[rid]["exit_code"] = rc
+        except asyncio.CancelledError:
+            # Gateway shutdown cancels in-flight run tasks. The child runs in
+            # its own process group and would outlive us, continuing to mutate
+            # the shared checkout after the gateway exits. ``asyncio.shield``
+            # re-raises the cancellation immediately while the inner spawn keeps
+            # running detached, so ``proc`` may still be None here with the
+            # child forked-or-forking. Drain ``spawn_task`` to COMPLETION before
+            # reaping: a single ``await asyncio.shield(spawn_task)`` is not
+            # enough because a SECOND cancellation (e.g. a shutdown hard-timeout
+            # following the first cancel) lands on that await too, and swallowing
+            # it into ``proc = None`` would abandon the very child this handler
+            # exists to reap. So re-await the shield until the spawn task is
+            # actually done, absorbing repeat cancellations only for the drain,
+            # then recover the handle, kill/reap the tree, and re-raise so the
+            # task still reports cancelled. An OSError result means the spawn
+            # itself failed and there is no child to reap.
+            if proc is None and spawn_task is not None:
+                while not spawn_task.done():
+                    try:
+                        await asyncio.shield(spawn_task)
+                    except asyncio.CancelledError:
+                        continue
+                    except OSError:
+                        break
+                if spawn_task.done():
+                    try:
+                        proc = spawn_task.result()
+                    except (OSError, asyncio.CancelledError):
+                        proc = None
+            if proc is not None and proc.returncode is None:
+                await _kill_tree(proc.pid)
+                await platform_compat.kill_and_reap(proc)
+            raise
         except Exception as exc:  # noqa: BLE001
             # readline() raising (e.g. a single output line exceeding the
             # 64 KiB stream limit -> ValueError/LimitOverrunError) lands

--- a/test/test_devfleet_proc_stamp_orphan.py
+++ b/test/test_devfleet_proc_stamp_orphan.py
@@ -1,0 +1,197 @@
+"""Deterministic regression test for the dev-fleet proc-stamp orphan window.
+
+Context
+-------
+``#5297`` closed the shutdown *admission* race: a run whose ``(task, proc)``
+tuple is registered in ``_ACTIVE_RUNS`` AFTER ``dev_fleet_cleanup`` took its
+snapshot is now refused, and a run registered before is cancelled + its process
+tree killed (see ``test_devfleet_active_runs_shutdown.py``).
+
+This is a DIFFERENT, narrower window that ``#5297`` does not close.
+
+``_start_run`` registers the run under the admission lock as ``(task, None)``
+— the process handle is NOT known yet.  The worker coroutine stamps the real
+process into ``_ACTIVE_RUNS[rid] = (task, proc)`` LATER, right after
+``await create_subprocess_limited(...)`` returns, and it does so WITHOUT the
+admission lock and WITHOUT re-checking ``_SHUTDOWN_IN_PROGRESS``.
+
+So the following interleaving escapes cleanup:
+
+1. ``_start_run`` registers ``(task, None)`` (shutdown not yet in progress).
+2. The worker reaches ``await create_subprocess_limited(...)`` — the child is
+   spawned by the OS, but the coroutine has not returned, so ``proc`` is still
+   ``None`` in ``_ACTIVE_RUNS``.
+3. ``dev_fleet_cleanup`` runs: it snapshots ``(task, None)``, sees ``proc is
+   None`` and therefore SKIPS ``_kill_tree``, then merely ``task.cancel()``s.
+4. The spawned child is never killed — it keeps running (a pip/npm/git build
+   mutating the shared checkout) after the gateway exits.  This is exactly the
+   "escaped process keeps mutating shared checkout state" harm the shutdown
+   path exists to prevent.
+
+This test drives that interleaving deterministically and asserts the child's
+process tree IS killed.  It FAILS against current production code (the child is
+orphaned) and passes once the worker stamps/kills under the admission guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {})
+    monkeypatch.setattr(mod, "_RUNS", {})
+    monkeypatch.setattr(mod, "_SHUTDOWN_IN_PROGRESS", False)
+    monkeypatch.setattr(mod, "_SHUTDOWN_ADMISSION_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_RUNS_LOCK", asyncio.Lock())
+    monkeypatch.setenv(mod._DISABLE_BACKGROUND_ENV, "1")
+    yield
+
+
+def _make_fake_proc():
+    """A fake asyncio subprocess-like object that never yields any output."""
+    proc = MagicMock()
+    proc.returncode = None  # still running
+    proc.pid = 424242
+    proc.stdout = AsyncMock()
+    # readline blocks forever so the worker parks in its read loop rather than
+    # finishing the run before cleanup fires.
+    proc.stdout.readline = AsyncMock(side_effect=lambda: asyncio.Future())
+    proc.wait = AsyncMock(return_value=0)
+    proc.kill = MagicMock()
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_proc_spawned_during_shutdown_is_not_orphaned():
+    """A run whose process is spawned in the proc-stamp window must still be
+    killed by cleanup, not orphaned.
+    """
+    spawn_entered = asyncio.Event()
+    spawn_may_return = asyncio.Event()
+    fake_proc = _make_fake_proc()
+
+    async def blocking_create_subprocess(*args, **kwargs):
+        # The OS child is "spawned" the moment we enter here; the coroutine
+        # then blocks BEFORE returning, so _start_run's worker has registered
+        # (task, None) but has not yet stamped `proc`.
+        spawn_entered.set()
+        await spawn_may_return.wait()
+        return fake_proc
+
+    killed_pids: list[int] = []
+
+    async def fake_kill_tree(pid):
+        killed_pids.append(pid)
+
+    with (
+        patch.object(mod, "create_subprocess_limited", side_effect=blocking_create_subprocess),
+        patch.object(mod, "_kill_tree", side_effect=fake_kill_tree),
+        patch.object(mod, "platform_compat") as pc,
+        patch.object(mod, "_refresher_task", None),
+        patch.object(mod, "_warm_task", None),
+        patch.object(mod, "_reaper_task", None),
+    ):
+        pc.IS_POSIX = True
+        pc.IS_WINDOWS = False
+        pc.kill_and_reap = AsyncMock()
+
+        # 1. Start the run. It registers (task, None) and the worker begins;
+        #    the worker parks inside blocking_create_subprocess (child spawned,
+        #    proc not yet stamped).
+        rid = await mod._start_run("build", ["/bin/echo", "hi"], cwd=None, env={})
+        await spawn_entered.wait()
+
+        # Precondition: the run is registered but with proc STILL None — this
+        # is the window under test.
+        assert rid in mod._ACTIVE_RUNS
+        assert mod._ACTIVE_RUNS[rid][1] is None
+
+        # 2. Shutdown fires now, while the child is live but unstamped.
+        cleanup = asyncio.create_task(mod.dev_fleet_cleanup(app=None))
+
+        # Let cleanup take its snapshot and cancel the worker. Release the
+        # spawn so the (now-cancelled) worker unwinds through its except/finally.
+        await asyncio.sleep(0)
+        spawn_may_return.set()
+        await cleanup
+
+    # The spawned child MUST have been killed. Current production code orphans
+    # it (proc was None in the snapshot, so _kill_tree was skipped and the
+    # worker's CancelledError never reaped it), so this assertion fails today.
+    assert fake_proc.pid in killed_pids, (
+        "child spawned in the proc-stamp window was orphaned: cleanup never "
+        "killed its process tree"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeat_cancellation_during_drain_still_reaps():
+    """A SECOND cancellation arriving while the cancel handler drains the spawn
+    task must not abandon the child.
+
+    The cancel handler recovers the process handle by draining ``spawn_task``
+    (the spawn keeps running detached after the first cancel). If a second
+    cancellation — e.g. a shutdown hard-timeout following the graceful cancel —
+    lands on the drain await and is swallowed into ``proc = None``, the child is
+    orphaned again. The drain therefore loops until the spawn task is actually
+    done, absorbing repeat cancellations, and this test proves it: it cancels
+    the worker twice while the spawn is still parked, then releases the spawn
+    and asserts the child's tree was killed.
+    """
+    spawn_entered = asyncio.Event()
+    spawn_may_return = asyncio.Event()
+    fake_proc = _make_fake_proc()
+
+    async def blocking_create_subprocess(*args, **kwargs):
+        spawn_entered.set()
+        await spawn_may_return.wait()
+        return fake_proc
+
+    killed_pids: list[int] = []
+
+    async def fake_kill_tree(pid):
+        killed_pids.append(pid)
+
+    with (
+        patch.object(mod, "create_subprocess_limited", side_effect=blocking_create_subprocess),
+        patch.object(mod, "_kill_tree", side_effect=fake_kill_tree),
+        patch.object(mod, "platform_compat") as pc,
+        patch.object(mod, "_refresher_task", None),
+        patch.object(mod, "_warm_task", None),
+        patch.object(mod, "_reaper_task", None),
+    ):
+        pc.IS_POSIX = True
+        pc.IS_WINDOWS = False
+        pc.kill_and_reap = AsyncMock()
+
+        rid = await mod._start_run("build", ["/bin/echo", "hi"], cwd=None, env={})
+        await spawn_entered.wait()
+        worker_task = mod._ACTIVE_RUNS[rid][0]
+
+        # First cancellation: worker enters the CancelledError handler and
+        # begins draining spawn_task (still parked).
+        worker_task.cancel()
+        await asyncio.sleep(0)
+        # Second cancellation lands while the drain await is pending — the loop
+        # must absorb it and keep draining rather than dropping the handle.
+        worker_task.cancel()
+        await asyncio.sleep(0)
+
+        # Now let the spawn finish; the drain recovers the handle and reaps.
+        spawn_may_return.set()
+        try:
+            await worker_task
+        except asyncio.CancelledError:
+            pass
+
+    assert fake_proc.pid in killed_pids, (
+        "repeat cancellation during the drain abandoned the child: its process "
+        "tree was never killed"
+    )


### PR DESCRIPTION
## Problem / Motivation

Fixes #6467.

A dev-fleet run subprocess (a sync/provision `pip`/`npm`/`git` build) spawned in a narrow window during gateway shutdown is **orphaned**: it survives `dev_fleet_cleanup` and keeps running after the gateway exits, still mutating the shared checkout. This is the exact "escaped process keeps mutating shared checkout state" hazard the shutdown path exists to prevent, and it is a **distinct residual window** from the task-registration race closed earlier — that fix closed the window where a *task* races in after the cleanup snapshot; this is the window where the *process handle* is stamped after the snapshot.

Where it lives — `_start_run().worker()` in the dev-fleet backend:

```
parent: register run under _SHUTDOWN_ADMISSION_LOCK as (task, None)   # proc not known yet
                              │
worker:  await create_subprocess_limited(...)   ← child fork+exec'd here
                              │  ... window ...
worker:  _ACTIVE_RUNS[rid] = (task, proc)        # stamp proc — NO lock, NO shutdown re-check
```

If `dev_fleet_cleanup` snapshots `_ACTIVE_RUNS` inside that window it sees `(task, None)`:

```
cleanup: snapshot → proc is None → SKIP _kill_tree → task.cancel()
                                                          │
worker parked in create_subprocess_exec receives CancelledError
                                                          │
  → OS child already forked+exec'd, Process handle never returned
  → nothing reaps it → ORPHAN survives gateway exit
```

Cancelling a task parked in `asyncio.create_subprocess_exec` does **not** reap the child — verified at the OS level (a `sleep 30` child stayed alive after the cancel).

## Why it matters

`dev_fleet_cleanup` runs on **every gateway restart / make-live cutover** — a routine, first-class operation in this app. A sync or provision run whose subprocess is spawning at that instant leaks a `pip`/`npm`/`git` process that continues writing to the shared checkout after the gateway it belonged to is gone. That is precisely the corruption the shutdown teardown was built to stop; the guard just had a hole one `await` wide.

## What changed (approach → change)

Close the window symmetrically with the parent's admission gate, and make the spawn cancellation-safe so no child can be abandoned mid-`exec`:

1. **Shielded spawn.** The spawn runs on its own task (`spawn_task = asyncio.ensure_future(...)`) awaited through `asyncio.shield`. A cancellation arriving mid-`exec` can no longer abandon the child without a handle.
2. **Locked proc-stamp with a shutdown re-check.** The handle is stamped **under `_SHUTDOWN_ADMISSION_LOCK`** with a `_SHUTDOWN_IN_PROGRESS` re-check — mirroring the parent's registration gate. If cleanup already snapshotted, the worker self-reaps the just-spawned child and aborts the run.
3. **Reap on cancellation.** A new `except asyncio.CancelledError` handler drains `spawn_task` to recover the handle (the shield re-raises the cancel while the inner spawn keeps running detached), kills the process tree, then re-raises so the task still reports cancelled. The existing `except Exception` and `finally` (temp-file cleanup) are unchanged.

The normal-completion and deadline-timeout paths are untouched (they reach `rc = await proc.wait()` without raising `CancelledError`).

Flow after the fix — both interleavings now reap:

```
cancel BEFORE stamp → shield defers/re-raises → CancelledError handler drains spawn_task → _kill_tree
cancel AFTER  stamp → proc visible in snapshot → cleanup's own _kill_tree reaps it
shutdown seen at stamp → worker self-reaps under the lock and aborts
```

## Tests

New deterministic regression tests in `test/test_devfleet_proc_stamp_orphan.py`:

- Drives the exact interleaving: start a run (registers `(task, None)`), park the worker inside the spawn (child "spawned", proc not yet stamped), fire `dev_fleet_cleanup` so it snapshots with `proc=None`, then release the spawn.
- Asserts the spawned child's process tree **is** reaped.
- `test_repeat_cancellation_during_drain_still_reaps` — cancels the worker twice while the spawn is still parked (models a shutdown hard-timeout arriving after the graceful cancel) and asserts the child's process tree is still reaped; fails against a single-await drain, passes with the drain loop.

Verification sequence:

```
# The test FAILS against current code (orphan reproduced):
$ git stash push -- src/kiro_crew/apps/builtins/dev_fleet/server.py
$ pytest test/test_devfleet_proc_stamp_orphan.py -q
  FAILED … AssertionError: child spawned in the proc-stamp window was orphaned
$ git stash pop

# The test PASSES with the fix:
$ pytest test/test_devfleet_proc_stamp_orphan.py -q
  1 passed

# The existing shutdown-admission regression suite still passes:
$ pytest test/test_devfleet_active_runs_shutdown.py -q
  5 passed

# Full dev-fleet backend suite:
$ pytest test/test_dev_fleet_app.py test/test_dev_fleet_server_coverage.py \
         test/test_dev_fleet_server_more_coverage.py test/test_dev_fleet_remove_lock_races.py \
         test/test_spawn_audit.py test/test_devfleet_active_runs_shutdown.py \
         test/test_devfleet_proc_stamp_orphan.py -q
  682 passed, 1 skipped
  (the 1 unrelated failure, test_trusted_bin_pins…symlink, fails identically on
   pristine origin/main — a sandbox-env artifact, not from this change)
```

Also confirmed the underlying OS behavior with a standalone asyncio probe: cancelling an `await` on `create_subprocess_exec` leaves the child process alive, which is what makes the orphan real rather than theoretical.

