### PR TITLE
fix: run background sessions on the configured acp_backend (#6502)

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -39,22 +39,49 @@ Callers: heartbeat callback, taskrunner lesson extraction.
 
 ### Multiplexed _bg runtime
 
-`get_bg_session()` acquires a `_bg` handle, dispatching by provider backend and
-returning `AcpSessionHandle | _ProviderBgSession`. Provider dispatch is via
-`_bg_provider_is_kiro()`, which resolves the `kirocrew-lite` agent backend:
+`get_bg_session()` acquires a `_bg` handle, dispatching by `agent.acp_backend`
+and returning `AcpSessionHandle | _ProviderBgSession`. Dispatch is via
+`_bg_backend_supports_runtime()` — positive membership in
+`ACP_BACKENDS_ACP_RUNTIME`, never an inequality (harness parity):
 
-- **kiro (`acp`)** — the only backend the multiplexed `AcpRuntime` supports.
-  Each caller (title generation, suggestions, folders, nav) gets its **own**
-  ephemeral `sessionId` multiplexed on a single shared `_bg_runtime` (an
-  `AcpRuntime`, kiro-cli only), created lazily under `_bg_runtime_lock`.
+- **runtime-capable backend** (`ACP_BACKENDS_ACP_RUNTIME`) — each caller (title
+  generation, suggestions, folders, nav) gets its **own** ephemeral `sessionId`
+  multiplexed on a single shared `_bg_runtime` (an `AcpRuntime` spawned under
+  the CONFIGURED backend), created lazily under `_bg_runtime_lock`.
   `create_session()` runs **outside** the lock so independent callers aren't
   serialized. The runtime is respawned-and-retried once on `AcpRuntimeDead`
   (`max_retries=1`, 2 attempts total).
-- **non-kiro** — falls back to a `_ProviderBgSession` over the shared
-  `BACKGROUND_KEY` `_Session`, serialized by its `Semaphore(1)`. `AcpRuntime` is
-  kiro-only, so any non-kiro backend must use the provider path. In the public
-  KiroCrew edition `agent.provider` is fixed to `acp`, so this branch is the
-  dormant fallback for the reserved `ACP_BACKEND_CLAUDE` seam only.
+- **any other backend** — falls back to a `_ProviderBgSession` over the shared
+  `BACKGROUND_KEY` `_Session`, serialized by its `Semaphore(1)`. In the public
+  Kiro Crew edition `agent.provider` is fixed to `acp` and only kiro and KAS are
+  selectable, so this branch is the dormant fallback for the reserved
+  `ACP_BACKEND_CLAUDE` seam only.
+
+A backend switch displaces the cached `_bg_runtime`. The displacement policy
+has ONE implementation, `_displace_bg_runtime_locked()`, reached from
+`_retire_stale_backend_bg_runtime()` and from the mismatch check inside
+`get_bg_session()`'s runtime branch: a runtime whose `acp_backend` no longer
+matches config is killed if idle, and **parked on `_draining_bg_runtimes` if it
+has live or initializing handles** — parked runtimes never receive a new
+session (only `_bg_runtime` is offered to callers), their in-flight work
+finishes untouched (killing mid-turn would abort an in-flight title
+generation), and `_reap_drained_bg_runtimes_locked()` kills each once its last
+handle drains. Either way the slot is freed, so the very next background call
+runs under the configured backend even while the old runtime is still
+draining. Parked runtimes stay shielded from the orphan-PID sweep
+(`_companion_runtime_pids`), block the account-identity sweep's completeness
+(`_retire_kiro_bg_runtime`) while they drain, and are reaped by a periodic
+watchdog hook (`bg_drain_reap`) as the backstop for an idle gateway where no
+other trigger runs. `close_all()` detaches both holders atomically under
+`_bg_runtime_lock` and kills the detached snapshot; its counterpart `_closing`
+gate in `get_bg_session()` refuses to spawn or park once shutdown has started.
+Note there is currently no dashboard edit surface for
+`agent.acp_backend` (a file/CLI edit lands at the next gateway start, where
+`_cfg` is fresh); `refresh_defaults()` re-reads config, so any invocation of it
+picks up a backend change, and a future edit surface gets retirement for free
+by routing through it like the other `agent.*` defaults. The provider-path
+retirement trigger is dormant in the public edition for the same reason the
+`ACP_BACKEND_CLAUDE` branch is: every selectable backend is runtime-capable.
 
 Both paths yield `AcpEvent` through the shared
 `acp/_dispatch.parse_session_update` parser, so there is no behavioral drift

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -99,6 +99,9 @@ from kiro_crew import model_registry, platform_compat, shutdown_event
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_KIRO,
+    ACP_BACKENDS_ACP_RUNTIME,
+    ACP_BACKENDS_SELECTABLE,
     PROVIDER_LABEL_CLAUDE,
     PROVIDER_LABEL_DEFAULT,
 )
@@ -380,6 +383,13 @@ _MAX_CONCURRENT_COLD_STARTS = 4
 # consumer reading ``sess.agent`` (e.g. ``runtime_pids``) saw the background
 # session as agent-less.
 BACKGROUND_AGENT = "kirocrew-lite"
+
+# Backends the _bg runtime path may spawn under: runtime-capable AND
+# operator-selectable. Identical sets today, so the intersection is pure
+# defense-in-depth — a future runtime-capable preview harness that is not yet
+# selectable must not be spawnable by the background path from a config object
+# that skipped the loader's _normalize_acp_backend.
+_BG_RUNTIME_BACKENDS = ACP_BACKENDS_ACP_RUNTIME & ACP_BACKENDS_SELECTABLE
 
 # Heartbeat session key — used by HeartbeatService.  Spawned with the full
 # ``kirocrew`` agent so polled tasks can call read-only MCP tools (CR/ticket
@@ -1127,6 +1137,14 @@ class SessionManager:
         # Guards lazy creation of _bg_runtime so concurrent callers don't each
         # spawn a runtime and leak all but the last (orphaned subprocesses).
         self._bg_runtime_lock = asyncio.Lock()
+        # Runtimes displaced from _bg_runtime by a backend switch while they
+        # still had live handles. Parked here they can never receive a NEW
+        # session (only _bg_runtime is offered to callers), their in-flight
+        # work finishes untouched, and _reap_drained_bg_runtimes_locked kills
+        # each one once its last handle drains. Bounded in practice: a switch
+        # parks at most one runtime and every _bg call reap-checks the list.
+        # Mutated only under _bg_runtime_lock.
+        self._draining_bg_runtimes: list["AcpRuntime"] = []
 
         # ── Per-session subagent runtimes (session sharing) ──
         # Maps parent_session_key → shared AcpRuntime for that session's
@@ -1157,6 +1175,7 @@ class SessionManager:
                 CleanupHook("orphan_mcp", self._orphan_mcp_hook),
                 CleanupHook("rss_threshold", self._rss_threshold_check),
                 CleanupHook("stuck_turn", self._stuck_turn_check),
+                CleanupHook("bg_drain_reap", self._bg_drain_reap_hook),
             ]
         )
 
@@ -1174,7 +1193,10 @@ class SessionManager:
         their responses. The warm pool IS drained, because a pre-warmed provider
         was constructed by the old factory and would hand the stale default to
         the very next session — and unlike a live session, a pooled provider has
