### PR TITLE
ci: collapse readiness runs on monotonic id, drop cancelled twins (#6366)

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -540,14 +540,16 @@ jobs:
                 transport_failed=true
                 break
               }
+              # Collapse to one run -- newest by monotonic id. Full rationale
+              # on the pull_request branch below; the two collapses must stay
+              # identical.
               run="$(jq -c --arg path "$file" '
                 [.workflow_runs[] | select(.path == $path)]
-                | sort_by(.created_at)
-                | last // empty
+                | max_by(.id) // empty
               ' <<<"$runs")"
             else
               runs="$(gh_retry gh api --method GET \
-                "repos/$REPO/actions/workflows/$file/runs?event=pull_request&head_sha=$SHA&per_page=20")" || {
+                "repos/$REPO/actions/workflows/$file/runs?event=pull_request&head_sha=$SHA&per_page=100")" || {
                 rc=$?
                 if [ "$rc" -eq 22 ]; then exit 1; fi
                 transport_failed=true
@@ -559,12 +561,27 @@ jobs:
               # workflow as "(not started)" -- a permanent pending verdict. The
               # query is already pinned to this exact head SHA, and only one
               # open PR can exist per source repository + branch.
+              # Collapse to one run on the monotonic run id, never on
+              # created_at: that timestamp has one-second granularity, and two
+              # runs of the same workflow on the same head routinely share a
+              # second (e.g. a workflow that fires on both synchronize and
+              # edited). jq's sort_by is stable and the API returns runs
+              # newest-first, so a created_at sort left same-second ties in
+              # API order and `last` picked the OLDEST run -- when that run
+              # was concurrency-cancelled, a lane whose newest run succeeded
+              # read as a blocking failure. max_by(.id) orders same-second
+              # runs correctly because ids increase monotonically, and it is
+              # sufficient on its own: a concurrency-cancelled twin is always
+              # superseded by a same-head run with a HIGHER id, so the newest
+              # run is never the cancelled duplicate. Deliberately NO
+              # cancelled-run filter here: dropping a cancelled newest run
+              # would revive an older verdict -- a manually cancelled rerun
+              # must read failure-class, not resurface a stale green.
               run="$(jq -c --arg head_repo "$HEAD_REPO" --arg head_ref "$HEAD_REF" '
                 [.workflow_runs[]
                  | select(.head_repository.full_name == $head_repo
                           and .head_branch == $head_ref)]
-                | sort_by(.created_at)
-                | last // empty
+                | max_by(.id) // empty
               ' <<<"$runs")"
             fi
             if [ -z "$run" ]; then

--- a/test/test_pr_readiness_evaluate.py
+++ b/test/test_pr_readiness_evaluate.py
@@ -148,6 +148,30 @@ def _run_json(name: str, *, status: str, conclusion: str) -> str:
     )
 
 
+def _runs_json(name: str, runs: list[dict]) -> str:
+    """Multi-run fixture, in the order given (the Actions API returns
+    newest-first). Each entry supplies id/status/conclusion; created_at
+    defaults to one shared second, the tie the collapse must break on id."""
+    return json.dumps(
+        {
+            "workflow_runs": [
+                {
+                    "head_repository": {"full_name": "kirodotdev/KiroCrew"},
+                    "head_branch": "feat/x",
+                    "path": (
+                        "dynamic/github-code-scanning/codeql"
+                        if name == "codeql"
+                        else f".github/workflows/{name}"
+                    ),
+                    "created_at": "2026-08-11T00:00:00Z",
+                    **run,
+                }
+                for run in runs
+            ]
+        }
+    )
+
+
 class Runner:
     """Executes the evaluate step against one stubbed repository state."""
 
@@ -182,11 +206,15 @@ class Runner:
             "TRIGGER_ACTION": "completed",
         }
         # Materialize the helper exactly as CI does: run the install step.
+        # cwd pins the children under this runner's own temp dir so a
+        # relative write in a future script revision cannot land in the
+        # repository root (pytest's CWD).
         subprocess.run(
             ["bash", "-c", _helper_script()],
             env=self.env,
             check=True,
             capture_output=True,
+            cwd=self.temp,
         )
         # Default fixtures: everything green and completed.
         green = _run_json("green.yml", status="completed", conclusion="success")
@@ -233,6 +261,7 @@ class Runner:
             env=env,
             capture_output=True,
             text=True,
+            cwd=self.temp,
         )
         outputs = {}
         for line in self.output.read_text().splitlines():
