### PR TITLE
fix(dev-fleet): stop a registry refusal from emptying node_modules on Pull+Build

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -118,7 +118,7 @@ verification. Route names below are relative to that prefix.
 | `/apps/dev-fleet/api/fleet` | Lightweight worktree + pod list (polled every 12s), including `main_repo` and `main_repo_inferred`. `?fresh=1` forces cache bypass. Answers `{worktrees: [], needs_setup: true}` when no main checkout was found (see Main Checkout Discovery) and `{worktrees: [], error}` when a named checkout is unreadable. |
 | `/apps/dev-fleet/api/worktree?name=` | Lazy per-branch detail: PR, commits, disk usage |
 | `/apps/dev-fleet/api/pod/logs?name=&n=` | Pod journal tail (recent N lines, default 120) |
-| `/apps/dev-fleet/api/run?id=` | Async run status + streamed output (last 60 lines) |
+| `/apps/dev-fleet/api/run?id=` | Async run status + streamed output (last 60 lines), plus `cause` on a sync failure the gateway can name |
 | `/apps/dev-fleet/api/prune-candidates` | List worktrees eligible for pruning |
 | `/apps/dev-fleet/api/prune-status` | Live prune progress: per-item state machine (`items`) + backward-compatible top-level counters |
 | `/apps/dev-fleet/api/disk` | Aggregate disk usage per worktree (async computation) |
@@ -617,6 +617,56 @@ publishes the same bundle the build just wrote into `website/dist`, which keeps
 the pinned `/assets` route and the staged `index.html` on the same hashed
 chunks. The run script stops at the first non-zero step, so a build or staging
 failure fails the sync rather than silently leaving the symlink in place.
+
+### Dependency preflight and the `node_modules` transaction
+
+`npm ci` deletes `node_modules` before it installs, so a registry refusal used to
+leave the checkout with an emptied tree, a stale bundle against new backend code,
+and no way back that did not need the registry that was unavailable. Two
+independent triggers recur: a private-registry token that expires on a clock, and
+a curated mirror that blocks a version the lockfile pins.
+
+**The symptom is handled as a transaction.** The `npm ci` step carries `stash`
+metadata; the generated runner moves the tree aside before the step, restores it
+on any non-zero outcome, and drops the backup on success. This lives in the runner
+because the runner is fail-fast — anything scheduled *after* a failed step never
+runs, which is precisely the case that needs the restore. When a tree **and** a
+leftover backup are both present the state is genuinely ambiguous (killed during
+the install leaves a partial tree plus the good backup; killed during the success
+cleanup leaves the good tree plus a half-deleted one, and nothing on disk tells
+them apart), so the runner stops and touches neither, naming both paths.
+
+**The cause is handled by a `Verify dependencies` step between `fetch` and
+`merge`.** It runs a real script-free `npm ci` in a scratch directory against the
+incoming lockfile, read from the fetched ref rather than the working tree. The
+position is the mechanism: the lockfile is knowable as soon as fetch lands, fetch
+moves only refs, so refusing there costs nothing and needs no rollback. It is not
+an auth check — retrieval is integrity-addressed, so an auth probe fails while the
+install it guards would have succeeded.
+
+Fetch, probe and merge consume ONE commit. `<remote>/<base branch>` cannot serve
+for that: it is mutable, and the status refresher re-fetches it every
+`_NET_REFRESH_S` seconds in the same process, so with a real install between them
+the probe could certify a revision the merge does not install. The fetch step also
+writes the tip it brought to a per-process ref (`refs/kirocrew/sync-base-<pid>`),
+which the refresher never touches; `_prune_dead_sync_base_refs` collects refs left
+by gateway processes that are gone, and leaves alone any whose PID is still alive.
+
+The probe executes a **snapshot** of `npm_preflight.py` copied into an unguessable
+`mkdtemp`, run with `-I`, never imported from the checkout. The module is
+stdlib-only, so the copy needs no package context. Both halves matter: `-I` drops
+the cwd from `sys.path`, and the snapshot means an editable install cannot make
+the tree being synced supply the code doing the verifying.
+
+**Failure causes reach the dashboard as an exit code, not as text.** The probe
+exits with a reserved code (41-45) and the runner owns two more (46 ambiguous
+tree, 47 restore failed); `npm_preflight.explain_exit` maps each to one
+registry-neutral sentence at run completion, surfaced as `cause` on `/run` and
+preferred by the UI over the last output line. Two properties keep it honest: a
+reserved code arriving from any step OTHER than the probe is demoted to a plain
+failure, because every other step runs worktree-controlled code that can exit any
+number it likes; and only the sync run kind is stamped at all, since `_start_run`
+is shared with `provision`, whose script enforces no such reservation.
 
 The build and the copy are ONE step because they share ONE holder of the staging
 lock (`.dist.staging.lock`, next to `static/dist`). `npm run build` empties

