### PR TITLE
fix(cron): enforce the history caps on append, not only at startup

### DIFF
--- a/src/kiro_crew/cron_history.py
+++ b/src/kiro_crew/cron_history.py
@@ -45,6 +45,30 @@ _MAX_INDEX_RECORDS = 2000
 _DENIAL_ERRNOS = frozenset({errno.EPERM, errno.EACCES, errno.EROFS})
 
 
+def _trim_file(path: Path, max_records: int) -> None:
+    """Keep only the newest *max_records* lines of the JSONL at *path*.
+
+    Writes through a temp then ``os.replace``, so a reader — which takes no lock
+    — sees either the whole old file or the whole new one, never a half-written
+    one. A no-op at or below the cap, so an append under the limit pays one read
+    and no rewrite.
+
+    The caller MUST hold the store lock: this reads the file and republishes it
+    whole, so an unlocked interleaving with an append drops the record that
+    landed between the read and the replace.
+    """
+    if max_records <= 0 or not path.exists():
+        return
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    if len(lines) <= max_records:
+        return
+    tmp = path.with_suffix(".tmp")
+    wfd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(wfd, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines[-max_records:]) + "\n")
+    os.replace(tmp, path)
+
+
 @dataclass
 class CronRunRecord:
     """Single cron execution record."""