-        no conversation to lose.
+        no conversation to lose. The shared background runtime is retired when
+        its ``agent.acp_backend`` no longer matches the re-read config: killed
+        if idle, parked to drain if it has live handles (see
+        :meth:`_retire_stale_backend_bg_runtime`).
         """
         cfg = KiroCrewConfig.load()
         async with self._pool_fill_lock:
@@ -1197,6 +1219,13 @@ class SessionManager:
             self._pool_health_task.cancel()
             self._pool_health_task = None
         await self.start_pool(blocking=False)
+        # A backend switch also strands the shared background runtime: it
+        # captured agent.acp_backend at spawn, lives outside the session map,
+        # and is shielded from the orphan-PID sweep, so nothing else ever
+        # retires it. Idle → retired here; busy → left to drain (killing it
+        # would abort an in-flight title generation) and retired by the next
+        # trigger.
+        await self._retire_stale_backend_bg_runtime()
         logger.info(
             "Session defaults refreshed: model=%s effort=%r (live sessions untouched)",
             cfg.agent.model,
@@ -1289,7 +1318,7 @@ class SessionManager:
     async def _ensure_background(self) -> None:
         """Create the persistent background session if it doesn't exist."""
         async with self._lock:
-            if BACKGROUND_KEY in self._sessions:
+            if self._closing or BACKGROUND_KEY in self._sessions:
                 return
         # Create outside lock
         if not self._provider_factory:
@@ -1302,7 +1331,10 @@ class SessionManager:
             logger.warning("Failed to create background session", exc_info=True)
             return
         async with self._lock:
-            if BACKGROUND_KEY not in self._sessions:
+            # _closing is rechecked because the start above spans the window
+            # in which close_all takes its session snapshot: registering now
+            # would leak this provider past graceful shutdown.
+            if not self._closing and BACKGROUND_KEY not in self._sessions:
                 sess = _Session(
                     provider=provider,
                     first_turn=FirstTurnState.NOTHING_ARMED,
@@ -1310,39 +1342,229 @@ class SessionManager:
                 )
                 self._sessions[BACKGROUND_KEY] = sess
                 logger.info("Background session created")
-            else:
-                await provider.shutdown()
+                return
+        # Racing registration lost, or shutdown began while we were starting:
+        # tear the fresh provider down instead of registering it.
+        await provider.shutdown()
 
     # ── Warm Pool ──
 
-    def _bg_provider_is_kiro(self) -> bool:
-        """True when the ``kirocrew-lite`` ``_bg`` agent resolves to the kiro
-        (``acp``) backend — the only backend the multiplexed ``AcpRuntime``
-        supports. For non-kiro backends ``_bg`` falls back to the provider-backed
-        ``_Session`` path serialized by ``Semaphore(1)``.
+    def _configured_bg_backend_raw(self) -> str | None:
+        """The ``agent.acp_backend`` the config currently declares, or ``None``
+        when the config cannot answer (a raising property, a non-string test
+        double). ``None`` means "unknown", never "kiro": the displacement sites
+        skip on it, so an unreadable probe can never assert a backend it did
+        not read and displace a correctly-configured runtime.
         """
         try:
-            prov = getattr(self._cfg.agent, "provider", "acp") or "acp"
+            backend = getattr(self._cfg.agent, "acp_backend", ACP_BACKEND_KIRO)
         except Exception:
-            prov = "acp"
-        return prov == "acp"
+            logger.warning(
+                "agent.acp_backend is unreadable; treating the _bg backend as unknown",
+                exc_info=True,
+            )
+            return None
+        return backend if isinstance(backend, str) else None
+
+    def _configured_bg_backend(self) -> str:
+        """The ``agent.acp_backend`` background runtimes must spawn under.
+
+        Degrades an unknown reading to the default (kiro) backend — losing chat
+        titles and consolidation to a config edge is worse than running the
+        floor backend, and the loader has already normalized any persisted
+        value (``_normalize_acp_backend``). Displacement decisions use
+        :meth:`_configured_bg_backend_raw` instead, so the degrade can spawn
+        conservatively but never destroys an existing runtime.
+        """
+        backend = self._configured_bg_backend_raw()
+        return backend if backend is not None else ACP_BACKEND_KIRO
+
+    def _bg_backend_supports_runtime(self) -> bool:
+        """True when the configured ``agent.acp_backend`` is one the multiplexed
+        ``AcpRuntime`` can serve — positive membership in
+        ``ACP_BACKENDS_ACP_RUNTIME``, never an inequality (harness-parity). A
+        backend outside that set falls through to the provider-backed
+        ``_Session`` path serialized by ``Semaphore(1)``.
+        """
+        return self._configured_bg_backend() in _BG_RUNTIME_BACKENDS
+
+    async def _reap_drained_bg_runtimes_locked(self) -> None:
+        """Kill and drop parked runtimes whose last live handle has drained.
+
+        Caller MUST hold ``_bg_runtime_lock``. A runtime that is still busy
+        stays parked for the next pass; a failed kill also stays parked so the
+        process is retried rather than orphaned (its PID shield in
+        ``_companion_runtime_pids`` holds until it is reaped). ``kill()`` is
+        called even on an already-dead runtime — it releases the PID tracking
+        and sweep-protection bookkeeping.
+        """
+        remaining: list["AcpRuntime"] = []
+        for runtime in self._draining_bg_runtimes:
+            try:
+                busy = runtime.is_alive() and runtime.has_active_or_initializing_sessions()
+            except Exception:
+                # Fail toward preserving work, not toward recycling — a probe
+                # that cannot answer must not kill a runtime whose handles may
+                # be live. The runtime stays parked and is probed again next
+                # pass.
+                busy = True
+            if busy:
+                remaining.append(runtime)
+                continue
+            try:
+                await runtime.kill(expected=True)  # drained backend-switch teardown
+                logger.info("Reaped a drained _bg runtime spawned under the previous backend")
+            except Exception:
+                logger.warning("Failed to reap a drained _bg runtime; will retry", exc_info=True)
+                remaining.append(runtime)
+        self._draining_bg_runtimes = remaining
+
+    async def _displace_bg_runtime_locked(
+        self, runtime: "AcpRuntime", cached_backend: str, configured_backend: str
+    ) -> None:
+        """Displace *runtime* from the ``_bg_runtime`` slot after a backend switch.
+
+        Caller MUST hold ``_bg_runtime_lock`` and have established that
+        ``cached_backend != configured_backend``. The ONE implementation of the
+        displacement policy — ``get_bg_session`` and
+        ``_retire_stale_backend_bg_runtime`` both route through it so the two
+        paths cannot drift. An idle runtime is killed; a busy one (or one whose
+        kill failed) is parked on ``_draining_bg_runtimes`` — an in-flight title
+        generation belongs to a caller unrelated to the switch, and aborting it
+        trades a stale backend for a lost result. Either way the slot is freed,
+        so the next spawn runs under the configured backend. The busy probe
+        fails toward preserving work, not toward recycling: a raising probe
+        parks rather than kills.
+        """
+        try:
+            busy = runtime.has_active_or_initializing_sessions()
+        except Exception:
+            busy = True
+        if busy:
+            logger.info(
+                "Parking the _bg runtime (PID %s, backend %r) to drain after a "
+                "switch to backend %r",
+                runtime.pid,
+                cached_backend,
+                configured_backend,
+            )
+            self._draining_bg_runtimes.append(runtime)
+            if len(self._draining_bg_runtimes) > 1:
+                # Each entry is a live agent process shielded from the orphan
+                # sweep; more than one parked at a time means backend flapping
+                # is outpacing the drain, which should be visible, not silent.
+                logger.warning(
+                    "%d _bg runtimes are parked draining after backend switches",
+                    len(self._draining_bg_runtimes),
+                )
+        else:
+            logger.info(
+                "Recycling the _bg runtime (PID %s) spawned under backend %r; "
+                "configured backend is now %r",
+                runtime.pid,
+                cached_backend,
+                configured_backend,
+            )
+            try:
+                await runtime.kill(expected=True)  # deliberate backend-switch teardown
+            except Exception:
+                logger.warning(
+                    "Backend-switch kill failed; parking the runtime for the reaper",
+                    exc_info=True,
+                )
+                self._draining_bg_runtimes.append(runtime)
+        self._bg_runtime = None
+
+    async def _retire_stale_backend_bg_runtime(self) -> None:
+        """Retire a cached ``_bg_runtime`` spawned under a different backend.
+
+        The runtime captures ``agent.acp_backend`` at spawn, so after a backend
+        switch the cached process would keep serving background work (chat
+        titles, suggestions, consolidation) on the previous backend
+        indefinitely — it lives outside the session map and is shielded from
+        the orphan-PID sweep. The displacement policy itself lives in
+        :meth:`_displace_bg_runtime_locked`.
+
+        Runs whenever :meth:`refresh_defaults` re-reads config and from both
+        branches of ``get_bg_session`` — there is currently no dashboard edit
+        surface for ``agent.acp_backend`` (a file/CLI edit lands at the next
+        gateway start, where ``_cfg`` is fresh), so these calls are what pick
+        up a backend change on any gateway that DID observe one, and any
+        future edit surface gets the retirement by routing through
+        ``refresh_defaults`` like the other ``agent.*`` defaults.
+
+        Fails toward preserving work on a holder that does not declare a
+        string ``acp_backend`` (a test double, a future holder): it is left in
+        place rather than recycled on a backend it may never have had.
+
+        Takes ``_bg_runtime_lock`` for the same reason
+        ``_retire_kiro_bg_runtime`` does: creation is serialized by that lock,
+        so a lazy creation racing this check can neither install a runtime
+        mid-retirement nor be discarded half-installed.
+        """
+        async with self._bg_runtime_lock:
+            # close_all's locked detach may already have run; parking into the
+            # cleared list after it would strand a shielded process until the
+            # next-startup orphan reaper. One gate here covers every park this
+            # helper (and its refresh_defaults / provider-path callers) can do.
+            if self._closing:
+                return
+            await self._reap_drained_bg_runtimes_locked()
+            runtime = self._bg_runtime
+            if runtime is None:
+                return
+            cached_backend = getattr(runtime, "acp_backend", None)
+            if not isinstance(cached_backend, str):
+                return
+            configured = self._configured_bg_backend_raw()
+            if configured is None or cached_backend == configured:
+                return
+            await self._displace_bg_runtime_locked(runtime, cached_backend, configured)
+
+    async def _provider_backed_bg_session(self) -> "_ProviderBgSession":
+        """The ``_bg`` fallback for a backend the multiplexed runtime cannot
+        serve: a ``_ProviderBgSession`` over the shared ``BACKGROUND_KEY``
+        ``_Session``, serialized by its ``Semaphore(1)``."""
+        if self._closing:
+            # Typed for the same reason as get_bg_session's gates: a shutdown
+            # racing this path must classify as shutdown, not as the missing-
+            # session error below (which _ensure_background's own _closing
+            # no-op would otherwise surface as).
+            raise SessionClosingError("session manager is closing; no background session")
+        await self._ensure_background()
+        sess = self._sessions.get(BACKGROUND_KEY)
+        if sess is None:
+            raise RuntimeError("background session unavailable for non-kiro _bg provider")
+        return _ProviderBgSession(sess)
 
     async def get_bg_session(self) -> "AcpSessionHandle | _ProviderBgSession":
-        """Acquire a ``_bg`` session handle, dispatching by provider backend.
+        """Acquire a ``_bg`` session handle, dispatching by ``agent.acp_backend``.
 
-        kiro (``acp``) → ephemeral ``AcpSessionHandle`` on the shared multiplexed
-        ``AcpRuntime`` (each caller gets its own ``sessionId``; runtime creation
-        guarded by ``_bg_runtime_lock``; respawn-once on death). non-kiro →
-        ``_ProviderBgSession`` over the shared ``BACKGROUND_KEY`` ``_Session``
-        serialized by its ``Semaphore(1)``. Caller MUST call ``session.destroy()``
-        in a finally block when done.
+        Runtime-capable backend (``ACP_BACKENDS_ACP_RUNTIME``) → ephemeral
+        ``AcpSessionHandle`` on the shared multiplexed ``AcpRuntime`` spawned
+        under the configured backend (each caller gets its own ``sessionId``;
+        runtime creation guarded by ``_bg_runtime_lock``; respawn-once on
+        death). Any other backend → ``_ProviderBgSession`` over the shared
+        ``BACKGROUND_KEY`` ``_Session`` serialized by its ``Semaphore(1)``.
+        Caller MUST call ``session.destroy()`` in a finally block when done.
+
+        Raises :class:`SessionClosingError` during gateway shutdown — spawning
+        or parking past ``close_all``'s locked detach would leak a process
+        until the next-startup orphan reaper.
         """