--- a/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
@@ -1,0 +1,372 @@
+"""Pre-merge installability probe for Dev Fleet's Pull+Build frontend half.
+
+``npm ci`` DELETES ``node_modules`` before it installs. So a registry that
+refuses one package turns a sync into damage rather than a no-op: the tree is
+emptied, the run aborts mid-reify, and the checkout is left with new source, a
+new lockfile, and no frontend dependencies at all. Re-pressing Pull+Build
+repeats the deletion.
+
+This module answers the one question that prevents that, BEFORE the merge
+lands: *can the incoming lockfile be installed at all?* It reads the lockfile
+out of the fetched ref (``git show``) rather than the working tree, so it can
+run between ``fetch`` and ``merge`` — the only point where the new lockfile is
+already knowable and nothing has been applied yet. A refusal there costs
+nothing, because ``fetch`` only moves remote refs.
+
+Two things it deliberately is NOT:
+
+* It is NOT a registry auth check. A dead registry token is invisible to a
+  build whose packages are all in npm's local cache, because cacache retrieval
+  is integrity-addressed: a tarball already on disk satisfies its lockfile
+  entry with no network and no credentials. A ``npm ping``-style probe would
+  therefore fail while the very install it guards would have succeeded — it
+  would block good syncs and teach operators to ignore it. Asking
+  "is this installable" instead is both narrower and correct, and it is
+  registry-agnostic: it holds for a public registry, a private mirror, or an
+  air-gapped cache alike.
+* It does NOT run the package tree's lifecycle scripts (``--ignore-scripts``).
+  The probe exists to answer a question, not to execute the worktree's install
+  hooks a second time; skipping them also keeps the probe strictly less
+  privileged than the step it guards.
+
+It performs a REAL install into a disposable directory rather than
+``npm ci --dry-run``, and that is not a preference. A dry run does not attempt
+retrieval at all: against a lockfile pinning a tarball that 404s, measured,
+``npm ci --dry-run --ignore-scripts`` exits 0 and reports "added 1 package"
+while the same command without ``--dry-run`` exits 1 on the missing tarball. A
+dry run would therefore pass exactly the case this module exists to catch, so
+the probe has to fetch. The cost of that honesty is one script-free install per
+sync -- seconds against a warm cache -- which is cheap next to the emptied
+``node_modules`` it prevents.
+
+The flags otherwise MIRROR the real step exactly. A probe that resolves
+differently from the install is worse than no probe: it either passes what will
+fail, or fails what would have worked. ``--no-audit``/``--no-fund`` are the only
+additions, and neither participates in resolution.
+
+The distinct exit codes do NOT drive a cross-process protocol: the runner only
+tests non-zero, and nothing outside this module reads which code came back. What
+the classification is for is :func:`explain` -- turning a failure into one
+registry-neutral sentence the dashboard can show instead of npm's log-file
+pointer. Keeping the codes separate is what makes that sentence specific, and
+what lets a caller tell a host condition (a full scratch filesystem) from a
+lockfile that genuinely cannot be installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import os
+import re
+import shutil
+import subprocess  # nosec B404 - probing npm/git is this module's purpose
+import sys
+import tempfile
+from pathlib import Path
+
+#: Line prefix the probe uses for a human-readable detail line in the run log.
+#: This is LOG TEXT ONLY -- it is never promoted into the authoritative failure
+#: diagnosis. That distinction is a security boundary: the run's stdout also
+#: carries worktree-controlled build output, so any in-band marker there can be
+#: forged by an install script printing the same prefix and then failing. The
+#: diagnosis therefore travels as an EXIT CODE, which a child of a step cannot
+#: forge, and the gateway maps it to text through :func:`explain`.
+DETAIL_PREFIX = "preflight: "
+
+#: The probe found the incoming lockfile installable.
+EXIT_OK = 0
+#: The registry refused to authenticate us (npm ``E401``/``E403``) -- the one
+#: failure an operator can act on directly, by refreshing their credential.
+EXIT_AUTH = 41
+#: Something else went wrong that we could not classify.
+EXIT_FAILED = 42
+#: A network-shaped failure -- the one class where a later retry can differ.
+EXIT_TRANSIENT = 43
+#: A package version the lockfile pins is not obtainable (npm ``E404``). On a
+#: curated mirror this is what a blocked version looks like, so it is NOT an
+#: auth problem, and refreshing a credential would not make the version appear.
+EXIT_UNAVAILABLE = 44
+#: The scratch filesystem ran out of room. Because the probe performs a REAL
+#: install it needs about as much space as a ``node_modules`` tree, and it takes
+#: that from ``TMPDIR`` (which the build environment's allowlist passes
+#: through). Its own class so a full temp filesystem reads as a host condition
+#: rather than a lockfile that cannot be installed.
+EXIT_NO_SPACE = 45
+#: The sync runner found a dependency tree AND a leftover backup of one, and
+#: cannot tell which is complete. Owned by the runner rather than the probe, but
+#: numbered here so ONE table maps every code the sync can exit with to text.
+EXIT_TREE_AMBIGUOUS = 46
+#: The runner could not put a stashed dependency tree back after a failed step.
+EXIT_RESTORE_FAILED = 47
+
+#: The checkout subdirectory holding the frontend half. A ``probe()`` parameter
+#: once carried this, but only ``main()`` ever called it and it never passed one
+#: -- the same reason the CLI's own ``--subdir`` flag was removed.
+_FRONTEND_SUBDIR = "website"
+
+#: Files the probe needs from the incoming ref to resolve the same way the real
+#: step will. ``.npmrc`` matters as much as the lockfile: it carries settings
+#: that change resolution (a minimum-release-age gate, for one), so omitting it
+#: would make the probe answer a different question than the install.
+_PROBE_FILES = ("package-lock.json", "package.json", ".npmrc")
+
+#: Ordered classification. First match wins, so the specific auth and
+#: not-found signals are tested before the generic network ones.
+_SIGNALS: tuple[tuple[int, re.Pattern[str]], ...] = (
+    (
+        EXIT_AUTH,
+        re.compile(
+            r"\bE401\b|\bE403\b|\bEAUTHUNKNOWN\b|\bENEEDAUTH\b"
+            r"|unable to authenticate|401 unauthorized|403 forbidden"
+            r"|authentication token seems to be invalid",
+            re.I,
+        ),
+    ),
+    (EXIT_UNAVAILABLE, re.compile(r"\bE404\b|404 not found", re.I)),
+    (EXIT_NO_SPACE, re.compile(r"\bENOSPC\b|no space left on device", re.I)),
+    (
+        EXIT_TRANSIENT,
+        re.compile(
+            r"\bETIMEDOUT\b|\bENOTFOUND\b|\bECONNRESET\b|\bECONNREFUSED\b"
+            r"|\bEAI_AGAIN\b|\bERR_SOCKET_TIMEOUT\b|network timeout|socket hang up",
+            re.I,
+        ),
+    ),
+)
+
+#: Human-facing, registry-neutral explanations. These are what the dashboard
+#: shows instead of npm's last output line, which is its "a complete log of this
+#: run can be found in ..." pointer — the least informative line it prints.
+_EXPLAIN = {
+    EXIT_AUTH: (
+        "the package registry rejected our credentials, so the incoming "
+        "lockfile cannot be installed — refresh the registry credential and "
+        "press Pull + Build again"
+    ),
+    EXIT_UNAVAILABLE: (
+        "a package version the incoming lockfile pins is not available from "
+        "the configured registry"
+    ),
+    EXIT_TRANSIENT: (
+        "the package registry could not be reached, so the incoming lockfile "
+        "could not be verified — try again in a moment"
+    ),
+    EXIT_NO_SPACE: (
+        "not enough room in the scratch directory to verify the incoming "
+        "lockfile — free space in the temporary directory and press Pull + "
+        "Build again"
+    ),
+    EXIT_TREE_AMBIGUOUS: (
+        "a previous sync left a dependency-tree backup beside the tree, and "
+        "which one is complete cannot be told from disk — remove whichever you "
+        "do not want to keep (the log lists both paths), then press Pull + "
+        "Build again"
+    ),
+    EXIT_RESTORE_FAILED: (
+        "the dependency tree could not be restored automatically; both the "
+        "partial tree and its backup were left in place — see the log for both "
+        "paths"
+    ),
+    EXIT_FAILED: "the incoming lockfile could not be installed",
+}
+
+
+def classify(output: str) -> int:
+    """Map npm's own diagnostics onto one of the ``EXIT_*`` codes.
+
+    Reads npm's error CODES rather than guessing from the registry URL, so the
+    result is the same whichever registry is configured. Unrecognized failures
+    are ``EXIT_FAILED``, never ``EXIT_TRANSIENT``: calling an unknown failure
+    "transient" invites a retry that cannot help and hides the real cause.
+    """
+    for code, pattern in _SIGNALS:
+        if pattern.search(output):
+            return code
+    return EXIT_FAILED
+
+
+#: Every code this module can explain. The sync runner needs this set because an
+#: exit code is only trustworthy from a step whose binary is OURS: a step running
+#: worktree-controlled code (an npm lifecycle script, a vite config) can exit any
+#: number it likes, and a forged 41 would make the dashboard assert a registry
+#: credential failure -- with a remedy -- for what was actually a build error. So
+#: the runner remaps a reserved code coming from any step other than the probe.
+RESERVED_EXIT_CODES = frozenset(_EXPLAIN)
+
+
+def explain_exit(rc: int) -> str:
+    """The sentence for a run's exit code, or ``""`` when we own no diagnosis.
+
+    Deliberately NOT a fallback: :func:`explain` answers ``EXIT_FAILED`` for
+    anything it does not recognise, which is right when a probe has already
+    decided the failure is its own. Here the input is the exit code of an
+    arbitrary step -- ``npm ci`` exiting 1, a compile error, a killed process --
+    and inventing "the incoming lockfile could not be installed" for those would
+    state a cause that was never established. Only codes this module assigns get
+    a sentence; everything else leaves the dashboard on its existing fallback.
+    """
+    return _EXPLAIN[rc] if rc in _EXPLAIN else ""
+
+
+def _os_error_code(exc: OSError) -> int:
+    """Classify an OSError from the probe's own filesystem work.
+
+    Every write the probe makes lands in ``TMPDIR``, and because the probe
+    performs a REAL install that directory can fill. An uncaught OSError would
+    kill the step with a traceback and no classified cause -- which puts the
+    dashboard back to showing whatever the last output line happened to be, the
+    exact defect this module exists to remove. So the probe's own IO is mapped
+    to a code here, in ONE place, rather than guarded a site at a time.
+    """
+    if getattr(exc, "errno", None) == errno.ENOSPC:
+        return EXIT_NO_SPACE
+    return EXIT_FAILED
+
+
+def _extract(git: str, repo: str, ref: str, subdir: str, dest: Path) -> tuple[int, str] | None:
+    """Copy the probe files out of *ref* into *dest*.
+
+    Reads from the fetched ref, NOT the working tree — that is what lets this
+    run before the merge. ``package-lock.json`` is required; the others are
+    optional because a checkout may legitimately not carry them.
+
+    Returns ``(code, detail)`` on failure, or ``None`` on success. It returns a
+    CODE rather than only a message because one of its failure modes is a full
+    scratch filesystem, which is a host condition and not a lockfile that cannot
+    be installed -- the caller must be able to tell those apart.
+    """
+    for name in _PROBE_FILES:
+        try:
+            proc = subprocess.run(  # nosec B603 - argv list, no shell
+                [git, "-C", repo, "show", f"{ref}:{subdir}/{name}"],
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return EXIT_TRANSIENT, f"reading {subdir}/{name} from {ref} timed out"
+        except OSError as exc:
+            return _os_error_code(exc), f"could not run git: {exc}"
+        if proc.returncode != 0:
+            if name == "package-lock.json":
+                return EXIT_FAILED, (
+                    f"cannot read {subdir}/{name} from {ref} "
+                    f"({(proc.stderr or b'').decode(errors='replace').strip()})"
+                )
+            continue
+        try:
+            (dest / name).write_bytes(proc.stdout)
+        except OSError as exc:
+            return _os_error_code(exc), f"could not write {name} to the scratch dir: {exc}"
+    return None
+
+
+def probe(
+    *,
+    git: str,
+    npm: str,
+    repo: str,
+    ref: str,
+    timeout: int = 900,
+) -> tuple[int, str]:
+    """Report whether *ref*'s lockfile is installable. Returns (code, detail).
+
+    Runs a REAL script-free install in a scratch directory, so it neither reads
+    nor writes the checkout's own ``node_modules``. Both halves of that matter:
+    a dry run never fetches, so it cannot answer the question at all; and an
+    already-populated tree would make even a real install report only the delta
+    against it, passing a lockfile that a delete-first ``npm ci`` cannot
+    install.
+    """
+    try:
+        tmp = Path(tempfile.mkdtemp(prefix="kirocrew-npm-preflight-"))
+    except OSError as exc:
+        # Creating the scratch directory is the FIRST thing that can fail on a
+        # full or unwritable TMPDIR, and an uncaught OSError here would kill the
+        # step with a traceback and no classified cause -- so the dashboard would
+        # be back to showing whatever the last output line happened to be, which
+        # is the defect this module exists to remove.
+        return _os_error_code(exc), f"could not create a scratch directory: {exc}"
+    try:
+        failure = _extract(git, repo, ref, _FRONTEND_SUBDIR, tmp)
+        if failure:
+            return failure
+        try:
+            proc = subprocess.run(  # nosec B603 - argv list, no shell
+                [npm, "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
+                cwd=str(tmp),
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+                env={**os.environ, "npm_config_update_notifier": "false"},
+            )
+        except subprocess.TimeoutExpired:
+            return EXIT_TRANSIENT, f"probe timed out after {timeout}s"
+        except OSError as exc:
+            return EXIT_FAILED, f"could not run npm: {exc}"
+        if proc.returncode == 0:
+            return EXIT_OK, ""
+        blob = "\n".join(
+            (
+                (proc.stdout or b"").decode(errors="replace"),
+                (proc.stderr or b"").decode(errors="replace"),
+            )
+        )
+        code = classify(blob)
+        return code, _first_error_line(blob) or f"npm exited {proc.returncode}"
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _first_error_line(blob: str) -> str:
+    """The first line that names the failure, for the operator-facing detail.
+
+    npm prints its diagnosis FIRST and its log-file pointer LAST, which is
+    exactly why the dashboard's "last output line" was uninformative. Taking
+    the first error-ish line inverts that. The log-pointer line is skipped
+    explicitly so it can never win when it is the only match.
+    """
+    for raw in blob.splitlines():
+        line = raw.strip()
+        if not line or "complete log of this run" in line:
+            continue
+        low = line.lower()
+        if low.startswith(("npm error", "npm err!", "error:")) or " error " in low:
+            return line[:400]
+    return ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: the sync runs this as one step of the Pull+Build run."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--git", required=True)
+    ap.add_argument("--npm", required=True)
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--ref", required=True)
+    # --subdir and --timeout were CLI flags no caller passed. The subdir is now
+    # _FRONTEND_SUBDIR and the timeout is probe()'s own default, so the surface
+    # matches the one real invocation.
+    args = ap.parse_args(argv)
+    code, detail = probe(
+        git=args.git,
+        npm=args.npm,
+        repo=args.repo,
+        ref=args.ref,
+    )
+    if code == EXIT_OK:
+        print(f"{DETAIL_PREFIX}incoming lockfile is installable", flush=True)
+        return EXIT_OK
+    # The DIAGNOSIS travels as the exit code, which the gateway maps through
+    # explain_exit(). Only a human-readable detail goes to stdout, and it is log
+    # text -- deliberately NOT an in-band marker the gateway promotes, because
+    # this same stream carries worktree-controlled build output that could print
+    # any marker it liked and then fail.
+    print(f"{DETAIL_PREFIX}{explain_exit(code)}", flush=True)
+    if detail:
+        print(f"{DETAIL_PREFIX}{detail}", flush=True)
+    return code
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a subprocess
+    sys.exit(main())

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -52,7 +52,7 @@ from typing import Any, Callable
 from aiohttp import web
 
 from kiro_crew import dep_sync, frontend, hooks, platform_compat
-from kiro_crew.apps.builtins.dev_fleet import gateway_service
+from kiro_crew.apps.builtins.dev_fleet import gateway_service, npm_preflight
 from kiro_crew.apps.proxy_auth import raw_request_target
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.env import find_node_tool, node_bin_dirs
@@ -1238,6 +1238,120 @@ _SHUTDOWN_IN_PROGRESS = False
 _RUNS_MAX_COMPLETED = 50
 
 
+#: ``_start_run`` label of the sync. The diagnosis stamp is gated on it because
+#: the sync runner is the only script that enforces the reserved-code
+#: reservation; a `provision` run reaches the same stamp while executing an
+#: agent-authored branch, and must not be able to assert a cause.
+_SYNC_RUN_LABEL = "sync"
+
+
+def _sync_base_ref() -> str:
+    """The ref this process pins the revision it is about to merge to.
+
+    ``<remote>/<base branch>`` cannot serve for this: it is a MUTABLE name, and
+    the status refresher re-fetches it every ``_NET_REFRESH_S`` seconds in this
+    same process. Resolving that name once in the probe and again in the merge --
+    with a real install in between -- lets the two land on different commits, so
+    the probe would certify a revision the merge does not install. Fetching the
+    tip into a ref of our own closes the window instead of narrowing it: the
+    refresher's fetch writes only the remote-tracking refs, so nothing can move
+    this one for the life of the run.
+
+    The PID is part of the name because ``_SYNC_LOCK`` is a lock in ONE process,
+    which makes syncs single-flight only within a single gateway. Two gateways
+    configured against the same checkout would otherwise share this ref, and the
+    second one's fetch would move it between the first one's probe and merge --
+    reopening exactly the window the ref exists to close. That configuration is
+    already destructive for a bigger reason (two syncs running ``git merge`` and
+    ``npm ci`` against one working tree), so this does not make concurrent syncs
+    safe; it only stops one gateway from invalidating another's probe.
+
+    Safe to force and safe to reuse: the fetch step rewrites it before any step
+    reads it, so a value left by an earlier run -- or by an earlier process that
+    happened to hold this PID -- can never be consumed.
+    """
+    return f"refs/kirocrew/sync-base-{os.getpid()}"
+
+
+async def _prune_dead_sync_base_refs(repo: str) -> None:
+    """Delete pinned base refs left behind by gateway processes that are gone.
+
+    The PID in the ref name is what stops two gateways on one checkout from
+    moving each other's pin, but nothing deletes the ref on the way out -- an
+    ordinary restart strands it, and so does a killed run. Without this every
+    gateway generation would leave one behind in the OPERATOR's own checkout,
+    bounded only by ``pid_max`` and visible in ``git for-each-ref`` forever.
+
+    A ref whose PID is still alive is LEFT ALONE. It may be a second gateway's
+    live pin, and deleting that would reopen exactly the window the PID suffix
+    exists to close -- so the prune is bounded by the number of live gateways,
+    which is the real floor. Liveness goes through
+    ``platform_compat.pid_exists``: a raw ``os.kill(pid, 0)`` is a liveness probe
+    only on POSIX, and on Windows it TERMINATES the process it is asked about --
+    which here would mean killing the very live gateway this is meant to spare.
+    ``pid_exists`` also collapses "exists but we cannot signal it" into alive,
+    which is the answer we want: unsure means do not touch.
+
+    Best-effort throughout: this is housekeeping, and a sync must not fail
+    because a stale ref could not be removed.
+    """
+    listed = await _git(
+        repo, "for-each-ref", "--format=%(refname)", "refs/kirocrew/"
+    )
+    if not listed:
+        return
+    mine = _sync_base_ref()
+    prefix = "refs/kirocrew/sync-base-"
+    for ref in listed.splitlines():
+        ref = ref.strip()
+        if not ref.startswith(prefix) or ref == mine:
+            continue
+        try:
+            pid = int(ref[len(prefix):])
+        except ValueError:
+            continue  # not one of ours to reason about
+        if pid <= 0:
+            # 0 and negatives are not PIDs: on POSIX they address the caller's
+            # process group and every process respectively, so they must never
+            # reach a liveness probe even a harmless one.
+            continue
+        if platform_compat.pid_exists(pid):
+            continue  # owner still running -- may be another gateway's live pin
+        await _git(repo, "update-ref", "-d", ref)
+
+
+#: The preflight probe's source, captured ONCE at import.
+#:
+#: The snapshot has to be of the code THIS gateway is running, not of whatever is
+#: on disk when a sync happens. Copying the file at sync time left a window from
+#: gateway start until the button press in which the module could be rewritten,
+#: and the copy is then executed as the one step trusted to assert a failure
+#: cause. Reading at import closes that: these bytes are the same ones the
+#: running process imported.
+#:
+#: ``None`` when the source cannot be read (a frozen or zipimported install has
+#: no readable ``__file__``). The sync REFUSES in that case rather than falling
+#: back to reading the file later -- the fallback is exactly the window this
+#: exists to remove, and refusing is the safe direction.
+try:
+    _PREFLIGHT_SOURCE: bytes | None = Path(npm_preflight.__file__).read_bytes()
+except OSError:  # pragma: no cover - frozen/zipimported install
+    _PREFLIGHT_SOURCE = None
+
+#: Label of the ONE sync step whose binary is ours, so its exit code can be
+#: trusted to mean what :mod:`npm_preflight` says it means. Every other step runs
+#: worktree-controlled code and can exit any number it likes, so a reserved code
+#: coming from one of those is remapped rather than believed.
+#:
+#: Named for the OUTCOME rather than the mechanism: this step runs a real install
+#: against the incoming lockfile, which on a cold cache is minutes of apparent
+#: silence under a 900s timeout. "Preflight" is a term the product does not use
+#: anywhere else, and an invented word next to a spinner reads as a hang; "Verify
+#: dependencies" reads as work. The runner's trust gate compares against this
+#: constant, so the display name and the gate cannot drift apart.
+_PREFLIGHT_LABEL = "Verify dependencies"
+
+
 def _parse_step_marker(text: str) -> tuple[int | None, str | None]:
     """Parse a ``::step::<idx>::<label>`` progress marker into (index, label).
 
