### PR TITLE
fix(hooks): nested-array paths now reach the sensitive-path keystone in target_paths

### DIFF
--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -500,9 +500,14 @@ def _target_path(event: LLMEvent) -> str:
     sensitive-path keystone was in fact reading two of the three, so a
     ``filePath`` target was displayed as vetted while never having been gated.
 
-    The FIRST path is shown when a call carries several. The gate denies on ANY of
-    them, so anything forbidden has already been refused before this runs; what is
-    left is a disclosure choice, and a prompt is a question rather than a manifest.
+    The FIRST path is shown when a call carries several, with a ``(+N more)``
+    count appended so the human is never told one file while consenting to a
+    batch — before the extraction became nesting-aware a multi-target batch
+    yielded nothing here, so the single-path display was honest by
+    construction; now that every nested target is collected, a bare first path
+    would under-disclose. The gate denies on ANY of them, so anything forbidden
+    has already been refused before this runs; what is left is a disclosure
+    choice, and a prompt is a question rather than a manifest.
 
     Returns ``""`` when the call carries no path, which is the ordinary case for
     a tool that acts on no file. That is deliberately NOT a refusal: most builtin
@@ -511,7 +516,11 @@ def _target_path(event: LLMEvent) -> str:
     which DO name a file.
     """
     found = target_paths(event.raw_tool_params)
-    return found[0] if found else ""
+    if not found:
+        return ""
+    if len(found) == 1:
+        return found[0]
+    return f"{found[0]} (+{len(found) - 1} more)"
 
 
 def _display_path(path: str) -> str:

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -596,7 +596,18 @@ class HookManager:
         # a write to ~/.ssh under that key was never gated and the human was asked
         # to approve a path the keystone should have refused outright.
         if raw_params:
-            for real_path in target_paths(raw_params):
+            real_paths = target_paths(raw_params)
+            if real_paths.truncated:
+                # The walk hit its work cap, so the list may be INCOMPLETE. A
+                # partial scan must not be trusted as a full one — deny, same
+                # deny-by-default shape as the unrecoverable shell command
+                # above. No legitimate tool call carries hundreds of target
+                # paths, so this refuses only attacker-shaped payloads.
+                return ToolHookResult.deny(
+                    "Blocked: tool arguments too large to verify for sensitive "
+                    "paths (deny-by-default)"
+                )
+            for real_path in real_paths:
                 if is_sensitive_path(real_path):
                     return ToolHookResult.deny(f"Blocked: access to sensitive path: {real_path}")
         # Config files are WRITE-protected (reads stay allowed): block the agent's
@@ -1474,8 +1485,41 @@ _SEARCH_PATH_FIELD = "path"
 TARGET_PATH_KEYS: tuple[str, ...] = ("path", "file_path", "filePath")
 
 
-def target_paths(raw_params: Mapping | None) -> list[str]:
-    """Every non-empty string path in *raw_params*, under any accepted spelling.
+#: Cap on the number of DISTINCT candidate paths collected below. The extractor
+#: runs synchronously on the gateway event loop for every tool call, and each
+#: collected path costs the keystone an ``is_sensitive_path`` resolution (two
+#: symlink-following syscall chains) — so an attacker-shaped batch carrying tens
+#: of thousands of paths could stall the loop. The cap does NOT fail open: hitting
+#: it sets ``TargetPaths.truncated`` and the gate DENIES an unverifiable call
+#: (same deny-by-default shape as the unrecoverable-shell-command branch).
+#: Generous on purpose: no legitimate tool schema names hundreds of files in one
+#: call, and a denied call merely falls to the human with a clear reason.
+_TARGET_PATH_MAX_PATHS = 256
+
+#: Budget of container nodes (dicts/lists) the walk will visit, bounding total
+#: traversal work independently of how the paths are arranged. Exceeding it also
+#: sets ``TargetPaths.truncated`` → deny. High enough that any real tool call is
+#: orders of magnitude below it.
+_TARGET_PATH_MAX_NODES = 10_000
+
+
+class TargetPaths(list):
+    """The collected paths, plus whether collection had to stop early.
+
+    A ``list`` subclass so every existing consumer (iteration in the gate loops,
+    ``found[0]`` in the consent prompt, truthiness, equality in tests) works
+    unchanged. ``truncated`` is True when the walk hit ``_TARGET_PATH_MAX_PATHS``
+    or ``_TARGET_PATH_MAX_NODES``, meaning the returned list may be INCOMPLETE —
+    a security consumer must treat that as "the call could not be verified" and
+    deny, never as "everything present was checked".
+    """
+
+    truncated: bool = False
+
+
+def target_paths(raw_params: Mapping | None) -> TargetPaths:
+    """Every non-empty string path in *raw_params*, under any accepted spelling,
+    at ANY nesting depth.
 
     Returns ALL of them rather than the first match, and callers deny if ANY is
     forbidden. That is deliberately different from "normalize the aliases onto one
@@ -1483,15 +1527,70 @@ def target_paths(raw_params: Mapping | None) -> list[str]:
     and picking wrong is how a sensitive path slips past. Checking every value
     present cannot be gamed by adding a second, innocent-looking alias, and needs
     no adjudication.
+
+    Nesting is walked for the same ground-truth reason: a batch-shaped tool
+    carries its real targets inside an array argument (e.g.
+    ``{"operations": [{"mode": "Line", "path": …}]}``), so an extraction that
+    read only the top-level keys never surfaced those paths to the
+    sensitive-path keystone — the call was then evaluated as having no target
+    at all and could auto-approve a read the flat spelling of the same path
+    would have denied. The walk is ITERATIVE and EXHAUSTIVE — there is no depth
+    bound that a sufficiently nested path could hide beyond, and no
+    ``RecursionError`` can escape into the gate — visits every dict/list value,
+    collects strings under ``TARGET_PATH_KEYS`` wherever they appear (including
+    a list of strings directly under such a key), and stays extract-only: no
+    sensitivity decision is made here, order of first appearance is preserved,
+    and duplicates collapse (set-backed, so collection is linear). The only
+    limits are the ``_TARGET_PATH_MAX_PATHS`` / ``_TARGET_PATH_MAX_NODES``
+    work caps, and those fail CLOSED: the result is marked ``truncated`` and
+    the gate denies the call as unverifiable rather than trusting a partial
+    scan. Over-extraction is the safe direction, since callers deny on ANY hit
+    and the consent prompt merely discloses more.
     """