-        if not self._bg_provider_is_kiro():
-            await self._ensure_background()
-            sess = self._sessions.get(BACKGROUND_KEY)
-            if sess is None:
-                raise RuntimeError("background session unavailable for non-kiro _bg provider")
-            return _ProviderBgSession(sess)
+        if self._closing:
+            # The typed error (not a bare RuntimeError) lets the handlers that
+            # special-case shutdown classify a restart-time title generation
+            # as a recognized shutdown rather than a generic failure.
+            raise SessionClosingError("session manager is closing; no background session")
+
+        if not self._bg_backend_supports_runtime():
+            # A cached runtime spawned under a previous runtime-capable backend
+            # is unreachable from the branch below, so no later runtime-path
+            # call can complete a retirement refresh_defaults() deferred while
+            # handles were live. Finish it here once those handles drain.
+            await self._retire_stale_backend_bg_runtime()
+            return await self._provider_backed_bg_session()
 
         # circular import: session -> acp.runtime -> acp.client -> session
         from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeDead
@@ -1350,7 +1572,33 @@ class SessionManager:
         max_retries = 1
         for attempt in range(max_retries + 1):
             async with self._bg_runtime_lock:
+                # Paired with close_all()'s locked detach: once _closing is
+                # set, spawning or parking here would install a runtime the
+                # shutdown sweep has already run past, leaking the process
+                # until the next-startup orphan reaper.
+                if self._closing:
+                    raise SessionClosingError("session manager is closing; no background session")
+                await self._reap_drained_bg_runtimes_locked()
                 runtime = self._bg_runtime
+                # Resolved ONCE per lock hold so the recycle decision and the
+                # spawn below cannot see two different values across awaits.
+                # The raw form gates displacement — an unreadable probe must
+                # never displace a correctly-configured runtime — while the
+                # degraded form feeds the capability recheck and the spawn.
+                configured_backend_raw = self._configured_bg_backend_raw()
+                configured_backend = (
+                    configured_backend_raw
+                    if configured_backend_raw is not None
+                    else ACP_BACKEND_KIRO
+                )
+                # Revalidated under the lock: the config can move to a backend
+                # the runtime cannot serve between the dispatch check above and
+                # this lock acquisition (dormant in the public edition, where
+                # every selectable backend is runtime-capable). Constructing a
+                # runtime under such a backend would misapply its credential /
+                # sandbox classification, so that caller is served through the
+                # provider path below instead.
+                runtime_capable = configured_backend in _BG_RUNTIME_BACKENDS
                 # Recycle a healthy-but-stale runtime (aged out or grown past
                 # its RSS threshold — see AcpRuntime._is_stale()) before the
                 # normal is_alive() respawn check. Only recycle when zero
