### PR TITLE
fix(installer): keep Windows updates in place and relaunch what they installed

### DIFF
--- a/website/electron/build/installer.nsh
+++ b/website/electron/build/installer.nsh
@@ -83,6 +83,16 @@ Var KiroScope
 Var KiroAnimationsEnabled
 Var KiroWindowVisible
 Var KiroVisibleUpdate
+; The app executable's filename, carried as a VARIABLE rather than referenced as
+; ${APP_EXECUTABLE_FILENAME} where it is used. That define comes from the
+; template's common.nsh, which is included AFTER this file, so a Function body --
+; compiled at !include time -- cannot see it: NSIS emits `warning 6000: unknown
+; variable/constant "{APP_EXECUTABLE_FILENAME}"` and silently drops it, which
+; would reduce an ownership test to a bare directory path. A !macro body is
+; expanded at its !insertmacro site and CAN see it, so customInit assigns this
+; variable and the Function reads it. (${APP_FILENAME} is fine at include time --
+; it comes from the generated header, not common.nsh.)
+Var KiroAppExeName
 
 ; The fade operates on the top-level dialog, the only window type for which
 ; AW_BLEND is supported. It runs once per page boundary and leaves the native
@@ -154,7 +164,66 @@ FunctionEnd
 ; fresh install must therefore own a directory that did not exist beforehand.
 ; Normalize a /D override to a product-name leaf and keep nesting past any
 ; collision. Registered updates retain their existing install root.
+;
+; AN UPDATE NEVER RELOCATES THE INSTALL, and that is checked FIRST -- before the
+; registry-derived guards below, not through them. electron-updater re-runs this
+; installer with `--updated` against an install that by definition already
+; exists, so the collision-nesting further down would resolve $INSTDIR to a
+; FRESH subdirectory and install the new version beside the running one instead
+; of over it. The result is two parallel installs: the update lands in one, the
+; shortcuts and the post-install relaunch keep pointing at the other, and the
+; stale copy re-discovers the very same update on its next feed check -- an
+; update loop the user cannot escape except by launching the new path by hand.
+;
+; The two guards below cannot carry this, because both are downstream of ONE
+; registry value: upstream's initMultiUser reads `InstallLocation` from
+; ${INSTALL_REGISTRY_KEY} into $perUserInstallationFolder /
+; $perMachineInstallationFolder, and customInit turns those into
+; $KiroHasPerUserInstallation / $KiroHasPerMachineInstallation. When that value
+; is missing both flags read 0, the guards fall through, and the update nests.
+; That is not hypothetical: on a machine that hit this loop the uninstall key
+; carried DisplayVersion, UninstallString and DisplayIcon all pointing at the
+; real install root while `InstallLocation` itself was absent. Why it was absent
+; is not established -- registryAddInstallInfo writes it unconditionally -- which
+; is exactly why the update path must not depend on it being there.
+;
+; The guard tests $KiroVisibleUpdate rather than ${isUpdated}, and that is NOT
+; interchangeable here. ${isUpdated} expands to a StdUtils::TestParameter plugin
+; call, and this is a Function, so its body is compiled when this file is
+; !included -- before the generated script runs !addplugindir. Writing
+; ${isUpdated} here fails the build at compile time with "Plugin not found,
+; cannot call StdUtils::TestParameter". customInit gets away with it because a
+; !macro body is only expanded at its !insertmacro site, which is late enough.
+; customInit sets $KiroVisibleUpdate from ${isUpdated} before it calls this
+; function, and the install-mode page's leave callback runs later still, so the
+; variable is populated on both call paths.
+;
+; The update bypass is NOT unconditional, and must not be made so. `--updated` is
+; a command-line flag on a user-runnable installer, so it can arrive alongside
+; `/D=<any existing directory>`; an unconditional bypass would then adopt a
+; directory this installer never created, record it as the install root, and the
+; generated uninstaller -- which removes $INSTDIR recursively -- would delete the
+; user's pre-existing contents there on uninstall. So the bypass requires proof
+; that the target IS one of our install roots, and the proof is the presence of
+; this app's own executable in it. Path equality against the canonical default is
+; deliberately not used as the test: a path can match while the directory belongs
+; to something else, whereas our executable being there cannot. A registered root
+; is still short-circuited by the $KiroHasPer*Installation guards below.
+;
+; $KiroAppExeName, not ${APP_EXECUTABLE_FILENAME}: that define is unavailable at
+; !include time, and NSIS drops it with `warning 6000` instead of failing loudly,
+; which would silently reduce this test to a bare directory path and let the
+; bypass fire for a directory we do not own. See the Var declaration.
+;
+; What remains covered: the loop this fixes needs an update whose install root is
+; already a Kiro Crew install, which is exactly the case the executable check
+; admits. An update that cannot prove ownership falls through to the ordinary
+; fresh-install ownership path instead of adopting the directory.
 Function KiroEnsureAppInstallDir
