### PR TITLE
test(session-storage): accept the cached kwarg in cotenant_sids forge-safe mocks

### DIFF
--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -2501,7 +2501,9 @@ class TestCotenantRefusalTextIsForgeSafe:
         monkeypatch.delenv("KIRO_HOME", raising=False)
         monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
         monkeypatch.setattr(paths, "_config_dir_memo", None)
-        monkeypatch.setattr(session_storage, "cotenant_sids", lambda: (frozenset(), self._REFUSALS))
+        monkeypatch.setattr(
+            session_storage, "cotenant_sids", lambda *, cached=False: (frozenset(), self._REFUSALS)
+        )
 
         reason = session_storage.reclaim_block_reason()
 
@@ -2521,7 +2523,9 @@ class TestCotenantRefusalTextIsForgeSafe:
         """
         _, kiro_home = stores
         _cli_half(kiro_home, "aaaa1111", log_bytes=64, age_days=40)
-        monkeypatch.setattr(session_storage, "cotenant_sids", lambda: (frozenset(), self._REFUSALS))
+        monkeypatch.setattr(
+            session_storage, "cotenant_sids", lambda *, cached=False: (frozenset(), self._REFUSALS)
+        )
 
         with pytest.raises(SessionStorageError, match="make reclaiming unsafe") as excinfo:
             session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)


### PR DESCRIPTION
## Problem / Motivation

`main` CI is red on **Backend Tests shard 3** (3.10, 3.12, Windows). Two forge-safe test mocks in `test/test_session_storage.py` (`TestCotenantRefusalTextIsForgeSafe`, lines ~2504/2524) monkeypatch `cotenant_sids` with a **no-argument** lambda, but production now calls `cotenant_sids(cached=cached)` (the function is `def cotenant_sids(*, cached: bool = False)`). The code under test therefore raises `TypeError: <lambda>() got an unexpected keyword argument 'cached'`.

## Why it matters

This is a main-side breakage, not specific to one PR: `main`'s own CI fails this job (e.g. run 33159160070 on `16239989d`, and the latest on `5c925e4e3`), so **every** PR rebased onto current main inherits a red shard-3 and cannot reach green. A one-PR-blocks-none fix unblocks the whole queue.

## What changed (motivation → approach → change)

- **Symptom:** `TypeError` on the `cached` kwarg in `test_move_to_trash_refusal_error_escapes_the_name` (and the sibling `reclaim_block_reason` test), failing shard 3 on all platforms.
- **Root cause:** a PR that added the keyword-only `cached` parameter to `cotenant_sids` updated the real call sites but missed these two mock lambdas.
- **Change:** update both mocks to accept the keyword-only arg, mirroring the real signature: `lambda *, cached=False: (frozenset(), self._REFUSALS)`. Two lines (plus black line-wrapping). No production code touched.

## Tests

`test/test_session_storage.py::TestCotenantRefusalTextIsForgeSafe` passes **2/2** locally with the fix (previously errored on both). `black --check` clean. No other no-arg `cotenant_sids` mock lambdas remain in the file.

## Related Issues

Fixes #6523

## Checklist

- [x] At most two commits (one), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — N/A (repairs an existing test's mock; no behavior change)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
