### PR TITLE
docs(comments): sweep stale icacls-subprocess lockdown rationale (#6359)

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -151,9 +151,11 @@ def _runs_file() -> Path:
 def _write_runs(payload: str) -> None:
     """Blocking half of :func:`_save_runs` — never call this on the event loop.
 
-    The owner-only lockdown spawns ``icacls`` on Windows, so this whole function
-    is a blocking syscall sequence and belongs in a worker thread (the same
-    reason ``_write_review_section`` and ``store.remove_run_dir`` are offloaded).
+    This whole function is a blocking syscall sequence — mkdir, temp creation,
+    lockdown (in-process per ``platform_compat``), payload write, replace — and
+    filesystem calls can stall on a slow volume, so it belongs in a worker
+    thread (the same reason ``_write_review_section`` and
+    ``store.remove_run_dir`` are offloaded).
     """
     f = _runs_file()
     f.parent.mkdir(parents=True, exist_ok=True)

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
@@ -42,8 +42,8 @@ from sage_lib.review_driver import _all_delivered  # noqa: E402
 async def _noop_save() -> None:
     """Stand-in for ``routes._save_runs``, which is a coroutine.
 
-    The registry write is offloaded to a worker thread because its owner-only
-    lockdown spawns ``icacls`` on Windows, so a plain ``lambda: None`` stub is
+    The registry write is offloaded to a worker thread because it is blocking
+    file IO (see ``_write_runs``), so a plain ``lambda: None`` stub is
     not awaitable and the patched call site would raise instead of no-op.
     """
 
@@ -146,9 +146,10 @@ class TestRunsPersistence(unittest.TestCase):
         self.assertIn("e5", runs.read_text(encoding="utf-8"))
 
     def test_the_lockdown_never_runs_on_the_event_loop(self):
-        """The owner-only lockdown spawns ``icacls`` on Windows, so persisting the
-        registry must not block the single gateway loop -- a freeze there stalls
-        every chat turn and the liveness heartbeat, not just this write.
+        """Persisting the registry is blocking file IO (the owner-only lockdown
+        itself is now in-process — ``platform_compat``), and it must not run on
+        the single gateway loop -- a stall there delays every chat turn and the
+        liveness heartbeat, not just this write.
 
         Asserted structurally rather than by timing, so it holds regardless of how
         fast the syscall happens to be on this host. The thread is RECORDED and
@@ -171,8 +172,8 @@ class TestRunsPersistence(unittest.TestCase):
         self.assertIn("write", seen, "_write_runs was never reached")
         self.assertNotEqual(
             seen["write"], seen["loop"],
-            "_write_runs ran on the event-loop thread; the icacls spawn inside it "
-            "would freeze the gateway")
+            "_write_runs ran on the event-loop thread; the blocking file IO inside "
+            "it would stall the gateway")
 
 
 class TestRecordReviewedDelivery(unittest.TestCase):

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
@@ -191,7 +191,7 @@ def _write(data: dict[str, Any]) -> None:
     # at ``policy_path()`` at all. The unlink the old code ran on lockdown
     # failure existed to remove a NEW file already PUBLISHED at a wide DACL;
     # that state is unreachable now, and keeping the unlink would instead
-    # delete the PREVIOUS, healthy governance ceiling on one transient icacls
+    # delete the PREVIOUS, healthy governance ceiling on one transient lockdown
     # failure — silently resetting the operator's autonomy policy.
     atomic_write(policy_path(), payload, restrict_to_owner=True)
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
@@ -230,7 +230,7 @@ class KeystoneFileBackend:
         # failure existed to remove a NEW store already PUBLISHED at a wide
         # DACL; that state is unreachable now, and keeping the unlink would
         # instead delete the PREVIOUS, healthy, already-locked-down store —
-        # every stored provider token — on one transient icacls failure.
+        # every stored provider token — on one transient lockdown failure.
         atomic_write(self._path, payload, restrict_to_owner=True)
 
     # -- SecretBackend -----------------------------------------------------

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
@@ -661,7 +661,7 @@ class TestPolicyLockdownOrdering(_HomeIsolated):
     inside ``atomic_write`` happens BEFORE the rename, so a transient lockdown
     or write failure can no longer reach — let alone delete — the previous,
     healthy ceiling (the old post-publish ``restrict_to_owner`` + unlink-on-
-    OSError shape silently reset the operator's autonomy policy on one icacls
+    OSError shape silently reset the operator's autonomy policy on one lockdown
     failure).
     """
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
@@ -307,7 +307,7 @@ class TestSecretStoreLockdownOrdering(unittest.TestCase):
     inside ``atomic_write`` happens BEFORE the rename, so a transient lockdown
     or write failure can no longer reach — let alone delete — the previous,
     healthy store (the old post-publish ``restrict_to_owner`` + unlink-on-
-    OSError shape destroyed every stored provider token on one icacls failure).
+    OSError shape destroyed every stored provider token on one lockdown failure).
     """
 
     def setUp(self):
