### PR TITLE
refactor(security): share one zip-inventory vet across untrusted-archive parse sites

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -57,6 +57,7 @@ from kiro_crew.validation import (
     ValidationError,
     validate_tool_args,
 )
+from kiro_crew.zip_vet import ZipInventoryRejected, vet_zip_inventory_bytes
 
 # Register OOXML office MIME types explicitly. The system mimetypes
 # database on AL2/AL2023 build hosts does NOT include .docx, .xlsx, or
@@ -3918,33 +3919,25 @@ def _vet_zip_eocd(data: bytes) -> None:
     """Refuse archives whose end-of-central-directory record declares an
     oversized inventory, BEFORE zipfile.ZipFile is constructed.
 
-    ZipFile.__init__ walks the whole central directory and allocates a
-    ZipInfo per entry, so a crafted archive with hundreds of thousands of
-    entries exhausts memory during construction -- ahead of any infolist()
-    check. The EOCD carries both the entry count and the central-directory
-    byte size; capping both bounds that allocation regardless of which field
-    lies (zipfile itself iterates the directory by its byte size).
+    Delegates to the shared vet (kiro_crew.zip_vet) so this endpoint, knowledge
+    ingest, and document parsing share one implementation of the preflight --
+    only the caps and the error channel stay per-caller. This endpoint's
+    observable behaviour is unchanged: a tail with no usable EOCD still reads as
+    "not a spreadsheet" (415), an over-cap inventory as an expansion refusal
+    (413).
     """
-    # EOCD (PK\x05\x06) sits within the last 22 + 65535 bytes (fixed record
-    # plus maximum comment length).
-    tail_start = max(0, len(data) - (22 + 65535))
-    eocd = data.rfind(b"PK\x05\x06", tail_start)
-    if eocd < 0 or len(data) < eocd + 22:
-        raise _SheetRefusal(415, "not an OOXML spreadsheet", "not_a_spreadsheet")
-    count = int.from_bytes(data[eocd + 10 : eocd + 12], "little")
-    cdir_size = int.from_bytes(data[eocd + 12 : eocd + 16], "little")
-    if count == 0xFFFF or cdir_size == 0xFFFFFFFF:
-        # Saturated classic fields mean the archive declares >= 65535 entries
-        # or a >= 4 GiB central directory -- both orders of magnitude past
-        # this endpoint's caps, so the ZIP64 records that would carry the
-        # real numbers can never change the verdict. Refusing outright keeps
-        # the vet free of a second record-location protocol to get right.
-        raise _SheetRefusal(413, "workbook expands too large", "workbook_expands_too_large")
-    if (
-        count > _SHEET_MAX_MEMBERS
-        or cdir_size > _SHEET_MAX_MEMBERS * _SHEET_MAX_CDIR_ENTRY_BYTES
-    ):
-        raise _SheetRefusal(413, "workbook expands too large", "workbook_expands_too_large")
+    try:
+        vet_zip_inventory_bytes(
+            data,
+            max_members=_SHEET_MAX_MEMBERS,
+            max_cdir_entry_bytes=_SHEET_MAX_CDIR_ENTRY_BYTES,
+        )
+    except ZipInventoryRejected as exc:
+        if exc.reason in ("missing_eocd", "truncated_eocd", "unreadable"):
+            raise _SheetRefusal(
+                415, "not an OOXML spreadsheet", "not_a_spreadsheet") from exc
+        raise _SheetRefusal(
+            413, "workbook expands too large", "workbook_expands_too_large") from exc
 
 
 def _parse_workbook_grid(data: bytes) -> dict:

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -61,6 +61,7 @@ from kiro_crew.knowledge.sync import SyncScheduler
 from kiro_crew.knowledge.watcher import KnowledgeWatcher
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
+from kiro_crew.zip_vet import ZipInventoryRejected, vet_zip_inventory
 
 logger = logging.getLogger(__name__)
 
@@ -1493,7 +1494,24 @@ def _inspect_zip_archive(path: str) -> str | None:
     synchronous zip I/O, so callers MUST run it off the event loop (via
     ``asyncio.to_thread``) — a large/hostile central directory would otherwise
     stall the gateway loop and heartbeat.
