### PR TITLE
test: pin real config values in slot-create inheritance test (#6522)

### DIFF
--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -10777,7 +10777,20 @@ class TestFolderCRUD:
                 "project_dir": "",
             },
         ]
+        # api_chat_slot_create reads only two config attributes on this
+        # agent-less path today: `default_agent` and `dashboard.default_project`.
+        # The load-bearing pin is `default_agent`: it is stamped into the slot
+        # when the request names no agent, and a mock-shaped value there
+        # survives into slot state until the coalesced slots broadcast at
+        # suspend_slots_push exit fails to json.dumps it — the TypeError
+        # escapes __exit__ and turns the successful create into a text/plain
+        # 500 (#6522). An empty default_agent also keeps resolve_agent_bindings
+        # out of this test: folder inheritance, not agent resolution, is what
+        # it exercises. The default_project pin is belt-and-braces — the
+        # handler isinstance-guards that read — but a real string keeps this
+        # fixture from leaning on the guard.
         mock_cfg = MagicMock()
+        mock_cfg.default_agent = ""
         mock_cfg.dashboard.default_project = ""
         monkeypatch.setattr(
             "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", lambda: mock_cfg


### PR DESCRIPTION
Closes #6522

## What this fixes

`test/test_dashboard_chat.py::TestFolderCRUD::test_slot_create_inherits_nearest_folder_project` fails deterministically on main (since 5c925e4e3, #6465), redding Backend Tests shards 2+3 on 3.10/3.12/Windows for every open PR. **The defect is test-only: the fixture, not the product.** This PR touches exactly one file, `test/test_dashboard_chat.py` (+13 comment/fixture lines).

## Root cause — two legs, both artifacts of a bare `MagicMock` config

The test stubbed `KiroCrewConfig.load` with a bare `MagicMock` (only `dashboard.default_project` pinned). On the agent-less `POST /api/chat/slots` path:

- **Leg 1 (harmless, logged, NOT the 500):** `mock_cfg.agents` is a truthy auto-created `MagicMock` whose `__iter__` yields nothing. `resolve_agent_bindings`' `elif config.agents:` guard passes and `next(iter(config.agents))` raises `StopIteration` — caught by the handler's `except Exception` at `chat_handlers.py:2019-2020` and logged (`WARNING chat_handlers.py:2020` in the CI log). The loader's guard is correct; the mock's shape defeats it.
- **Leg 2 (the actual 500):** with no `agent` in the request body the handler runs `agent = cfg.default_agent or ""`, stamping a **truthy MagicMock** into the slot. The coalesced slots broadcast at `suspend_slots_push` exit then fails `json.dumps(slots_data)` (`TypeError: Object of type MagicMock is not JSON serializable`, `state.py:8393`); the TypeError escapes `__exit__`, aiohttp renders a text/plain 500, and the test's `resp.json()` raises `ContentTypeError`.

## Why the issue's suggested fix is deliberately NOT implemented

#6522 proposes `next(iter(config.agents), None)` in `src/kiro_crew/config/loader.py`. That is not the defect: the loader already guards the genuinely-empty case (`elif config.agents:` / an `else:` branch returning safe defaults), and the StopIteration it would silence is already swallowed by the handler (Leg 1). Implementing it would leave the test red, because the 500 comes from Leg 2 — a mock-shaped `default_agent` reaching slot state. The divergence from the issue text is intentional, not an oversight; the corrected diagnosis was posted on the issue by triage.

## The fix

Pin the two config attributes this path actually reads to real values, following the file's established narrow-mock convention (e.g. the `_cc_cfg` site documents its read set the same way):

- `mock_cfg.default_agent = ""` — the **load-bearing** pin: nothing mock-shaped reaches slot state, and an empty agent keeps `resolve_agent_bindings` out of a test that exercises folder inheritance, not agent resolution.
- `mock_cfg.dashboard.default_project = ""` (pre-existing) — belt-and-braces; the handler isinstance-guards that read.

Sibling survey (spec item): every other `mock_cfg` site in the file either sets a real `agents` dict and exercises agent-explicit paths, patches `resolve_agent_bindings` itself, makes `load` raise (so `cfg is None`), or patches a different module's `load` with a documented read set. None reaches the agent-less slot-create path with an unpinned `default_agent`; all pass today and are untouched per the do-not-mass-rewrite rule.

## Verification

- Named test passes locally on **3.10.20 and 3.12.13**.
- **Full backend suite vs clean-main control** (same host, control worktree at 5c925e4e3): control 87 failed / 72,599 passed / 2 errors; branch 86 failed / 72,598 passed / 2 errors. The failure-set diff is **exactly this test flipping to pass** (the second control-only diff line is that same failure's captured aiohttp error-log output, not a test id). Zero branch-only regressions. Remaining failures are the known host-env set (AF_UNIX path too long, missing gh binary, sandbox home).
- Lint gates green with repo-pinned tooling: `isort` ✅ `flake8` ✅ `mypy` (1152 files, no issues) ✅ CI-identical black ratchet ✅.
- `git diff --stat`: only `test/test_dashboard_chat.py`; nothing under `src/kiro_crew/`.

## Pre-push review fleet

- **GPT 5.6 Sol: PASS, zero findings.** Independently traced both legs closed; confirmed the loader normalizes non-string `default_agent` values so the mock shape is fixture-only (no masked product defect); assertions still discriminate (broken nearest-ancestor walking would surface `root_project`, the test asserts `parent_project`).
- **Opus 5: PASS, zero blocking.** Confirmed the only AUTOSDE rule matching a test-only diff (`no-test-side-effects`) is moved TOWARD, not violated; verified the handler read-set claim and the sibling survey repo-wide. Two comment-wording advisories (name the load-bearing pin; date the read-set snapshot) — both adopted in this head.

## Inherited main-reds (not this PR's)

Main is currently also red on **Frontend Lint & Type Check** and **Coverage Gate** (CI run 33162369859 on 5c925e4e3), unrelated to this change and out of scope here. Please don't attribute those lanes to this diff.

## Out-of-scope follow-up filed

Hardening `api_chat_slot_create` so a broadcast failure during unwind cannot 500 an already-successful create is a real improvement but a failure-semantics design decision — filed separately as #6532 per the fix scope, not folded in.