@@ -1266,6 +1380,12 @@ async def _start_run(
     ``sandboxed_spawn_argv`` — deleted when the run finishes.
     """
     rid = uuid.uuid4().hex[:12]
+    # The run KIND, captured before the output loop can touch it. `label` is
+    # rebound inside that loop by the `::step::` handler, so by completion it
+    # holds the last STEP's label on a run that emits markers and is UNBOUND on
+    # one that does not -- reading it at the diagnosis stamp would suppress
+    # every real cause on the sync path and raise NameError on a provision.
+    run_kind = label
     async with _RUNS_LOCK:
         # Bound memory: evict the oldest COMPLETED runs beyond the cap
         # (running entries are never evicted — reattach depends on them).
@@ -1391,6 +1511,28 @@ async def _start_run(
                 else:
                     _RUNS[rid]["status"] = "done"
                     _RUNS[rid]["exit_code"] = rc
+                    # The failure DIAGNOSIS is derived here, from the exit code,
+                    # and never read out of the child's stdout. That stream also
+                    # carries worktree-controlled build output, so a marker in it
+                    # could be forged by an install script printing the marker
+                    # and then failing -- and the dashboard would present the
+                    # forgery as authoritative, remedy included.
+                    #
+                    # An exit code is not self-authenticating either: worktree
+                    # code can exit 41 as easily as it can print a marker. What
+                    # makes the code trustworthy is the SCRIPT that produced it,
+                    # and only the sync runner enforces the reservation (a
+                    # reserved code from any step but the probe is demoted to a
+                    # plain failure). So only that kind may be stamped. A
+                    # `provision` run reaches this same line while executing an
+                    # agent-authored branch with no such remapping, and stamping
+                    # it would hand back exactly the forged-diagnosis-plus-remedy
+                    # this boundary exists to refuse -- latent only for as long as
+                    # no consumer reads `cause` off a non-sync run.
+                    if run_kind == _SYNC_RUN_LABEL:
+                        cause = npm_preflight.explain_exit(rc)
+                        if cause:
+                            _RUNS[rid]["cause"] = cause
         except asyncio.CancelledError:
             # Gateway shutdown cancels in-flight run tasks. The child runs in
             # its own process group and would outlive us, continuing to mutate
@@ -3771,7 +3913,7 @@ async def _sync_start_locked() -> dict:
             "<data-home>/node-bin-dir (written by ensure-node.sh), then in "
             "mise / asdf / nvm / fnm / volta install dirs, then in "
             f"{_TRUSTED_PATH}. Fix: run `bash ensure-node.sh` in the main "
-            "checkout and press Pull + build again — no restart needed. To point "
+            "checkout and press Pull + Build again — no restart needed. To point "
             "at a toolchain by hand instead, set "
             "KIROCREW_NODE_BIN_DIR=/abs/path/to/node/bin in the gateway's "
             "service environment; that one does need a restart, because a "
@@ -3820,10 +3962,22 @@ async def _sync_start_locked() -> dict:
     # This mirrors pip rather than deviating from it: the INSTALLED pip reads the
     # merged project's metadata, and an old pip refusing a too-new project is the
     # behaviour being stood in for here.
-    fetch_step = ([git_bin, "fetch", remote, BASE_BRANCH], "standard",
+    # The fetch pins the tip it brought into this process's own base ref as well
+    # as updating the remote-tracking ref, so the probe below and the merge here
+    # consume ONE commit even though the refresher keeps fetching underneath
+    # them. Resolved once here so every step of this run names the same ref, and
+    # refs stranded by gateway processes that are gone are cleared first so they
+    # do not accumulate in the operator's checkout.
+    sync_base_ref = _sync_base_ref()
+    await _prune_dead_sync_base_refs(str(repo))
+    fetch_step = ([git_bin, "fetch", remote, BASE_BRANCH,
+                   f"+refs/heads/{BASE_BRANCH}:{sync_base_ref}"], "standard",
                   _build_env(with_credentials=True), "Pull")
-    merge_step = ([git_bin, "merge", "--ff-only", f"{remote}/{BASE_BRANCH}"], "strict",
-                  _build_env(), "Pull")
+    # Labelled distinctly from the fetch: with the preflight between them, two
+    # steps both called "Pull" would render as Pull -> Preflight -> Pull and read
+    # like the run had restarted.
+    merge_step = ([git_bin, "merge", "--ff-only", sync_base_ref], "strict",
+                  _build_env(), "Merge")
     # The venv must be an install OF this checkout before either install step
     # runs, and that is true of the reinstall just as much as the substitute.
     #
@@ -3842,6 +3996,101 @@ async def _sync_start_locked() -> dict:
             "install, or run the sync from the checkout that venv serves."
         )}
     dep_sync_snapshot: Path | None = None
+    # Whether the frontend half runs at all is decided BEFORE the step list is
+    # assembled, because the preflight belongs between fetch and merge and there
+    # is nothing to preflight when the frontend half is skipped (see the edition
+    # rationale where the build steps are appended).
+    frontend_half = not frontend.edition_configured()
+    # The preflight goes AFTER fetch and BEFORE merge, and that position is the
+    # whole point rather than a detail.
+    #
+    # `npm ci` deletes website/node_modules before installing, so a registry
+    # that refuses one package does not merely fail the sync — it empties the
+    # tree and leaves the checkout with new source, a new lockfile and no
+    # frontend dependencies. The lockfile that will be installed is knowable as
+    # soon as fetch lands (it is in the fetched ref), and fetch moves only
+    # remote refs, so between the two is the one moment where the question can
+    # be asked while a refusal still costs nothing.
+    #
+    # The runner is fail-fast, so no extra refusal plumbing is needed: a failing
+    # preflight step stops the run before the merge step is reached.
+    #
+    # Only ONE preflight is built, and it runs in the credential-free build tier
+    # like every other npm invocation here — `_run_cmd` would have been the
+    # obvious host for it but it overwrites PATH with _TRUSTED_PATH
+    # unconditionally, and npm's wrapper needs `node` to resolve BY NAME, which
+    # only _build_env()'s node-augmented PATH provides.
+    preflight_steps: list[tuple[list[str], str, dict, str]] = []
+    preflight_cleanup: list[str] = []
+    if frontend_half:
+        # Executed as a SNAPSHOT by path, never imported from the checkout.
+        #
+        # `-I` alone was not enough. It drops the cwd from sys.path, which closes
+        # the untracked-`kiro_crew/`-at-the-checkout-root shadow -- but the
+        # install is EDITABLE, so `import kiro_crew...` still resolves into the
+        # checkout's own `src/` tree. This step is trusted to assert a failure
+        # cause precisely BECAUSE its binary is ours, so importing a tree that is
+        # itself the thing being synced put the boundary's own key under the mat.
+        #
+        # Copying the module out and running that copy is the same move this
+        # function already makes for dep_sync a few lines below, and it works
+        # here for a reason worth stating: npm_preflight imports nothing but the
+        # stdlib, so a by-path snapshot needs no package context at all.
+        #
+        # mkdtemp rather than a fixed path, for the reason the dep_sync snapshot
+        # gives: executing a script by path would put its DIRECTORY on sys.path,
+        # so a predictable one would let anything dropped beside the snapshot
+        # shadow a stdlib module it imports. mkdtemp is unguessable and 0o700 --
+        # and `-I` removes that directory from sys.path as well, so neither the
+        # checkout nor the snapshot's own neighbours can reach the interpreter.
+        if _PREFLIGHT_SOURCE is None:
+            return {
+                "ok": False,
+                "error": (
+                    "the dependency preflight's own source could not be read at "
+                    "startup, so there is nothing trustworthy to run it from — "
+                    "reinstall the gateway from a source checkout"
+                ),
+            }
+        snap_dir: Path | None = None
+        try:
+            snap_dir = Path(tempfile.mkdtemp(prefix="kirocrew-npm-preflight-"))
+            snap = snap_dir / "npm_preflight.py"
+            # The BYTES captured at import, not a copy of the file as it is now:
+            # copying at sync time would execute whatever had been written to the
+            # checkout since this gateway started.
+            snap.write_bytes(_PREFLIGHT_SOURCE)
+        except OSError as exc:
+            # mkdtemp can succeed and the COPY still fail, and nothing has
+            # registered the directory for the run's cleanup yet at this point --
+            # so remove it here or a failed sync leaks one temp directory every
+            # time, which is the same litter the pinned base refs were just
+            # taught to avoid.
+            if snap_dir is not None:
+                shutil.rmtree(snap_dir, ignore_errors=True)
+            # A full or unwritable TMPDIR must not escape as a 500: the sync
+            # answers a UI action, so it degrades to the same {"ok": False} shape
+            # every other refusal here uses. Refusing is also the SAFE outcome --
+            # without a probe there is nothing to trust, and the alternative
+            # (proceed unprobed) is exactly the destructive path this change
+            # exists to prevent.
+            return {
+                "ok": False,
+                "error": (
+                    "could not stage the dependency preflight: "
+                    f"{exc.strerror or exc} — free space in the temporary "
+                    "directory and press Pull + Build again"
+                ),
+            }
+        # File before directory: the run's cleanup unlinks each entry and falls
+        # back to rmdir, which only succeeds on an empty one.
+        preflight_cleanup = [str(snap), str(snap_dir)]
+        preflight_steps = [(
+            [sys.executable, "-I", "-X", "utf8", str(snap),
+             "--git", git_bin, "--npm", npm_bin, "--repo", str(repo),
+             "--ref", sync_base_ref],
+            "strict", _build_env(), _PREFLIGHT_LABEL,
+        )]
     if locked_scripts:
         logger.info(
             "dev-fleet: %s locked by a running process; substituting a "
@@ -3857,6 +4106,7 @@ async def _sync_start_locked() -> dict:
         shutil.copyfile(dep_sync.__file__, dep_sync_snapshot)
         steps = [
             fetch_step,
+            *preflight_steps,
             merge_step,
             ([sys.executable, str(dep_sync_snapshot), str(repo), str(target_py)],
              "strict", _build_env(), "pip install"),
@@ -3864,6 +4114,7 @@ async def _sync_start_locked() -> dict:
     else:
         steps = [
             fetch_step,
+            *preflight_steps,
             merge_step,
             ([str(target_py), "-m", "pip", "install", "-e", "."], "strict",
              _build_env(), "pip install"),
@@ -3888,7 +4139,7 @@ async def _sync_start_locked() -> dict:
     # which strips KIROCREW_EDITION_DIR, so the guard would read "stock" on every
     # install and never fire. apps/backend.py therefore propagates that one var
     # explicitly, the same way it already propagates KIROCREW_PROJECT_DIR.
-    if frontend.edition_configured():
+    if not frontend_half:
         logger.info(
             "dev-fleet: skipping the frontend build and dist staging -- this is "
             "an edition checkout and the sync build cannot recompose the "
@@ -3919,6 +4170,11 @@ async def _sync_start_locked() -> dict:
              "strict", _build_env(), "npm build + stage"),
         ]
     cleanups: list[str] = []
+    # The preflight's snapshot is removed with the run's other temporaries. It is
+    # registered here rather than left behind: a leaked mkdtemp per sync is how
+    # the dependency-only path already accumulates one, and repeating that would
+    # litter the operator's temp directory on every Pull + Build.
+    cleanups.extend(preflight_cleanup)
     if dep_sync_snapshot is not None:
         # File first, then its directory: the cleanup loop removes entries in
         # order, and a directory cannot go until it is empty.
@@ -3932,8 +4188,18 @@ async def _sync_start_locked() -> dict:
         if cleanup:
             cleanups.append(cleanup)
         wrapped_steps.append({"argv": w_argv, "env": w_env, "label": label})
+    for step in wrapped_steps:
+        if step["label"] == "npm ci":
+            # `npm ci` deletes node_modules BEFORE it installs, and a tree it
+            # emptied is the one artifact of a failed sync that cannot be
+            # rebuilt without the registry — which is exactly what is unavailable
+            # when this step fails. So the runner moves it aside first and puts it
+            # back if the step does not succeed, making the failure a no-op
+            # instead of damage. A separate "restore" step could not do this: the
+            # runner is fail-fast, so anything after a failed step never runs.
+            step["stash"] = str(Path(repo) / "website" / "node_modules")
     script = (
-        "import subprocess, sys, json\n"
+        "import os, shutil, subprocess, sys, json\n"
         # Align the writer with the reader. `_start_run` decodes this stream as
         # UTF-8 (`line.decode(errors="replace")`), but a piped stdout on Windows
         # encodes with the process locale codepage — so any non-ASCII that ever
@@ -3943,8 +4209,12 @@ async def _sync_start_locked() -> dict:
         "sys.stdout.reconfigure(encoding='utf-8', errors='replace')\n"
         f"steps = json.loads({json.dumps(json.dumps(wrapped_steps))})\n"
         f"cwd = {json.dumps(repo)}\n"
-        "for i, st in enumerate(steps):\n"
-        "    print(f'::step::{i}::{st[\"label\"]}', flush=True)\n"
+        # The reserved diagnosis codes, and the ONE step label allowed to assert
+        # one. Inlined as literals because this script is stdlib-only by design:
+        # it must not import kiro_crew, so what it does cannot change with the
+        # revision being merged underneath it.
+        f"RESERVED = {sorted(npm_preflight.RESERVED_EXIT_CODES)!r}\n"
+        f"PREFLIGHT = {json.dumps(_PREFLIGHT_LABEL)}\n"
         # reconfigure() above rebinds only THIS process's stdout object. Each
         # step is a separate process that inherits the same pipe and re-derives
         # its own encoding from the locale, so the Python steps — pip, and the
@@ -3955,14 +4225,151 @@ async def _sync_start_locked() -> dict:
         # ignore the variable and are unaffected. Assigned rather than
         # defaulted: the reader's encoding is fixed, so a divergent inherited
         # value would be the defect, not a preference to preserve.
+        "def run(st):\n"
         "    env = dict(st['env'])\n"
         "    env['PYTHONIOENCODING'] = 'utf-8:replace'\n"
-        "    r = subprocess.run(st['argv'], cwd=cwd, env=env)\n"
-        "    if r.returncode != 0:\n"
-        "        sys.exit(r.returncode)\n"
+        "    return subprocess.run(st['argv'], cwd=cwd, env=env).returncode\n"
+        # `rmtree(..., ignore_errors=True)` alone is not safe HERE, even though
+        # it is the right default elsewhere: every deletion below decides what
+        # the next rename does, so a partial removal that is silently ignored
+        # leaves a directory in place, makes the following rename fail, and ends
+        # with the transaction restoring a PARTIAL tree over a good one. So the
+        # deletions whose outcome is load-bearing are CONFIRMED, and one that
+        # will not complete stops the step with both trees intact -- a refused
+        # sync is recoverable, a half-restored node_modules is not.
+        "def gone(p):\n"
+        # rmtree REFUSES a symlink ("Cannot call rmtree on a symbolic link"),
+        # and ignore_errors=True swallows that refusal -- so a symlinked
+        # node_modules left its backup undeletable, the next sync saw both paths,
+        # and every Pull + Build from then on refused as ambiguous. A permanent
+        # wedge escapable only by hand. Unlink the link, rmtree only real trees.
+        "    if os.path.islink(p):\n"
+        "        try:\n"
+        "            os.unlink(p)\n"
+        "        except OSError:\n"
+        "            pass\n"
+        "    else:\n"
+        "        shutil.rmtree(p, ignore_errors=True)\n"
+        # lexists, not exists: a DANGLING symlink is still something at this
+        # path, and reporting it as gone would let the runner proceed as though
+        # the slot were clear.
+        "    return not os.path.lexists(p)\n"
+        # Leftover state from an earlier run is reconciled BEFORE any step runs,
+        # and BOTH halves of that belong here. Splitting them was a defect: with
+        # adoption left on the `npm ci` step, a run killed just after stashing
+        # left node_modules absent and its intact backup unclaimed, and the next
+        # run's recovery sat behind every earlier step succeeding -- so a still
+        # failing preflight meant the tree stayed missing with the copy right
+        # there. Both paths are knowable from disk with nothing applied, so both
+        # decisions are made here.
+        "for st in steps:\n"
+        "    stash = st.get('stash')\n"
+        "    if not stash:\n"
+        "        continue\n"
+        "    backup = stash + '.kirocrew-sync-backup'\n"
+        # lexists, not isdir, for every presence gate. isdir FOLLOWS a symlink,
+        # so a DANGLING node_modules reads as absent -- and then the backup-only
+        # branch below calls os.rename(<dir>, <dangling link>), which fails
+        # ENOTDIR and crashes the runner on every sync, with the tree never
+        # recovered. lexists asks the only question these gates actually mean: is
+        # there anything at this path.
+        "    have_tree = os.path.lexists(stash)\n"
+        "    have_backup = os.path.lexists(backup)\n"
+        # BOTH present is genuinely AMBIGUOUS and no rule can be right:
+        #
+        #   * killed DURING npm ci -> stash is the partial tree npm was
+        #     writing, backup is the last good one.
+        #   * a backup that outlived a SUCCESSFUL sync (its cleanup failed) ->
+        #     stash is the good tree and backup is stale.
+        #
+        # Nothing on disk tells those apart, so either choice destroys the good
+        # copy in one of them. The only move that cannot lose data is to touch
+        # NEITHER and stop -- and to say what to do next, because otherwise
+        # every later press refuses identically and the operator has to deduce
+        # that a directory needs removing.
+        "    if have_tree and have_backup:\n"
+        # The paths are LOG text; the diagnosis is the exit code, which the
+        # gateway maps. Nothing here is promoted out of stdout.
+        "        print('a previous sync left a dependency-tree backup beside the '\n"
+        "              'tree', flush=True)\n"
+        "        print('tree: %s' % stash, flush=True)\n"
+        "        print('backup: %s' % backup, flush=True)\n"
+        f"        sys.exit({npm_preflight.EXIT_TREE_AMBIGUOUS})\n"
+        # Backup only: unambiguous recovery, so claim it now rather than on the
+        # step that happens to own the transaction.
+        "    if have_backup:\n"
+        "        print('restoring a dependency tree left stashed by an earlier '\n"
+        "              'run', flush=True)\n"
+        "        os.rename(backup, stash)\n"
+        "for i, st in enumerate(steps):\n"
+        "    print(f'::step::{i}::{st[\"label\"]}', flush=True)\n"
+        # node_modules transaction. `npm ci` empties the directory before it
+        # installs, so it is moved aside first: on success the backup is
+        # dropped, and on ANY non-zero outcome (including the step raising) it
+        # is put back. rc is pre-seeded non-zero so an exception restores rather
+        # than discards.
+        "    stash = st.get('stash')\n"
+        "    backup = (stash + '.kirocrew-sync-backup') if stash else None\n"
+        # Leftover state was reconciled before this loop, so a backup cannot
+        # exist here: move the tree aside and let the step install into a clean
+        # directory, which is what `npm ci` requires anyway.
+        # lexists here too: with isdir a SYMLINKED node_modules would not be
+        # moved aside at all, so the step would run with no backup to restore --
+        # the transaction silently absent on exactly the layouts that most need
+        # it (a link into a shared store).
+        "    if backup and os.path.lexists(stash):\n"
+        "        os.rename(stash, backup)\n"
+        "    rc = 1\n"
+        "    try:\n"
+        "        rc = run(st)\n"
+        # An exit code is only trustworthy from the step whose binary is OURS.
+        # Every other step runs worktree-controlled code -- an npm lifecycle
+        # script, a vite config -- and can exit any number it likes, so a forged
+        # 41 would make the dashboard assert a registry-credential failure, with
+        # a remedy, for what was actually a build error. Reserved codes from
+        # those steps are therefore reported as a plain failure, with the true
+        # code kept in the log rather than believed.
+        "        if rc in RESERVED and st['label'] != PREFLIGHT:\n"
+        "            print('step %s exited %d, which is a reserved diagnosis '\n"
+        "                  'code; reporting it as a plain failure because only '\n"
+        "                  'the %s step may assert one'\n"
+        "                  % (st['label'], rc, PREFLIGHT), flush=True)\n"
+        "            rc = 1\n"
+        "    finally:\n"
+        # lexists: the backup is whatever `os.rename` moved here, so if the tree
+        # was a symlink the backup is one too. With isdir a DANGLING one skipped
+        # this whole block -- the tree stayed moved aside and was never restored
+        # nor dropped, which is the data loss the transaction exists to prevent.
+        "        if backup and os.path.lexists(backup):\n"
+        "            if rc == 0:\n"
+        # A backup that will not delete on the SUCCESS path is not dangerous:
+        # the tree on disk is the new good one, and the next run's both-exist
+        # branch handles the leftover. Say so rather than failing a sync that
+        # already worked.
+        "                if not gone(backup):\n"
+        "                    print('note: a dependency-tree backup could not be '\n"
+        "                          'removed and was left at %s' % backup,\n"
+        "                          flush=True)\n"
+        "            elif gone(stash):\n"
+        "                os.rename(backup, stash)\n"
+        "                print('restored %s after a failed step' % stash,\n"
+        "                      flush=True)\n"
+        "            else:\n"
+        # The rename would fail anyway, and forcing it is how a partial tree
+        # ends up installed over a good backup. Leave BOTH, name them in the
+        # log, and REPLACE the step's exit code: "the tree could not be put
+        # back" outranks whatever the step itself failed with, because it is the
+        # part the operator has to act on.
+        "                print('partial: %s' % stash, flush=True)\n"
+        "                print('backup: %s' % backup, flush=True)\n"
+        f"                rc = {npm_preflight.EXIT_RESTORE_FAILED}\n"
+        "    if rc != 0:\n"
+        "        sys.exit(rc)\n"
     )
     cmd = [sys.executable, "-c", script]
-    rid = await _start_run("sync", cmd, env=_build_env(), cleanup_paths=cleanups)
+    rid = await _start_run(
+        _SYNC_RUN_LABEL, cmd, env=_build_env(), cleanup_paths=cleanups
+    )
     _SYNC_RID = rid
     return {"ok": True, "run_id": rid}
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -935,15 +935,34 @@ def _steps_from_script(script):
     return [s["label"] for s in _json.loads(_json.loads(m.group(1)))]
 
 
+def _sync_steps_from_script(script):
+    """Same extraction as :func:`_steps_from_script`, but the whole step dicts.
+
+    The metadata the runner acts on (``stash``) lives beside the
+    label, and asserting on it through the label-only view is impossible.
+    """
+    import json as _json
+    import re
+
+    m = re.search(r"steps = json\.loads\((.*?)\)\n", script, re.S)
+    assert m, "steps assignment not found — the script shape changed"
+    return _json.loads(_json.loads(m.group(1)))
+
+
 #: The main checkout the sync tests run against. Pinned rather than ambient so the
 #: sync's refusal path (no checkout discovered) cannot decide their outcome.
 _SYNC_REPO = "/fake/main-checkout"
 
 
+#: cleanup_paths captured from the last ``_run_sync``. The harness stubs
+#: ``_start_run``, so a test cannot see what the sync registered for removal any
+#: other way, and asserting on it is how a leaked snapshot gets caught.
+_LAST_CLEANUP_PATHS: list[str] = []
+
+
 async def _run_sync(mod, locked):
     """Drive _sync_start_locked with the probe stubbed; return its result dict
     plus the generated script (None when the sync refused).
-
     MAIN_REPO is pinned because the sync refuses outright when no checkout was
     discovered, and these tests are about the sync's own behaviour: leaving it
     ambient makes them pass or fail on whether the HOST running them happens to
@@ -971,6 +990,11 @@ async def _run_sync(mod, locked):
     # sync staged for removal (the dependency-only path snapshots dep_sync into a
     # temp dir) would outlive the test. Remove exactly what it registered, in the
     # order it registered it — file before directory.
+    global _LAST_CLEANUP_PATHS
+    _LAST_CLEANUP_PATHS = list(
+        (mock_start.call_args.kwargs.get("cleanup_paths") or [])
+        if mock_start.call_args else []
+    )
     if mock_start.call_args:
         for path in mock_start.call_args.kwargs.get("cleanup_paths") or []:
             try:
@@ -5408,9 +5432,14 @@ async def test_sync_build_steps_never_see_credential_helpers(monkeypatch):
         # The build+stage step is a build step too and must not be exempt from
         # the credential-absence invariant just because it runs via `python -c`.
         or any("build_and_stage" in str(x) for x in a)
+        # Neither is the preflight: it runs npm against the incoming lockfile,
+        # so it is squarely in the worktree-controlled tier. With the operator
+        # repair seam removed, NOTHING on the sync path carries credentials
+        # except the fetch step.
+        or any("npm_preflight" in str(x) for x in a)
     ]
     assert fetch_envs and all(key in e for e in fetch_envs)