+    found = TargetPaths()
     if not isinstance(raw_params, Mapping):
-        return []
-    found: list[str] = []
-    for key in TARGET_PATH_KEYS:
-        value = raw_params.get(key)
-        if isinstance(value, str) and value.strip() and value not in found:
-            found.append(value)
+        return found
+    seen: set[str] = set()
+    nodes = 0
+    # Explicit LIFO stack, entries pushed in reverse so traversal matches
+    # document order: at each mapping the accepted spellings are collected in
+    # ``TARGET_PATH_KEYS`` order first (preserving the flat extraction's
+    # historical ordering), then every value is walked in insertion order.
+    stack: list[object] = [raw_params]
+    while stack:
+        if len(found) >= _TARGET_PATH_MAX_PATHS or nodes >= _TARGET_PATH_MAX_NODES:
+            found.truncated = True
+            return found
+        node = stack.pop()
+        nodes += 1
+        if isinstance(node, Mapping):
+            for key in TARGET_PATH_KEYS:
+                _collect_path_strings(node.get(key), found, seen)
+            stack.extend(reversed(list(node.values())))
+        elif isinstance(node, (list, tuple)):
+            stack.extend(reversed(node))
     return found
+
+
+def _collect_path_strings(value: object, found: TargetPaths, seen: set[str]) -> None:
+    """Collect *value* (or its items, for a sequence) as candidate paths.
+
+    Handles a string or an arbitrarily nested list/tuple of strings directly
+    under an accepted key, iteratively. Non-string leaves are ignored — the
+    generic walk in ``target_paths`` still descends into any mappings inside.
+    """
+    pending: list[object] = [value]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, str):
+            if item.strip() and item not in seen:
+                if len(found) >= _TARGET_PATH_MAX_PATHS:
+                    found.truncated = True
+                    return
+                seen.add(item)
+                found.append(item)
+        elif isinstance(item, (list, tuple)):
+            pending.extend(reversed(item))
 
 
 # The SCOPE-bearing arguments of a file search as ``(canonical, accepted spellings)``,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6687,6 +6687,32 @@ class TestChatPermissionRequest:
         assert "/home/tester/thesis.md" in capsys.readouterr().out
 
     @pytest.mark.asyncio
