### PR TITLE
fix(auto-improvement): persist archive text as UTF-8

### DIFF
--- a/docs/system-specs/modules/auto-improvement.md
+++ b/docs/system-specs/modules/auto-improvement.md
@@ -927,6 +927,16 @@ sessions/<key>.json  chat-session records (resume)
 logs/
 ```
 
+All archive text is UTF-8, including raw candidate diffs and TSV descriptions. When an
+existing `results.tsv` is not valid UTF-8, Archive initialization fails closed with an
+error naming the file and the remedy — it never decodes with the current host locale,
+because an archive written under one legacy code page and opened under another would be
+silently transcoded to mojibake. An incomplete UTF-8 sequence at EOF is reported as a
+crash-torn append (recoverable by deleting the incomplete final line) rather than
+misread as legacy text. Agent output is not restricted to the gateway host's locale, so
+durable state must not inherit a legacy Windows code page that cannot represent the
+candidate text.
+
 Disposable clones and worktrees live **outside** `data/` under
 `~/.autoimprove-scratch` (override: `AUTO_IMPROVEMENT_SCRATCH`), because they are
 large, regenerable, and must not be mistaken for the durable record.

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/archive.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/archive.py
@@ -78,6 +78,15 @@ def _jsonable(obj):
     return obj
 
 
+class ArchiveEncodingError(ValueError):
+    """``results.tsv`` holds bytes that are not valid UTF-8.
+
+    Raised instead of guessing a codec: there is no in-band record of which
+    code page wrote a legacy file, so any locale-based decode can silently
+    corrupt it. The message names the file and the operator remedy.
+    """
+
+
 class Archive:
     """The on-disk ``results/`` archive. Append-only; reconstructable on restart."""
 
@@ -95,18 +104,47 @@ class Archive:
 
     def _ensure_tsv(self) -> None:
         if not self.tsv.exists():
-            self.tsv.write_text("\t".join(CONTROL_COLUMNS) + "\n")
+            self.tsv.write_text("\t".join(CONTROL_COLUMNS) + "\n", encoding="utf-8")
+            return
+
+        raw = self.tsv.read_bytes()
+        try:
+            raw.decode("utf-8")
+        except UnicodeDecodeError as error:
+            # Never decode with the CURRENT host locale: an archive written
+            # under one legacy code page and opened under another host would be
+            # silently transcoded to mojibake (CP1252 ``café`` read as CP1251
+            # becomes ``cafй``). There is no in-band record of which code page
+            # wrote the file, so any guess can corrupt it. Preserve the bytes
+            # untouched and fail closed with the remedy in the message.
+            if error.end == len(raw) and error.reason == "unexpected end of data":
+                # A crash can tear the final UTF-8 code point of an append;
+                # everything before the torn tail is intact.
+                hint = (
+                    "the final append looks crash-torn; delete the incomplete "
+                    "final line to recover the archive"
+                )
+            else:
+                hint = (
+                    "the file looks legacy-encoded; re-encode it to UTF-8 "
+                    "(e.g. `iconv -f <source-codepage> -t utf-8`) or move it "
+                    "aside to start a fresh archive"
+                )
+            raise ArchiveEncodingError(
+                f"{self.tsv} is not valid UTF-8 at byte {error.start}; "
+                f"the file was left untouched — {hint}."
+            ) from error
 
     # ── run metadata ────────────────────────────────────────────────────
 
     def write_meta(self, meta: dict) -> None:
-        self.meta_path.write_text(json.dumps(_jsonable(meta), indent=2))
+        self.meta_path.write_text(json.dumps(_jsonable(meta), indent=2), encoding="utf-8")
 
     def read_meta(self) -> dict:
         if not self.meta_path.exists():
             return {}
         try:
-            return json.loads(self.meta_path.read_text())
+            return json.loads(self.meta_path.read_text(encoding="utf-8"))
         except Exception:  # noqa: BLE001
             return {}
 
@@ -123,9 +161,11 @@ class Archive:
         # copy would defeat its only purpose. Nothing here is served raw: the read side
         # (`backend/routes.py:_redact_for_display`) credential-scans before the diff
         # reaches a browser, and every push path scans before anything leaves the host.
-        diff_path.write_text(diff or "")  # lgtm[py/clear-text-storage-sensitive-data]
+        diff_path.write_text(
+            diff or "", encoding="utf-8"
+        )  # lgtm[py/clear-text-storage-sensitive-data]
         json_path.write_text(  # lgtm[py/clear-text-storage-sensitive-data]
-            json.dumps(_jsonable(detail), indent=2)
+            json.dumps(_jsonable(detail), indent=2), encoding="utf-8"
         )
         return diff_path.name
 
@@ -153,9 +193,9 @@ class Archive:
             return text.replace("\t", " ").replace("\r", " ").replace("\n", " ")
 
         line = "\t".join(_cell(c) for c in CONTROL_COLUMNS)
-        with self.tsv.open("a") as f:
+        with self.tsv.open("a", encoding="utf-8") as f:
             f.write(line + "\n")
-        with self.jsonl.open("a") as f:
+        with self.jsonl.open("a", encoding="utf-8") as f:
             # Local plaintext archive row — same reasoning as `save_candidate` above.
             f.write(json.dumps(_jsonable(row)) + "\n")  # lgtm[py/clear-text-storage-sensitive-data]
 
@@ -167,7 +207,7 @@ class Archive:
         n = 0
         if not self.jsonl.exists():
             return 0
-        for line in self.jsonl.read_text().splitlines():
+        for line in self.jsonl.read_text(encoding="utf-8").splitlines():
             try:
                 n = max(n, int(json.loads(line).get("cycle", 0)))
             except Exception:  # noqa: BLE001
@@ -179,7 +219,7 @@ class Archive:
         excluding kept ones — the proposer's memory of strong near-misses."""
         rows: list[dict] = []
         if self.jsonl.exists():
-            for line in self.jsonl.read_text().splitlines():
+            for line in self.jsonl.read_text(encoding="utf-8").splitlines():
                 try:
                     rows.append(json.loads(line))
                 except Exception:  # noqa: BLE001
@@ -202,5 +242,6 @@ class Archive:
 
     def write_drift(self, cycle: int, payload: dict) -> None:
         (self.drift_dir / f"rebest-{cycle}.json").write_text(
-            json.dumps(_jsonable({"cycle": cycle, "ts": time.time(), **payload}), indent=2)
+            json.dumps(_jsonable({"cycle": cycle, "ts": time.time(), **payload}), indent=2),
+            encoding="utf-8",
         )

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_spine_archive_cov80.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_spine_archive_cov80.py
@@ -14,15 +14,38 @@ archive that positional readers parse.
 from __future__ import annotations
 
 import json
+import locale
 from dataclasses import dataclass
 from pathlib import Path
+
+import pytest
 
 from kiro_crew.apps.builtins.auto_improvement.spine.archive import (
     CONTROL_COLUMNS,
     Archive,
+    ArchiveEncodingError,
     _jsonable,
     _render_secondary,
 )
+
+
+def _simulate_legacy_locale(monkeypatch) -> None:
+    """Make encoding=None behave like a Windows legacy code page."""
+    real_open = Path.open
+
+    def legacy_open(
+        path,
+        mode="r",
+        buffering=-1,
+        encoding=None,
+        errors=None,
+        newline=None,
+    ):
+        if "b" not in mode and encoding in (None, "locale"):
+            encoding = "cp1252"
+        return real_open(path, mode, buffering, encoding, errors, newline)
+
+    monkeypatch.setattr(Path, "open", legacy_open)
 
 
 def _rows(archive: Archive) -> list[dict]:
@@ -99,6 +122,89 @@ class TestRunMetadata:
         archive = Archive(tmp_path / "results")
         archive.meta_path.write_text("{not json")
         assert archive.read_meta() == {}
+
+
+class TestDurableTextEncoding:
+    def test_legacy_tsv_fails_closed_and_is_not_corrupted_across_host_locales(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Written under codec A (cp1252), opened on a host whose locale is
+        # codec B (cp1251): the archive must never be transcoded by guess —
+        # cp1252 "café" decoded as cp1251 would silently become "cafй".
+        root = tmp_path / "results"
+        root.mkdir()
+        tsv = root / "results.tsv"
+        original = ("\t".join(CONTROL_COLUMNS) + "\n1\tlegacy\t\t\t\t\t\t\tcafé\t\t\n").encode(
+            "cp1252"
+        )
+        tsv.write_bytes(original)
+        monkeypatch.setattr(locale, "getpreferredencoding", lambda _do_setlocale=False: "cp1251")
+
+        with pytest.raises(ArchiveEncodingError, match="legacy-encoded"):
+            Archive(root)
+
+        assert tsv.read_bytes() == original
+        assert not list(root.glob(".results.tsv.*.tmp"))
+
+    def test_legacy_tsv_error_names_the_file_and_a_remedy(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        root = tmp_path / "results"
+        root.mkdir()
+        tsv = root / "results.tsv"
+        tsv.write_bytes(("café\n").encode("cp1252"))
+        monkeypatch.setattr(locale, "getpreferredencoding", lambda _do_setlocale=False: "cp1252")
+
+        with pytest.raises(ArchiveEncodingError) as excinfo:
+            Archive(root)
+
+        message = str(excinfo.value)
+        assert str(tsv) in message
+        assert "left untouched" in message
+        assert "utf-8" in message.lower()
+
+    def test_torn_utf8_tsv_is_not_misclassified_as_legacy(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        root = tmp_path / "results"
+        root.mkdir()
+        tsv = root / "results.tsv"
+        prefix = "\t".join(CONTROL_COLUMNS) + "\n1\tlegacy\t\t\t\t\t\t\tcafé "
+        original = prefix.encode("utf-8") + "🚀".encode("utf-8")[:3]
+        tsv.write_bytes(original)
+        monkeypatch.setattr(locale, "getpreferredencoding", lambda _do_setlocale=False: "cp1252")
+
+        with pytest.raises(ArchiveEncodingError, match="crash-torn") as excinfo:
+            Archive(root)
+
+        assert str(tsv) in str(excinfo.value)
+        assert tsv.read_bytes() == original
+        assert not list(root.glob(".results.tsv.*.tmp"))
+
+    def test_archive_round_trips_agent_text_under_a_legacy_locale(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        _simulate_legacy_locale(monkeypatch)
+        text = "東京 🚀"
+        archive = Archive(tmp_path / "results")
+
+        archive.write_meta({"label": text})
+        archive.save_candidate(cand_id="unicode", diff=f"+{text}\n", detail={"label": text})
+        archive.append_row(
+            {"cycle": 1, "cand_id": "unicode", "description": text, "primary_delta": -1}
+        )
+        archive.write_drift(1, {"reason": text})
+
+        reopened = Archive(archive.root)
+        assert reopened.read_meta()["label"] == text
+        assert reopened.top_k()[0]["description"] == text
+        assert text in (archive.candidates_dir / "unicode.diff").read_text(encoding="utf-8")
+        detail = json.loads((archive.candidates_dir / "unicode.json").read_text(encoding="utf-8"))
+        assert detail["label"] == text
+        cells = archive.tsv.read_text(encoding="utf-8").splitlines()[1].split("\t")
+        assert cells[CONTROL_COLUMNS.index("description")] == text
+        drift = json.loads((archive.drift_dir / "rebest-1.json").read_text(encoding="utf-8"))
+        assert drift["reason"] == text
 
 
 class TestArchiveLayout:


### PR DESCRIPTION
## Problem / Motivation

Auto Improvement archives candidate diffs, metadata, descriptions, JSONL summaries, and drift snapshots using the process locale's default text encoding. On Windows systems with a legacy code page, candidate content containing characters outside that code page (for example CJK text plus emoji) raises `UnicodeEncodeError` while the candidate is being preserved.

## Why it matters

Agent output and repository diffs may contain arbitrary Unicode. A locale-dependent archive can abort candidate preservation and leave resume/audit state incomplete on otherwise supported Windows hosts.

## What changed (motivation → approach → change)

The failure comes from Archive-owned text files relying on the platform default encoding. All text reads and writes in `Archive` now explicitly use UTF-8, while preserving the existing file formats and append/atomic-write behavior.

If an existing `results.tsv` is not valid UTF-8, `Archive` initialization now fails closed with `ArchiveEncodingError`, naming the file and the remedy. It never decodes with the current host locale: there is no record of which code page wrote a legacy file, so a locale guess could silently transcode it to mojibake (an archive written under CP1252 and opened on a CP1251 host would turn `café` into `cafй`). A crash-torn UTF-8 tail gets its own recovery hint (delete the incomplete final line) instead of being misread as legacy text.

A deterministic regression test simulates a legacy cp1252 locale and verifies round trips through metadata, raw diff and detail files, TSV and JSONL records, and drift snapshots. A second regression pins the fail-closed path: a cp1252-written TSV opened under a simulated cp1251 host locale raises and leaves the file byte-identical. The Auto Improvement system spec now records the UTF-8 persistence invariant.

## Tests

- Red-before regression: simulated legacy encoding raised `UnicodeEncodeError` while writing a CJK-plus-emoji candidate diff; the cross-locale tests fail against the previous locale-decode behavior (mutation-verified).
- `pytest src/kiro_crew/apps/builtins/auto_improvement/tests/test_spine_archive_cov80.py`: 31 passed.
- `pytest src/kiro_crew/apps/builtins/auto_improvement`: 1061 passed, 46 skipped.
- isort, flake8, black, `mypy`, and the full backend suite at exact pristine-main baseline parity.

## Manual verification

The original author's host preferred encoding is CP950. The same non-ASCII archive operation failed before the fix and succeeds with the explicit UTF-8 paths.

## Pattern harvest

Rule candidate: flag `write_text` / `read_text` / `open` calls on durable state files that omit an explicit `encoding=` argument — the platform default silently binds the file to the writing host's locale, which corrupts or crashes reads on any host with a different code page.

## Related Issues

no linked issue: direct correctness fix found on current `main`; no tracking issue was created.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