@@ -1364,8 +1612,28 @@ class SessionManager:
                 # then raises AcpRuntimeDead and is backstopped by the
                 # max_retries respawn loop below (it costs one extra respawn, not
                 # a dropped prompt — a mid-prompt session is always registered).
-                if runtime is not None and runtime.is_alive():
-                    if not runtime.has_active_sessions():
+                if runtime_capable and runtime is not None and runtime.is_alive():
+                    # A runtime spawned under a previous agent.acp_backend must
+                    # not serve NEW background work after a switch — checked
+                    # BEFORE the busy branch, because under sustained load a
+                    # busy runtime never reaches a zero-session window and the
+                    # switch would otherwise never take effect. The displacement
+                    # policy (kill idle / park busy, always free the slot) lives
+                    # in _displace_bg_runtime_locked. Fails toward preserving
+                    # work on a holder that does not declare a string backend (a
+                    # test double) — it falls through to the staleness check
+                    # rather than being recycled on a backend it may never have
+                    # had.
+                    cached_backend = getattr(runtime, "acp_backend", None)
+                    if (
+                        configured_backend_raw is not None
+                        and isinstance(cached_backend, str)
+                        and cached_backend != configured_backend_raw
+                    ):
+                        await self._displace_bg_runtime_locked(
+                            runtime, cached_backend, configured_backend_raw
+                        )
+                    elif not runtime.has_active_sessions():
                         reason = await runtime._is_stale()
                         if reason:
                             logger.info(
@@ -1389,7 +1657,9 @@ class SessionManager:
                             len(runtime._session_queues),
                         )
 
-                if self._bg_runtime is None or not self._bg_runtime.is_alive():
+                if runtime_capable and (
+                    self._bg_runtime is None or not self._bg_runtime.is_alive()
+                ):
                     # Reap the dead runtime before replacing it — kill() releases
                     # its PID tracking + sweep-protection shield. Overwriting
                     # without kill would leak the process and its protected-PID.
@@ -1411,6 +1681,11 @@ class SessionManager:
                     runtime = AcpRuntime(
                         agent="kirocrew-lite",
                         sandbox_mode=getattr(self._cfg.agent, "sandbox", "auto"),
+                        # The runtime defaults to the kiro backend, so omitting
+                        # this pins background work (chat titles, suggestions,
+                        # tips, nav links, the model picker, consolidation) to
+                        # kiro-cli regardless of the configured backend.
+                        acp_backend=configured_backend,
                         # kirocrew-lite's config is written by Kiro Crew itself
                         # with an empty mcpServers map, so no MCP server can
                         # ever report on this runtime. Opting out keeps hot
@@ -1421,8 +1696,21 @@ class SessionManager:
                     )
                     await runtime.spawn()
                     self._bg_runtime = runtime
+                # Pinned under the lock: the selection made here must be the
+                # runtime this caller uses, whatever a concurrent displacement
+                # does to the slot afterwards — dereferencing self._bg_runtime
+                # outside the lock would turn that race into an AttributeError
+                # instead of the AcpRuntimeDead the retry loop handles.
+                selected = self._bg_runtime if runtime_capable else None
+            if selected is None:
+                # The capability recheck under the lock found a backend the
+                # runtime cannot serve. Displace the cached runtime through the
+                # retire helper (park/kill under its own lock hold), then serve
+                # this caller on the provider path.
+                await self._retire_stale_backend_bg_runtime()
+                return await self._provider_backed_bg_session()
             try:
-                return await self._bg_runtime.create_session(agent="kirocrew-lite")
+                return await selected.create_session(agent="kirocrew-lite")
             except AcpRuntimeDead:
                 if attempt >= max_retries:
                     raise
@@ -2130,9 +2418,11 @@ class SessionManager:
         - ``self._subagent_runtimes`` — companion runtimes multiplexing a parent
           session's subagents (alive for the parent's whole lifetime).
         - ``self._bg_runtime`` — the background runtime backing ``get_bg_session``
-          (kirocrew-lite title-gen / memory consolidation).
+          (kirocrew-lite title-gen / memory consolidation), plus any
+          ``_draining_bg_runtimes`` displaced by a backend switch while their
+          handles finish — killing one mid-drain is exactly what parking avoids.
 
-        Both are shielded from the sweep by unioning their live PIDs into the
+        All are shielded from the sweep by unioning their live PIDs into the
         active set here (mirrors ``_pool_pids``/``_in_flight_pids``). Only alive
         runtimes contribute — a dead entry SHOULD be reaped. Returns a copy.
         """
@@ -2143,12 +2433,12 @@ class SessionManager:
                     pids.add(runtime.pid)
             except Exception:
                 logger.debug("companion runtime pid probe failed", exc_info=True)
-        bg = self._bg_runtime
-        try:
-            if bg is not None and bg.is_alive() and isinstance(bg.pid, int):
-                pids.add(bg.pid)
-        except Exception:
-            logger.debug("bg runtime pid probe failed", exc_info=True)
+        for bg in [self._bg_runtime, *self._draining_bg_runtimes]:
+            try:
+                if bg is not None and bg.is_alive() and isinstance(bg.pid, int):
+                    pids.add(bg.pid)
+            except Exception:
+                logger.debug("bg runtime pid probe failed", exc_info=True)
         return pids
 
     _POOL_HEALTH_INTERVAL = 30  # seconds between health sweeps
@@ -4455,13 +4745,20 @@ class SessionManager:
         companion-runtime sweep carries: creation of this runtime is serialized by
         the same ``_bg_runtime_lock`` held here, so none can be installed during it.
 
-        Returns True when no kiro-backed background runtime remains.
+        Returns True when no kiro-backed background runtime remains — including
+        the ``_draining_bg_runtimes`` displaced by a backend switch: an idle one
+        is reaped here, and one still draining holds the old account alive, so
+        it blocks completeness the same way a busy ``_bg_runtime`` does.
         """
 
         async with self._bg_runtime_lock:
+            await self._reap_drained_bg_runtimes_locked()
+            complete = not any(
+                _provider_uses_kiro_identity_store(rt) for rt in self._draining_bg_runtimes
+            )
             runtime = self._bg_runtime
             if runtime is None or not _provider_uses_kiro_identity_store(runtime):
-                return True
+                return complete
             if runtime.has_active_or_initializing_sessions():
                 return False
             try:
@@ -4476,7 +4773,7 @@ class SessionManager:
             # reference in place rather than orphaning a live process.
             self._bg_runtime = None
             logger.info("Retired the background runtime started under the previous account")
