### PR TITLE
fix: guard slowloris connection_made against macOS SO_KEEPALIVE OSError (#6525)

### DIFF
--- a/src/kiro_crew/dashboard/slowloris.py
+++ b/src/kiro_crew/dashboard/slowloris.py
@@ -32,9 +32,12 @@ a hardened reverse proxy; this guard is the in-process backstop.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 from aiohttp import web
+
+logger = logging.getLogger(__name__)
 
 # Max seconds a client may take to send the complete request line + headers
 # before the connection is force-closed. Generous enough for any legitimate
@@ -70,7 +73,21 @@ class SlowlorisRequestHandler(web.RequestHandler):
         self._srh_disarmed = False
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
-        super().connection_made(transport)
+        try:
+            super().connection_made(transport)
+        except OSError:
+            # The socket can race closed between accept() and this callback
+            # (observed on macOS, where aiohttp's tcp_keepalive() setsockopt
+            # then raises EINVAL). The connection is already dead: close it
+            # quietly and leave the deadline unarmed instead of letting the
+            # error escape the transport callback as an unhandled asyncio
+            # exception dump. force_close() is safe even when the base call
+            # failed partway (it tolerates a missing transport/waiter).
+            logger.debug(
+                "dropping connection that closed during setup", exc_info=True
+            )
+            self.force_close()
+            return
         if self._srh_timeout and self._srh_timeout > 0:
             self._srh_handle = self._loop.call_later(
                 self._srh_timeout, self._srh_expire

--- a/test/test_dashboard_slowloris.py
+++ b/test/test_dashboard_slowloris.py
@@ -14,6 +14,8 @@ wiring into the dashboard / API server start paths:
 from __future__ import annotations
 
 import asyncio
+import errno
+import socket
 
 import aiohttp
 import pytest
@@ -121,3 +123,94 @@ def test_start_paths_use_hardened_runner() -> None:
     # fixed closing paren) so passing extra kwargs — e.g.
     # max_field_size=_MAX_HEADER_FIELD_SIZE — still satisfies the invariant.
     assert src.count("build_hardened_runner(app") == 2
+
+
+class _RacedClosedSocket:
+    """Socket stub that fails setsockopt like a raced-closed fd.
+
+    Mirrors the macOS failure where the peer closes between ``accept()`` and
+    ``connection_made``: every ``setsockopt`` raises ``EINVAL``. aiohttp's
+    ``tcp_nodelay`` (base-protocol path) suppresses its own OSError, but
+    ``tcp_keepalive`` (request-handler path) does not — that unguarded call is
+    the one this regression pins.
+    """
+
+    family = socket.AF_INET
+
+    def setsockopt(self, level: int, optname: int, value: object) -> None:
+        raise OSError(errno.EINVAL, "Invalid argument")
+
+
+class _RacedClosedTransport(asyncio.Transport):
+    """Transport whose extra-info socket raises on setsockopt; records close."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.closed = False
+
+    def get_extra_info(self, name: str, default: object = None) -> object:
+        if name == "socket":
+            return _RacedClosedSocket()
+        return default
+
+    def close(self) -> None:
+        self.closed = True
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+
+@pytest.mark.asyncio
+async def test_connection_made_oserror_is_contained() -> None:
+    """A socket that raced closed before setup is dropped without an escape.
+
+    aiohttp's base ``connection_made`` runs ``tcp_keepalive`` unguarded; on a
+    raced-closed socket the ``setsockopt`` OSError would otherwise escape the
+    transport callback as an unhandled asyncio exception dump. The guard must
+    swallow it, close the dead transport, and leave the deadline unarmed.
+    """
+    runner = build_hardened_runner(
+        await _make_app(), header_read_timeout=30.0, keepalive_timeout=75.0
+    )
+    await runner.setup()
+    try:
+        server = runner.server
+        assert isinstance(server, SlowlorisServer)
+        handler = server()
+        assert isinstance(handler, SlowlorisRequestHandler)
+        transport = _RacedClosedTransport()
+
+        # Must not raise despite the base call failing on setsockopt.
+        handler.connection_made(transport)
+
+        # The connection is treated as dead: transport closed, deadline never
+        # armed, and no request-serving task was started for it.
+        assert transport.closed
+        assert handler._srh_handle is None
+        assert handler._task_handler is None
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_connection_made_non_oserror_still_escapes() -> None:
+    """The guard is scoped to OSError; other exceptions must propagate."""
+    runner = build_hardened_runner(
+        await _make_app(), header_read_timeout=30.0, keepalive_timeout=75.0
+    )
+    await runner.setup()
+    try:
+        server = runner.server
+        assert isinstance(server, SlowlorisServer)
+        handler = server()
+
+        class _Boom(asyncio.Transport):
+            def get_extra_info(self, name: str, default: object = None) -> object:
+                if name == "socket":
+                    raise RuntimeError("not an OSError")
+                return default
+
+        with pytest.raises(RuntimeError):
+            handler.connection_made(_Boom())
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

On macOS (0.5.0-insider.1 Desktop app), the backend emits a repeating `ASYNCIO UNHANDLED` crash dump:

```
SlowlorisRequestHandler.connection_made
  -> super().connection_made(transport)            (slowloris.py:73)
  -> aiohttp web_protocol.RequestHandler.connection_made
  -> aiohttp tcp_helpers.tcp_keepalive(real_transport)
  -> sock.setsockopt(SOL_SOCKET, SO_KEEPALIVE, 1)
OSError: [Errno 22] Invalid argument
```

The issue's own "What happened" narrative (a copy-on-write filesystem overlay theory) is an incorrect self-diagnosis; the actionable defect is this unhandled asyncio exception in the crash log.

## Why it matters

Every raced-closed connection produces a full unhandled-exception dump in the log — noisy and alarming for users, who read it as data-loss/persistence failure (that is literally how #6525 got filed). Functionally it is benign (the connection is already dead), but the error escaping the transport callback also skips the slowloris bookkeeping for that connection.

## What changed (motivation → approach → change)

Symptom: unhandled `OSError: [Errno 22]` dumps from `connection_made`. Root cause: `SlowlorisRequestHandler.connection_made` calls `super().connection_made(transport)`, which routes into aiohttp's `RequestHandler.connection_made` → `tcp_keepalive()` → `sock.setsockopt(SO_KEEPALIVE)`. On macOS, when the socket races closed between `accept()` and `connection_made`, that `setsockopt` raises `OSError(EINVAL)`; aiohttp does not guard the call, so the exception escapes the transport callback as an unhandled asyncio exception.

Change: guard the `super().connection_made(transport)` call in `try/except OSError`. On `OSError`, treat the connection as dead — `self.force_close()`, do not arm the deadline timer, log once at debug (`exc_info=True`), return cleanly. Verified against aiohttp 3.14.3 ordering: `BaseProtocol.connection_made` sets `self.transport` before `tcp_keepalive()` runs, so `force_close()` correctly closes the dead transport; the serving task and manager registration never happen (both come after the raise), so there is nothing else to unwind. Non-`OSError` exceptions still propagate; the normal path (arm the one-shot deadline) is unchanged.

## Tests

Added to `test/test_dashboard_slowloris.py`:

- `test_connection_made_oserror_is_contained` — drives `connection_made` with a transport whose extra-info socket raises `OSError(errno.EINVAL)` on `setsockopt` (the exact raced-closed macOS mechanism; aiohttp's own `tcp_nodelay` suppresses its OSError, `tcp_keepalive` does not). Asserts no exception escapes, the transport is closed, the deadline is never armed, and no serving task is started. Mutation-verified: reverting the try/except turns this test red.
- `test_connection_made_non_oserror_still_escapes` — pins that the guard is scoped to `OSError` and does not swallow other exceptions.

All four pre-existing slowloris tests stay green (slow-header force-close, keep-alive not reaped, runner wiring, start-path usage), confirming the normal-path deadline semantics are unchanged.

## Manual verification

N/A — unit coverage sufficient: the regression test reproduces the exact failing `setsockopt` call path from the crash dump, and the failure is macOS-timing-dependent so it cannot be deterministically reproduced by hand.

## Related Issues

Closes #6525

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, behavior-preserving defensive guard
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (aiohttp connection handler); no rendered UI delta.