-    assert len(build_envs) == 4  # merge + pip + npm ci + (npm build + stage)
+    assert len(build_envs) == 5  # merge + preflight + pip + npm ci + (build + stage)
     assert all(key not in e for e in build_envs)
 
 
@@ -9206,3 +9235,787 @@ async def test_make_live_artifact_checks_are_executor_offloaded(
         f"all submitted callables: {submitted_qualnames!r}.  "
         "Zero entries means the checks are still inline on the event loop."
     )
+
+
+# --- Pull+Build: preflight, node_modules transaction, operator repair seam ---
+#
+# `npm ci` deletes node_modules before installing, so a registry that refuses one
+# package used to turn a sync into damage: the tree was emptied, the run aborted
+# mid-reify, and the checkout was left with new source, a new lockfile and no
+# frontend dependencies. These pin the three properties that make that failure a
+# no-op instead.
+
+
+@pytest.mark.asyncio
+async def test_sync_preflights_between_fetch_and_merge(monkeypatch):
+    """The probe must sit AFTER fetch and BEFORE merge.
+
+    That position is the whole mechanism, not a detail: the incoming lockfile is
+    only knowable once fetch has landed, and fetch moves nothing but remote refs
+    — so it is the one moment where a refusal costs nothing. After the merge the
+    refusal would already be too late; before the fetch there is nothing to read.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+    labels = _steps_from_script(script)
+
+    assert mod._PREFLIGHT_LABEL in labels, labels
+    # The probe sits between the fetch and the merge, which is the whole point:
+    # the lockfile is knowable once fetch lands, and refusing before merge costs
+    # nothing. The merge is labelled distinctly from the fetch so the rendered
+    # stepper does not read Pull -> Preflight -> Pull, like a restarted run.
+    assert labels[0] == "Pull", labels
+    assert labels.index(mod._PREFLIGHT_LABEL) == 1, labels
+    assert labels[2] == "Merge", labels
+    assert labels.count("Pull") == 1, labels
+    assert labels.index("pip install") > labels.index(mod._PREFLIGHT_LABEL), labels
+
+
+@pytest.mark.asyncio
+async def test_sync_preflight_probes_the_incoming_ref_not_the_working_tree(monkeypatch):
+    """It must read the lockfile from the FETCHED ref.
+
+    Reading the working tree would answer the question about the revision we
+    already have, which is never the one that is about to be installed — and it
+    could only be done after the merge, i.e. after the point where refusing is
+    still free.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    argvs = await _sync_step_argvs(monkeypatch)
+    probe = [a for a in argvs if any("npm_preflight" in str(x) for x in a)]
+    assert probe, f"no preflight step in {argvs}"
+    argv = probe[0]
+    assert argv[0] == sys.executable, argv
+    assert "--ref" in argv
+    ref = argv[argv.index("--ref") + 1]
+    # The ref the fetch step pinned, not a path and not a mutable
+    # remote-tracking name: reading the working tree would answer the question
+    # about the revision we already have, and a name the refresher can move
+    # would answer it about a revision the merge may not install.
+    assert ref == mod._sync_base_ref(), ref
+    assert not ref.endswith(f"/{mod.BASE_BRANCH}"), ref
+    assert not ref.startswith("/") and not ref.startswith("."), ref
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_the_preflight_on_an_edition_checkout(monkeypatch):
+    """No frontend half means nothing to preflight.
+
+    The edition path deliberately runs no npm at all, so a probe there would be
+    a network round trip that can only produce a false refusal.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: True)
+    _, script = await _run_sync(mod, [])
+    assert mod._PREFLIGHT_LABEL not in _steps_from_script(script)
+
+
+@pytest.mark.asyncio
+async def test_npm_ci_step_carries_a_node_modules_stash(monkeypatch):
+    """The transaction is attached to the npm ci step, and ONLY to it.
+
+    It cannot be a later "restore" step: the runner is fail-fast, so anything
+    after a failed step never runs — which is exactly the case that needs the
+    restore.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+    steps = _sync_steps_from_script(script)
+    stashed = {s["label"]: s["stash"] for s in steps if s.get("stash")}
+    assert list(stashed) == ["npm ci"], stashed
+    assert stashed["npm ci"] == str(Path(_SYNC_REPO) / "website" / "node_modules")
+    # The runner must actually put it back, and only on a non-zero outcome.
+    assert "os.rename(backup, stash)" in script
+    # Deletions whose outcome decides the next rename are CONFIRMED, not
+    # fire-and-forget: a silently partial removal leaves a directory in place,
+    # makes the rename fail, and ends with a partial tree restored over a good
+    # one.
+    assert "def gone(p):" in script
+    # lexists, not exists: a DANGLING symlink is still something at this path,
+    # and the helper must unlink a symlink rather than rmtree it -- rmtree refuses
+    # a link and ignore_errors=True hides the refusal, which used to leave the
+    # backup in place and make every later sync refuse as ambiguous.
+    assert "return not os.path.lexists(p)" in script
+    assert "if os.path.islink(p):" in script
+    assert "os.unlink(p)" in script
+    assert "elif gone(stash):" in script
+
+
+@pytest.mark.asyncio
+async def test_sync_never_runs_an_operator_supplied_command(monkeypatch):
+    """No configurable command executes on the sync path. This is a RATCHET.
+
+    An operator-declared "repair the registry credential" hook was written, then
+    removed: its whole purpose is to run a program that touches the operator's
+    credential material, and the operator declares the command while an agent
+    can rewrite the FILE it names -- or a script among its arguments. Withholding
+    git's credential helpers did not close it either, because HOME is itself the
+    channel those credentials arrive through. No validation of argv[0] can make
+    "the operator chose this command" mean "this is the code that will run", so
+    the seam does not belong on a path that runs unattended.
+
+    Restoring it needs its own change with its own threat model, not a revert.
+    """
+    monkeypatch.setenv("KIROCREW_DEVFLEET_NPM_AUTH_REPAIR", "/bin/sh -c true")
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+
+    steps = _sync_steps_from_script(script)
+    assert not any("repair" in s for s in steps), steps
+    assert not hasattr(mod, "_npm_auth_repair_argv")
+    for token in ("KIROCREW_DEVFLEET_NPM_AUTH_REPAIR", "npm_auth_repair"):
+        assert token not in script
+    # The declared command must appear NOWHERE in the generated script. Asserted
+    # this way rather than against a list of expected argv[0]s: the toolchain
+    # binaries are resolved from the host (npm is /usr/bin/npm on one platform
+    # and /opt/homebrew/bin/npm on another), so a path allowlist tests the host
+    # rather than the property.
+    assert "/bin/sh" not in script
+    for s in steps:
+        assert "/bin/sh" not in " ".join(map(str, s["argv"])), s["argv"]
+
+
+@pytest.mark.asyncio
+async def test_a_stashed_tree_is_recovered_before_any_step_runs(monkeypatch):
+    """Recovery must not sit behind the steps that precede the transaction.
+
+    A run killed just after the move-aside leaves the tree absent and its backup
+    unclaimed. With adoption on the `npm ci` step, the next run's recovery was
+    gated on every earlier step succeeding -- so a preflight that still failed
+    left the tree missing with an intact copy sitting right beside it. Both
+    halves of leftover-state reconciliation therefore happen before the loop.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+
+    claim = script.index("left stashed by an earlier")
+    loop_at = script.index("for i, st in enumerate(steps):")
+    assert claim < loop_at, "the stashed tree must be reclaimed before any step runs"
+    # The step's pre-run section now only moves the tree ASIDE -- no second,
+    # redundant adoption. (The `finally` block legitimately renames the backup
+    # back; that is the restore, not a reconciliation.)
+    prerun = script[loop_at:script.index("    try:", loop_at)]
+    assert "os.rename(stash, backup)" in prerun
+    assert "os.rename(backup, stash)" not in prerun
+
+
+@pytest.mark.asyncio
+async def test_the_failure_cause_is_never_taken_from_child_output(monkeypatch):
+    """A build script must not be able to forge the authoritative diagnosis.
+
+    The run's stdout carries worktree-controlled output, so any in-band marker
+    the gateway promoted could be printed by an npm lifecycle script that then
+    fails -- and the dashboard would present the forgery as the cause, remedy
+    included. Redaction does not help: it strips credentials, not instructions.
+    So the diagnosis is derived from the EXIT CODE, which a step's own child
+    cannot choose, and nothing is parsed out of the stream.
+    """
+    _, script = await _run_sync(mod, [])
+    # No promotable marker is emitted by the runner at all.
+    assert "::cause::" not in script
+    # And the worker has no branch that lifts text out of a line.
+    import inspect
+    body = inspect.getsource(mod._start_run)
+    assert "::cause::" not in body
+    assert 'npm_preflight.explain_exit(rc)' in body, \
+        "the cause must be derived from the exit code, gateway-side"
+
+
+@pytest.mark.asyncio
+async def test_runner_refuses_when_a_tree_and_a_backup_both_exist(monkeypatch):
+    """Both paths present is AMBIGUOUS, so the runner touches neither.
+
+    Killed during npm ci leaves a partial tree plus the good backup; a backup
+    outliving a successful sync leaves the good tree plus a stale one. Nothing on
+    disk distinguishes them, so either rule destroys the good copy in one case.
+    Stopping is the only branch that cannot lose data, and it exits with a code
+    the gateway maps to a sentence naming the next step.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+
+    assert f"sys.exit({mod.npm_preflight.EXIT_TREE_AMBIGUOUS})" in script
+    assert "print('tree: %s' % stash, flush=True)" in script
+    assert "print('backup: %s' % backup, flush=True)" in script
+    # The refusal is reconciliation, so it lands before any step runs.
+    refuse = script.index(f"sys.exit({mod.npm_preflight.EXIT_TREE_AMBIGUOUS})")
+    assert refuse < script.index("for i, st in enumerate(steps):")
+    # The mapped sentence names what to do, not merely what happened.
+    text = mod.npm_preflight.explain_exit(mod.npm_preflight.EXIT_TREE_AMBIGUOUS)
+    assert "press Pull + Build again" in text
+
+
+@pytest.mark.asyncio
+async def test_only_the_preflight_step_may_assert_a_diagnosis(monkeypatch):
+    """A reserved exit code is trusted from ONE step and remapped from the rest.
+
+    Moving the diagnosis off stdout onto exit codes did not by itself make it
+    unforgeable: every step except the preflight runs worktree-controlled code
+    (an npm lifecycle script, a vite config) and can exit any number it likes.
+    A forged 41 would have the dashboard assert a registry-credential failure --
+    remedy included -- for what was actually a build error. So the runner trusts
+    a reserved code only from the step whose binary is ours, and keeps the true
+    code in the log rather than believing it.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+
+    assert "if rc in RESERVED and st['label'] != PREFLIGHT:" in script
+    # The gate must sit on the value the STEP returned, before the finally block
+    # can set a runner-owned code of its own.
+    gate = script.index("if rc in RESERVED and st['label'] != PREFLIGHT:")
+    assert script.index("rc = run(st)") < gate < script.index("    finally:")
+    # Both literals come from the modules that own them, so they cannot drift
+    # from the step label or the explain table.
+    assert f"PREFLIGHT = {json.dumps(mod._PREFLIGHT_LABEL)}" in script
+    reserved = sorted(mod.npm_preflight.RESERVED_EXIT_CODES)
+    assert f"RESERVED = {reserved!r}" in script
+    # Every code the gateway will explain must be in the guarded set, or a code
+    # it explains could still arrive forged.
+    for code in reserved:
+        assert mod.npm_preflight.explain_exit(code), code
+
+
+def test_the_trusted_label_matches_the_step_that_carries_it():
+    """The trust check keys on a label, so the label must be the real one.
+
+    If the step were renamed without updating the constant, every reserved code
+    would be remapped -- the probe's own diagnosis would silently stop reaching
+    the dashboard, and nothing would fail.
+    """
+    import inspect
+
+    src = inspect.getsource(mod._sync_start_locked)
+    assert "_PREFLIGHT_LABEL," in src, (
+        "the preflight step must be labelled from the constant the runner's "
+        "trust check uses, not from a repeated literal"
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_and_merge_consume_one_immutable_commit(monkeypatch):
+    """Fetch, probe and merge must share a commit no background fetch can move.
+
+    ``<remote>/<base branch>`` is a mutable name and the status refresher
+    re-fetches it every _NET_REFRESH_S seconds in this same process. With a real
+    install sitting between the probe and the merge, resolving that name twice
+    lets them land on different commits -- the probe would certify a revision
+    that is not the one installed, which is worse than not probing at all,
+    because the promise is what makes the merge look safe.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+    steps = _sync_steps_from_script(script)
+    by_label = {}
+    for st in steps:
+        by_label.setdefault(st["label"], []).append(st["argv"])
+
+    fetch = next(a for a in by_label["Pull"] if "fetch" in a)
+    merge = next(a for a in by_label["Merge"] if "merge" in a)
+    probe = by_label[mod._PREFLIGHT_LABEL][0]
+
+    # The fetch pins the tip it brought, forcing, because the ref is ours.
+    pinned = mod._sync_base_ref()
+    assert f"+refs/heads/{mod.BASE_BRANCH}:{pinned}" in fetch
+    # Both consumers name that pinned ref...
+    assert merge[-1] == pinned
+    assert probe[probe.index("--ref") + 1] == pinned
+    # ...the ref is PER PROCESS, because _SYNC_LOCK only makes syncs
+    # single-flight inside one gateway: two gateways on one checkout would
+    # otherwise share this name and the second one's fetch would move it
+    # between the first one's probe and merge, reopening the window.
+    assert str(os.getpid()) in pinned, pinned
+    assert pinned.startswith("refs/kirocrew/sync-base-"), pinned
+    # ...and neither still names the mutable one, which is the actual defect.
+    mutable = [a for a in merge + probe if a.endswith("/" + mod.BASE_BRANCH)]
+    assert not mutable, (
+        f"{mutable} is a mutable remote-tracking name; the refresher can move "
+        "it between the probe and the merge"
+    )
+    # The pin must be written before anything reads it, or a ref left by an
+    # earlier run could be probed and merged.
+    labels = [st["label"] for st in steps]
+    assert labels.index("Pull") < labels.index(mod._PREFLIGHT_LABEL)
+
+
+def test_the_frontend_declares_no_resolution_input_the_probe_cannot_mirror():
+    """A tripwire on the probe's three-file mirror, not on the frontend.
+
+    The preflight installs a scratch copy of ``_PROBE_FILES`` and refuses the
+    sync when that install fails. The gate is fail-closed and has no bypass, so
+    a resolution input the mirror does NOT carry makes the scratch install fail
+    while the real one would have succeeded -- which hard-blocks every
+    Pull + Build until somebody edits npm_preflight.
+
+    ``workspaces`` and ``file:``/``link:`` specifiers are that class: both make
+    npm read paths that exist in the checkout and not in the scratch directory.
+    Neither is present today, so this pins the assumption rather than reporting a
+    defect: whoever introduces one gets this failure at that moment, instead of
+    an unexplained refusal of every update afterwards. Fixing it then means
+    teaching the probe to skip (restoring today's unguarded behaviour for that
+    case) or to copy what the new input needs -- not deleting this test.
+    """
+    root = Path(__file__).resolve().parents[1]
+    pkg_path = root / "website" / "package.json"
+    if not pkg_path.is_file():  # editions ship without the frontend half
+        pytest.skip("no frontend half in this checkout")
+    pkg = json.loads(pkg_path.read_text(encoding="utf-8"))
+
+    assert "workspaces" not in pkg, (
+        "website/package.json now declares workspaces, which npm resolves from "
+        "sibling directories the preflight's scratch copy does not have. The "
+        "probe would refuse every sync. See _PROBE_FILES in npm_preflight."
+    )
+
+    local = {}
+    for field in ("dependencies", "devDependencies", "optionalDependencies"):
+        for name, spec in (pkg.get(field) or {}).items():
+            if isinstance(spec, str) and spec.startswith(("file:", "link:")):
+                local[f"{field}.{name}"] = spec
+    assert not local, (
+        f"local-path dependencies {local} resolve against the checkout, which "
+        "the preflight's scratch copy is not. The probe would refuse every "
+        "sync. See _PROBE_FILES in npm_preflight."
+    )
+
+    # The mirror must also still carry the inputs it claims to: a copy that
+    # dropped .npmrc would answer a different question than the install.
+    for name in ("package-lock.json", "package.json", ".npmrc"):
+        assert name in mod.npm_preflight._PROBE_FILES, name
+
+
+@pytest.mark.asyncio
+async def test_only_the_sync_kind_can_be_stamped_with_a_diagnosis(monkeypatch):
+    """The stamp must be gated on the kind whose script enforces the reservation.
+
+    ``_start_run`` is kind-agnostic and also serves ``provision <name>``, which
+    executes an agent-authored branch with no reserved-code remapping. Deriving
+    the cause for every kind would hand a provision run's exit 41 back as "the
+    package registry rejected our credentials" plus a remedy -- the same forged
+    authoritative diagnosis the runner-side demotion exists to refuse, arriving
+    by the other door.
+
+    Driven end to end rather than read out of the source: an earlier version of
+    this test asserted on ``inspect.getsource`` and passed while the gate was
+    comparing a variable that the ``::step::`` handler had already rebound, so
+    the sync path silently stamped nothing and the provision path raised
+    NameError. Only running it catches that.
+    """
+    seen = {}
+
+    for kind, emits_steps in (("sync", True), ("provision wt-x", False)):
+        lines = [b"::step::0::4::Pull\n"] if emits_steps else []
+        lines.append(b"npm error code E401\n")
+
+        class FakeProc:
+            pid = 4242
+            returncode = None
+
+            def __init__(self):
+                self.stdout = self
+                self._lines = list(lines)
+
+            async def readline(self):
+                return self._lines.pop(0) if self._lines else b""
+
+            async def wait(self):
+                self.returncode = mod.npm_preflight.EXIT_AUTH
+                return mod.npm_preflight.EXIT_AUTH
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+        rid = await mod._start_run(kind, ["true"], env={})
+        for _ in range(80):
+            await mod.asyncio.sleep(0.05)
+            async with mod._RUNS_LOCK:
+                if mod._RUNS.get(rid, {}).get("status") not in (None, "running"):
+                    break
+        async with mod._RUNS_LOCK:
+            seen[kind] = dict(mod._RUNS[rid])
+
+    # The sync run is the one kind allowed to assert a cause -- and it must
+    # actually get one, which the shadowed comparison silently prevented.
+    assert seen["sync"].get("cause"), (
+        "the sync run was not stamped; the gate is reading something other than "
+        "the run kind"
+    )
+    assert "registry" in seen["sync"]["cause"].lower()
+    assert seen["sync"]["exit_code"] == mod.npm_preflight.EXIT_AUTH
+
+    # The provision run must be stamped with nothing AND must still complete
+    # normally: an unbound name here turned a finished run into exit -1.
+    assert not seen["provision wt-x"].get("cause"), seen["provision wt-x"]
+    assert seen["provision wt-x"]["exit_code"] == mod.npm_preflight.EXIT_AUTH, (
+        "the provision run's exit code was rewritten -- the completion path "
+        "raised before recording it"
+    )
+
+
+def test_the_stamp_gate_reads_a_name_the_step_handler_cannot_rebind():
+    """The gate must not read a variable the output loop assigns to.
+
+    This is the defect that shipped once: ``label`` is the function parameter
+    AND the ``::step::`` handler's target, so at completion it held the last
+    step's label or was unbound. Whatever the gate compares has to be assigned
+    exactly once, which is checked here on the parse tree rather than by counting
+    substrings -- the first version of this test counted ``run_kind =`` and
+    matched ``run_kind ==`` too.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(mod._start_run)))
+
+    # The name the gate actually compares against.
+    gates = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Compare)
+        and isinstance(n.left, ast.Name)
+        and any(
+            isinstance(c, ast.Name) and c.id == "_SYNC_RUN_LABEL"
+            for c in n.comparators
+        )
+    ]
+    assert len(gates) == 1, f"expected one kind gate, found {len(gates)}"
+    guarded = gates[0].left.id
+
+    targets = [
+        t.id
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.Assign, ast.AugAssign, ast.For, ast.AsyncFor))
+        for t in ast.walk(n.target if hasattr(n, "target") else n.targets[0])
+        if isinstance(t, ast.Name)
+    ]
+    assert targets.count(guarded) == 1, (
+        f"{guarded!r} is assigned {targets.count(guarded)} times in "
+        "_start_run; the gate's variable must be bound once, before any output "
+        "is read, or a later handler can rebind it out from under the gate"
+    )
+    assert guarded not in {a.arg for a in tree.body[0].args.args}, (
+        f"{guarded!r} is the parameter itself -- use a local captured at entry, "
+        "so a handler that rebinds the parameter cannot reach the gate"
+    )
+
+
+def test_the_stamp_gate_and_the_sync_label_are_one_constant():
+    """A literal in either place would let the two drift apart silently.
+
+    Drift in one direction re-opens the forgery; in the other it suppresses the
+    diagnosis this PR exists to deliver, and neither shows up as a failure.
+    """
+    assert mod._SYNC_RUN_LABEL == "sync"
+    src = Path(mod.__file__).read_text(encoding="utf-8")
+    assert '_start_run("sync"' not in src, (
+        "the sync is started with a literal label; use _SYNC_RUN_LABEL"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prune_clears_dead_sync_refs_and_spares_live_ones(tmp_path, monkeypatch):
+    """The PID suffix is only affordable if the refs it strands get collected.
+
+    Nothing deletes the pinned ref on the way out, so an ordinary gateway
+    restart leaves one behind in the OPERATOR's checkout -- unbounded except by
+    pid_max and visible in ``git for-each-ref`` forever. The prune removes those,
+    and must LEAVE ALONE any ref whose PID is still alive: that one may be a
+    second gateway's live pin, and deleting it would reopen the very window the
+    suffix closes.
+    """
+    import subprocess as sp
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "p", "GIT_AUTHOR_EMAIL": "p@e",
+        "GIT_COMMITTER_NAME": "p", "GIT_COMMITTER_EMAIL": "p@e",
+    }
+
+    def git(*a):
+        return sp.run(
+            ["git", *a], cwd=repo, env=env, capture_output=True, text=True,
+            encoding="utf-8", check=True,
+        ).stdout.strip()
+
+    git("init", "-q", "-b", "main")
+    (repo / "f.txt").write_text("one\n")
+    git("add", "f.txt")
+    git("commit", "-q", "-m", "one")
+    head = git("rev-parse", "HEAD")
+
+    # A ref for THIS process (skipped by name), one for a PID that is certainly
+    # gone, one for a DIFFERENT but LIVE process -- pid 1 always exists and is
+    # never us, and signalling it raises PermissionError rather than succeeding,
+    # so it exercises the alive-but-not-ours branch too -- and one that is not
+    # ours to reason about. The live foreign PID is the case that matters: it
+    # stands in for a second gateway's pin, and it is the only ref whose survival
+    # depends on the liveness check rather than on the name check.
+    mine = mod._sync_base_ref()
+    dead_pid = 999_999_999  # above any real pid_max
+    dead = f"refs/kirocrew/sync-base-{dead_pid}"
+    live_other = "refs/kirocrew/sync-base-1"
+    foreign = "refs/kirocrew/something-else"
+    for ref in (mine, dead, live_other, foreign):
+        git("update-ref", ref, head)
+
+    async def fake_git(git_dir, *args, **kw):
+        return sp.run(
+            ["git", *args], cwd=git_dir, env=env, capture_output=True, text=True,
+            encoding="utf-8", check=False,
+        ).stdout
+    monkeypatch.setattr(mod, "_git", fake_git)
+
+    await mod._prune_dead_sync_base_refs(str(repo))
+
+    remaining = set(
+        git("for-each-ref", "--format=%(refname)", "refs/kirocrew/").splitlines()
+    )
+    assert mine in remaining, (
+        "the prune deleted THIS process's live pin; a sync would then fetch into "
+        "a ref another gateway could move"
+    )
+    assert live_other in remaining, (
+        "the prune deleted a ref belonging to a process that is STILL ALIVE -- "
+        "that may be a second gateway's pin, and removing it reopens exactly the "
+        "window the PID suffix exists to close"
+    )
+    assert dead not in remaining, f"stale ref {dead} survived the prune"
+    assert foreign in remaining, (
+        "the prune deleted a ref outside its own naming scheme"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prune_runs_before_the_fetch_step_is_built(monkeypatch):
+    """Ordering: the prune must not be able to race the fetch that writes our pin.
+
+    It only ever deletes refs for PIDs that are gone, so it cannot touch our own
+    -- but running it before the steps are built keeps that guarantee structural
+    rather than incidental.
+    """
+    calls: list[str] = []
+
+    async def spy(repo):
+        calls.append(repo)
+    monkeypatch.setattr(mod, "_prune_dead_sync_base_refs", spy)
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+
+    assert calls, "the sync never pruned stale pinned refs"
+    steps = _sync_steps_from_script(script)
+    fetch = [st for st in steps if "fetch" in st["argv"]]
+    assert fetch, "no fetch step"
+    # The pin the fetch writes is this process's, which the prune never removes.
+    assert mod._sync_base_ref() in " ".join(fetch[0]["argv"])
+
+
+@pytest.mark.asyncio
+async def test_preflight_runs_a_snapshot_not_the_editable_source(monkeypatch):
+    """The probe must execute a private COPY by path, never import the checkout.
+
+    Two distinct holes close here. ``-c`` puts the cwd -- the checkout -- first on
+    ``sys.path``, so an untracked ``kiro_crew/`` package at its root would win;
+    ``-I`` fixes that. But the install is EDITABLE, so ``import kiro_crew...``
+    resolves into the checkout's own ``src/`` tree even under ``-I``, and this
+    step is trusted to assert a failure cause precisely BECAUSE its binary is
+    ours. Importing the tree being synced put the boundary's own key under the
+    mat. Running a snapshot by path consults neither.
+
+    Verified end to end in $KIROCREW_SCRATCH/shadow_probe.py: a planted shadow
+    wins without -I, the import still lands in the editable tree WITH -I, and a
+    by-path snapshot runs standalone because npm_preflight imports only stdlib.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    argvs = await _sync_step_argvs(monkeypatch)
+    probe = [
+        a for a in argvs
+        if any("npm_preflight" in str(x) for x in a) and str(a[0]) == sys.executable
+    ]
+    assert probe, f"no preflight step in {argvs}"
+    argv = probe[0]
+
+    # No import of the package at all -- that is the point.
+    joined = " ".join(str(x) for x in argv)
+    assert "-c" not in argv, argv
+    assert "import" not in joined, (
+        "the probe still imports the module; an editable install resolves that "
+        "into the checkout being synced"
+    )
+    # A script path, and NOT one inside the checkout.
+    script = [str(x) for x in argv if str(x).endswith("npm_preflight.py")]
+    assert len(script) == 1, argv
+    assert "/src/kiro_crew/" not in script[0], (
+        f"{script[0]} is the editable source itself, not a snapshot"
+    )
+    # Isolated, with the flags ahead of the script path -- after it they would be
+    # argv for the program and the protection would vanish silently.
+    assert argv.index("-I") < argv.index(script[0]), argv
+    assert argv.index("-X") < argv.index(script[0]), argv
+
+
+@pytest.mark.asyncio
+async def test_the_preflight_snapshot_is_registered_for_cleanup(monkeypatch):
+    """The snapshot must not leak one temp directory per Pull + Build.
+
+    The run's cleanup unlinks each registered path and falls back to rmdir, which
+    only succeeds on an empty directory -- so the FILE has to be registered ahead
+    of its directory. The dependency-only path already leaks its own snapshot dir
+    by registering neither; this asserts we do not repeat that.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    await _run_sync(mod, [])
+
+    paths = list(_LAST_CLEANUP_PATHS)
+    snaps = [p for p in paths if "npm-preflight" in p]
+    assert snaps, f"the preflight snapshot is not registered for cleanup: {paths}"
+    files = [p for p in snaps if p.endswith(".py")]
+    dirs = [p for p in snaps if not p.endswith(".py")]
+    assert files and dirs, f"expected both the file and its directory: {snaps}"
+    assert paths.index(files[0]) < paths.index(dirs[0]), (
+        "the directory is registered before its file, so rmdir will fail on a "
+        "non-empty directory and the snapshot will leak"
+    )
+
+
+@pytest.mark.parametrize("failing", ["mkdtemp", "write"])
+@pytest.mark.asyncio
+async def test_a_full_tmpdir_refuses_the_sync_instead_of_raising(
+    monkeypatch, tmp_path, failing
+):
+    """Staging the snapshot can fail; that must refuse, and leave nothing behind.
+
+    ``mkdtemp`` and the snapshot write both raise OSError on a full or unwritable
+    TMPDIR. The sync answers a UI action, so an escaping OSError would surface as
+    an unhandled HTTP 500 with no remedy. Refusing is also the SAFE outcome: with
+    no probe there is nothing to trust, and proceeding unprobed is precisely the
+    destructive path this change exists to prevent.
+
+    The write case matters twice over: mkdtemp has already SUCCEEDED by then, and
+    the refusal returns before anything is registered for the run's cleanup, so a
+    directory would survive every failed sync -- in the product, not merely in
+    this test. Both sites are driven for real; an assertion on the source would
+    not notice a second unguarded call appearing beside the first.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    boom = OSError(28, "No space left on device")
+    # Direct the REAL mkdtemp under this test's tmp_path, so even a regression
+    # that reintroduces the leak cannot litter the host running the suite.
+    real_mkdtemp = mod.tempfile.mkdtemp
+
+    if failing == "mkdtemp":
+        monkeypatch.setattr(
+            mod.tempfile, "mkdtemp",
+            lambda *a, **kw: (_ for _ in ()).throw(boom),
+        )
+    else:
+        monkeypatch.setattr(
+            mod.tempfile, "mkdtemp",
+            lambda *a, **kw: real_mkdtemp(*a, **{**kw, "dir": str(tmp_path)}),
+        )
+        real_write = Path.write_bytes
+
+        def fail_write(self, data):
+            if self.name == "npm_preflight.py":
+                raise boom
+            return real_write(self, data)
+
+        monkeypatch.setattr(Path, "write_bytes", fail_write)
+
+    result, script = await _run_sync(mod, [])
+
+    assert result.get("ok") is False, result
+    assert "preflight" in result["error"].lower(), result
+    assert "No space left on device" in result["error"], result
+    # A refusal means no run was started at all, so no steps ran.
+    assert script is None, "the sync started a run despite failing to stage"
+    # And the partial snapshot is gone: nothing registered it for cleanup, so the
+    # refusal path has to remove it itself.
+    leaked = list(tmp_path.glob("kirocrew-npm-preflight-*"))
+    assert not leaked, (
+        f"the refusal left {leaked} behind; every failed sync would leak one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_snapshot_is_written_from_bytes_captured_at_import(monkeypatch):
+    """The probe's snapshot must be of the code THIS gateway is running.
+
+    Copying the module file at sync time left a window from gateway start until
+    the button press in which the source could be rewritten -- and the copy is
+    then executed as the one step trusted to assert a failure cause. Capturing at
+    import closes it: the bytes are the ones the running process imported.
+
+    Driven by rewriting the file on disk AFTER import and asserting the snapshot
+    does not contain the change.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    written: dict = {}
+    real_write = Path.write_bytes
+
+    def spy(self, data):
+        if self.name == "npm_preflight.py":
+            written["data"] = data
+        return real_write(self, data)
+
+    monkeypatch.setattr(Path, "write_bytes", spy)
+    # Whatever is on disk now is irrelevant: the module was imported long ago.
+    monkeypatch.setattr(
+        mod, "_PREFLIGHT_SOURCE", b"# captured at import\nmarker = 1\n"
+    )
+    await _run_sync(mod, [])
+
+    assert "data" in written, "the snapshot was never written"
+    assert written["data"] == b"# captured at import\nmarker = 1\n", (
+        "the snapshot was re-read from disk instead of using the captured bytes"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_refuses_when_the_probe_source_could_not_be_captured(monkeypatch):
+    """An unreadable probe source refuses rather than falling back to a re-read.
+
+    A frozen or zipimported install has no readable ``__file__``. Falling back to
+    copying the file at sync time would reintroduce exactly the window the
+    import-time capture removes, so the sync refuses instead -- the same safe
+    direction the full-TMPDIR path takes.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    monkeypatch.setattr(mod, "_PREFLIGHT_SOURCE", None)
+
+    result, script = await _run_sync(mod, [])
+
+    assert result.get("ok") is False, result
+    assert "preflight" in result["error"].lower(), result
+    assert script is None, "the sync started a run with no trustworthy probe"
+
+
+@pytest.mark.asyncio
+async def test_every_stash_presence_gate_uses_lexists(monkeypatch):
+    """Presence gates must not follow symlinks.
+
+    ``isdir`` follows a link, so a DANGLING node_modules read as absent: the
+    reconciliation then took the backup-only branch and called
+    ``os.rename(<dir>, <dangling link>)``, which fails ENOTDIR and crashes the
+    runner on every sync with the tree never recovered. The move-aside gate has
+    the mirror bug -- with ``isdir`` a symlinked tree is never stashed, so the
+    step runs with no backup at all, on exactly the layouts that most need one.
+
+    Verified end to end in $KIROCREW_SCRATCH/runner_probe.py (scenarios 8 and 9);
+    this pins the shape so the gates cannot silently revert.
+    """
+    monkeypatch.setattr(mod.frontend, "edition_configured", lambda: False)
+    _, script = await _run_sync(mod, [])
+
+    assert "have_tree = os.path.lexists(stash)" in script
+    assert "have_backup = os.path.lexists(backup)" in script
+    assert "if backup and os.path.lexists(stash):" in script
+    # No presence gate on either path may follow a link.
+    for bad in (
+        "os.path.isdir(stash)",
+        "os.path.isdir(backup)",
+        "os.path.exists(stash)",
+        "os.path.exists(backup)",
+    ):
+        assert bad not in script, f"{bad} follows symlinks; use lexists"

--- a/test/test_dev_fleet_npm_preflight.py
+++ b/test/test_dev_fleet_npm_preflight.py
@@ -1,0 +1,359 @@
+"""Unit tests for the Pull+Build pre-merge installability probe.
+
+The probe's value is entirely in WHICH answer it gives: the exit code decides
+whether the sync stops, and the classification decides which sentence the
+dashboard shows in place of npm's log-file pointer. So these pin the
+classification and the operator-facing message, not the plumbing.
+"""
+
+from __future__ import annotations
+
+import errno
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.apps.builtins.dev_fleet import npm_preflight as np
+
+
+class TestClassify:
+    """npm's own error CODES are the signal, so the verdict is the same
+    whichever registry is configured."""
+
+    @pytest.mark.parametrize(
+        "blob",
+        [
+            "npm error code E401\nnpm error Unable to authenticate",
+            "npm error code E403",
+            "npm ERR! 401 Unauthorized - GET https://example.invalid/x",
+            "HttpErrorAuthUnknown: Unable to authenticate, need: Bearer realm=...",
+            "npm error your authentication token seems to be invalid",
+            "npm error code ENEEDAUTH",
+        ],
+    )
+    def test_auth_failures(self, blob):
+        assert np.classify(blob) == np.EXIT_AUTH
+
+    @pytest.mark.parametrize(
+        "blob",
+        [
+            "npm error code E404\nnpm error 404 Not Found - GET .../left-pad",
+            "npm error 404 Not Found",
+        ],
+    )
+    def test_missing_version(self, blob):
+        """A curated mirror answers a blocked version with 404. That is NOT an
+        auth problem, and a credential refresh cannot fix it -- which is the
+        whole reason it gets its own code."""
+        assert np.classify(blob) == np.EXIT_UNAVAILABLE
+
+    @pytest.mark.parametrize(
+        "blob",
+        [
+            "npm error code ETIMEDOUT",
+            "npm error network timeout at: https://example.invalid",
+            "npm error code ENOTFOUND",
+            "npm error code ECONNRESET",
+            "npm error code EAI_AGAIN",
+        ],
+    )
+    def test_network_failures(self, blob):
+        assert np.classify(blob) == np.EXIT_TRANSIENT
+
+    def test_unrecognized_is_not_called_transient(self):
+        """Calling an unknown failure transient invites a retry that cannot
+        help and hides the real cause."""
+        assert np.classify("npm error something entirely new") == np.EXIT_FAILED
+
+    def test_auth_wins_over_a_co_occurring_network_signal(self):
+        """Ordering matters: a run that 401s often also logs a socket error
+        afterwards, and the auth failure is the actionable half."""
+        assert np.classify("npm error code E401\nnpm error code ECONNRESET") == np.EXIT_AUTH
+
+    def test_every_nonzero_code_has_a_registry_neutral_explanation(self):
+        for code in (
+            np.EXIT_AUTH,
+            np.EXIT_UNAVAILABLE,
+            np.EXIT_TRANSIENT,
+            np.EXIT_NO_SPACE,
+            np.EXIT_FAILED,
+        ):
+            text = np.explain_exit(code)
+            assert text and text[0].islower()
+            for leak in ("npm", "codeartifact", "amazon", "harmony"):
+                assert (
+                    leak not in text.lower()
+                ), "the operator-facing explanation must name no vendor or tool"
+
+
+class TestFirstErrorLine:
+    """npm prints its diagnosis FIRST and its log-file pointer LAST, which is
+    why 'the last output line' was the least informative thing to show."""
+
+    def test_prefers_the_diagnosis_over_the_log_pointer(self):
+        blob = (
+            "npm warn deprecated foo@1.0.0\n"
+            "npm error code E401\n"
+            "npm error Unable to authenticate, your token seems to be invalid\n"
+            "npm error A complete log of this run can be found in: "
+            "/home/u/.npm/_logs/2026-08-28T11_21_33_570Z-debug-0.log\n"
+        )
+        assert np._first_error_line(blob) == "npm error code E401"
+
+    def test_never_returns_the_log_pointer_even_when_it_is_the_only_match(self):
+        blob = (
+            "npm error A complete log of this run can be found in: "
+            "/home/u/.npm/_logs/x-debug-0.log\n"
+        )
+        assert np._first_error_line(blob) == ""
+
+    def test_is_bounded(self):
+        assert len(np._first_error_line("npm error " + "x" * 5000)) <= 400
+
+
+class TestProbe:
+    """The probe must isolate itself from the checkout's own node_modules."""
+
+    def test_missing_lockfile_in_the_ref_is_a_failure_not_a_pass(self, monkeypatch):
+        """Fail closed. A ref whose lockfile cannot be read is exactly the case
+        where proceeding would delete node_modules for nothing."""
+
+        def fake_run(argv, **kw):
+            return subprocess.CompletedProcess(argv, 1, b"", b"path does not exist")
+
+        monkeypatch.setattr(np.subprocess, "run", fake_run)
+        code, detail = np.probe(
+            git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main"
+        )
+        assert code == np.EXIT_FAILED
+        assert "package-lock.json" in detail
+
+    def test_mirrors_the_real_step_and_skips_lifecycle_scripts(self, monkeypatch):
+        """A probe that resolves differently from the install is worse than no
+        probe: it either passes what will fail or fails what would have worked.
+        And it must not execute the tree's install hooks."""
+        seen: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            seen.append(list(argv))
+            if "show" in argv:
+                return subprocess.CompletedProcess(argv, 0, b"{}", b"")
+            return subprocess.CompletedProcess(argv, 0, b"added 1 package", b"")
+
+        monkeypatch.setattr(np.subprocess, "run", fake_run)
+        code, _ = np.probe(git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main")
+        assert code == np.EXIT_OK
+        ci = [a for a in seen if "ci" in a]
+        assert ci, seen
+        assert "--ignore-scripts" in ci[0]
+        # Flags that would change RESOLUTION must not be added.
+        for changer in ("--legacy-peer-deps", "--force", "--omit", "--registry"):
+            assert changer not in ci[0], f"{changer} makes the probe answer a different question"
+
+    def test_must_not_use_dry_run(self, monkeypatch):
+        """``--dry-run`` does not attempt retrieval, so it cannot answer this
+        question at all.
+
+        Measured against a lockfile pinning a tarball that 404s:
+        ``npm ci --dry-run --ignore-scripts`` exits 0 and reports "added 1
+        package", while the same command WITHOUT ``--dry-run`` exits 1 on the
+        missing tarball. A dry run would therefore pass exactly the case this
+        module exists to catch -- an uncached package the registry will not hand
+        over -- and the sync would go on to empty node_modules regardless.
+        """
+        seen: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            seen.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, b"{}", b"")
+
+        monkeypatch.setattr(np.subprocess, "run", fake_run)
+        np.probe(git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main")
+        ci = [a for a in seen if "ci" in a]
+        assert ci, seen
+        assert "--dry-run" not in ci[0], (
+            "a dry run reports success without fetching, which is the one "
+            "outcome this probe must never produce"
+        )
+
+    def test_reads_the_settings_that_change_resolution(self, monkeypatch):
+        """.npmrc carries resolution-affecting settings (a minimum-release-age
+        gate, for one), so omitting it would make the probe disagree with the
+        install it guards."""
+        assert set(np._PROBE_FILES) >= {"package-lock.json", "package.json", ".npmrc"}
+
+    def test_timeout_is_transient_not_a_hard_failure(self, monkeypatch):
+        def fake_run(argv, **kw):
+            if "show" in argv:
+                return subprocess.CompletedProcess(argv, 0, b"{}", b"")
+            raise subprocess.TimeoutExpired(argv, 1)
+
+        monkeypatch.setattr(np.subprocess, "run", fake_run)
+        code, detail = np.probe(
+            git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main", timeout=1
+        )
+        assert code == np.EXIT_TRANSIENT
+        assert "timed out" in detail
+
+    def test_leaves_no_scratch_directory_behind(self, monkeypatch, tmp_path):
+        made: list[str] = []
+        real_mkdtemp = np.tempfile.mkdtemp
+
+        def spy(*a, **kw):
+            # Confine the REAL directory under this test's tmp_path. probe()
+            # cleans up with ignore_errors=True, so a cleanup failure is silent:
+            # without this the residue would survive in the shared temp dir
+            # instead of somewhere pytest reclaims, and the only signal would be
+            # this test's own assertion.
+            kw.setdefault("dir", str(tmp_path))
+            path = real_mkdtemp(*a, **kw)
+            made.append(path)
+            return path
+
+        monkeypatch.setattr(np.tempfile, "mkdtemp", spy)
+        monkeypatch.setattr(
+            np.subprocess,
+            "run",
+            lambda argv, **kw: subprocess.CompletedProcess(argv, 0, b"{}", b""),
+        )
+        np.probe(git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main")
+        assert made, "probe never created a scratch directory"
+        assert made[0].startswith(str(tmp_path)), (
+            f"{made[0]} is outside this test's tmp_path; probe cleans up with "
+            "ignore_errors=True, so a silent cleanup failure would leave residue "
+            "in the shared temp directory"
+        )
+        assert not Path(made[0]).exists(), f"probe left {made[0]} behind"
+
+
+class TestCli:
+    """The exit code is the only channel the diagnosis travels on.
+
+    stdout is shared with worktree-controlled build output, so nothing the
+    gateway promotes may be parsed out of it: an install script could print any
+    marker and then fail, and the dashboard would show the forgery as
+    authoritative -- remedy included.
+    """
+
+    def test_success_says_so_without_a_promotable_marker(self, monkeypatch, capsys):
+        monkeypatch.setattr(np, "probe", lambda **kw: (np.EXIT_OK, ""))
+        rc = np.main(["--git", "g", "--npm", "n", "--repo", "r", "--ref", "x"])
+        assert rc == np.EXIT_OK
+        out = capsys.readouterr().out
+        assert "installable" in out
+        assert "::" not in out, "stdout must carry no in-band marker at all"
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            np.EXIT_AUTH,
+            np.EXIT_UNAVAILABLE,
+            np.EXIT_TRANSIENT,
+            np.EXIT_NO_SPACE,
+            np.EXIT_FAILED,
+        ],
+    )
+    def test_failure_propagates_the_code_and_logs_a_plain_detail(self, monkeypatch, capsys, code):
+        monkeypatch.setattr(np, "probe", lambda **kw: (code, "npm error code E401"))
+        rc = np.main(["--git", "g", "--npm", "n", "--repo", "r", "--ref", "x"])
+        assert rc == code, "the code IS the diagnosis"
+        out = capsys.readouterr().out
+        assert out.startswith(np.DETAIL_PREFIX), out
+        assert "::" not in out, "stdout must carry no in-band marker at all"
+        assert np.explain_exit(code) in out
+
+    def test_the_gateway_maps_only_codes_this_module_owns(self):
+        """``explain_exit`` must not invent a cause for an ordinary failure.
+
+        Its input is the exit code of an ARBITRARY step -- ``npm ci`` exiting 1,
+        a compile error, a killed process -- so falling back to "the incoming
+        lockfile could not be installed" would state a cause never established.
+        """
+        for code in (
+            np.EXIT_AUTH,
+            np.EXIT_UNAVAILABLE,
+            np.EXIT_TRANSIENT,
+            np.EXIT_NO_SPACE,
+            np.EXIT_FAILED,
+            np.EXIT_TREE_AMBIGUOUS,
+            np.EXIT_RESTORE_FAILED,
+        ):
+            assert np.explain_exit(code), code
+        for foreign in (1, 2, 127, 130, 137, -1):
+            assert np.explain_exit(foreign) == "", foreign
+        assert np.explain_exit(np.EXIT_OK) == ""
+
+
+class TestScratchFilesystemFailures:
+    """The probe performs a REAL install, so its scratch directory can fill.
+
+    Every one of its own filesystem operations is mapped to a classified code in
+    one place. An uncaught OSError anywhere here would kill the step with a
+    traceback and NO cause, which puts the dashboard back to showing whatever
+    npm's last output line happened to be -- the exact defect this module exists
+    to remove. So the coverage is per-SITE, because the class of bug is "one site
+    was missed".
+    """
+
+    def test_a_full_scratch_dir_maps_to_the_out_of_space_code(self):
+        assert np._os_error_code(OSError(errno.ENOSPC, "No space left")) == np.EXIT_NO_SPACE
+
+    def test_other_os_errors_are_not_reported_as_out_of_space(self):
+        assert np._os_error_code(OSError(errno.EACCES, "denied")) == np.EXIT_FAILED
+        assert np._os_error_code(OSError()) == np.EXIT_FAILED
+
+    def test_mkdtemp_failure_is_classified_not_raised(self, monkeypatch):
+        def boom(*a, **kw):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        monkeypatch.setattr(np.tempfile, "mkdtemp", boom)
+        code, detail = np.probe(
+            git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main"
+        )
+        assert code == np.EXIT_NO_SPACE
+        assert "scratch" in detail
+
+    def test_write_failure_during_extraction_is_classified_not_raised(self, monkeypatch):
+        """The site the reviewer named: the lockfile write itself."""
+        monkeypatch.setattr(
+            np.subprocess,
+            "run",
+            lambda argv, **kw: subprocess.CompletedProcess(argv, 0, b"{}", b""),
+        )
+        real = np.Path.write_bytes
+
+        def boom(self, data):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        monkeypatch.setattr(np.Path, "write_bytes", boom)
+        try:
+            code, detail = np.probe(
+                git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main"
+            )
+        finally:
+            monkeypatch.setattr(np.Path, "write_bytes", real)
+        assert code == np.EXIT_NO_SPACE
+        assert "scratch dir" in detail
+
+    def test_git_spawn_failure_during_extraction_is_classified(self, monkeypatch):
+        def boom(argv, **kw):
+            raise OSError(errno.ENOENT, "No such file")
+
+        monkeypatch.setattr(np.subprocess, "run", boom)
+        code, detail = np.probe(
+            git="/nope/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main"
+        )
+        assert code == np.EXIT_FAILED
+        assert "could not run git" in detail
+
+    def test_extraction_timeout_is_transient(self, monkeypatch):
+        def boom(argv, **kw):
+            raise subprocess.TimeoutExpired(argv, 60)
+
+        monkeypatch.setattr(np.subprocess, "run", boom)
+        code, detail = np.probe(
+            git="/usr/bin/git", npm="/usr/bin/npm", repo="/repo", ref="origin/main"
+        )
+        assert code == np.EXIT_TRANSIENT
+        assert "timed out" in detail

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -715,6 +715,29 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "dep_sync.py::_probe_interpreter",
         "dep_sync.py::sync",
         "dep_sync.py::sync_or_reinstall",
+        # npm_preflight is the sync's pre-merge installability probe, and like
+        # dep_sync it runs AS one of the sync steps -- which server.py already
+        # wrapped through sandboxed_spawn_argv before handing it to the runner.
+        # So both of its spawns are already inside that sandbox, and routing them
+        # again would nest one sandbox inside itself; the chokepoint is applied at
+        # the call site, exactly as for server.py::worker.
+        #
+        # Neither argv is agent-influenced. _extract spawns
+        # `<git> -C <repo> show <remote>/<base branch>:website/<fixed filename>`:
+        # the binary comes from _trusted_bin (never PATH), the repo from the
+        # operator-configured checkout, the branch from the BASE_BRANCH constant,
+        # and the three filenames from a module-level tuple. probe spawns
+        # `<npm> ci --ignore-scripts --no-audit --no-fund` with cwd set to its own
+        # mkdtemp scratch directory -- not a repository, and not a path any caller
+        # supplies.
+        #
+        # The lockfile it installs IS repo-controlled, but that is input data to
+        # npm rather than steering of argv or cwd, it is the same content the real
+        # `npm ci` step installs, and --ignore-scripts is what keeps that content
+        # from getting code executed. A filesystem-scoped wrapper here would also
+        # block the scratch-directory writes that are the whole point of the probe.
+        "apps/builtins/dev_fleet/npm_preflight.py::_extract",
+        "apps/builtins/dev_fleet/npm_preflight.py::probe",
         # Foreground last-resort restart (Make Live on hosts with no drivable
         # service manager): a detached `kirocrew restart --port <marker port>`,
         # fixed argv whose binary is validated (basenamed kirocrew, absolute,

--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -59,6 +59,9 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 // stalls in one band, then jumps. An indeterminate spinner plus the step name
 // and elapsed time is the honest signal.
 const STEP_MARKER_RE = /^::step::(\d+)::(.+)$/
+// The failure diagnosis arrives on the run as `cause`, derived by the gateway
+// from the exit code -- never parsed out of this stream, which also carries
+// worktree-controlled build output. So the log needs no marker handling.
 
 function filterStepMarkers(lines: string[]): string[] {
   return lines.filter((l) => !STEP_MARKER_RE.test(l))
@@ -577,7 +580,10 @@ interface Worktree {
   provision_run_id?: string | null
 }
 interface FleetData { worktrees: Worktree[]; error?: string; needs_setup?: boolean; main_repo?: string; main_repo_inferred?: boolean; base_branch?: string; sync_run_id?: string; build_pending?: boolean; gateway_service_active?: boolean; gateway_service_reason?: string | null; pods_available?: boolean; pods_unavailable_reason?: string | null; serving_install_reason?: string | null; staged_target?: string | null; staged_cancel_available?: boolean; manual_restart?: string }
-interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; lines: string[]; startedAt: number; exit?: number | null; last?: string; stepLabel?: string }
+// `lastIsCause` distinguishes the two things `last` can hold. A gateway-composed
+// diagnosis is decision-critical prose ending in the action to take, so it must
+// not render in the muted 11.5px monospace the raw log tail uses.
+interface SyncRun { rid: string; status: 'running' | 'done' | 'error'; lines: string[]; startedAt: number; exit?: number | null; last?: string; lastIsCause?: boolean; stepLabel?: string }
 // Provision run state: the FULL output is kept (not just the last
 // line) so the expandable log panel can show everything, and a failed run
 // persists (failed=true) until the user dismisses it rather than vanishing.
@@ -845,19 +851,25 @@ export default function DevFleetPage() {
     if (syncRun?.rid === fleet.sync_run_id) return // already tracking this run
     syncAttachedRef.current = true
     const rid = fleet.sync_run_id
-    api.get<{ status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string }>('/run?id=' + rid)
+    api.get<{ status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string; cause?: string }>('/run?id=' + rid)
       .then((run) => {
         if (!run) return
         const t0 = run.started ? run.started * 1000 : Date.now()
         const out = run.output || []
-        const last = [...out].reverse().find((l) => l?.trim() && !STEP_MARKER_RE.test(l)) || ''
+        // Same preference as the two poll paths: a reported cause outranks the
+        // last output line, which for npm is its log-file pointer. Missing it
+        // here meant a page RELOAD after a failed build showed the uninformative
+        // line even though the diagnosis was stored on the run.
+        const last = run.cause
+          || [...out].reverse().find((l) => l?.trim() && !STEP_MARKER_RE.test(l))
+          || ''
         if (run.status === 'running') {
           setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, stepLabel: run.step_label })
           pollSyncRun(rid, t0)
         } else if (run.status === 'done' || run.status === 'timeout') {
           // Show the completed/failed result so user sees it on revisit
           const okRun = run.exit_code === 0
-          setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last })
+          setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last, lastIsCause: Boolean(run.cause) })
         }
       })
       .catch(() => { /* run endpoint unreachable — nothing to reattach */ })
