### PR TITLE
fix(ci): make both npm majors resolve the frontend tree identically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1309,6 +1309,64 @@ jobs:
           npm run lint:phantom-classes -- --test
           npm run lint:phantom-classes
 
+  # Prove `npm ci` still works on the OLDEST Node the frontend claims to support.
+  # Every other job here runs the .nvmrc toolchain (Node 24 / npm 11), and npm 11
+  # and npm 10 (Node 22) build different ideal trees for an OPTIONAL PEER
+  # dependency: npm 10 wants a nested entry for it, npm 11 does not install it at
+  # all. A lockfile regenerated under npm 11 therefore drops what npm 10 demands,
+  # and `npm ci` dies with EUSAGE ("Missing: <pkg> from lock file") for everyone
+  # on the declared floor while all of CI stays green. That happened twice to the
+  # same dependency, the second time as a side effect of a change about something
+  # else entirely.
+  #
+  # The specific divergence is gone -- an `overrides` entry now makes both majors
+  # resolve that dependency identically, so neither can drop anything. This job
+  # exists because that is a property of today's dependency tree, not a guarantee:
+  # the next package with an unsatisfiable optional peer reintroduces the whole
+  # class, and without a job on the floor nothing would notice.
+  lockfile-engines-floor:
+    name: Lockfile Installs On Declared Node Floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Pinned to the floor, NOT to `engines.node` via node-version-file: that
+      # input resolves a range like ">=22" to the NEWEST matching release, which
+      # would quietly re-test Node 24 and make this job vacuous. The literal is
+      # held to engines.node statically instead, by
+      # test_the_engines_floor_job_pins_the_declared_floor -- one derivation of
+      # the floor, in the file that already governs every other node pin.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: npm ci on the engines floor
+        working-directory: website
+        # A real install, not `--dry-run`: dry-run still fires the postinstall
+        # patch script but leaves no node_modules for it to patch, so it fails
+        # for a reason that has nothing to do with the lockfile. Installing for
+        # real also makes the gate mean what its name says -- `npm ci` works on
+        # the declared floor -- rather than only that resolution succeeded.
+        #
+        # The failure hint matters because this job is the ONLY one on the floor:
+        # whoever trips it is on Node 24 and cannot reproduce the red locally, so
+        # naming the reproduction turns an opaque failure into a self-servicing
+        # one.
+        run: |
+          npm ci --no-audit --no-fund || {
+            echo "::error::npm ci failed on Node $(node -v), the engines.node floor." \
+              "Every other job runs the .nvmrc toolchain (Node 24 / npm 11), so this can" \
+              "fail while they pass: the two npm majors resolve optional peer dependencies" \
+              "differently. Reproduce without installing Node 22:" \
+              "cd website && npx -y npm@10 ci. If it is a lockfile disagreement, prefer" \
+              "removing the divergence (an overrides entry both majors resolve the same way)" \
+              "over hand-adding whichever entry one major happens to want."
+            exit 1
+          }
+
   cfn-lint:
     name: CloudFormation Lint
     runs-on: ubuntu-latest

--- a/test/test_node_version_pins.py
+++ b/test/test_node_version_pins.py
@@ -9,6 +9,14 @@ EOL major in one job while the rest of the repo moves on:
 * exact pins (``24.19.0``) must have a major >= the ``.nvmrc`` major (the
   vulnerability-scan workflow pins an exact patch on purpose).
 
+One job is deliberately NOT on the toolchain pin: ``lockfile-engines-floor``
+exists to prove ``npm ci`` still works on the OLDEST Node the frontend claims
+to support, so pinning it to ``.nvmrc`` would make it a duplicate of the jobs
+that already run there. It is not exempt, only measured against a different
+source of truth — ``website/package.json``'s ``engines.node`` — which
+``test_the_engines_floor_job_pins_the_declared_floor`` enforces. Both rules
+together mean no pin in this repo is unaccounted for.
+
 Static and offline by design: this reads only files in the repo, never
 nodejs.org, so it cannot flake on network and never gates on "is there a newer
 Node" — only on internal consistency.
@@ -16,6 +24,7 @@ Node" — only on internal consistency.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -24,6 +33,12 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 NVMRC = ROOT / ".nvmrc"
+WEBSITE_PACKAGE_JSON = ROOT / "website" / "package.json"
+
+# The one job whose pin is the frontend's SUPPORTED FLOOR, not the toolchain pin.
+# Keyed by (workflow file, job id) rather than by workflow name so the carve-out
+# cannot widen to the rest of ci.yml.
+ENGINES_FLOOR_JOB = ("ci.yml", "lockfile-engines-floor")
 
 
 def _nvmrc_major() -> int:
