### PR TITLE
fix: repair three cross-merge breakages redding main's CI

### DIFF
--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -10779,6 +10779,12 @@ class TestFolderCRUD:
         ]
         mock_cfg = MagicMock()
         mock_cfg.dashboard.default_project = ""
+        # A bare MagicMock leaks into the slot: the handler stamps
+        # cfg.default_agent (a truthy MagicMock) as the slot's agent when the
+        # request names none, and the coalesced slots broadcast then dies in
+        # json.dumps ("Object of type MagicMock is not JSON serializable"),
+        # 500ing the create. Pin it to a string like the sibling cfg mocks.
+        mock_cfg.default_agent = ""
         monkeypatch.setattr(
             "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", lambda: mock_cfg
         )

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -2501,7 +2501,9 @@ class TestCotenantRefusalTextIsForgeSafe:
         monkeypatch.delenv("KIRO_HOME", raising=False)
         monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
         monkeypatch.setattr(paths, "_config_dir_memo", None)
-        monkeypatch.setattr(session_storage, "cotenant_sids", lambda: (frozenset(), self._REFUSALS))
+        monkeypatch.setattr(
+            session_storage, "cotenant_sids", lambda *, cached=False: (frozenset(), self._REFUSALS)
+        )
 
         reason = session_storage.reclaim_block_reason()
 
@@ -2521,7 +2523,9 @@ class TestCotenantRefusalTextIsForgeSafe:
         """
         _, kiro_home = stores
         _cli_half(kiro_home, "aaaa1111", log_bytes=64, age_days=40)
-        monkeypatch.setattr(session_storage, "cotenant_sids", lambda: (frozenset(), self._REFUSALS))
+        monkeypatch.setattr(
+            session_storage, "cotenant_sids", lambda *, cached=False: (frozenset(), self._REFUSALS)
+        )
 
         with pytest.raises(SessionStorageError, match="make reclaiming unsafe") as excinfo:
             session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)

--- a/website/src/apps/aws-control/DrivePage.tsx
+++ b/website/src/apps/aws-control/DrivePage.tsx
@@ -23,14 +23,6 @@
  * react-query key. All AWS access runs through the gateway's audited CLI
  * chokepoint; this surface never talks to AWS from the browser.
  */
-/* eslint-disable jsx-a11y/control-has-associated-label --
-   The two inline confirm strips render as a <td colSpan={5}>, which jsx-a11y
-   treats as a gridcell needing an accessible name and then searches only two
-   levels deep for one. The strips DO name their controls (Cancel, Delete file,
-   Delete folder, each with its own i18n text) - they just sit one level further
-   in, behind the flex wrapper the strip needs, because a <td> cannot itself be
-   the flex container: display:flex drops display:table-cell and the strip stops
-   spanning the row. */
 import { Fragment, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {


### PR DESCRIPTION
## Problem / Motivation

`main` is red on every open PR's merge ref (and on its own CI) from three independent cross-merge collisions:

1. **Frontend Lint & Type Check**: the whole-file `jsx-a11y/control-has-associated-label` eslint-disable at the top of `website/src/apps/aws-control/DrivePage.tsx` (added in #6446) no longer suppresses anything, so eslint counts the directive itself as a warning (`Unused eslint-disable directive`) — putting `src/` at **665 warnings against the job's hard ceiling of 664** (`npx eslint src/ --max-warnings 664`).
2. **Backend Tests (3.10, 3) + Backend Tests (Windows) (3)**: `test_session_storage.py`'s `TestCotenantRefusalTextIsForgeSafe` monkeypatches `cotenant_sids` with **zero-arg lambdas** (added in #6444), but #6313 (merged after) gave `cotenant_sids` a keyword-only `cached` parameter and `move_to_trash` now calls `cotenant_sids(cached=...)` → `TypeError: ... got an unexpected keyword argument 'cached'`. #6313 updated the two *named* test doubles in the same file (`claimed_late`, `unreadable_late`) but missed these two lambdas.

3. **Backend Tests (3.10, 2)**: `test_dashboard_chat.py`'s new `test_slot_create_inherits_nearest_folder_project` (added in #6465) builds its cfg as a **bare `MagicMock`**; the slot-create handler stamps `cfg.default_agent` (a truthy MagicMock) as the slot's agent on an agent-less create, and the coalesced slots broadcast dies in `json.dumps` (`Object of type MagicMock is not JSON serializable`) → 500. Pinned `default_agent` to a string like the sibling cfg mocks in the same file. (Reproduced on pristine main tip `5c925e4e3` — the commit that added it.)

## Why it matters

Every open PR currently inherits both reds regardless of its own diff. The lint gate's own comment says to ratchet the ceiling down, never up — so the correct fix is removing the dead directive, not raising the number.

## What changed (motivation → approach → change)

- Deleted the unused eslint-disable block in `DrivePage.tsx` (8 comment lines). The suppression is genuinely dead: the file lints at **zero** problems without it, and `npx eslint src/` returns to exactly **664**.
- Fixed the two stale lambdas to accept the keyword (`lambda *, cached=False: ...`), matching the signature #6313 already gave the named doubles in the same file.

## Tests

Full `test/test_session_storage.py`: **174 passed** (was 1 failing on both affected shards). The frontend-lint CI job is itself the regression test for the eslint half.

## Manual verification

`npx eslint src/apps/aws-control/DrivePage.tsx` → 0 problems; `npx eslint src/ --max-warnings 664` → exit 0 at 664. `isort`/`flake8`/`black` clean on the touched test file.

## Screenshots / video

N/A — no user-visible change (comment deletion + test-double signature fix).

no linked issue: main-CI breakage discovered while driving PR #6513; filed directly to unblock all open PRs.