+  ${If} $KiroVisibleUpdate == 1
+  ${AndIf} ${FileExists} "$KiroInstallDir\$KiroAppExeName"
+    Return
+  ${EndIf}
   ${If} $KiroScope == "current"
   ${AndIf} $KiroHasPerUserInstallation == 1
     Return
@@ -300,9 +369,31 @@ FunctionEnd
 !macroend
 
 ; Add callbacks around the stock MUI finish page without replacing its controls,
-; localization, run-after-finish behavior, or automatic progress handoff. The
-; packaging contract compares this copied StartApp block with electron-builder's
-; locked template so a dependency upgrade cannot silently drift from upstream.
+; localization, run-after-finish behavior, or automatic progress handoff.
+;
+; StartApp DELIBERATELY DIVERGES from electron-builder's template in exactly one
+; expression, and the packaging contract asserts that divergence instead of
+; equality so a dependency upgrade still cannot change it silently. Upstream
+; launches "$launchLink", which installSection.nsh resolves to $newStartMenuLink
+; whenever that shortcut exists and only falls back to the installed executable
+; when it does not. A shortcut is a POINTER, and on an update it is not
+; necessarily repointed: registryAddInstallInfo records KeepShortcuts="true", so
+; addStartMenuLink keeps whatever the previous install left behind. When that
+; shortcut names a different install root than the one this run just wrote --
+; exactly what the nesting bug guarded against above produces -- the relaunch
+; starts the OLD executable. The user then lands back on the version they just
+; updated away from, the app re-discovers the same update on its next feed check,
+; and every subsequent attempt repeats it. Launching
+; $INSTDIR\${APP_EXECUTABLE_FILENAME} names the bytes this installer just
+; installed, which is the one target that cannot be stale -- and it is not an
+; invented target: installSection.nsh assigns $launchLink exactly this path
+; whenever no Start Menu shortcut exists, so this promotes upstream's own
+; fallback to the only case. ${APP_EXECUTABLE_FILENAME} is defined globally in
+; the template's common.nsh, so it resolves wherever this macro is inserted.
+;
+; Losing the shortcut's AppUserModelID with it costs nothing here: main.js calls
+; app.setAppUserModelId() on win32 during startup, so taskbar grouping and
+; notification identity are established by the app itself either way.
 !macro customFinishPage
   !ifndef HIDE_RUN_AFTER_FINISH
     Function StartApp
@@ -311,7 +402,7 @@ FunctionEnd
       ${else}
         StrCpy $1 ""
       ${endif}
-      ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
+      ${StdUtils.ExecShellAsUser} $0 "$INSTDIR\${APP_EXECUTABLE_FILENAME}" "open" "$1"
     FunctionEnd
 
     !define MUI_FINISHPAGE_RUN
@@ -365,6 +456,9 @@ FunctionEnd
 ; This runs for silent installs too and does not replace or restyle any page.
 !macro customInit
   StrCpy $KiroWindowVisible 0