+
+    The member cap runs TWICE, deliberately. The shared vet (kiro_crew.zip_vet)
+    reads the archive tail first, so the declared central-directory size — the
+    field ZipFile's construction loop actually reads and allocates from — is
+    bounded BEFORE ZipFile exists. The infolist() pass below then bounds the
+    aggregate declared expansion, which only the parsed records can answer. The
+    rejection reasons are unchanged: an archive that the preflight refuses would
+    have been refused by the count check anyway, just after the allocation.
     """
+    try:
+        vet_zip_inventory(path, max_members=_MAX_INGEST_ARCHIVE_MEMBERS)
+    except ZipInventoryRejected as exc:
+        # Same reasons this function already returns, so the API error body and
+        # the SEL outcome do not change shape: a tail we cannot parse is a bad
+        # archive, an over-cap inventory is too many members.
+        if exc.reason in ("missing_eocd", "truncated_eocd", "unreadable"):
+            return "bad_archive"
+        return "too_many_members"
     try:
         with zipfile.ZipFile(path) as zf:
             infos = zf.infolist()

--- a/src/kiro_crew/doc_parser.py
+++ b/src/kiro_crew/doc_parser.py
@@ -33,6 +33,7 @@ except ModuleNotFoundError:  # pragma: no cover — exercised via monkeypatch
 
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
+from kiro_crew.zip_vet import ZipInventoryRejected, vet_zip_inventory
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,13 @@ logger = logging.getLogger(__name__)
 
 _MAX_ZIP_ENTRY = 50 * 1024 * 1024  # 50 MB per ZIP entry (decompressed)
 _MAX_DECOMPRESS = 50 * 1024 * 1024  # 50 MB for zlib decompression
+# Inventory bound for OOXML containers. The per-entry cap above bounds what one
+# member can expand to, but nothing here previously bounded how MANY members an
+# archive declares — and ZipFile's construction allocates from the declared
+# central-directory size before any per-entry limit can apply. Generous next to
+# real documents (a large deck with per-slide media is in the low thousands of
+# parts), so this refuses crafted inventories without narrowing legitimate ones.
+_MAX_ARCHIVE_MEMBERS = 20000
 
 # ── Public API ──
 
@@ -120,6 +128,21 @@ def _safe_decompress(data: bytes, max_size: int | None = None) -> bytes:
     return result
 
 
+def _vet_archive_inventory(path: str) -> bool:
+    """Preflight an OOXML container's declared inventory before opening it.
+
+    Returns True when the archive is within bounds. Fails closed: a rejected or
+    unreadable tail returns False, and the caller degrades to "" like every
+    other unreadable-document path in this module.
+    """
+    try:
+        vet_zip_inventory(path, max_members=_MAX_ARCHIVE_MEMBERS)
+    except ZipInventoryRejected as exc:
+        logger.warning("archive inventory rejected (%s)", exc.reason)
+        return False
+    return True
+
+
 def _read_zip_entry(
     zf: zipfile.ZipFile, name: str, max_size: int | None = None,
 ) -> bytes | None:
@@ -150,6 +173,8 @@ def _extract_docx(path: str) -> str:
     """
     assert _xml_fromstring is not None  # extract_text() gates the None case
     if is_sensitive_path(path):
+        return ""
+    if not _vet_archive_inventory(path):
         return ""
     paragraphs: list[str] = []
     with zipfile.ZipFile(path, "r") as zf:
@@ -182,6 +207,8 @@ def _extract_pptx(path: str) -> str:
     """
     assert _xml_fromstring is not None  # extract_text() gates the None case
     if is_sensitive_path(path):
+        return ""
+    if not _vet_archive_inventory(path):
         return ""
     slides: list[tuple[int, str]] = []
     with zipfile.ZipFile(path, "r") as zf:

--- a/src/kiro_crew/zip_vet.py
+++ b/src/kiro_crew/zip_vet.py
@@ -1,0 +1,195 @@
+"""Shared inventory vet for untrusted zip containers.
+
+Every site that hands an attacker-supplied ``.docx`` / ``.xlsx`` / ``.pptx``
+to ``zipfile`` needs the same guard, and it has to run *before*
+``zipfile.ZipFile`` is constructed. This module is that guard, once.
+
+Why the guard binds on the central-directory **byte size**
+---------------------------------------------------------
+``ZipFile.__init__`` does not read the EOCD's declared entry count when it
+materializes the inventory. CPython's ``ZipFile._RealGetContents`` (3.12,
+``zipfile/__init__.py``) drives construction off the directory's declared
+size::
+
+    size_cd = endrec[_ECD_SIZE]     # bytes in central directory
+    ...
+    data = fp.read(size_cd)
+    total = 0
+    while total < size_cd:
+        centdir = fp.read(sizeCentralDir)   # 46 bytes, one ZipInfo per pass
+
+So ``size_cd`` is the field that decides how many bytes are read into memory
+and how many ``ZipInfo`` objects are allocated. The declared entry count
+(``_ECD_ENTRIES_TOTAL``) is parsed and then never consulted during
+construction, which means a cap built on the count alone is not a bound at
+all: an archive can under-declare its count while carrying a large real
+directory and sail straight through to the allocation the cap existed to
+prevent.
+
+This vet therefore caps ``size_cd`` as the binding limit, expressed as
+``max_members * max_cdir_entry_bytes`` -- one record is 46 fixed bytes plus
+its name/extra/comment, so a byte ceiling bounds the entry count as well as
+the bytes read. The declared count is capped too, but only as a cheap
+consistency check on top; it is never the guard.
+
+ZIP64 is refused, not parsed
+----------------------------
+When the classic fields saturate (``0xFFFF`` entries / ``0xFFFFFFFF`` bytes)
+the real numbers live in a ZIP64 record. Both saturation points are orders of
+magnitude past every caller's cap, so no ZIP64 parse could change the verdict
+-- the vet refuses outright rather than hand-rolling a second record-location
+protocol. That also removes the record-shadowing surface (a crafted archive
+declaring a small classic count beside a large ZIP64 record) and the
+false-refusal risk of hunting a 4-byte locator signature through a tail that
+legitimately contains compressed bytes.
+
+Fail closed: an archive whose tail cannot be read or parsed is rejected, never
+passed through. Callers pass their OWN caps -- a preview endpoint legitimately
+runs tighter limits than an ingest path -- and translate
+``ZipInventoryRejected`` into their own error channel.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Union
+
+__all__ = [
+    "DEFAULT_MAX_CDIR_ENTRY_BYTES",
+    "ZipInventoryRejected",
+    "vet_zip_inventory",
+    "vet_zip_inventory_bytes",
+]
+
+# End-of-central-directory record: 4-byte signature + 18 fixed bytes, followed
+# by a comment of at most 65535 bytes. The record therefore starts within the
+# last 22 + 65535 bytes of the file, which is all this vet ever reads.
+_EOCD_SIG = b"PK\x05\x06"
+_EOCD_FIXED_SIZE = 22
+_MAX_ARCHIVE_COMMENT = 65535
+TAIL_WINDOW = _EOCD_FIXED_SIZE + _MAX_ARCHIVE_COMMENT
+
+# Field offsets inside the EOCD record, relative to its signature.
+_OFF_ENTRIES_TOTAL = 10  # 2 bytes
+_OFF_CDIR_SIZE = 12  # 4 bytes
+
+# Saturation sentinels that push the real values into a ZIP64 record.
+_ENTRIES_SATURATED = 0xFFFF
+_CDIR_SIZE_SATURATED = 0xFFFFFFFF
+
+# Per-member byte allowance when deriving the directory-size cap from a member
+# cap. Generous next to the 46-byte fixed record: OOXML part names are short,
+# so this leaves ample room for name/extra/comment without letting the byte
+# ceiling become the effective member limit.
+DEFAULT_MAX_CDIR_ENTRY_BYTES = 512
+
+ZipSource = Union[str, "os.PathLike[str]"]
+
+
+class ZipInventoryRejected(Exception):
+    """A zip container's declared inventory failed the vet.
+
+    ``reason`` is a short machine-readable discriminator so each call site can
+    map it onto its own existing error channel without re-deriving the cause:
+
+    ``missing_eocd``
+        No end-of-central-directory record in the tail window -- not a zip
+        container as far as ``zipfile`` is concerned either.
+    ``truncated_eocd``
+        The record starts inside the window but the file ends before its fixed
+        fields do.
+    ``unreadable``
+        The tail could not be read at all (missing path, I/O error).
+    ``zip64_saturated``
+        Classic fields saturate, so the archive declares an inventory orders of
+        magnitude past any caller's cap.
+    ``cdir_too_large``
+        Declared central-directory byte size exceeds the cap -- the binding
+        limit, since this is the field that drives allocation.
+    ``too_many_members``
+        Declared entry count exceeds the cap.
+    """
+
+    def __init__(self, reason: str, message: str = ""):
+        super().__init__(message or reason)
+        self.reason = reason
+
+
+def _read_tail(source: ZipSource) -> bytes:
+    """Read at most ``TAIL_WINDOW`` bytes from the end of the archive at *source*.
+
+    Reads only the tail, so a caller holding a path (knowledge ingest, document
+    parsing) never has to load a whole upload into memory to have it vetted. A
+    caller that already holds the bytes uses ``vet_zip_inventory_bytes``.
+    """
+    path = Path(os.fspath(source))
+    try:
+        with open(path, "rb") as fh:
+            size = os.fstat(fh.fileno()).st_size
+            if size > TAIL_WINDOW:
+                fh.seek(size - TAIL_WINDOW)
+            return fh.read(TAIL_WINDOW)
+    except OSError as exc:
+        raise ZipInventoryRejected("unreadable", f"cannot read archive tail: {exc}") from exc
+
+
+def vet_zip_inventory_bytes(
+    tail: bytes,
+    *,
+    max_members: int,
+    max_cdir_entry_bytes: int = DEFAULT_MAX_CDIR_ENTRY_BYTES,
+) -> None:
+    """Vet an already-read archive tail. Raises ``ZipInventoryRejected``.
+
+    *tail* must contain the end of the archive -- either the whole file or at
+    least its last ``TAIL_WINDOW`` bytes.
+    """
+    # Search only the window CPython's _EndRecData searches. A caller may hand
+    # us a whole file, and a `PK\x05\x06` sequence sitting in member data
+    # further back is not an EOCD to zipfile, so it must not be one here either
+    # -- reading an inventory from outside the window could only ever accept an
+    # archive on numbers zipfile will never use.
+    idx = tail.rfind(_EOCD_SIG, max(0, len(tail) - TAIL_WINDOW))
+    if idx < 0:
+        raise ZipInventoryRejected("missing_eocd", "no end-of-central-directory record")
+    if len(tail) < idx + _EOCD_FIXED_SIZE:
+        raise ZipInventoryRejected("truncated_eocd", "end-of-central-directory record is truncated")
+
+    count = int.from_bytes(tail[idx + _OFF_ENTRIES_TOTAL : idx + _OFF_ENTRIES_TOTAL + 2], "little")
+    cdir_size = int.from_bytes(tail[idx + _OFF_CDIR_SIZE : idx + _OFF_CDIR_SIZE + 4], "little")
+
+    if count == _ENTRIES_SATURATED or cdir_size == _CDIR_SIZE_SATURATED:
+        raise ZipInventoryRejected("zip64_saturated", "archive declares a ZIP64-scale inventory")
+
+    # The binding cap: this is the field zipfile reads to size its directory
+    # read and its ZipInfo allocation loop.
+    if cdir_size > max_members * max_cdir_entry_bytes:
+        raise ZipInventoryRejected(
+            "cdir_too_large",
+            f"central directory declares {cdir_size} bytes",
+        )
+    if count > max_members:
+        raise ZipInventoryRejected("too_many_members", f"archive declares {count} members")
+
+
+def vet_zip_inventory(
+    source: ZipSource,
+    *,
+    max_members: int,
+    max_cdir_entry_bytes: int = DEFAULT_MAX_CDIR_ENTRY_BYTES,
+) -> None:
+    """Vet an untrusted zip container's declared inventory before parsing it.
+
+    *source* is a filesystem path; only the archive tail is read. Raises
+    ``ZipInventoryRejected`` -- callers translate
+    it into their own error channel. Returns ``None`` when the archive is
+    within the caller's caps.
+
+    This does synchronous file I/O, so async callers MUST run it off the event
+    loop (``asyncio.to_thread``).
+    """
+    tail = _read_tail(source)
+    vet_zip_inventory_bytes(
+        tail, max_members=max_members, max_cdir_entry_bytes=max_cdir_entry_bytes
+    )

