### PR TITLE
fix: close three gaps the artifact-frame review found

### DIFF
--- a/src/kiro_crew/dashboard/handlers/sandbox_doc.py
+++ b/src/kiro_crew/dashboard/handlers/sandbox_doc.py
@@ -24,9 +24,8 @@ Security posture, mirroring the webapp-preview channel next door:
   origin does not turn model HTML into same-origin script. The sandbox flags
   match what the embedding iframes already grant, so nothing the frame could do
   before is newly permitted or newly denied. ``frame-ancestors`` on the same
-  response names the request's own origin, NOT ``'self'`` — ``'self'`` resolves
-  against this response's opaque origin and therefore matches no ancestor at
-  all, which blocks the very frames the channel exists to serve.
+  response is ``'self'`` plus the ancestors ``'self'`` cannot express — see
+  ``origin.frame_ancestors_value`` for why both halves are load-bearing.
 * Every authorization decision is SEL-audited, rejected probes included. The
   token itself is never logged.
 * Entries expire, are capped in count and size, and are evicted oldest-first, so

--- a/src/kiro_crew/dashboard/handlers/webapp_preview.py
+++ b/src/kiro_crew/dashboard/handlers/webapp_preview.py
@@ -37,9 +37,8 @@ Security model (all LLM-influenceable inputs re-validated at serve time):
   forces an opaque origin even if the document is opened OUTSIDE the
   sandboxed iframe — the previewed app can never reach dashboard cookies,
   storage, or same-origin APIs. ``frame-ancestors`` keeps third-party