@@ -938,18 +950,20 @@ export default function DevFleetPage() {
       await sleep(2000)
       if (!pollAliveRef.current) return
       if (cancelledRunsRef.current.has(rid)) return
-      let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string } | null = null
+      let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string; cause?: string } | null = null
       try { run = await api.get('/run?id=' + rid) } catch { continue }
       if (!run) continue
       const t0 = run.started ? run.started * 1000 : startedAt
       const out = run.output || []
-      const last = [...out].reverse().find((l: string) => l?.trim() && !STEP_MARKER_RE.test(l)) || ''
+      const last = run.cause
+        || [...out].reverse().find((l: string) => l?.trim() && !STEP_MARKER_RE.test(l))
+        || ''
       if (run.status === 'done' || run.status === 'timeout') {
         const okRun = run.exit_code === 0
-        setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last })
+        setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last, lastIsCause: Boolean(run.cause) })
         return
       }
-      setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, last, stepLabel: run.step_label })
+      setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, last, lastIsCause: Boolean(run.cause), stepLabel: run.step_label })
     }
   }
 
@@ -963,7 +977,7 @@ export default function DevFleetPage() {
       // keep polling and still issue the restart after unmount; the React state
       // setters below are safe no-ops once the component is gone.
       if (cancelledRunsRef.current.has(rid)) return
-      let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string } | null = null
+      let run: { status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string; cause?: string } | null = null
       let gone = false
       try { run = await api.get('/run?id=' + rid) } catch (e) {
         // 404 = the gateway restarted and dropped the run registry — the run
@@ -982,10 +996,16 @@ export default function DevFleetPage() {
       }
       const out = run.output || []
       const t0 = run.started ? run.started * 1000 : startedAt
-      const last = [...out].reverse().find((l) => l?.trim() && !STEP_MARKER_RE.test(l)) || ''
+      // Prefer the cause a step reported over the last output line. npm prints
+      // its diagnosis FIRST and its "a complete log of this run can be found
+      // in ..." pointer LAST, so the last line is the least informative one it
+      // produces — which is what this used to surface on every failed build.
+      const last = run.cause
+        || [...out].reverse().find((l) => l?.trim() && !STEP_MARKER_RE.test(l))
+        || ''
       if (run.status === 'done' || run.status === 'timeout') {
         const okRun = run.exit_code === 0
-        setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last })
+        setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last, lastIsCause: Boolean(run.cause) })
         setFlag('__syncmain', false)
         if (okRun) {
           // Auto-restart the gateway when the service is drivable — the build
@@ -1020,11 +1040,17 @@ export default function DevFleetPage() {
             notify(i18nT('pages.devFleetPage.synced_restart_gateway_to_apply_the_new_build'), { type: 'success' })
           }
         }
