### PR TITLE
test(terminal): name GRADLE_OPTS in the sandboxed probe env allowlist

### DIFF
--- a/test/test_terminal_commands.py
+++ b/test/test_terminal_commands.py
@@ -1129,6 +1129,13 @@ class TestRunProbe:
         # environment is built from nothing instead of filtered down.
         for name in ("GH_TOKEN", "GITHUB_TOKEN", "KUBECONFIG", "NPM_TOKEN"):
             monkeypatch.setenv(name, f"leaked-{name}")
+        # `GRADLE_OPTS` is named in the allowlist below because the sandbox launcher
+        # writes it, so a marker in the parent is what keeps the check honest: naming
+        # the variable alone would let a future filtered-inherit hand the child the
+        # parent's value under an allowed name. The launcher APPENDS to whatever it
+        # finds, so an inherited value survives into the child and trips the
+        # `leaked-` assertion below.
+        monkeypatch.setenv("GRADLE_OPTS", "leaked-GRADLE_OPTS")
         # HOME keeps the `leaked-` marker but must be an ABSOLUTE path: on hosts
         # where the userns sandbox is unavailable the probe child runs unsandboxed
         # and inherits pytest's CWD (the repo root), and the workspace resolver
@@ -1141,12 +1148,20 @@ class TestRunProbe:
         assert out is not None
         assert "leaked-" not in out
         # And the allowlist really is minimal. The extras are not ours: the sandbox
-        # launcher injects its own markers (`KIROCREW_*`, `GIT_SSH_COMMAND`) and the
-        # shell adds `PWD`/`SHLVL`/`_`, so they are named rather than blanket-allowed
-        # — a NEW name appearing here should fail this and be looked at.
+        # launcher injects its own markers (`KIROCREW_*`, `GIT_SSH_COMMAND`,
+        # `GRADLE_OPTS`) and the shell adds `PWD`/`SHLVL`/`_`, so they are named
+        # rather than blanket-allowed — a NEW name appearing here should fail this
+        # and be looked at.
         ours = {"TERM", "NO_COLOR", "PAGER", "GIT_PAGER", "PATH", "LANG", "LC_ALL", "LC_CTYPE"}
+        # `GRADLE_OPTS` carries no inherited value: the launcher's guard appends
+        # `-Dorg.gradle.daemon=false` to whatever the ALLOWLISTED env holds, and the
+        # allowlist never carries it, so the child sees only the flag the launcher
+        # wrote. That the launcher always writes it is pinned from the shipped
+        # launcher source by
+        # test_sandbox_gradle_daemon.py::test_sets_the_flag_when_gradle_opts_is_absent.
         sandbox_injected = {"KIROCREW_HOST_PID", "KIROCREW_SANDBOX_ACTIVE",
-                            "KIROCREW_SANDBOX_LEVEL", "KIROCREW_SPAWNED", "GIT_SSH_COMMAND"}
+                            "KIROCREW_SANDBOX_LEVEL", "KIROCREW_SPAWNED",
+                            "GIT_SSH_COMMAND", "GRADLE_OPTS"}
         shell_added = {"PWD", "SHLVL", "_"}
         # macOS injects __CF_USER_TEXT_ENCODING into every spawned process
         # unconditionally (CoreFoundation per-user encoding preference). This is


### PR DESCRIPTION
## What

`TestRunProbe::test_the_environment_is_an_allowlist_not_a_filtered_inherit` asserts the probe child's environment is a subset of a named allowlist. The namespace launcher writes `GRADLE_OPTS=-Dorg.gradle.daemon=false` into every sandboxed child (added to stop a Gradle daemon outliving the sandbox with the credential paths still masked), and the test never listed that name — so the subset assertion failed with `Extra items in the left set: 'GRADLE_OPTS'`.

## Why it only shows up on the release lane

`ci.yml`'s sharded matrix runs on hosts without unprivileged user namespaces, where the probe falls back to an unsandboxed child and the launcher never runs — so `GRADLE_OPTS` is simply absent and the subset assertion holds. `release.yml` enables the sysctl itself specifically so the sandbox-dependent tests run for real, which is where it surfaces. It blocked the `0.5.0-rc.1` release candidate.

## The fix, and why it is not just a widened allowlist

Naming the variable alone would weaken the assertion: a later filtered-inherit could hand the child the parent's value under a now-allowed name and nothing would notice. So the parent also gets a `leaked-GRADLE_OPTS` marker. The launcher **appends** to whatever it finds, so an inherited value survives into the child and trips the existing `assert "leaked-" not in out`.

That the launcher always writes the variable is pinned independently, from the shipped launcher source rather than a re-implementation, by `test_sandbox_gradle_daemon.py::test_sets_the_flag_when_gradle_opts_is_absent`. And `_probe_env()` builds the environment from nothing, so `GRADLE_OPTS` is never in the child's incoming env — the child sees only the flag the launcher wrote.

## Verification

- `test/test_terminal_commands.py` + `test/test_sandbox_gradle_daemon.py`: 164 passed, 1 skipped.
- Mutation-verified the new marker is not vacuous: adding `GRADLE_OPTS` to `_probe_env()`'s inherited-locale loop makes the test fail on `'leaked-' is contained here: ADLE_OPTS=leaked-GRADLE_OPTS`. Reverted.
- flake8, isort, and the baselined black gate are clean.

This host has no unprivileged userns (`unshare(CLONE_NEWUSER)` → EPERM), so the sandboxed path itself is exercised by CI rather than locally; the failing run's own output confirms `GRADLE_OPTS` was the only extra name.