+    async def test_a_multi_target_call_discloses_the_count(self, monkeypatch, capsys):
+        # Now that extraction is nesting-aware, a batch call yields every target,
+        # and showing only the first would have the human consent to one file
+        # while approving the whole batch. The first path plus a count keeps the
+        # prompt honest without turning it into a manifest.
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(
+                title="Read the notes",
+                tool_name="read",
+                raw_params={
+                    "operations": [
+                        {"mode": "Line", "path": "/home/tester/thesis.md"},
+                        {"mode": "Line", "path": "/home/tester/notes.md"},
+                        {"mode": "Line", "path": "/home/tester/refs.md"},
+                    ]
+                },
+            ),
+            answer="a",
+        )
+        assert provider.calls == [("approve", 7, False)]
+        out = capsys.readouterr().out
+        assert "/home/tester/thesis.md" in out
+        assert "(+2 more)" in out
+
+    @pytest.mark.asyncio
     async def test_a_pathless_call_is_still_asked_about(self, monkeypatch):
         # Absence of a path is NOT a refusal. Most builtin calls legitimately act
         # on no file, so denying whenever a path cannot be found would refuse

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -1804,3 +1804,140 @@ class TestTargetPathSpellings:
         assert target_paths({"path": {"nested": 1}, "filePath": "   "}) == []
         assert target_paths(None) == []
         assert target_paths({"path": "/a", "file_path": "/a"}) == ["/a"], "deduped"