@@ -32,19 +47,31 @@ def _nvmrc_major() -> int:
     return int(text)
 
 
-def _setup_node_versions() -> list[tuple[str, str]]:
-    """Return (workflow-relative-path, node-version) for every setup-node step."""
-    found: list[tuple[str, str]] = []
+def _engines_floor_major() -> int:
+    """The major from ``website/package.json``'s ``engines.node``."""
+    spec = json.loads(WEBSITE_PACKAGE_JSON.read_text(encoding="utf-8"))["engines"]["node"]
+    # Only a `>=` floor is parseable as "the oldest supported major". A caret, a
+    # range or an upper bound would make the floor ambiguous, and the workflow
+    # step that re-derives it in shell would disagree with this test, so refuse
+    # the shape outright rather than guess.
+    match = re.fullmatch(r">=(\d+)(?:\.\d+(?:\.\d+)?)?", str(spec))
+    assert match, f"engines.node must be a bare `>=major` floor, got {spec!r}"
+    return int(match.group(1))
+
+
+def _setup_node_versions() -> list[tuple[str, str, str]]:
+    """Return (workflow file name, job id, node-version) for every setup-node step."""
+    found: list[tuple[str, str, str]] = []
     workflow_files = sorted([*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")])
     for wf in workflow_files:
         doc = yaml.safe_load(wf.read_text(encoding="utf-8"))
-        for job in (doc.get("jobs") or {}).values():
+        for job_id, job in (doc.get("jobs") or {}).items():
             for step in job.get("steps") or []:
                 if not str(step.get("uses", "")).startswith("actions/setup-node@"):
                     continue
                 version = (step.get("with") or {}).get("node-version")
                 assert version is not None, f"{wf.name}: setup-node step without node-version"
-                found.append((wf.name, str(version)))
+                found.append((wf.name, str(job_id), str(version)))
     return found
 
 
@@ -59,7 +86,9 @@ def test_every_workflow_node_pin_tracks_nvmrc() -> None:
     # A glob/parse that silently matched nothing would make this gate vacuous;
     # the repo has setup-node steps across ci/build/pages/docker workflows.
     assert len(pins) >= 10, f"expected >= 10 setup-node pins, found {len(pins)}: {pins}"
-    for wf_name, version in pins:
+    for wf_name, job_id, version in pins:
+        if (wf_name, job_id) == ENGINES_FLOOR_JOB:
+            continue  # measured against engines.node instead — see the test below
         assert re.fullmatch(r"\d+(\.\d+\.\d+)?", version), (
             f"{wf_name}: node-version {version!r} is neither a bare major nor an exact "
             f"major.minor.patch pin"
@@ -74,3 +103,25 @@ def test_every_workflow_node_pin_tracks_nvmrc() -> None:
                 f"{wf_name}: floating pin {version} does not equal the .nvmrc major {target} — "
                 f"bump .nvmrc and every workflow together"
             )
+
+
+def test_the_engines_floor_job_pins_the_declared_floor() -> None:
+    """The floor job must sit on engines.node, and the floor must not lead the toolchain.
+
+    Without this, skipping the job above would leave its pin governed by nothing:
+    the job would keep passing on whatever Node it happened to name, including one
+    the frontend never claimed to support.
+    """
+    wf_name, job_id = ENGINES_FLOOR_JOB
+    pins = [v for (w, j, v) in _setup_node_versions() if (w, j) == (wf_name, job_id)]
+    assert pins == [str(_engines_floor_major())], (
+        f"{wf_name}: job {job_id} must pin exactly the engines.node floor "
+        f"{_engines_floor_major()}, found {pins}"
+    )
+    # A floor ahead of the toolchain pin would mean the repo's own .nvmrc names a
+    # Node the frontend refuses to run on. Equal is legal but redundant: the job
+    # then duplicates the jobs already on the toolchain pin and can be deleted.
+    assert _engines_floor_major() <= _nvmrc_major(), (
+        f"engines.node floor {_engines_floor_major()} is ahead of the .nvmrc major "
+        f"{_nvmrc_major()}"
+    )

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1315,36 +1315,6 @@
         "react-dom": "^18.3.1 || ^19.0.0"
       }
     },
