### PR TITLE
fix(auto-improvement): persist PR queue text as UTF-8

### DIFF
--- a/docs/system-specs/modules/auto-improvement.md
+++ b/docs/system-specs/modules/auto-improvement.md
@@ -217,6 +217,11 @@ durable queue (`pr_queue/<fp>.diff`) for a human to look at rather than publishi
 silently-altered patch. PR *prose* is the opposite case — a rewritten sentence is still a
 valid sentence — so the title and body are redacted in place.
 
+Every PR-queue text artifact (the verified ``.diff`` and its ``.pr.md`` description) is
+written as UTF-8 by the GitHub recipe, the direct-commit fallback, and the dry-run recipe.
+Candidate content is arbitrary Unicode, so the durable queue must not depend on the host's
+legacy Windows code page.
+
 Note the two distinct failure modes for prose, which the first version conflated. "Scanned,
 and it had a hit" is redacted and ships. "Could not scan at all" is **not** the same thing,
 and it now raises `ProseRedactionUnavailable` so `draft()` degrades to the queue instead of

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
@@ -421,7 +421,7 @@ class GitHubPRRecipe:
         the morning-collection workflow keeps working offline.
         """
         self.pr_queue_dir.mkdir(parents=True, exist_ok=True)
-        (self.pr_queue_dir / f"{fingerprint}.diff").write_text(diff or "")
+        (self.pr_queue_dir / f"{fingerprint}.diff").write_text(diff or "", encoding="utf-8")
         body_path = self.pr_queue_dir / f"{fingerprint}.pr.md"
         # The title and body are agent-authored PROSE, so unlike the diff they can be
         # redacted without breaking anything the gate proved — a rewritten sentence is
@@ -436,14 +436,16 @@ class GitHubPRRecipe:
             summary = _redact_prose(summary)
             description = _strip_leading_h1(_redact_prose(description))
         except ProseRedactionUnavailable as exc:
-            body_path.write_text(f"# {summary}\n\n{_strip_leading_h1(description)}\n")
+            body_path.write_text(
+                f"# {summary}\n\n{_strip_leading_h1(description)}\n", encoding="utf-8"
+            )
             logger.warning(
                 "PR draft degraded to queue for %s: %s — prose was not published",
                 fingerprint,
                 exc,
             )
             return f"QUEUED:{fingerprint}"
-        body_path.write_text(f"# {summary}\n\n{description}\n")
+        body_path.write_text(f"# {summary}\n\n{description}\n", encoding="utf-8")
 
         if shutil.which("gh") is None:
             logger.info("gh CLI not on PATH — PR queued at %s", body_path)

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/pr_pipeline.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/pr_pipeline.py
@@ -356,7 +356,7 @@ class CrPipeline:
 
             qdir = Path(qdir)
             qdir.mkdir(parents=True, exist_ok=True)
-            (qdir / f"{fp}.diff").write_text(diff or "")
+            (qdir / f"{fp}.diff").write_text(diff or "", encoding="utf-8")
             # Same shape as the recipe's queue copy ("# <summary>\n\n<description>"); strip
             # a leading H1 in the description so we don't render two titles.
             body = description or ""
@@ -367,7 +367,7 @@ class CrPipeline:
             # never reached this writer — so a direct-committed fix's description was written
             # to a filename nothing reads and silently never rendered. Raised by the GPT
             # review of this branch.
-            (qdir / f"{fp}.pr.md").write_text(f"# {summary}\n\n{body}\n")
+            (qdir / f"{fp}.pr.md").write_text(f"# {summary}\n\n{body}\n", encoding="utf-8")
         except Exception:  # noqa: BLE001 — the queue copy is for display; never fatal
             self.log.debug("direct-commit queue-copy write failed for %s", fp, exc_info=True)
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/profile.py
@@ -642,12 +642,12 @@ class StubPRRecipe:
         parent_ref: str | None = None,
     ) -> str:
         self.queue_dir.mkdir(parents=True, exist_ok=True)
-        (self.queue_dir / f"{fingerprint}.diff").write_text(diff or "")
+        (self.queue_dir / f"{fingerprint}.diff").write_text(diff or "", encoding="utf-8")
         # `.pr.md` to match the real recipe and the display reader (routes/commit read
         # `<fp>.pr.md`); the stub's copy is never displayed, but keeping the name in step
         # avoids teaching a future maintainer the wrong convention.
         (self.queue_dir / f"{fingerprint}.pr.md").write_text(
-            f"# stub CR: {summary}\n\n{description}\n"
+            f"# stub CR: {summary}\n\n{description}\n", encoding="utf-8"
         )
         return f"QUEUED:{fingerprint}"
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from kiro_crew.apps.builtins.auto_improvement.profiles.github_repo import pr_recipe as pr
-from kiro_crew.apps.builtins.auto_improvement.spine.profile import PRRecipe
+from kiro_crew.apps.builtins.auto_improvement.spine.pr_pipeline import CrPipeline
+from kiro_crew.apps.builtins.auto_improvement.spine.profile import PRRecipe, StubPRRecipe
 
 
 def _broken_scanner(_text: str) -> str:
@@ -31,6 +34,94 @@ def _recipe(tmp_path: Path, **kw) -> pr.GitHubPRRecipe:
         base_ref=kw.pop("base_ref", "origin/main"),
         **kw,
     )
+
+
+def _simulate_legacy_locale(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make omitted ``Path.write_text`` encodings deterministic on every host."""
+    original = Path.write_text
+
+    def write_text(
+        path: Path,
+        data: str,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> int:
+        return original(
+            path,
+            data,
+            encoding="cp1252" if encoding is None else encoding,
+            errors=errors,
+            newline=newline,
+        )
+
+    monkeypatch.setattr(Path, "write_text", write_text)
+
+
+class TestQueueEncoding:
+    """Queue artifacts must preserve agent-authored Unicode on legacy Windows locales."""
+
+    _summary = "fix: 保存候選 🚀"
+    _description = "說明 🧪"
+    _diff = "+新增 🛠️\n"
+
+    def test_github_recipe_writes_utf8(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _simulate_legacy_locale(monkeypatch)
+        monkeypatch.setattr(pr.shutil, "which", lambda _name: None)
+        recipe = _recipe(tmp_path)
+
+        assert (
+            recipe.draft(
+                summary=self._summary,
+                description=self._description,
+                diff=self._diff,
+                fingerprint="github",
+            )
+            == "QUEUED:github"
+        )
+        assert (recipe.pr_queue_dir / "github.diff").read_text(encoding="utf-8") == self._diff
+        assert self._description in (recipe.pr_queue_dir / "github.pr.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_direct_commit_copy_writes_utf8(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _simulate_legacy_locale(monkeypatch)
+        queue = tmp_path / "direct"
+        pipeline = CrPipeline(ledger=MagicMock(), measurer=MagicMock())
+        profile = SimpleNamespace(pr_recipe=SimpleNamespace(pr_queue_dir=queue))
+
+        pipeline._write_queue_copy(
+            profile=profile,
+            fp="direct",
+            summary=self._summary,
+            description=self._description,
+            diff=self._diff,
+        )
+
+        assert (queue / "direct.diff").read_text(encoding="utf-8") == self._diff
+        assert self._description in (queue / "direct.pr.md").read_text(encoding="utf-8")
+
+    def test_dry_run_recipe_writes_utf8(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _simulate_legacy_locale(monkeypatch)
+        recipe = StubPRRecipe(tmp_path / "stub")
+
+        assert (
+            recipe.draft(
+                summary=self._summary,
+                description=self._description,
+                diff=self._diff,
+                fingerprint="stub",
+            )
+            == "QUEUED:stub"
+        )
+        assert (recipe.queue_dir / "stub.diff").read_text(encoding="utf-8") == self._diff
+        assert self._description in (recipe.queue_dir / "stub.pr.md").read_text(encoding="utf-8")
 
 
 class TestProtocolConformance:
@@ -341,6 +432,7 @@ class TestPushedContentIsScanned:
         from kiro_crew.apps.builtins.auto_improvement.profiles.github_repo import pr_recipe as PR
 
         recipe = _recipe(tmp_path)
+        _simulate_legacy_locale(monkeypatch)
 
         gh_calls: list[list[str]] = []
         monkeypatch.setattr(PR.subprocess, "run", lambda argv, **kw: gh_calls.append(argv))
@@ -351,16 +443,20 @@ class TestPushedContentIsScanned:
         monkeypatch.setattr(security_mod, "redact", _broken_scanner)
         out = recipe.draft(
             fingerprint="fp-unscannable",
-            summary="fix: something",
-            description="body with aws_access_key_id=AKIAIOSFODNN7EXAMPLE",
-            diff="--- a\n+++ b\n",
+            summary="fix: 保存候選 🚀",
+            description="說明 🧪 with aws_access_key_id=AKIAIOSFODNN7EXAMPLE",
+            diff="--- a\n+++ b\n+新增 🛠️\n",
         )
 
         assert out == "QUEUED:fp-unscannable", f"it published anyway: {out!r}"
         assert gh_calls == [], "gh was invoked with unscanned prose"
         # The evidence still survives on disk for the human.
-        assert (recipe.pr_queue_dir / "fp-unscannable.pr.md").is_file()
-        assert (recipe.pr_queue_dir / "fp-unscannable.diff").is_file()
+        assert "說明 🧪" in (recipe.pr_queue_dir / "fp-unscannable.pr.md").read_text(
+            encoding="utf-8"
+        )
+        assert "新增 🛠️" in (recipe.pr_queue_dir / "fp-unscannable.diff").read_text(
+            encoding="utf-8"
+        )
 
 
 class TestEveryPushPathScansContent:


### PR DESCRIPTION
## Problem / Motivation

Auto Improvement's durable PR queue writes verified diffs and PR descriptions with `Path.write_text` but no explicit encoding. On Windows systems using a legacy code page, agent-authored CJK or emoji content can raise `UnicodeEncodeError`; the direct-commit best-effort path can instead leave an empty queue artifact after swallowing the write failure.

## Why it matters

The PR queue is the recovery record when publishing is unavailable or refused. Candidate diffs and prose are arbitrary Unicode, so locale-dependent persistence can lose the only durable copy of an otherwise verified change.

## What changed (motivation → approach → change)

All seven PR-queue text writes now explicitly use UTF-8: the GitHub recipe's diff and both prose branches, the direct-commit queue copy, and the dry-run recipe. Existing file formats, ordering, redaction behavior, and exception semantics are unchanged. Deterministic tests force omitted encodings to cp1252 and verify Unicode round trips through all three producers, including the scanner-unavailable fallback.

## Tests

- Red-before: the three producer regressions failed under simulated cp1252; the direct writers raised `UnicodeEncodeError`, while the best-effort direct-commit copy left an empty diff.
- `pytest -q -n 0 .../tests/test_pr_recipe.py`: 63 passed.
- `pytest -q -n 0 src/kiro_crew/apps/builtins/auto_improvement`: 957 passed, 63 skipped.
- isort, flake8, mypy on the four changed Python files, documentation lint, and `git diff --check` passed.
- Two independent read-only reviews passed after adding scanner-failure Unicode coverage.

## Manual verification

The host's preferred encoding is CP950. The regression uses cp1252 explicitly so it remains deterministic on every platform and confirms both CJK and emoji survive UTF-8 decoding.

## Related Issues

N/A — direct correctness fix found on current `main`; no issue was created.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template currently contains only the OSPO placeholder and instructs contributors not to invent CLA text.