+        // With a named cause the detail is already a self-sufficient sentence
+        // ending in the action to take, so prefixing it with "(exit 41)" adds a
+        // reserved code that means nothing outside this codebase. Only the raw
+        // log-tail fallback still carries the code, where it is the only
+        // machine-readable thing the toast has.
+        else if (run.cause) notify(`${i18nT('pages.devFleetPage.pull_build_failed')}: ${run.cause}`, { type: 'error' })
         else notify(i18nT('pages.devFleetPage.pull_build_failed_exit_code_detail', { code: run.exit_code, detail: last }), { type: 'error' })
         invalidateFleet()
         return
       }
-      setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, last, stepLabel: run.step_label })
+      setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, last, lastIsCause: Boolean(run.cause), stepLabel: run.step_label })
     }
     setSyncRun((s) => (s && s.rid === rid ? { ...s, status: 'error', last: 'timed out after 30 min' } : s))
     setFlag('__syncmain', false)
@@ -1680,9 +1706,41 @@ export default function DevFleetPage() {
     }
     // error
     return (
-      <div style={{ gridColumn: '4 / -1', display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 } as CSSProperties}>
-        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--danger)' }}>{i18nT('pages.devFleetPage.pull_build_failed')}</span>
-        <span style={{ ...mono, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } as CSSProperties} title={syncRun.last}>{syncRun.last}</span>
+      <div style={{ gridColumn: '4 / -1', display: 'flex', alignItems: 'flex-start', gap: 8, minWidth: 0 } as CSSProperties}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--danger)', whiteSpace: 'nowrap' }}>{i18nT('pages.devFleetPage.pull_build_failed')}</span>
+        {/* A gateway-composed diagnosis is rendered as PROSE -- body colour, not
+            monospace -- because it is the one line the user has to act on, and
+            the muted 11.5px log styling was burying the remedy in the noise it
+            exists to replace. It also wraps in full rather than ellipsizing: a
+            cause can end with the action to take, and `title`-only overflow puts
+            that action out of reach of keyboard and touch users.
+
+            The raw log tail gets the opposite treatment: it is clamped to two
+            lines, because an uncapped npm line would otherwise stretch this
+            header several lines tall for text whose full form already lives one
+            click away in the Log panel. */}
+        <span
+          style={{
+            ...(syncRun.lastIsCause
+              ? {
+                  color: 'var(--text)',
+                  fontSize: 12.5,
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                }
+              : {
+                  ...mono,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  overflowWrap: 'anywhere',
+                }),
+            minWidth: 0,
+            flex: 1,
+          } as CSSProperties}
+          title={syncRun.lastIsCause ? undefined : syncRun.last}
+        >{syncRun.last}</span>
         <Clickable aria-label={i18nT('pages.devFleetPage.toggle_log')} onClick={() => setSyncLogOpen((o) => !o)} style={{ background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 11, padding: 2 } as CSSProperties}>{syncLogOpen ? i18nT('pages.devFleetPage.log') : i18nT('pages.devFleetPage.log_2')}</Clickable>
         <Clickable aria-label={i18nT('pages.devFleetPage.dismiss_sync_status')} onClick={() => dismissSync(syncRun?.rid)} style={{ background: 'none', border: 'none', color: 'var(--muted)', cursor: 'pointer', fontSize: 14, padding: 2 } as CSSProperties}>{"\u00d7"}</Clickable>
       </div>