-            return True
+            return complete
 
     async def remove_if_unclaimed(self, key: str) -> bool:
         """Remove *key* only if its speculative session is still unclaimed.
@@ -4742,12 +5039,23 @@ class SessionManager:
         # or warm-pool providers), so the session-shutdown loop below does not
         # cover them; without this they survive a graceful shutdown until the
         # next-startup orphan reaper.
-        if self._bg_runtime is not None:
-            try:
-                await self._bg_runtime.kill(expected=True)  # graceful shutdown
-            except Exception:
-                logger.debug("close_all: _bg_runtime kill failed", exc_info=True)
+        # Detach BOTH background-runtime holders under their lock so a
+        # get_bg_session racing shutdown can neither install nor park a
+        # runtime into a snapshot this sweep has already run past (its own
+        # _closing gate refuses once the flag is up), and no concurrent reap
+        # can rebind the list mid-iteration. Kills run on the detached
+        # snapshot outside the lock so a wedged kill cannot hold it.
+        async with self._bg_runtime_lock:
+            _bg_doomed = [
+                rt for rt in (self._bg_runtime, *self._draining_bg_runtimes) if rt is not None
+            ]
             self._bg_runtime = None
+            self._draining_bg_runtimes = []
+        for _bg_rt in _bg_doomed:
+            try:
+                await _bg_rt.kill(expected=True)  # graceful shutdown
+            except Exception:
+                logger.debug("close_all: _bg runtime kill failed", exc_info=True)
         for _key in list(self._subagent_runtimes):
             try:
                 await self.release_subagent_runtime(_key)
@@ -5679,6 +5987,26 @@ class SessionManager:
             await self._expire_idle(self._idle_timeout)
         except Exception:
             logger.exception("Cleanup loop: _expire_idle crashed; continuing")
+
+    async def _bg_drain_reap_hook(self) -> None:
+        """Periodic backstop for parked backend-switch runtimes.
+
+        Every other reap trigger (``get_bg_session``, ``refresh_defaults``, the
+        identity sweep) requires someone to CALL it; on an otherwise idle
+        gateway a parked runtime whose last handle drained would sit shielded
+        from the orphan sweep indefinitely. Cheap no-op when nothing is parked
+        (the common case) — the lock is only taken when the list is non-empty.
+        """
+        if not self._draining_bg_runtimes:
+            return
+        try:
+            async with self._bg_runtime_lock:
+                await self._reap_drained_bg_runtimes_locked()
+        except Exception:
+            # CleanupHook contract: the hook owns its error handling. The
+            # dispatcher's backstop logs at debug only, which would hide a
+            # permanently failing reap — the one case this hook exists for.
+            logger.warning("bg_drain_reap hook failed; will retry next tick", exc_info=True)
 
     async def _orphan_mcp_hook(self) -> None:
         """Sweep MCP servers orphaned by crashed/expired sessions. Preserves the

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -10,12 +10,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro_crew.acp.types import AcpPromptStats
+from kiro_crew.acp.types import ACP_BACKEND_KAS, ACP_BACKEND_KIRO, AcpPromptStats
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.session import (
     _BG_BLIND_RECYCLE_PROMPTS,
     BACKGROUND_KEY,
+    SessionClosingError,
     SessionManager,
 )
 
@@ -4357,6 +4358,449 @@ class TestGetBgSessionRecycle:
         # offloaded _is_stale() probe.
         stale._is_stale.assert_not_awaited()
         assert result is sentinel
