### PR TITLE
fix(workflows): reject non-object JSON bodies

### DIFF
--- a/docs/system-specs/modules/workflow-gates.md
+++ b/docs/system-specs/modules/workflow-gates.md
@@ -93,7 +93,9 @@ crashing.
 The backend half of the tab is covered without gate ids, in
 `test_workflows_app.py` (manifest shape, `handle_validate` / `handle_run` /
 `handle_examples`, and redaction of credentials and exfiltration URLs before a
-run payload leaves the handler).
+run payload leaves the handler) and `test_workflow_handler_json_contract.py`
+(every legacy mutation handler rejects a non-object JSON body with a coded 400
+before service dispatch, while object bodies still reach that service).
 
 ## Group F: fitness gates on the engine itself
 

--- a/docs/system-specs/modules/workflows.md
+++ b/docs/system-specs/modules/workflows.md
@@ -866,6 +866,10 @@ caller's `X-Session-Key` header becomes the run's `author` and `session_key`.
 | `PATCH /api/workflows/definitions/{id-or-slug}` | `{source, expected_revision, name?, description?, slug?}` | append a revision; 404 when unknown, 409 on stale revision |
 | `POST /api/workflows/definitions/{id-or-slug}/run` | `{input?, args?, budget_total?, timeout_secs?}` | run the exact saved revision; 404 when unknown, 409 on execution admission rejection, 503 when its executor is unavailable |
 
+Every mutation route that accepts JSON requires a top-level object. A syntactically
+valid scalar or array is rejected with 400 and `code: invalid_json` instead of
+reaching field access and surfacing as an internal-server error.
+
 With no `workflow_service` on state, every route answers 503.
 
 Every response body passes through `_redact_obj`, which redacts dict **keys** as

--- a/src/kiro_crew/dashboard/handlers/workflows.py
+++ b/src/kiro_crew/dashboard/handlers/workflows.py
@@ -340,6 +340,8 @@ async def api_workflow_author(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
+    if not isinstance(body, dict):
+        return _error("JSON body must be an object", "invalid_json", 400)
     intent = (body.get("intent") or "").strip()
     if not intent:
         return web.json_response({"error": "intent is required"}, status=400)
@@ -368,6 +370,8 @@ async def api_workflow_run(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
+    if not isinstance(body, dict):
+        return _error("JSON body must be an object", "invalid_json", 400)
     source = body.get("source", "")
     if not isinstance(source, str) or not source.strip():
         return web.json_response({"error": "source is required"}, status=400)
@@ -401,6 +405,8 @@ async def api_workflow_run_intent(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         return web.json_response({"error": "invalid JSON"}, status=400)
+    if not isinstance(body, dict):
+        return _error("JSON body must be an object", "invalid_json", 400)
     intent = (body.get("intent") or "").strip()
     if not intent:
         return web.json_response({"error": "intent is required"}, status=400)
@@ -509,6 +515,8 @@ async def api_workflow_run_rerun(request: web.Request) -> web.Response:
         body = await request.json()
     except Exception:
         body = {}
+    if not isinstance(body, dict):
+        return _error("JSON body must be an object", "invalid_json", 400)
     from_index = body.get("from_index", 0)
     if not isinstance(from_index, int):
         from_index = 0

--- a/test/test_workflow_handler_json_contract.py
+++ b/test/test_workflow_handler_json_contract.py
@@ -1,0 +1,104 @@
+"""JSON object contract for the legacy workflow mutation handlers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers.workflows import (
+    api_workflow_author,
+    api_workflow_run,
+    api_workflow_run_intent,
+    api_workflow_run_rerun,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize(
+    ("route", "path", "handler", "service_method"),
+    [
+        ("/api/workflows/author", "/api/workflows/author", api_workflow_author, "author"),
+        ("/api/workflows/run", "/api/workflows/run", api_workflow_run, "start"),
+        (
+            "/api/workflows/run_intent",
+            "/api/workflows/run_intent",
+            api_workflow_run_intent,
+            "start_from_intent",
+        ),
+        (
+            "/api/workflows/runs/{run_id}/rerun",
+            "/api/workflows/runs/wf_1/rerun",
+            api_workflow_run_rerun,
+            "rerun_subtree",
+        ),
+    ],
+)
+@pytest.mark.parametrize("payload", [[], "not-an-object"])
+async def test_mutation_handlers_reject_non_object_json(
+    route, path, handler, service_method, payload
+) -> None:
+    method = AsyncMock()
+    app = web.Application()
+    app["state"] = SimpleNamespace(workflow_service=SimpleNamespace(**{service_method: method}))
+    app.router.add_post(route, handler)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(path, json=payload)
+        body = await response.json()
+
+    assert response.status == 400
+    assert body == {"error": "JSON body must be an object", "code": "invalid_json"}
+    method.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("route", "path", "handler", "service_method", "payload"),
+    [
+        (
+            "/api/workflows/author",
+            "/api/workflows/author",
+            api_workflow_author,
+            "author",
+            {"intent": "ship it"},
+        ),
+        (
+            "/api/workflows/run",
+            "/api/workflows/run",
+            api_workflow_run,
+            "start",
+            {"source": "print('ok')"},
+        ),
+        (
+            "/api/workflows/run_intent",
+            "/api/workflows/run_intent",
+            api_workflow_run_intent,
+            "start_from_intent",
+            {"intent": "ship it"},
+        ),
+        (
+            "/api/workflows/runs/{run_id}/rerun",
+            "/api/workflows/runs/wf_1/rerun",
+            api_workflow_run_rerun,
+            "rerun_subtree",
+            {"from_index": 0},
+        ),
+    ],
+)
+async def test_mutation_handlers_keep_valid_object_path(
+    route, path, handler, service_method, payload
+) -> None:
+    method = AsyncMock(return_value={"run_id": "wf_2"})
+    app = web.Application()
+    app["state"] = SimpleNamespace(workflow_service=SimpleNamespace(**{service_method: method}))
+    app.router.add_post(route, handler)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(path, json=payload)
+
+    assert response.status == 200
+    method.assert_awaited_once()


### PR DESCRIPTION
## Problem / Motivation

Four legacy workflow mutation endpoints parse syntactically valid JSON and then immediately treat it as a mapping. An array or scalar therefore reaches `.get(...)` and becomes an aiohttp 500 instead of a client-input refusal.

## Why it matters

A valid-but-wrong JSON shape is a caller error, not a server failure. Returning 500 obscures the actionable boundary and makes clients unable to distinguish the refusal through the backend's machine-readable error contract.

## What changed (motivation → approach → change)

The four object-required endpoints now check the parsed top-level value before field access and return the module's established coded refusal:

- HTTP 400
- `code: invalid_json`
- advisory error: `JSON body must be an object`

The guard is limited to author, run, run_intent, and rerun. Existing malformed-body behavior and unrelated legacy error responses are unchanged.

## Tests

- Red-before: array JSON reproduced HTTP 500 in all four handlers before the production guards.
- The regression now covers array and scalar JSON across all four routes, asserts the exact 400 code, and proves the service method is not awaited.
- Valid object controls prove each original service path is still dispatched exactly once and returns 200.
- 25 focused handler and saved-workflow tests passed.
- 18 contract/error-code gate tests passed.
- Black baseline, isort, flake8, diff-check, and docs-lint passed.
- Two independent read-only reviews passed with no findings; one additionally ran 26 focused tests.

## Manual verification

N/A — real aiohttp TestClient coverage exercises the HTTP boundary and service dispatch contract directly.

## Related Issues

N/A — self-mined defect; duplicate PR and issue searches found no overlapping work.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository template placeholder; no contributor action is currently defined.