### PR TITLE
fix(dashboard): pre-expand a reveal target's dormant section before scrolling (#6479)

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1997,14 +1997,18 @@ function ChatSidebar({
   // an unanswered question, unread output — and a row the user JUST moved,
   // which must stay visible at its destination whatever its age. The collapse
   // de-noises settled work; a row that needs the user is not settled.
-  const isStaleExempt = (s: Slot): boolean =>
+  // Memoized (not just for render cost): the reveal-in-sidebar effect below
+  // consults it to decide whether the target row needs its dormant section
+  // pre-expanded, so it must be a listable effect dependency.
+  const isStaleExempt = useCallback((s: Slot): boolean =>
     pinned.has(s.key) || s.key === activeSlot || runningSet.has(s.key)
     || (subagentCounts[s.key] ?? 0) > 0 || !!s.pending_approval
     || !!s.needs_input || unreadSet.has(s.key)
     // Read-time expiry: an entry only counts while younger than one heartbeat
     // interval, so correctness never depends on the prune timer having fired
     // (the timer is gated on the feature being on; the writer is not).
-    || (staleRecentlyMoved.get(s.key) ?? 0) > Date.now() - STALE_COLLAPSE_TICK_MS
+    || (staleRecentlyMoved.get(s.key) ?? 0) > Date.now() - STALE_COLLAPSE_TICK_MS,
+  [pinned, activeSlot, runningSet, subagentCounts, unreadSet, staleRecentlyMoved])
   const splitStale = (list: Slot[]): StaleSplit<Slot> => {
     // Inert while the list is narrowed: a search or status chip must reach
     // every match (the same invariant that sends the folder filter inert
@@ -2689,8 +2693,9 @@ function ChatSidebar({
       for (const s of stale) next.add(slotFolders[s.key] || 'root')
       return next
     })
-    // isStaleExempt/slotFolders are render-fresh closures; keying the effect on
-    // them would re-fire it every render. The transition is what matters.
+    // Deliberately keyed on the narrowed→clear transition alone: the bridge
+    // must fire exactly when the narrow ends, not whenever the collapse
+    // inputs it reads happen to change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listNarrowed])
 
@@ -3078,6 +3083,21 @@ function ChatSidebar({
     // Reveal means "show me this row", so drop every filter hiding the target
     // rather than scrolling to nothing (#912 D5). Registered in one list above.
     for (const dim of revealBlockingFilters) if (dim.hides(slot)) dim.clear(slot)
+    // The stale-session collapse is a per-container disclosure, not a filter
+    // dimension (clearing a dimension drops it everywhere; a reveal should
+    // open ONE dormant section, not all of them), so it is handled here
+    // rather than in the registry: pre-expand the target's container when the
+    // row is stale-collapsible, or the retry loop below scrolls to a row that
+    // never rendered (#6479). Gated on the collapse being ACTIVE (same gate
+    // as the narrow-bridge consumer above): with the feature off or under a
+    // non-date sort the row renders anyway, and the write would leave that
+    // container's section pre-opened whenever the collapse next re-engages.
+    // Deliberately NOT gated on `listNarrowed`: the filter clearing two lines
+    // up has not committed yet, so it would still read true here.
+    if (staleCollapseMs > 0 && sortKey === 'date-desc' && !isStaleExempt(slot)) {
+      const container = slotFolders[key] || 'root'
+      setStaleExpanded(prev => (prev.has(container) ? prev : new Set(prev).add(container)))
+    }
     if (slot.folder_id) {
       // Expand all collapsed ancestor folders. Cycle-guarded: a hand-edited
       // folders.json can contain a parent_id loop and must not hang the tab.
@@ -3136,7 +3156,7 @@ function ChatSidebar({
       revealFlashTimersRef.current = [t1, t2]
     }
     tryScroll()
-  }, [revealRequest, dispatch, slots, folders, revealBlockingFilters, updateFolderMutation])
+  }, [revealRequest, dispatch, slots, folders, revealBlockingFilters, updateFolderMutation, isStaleExempt, slotFolders, staleCollapseMs, sortKey])
   const renameCommit = useCallback((id: string, name: string) => {
     if (name.trim()) updateFolderMutation.mutate({ id, body: { name: name.trim() } })
     setEditingId(null)

--- a/website/src/test/ChatSidebar.revealStaleExpand.test.tsx
+++ b/website/src/test/ChatSidebar.revealStaleExpand.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Reveal-in-sidebar must pre-expand the stale-session ("Dormant sessions")
+ * section hiding its target. The stale collapse is a per-container disclosure,
+ * not a registered filter dimension, so the reveal effect's filter-clearing
+ * walk cannot see it: without the pre-expand, revealing a dormant NON-active
+ * session scrolls to a row that never rendered (#6479).
+ *
+ * Scope pins: expansion opens ONLY the target's container (root or its
+ * folder), and an exempt target (the active session) opens nothing.
+ * The collapse itself is pinned in ChatSidebar.staleCollapse.test.tsx; the
+ * filter-dimension walk in ChatSidebar.revealFilterDimensions.test.tsx.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { requestSlotReveal } from '../store/chatSlice'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Render framer-motion elements as plain DOM (jsdom can't run projection).
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER_PROPS = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: Record<string, unknown> & { children?: unknown }, ref: unknown) => {
+      const clean: Record<string, unknown> = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (FRAMER_PROPS.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref }, props.children as never)
+    })
+  const motion = new Proxy({}, { get: (_t, tag: string) => make(tag) })
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children?: unknown }) => React.createElement(React.Fragment, null, children as never),
+    LayoutGroup: ({ children }: { children?: unknown }) => React.createElement(React.Fragment, null, children as never),
+  }
+})
+
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+
+// The folders query REFETCHES on mount (seeded cache data is stale), so the
+// mock must serve the test's folders or the refetch wipes them — which reads
+// as every filed slot "moving" to root and move-exempts it from the collapse.
+const chatFoldersMock = vi.hoisted(() => vi.fn().mockResolvedValue([]))
+
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, {
+    get: (_t, prop: string) => {
+      if (prop === 'chatFolders') return chatFoldersMock
+      return vi.fn().mockResolvedValue([])
+    },
+  }),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+
+import ChatSidebar from '../pages/ChatSidebar'
+
+const hoursAgo = (h: number) => new Date(Date.now() - h * 3600_000).toISOString()
+
+type FixtureSlot = Record<string, unknown>
+
+const slot = (key: string, title: string, ageHours: number, extra: Record<string, unknown> = {}) => ({
+  key, title, running: false, messages: 2,
+  created: hoursAgo(ageHours + 1), last_turn_ts: hoursAgo(ageHours), ...extra,
+})
+
+function renderSidebar(slots: FixtureSlot[], { folders = [] as FixtureSlot[], activeSlot = null as string | null } = {}) {
+  chatFoldersMock.mockResolvedValue(folders)
+  // Spread the real slice defaults: RTK REPLACES a slice with preloadedState
+  // rather than merging, so a partial drops keys the reducers assume exist
+  // (revealRequest/revealNonce here).
+  const defaults = createTestStore().getState()
+  const store = createTestStore({
+    dashboard: {
+      ...defaults.dashboard,
+      status: {}, connected: true, slots, approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      slotsLoaded: true,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as never,
+    chat: {
+      ...defaults.chat,
+      activeSlot, slotStatusDetail: {},
+      revealRequest: null, revealNonce: 0,
+    } as never,
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  qc.setQueryData(['chat-folders'], folders)
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={slots as never} activeSlot={activeSlot} unreadSlots={[]}
+              history={[]} historyHasMore={false} defaultAgent="" installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return { ...view, store, qc }
+}
+
+/** jsdom has no scrollIntoView; the reveal effect calls it on the found row. */
+function withScrollStub(fn: () => Promise<void>) {
+  const original = Element.prototype.scrollIntoView
+  Element.prototype.scrollIntoView = vi.fn()
+  return fn().finally(() => { Element.prototype.scrollIntoView = original })
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.clearAllMocks())
+
+describe('reveal-in-sidebar pre-expands the stale-session section', () => {
+  it('renders a dormant non-active root session when revealed', async () => {
+    await withScrollStub(async () => {
+      const utils = renderSidebar([
+        slot('fresh', 'fresh session', 2),
+        slot('dormant', 'dormant session', 5 * 24),
+      ], { activeSlot: 'fresh' })
+      // Precondition: the target really is collapsed before the reveal.
+      await waitFor(() => expect(utils.getByTestId('stale-expander-root')).toBeInTheDocument())
+      expect(utils.queryByText('dormant session')).toBeNull()
+
+      utils.store.dispatch(requestSlotReveal('dormant'))
+
+      await waitFor(() => expect(utils.queryByText('dormant session')).not.toBeNull())
+    })
+  })
+
+  it('opens only the target folder\'s section, not every container\'s', async () => {
+    await withScrollStub(async () => {
+      const folders = [{ id: 'f1', name: 'Work', order: 0, collapsed: false }]
+      const utils = renderSidebar([
+        slot('fresh', 'fresh session', 2),
+        slot('in-dormant', 'foldered dormant', 5 * 24, { folder_id: 'f1' }),
+        slot('root-dormant', 'root dormant', 5 * 24),
+      ], { folders, activeSlot: 'fresh' })
+      await waitFor(() => expect(utils.getByTestId('stale-expander-f1')).toBeInTheDocument())
+      expect(utils.queryByText('foldered dormant')).toBeNull()
+
+      utils.store.dispatch(requestSlotReveal('in-dormant'))
+
+      await waitFor(() => expect(utils.queryByText('foldered dormant')).not.toBeNull())
+      // Per-container scope: the root's dormant section stays collapsed.
+      expect(utils.queryByText('root dormant')).toBeNull()
+    })
+  })
+
+  it('an exempt target opens no dormant section', async () => {
+    await withScrollStub(async () => {
+      const utils = renderSidebar([
+        slot('fresh', 'fresh session', 2),
+        slot('dormant', 'dormant session', 5 * 24),
+      ], { activeSlot: 'fresh' })
+      await waitFor(() => expect(utils.getByTestId('stale-expander-root')).toBeInTheDocument())
+
+      // The active session is stale-exempt: it renders outside the dormant
+      // section, so revealing it must not pop the section open.
+      utils.store.dispatch(requestSlotReveal('fresh'))
+
+      await waitFor(() => expect(Element.prototype.scrollIntoView).toHaveBeenCalled())
+      expect(utils.queryByText('dormant session')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The reveal-in-sidebar effect in `website/src/pages/ChatSidebar.tsx` clears every registered filter dimension hiding its target and expands collapsed ancestor folders — but it knows nothing about the stale-session collapse added by #6473. A dormant (stale-collapsible) non-active session stays behind its container's "Dormant sessions" expander, so the bounded scroll-retry loop hunts for a row that never renders, gives up after ~2s, and the reveal silently does nothing.

Today this cannot dead-end in shipped code — the only reveal dispatcher targets `activeSlot`, which `isStaleExempt` always exempts — but any future dispatcher revealing a non-active session (a notification "show me this session", a search-result jump) would hit it. Follow-up filed from PR #6473's Design Review.

## Why it matters

Reveal-in-sidebar's contract is "show me this row, whatever is hiding it". A hiding dimension the effect cannot see is silent breakage of that contract: the button looks broken with no error, the retry budget burns 20 attempts against a row that structurally cannot appear, and the failure only reproduces for users with the stale collapse engaged — the hardest kind of report to triage.

## What changed (motivation → approach → change)

Symptom: reveal scrolls to nothing when the target collapses behind a dormant-sessions expander. Root cause: the stale collapse is a **per-container disclosure**, not a registered filter dimension — `dim.clear()` semantics (drop the dimension everywhere) would be wrong for it, since a reveal should open ONE dormant section, not all of them. So the reveal effect handles it beside the filter walk rather than in the registry:

- When the target slot is stale-collapsible (`!isStaleExempt(slot)`) **and the collapse is actually active** (`staleCollapseMs > 0 && sortKey === 'date-desc'`, the same gate the narrow-bridge consumer uses), add its container key (`slotFolders[key] || 'root'` — the exact expression `renderStaleSection`'s two call sites key on) to the `staleExpanded` set, alongside the existing filter clearing. The row is then guaranteed to render before the scroll-retry loop looks for it.
- The active-gate matters because `staleExpanded` is neither persisted nor garbage-collected: an ungated write while the feature is off (or under a non-date sort, where the collapse is inert) would leave that container's section pre-opened whenever the collapse next re-engages. It is deliberately NOT gated on `listNarrowed`, whose clearing two lines above has not committed yet.
- `isStaleExempt` is wrapped in `useCallback` (over already-memoized inputs) so the effect can list it as a dependency without tripping the exhaustive-deps ratchet; the narrow-bridge effect's `eslint-disable` rationale — which claimed `isStaleExempt`/`slotFolders` are render-fresh closures — is reworded to its real reason (transition keying), since this change falsifies that premise.

## Tests

New `website/src/test/ChatSidebar.revealStaleExpand.test.tsx` (red-before-green verified — the two behavioral cases fail without the source change):

- revealing a dormant non-active root session renders its row (was: scroll-retry dead-end)
- revealing a dormant foldered session opens only that folder's dormant section — the root's stays collapsed (pins per-container scope)
- revealing a stale-exempt target (the active session) opens no dormant section (pins the gate)

## Manual verification

N/A — unit coverage sufficient: the pinning tests drive the real component through the real store dispatch (`requestSlotReveal`) and assert on rendered DOM; no production dispatcher can currently reach the fixed path (see Problem).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no reachable rendered delta — the only production reveal dispatcher targets the active slot, which is always stale-exempt; the change only affects a path future dispatchers will take, and is pinned by component tests.

## Related Issues

Closes #6479

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior pinned in code comments and tests
- [x] No secrets, credentials, or internal references in the diff
