### PR TITLE
fix(release): unblock the 0.5.0 release candidate test lane

### DIFF
--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -886,18 +886,35 @@ class TestTrashBatchNamesAreLogSafe:
             def is_dir() -> bool:
                 return True
 
-        manifests: dict[str, tuple[dict[str, object], list[dict[str, object]]] | None] = {
+        # Shaped for `_summarize_manifest` — (header, sessions, staged_bytes) —
+        # because that is the seam `list_trash` reads since #6312. Patching
+        # `_read_manifest` instead lets the real `_summarize_manifest` run, and it
+        # does `batch / MANIFEST_NAME`, which a name-only double cannot support.
+        manifests: dict[str, tuple[dict[str, object], int, int] | None] = {
             "missing": None,
-            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, []),
+            "disagreeing": ({"batch_id": "someone-else", "created_at": _NOW}, 0, 0),
         }
+
+        # Forge ONLY the trash root's own enumeration, via a Path subclass whose
+        # `iterdir` yields the double. Patching `session_storage.Path.iterdir`
+        # (i.e. `pathlib.Path.iterdir`) globally leaks across the xdist worker:
+        # a sibling test in the same process that legitimately iterates a real
+        # directory then reaches the unpatched `_summarize_manifest`, which does
+        # `<_ForgedDir> / MANIFEST_NAME` and raises TypeError (refs #6425).
+        class _ForgedRoot(type(session_storage.trash_root())):
+            def iterdir(self):  # type: ignore[override]
+                return iter([_ForgedDir()])
+
+        forged_root = _ForgedRoot(session_storage.trash_root())
+
         for label, parsed in manifests.items():
             caplog.clear()
-            monkeypatch.setattr(session_storage.Path, "iterdir", lambda self: iter([_ForgedDir()]))
+            monkeypatch.setattr(session_storage, "trash_root", lambda: forged_root)
             monkeypatch.setattr(
                 session_storage.platform_compat, "is_link_or_junction", lambda p: False
             )
             monkeypatch.setattr(
-                session_storage, "_read_manifest", lambda batch, parsed=parsed: parsed
+                session_storage, "_summarize_manifest", lambda batch, parsed=parsed: parsed
             )
 
             with caplog.at_level(logging.DEBUG, logger="kiro_crew.session_storage"):

--- a/test/test_terminal_commands.py
+++ b/test/test_terminal_commands.py
@@ -1129,6 +1129,13 @@ class TestRunProbe:
         # environment is built from nothing instead of filtered down.
         for name in ("GH_TOKEN", "GITHUB_TOKEN", "KUBECONFIG", "NPM_TOKEN"):
             monkeypatch.setenv(name, f"leaked-{name}")
+        # `GRADLE_OPTS` is named in the allowlist below because the sandbox launcher
+        # writes it, so a marker in the parent is what keeps the check honest: naming
+        # the variable alone would let a future filtered-inherit hand the child the
+        # parent's value under an allowed name. The launcher APPENDS to whatever it
+        # finds, so an inherited value survives into the child and trips the
+        # `leaked-` assertion below.
+        monkeypatch.setenv("GRADLE_OPTS", "leaked-GRADLE_OPTS")
         # HOME keeps the `leaked-` marker but must be an ABSOLUTE path: on hosts
         # where the userns sandbox is unavailable the probe child runs unsandboxed
         # and inherits pytest's CWD (the repo root), and the workspace resolver
@@ -1141,12 +1148,20 @@ class TestRunProbe:
         assert out is not None
         assert "leaked-" not in out
         # And the allowlist really is minimal. The extras are not ours: the sandbox
-        # launcher injects its own markers (`KIROCREW_*`, `GIT_SSH_COMMAND`) and the
-        # shell adds `PWD`/`SHLVL`/`_`, so they are named rather than blanket-allowed
-        # — a NEW name appearing here should fail this and be looked at.
+        # launcher injects its own markers (`KIROCREW_*`, `GIT_SSH_COMMAND`,
+        # `GRADLE_OPTS`) and the shell adds `PWD`/`SHLVL`/`_`, so they are named
+        # rather than blanket-allowed — a NEW name appearing here should fail this
+        # and be looked at.
         ours = {"TERM", "NO_COLOR", "PAGER", "GIT_PAGER", "PATH", "LANG", "LC_ALL", "LC_CTYPE"}
