### PR TITLE
fix(crew-companion): give ContextMenu the role=menu keyboard contract (#6266)

### DIFF
--- a/website/src/apps/crew-companion/ContextMenu.tsx
+++ b/website/src/apps/crew-companion/ContextMenu.tsx
@@ -4,7 +4,8 @@ import React from 'react'
  * Used by PetWidget (overlay) and ChatPanel (chat window).
  * Handles edge clamping, click-outside dismiss, and optional hitbox reporting for overlay use.
  */
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useLayoutEffect, useRef, useCallback } from 'react'
+import { useMenuKeyboard } from '../../hooks/useMenuKeyboard'
 import { petBridge } from './petBridge'
 
 const api = petBridge
@@ -36,6 +37,67 @@ const MENU_MIN_W = 160
 
 export function ContextMenu({ x, y, items, reportHitbox, onAction, onClose }: Props) {
   const menuRef = useRef<HTMLDivElement>(null)
+
+  /*
+   * Shared role="menu" keyboard contract (#6231, ported here for #6266): arrow
+   * navigation with wrap, Home/End, Tab containment, and focus entry onto the
+   * first row on open. This copy was absent from #6231's five-surface inventory
+   * because the inventory enumerated `role="menu"` containers — which this file
+   * lacked by omission — so its rows carried orphaned `role="menuitem"` with no
+   * owning menu and no keyboard contract behind the promise that role makes.
+   *
+   * The component renders unconditionally while mounted (hosts unmount it to
+   * close), so `enabled` is simply true and the hook's cleanup drops the
+   * document listener on unmount — same posture as the mochi sibling.
+   *
+   * Escape and Enter/Space stay where they are: the hook deliberately owns
+   * navigation only. The window-level Escape/click-outside/blur closers below
+   * are independent of the hook and unchanged.
+   */
+  useMenuKeyboard({ enabled: true, containerRef: menuRef })
+
+  /*
+   * The element that was focused when this menu MOUNTED — the surface the user
+   * right-clicked (or reached with the keyboard). Captured during the first
+   * RENDER on purpose, not in an effect: render runs before `useMenuKeyboard`'s
+   * focus-entry effect moves focus onto the first row, so this is the last
+   * moment the opener is still `document.activeElement`. `undefined` is the
+   * "not yet captured" sentinel — `activeElement` itself can in principle be
+   * null, and using null for both would re-run the capture on a later render
+   * and latch a menu ROW as the opener. Same spelling as the mochi sibling.
+   *
+   * In the overlay host today the opener is `<body>` — the `.cc-pet` div the
+   * user right-clicks is not focusable — so the restore below is a no-op
+   * there. The capture exists for hosts whose opener IS focusable (and for a
+   * future focusable pet); making `.cc-pet` focusable is its own change.
+   */
+  const opener = useRef<Element | null | undefined>(undefined)
+  if (opener.current === undefined) opener.current = document.activeElement
+
+  /*
+   * Give focus back when the menu goes away. Focus ENTRY without a matching
+   * restore is a regression, not half a feature: hosts render this component
+   * conditionally, so closing it UNMOUNTS the element that holds focus and the
+   * browser drops focus to `<body>`. Restore only if focus is still inside the
+   * menu being destroyed — if an action moved focus elsewhere, or an outside
+   * click already did, focus has a rightful owner and is left alone.
+   *
+   * `useLayoutEffect`, NOT `useEffect`: layout cleanups run synchronously while
+   * the menu is STILL in the document and still holds focus; a passive cleanup
+   * runs after the commit, when `activeElement` has already reset to `<body>`,
+   * so the guard would read "focus is not in the menu" every time and restore
+   * nothing. The container is captured at mount rather than read as
+   * `menuRef.current` in the cleanup because React detaches host refs while
+   * tearing the tree down.
+   */
+  useLayoutEffect(() => {
+    const menu = menuRef.current
+    return () => {
+      if (menu?.contains(document.activeElement)) {
+        ;(opener.current as HTMLElement | null)?.focus?.()
+      }
+    }
+  }, [])
 
   // Clamp position so menu stays within viewport
   const [clampedX, setClampedX] = React.useState(x)
@@ -127,6 +189,7 @@ export function ContextMenu({ x, y, items, reportHitbox, onAction, onClose }: Pr
       ) : null}
       <div
         ref={menuRef}