+        await mgr.close_all()
+
+
+class TestGetBgSessionBackendSwitch:
+    """The _bg runtime spawns under the CONFIGURED ``agent.acp_backend``, and a
+    cached runtime spawned under a different backend is recycled once idle —
+    otherwise background work (chat titles, suggestions, consolidation) keeps
+    running the previous backend indefinitely."""
+
+    @staticmethod
+    def _fresh_runtime():
+        rt = AsyncMock()
+        rt.spawn = AsyncMock()
+        rt.is_alive = lambda: True
+        rt.create_session = AsyncMock(return_value=object())
+        return rt
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("backend", [ACP_BACKEND_KIRO, ACP_BACKEND_KAS])
+    async def test_runtime_spawns_under_the_configured_backend(self, cfg, backend):
+        cfg.agent.acp_backend = backend
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        rt = self._fresh_runtime()
+
+        with patch("kiro_crew.acp.runtime.AcpRuntime", return_value=rt) as ctor:
+            result = await mgr.get_bg_session()
+
+        assert ctor.call_args.kwargs["acp_backend"] == backend
+        assert result is rt.create_session.return_value
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_recycles_an_idle_runtime_spawned_under_a_different_backend(self, cfg):
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        stranded = AsyncMock()
+        stranded.is_alive = lambda: True
+        stranded.has_active_sessions = lambda: False
+        stranded.has_active_or_initializing_sessions = lambda: False
+        stranded.acp_backend = ACP_BACKEND_KIRO  # spawned before the switch
+        stranded._is_stale = AsyncMock(return_value=None)  # must NOT be consulted
+        stranded.kill = AsyncMock()
+        stranded.pid = 333
+        mgr._bg_runtime = stranded
+
+        rt2 = self._fresh_runtime()
+        with patch("kiro_crew.acp.runtime.AcpRuntime", return_value=rt2) as ctor:
+            result = await mgr.get_bg_session()
+
+        stranded.kill.assert_awaited_once()  # mismatched + idle → recycled
+        stranded._is_stale.assert_not_awaited()  # mismatch outranks staleness
+        assert ctor.call_args.kwargs["acp_backend"] == ACP_BACKEND_KAS
+        assert result is rt2.create_session.return_value
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_a_busy_mismatched_runtime_is_parked_and_never_serves_a_new_caller(self, cfg):
+        """A post-switch caller must never create_session() on the old-backend
+        runtime — under sustained load a busy runtime never reaches a
+        zero-session window, so waiting for one would let the switch never
+        take effect. Its in-flight handles are not killed either."""
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        busy = AsyncMock()
+        busy.is_alive = lambda: True
+        busy.has_active_sessions = lambda: True
+        busy.has_active_or_initializing_sessions = lambda: True
+        busy.acp_backend = ACP_BACKEND_KIRO  # spawned before the switch
+        busy.kill = AsyncMock()
+        busy.create_session = AsyncMock()
+        busy.pid = 335
+        mgr._bg_runtime = busy
+
+        rt2 = self._fresh_runtime()
+        with patch("kiro_crew.acp.runtime.AcpRuntime", return_value=rt2) as ctor:
+            result = await mgr.get_bg_session()
+
+        busy.kill.assert_not_awaited()  # live handles are never killed
+        busy.create_session.assert_not_awaited()  # new work goes to the new runtime
+        assert busy in mgr._draining_bg_runtimes
+        assert ctor.call_args.kwargs["acp_backend"] == ACP_BACKEND_KAS
+        assert result is rt2.create_session.return_value
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_a_parked_runtime_is_reaped_once_its_handles_drain(self, cfg):
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        drained = AsyncMock()
+        drained.is_alive = lambda: True
+        drained.has_active_or_initializing_sessions = lambda: False
+        drained.kill = AsyncMock()
+        mgr._draining_bg_runtimes = [drained]
+
+        still_busy = AsyncMock()
+        still_busy.is_alive = lambda: True
+        still_busy.has_active_or_initializing_sessions = lambda: True
+        still_busy.kill = AsyncMock()
+        mgr._draining_bg_runtimes.append(still_busy)
+
+        rt = self._fresh_runtime()
+        with patch("kiro_crew.acp.runtime.AcpRuntime", return_value=rt):
+            await mgr.get_bg_session()
+
+        drained.kill.assert_awaited_once()  # drained → reaped
+        still_busy.kill.assert_not_awaited()  # busy → stays parked
+        assert mgr._draining_bg_runtimes == [still_busy]
+        mgr._draining_bg_runtimes = []
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_reap_keeps_the_runtime_parked(self, cfg):
+        """Dropping a parked runtime whose kill failed would orphan a possibly
+        live process outside every sweep; keeping it parked retries the kill
+        on the next pass."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        stuck = AsyncMock()
+        stuck.is_alive = lambda: True
+        stuck.has_active_or_initializing_sessions = lambda: False
+        stuck.kill = AsyncMock(side_effect=RuntimeError("boom"))
+        mgr._draining_bg_runtimes = [stuck]
+
+        async with mgr._bg_runtime_lock:
+            await mgr._reap_drained_bg_runtimes_locked()
+
+        assert mgr._draining_bg_runtimes == [stuck]
+        mgr._draining_bg_runtimes = []
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_matching_backend_is_reused_not_recycled(self, cfg):
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        cached = AsyncMock()
+        cached.is_alive = lambda: True
+        cached.has_active_sessions = lambda: False
+        cached.acp_backend = ACP_BACKEND_KAS
+        cached._is_stale = AsyncMock(return_value=None)
+        cached.kill = AsyncMock()
+        cached.pid = 334
+        sentinel = object()
+        cached.create_session = AsyncMock(return_value=sentinel)
+        mgr._bg_runtime = cached
+
+        with patch(
+            "kiro_crew.acp.runtime.AcpRuntime",
+            side_effect=AssertionError("should not respawn a matching runtime"),
+        ):
+            result = await mgr.get_bg_session()
+
+        cached.kill.assert_not_awaited()
+        assert result is sentinel
+        await mgr.close_all()
+
+
+class TestRetireStaleBackendBgRuntime:
+    """A backend switch retires the cached _bg runtime only once its live
+    handles drain — killing it mid-turn would abort an in-flight title
+    generation belonging to a caller unrelated to the switch."""
+
+    @staticmethod
+    def _runtime(*, backend, busy):
+        rt = AsyncMock()
+        rt.acp_backend = backend
+        rt.has_active_or_initializing_sessions = lambda: busy
+        rt.kill = AsyncMock()
+        rt.pid = 444
+        return rt
+
+    @pytest.mark.asyncio
+    async def test_idle_mismatched_runtime_is_retired(self, cfg):
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        rt = self._runtime(backend=ACP_BACKEND_KIRO, busy=False)
+        mgr._bg_runtime = rt
+
+        await mgr._retire_stale_backend_bg_runtime()
+
+        rt.kill.assert_awaited_once()
+        assert mgr._bg_runtime is None
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_a_live_handle_is_never_killed_by_a_backend_switch(self, cfg):
+        """The busy runtime is parked to drain — its slot is freed so new work
+        runs under the configured backend, but its in-flight handles finish."""
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        rt = self._runtime(backend=ACP_BACKEND_KIRO, busy=True)
+        mgr._bg_runtime = rt
+
+        await mgr._retire_stale_backend_bg_runtime()
+
+        rt.kill.assert_not_awaited()
+        assert mgr._bg_runtime is None
+        assert rt in mgr._draining_bg_runtimes
+        mgr._draining_bg_runtimes = []
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_matching_backend_is_left_alone(self, cfg):
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        rt = self._runtime(backend=ACP_BACKEND_KAS, busy=False)
+        mgr._bg_runtime = rt
+
+        await mgr._retire_stale_backend_bg_runtime()
+
+        rt.kill.assert_not_awaited()
+        assert mgr._bg_runtime is rt
+        mgr._bg_runtime = None
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_on_a_holder_without_a_string_backend(self, cfg):
+        """A holder that does not declare a string acp_backend (a test double,
+        a future holder) is left running rather than recycled on a backend it
+        may never have had."""
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        rt = self._runtime(backend=object(), busy=False)
+        mgr._bg_runtime = rt
+
+        await mgr._retire_stale_backend_bg_runtime()
+
+        rt.kill.assert_not_awaited()
+        assert mgr._bg_runtime is rt
+        mgr._bg_runtime = None
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_kill_parks_the_runtime_for_the_reaper(self, cfg):
+        """Dropping the reference after a failed kill would orphan a live
+        process outside every sweep; parking it retries the kill later while
+        keeping its PID shielded."""
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        rt = self._runtime(backend=ACP_BACKEND_KIRO, busy=False)
+        rt.kill = AsyncMock(side_effect=RuntimeError("boom"))
+        mgr._bg_runtime = rt
+
+        await mgr._retire_stale_backend_bg_runtime()
+
+        assert mgr._bg_runtime is None
+        assert rt in mgr._draining_bg_runtimes
+        mgr._draining_bg_runtimes = []
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_refresh_defaults_triggers_the_retirement(self, cfg):
+        """refresh_defaults() re-reads config, so any invocation of it (and any
+        future agent.acp_backend edit surface routed through it) must also run
+        the retirement check."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        with (
+            patch.object(mgr, "start_pool", AsyncMock()),
+            patch.object(mgr, "_retire_stale_backend_bg_runtime", AsyncMock()) as retire,
+            patch("kiro_crew.session.build_provider_factory", return_value=MagicMock()),
+            patch("kiro_crew.session.KiroCrewConfig.load", return_value=cfg),
+        ):
+            await mgr.refresh_defaults()
+
+        retire.assert_awaited_once()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_identity_sweep_incomplete_while_a_parked_runtime_drains(self, cfg):
+        """A parked runtime still runs under the previous account, so the
+        identity baseline must not advance past it (advancing would record the
+        switch as handled and no later turn would re-sweep); once its handles
+        drain it is reaped and completeness is restored."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        parked = AsyncMock()
+        parked.uses_kiro_identity_store = True
+        parked.is_alive = lambda: True
+        parked.has_active_or_initializing_sessions = lambda: True
+        parked.kill = AsyncMock()
+        mgr._draining_bg_runtimes = [parked]
+
+        assert await mgr._retire_kiro_bg_runtime() is False
+        parked.kill.assert_not_awaited()
+
+        parked.has_active_or_initializing_sessions = lambda: False
+        assert await mgr._retire_kiro_bg_runtime() is True
+        parked.kill.assert_awaited_once()
+        assert mgr._draining_bg_runtimes == []
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_periodic_hook_reaps_a_drained_parked_runtime(self, cfg):
+        """The watchdog hook is the backstop for an idle gateway where no
+        background call, refresh, or identity sweep ever runs the other reap
+        triggers — without it a drained parked runtime sits shielded from the
+        orphan sweep indefinitely."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        assert any(h.name == "bg_drain_reap" for h in mgr._watchdog._hooks)
+
+        drained = AsyncMock()
+        drained.is_alive = lambda: True
+        drained.has_active_or_initializing_sessions = lambda: False
+        drained.kill = AsyncMock()
+        mgr._draining_bg_runtimes = [drained]
+
+        await mgr._bg_drain_reap_hook()
+
+        drained.kill.assert_awaited_once()
+        assert mgr._draining_bg_runtimes == []
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_close_all_kills_the_slot_and_every_parked_runtime(self, cfg):
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        slot = AsyncMock()
+        slot.kill = AsyncMock()
+        parked = AsyncMock()
+        parked.kill = AsyncMock()
+        mgr._bg_runtime = slot
+        mgr._draining_bg_runtimes = [parked]
+
+        await mgr.close_all()
+
+        slot.kill.assert_awaited_once()
+        parked.kill.assert_awaited_once()
+        assert mgr._bg_runtime is None
+        assert mgr._draining_bg_runtimes == []
+
+    @pytest.mark.asyncio
+    async def test_get_bg_session_refuses_while_closing(self, cfg):
+        """A runtime spawned or parked after close_all's locked detach would
+        leak until the next-startup orphan reaper. The error is the typed
+        SessionClosingError so shutdown-aware handlers classify it."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        mgr._closing = True
+
+        with pytest.raises(SessionClosingError):
+            await mgr.get_bg_session()
+
+        mgr._closing = False
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_retire_helper_does_not_park_while_closing(self, cfg):
+        """refresh_defaults (or the provider path) racing close_all must not
+        append to a draining list the shutdown sweep has already cleared."""
+        cfg.agent.acp_backend = ACP_BACKEND_KAS
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        rt = self._runtime(backend=ACP_BACKEND_KIRO, busy=True)
+        mgr._bg_runtime = rt
+        mgr._closing = True
+
+        await mgr._retire_stale_backend_bg_runtime()
+
+        assert mgr._draining_bg_runtimes == []
+        assert mgr._bg_runtime is rt  # left for close_all's own detach
+        mgr._closing = False
+        mgr._bg_runtime = None
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_backend_never_displaces_a_cached_runtime(self, cfg):
+        """An unreadable probe must not assert a backend it did not read: a
+        correctly-configured KAS runtime survives a config edge instead of
+        being invisibly recycled onto kiro."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        class _Boom:
+            @property
+            def acp_backend(self):
+                raise RuntimeError("config exploded")
+
+        from types import SimpleNamespace
+
+        mgr._cfg = SimpleNamespace(agent=_Boom())
+        rt = self._runtime(backend=ACP_BACKEND_KAS, busy=False)
+        mgr._bg_runtime = rt
+
+        await mgr._retire_stale_backend_bg_runtime()
+
+        rt.kill.assert_not_awaited()
+        assert mgr._bg_runtime is rt
+        assert mgr._draining_bg_runtimes == []
+        mgr._bg_runtime = None
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_backend_moving_under_the_lock_falls_back_to_the_provider_path(self, cfg):
+        """If the config moves to a backend the runtime cannot serve between
+        dispatch and the lock, the caller must not get a runtime constructed
+        under a backend it cannot classify — it is served through the
+        provider-backed path instead."""
+        cfg.agent.acp_backend = "claude"  # non-runtime; assigned directly, loader normalizes
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        provider_handle = object()
+
+        with (
+            # Dispatch saw a runtime-capable backend...
+            patch.object(mgr, "_bg_backend_supports_runtime", lambda: True),
+            # ...but the in-lock revalidation reads the moved config and must
+            # divert to the provider path without constructing a runtime.
+            patch.object(
+                mgr, "_provider_backed_bg_session", AsyncMock(return_value=provider_handle)
+            ),
+            patch(
+                "kiro_crew.acp.runtime.AcpRuntime",
+                side_effect=AssertionError("must not construct a runtime for a moved backend"),
+            ),
+        ):
+            result = await mgr.get_bg_session()
+
+        assert result is provider_handle
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_ensure_background_does_not_register_a_provider_while_closing(self, cfg):
+        """A provider whose start spans close_all's session snapshot must be
+        torn down, not registered — a session registered after the snapshot
+        escapes graceful cleanup."""
+        started = AsyncMock()
+
+        def _factory(*a, **k):
+            return started
+
+        mgr = SessionManager(cfg, provider_factory=_factory)
+
+        real_start = started.start
+
+        async def _start_then_close():
+            mgr._closing = True
+            await real_start()
+
+        started.start = _start_then_close
+
+        await mgr._ensure_background()
+
+        assert BACKGROUND_KEY not in mgr._sessions
+        started.shutdown.assert_awaited_once()
+        mgr._closing = False
         await mgr.close_all()
 
 