### PR DESCRIPTION
## 1. What is the problem?

`npm ci` deletes `website/node_modules` before it installs. Dev Fleet's Pull+Build runs its steps strict-sequentially with fail-fast and no rollback, so a package registry that refuses a single package does not merely fail the sync -- it **damages the checkout**:

| step | outcome | what it leaves |
|---|---|---|
| fetch / merge | applied | new source + new lockfile |
| pip install | applied | env installed against the new source |
| `npm ci` | fails | `node_modules` **emptied**, not restored |
| build + stage | never runs | `dist` frozen at the previous revision |

The result is a state no revision ever produced, and pressing Pull+Build again repeats the deletion. Meanwhile the only thing the dashboard shows is npm's *last* output line -- its `A complete log of this run can be found in ...` pointer, the least informative line it prints. The `npm error code E401` and the failing package name are earlier in the output and never reach the user.

## 2. Why this issue matters to the user

The failure has two independent triggers that both recur: a private-registry token that expires on a clock, and a curated mirror that blocks a version the lockfile pins. Either is normally a transient inconvenience. Here each turns into a broken checkout with a stale frontend bundle against new backend code, and no path back that does not require the very registry that is unavailable. The failure is also silent about its own cause, so a user gets a log path and no way to discover the remedy.

Why it stays hidden until it bites is worth stating: npm's cache retrieval is **integrity-addressed**, so a build whose packages are all cached succeeds with a completely dead token. Nothing surfaces until a lockfile change introduces the first cache miss -- which is exactly when the destructive path runs.