-  sites from embedding the preview; it names the request's own origin rather
-  than ``'self'``, which would resolve against this response's opaque origin
-  and match no ancestor at all (blocking the intended embed too).
+  sites from embedding the preview; it is ``'self'`` plus the ancestors
+  ``'self'`` cannot express (see ``origin.frame_ancestors_value``).
 - Dotfiles (and thus ``.kirocrew-deploy.json`` style manifests / VCS dirs)
   are never served.
 """

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -119,6 +119,7 @@ from kiro_crew.dashboard.origin import (
     check_host,
     check_origin,
     dashboard_socket_path,
+    frame_ancestors_value,
     resolve_dashboard_host,
     should_canonicalize_host,
 )
@@ -957,7 +958,11 @@ def _apply_security_headers(
     # instance dashboard across loopback ports, while any local page without a
     # validly-signed token stays blocked (clickjacking).
     extra_ancestors = _extra_frame_ancestors(request, app)
-    frame_ancestors = " ".join(["'self'", *extra_ancestors])
+    # Same builder the sandboxed-document responses use. Hand-joining here instead
+    # would leave the shell as the one ancestor source nothing validates, which is
+    # exactly how an inexpressible entry (a bracketed IPv6 literal) reached a
+    # header before and made engines drop the whole directive.
+    frame_ancestors = frame_ancestors_value(extra_ancestors)
     resp.headers.setdefault(
         "Content-Security-Policy",
         _BASE_CSP.format(

--- a/test/test_dashboard_security_headers.py
+++ b/test/test_dashboard_security_headers.py
@@ -351,6 +351,37 @@ class TestApplySecurityHeaders:
         assert "localhost:3000" not in csp
         assert resp.headers["X-Frame-Options"] == "SAMEORIGIN"
 
+    def test_shell_csp_ancestors_go_through_the_same_validator(self, monkeypatch) -> None:
+        """The dashboard shell's ``frame-ancestors`` is built by
+        ``origin.frame_ancestors_value``, the same joiner the sandboxed-document
+        responses use — not a local ``" ".join``.
+
+        This is the third ancestor-emitting site. While it hand-joined, it was the
+        one source nothing validated, so the helper's guarantee that no future
+        ancestor can reintroduce an inexpressible entry did not actually hold for
+        the shell. That class of bug is not hypothetical: a bracketed IPv6 literal
+        WAS being emitted, and engines refuse the whole source expression when they
+        see one, dropping every ancestor with it.
+
+        Asserted by behaviour rather than by reading the source: an inexpressible
+        ancestor must not reach the header even when ``_extra_frame_ancestors``
+        offers one.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.server._extra_frame_ancestors",
+            lambda request, app: ["http://[::1]:5476", "http://localhost:5476"],
+        )
+        request = make_mocked_request("GET", "/")
+        resp = _make_response()
+        _apply_security_headers(resp, _make_app(with_instances=True), request=request)
+        csp = resp.headers["Content-Security-Policy"]
+        frame_anc = next(d for d in csp.split(";") if d.strip().startswith("frame-ancestors"))
+        assert "[::1]" not in frame_anc
+        # The expressible sibling still gets through, so this is a filter and not
+        # a blanket refusal.
+        assert "http://localhost:5476" in frame_anc
+        assert "'self'" in frame_anc
+
     def test_frame_ancestors_ignores_forged_unsigned_cookie(self) -> None:
         """A forged/unsigned ``mc_token_<port>`` cookie must NOT get its parent
         origin into frame-ancestors. Unlike the positive tests above, this test

--- a/website/src/components/ArtifactBody.tsx
+++ b/website/src/components/ArtifactBody.tsx
@@ -47,7 +47,9 @@ const NO_DOCUMENT_BOX_HEIGHT = 480
  *
  * Deliberately NOT an automatic re-mint: a second `load` also happens when a
  * link inside an artifact navigates the frame, and silently pulling the reader
- * back would fight an action they took. Surfacing the existing retry is enough. */
+ * back would fight an action they took. Offering the retry is the right response
+ * to either cause — in both, the frame has stopped showing the artifact — which
+ * is why the window re-arms on EVERY load rather than only on a new url. */
 const DOC_REPORT_GRACE_MS = 3000
 
 function readThemeVars(): Record<string, string> {
@@ -379,6 +381,13 @@ export const ArtifactBodyIframe = memo(function ArtifactBodyIframe({
             src={blobUrl}
             onLoad={() => {
               loadedUrlRef.current = blobUrl
+              // Every load restarts the observation, not just a new url. The case
+              // this exists for is the engine renavigating a SPENT url after a
+              // successful render (a back/forward-cache eviction), so keeping a
+              // previous document's report would skip the window exactly when it
+              // is needed and leave a 404 in the frame with no affordance.
+              reportedRef.current = false
+              setDocSilent(false)
               setLoadNonce(n => n + 1)
               setEverLoaded(true)
               onIframeLoad?.()

--- a/website/src/test/ArtifactBody.iframeBlob.test.tsx
+++ b/website/src/test/ArtifactBody.iframeBlob.test.tsx
@@ -398,6 +398,25 @@ describe('ArtifactBodyIframe surfaces a frame showing something that is not ours
     expect(screen.queryByText(/couldn't render this artifact/i)).toBeNull()
   })
 
+  it('offers a retry when the engine renavigates a spent url after a good render', async () => {
+    // THE case this feature exists for, and the one an earlier version silently
+    // skipped: the document rendered and reported, then the engine navigated the
+    // frame again on its own (a back/forward-cache eviction) and re-requested a
+    // single-use url, landing on a 404. Keying the observation on the url meant a
+    // previous document's report suppressed the window exactly when it mattered.
+    const frame = await loadedFrame('<p>evicted</p>')
+    reportHeight(frame, 420)
+    await act(async () => { vi.advanceTimersByTime(4000) })
+    expect(screen.queryByText(/couldn't render this artifact/i)).toBeNull()
+
+    // Same url, second load — nothing reports this time, because what the frame
+    // is showing is not ours.
+    fireEvent.load(frame)
+    await act(async () => { vi.advanceTimersByTime(4000) })
+    expect(screen.getByText(/couldn't render this artifact/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
+  })
+
   it('re-mints rather than re-rendering the spent url when the retry is taken', async () => {
     // Re-pointing the frame at the same spent URL recovers nothing — it 404s
     // again. Recovery is a fresh mint.


### PR DESCRIPTION
Follow-ups to [#6461](https://github.com/kirodotdev/KiroCrew/pull/6461). Each of these is an internal contradiction that change introduced, found by its own review round after merge — not a new capability. Six files, no new surface.

## The dead-frame retry never fired in the case it exists for

#6461 added a grace window: a frame whose document never reports its height is showing something this surface did not build (the document URL is single-use, so an engine-initiated renavigation lands on a 404 that fires `load` like any other navigation), and the reader gets the existing retry.

It was armed only when no document had reported yet, and that flag reset only when a **new** URL landed. So once a document rendered and reported, a renavigation of the *same spent* URL — the back/forward-cache eviction case `artifacts.md` explicitly claims is covered — bumped the load counter, hit the guard, and left a 404 inside the frame with no notice and no retry. Code and spec disagreed, and the disagreement hid the whole feature.

The window now re-arms on **every** load. A link inside an artifact navigating the frame arms it too, and that is the right outcome rather than a cost: in both cases the frame has stopped showing the artifact, and offering the retry is milder than silently re-minting over an action the reader took.

## The dashboard shell was the one ancestor source nothing validated

Three sites build a `frame-ancestors` value from `_extra_frame_ancestors`. Two route through `origin.frame_ancestors_value`, which re-validates every entry against a strict origin form; the shell CSP hand-joined `'self'` with the extras, so the helper's own guarantee — that no future ancestor source can reintroduce an inexpressible entry — did not hold for the shell.

Not a hypothetical class: `http://[::1]:<port>` **was** being emitted before #6461. A CSP host-source admits only letters, digits and hyphens, so an engine that sees a bracketed IPv6 literal refuses the whole source expression and drops every ancestor with it — which is why that grant never worked and why it produced a console warning per framed response.

The new test asserts this by behaviour, not by reading the source: with `_extra_frame_ancestors` stubbed to offer both an inexpressible and an expressible entry, the header must carry the expressible one and `'self'` while the IPv6 literal never appears. That distinguishes a filter from a blanket refusal.

## Two docstrings documented a reverted design, and a disproved mechanism

`sandbox_doc.py` and `webapp_preview.py` both said the header names the request's own origin **rather than** `'self'`, because `'self'` would resolve against the response's opaque origin and match no ancestor at all.

Both halves are wrong. A probe with `frame-ancestors 'self'` loaded fine at single-level nesting in Chrome 152, so the opaque-origin explanation is disproved; the real cause of the original blanking is that the directive is matched against **every** ancestor, which `'self'` alone cannot satisfy at nesting depth. And the server-derived-origin design those paragraphs describe was reverted before #6461 merged — it named `http://localhost:<port>` while a phone was on `https://<tunnel-host>` and blanked every frame on that path. The code three hunks below each docstring emits `'self'`, and four tests pin exactly that.

A stale docstring that restates a falsified mechanism is worse than none: it is what a future reader would reason from.

## Tests

Both new guards mutation-verified — each mutation turns exactly its own target red, suite green when restored:

| mutation | result |
|---|---|
| shell CSP back to `" ".join(["'self'", *extra])` | 1 red |
| drop the per-load reset of the report flag | 1 red |

Backend 211 passed across the four touched modules; `isort` / `flake8` / `mypy` / `black` / `docs-lint` clean. `tsc` clean, `eslint` 0 errors (2 pre-existing warnings in untouched branches of the same file), 37 frontend cases passed across the touched files, `npm run build` clean.

<!-- no-visual-delta -->
**Why no screenshot:** no UI is added or changed. Two of the three fixes are a response header and two docstrings; the third makes an already-shipped failure notice fire in one more case, using the same markup and copy #6461 already carries evidence for. The one behaviour a screenshot could show — the retry appearing after an engine-initiated renavigation — cannot be provoked in a headless Chromium run, since it depends on the engine deciding to evict and reload the frame; it is pinned by the test instead.
