### PR TITLE
feat(discord): name-preserving document verb, and wire file_send to it

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -774,10 +774,10 @@ async def api_channel_upload_file(request: web.Request) -> web.Response:
     renderers' extraction path enforces, on the same shared predicate. The
     destination comes exclusively from the caller's session map entry — a
     request cannot name an arbitrary conversation, which is what keeps this
-    endpoint from being a broadcast primitive. Delivery today: Telegram via
-    the purpose-built ``send_document`` (name-preserving); Discord is an
-    explicit skip until its transport grows a document verb that preserves an
-    admitted filename (see the delivery-branch comment below).
+    endpoint from being a broadcast primitive. Delivery today: Telegram and
+    Discord, each via its own purpose-built name-preserving ``send_document``
+    (see the delivery-branch comment below); every other channel is a skip
+    until its transport grows that verb.
 
     "Cannot deliver here" is a SKIP (``delivered: false``), not an error: most
     sessions mirror nowhere, and the caller falls back to the dashboard card
@@ -839,15 +839,13 @@ async def api_channel_upload_file(request: web.Request) -> web.Response:
     ):
         return _skip("restricted_session")
     deliver = None
-    if link.channel_type == "telegram":
+    # Both legs resolve the SAME purpose-built verb: a name-preserving document
+    # send, distinct from each transport's extraction upload whose filename
+    # sanitizer maps any non-raster mime to `.bin` (`upload_filename`) — correct
+    # for LLM-authored reference paths, wrong for a name this endpoint's gate
+    # already scanned. A channel is listed here only once it has that verb.
+    if link.channel_type in ("telegram", "discord"):
         deliver = getattr(transport, "send_document", None)
-    # Discord is deliberately NOT wired: its transport upload verb serves the
-    # image-extraction pipeline, whose filename sanitizer maps any non-raster
-    # mime to `.bin` (`upload_filename`) — correct for LLM-authored reference
-    # paths, but it would deliver `report.pdf` as `report.bin` here. Until the
-    # transport grows a document verb that preserves an ADMITTED name (the
-    # gate already scanned it), Discord callers keep the dashboard-link
-    # fallback rather than a corrupted attachment.
     if deliver is None:
         return _skip(f"channel_upload_unsupported:{link.channel_type}")
     # Off-loop: the gate reads up to MAX_FILE_BYTES and regex-scans the content

--- a/src/kiro_crew/discord/client.py
+++ b/src/kiro_crew/discord/client.py
@@ -40,6 +40,7 @@ import urllib.parse
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Awaitable, Callable, TypeVar
 
 import aiohttp
@@ -775,6 +776,49 @@ class DiscordClient:
         )
         return str(result.get("id", "")) if result is not None else None
 
+    async def send_document(
+        self,
+        channel_id: str,
+        document: OutboundFile,
+        *,
+        caption: str | None = None,
+        reply_to_message_id: str | None = None,
+    ) -> str | None:
+        """Upload ONE file as a named attachment. Returns the message id or None.
+
+        The generic-file counterpart of :meth:`send_message_with_files`, for
+        attachments that are not raster images (PDF, CSV, archives — whatever the
+        caller's own gates admitted).
+
+        ``filenames`` pins the document's real name: the multipart sanitizer is
+        aimed at LLM-authored reference paths and maps any non-raster mime to
+        ``.bin``, and this caller's name has already passed the file_send gates —
+        letting the sanitizer rewrite the extension would deliver ``report.pdf``
+        as ``report.bin`` and break the receiver's file-type association.
+
+        Refuses over ``DISCORD_MAX_TOTAL_UPLOAD_BYTES`` rather than uploading
+        into a 413: one attachment IS the whole upload, so the message ceiling is
+        this file's ceiling. The caller gets None and keeps its existing
+        dashboard-link fallback.
+        """
+        if not document.data:
+            return None
+        if len(document.data) > DISCORD_MAX_TOTAL_UPLOAD_BYTES:
+            logger.warning(
+                "discord: refusing a %d-byte document (ceiling %d)",
+                len(document.data),
+                DISCORD_MAX_TOTAL_UPLOAD_BYTES,
+            )
+            return None
+        result = await self._api_multipart(
+            "POST",
+            f"/channels/{channel_id}/messages",
+            _create_payload(caption or "", None, reply_to_message_id),
+            [document],
+            filenames=[Path(document.path or "").name],
+        )
+        return str(result.get("id", "")) if result is not None else None
+
     async def edit_message_with_files(
         self,
         channel_id: str,
@@ -1397,13 +1441,19 @@ class DiscordClient:
         files: Sequence[OutboundFile],
         *,
         timeout: int = 60,
+        filenames: Sequence[str] | None = None,
     ) -> DiscordApiResult:
-        """Send multipart, rebuilding the single-use form for every attempt."""
+        """Send multipart, rebuilding the single-use form for every attempt.
+
+        *filenames*, when supplied, is used verbatim in place of
+        :func:`upload_filename` — see :meth:`send_document` for when that is the
+        right call. Omit it for anything whose name the model influenced.
+        """
         return await self._api_request(
             method,
             path,
             timeout=timeout,
-            build=lambda: {"data": _build_upload_form(payload, files)},
+            build=lambda: {"data": _build_upload_form(payload, files, filenames=filenames)},
         )
 
     async def _api(
@@ -1421,9 +1471,13 @@ class DiscordClient:
         payload: dict[str, Any],
         files: Sequence[OutboundFile],
         timeout: int = 60,
+        *,
+        filenames: Sequence[str] | None = None,
     ) -> Any:
         """:meth:`api_files` reduced to its body, mirroring :meth:`_api`."""
-        return (await self.api_files(method, path, payload, files, timeout=timeout)).data
+        return (
+            await self.api_files(method, path, payload, files, timeout=timeout, filenames=filenames)
+        ).data
 
     async def _api_request(
         self,
@@ -1561,13 +1615,26 @@ def _safe_description(alt: str) -> str:
     return out[:1024]
 
 
-def _build_upload_form(payload: dict[str, Any], files: Sequence[OutboundFile]) -> aiohttp.FormData:
-    """Build matching attachment descriptors and indexed file parts."""
+def _build_upload_form(
+    payload: dict[str, Any],
+    files: Sequence[OutboundFile],
+    *,
+    filenames: Sequence[str] | None = None,
+) -> aiohttp.FormData:
+    """Build matching attachment descriptors and indexed file parts.
+
+    *filenames* is positional against *files* and used verbatim when supplied,
+    bypassing :func:`upload_filename` for a name the caller's own gates already
+    admitted (see :meth:`DiscordClient.send_document`). The descriptor and the
+    file part always carry the SAME name — Discord matches them by ``id``, and a
+    mismatch is what renames an attachment mid-upload.
+    """
     form = aiohttp.FormData()
     descriptors: list[dict[str, Any]] = []
     names: list[str] = []
     for index, file in enumerate(files):
-        name = upload_filename(file, index)
+        pinned = filenames[index] if filenames is not None and index < len(filenames) else ""
+        name = pinned or upload_filename(file, index)
         names.append(name)
         descriptor: dict[str, Any] = {"id": index, "filename": name}
         if file.alt:

--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -189,6 +189,36 @@ class DiscordTransport(MessagingTransport):
         mid = await self._client.send_message_with_files(conversation_id, content, files)
         return str(mid or "")
 
+    async def send_document(
+        self,
+        conversation_id: str,
+        file: OutboundFile,
+        *,
+        caption: str = "",
+        thread_id: str | None = None,
+    ) -> str:
+        """Send one validated file, keeping its admitted name. Returns the message id.
+
+        The name-preserving counterpart of :meth:`send_message_with_files`, whose
+        sanitizer is aimed at LLM-authored reference paths and would deliver
+        ``report.pdf`` as ``report.bin``. A caller here has already gated the name
+        (``file_send``), so the real basename is pinned onto the multipart part.
+        ``file`` carries validated bytes (the ``OutboundFile`` contract — the path
+        is provenance, never re-opened).
+
+        ``thread_id``, when present, IS the destination: a Discord thread's
+        snowflake is its channel id, which is why the persisted link is built as
+        ``ChannelLink("discord", channel_id=...)`` with no thread id at all (see
+        :meth:`may_send_to`). The parameter exists for cross-transport parity, and
+        honouring it costs nothing because the value it would carry is a channel.
+        """
+        mid = await self._client.send_document(
+            thread_id or conversation_id,
+            file,
+            caption=caption or None,
+        )
+        return str(mid or "")
+
     async def resolve_conversation(self, user_id: str) -> str:
         # Proactive sends need a DM channel; the client's create_dm_channel
         # POSTs /users/@me/channels to create (or return) it for a user id.

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -99,6 +99,24 @@ class MultipartFake:
             channel_id, text, components=components, reply_to_message_id=reply_to_message_id
         )
 