-    "node_modules/@pierre/trees/node_modules/@pierre/theming": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-1.0.0.tgz",
-      "integrity": "sha512-WsdrnhKfjeyXGDikZmN9pkpeZ5S/cl6EE72feiSc0tlynT1tMYqXqouhuv/foK+PY9OEnebOAVRQn3+rAstR8g==",
-      "license": "apache-2.0",
-      "peerDependencies": {
-        "@pierre/theme": "^1.1.0",
-        "@shikijs/themes": "^3.0.0 || ^4.0.0",
-        "react": "^18.3.1 || ^19.0.0",
-        "react-dom": "^18.3.1 || ^19.0.0",
-        "shiki": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@pierre/theme": {
-          "optional": true
-        },
-        "@shikijs/themes": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "shiki": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -154,6 +154,7 @@
     "@inquirer/type": "4.0.4",
     "@mermaid-js/parser": "1.2.0",
     "@mswjs/interceptors": "0.41.3",
+    "@pierre/theming": "1.0.1",
     "@smithy/types": "4.13.1",
     "@tanstack/query-core": "5.96.0",
     "@types/node": "24.13.3",


### PR DESCRIPTION
## Problem / Motivation

`npm ci` in `website/` fails on `origin/main` for anyone running Node 22:

```
npm error code EUSAGE
npm error Missing: @pierre/theme@1.1.0 from lock file
```

Reproduced on `7389db990` with Node 22.23.1 / npm 10.9.8. `website/package.json`
declares `engines.node: ">=22"` and the README states "Node.js 22+ (24 LTS
recommended)", so this is a supported configuration that cannot install
dependencies at all.

## Why it matters

The floor is broken for contributors and invisible to CI at the same time.

npm 11 (Node 24) and npm 10 (Node 22) build **different ideal trees** for an
optional peer dependency. All 21 other `node-version` pins across this repo's
workflows are 24, so npm 11 is the only resolver CI ever exercises — and npm 11
is perfectly happy with a lockfile npm 10 rejects.

This is the second occurrence. #4427 fixed it (closing #4417) and it was undone
by a lockfile regeneration in a change about something else, with nothing going
red.

## What changed (motivation → approach → change)

**Root cause — a resolver disagreement, not a stale lockfile.**
`@pierre/trees@1.0.0-beta.6` pins `@pierre/theming@1.0.0`, whose **optional** peer
is `@pierre/theme@^1.1.0`. The hoisted `@pierre/theme@2.0.0` (from
`@pierre/diffs`) does not satisfy `^1.1.0`. npm 10 resolves that by nesting
`@pierre/theme@1.1.0` and requires the lockfile to record it; npm 11 declines to
install the optional peer at all and records nothing.

**Why not just restore the entry.** That is what #4427 did, and it treats the
symptom: the entry is dropped again by the next `npm install` on the repo's own
toolchain, and repairing it requires an npm 10 that no repo file pins,
provisions, or documents. The first revision of this PR did exactly that; the
Design review correctly called it "converts silent breakage into recurring
friction rather than removing the cause."

**What this does instead — remove the disagreement.** `@pierre/theming@1.0.1`
widened the peer to `"^1.1.0 || ^2.0.0"`, which the hoisted `2.0.0` satisfies, so
an `overrides` entry pinning `theming` to `1.0.1` leaves nothing for either major
to nest. Three properties make this the right shape rather than a bigger hammer:

- **It dedupes rather than adding a version.** `@pierre/diffs` already depends on
  `theming@1.0.1`, so the bundle already ships it; `@pierre/trees` now shares that
  copy. The lockfile **shrinks by 30 lines and one package** (990 → 988).
- **Both majors now regenerate the lockfile byte-identically** (verified in both
  directions). A contributor on Node 24 can no longer break Node 22 — the failure
  mode is gone, not merely detected.
- **`overrides` is this repo's established mechanism** for exactly this: `website/package.json`
  already carries 50 entries, and `website/electron/package.json` uses one to pin
  a transitive dependency for the same class of reason.

Upgrading past the split was checked first and is not available: `1.0.0-beta.6` is
the newest published `@pierre/trees`, and it pins `theming@1.0.0` exactly.

**The gate still earns its place**, because agreement is a property of today's
dependency tree — the next package with an unsatisfiable optional peer
reintroduces the whole class, and with every job on Node 24 nothing would notice.
`lockfile-engines-floor` runs `npm ci` for real on the declared floor.

- **A real install, not `--dry-run`:** dry-run still fires the `postinstall`
  happy-dom patch with no `node_modules` to patch, failing for an unrelated
  reason. ~7s with a warm cache.
