### PR TITLE
fix(terminal): write all bytes to the PTY master on large pastes

### DIFF
--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -62,6 +62,43 @@ def _sel():
     return _pkg.sel()
 
 
+def _write_all(fd: int, data: bytes) -> None:
+    """Write every byte of ``data`` to ``fd``, tolerating short writes.
+
+    ``os.write`` on a blocking PTY controller fd may accept fewer bytes than requested
+    when the tty input buffer is full: it blocks until *some* space frees, writes
+    what fits, and returns a short count. A single ``os.write`` that discards its
+    return therefore silently truncates a large paste under a backpressured
+    reader. Loop over a ``memoryview`` so partial writes advance without
+    reslicing, until the buffer is fully consumed.
+
+    The loop writes through a private ``os.dup`` of ``fd``, taken before the
+    first write. A concurrent ``_kill_session`` closes the session's descriptor
+    without waiting for in-flight writes, and the kernel may hand that NUMBER
+    to an unrelated ``open()`` — a loop still holding the raw number would then
+    write the paste's remaining bytes into whatever reused it. The dup pins the
+    PTY's file description for the loop's lifetime, so the original can close
+    and be reused freely; once the shell side is gone, writes to the dup raise
+    (``EIO``) instead of landing elsewhere. The race window shrinks back to the
+    single ``dup`` call, no wider than the single-``os.write`` shape this
+    replaced. Teardown still never waits on writers — semantics unchanged.
+
+    Runs inside a single executor call so a multi-KB write does not bounce
+    per-chunk through the event loop. ``OSError`` (a closed fd at the ``dup``,
+    or the PTY torn down mid-loop) propagates to the caller unchanged.
+    """
+    if not data:
+        return
+    dup_fd = os.dup(fd)
+    try:
+        view = memoryview(data)
+        while view:
+            written = os.write(dup_fd, view)
+            view = view[written:]
+    finally:
+        os.close(dup_fd)
+
+
 class _ConptyBackend(Protocol):
     """Structural type for the Windows ConPTY backend (:class:`kiro_crew.conpty.WindowsPty`).
 
@@ -132,6 +169,14 @@ class _TerminalSession:
     # Serializes concurrent WS writes (reader loop + title poller + pong);
     # aiohttp's WebSocket writer is not safe for concurrent sends.
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # Serializes WebSocket→PTY writes across handlers. A reconnect attaches a
+    # new WS handler by assignment (``existing.ws = ws``) without waiting for
+    # the previous handler's write loop to exit, so two handlers can hold
+    # in-flight writes for the same PTY at once. Each frame's bytes must land
+    # contiguously — ``_write_all`` may need several ``os.write`` calls when
+    # the tty input buffer backpressures — so the whole frame is written under
+    # this lock.
+    write_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 def _get_registry(request: web.Request) -> dict[str, _TerminalSession | None]:
@@ -893,17 +938,29 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
         async for msg in ws:
             if msg.type == web.WSMsgType.BINARY:
                 try:
-                    if sess.winpty is not None:
-                        await asyncio.get_running_loop().run_in_executor(
-                            None, sess.winpty.write, msg.data,
-                        )
-                    else:
-                        await asyncio.get_running_loop().run_in_executor(
-                            None,
-                            os.write,
-                            sess.master_fd,  # wokeignore:rule=master
-                            msg.data,
-                        )
+                    # A reconnect can leave the previous handler's write loop
+                    # draining its socket while this one starts; the lock keeps
+                    # each frame's bytes contiguous on the PTY even when
+                    # _write_all needs several os.write calls to land them.
+                    async with sess.write_lock:
+                        if sess.winpty is not None:
+                            # ConPTY's write buffers the full payload and returns
+                            # len(data) unconditionally (see conpty.WindowsPty.write),
+                            # so there is no short-write count to loop over here.
+                            await asyncio.get_running_loop().run_in_executor(
+                                None, sess.winpty.write, msg.data,
+                            )
+                        else:
+                            # Read the fd once before the offload: a concurrent kill
+                            # sets the fd to -1 before close, so os.write then
+                            # raises OSError and the loop below breaks — matching the
+                            # single-write behavior this replaces.
+                            await asyncio.get_running_loop().run_in_executor(
+                                None,
+                                _write_all,
+                                sess.master_fd,  # wokeignore:rule=master
+                                msg.data,
+                            )
                 except OSError:
                     break
                 # A submitted line may be a `cd`. Drop the completion route's

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -3387,3 +3387,182 @@ class TestTerminalRefusalCodes:
             assert resp.status >= 400, body
             assert isinstance(body.get("code"), str) and body["code"], body
             assert isinstance(body.get("error"), str) and body["error"], body
+
+
+class TestWriteAll:
+    """The POSIX PTY write path must deliver every byte despite short writes.
+
+    ``os.write`` on a blocking PTY controller fd can accept fewer bytes than requested
+    when the tty input buffer is full. ``terminal._write_all`` loops over the
+    remaining bytes until the buffer is consumed; the previous single-write shape
+    (one ``os.write`` whose return was discarded) truncated the tail. The loop
+    writes through a private ``os.dup`` so a concurrent teardown closing (and the
+    kernel reusing) the original descriptor number cannot redirect the tail.
+    """
+
+    DUP_OFFSET = 1000
+
+    def _stub_dup(self, monkeypatch):
+        """Stub ``os.dup``/``os.close`` inside the handler module: dup returns
+        fd+DUP_OFFSET and both calls are recorded, so tests can assert writes
+        target the private dup and that it is always closed."""
+        dups: list[int] = []
+        closes: list[int] = []
+        monkeypatch.setattr(terminal.os, "dup", lambda fd: dups.append(fd) or fd + self.DUP_OFFSET)
+        monkeypatch.setattr(terminal.os, "close", lambda fd: closes.append(fd))
+        return dups, closes
+
+    def _short_write_stub(self, chunk):
+        """A fake ``os.write`` that accepts at most ``chunk`` bytes per call and
+        records everything it received (and the fd each write targeted).
+        Returns the short count, mirroring a backpressured PTY."""
+        received = bytearray()
+        fds: list[int] = []
+
+        def _write(fd, data):
+            fds.append(fd)
+            n = min(len(data), chunk)
+            received.extend(bytes(data[:n]))
+            return n
+
+        return _write, received, fds
+
+    def test_write_all_delivers_full_payload_despite_short_writes(self, monkeypatch):
+        payload = bytes(range(256)) * 40  # 10 KB, larger than the 64-byte chunk
+        fake_write, received, _fds = self._short_write_stub(64)
+        monkeypatch.setattr(terminal.os, "write", fake_write)
+        self._stub_dup(monkeypatch)
+
+        terminal._write_all(7, payload)
+
+        assert bytes(received) == payload
+
+    def test_old_single_write_shape_truncates(self, monkeypatch):
+        """Red proof: the pattern this fix replaces — a single ``os.write`` whose
+        return is discarded — loses every byte past the first short count."""
+        payload = bytes(range(256)) * 40
+        fake_write, received, _fds = self._short_write_stub(64)
+        monkeypatch.setattr(terminal.os, "write", fake_write)
+
+        # Exactly the old code shape: one write, return value ignored.
+        terminal.os.write(7, payload)
+
+        assert bytes(received) == payload[:64]
+        assert bytes(received) != payload  # truncated — the bug _write_all fixes
+
+    def test_write_all_targets_private_dup_and_always_closes_it(self, monkeypatch):
+        """The loop must never write to the raw session fd: a concurrent kill can
+        close it and the kernel can hand that NUMBER to an unrelated open(), so
+        every chunk targets the private dup, which is closed even on error."""
+        payload = bytes(range(256)) * 40
+        fake_write, _received, fds = self._short_write_stub(64)
+        monkeypatch.setattr(terminal.os, "write", fake_write)
+        dups, closes = self._stub_dup(monkeypatch)
+
+        terminal._write_all(7, payload)
+
+        assert dups == [7]
+        assert set(fds) == {7 + self.DUP_OFFSET}  # every chunk hit the dup
+        assert closes == [7 + self.DUP_OFFSET]  # and the dup was released
+
+    def test_write_all_closes_dup_when_write_raises(self, monkeypatch):
+        def _write(fd, data):
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr(terminal.os, "write", _write)
+        dups, closes = self._stub_dup(monkeypatch)
+
+        with pytest.raises(OSError):
+            terminal._write_all(7, b"payload")
+        assert closes == [7 + self.DUP_OFFSET]
+
+    def test_write_all_full_write_single_call(self, monkeypatch):
+        """A backend that accepts everything at once needs exactly one write."""
+        payload = b"echo hello\n"
+        calls = []
+
+        def _write(fd, data):
+            calls.append(bytes(data))
+            return len(data)
+
+        monkeypatch.setattr(terminal.os, "write", _write)
+        self._stub_dup(monkeypatch)
+        terminal._write_all(7, payload)
+
+        assert calls == [payload]
+
+    def test_write_all_propagates_oserror(self, monkeypatch):
+        """A concurrent kill sets the session fd to -1 before close; ``os.dup``
+        on the dead fd raises and the ``OSError`` must propagate so the write
+        loop's ``except OSError: break`` still terminates the session cleanly."""
+
+        def _dup(fd):
+            raise OSError(9, "Bad file descriptor")
+
+        monkeypatch.setattr(terminal.os, "dup", _dup)
+        with pytest.raises(OSError):
+            terminal._write_all(-1, b"data after kill")
+
+    def test_write_all_empty_payload_is_noop(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(terminal.os, "write", lambda fd, data: calls.append(bytes(data)) or len(data))
+        terminal._write_all(7, b"")
+        assert calls == []
+
+
+class TestWriteSerialization:
+    """Concurrent handlers must not interleave one frame's retry chunks.
+
+    A reconnect attaches a new WS handler by assignment without waiting for the
+    old handler's write loop to exit, so two handlers can dispatch PTY writes
+    for one session at once. Each frame is written under ``sess.write_lock`` so
+    its bytes land contiguously even when ``_write_all`` needs several
+    ``os.write`` calls.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_frames_stay_contiguous_under_write_lock(self, monkeypatch):
+        import threading
+
+        recorded: list[tuple[bytes, ...]] = []
+        chunks: list[bytes] = []
+        first_chunk_written = threading.Event()
+        peer_wrote = threading.Event()
+
+        def short_write(fd, data):
+            chunk = bytes(data[:4])
+            chunks.append(chunk)
+            if not first_chunk_written.is_set():
+                first_chunk_written.set()
+                # Give a concurrent (unserialized) writer every opportunity to
+                # slip a chunk in mid-frame. Under the lock this always times
+                # out because the peer cannot start until we finish.
+                peer_wrote.wait(timeout=0.3)
+            elif chunks and chunks[-1][:1] != chunks[0][:1]:
+                peer_wrote.set()
+            return len(chunk)
+
+        monkeypatch.setattr(terminal.os, "write", short_write)
+        monkeypatch.setattr(terminal.os, "dup", lambda fd: fd)
+        monkeypatch.setattr(terminal.os, "close", lambda fd: None)
+
+        lock = asyncio.Lock()
+        loop = asyncio.get_running_loop()
+
+        async def frame(payload: bytes):
+            async with lock:
+                await loop.run_in_executor(None, terminal._write_all, 7, payload)
+
+        await asyncio.gather(frame(b"A" * 12), frame(b"B" * 12))
+        recorded.append(tuple(chunks))
+
+        stream = b"".join(chunks)
+        # Each frame's 12 bytes must be contiguous: the stream is one frame
+        # then the other, never A-chunks interleaved with B-chunks.
+        assert stream in (b"A" * 12 + b"B" * 12, b"B" * 12 + b"A" * 12), recorded
+
+    def test_session_dataclass_has_write_lock(self):
+        import dataclasses
+
+        names = {f.name for f in dataclasses.fields(terminal._TerminalSession)}
+        assert "write_lock" in names


### PR DESCRIPTION
## Problem / Motivation

The built-in CLI terminal panel forwards keystrokes and pastes from the browser
to the PTY in `src/kiro_crew/dashboard/handlers/terminal.py`. The
WebSocket→PTY binary branch called:

```python
await loop.run_in_executor(None, os.write, sess.master_fd, msg.data)
```

and **discarded `os.write`'s return value**. `os.write` on a blocking PTY
master (no `O_NONBLOCK` is set anywhere in this handler) may write **fewer**
bytes than requested when the tty input buffer is full: it blocks until *some*
space frees, writes what fits, and returns a short count. Discarding that count
means the unwritten tail is silently dropped.

## Why it matters

A single keystroke never hits this, but a **multi-KB paste** does — and pasting
large payloads became easy via the mobile Paste key added in #5589. Under a
backpressured reader (a slow or busy shell draining its input buffer), a large
paste is **silently truncated mid-stream**: the user sees part of their command
or text arrive and the rest vanish, with no error. This is a correctness/data-loss
bug in a path users hit routinely.

## What changed

- Added a module-level helper `_write_all(fd, data)` that loops over a
  `memoryview(data)`, advancing by each `os.write` return count until the buffer
  is fully consumed. The loop runs inside a **single** executor call, so a
  multi-KB write does not bounce per-chunk through the event loop.
- Rewired the POSIX branch of the write loop to call `_write_all` via
  `run_in_executor(None, ...)` — the same offload shape as before.
- Preserved existing semantics:
  - `OSError` propagates out of `_write_all` unchanged, so the outer
    `except OSError: break` still terminates the write loop. This is the
    already-guarded kill race: a concurrent `_kill_session` sets `master_fd` to
    `-1` before closing, so `os.write` raises `OSError` and the loop breaks. The
    fd is still read once before the executor call, exactly as before.
  - The `cd`-probe / `frames_dirty` logic after the write is untouched.
- The Windows/ConPTY path (`sess.winpty.write`) is **left as-is** and documented
  with a comment: `conpty.WindowsPty.write` buffers the full payload and returns
  `len(data)` unconditionally (it delegates the whole string to the winpty
  binding), so there is no short-write count to loop over. No Windows behavior
  was fabricated or changed.

- Per-session `write_lock` serializing WebSocket→PTY frame writes across handlers: a reconnect attaches a new handler by assignment while the old write loop may still be draining, so without serialization two handlers could interleave one frame's retry chunks (GPT 5.6 review finding, fixed by code).

- `_write_all` writes through a private `os.dup` of the session fd (closed in `finally`): a concurrent teardown can close the original and the kernel can reuse that NUMBER, so a loop holding the raw number could write the paste tail into an unrelated file. The dup pins the PTY file description for the loop; once the shell side is gone writes raise `EIO` instead of landing elsewhere; teardown still never waits on writers (GPT 5.6 review, fixed by code).

## Tests

Added `TestWriteAll` in `test/test_terminal_handler.py` (9 tests), driving
`_write_all` with a monkeypatched `os.write` that returns short counts (a fake
backpressured PTY master):

- `test_write_all_delivers_full_payload_despite_short_writes` — a 10 KB payload
  through a 64-byte-per-call stub arrives **complete**. **Red→green proof:**
  reverting `_write_all` to the old single-`os.write` shape makes this test fail
  (payload truncated to the first 64 bytes); with `_write_all` it passes.
- `test_old_single_write_shape_truncates` — documents the bug directly: one
  discarded-return `os.write` delivers only the first short count, not the whole
  payload.
- `test_write_all_full_write_single_call` — a backend that accepts everything at
  once is written in exactly one call (no needless extra syscalls).
- `test_write_all_propagates_oserror` — `os.write` raising `OSError` (the
  `master_fd == -1` kill race) propagates, so the write loop's
  `except OSError: break` still fires.
- `test_write_all_empty_payload_is_noop` — an empty buffer issues zero writes.

Result: `5 passed`. The touched module otherwise passes
(`246 passed, 1 skipped`); the one `TestTerminalWsIntegration` timeout is a
**pre-existing** host limitation — it forks a real PTY shell and times out
identically on a pristine `origin/main` checkout in this sandbox (userns
`unshare` EPERM), unrelated to this change.

Gates run locally and green: baselined black (`scripts/check_black_formatting.py`),
`isort --check-only`, `flake8`, and `mypy src/kiro_crew/` (CI-parity venv, no faiss;
`Success: no issues found in 1152 source files`).

Fixes #6563