--- a/test/test_session_coverage.py
+++ b/test/test_session_coverage.py
@@ -30,6 +30,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, ACP_BACKEND_KIRO
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import KiroCrewAgentConfig
 from kiro_crew.messaging.link import ChannelLink
@@ -384,8 +385,11 @@ class TestProviderBgSession:
 
 class TestGetBgSessionNonKiro:
     @pytest.mark.asyncio
-    async def test_non_kiro_backend_gets_the_provider_backed_adapter(self, cfg) -> None:
-        cfg.agent.provider = "claude_code"
+    async def test_non_runtime_backend_gets_the_provider_backed_adapter(self, cfg) -> None:
+        # A backend the multiplexed AcpRuntime cannot serve must fall through
+        # to the provider path even though agent.provider is still "acp" (a
+        # one-member enum) — dispatch is keyed on acp_backend, not provider.
+        cfg.agent.acp_backend = ACP_BACKEND_CLAUDE
         mgr = SessionManager(cfg)
         sess = _register(mgr, BACKGROUND_KEY, provider=_StreamingProvider())
 
@@ -399,12 +403,35 @@ class TestGetBgSessionNonKiro:
     async def test_missing_background_session_is_a_named_error(self, cfg) -> None:
         """Silently returning None here surfaces much later as an
         AttributeError inside a chat-title turn."""
-        cfg.agent.provider = "bedrock"
+        cfg.agent.acp_backend = ACP_BACKEND_CLAUDE
         mgr = SessionManager(cfg)
 
         with patch.object(mgr, "_ensure_background", AsyncMock()):
             with pytest.raises(RuntimeError, match="background session unavailable"):
                 await mgr.get_bg_session()
+
+    @pytest.mark.asyncio
+    async def test_provider_path_retires_a_drained_runtime_left_by_a_switch(self, cfg) -> None:
+        """After a switch to a backend the runtime cannot serve, the runtime
+        branch is never taken again — so the provider path itself must finish
+        a retirement that refresh_defaults deferred while handles were live."""
+        cfg.agent.acp_backend = ACP_BACKEND_CLAUDE
+        mgr = SessionManager(cfg)
+        _register(mgr, BACKGROUND_KEY, provider=_StreamingProvider())
+
+        stranded = AsyncMock()
+        stranded.acp_backend = ACP_BACKEND_KIRO  # spawned before the switch
+        stranded.has_active_or_initializing_sessions = lambda: False
+        stranded.kill = AsyncMock()
+        stranded.pid = 555
+        mgr._bg_runtime = stranded
+
+        with patch.object(mgr, "_ensure_background", AsyncMock()):
+            handle = await mgr.get_bg_session()
+
+        assert isinstance(handle, _ProviderBgSession)
+        stranded.kill.assert_awaited_once()
+        assert mgr._bg_runtime is None
 
 
 # ── Registry reads ───────────────────────────────────────────────────────────