+
+
+class TestTargetPathNestedExtraction:
+    """``target_paths`` read only the TOP-LEVEL ``TARGET_PATH_KEYS`` string
+    values, so a tool that nests its path inside an array argument — the batch
+    read shape ``{"operations": [{"mode": "Line", "path": …}]}`` — yielded ``[]``
+    and the sensitive-path keystone in ``on_tool_call`` never saw the target.
+    Worse than a missed deny: a read-kind call with the nested spelling was
+    AUTO-APPROVED while the flat spelling of the same path is denied (#6543).
+
+    The fix recurses into dict/list values (depth-bounded) and stays
+    extract-only; ``cli_chat``'s consent prompt shares the helper, so the
+    disclosure and the gate widen together.
+    """
+
+    @staticmethod
+    def _gate():
+        from kiro_crew.hooks import HookManager, HooksConfig
+
+        return HookManager(HooksConfig.from_dict({}))
+
+    def test_a_sensitive_path_nested_in_an_array_argument_is_denied(self):
+        """The reported fence miss, end to end through the gate."""
+        from kiro_crew.hooks import TOOL_DENY
+
+        decision = self._gate().on_tool_call(
+            "Read the notes",
+            session_key="cli_chat",
+            tool_kind="read",
+            raw_params={"operations": [{"mode": "Line", "path": "~/.ssh/id_rsa"}]},
+        )
+        assert decision.action == TOOL_DENY, (
+            "a sensitive path nested in an array argument reached no check; "
+            "the call would be auto-approved"
+        )
+
+    def test_single_op_array_extraction(self):
+        from kiro_crew.hooks import target_paths
+
+        params = {"operations": [{"mode": "Line", "path": "~/.ssh/id_rsa"}]}
+        assert target_paths(params) == ["~/.ssh/id_rsa"]
+
+    def test_two_op_array_extraction_preserves_order_and_dedups(self):
+        from kiro_crew.hooks import target_paths
+
+        params = {
+            "operations": [
+                {"mode": "Line", "path": "/tmp/a.txt"},
+                {"mode": "Line", "file_path": "~/.aws/credentials"},
+                {"mode": "Line", "path": "/tmp/a.txt"},
+            ]
+        }
+        assert target_paths(params) == ["/tmp/a.txt", "~/.aws/credentials"]
+
+    def test_negative_control_pattern_only_yields_nothing(self):
+        """A search-shaped call with no path key emits no candidates — the
+        widening must not start inventing targets from unrelated arguments."""
+        from kiro_crew.hooks import target_paths
+
+        assert target_paths({"pattern": "x"}) == []
+        assert target_paths({"operations": [{"mode": "Directory", "depth": 2}]}) == []
+
+    def test_list_of_strings_directly_under_a_path_key_is_collected(self):
+        from kiro_crew.hooks import target_paths
+
+        assert target_paths({"path": ["/tmp/a", "~/.ssh/id_rsa"]}) == [
+            "/tmp/a",
+            "~/.ssh/id_rsa",
+        ]
+
+    def test_an_ordinary_nested_path_is_still_allowed(self):
+        """The absence direction: recursing must not start denying ordinary
+        batch reads, or the gate would refuse most real multi-file calls."""
+        from kiro_crew.hooks import TOOL_DENY
+
+        decision = self._gate().on_tool_call(
+            "Read the notes",
+            session_key="cli_chat",
+            tool_kind="read",
+            raw_params={"operations": [{"mode": "Line", "path": "/tmp/notes.md"}]},
+        )
+        assert decision.action != TOOL_DENY, "ordinary nested path wrongly denied"
+
+    def test_a_deeply_nested_path_is_still_found_without_raising(self):
+        """The walk is iterative and exhaustive: depth alone cannot hide a
+        path (no RecursionError, no fail-open depth bound)."""
+        from kiro_crew.hooks import target_paths
+
+        deep: dict = {"path": "~/.ssh/id_rsa"}
+        for _ in range(1000):
+            deep = {"wrapper": [deep]}
+        result = target_paths(deep)
+        assert result == ["~/.ssh/id_rsa"]
+        assert result.truncated is False
+
+    def test_work_cap_fails_closed_as_truncated_and_the_gate_denies(self):
+        """An attacker-shaped payload that exhausts the work caps must mark the
+        result truncated, and the gate must DENY the unverifiable call rather
+        than trust a partial scan — deny-by-default, never silent fail-open."""
+        from kiro_crew.hooks import (
+            _TARGET_PATH_MAX_PATHS,
+            TOOL_DENY,
+            target_paths,
+        )
+
+        # Path-count cap: more distinct candidates than the cap.
+        flood = {"path": [f"/n/a/{i}" for i in range(_TARGET_PATH_MAX_PATHS + 10)]}
+        result = target_paths(flood)
+        assert result.truncated is True
+        assert len(result) == _TARGET_PATH_MAX_PATHS
+
+        # Node-budget cap: a huge container structure with no paths at all is
+        # still unverifiable — the walk stopped before proving absence.
+        wide: dict = {"blobs": [{"x": i} for i in range(20_000)]}
+        assert target_paths(wide).truncated is True
+
+        decision = self._gate().on_tool_call(
+            "Read the notes",
+            session_key="cli_chat",
+            tool_kind="read",
+            raw_params=flood,
+        )
+        assert decision.action == TOOL_DENY, (
+            "a truncated (unverifiable) argument scan must deny, or the cap "
+            "becomes a bypass: park a sensitive path beyond it"
+        )
+
+    def test_ordinary_calls_are_nowhere_near_the_work_caps(self):
+        """The caps must not start refusing real batch reads."""
+        from kiro_crew.hooks import target_paths
+
+        params = {
+            "operations": [{"mode": "Line", "path": f"/tmp/f{i}.txt"} for i in range(40)]
+        }
+        result = target_paths(params)
+        assert len(result) == 40
+        assert result.truncated is False


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

The tool-tier sensitive-path fence misses a path nested in an array argument. `target_paths()` in `src/kiro_crew/hooks.py` reads only the TOP-LEVEL `TARGET_PATH_KEYS` string values (`path` / `file_path` / `filePath`), so a tool that nests its target inside an array argument -- the batch read shape `{"operations": [{"mode": "Line", "path": "<a credential path>"}]}` -- yields `[]`. The sensitive-path keystone in `on_tool_call` then never sees the target, and (verified on main `2df4f2d9f`) a read-kind call with the nested spelling is AUTO-APPROVED, while the flat spelling of the same path is denied.

## Why it matters