@@ -340,7 +340,7 @@ class TestSecretStoreLockdownOrdering(unittest.TestCase):
         )
 
     def test_a_failed_lockdown_preserves_the_previous_store(self):
-        """One transient icacls failure must not delete every stored token."""
+        """One transient lockdown failure must not delete every stored token."""
         from unittest import mock
 
         self.backend.put("pagerduty", "api_token", "u+secretvalue")

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -183,9 +183,10 @@ def _unregister_notification_channels(request: web.Request, name: str) -> None:
 def _sync_builtin_config(name: str, *, enabled: bool) -> None:
     """Update config.json for a builtin app so gateway reads the right state on restart.
 
-    Blocking: performs a file-locked read-modify-write of config.json and, on
-    Windows, spawns ``icacls`` (``restrict_to_owner``). Callers on the event
-    loop must offload this through ``asyncio.to_thread``.
+    Blocking: performs a file-locked read-modify-write of config.json and then,
+    on Windows, applies the owner-only lockdown (``restrict_to_owner``,
+    in-process — but a possible SMB round-trip on a network-homed data home).
+    Callers on the event loop must offload this through ``asyncio.to_thread``.
     """
     cfg_key, _ = _BUILTIN_SERVICE_APPS.get(name, (None, None))
     if cfg_key is None:
@@ -209,13 +210,17 @@ def _sync_builtin_config(name: str, *, enabled: bool) -> None:
         raise OSError(f"Could not read config.json: {exc}") from exc
     if not platform_compat.IS_POSIX:  # pragma: no cover — exercised on Windows CI
         # POSIX mode bits are meaningless on Windows, so the preserved mode
-        # protects nothing there, and the shared helpers deliberately apply
-        # no DACL themselves because they are also called from loop-reachable
-        # paths (restrict_to_owner spawns icacls, a blocking subprocess).
-        # This caller runs off-loop (to_thread), so it applies the owner
-        # lockdown here: config.json can hold inline credentials. Warn rather
-        # than raise — the settings write itself succeeded, and the callers
-        # must still notify the service of the new enabled state.
+        # protects nothing there. update_config_locked's write path
+        # (write_config_atomically) applies the owner-only DACL itself on a
+        # LOCAL volume, but deliberately skips it on a network-homed data home
+        # (it can be reached from the event loop, and a DACL write to a UNC or
+        # mapped-drive path costs an unbounded SMB round-trip). This caller
+        # runs off-loop (to_thread), so it can afford that round-trip and
+        # applies the lockdown unconditionally — on a network-homed data home
+        # this is the only lockdown config.json gets, and config.json can hold
+        # inline credentials. Warn rather than raise — the settings write
+        # itself succeeded, and the callers must still notify the service of
+        # the new enabled state.
         try:
             platform_compat.restrict_to_owner(config_path())
         except OSError:
@@ -475,7 +480,7 @@ async def handle_publish_providers(request: web.Request) -> web.Response:
     # Gate 1 — platform: advertising a destination whose every mutating route
     # refuses is worse than not advertising it. In a worker thread with the
     # registry read below: the admission path can initialize the SEL audit log,
-    # which shells out on a fresh Windows gateway.
+    # which is blocking file IO on a fresh gateway.
     admits_cloud = await asyncio.to_thread(admits_cloud_deployment, "aws")
 
     # Gate 2 — operator: governance ceiling ∩ publish.allowed_destinations. Only
@@ -1572,8 +1577,10 @@ async def handle_enable_app(request: web.Request) -> web.Response:
         origin = info.get("origin", "")
         if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
             try:
-                # to_thread: the sync helper does file I/O and, on Windows,
-                # spawns icacls — neither may run on the event loop.
+                # to_thread: the sync helper does a file-locked read-modify-write
+                # of config.json and, on Windows, applies the owner-only lockdown
+                # (a possible SMB round-trip on a network-homed data home) —
+                # neither may run on the event loop.
                 await asyncio.to_thread(_sync_builtin_config, name, enabled=True)
             except OSError as exc:
                 logger.warning("Failed to sync config.json for %s: %s", name, exc)
@@ -1666,8 +1673,10 @@ async def handle_disable_app(request: web.Request) -> web.Response:
         origin = info.get("origin", "")
         if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
             try:
-                # to_thread: the sync helper does file I/O and, on Windows,
-                # spawns icacls — neither may run on the event loop.
+                # to_thread: the sync helper does a file-locked read-modify-write
+                # of config.json and, on Windows, applies the owner-only lockdown
+                # (a possible SMB round-trip on a network-homed data home) —
+                # neither may run on the event loop.
                 await asyncio.to_thread(_sync_builtin_config, name, enabled=False)
             except OSError as exc:
                 logger.warning("Failed to sync config.json for %s: %s", name, exc)

--- a/src/kiro_crew/auth/provider.py
+++ b/src/kiro_crew/auth/provider.py
@@ -49,8 +49,8 @@ class KasAuthProvider:
         # KIRO_API_KEY is a headless bypass matching KAS's EnvAuthProvider: a raw bearer
         # with no refresh and no profile ARN (region falls back us-east-1).
         api_key = os.environ.get("KIRO_API_KEY")
-        # Vault reads do file IO and (on Windows) restrict_to_owner's icacls
-        # subprocess inside key checks — off the event loop.
+        # Vault reads do file IO (plus owner-only key checks) — off the
+        # event loop.
         token = await asyncio.to_thread(self._store.resolve)
         if token is None:
             if api_key:

--- a/src/kiro_crew/auth/refresh.py
+++ b/src/kiro_crew/auth/refresh.py
@@ -93,15 +93,15 @@ async def ensure_fresh(
     async with identity_lock:
         # Re-check after awaiting the in-process lock: a sibling coroutine may have
         # refreshed while we waited, making both the flock and the HTTP call moot.
-        # Vault reads do file IO (and Windows icacls in key checks) — off-loop.
+        # Vault reads do file IO (plus owner-only key checks) — off-loop.
         current = await asyncio.to_thread(store.load, token.identity)
         if current is not None and not current.is_expired():
             return current
 
         def _open_refresh_lock() -> int:
-            # lock_path runs make_owner_only_dir (a synchronous icacls subprocess on
-            # Windows, up to seconds) and os.open is blocking IO — the whole lock-file
-            # setup stays off the event loop.
+            # lock_path runs make_owner_only_dir (blocking filesystem work; the
+            # Windows DACL is applied in-process) and os.open is blocking IO — the
+            # whole lock-file setup stays off the event loop.
             lock_path = store.lock_path(token.identity)
             lock_path.parent.mkdir(parents=True, exist_ok=True)
             return os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
@@ -117,7 +117,7 @@ async def ensure_fresh(
                 if current is not None and not current.is_expired():
                     return current
                 refreshed = await _refresh(current or token, session=session)
-                # store.save may spawn a Windows icacls subprocess (DACL) — off-loop.
+                # store.save does blocking file IO (owner-only lockdown included) — off-loop.
                 await asyncio.to_thread(store.save, refreshed)
                 return refreshed
             finally:

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1750,8 +1750,9 @@ async def _run_task(args: argparse.Namespace) -> None:
         embedding_dim=cfg.memory.embedding_dim,
         decay_rates=cfg.memory.decay_rates or None,
     )
-    # CALLER CONTRACT (vector_memory.py): async callers offload init() — the
-    # Windows path shells out to icacls and would freeze the loop for seconds.
+    # CALLER CONTRACT (vector_memory.py): async callers offload init() — it is
+    # blocking file IO end to end (sqlite connect, migrations, lockdown pass)
+    # and would stall the loop.
     await asyncio.to_thread(vector_memory.init)
     # Embeddings are always-on: wire the factory; bind embed_fn when the model
     # is already present. Deliberately NO download kick here — `kirocrew run`

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -1846,9 +1846,8 @@ async def require_owner_dashboard_request(
         return None
 
     # Off the loop: the FIRST sel() of a process CONSTRUCTS the log (trust-dir
-    # creation, key validation, on Windows an icacls subprocess), so on a fresh
-    # gateway whose first mutating request is non-owner this would stall every
-    # other request.
+    # creation, key validation — blocking file IO), so on a fresh gateway whose
+    # first mutating request is non-owner this would stall every other request.
     caller = str(request.get("user") or "unknown")
     try:
         from kiro_crew.sel import sel as _sel

--- a/src/kiro_crew/dashboard/handlers/feedback.py
+++ b/src/kiro_crew/dashboard/handlers/feedback.py
@@ -293,7 +293,7 @@ async def api_feedback_submit(request: web.Request) -> web.Response:
     kiro_crew_version, _ = redact_exfiltration_urls(kiro_crew_version)
     kiro_crew_version, _ = redact_credentials(kiro_crew_version)
     # Off the event loop: install_id() may create the id file and set
-    # owner-only permissions (a subprocess on Windows) on first use.
+    # owner-only permissions (blocking file IO) on first use.
     user_id = await asyncio.to_thread(_survey_identity)
 
     payload = {

--- a/src/kiro_crew/dashboard/handlers/mcp_custom.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_custom.py
@@ -542,8 +542,8 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
             return web.json_response(
                 {"error": _oauth_err, "code": "oauth_field_not_editable"}, status=400
             )
-        # Same offload rationale as the add path: the store write applies an
-        # owner-only DACL via a subprocess on Windows.
+        # Same offload rationale as the add path: the store write is blocking
+        # file IO (owner-only lockdown included, in-process on Windows).
         replaced = await _mcp._offload_config_write(_replace_kirocrew_spec, name, spec)
     if not replaced:
         return web.json_response({"error": f"server '{name}' not found"}, status=404)

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -241,9 +241,10 @@ async def _get_vector_store_async(state: DashboardState):
     """Async facade over ``_get_vector_store`` honouring init's caller contract.
 
     ``VectorMemoryStore.init()`` documents that async callers must offload it
-    (the Windows path shells out to icacls, freezing the loop for seconds), so
-    the standalone fallback inside ``_get_vector_store`` must not run inline in
-    a handler (#5221). Fast path: when a store is already resolvable without
+    (it is blocking file IO end to end — sqlite connect, migrations, the
+    owner-only lockdown pass), so the standalone fallback inside
+    ``_get_vector_store`` must not run inline in a handler (#5221). Fast path:
+    when a store is already resolvable without
     running ``init()`` — the context_builder supplied one, or a prior call
     cached the standalone fallback on ``state`` — delegate synchronously, so
     the common request path pays no thread hop. In both fast-path cases
@@ -256,7 +257,7 @@ async def _get_vector_store_async(state: DashboardState):
     # inside the worker would race a concurrent loop-side ``_get_memory`` into
     # publishing a second MemoryStore, detaching ``vector_store`` from the
     # object every other handler reads. MemoryStore's own ``init()`` is a
-    # cheap mkdir+seed (not the icacls-bearing one this wrapper offloads) and
+    # cheap mkdir+seed (not the lockdown-bearing one this wrapper offloads) and
     # ran on the loop for every request before #5221.
     mem = _get_memory(state)
     if mem.vector_store or hasattr(state, "_standalone_vector"):

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -3641,8 +3641,8 @@ async def _slack_config_save_locked(request: web.Request) -> web.Response:
 
     # ── Phase 2: commit. All validation passed, so writes are safe. ──
     if env_updates:
-        # Off-loop: on Windows the owner-only lockdown shells out to icacls,
-        # which must not block the event loop.
+        # Off-loop: the .env write is blocking file IO (lock, temp write,
+        # owner-only lockdown, replace) and must not block the event loop.
         await _write_env_off_loop(env_updates)
         # Keep the live process environment in sync with the new .env state.
         # load_credentials() lets os.environ win over .env, so without this a
@@ -4068,8 +4068,8 @@ async def _discord_config_save_locked(request: web.Request) -> web.Response:
                 relabel="session_folder" in staged,
             )
     if env_updates:
-        # Off-loop: on Windows the owner-only lockdown shells out to icacls,
-        # which must not block the event loop.
+        # Off-loop: the .env write is blocking file IO (lock, temp write,
+        # owner-only lockdown, replace) and must not block the event loop.
         await _write_env_off_loop(env_updates)
         # Keep the live process environment in sync with the new .env state
         # (load_credentials() lets os.environ win over .env — see the Slack
@@ -4451,8 +4451,8 @@ async def _telegram_config_save_locked(request: web.Request) -> web.Response:
                 relabel="session_folder" in staged,
             )
     if env_updates:
-        # Off-loop: on Windows the owner-only lockdown shells out to icacls,
-        # which must not block the event loop.
+        # Off-loop: the .env write is blocking file IO (lock, temp write,
+        # owner-only lockdown, replace) and must not block the event loop.
         await _write_env_off_loop(env_updates)
         # Keep the live process environment in sync with the new .env state
         # (load_credentials() lets os.environ win over .env — see the Slack
@@ -4588,8 +4588,8 @@ async def api_teams_activity(request: web.Request) -> web.Response:
     throttled_source = "" if is_proxied_request(request) else source
     if throttled_source and webhooks.auth_throttle_blocked(throttled_source):
         # Off the loop: the first ``sel()`` of a process CONSTRUCTS the log
-        # (trust-dir creation, key validation, an icacls subprocess on Windows),
-        # and this route can be the first request a fresh gateway ever serves.
+        # (trust-dir creation, key validation — blocking file IO), and this
+        # route can be the first request a fresh gateway ever serves.
         await asyncio.to_thread(
             lambda: _sel().log_api_access(
                 caller=source,
@@ -5093,8 +5093,9 @@ async def api_teams_config_save(request: web.Request) -> web.Response:
                     relabel="session_folder" in changes,
                 )
         if env_updates:
-            # Off-loop: restrict_to_owner spawns whoami/icacls subprocesses on
-            # Windows, which would stall the gateway loop if run inline.
+            # Off-loop: the .env write is blocking file IO (lock, temp write,
+            # owner-only lockdown, replace) that would stall the gateway loop
+            # if run inline.
             #
             # Cancellation guard: _write_env_off_loop shields + drains its
             # worker, so a CancelledError from it means the .env write has
@@ -5430,8 +5431,8 @@ async def api_webex_config_save(request: web.Request) -> web.Response:
                     relabel="session_folder" in changes,
                 )
         if env_updates:
-            # Off-loop: on Windows the owner-only lockdown shells out to icacls,
-            # which must not block the event loop.
+            # Off-loop: the .env write is blocking file IO (lock, temp write,
+            # owner-only lockdown, replace) and must not block the event loop.
             #
             # Cancellation guard: see Teams save for the full rationale. Only
             # roll config back when the .env write actually failed, not when
@@ -6021,8 +6022,8 @@ async def _wecom_config_save_locked(request: web.Request) -> web.Response:
                 relabel="session_folder" in staged,
             )
     if env_updates:
-        # Off-loop: on Windows the owner-only lockdown shells out to icacls,
-        # which must not block the event loop.
+        # Off-loop: the .env write is blocking file IO (lock, temp write,
+        # owner-only lockdown, replace) and must not block the event loop.
         #
         # Cancellation guard: see Teams save for the full rationale. Only
         # roll config back when the .env write actually failed, not when
@@ -6515,8 +6516,8 @@ async def _feishu_config_save_locked(request: web.Request) -> web.Response:
             return _corrupt_config()
 
     if env_updates:
-        # Off-loop: on Windows the owner-only lockdown shells out to icacls,
-        # which must not block the event loop.
+        # Off-loop: the .env write is blocking file IO (lock, temp write,
+        # owner-only lockdown, replace) and must not block the event loop.
         #
         # Cancellation guard: see the WeCom save for the full rationale. Only
         # roll config back when the .env write actually failed, not when

--- a/src/kiro_crew/dashboard/handlers/secrets.py
+++ b/src/kiro_crew/dashboard/handlers/secrets.py
@@ -39,9 +39,9 @@ async def _owner_only(request: web.Request, operation: str) -> web.Response | No
     if is_owner_dashboard_request(request):
         return None
     # Off the loop: the FIRST sel() of a process CONSTRUCTS the log (trust-dir
-    # creation, key validation, on Windows an icacls subprocess), so on a fresh
-    # gateway whose first secrets request is non-owner this would otherwise
-    # stall every other request. Same reasoning as agents._require_owner.
+    # creation, key validation — blocking file IO), so on a fresh gateway whose
+    # first secrets request is non-owner this would otherwise stall every other
+    # request. Same reasoning as agents._require_owner.
     caller = str(request.get("user") or "unknown")
     try:
         await asyncio.to_thread(

--- a/src/kiro_crew/dashboard/handlers/session_control.py
+++ b/src/kiro_crew/dashboard/handlers/session_control.py
@@ -46,9 +46,9 @@ async def _require_internal(request: web.Request) -> web.Response | None:
     # Off the loop AND best-effort, the two properties `_audit_denied` exists to
     # carry for exactly this shape of site: a refusal logged BEFORE the audit
     # middleware has run. `log_api_access` only enqueues, but the FIRST `sel()` of
-    # a process constructs the log -- trust-dir creation, key validation, and on
-    # Windows an `icacls` subprocess -- so a fresh gateway whose first
-    # session-control request is unauthenticated would run that synchronously on
+    # a process constructs the log -- trust-dir creation and key validation,
+    # blocking file IO -- so a fresh gateway whose first session-control request
+    # is unauthenticated would run that synchronously on
     # the event loop. And construction can raise (a trust root too short to sign
     # the chain), which unguarded would turn this 403 into a 500: losing the
     # denial in order to report it.

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -1064,8 +1064,8 @@ def _audit(
 
     Dispatched OFF the loop when one is running, mirroring
     ``update_metadata_off_loop``. ``log_tool_invocation`` only enqueues, but the
-    FIRST ``sel()`` of a process CONSTRUCTS the log -- trust-dir creation, key
-    validation, and on Windows an ``icacls`` subprocess -- and this can genuinely
+    FIRST ``sel()`` of a process CONSTRUCTS the log -- trust-dir creation and
+    key validation, blocking file IO -- and this can genuinely
     be that first call: ``sel_audit_middleware`` logs AFTER ``await handler(...)``,
     so on a fresh gateway the first authenticated request constructs the log
     inside whatever handler runs first. Offloading here covers every call site
@@ -1096,8 +1096,8 @@ def _sel_off_loop(write: "Callable[[], None]", what: str) -> None:
     to be found separately, having been missed while the other two were fixed.
 
     Two failure modes, both handled: a loop-blocking construct (a ``sel()`` that
-    creates the trust dir, validates keys, and on Windows shells out to
-    ``icacls``), and a construct that RAISES, which unguarded turns a 403 into a
+    creates the trust dir and validates keys — blocking file IO), and a construct
+    that RAISES, which unguarded turns a 403 into a
     500 -- losing the refusal in order to report it. An audit that cannot be
     written must never change what the caller is told.
     """
@@ -1137,9 +1137,9 @@ async def stop_target(
     # Prewarmed BEFORE `authorize_target`, and that ordering is load-bearing.
     # `stop_slot_turn`'s IDLE branch logs to the SEL with no await before it, so on
     # a fresh gateway a first `session_stop` against an idle slot would CONSTRUCT
-    # the log on the loop -- trust-dir creation, key validation, and on Windows an
-    # `icacls` subprocess. Constructing it off-loop first makes that call a cheap
-    # cache hit. Per-request, not a boot step: prewarming at startup is what
+    # the log on the loop -- trust-dir creation and key validation, blocking file
+    # IO. Constructing it off-loop first makes that call a cheap cache hit.
+    # Per-request, not a boot step: prewarming at startup is what
     # `no-new-work-on-gateway-boot-path` forbids, and a background task would only
     # narrow the race rather than close it.
     #

--- a/src/kiro_crew/deploy/handlers.py
+++ b/src/kiro_crew/deploy/handlers.py
@@ -1352,7 +1352,7 @@ async def _handle_get_config(_request: web.Request) -> web.Response:
 
     cfg = await asyncio.to_thread(_load_config)
     # In a worker thread: the admission path can initialize the SEL audit log,
-    # which shells out on a fresh Windows gateway.
+    # which is blocking file IO on a fresh gateway.
     enabled = await asyncio.to_thread(admits_cloud_deployment, "aws")
     if isinstance(cfg, dict):
         cfg = {**cfg, "cloudDeploymentEnabled": enabled}
@@ -2294,8 +2294,9 @@ def _cloud_gated(handler):
     previously-permitted deployment left behind.
 
     Runs the check in a worker thread: the admission path can initialize the SEL
-    audit log, which on a fresh Windows gateway shells ``icacls`` and would
-    otherwise stall the event loop for every request.
+    audit log, which on a fresh gateway does blocking file IO (trust-dir
+    creation, key validation) and would otherwise stall the event loop for
+    every request.
     """
 
     @functools.wraps(handler)

--- a/src/kiro_crew/eval/runner.py
+++ b/src/kiro_crew/eval/runner.py
@@ -248,10 +248,11 @@ class EvalRunner:
             conv_log.init()
             lesson_store = LessonStore(base_dir=ws)
             vector_store = VectorMemoryStore(db_path=ws / "vector_memory.db")
-            # Off the loop: init() now tightens the DB and its sidecars to
-            # owner-only, which on Windows shells out to icacls up to 11 times.
-            # This runs once per scenario, so a synchronous call would freeze the
-            # loop for seconds on every one.
+            # Off the loop: init() tightens the DB and its sidecars to
+            # owner-only — blocking file IO alongside the sqlite connect and
+            # migrations (the Windows lockdown itself is now in-process).
+            # This runs once per scenario, so a synchronous call would stall
+            # the loop on every one.
             await asyncio.to_thread(vector_store.init)
 
             # Wrap provider factory so all sessions share the same workspace root

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -319,9 +319,10 @@ async def run_gatewayd(
     """
     socket_path = Path(socket_path)
     # Off the event loop for the same reason as the manager's call: the
-    # owner-only step shells out to icacls on Windows. Startup is the least
-    # contended moment in this process, but the daemon's signal handlers and
-    # supervising ping are already live, so it is offloaded here too.
+    # owner-only step is blocking filesystem work (the Windows DACL is applied
+    # in-process). Startup is the least contended moment in this process, but
+    # the daemon's signal handlers and supervising ping are already live, so it
+    # is offloaded here too.
     await asyncio.to_thread(transport.prepare_dir, socket_path)
     # Singleton guard (race-free): acquire an exclusive advisory lock on a
     # lockfile beside the endpoint BEFORE probing/unlinking/binding. Without it,

--- a/src/kiro_crew/mcp_gateway/transport.py
+++ b/src/kiro_crew/mcp_gateway/transport.py
@@ -518,7 +518,7 @@ def prepare_dir(socket_path: str | os.PathLike[str]) -> None:
     """
     parent = Path(socket_path).parent
     # Called by attribute so the hermetic-test stub in conftest can intercept
-    # the Windows icacls path.
+    # the Windows DACL path.
     platform_compat.make_owner_only_dir(parent)
 
 

--- a/src/kiro_crew/session_image_repair.py
+++ b/src/kiro_crew/session_image_repair.py
@@ -565,8 +565,9 @@ def _write_backup_exclusively(path: Path, backup_path: Path) -> None:
             handle.flush()
             os.fsync(handle.fileno())
     except BaseException:
-        # The lockdown is fail-loud and shells out to icacls on Windows, so it
-        # can raise while we still hold the raw fd. Close it before unlinking:
+        # The lockdown is fail-loud (in-process on Windows, but any failure
+        # raises), so it can raise while we still hold the raw fd. Close it before
+        # unlinking:
         # Windows refuses to remove a file with an open handle, and a stranded
         # empty sidecar would make every later --apply raise BackupExistsError --
         # a permanent block produced by a failure that changed nothing.

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -1716,7 +1716,7 @@ def _build_snapshot(
             # success. Failing here leaves the temp for the handler below to remove and
             # publishes nothing, which is what makes the "abort rather than ship an
             # under-protected archive" promise true by construction. POSIX applies chmod
-            # 0o600; Windows applies an owner-only DACL via icacls, and a
+            # 0o600; Windows applies an owner-only DACL in-process, and a
             # same-directory rename carries the explicit ACE with the file.
             platform_compat.restrict_to_owner(str(tmp_tar))
             tmp_tar.rename(outfile)
@@ -2421,8 +2421,8 @@ def _lock_down_restored(path: Path, component: str) -> None:
     restrict_to_owner (fail-loud), NOT chmod_safe (which swallows OSError): security
     files include sel_hmac.key. Mirrors the create path's deliberate fail-loud
     lockdown -- better to abort than silently land a restored secret group- or
-    world-readable. POSIX applies chmod 0o600; Windows applies an owner-only DACL via
-    icacls. The freshly copied file is unlinked on failure so the abort this promises
+    world-readable. POSIX applies chmod 0o600; Windows applies an owner-only DACL
+    in-process. The freshly copied file is unlinked on failure so the abort this promises
     actually removes the exposed artifact, instead of leaving the restored secret
     under the destination's inherited DACL after the OSError propagates.
     """

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -918,11 +918,11 @@ class VectorMemoryStore:
         just created.
 
         Missing files are skipped BY AN EXISTENCE CHECK, not by catching the failure:
-        on Windows ``restrict_to_owner`` shells out, so a missing path raises plain
-        ``OSError`` (icacls exits non-zero) rather than ``FileNotFoundError``, which
-        only ever comes from the POSIX ``os.chmod``. Catching alone would spawn up to
-        five futile ``icacls`` processes on a clean init and log a false "may be
-        readable by other users" warning for each, twice per init. The race between
+        on Windows ``restrict_to_owner`` raises plain ``OSError`` for a missing path
+        (the in-process DACL write's failure is translated to ``OSError``) rather
+        than ``FileNotFoundError``, which only ever comes from the POSIX
+        ``os.chmod``. Catching alone would log a false "may be readable by other
+        users" warning for each missing file, twice per init. The race between
         the check and the call is benign: a file that appears in between is created by
         SQLite or FAISS inside the already-tightened directory, so it inherits
         owner-only access on both platforms and the next init covers it regardless.
@@ -951,7 +951,7 @@ class VectorMemoryStore:
         # pass below repairs what already EXISTS, which a tightened parent cannot do:
         # Windows grants *Bypass Traverse Checking* to Everyone by default, so a
         # pre-lockdown file stays reachable through it. Full reasoning -- the sidecar
-        # file set, the every-init rationale, the Windows icacls cost, the fail-soft
+        # file set, the every-init rationale, the Windows lockdown cost, the fail-soft
         # contract -- lives in docs/guides/windows-install.md, "The memory store".
         #
         # SCOPE: with the default `db_path` this directory IS the data home
@@ -1007,10 +1007,13 @@ class VectorMemoryStore:
         # no-op on Windows. Cost, file set and fail-soft contract:
         # docs/guides/windows-install.md, "The memory store".
         #
-        # CALLER CONTRACT: an async caller must offload this. The Windows path shells
-        # out to icacls, so calling ``init()`` directly on an event loop freezes it
-        # for seconds. All async callers now offload: ``eval.runner``,
-        # ``slack.gateway`` and ``cli_server._run_task`` via ``asyncio.to_thread``
+        # CALLER CONTRACT: an async caller must offload this. ``init()`` is
+        # blocking end to end — the sqlite connect, the schema migrations, and
+        # this lockdown pass (in-process on Windows since the advapi32
+        # conversion, but still filesystem work that can stall on a slow
+        # volume) — so calling it directly on an event loop stalls every task.
+        # All async callers now offload: ``eval.runner``, ``slack.gateway`` and
+        # ``cli_server._run_task`` via ``asyncio.to_thread``
         # (#5389); ``dashboard/handlers/memory.py``'s standalone fallback routes
         # through ``_get_vector_store_async``, which offloads the init-bearing
         # path (#5221).

--- a/src/kiro_crew/whatsapp/client.py
+++ b/src/kiro_crew/whatsapp/client.py
@@ -273,8 +273,8 @@ class WhatsAppClient:
         # after the restriction failed would pair the device and leave that
         # credential readable by any other local principal, which is exactly the
         # case a warning nobody reads does not cover.
-        # Off the loop: on Windows these resolve a SID and shell out to `icacls`,
-        # which is a subprocess on the one event loop that also carries every other
+        # Off the loop: these are blocking filesystem calls (the Windows DACL is
+        # applied in-process), and the one event loop also carries every other
         # channel and the liveness heartbeat. Still awaited rather than
         # fire-and-forget, because pairing must not begin until the credential's
         # directory is actually locked down.


### PR DESCRIPTION
Refs #6359 — resolves the stale-comment half; the chmod fail-loud-vs-warn half remains open for a human decision.

## What

Comment-text-only sweep, no behavior change. PR #5266 replaced the Windows owner-only lockdown's `icacls` subprocess with an in-process `advapi32` call (`platform_compat._apply_owner_only_dacl`), but ~25 comments/docstrings across `src/` still asserted the dead subprocess constraint in the present tense — load-bearing rationale that would lead a reader to re-derive decisions from a constraint that no longer exists.

Every hit of the corrected backtick-optional grep pattern (from the issue's triage thread) is rewritten to the current truth, plus same-class sites the pattern misses by phrasing ("an icacls subprocess", "shells out on a fresh Windows gateway", "a subprocess on Windows", "whoami/icacls"). After the sweep, the pattern returns zero hits in `src/` outside the two excluded chmod sites.

## Hard constraints honored

- **Every `asyncio.to_thread` offload stays** — only the stated reason changes (blocking file IO / slow-volume stalls, per `_apply_owner_only_dacl`'s documented policy: offloading remains good practice, no longer mandatory).
- **Second still-true blocking reasons keep their mandate** — e.g. `apps/routes.py` `_sync_builtin_config` keeps its "must offload" contract (file-locked config.json read-modify-write + the possible SMB round-trip its unconditional lockdown pays on a network-homed data home, which `write_config_atomically` deliberately skips).
- **Excluded (untouched):** the two `os.chmod(0o600)` sites and their rationale blocks — `src/kiro_crew/sel.py:~1145-1151` and `src/kiro_crew/workflows/store.py:~140-148` (`lockdown-ok: #5228`). Their fail-loud-vs-warn security decision stays open on #6359.

## Deliberate non-changes

- `mcp_gateway/rewriter.py:442`, `config/loader.py:974`, ops-mission-control incident notes at `test_policy_store.py`/`test_security.py` class docstrings — past-tense history of code that genuinely used the subprocess.
- `code_review_sage/tests/test_store_selfheal.py` `OSError("icacls failed")` — arbitrary simulated-error fixture strings.
- `computer_use/launch_windows.py:529` — describes using `icacls` as a measurement tool, unrelated to the lockdown.
- Test name `test_the_lockdown_never_runs_on_the_event_loop` kept (renaming is out of scope for a comment-only sweep); its docstring now states the real invariant (blocking file IO off the loop).

## Verification

- Behavior-neutrality: every changed line is a comment, docstring, or one of two test message strings (docstring + assertion message in `code_review_sage/tests/test_backend_routes.py`).
- `isort` / `flake8` / `mypy` / diff-scoped black gate green; full backend suite run — 72,586 passed; the 96 failures + 2 errors are the known host-env set (xdist worker-cap, AF_UNIX path length), disjoint from every file this PR touches.
- Two pre-push blind review rounds (GPT + Opus lanes): round 1 fixed a fabricated `fsync` step, the non-local-volume DACL-skip nuance in `apps/routes.py`, and 2 missed sites (`mcp_custom.py`, `feedback.py`); round 2 fixed 2 more missed-phrasing sites (`apps/routes.py:483`, `deploy/handlers.py:1355`), an operation-ordering error (lockdown precedes payload write), and wording/wrap nits. Opus round 2: PASS.

no linked issue auto-close: intentionally "Refs" not "Closes" — the chmod half of #6359 must stay open.
