### PR TITLE
fix(chat): return user-row mid in send receipt so a just-sent message is pinnable this turn

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -624,7 +624,18 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     # agent itself decides whether to operate a browser or read with web_fetch
     # (the system prompt and the kirocrew-commands / web-browse skills tell it
     # how), so the backend injects nothing here.
-    slot.append("user", message, "msg msg-u", meta=_redact_meta(user_meta) if user_meta else None)
+    # Capture the server-minted `meta.mid` off the appended row so the send
+    # receipt can carry it back (see the receipts below). The dashboard renders
+    # this user turn optimistically and no `chat_message` user echo is broadcast
+    # for it (`append` defaults `broadcast_user=False`), so the receipt is the
+    # ONLY channel that can hand the client this row's stable id before the
+    # `chat_done` refresh rebuilds the transcript from disk. Without it, the
+    # message-pin control (keyed on `meta.mid`) stays withheld for the whole
+    # turn.
+    _user_row = slot.append(
+        "user", message, "msg msg-u", meta=_redact_meta(user_meta) if user_meta else None
+    )
+    _user_mid = _user_row.get("meta", {}).get("mid")
 
     # Note: untitled slots display as "New Session…" via _ChatSlot.display_title
     # (serialization layer), so there's no bare chat-N flash to patch here. The
@@ -818,7 +829,15 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
     state.push_slots_update()
 
     if ws_mode:
-        return web.json_response({"ok": True, "slot": slot.key})
+        # Carry the server-minted user-row `mid` back (see the append above). A
+        # confirmed dashboard send reconciles it onto the optimistic bubble so
+        # the message-pin control lights up immediately instead of only after
+        # the chat_done refresh. Omitted when absent so the receipt shape is
+        # unchanged for callers that never minted one.
+        _receipt: dict[str, Any] = {"ok": True, "slot": slot.key}
+        if _user_mid:
+            _receipt["mid"] = _user_mid
+        return web.json_response(_receipt)
 
     resp = web.StreamResponse()
     resp.content_type = "text/event-stream"

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -8525,6 +8525,70 @@ class TestApiChatAgentPassing:
             mock_emit.assert_called_once_with("slot-r", "new-agent", outcome="denied_running")
 
 
