### PR TITLE
fix(mcp-gateway): repair a stale adopted daemon instead of only reporting it

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -401,7 +401,9 @@ async def run_gatewayd(
     async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         task = asyncio.current_task()
         try:
-            await _handle_connection(reader, writer, pool, resolver, socket_path, hot_keys)
+            await _handle_connection(
+                reader, writer, pool, resolver, socket_path, hot_keys, stop_event=stop_event
+            )
         except asyncio.CancelledError:
             # Normal on shutdown — propagate for the gather() below.
             raise
@@ -2077,6 +2079,88 @@ def _audit_prewarm_spawn(pool_label: str) -> None:
         logger.debug("SEL audit emit for prewarm spawn failed", exc_info=True)
 
 
+def _audit_stand_down(reason: str, outcome: str) -> None:
+    """Emit a SEL audit event for a stand-down request.
+
+    A stand-down ends the daemon, so it is the most consequential frame the
+    control surface accepts and belongs in the HMAC-chained SEL alongside the
+    claim/abort/peer decisions. Wrapped defensively -- an audit-log failure must
+    never break connection handling.
+    """
+    try:
+        SecurityEventLog().log_api_access(
+            caller="gateway-manager",
+            operation="mcp-gateway.stand_down",
+            outcome=outcome,
+            source="gateway",
+            resources=",".join(resolvable_target_stems()) or "(none)",
+            error=reason,
+        )
+    except Exception:  # pragma: no cover — audit must never break the handler
+        logger.debug("SEL audit emit for stand-down failed", exc_info=True)
+
+
+def _apply_stand_down(frame: dict[str, Any], stop_event: Optional[asyncio.Event]) -> dict[str, Any]:
+    """Yield the socket voluntarily so a daemon with a current target map can bind.
+
+    ``manager._report_adoption_drift`` can already SEE that an adopted survivor's
+    baked target map no longer covers the configured stub set; its own warning
+    ends "Replace the daemon to restore them", and this frame is how that
+    replacement happens without anyone unlinking a live socket.
+
+    Setting ``stop_event`` takes exactly the graceful path SIGTERM takes (the
+    signal handlers installed by ``_amain`` do only ``stop_event.set()``):
+    accepts stop, attached stubs drain, ``pool.shutdown_all()`` runs, the
+    endpoint is removed, the lock is released, the process exits. Doing it this
+    way round is the whole point. The alternative -- the starting gateway
+    unlinking the socket to take it -- is a connect-probe-then-unlink, which in
+    its documented false-stale window steals a LIVE incumbent's endpoint and
+    re-introduces the socket-theft class the flock guard exists to prevent. Here
+    the incumbent decides, and the request only ever arrives over a connection
+    that proves the incumbent is alive, so there is no stale-vs-live judgement to
+    get wrong.
+
+    ``need`` is the list of target stems the caller requires. A daemon that
+    already resolves ALL of them is REFUSED: there is nothing to gain by cycling
+    it, and honouring the request would turn this into a bare kill switch a
+    confused caller could aim at a daemon serving it correctly. A SUPERSET is
+    therefore fit -- extra stems a newer config no longer asks for are harmless,
+    and refusing on inequality would cycle a perfectly good daemon.
+
+    Trust basis for the rest is the same uid-gated owner-only socket that
+    authenticates Register/Claim/Abort.
+    """
+    need = frame.get("need")
+    if not isinstance(need, list) or not need or not all(isinstance(s, str) and s for s in need):
+        _audit_stand_down("missing or invalid need list", "denied")
+        return {"type": "stand-down-rejected", "reason": "missing or invalid 'need' stem list"}
+    served = set(resolvable_target_stems())
+    missing = sorted(set(need) - served)
+    if not missing:
+        _audit_stand_down("already covers every needed stem", "denied")
+        return {
+            "type": "stand-down-rejected",
+            "reason": "this daemon already resolves every requested target stem",
+        }
+    if stop_event is None:
+        # Reached only by a handler wired without a stop event (unit tests
+        # constructing _handle_connection directly). Refuse rather than claim a
+        # shutdown that cannot happen -- an accepted-but-inert control frame is
+        # worse than a rejected one, because the caller then waits for a lock
+        # that is never released.
+        _audit_stand_down("handler has no stop event", "denied")
+        return {"type": "stand-down-rejected", "reason": "shutdown not wired on this handler"}
+    logger.warning(
+        "gatewayd: standing down on request — this daemon cannot resolve %s, "
+        "which the caller's current config requires; draining so a daemon with "
+        "the current target map can bind",
+        ", ".join(missing),
+    )
+    _audit_stand_down(f"missing {','.join(missing)}", "allowed")
+    stop_event.set()
+    return {"type": "standing-down", "missing": missing}
+
+
 async def _handle_connection(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
@@ -2084,6 +2168,8 @@ async def _handle_connection(
     resolver: TargetResolver,
     socket_path: Path,
     hot_keys: Optional[HotKeyStore] = None,
+    *,
+    stop_event: Optional[asyncio.Event] = None,
 ) -> None:
     """Process one stub connection end-to-end.
 
@@ -2211,6 +2297,17 @@ async def _handle_connection(
     # same uid-gated 0700 socket as Register/Claim.
     if register.get("type") == "abort":
         await _write_json_line(writer, await _apply_abort(register, pool))
+        return
+
+    # Stand-down short-circuit (one-shot control connection from a STARTING
+    # gateway): "your baked target map cannot resolve what my config needs --
+    # yield the socket". The only frame that ends the daemon, and the mechanism
+    # that turns _report_adoption_drift's warning into an actual repair. Trust
+    # basis: same uid-gated owner-only socket as Register/Claim/Abort.
+    # Validation, the already-covers refusal and auditing live in
+    # ``_apply_stand_down``.
+    if register.get("type") == "stand-down":
+        await _write_json_line(writer, _apply_stand_down(register, stop_event))
         return
 
     # App-call short-circuit (one-shot control connection from the dashboard):

--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -69,6 +69,41 @@ _SHUTDOWN_GRACE_SECS = TOTAL_SHUTDOWN_BUDGET_SECS
 # Respawn backoff: start here, double up to max.
 _RESPAWN_BACKOFF_START_SECS = 1.0
 _RESPAWN_BACKOFF_MAX_SECS = 60.0
+# How many times start() will re-run assess-then-spawn before giving up. Two,
+# because the socket can change hands exactly once under a single start: a stale
+# incumbent yields and another gateway instance on the same machine wins the
+# freed lock first. Round two assesses that daemon; the cap is what stops two
+# instances trading the socket in a loop, and giving up is an ERROR rather than a
+# silent success against a daemon that cannot serve the configured stems.
+_ELECTION_ROUNDS = 2
+# Lifetime cap on stand-down requests one manager will issue. _ELECTION_ROUNDS
+# bounds hand-offs WITHIN one start(); this bounds them across the whole process,
+# which is the case the other cap cannot reach: the watchdog also assesses
+# incumbents, on an unbounded respawn loop, so two long-lived gateway instances
+# sharing a socket path with divergent stub sets would otherwise stand each
+# other's daemon down on every respawn, forever. Past the cap this manager stops
+# asking and adopts whatever holds the socket, logging why -- a bounded number of
+# cycles followed by a loud, stable, still-degrading-safely state. Removing the
+# oscillation entirely needs an ownership/generation lease so one instance is the
+# authorised successor; that is a protocol design and is deliberately not
+# invented here.
+_MAX_STAND_DOWN_REQUESTS = 3
+
+# What to do about the daemon holding the socket. Plain strings rather than an
+# Enum so they read the same in a log line as in a branch.
+#: Keep the incumbent (it covers our stems, or it will not yield and still serves).
+_ADOPT = "adopt"
+#: It released the socket; put our own daemon there.
+_SPAWN = "spawn"
+#: Neither is safe right now -- fail the start rather than report a false ready.
+_ABORT = "abort"
+
+# Outcomes of a stand-down request. _DRAINING must stay distinct from _REFUSED:
+# a daemon that ACCEPTED has already closed its accept loop and so is not
+# adoptable, while one that REFUSED is still serving and is.
+_RELEASED = "released"
+_DRAINING = "draining"
+_REFUSED = "refused"
 
 # Python module invoked as the gateway daemon. Kept as a constant so
 # tests can monkey-patch it and the spawn path stays one line.
@@ -141,12 +176,19 @@ class GatewaySpec:
 class GatewayManager:
     """Supervise a single gateway daemon subprocess."""
 
+    #: Class-level default so the attribute is TOTAL regardless of construction
+    #: path. Call sites and tests build this object via ``__new__``, bypassing
+    #: ``__init__``, and an instance-only attribute would raise AttributeError on
+    #: every such path the moment the adoption gate reads it.
+    _stand_downs_issued: int = 0
+
     def __init__(self, spec: GatewaySpec) -> None:
         self._spec = spec
         self._process: asyncio.subprocess.Process | None = None
         self._watchdog: asyncio.Task[None] | None = None
         self._stopping = False
         self._adopted = False
+        self._stand_downs_issued = 0
         self._lifecycle_lock = asyncio.Lock()
 
     @property
@@ -184,26 +226,155 @@ class GatewayManager:
         # survivor from a prior gateway), adopt it instead of spawning a
         # competitor. gatewayd's flock guard already makes a duplicate spawn
         # a clean no-op, but adopting skips the wasted spawn/exit churn.
-        incumbent = await self._ping_payload()
-        if incumbent is not None:
-            self._adopted = True
-            logger.info(
-                "mcp-gateway: a healthy daemon already owns %s — adopting "
-                "(no spawn)", self._spec.socket_path,
-            )
-            # Adoption skips _spawn_once, which is the ONLY place
-            # spec.mcp_target_env is applied. Check the incumbent actually
-            # covers what this spec would have given it, and say so if not.
-            self._report_adoption_drift(incumbent)
-            # Supervise even when adopting: the adopted daemon may be a
-            # prior-gateway survivor with no other watchdog in this process.
-            # The watchdog's adopted branch re-checks liveness by ping and
-            # re-elects (spawns a replacement) if the adopted daemon dies.
-            self._watchdog = asyncio.create_task(
-                self._run_watchdog(), name="mcp-gateway-watchdog"
-            )
-            return True
+        #
+        # Bounded election, because the socket can change hands once under a
+        # single start: a stale incumbent yields, and a DIFFERENT daemon (a
+        # second gateway instance on the same machine) can win the freed lock
+        # before our own spawn does. Round two assesses that daemon the same way
+        # round one assessed the first, and the cap is what stops two instances
+        # trading the socket indefinitely.
+        for _attempt in range(_ELECTION_ROUNDS):
+            incumbent = await self._ping_payload()
+            if incumbent is not None:
+                # Adoption skips _spawn_once, which is the ONLY place
+                # spec.mcp_target_env is applied. Check the incumbent actually
+                # covers what this spec would have given it, and say so if not.
+                missing = self._adoption_drift(incumbent)
+                if not missing:
+                    return self._adopt_incumbent()
+                verdict = await self._repair_or_adopt(missing)
+                if verdict == _ADOPT:
+                    return self._adopt_incumbent()
+                if verdict == _ABORT:
+                    # A draining incumbent: no longer adoptable (it has closed
+                    # its accept loop) and not yet replaceable (it still holds
+                    # the lock). Reporting ready here would be worse than the
+                    # drift -- it would hand sessions a daemon that accepts
+                    # nothing. Fail the start; the socket frees itself moments
+                    # later and the next start converges.
+                    return False
+                # _SPAWN: the incumbent released the socket. Fall through.
 
+            spawned = await self._spawn_and_confirm()
+            if spawned is None:
+                return False
+            if not self._adoption_drift(spawned):
+                if self.is_running:
+                    self._watchdog = asyncio.create_task(
+                        self._run_watchdog(), name="mcp-gateway-watchdog"
+                    )
+                    logger.info(
+                        "mcp-gateway: started pid=%s socket=%s",
+                        self._process.pid if self._process else "?",
+                        self._spec.socket_path,
+                    )
+                    return True
+                # Our spawn lost the lock, but whoever holds it covers what we
+                # need. Adopt rather than fight: a fit daemon is fit regardless
+                # of who started it, and leaving _adopted False here would send
+                # the watchdog spawning doomed competitors.
+                return self._adopt_incumbent()
+            # A foreign daemon holds the socket and cannot serve our stems. Drop
+            # our exited handle and let the next round assess it as an incumbent.
+            logger.warning(
+                "mcp-gateway: our spawn on %s lost the election to a daemon that "
+                "cannot resolve the configured target stems — re-electing",
+                self._spec.socket_path,
+            )
+            self._process = None
+        logger.error(
+            "mcp-gateway: could not put a daemon covering the configured target "
+            "stems on %s within %d election rounds; gateway unavailable",
+            self._spec.socket_path, _ELECTION_ROUNDS,
+        )
+        return False
+
+    def _adopt_incumbent(self) -> bool:
+        """Adopt the daemon on the socket and supervise it. Always ``True``."""
+        self._adopted = True
+        self._process = None
+        logger.info(
+            "mcp-gateway: a healthy daemon already owns %s — adopting "
+            "(no spawn)", self._spec.socket_path,
+        )
+        # Supervise even when adopting: the adopted daemon may be a
+        # prior-gateway survivor with no other watchdog in this process.
+        # The watchdog's adopted branch re-checks liveness by ping and
+        # re-elects (spawns a replacement) if the adopted daemon dies.
+        self._watchdog = asyncio.create_task(
+            self._run_watchdog(), name="mcp-gateway-watchdog"
+        )
+        return True
+
+    async def _repair_or_adopt(self, missing: list[str]) -> str:
+        """Try to replace a stale incumbent; decide what the caller does next.
+
+        Returns :data:`_SPAWN` (it yielded, put our own daemon there),
+        :data:`_ADOPT` (it will not yield -- keep it, degraded, and say so) or
+        :data:`_ABORT` (it accepted but is still draining, so it is neither
+        adoptable nor replaceable right now).
+
+        The ``_ADOPT`` branch is the deliberate fail-open and it preserves main's
+        prior behaviour exactly: an incumbent that refuses is still SERVING, so
+        adopting keeps every server it can resolve working, and the stubs for the
+        stems it cannot resolve degrade to per-session exec rather than dying.
+        Refusing to adopt would instead leave the socket held by a daemon nobody
+        supervises and no working broker at all.
+        """
+        if self._stand_downs_issued >= _MAX_STAND_DOWN_REQUESTS:
+            # Oscillation guard. Reached only when this process has already asked
+            # _MAX_STAND_DOWN_REQUESTS times, which in practice means another
+            # live gateway instance keeps re-winning the socket with a different
+            # target map. Settle instead of trading the socket forever.
+            logger.error(
+                "mcp-gateway: incumbent on %s still cannot resolve %s, but this "
+                "gateway has already issued %d stand-downs — adopting it instead "
+                "of contending further. Another gateway instance is likely "
+                "sharing this socket path with a different stub set; these "
+                "servers' stubs stay on per-session exec.",
+                self._spec.socket_path,
+                ", ".join(missing),
+                self._stand_downs_issued,
+            )
+            return _ADOPT
+        logger.warning(
+            "mcp-gateway: incumbent on %s cannot resolve %s — asking it to "
+            "stand down so a daemon with the current target map can bind",
+            self._spec.socket_path, ", ".join(missing),
+        )
+        outcome = await self._request_stand_down(missing)
+        if outcome == _RELEASED:
+            logger.info(
+                "mcp-gateway: stale incumbent stood down and released %s — "
+                "spawning a daemon for the current target map",
+                self._spec.socket_path,
+            )
+            return _SPAWN
+        if outcome == _DRAINING:
+            logger.error(
+                "mcp-gateway: incumbent on %s accepted the stand-down but had not "
+                "released the socket within %.0fs. It is draining and no longer "
+                "accepting, so it is NOT adopted — adopting a daemon that cannot "
+                "accept would make every server unreachable instead of only the "
+                "drifted ones. Starting without a shared broker; sessions fall "
+                "back to per-session MCP and the next start finds it free.",
+                self._spec.socket_path, _SHUTDOWN_GRACE_SECS,
+            )
+            return _ABORT
+        return _ADOPT
+
+    async def _spawn_and_confirm(self) -> Optional[dict]:
+        """Spawn a daemon and return the ``pong`` of whoever ends up serving.
+
+        ``None`` means the start failed outright (spawn raised, shutdown
+        intervened, the endpoint never appeared, or nothing answered) and the
+        process handle is already cleaned up.
+
+        A returned pong is NOT proof the daemon is ours: gatewayd's flock guard
+        makes a duplicate spawn exit rc=0 without binding, so on a contended
+        socket the answer can come from a foreign daemon. The caller decides by
+        coverage, which is why this returns the frame rather than a bool.
+        """
         # Clear any stale socket from a prior crash.
         await self._clear_stale_socket()
         # Owner-only containing directory: the socketsec model calls this the
@@ -222,7 +393,7 @@ class GatewayManager:
             await self._spawn_once()
         except Exception:
             logger.exception("mcp-gateway: initial spawn failed")
-            return False
+            return None
 
         # Re-check after spawn: shutdown() may have been called while we
         # were awaiting _spawn_once(). If so, terminate the freshly-spawned
@@ -230,7 +401,7 @@ class GatewayManager:
         if self._stopping:
             logger.info("mcp-gateway: stopping flag set after spawn — aborting start")
             await self._terminate_process(grace_secs=_SHUTDOWN_GRACE_SECS)
-            return False
+            return None
 
         ok = await self._wait_for_socket(self._spec.socket_path, _SOCKET_READY_TIMEOUT_SECS)
         if not ok:
@@ -239,27 +410,29 @@ class GatewayManager:
                 _SOCKET_READY_TIMEOUT_SECS,
             )
             await self._terminate_process(grace_secs=_SHUTDOWN_GRACE_SECS)
-            return False
+            return None
 
         # One ping/pong round-trip confirms the daemon's accept loop is
         # live before we hand control back to the caller. Without this the
         # socket appearing only proves bind() succeeded; the handler task
         # might still be wiring up when the first stub connects.
-        if not await self._ping_once():
+        pong = await self._ping_payload()
+        if pong is None:
             logger.warning("mcp-gateway ping failed — treating start as failure")
             await self._terminate_process(grace_secs=_SHUTDOWN_GRACE_SECS)
-            return False
-
-        self._watchdog = asyncio.create_task(self._run_watchdog(), name="mcp-gateway-watchdog")
-        logger.info(
-            "mcp-gateway: started pid=%s socket=%s",
-            self._process.pid if self._process else "?",
-            self._spec.socket_path,
-        )
-        return True
+            return None
+        return pong
 
     async def shutdown(self) -> None:
         """Stop the watchdog and terminate the daemon."""
+        # Set BEFORE contending for the lock, not inside the locked section. A
+        # start() that met a stale incumbent can hold this lock for the whole
+        # stand-down wait (another process's drain budget), and _stopping is the
+        # only way to tell it to give up; setting it after acquiring the lock
+        # would mean shutdown waits out that drain before it can even say so.
+        # Safe to hoist: the flag is monotonic (only ever set on the way down)
+        # and every path that reads it already treats it as "abort".
+        self._stopping = True
         async with self._lifecycle_lock:
             await self._shutdown_locked()
 
@@ -417,18 +590,25 @@ class GatewayManager:
                     break
         return stems
 
-    def _report_adoption_drift(self, pong: dict) -> bool:
+    def _adoption_drift(self, pong: dict) -> list[str]:
         """Warn when an incumbent daemon's target map does not cover this spec.
 
-        Returns ``True`` iff drift was found. Reports rather than refuses, and
-        that split is deliberate: refusing adoption cannot actually replace the
-        incumbent, because gatewayd's flock guard makes a competing spawn a
-        clean no-op -- the stale daemon would keep the socket and we would have
-        traded a warning for an outage. What makes the drift SAFE is the
-        gatewayd-side change that answers an unknown target at the
-        ensure_backend pre-flight with ``fallback: true``, so a stub degrades to
-        a per-session exec instead of dying. This method's job is to make the
-        cost of that degradation visible, since it is real: pooling and the
+        Returns the sorted target stems the incumbent CANNOT resolve (empty when
+        it covers everything), so the caller can both report the cost and name
+        those stems in a stand-down request. Reporting is not refusing, and
+        that split is deliberate: this method only MEASURES the drift, and the
+        caller decides. Refusing adoption on its own would not help -- gatewayd's
+        flock guard makes a competing spawn a clean no-op while the stale daemon
+        keeps the socket, so a bare refusal trades a warning for an outage. The
+        repair therefore goes through ``_repair_or_adopt``, which asks the
+        incumbent to RELEASE the socket first (``_request_stand_down``); only
+        then is a competing spawn able to bind.
+
+        Two things still make the un-repaired case safe, and both matter because
+        an incumbent may refuse: the gatewayd side answers an unknown target at
+        the ensure_backend pre-flight with ``fallback: true``, so a stub degrades
+        to a per-session exec instead of dying, and this method's warning makes
+        the cost of that degradation visible, since it is real -- pooling and the
         strict session key are lost for every server the incumbent cannot serve.
 
         The drift is otherwise invisible and self-perpetuating: the target map is
@@ -437,17 +617,20 @@ class GatewayManager:
         predates a ``stub_servers`` change serves a stale map for as long as it
         holds the socket -- observed in the field as a 25-day-old daemon that
         silently removed ``kirocrew-core``'s entire tool surface from every
-        session. Automatic replacement needs a reap seam an adopted manager does
-        not have (it owns no PID) and is tracked separately.
+        session.
         """
         required = self._required_target_stems()
         if not required:
-            return False
+            return []
         reported = pong.get("targets")
         if not isinstance(reported, list):
             # A daemon too old to report coverage. Unverifiable, not proven bad
             # -- but it is exactly the pre-upgrade survivor class that carries a
-            # stale map, so say so instead of assuming coverage.
+            # stale map, so say so instead of assuming coverage. Treated as
+            # drifted on EVERY required stem, which makes it a stand-down
+            # candidate: such a daemon does not understand the frame either, so
+            # it answers by closing the connection and the caller falls through
+            # to adopting it with this warning already on the record.
             logger.warning(
                 "mcp-gateway: incumbent daemon on %s does not report its target "
                 "map (pre-upgrade daemon), so its coverage of %d configured "
@@ -456,19 +639,112 @@ class GatewayManager:
                 "replace.",
                 self._spec.socket_path, len(required),
             )
-            return True
+            return sorted(required)
         missing = sorted(required - {s for s in reported if isinstance(s, str)})
         if not missing:
-            return False
+            return []
         logger.warning(
             "mcp-gateway: incumbent daemon on %s is STALE -- its target map is "
             "missing %s. Its env was baked when it spawned and an adopted daemon "
-            "never re-applies a new one, so these servers' stubs will degrade to "
+            "never re-applies a new one, so these servers' stubs would degrade to "
             "per-session exec: their tools keep working, but pooling and the "
-            "strict session key are LOST. Replace the daemon to restore them.",
+            "strict session key are LOST.",
             self._spec.socket_path, ", ".join(missing),
         )
-        return True
+        return missing
+
+    async def _request_stand_down(self, need: list[str]) -> str:
+        """Ask a stale incumbent to yield the socket.
+
+        Returns :data:`_RELEASED` (accepted and the lock is free),
+        :data:`_DRAINING` (accepted but not finished within the budget) or
+        :data:`_REFUSED` (did not accept, or never answered). The caller MUST
+        keep ``_DRAINING`` distinct from ``_REFUSED``: a daemon that accepted has
+        already closed its accept loop, so it is no longer adoptable, whereas one
+        that refused is still serving and is.
+
+        Voluntary by design. The starting gateway must not take the endpoint
+        itself: :meth:`_clear_stale_socket` is a connect-probe-then-unlink, and
+        in its documented false-stale window that unlinks a LIVE incumbent's
+        socket -- the socket-theft class the flock guard exists to prevent. Here
+        the incumbent runs its own SIGTERM-equivalent drain and removes its own
+        endpoint, so there is no stale-vs-live judgement to get wrong.
+
+        ``need`` travels with the request so a daemon that already resolves every
+        requested stem can refuse (see ``gatewayd._apply_stand_down``).
+
+        What is waited ON is the singleton LOCK becoming free, not the endpoint
+        disappearing, and the difference is load-bearing. A draining daemon stops
+        accepting first and releases the lock last, so the endpoint goes away
+        while the lock is still held -- on Windows for the daemon's whole drain,
+        since the kernel drops a pipe name as soon as the last handle closes. A
+        replacement spawned in that gap loses the lock, exits rc=0 without
+        binding, and ``_wait_for_socket`` then fails the start with no watchdog
+        left to retry. The lock is precisely what the replacement must win, so it
+        is the only correct readiness signal.
+
+        Bounded by the daemon's own published shutdown budget, and abandoned as
+        soon as ``_stopping`` is set so a shutdown racing a start is not made to
+        wait out another process's drain.
+        """
+        self._stand_downs_issued += 1
+        reply = await self._control_roundtrip({"type": "stand-down", "need": sorted(need)})
+        if reply is None or reply.get("type") != "standing-down":
+            logger.warning(
+                "mcp-gateway: stand-down request on %s was not accepted (%s)",
+                self._spec.socket_path,
+                (reply or {}).get("reason") or "no answer",
+            )
+            return _REFUSED
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _SHUTDOWN_GRACE_SECS
+        while loop.time() < deadline:
+            if self._stopping:
+                logger.info(
+                    "mcp-gateway: abandoning the stand-down wait on %s — shutting down",
+                    self._spec.socket_path,
+                )
+                return _DRAINING
+            if await asyncio.to_thread(transport.singleton_lock_free, self._spec.socket_path):
+                return _RELEASED
+            await asyncio.sleep(_SOCKET_POLL_INTERVAL_SECS)
+        if await asyncio.to_thread(transport.singleton_lock_free, self._spec.socket_path):
+            return _RELEASED
+        return _DRAINING
+
+    async def _control_roundtrip(self, frame: dict[str, Any]) -> Optional[dict]:
+        """Send one control frame on a fresh connection and return the reply.
+
+        ``None`` on any transport, timeout, decode or non-object reply. Bounded
+        by ``_PING_TIMEOUT_SECS`` at connect / drain / read, which is what keeps
+        a wedged daemon from stalling gateway startup.
+        """
+        try:
+            reader, writer = await asyncio.wait_for(
+                transport.connect(self._spec.socket_path, limit=READ_BUFFER_LIMIT_BYTES),
+                timeout=_PING_TIMEOUT_SECS,
+            )
+        except (asyncio.TimeoutError, OSError) as exc:
+            logger.warning(
+                "mcp-gateway %s connect failed: %s", frame.get("type", "control"), exc
+            )
+            return None
+        try:
+            writer.write(json.dumps(frame).encode("utf-8") + b"\n")
+            await asyncio.wait_for(writer.drain(), timeout=_PING_TIMEOUT_SECS)
+            line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=_PING_TIMEOUT_SECS)
+            msg = json.loads(line.decode("utf-8"))
+            return msg if isinstance(msg, dict) else None
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError, ConnectionError,
+                asyncio.LimitOverrunError, UnicodeDecodeError, json.JSONDecodeError,
+                OSError):
+            return None
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
 
     async def _ping_payload(self) -> Optional[dict]:
         """The daemon's ``pong`` payload, or ``None`` if it did not answer one.
@@ -688,19 +964,41 @@ class GatewayManager:
             # or gatewayd's flock guard rejected our last spawn (it exited
             # rc=0 without binding). If so, adopt the incumbent and stand the
             # watchdog down instead of respawn-looping doomed competitors.
-            if await self._ping_once():
-                self._adopted = True
-                logger.info(
-                    "mcp-gateway: socket %s already served by another daemon "
-                    "— adopting; watchdog will supervise it via ping",
-                    self._spec.socket_path,
-                )
-                # continue (NOT return): re-enter the loop so the adopted
-                # branch (proc is None and self._adopted) supervises the
-                # incumbent by ping and re-elects if it later dies. Returning
-                # here would terminate the watchdog and leave the adopted
-                # daemon unsupervised.
-                continue
+            #
+            # Same repair gate as the startup path: the incumbent this loop meets
+            # is reached by exactly the same reasoning, so a respawn must not
+            # silently accept a target map startup would have tried to replace.
+            #
+            # No SEPARATE post-respawn coverage check is needed here, unlike in
+            # _start_locked. A respawn that loses the flock exits rc=0, the
+            # wait-race below observes that exit, and control returns to THIS
+            # gate — so a stale daemon that won the socket is re-assessed within
+            # one backoff cycle rather than accepted permanently. _start_locked
+            # needed its own check because it returns to the caller instead of
+            # looping back to a gate.
+            incumbent = await self._ping_payload()
+            if incumbent is not None:
+                missing = self._adoption_drift(incumbent)
+                verdict = _ADOPT if not missing else await self._repair_or_adopt(missing)
+                if verdict == _ABORT:
+                    # Draining incumbent: neither adoptable nor replaceable yet.
+                    # Back off and re-assess rather than spawning into a held lock.
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, _RESPAWN_BACKOFF_MAX_SECS)
+                    continue
+                if verdict == _ADOPT:
+                    self._adopted = True
+                    logger.info(
+                        "mcp-gateway: socket %s already served by another daemon "
+                        "— adopting; watchdog will supervise it via ping",
+                        self._spec.socket_path,
+                    )
+                    # continue (NOT return): re-enter the loop so the adopted
+                    # branch (proc is None and self._adopted) supervises the
+                    # incumbent by ping and re-elects if it later dies. Returning
+                    # here would terminate the watchdog and leave the adopted
+                    # daemon unsupervised.
+                    continue
             try:
                 await self._clear_stale_socket()
                 await self._spawn_once()

--- a/src/kiro_crew/mcp_gateway/transport.py
+++ b/src/kiro_crew/mcp_gateway/transport.py
@@ -587,6 +587,40 @@ def endpoint_exists(socket_path: str | os.PathLike[str]) -> bool:
     return Path(socket_path).exists()
 
 
+def singleton_lock_free(socket_path: str | os.PathLike[str]) -> bool:
+    """Whether a replacement daemon could win the singleton lock right now.
+
+    Blocking (it opens a file and takes an advisory lock), so callers run it in
+    a thread. Acquires and immediately releases, which is the only way to ask
+    the question: the lock is held by an fd in another process and there is no
+    read-only "is it held" call.
+
+    This -- not :func:`endpoint_exists` -- is what "the incumbent has finished
+    releasing" means. A draining daemon stops accepting FIRST and releases the
+    lock LAST (``run_gatewayd`` closes the server, drains, shuts the pool down,
+    tears the endpoint down, and only then drops the lock), so the endpoint
+    stops being reachable well before a replacement could bind: on Windows at
+    the very start of shutdown, because the kernel drops a pipe name when the
+    last handle closes, so the whole drain sits inside that gap; on POSIX
+    between ``teardown`` unlinking the socket and process exit closing the fd. A
+    replacement spawned inside the gap loses the lock and exits rc=0 without
+    binding, and nothing rebinds afterwards.
+
+    ``True`` on an inconclusive failure: the caller uses this to decide whether
+    to spawn, and the flock itself remains the real arbiter -- a spawn that
+    turns out to be premature loses the lock and exits cleanly, which is the
+    outcome this probe exists to make rare rather than the one it must prevent.
+    """
+    try:
+        fd = acquire_singleton_lock(socket_path)
+    except OSError:
+        return True
+    if fd is None:
+        return False
+    os.close(fd)
+    return True
+
+
 async def remove_stale(socket_path: str | os.PathLike[str]) -> None:
     """Remove an endpoint left behind by a prior crash.
 

--- a/test/test_mcp_gateway_adopted_daemon_repair.py
+++ b/test/test_mcp_gateway_adopted_daemon_repair.py
@@ -1,0 +1,768 @@
+"""Repairing a stale adopted daemon, not just reporting it.
+
+``test_mcp_gateway_target_map_drift`` pins the DETECTION half: an adopted
+survivor whose baked target map no longer covers the configured stub set is
+found and warned about, and an unknown target at the pre-flight degrades to a
+per-session exec instead of dying. What that leaves is the cost the warning
+itself names -- pooling and the strict session key stay lost for every drifted
+server, for as long as the daemon holds the socket.
+
+This module pins the REPAIR: the incumbent is asked to release the socket, and a
+daemon carrying the current map binds in its place.
+
+Doing it by asking rather than taking is the whole design. The starting gateway
+must not unlink the endpoint itself: ``_clear_stale_socket`` is a
+connect-probe-then-unlink whose documented false-stale window would take a LIVE
+incumbent's socket, which is the socket-theft class the flock guard exists to
+prevent. A voluntary stand-down has no such window -- the request only ever
+reaches a daemon that just answered on that socket.
+
+Three properties beyond "it works" are pinned here, each found by review:
+
+* the wait is on the singleton LOCK, not the endpoint (they part company for a
+  daemon's whole drain on Windows);
+* a daemon that ACCEPTED but is still draining is never adopted (it accepts
+  nothing, so adopting it is worse than the drift);
+* an incumbent that REFUSES is still adopted, exactly as before, because it is
+  still serving -- the fail-open is deliberate and must not regress.
+
+Every test that starts a real daemon isolates KIROCREW_HOME and the working
+directory: the suite sets neither, and ``manager._gatewayd_log_path`` falls back
+to ``config_dir()`` -- the operator's real data home -- while a spawned daemon
+inherits pytest's CWD, which is the checkout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.mcp_gateway import gatewayd as gw
+from kiro_crew.mcp_gateway import manager as mgr
+from kiro_crew.mcp_gateway import transport
+from kiro_crew.mcp_gateway.gatewayd import resolvable_target_stems
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="observes a socket file and lock being released"
+)
+
+_TARGET_PREFIXES = ("KIROCREW_MCP_TARGET_", "MC_MCP_TARGET_")
+
+
+def _only_targets(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str]) -> None:
+    """Make ``mapping`` the process's ENTIRE target set, leaving the rest of env alone.
+
+    Never ``setattr(os, "environ", {...})``: ``gatewayd.os`` is the shared stdlib
+    module, so replacing its ``environ`` replaces the process-wide mapping and
+    drops every variable the suite set for isolation -- including KIROCREW_HOME,
+    which sends a spawned daemon's log into the operator's real data home.
+    """
+    for key in [k for k in os.environ if any(k.startswith(p) for p in _TARGET_PREFIXES)]:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in mapping.items():
+        monkeypatch.setenv(key, value)
+
+
+def _manager(tmp_path: Path, target_env: dict[str, str]) -> mgr.GatewayManager:
+    return mgr.GatewayManager(
+        mgr.GatewaySpec(socket_path=tmp_path / "gw.sock", mcp_target_env=dict(target_env))
+    )
+
+
+# ── gatewayd: the daemon yields its own socket ─────────────────────
+
+
+class TestApplyStandDown:
+    def test_stands_down_when_it_cannot_resolve_a_needed_stem(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+        stop = asyncio.Event()
+        reply = gw._apply_stand_down({"type": "stand-down", "need": ["KIROCREW_CORE", "PDF"]}, stop)
+        assert reply["type"] == "standing-down"
+        assert reply["missing"] == ["KIROCREW_CORE"]
+        assert stop.is_set(), "the daemon must take the graceful SIGTERM path"
+
+    def test_refuses_when_it_already_covers_everything_needed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not a bare kill switch: nothing to gain means nothing to do."""
+        _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+        stop = asyncio.Event()
+        reply = gw._apply_stand_down({"type": "stand-down", "need": ["PDF"]}, stop)
+        assert reply["type"] == "stand-down-rejected"
+        assert not stop.is_set()
+
+    def test_a_superset_daemon_is_fit_and_refuses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Coverage is a superset test, matching the drift check.
+
+        A daemon serving MORE than this config needs (another agent's servers) is
+        fit; cycling it would be a needless full broker outage. This is why the
+        frame carries the needed stems rather than an equality fingerprint.
+        """
+        _only_targets(
+            monkeypatch,
+            {
+                "KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf",
+                "KIROCREW_MCP_TARGET_EXCALIDRAW": "node x.js",
+            },
+        )
+        stop = asyncio.Event()
+        reply = gw._apply_stand_down({"type": "stand-down", "need": ["PDF"]}, stop)
+        assert reply["type"] == "stand-down-rejected"
+        assert not stop.is_set()
+
+    @pytest.mark.parametrize("need", [None, [], "PDF", ["", "PDF"], [17]])
+    def test_refuses_a_malformed_need(self, need: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+        stop = asyncio.Event()
+        frame: dict[str, Any] = {"type": "stand-down"}
+        if need is not None:
+            frame["need"] = need
+        assert gw._apply_stand_down(frame, stop)["type"] == "stand-down-rejected"
+        assert not stop.is_set()
+
+    def test_refuses_when_shutdown_is_not_wired(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An accepted-but-inert frame would leave the caller waiting on a lock
+        that is never released."""
+        _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+        reply = gw._apply_stand_down({"type": "stand-down", "need": ["CORE"]}, None)
+        assert reply["type"] == "stand-down-rejected"
+
+
+# ── the lock probe ─────────────────────────────────────────────────
+
+
+class TestSingletonLockFree:
+    def test_free_when_nobody_holds_it(self, short_sock_dir: Path) -> None:
+        assert transport.singleton_lock_free(short_sock_dir / "gw.sock") is True
+
+    def test_held_while_another_holder_has_it(self, short_sock_dir: Path) -> None:
+        sock = short_sock_dir / "gw.sock"
+        fd = transport.acquire_singleton_lock(sock)
+        assert fd is not None
+        try:
+            assert transport.singleton_lock_free(sock) is False
+        finally:
+            os.close(fd)
+        assert transport.singleton_lock_free(sock) is True
+
+    def test_the_probe_leaves_the_lock_available(self, short_sock_dir: Path) -> None:
+        """Acquire-and-release, not acquire-and-hold -- a leak wedges every spawn."""
+        sock = short_sock_dir / "gw.sock"
+        assert transport.singleton_lock_free(sock) is True
+        fd = transport.acquire_singleton_lock(sock)
+        assert fd is not None, "the probe must not still be holding the lock"
+        os.close(fd)
+
+
+# ── the stand-down request ─────────────────────────────────────────
+
+
+class TestRequestStandDown:
+    @pytest.mark.asyncio
+    async def test_a_refusal_short_circuits_before_the_wait(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager,
+            "_control_roundtrip",
+            AsyncMock(return_value={"type": "stand-down-rejected", "reason": "covered"}),
+        )
+        looked = {"n": 0}
+
+        def _free(_p: Path) -> bool:
+            looked["n"] += 1
+            return True
+
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", _free)
+        assert await manager._request_stand_down(["CORE"]) == mgr._REFUSED
+        assert looked["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_answer_is_a_refusal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-upgrade daemon refuses an unrecognised frame by closing."""
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(manager, "_control_roundtrip", AsyncMock(return_value=None))
+        assert await manager._request_stand_down(["CORE"]) == mgr._REFUSED
+
+    @pytest.mark.asyncio
+    async def test_waits_on_the_lock_not_the_endpoint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Windows shape: the endpoint is gone long before the lock is free.
+
+        run_gatewayd closes its server FIRST and releases the lock LAST, so on
+        Windows the pipe name stops resolving at the very start of shutdown and
+        the whole drain sits inside that gap. Waiting on the endpoint would
+        return here immediately, the replacement would lose the still-held lock,
+        exit rc=0 without binding, and nothing would rebind.
+        """
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager, "_control_roundtrip", AsyncMock(return_value={"type": "standing-down"})
+        )
+        monkeypatch.setattr(mgr.transport, "endpoint_exists", lambda _p: False)
+        drain = {"ticks": 0}
+
+        def _free(_p: Path) -> bool:
+            drain["ticks"] += 1
+            return drain["ticks"] > 4
+
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", _free)
+        assert await manager._request_stand_down(["CORE"]) == mgr._RELEASED
+        assert drain["ticks"] == 5, "the wait must track the lock, not the endpoint"
+
+    @pytest.mark.asyncio
+    async def test_a_drain_that_outruns_the_budget_is_draining_not_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager, "_control_roundtrip", AsyncMock(return_value={"type": "standing-down"})
+        )
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", lambda _p: False)
+        monkeypatch.setattr(mgr, "_SHUTDOWN_GRACE_SECS", 0.2)
+        assert await manager._request_stand_down(["CORE"]) == mgr._DRAINING
+
+    @pytest.mark.asyncio
+    async def test_gives_up_the_wait_when_shutdown_is_requested(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shutdown must not be made to wait out another process's drain."""
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(
+            manager, "_control_roundtrip", AsyncMock(return_value={"type": "standing-down"})
+        )
+
+        def _free(_p: Path) -> bool:
+            manager._stopping = True
+            return False
+
+        monkeypatch.setattr(mgr.transport, "singleton_lock_free", _free)
+        monkeypatch.setattr(mgr, "_SHUTDOWN_GRACE_SECS", 30.0)
+        assert await manager._request_stand_down(["CORE"]) == mgr._DRAINING
+
+
+class TestShutdownAnnouncesItselfEarly:
+    @pytest.mark.asyncio
+    async def test_stopping_is_set_before_the_lifecycle_lock_is_taken(self, tmp_path: Path) -> None:
+        """Otherwise a start mid-stand-down-wait can never observe the shutdown."""
+        manager = _manager(tmp_path, {})
+        await manager._lifecycle_lock.acquire()
+        try:
+            task = asyncio.create_task(manager.shutdown())
+            await asyncio.sleep(0.05)
+            assert manager._stopping is True, "shutdown must announce before blocking"
+            assert not task.done(), "and it is genuinely still waiting for the lock"
+        finally:
+            manager._lifecycle_lock.release()
+            await asyncio.wait_for(task, timeout=10)
+
+
+# ── the repair decision ────────────────────────────────────────────
+
+
+class TestRepairOrAdopt:
+    @pytest.mark.asyncio
+    async def test_a_yielding_incumbent_makes_room_for_a_spawn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        asked = AsyncMock(return_value=mgr._RELEASED)
+        monkeypatch.setattr(manager, "_request_stand_down", asked)
+        assert await manager._repair_or_adopt(["CORE"]) == mgr._SPAWN
+        asked.assert_awaited_once_with(["CORE"])
+
+    @pytest.mark.asyncio
+    async def test_a_refusing_incumbent_is_still_adopted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fail-open must not regress: a refusing daemon is still SERVING, so
+        adopting keeps every server it can resolve working and the drifted ones
+        degrade to per-session exec."""
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._REFUSED))
+        assert await manager._repair_or_adopt(["CORE"]) == mgr._ADOPT
+
+    @pytest.mark.asyncio
+    async def test_a_draining_incumbent_is_never_adopted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Accepted-but-slow is not the same as refused.
+
+        Once a daemon accepts it closes its accept loop, so it answers ping while
+        accepting no new connection. Adopting it would turn a partial degradation
+        (the drifted servers lose pooling) into a total outage (nothing can
+        register) and report success while doing it.
+        """
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._DRAINING))
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            assert await manager._repair_or_adopt(["CORE"]) == mgr._ABORT
+        assert any(
+            "NOT adopted" in r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+        )
+
+
+class TestOscillationCap:
+    """Bounding the case _ELECTION_ROUNDS cannot reach: two long-lived instances.
+
+    The watchdog also assesses incumbents on an unbounded respawn loop, so
+    without a process-lifetime cap two gateways sharing a socket path with
+    divergent stub sets would stand each other's daemon down forever.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stops_asking_past_the_cap_and_settles_loudly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        asked = AsyncMock(return_value=mgr._REFUSED)
+        monkeypatch.setattr(manager, "_request_stand_down", asked)
+
+        for _ in range(mgr._MAX_STAND_DOWN_REQUESTS):
+            assert await manager._repair_or_adopt(["CORE"]) == mgr._ADOPT
+            manager._stand_downs_issued += 1  # the real counter lives in the mocked method
+        assert asked.await_count == mgr._MAX_STAND_DOWN_REQUESTS
+
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            assert await manager._repair_or_adopt(["CORE"]) == mgr._ADOPT
+        assert asked.await_count == mgr._MAX_STAND_DOWN_REQUESTS, "must stop asking"
+        assert any(
+            "already issued" in r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_counter_advances_on_every_real_request(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {})
+        monkeypatch.setattr(manager, "_control_roundtrip", AsyncMock(return_value=None))
+        assert manager._stand_downs_issued == 0
+        await manager._request_stand_down(["CORE"])
+        await manager._request_stand_down(["CORE"])
+        assert manager._stand_downs_issued == 2
+
+    def test_the_counter_is_total_without_init(self) -> None:
+        """Built via __new__, as several call sites and tests do."""
+        bare = mgr.GatewayManager.__new__(mgr.GatewayManager)
+        assert bare._stand_downs_issued == 0
+
+
+# ── the election ───────────────────────────────────────────────────
+
+
+class TestElection:
+    """What happens when our own spawn loses the socket to somebody else.
+
+    The flock guard makes a duplicate spawn exit rc=0 WITHOUT binding, so a pong
+    arriving after our spawn is not proof the daemon is ours.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_fit_incumbent_is_adopted_with_no_stand_down(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_payload",
+            AsyncMock(return_value={"type": "pong", "targets": ["PDF"]}),
+        )
+        asked = AsyncMock(return_value=mgr._RELEASED)
+        monkeypatch.setattr(manager, "_request_stand_down", asked)
+        spawned = AsyncMock(side_effect=RuntimeError("must not spawn"))
+        monkeypatch.setattr(manager, "_spawn_and_confirm", spawned)
+        try:
+            assert await manager._start_locked() is True
+            assert manager._adopted is True
+            asked.assert_not_awaited()
+            spawned.assert_not_awaited()
+        finally:
+            if manager._watchdog is not None:
+                manager._watchdog.cancel()
+
+    @pytest.mark.asyncio
+    async def test_a_stale_incumbent_that_yields_is_replaced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "kirocrew mcp-core"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_payload",
+            AsyncMock(return_value={"type": "pong", "targets": ["PDF"]}),
+        )
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._RELEASED))
+        proc = MagicMock()
+        proc.returncode = None
+        proc.pid = 4242
+
+        async def _spawn() -> dict[str, Any]:
+            manager._process = proc
+            return {"type": "pong", "targets": ["CORE"]}
+
+        monkeypatch.setattr(manager, "_spawn_and_confirm", _spawn)
+        try:
+            assert await manager._start_locked() is True
+            assert manager.is_running, "we must own the replacement"
+            assert manager._adopted is False
+        finally:
+            if manager._watchdog is not None:
+                manager._watchdog.cancel()
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_stale_daemon_forces_one_more_round(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Round two assesses whoever won the freed lock; here it yields."""
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "kirocrew mcp-core"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_payload",
+            AsyncMock(side_effect=[None, {"type": "pong", "targets": ["PDF"]}]),
+        )
+        stood_down = AsyncMock(return_value=mgr._RELEASED)
+        monkeypatch.setattr(manager, "_request_stand_down", stood_down)
+        proc = MagicMock()
+        proc.returncode = None
+        proc.pid = 4242
+        rounds: list[int] = []
+
+        async def _spawn() -> dict[str, Any]:
+            rounds.append(1)
+            if len(rounds) == 1:
+                return {"type": "pong", "targets": ["PDF"]}  # lost the flock
+            manager._process = proc
+            return {"type": "pong", "targets": ["CORE"]}
+
+        monkeypatch.setattr(manager, "_spawn_and_confirm", _spawn)
+        try:
+            assert await manager._start_locked() is True
+            assert len(rounds) == 2, "a foreign stale daemon must force round two"
+            stood_down.assert_awaited_once_with(["CORE"])
+            assert manager.is_running
+        finally:
+            if manager._watchdog is not None:
+                manager._watchdog.cancel()
+
+    @pytest.mark.asyncio
+    async def test_rounds_are_bounded_and_exhaustion_is_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "kirocrew mcp-core"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_payload",
+            AsyncMock(return_value={"type": "pong", "targets": ["PDF"]}),
+        )
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._RELEASED))
+        spawn = AsyncMock(return_value={"type": "pong", "targets": ["PDF"]})
+        monkeypatch.setattr(manager, "_spawn_and_confirm", spawn)
+
+        with caplog.at_level(logging.ERROR, logger=mgr.logger.name):
+            assert await manager._start_locked() is False
+        assert spawn.await_count == mgr._ELECTION_ROUNDS
+        assert manager._adopted is False
+        assert any(
+            "election rounds" in r.getMessage()
+            for r in caplog.records
+            if r.levelno >= logging.ERROR
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_fails_rather_than_claiming_ready_on_a_draining_incumbent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "kirocrew mcp-core"})
+        monkeypatch.setattr(
+            manager,
+            "_ping_payload",
+            AsyncMock(return_value={"type": "pong", "targets": ["PDF"]}),
+        )
+        monkeypatch.setattr(manager, "_request_stand_down", AsyncMock(return_value=mgr._DRAINING))
+        spawned = AsyncMock(side_effect=RuntimeError("must not spawn into a held lock"))
+        monkeypatch.setattr(manager, "_spawn_and_confirm", spawned)
+
+        assert await manager._start_locked() is False
+        spawned.assert_not_awaited()
+        assert manager._adopted is False
+        assert manager._watchdog is None
+
+
+# ── end to end over a real socket ──────────────────────────────────
+
+
+async def _round_trip(socket_path: Path, frame: dict[str, Any]) -> dict[str, Any]:
+    reader, writer = await asyncio.wait_for(transport.connect(socket_path), timeout=10)
+    try:
+        writer.write(json.dumps(frame).encode("utf-8") + b"\n")
+        await writer.drain()
+        line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=10)
+        result = json.loads(line.decode("utf-8"))
+        assert isinstance(result, dict)
+        return result
+    finally:
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+
+async def _await_endpoint(socket_path: Path, *, timeout: float = 60.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if await asyncio.to_thread(transport.endpoint_exists, socket_path):
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"daemon never bound {socket_path}")
+
+
+def _isolate(monkeypatch: pytest.MonkeyPatch, home: Path) -> Path:
+    """Scope a real daemon's side effects: its data home AND its CWD.
+
+    KIROCREW_HOME because the suite does not set it and
+    ``manager._gatewayd_log_path`` falls back to ``config_dir()`` -- the
+    operator's real data home. The working directory because a spawned daemon
+    INHERITS pytest's CWD, which is the checkout; ``_spawn_once`` deliberately
+    passes no ``cwd`` (in production the daemon should inherit the gateway's), so
+    the test moves itself rather than changing that.
+    """
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    monkeypatch.chdir(home)
+    return home
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_a_real_daemon_leaves_nothing_in_the_repository(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No test side effects, asserted rather than assumed."""
+    repo = Path(__file__).resolve().parent.parent
+
+    def _snapshot() -> set[str]:
+        skip = {".git", ".venv", "node_modules", "__pycache__"}
+        return {e.name for e in repo.iterdir() if e.name not in skip}
+
+    before = _snapshot()
+    run_dir = _isolate(monkeypatch, tmp_path / "home")
+    assert Path.cwd() == run_dir.resolve(), "the test must not run in the checkout"
+    _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+
+    sock = short_sock_dir / "gw.sock"
+    stop = asyncio.Event()
+    daemon = asyncio.create_task(
+        gw.run_gatewayd(socket_path=sock, max_backends=1, idle_timeout_secs=60, stop_event=stop)
+    )
+    try:
+        await _await_endpoint(sock)
+        assert (await _round_trip(sock, {"type": "ping"}))["type"] == "pong"
+    finally:
+        stop.set()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(daemon, timeout=30)
+
+    assert _snapshot() == before, "a daemon under test must not write into the repo"
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_the_stand_down_frame_is_wired_into_the_serving_daemon(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ends the real daemon AND frees the lock a replacement must win.
+
+    This is the test that fails if ``run_gatewayd`` stops forwarding its
+    ``stop_event`` into the handler: the frame would answer
+    ``stand-down-rejected`` and the socket would stay bound.
+    """
+    _isolate(monkeypatch, tmp_path / "home")
+    _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+    sock = short_sock_dir / "gw.sock"
+    stop = asyncio.Event()
+    daemon = asyncio.create_task(
+        gw.run_gatewayd(socket_path=sock, max_backends=1, idle_timeout_secs=60, stop_event=stop)
+    )
+    try:
+        await _await_endpoint(sock)
+        reply = await _round_trip(sock, {"type": "stand-down", "need": ["KIROCREW_CORE"]})
+        assert reply["type"] == "standing-down"
+        await asyncio.wait_for(daemon, timeout=60)
+        assert not await asyncio.to_thread(transport.endpoint_exists, sock)
+        assert await asyncio.to_thread(
+            transport.singleton_lock_free, sock
+        ), "and its lock, which is what a replacement must win"
+    finally:
+        stop.set()
+        if not daemon.done():
+            daemon.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await daemon
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_a_stale_survivor_is_repaired_end_to_end(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The field case, start to finish, with TWO real daemon processes.
+
+    The survivor is a real subprocess launched with an OLD target map, standing
+    in for the 25-day-old daemon the drift module describes. That matters: its
+    environment is genuinely frozen at spawn, so the manager cannot influence
+    what it reports -- the invariant the whole check rests on, and one an
+    in-process survivor sharing ``os.environ`` cannot model.
+
+    The gateway then starts wanting a stem the survivor does not have. Before
+    this change it adopted the survivor and every session's stub for that server
+    degraded to per-session exec; now the survivor yields and a daemon with the
+    current map binds.
+    """
+    home = tmp_path / "home"
+    run_dir = _isolate(monkeypatch, home)
+    sock = short_sock_dir / "gw.sock"
+
+    stale_env = {
+        **{
+            k: v
+            for k, v in os.environ.items()
+            if not any(k.startswith(p) for p in _TARGET_PREFIXES)
+        },
+        "KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio",
+        "KIROCREW_HOME": str(home),
+    }
+    survivor = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "kiro_crew.mcp_gateway.gatewayd",
+        "--socket",
+        str(sock),
+        "--idle-timeout-secs",
+        "60",
+        "--max-backends",
+        "2",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        env=stale_env,
+        cwd=str(run_dir),
+        start_new_session=True,
+    )
+    manager: mgr.GatewayManager | None = None
+    try:
+        await _await_endpoint(sock)
+        assert (await _round_trip(sock, {"type": "ping"}))["targets"] == ["PDF"]
+
+        # The starting gateway's config now wants kirocrew-core stubbed too.
+        wanted = {
+            "KIROCREW_MCP_TARGET_KIROCREW_CORE": "kirocrew mcp-core",
+            "KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio",
+        }
+        _only_targets(monkeypatch, wanted)
+        manager = mgr.GatewayManager(
+            mgr.GatewaySpec(
+                socket_path=sock,
+                max_backends=2,
+                idle_timeout_secs=60,
+                mcp_target_env=dict(wanted),
+            )
+        )
+
+        assert await manager.start() is True, "the gateway must come up"
+        await asyncio.wait_for(survivor.wait(), timeout=60)
+        assert manager._adopted is False, "the stale survivor must not be adopted"
+        assert manager.is_running, "we must own the replacement"
+        assert manager._process is not None
+        assert manager._process.pid != survivor.pid, "two distinct real processes"
+
+        pong = await _round_trip(sock, {"type": "ping"})
+        assert "KIROCREW_CORE" in pong["targets"], "the new daemon covers the new stem"
+    finally:
+        if manager is not None:
+            await manager.shutdown()
+        if survivor.returncode is None:
+            survivor.kill()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(survivor.wait(), timeout=10)
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_a_covering_survivor_is_still_adopted_end_to_end(
+    short_sock_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The behaviour adoption exists for must survive the repair layer.
+
+    A survivor already covering the wanted stems is adopted with no spawn and no
+    teardown -- otherwise this change would trade a partial degradation for a
+    full broker cycle on every ordinary restart.
+    """
+    _isolate(monkeypatch, tmp_path / "home")
+    sock = short_sock_dir / "gw.sock"
+    targets = {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio"}
+    _only_targets(monkeypatch, targets)
+    manager = mgr.GatewayManager(
+        mgr.GatewaySpec(
+            socket_path=sock, max_backends=2, idle_timeout_secs=60, mcp_target_env=dict(targets)
+        )
+    )
+    stop = asyncio.Event()
+    survivor = asyncio.create_task(
+        gw.run_gatewayd(socket_path=sock, max_backends=2, idle_timeout_secs=60, stop_event=stop)
+    )
+    try:
+        await _await_endpoint(sock)
+        assert await manager.start() is True
+        assert manager._adopted is True, "a covering survivor must still be adopted"
+        assert not manager.is_running, "adoption must not spawn a competitor"
+        assert not survivor.done(), "and must not tear it down"
+    finally:
+        await manager.shutdown()
+        stop.set()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(survivor, timeout=30)
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_stand_down_is_recorded_in_the_security_event_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The audit claim is asserted, not just documented.
+
+    A stand-down ends the daemon, so it is the most consequential frame the
+    control surface accepts; both the allow and the refusal belong in the SEL
+    beside the claim/abort/peer decisions.
+    """
+    _isolate(monkeypatch, tmp_path / "home")
+    _only_targets(monkeypatch, {"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf"})
+    recorded: list[dict[str, Any]] = []
+
+    class _Spy:
+        def log_api_access(self, **kwargs: Any) -> None:
+            recorded.append(kwargs)
+
+    monkeypatch.setattr(gw, "SecurityEventLog", _Spy)
+
+    gw._apply_stand_down({"type": "stand-down", "need": ["PDF"]}, asyncio.Event())
+    gw._apply_stand_down({"type": "stand-down", "need": ["KIROCREW_CORE"]}, asyncio.Event())
+
+    ops = [r for r in recorded if r.get("operation") == "mcp-gateway.stand_down"]
+    assert len(ops) == 2, f"both outcomes must be audited, got {recorded}"
+    assert ops[0]["outcome"] == "denied"
+    assert ops[1]["outcome"] == "allowed"
+    assert resolvable_target_stems() == ["PDF"]

--- a/test/test_mcp_gateway_target_map_drift.py
+++ b/test/test_mcp_gateway_target_map_drift.py
@@ -102,9 +102,9 @@ def test_the_field_case_is_reported(caplog) -> None:
         }
     )
     with caplog.at_level(logging.WARNING):
-        assert (
-            mgr._report_adoption_drift({"type": "pong", "targets": ["EXCALIDRAW", "PDF"]}) is True
-        )
+        assert mgr._adoption_drift({"type": "pong", "targets": ["EXCALIDRAW", "PDF"]}) == [
+            "KIROCREW_CORE"
+        ]
     assert "KIROCREW_CORE" in caplog.text
     assert "STALE" in caplog.text
 
@@ -113,7 +113,7 @@ def test_a_covering_daemon_is_silent(caplog) -> None:
     """No warning on the healthy path, or the signal is worthless."""
     mgr = _manager({"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio"})
     with caplog.at_level(logging.WARNING):
-        assert mgr._report_adoption_drift({"type": "pong", "targets": ["PDF"]}) is False
+        assert mgr._adoption_drift({"type": "pong", "targets": ["PDF"]}) == []
     assert caplog.text == ""
 
 
@@ -123,10 +123,8 @@ def test_a_superset_daemon_is_also_silent(caplog) -> None:
     mgr = _manager({"KIROCREW_MCP_TARGET_PDF": "npx -y server-pdf --stdio"})
     with caplog.at_level(logging.WARNING):
         assert (
-            mgr._report_adoption_drift(
-                {"type": "pong", "targets": ["PDF", "EXCALIDRAW", "KIROCREW_CORE"]}
-            )
-            is False
+            mgr._adoption_drift({"type": "pong", "targets": ["PDF", "EXCALIDRAW", "KIROCREW_CORE"]})
+            == []
         )
     assert caplog.text == ""
 
@@ -137,7 +135,7 @@ def test_a_daemon_that_cannot_report_is_flagged_as_unverifiable(caplog) -> None:
     case this exists to catch."""
     mgr = _manager({"KIROCREW_MCP_TARGET_KIROCREW_CORE": "kirocrew mcp-core"})
     with caplog.at_level(logging.WARNING):
-        assert mgr._report_adoption_drift({"type": "pong"}) is True
+        assert mgr._adoption_drift({"type": "pong"}) == ["KIROCREW_CORE"]
     assert "does not report its target map" in caplog.text
 
 
@@ -146,7 +144,7 @@ def test_nothing_configured_means_nothing_to_verify(caplog) -> None:
     socket is then not a drift finding."""
     mgr = _manager({})
     with caplog.at_level(logging.WARNING):
-        assert mgr._report_adoption_drift({"type": "pong"}) is False
+        assert mgr._adoption_drift({"type": "pong"}) == []
     assert caplog.text == ""
 
 


### PR DESCRIPTION
## What is the problem?

[#6432](https://github.com/kirodotdev/KiroCrew/pull/6432) made an adopted daemon's stale target map **visible** and **safe**. Visible: `_report_adoption_drift` compares the incumbent's reported stems against the ones the current spec wants and warns about the gap. Safe: an unknown target at the `ensure_backend` pre-flight is now fallback-eligible, so a stub degrades to a per-session exec instead of dying.

What it deliberately left is the cost its own warning names:

> these servers' stubs will degrade to per-session exec: their tools keep working, but pooling and the strict session key are LOST. **Replace the daemon to restore them.**

Nothing replaced the daemon. That sentence was an instruction to a human, and the method's docstring said so outright -- "Automatic replacement needs a reap seam an adopted manager does not have (it owns no PID) and is tracked separately." Until then, a survivor keeps serving its stale map for as long as it holds the socket: in the field, a 25-day-old daemon that had every session's `kirocrew-core` stub fall back for weeks.

## Why this issue matters to the user

The degradation is silent to the user and permanent for the daemon's lifetime. Their tools still work, so nothing looks broken -- they simply lose backend sharing and the strict session key for every drifted server, on every session, until somebody reads a gateway log line and stops the orphan by hand. Restarting the gateway does not help, because the restart re-adopts the same orphan.

## How our fix solves it

**Symptom:** a drifted server's stubs stay on per-session exec indefinitely, with only a log line to say so.

**Direct cause:** the drift was measured but nothing acted on it -- `_report_adoption_drift`'s return value was unused at its call site.

**Root cause:** there was no way to get the socket back. A daemon's target map is baked into its process env at `_spawn_once` and a frozen `GatewaySpec` is never re-applied, so the only repair is a different process -- and the incumbent holds the endpoint.

**Fix.** `gatewayd` accepts a `stand-down` frame carrying the target stems the caller needs, and yields by setting its own `stop_event` -- which is exactly what the SIGTERM handler does. The manager asks a drifted incumbent to stand down, waits for it to release the singleton lock, then spawns a daemon carrying the current map. `_report_adoption_drift` becomes `_adoption_drift` and returns the missing stems instead of a bool, so the same computation both reports the cost and names the stems in the request.

**Asking rather than taking is the design, and it is what makes this safe.** The starting gateway must not unlink the endpoint itself: `_clear_stale_socket` is a connect-probe-then-unlink whose documented false-stale window would take a LIVE incumbent's socket, which is the socket-theft class the flock guard exists to prevent. A request that arrives over a connection the incumbent just answered has no such window -- the incumbent decides, and it is provably alive. This is the seam the #6432 docstring called tracked-separately; that paragraph is corrected in this diff rather than left contradicting it.

**The frame refuses when there is nothing to gain.** It carries the needed stems, not an equality fingerprint, so a daemon serving a SUPERSET is fit and is never cycled -- extra stems from another agent's servers are harmless. That also stops the frame being a bare kill switch a confused caller could aim at a daemon serving it correctly. Its trust basis is the uid-gated owner-only socket that already authenticates Register/Claim/Abort, and both outcomes are recorded in the HMAC-chained SEL beside them.

Three further properties are load-bearing, each found by review of the earlier attempt:

- **The wait is on the singleton LOCK, not the endpoint.** `run_gatewayd` closes its server first and releases the lock last, so the endpoint stops being reachable well before a replacement could bind -- on Windows for the daemon's entire drain, because the kernel drops a pipe name as soon as the last handle closes, so the whole drain sits inside that gap. A replacement spawned there loses the lock, exits rc=0 without binding, and `_wait_for_socket` then fails the start with no watchdog left to retry. The lock is precisely what the replacement must win.
- **An incumbent that ACCEPTED but is still draining is never adopted.** It has closed its accept loop, so it answers ping while accepting nothing; adopting it would turn a partial degradation (the drifted servers lose pooling) into a total outage (nothing can register) and report success. Neither can it be replaced yet, since it still holds the lock -- so the start fails, and the socket frees itself moments later.
- **An incumbent that REFUSES is still adopted, exactly as before.** It is still serving, so every server it can resolve keeps working and the drifted ones keep degrading safely. This fail-open is deliberate and is pinned by a test so it cannot regress.

`start()` runs a bounded election, because the freed socket can be won by a second gateway instance on the same machine before our own spawn gets it; a pong after our spawn is not proof the daemon is ours, since the flock guard makes a duplicate spawn exit rc=0 without binding. A separate process-lifetime cap on stand-down requests bounds the case the election cap cannot reach -- the watchdog also assesses incumbents, on an unbounded respawn loop, so two long-lived gateways with divergent stub sets would otherwise stand each other down forever. Past the cap this manager settles, adopts, and says why.

## What tests we did

New `test/test_mcp_gateway_adopted_daemon_repair.py` (34 tests): the frame's refusals (already-covered, superset, malformed `need`, unwired handler), the lock probe against a real lock file including that it releases rather than holds, the stand-down outcomes (refused / draining / released), the lock-vs-endpoint wait, the repair decision, the oscillation cap, the election, and four end-to-end tests over real sockets. The headline one spawns **two real daemon processes**: a survivor subprocess with an old map, then the manager's own spawn path replacing it -- a real subprocess because its environment is genuinely frozen at spawn, which is the invariant the whole check rests on and one an in-process survivor sharing `os.environ` cannot model. It asserts the two PIDs differ and that the daemon left on the socket covers the new stem.

Five mutants applied, all killed:

| Mutant | Killed by |
|---|---|
| repair reverted to #6432's report-only adoption | 4 election/repair tests + the two-process e2e |
| a draining incumbent adopted | the never-adopt test + the start-level test |
| wait reverted to the endpoint signal | the Windows-shaped drain test + 2 others |
| already-covers refusal removed | the superset test + the SEL audit test |
| `stop_event` unwired from the accept loop | the wired-frame e2e (the frame would be inert) |

Every test that starts a real daemon isolates `KIROCREW_HOME` **and** the working directory, and one test snapshots the repo tree before and after to assert it. Both matter: the suite sets neither, `manager._gatewayd_log_path` falls back to `config_dir()` (the operator's real data home), and a spawned daemon inherits pytest's CWD, which is the checkout. `_spawn_once` deliberately still passes no `cwd` -- in production the daemon should inherit the gateway's -- so the test moves itself rather than bending production behaviour.

Gates green: `isort`, `flake8`, `mypy` (src clean), `black` on every file the gate enforces (`manager.py` and `transport.py` are in `.github/black-baseline.txt`, so they are deliberately left unformatted; `gatewayd.py` and both test files are enforced and clean). 2,145 tests pass across the target-map-drift, adopted-daemon-repair, mcp-gateway, gatewayd, transport, shareability and stop-kill-cancel selection -- including #6432's own drift tests, moved to the widened return.

## Any other suggestions on the work

- **The oscillation cap is a bound, not a cure.** Two same-host gateway instances with divergent stub sets will still trade the socket a few times before settling. Removing that needs an ownership/generation lease so one instance is the authorised successor -- a protocol design, deliberately not invented behind a bug fix. Worth its own issue if it is judged reachable in practice.
- **No new spec file.** `mcp_gateway`'s daemon-lifecycle behaviour is documented in code comments throughout and #6432 added none either, so the reasoning went into docstrings beside the code. Happy to add one if maintainers would rather it lived under `docs/system-specs/`.
- **`stand-down` is a new control verb**, so it widens the daemon's control surface by one. It is gated exactly like `claim`/`abort`, and a same-uid peer can already signal the daemon directly, so the boundary is unchanged -- but it is the first frame that ends the daemon and deserves an eye on that basis.
- Supersedes [#6256](https://github.com/kirodotdev/KiroCrew/pull/6256), which carried this repair plus a detection half that #6432 has since implemented differently and better; that PR is being closed in favour of this one.

Refs #6432
