### PR TITLE
fix(doctor): gate spec-check on platform predicate (#6548)

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -561,7 +561,17 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
             if name not in _OPT_IN_MCPS:
                 issues.append(f"{ref} config")
             continue
-        if ref not in tools and name not in _OPT_IN_MCPS and name not in gated_off:
+        if name in gated_off:
+            # A gated-off server that still has an mcpServers entry is a stale
+            # leftover (e.g. config copied from a macOS host, or the platform
+            # changed). The driver is unavailable so probing would fail or time
+            # out. Print informational and skip — do not auto-mount, do not warn
+            # about missing tools ref, and do not probe.
+            print(
+                f"  {ref}: ℹ️  spec gate closed — stale entry can be removed"
+            )
+            continue
+        if ref not in tools and name not in _OPT_IN_MCPS:
             # Mounting an opt-in server IS granting it: the `@` ref is what makes
             # kiro-cli load it. Doctor repairs a broken always-on mount, but it
             # must never hand an agent a set the user did not assign.

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -27,7 +27,7 @@ from kiro_crew.acp.kas_transport import (
     build_kas_argv,
 )
 from kiro_crew.acp.types import ACP_BACKEND_KAS
-from kiro_crew.agent import AGENT_FILENAME
+from kiro_crew.agent import AGENT_FILENAME, _gated_off_servers
 from kiro_crew.agent_discovery import (
     _read_agent_spec,
     project_agent_files,
@@ -525,9 +525,15 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
     config_changed = False
 
     probe_targets = []
+    gated_off = _gated_off_servers()
     for name in _MANAGED_MCPS:
         ref = f"@{name}"
         if name not in mcps:
+            # A server whose spec gate is closed on this platform is legitimately
+            # absent — the installer never writes it. Report informational only.
+            if name in gated_off:
+                print(f"  {ref}: \u2139\ufe0f  spec gate closed (not supported on this platform)")
+                continue
             # An opt-in set is granted per agent, so its absence from THIS spec is
             # the normal state, not a broken install. Say nothing and probe
             # nothing; the always-on servers below are the ones whose absence
@@ -555,7 +561,7 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
             if name not in _OPT_IN_MCPS:
                 issues.append(f"{ref} config")
             continue
-        if ref not in tools and name not in _OPT_IN_MCPS:
+        if ref not in tools and name not in _OPT_IN_MCPS and name not in gated_off:
             # Mounting an opt-in server IS granting it: the `@` ref is what makes
             # kiro-cli load it. Doctor repairs a broken always-on mount, but it
             # must never hand an agent a set the user did not assign.

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -2222,3 +2222,101 @@ class TestCronHealth:
         self._run(monkeypatch, tmp_path)
 
         assert path.read_bytes() == before, "doctor must not mutate crons.json"
+
+
+class TestMcpToolsSpecGate:
+    """Spec-gate awareness in _doctor_mcp_tools.
+
+    When a managed server's spec_gate is closed (e.g. kirocrew-computer on
+    Linux), its absence from mcpServers is informational, not an error, and
+    it must not be auto-mounted into tools.
+    """
+
+    def _write_agent(self, tmp_path: Path, body: dict) -> Path:
+        agent = tmp_path / "agent.md"
+        agent.write_text(json.dumps(body), encoding="utf-8")
+        return agent
+
+    def test_gated_off_server_missing_from_mcpservers_is_informational(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        """A gated-off always-on server absent from mcpServers prints an
+        informational line and does NOT append to issues."""
+        monkeypatch.setattr(
+            cli_doctor, "_gated_off_servers", lambda: frozenset({"kirocrew-computer"})
+        )
+        monkeypatch.setattr(cli_doctor, "_MANAGED_MCPS", ("kirocrew-computer",))
+        monkeypatch.setattr(cli_doctor, "_OPT_IN_MCPS", ())
+
+        agent_path = self._write_agent(tmp_path, {
+            "tools": [],
+            "allowedTools": [],
+            "mcpServers": {},
+        })
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_tools(agent_path, issues)
+
+        out = capsys.readouterr().out
+        assert "spec gate closed" in out
+        assert issues == []
+
+    def test_non_gated_server_missing_from_mcpservers_reports_error(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        """A non-gated always-on server absent from mcpServers still reports
+        the error and appends to issues (existing behavior preserved)."""
+        monkeypatch.setattr(
+            cli_doctor, "_gated_off_servers", lambda: frozenset()
+        )
+        monkeypatch.setattr(cli_doctor, "_MANAGED_MCPS", ("kirocrew-computer",))
+        monkeypatch.setattr(cli_doctor, "_OPT_IN_MCPS", ())
+
+        agent_path = self._write_agent(tmp_path, {
+            "tools": [],
+            "allowedTools": [],
+            "mcpServers": {},
+        })
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_tools(agent_path, issues)
+
+        out = capsys.readouterr().out
+        assert "missing from mcpServers" in out
+        assert "@kirocrew-computer config" in issues
+
+    def test_gated_off_server_present_in_mcpservers_is_not_auto_mounted(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        """A gated-off server that has an mcpServers entry but no tools ref
+        must NOT be auto-mounted into tools."""
+        monkeypatch.setattr(
+            cli_doctor, "_gated_off_servers", lambda: frozenset({"kirocrew-computer"})
+        )
+        monkeypatch.setattr(cli_doctor, "_MANAGED_MCPS", ("kirocrew-computer",))
+        monkeypatch.setattr(cli_doctor, "_OPT_IN_MCPS", ())
+        monkeypatch.setattr(cli_doctor, "may_skip_gate_now", lambda ref: True)
+        monkeypatch.setattr(cli_doctor, "warm_backend", lambda: None)
+
+        # probe_server is async; provide a coroutine that returns a simple result
+        class _FakeProbeResult:
+            def __init__(self):
+                self.name = "kirocrew-computer"
+                self.status = "ok"
+                self.tools = ["tool1"]
+                self.error = None
+
+        async def _fake_probe(info):
+            return _FakeProbeResult()
+
+        monkeypatch.setattr(cli_doctor, "probe_server", _fake_probe)
+
+        agent_path = self._write_agent(tmp_path, {
+            "tools": [],
+            "allowedTools": [],
+            "mcpServers": {"kirocrew-computer": {"command": "/usr/bin/test", "args": []}},
+        })
+        issues: list[str] = []
+        cli_doctor._doctor_mcp_tools(agent_path, issues)
+
+        # The tools ref should NOT have been added
+        rewritten = json.loads(agent_path.read_text(encoding="utf-8"))
+        assert "@kirocrew-computer" not in rewritten.get("tools", [])

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -2283,31 +2283,25 @@ class TestMcpToolsSpecGate:
         assert "missing from mcpServers" in out
         assert "@kirocrew-computer config" in issues
 
-    def test_gated_off_server_present_in_mcpservers_is_not_auto_mounted(
+    def test_gated_off_server_present_in_mcpservers_is_not_probed(
         self, monkeypatch, tmp_path: Path, capsys
     ) -> None:
         """A gated-off server that has an mcpServers entry but no tools ref
-        must NOT be auto-mounted into tools."""
+        must NOT be auto-mounted into tools, must NOT print the misleading
+        'unreachable' warning, and must NOT be probed."""
         monkeypatch.setattr(
             cli_doctor, "_gated_off_servers", lambda: frozenset({"kirocrew-computer"})
         )
         monkeypatch.setattr(cli_doctor, "_MANAGED_MCPS", ("kirocrew-computer",))
         monkeypatch.setattr(cli_doctor, "_OPT_IN_MCPS", ())
-        monkeypatch.setattr(cli_doctor, "may_skip_gate_now", lambda ref: True)
+
+        # If probe_server is ever called, that means the gated-off server was
+        # not skipped. Blow up loudly so the test fails.
+        async def _probe_must_not_be_called(info):
+            raise AssertionError("probe_server must not be called for a gated-off server")
+
+        monkeypatch.setattr(cli_doctor, "probe_server", _probe_must_not_be_called)
         monkeypatch.setattr(cli_doctor, "warm_backend", lambda: None)
-
-        # probe_server is async; provide a coroutine that returns a simple result
-        class _FakeProbeResult:
-            def __init__(self):
-                self.name = "kirocrew-computer"
-                self.status = "ok"
-                self.tools = ["tool1"]
-                self.error = None
-
-        async def _fake_probe(info):
-            return _FakeProbeResult()
-
-        monkeypatch.setattr(cli_doctor, "probe_server", _fake_probe)
 
         agent_path = self._write_agent(tmp_path, {
             "tools": [],
@@ -2317,6 +2311,14 @@ class TestMcpToolsSpecGate:
         issues: list[str] = []
         cli_doctor._doctor_mcp_tools(agent_path, issues)
 
+        out = capsys.readouterr().out
+        # Should print informational about stale entry
+        assert "spec gate closed" in out
+        assert "stale entry can be removed" in out
+        # Must NOT print the misleading "unreachable" warning
+        assert "unreachable" not in out
         # The tools ref should NOT have been added
         rewritten = json.loads(agent_path.read_text(encoding="utf-8"))
         assert "@kirocrew-computer" not in rewritten.get("tools", [])
+        # No issues appended
+        assert issues == []


### PR DESCRIPTION
## Summary

Fixes #6548 — `kirocrew doctor` reported an unfixable `@kirocrew-computer missing from mcpServers` on non-macOS hosts because the doctor loop did not consult the same `spec_gate` predicate that the installer uses to decide whether to emit the server entry.

## Changes

**`src/kiro_crew/cli_doctor.py`** (+18/-1):
- Import `_gated_off_servers` from `kiro_crew.agent`
- Call `_gated_off_servers()` once before the server iteration loop
- Server absent from mcpServers + gate closed → prints informational message (`ℹ️ spec gate closed`) instead of appending to `issues`
- Server present in mcpServers + gate closed (stale leftover) → prints informational (`ℹ️ spec gate closed — stale entry can be removed`), skips auto-mount, misleading warning, and probe

**`test/test_cli_doctor.py`** (+100):
- New `TestMcpToolsSpecGate` class with 3 tests:
  - Gated-off server missing from mcpServers is informational (not error)
  - Non-gated server missing from mcpServers still reports error (regression guard)
  - Gated-off server with stale mcpServers entry is not probed, not auto-mounted

## Testing
- Both files pass Python syntax validation
- Tests could not be run in this environment (INTEGRATIONS_ONLY network, missing deps)
- Manual review confirms semantic correctness

## Non-blocking note
A stale `allowedTools` grant for a gated-off server is not revoked by the early `continue`. This is inert (kiro-cli cannot spawn the server) but creates a minor inconsistency with other grant writers. Could be addressed in a follow-up.