### PR TITLE
fix(dashboard): guard connection_made against OSError on macOS socket race

### DIFF
--- a/src/kiro_crew/dashboard/slowloris.py
+++ b/src/kiro_crew/dashboard/slowloris.py
@@ -70,7 +70,15 @@ class SlowlorisRequestHandler(web.RequestHandler):
         self._srh_disarmed = False
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
-        super().connection_made(transport)
+        try:
+            super().connection_made(transport)
+        except OSError:
+            # On macOS a socket that raced closed between accept() and
+            # connection_made makes setsockopt raise OSError (Errno 22).
+            # Drop the doomed connection cleanly instead of crash-dumping.
+            transport.close()
+            self._srh_disarmed = True
+            return
         if self._srh_timeout and self._srh_timeout > 0:
             self._srh_handle = self._loop.call_later(
                 self._srh_timeout, self._srh_expire

--- a/test/test_dashboard_slowloris.py
+++ b/test/test_dashboard_slowloris.py
@@ -121,3 +121,41 @@ def test_start_paths_use_hardened_runner() -> None:
     # fixed closing paren) so passing extra kwargs — e.g.
     # max_field_size=_MAX_HEADER_FIELD_SIZE — still satisfies the invariant.
     assert src.count("build_hardened_runner(app") == 2
+
+
+@pytest.mark.asyncio
+async def test_connection_made_oserror_closes_transport_and_disarms() -> None:
+    """If super().connection_made raises OSError the transport is closed cleanly.
+
+    On macOS a socket that raced closed between accept() and connection_made
+    causes setsockopt (inside aiohttp's tcp_keepalive) to raise OSError.
+    The guard must close the transport, mark the handler disarmed, and never
+    arm the deadline timer.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    app = await _make_app()
+    runner = build_hardened_runner(app, header_read_timeout=5.0)
+    await runner.setup()
+    try:
+        server = runner.server
+        handler = server()
+
+        transport = MagicMock()
+        transport.close = MagicMock()
+
+        # Patch the parent class connection_made to raise OSError, simulating
+        # a macOS race where the socket is already dead.
+        with patch.object(
+            web.RequestHandler, "connection_made", side_effect=OSError(22, "Invalid argument")
+        ):
+            handler.connection_made(transport)
+
+        # The transport must have been closed.
+        transport.close.assert_called_once()
+        # The handler must be disarmed so the deadline timer is never armed.
+        assert handler._srh_disarmed is True
+        # No timer handle should be set.
+        assert handler._srh_handle is None
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
## Summary

Fixes #6525.

On macOS, a socket that raced closed between `accept()` and `connection_made` causes `setsockopt(SOL_SOCKET, SO_KEEPALIVE, 1)` (inside aiohttp's `tcp_keepalive()`) to raise `OSError: [Errno 22] Invalid argument`. Since aiohttp does not guard this internally, the exception escapes the asyncio transport callback and produces repeated unhandled-exception dumps in the log.

## Changes

**`src/kiro_crew/dashboard/slowloris.py`**
- Wrapped `super().connection_made(transport)` in `try/except OSError`
- On catch: closes the dead transport, marks the handler disarmed, and returns early (no timer armed)

**`test/test_dashboard_slowloris.py`**
- Added `test_connection_made_oserror_closes_transport_and_disarms` which mocks `RequestHandler.connection_made` to raise `OSError(22, ...)` and verifies the transport is closed, the handler is disarmed, and no timer handle is set.

## Testing

- Both files pass Python AST validation (syntactically correct)
- New test covers the exact failure scenario from the issue