This is the always-on keystone the security model leans on: it is what stops an agent from reading credential paths and from rewriting its own governance trust roots even when the display title hides the target. A prompt-injected agent using a batch-shaped tool call could read a credential file with zero human involvement -- not just "the human was asked when they should not have been", but silent auto-approval.

## What changed (motivation -> approach -> change)

Symptom: nested path yields `[]` -> root cause: extraction is flat while real tool schemas nest their targets -> change: make extraction structural.

- `target_paths()` now walks dict/list values ITERATIVELY and EXHAUSTIVELY, collecting strings under `TARGET_PATH_KEYS` wherever they appear (including a list of strings directly under a path key). Iterative means no `RecursionError` can escape into the gate; exhaustive means there is no depth bound a sufficiently nested path could hide beyond.
- The extractor stays extract-only: no sensitivity decision, order of first appearance preserved (the flat extraction's `TARGET_PATH_KEYS`-order at each mapping is kept), duplicates collapse via a companion set (linear, not quadratic).
- Two work caps bound the synchronous event-loop cost of an attacker-shaped payload (256 distinct paths / 10k container nodes). The caps fail CLOSED: exceeding either marks the returned `TargetPaths` (a list subclass, so every existing consumer is unchanged) as `truncated`, and `on_tool_call` DENIES the call as unverifiable -- the same deny-by-default shape as the unrecoverable-shell-command branch. A partial scan is never trusted as a full one. Both pre-push review lanes (gpt-5.6-sol and claude-opus-5) independently required exactly this: a silent depth/size bound would have relocated the reported bug behind a nesting/volume requirement, and unbounded exhaustive work on the event loop would have violated the no-blocking-call rule.
- `cli_chat`'s consent prompt shares the helper; now that a batch yields every target, showing only `found[0]` would have the human consent to one file while approving a batch, so a multi-target call shows the first path plus a `(+N more)` count.

Deviation from the dispatch spec, stated openly: the spec said "do not change on_tool_call", but deny-on-truncation requires the keystone block to consult the truncation flag. The touch is minimal (the extraction loop gains one guard) and strictly strengthening; both review lanes prescribed it.

Deliberately NOT in this PR: the governance plane's `_tool_arg_paths` (`platform/governance.py`) is a separate flat extractor of the same three keys and still does not see nested paths, so an operator `filesystem.read` ceiling does not bind on a nested-path call. That is a pre-existing gap on main in a different plane, filed as a follow-up issue rather than folded in.

## Tests

New `TestTargetPathNestedExtraction` in `test/test_hooks.py` (mutation-verified: the core cases fail on base):

- the reported fence miss end-to-end: a sensitive path nested in an array argument is DENIED through `on_tool_call` (read kind, so the deny proves the keystone, not the config-write gate)
- single-op and two-op array extraction, order preserved and deduped
- negative controls: `{"pattern": "x"}` and a pathless operations array yield nothing (widening must not invent targets)
- a list of strings directly under a path key is collected
- an ordinary nested path is still allowed (absence direction)
- a 1000-level-deep path is still FOUND without raising (no fail-open depth bound)
- work-cap behavior: a path-count flood and a node-count flood both come back `truncated`, and the gate DENIES the truncated call
- ordinary 40-op batches are nowhere near the caps

New in `test/test_cli.py`: a multi-target call's consent prompt shows the first path plus `(+2 more)`.

Gates: isort, flake8 clean on all touched files; `scripts/check_black_formatting.py` passed (4 files in scope); mypy shows only 2 pre-existing errors in `transcribe.py` (identical on pristine main, A/B-verified). Full backend pytest: 68044 passed; 122 failed + 2 errors, all in files disjoint from this diff except 2 `TestDenialNoticeEncoding` cp950 cases in `test_cli.py` that fail byte-identically on pristine `origin/main` in this environment (A/B-verified via a detached worktree).

## Manual verification

Probe on base vs fix: on main, `target_paths({"operations": [{"mode": "Line", "path": "<ssh key path>"}]})` returns `[]` and `on_tool_call` returns `auto_approve`; with this change it returns the path and the call is denied, while the flat spelling behaves identically before and after.

## Related Issues

Closes #6543

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A: no doc documents the extraction depth; behavior contract lives in the helper's docstring, updated in the same commit
- [x] No secrets, credentials, or internal references in the diff