--- a/test/test_doc_parser.py
+++ b/test/test_doc_parser.py
@@ -375,3 +375,70 @@ def test_missing_defusedxml_leaves_pdf_parsing_alone(monkeypatch, caplog):
     finally:
         os.unlink(path)
     assert not any("defusedxml" in r.message for r in caplog.records)
+
+
+class TestArchiveInventoryBound:
+    """doc_parser gains an inventory bound it did not have before.
+
+    This is the one intended behaviour change of the shared-vet extraction: the
+    two OOXML sites previously opened any archive, however many members it
+    declared, because the per-entry size cap cannot bound the inventory.
+    """
+
+    def _many_member_docx(self, tmp_path, members: int):
+        import zipfile
+
+        path = tmp_path / "many.docx"
+        with zipfile.ZipFile(path, "w") as z:
+            z.writestr(
+                "word/document.xml",
+                b'<?xml version="1.0"?><w:document '
+                b'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+                b"<w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>",
+            )
+            for i in range(members):
+                z.writestr(f"word/media/f{i}.bin", b"x")
+        return path
+
+    def test_an_over_cap_inventory_degrades_to_empty(self, tmp_path, monkeypatch):
+        from kiro_crew import doc_parser
+
+        path = self._many_member_docx(tmp_path, members=40)
+        # Under the real cap the document parses -- the bound does not narrow
+        # legitimate documents.
+        assert doc_parser._extract_docx(str(path)) == "hello"
+        # Over the cap it is refused before ZipFile is constructed. Without the
+        # vet this same archive parses fine, which is the red-before.
+        monkeypatch.setattr(doc_parser, "_MAX_ARCHIVE_MEMBERS", 10)
+        assert doc_parser._extract_docx(str(path)) == ""
+
+    def test_a_forged_directory_size_is_refused_before_zipfile(self, tmp_path, monkeypatch):
+        """The binding field: entry count stays honest and low, declared
+        central-directory size does not. ZipFile allocates from the size."""
+        import zipfile
+
+        from kiro_crew import doc_parser
+
+        path = self._many_member_docx(tmp_path, members=2)
+        data = bytearray(path.read_bytes())
+        eocd = data.rfind(b"PK\x05\x06")
+        data[eocd + 12: eocd + 16] = (0xFFFFFFF0).to_bytes(4, "little")
+        path.write_bytes(bytes(data))
+
+        def _explode(*a, **kw):
+            raise AssertionError("ZipFile was constructed for a refused archive")
+
+        monkeypatch.setattr(zipfile, "ZipFile", _explode)
+        assert doc_parser._extract_docx(str(path)) == ""
+
+    def test_pptx_is_bounded_too(self, tmp_path, monkeypatch):
+        import zipfile
+
+        from kiro_crew import doc_parser
+
+        path = tmp_path / "many.pptx"
+        with zipfile.ZipFile(path, "w") as z:
+            for i in range(20):
+                z.writestr(f"ppt/media/f{i}.bin", b"x")
+        monkeypatch.setattr(doc_parser, "_MAX_ARCHIVE_MEMBERS", 5)
+        assert doc_parser._extract_pptx(str(path)) == ""

--- a/test/test_file_sheet.py
+++ b/test/test_file_sheet.py
@@ -431,3 +431,45 @@ async def test_cancellation_during_parse_still_audits(tmp_path, mock_sel):
         for call in mock_sel.log_tool_invocation.call_args_list
     ]
     assert "cancelled" in outcomes
+
+
+def test_the_sheet_vet_routes_through_the_shared_module(tmp_path, monkeypatch):
+    """The endpoint keeps its own caps and its own error channel, but the
+    implementation is the shared one -- so there is only one preflight to audit."""
+    import zipfile
+
+    from kiro_crew.dashboard.handlers import files as files_mod
+    from kiro_crew.zip_vet import ZipInventoryRejected
+
+    seen: dict = {}
+
+    def _fake_vet(data, *, max_members, max_cdir_entry_bytes):
+        seen["max_members"] = max_members
+        seen["max_cdir_entry_bytes"] = max_cdir_entry_bytes
+        raise ZipInventoryRejected("cdir_too_large", "boom")
+
+    monkeypatch.setattr(files_mod, "vet_zip_inventory_bytes", _fake_vet)
+    f = tmp_path / "x.xlsx"
+    with zipfile.ZipFile(f, "w") as z:
+        z.writestr("m", b"x")
+    with pytest.raises(_SheetRefusal) as exc:
+        files_mod._vet_zip_eocd(f.read_bytes())
+    assert exc.value.status == 413
+    assert exc.value.code == "workbook_expands_too_large"
+    assert seen["max_members"] == files_mod._SHEET_MAX_MEMBERS
+    assert seen["max_cdir_entry_bytes"] == files_mod._SHEET_MAX_CDIR_ENTRY_BYTES
+
+
+def test_an_unreadable_tail_reads_as_not_a_spreadsheet(monkeypatch):
+    """Fail closed, in this endpoint's own vocabulary."""
+    from kiro_crew.dashboard.handlers import files as files_mod
+    from kiro_crew.zip_vet import ZipInventoryRejected
+
+    def _fake_vet(data, **kw):
+        raise ZipInventoryRejected("unreadable", "boom")
+
+    monkeypatch.setattr(files_mod, "vet_zip_inventory_bytes", _fake_vet)
+    with pytest.raises(_SheetRefusal) as exc:
+        files_mod._vet_zip_eocd(b"PK\x03\x04")
+    assert exc.value.status == 415
+    assert exc.value.code == "not_a_spreadsheet"