--- a/test/test_session_more_coverage.py
+++ b/test/test_session_more_coverage.py
@@ -38,6 +38,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kiro_crew import platform_compat
+from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, ACP_BACKEND_KAS
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
 from kiro_crew.session import (
@@ -528,17 +529,36 @@ class TestEvictStaleSession:
 
 
 class TestBackgroundProviderDispatch:
-    def test_an_unreadable_provider_setting_defaults_to_the_kiro_backend(self, mgr) -> None:
+    def test_an_unreadable_backend_setting_defaults_to_the_kiro_backend(self, mgr) -> None:
         """``_bg`` must keep working when the config object cannot answer — the
         alternative is losing chat titles and consolidation to a config edge."""
 
         class _Boom:
             @property
-            def provider(self):
+            def acp_backend(self):
                 raise RuntimeError("config exploded")
 
         mgr._cfg = SimpleNamespace(agent=_Boom())
-        assert mgr._bg_provider_is_kiro() is True
+        assert mgr._bg_backend_supports_runtime() is True
+
+    def test_a_non_string_backend_defaults_to_the_kiro_backend(self, mgr) -> None:
+        """A non-string value degrades to the floor backend for dispatch,
+        mirroring the loader's ``_normalize_acp_backend`` posture."""
+        mgr._cfg = SimpleNamespace(agent=SimpleNamespace(acp_backend=object()))
+        assert mgr._bg_backend_supports_runtime() is True
+
+    def test_a_runtime_incapable_backend_falls_through_to_the_provider_path(self, mgr) -> None:
+        """A backend outside ACP_BACKENDS_ACP_RUNTIME must dispatch to the
+        provider-backed ``_Session`` path even while agent.provider reads
+        "acp" — the predicate is keyed on acp_backend, never on provider."""
+        mgr._cfg = SimpleNamespace(
+            agent=SimpleNamespace(provider="acp", acp_backend=ACP_BACKEND_CLAUDE)
+        )
+        assert mgr._bg_backend_supports_runtime() is False
+
+    def test_the_kas_backend_is_runtime_capable(self, mgr) -> None:
+        mgr._cfg = SimpleNamespace(agent=SimpleNamespace(acp_backend=ACP_BACKEND_KAS))
+        assert mgr._bg_backend_supports_runtime() is True
 
     @pytest.mark.asyncio
     async def test_ensure_background_no_ops_without_a_factory(self, mgr) -> None:


### PR DESCRIPTION
## Problem / Motivation

After `agent.acp_backend` is switched to KAS, background sessions — chat titles, suggestions, tips, nav links, the model picker, memory consolidation — keep running the Kiro CLI backend. Three verified causes (#6502):

1. `SessionManager.get_bg_session()` constructed `AcpRuntime` without `acp_backend`, so the runtime always took the kiro default.
2. `_bg_provider_is_kiro()` read `agent.provider` — a one-member enum — so the dispatch predicate was unconditionally true and never consulted `agent.acp_backend`, contradicting its own docstring.
3. The cached `_bg_runtime` is process-lifetime and deliberately shielded from the orphan-PID sweep, so an already-spawned Kiro CLI background runtime survived the switch indefinitely.

## Why it matters

An operator who selects KAS gets a gateway whose visible chat runs KAS while every background surface silently keeps spawning and billing the other harness — invisible, unbounded in duration, and impossible to fix without a restart (and before this change, even a restart did not fix cause 1).

## What changed (motivation → approach → change)

- **Spawn under the configured backend.** `get_bg_session()` resolves `agent.acp_backend` once per `_bg_runtime_lock` hold and passes it to `AcpRuntime(...)`. Resolution has two forms: a raw form (`_configured_bg_backend_raw`, `None` = "config could not answer") that gates displacement so an unreadable probe can never displace a correctly-configured runtime, and a degraded form that falls to the kiro floor for dispatch and spawn (H1/H3, logged).
- **Re-key the predicate.** `_bg_provider_is_kiro()` → `_bg_backend_supports_runtime()`: positive membership in `_BG_RUNTIME_BACKENDS = ACP_BACKENDS_ACP_RUNTIME & ACP_BACKENDS_SELECTABLE` (identical sets today; the intersection keeps a future runtime-capable-but-unselectable harness out of the background path). A backend outside the set falls through to the provider-backed `_Session` path. Membership is revalidated under the lock with a provider-path fallback, so a config move between dispatch and lock acquisition cannot construct a runtime under a backend it cannot classify.
- **Displace, drain, reap.** A cached runtime whose backend no longer matches config is displaced immediately by the single policy implementation `_displace_bg_runtime_locked`: killed if idle, parked on `_draining_bg_runtimes` if it has live handles — new sessions can never join it (so the switch takes effect on the very next background call, even under sustained load), while in-flight work (an active title generation) finishes untouched. Parked runtimes keep their orphan-sweep PID shield, block the account-identity sweep's completeness, and are reaped once drained from four triggers: `get_bg_session`, `refresh_defaults()`, the identity sweep, and a new `bg_drain_reap` watchdog hook (the backstop for an idle gateway).
- **Shutdown discipline.** `close_all()` detaches both holders atomically under `_bg_runtime_lock` and kills the detached snapshot; `get_bg_session` raises the typed `SessionClosingError` once `_closing` is set (top-level, in-lock, and in the provider helper); `_ensure_background()` rechecks `_closing` before registering and tears the loser provider down instead.

**Harness-parity note (pre-empting an H13 reading):** the kiro path gains one awaited reap per call, the `SessionClosingError` failure mode, and the `runtime_capable` conditional — all backend-agnostic lifecycle machinery whose kiro-configured outcome is unchanged. Identity stays positive (`ACP_BACKENDS_*` membership, H6), the degrade target is the kiro floor (H1/H3), and no per-harness literal is collapsed (H9/H10 — the change *stops* inheriting the kiro default). Honoring `agent.acp_backend` is the config contract, not a widening for an adapter.

**Sandbox posture note:** the background runtime now spawns under the configured backend, so on a KAS install it is no longer an `ACP_BACKENDS_INTERNAL_SANDBOX` member; with `agent.sandbox` defaulting to `"off"` that background process has neither the seatbelt nor a harness-internal sandbox. This mirrors exactly what main chat sessions already get under KAS (the spawn still routes through the `AcpRuntime` seam and `wrap_argv`), but it is a real posture delta reviewers should see stated rather than discover.

## Tests

31 new/updated tests across `test/test_session.py`, `test/test_session_coverage.py`, `test/test_session_more_coverage.py`, locking in (spec items 4a–4c):

- config with `acp_backend=KAS` spawns the background runtime under KAS, never kiro (mutation-verified: 5 mutations killed, including reverting the predicate to `agent.provider`, narrowing membership to kiro-only, and dropping the constructor kwarg);
- a backend switch while a background handle is live never kills that handle — it is parked, never serves a new caller, and is reaped once drained (plus: failed-kill parks for retry, failed-reap keeps parked, watchdog-hook backstop, `close_all` kills slot + every parked runtime);
- the identity sweep reports incomplete while a kiro-identity runtime drains and complete once reaped;
- an unreadable config never displaces a cached runtime; a runtime-incapable backend falls to the provider path even with `provider="acp"`; the provider path finishes a deferred retirement; `SessionClosingError` on every shutdown-raced entry; `_ensure_background` tears down instead of registering while closing.

Local gates green: isort, flake8, mypy (0 issues / 1147 files), diff-scoped black + subprocess-encoding, brand, harness-parity, docs-lint, and the full pytest suite — 71,988 passed; the 94 failures + 2 errors are host-environment and byte-identical (same 15 files, same counts) on a pristine `main` worktree on this machine.

Pre-push adversarial review: 4 dual-model blind rounds (GPT + Opus subagents, fresh context per round). Round 1: 1 blocking + 6 advisories fixed. Round 2: 2 blocking + 6 advisories fixed. Round 3: 1 High + 2 Medium + 6 advisories fixed. Round 4: dual PASS; 2 hardening advisories adopted.

## Manual verification

N/A — unit coverage sufficient: the fix is dispatch/lifecycle logic inside `SessionManager`, fully exercisable through the mocked-runtime seams the existing background-session tests already use; no UI surface changed.

## Deliberately deferred

- **AgentBackendTab third status state** (schema-unknown vs schema-says-no), recorded in the issue's final paragraph — out of scope per the task spec.
- **Drain deadline / list cap for parked runtimes** (round-4 advisory): a parked runtime whose handle wedges in active state stays alive until shutdown. The wedge requires a caller violating the documented `destroy()`-in-finally contract, the same class that already blocked the pre-existing staleness recycle indefinitely; a forced kill past a deadline would abort exactly the in-flight work the parking exists to protect. The `>1` parked warning makes accumulation visible. Worth a follow-up if a real wedge is ever observed.
- There is currently **no live edit surface** for `agent.acp_backend` (it is not in the dashboard's `_EDITABLE_CONFIG`; a file/CLI edit lands at the next gateway start, where causes 2–3 are moot and cause 1 was the restart-surviving defect). Any future edit surface gets live retirement for free by routing through `refresh_defaults()` like the other `agent.*` defaults.

Closes #6502
