### PR TITLE
refactor(acp): consolidate availableModels parsing onto parse_advertised_models (#6382)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2468,6 +2468,12 @@ class AcpClient:
         claude-agent-acp) instead of a hardcoded guess. Best-effort and never
         raises — a backend that omits ``models`` simply leaves the list empty.
 
+        The shape walk is delegated to
+        :func:`kiro_crew.acp.session_handle.parse_advertised_models` so this
+        snapshot stays directly comparable with the pooled-runtime probe
+        (#6382). This path keeps its dict-only ``models`` gate and its
+        non-empty assignment guard — both are call-site policy, not parsing.
+
         Also records ``currentModelId`` for ``_track_metadata``'s context
         window lookup.
         """
@@ -2477,23 +2483,18 @@ class AcpClient:
         current_model_id = models.get("currentModelId")
         if isinstance(current_model_id, str) and current_model_id:
             self._resolved_model_id = current_model_id
-        advertised = models.get("availableModels")
-        if not isinstance(advertised, list):
-            return
-        captured: list[dict[str, str]] = []
-        for m in advertised:
-            if not isinstance(m, dict):
-                continue
-            model_id = m.get("modelId") or m.get("value") or ""
-            if not model_id:
-                continue
-            captured.append(
-                {
-                    "modelId": str(model_id),
-                    "name": str(m.get("name") or model_id),
-                    "description": str(m.get("description") or ""),
-                }
-            )
+        # Imported lazily: acp.session_handle imports this module at module
+        # level, so a top-level import here would be a cycle.
+        from kiro_crew.acp.session_handle import parse_advertised_models
+
+        # Parse the gated sub-payload, not the whole response: the parser's
+        # dict-or-list fallback would otherwise let an EMPTY (falsy) models
+        # object fall through to a top-level ``availableModels`` key, sourcing
+        # the list from a payload the dict gate above never saw.
+        # NOTE: the pre-consolidation code returned early on a malformed
+        # ``availableModels``; nothing may be appended after this block
+        # without re-adding that malformed-payload guard.
+        captured = parse_advertised_models({"models": models})
         if captured:
             self._available_models = captured
 

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -372,7 +372,11 @@ def parse_advertised_models(resp: dict[str, Any]) -> list[dict[str, str]]:
 
     Accepts both response shapes: a ``models`` object
     ``{availableModels: [...], currentModelId}`` and a bare list under either
-    key. Normalization matches :meth:`AcpSessionHandle._normalize_models`, so a
+    key. A falsy ``models`` value (``{}``, ``[]``, ``None``) falls through to a
+    top-level ``availableModels`` — callers that gate on ``models`` themselves
+    should pass a wrapped envelope (e.g. ``{"models": models}``) so the
+    fallback cannot source the list from a payload their gate never saw. Normalization matches
+    :meth:`AcpSessionHandle._normalize_models`, so a
     probe's answer and a session-init snapshot are directly comparable.
     """
     models = resp.get("models") or resp.get("availableModels")
@@ -1688,7 +1692,20 @@ class AcpSessionHandle:
                 self._resolved_model_id = current_model_id
             avail = models.get("availableModels", [])
             if isinstance(avail, list):
-                self._available_models = self._normalize_models(avail)
+                # The shape walk is delegated to the canonical parser so this
+                # snapshot and a probe's answer stay directly comparable
+                # (#6382). The envelope is the same checked-binding discipline
+                # as the client's, though here the parser's dict-or-list
+                # fallback is unreachable by construction (the inner dict
+                # always has a key). The isinstance check above is the
+                # assignment gate: a non-list ``availableModels`` must not
+                # clobber a previously-stored list. A well-formed EMPTY list
+                # still overwrites — that asymmetry with
+                # ``AcpClient._capture_available_models`` (non-empty guard) is
+                # pre-existing policy, deliberately unchanged here.
+                self._available_models = parse_advertised_models(
+                    {"models": {"availableModels": avail}}
+                )
             # A backend may advertise its model list without echoing
             # ``currentModelId`` (it is best-effort in the ACP shape). When it
             # names exactly one model that IS the served model unambiguously, so
@@ -1701,13 +1718,18 @@ class AcpSessionHandle:
             if not self._resolved_model_id and len(self._available_models) == 1:
                 self._resolved_model_id = self._available_models[0]["modelId"]
         elif isinstance(models, list):
-            self._available_models = self._normalize_models(models)
+            self._available_models = parse_advertised_models({"availableModels": models})
 
     @staticmethod
     def _normalize_models(advertised: list[Any]) -> list[dict[str, str]]:
         """Normalize advertised models to ``{modelId, name, description}`` with
-        guaranteed keys (parity with AcpClient._capture_available_models), so the
-        dashboard model dropdown gets a stable shape regardless of backend."""
+        guaranteed keys — the canonical normalization. Every consumer
+        (``parse_advertised_models``, and through it ``store_session_config``,
+        ``AcpClient._capture_available_models``, and the pooled-runtime
+        entitlement probe ``AcpRuntime.probe_advertised_models``) shares this
+        shape, so probe answers and session-init snapshots are directly
+        comparable and the dashboard model dropdown gets a stable shape
+        regardless of backend."""
         captured: list[dict[str, str]] = []
         for m in advertised:
             if not isinstance(m, dict):

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -7136,6 +7136,74 @@ class TestCaptureAvailableModels:
         )
         assert c.available_models()[0]["modelId"] == "m1"
 
+    def test_capture_matches_canonical_parser(self):
+        """Drift-pin (#6382): the client-side capture normalizes exactly like
+        ``parse_advertised_models`` — hard-coded expectation so a regression
+        inside the canonical parser (name fallback, description default,
+        value-as-id, non-dict skip) fails this pin too."""
+        resp = {
+            "models": {
+                "currentModelId": "m1",
+                "availableModels": [
+                    {"modelId": "m1", "name": "M1", "description": "d"},
+                    {"value": "m2"},
+                    {"name": "no id — skipped"},
+                    "not-a-dict",
+                ],
+            }
+        }
+        c = self._client()
+        c._capture_available_models(resp)
+        assert c.available_models() == [
+            {"modelId": "m1", "name": "M1", "description": "d"},
+            {"modelId": "m2", "name": "m2", "description": ""},
+        ]
+
+    def test_capture_delegates_to_canonical_parser(self, monkeypatch):
+        """Anti-re-fork pin (#6382): the list must be SOURCED from
+        ``parse_advertised_models`` AND called with the gated envelope
+        ``{"models": models}`` — a restored inline walk, a whole-response
+        re-resolution, or a wrong envelope all fail this pin.
+
+        Depends on the function-local import in ``_capture_available_models``;
+        if that import is ever hoisted to module scope, patch
+        ``kiro_crew.acp.client.parse_advertised_models`` instead.
+        """
+        from kiro_crew.acp import session_handle as sh
+
+        sentinel = [
+            {"modelId": "sentinel-a", "name": "A", "description": ""},
+            {"modelId": "sentinel-b", "name": "B", "description": ""},
+        ]
+        calls: list = []
+
+        def _fake(resp):
+            calls.append(resp)
+            return list(sentinel)
+
+        monkeypatch.setattr(sh, "parse_advertised_models", _fake)
+        c = self._client()
+        c._capture_available_models({"models": {"availableModels": [{"modelId": "real"}]}})
+        assert c.available_models() == sentinel
+        assert calls == [{"models": {"availableModels": [{"modelId": "real"}]}}]
+
+    def test_malformed_later_response_keeps_prior_snapshot(self):
+        """The non-empty assignment guard survives the consolidation: a later
+        malformed response must not clear an already-captured list."""
+        c = self._client()
+        c._capture_available_models({"models": {"availableModels": [{"modelId": "m1"}]}})
+        assert [m["modelId"] for m in c.available_models()] == ["m1"]
+        c._capture_available_models({"models": {"availableModels": "nope"}})
+        assert [m["modelId"] for m in c.available_models()] == ["m1"]
+
+    def test_empty_models_object_ignores_top_level_available_models(self):
+        """An EMPTY (falsy) ``models`` object must not let the parser's
+        dict-or-list fallback source the list from a top-level
+        ``availableModels`` key the dict gate never saw (#6382)."""
+        c = self._client()
+        c._capture_available_models({"models": {}, "availableModels": [{"modelId": "x"}]})
+        assert c.available_models() == []
+
 
 def _scripted_process(lines, *, returncode=None):
     """Build a mock subprocess whose stdout.readline yields *lines* in order.

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -8121,3 +8121,123 @@ class TestParseAdvertisedModels:
         assert parse_advertised_models({}) == []
         assert parse_advertised_models({"models": {"availableModels": "nope"}}) == []
         assert parse_advertised_models({"models": 7}) == []
+
+
+class TestStoreSessionConfigParseConsolidation:
+    """Drift-pin (#6382): ``store_session_config`` sources its model list from
+    ``parse_advertised_models``, so the session-init snapshot can never drift
+    from what a pooled-runtime probe would parse out of the same payload."""
+
+    def _handle(self):
+        rt, _, _ = _make_runtime()
+        q = _register(rt, "sA")
+        return AcpSessionHandle("sA", q["sA"], rt)
+
+    def test_models_object_shape_matches_canonical_parser(self):
+        # Mixed modelId/value spellings + a missing description exercise every
+        # normalization branch; hard-coded expectation so a regression inside
+        # parse_advertised_models fails this pin too.
+        resp = {
+            "models": {
+                "currentModelId": "kiro-model-x",
+                "availableModels": [
+                    {"modelId": "kiro-model-x", "name": "X", "description": "d"},
+                    {"value": "kiro-model-y"},
+                    {"name": "no id — skipped"},
+                    "not-a-dict",
+                ],
+            }
+        }
+        handle = self._handle()
+        handle.store_session_config(resp)
+        assert handle.available_models == [
+            {"modelId": "kiro-model-x", "name": "X", "description": "d"},
+            {"modelId": "kiro-model-y", "name": "kiro-model-y", "description": ""},
+        ]
+
+    def test_bare_list_shape_matches_canonical_parser(self):
+        resp = {"availableModels": [{"modelId": "kiro-model-x"}, {"value": "kiro-model-y"}]}
+        handle = self._handle()
+        handle.store_session_config(resp)
+        assert handle.available_models == [
+            {"modelId": "kiro-model-x", "name": "kiro-model-x", "description": ""},
+            {"modelId": "kiro-model-y", "name": "kiro-model-y", "description": ""},
+        ]
+
+    def test_bare_list_under_models_key_matches_canonical_parser(self):
+        """The bare-list branch is the only site that RE-KEYS the payload
+        (``models`` list → ``{"availableModels": models}`` envelope) — reach
+        it via the ``models`` key so the re-key itself is pinned."""
+        handle = self._handle()
+        handle.store_session_config(
+            {"models": [{"modelId": "kiro-model-x"}, {"value": "kiro-model-y"}]}
+        )
+        assert handle.available_models == [
+            {"modelId": "kiro-model-x", "name": "kiro-model-x", "description": ""},
+            {"modelId": "kiro-model-y", "name": "kiro-model-y", "description": ""},
+        ]
+
+    def test_dict_branch_delegates_to_canonical_parser(self, monkeypatch):
+        """Anti-re-fork pin (#6382): the dict branch must SOURCE its list from
+        ``parse_advertised_models`` AND call it with the checked-binding
+        envelope — a restored inline walk, a whole-response re-resolution, or
+        a wrong envelope all fail this pin."""
+        import kiro_crew.acp.session_handle as sh
+
+        sentinel = [
+            {"modelId": "sentinel-a", "name": "A", "description": ""},
+            {"modelId": "sentinel-b", "name": "B", "description": ""},
+        ]
+        calls: list = []
+
+        def _fake(resp):
+            calls.append(resp)
+            return list(sentinel)
+
+        monkeypatch.setattr(sh, "parse_advertised_models", _fake)
+        handle = self._handle()
+        handle.store_session_config({"models": {"availableModels": [{"modelId": "real"}]}})
+        assert handle.available_models == sentinel
+        assert calls == [{"models": {"availableModels": [{"modelId": "real"}]}}]
+
+    def test_bare_list_branch_delegates_to_canonical_parser(self, monkeypatch):
+        import kiro_crew.acp.session_handle as sh
+
+        sentinel = [
+            {"modelId": "sentinel-a", "name": "A", "description": ""},
+            {"modelId": "sentinel-b", "name": "B", "description": ""},
+        ]
+        calls: list = []
+
+        def _fake(resp):
+            calls.append(resp)
+            return list(sentinel)
+
+        monkeypatch.setattr(sh, "parse_advertised_models", _fake)
+        handle = self._handle()
+        handle.store_session_config({"availableModels": [{"modelId": "real"}]})
+        assert handle.available_models == sentinel
+        assert calls == [{"availableModels": [{"modelId": "real"}]}]
+
+    def test_well_formed_empty_list_still_overwrites_prior_snapshot(self):
+        """Pre-existing call-site policy pinned through the consolidation: a
+        WELL-FORMED empty ``availableModels`` list DOES clear a prior snapshot
+        here (unlike ``AcpClient._capture_available_models``'s non-empty
+        guard). Switching this site to a client-style guard would be a
+        behavior change this test exists to catch."""
+        handle = self._handle()
+        handle.store_session_config({"models": {"availableModels": [{"modelId": "kiro-model-x"}]}})
+        assert [m["modelId"] for m in handle.available_models] == ["kiro-model-x"]
+        handle.store_session_config({"models": {"availableModels": []}})
+        assert handle.available_models == []
+
+    def test_malformed_inner_shape_does_not_clobber_prior_snapshot(self):
+        """The assignment guard survives the consolidation: a later response
+        whose ``availableModels`` is malformed must not clear an
+        already-captured list (the canonical parser returns ``[]`` for it, but
+        assignment policy is the call site's, not the parser's)."""
+        handle = self._handle()
+        handle.store_session_config({"models": {"availableModels": [{"modelId": "kiro-model-x"}]}})
+        assert [m["modelId"] for m in handle.available_models] == ["kiro-model-x"]
+        handle.store_session_config({"models": {"availableModels": "nope"}})
+        assert [m["modelId"] for m in handle.available_models] == ["kiro-model-x"]


### PR DESCRIPTION
Refs #6382 — resolves item 3 (parser consolidation); items 1–2 (staleness heuristic, probe lifecycle) remain open for a human. Deliberately NOT "Closes".

## What

The `availableModels` extraction from ACP session payloads existed in three independent spellings that could drift apart, breaking the probe-vs-snapshot comparability guarantee the #6356 pooled-runtime heal relies on. This folds the two older parsers onto the canonical `parse_advertised_models`:

- `AcpSessionHandle.store_session_config` (dict branch and bare-list branch): the inline dict-shape walk is replaced by a call to `parse_advertised_models` on the **checked binding**, wrapped in a canonical envelope (`{"models": {"availableModels": avail}}` / `{"availableModels": models}`). Side effects — `currentModelId` resolution and single-model adoption — are unchanged and operate on the returned list.
- `AcpClient._capture_available_models`: same substitution with the `{"models": models}` envelope. Keeps its dict-only `models` gate and non-empty assignment guard (call-site policy, not parsing). The import is function-local per the documented cycle-break (`acp.session_handle` imports `acp.client` at module level).

**No behavior change.** The checked-binding envelopes exist precisely so the parser's dict-or-list fallback can never source the list from a payload a call site's gate never saw (e.g. an empty falsy `models` dict next to a top-level `availableModels` key). The handle's clear-on-well-formed-empty-list vs the client's non-empty guard is a pre-existing asymmetry, deliberately kept and now pinned by tests.

## Tests

- Hard-coded normalization pins for both call sites (mixed `modelId`/`value` spellings, missing name/description, non-dict entries).
- Sentinel delegation pins (monkeypatched `parse_advertised_models` recording its argument): a restored inline fork, a whole-response re-resolution, or a wrong envelope all fail.
- Assignment-guard pins: malformed later response keeps the prior snapshot (both sites); well-formed empty list still overwrites at the handle (pre-existing policy); empty `models` object ignores a top-level `availableModels` (client).
- Bare-list-under-`models`-key test pinning the one branch that re-keys its payload.
- Drift-pin mutation-verified: a re-forked walk without the `value` fallback fails the pin.

## Adversarial review (pre-push, blind, dual-model)

- 3 rounds, GPT lane + Opus lane each round (separate model-pinned subagents).
- 15 findings total: 13 fixed (incl. the empty-falsy-dict fallthrough divergence both lanes converged on, guard/parse binding separation, self-referential test assertions, envelope-argument sentinel hardening), 1 documented trade-off, 1 noise.
- Trade-off kept: the two sites use different envelope forms — each mirrors its own checked binding; unifying them would decouple the guard from the parsed value again.
- Final round: PASS / PASS.

## Verification

- `isort` / `flake8` / `mypy` / diff-scoped black gate: clean.
- Targeted ACP suites (`test_acp_runtime`, `test_acp_client`, `test_acp_client_more_coverage`, `test_acp_dynamic_config`, `test_acp_provider`): 1010 passed.
- Full `python -m pytest`: 95 failures, all in the known host-environment set for this machine (AF_UNIX path length, xdist host budget, file-explorer/design-tweak env deps) — zero in ACP/model-related tests.

No UI change — no screenshots required.
