### PR TITLE
fix: adopt the shared menu keyboard contract in ChannelPage (#6269)

### DIFF
--- a/website/src/i18n/locales/bn.json
+++ b/website/src/i18n/locales/bn.json
@@ -8385,6 +8385,7 @@
       "limit_reached": "সীমায় পৌঁছেছে",
       "listen_all": "সব",
       "listen_mention": "মেনশন",
+      "listen_mode": "শোনার মোড",
       "listen_silent": "নীরব",
       "loading_channels": "চ্যানেল লোড হচ্ছে...",
       "mention_suggestions": "মেনশনের সাজেশন",

--- a/website/src/i18n/locales/de.json
+++ b/website/src/i18n/locales/de.json
@@ -8385,6 +8385,7 @@
       "limit_reached": "Grenze erreicht",
       "listen_all": "alle",
       "listen_mention": "Erwähnung",
+      "listen_mode": "Zuhörmodus",
       "listen_silent": "stumm",
       "loading_channels": "Kanäle werden geladen…",
       "mention_suggestions": "Erwähnungsvorschläge",

--- a/website/src/i18n/locales/en-XA.json
+++ b/website/src/i18n/locales/en-XA.json
@@ -8294,6 +8294,7 @@
       "reply_2_other": "[{{count}} ŕèþĺìèş ············]",
       "listen_all": "[àĺĺ ·····]",
       "listen_mention": "[ɱèñţìøñ ···········]",
+      "listen_mode": "[Ĺìşţèñ ɱøðè ··········]",
       "listen_silent": "[şìĺèñţ ·········]",
       "preset_custom_empty": "[Çùşţøɱ (èɱþţý) ·············]",
       "preset_incident_response": "[Ìñçìðèñţ Ŕèşþøñşè ···············]",

--- a/website/src/i18n/locales/en.manual.json
+++ b/website/src/i18n/locales/en.manual.json
@@ -2891,6 +2891,7 @@
       "reply_2_other": "{{count}} replies",
       "listen_all": "all",
       "listen_mention": "mention",
+      "listen_mode": "Listen mode",
       "listen_silent": "silent",
       "preset_custom_empty": "Custom (empty)",
       "preset_incident_response": "Incident Response",

--- a/website/src/i18n/locales/es.json
+++ b/website/src/i18n/locales/es.json
@@ -8510,6 +8510,7 @@
       "limit_reached": "Límite alcanzado",
       "listen_all": "todos",
       "listen_mention": "menciones",
+      "listen_mode": "Modo de escucha",
       "listen_silent": "silencioso",
       "loading_channels": "Cargando canales...",
       "mention_suggestions": "Sugerencias de menciones",

--- a/website/src/i18n/locales/fr.json
+++ b/website/src/i18n/locales/fr.json
@@ -8510,6 +8510,7 @@
       "limit_reached": "Limite atteinte",
       "listen_all": "tout",
       "listen_mention": "mentions",
+      "listen_mode": "Mode d'écoute",
       "listen_silent": "silencieux",
       "loading_channels": "Chargement des canaux...",
       "mention_suggestions": "Suggestions de mentions",

--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -8385,6 +8385,7 @@
       "limit_reached": "सीमा पूरी हुई",
       "listen_all": "सभी",
       "listen_mention": "मेंशन",
+      "listen_mode": "सुनने का मोड",
       "listen_silent": "साइलेंट",
       "loading_channels": "चैनल लोड हो रहे हैं...",
       "mention_suggestions": "मेंशन सुझाव",

--- a/website/src/i18n/locales/it.json
+++ b/website/src/i18n/locales/it.json
@@ -8510,6 +8510,7 @@
       "limit_reached": "Limite raggiunto",
       "listen_all": "tutti",
       "listen_mention": "menzione",
+      "listen_mode": "Modalità di ascolto",
       "listen_silent": "silenzioso",
       "loading_channels": "Caricamento dei canali...",
       "mention_suggestions": "Suggerimenti di menzione",

--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -8260,6 +8260,7 @@
       "limit_reached": "制限に達しました",
       "listen_all": "すべて",
       "listen_mention": "メンション",
+      "listen_mode": "リッスンモード",
       "listen_silent": "サイレント",
       "loading_channels": "チャネルを読み込み中…",
       "mention_suggestions": "メンション候補",

--- a/website/src/i18n/locales/ko.json
+++ b/website/src/i18n/locales/ko.json
@@ -8260,6 +8260,7 @@
       "limit_reached": "한도 도달",
       "listen_all": "전체",
       "listen_mention": "멘션",
+      "listen_mode": "수신 모드",
       "listen_silent": "무음",
       "loading_channels": "채널 불러오는 중…",
       "mention_suggestions": "멘션 제안",

--- a/website/src/i18n/locales/pt.json
+++ b/website/src/i18n/locales/pt.json
@@ -8510,6 +8510,7 @@
       "limit_reached": "Limite atingido",
       "listen_all": "todas",
       "listen_mention": "menção",
+      "listen_mode": "Modo de escuta",
       "listen_silent": "silencioso",
       "loading_channels": "Carregando canais...",
       "mention_suggestions": "Sugestões de menção",

--- a/website/src/i18n/locales/ru.json
+++ b/website/src/i18n/locales/ru.json
@@ -8635,6 +8635,7 @@
       "limit_reached": "Достигнут лимит",
       "listen_all": "все",
       "listen_mention": "упоминания",
+      "listen_mode": "Режим прослушивания",
       "listen_silent": "тихий",
       "loading_channels": "Загрузка каналов...",
       "mention_suggestions": "Подсказки для упоминаний",

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -8260,6 +8260,7 @@
       "limit_reached": "已达上限",
       "listen_all": "全部",
       "listen_mention": "提及",
+      "listen_mode": "收听模式",
       "listen_silent": "静默",
       "loading_channels": "加载频道…",
       "mention_suggestions": "提及建议",

--- a/website/src/pages/ChannelPage.tsx
+++ b/website/src/pages/ChannelPage.tsx
@@ -10,6 +10,7 @@ import MarkdownRenderer from '../components/MarkdownRenderer'
 import AgentSelector from '../components/AgentSelector'
 import { useAgents } from '../hooks/useAgents'
 import { useImeGuard } from '../hooks/useImeGuard'
+import { useMenuKeyboard, menuItemsOf } from '../hooks/useMenuKeyboard'
 import { AnimatePresence } from 'framer-motion'
 import DetailPanel from '../components/DetailPanel'
 
@@ -192,12 +193,46 @@ function AgentControlRow({ agent, onDismiss, onListenChange, onClearContext }: {
 }) {
   const [menu, setMenu] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  // The trigger, so an explicit dismissal can hand focus back to it: the menu
+  // keyboard contract moves focus INTO the menu on open, and the row holding
+  // it is unmounted by the close — without a restore, focus would be orphaned
+  // on <body>. Outside-click dismissal is left alone (the browser routes focus
+  // per the click target), matching the MicSourceMenu posture (#6267).
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  // The role="menu" element itself — narrower than `menuRef` (which wraps the
+  // trigger too) so item discovery never picks up the trigger button.
+  const menuListRef = useRef<HTMLDivElement>(null)
   const alive = agent.state !== 'done' && agent.state !== 'failed'
+
+  // role="menu" promises the WAI-ARIA menu keyboard contract (arrow-key row
+  // navigation with wrap, Home/End, Tab containment). The shared hook owns it
+  // for all role="menu" surfaces rather than re-spelled here (#6231, #6269).
+  // The rows are native <button>s (`Btn`), so the hook's item discovery finds
+  // them with no extra markup. Escape stays owned by the dismiss effect below:
+  // what "close" means here — menu state, focus restore — is this host's
+  // business. Focus ENTRY is host-owned too (`focusFirstOnOpen: false`): this
+  // menu is not portalled and sits inside the agents rail's scroll container,
+  // so the hook's plain `.focus()` entry would scroll the rail on every open,
+  // shifting the row the user just clicked out from under the pointer —
+  // `preventScroll` keeps the rail still (arrow navigation still scrolls a
+  // focused row into view, which is wanted).
+  useMenuKeyboard({ enabled: menu, containerRef: menuListRef, focusFirstOnOpen: false })
+  useEffect(() => {
+    if (menu) menuItemsOf(menuListRef.current)[0]?.focus({ preventScroll: true })
+  }, [menu])
 
   useEffect(() => {
     if (!menu) return
     const close = (e: MouseEvent) => { if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenu(false) }
-    const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') setMenu(false) }
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setMenu(false)
+        // Focus lives inside the menu at this point (focus entry on open, Tab
+        // containment while open, and any outside mousedown already closed the
+        // menu) — hand it back to the trigger before its row unmounts.
+        triggerRef.current?.focus()
+      }
+    }
     document.addEventListener('mousedown', close)
     document.addEventListener('keydown', esc)
     return () => { document.removeEventListener('mousedown', close); document.removeEventListener('keydown', esc) }
@@ -210,12 +245,19 @@ function AgentControlRow({ agent, onDismiss, onListenChange, onClearContext }: {
         <div className="text-sm font-medium text-text truncate">{agent.role}</div>
         {agent.agentName && <div className="text-[11px] text-muted font-mono truncate">{agent.agentName}</div>}
         <div className="relative inline-block" ref={menuRef}>
-          <Btn onClick={() => setMenu(!menu)} className="!p-0 !border-none !rounded-none text-[13px] text-muted hover:text-text">
+          <Btn ref={triggerRef} onClick={() => setMenu(!menu)} aria-haspopup="menu" aria-expanded={menu} className="!p-0 !border-none !rounded-none text-[13px] text-muted hover:text-text">
             <Badge variant={LISTEN_BADGE[agent.listenMode]?.variant || 'warn'}>{LISTEN_BADGE[agent.listenMode]?.label || agent.listenMode}</Badge>
           </Btn>
-          {menu && <div role="menu" className="absolute top-full left-0 mt-1 bg-bg-elevated border border-border rounded-md shadow-lg z-10">
+          {menu && <div role="menu" ref={menuListRef} aria-label={i18nT('pages.channelPage.listen_mode')} className="absolute top-full left-0 mt-1 bg-bg-elevated border border-border rounded-md shadow-lg z-10">
             {LISTEN_MODES.map(m => (
-              <Btn key={m} onClick={() => { onListenChange(m); setMenu(false) }}
+              <Btn key={m} role="menuitemradio" aria-checked={m === agent.listenMode}
+                onClick={() => {
+                  onListenChange(m); setMenu(false)
+                  // Activation is an explicit dismissal too: the row that has
+                  // focus is being unmounted, so restore to the trigger rather
+                  // than dropping focus on <body>.
+                  triggerRef.current?.focus()
+                }}
                 className={`!rounded-none block w-full text-left px-3 py-1.5 text-[13px] !border-none ${m === agent.listenMode ? 'text-accent bg-accent/10' : 'text-text hover:bg-bg-hover'}`}>
                 <Badge variant={LISTEN_BADGE[m]?.variant || 'warn'}>{LISTEN_BADGE[m]?.label || m}</Badge>
               </Btn>

--- a/website/src/test/ChannelPage.menuKeyboard.test.tsx
+++ b/website/src/test/ChannelPage.menuKeyboard.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ChannelPage from '../pages/ChannelPage'
+import { renderWithProviders } from './helpers'
+import { api } from '../api/client'
+
+vi.mock('../api/client')
+
+beforeAll(() => {
+  // jsdom doesn't implement scrollIntoView
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const mockChannel = {
+  id: 'ch1',
+  topic: 'Test Channel',
+  members: {
+    a1: { id: 'a1', role: 'Researcher', agent_name: 'kirocrew', state: 'listening', listen_mode: 'mention', approval_policy: 'writes', session_key: 'k1' },
+  },
+  messages: [],
+}
+
+/**
+ * The listen-mode dropdown in the agents panel declares role="menu", which
+ * promises the WAI-ARIA menu keyboard contract (arrows move focus between the
+ * rows and wrap, Home/End jump to the boundaries, Tab is contained while the
+ * menu is open). None of that existed here: the rows were reachable only by
+ * mouse — the defect class #6231 fixed on its five inventoried surfaces via
+ * the shared useMenuKeyboard hook; this surface was outside that inventory
+ * (#6269).
+ */
+describe('ChannelPage — listen-mode menu keyboard contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api).channelsList = vi.fn().mockResolvedValue({ channels: [mockChannel] })
+    vi.mocked(api).channelGet = vi.fn().mockResolvedValue(mockChannel)
+    vi.mocked(api).channelPresets = vi.fn().mockResolvedValue({ presets: [] })
+    vi.mocked(api).channelUpdateAgent = vi.fn().mockResolvedValue({ ok: true })
+  })
+
+  const menuEl = () => document.querySelector('[role="menu"]') as HTMLElement | null
+  /** The three listen-mode rows, in document order (all / mention / silent). */
+  const rowsOf = () => Array.from(menuEl()!.querySelectorAll<HTMLButtonElement>('button'))
+
+  /**
+   * Open the agents sidebar, then the listen-mode menu of the single agent
+   * row. Returns the menu trigger, grabbed BEFORE opening the menu so it is
+   * unambiguous.
+   */
+  async function openListenMenu() {
+    renderWithProviders(<ChannelPage />)
+    await waitFor(() => screen.getByRole('button', { name: '1 agent' }))
+    await userEvent.click(screen.getByRole('button', { name: '1 agent' }))
+    // The trigger renders the current listen-mode badge ("mention" for this
+    // fixture) inside the agent row.
+    const trigger = (await screen.findByText('mention', { selector: 'span' })).closest('button') as HTMLButtonElement
+    fireEvent.click(trigger)
+    await waitFor(() => expect(menuEl()).toBeTruthy())
+    return trigger
+  }
+
+  it('moves focus into the menu when it opens', async () => {
+    await openListenMenu()
+    // role="menu" tells assistive tech that focus is managed inside the menu,
+    // so opening must land the user there rather than leaving focus on the
+    // trigger with the menu an unreachable island.
+    expect(menuEl()!.contains(document.activeElement)).toBe(true)
+    expect(rowsOf()[0]).toHaveFocus()
+  })
+
+  it('walks the rows with ArrowDown and wraps past the last one', async () => {
+    await openListenMenu()
+    const rows = rowsOf()
+    expect(rows).toHaveLength(3) // all / mention / silent
+    rows[0].focus()
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(rows[1]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowDown' })
+    expect(rows[0]).toHaveFocus() // wraps, rather than dead-ending
+  })
+
+  it('walks the rows with ArrowUp and wraps past the first one', async () => {
+    await openListenMenu()
+    const rows = rowsOf()
+    rows[0].focus()
+    fireEvent.keyDown(document, { key: 'ArrowUp' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'ArrowUp' })
+    expect(rows[1]).toHaveFocus()
+  })
+
+  it('jumps to the boundary rows with Home and End', async () => {
+    await openListenMenu()
+    const rows = rowsOf()
+    rows[1].focus()
+    fireEvent.keyDown(document, { key: 'End' })
+    expect(rows[2]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Home' })
+    expect(rows[0]).toHaveFocus()
+  })
+
+  it('contains Tab and Shift-Tab inside the open menu', async () => {
+    // #2533: a Tab out of a still-open menu drops a keyboard user behind it
+    // with no obvious way back.
+    await openListenMenu()
+    const rows = rowsOf()
+    rows[2].focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(rows[0]).toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(rows[2]).toHaveFocus()
+  })
+
+  it('closes on Escape and hands focus back to the trigger', async () => {
+    // "Escape closes" is a pin on existing behaviour; the focus restore is the
+    // new part. Focus now ENTERS the menu on open, so closing without a
+    // restore would orphan focus on <body> and lose the user's place.
+    const trigger = await openListenMenu()
+    expect(trigger).not.toHaveFocus()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(menuEl()).toBeNull()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('hands focus back to the trigger after picking a row', async () => {
+    const trigger = await openListenMenu()
+    const rows = rowsOf()
+    // Pick "all" (row 0); the pick still reports upstream.
+    fireEvent.click(rows[0])
+    await waitFor(() => expect(vi.mocked(api).channelUpdateAgent).toHaveBeenCalledWith('ch1', 'a1', { listen: 'all' }))
+    expect(menuEl()).toBeNull()
+    // The focused row is unmounted by the close, so without a restore focus
+    // falls to <body> and the next Tab restarts from the top of the document.
+    expect(trigger).toHaveFocus()
+  })
+
+  it('marks the rows as menuitemradio with the current mode checked', async () => {
+    // The current mode was conveyed only by colour; aria-checked is the only
+    // thing assistive tech can perceive — assert the programmatic state.
+    await openListenMenu()
+    const radios = Array.from(menuEl()!.querySelectorAll('[role="menuitemradio"]'))
+    expect(radios).toHaveLength(3)
+    expect(radios.map(r => r.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false'])
+  })
+
+  it('names the menu so the radio group has a referent', async () => {
+    // Focus entry lands an AT user inside the menu with no surrounding row
+    // context, so "menu, 3 items" of bare mode words ("all"/"mention"/
+    // "silent") needs a group name saying what they control.
+    await openListenMenu()
+    expect(menuEl()!.getAttribute('aria-label')).toBe('Listen mode')
+  })
+
+  it('dismisses on a mousedown in the composer without stealing focus', async () => {
+    // The host's outside-mousedown dismissal is what makes "menu open while
+    // an outside editor holds the caret" unreachable (the hook's document
+    // listener assumes at most one open menu and defers to outside editable
+    // targets — that guard is pinned in the hook's own test). Assert the
+    // reachable invariant: interacting with the composer closes the menu, and
+    // outside-pointer dismissal does NOT restore focus to the trigger (the
+    // browser routes focus per the click target).
+    const trigger = await openListenMenu()
+    const composer = document.querySelector('textarea') as HTMLTextAreaElement
+    expect(composer).toBeTruthy()
+    fireEvent.mouseDown(composer)
+    expect(menuEl()).toBeNull()
+    expect(trigger).not.toHaveFocus()
+  })
+})


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

The agents-panel listen-mode dropdown in `ChannelPage.tsx` declares `role="menu"` — which promises the WAI-ARIA menu keyboard contract (arrow-key row navigation, Home/End, Tab containment) — but wired no keyboard handling at all. The rows were reachable only by mouse, and a screen-reader user who was just told "menu" got nothing from the arrow keys they reach for first. This is the defect class #6231 fixed on its five inventoried surfaces via the shared `useMenuKeyboard` hook (PR #6267); ChannelPage was outside that inventory. Filed by the First Principles review lane on PR #6267 as the ChannelPage analogue of #6266.

## Why it matters

A keyboard-only or assistive-technology user cannot change an agent's listen mode at all: the trigger opens the menu, but focus never enters it, arrows do nothing, and Tab walks out behind the still-open menu. The current mode was also conveyed only by colour, which assistive tech cannot perceive.

## What changed (motivation → approach → change)

Symptom: `role="menu"` with zero keyboard wiring. Root cause: the surface predates the shared hook and was outside #6231's inventory. Change — a mechanical adoption of the merged hook, mirroring the closest #6267 surface (`MicSourceMenu`):

- Attach a dedicated ref to the `role="menu"` element (narrower than the wrapper ref, so item discovery never picks up the trigger) and wire `useMenuKeyboard({ enabled: menu, containerRef })`: arrow walk with wrap, Home/End, Tab containment, document IME latch.
- Focus entry is host-owned (`focusFirstOnOpen: false` + `focus({ preventScroll: true })`): this menu is not portalled and sits inside the agents rail's scroll container, so the hook's default entry would scroll the rail on every open, shifting the row the user just clicked out from under the pointer.
- Rows become `role="menuitemradio"` with `aria-checked`, and the menu gets an accessible name (`aria-label`, new catalog key `pages.channelPage.listen_mode`, translated in all 11 locales + regenerated pseudolocale) so the announced radio state has a referent.
- Focus restores to the trigger on explicit dismissal (Escape / row activation), matching the MicSourceMenu posture from #6267; outside-click dismissal is deliberately left alone (the browser routes focus per the click target).

Deliberately NOT touched, per the issue's own scope guard: the deferred adoptions the issue inventories (WindowsTitlebarMenu, SessionFlyout, SlotTagPopover, BusySendButton, MarkdownPanel) each need their own judgment.

## Tests

New `website/src/test/ChannelPage.menuKeyboard.test.tsx` (9 tests, 8 verified red before the wiring):

- focus enters the menu on open, landing on the first row
- ArrowDown walks the rows and wraps past the last; ArrowUp wraps past the first
- Home/End jump to the boundary rows
- Tab and Shift-Tab are contained inside the open menu
- Escape closes and hands focus back to the trigger
- picking a row reports upstream (`channelUpdateAgent`) and hands focus back to the trigger
- rows are `menuitemradio` with the current mode `aria-checked`
- the menu carries its accessible name ("Listen mode")
- a mousedown in the composer dismisses the menu without stealing focus to the trigger (pins the host's outside-mousedown dismissal shape, which is what keeps the hook's one-open-menu precondition true)

## Manual verification

N/A — unit coverage sufficient: the keyboard contract is real-DOM-focus asserted per keystroke, and the hook itself carries its own suite (`useMenuKeyboard.test.tsx`). Focus-trace evidence below in place of screenshots.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** keyboard focus behaviour and non-rendering ARIA attributes only — no pixel renders differently, so a still frame cannot show the delta. Evidence is the focus-trace assertion dump (real DOM focus moves asserted per keystroke), same posture as PR #6267:

```
✓ ChannelPage — listen-mode menu keyboard contract > moves focus into the menu when it opens
✓ ChannelPage — listen-mode menu keyboard contract > walks the rows with ArrowDown and wraps past the last one
✓ ChannelPage — listen-mode menu keyboard contract > walks the rows with ArrowUp and wraps past the first one
✓ ChannelPage — listen-mode menu keyboard contract > jumps to the boundary rows with Home and End
✓ ChannelPage — listen-mode menu keyboard contract > contains Tab and Shift-Tab inside the open menu
✓ ChannelPage — listen-mode menu keyboard contract > closes on Escape and hands focus back to the trigger
✓ ChannelPage — listen-mode menu keyboard contract > hands focus back to the trigger after picking a row
✓ ChannelPage — listen-mode menu keyboard contract > marks the rows as menuitemradio with the current mode checked
✓ ChannelPage — listen-mode menu keyboard contract > names the menu so the radio group has a referent
✓ ChannelPage — listen-mode menu keyboard contract > dismisses on a mousedown in the composer without stealing focus
```

## Related Issues

Fixes #6269

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface
- [x] No secrets, credentials, or internal references in the diff
