### PR TITLE
ci: close the four actionable zizmor workflow findings

### DIFF
--- a/.github/workflows/add-contributor.yml
+++ b/.github/workflows/add-contributor.yml
@@ -62,6 +62,7 @@ jobs:
       # Check out the default branch. github.event.repository is absent on
       # schedule/workflow_dispatch payloads, so fall back to github.ref_name
       # (the default branch on both triggers). We only read/write tracked files.
+      # persist-credentials retained: add / "Open or update the contributors PR" runs git fetch + git push --force-with-lease against origin
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch || github.ref_name }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -95,12 +95,16 @@ jobs:
             artifact-name: build-linux-arm64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: website/package-lock.json
+          # cache disabled: this workflow is workflow_call-only from
+          # nightly.yml / release.yml, so every run builds published bytes.
+          # An Actions cache is writable from any branch and readable by a
+          # tag run (zizmor cache-poisoning).
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -125,6 +129,13 @@ jobs:
         # (The x64 leg stayed quiet only because ci.yml's linux-packaging job
         # already writes that key, so both post steps hit and skip saving.)
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # cache disabled explicitly: setup-uv's default (enable-cache: auto)
+        # turns the cache ON for hosted runners, and this workflow only ever
+        # runs on a publish path, so a restored entry would reach signed bytes
+        # (zizmor cache-poisoning). This also makes the reserveCache collision
+        # described above unreachable -- nothing saves a cache now.
+        with:
+          enable-cache: false
 
       - name: Stamp version
         env:
@@ -185,6 +196,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download Linux x64 build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -26,17 +26,24 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
+          # cache disabled: this workflow is workflow_call-only from
+          # nightly.yml / release.yml, so every run builds published bytes.
+          # An Actions cache is writable from any branch and readable by a
+          # tag run (zizmor cache-poisoning).
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: website/package-lock.json
+          # cache disabled: this workflow is workflow_call-only from
+          # nightly.yml / release.yml, so every run builds published bytes.
+          # An Actions cache is writable from any branch and readable by a
+          # tag run (zizmor cache-poisoning).
 
       - name: Stamp wheel version (PEP 440)
         env:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -169,12 +169,16 @@ jobs:
       HAS_WINDOWS_SIGNING: ${{ secrets.AWS_WINDOWS_SIGNING_ROLE_ARN != '' && inputs.use_prod_environment == true && 'true' || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: website/package-lock.json
+          # cache disabled: this workflow is workflow_call-only from
+          # nightly.yml / release.yml, so every run builds published bytes.
+          # An Actions cache is writable from any branch and readable by a
+          # tag run (zizmor cache-poisoning).
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -182,6 +186,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # cache disabled explicitly: setup-uv's default (enable-cache: auto)
+        # turns the cache ON for hosted runners, and this workflow only ever
+        # runs on a publish path, so a restored entry would reach the signed
+        # installer (zizmor cache-poisoning).
+        with:
+          enable-cache: false
         # The build script provisions python-build-standalone interpreters
         # through uv; windows-latest does not ship it, and the script's
         # curl|sh fallback is POSIX-shaped.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -88,6 +90,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -144,6 +148,8 @@ jobs:
       os: ${{ steps.compute.outputs.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         if: github.event_name == 'pull_request'
@@ -189,6 +195,8 @@ jobs:
         os: ${{ fromJSON(needs.desktop-matrix.outputs.os) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
       linux_packaging: ${{ steps.filter.outputs.linux_packaging }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -143,6 +145,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -175,6 +179,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # Full history is fetched lazily by the script only for the (skipped)
         # history scan; the working-tree gate needs just the checkout.
+        with:
+          persist-credentials: false
       - name: Scan working tree for internal markers
         # Blocking gate: fails the build on any Amazon-internal marker in the
         # public tree (internal domains/hosts, ticket ids, aliases, credential
@@ -193,6 +199,8 @@ jobs:
     # always-on job cannot be dodged by a path-filter edge case.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Verify _vendor tree against the committed sha256 manifest
         # Blocking gate: fails on any modified, missing, or added file under
@@ -208,6 +216,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # persist-credentials retained: brand-lint/Check the product name on the lines this change adds runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check the product name on the lines this change adds
@@ -237,6 +247,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # persist-credentials retained: focus-cue-lint/Check the focus cues on the elements this change touches runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check the focus cues on the elements this change touches
@@ -264,6 +276,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # persist-credentials retained: changelog-history/Check that shipped changelog sections survived this change runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check that shipped changelog sections survived this change
@@ -304,6 +318,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Check for bare module-global asyncio primitives
         # An asyncio.Lock/Event/Queue created at module scope binds to the
@@ -326,6 +342,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # persist-credentials retained: harness-parity/Check harness identity tests on the lines this change adds runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check harness identity tests on the lines this change adds
@@ -360,6 +378,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Verify the linter's own checks still fire
         # Self-test first: a gate that has silently stopped detecting anything is
@@ -392,6 +412,7 @@ jobs:
       # so a regression here is visible in the log instead of silent.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -482,6 +503,8 @@ jobs:
       SHARD_COUNT: 4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -614,6 +637,8 @@ jobs:
       MDNB_GIT_TIMEOUT_SEC: 120
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -726,6 +751,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -804,6 +831,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -859,6 +888,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -1056,6 +1087,8 @@ jobs:
       # downloads because actions/checkout cleans the workspace by default and
       # would otherwise delete them.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # The gate parses the Cobertura reports through defusedxml rather than the
       # stdlib parser, which resolves external entities -- and on a fork PR the
@@ -1163,6 +1196,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # persist-credentials retained: frontend-lint/Check for new hardcoded UI strings runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1330,6 +1365,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Pinned to the floor, NOT to `engines.node` via node-version-file: that
       # input resolves a range like ">=22" to the NEWEST matching release, which
@@ -1373,6 +1410,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -1400,6 +1439,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -1444,6 +1485,8 @@ jobs:
     env:
       SHARD_COUNT: 4
     steps:
+      # persist-credentials retained: frontend-test/Run the diff-scoped vitest gates runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1568,6 +1611,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -1636,6 +1681,8 @@ jobs:
     if: needs.changes.outputs.only_backend != 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -1668,6 +1715,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      # persist-credentials retained: e2e/Scan the rendered dashboard runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -80,6 +80,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Non-blocking size signal: raise a concern when the REVIEWABLE diff is
       # large enough that a single review pass may not cover it reliably. Only

--- a/.github/workflows/cleanup-temp-screenshots.yml
+++ b/.github/workflows/cleanup-temp-screenshots.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # persist-credentials retained: prune / "Open PR if anything was pruned" runs git fetch + git push --force-with-lease against origin
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history: file age is derived from each file's last commit date.

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   autosde-rules:
@@ -17,6 +16,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve diff base (merge-base)
         id: diffbase
@@ -199,6 +199,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve diff base (merge-base)
         id: diffbase
@@ -291,6 +292,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve diff base (merge-base)
         id: diffbase
@@ -349,6 +351,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # ── Conventional commit format on PR title ──────────────────────
       # PR title becomes the squash-merge commit message, so it must

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,6 +38,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # The gate runs on every event EXCEPT the one that applies the override
       # label. Because a new push is a `synchronize` event (not `labeled`), the

--- a/.github/workflows/dependency-vulnerability.yml
+++ b/.github/workflows/dependency-vulnerability.yml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -48,6 +48,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -199,6 +201,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/fork-workflow-guard.yml
+++ b/.github/workflows/fork-workflow-guard.yml
@@ -41,9 +41,7 @@ on:
     types: [labeled, unlabeled, synchronize]
 
 permissions:
-  checks: write
   contents: read
-  pull-requests: write
 
 concurrency:
   group: fork-workflow-guard-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
@@ -54,6 +52,15 @@ jobs:
     name: Fork workflow-change guard
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # `checks: write` posts this guard's own check-run. The reads are all GETs:
+    # `pull-requests: read` for the open-PR list and the changed-file list,
+    # `issues: read` for the label list (labels are an issues endpoint). No
+    # write to the PR -- only strip-stale-override removes the override label.
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: read
+      issues: read
     # FORK ONLY, both event shapes. Same-repo PRs are unaffected.
     if: >-
       ( github.event_name == 'workflow_run'

--- a/.github/workflows/memory-benchmark.yml
+++ b/.github/workflows/memory-benchmark.yml
@@ -99,6 +99,8 @@ jobs:
         timeline: [now, anchored]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -217,6 +219,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # persist-credentials retained: accept / "Open a PR to accept the new baseline" runs git ls-remote, git fetch and git push --force-with-lease against origin
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: src/kiro_crew/__init__.py
+          persist-credentials: false
 
       - name: Compute version
         id: stamp

--- a/.github/workflows/ota-test.yml
+++ b/.github/workflows/ota-test.yml
@@ -62,6 +62,8 @@ jobs:
       CDP_PORT: "9222"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,8 @@ jobs:
         working-directory: site
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Checkout manifest verifier contract
         if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download wheel artifact
         if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
@@ -94,11 +96,13 @@ jobs:
       - name: Locate wheel and compute checksum
         id: wheel
         if: env.HAS_PUBLISH_ROLE && env.HAS_MANIFEST_KEY
+        env:
+          WHEEL_ARTIFACT: ${{ inputs.wheel_artifact }}
         run: |
           set -euo pipefail
           mapfile -t WHEELS < <(find cli-dist -type f -name '*.whl' -print)
           if [ "${#WHEELS[@]}" -ne 1 ]; then
-            echo "::error::Expected exactly one .whl in artifact '${{ inputs.wheel_artifact }}'; found ${#WHEELS[@]}"
+            echo "::error::Expected exactly one .whl in artifact '${WHEEL_ARTIFACT}'; found ${#WHEELS[@]}"
             exit 1
           fi
           WHEEL="${WHEELS[0]}"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -101,6 +101,8 @@ jobs:
       image: ${{ steps.image.outputs.name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Validate build or promotion mode
         run: |

--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -78,6 +78,7 @@ jobs:
           # restricts WHICH refs may trigger a publish; this decides WHAT gets
           # published.
           ref: main
+          persist-credentials: false
 
       # Fail-closed, deliberately NOT the `if: env.HAS_SIGNING_SECRETS` skip
       # pattern the other publish lanes use. Those turn a missing secret into a

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -118,6 +118,8 @@ jobs:
       FORMAT: ${{ inputs.format }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Resolve every arch-dependent name in ONE fail-closed place: the
       # published basename, the electron-updater channel file, and the ELF

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -111,6 +111,8 @@ jobs:
       EXPECT_SUBJECT_CN: "Amazon Web Services, Inc."
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Windows publishes x64 only, so these are constants rather than inputs.
       # There is deliberately no `arch` parameter: with none, nothing can request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Verify exact candidate SHA
         run: |
@@ -100,12 +101,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      # cache disabled: published artifacts must not restore a cache writable from
+      # lower-trust branches (zizmor cache-poisoning)
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            setup.cfg
+          enable-cache: false
 
       - name: Install pinned test dependencies
         run: uv pip install --system -e ".[voice,desktop]" --group dev
@@ -142,6 +142,8 @@ jobs:
       artifact_digest: ${{ steps.resolve.outputs.artifact_digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Resolve and verify immutable candidate bundle
         id: resolve
@@ -209,6 +211,7 @@ jobs:
           # Full history so the stable tag resolves unambiguously, and so the
           # CHANGELOG read is of the tagged commit rather than a partial tree.
           fetch-depth: 0
+          persist-credentials: false
       - name: Verify stable publication preconditions
         env:
           CHANNEL: ${{ needs.version.outputs.channel }}
@@ -677,6 +680,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -836,6 +841,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download this run's immutable artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -119,6 +119,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: packaging/signing
+          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -272,6 +273,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: packaging/signing
+          persist-credentials: false
 
       # Install the CDSigner SigV4 client BEFORE AWS credentials are
       # configured (same supply-chain ordering as the sign job). Same
@@ -515,6 +517,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: inputs.promote
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         if: env.HAS_SIGNING_SECRETS

--- a/.github/workflows/test-durations.yml
+++ b/.github/workflows/test-durations.yml
@@ -29,6 +29,7 @@ jobs:
     # runs the WHOLE suite unsharded to record per-test durations.
     timeout-minutes: 90
     steps:
+      # persist-credentials retained: refresh / "Open PR if durations changed" runs git push --force origin
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## Problem / Motivation

A `zizmor` 1.29.0 audit of `origin/main` (38 workflows) reports 169 findings. Four
classes carry real risk rather than lint noise:

- **`template-injection` (High)** — `publish-cli.yml` interpolates
  `${{ inputs.wheel_artifact }}` straight into a `run:` body.
- **`excessive-permissions` (High ×2, Medium ×1)** — `code-review.yml` and
  `fork-workflow-guard.yml` grant write scopes at the *workflow* level, so every
  job in each file inherits them.
- **`cache-poisoning` (High)** — the release path restores dependency caches in the
  same runs that build the artifacts this repo signs and publishes.
- **`artipacked` (Medium ×63)** — `actions/checkout` steps omit
  `persist-credentials: false`, leaving the `GITHUB_TOKEN` in `.git/config` for the
  rest of the job.

## Why it matters

Each one is a privilege that outlives the step that needed it.

`publish-cli.yml`'s interpolation is expanded by the runner into the script text
before bash parses it, so a value holding a single quote closes the string and the
remainder executes — in the one job that holds the publish role and the manifest
signing key. Not reachable today (the only callers are in-repo), but that job is the
wrong place to keep the pattern one refactor away from reachable.

`fork-workflow-guard.yml` runs on `pull_request_target` + `workflow_run`, i.e. with
repo write in the context of a **fork** PR. A file-wide `pull-requests: write` /
`checks: write` means any job later added to that file — including one that touches
fork-controlled data — can post reviews, edit PR bodies and write check runs. That is
exactly the privilege class the guard workflow exists to police.

Actions caches are writable from any branch of the repo and readable by tag runs, so
a cache entry written from a lower-trust context can end up inside bytes this repo
signs and ships. The trust boundary that matters is not who can push a tag — it is
who can write a cache key a tag run will restore.

And the persisted checkout credential is readable by every later step in the job, and
leaves the runner entirely if the workspace (or anything under it, including `.git`)
is ever uploaded via `actions/upload-artifact`, since artifacts are downloadable by
anyone with repo read access.

## What changed (motivation → approach → change)

**`template-injection`** — the same step already references `${GITHUB_SHA}` and
`${PROMOTION_BASE_VERSION}` as shell variables, so the fix brings one line into line
with its neighbours: the input passes through a step-level `env:` and is read as
`${WHEEL_ARTIFACT}`, which bash expands after parsing rather than the runner
expanding into the script text.

**`excessive-permissions`** — root cause is a write scope declared once at file level
for the benefit of one job. Each file's default is narrowed to `contents: read` and
the scope pushed down:

- `fork-workflow-guard.yml`: the `guard` job declares `checks: write` (it posts its
  own check-run) plus `pull-requests: read` and `issues: read` for the PR and label
  GETs. `strip-stale-override` already carried its own block and is unchanged — it is
  the only job that writes to the PR.
- `code-review.yml`: `pull-requests: write` is dropped outright rather than pushed
  down. No job in this file posts to the PR; every gate reports through
  `::warning::` / `::error::` annotations, and the one reusable call
  (`dependency-vulnerability.yml`) declares `contents: read` itself.

**`cache-poisoning`** — the audit anchors this on `release.yml`, but the job it points
at (`release-candidate-tests`) only runs pytest and ships nothing. The bytes that get
signed and published are built by the three reusable workflows `release.yml` invokes
through `workflow_call`. Fixing only the anchor would have left the actual exposure
open, so all six restores on the publish path are disabled, each with the reason
recorded inline:

| Where | Was |
|---|---|
| `release.yml` `release-candidate-tests` | `setup-uv` `enable-cache: true` (plus a now-removed inert `cache-dependency-glob`) |
| `build-wheel.yml` | `setup-python` `cache: pip`; `setup-node` `cache: npm` |
| `build-desktop.yml` | `setup-node` `cache: npm`; **`setup-uv` with no `with:` block** |
| `build-windows.yml` | `setup-node` `cache: npm`; **`setup-uv` with no `with:` block** |

The last two are worth naming: `setup-uv`'s `enable-cache` defaults to `auto`, which
turns the cache **on** for hosted runners, and both matrices are entirely hosted. uv
provisions the python-build-standalone interpreter and installs each build's Python
dependencies, so a poisoned entry restored on a `v*` tag run reaches the Electron app
and the Authenticode-signed NSIS installer. An absent key is invisible to a grep for
`cache:`, which is why these two survived the first pass.

Disabling all six unconditionally is safe: the three build workflows are
`workflow_call`-only and their sole callers are `nightly.yml` (`schedule` +
`workflow_dispatch`) and `release.yml` (`push: tags: ["v*"]`), so they never run on a
PR and every run of them produces published bytes. The cost is a cold install on two
low-frequency paths. Caches on PR-triggered CI jobs are deliberately left alone —
those produce no signed bytes, so the boundary is not crossed.

`zizmor` scores none of the five non-anchor sites, because it cannot see caller
context through `workflow_call`. The scanner reading zero past the anchor is a blind
spot, not an all-clear.

**`artipacked`** — 52 of the 63 steps are a plain omission and now set
`persist-credentials: false`. One of those 52 is `ci.yml`'s `lockfile-engines-floor`,
which main added while this branch was in review — a fresh instance of the same class,
swept here rather than left to reopen the count.

The remaining 11 are not the same problem: a later step in the same job runs
authenticated git against the same remote, so removing the credential would break it.
Each keeps it and carries an inline comment naming the command that requires it:

| Workflow | Job | Requires |
|---|---|---|
| `add-contributor.yml` | `add` | `git fetch` + `git push --force-with-lease` |
| `cleanup-temp-screenshots.yml` | `prune` | `git fetch` + `git push --force-with-lease` |
| `memory-benchmark.yml` | `accept` | `git ls-remote`, `git fetch`, `git push --force-with-lease` |
| `test-durations.yml` | `refresh` | `git push --force` |
| `ci.yml` | `brand-lint`, `focus-cue-lint`, `changelog-history`, `harness-parity`, `frontend-lint`, `frontend-test`, `e2e` | `git fetch --depth=1 origin <base>` via `.github/scripts/resolve-i18n-base.sh` |

The four commit-and-push jobs each run two or three authenticated operations, so the
narrow `http.extraheader` pattern already used at `fork-gpt-review.yml:187` does not
apply to them.

`ci.yml`'s seven are a different case and are left as a **follow-up**: they share a
single `git fetch --depth=1 origin <base>` inside one script, and since this
repository is public that fetch needs no credential at all — so the follow-up is
plain `persist-credentials: false` on all seven, not the extraheader pattern. It is
deferred rather than done here because it changes the failure mode of seven
diff-scoped CI gates (a fetch that cannot authenticate today fails loudly by design,
per the comment in `resolve-i18n-base.sh`), and that deserves its own diff rather than
riding along on this one. It would take the residual count from 11 to 4.

### Deliberately not in this change

- **`secrets-inherit` ×6 (Medium)** — `nightly.yml` and `release.yml` hand the whole
  secret store to reusable callees. Worth fixing, but a missing secret surfaces as a
  publish-lane failure rather than a lint failure, so it wants a real prerelease
  window to verify against.
- **`adhoc-packages` ×2 (Low)** — two AI review lanes install unpinned packages.
- **`dangerous-triggers` ×11 (High)** — audited in the source; already gated by
  design in the fork-review workflows.
- **82 Informational** — `template-injection` on trusted `github.*` contexts, and one
  `superfluous-actions`. Noise.

## Tests

N/A — this repo has no unit-test surface for workflow YAML semantics, and the change
adds no product code. The existing contract tests that read workflow YAML are the
regression net, and they are run below.

## Manual verification

```
zizmor --format=json --no-online-audits .github/workflows/
```

Measured against `origin/main` at `a9e5ff608`:

| ident | main | this branch |
|---|---|---|
| `template-injection` (High) | 1 | **0** |
| `excessive-permissions` (High+Medium) | 3 | **0** |
| `cache-poisoning` (High) | 1 | **0** |
| `artipacked` (Medium) | 63 | **11** (the documented residuals above) |
| **total** | **169** | **112** |

The residual `artipacked` count is per the finding's own guidance — zero, *or* a
documented residual set naming the auth-requiring exceptions.

Also verified:

- All 38 workflow files parse under `yaml.safe_load`.
- The **935 tests that read workflow YAML** pass (18 contract files, plus
  `test_workflow_permissions.py` and `auto_improvement/tests/test_github_profile.py`) —
  these are the real regression net for this diff,
  since they assert on workflow structure directly (node pins, readiness aggregation,
  AI-review lane shape, eslint ceiling, reusable-workflow permissions).
- Per-file completeness: `persist-credentials: false` + documented retentions ==
  total checkouts, for every workflow. That invariant is what proves no checkout was
  silently skipped.
- Because zizmor cannot follow `workflow_call`, the cache work is asserted directly
  instead: every `setup-uv` in the three build lanes pins `enable-cache: false`, and
  no `cache:` / `cache-dependency-path` / `enable-cache: true` key remains in any of
  them.

The real risk in this change is the inverse direction: a job judged not to need the
credential that actually does. That is not detectable by the audit — only by running
the workflows. CI on this PR exercises the `ci.yml` and `code-review.yml` paths
directly, including all seven diff-scoped gates that keep their credential, so a
misjudgement there fails this PR. The publish/release/sign paths are not exercised by
a PR run and were verified by reading each job for authenticated git usage.

<!-- no-visual-delta -->
**Why no screenshot:** the diff touches only `.github/workflows/*.yml` — no
application code and no rendered surface.

## Related Issues

no linked issue: tracked in Taskei rather than GitHub, and this PR covers four of the
six audit tickets rather than resolving any one of them.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