+    async def send_document(
+        self,
+        channel_id: str,
+        document: Any,
+        *,
+        caption: Any = None,
+        reply_to_message_id: Any = None,
+    ) -> str | None:
+        """Record the destination alongside the file: the document verb routes a
+        thread to its own channel id, which is the part a caller can get wrong."""
+        getattr(self, "uploads", []).append(("document", [document]))
+        getattr(self, "documents", []).append((channel_id, document, caption))
+        if getattr(self, "raise_uploads", False):
+            raise RuntimeError("document send exploded")
+        if getattr(self, "fail_uploads", False):
+            return None
+        return await self.send_message(channel_id, caption or "")  # type: ignore[attr-defined]
+
     async def edit_message_with_files(
         self,
         channel_id: str,
@@ -135,6 +153,8 @@ class FakeClient(MultipartFake):
         self.attachment_bodies: dict[str, bytes] = {}
         self.attachment_downloads: list[str] = []
         self.uploads: list[tuple[str, list[Any]]] = []
+        #: (channel_id, document, caption) per name-preserving document send.
+        self.documents: list[tuple[str, Any, Any]] = []
         self.edit_ok = True
         #: When set, every send returns None, which is what the real client does
         #: for a revoked token or a dead network.

--- a/test/test_discord_outbound_files.py
+++ b/test/test_discord_outbound_files.py
@@ -60,8 +60,36 @@ async def _turn(body: str | tuple[str, ...], **kw: Any) -> FakeClient:
     return cli
 
 
-def _fields(payload: dict, files: list) -> list[tuple[dict, Any, Any]]:
-    return [(o, h, v) for (o, h, v) in _build_upload_form(payload, files)._fields]
+def _fields(payload: dict, files: list, **kw: Any) -> list[tuple[dict, Any, Any]]:
+    return [(o, h, v) for (o, h, v) in _build_upload_form(payload, files, **kw)._fields]
+
+
+def _doc(name: str = "report.pdf", *, data: bytes = b"%PDF-1.4 body") -> Any:
+    return outbound.OutboundFile(
+        path=f"/tmp/outbox/{name}", data=data, alt="", mime="application/pdf"
+    )
+
+
+def _client(monkeypatch: Any, reply: dict) -> tuple[Any, list[dict]]:
+    """A DiscordClient whose session records the multipart body it was handed."""
+    from contextlib import asynccontextmanager
+
+    from kiro_crew.discord.client import DiscordClient
+
+    seen: list[dict] = []
+
+    @asynccontextmanager
+    async def request(method: str, url: str, **kw: Any) -> Any:
+        seen.append({k: v for k, v in kw.items() if k == "data"})
+
+        async def response_json(content_type: Any = None) -> Any:
+            return reply
+
+        yield SimpleNamespace(status=200, json=response_json)
+
+    client = DiscordClient(token="t")
+    monkeypatch.setattr(client, "_ensure_session", lambda: _done(SimpleNamespace(request=request)))
+    return client, seen
 
 
 def _description(alt: str) -> str:
@@ -425,6 +453,72 @@ class TestMultipartWire:
         client = DiscordClient(token="t")
         monkeypatch.setattr(client, "_api_multipart", lambda *a, **kw: _done({}))
         assert asyncio.run(client.send_message_with_files("c1", "hi", [_file()])) == ""
+
+
+class TestDocumentVerb:
+    """The name-preserving document send (issue #6058).
+
+    Separate from ``send_message_with_files`` on purpose: that path's sanitizer
+    is aimed at LLM-authored reference paths and maps every non-raster mime to
+    ``.bin``, so it would deliver ``report.pdf`` as ``report.bin``. These tests
+    pin BOTH halves — the admitted name survives here, and the extraction path's
+    derivation is untouched.
+    """
+
+    def test_the_extraction_path_still_derives_the_name(self) -> None:
+        # The guarantee `upload_filename` makes to its existing callers: an
+        # untrusted path, a non-raster mime, `.bin`. Unchanged by this verb.
+        assert upload_filename(_doc(), 0) == "report.bin"
+        fields = _fields({"content": ""}, [_doc()])
+        assert json.loads(fields[0][2])["attachments"][0]["filename"] == "report.bin"
+        assert fields[1][0]["filename"] == "report.bin"
+
+    def test_a_pinned_name_survives_into_descriptor_and_part(self) -> None:
+        # Discord matches a descriptor to its part by `id`; a name that differs
+        # between the two is what renames an attachment mid-upload.
+        fields = _fields({"content": ""}, [_doc()], filenames=["report.pdf"])
+        assert json.loads(fields[0][2])["attachments"][0]["filename"] == "report.pdf"
+        assert fields[1][0]["filename"] == "report.pdf" and fields[1][2] == b"%PDF-1.4 body"
+
+    def test_a_short_pin_list_falls_back_per_file(self) -> None:
+        fields = _fields({"content": ""}, [_doc(), _file("/tmp/b.png")], filenames=["report.pdf"])
+        assert [a["filename"] for a in json.loads(fields[0][2])["attachments"]] == ["report.pdf", "b.png"]
+
+    def test_send_document_pins_the_basename_on_the_wire(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, seen = _client(monkeypatch, {"id": "77"})
+        assert asyncio.run(client.send_document("c1", _doc(), caption="weekly numbers")) == "77"
+        form = seen[-1]["data"]._fields
+        payload = json.loads(form[0][2])
+        assert payload["content"] == "weekly numbers"
+        assert payload["attachments"] == [{"id": 0, "filename": "report.pdf"}]
+        assert form[1][0]["filename"] == "report.pdf" and form[1][2] == b"%PDF-1.4 body"
+
+    def test_a_document_over_the_upload_ceiling_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # One attachment IS the whole upload, so the message ceiling is this
+        # file's ceiling. Refused locally rather than uploaded into a 413.
+        client, seen = _client(monkeypatch, {"id": "77"})
+        over = _doc(data=b"x" * (DISCORD_MAX_TOTAL_UPLOAD_BYTES + 1))
+        assert asyncio.run(client.send_document("c1", over)) is None and seen == []
+        assert asyncio.run(client.send_document("c1", _doc(data=b""))) is None and seen == []
+
+    def test_the_caption_is_clamped_to_the_content_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, seen = _client(monkeypatch, {"id": "77"})
+        assert asyncio.run(client.send_document("c1", _doc(), caption="c" * (DISCORD_MAX_TEXT + 50))) == "77"
+        assert len(json.loads(seen[-1]["data"]._fields[0][2])["content"]) == DISCORD_MAX_TEXT
+
+    def test_the_transport_returns_the_message_id_and_routes_a_thread(self) -> None:
+        transport = DiscordTransport(cli := FakeClient(), allowed_user_ids=["u1"])  # type: ignore[arg-type]
+        doc = _doc()
+        assert asyncio.run(transport.send_document("c1", doc, caption="hi")).isdigit()
+        # A Discord thread's snowflake IS its channel id, so a supplied
+        # thread_id is the destination rather than a second parameter.
+        assert asyncio.run(transport.send_document("c1", doc, thread_id="t9")).isdigit()
+        assert [(chan, f is doc, cap) for chan, f, cap in cli.documents] == [("c1", True, "hi"), ("t9", True, None)]
+
+    def test_a_refused_transport_send_reports_an_empty_id(self) -> None:
+        transport = DiscordTransport(cli := FakeClient(), allowed_user_ids=["u1"])  # type: ignore[arg-type]
+        cli.fail_uploads = True
+        assert asyncio.run(transport.send_document("c1", _doc())) == ""
 
 
 class TestTransportVerb:

--- a/test/test_file_send_channel.py
+++ b/test/test_file_send_channel.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -37,6 +38,20 @@ def outbox_file(tmp_path):
     outbox = tmp_path / "outbox"
     outbox.mkdir()
     f = outbox / "report.txt"
+    f.write_text("hello world", encoding="utf-8")
+    return f
+
+
+@pytest.fixture
+def outbox_pdf(tmp_path):
+    """A non-raster document in the outbox — the extension the extraction
+    sanitizer would rewrite to `.bin`, which is what the document verb exists
+    to preserve. The delivered name comes from ``OutboundFile.path`` (the
+    resolved file on disk), not from the request's ``filename`` field.
+    """
+    outbox = tmp_path / "outbox"
+    outbox.mkdir(exist_ok=True)
+    f = outbox / "report.pdf"
     f.write_text("hello world", encoding="utf-8")
     return f
 
@@ -778,12 +793,95 @@ class TestChannelUploadEndpoint:
         assert kwargs["thread_id"] == "7"
 
     @pytest.mark.asyncio
-    async def test_discord_destination_is_an_explicit_skip(self, tmp_path, outbox_file):
-        # Deliberate: Discord's transport upload verb serves the image
-        # extraction pipeline, whose sanitizer maps any non-raster mime to
-        # `.bin` — report.pdf would arrive as report.bin. Until a
-        # name-preserving document verb exists, Discord callers keep the
-        # dashboard-link fallback rather than a corrupted attachment.
+    async def test_discord_destination_gets_send_document(self, tmp_path, outbox_pdf):
+        # Issue #6058: Discord was an explicit skip while its only upload verb
+        # was the extraction one, whose sanitizer maps any non-raster mime to
+        # `.bin` (report.pdf would arrive as report.bin). It now has the same
+        # purpose-built name-preserving verb Telegram uses, so it delivers.
+        from unittest.mock import AsyncMock
+
+        transport = MagicMock(spec_set=["send_document", "send_message_with_files"])
+        transport.send_document = AsyncMock(return_value="900")
+        transport.send_message_with_files = AsyncMock(return_value="901")
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("discord", "555"), transport),
+        ), patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_pdf.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={
+                        "file_path": str(outbox_pdf),
+                        "filename": "report.pdf",
+                        "description": "weekly numbers",
+                    },
+                    headers={"X-Session-Key": "discord:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200
+        assert body == {"ok": True, "delivered": True, "channel_type": "discord"}
+        transport.send_document.assert_awaited_once()
+        # The extraction verb stays out of this path: it is the one whose
+        # sanitizer would rename the attachment.
+        transport.send_message_with_files.assert_not_called()
+        args, kwargs = transport.send_document.call_args
+        assert args[0] == "555"
+        outbound = args[1]
+        # The OutboundFile contract: the gated bytes ARE the payload.
+        assert outbound.data == b"hello world"
+        assert outbound.path == str(outbox_pdf)
+        # `.pdf` survives end-to-end — the whole point of the separate verb.
+        # `upload_filename` would have made this `report.bin`.
+        from kiro_crew.messaging.outbound_files import upload_filename
+
+        assert Path(outbound.path).name == "report.pdf"
+        assert upload_filename(outbound, 0) == "report.bin"
+        assert outbound.mime == "application/pdf"
+        assert kwargs["caption"] == "weekly numbers"
+
+    @pytest.mark.asyncio
+    async def test_discord_outbound_text_is_redacted_in_display_form(self, tmp_path, outbox_file):
+        # Same boundary rule as the Telegram leg: redact() scans literal bytes,
+        # and Discord renders markdown, so AKIA**…** displays as an intact key.
+        from unittest.mock import AsyncMock
+
+        key = "AKIA" + "IOSFODNN7EXAMPLE"
+        transport = MagicMock(spec_set=["send_document"])
+        transport.send_document = AsyncMock(return_value="900")
+        app = self._app()
+        with patch(
+            "kiro_crew.dashboard.chat_runner._resolve_mirror_target",
+            return_value=(self._link("discord", "555"), transport),
+        ), patch(
+            "kiro_crew.config.loader.outbox_dir", return_value=outbox_file.parent
+        ), patch(
+            "kiro_crew.config.loader.workspace_root", return_value=tmp_path
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/channel/upload-file",
+                    json={
+                        "file_path": str(outbox_file),
+                        "filename": "report.pdf",
+                        "description": f"{key[:4]}**{key[4:]}**",
+                    },
+                    headers={"X-Session-Key": "discord:1"},
+                )
+                body = await resp.json()
+        assert resp.status == 200 and body["delivered"] is True
+        caption = transport.send_document.call_args[1]["caption"]
+        assert key not in caption.replace("*", "").replace("`", "").replace("_", "")
+
+    @pytest.mark.asyncio
+    async def test_a_discord_transport_without_the_verb_is_still_a_skip(self, tmp_path, outbox_file):
+        # The channel list is not the authority — the verb is. A transport that
+        # predates it keeps the dashboard-link fallback rather than being routed
+        # into the extraction upload whose sanitizer renames the attachment.
         from unittest.mock import AsyncMock
 
         transport = MagicMock(spec_set=["send_message_with_files"])


### PR DESCRIPTION
Closes #6058.

## The gap

`file_send` could not deliver natively to Discord. `api_channel_upload_file` — the endpoint that serves every non-Slack channel — resolved a delivery verb for Telegram only and answered `channel_upload_unsupported:discord` for Discord, so a Discord-linked session got a dashboard link instead of an attachment.

The reason was real, not an oversight. Discord's only upload verb, `send_message_with_files`, serves the image-extraction pipeline, and its filename sanitizer maps every non-raster mime to `.bin`:

```python
# messaging/outbound_files.py
ext = _MIME_EXT.get(file.mime or "", "bin")
```

Routing this endpoint through it would have delivered `report.pdf` as `report.bin`. That sanitizer is correct for what it guards — names lifted out of LLM-authored reply text — and wrong for a name this endpoint's own gate already scanned. So Discord gets its own verb, exactly as Telegram did.

## What changed

| | |
|---|---|
| `discord/client.py` | `send_document` — one `OutboundFile`, optional caption, the real basename pinned onto the multipart part. Mirrors `TelegramClient.send_document` and its rationale. |
| `discord/client.py` | `filenames` plumbed through `_build_upload_form` / `api_files` / `_api_multipart` — the same escape hatch Telegram's `_api_multipart` already has. |
| `discord/transport.py` | `DiscordTransport.send_document`, so a caller holding a transport does not reach past it into the client. |
| `dashboard/handlers/files.py` | The delivery branch resolves `send_document` for `discord` too; the now-stale skip comment is gone. |

Discord's own limits, in the shape Telegram's leg uses:

- **25 MB** (`DISCORD_MAX_TOTAL_UPLOAD_BYTES`) refused locally rather than uploaded into a 413. One attachment IS the whole upload, so the message ceiling is this file's ceiling.
- **Caption** rides through `_create_payload`, so `DISCORD_MAX_TEXT` (2000) clamps it on the shared path rather than in a second place.

`redact_for_display` on the caption, the restricted-session ceiling, the shared admission gate, and the skip-vs-error semantics are all reused unchanged.

## What deliberately did NOT change

`upload_filename` and `send_message_with_files` are untouched. The former's docstring guarantees untrusted-path input for **every** existing caller (Slack, Telegram, Webex, Discord extraction); a trust flag on it would put that guarantee behind a boolean and make the safe behaviour opt-in. A separate verb keeps the sanitizer's contract absolute.

Two guards pin that boundary rather than trusting the comment:

- `test_the_extraction_path_still_derives_the_name` asserts `upload_filename` still yields `report.bin` for a `.pdf`, and that a form built **without** `filenames` still carries the derived name.
- `test_a_discord_transport_without_the_verb_is_still_a_skip` — the channel list is not the authority, the verb is. A transport predating `send_document` keeps the dashboard-link fallback; the extraction upload can never become the fallback.

## Verification

Red-before proven: with the test files applied and `src/` reverted, 7 of the 8 new `TestDocumentVerb` cases and both new endpoint cases fail (`'DiscordClient' object has no attribute 'send_document'`, `channel_upload_unsupported:discord`). The one that passes on base is the `upload_filename` invariance guard — correct, it asserts unchanged behaviour.

- 315 pass across `test_discord_outbound_files.py`, `test_file_send_channel.py`, `test_discord.py`
- 1095 pass across the wider Discord / file-send / upload-gate selection
- black (baselined diff gate), isort, flake8, mypy, brand, changelog-history, loop-bound-locks, harness-parity, subprocess-encoding, lockdown-before-publish all clean

`outbox_pdf` is a new fixture: the delivered name comes from `OutboundFile.path` (the resolved file on disk), not from the request's `filename` field, so proving `.pdf` survives end-to-end needs a `.pdf` on disk.

## Scope note

`handlers/files.py` is touched only inside `api_channel_upload_file` (~`:764-870`) — the delivery branch and the docstring sentence describing it. No reformatting, no import re-ordering, nothing outside that region, to stay additive against the other open PRs on this file.