+class TestApiChatSendReceiptMid:
+    """The immediate-dispatch receipt carries the user row's server-minted `mid`.
+
+    The dashboard renders the user turn optimistically and no `chat_message`
+    user echo is broadcast for a dashboard send (`append` defaults
+    `broadcast_user=False`), so the send receipt is the only channel that can
+    hand the client the row's stable id before the chat_done refresh. The
+    message-pin control is gated on `meta.mid`, so a missing id keeps the
+    just-sent message unpinnable for the whole turn.
+    """
+
+    @pytest.mark.asyncio
+    async def test_immediate_dispatch_receipt_carries_the_user_row_mid(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+
+        async def fake_run_chat(st, sl, msg, *, _directive_user_origin):
+            sl.append("chunk", "ack", "chunk")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat?ws=1",
+                json={"message": "hello", "slot": "mid-slot"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["ok"] is True
+        # The receipt id must be the SAME id stamped on the appended user row —
+        # that is the identity the client stamps on the optimistic bubble and
+        # the pin endpoint keys on.
+        slot = state._slots["mid-slot"]
+        user_rows = [m for m in slot.messages if m["role"] == "user"]
+        assert user_rows, "the send must have appended a user row"
+        row_mid = user_rows[-1]["meta"]["mid"]
+        assert row_mid
+        assert data["mid"] == row_mid
+
+    @pytest.mark.asyncio
+    async def test_queued_send_receipt_carries_no_mid(self, tmp_path, monkeypatch):
+        """A busy slot queues the message and broadcasts its own queue card; the
+        optimistic bubble is not this row's receipt, so no `mid` is returned
+        (mirrors `confirmedDelivered`, which excludes a queued acceptance)."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("busy-slot")
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        slot.task = mock_task  # slot.running is True → the busy/queue branch
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat?ws=1",
+                json={"message": "queue me", "slot": "busy-slot"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["queued"] is True
+        assert "mid" not in data
+
+
 # ── Plan action & auto-run tests ──
 
 

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -531,7 +531,7 @@ export default function ChatPane({
         // "no card and no ask" skipped the body entirely, which would have skipped
         // this confirmation too. `confirmedDelivered` accepts only an IMMEDIATE
         // dispatch: a queued acceptance is not a receipt for this bubble.
-        if (confirmedDelivered(body)) dispatch(confirmOptimisticSend({ slot: slotKey, sendId }))
+        if (confirmedDelivered(body)) dispatch(confirmOptimisticSend({ slot: slotKey, sendId, mid: typeof body.mid === 'string' ? body.mid : undefined }))
         if (!cardAtSend && !askAtSend) return
         // `ok` only: a QUEUED acceptance is still cancellable — the queued
         // path retires at its queue_pop instead (removeQueuedMessage).

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4479,7 +4479,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         // a rejected response, a queued acceptance, or the abort-timeout path:
         // there delivery of THIS row is unknown, which is what the indicator
         // exists to say (see `confirmedDelivered`).
-        dispatch(confirmOptimisticSend({ slot, sendId }))
+        // The receipt carries the server-minted user-row `mid` (when the send
+        // dispatched immediately); handing it to the reconcile stamps it onto
+        // this optimistic bubble so message-pinning works this turn instead of
+        // only after the chat_done refresh.
+        dispatch(confirmOptimisticSend({ slot, sendId, mid: typeof body.mid === 'string' ? body.mid : undefined }))
       }
       if (body.ok && !body.queued && cardAtSend && slot === entrySendSlot) {
         // Immediate dispatch confirmed (`ok`): the message consumed the slot's

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -3092,8 +3092,8 @@ const chatSlice = createSlice({
      *  pushes into the active `messages` while `appendSlotMessage` may have used
      *  `slotMessages[slot]`, and the user can switch sessions while the POST is
      *  in flight. `sendId` is unique per send, so scanning both cannot mis-hit. */
-    confirmOptimisticSend(state, action: PayloadAction<{ slot: string; sendId: string }>) {
-      const { slot, sendId } = action.payload
+    confirmOptimisticSend(state, action: PayloadAction<{ slot: string; sendId: string; mid?: string }>) {
+      const { slot, sendId, mid } = action.payload
       if (isUnsafeKey(slot)) return
       const confirm = (msgs: ChatMessage[] | undefined): boolean => {
         if (!msgs) return false
@@ -3103,6 +3103,15 @@ const chatSlice = createSlice({
           if (m.role !== 'user' || m.meta?.sendId !== sendId) continue
           const meta = { ...(m.meta || {}) }
           delete meta.optimistic
+          // Stamp the server-minted row id the receipt carried back. The bubble
+          // was appended client-side with only a `sendId` (no server identity),
+          // and no `chat_message` echo carries the `mid` for a dashboard send,
+          // so this is the only point it can land before the chat_done refresh.
+          // The message-pin control is gated on `meta.mid`, so without it the
+          // just-sent message cannot be pinned for the whole turn. Only set when
+          // the row has none yet — never overwrite a `mid` a refresh already
+          // reconciled (identity must not change once assigned).
+          if (mid && !meta.mid) meta.mid = mid
           m.meta = meta
           return true
         }

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -1104,6 +1104,44 @@ describe('confirmOptimisticSend — the send response retires the pending state'
     expect(state.messages[0].meta?.sendId).toBe('s-confirm-1')
   })
 
+  it('stamps the receipt mid on the confirmed bubble so it becomes pinnable this turn', () => {
+    let state = reducer(withSlot, appendMessage({
+      role: 'user', content: 'ship it', cls: '', ts: '2026-08-16T10:00:00.000Z',
+      meta: { sendId: 's-mid-1' },
+    }))
+    // The optimistic bubble is born with NO mid (the pin control is gated on it).
+    expect(state.messages[0].meta?.mid).toBeUndefined()
+
+    state = reducer(state, confirmOptimisticSend({ slot: 'slot-1', sendId: 's-mid-1', mid: 'm-server-42' }))
+
+    expect(state.messages[0].meta?.mid).toBe('m-server-42')
+    expect(state.messages[0].meta?.optimistic).toBeUndefined()
+  })
+
+  it('leaves the bubble without a mid when the receipt carried none (queued/steer send)', () => {
+    let state = reducer(withSlot, appendMessage({
+      role: 'user', content: 'ship it', cls: '', ts: '2026-08-16T10:00:00.000Z',
+      meta: { sendId: 's-nomid' },
+    }))
+
+    state = reducer(state, confirmOptimisticSend({ slot: 'slot-1', sendId: 's-nomid' }))
+
+    expect(state.messages[0].meta?.mid).toBeUndefined()
+    expect(state.messages[0].meta?.optimistic).toBeUndefined()
+  })
+
+  it('never overwrites a mid a refresh already reconciled (identity is stable once assigned)', () => {
+    let state = reducer(withSlot, appendMessage({
+      role: 'user', content: 'ship it', cls: '', ts: '2026-08-16T10:00:00.000Z',
+      meta: { sendId: 's-existing', mid: 'm-already-here' },
+    }))
+
+    state = reducer(state, confirmOptimisticSend({ slot: 'slot-1', sendId: 's-existing', mid: 'm-late-different' }))
+
+    expect(state.messages[0].meta?.mid).toBe('m-already-here')
+    expect(state.messages[0].meta?.optimistic).toBeUndefined()
+  })
+
   it('confirms only the matching send, leaving a sibling in-flight bubble pending', () => {
     let state = reducer(withSlot, appendMessage({ role: 'user', content: 'first', cls: '', ts: '2026-08-16T10:00:00.000Z', meta: { sendId: 's-a' } }))
     state = reducer(state, appendMessage({ role: 'user', content: 'second', cls: '', ts: '2026-08-16T10:00:01.000Z', meta: { sendId: 's-b' } }))

--- a/website/src/test/sendDelivery.test.ts
+++ b/website/src/test/sendDelivery.test.ts
@@ -55,6 +55,14 @@ describe('readSendReceipt', () => {
     expect((await readSendReceipt(res(true, async () => ({ queued: true })))).outcome).toBe('accepted')
   })
 
+  it('surfaces the server-minted mid from an immediate-dispatch receipt', async () => {
+    // The mid is what the client stamps on the optimistic bubble to make the
+    // just-sent message pinnable this turn; it must survive parsing.
+    const receipt = await readSendReceipt(res(true, async () => ({ ok: true, slot: 's1', mid: 'm-abc123' })))
+    expect(receipt.outcome).toBe('accepted')
+    expect(receipt.body.mid).toBe('m-abc123')
+  })
+
   it('reads an explicit refusal, and keeps the reason the server sent', async () => {
     const receipt = await readSendReceipt(res(false, async () => ({ ok: false, error: 'slot agent mismatch' })))
     expect(receipt.outcome).toBe('refused')

--- a/website/src/utils/sendDelivery.ts
+++ b/website/src/utils/sendDelivery.ts
@@ -6,6 +6,11 @@ export interface SendReceiptBody {
   queued?: boolean
   /** A steer-flagged send was injected into the running turn. */
   steered?: boolean
+  /** The server-minted stable id (`meta.mid`) of the user row this send
+   *  appended. Present only on a confirmed immediate dispatch; the client
+   *  stamps it onto the optimistic bubble so message-pinning works before the
+   *  chat_done refresh rebuilds the transcript from disk. */
+  mid?: string
   /** Server-authored refusal prose. Typed `unknown` because it arrives off the
    *  wire: a caller that renders it must narrow it to a string first. */
   error?: unknown


### PR DESCRIPTION
## Problem / Motivation

A just-sent user message cannot be pinned for the entire duration of the turn it starts. The copy and copy-link controls appear on hover, but the **pin control is missing** — then it appears once the turn finishes. To the user this reads as arbitrary: "some messages that are sent + already processed are missing a pin icon."

## Why it matters

Pinning a message you *just* sent (e.g. the instruction you want to keep referring to while the agent works) is exactly when a user reaches for the pin — and it is the one moment the control is unavailable. The gap lasts the whole turn, which on a long agent turn can be minutes.

## What changed (motivation → approach → change)

**Root cause.** The message-pin control (`UserMessage` + `AssistantMessage` in `website/src/pages/ChatPage.tsx`) is gated on the row carrying a server-minted stable id, `meta.mid`; `pinMessage`/`isPinned` (`hooks/useChatPins.ts`) key entirely on `mid`. A dashboard send appends the optimistic user bubble client-side with only a `sendId` and **no `mid`** (`store/chatSlice.ts` `appendMessage`). The server mints and persists the real `mid` on `slot.append` (`dashboard/state.py`), but:

- No `chat_message` user echo is broadcast for a dashboard send — `DashboardState.append` defaults `broadcast_user=False` (the composer already rendered the bubble), so `reconcileOptimisticEcho` (which would carry a `mid`) never fires.
- `confirmOptimisticSend` (the send-receipt reconcile) only cleared the `optimistic` flag; it never stamped a `mid`.

So the bubble gained a `mid` only when `chat_done` fired `refreshSlot`, which rebuilds the transcript from disk (rows carry the persisted `mid`).

**Approach.** The send receipt is the only channel that reaches the client before `chat_done`, so thread the `mid` through it. `POST /api/chat?ws=1` (the dashboard's send) already appends the user row synchronously and returns a JSON receipt; `append` returns the row dict, which carries `meta.mid`.

**Change.**
- Backend (`chat_handlers.py`): capture the appended user row and add its `mid` to the `ws_mode` receipt (`{"ok": true, "slot": ..., "mid": ...}`). Omitted when absent, so the receipt shape is unchanged for callers that never minted one. Only the immediate-dispatch path returns it — the queued/steer/crew branches deliberately do not, mirroring `confirmedDelivered` (a queued acceptance is not a receipt for the optimistic bubble).
- Frontend (`sendDelivery.ts`, `chatSlice.ts`, `ChatPage.tsx`): add optional `mid` to `SendReceiptBody`; `confirmOptimisticSend` stamps it onto the reconciled bubble, guarded by `!meta.mid` so it never overwrites a `mid` a later refresh already reconciled (identity is stable once assigned); ChatPage passes `body.mid` through.

No duplicate-row risk: `refreshSlot.fulfilled` rebuilds `messages` wholesale from the server page (the optimistic row is replaced by its disk twin, not merged as a second row keyed on `mid`), and the stamped `mid` is byte-identical to the persisted one, so pin state (keyed on `mid`) is continuous across the refresh.

## Tests

- `test/test_dashboard_chat.py::TestApiChatSendReceiptMid`
  - `test_immediate_dispatch_receipt_carries_the_user_row_mid` — the receipt `mid` equals the id stamped on the appended user row.
  - `test_queued_send_receipt_carries_no_mid` — a busy-slot (queued) send returns `queued: true` and no `mid`.
- `website/src/test/chatSlice.test.ts` (`confirmOptimisticSend` block) — stamps the receipt `mid`; leaves the bubble without a `mid` when the receipt carried none; never overwrites an existing `mid`.
- `website/src/test/sendDelivery.test.ts` — `readSendReceipt` surfaces `mid` from an immediate-dispatch receipt.

## Manual verification

N/A — the change is exercised end-to-end by the unit tests above (backend receipt shape + frontend reconcile). The rendered pin control itself is unchanged; only the timing of when the row acquires the `meta.mid` it is gated on moves earlier.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No pixel or layout change. The pin control already exists and is rendered the same way; this change only makes the just-sent row acquire the `meta.mid` it is gated on at send-confirm time instead of at `chat_done`, so the existing control appears sooner. There is no new or restyled UI to capture.

## Related Issues

Fixes #6554

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