## 3. How our fix solves it

**The symptom is a destroyed `node_modules`, so that step becomes a transaction.** The `npm ci` step carries `stash` metadata: the tree is moved aside before it runs, put back on any non-zero outcome, and the backup dropped on success. This lives in the runner rather than a separate step because the runner is fail-fast -- anything scheduled *after* a failed step never runs, which is precisely the case that needs the restore. The runner stays stdlib-only, so what it does cannot change with the revision being merged underneath it.

Two refinements came out of review and both matter:

- Deletions whose outcome decides the next `rename` are **confirmed**, not fire-and-forget. A silently partial removal leaves a directory in place, makes the rename fail, and ends with a partial tree restored over a good one.
- When a tree **and** a leftover backup both exist, the state is genuinely ambiguous: killed during `npm ci` leaves a partial tree plus the good backup, killed during the success cleanup leaves the good new tree plus a half-deleted one, and nothing on disk distinguishes them. Either rule destroys the good copy in one case, so the runner **stops and touches neither**, naming both paths. A refused sync is recoverable; a `node_modules` replaced by a partial tree is not.

**The cause is that the sync commits to a destructive step before knowing whether it can succeed, so a preflight goes between `fetch` and `merge`.** It asks the one question that matters -- is the incoming lockfile installable? -- reading the lockfile from the fetched ref (`git show`), not the working tree. That is what makes the position possible: the lockfile is knowable as soon as fetch lands, and fetch moves only remote refs, so a refusal costs nothing and nothing needs rolling back. No new refusal plumbing was required; the existing fail-fast runner already stops before `merge`.

The probe and the merge are pinned to ONE commit. `<remote>/main` could not serve for this: it is a mutable name, and the status refresher re-fetches it every 60s in this same process, so with a real install sitting between them the probe could certify a revision the merge does not install -- worse than not probing, because the promise is what makes the merge look safe. The fetch step now also writes the tip it brought to a ref of our own (`refs/kirocrew/sync-base`), which the refresher's fetch cannot move, and both consumers name that ref. This closes the window rather than narrowing it.

Three deliberate choices there, all load-bearing:

- It performs a **real script-free install** in a disposable directory, not `npm ci --dry-run`. Measured: against a lockfile pinning a tarball that 404s, `npm ci --dry-run --ignore-scripts` exits 0 and reports "added 1 package", while the same command without `--dry-run` exits 1. A dry run would pass exactly the case this exists to catch.
- It is **not** a registry auth check. Because retrieval is integrity-addressed, an auth probe fails while the install it guards would have succeeded -- it would block good syncs and train operators to ignore it.
- It **mirrors the real step's flags** otherwise, and runs with `--ignore-scripts`. A probe that resolves differently from the install is worse than no probe.

**Failure causes now reach the dashboard.** The diagnosis travels as an exit code, not as text: only the preflight step -- the one step whose binary is ours -- may assert one, and a reserved code arriving from any other step is reported as a plain failure with the true code kept in the log. The gateway maps the code to a sentence at run completion, and the UI prefers that over the last output line. An earlier revision carried the cause as a `::cause::` stdout marker; that was removed because any step's stdout can forge it, including worktree-controlled build output, and redaction is the wrong instrument -- it strips credentials, not instructions. Exit codes alone were not sufficient either: a lifecycle script can exit 41 as easily as it can print a marker, which is why the trust boundary is the step identity rather than the channel. The stamp is also gated on the run KIND: `_start_run` is shared with `provision`, which executes an agent-authored branch with no such remapping, so only the sync -- the one kind whose script enforces the reservation -- may be stamped at all.

**What is deliberately NOT here.** An operator-configurable "repair the registry credential" hook was written for this and removed. Its purpose is to run a program that touches the operator's credential material. The operator declares the command, but an agent can rewrite the FILE it names -- or a script among its arguments -- and withholding git's credential helpers does not close that, because HOME is itself the channel those credentials arrive through. No validation of `argv[0]` makes "the operator chose this command" mean "this is the code that will run", so it does not belong on a path that runs unattended. A test pins that no configurable command executes on the sync path; reviving the idea needs its own change with its own threat model.

## 4. What tests we did

**Unit (30, `test/test_dev_fleet_npm_preflight.py`)** -- classification of auth / missing-version / network / out-of-space / unrecognized signals from npm's own error codes; that an unrecognized failure is *not* labelled transient; that auth wins over a co-occurring network signal; that the operator-facing explanation names no vendor or tool; that the first *error* line is preferred over the log pointer and the pointer is never returned even when it is the only match; that a missing lockfile fails closed; that `--dry-run` is forbidden and no resolution-changing flag is added; that a full scratch filesystem returns the classified code instead of an uncaught `OSError`; that the scratch directory is always removed.

**Sync wiring (`test/test_dev_fleet_app.py`)** -- the preflight sits between fetch and merge; it probes a remote-tracking ref rather than the working tree; it is skipped on an edition checkout; the `stash` is attached to `npm ci` and only to it; deletions are confirmed; the ambiguous both-exist state refuses before any deletion or rename; and no configurable command executes on the sync path.

**Ratchet updated** -- `test_sync_build_steps_never_see_credential_helpers` now counts the preflight as a build step (4 -> 5), so nothing on the sync path carries credentials except the fetch step.

**Mutation-verified** -- each new invariant was confirmed red on unpatched code: preflight moved after merge, `stash` dropped, and (before the seam was removed) repair gated on any failure, repair given a credential-free env, repair output echoed.

**Behavioural, against the real generated runner** -- the script was extracted and driven through eight scenarios in a scratch tree: a failing stashed step restores the tree byte-for-byte and leaks no backup; a succeeding step keeps what it installed and drops the backup; a leftover backup is adopted when it is the only copy; both-present refuses and modifies neither; repair metadata, if present, is ignored; a reserved diagnosis code forged by a worktree-controlled step is neutralised; and the same code from the preflight step is trusted.

**Against real git**, the ref pinning was proven rather than argued: a probe advances an upstream mid-run, fires the refresher's exact command, and asserts the tracking ref moved while the pinned ref did not, that the merge landed the probed commit, that a pin left by an earlier run is overwritten before it can be read -- and that the OLD form would have drifted under the same sequence, so the change answers a real difference.

**Gates** -- isort, flake8, mypy and the repo's black gate clean on all changed files; `tsc -b` clean; eslint on the changed page reports only three pre-existing warnings. 313 scoped tests pass in the **pod's own editable install**. One unrelated failure (`test_trusted_bin_pins_the_resolved_target_not_the_symlink`) was A/B-confirmed to fail identically on the unmodified base checkout at the same commit -- it is env-owned (`KIROCREW_DEVFLEET_BIN_GH` is set on that host).

**Pod** -- verified in an isolated pod, never against the live gateway; the served bundle was confirmed to carry the frontend change rather than a stale one.

## 5. Any other suggestions on the work

- A full end-to-end Pull+Build could not be exercised in the pod: the sync refuses unless the primary checkout is on the base branch, and a feature worktree never is. The runner behaviour is covered by driving the real generated script directly instead.
- The preflight costs one script-free install per sync -- seconds against a warm cache, and it takes its space from `TMPDIR`, which the build env allowlists. That is the price of asking a question a dry run cannot answer.
- Two adjacent gaps in the same file are out of scope and each deserves its own PR: the pod unit template has no `StartLimitBurst`, so a pod whose worktree was deleted out-of-band restart-loops without bound; and `_MAKE_LIVE_COMMITTED` is never reset at runtime, so a cutover that dispatches but never completes wedges subsequent attempts for the process lifetime.


### Accepted and deferred, named rather than dropped

- **The diagnosis text is composed in the backend, not the i18n catalog.** The dashboard ships in twelve languages, and these sentences bypass all of them. Mapping the reserved exit codes to catalog keys in the frontend is the right end state, and `exit_code` already travels to the UI. It is not folded in here because this surface ALREADY carries backend English -- the raw npm tail and the step label both -- so moving one of the three leaves the inconsistency in place; the whole surface should move at once, in its own change.
- **The same root cause has two unfixed siblings.** `npm ci` deleting before it installs, with no rollback in the caller, also lives at `frontend.py` `build_frontend_sync` and its async sibling, reached from `cli_server.py` and the auto-update path in `dashboard/handlers/updates.py`. A registry refusal there still empties `node_modules` with no restore. (`pod/provision.py` is exempt -- it skips when the tree is already populated.) A shared fix is larger than this change and belongs in its own PR; this one fixes the path a user presses. Tracked as #6693.
- **The generated runner has grown into a transaction manager authored as concatenated string literals.** It is stdlib-only by design, so what it does cannot change with the revision being merged underneath it -- but that property is also obtainable the way this same file already gets it for `dep_sync`: snapshot a real, lintable module to a scratch path and execute that. Worth doing, and too large to fold in at this point in review without a reviewer having seen it. Tracked as #6698.
- **The preflight installs on every sync, including backend-only ones.** When no `_PROBE_FILES` input changed, the populated tree already answers the question and the transaction covers the cache-cleared edge, so the scratch install is cost without information. Skipping on an unchanged lockfile is a behaviour change rather than a fix, so it is not folded in here. Left for the shared follow-up in #6693, which touches the same code.