+        role="menu"
         style={{
           position: 'fixed', left: clampedX, top: clampedY, zIndex: 99999,
         /*
@@ -151,12 +214,12 @@ export function ContextMenu({ x, y, items, reportHitbox, onAction, onClose }: Pr
     >
       {items.map((entry, i) => {
         if ('separator' in entry && entry.separator) {
-          return <div key={`sep-${i}`} style={{ height: 1, background: 'var(--border, rgba(255,255,255,0.15))', margin: '2px 0' }} />
+          return <div key={`sep-${i}`} role="separator" style={{ height: 1, background: 'var(--border, rgba(255,255,255,0.15))', margin: '2px 0' }} />
         }
         const item = entry as ContextMenuItem
         return (
           <div
-            role="menuitem" tabIndex={0} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleAction(item.action) } }}
+            role="menuitem" tabIndex={0} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); handleAction(item.action) } }}
             key={item.action}
             onClick={(e) => { e.stopPropagation(); handleAction(item.action) }}
             style={{

--- a/website/src/test/CrewCompanionContextMenu.test.tsx
+++ b/website/src/test/CrewCompanionContextMenu.test.tsx
@@ -47,6 +47,18 @@ const items: ContextMenuEntry[] = [
   { label: 'Turn off companion', action: 'quit', danger: true },
 ]
 
+/*
+ * Three rows with a separator in the middle, mirroring `mochiItems` below, so
+ * the companion keyboard-contract block can assert the same walk/skip/wrap
+ * shape the mochi block pins (#6266 ports #6231's contract onto this copy).
+ */
+const companionKbItems: ContextMenuEntry[] = [
+  { label: 'Change avatar', action: 'gallery' },
+  { label: 'Hide', action: 'hide' },
+  { separator: true },
+  { label: 'Turn off companion', action: 'quit', danger: true },
+]
+
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
@@ -441,6 +453,263 @@ describe('mochi context menu — focus returns to the opener on close (#6267 rev
       const utils = render(<MochiMenuHost />)
       const opener = utils.getByTestId('opener')
       const elsewhere = utils.getByTestId('elsewhere')
+      opener.focus()
+      fireEvent.click(opener)
+      expect(menuRows(utils.container)[0]).toHaveFocus()
+      // Past the 50ms guard so the close-on-outside-mousedown listener is live.
+      act(() => { vi.advanceTimersByTime(60) })
+      // A real click on another control focuses it and then dismisses the menu.
+      elsewhere.focus()
+      fireEvent.mouseDown(document.body)
+      expect(menuRows(utils.container)).toHaveLength(0)
+      expect(elsewhere).toHaveFocus()
+      expect(opener).not.toHaveFocus()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+/*
+ * ───── crew-companion's ContextMenu: the role="menu" keyboard contract (#6266) ─────
+ *
+ * The crew-companion copy is the separately-vendored sibling of the mochi menu
+ * above. Its rows carried `role="menuitem"` but its container declared no
+ * `role="menu"` and its dividers no `role="separator"` — an ARIA structural
+ * violation (menuitem requires a menu/menubar ancestor) — and, because #6231's
+ * inventory enumerated `role="menu"` CONTAINERS, this file was invisible to it
+ * and never received the shared `useMenuKeyboard` wiring. These tests mirror
+ * the mochi block above onto the companion surface, plus the roles themselves.
+ */
+
+function renderCompanionKbMenu(
+  handlers: { onAction?: (a: string) => void; onClose?: () => void; reportHitbox?: boolean } = {},
+) {
+  return render(
+    <ContextMenu
+      x={10}
+      y={10}
+      items={companionKbItems}
+      reportHitbox={handlers.reportHitbox}
+      onAction={handlers.onAction ?? (() => {})}
+      onClose={handlers.onClose ?? (() => {})}
+    />,
+  )
+}
+
+describe('crew-companion context menu — role="menu" keyboard contract (#6266)', () => {
+  it('declares role="menu" on the container and role="separator" on the divider', () => {
+    // Rendered in OVERLAY mode (reportHitbox), the configuration the only
+    // production host (PetContextMenu) actually uses — the backdrop is a
+    // role="presentation" sibling outside the menu container and must not
+    // perturb the roles or the item list.
+    const setMenuHitbox = vi.spyOn(petBridge, 'setMenuHitbox').mockImplementation(() => {})
+    const { container } = renderCompanionKbMenu({ reportHitbox: true })
+    expect(setMenuHitbox).toHaveBeenCalled()
+    // The container is the element that owns the menuitem rows; without
+    // role="menu" they are orphaned and the ARIA structure is invalid.
+    const menu = container.querySelector('[role="menu"]') as HTMLElement | null
+    expect(menu).not.toBeNull()
+    expect(menuRows(menu!)).toHaveLength(3)
+    const separator = menu!.querySelector('[role="separator"]')
+    expect(separator).not.toBeNull()
+  })
+
+  it('moves DOM focus onto the first menuitem when the menu opens', () => {
+    const { container } = renderCompanionKbMenu()
+    const rows = menuRows(container)
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('ArrowDown walks the menuitems in order, skips the separator, and wraps last → first', () => {
+    const { container } = renderCompanionKbMenu()
+    const rows = menuRows(container)
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(rows[1]).toHaveFocus()
+    // The separator sits between rows[1] and rows[2] in the markup; one
+    // ArrowDown crosses it.
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(rows[2]).toHaveFocus()
+    // Wrap, not clamp: this is the menu contract, not the listbox one.
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('ArrowUp wraps first → last and then walks back up, skipping the separator', () => {
+    const { container } = renderCompanionKbMenu()
+    const rows = menuRows(container)
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document.body, { key: 'ArrowUp' })
+    expect(rows[1]).toHaveFocus()
+  })
+
+  it('Home and End jump to the boundary menuitems', () => {
+    const { container } = renderCompanionKbMenu()
+    const rows = menuRows(container)
+    fireEvent.keyDown(document.body, { key: 'End' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document.body, { key: 'Home' })
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('contains Tab inside the menu: last → first, and Shift-Tab first → last', () => {
+    const { container } = renderCompanionKbMenu()
+    const rows = menuRows(container)
+    // Focused directly rather than arrowed to, so this test fails only on the
+    // Tab containment it is about (#2533) and not on the arrow keys.
+    rows[2].focus()
+    fireEvent.keyDown(document.body, { key: 'Tab' })
+    expect(rows[0]).toHaveFocus()
+    fireEvent.keyDown(document.body, { key: 'Tab', shiftKey: true })
+    expect(rows[2]).toHaveFocus()
+  })
+
+  it('PIN: Enter on the focused menuitem still fires onAction and closes', () => {
+    const onAction = vi.fn()
+    const onClose = vi.fn()
+    const { container } = renderCompanionKbMenu({ onAction, onClose })
+    const rows = menuRows(container)
+    rows[1].focus()
+    // The per-row Enter/Space handler is the menu's activation path and is NOT
+    // moved into the shared hook (the hook deliberately owns navigation only).
+    fireEvent.keyDown(rows[1], { key: 'Enter' })
+    expect(onAction).toHaveBeenCalledWith('hide')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('PIN: entering and moving focus does not self-close the menu', () => {
+    vi.useFakeTimers()
+    try {
+      const onClose = vi.fn()
+      const { container } = renderCompanionKbMenu({ onClose })
+      // Past the 50ms guard, so the close-on-window-blur listener is live for
+      // the focus moves below — element blurs do not bubble and must not trip
+      // the WINDOW blur closer.
+      vi.advanceTimersByTime(60)
+      const rows = menuRows(container)
+      expect(rows[0]).toHaveFocus()
+      expect(onClose).not.toHaveBeenCalled()
+      fireEvent.keyDown(document.body, { key: 'ArrowDown' })
+      expect(rows[1]).toHaveFocus()
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+/*
+ * ───── crew-companion's ContextMenu: focus RESTORE on close ─────
+ *
+ * Focus entry (pinned above) without a matching restore strands a keyboard
+ * user on `<body>` when the focused row unmounts — the same debt #6267's
+ * review called out on the mochi copy. Same minimal-controlled-host shape as
+ * the mochi restore block above: `onClose` flips real state so the menu
+ * genuinely unmounts, with a focusable opener standing in for the surface
+ * that was right-clicked.
+ */
+
+function CompanionMenuHost({ onAction }: { onAction?: (action: string) => void }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button data-testid="cc-opener" onClick={() => setOpen(true)}>Open menu</button>
+      <button data-testid="cc-elsewhere">Somewhere else</button>
+      {open ? (
+        <ContextMenu
+          x={10}
+          y={10}
+          items={companionKbItems}
+          onAction={(action) => onAction?.(action)}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+describe('crew-companion context menu — focus returns to the opener on close (#6266)', () => {
+  function openFromOpener(onAction?: (action: string) => void) {
+    const utils = render(<CompanionMenuHost onAction={onAction} />)
+    const opener = utils.getByTestId('cc-opener')
+    opener.focus()
+    expect(opener).toHaveFocus()
+    fireEvent.click(opener)
+    const rows = menuRows(utils.container)
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toHaveFocus()
+    return { ...utils, opener, rows }
+  }
+
+  it('Escape unmounts the menu and returns focus to the opener', () => {
+    vi.useFakeTimers()
+    try {
+      const { container, opener } = openFromOpener()
+      // Past the 50ms listener guard; inside `act` because advancing timers
+      // runs React effects.
+      act(() => { vi.advanceTimersByTime(60) })
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(menuRows(container)).toHaveLength(0)
+      expect(opener).toHaveFocus()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('Enter on the focused menuitem unmounts the menu and returns focus to the opener', () => {
+    const onAction = vi.fn()
+    const { container, opener, rows } = openFromOpener(onAction)
+    // Activation from the keyboard is the path that MATTERS for restore: this
+    // user has no pointer to re-establish a focus position with.
+    fireEvent.keyDown(rows[0], { key: 'Enter' })
+    expect(onAction).toHaveBeenCalledWith('gallery')
+    expect(menuRows(container)).toHaveLength(0)
+    expect(opener).toHaveFocus()
+  })
+
+  it('clicking a menuitem unmounts the menu and returns focus to the opener', () => {
+    const onAction = vi.fn()
+    const { container, opener, rows } = openFromOpener(onAction)
+    fireEvent.click(rows[1])
+    expect(onAction).toHaveBeenCalledWith('hide')
+    expect(menuRows(container)).toHaveLength(0)
+    expect(opener).toHaveFocus()
+  })
+
+  it('PIN: an action that moves focus elsewhere ends with focus where the ACTION put it, not on the opener', () => {
+    // Real actions open other surfaces and focus something there. Whatever the
+    // close/restore ordering, the user must end up where the action sent them.
+    // Same PIN as the mochi block above (and the same caveat: `handleAction`
+    // calls onClose() before onAction(), so the action's own focus() lands
+    // after the restore and wins on ordering — the contains guard is not what
+    // makes this pass, but the invariant is worth stating on this copy too).
+    let elsewhere: HTMLElement | null = null
+    const utils = render(<CompanionMenuHost onAction={() => { elsewhere?.focus() }} />)
+    elsewhere = utils.getByTestId('cc-elsewhere')
+    const opener = utils.getByTestId('cc-opener')
+    opener.focus()
+    fireEvent.click(opener)
+    const rows = menuRows(utils.container)
+    expect(rows[0]).toHaveFocus()
+    fireEvent.click(rows[1])
+    expect(menuRows(utils.container)).toHaveLength(0)
+    expect(elsewhere).toHaveFocus()
+    expect(opener).not.toHaveFocus()
+  })
+
+  it('PIN: dismissing by an outside click leaves focus where the click put it — it is not yanked back to the opener', () => {
+    // The everyday shape of "focus already left the menu on its own": the user
+    // clicked another control, which both focused it and dismissed the menu.
+    // Same belt-and-braces caveat as the mochi copy of this PIN: react-dom's
+    // commit-phase focus snapshot also defends this, so the test protects the
+    // invariant rather than discriminating the contains guard.
+    vi.useFakeTimers()
+    try {
+      const utils = render(<CompanionMenuHost />)
+      const opener = utils.getByTestId('cc-opener')
+      const elsewhere = utils.getByTestId('cc-elsewhere')
       opener.focus()
       fireEvent.click(opener)
       expect(menuRows(utils.container)[0]).toHaveFocus()


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** roles (`role="menu"`/`role="separator"` attributes) and keyboard focus wiring only — no layout, style, markup-order, or pixel change; ARIA role attributes do not render.

## Summary

`website/src/apps/crew-companion/ContextMenu.tsx` is the separately-vendored sibling of the mochi `ContextMenu`. Its rows carried `role="menuitem"` but the container declared no `role="menu"` and the dividers no `role="separator"` — an ARIA structural violation (`menuitem` requires a `menu`/`menubar` ancestor), so assistive technology heard orphaned menuitems with no owning menu. Because #6231's five-surface inventory enumerated `role="menu"` **containers**, this file was invisible to it by omission and never received the shared `useMenuKeyboard` wiring its siblings got.

This PR ports the sibling's contract onto this copy — no new contract invented:

- `useMenuKeyboard({ enabled: true, containerRef: menuRef })`, the way mochi calls it: arrow navigation with wrap, Home/End, Tab containment, focus entry onto the first row on open. Import path resolved from this file's own depth (`../../hooks/useMenuKeyboard`).
- `role="menu"` on the container that already carries `ref={menuRef}`.
- `role="separator"` on the divider branch.
- Opener-focus restore on unmount (`useLayoutEffect` cleanup guarded by "focus is still inside the menu"), same spelling as mochi — focus **entry** without a matching restore strands a keyboard user on `<body>` when the focused row unmounts.
- **Activation path decision (per the issue's fix strategy):** the rows' inline Enter/Space handler **stays**. The hook deliberately owns navigation only (its own doc block says so), and the mochi sibling keeps its per-row activation handler the same way — there is no duplicate activation path to remove. One parity touch: `e.stopPropagation()` added to match mochi's handler exactly.
- The window-level Escape / click-outside / blur closers and the `cc-menu-backdrop` overlay hitbox behaviour are untouched — they are independent of the hook and pinned by existing tests.

## Tests

New blocks in `website/src/test/CrewCompanionContextMenu.test.tsx` mirror the existing mochi keyboard-contract and focus-restore blocks onto the companion surface, reusing the file's existing `menuRows` DOM query helper: container/divider roles present (rendered in overlay `reportHitbox` mode, the configuration the production host uses), focus lands on the first menuitem on open, ArrowDown/ArrowUp walk and **wrap** (menu contract, not listbox), separator skipped, Home/End jump, Tab/Shift-Tab contained, Enter activation + no-self-close PINs, and the full five-case restore block (Escape, Enter, click, action-moves-focus PIN, outside-click PIN) against a controlled host that genuinely unmounts.

Non-vacuity verified by mutation: reverting the source changes turns 9 tests red; mutating the restore to `useEffect` (the documented silent-failure mode) turns exactly the 2 keyboard-restore tests red. Restored and re-verified green.

## Gates

- `npx tsc -b` clean; `npx vitest run` full suite: 25692 passed / 1 expected fail / 3 skipped
- isort / flake8 / mypy (CI-pinned versions) clean; full backend pytest: 72698 passed — the 6 failures are the known env-dependent install-probe tests (`test_issue_radar_gh_bin`, `test_source_providers`, `test_cli_doctor` venv probes) and this diff touches zero Python files
- Pre-push model-pinned review fleet: gpt-5.6-sol **PASS**, claude-opus-5 **PASS**. All in-scope Medium/Low advisories applied (restore-test parity with mochi's five cases, overlay-mode coverage, `stopPropagation` parity, opener-is-`<body>`-today comment).

## Known advisories (out of scope, recorded here)

- GPT reviewer (Medium): in the pet overlay the Electron window is `setFocusable(false)` while the panel is closed, so OS keyboard events cannot reach the overlay document at all — the keyboard contract is inert there until the window is made focusable while a menu is open. That is an Electron main-process change (`windows`/hitbox lifecycle), outside this issue's binding scope guard (companion `ContextMenu.tsx` + one test file only).
- Opus reviewer (Low): the `role="menu"` container has no accessible name — a family-level gap shared with the mochi sibling; naming only this copy would diverge from the contract this PR exists to mirror.
- Opus reviewer (Medium, addressed in comments): the overlay's opener is `<body>` today (`.cc-pet` is not focusable), so the restore is forward-looking there; stated at the capture site.

## Visual delta

None intended and none observed: roles and keyboard wiring only — no layout, style, or markup-order change. No screenshots required.

Closes #6266