@@ -540,3 +569,179 @@ class TestLaneStateIsLoggedNotOnlySummarized:
         )
         assert "CodeQL" in log_line
         assert "pending=[CodeQL" in log_line
+
+
+class TestSameSecondRunCollapse:
+    """The per-workflow collapse must be deterministic on the monotonic run
+    id, not on second-granularity created_at: two runs of one workflow on one
+    head routinely share a created_at second (synchronize + edited both fire),
+    the API returns runs newest-first, and jq's sort_by is stable -- so a
+    created_at sort picked the OLDEST run of a tied group. When that run was
+    concurrency-cancelled, a lane whose newest run succeeded published
+    "failure: N blocking readiness item(s)" on a fully-green PR."""
+
+    def test_same_second_cancelled_twin_does_not_mask_a_success(
+        self, runner: Runner
+    ):
+        # The observed shape: newest-first API order, the newer (higher-id)
+        # run succeeded, its same-second concurrency-cancelled twin sits
+        # after it. A created_at collapse selects the cancelled twin and
+        # reddens the lane; the id collapse must reach the success.
+        (runner.fixtures / "ci_runs.json").write_text(
+            _runs_json(
+                "ci.yml",
+                [
+                    {
+                        "id": 33096637341,
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                    {
+                        "id": 33096636697,
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                    },
+                ],
+            )
+        )
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "success"
+        assert outputs["label"] == "readiness: passed"
+
+    def test_a_cancelled_newest_run_stays_red(self, runner: Runner):
+        # There is deliberately no cancelled-run filter: when the run with
+        # the highest id was cancelled (e.g. a maintainer cancelled a rerun),
+        # it IS the verdict and the lane must stay failure-class. Dropping it
+        # would resurface the older success -- a stale green on a revision
+        # whose latest validation never completed.
+        (runner.fixtures / "ci_runs.json").write_text(
+            _runs_json(
+                "ci.yml",
+                [
+                    {
+                        "id": 500,
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                    },
+                    {
+                        "id": 400,
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                ],
+            )
+        )
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "failure"
+        assert outputs["label"] == "readiness: action required"
+
+    def test_all_runs_cancelled_still_reads_failure_class(
+        self, runner: Runner
+    ):
+        # When every run of the workflow was cancelled there is no verdict,
+        # and the lane must stay a blocking red -- not report "(not started)"
+        # and pend forever, and never read as green.
+        (runner.fixtures / "ci_runs.json").write_text(
+            _runs_json(
+                "ci.yml",
+                [
+                    {
+                        "id": 200,
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                    },
+                    {
+                        "id": 100,
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                    },
+                ],
+            )
+        )
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "failure"
+        assert outputs["label"] == "readiness: action required"
+
+    def test_a_real_failure_with_a_cancelled_twin_stays_red(
+        self, runner: Runner
+    ):
+        # The cancelled-twin drop must never launder a genuine red: a
+        # completed/failure run is a verdict, and it wins the collapse over
+        # its cancelled sibling exactly like a success would.
+        (runner.fixtures / "ci_runs.json").write_text(
+            _runs_json(
+                "ci.yml",
+                [
+                    {
+                        "id": 700,
+                        "status": "completed",
+                        "conclusion": "failure",
+                    },
+                    {
+                        "id": 600,
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                    },
+                ],
+            )
+        )
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "failure"
+        assert outputs["label"] == "readiness: action required"
+
+    def test_codeql_collapse_breaks_the_same_tie_the_same_way(
+        self, runner: Runner
+    ):
+        # The dynamic CodeQL resolution is a second, separately-written
+        # collapse over the same API shape; it must break the same-second
+        # tie identically or the defect just moves lanes.
+        (runner.fixtures / "codeql_runs.json").write_text(
+            _runs_json(
+                "codeql",
+                [
+                    {
+                        "id": 900,
+                        "status": "completed",
+                        "conclusion": "success",
+                    },
+                    {
+                        "id": 800,
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                    },
+                ],
+            )
+        )
+        proc, outputs = runner.evaluate()
+        assert proc.returncode == 0, proc.stderr
+        assert outputs["status_state"] == "success"
+        assert outputs["label"] == "readiness: passed"
+
+    def test_the_two_collapse_sites_carry_identical_logic(self):
+        # The workflow resolves runs at two separately-written sites (the
+        # monitored-workflow loop and the dynamic CodeQL read). Behavioral
+        # tests exercise one shape each; this pins the collapse FRAGMENT
+        # itself so an edit to one site cannot drift from the other for
+        # shapes no fixture covers. The fragment starts after the
+        # site-specific select() line and runs to the terminal collapse.
+        script = _evaluate_script()
+        fragment = "| max_by(.id) // empty"
+        lines = [ln.strip() for ln in script.splitlines()]
+        count = lines.count(fragment)
+        assert count == 2, (
+            "expected exactly the two run-collapse sites (monitored"
+            f" workflows + dynamic CodeQL), found {count}"
+        )
+        # No site may re-grow a filter stage between the select() and the
+        # collapse: the line preceding each collapse must be the end of the
+        # site-specific select bracket.
+        for i, line in enumerate(lines):
+            if line == fragment:
+                assert lines[i - 1].endswith("]"), (
+                    "a collapse site carries an extra pipeline stage between"
+                    f" select() and the collapse: {lines[i - 1]!r}"
+                )


### PR DESCRIPTION
# Summary

Fixes the PR Readiness merge gate reading a **concurrency-cancelled twin** as the verdict for a workflow whose newest run on the same head **succeeded**, publishing `failure: N blocking readiness item(s)` on a fully-green PR (observed on #5266 at head `78c91f7f`).

## Root cause

`pr-readiness.yml` collapsed each monitored workflow's runs with `sort_by(.created_at) | last`. `created_at` has one-second granularity, two runs of one workflow on one head routinely share a second (`codex-review.yml` fires on both `synchronize` and `edited`), jq's `sort_by` is stable, and the Actions API returns runs newest-first — so within a same-second tie group `last` selected the **oldest** run, the opposite of "newest run wins". When that oldest run was concurrency-cancelled, the lane read `cancelled` (failure-class).

## Fix

Both run-resolution sites (the monitored-workflow loop and the dynamic CodeQL read) now collapse with **`max_by(.id)`** — run ids increase monotonically, so same-second ties order correctly. This alone fully covers #6366: a concurrency-cancelled twin is always superseded by a higher-id run on the same head, so the newest run is never the cancelled duplicate.

**Deliberately no cancelled-run filter.** An earlier revision of this branch also dropped cancelled runs when a live sibling existed; both the pre-push Opus review and the server-side GPT lane flagged the same residual: a *manually* cancelled newest rerun would be discarded and an older success resurfaced — a stale green on a revision whose latest validation never completed. The filter was removed; the newest run is the verdict even when cancelled, which keeps the fail-safe direction (a cancelled rerun blocks, never unblocks). A regression test pins this exact shape.

Also: the monitored-workflow query's `per_page` rises from 20 to 100 (the API max, matching the CodeQL site), shrinking the pre-existing window where the newest run could sit beyond the fetched page.

Validated against the issue's captured reproduction data: the same-second `success`+`cancelled` pair from head `78c91f7f` resolves to the success under `max_by(.id)`, and to `"cancelled"` under the old expression.

## Tests

- 6 new tests in `test/test_pr_readiness_evaluate.py`, executing the **real** evaluate step through the existing gh-stub harness (4 red against the pre-fix workflow, mutation-verified):
  - same-second cancelled twin no longer masks a success (the #6366 shape)
  - a cancelled **newest** run stays red — the no-filter decision is pinned, a stale green cannot resurface
  - all-runs-cancelled reads failure-class (not "(not started)")
  - a real failure with a cancelled twin stays red
  - the CodeQL site breaks the same tie the same way
  - a parity guard pinning both collapse sites to the identical fragment with no extra pipeline stage, so the duplicated sites cannot drift silently
- Both `Runner` subprocess spawns now pass `cwd=` (test-hygiene hardening: children no longer inherit pytest's CWD, the repo root)
- Full local floor: pytest 71621 passed (84 failures are this host's known pre-existing env set, none related), isort / flake8 / mypy clean, black-baseline / subprocess-encoding / brand / harness-parity gates green

## Review dispositions

- **GPT server lane (BLOCKING on `bc0af3270`, cancel-filter revives a stale green):** accepted and fixed — the cancelled-run filter is removed at both sites; `max_by(.id)` alone fixes #6366 and the new `test_a_cancelled_newest_run_stays_red` pins the guard.
- **Pre-push Opus (advisory, same mechanism):** same disposition.
- **Pre-push GPT (Low, per-page truncation):** pre-existing property; mitigated by `per_page=100`. Full pagination deliberately not added — it broadens the change beyond run resolution for a scenario needing >100 same-head runs of one workflow.

Closes #6366