+  ; Resolved HERE, not at the use site: see the Var declaration for why a
+  ; Function body cannot reference ${APP_EXECUTABLE_FILENAME} directly.
+  StrCpy $KiroAppExeName "${APP_EXECUTABLE_FILENAME}"
   StrCpy $KiroVisibleUpdate 0
   ${If} ${isUpdated}
     StrCpy $KiroVisibleUpdate 1

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -237,10 +237,41 @@ describe("first-download installer design contract", () => {
       /!macro customFinishPage[\s\S]*?MUI_PAGE_CUSTOMFUNCTION_SHOW KiroFadeInPage[\s\S]*?MUI_PAGE_CUSTOMFUNCTION_LEAVE KiroFadeOutPage[\s\S]*?!insertmacro MUI_PAGE_FINISH/
     );
     const startAppContract = /Function StartApp[\s\S]*?!define MUI_FINISHPAGE_RUN_FUNCTION "StartApp"/;
+    // StartApp may diverge from electron-builder's locked template in EXACTLY
+    // ONE expression: the launch target. Upstream launches $launchLink, which
+    // installSection.nsh resolves to the Start Menu shortcut when one exists --
+    // and an update does not necessarily repoint that shortcut, because
+    // registryAddInstallInfo records KeepShortcuts="true". A shortcut left
+    // naming a previous install root makes the post-update relaunch start the
+    // OLD executable, which is the update loop this diverges to prevent. So the
+    // assertion rewrites our launch line back to upstream's and demands
+    // equality: the one intended difference is pinned, and any OTHER drift from
+    // the template still fails here.
+    const oursStartApp = normalizedNsisBlock(installer, startAppContract);
+    const upstreamStartApp = normalizedNsisBlock(assistedInstallerTemplate, startAppContract);
+    const oursLaunch =
+      '${StdUtils.ExecShellAsUser} $0 "$INSTDIR\\${APP_EXECUTABLE_FILENAME}" "open" "$1"';
+    const upstreamLaunch = '${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"';
+    assert.ok(
+      oursStartApp.includes(oursLaunch),
+      "StartApp must relaunch the executable this installer just wrote"
+    );
     assert.equal(
-      normalizedNsisBlock(installer, startAppContract),
-      normalizedNsisBlock(assistedInstallerTemplate, startAppContract),
-      "customFinishPage must retain electron-builder's locked StartApp contract"
+      oursStartApp.includes(upstreamLaunch),
+      false,
+      "StartApp must not relaunch through a shortcut an update may leave stale"
+    );
+    // Fails when a dependency upgrade changes upstream's launch line, so the
+    // divergence gets re-derived against the new template instead of silently
+    // continuing to pass against a line that no longer exists.
+    assert.ok(
+      upstreamStartApp.includes(upstreamLaunch),
+      "upstream StartApp no longer launches $launchLink -- re-derive this divergence"
+    );
+    assert.equal(
+      oursStartApp.replace(oursLaunch, upstreamLaunch),
+      upstreamStartApp,
+      "customFinishPage may diverge from the locked StartApp contract ONLY in its launch target"
     );
     assert.match(buildWorkflow, /test-windows-installer\.ps1/);
     assert.match(runtimeScript, /^\$MaxInstallSeconds = 120$/m);
@@ -327,6 +358,82 @@ describe("first-download installer design contract", () => {
       /Function KiroAbortPre[\s\S]*?\$KiroVisibleUpdate == 1[\s\S]*?Abort[\s\S]*?FunctionEnd[\s\S]*?!define MUI_PAGE_FUNCTION_ABORTWARNING KiroAbortPre/
     );
     assert.doesNotMatch(installer, /NSD_(?:Create|Kill)Timer|Sleep\s+\d+/);
+  });
+
+  it("never relocates the install root on an update", () => {
+    // electron-updater re-runs this installer with --updated against an install
+    // that by definition already exists, so KiroEnsureAppInstallDir's
+    // collision-nesting would resolve $INSTDIR to a FRESH subdirectory and put
+    // the new version beside the running one instead of over it. That leaves two
+    // parallel installs, and the post-install relaunch plus every shortcut kept
+    // by KeepShortcuts="true" go on naming the old one -- so the app comes back
+    // on the version it just updated away from and re-offers the same update
+    // forever.
+    //
+    // The guard has to be the FIRST thing the function does. The two guards
+    // after it are both downstream of one registry value: upstream reads
+    // InstallLocation into $perUserInstallationFolder /
+    // $perMachineInstallationFolder, and customInit turns those into
+    // $KiroHasPer*Installation. When that value is absent both read 0 and the
+    // update nests, which is why the update path must not depend on them.
+    const ensureInstallDir = normalizedNsisBlock(
+      installer,
+      /Function KiroEnsureAppInstallDir[\s\S]*?FunctionEnd/
+    );
+    assert.match(
+      ensureInstallDir,
+      /^Function KiroEnsureAppInstallDir\n\$\{If\} \$KiroVisibleUpdate == 1\n\$\{AndIf\} \$\{FileExists\} "\$KiroInstallDir\\\$KiroAppExeName"\nReturn\n\$\{EndIf\}\n/,
+      "an update must return before any install-dir nesting can run, and only for a root it can prove is ours"
+    );
+    // The update bypass must stay conditional on that ownership proof. `--updated`
+    // is a command-line flag on a user-runnable installer, so it can arrive with
+    // `/D=<any existing directory>`; an unconditional bypass would adopt a
+    // directory this installer never created and the generated uninstaller, which
+    // removes $INSTDIR recursively, would delete the user's contents there.
+    assert.equal(
+      /\$\{If\} \$KiroVisibleUpdate == 1\nReturn/.test(ensureInstallDir),
+      false,
+      "the update bypass must require proof the install root is ours, not return unconditionally"
+    );
+    // The ownership test must read the executable name from a VARIABLE, never the
+    // ${APP_EXECUTABLE_FILENAME} define. That define lives in the template's
+    // common.nsh, which is included after installer.nsh, so a Function body --
+    // compiled at !include time -- cannot see it. NSIS does not fail loudly on
+    // that: it emits `warning 6000: unknown variable/constant` and DROPS the
+    // token, silently reducing the test to a bare directory path so the bypass
+    // fires for a directory we do not own. customInit assigns $KiroAppExeName
+    // instead, because a !macro body expands late enough to see the define.
+    assert.equal(
+      /\$\{APP_EXECUTABLE_FILENAME\}/.test(ensureInstallDir),
+      false,
+      "KiroEnsureAppInstallDir must not reference the ${APP_EXECUTABLE_FILENAME} define at include time"
+    );
+    assert.match(
+      installer,
+      /!macro customInit[\s\S]*?StrCpy \$KiroAppExeName "\$\{APP_EXECUTABLE_FILENAME\}"/,
+      "customInit must resolve $KiroAppExeName, since only a macro body sees that define"
+    );
+    // The guard must NOT be written as ${isUpdated}. That expands to a
+    // StdUtils::TestParameter plugin call, and a Function body is compiled when
+    // installer.nsh is !included -- before the generated script runs
+    // !addplugindir -- so it breaks the build with "Plugin not found, cannot
+    // call StdUtils::TestParameter". Only a !macro body (customInit) may test it,
+    // because that expands at its !insertmacro site. Asserted here because the
+    // two forms look interchangeable and the failure is invisible until an actual
+    // NSIS compile runs in CI.
+    assert.equal(
+      /\$\{isUpdated\}/.test(ensureInstallDir),
+      false,
+      "KiroEnsureAppInstallDir must not call the plugin-backed ${isUpdated} at include time"
+    );
+    // The fresh-install protection the guard sits in front of must stay: a first
+    // install still may not adopt a directory it did not create, because the
+    // generated uninstaller removes $INSTDIR recursively.
+    assert.match(
+      ensureInstallDir,
+      /KiroFreshInstallDirExists:\nStrCpy \$KiroInstallDir "\$KiroInstallDir\\\$\{APP_FILENAME\}"/,
+      "a fresh install must still nest past a directory it does not own"
+    );
   });
 
   it("keeps install-root ownership and legacy startup cleanup without custom pages", () => {


### PR DESCRIPTION
## Problem / Motivation

On Windows an auto-update could leave the user on the version they had just updated away from, and re-offer the same update forever.

Observed going from `0.4.0-insider.13` to `0.5.0-insider.1`. From the affected machine's `gateway-launch.log`: the install was dispatched, the installer was executed with `--updated,--force-run`, and a fresh process appeared 53s later whose launch check reported `found 0.5.0-insider.1 (running 0.4.0-insider.13)`. Repeating the update repeated the outcome; the only escape was quitting and launching from a shortcut that happened to point at the new install.

On disk there were two installs side by side:

| path | version | pointed at by |
| --- | --- | --- |
| `...\Programs\KiroCrew\KiroCrew.exe` | 0.4.0-insider.13 | Start Menu shortcut |
| `...\Programs\KiroCrew\KiroCrew\KiroCrew.exe` | 0.5.0-insider.1 | Desktop shortcut |

So the install itself succeeded. What failed was *where* it went and *what* got relaunched afterwards.

## Why it matters

A Windows user can be pinned to an old build indefinitely while being prompted to update on every check. Each attempt costs a full download, install and restart, and then appears to fail for no stated reason — nothing in the app reports that the relaunch landed on a different install than the one it just wrote, so there is no signal to act on. It also compounds: each attempt can add another parallel install, and each parallel install is another root the next update may pick.

## What changed (motivation → approach → change)

Two independent causes, both in `website/electron/build/installer.nsh`.

**1. An update could relocate the install root.**

`KiroEnsureAppInstallDir` exists so a FRESH install never adopts a directory it did not create — the generated uninstaller removes `$INSTDIR` recursively, so adopting a user's existing directory would later delete it. It implements that by nesting past any collision. It skipped the nesting for an already-registered install via `$KiroHasPerUserInstallation` / `$KiroHasPerMachineInstallation`, but both of those are downstream of a single registry value: upstream's `initMultiUser` reads `InstallLocation` from the uninstall key into `$perUserInstallationFolder`. When that value is absent both flags read `0`, an update falls through into the collision nesting, and the new version is written to a fresh subdirectory beside the running one.

Fix: on an update, bypass the nesting — but only for an install root this installer can prove is one of ours, evidenced by the app's own executable already being present in it. An update must never relocate the install root, and it must not depend on a registry hint being present in order to not do so.

The bypass is deliberately **not** unconditional. `--updated` is a command-line flag on a user-runnable installer, so it can arrive alongside `/D=<any existing directory>`; an unconditional bypass would adopt a directory this installer never created, record it as the install root, and the generated uninstaller — which removes `$INSTDIR` recursively — would then delete the user's pre-existing contents there. Path equality against the canonical default is not used as the ownership test, because a path can match while the directory belongs to something else, whereas our executable being present cannot. A registered root is still short-circuited by the existing `$KiroHasPer*Installation` guards. An update that cannot prove ownership falls through to the ordinary fresh-install path instead of adopting the directory.

The loop this PR fixes needs an update whose install root is already a Kiro Crew install, which is exactly the case the executable check admits — so narrowing the bypass this way costs the fix nothing.

The guard tests `$KiroVisibleUpdate`, not `${isUpdated}`, and the two are not interchangeable at this point in the file. `${isUpdated}` expands to a `StdUtils::TestParameter` plugin call, and `KiroEnsureAppInstallDir` is a `Function`, so its body is compiled when `installer.nsh` is `!include`d — before the generated script runs `!addplugindir`. The first revision of this PR used `${isUpdated}` there and CI's `Build Windows Installer (x64)` correctly refused it with `Plugin not found, cannot call StdUtils::TestParameter`. `customInit` may test `${isUpdated}` because a `!macro` body is only expanded at its `!insertmacro` site, and it already sets `$KiroVisibleUpdate` from it before calling this function; the install-mode page's leave callback runs later still, so the variable is populated on both call paths. This is also the form the file's five existing update-conditional callbacks already use.

This removes no protection an update previously had. The file-destination check further down already did not run for a registered update, because the `$KiroHasPer*Installation` guard returns before reaching it. The only path that used to fall through into that check was an update whose registry hint was missing — the same path that then mis-resolved `$INSTDIR`. A first install, the case where the check actually protects a directory we might otherwise adopt and later delete, still runs the function in full.

**2. The post-install relaunch could start the old executable.**

`StartApp` launched `$launchLink`, which `installSection.nsh` resolves to the Start Menu shortcut whenever one exists and only falls back to the installed executable when one does not. A shortcut is a pointer, and an update does not necessarily repoint it: `registryAddInstallInfo` records `KeepShortcuts="true"`, so `addStartMenuLink` keeps whatever the previous install left behind. A shortcut still naming a previous install root therefore makes the relaunch start the old binary — which re-discovers the same update on its next feed check, closing the loop.

Fix: launch `$INSTDIR\${APP_EXECUTABLE_FILENAME}`, the bytes this installer just wrote, which is the one target that cannot be stale. This is not an invented target: `installSection.nsh` assigns `$launchLink` exactly this path when no Start Menu shortcut exists, so the change promotes upstream's own fallback to the only case. Losing the shortcut's AppUserModelID costs nothing here — `main.js` calls `app.setAppUserModelId()` on win32 during startup, so taskbar grouping and notification identity are established by the app itself either way.

**Scope note, stated rather than papered over:** *why* `InstallLocation` was absent on the affected machine is not established. `registryAddInstallInfo` writes it unconditionally, and every sibling value on that same key (`DisplayVersion`, `UninstallString`, `DisplayIcon`) correctly named the real install root. Both fixes are deliberately designed to hold whether or not that value is present, instead of this PR waiting on that answer.

## Tests

`website/electron/test/packaging.test.js`:

- **New — `never relocates the install root on an update`.** Asserts the update return is the *first* thing `KiroEnsureAppInstallDir` does *and* that it is gated on the `${FileExists}` ownership proof, so no install-dir nesting can run ahead of it and no unconditional bypass can creep back in. It separately asserts the fresh-install nesting it guards is still present (so the fix cannot be "achieved" by deleting the protection), and that the function does **not** call `${isUpdated}`, locking in the include-time plugin constraint above — the two forms look interchangeable and that failure is invisible until a real NSIS compile runs.
- **Changed — the StartApp contract.** It previously asserted plain equality with electron-builder's locked `assistedInstaller.nsh` block. It now asserts exactly one permitted divergence: our launch line rewritten back to upstream's must equal upstream's block, so any *other* drift from the template still fails. It also asserts upstream still launches `$launchLink`, so a dependency upgrade that changes that line fails here and forces the divergence to be re-derived, instead of silently passing against a line that no longer exists.

Both were verified to catch a regression rather than merely pass: reverting `installer.nsh` to `origin/main` fails both (35/37 pass), and restoring it returns 37/37. Full electron suite: 1406 tests, 0 failures.

## Manual verification

Not performed, and I want to be precise about why rather than claim coverage this does not have. Reproducing the end-to-end behavior needs a signed Windows installer published to the update feed, which only the release lane produces — a locally built installer does not exercise the `--updated` handoff electron-updater drives. The behavior this fixes is only observable across two published builds, so it is worth watching on the next insider update rather than treated as verified here.

What *is* checked locally: the local gate has **no NSIS compile step**, which is a real limit of it — CI's `Build Windows Installer (x64)` is the first thing that actually runs `makensis`, and it caught two distinct instances of the same underlying constraint during this PR:

1. `${isUpdated}` inside `KiroEnsureAppInstallDir` — it expands to a `StdUtils::TestParameter` plugin call, and the plugin directory is not registered yet at `!include` time. Hard failure: `Plugin not found, cannot call StdUtils::TestParameter`.
2. `${APP_EXECUTABLE_FILENAME}` inside the same function — that define comes from the template's `common.nsh`, included *after* this file. **Soft** failure: `warning 6000: unknown variable/constant "{APP_EXECUTABLE_FILENAME}" detected, ignoring`, which would have silently reduced the ownership test to a bare directory path.

The invariant behind both, now stated in the file and asserted by tests rather than rediscovered a third time: **a `Function` body in `installer.nsh` is compiled at `!include` time, so it may use only variables and this file's own defines. Anything from the template's `common.nsh`, and any plugin-backed macro, must be resolved inside a `!macro` body first** — a macro body is expanded at its `!insertmacro` site, which is late enough. `customInit` therefore assigns `$KiroAppExeName`, and the function reads that. The file's other `Function` definitions (`StartApp`, `KiroFinishPagePre`, `KiroValidateInstallDirAfterMode`) are nested inside `!macro` blocks, so they are unaffected — which is why `StartApp` may reference the define directly. `${APP_FILENAME}` remains legal at include time because it comes from the generated header, not `common.nsh`.

`test-windows-installer.ps1` (wired into `build.yml`) then performs a real Windows install of the produced installer.

**Disclosure on review fidelity:** the pre-push local-review subagent lane did not actually execute in this environment. Both reviewer subagents (the `gpt-5.6-sol` mirror of `codex-review.yml` and the `claude-opus-4.8` mirror of `claude-review.yml` + AUTOSDE) returned a conclusion having issued no tool calls at all — their transcripts contain only preamble — so neither read the brief or the diff. Rather than record that as a clean local gate, the review was performed directly against both contracts, and the two adjudications it turned up are written into the code comments: that the early return removes no guard which previously applied to updates, and that the new launch target is upstream's own fallback path. The server-side reviewers are therefore the first real review of this diff.

## Related Issues

no linked issue: found while diagnosing a user report in a chat session; nothing tracked was filed for it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, the reasoning lives in the changed file's comments, which is where this project documents installer behavior
- [x] No secrets, credentials, or internal references in the diff
