### PR TITLE
fix(context): require self-contained [OPTIONS:] labels so single-sent chips keep their meaning

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1137,6 +1137,13 @@ _CRITICAL_RULES_TAIL = (
     '"Yes, delete it"). Never phrase a label in your own voice or as your own '
     'next action ("I\'ll merge it", "Let me show the diff", "I can rebase '
     'first"), and never phrase it as a question back to the user.\n'
+    "Every option must be SELF-CONTAINED: each rendered chip carries its own "
+    "send control, so the user can send any single option alone, and ONLY that "
+    "option's text is sent -- none of its siblings come with it. Never write "
+    'an option that only makes sense combined with another one ("Build the '
+    'widget" | "Include the stop button too" -- sent alone, the second names '
+    "no action). Fold the shared base action into each label instead "
+    '("Build the widget with the stop button included").\n'
     "[END CRITICAL RULES]\n\n"
 )
 # The dashboard variant is the module's canonical block: tests and the
@@ -3133,7 +3140,9 @@ class ContextBuilder:
                 "as the very last line — exactly once, nothing after it. "
                 "Users can select multiple options before submitting. Label each choice "
                 'in the user\'s voice as an instruction to you — "Merge it now", not '
-                '"I\'ll merge it".)'
+                '"I\'ll merge it". Make each choice self-contained — any single one can '
+                "be sent alone, so never write a choice that merely modifies a sibling "
+                '("Include the stop button too"); fold the base action into it.)'
             )
             # Situational nudges for tools that may otherwise never surface with
             # MCP Tool Search. Gated on having a dashboard tab open, because

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -94,6 +94,35 @@ class TestContextBuilder:
         # backwards once clicked.
         assert "in the USER's voice" in ctx
 
+    def test_option_labels_must_be_self_contained(self, tmp_path):
+        """Each [OPTIONS:] chip carries its own send control, so any single
+        option can be sent alone -- and only that option's text goes out. An
+        option written as a modifier of its sibling ("Include the stop button
+        too" next to "Build the Loops strip") names no action when sent by
+        itself, so both the critical-rules block and the per-turn interactive
+        reminder must require self-contained labels."""
+        builder = ContextBuilder(
+            memory=MemoryStore(workspace=tmp_path / "ws"),
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+            lessons=LessonStore(base_dir=tmp_path),
+        )
+        ctx = builder.build_session_context()
+        assert "SELF-CONTAINED" in ctx, "critical rules missing self-contained option rule"
+        # The rule qualifies the label rules, so it must come after the voice
+        # rule it extends -- before it, it reads as a standalone non sequitur.
+        assert ctx.index("in the USER's voice") < ctx.index("SELF-CONTAINED")
+        # The per-turn reminder is the version most models actually act on;
+        # it must carry the same constraint.
+        msg, _ = builder.build_message(
+            "pick one", is_new_session=False, interactive=True
+        )
+        assert "self-contained" in msg, "interactive reminder missing self-contained rule"
+        # Non-interactive turns get no OPTIONS reminder at all, so no rule either.
+        auto_msg, _ = builder.build_message(
+            "pick one", is_new_session=False, interactive=False
+        )
+        assert "self-contained" not in auto_msg
+
     def test_url_backtick_carve_out_follows_the_path_rule(self, tmp_path):
         """A backticked URL is a click-to-copy chip, not a link.
 


### PR DESCRIPTION
## Problem / Motivation

The `[OPTIONS:]` follow-up chips above the composer are a split button: the chip body composes into the input, but the `↑` segment sends **only that chip's own text** immediately. Nothing in the option-authoring guidance (the critical-rules block or the per-turn interactive reminder in `context.py`) requires labels to be self-contained, so agents legally emit dependent option sets like:

> `[OPTIONS: Build the read-only Loops strip in Glance now | Include the stop button too]`

Sending the second chip alone delivers the bare text "Include the stop button too" — the action it was modifying never arrives, and the turn cannot achieve what the user intended by clicking it.

## Why it matters

Single-chip send is a first-class gesture (every chip renders its own send segment; quick-send makes a single click send instantly). Any user who picks a dependent option alone gets a degraded turn: the agent receives a modifier with no action, has to guess, and may do nothing or the wrong thing. The failure is silent — the user believes they issued a complete instruction.

## What changed (motivation → approach → change)

Observed symptom: a chip that only makes sense combined with its sibling is offered as an independently-sendable control. Root cause: the UI works as designed (per-chip send is intentional), but the prompt contract that authors the labels never required independence — the voice rule covers *how* a label reads, not *whether it stands alone*. The fix belongs on the authoring side, since the UI cannot know inter-option dependencies:

- `src/kiro_crew/context.py` `_CRITICAL_RULES_TAIL`: added a rule after the voice rule — every option must be SELF-CONTAINED because any single option can be sent alone with none of its siblings; fold the shared base action into each label instead.
- `src/kiro_crew/context.py` per-turn interactive reminder: added the terse form of the same constraint, since this reminder is what models most reliably act on.

Both variants of the critical-rules block (`_CRITICAL_RULES` / `_CRITICAL_RULES_CHANNEL`) inherit the rule through the shared tail, so every surface (dashboard chips, Slack/Discord/Telegram buttons) gets it.

## Tests

- `test/test_context.py::TestContextBuilder::test_option_labels_must_be_self_contained` (new): asserts the rule is present in the session context, ordered **after** the voice rule it extends, present in the interactive reminder, and absent from non-interactive turns. Mutation-proofed: fails against unmodified `context.py` (`AssertionError: critical rules missing self-contained option rule`), passes with the fix.
- Full `test/test_context.py` (90 passed) plus the sibling files that pin these blocks — `test_context_marker_neutralization.py`, `test_context_ui_language.py`, `test/metrics/test_context_blocks.py`, `test_subagent_context_groups.py` (96 passed).

## Manual verification

N/A — unit coverage sufficient: the change is two prompt strings selected deterministically at injection time, and the tests assert the exact injected content on both paths (session context and per-turn reminder).

## Related Issues

no linked issue: defect observed live on a 0.5.0.14 dashboard session (dependent chip pair in the composer suggestion strip); fixed directly rather than filing first.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no module doc restates the option-label authoring rules
- [x] No secrets, credentials, or internal references in the diff

