### PR TITLE
fix: release pdf page caches during extraction

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -150,7 +150,10 @@ It includes markdown/plain-text (`.md`/`.txt`/`.org`), source-code extensions, a
 **`.pptx` is intentionally out of `SUPPORTED`** even though `_read_pptx` exists: python-pptx is not declared in `setup.cfg`, so the format is kept off the allowlist (the comment at `readers.py` documents this). Reachable only if `.pptx` were re-added to `SUPPORTED`.
 
 **Binary/optional-dep readers** degrade gracefully — a missing optional import returns an `{'format': 'error'}` meta with an install hint rather than raising:
-- `_read_pdf` — pdfplumber; concatenates per-page `extract_text()`, records `page_count`.
+- `_read_pdf` — pdfplumber; concatenates per-page `extract_text()`, records `page_count`,
+  and releases each page immediately after extraction so its parsed-layout cache does not
+  remain resident until the whole document closes (`Page.close()` when available, with
+  `flush_cache()` compatibility for pdfplumber 0.10).
 - `_read_docx` — python-docx; converts `Heading N` paragraph styles to `#`-prefixed markdown (`content_type: 'markdown'`), records `paragraph_count`.
 - `_read_html` — html2text when importable (`ignore_images=True`, `ignore_links=False`); otherwise a regex fallback strips `<script>`/`<style>` and tags.
 

--- a/src/kiro_crew/knowledge/readers.py
+++ b/src/kiro_crew/knowledge/readers.py
@@ -132,7 +132,20 @@ class FileReader:
             return _missing_dep('PDF', 'pdfplumber')
         try:
             with pdfplumber.open(path) as pdf:
-                pages = [p.extract_text() or '' for p in pdf.pages]
+                pages: list[str] = []
+                for page in pdf.pages:
+                    try:
+                        pages.append(page.extract_text() or '')
+                    finally:
+                        # pdfplumber caches the parsed layout on each Page. Release
+                        # it before parsing the next page so large PDFs do not keep
+                        # every page's layout resident until the document closes.
+                        # Page.close() also clears the text-map cache when available;
+                        # pdfplumber 0.10 only exposes flush_cache().
+                        close_page = getattr(page, 'close', None)
+                        if close_page is None:
+                            close_page = page.flush_cache
+                        close_page()
                 return '\n'.join(pages), {'format': 'pdf', 'page_count': len(pages)}
         except Exception as e:
             return _read_error(e)

--- a/test/test_knowledge.py
+++ b/test/test_knowledge.py
@@ -435,6 +435,74 @@ class TestFileReaderPdf:
         assert meta["format"] == "pdf"
         assert meta["page_count"] == 1
 
+    def test_read_pdf_releases_each_page_cache(self, monkeypatch):
+        events = []
+
+        class FakePage:
+            def __init__(self, number, text=None, error=None):
+                self.number = number
+                self.text = text
+                self.error = error
+
+            def extract_text(self):
+                events.append(("extract", self.number))
+                if self.error is not None:
+                    raise self.error
+                return self.text
+
+            def close(self):
+                events.append(("close", self.number))
+
+        class FakePdf:
+            def __init__(self, pages):
+                self.pages = pages
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        class FakeLegacyPage:
+            def extract_text(self):
+                events.append(("extract", 4))
+                return "legacy"
+
+            def flush_cache(self):
+                events.append(("flush", 4))
+
+        first_pages = [FakePage(1, "first"), FakePage(2, "second")]
+        failing_pages = [FakePage(3, error=ValueError("bad page"))]
+        legacy_pages = [FakeLegacyPage()]
+        opened = iter((FakePdf(first_pages), FakePdf(failing_pages), FakePdf(legacy_pages)))
+
+        class FakePdfplumber:
+            @staticmethod
+            def open(_path):
+                return next(opened)
+
+        monkeypatch.setattr(readers, "pdfplumber", FakePdfplumber)
+
+        text, meta = FileReader()._read_pdf("ok.pdf")
+        assert text == "first\nsecond"
+        assert meta == {"format": "pdf", "page_count": 2}
+        assert events == [
+            ("extract", 1),
+            ("close", 1),
+            ("extract", 2),
+            ("close", 2),
+        ]
+
+        text, meta = FileReader()._read_pdf("bad.pdf")
+        assert text == "Error reading file: bad page"
+        assert meta == {"format": "error", "error": "bad page"}
+        assert events[-2:] == [("extract", 3), ("close", 3)]
+
+        text, meta = FileReader()._read_pdf("legacy.pdf")
+        assert text == "legacy"
+        assert meta == {"format": "pdf", "page_count": 1}
+        assert events[-2:] == [("extract", 4), ("flush", 4)]
+
     def test_read_pdf_does_not_hit_missing_dep_guard(self, tmp_path):
         # A malformed PDF must surface a real parse error, never the
         # 'PDF support requires pdfplumber' sentinel (which only fires when


### PR DESCRIPTION
## Problem / Motivation

PDF ingestion keeps every parsed page layout resident until the complete document closes.
`pdfplumber` caches layout and text-map data on each `Page`, so peak memory grows with the
number and complexity of pages even after their text has already been extracted.

## Why it matters

Large PDFs can create avoidable memory pressure during knowledge ingestion and make the
gateway more susceptible to process or host out-of-memory failures.

## What changed (motivation → approach → change)

Extract pages in document order and release each page in a `finally` block before moving to
the next one. Prefer `Page.close()` where available because it also clears the text-map
cache, while falling back to `flush_cache()` for the declared `pdfplumber 0.10` minimum.
Text output, page counts, missing-dependency handling, and parse-error behavior remain
unchanged.

## Tests

- Added regression coverage proving each page is released before the next page is parsed.
- Covered cache release when extraction raises and the `pdfplumber 0.10` fallback path.
- `python -m pytest -q -n0 test/test_knowledge.py` — 169 passed.
- Isort, Flake8, MyPy, docs lint, scrub lint, subprocess-encoding, and diff checks passed.

## Manual verification

Verified the cache APIs against both the minimum `pdfplumber 0.10.0` and current
`pdfplumber 0.11.10` releases.

## Related Issues

N/A — no matching open issue found.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template states that OSPO will supply the CLA wording.