@@ -253,6 +277,16 @@ class CronHistoryStore:
             ifd = os.open(str(self._index_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
             with os.fdopen(ifd, "a", encoding="utf-8") as f:
                 f.write(json.dumps(record.to_dict(include_trace=False)) + "\n")
+            # The caps are enforced on the write path, not only by ``rotate_all``.
+            # That runs once per process, from ``CronService.start``, so it bounds
+            # the history a gateway INHERITS, never the history the gateway itself
+            # writes — and a long-lived gateway is where the growth happens. Every
+            # read (``get_job_history``, ``get_all_history``, ``get_run_detail``)
+            # loads its whole file, so an unbounded index also makes each dashboard
+            # request cost more as the process ages. The trim runs under the lock
+            # this method already holds, so it adds no second critical section.
+            _trim_file(job_path, self._max_records_per_job)
+            _trim_file(self._index_path, self._max_index_records)
         finally:
             self._unlock(fd)
 
@@ -378,15 +412,7 @@ class CronHistoryStore:
             return
         fd = self._lock()
         try:
-            lines = job_path.read_text(encoding="utf-8").strip().splitlines()
-            if len(lines) <= self._max_records_per_job:
-                return
-            keep = lines[-self._max_records_per_job:]
-            tmp = job_path.with_suffix(".tmp")
-            wfd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with os.fdopen(wfd, "w", encoding="utf-8") as f:
-                f.write("\n".join(keep) + "\n")
-            os.replace(tmp, job_path)
+            _trim_file(job_path, self._max_records_per_job)
         finally:
             self._unlock(fd)
 
@@ -405,23 +431,8 @@ class CronHistoryStore:
             for p in self._dir.glob("*.jsonl"):
                 if p.name == "_index.jsonl":
                     continue
-                lines = p.read_text(encoding="utf-8").strip().splitlines()
-                if len(lines) > self._max_records_per_job:
-                    keep = lines[-self._max_records_per_job:]
-                    tmp = p.with_suffix(".tmp")
-                    wfd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                    with os.fdopen(wfd, "w", encoding="utf-8") as f:
-                        f.write("\n".join(keep) + "\n")
-                    os.replace(tmp, p)
-            if self._index_path.exists():
-                lines = self._index_path.read_text(encoding="utf-8").strip().splitlines()
-                if len(lines) > self._max_index_records:
-                    keep = lines[-self._max_index_records:]
-                    tmp = self._index_path.with_suffix(".tmp")
-                    wfd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                    with os.fdopen(wfd, "w", encoding="utf-8") as f:
-                        f.write("\n".join(keep) + "\n")
-                    os.replace(tmp, self._index_path)
+                _trim_file(p, self._max_records_per_job)
+            _trim_file(self._index_path, self._max_index_records)
         finally:
             self._unlock(fd)
 

--- a/test/test_cron_history.py
+++ b/test/test_cron_history.py
@@ -804,3 +804,79 @@ def test_deferred_store_reads_as_disabled_until_prepared(tmp_path: Path) -> None
     # Idempotent: a second prepare neither re-probes nor flips the verdict.
     store.prepare()
     assert store.enabled is True
+
+
+# ── append enforces the caps (not only an explicit rotate) ───────────────
+
+
+@pytest.fixture
+def small_store(tmp_path: Path) -> CronHistoryStore:
+    """Store with tiny caps so the bound is reachable without thousands of writes."""
+    return CronHistoryStore(
+        base_dir=tmp_path,
+        cron_max_records_per_job=5,
+        cron_max_index_records=8,
+    )
+
+
+@pytest.mark.asyncio
+async def test_append_bounds_the_job_file_without_an_explicit_rotate(
+    small_store: CronHistoryStore,
+) -> None:
+    """The per-job cap must hold continuously, not just after a rotate call.
+
+    ``rotate_all`` runs once, from ``CronService.start``. A gateway that stays up
+    keeps appending, so a cap enforced only at startup does not bound anything
+    for the lifetime of the process — which is exactly when the history grows.
+    """
+    for i in range(12):
+        await small_store.append(_record(run_id=f"r{i}"))
+
+    records, total = await small_store.get_job_history("job1", limit=50)
+    assert total == 5, "job file grew past cron_max_records_per_job"
+    # Newest kept, oldest dropped — same end state an explicit rotate produces.
+    assert [r["run_id"] for r in records] == ["r11", "r10", "r9", "r8", "r7"]
+
+
+@pytest.mark.asyncio
+async def test_append_bounds_the_global_index(
+    small_store: CronHistoryStore, tmp_path: Path
+) -> None:
+    """The index is read whole on every dashboard history request, so it is
+    the file whose unbounded growth costs the most."""
+    for i in range(20):
+        await small_store.append(_record(job_id=f"job{i % 3}", run_id=f"r{i}"))
+
+    index_path = tmp_path / "cron-history" / "_index.jsonl"
+    index_lines = index_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(index_lines) == 8, "index grew past cron_max_index_records"
+    # Newest-first retention across jobs, matching rotate_all's behaviour.
+    assert [json.loads(ln)["run_id"] for ln in index_lines] == [f"r{i}" for i in range(12, 20)]
+
+
+@pytest.mark.asyncio
+async def test_append_under_the_cap_keeps_every_record(
+    small_store: CronHistoryStore,
+) -> None:
+    """Negative control: the trim must not fire below the cap."""
+    for i in range(4):
+        await small_store.append(_record(run_id=f"r{i}"))
+
+    records, total = await small_store.get_job_history("job1", limit=50)
+    assert total == 4
+    assert [r["run_id"] for r in records] == ["r3", "r2", "r1", "r0"]
+
+
+@pytest.mark.asyncio
+async def test_append_trim_preserves_the_full_trace_of_kept_records(
+    small_store: CronHistoryStore,
+) -> None:
+    """Trimming rewrites the job file; the surviving records must stay intact,
+    including the trace that only ``get_run_detail`` returns."""
+    for i in range(9):
+        await small_store.append(_record(run_id=f"r{i}", trace=f"trace-{i}"))
+
+    detail = await small_store.get_run_detail("job1", "r8")
+    assert detail is not None
+    assert detail["trace"] == "trace-8"
+    assert await small_store.get_run_detail("job1", "r0") is None


### PR DESCRIPTION
## Problem / Motivation

`CronHistoryStore` carries two operator-settable caps —
`cron_max_records_per_job` (100) and `cron_max_index_records` (2000). Neither
bounds anything a running gateway writes.

The only production caller of either cap is `rotate_all()`, and it runs **once
per process**, from `CronService.start()` (`cron.py:1279`). `rotate()` — the
single-job trim — has **no production caller at all**.

So the caps bound the history a gateway *inherits* at boot, and nothing it
appends afterwards. `_append_sync` writes one record per run to
`{job_id}.jsonl` and one to the shared `_index.jsonl`, and never trims either.

The existing test suite shows this directly: `test_rotate_trims_to_max` appends
150 records and has to call `rotate("job1")` explicitly before the count drops
to 100. Without that call the file simply keeps all 150.

## Why it matters

A gateway is a long-lived process, so the window in which history grows is
exactly the window in which nothing enforces the cap.

Two costs, and the second is the one users feel:

- **Disk.** Each job record carries a trace of up to `cron_trace_cap_kb`
  (50KB default). A per-minute cron is 1,440 records/day for that one job.
- **Every read gets slower.** `get_job_history`, `get_all_history` and
  `get_run_detail` each `read_text()` their file **whole** and then filter in
  Python. `_index.jsonl` is shared by every job, so it is the file that grows
  fastest, and it is the one behind the dashboard's cross-job History tab. An
  unbounded index makes each of those requests cost more the longer the gateway
  has been up — and a restart silently "fixes" it, which is what makes the
  growth easy to miss.

## What changed (motivation → approach → change)

The caps are a property of the store, so they are enforced where records enter
it rather than at one lifecycle event that happens to run first.

`_append_sync` already takes the store's exclusive lock and already knows both
paths, so the trim goes **there**, inside the critical section it already holds
— no second lock acquisition, no new task, no schedule to tune. `_trim_file`
returns immediately at or below the cap, so an append under the limit pays one
read and no rewrite.

The trim itself is not new logic: `rotate`, `rotate_all` (job files) and
`rotate_all` (index) each carried their own copy of the same
read → keep-last-N → temp → `os.replace` sequence. All three now call one
`_trim_file(path, max_records)` helper, so the write path and the explicit
rotate cannot drift apart. Net effect on the production file is **-26 lines**.

Deliberately unchanged:

- **Retention semantics.** Newest-N-kept, oldest dropped — the same end state
  `rotate_all()` already produced. No new constant, no new config key, no
  change to either default.
- **The publish mechanism.** Still temp + `os.replace`, so a reader (which
  takes no lock, by documented design) sees the whole old file or the whole new
  one, never a partial one.
- **`rotate` / `rotate_all` remain.** `rotate_all()` at startup still trims a
  history inherited from an older build that never had this enforcement.

No spec change: `learn-cron-dashboard.md` documents the store as "written
unconditionally by the executor and surfaced at `GET /api/crons/{id}/history`",
and `security.md` covers `cron-history` as a sensitive leaf. Neither documents
rotation timing, and neither statement changes here.

## Tests

Four tests added to `test/test_cron_history.py`, driving the real store through
its public `append()` API. Before the change: **3 failed, 34 passed**; after:
**37 passed**.

Locking in the fix:
- `test_append_bounds_the_job_file_without_an_explicit_rotate` — 12 appends
  against a cap of 5 leave 5 records, newest kept (`12 == 5` before).
- `test_append_bounds_the_global_index` — 20 appends across 3 jobs against an
  index cap of 8 leave 8, newest-first across jobs (`20 == 8` before).
- `test_append_trim_preserves_the_full_trace_of_kept_records` — the rewrite
  keeps surviving records intact, including the `trace` only `get_run_detail`
  returns, and the evicted record is genuinely gone.

Locking in what must not move:
- `test_append_under_the_cap_keeps_every_record` — negative control; the trim
  must not fire below the cap. **This one passes on `main` too**, which is what
  makes it a control rather than a restatement of the fix.

Mutation checks, reported as measured:
- Removing the `_trim_file` call from the append path turns the three new
  assertions red (and the two pre-existing `rotate` tests, since the sed hit
  their shared call site too) — so the tests bite on the mechanism.
- Widening `_trim_file`'s boundary from `<= max_records` to `< max_records`
  leaves **all 37 green**. I am not claiming coverage there: at exactly the cap
  that mutation only performs a redundant rewrite that republishes identical
  content, so no test *should* distinguish it.

Wider run: `test/test_cron_history.py` + `test/test_cron_script.py` — **148
passed, 2 skipped**. Every pre-existing `rotate`/`rotate_all` test passes
unchanged through the shared helper.

Gates (Windows, Python 3.10.6): `flake8` clean, `isort --check-only` clean,
`mypy src/kiro_crew/cron_history.py` — Success. Both files are in
`.github/black-baseline.txt`, so neither was reformatted; measured at the repo's
`line-length = 100`, `cron_history.py` goes **3 → 1** black hunks (the dedup
removed non-conforming lines) and `test_cron_history.py` stays **6 → 6**. No new
violation is introduced.

## Manual verification

N/A — unit coverage sufficient: the change is a bounded rewrite on the store's
own write path, and the tests exercise it end-to-end through `append()` and the
public readers rather than by calling the helper directly.

## Related Issues

None — found by reading the module.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no spec documents rotation timing (see above)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