- **The failure output names the reproduction** (`npx -y npm@10 ci`) and says to
  prefer removing a divergence over hand-adding an entry. Whoever trips this job
  is on Node 24 and cannot reproduce it locally, so the hint is what makes the red
  self-servicing — addressing the Design review's suggestion directly.
- **The pin is held to `engines.node` statically, in one place.** The first
  revision also had an in-job shell step re-deriving the floor; the First
  Principles review was right that this ships one invariant twice, and the pytest
  test is strictly stronger (it also caps the floor at `.nvmrc`, and refuses an
  unparseable `engines.node` where the shell regex would silently compute garbage
  from a range like `">=22 <25"`). The shell step is gone.

**Reconciling with the single-toolchain-pin invariant.**
`test_every_workflow_node_pin_tracks_nvmrc` requires every `setup-node` pin to
equal the `.nvmrc` major, and caught the new job immediately — correctly, on its
own terms. This is the repo's first pin that must *not* track the toolchain.

It is **not exempted**, which would leave the pin governed by nothing: it is
skipped there and enforced against `engines.node` by a new test. The carve-out is
keyed by `(workflow file, job id)` rather than workflow name so it cannot widen to
the rest of `ci.yml`.

## Tests

`test/test_node_version_pins.py` gains `test_the_engines_floor_job_pins_the_declared_floor`
plus the narrowed carve-out. Mutation-verified rather than assumed:

| Mutation | Expected | Result |
|---|---|---|
| Floor job pin `22` → `24` | new test red | **red** — "must pin exactly the engines.node floor 22, found ['24']" |
| `engines.node` → `">=20"`, pin stays 22 | new test red | **red** — "…floor 20, found ['22']" |
| Rename the floor job id | carve-out must not widen | **both tests red** |
| `engines.node` → `"^22"` (unparseable floor) | shape assertion red | **red** |
| Control | all green | **3 passed** |

Renaming the job is the row worth reading: it returns the pin to the `.nvmrc` rule
*and* empties the new test, so the exception cannot be inherited by a
differently-named job.

The CI job has no unit test — it is a CI job — so it was falsified by executing
it as shell. **This is the regression test for the actual defect:**

| Mutation | Expected | Result |
|---|---|---|
| Delete the `overrides` entry, regenerate under npm 11 (the repo toolchain) | floor gate red | **red** — `EUSAGE` / `Missing: @pierre/theme@1.1.0` |
| Control (entry present) | gate green | **green** — real `npm ci` succeeds on Node 22 in 7s |

So the override is precisely what removes the divergence, *and* the gate still
catches the class if it is ever removed.

Also run locally: the 23 test files that read `.github/workflows/` or
`website/package.json` (1309 passed); `scripts/check_npm_audit.py` ("audit
passed: 3 lockfiles, 0 governed exceptions"); `scripts/check_black_formatting.py`;
flake8; isort; `mypy --platform linux src/kiro_crew` clean.

## Manual verification

Full 2×2 over both resolvers, since the defect *is* a resolver disagreement:

| lockfile | npm 10 (Node 22, the floor) | npm 11 (Node 24, the toolchain) |
|---|---|---|
| `origin/main` | ❌ `EUSAGE Missing: @pierre/theme@1.1.0` | ✅ 989 packages |
| this branch | ✅ 988 packages, `postinstall` patch applied | ✅ 988 packages |

Both cells on the bottom row now agree on the **same** count — that is the
property the first revision did not have (989 vs 990). Regeneration is stable
under both majors: each produces a byte-identical lockfile.

`@pierre/theming` moves `1.0.0` → `1.0.1` under `@pierre/trees`, so the frontend
was exercised for real: real `npm ci` on Node 22 (7s, postinstall patch applied),
`npx tsc -b` clean, `npm run build` exit 0 producing `dist/index.html`, and the
46 `PierreWorkspaceTree` tests pass. Note those tests use
`src/test/__mocks__/pierreTreesReact.tsx`, so the build and typecheck are the real
evidence for the version move, not the unit tests.

`actionlint` is not available in this environment; the workflow parses as YAML and
the job's step was executed verbatim as shell, but the YAML is worth a reviewer's
eye.

## Related Issues

Prior occurrence: #4417, fixed by #4427. This replaces that fix's approach with
one the repo's own toolchain cannot undo.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (all mutation-verified; see Tests)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the test module's docstring documents the two-source-of-truth rule; no doc under `docs/` describes the Node pin invariant or the `overrides` policy
- [x] No secrets, credentials, or internal references in the diff