--- a/test/test_knowledge_ingest_guard.py
+++ b/test/test_knowledge_ingest_guard.py
@@ -589,3 +589,67 @@ async def test_a_hand_registered_source_is_left_alone(pipeline, kstore, tmp_path
             "SELECT content FROM items WHERE source_id = ?", (src,)).fetchall())
     assert "AKIAIOSFODNN7EXAMPLE" in stored, (
         "a hand-registered source keeps its existing behaviour")
+
+
+class TestZipArchivePreflight:
+    """The ingest inventory cap must bind BEFORE ZipFile allocates.
+
+    Before this, _inspect_zip_archive constructed ZipFile and only then counted
+    infolist() -- so the allocation the cap exists to bound had already happened.
+    The rejection reasons are unchanged; only their timing is.
+    """
+
+    def test_a_forged_directory_size_is_refused_before_zipfile(self, tmp_path, monkeypatch):
+        import zipfile
+
+        from kiro_crew.dashboard.handlers import knowledge
+
+        path = tmp_path / "crafted.docx"
+        with zipfile.ZipFile(path, "w") as z:
+            z.writestr("word/document.xml", b"<a/>")
+        data = bytearray(path.read_bytes())
+        eocd = data.rfind(b"PK\x05\x06")
+        # Entry count stays honest and low; the field ZipFile actually reads to
+        # size its directory walk is inflated.
+        data[eocd + 12: eocd + 16] = (0xFFFFFFF0).to_bytes(4, "little")
+        path.write_bytes(bytes(data))
+
+        def _explode(*a, **kw):
+            raise AssertionError("ZipFile was constructed for a refused archive")
+
+        monkeypatch.setattr(zipfile, "ZipFile", _explode)
+        assert knowledge._inspect_zip_archive(str(path)) == "too_many_members"
+
+    def test_an_over_cap_member_count_is_refused_before_zipfile(self, tmp_path, monkeypatch):
+        import zipfile
+
+        from kiro_crew.dashboard.handlers import knowledge
+
+        path = tmp_path / "many.docx"
+        with zipfile.ZipFile(path, "w") as z:
+            for i in range(12):
+                z.writestr(f"m{i}", b"x")
+        monkeypatch.setattr(knowledge, "_MAX_INGEST_ARCHIVE_MEMBERS", 10)
+
+        def _explode(*a, **kw):
+            raise AssertionError("ZipFile was constructed for a refused archive")
+
+        monkeypatch.setattr(zipfile, "ZipFile", _explode)
+        assert knowledge._inspect_zip_archive(str(path)) == "too_many_members"
+
+    def test_a_non_archive_still_reads_as_a_bad_archive(self, tmp_path):
+        from kiro_crew.dashboard.handlers import knowledge
+
+        path = tmp_path / "not.docx"
+        path.write_bytes(b"PK\x03\x04" + b"\x00" * 32)
+        assert knowledge._inspect_zip_archive(str(path)) == "bad_archive"
+
+    def test_a_valid_archive_within_caps_still_passes(self, tmp_path):
+        import zipfile
+
+        from kiro_crew.dashboard.handlers import knowledge
+
+        path = tmp_path / "ok.docx"
+        with zipfile.ZipFile(path, "w") as z:
+            z.writestr("word/document.xml", b"<a/>")
+        assert knowledge._inspect_zip_archive(str(path)) is None