+        # `GRADLE_OPTS` carries no inherited value: the launcher's guard appends
+        # `-Dorg.gradle.daemon=false` to whatever the ALLOWLISTED env holds, and the
+        # allowlist never carries it, so the child sees only the flag the launcher
+        # wrote. That the launcher always writes it is pinned from the shipped
+        # launcher source by
+        # test_sandbox_gradle_daemon.py::test_sets_the_flag_when_gradle_opts_is_absent.
         sandbox_injected = {"KIROCREW_HOST_PID", "KIROCREW_SANDBOX_ACTIVE",
-                            "KIROCREW_SANDBOX_LEVEL", "KIROCREW_SPAWNED", "GIT_SSH_COMMAND"}
+                            "KIROCREW_SANDBOX_LEVEL", "KIROCREW_SPAWNED",
+                            "GIT_SSH_COMMAND", "GRADLE_OPTS"}
         shell_added = {"PWD", "SHLVL", "_"}
         # macOS injects __CF_USER_TEXT_ENCODING into every spawned process
         # unconditionally (CoreFoundation per-user encoding preference). This is


### PR DESCRIPTION
Unblocks the `Test Release Candidate SHA` job on the `v0.5.0-insider.1` run, which failed 2 of 71528 tests and stopped the `0.5.0-rc.1` candidate.

## Why only this lane

`release.yml` sets the unprivileged-userns sysctl itself so the sandbox-dependent tests run for real rather than skipping. `ci.yml`'s sharded matrix runs where userns is unavailable, so neither of these two paths is reached there — both failures are invisible on `main`'s normal CI and surface for the first time on the RC gate.

## Failure 1 — `test_session_storage.py::TestTrashBatchNamesAreLogSafe::test_both_sites_escape_without_touching_the_filesystem`

```
TypeError: unsupported operand type(s) for /: '_ForgedDir' and 'str'
```

The double is shaped for `_read_manifest`, but `list_trash` reads `_summarize_manifest`, which does `batch / MANIFEST_NAME`. A name-only double cannot support that, so the test raised instead of asserting. Already fixed on `main` — this backports both halves:

- `0122c1d391` — pin the trash log-safety test to the seam `list_trash` reads (#6400)
- `ba19395240` — scope the forged-iterdir patch to the trash root, so a sibling test in the same xdist worker cannot reach the double (#6426)

## Failure 2 — `test_terminal_commands.py::TestRunProbe::test_the_environment_is_an_allowlist_not_a_filtered_inherit`

```
Extra items in the left set: 'GRADLE_OPTS'
```

The namespace launcher writes `GRADLE_OPTS=-Dorg.gradle.daemon=false` into every sandboxed child (so a Gradle daemon cannot outlive the sandbox holding the credential paths masked), and the allowlist never listed it. Not yet fixed anywhere — the `main` fix is [PR #6569](https://github.com/kirodotdev/KiroCrew/pull/6569) and is carried here as the third cherry-pick.

Naming the variable alone would weaken the assertion, so the parent also gets a `leaked-GRADLE_OPTS` marker: the launcher appends to whatever it finds, so a future filtered-inherit handing the child the parent's value still trips the existing `assert "leaked-" not in out`. `_probe_env()` builds from nothing, so the marker is dropped and the child sees only the flag the launcher wrote.

## Verification

- Both originally-failing tests now pass on this branch; `test_session_storage.py` + `test_terminal_commands.py` together: 307 passed, 1 skipped.
- Mutation-verified the new marker is not vacuous: adding `GRADLE_OPTS` to `_probe_env()`'s inherited-locale loop fails the test on `'leaked-' is contained here: ADLE_OPTS=leaked-GRADLE_OPTS`. Reverted.
- flake8, isort and the baselined black gate clean. Test-only change, no production code touched.
- Squashed to one commit for the commit-count gate; the three cherry-picked sources are named in the commit message.

This host has no unprivileged userns (`unshare(CLONE_NEWUSER)` → EPERM), so the sandboxed path is exercised by this lane rather than locally.