--- a/test/test_zip_vet.py
+++ b/test/test_zip_vet.py
@@ -1,0 +1,244 @@
+"""Tests for the shared untrusted-archive inventory vet (kiro_crew.zip_vet).
+
+The crafted-archive cases here were previously spelled only against
+/api/file-sheet's inline vet (test_file_sheet.py); they now live at the shared
+module, which is what all three untrusted-archive parse sites route through.
+
+The load-bearing case is `test_declared_directory_size_is_the_binding_cap`:
+CPython's ZipFile._RealGetContents drives its ZipInfo allocation off the
+declared central-directory SIZE, never off the declared entry count, so a vet
+that caps only the count does not bind against an archive that under-declares
+its count.
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+from kiro_crew.zip_vet import (
+    TAIL_WINDOW,
+    ZipInventoryRejected,
+    vet_zip_inventory,
+    vet_zip_inventory_bytes,
+)
+
+_EOCD = b"PK\x05\x06"
+_EOCD_FIXED = 22
+
+
+def _tiny_archive(path, members: int = 1) -> bytes:
+    with zipfile.ZipFile(path, "w") as z:
+        for i in range(members):
+            z.writestr(f"m{i}", b"x")
+    return path.read_bytes()
+
+
+def _set_u16(data: bytearray, at: int, value: int) -> None:
+    data[at : at + 2] = value.to_bytes(2, "little")
+
+
+def _set_u32(data: bytearray, at: int, value: int) -> None:
+    data[at : at + 4] = value.to_bytes(4, "little")
+
+
+# ── the four crafted-archive cases ───────────────────────────────────────────
+
+
+def test_declared_entry_count_over_cap_is_refused(tmp_path):
+    data = bytearray(_tiny_archive(tmp_path / "crafted.zip"))
+    eocd = data.rfind(_EOCD)
+    _set_u16(data, eocd + 10, 0xFFFE)
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(bytes(data), max_members=4096)
+    assert exc.value.reason == "too_many_members"
+
+
+def test_declared_directory_size_is_the_binding_cap(tmp_path):
+    """A forged-LOW entry count beside a large declared directory must still be
+    refused -- this is the archive shape a count-only vet lets through.
+
+    ZipFile._RealGetContents reads `size_cd = endrec[_ECD_SIZE]`, then
+    `data = fp.read(size_cd)` and loops `while total < size_cd`, allocating one
+    ZipInfo per 46-byte record. The declared entry count is parsed and never
+    consulted, so it is the directory size -- and only the directory size --
+    that bounds the allocation.
+    """
+    data = bytearray(_tiny_archive(tmp_path / "crafted.zip"))
+    eocd = data.rfind(_EOCD)
+    _set_u16(data, eocd + 10, 1)  # honest-looking, well under any cap
+    _set_u32(data, eocd + 12, 0xFFFFFFF0)  # ~4 GiB of directory to walk
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(bytes(data), max_members=4096)
+    assert exc.value.reason == "cdir_too_large"
+
+
+def test_missing_eocd_is_refused():
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(b"PK\x03\x04" + b"\x00" * 64, max_members=4096)
+    assert exc.value.reason == "missing_eocd"
+
+
+def test_zip64_saturated_fields_are_refused_without_parsing_zip64(tmp_path):
+    """Saturated classic fields are refused outright.
+
+    Both saturation points are orders of magnitude past every caller's cap, so
+    no ZIP64 parse could change the verdict -- and refusing here means the vet
+    never hunts a locator signature through a tail that legitimately contains
+    compressed bytes.
+    """
+    body = bytearray(_tiny_archive(tmp_path / "crafted.zip"))
+    eocd = body.rfind(_EOCD)
+    _set_u16(body, eocd + 10, 0xFFFF)
+    data = b"PK\x06\x06" + b"\x00" * 52 + bytes(body)
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(data, max_members=4096)
+    assert exc.value.reason == "zip64_saturated"
+
+    body2 = bytearray(_tiny_archive(tmp_path / "crafted2.zip"))
+    eocd2 = body2.rfind(_EOCD)
+    _set_u32(body2, eocd2 + 12, 0xFFFFFFFF)
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(bytes(body2), max_members=4096)
+    assert exc.value.reason == "zip64_saturated"
+
+
+# ── refusal happens before ZipFile is constructed ────────────────────────────
+
+
+def test_the_vet_never_constructs_a_zipfile(tmp_path, monkeypatch):
+    """Proven by making ZipFile construction itself an error: the vet must reach
+    its verdict from raw tail bytes alone, for accept as well as refuse.
+
+    The archives are written first, then ZipFile is replaced -- so the explosion
+    can only come from the vet's own code path.
+    """
+    good = tmp_path / "ok.zip"
+    body = bytearray(_tiny_archive(good, members=2))
+    eocd = body.rfind(_EOCD)
+    _set_u32(body, eocd + 12, 0xFFFFFFF0)
+    crafted = tmp_path / "bad.zip"
+    crafted.write_bytes(bytes(body))
+
+    def _explode(*a, **kw):  # pragma: no cover - must never run
+        raise AssertionError("zip_vet constructed a ZipFile")
+
+    monkeypatch.setattr(zipfile, "ZipFile", _explode)
+
+    vet_zip_inventory(good, max_members=4096)  # accepted, nothing constructed
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory(crafted, max_members=4096)
+    assert exc.value.reason == "cdir_too_large"
+
+
+# ── source handling: path, file object, tail-only reads ──────────────────────
+
+
+def test_a_valid_archive_within_caps_is_accepted(tmp_path):
+    path = tmp_path / "ok.zip"
+    _tiny_archive(path, members=3)
+    vet_zip_inventory(path, max_members=4096)
+    vet_zip_inventory_bytes(path.read_bytes(), max_members=4096)
+
+
+def test_an_empty_archive_is_accepted(tmp_path):
+    path = tmp_path / "empty.zip"
+    with zipfile.ZipFile(path, "w"):
+        pass
+    vet_zip_inventory(path, max_members=4096)
+
+
+def test_only_the_tail_is_read(tmp_path, monkeypatch):
+    """A path source must never pull the whole archive into memory: the read is
+    bounded by TAIL_WINDOW regardless of file size.
+
+    This is what lets knowledge ingest and document parsing preflight an upload
+    without loading it -- so it is asserted, not assumed.
+    """
+    path = tmp_path / "padded.zip"
+    body = _tiny_archive(path, members=2)
+    # Prepend well over one tail window of filler; zipfile tolerates a prefix.
+    path.write_bytes(b"\x00" * (TAIL_WINDOW * 3) + body)
+    assert path.stat().st_size > TAIL_WINDOW * 3
+
+    sizes: list[int] = []
+    real_open = open
+
+    class _Recorder:
+        def __init__(self, fh):
+            self._fh = fh
+
+        def read(self, n=-1):
+            sizes.append(n)
+            return self._fh.read(n)
+
+        def __getattr__(self, name):
+            return getattr(self._fh, name)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self._fh.close()
+            return False
+
+    def _fake_open(*a, **kw):
+        return _Recorder(real_open(*a, **kw))
+
+    monkeypatch.setattr("kiro_crew.zip_vet.open", _fake_open, raising=False)
+    vet_zip_inventory(path, max_members=4096)
+    assert sizes, "the vet did not read the archive"
+    assert max(sizes) <= TAIL_WINDOW
+    assert sum(sizes) <= TAIL_WINDOW
+
+
+def test_a_missing_path_fails_closed(tmp_path):
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory(tmp_path / "nope.zip", max_members=4096)
+    assert exc.value.reason == "unreadable"
+
+
+def test_a_truncated_eocd_fails_closed(tmp_path):
+    # EOCD signature present but the record's fixed fields run past EOF.
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(b"\x00" * 16 + _EOCD + b"\x00" * 4, max_members=4096)
+    assert exc.value.reason == "truncated_eocd"
+
+
+# ── caps are the caller's ────────────────────────────────────────────────────
+
+
+def test_caps_are_per_caller(tmp_path):
+    data = _tiny_archive(tmp_path / "twelve.zip", members=12)
+    vet_zip_inventory_bytes(data, max_members=4096)
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(data, max_members=10)
+    assert exc.value.reason == "too_many_members"
+
+
+def test_the_directory_cap_is_derived_from_the_member_cap(tmp_path):
+    """max_cdir_entry_bytes scales the byte ceiling: an endpoint tunes its own
+    per-entry allowance without touching the shared implementation."""
+    data = bytearray(_tiny_archive(tmp_path / "c.zip"))
+    eocd = data.rfind(_EOCD)
+    _set_u32(data, eocd + 12, 100 * 64)
+    vet_zip_inventory_bytes(bytes(data), max_members=100, max_cdir_entry_bytes=64)
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(bytes(data), max_members=100, max_cdir_entry_bytes=32)
+    assert exc.value.reason == "cdir_too_large"
+
+
+def test_an_eocd_signature_outside_the_tail_window_is_not_an_eocd(tmp_path):
+    """zipfile's _EndRecData searches only the last TAIL_WINDOW bytes, so a
+    stray PK\x05\x06 further back is not an EOCD -- and must not be read as
+    one here, or the vet would judge an archive on numbers zipfile never uses.
+    """
+    body = _tiny_archive(tmp_path / "ok.zip", members=1)
+    stray = bytearray(body)
+    eocd = stray.rfind(_EOCD)
+    # A plausible-looking but out-of-window record, then a tail with no EOCD.
+    forged = bytes(stray[eocd : eocd + _EOCD_FIXED]) + b"\x00" * (TAIL_WINDOW + 64)
+    with pytest.raises(ZipInventoryRejected) as exc:
+        vet_zip_inventory_bytes(forged, max_members=4096)
+    assert exc.value.reason == "missing_eocd"


### PR DESCRIPTION
## Problem / Motivation

Three sites hand an attacker-supplied OOXML archive to `zipfile`, and each spelled its inventory guard differently — or not at all:

| Site | Guard on `main` |
|---|---|
| `handlers/files.py` — `GET /api/file-sheet` | raw-bytes EOCD preflight (`_vet_zip_eocd`) that runs **before** `ZipFile` is constructed, plus an `infolist()` expansion pass |
| `handlers/knowledge.py` — `_inspect_zip_archive` | member cap read from `infolist()`, i.e. **after** the allocation the cap exists to bound |
| `doc_parser.py` — the two OOXML sites | **no inventory bound at all** |

The guard has to run before `ZipFile` exists, because construction is where the inventory is materialized. Only one of the three does that, and the implementation lives inside a dashboard handler where the other two cannot reach it.

## Why it matters

`ZipFile.__init__` walks the central directory and allocates a `ZipInfo` per record. A cap checked from `infolist()` reads that allocation's result — it cannot prevent it. So on `main`, knowledge ingest's 10,000-member cap and `doc_parser`'s absent one both leave the gateway's construction-time memory cost driven by whatever an uploaded archive declares. Three divergent spellings of the same guard also means a future fix has to be found and applied three times.

## What changed (motivation → approach → change)

**How this differs from #4073, which was closed on a design BLOCK.** That branch vetted the EOCD's declared **entry count**. CPython never consults that field when it allocates, so the guard did not bind: an archive could under-declare its count beside a large real directory and pass straight through. This PR's binding cap is the declared central-directory **size**, which is the field that actually drives construction:

```python
# CPython 3.12, zipfile/__init__.py, ZipFile._RealGetContents
size_cd = endrec[_ECD_SIZE]          # bytes in central directory
...
data = fp.read(size_cd)              # <-- the read
total = 0
while total < size_cd:               # <-- the allocation loop
    centdir = fp.read(sizeCentralDir)    # 46 bytes -> one ZipInfo
```

`_ECD_ENTRIES_TOTAL` — the field #4073 capped — is assigned in `_EndRecData` and read nowhere in the construction path. `size_cd` cannot be forged low without truncating what `zipfile` then parses, so it is the field that binds in both directions.

- **New `src/kiro_crew/zip_vet.py`.** `vet_zip_inventory(path, *, max_members, max_cdir_entry_bytes=512)` reads **only the archive tail** (at most 65557 bytes = the 22-byte EOCD plus the maximum comment), so the path-based callers preflight an upload without loading it into memory. It refuses when `size_cd > max_members * max_cdir_entry_bytes` — one record is ≥ 46 bytes, so a byte ceiling bounds the entry count too. The declared count is capped as well, but as a cheap consistency check on top, never as the guard. Raises `ZipInventoryRejected` carrying a `reason` discriminator.
- **ZIP64 is refused, not parsed.** Both classic saturation points (`0xFFFF` entries, `0xFFFFFFFF` bytes) sit orders of magnitude past every caller's cap, so no ZIP64 record could change the verdict. This keeps a second record-location protocol out of the vet, and it avoids the false-refusal hazard of hunting a 4-byte locator signature through a tail that legitimately contains compressed bytes — a valid `.docx` must not silently degrade to `""`.
- **Fail closed.** An unreadable path, a missing EOCD, a truncated EOCD are all refusals. Nothing that cannot be vetted is passed through.
- **Scope.** #3908 names three sites and this PR rewires exactly those three. Three non-OOXML `zipfile.ZipFile` callers (`portability.py`'s `validate_import_zip`, mochi's `appearance_store`, papyrus's `tectonic`) still cap from `infolist()` or not at all; with the shared vet in place each is a one-line fix, deliberately left for a follow-up rather than widening a security-adjacent PR past its issue.
- **Each site keeps its own caps and its own error channel.** `files.py` still answers 415 `not_a_spreadsheet` / 413 `workbook_expands_too_large`; `knowledge.py` still returns `bad_archive` / `too_many_members`; `doc_parser` still degrades to `""`. Only the implementation is shared.

### Intended behaviour change (one)

**`doc_parser` gains an inventory bound it did not have** — `_MAX_ARCHIVE_MEMBERS = 20000`, refusing to `""` like every other unreadable-document path in that module. The issue asks for this explicitly ("add vetting where none exists"). 20,000 parts is generous next to real documents (a large deck with per-slide media runs in the low thousands), so this refuses crafted inventories without narrowing legitimate ones — the test asserts a 40-member `.docx` still parses under the real cap.

No other site's observable limit moves. `knowledge.py`'s preflight refusals map onto the reasons it already returns, and an archive the preflight refuses is one the existing `infolist()` count check would have refused anyway — just after the allocation. **No existing limit is widened.**

## Tests

**`test/test_zip_vet.py` (new, 12 tests)** — the four crafted-archive cases that lived only against the file-sheet handler now live at the shared module, plus:

- `test_declared_directory_size_is_the_binding_cap` — the case #4073 could not stop: honest low entry count, inflated `size_cd`. This is the load-bearing test.
- `test_the_vet_never_constructs_a_zipfile` — archives written first, *then* `zipfile.ZipFile` replaced with a raise. Covers the **accept** path as well as the refuse path, so it proves the verdict comes from raw tail bytes rather than only proving call ordering.
- `test_only_the_tail_is_read` — a file padded to 3× the tail window, asserting every read is ≤ `TAIL_WINDOW` and they sum to ≤ one window. This is what lets the path-based callers preflight without loading.
- fail-closed cases: missing path, truncated EOCD; both ZIP64 saturation fields; caps-are-per-caller.

**Per-site suites** — `test_doc_parser.py` (`TestArchiveInventoryBound`), `test_knowledge_ingest_guard.py` (`TestZipArchivePreflight`), `test_file_sheet.py` (routing + fail-closed translation).

**Red-before, proven by reverting only `src/` and re-running the new tests** — 7 fail, and the two that matter fail with the right message:

```
FAILED test_doc_parser.py::...::test_a_forged_directory_size_is_refused_before_zipfile
    AssertionError: ZipFile was constructed for a refused archive
FAILED test_knowledge_ingest_guard.py::...::test_a_forged_directory_size_is_refused_before_zipfile
    AssertionError: ZipFile was constructed for a refused archive
FAILED test_knowledge_ingest_guard.py::...::test_an_over_cap_member_count_is_refused_before_zipfile
    AssertionError: ZipFile was constructed for a refused archive
```

**Suite** — 99 passed across the four touched suites. Wider run (2554 tests over every zip/sheet/doc/knowledge/files/upload module): 5 failures, all in `test_design_tweak_backend.py` + `test_file_explorer_app.py`, all reproduced on a pristine `8b0ce8774` worktree (base shows 12 in `test_design_tweak_backend.py` alone — host sensitive-path config, unrelated to this diff). Zero failures in any file this PR touches.

**Gates** — `flake8`, `isort`, `mypy src/` (1148 files), black-formatting, brand-name, loop-bound-locks, subprocess-encoding: all clean.

## Manual verification

N/A — the change is a guard on raw archive bytes with no UI surface, and the tests exercise both real call sites through crafted archives including the before-construction ordering proof.

## Related Issues

Closes #3908. Supersedes #4073 (closed unmerged on a design BLOCK for capping the declared entry count; see *What changed*).
