### PR TITLE
refactor: consolidate model-fallback post-merge follow-ups (#5447)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -287,7 +287,6 @@ src/kiro_crew/eval/scenario.py
 src/kiro_crew/frontend.py
 src/kiro_crew/gateway_shutdown_budget.py
 src/kiro_crew/github_runner.py
-src/kiro_crew/heartbeat.py
 src/kiro_crew/history.py
 src/kiro_crew/hooks.py
 src/kiro_crew/image_artifacts.py
@@ -774,7 +773,6 @@ test/test_handlers_files_upload.py
 test/test_handlers_mcp_coverage.py
 test/test_handlers_memory_coverage.py
 test/test_heartbeat_atomic_merge.py
-test/test_heartbeat_cycle_recycle.py
 test/test_heartbeat_prompt_deliver.py
 test/test_heartbeat_retention.py
 test/test_heartbeat_sel_prune_offload.py

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,11 @@ kirocrew-data.tar.gz
 # deliverables (e.g. temp-screenshots/) are unaffected. (`*.log` is already ignored above.)
 .pr-body.md
 .r*-logs/
+# Staged blind-review artifacts (prepare-pr review lanes point subagents at
+# .review-<n>.diff files) and the autofix work-dir heartbeat — scratch, never
+# a deliverable, and a `git add -A` would otherwise sweep them into the PR.
+.review-*.diff
+.heartbeat
 
 # AI attribution tracking data
 .attribution/

--- a/docs/system-specs/features/model-fallback.md
+++ b/docs/system-specs/features/model-fallback.md
@@ -51,21 +51,34 @@ skip rules and marker semantics cannot diverge:
 
 Each candidate gets `FALLBACK_CANDIDATE_ATTEMPTS` (2: initial + one ~2s retry) —
 deliberately not a fresh full budget, because throttle events are frequently
-cell-scoped and model-agnostic. A non-transient error mid-chain propagates
-immediately. Chain exhaustion surfaces the original error class with the chain's
-story attached (`_kc_fallback_story`).
+cell-scoped and model-agnostic. The budget lives in one place: the in-walk
+surfaces consume it via `FallbackState.should_retry_active`, and the dashboard's
+counter rewind derives from the same constant
+(`fallback_rewound_transient_budget()`). A non-transient error mid-chain
+propagates immediately. Chain exhaustion surfaces the original error class with
+the chain's story attached (`FALLBACK_STORY_ATTR`, built by
+`FallbackState.exhaustion_story`); the unattended surfaces append it to their
+terminal error text via `append_fallback_story` — the cron failure alert, the
+sub-agent `info.error`, and the heartbeat failure log — so an unattended failure
+names the whole walk, not just the last candidate's error. The story is
+redacted and capped centrally in `fallback_story_of` (`_FALLBACK_STORY_CAP`):
+walked ids originate in config (LLM-reachable via MCP, advertised check fails
+open), and consumers like the heartbeat log apply no redaction of their own.
 
 ## Surfaces
 
 - **`stream_and_collect`** (Case 2.75; cron and heartbeat pass the chain via
   `fallback_models=configured_fallback_chain()`): walks in-place and re-prompts.
   Delivered results are prefixed with a redacted warning line
-  (`_annotate_model_fallback`, `slack/gateway.py`).
+  (`annotate_model_fallback`, one body in `llm_helpers` next to
+  `TURN_FALLBACK_ATTR`, used by the cron/heartbeat delivery and the sub-agent
+  completion path).
 - **Dashboard** (`chat_runner`): the pre-token exhaustion branch swaps, appends a
   persisted notice card ("⚠️ X is throttled — running on Y until X recovers."),
   and re-queues the same message on the same live session
   (`SYNTHETIC_RECOVERY_KIND`). The per-candidate budget rides the existing
-  transient counter (`TRANSIENT_RETRIES - 1` rewind = one in-branch retry).
+  transient counter, rewound to `fallback_rewound_transient_budget()` (derived
+  from the same `FALLBACK_CANDIDATE_ATTEMPTS` constant = one in-branch retry).
   Nested turns (`_prompt_depth > 0`) get no fallback. Chain exhaustion falls
   through to the unchanged terminal branch with the story prepended.
 - **Sub-agents** (`subagent._stream_with_transient_retry`): same walk on the
@@ -80,7 +93,8 @@ one `set_model(primary)` — quiet on success (log only; recovery is the expecte
 state), staying on the fallback on transient failure, and dropping a stale
 marker without touching the model when the session moved on by other means.
 
-The dashboard mirrors this with slot state (`_active_fallback_model`,
+The dashboard's slot probe (`_probe_fallback_restore_for_slot_locked`) wraps the
+same `probe_fallback_restore` body with slot-held state (`_active_fallback_model`,
 `_fallback_primary_model`) and one extra rule: **an explicit user pick is never
 overridden.** Picks are detected by a generation counter
 (`slot._model_pick_gen`) bumped ONLY by the explicit set-model surfaces

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -179,10 +179,9 @@ from kiro_crew.llm_helpers import (
     acp_error_is_transient,
     advance_fallback_candidate,
     configured_fallback_chain,
-    provider_active_model,
-    provider_raw_model,
+    fallback_rewound_transient_budget,
+    probe_fallback_restore,
     record_interaction_event,
-    resolve_substitute_set_model,
     run_bg_oneliner,
     transient_retry_delay,
 )
@@ -965,69 +964,47 @@ async def _probe_fallback_restore_for_slot(slot: Any, client: Any) -> None:
 
 
 async def _probe_fallback_restore_for_slot_locked(slot: Any, client: Any) -> None:
-    """Body of the restore probe; caller holds ``slot._model_pick_lock``."""
+    """Body of the restore probe; caller holds ``slot._model_pick_lock``.
+
+    Thin slot-state adapter over the SHARED probe body
+    (:func:`llm_helpers.probe_fallback_restore` — the same
+    probe/witness/clear sequencing the unattended surfaces use, so the two
+    cannot diverge). Only the slot-specific pieces live here:
+
+    - ``state``: the sticky fallback record is slot-held, not the provider
+      marker.
+    - ``stale``: an explicit user pick made AFTER the swap bumps the pick
+      generation — including a pick of the fallback model itself, which
+      neither the served model nor slot.model can distinguish from our own
+      swap (the automatic provider backfill also writes the served fallback
+      into an unpinned slot's model, so comparing slot.model VALUES would
+      misread the backfill as a pick and permanently abandon restoration). An
+      explicit pick must never be overridden by a restore.
+    - ``clear``: slot fields and the provider marker drop as one logical
+      record (:func:`_clear_fallback_sticky_state`).
+    - ``on_restored``: heal slot.model if the automatic backfill wrote the
+      fallback into an unpinned slot while the fallback was active —
+      slot.model is re-sent as a set_model override on resume, so leaving the
+      fallback id there would re-pin the fallback after the primary
+      recovered. No explicit pick happened (``stale`` checked first), so the
+      snapshot is the honest value.
+    """
     candidate = slot._active_fallback_model
     if not candidate:
         return
-    primary = slot._fallback_primary_model
-    current = provider_active_model(client)
-    _moved_off = current and current.strip().lower() != candidate.strip().lower()
-    # An explicit user pick made AFTER the swap bumps the pick generation —
-    # including a pick of the fallback model itself, which neither the served
-    # model nor slot.model can distinguish from our own swap (the automatic
-    # provider backfill also writes the served fallback into an unpinned
-    # slot's model, so comparing slot.model VALUES would misread the backfill
-    # as a pick and permanently abandon restoration). An explicit pick must
-    # never be overridden by a restore.
-    _user_repicked = slot._model_pick_gen != slot._fallback_pick_gen
-    if _moved_off or _user_repicked or not primary:
-        # Session moved off our fallback by other means (explicit pick, reset)
-        # or the primary was never known — the sticky state is stale.
-        _clear_fallback_sticky_state(slot, client)
-        return
-    set_model_fn = resolve_substitute_set_model(client)
-    if set_model_fn is None:
-        return
-    try:
-        await set_model_fn(primary)
-    except Exception as exc:
-        logger.info(
-            "model fallback: primary %s still unavailable on slot %s (%s); staying on %s",
-            primary,
-            slot.key,
-            exc,
-            candidate,
-        )
-        return
-    # Witness the restore before heal+clear (same check as
-    # llm_helpers.probe_fallback_restore): a non-raising set_model(primary)
-    # can be a silent no-op when resolve collapses the target to "". Clearing
-    # sticky state while still ON the fallback re-opens the backfill
-    # permanent-pin door this state exists to close. Keep everything and
-    # retry at the next genuine turn start.
-    _raw = provider_raw_model(client)
-    if _raw and candidate and _raw.strip().lower() == str(candidate).strip().lower():
-        logger.info(
-            "model fallback: restore to %s was a silent no-op on slot %s (still on %s); "
-            "keeping fallback",
-            primary,
-            slot.key,
-            candidate,
-        )
-        return
-    # Heal slot.model if the automatic backfill wrote the fallback into an
-    # unpinned slot while the fallback was active: slot.model is re-sent as a
-    # set_model override on resume, so leaving the fallback id there would
-    # re-pin the fallback after the primary recovered. No explicit pick
-    # happened (checked above), so the snapshot is the honest value.
-    if (slot.model or "") != slot._fallback_slot_model:
-        slot.model = slot._fallback_slot_model
-    _clear_fallback_sticky_state(slot, client)
-    logger.warning(
-        "model fallback: restored %s -> %s (reason=primary-recovered, surface=dashboard, slot=%s)",
-        candidate,
-        primary,
-        slot.key,
+
+    def _heal_backfilled_slot_model() -> None:
+        if (slot.model or "") != slot._fallback_slot_model:
+            slot.model = slot._fallback_slot_model
+
+    await probe_fallback_restore(
+        client,
+        surface="dashboard",
+        state=(slot._fallback_primary_model, candidate),
+        stale=slot._model_pick_gen != slot._fallback_pick_gen,
+        clear=lambda: _clear_fallback_sticky_state(slot, client),
+        on_restored=_heal_backfilled_slot_model,
+        log_suffix=f", slot={slot.key}",
     )
 
 
@@ -1040,15 +1017,26 @@ def _clear_fallback_sticky_state(slot: Any, client: Any) -> None:
     unrelated fallback walk (the marker-first primary seeding in
     ``advance_fallback_candidate`` would then "restore" a model the user
     explicitly moved away from).
+
+    Marker FIRST, and a failed marker clear returns WITHOUT blanking the
+    slot fields: blanking them around a surviving marker would orphan it
+    with no dashboard path left to revisit it (only its stale-primary
+    reseeding harm above would remain), so the record is retained
+    DELIBERATELY — the next turn's probe re-attempts the clear, which
+    succeeds for a transient failure and keeps re-failing for a permanently
+    hostile attribute. In practice the branch is dead: neither the real ACP
+    provider nor the client defines raising attribute hooks, so only exotic
+    test doubles reach it; the ordering costs nothing.
     """
-    slot._active_fallback_model = ""
-    slot._fallback_primary_model = ""
-    slot._fallback_slot_model = ""
     try:
         if getattr(client, TURN_FALLBACK_ATTR, None) is not None:
             setattr(client, TURN_FALLBACK_ATTR, None)
     except Exception:
-        logger.debug("clearing fallback marker failed", exc_info=True)
+        logger.debug("clearing fallback marker failed; keeping slot state for retry", exc_info=True)
+        return
+    slot._active_fallback_model = ""
+    slot._fallback_primary_model = ""
+    slot._fallback_slot_model = ""
 
 
 def _context_usage_payload(slot_key: str, client: Any) -> dict[str, Any]:
@@ -9296,13 +9284,15 @@ async def _run_chat(
             # be said out loud), then re-queue the SAME message on the SAME
             # live session, exactly like the same-model retry above.
             #
-            # Attempt budget: rewinding the counter to TRANSIENT_RETRIES - 1
-            # grants the candidate exactly ONE more pass through the
-            # same-model branch above, so each candidate gets two attempts
-            # (this re-queued one + one retry) before the next exhaustion
-            # lands back here and advances the chain — see
-            # llm_helpers.FALLBACK_CANDIDATE_ATTEMPTS for why not a full
-            # fresh budget. Nested turns (_prompt_depth > 0) get no fallback
+            # Attempt budget: rewinding the counter grants the candidate
+            # exactly one more pass through the same-model branch above, so
+            # each candidate gets FALLBACK_CANDIDATE_ATTEMPTS attempts (this
+            # re-queued one + the rewound passes) before the next exhaustion
+            # lands back here and advances the chain. The rewind value is
+            # derived in ONE place with the unattended surfaces' budget — see
+            # llm_helpers.fallback_rewound_transient_budget /
+            # FallbackState.should_retry_active. Nested turns
+            # (_prompt_depth > 0) get no fallback
             # in v1 and Stop-suppressed cycles never swap (both guarded in
             # the condition before the side-effecting swap runs).
             slot.purge_chunks()
@@ -9327,7 +9317,7 @@ async def _run_chat(
                 _fb_candidate,
                 slot._fallback_candidate_idx,
             )
-            slot._transient_5xx_retries = TRANSIENT_RETRIES - 1
+            slot._transient_5xx_retries = fallback_rewound_transient_budget()
             await asyncio.sleep(transient_retry_delay(1))
             # Stop guard AFTER the sleep (review finding on 1a61ddcf): a Stop
             # pressed during this backoff resolves while no prompt is active,

--- a/src/kiro_crew/heartbeat.py
+++ b/src/kiro_crew/heartbeat.py
@@ -20,6 +20,7 @@ from kiro_crew import platform_compat, shutdown_event
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.executors import maintenance_executor
+from kiro_crew.llm_helpers import append_fallback_story
 from kiro_crew.memory import MemoryStore, workspace_dir
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.sel import sel
@@ -171,9 +172,7 @@ class HeartbeatService:
 
         if self._tick % _FTS_REBUILD_TICKS == 0:
             loop = asyncio.get_running_loop()
-            count = await loop.run_in_executor(
-                maintenance_executor(), self._memory.rebuild_index
-            )
+            count = await loop.run_in_executor(maintenance_executor(), self._memory.rebuild_index)
             logger.info("FTS index rebuilt: %d files", count)
 
         if self._tick % _PRUNE_TICKS == 0:
@@ -244,8 +243,15 @@ class HeartbeatService:
                 )
                 for (task_text, deliver), result in zip(tasks, results):
                     if isinstance(result, BaseException):
+                        # A chain-exhaustion failure carries the fallback story
+                        # on the exception; this log line is the heartbeat's
+                        # terminal error text, so append it here — the walk
+                        # must not be reported as just the last candidate's
+                        # failure (llm_helpers.FALLBACK_STORY_ATTR).
                         logger.warning(
-                            "Heartbeat task failed: %s", task_text[:80], exc_info=result,
+                            "Heartbeat task failed: %s",
+                            append_fallback_story(task_text[:80], result),
+                            exc_info=result,
                         )
                         keep.append((task_text, deliver))
                     elif _should_keep(result):
@@ -258,7 +264,10 @@ class HeartbeatService:
                 # between this final read and os.replace. The entire durable
                 # transaction runs off the gateway event-loop thread.
                 appended_count = await asyncio.to_thread(
-                    _rewrite_heartbeat_locked, path, tasks, keep,
+                    _rewrite_heartbeat_locked,
+                    path,
+                    tasks,
+                    keep,
                 )
                 if appended_count:
                     logger.info(

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -30,7 +30,13 @@ from kiro_crew.providers.base import (
     LLMEvent,
     LLMProvider,
 )
-from kiro_crew.security import is_denied, is_sensitive_bash_command, is_sensitive_path
+from kiro_crew.security import (
+    is_denied,
+    is_sensitive_bash_command,
+    is_sensitive_path,
+    redact_credentials,
+    redact_exfiltration_urls,
+)
 from kiro_crew.sel import sel as _sel
 
 _PROMPT_BUSY_RETRIES = 2
@@ -217,6 +223,26 @@ def first_advertised_fallback(advertised: Any, rejected: str | None) -> str | No
 # across a 4-candidate chain).
 FALLBACK_CANDIDATE_ATTEMPTS = 2
 
+
+def fallback_rewound_transient_budget() -> int:
+    """Same-model counter value that grants a fresh fallback candidate its budget.
+
+    The dashboard's interactive ladder does not hold a :class:`FallbackState`
+    between turns — after a swap it rewinds ``slot._transient_5xx_retries`` so
+    the candidate gets exactly :data:`FALLBACK_CANDIDATE_ATTEMPTS` - 1 further
+    passes through the same-model retry branch (the re-queued turn itself is
+    the first attempt) before the next exhaustion advances the chain. Deriving
+    the rewind here keeps the per-candidate budget in ONE place with
+    :meth:`FallbackState.should_retry_active`, the encoding the unattended
+    surfaces use. Clamped at zero so the counter can never go negative:
+    a FALLBACK_CANDIDATE_ATTEMPTS above TRANSIENT_RETRIES + 1 cannot be
+    expressed by this counter encoding at all — it collapses to the full
+    same-model budget (the documented "deliberately not a fresh full budget"
+    stance caps the useful range at TRANSIENT_RETRIES + 1).
+    """
+    return max(0, TRANSIENT_RETRIES - (FALLBACK_CANDIDATE_ATTEMPTS - 1))
+
+
 # Provider attribute carrying the active fallback as ``(primary, candidate)``.
 # Doubles as (a) the sticky-restore marker — the next stream_and_collect call
 # on the same provider probes one ``set_model(primary)`` restore — and (b) the
@@ -225,6 +251,115 @@ FALLBACK_CANDIDATE_ATTEMPTS = 2
 # successful restore, never on turn completion: the swap is sticky for the
 # remainder of the session by design.
 TURN_FALLBACK_ATTR = "_kc_active_fallback"
+
+# Exception attribute carrying the chain-exhaustion story (set by the fallback
+# walks when every candidate also failed). The delivering surface appends it to
+# the terminal error text via :func:`append_fallback_story` so an unattended
+# failure names the whole walk, not just the last candidate's error.
+FALLBACK_STORY_ATTR = "_kc_fallback_story"
+
+# Bound on the story text a consumer will accept. The walked ids originate in
+# ``agent.fallback_model`` config (LLM-reachable via MCP) and the advertised
+# check fails OPEN on an empty list, so an arbitrarily long config string can
+# reach the walk — bound and redact it centrally before it rides any error
+# surface (WS frames, Slack alerts, log lines).
+_FALLBACK_STORY_CAP = 500
+
+
+def fallback_story_of(exc: BaseException) -> str:
+    """The chain-exhaustion story carried on *exc*, redacted+capped, or ``""``.
+
+    Reads :data:`FALLBACK_STORY_ATTR`; anything but a non-empty string is
+    treated as absent (the attribute is best-effort — a frozen exception type
+    may have refused the set, and a hostile ``__getattribute__`` must not
+    break error delivery). Redaction and the :data:`_FALLBACK_STORY_CAP`
+    bound live HERE so every consumer (cron alert, sub-agent error, heartbeat
+    log) gets the same safe text — no per-surface drift. Never raises.
+    """
+    try:
+        story = getattr(exc, FALLBACK_STORY_ATTR, None)
+        if not isinstance(story, str) or not story:
+            return ""
+        story = redact_credentials(redact_exfiltration_urls(story)[0])[0]
+    except Exception:  # noqa: BLE001 — a story must never break error delivery
+        logger.debug("fallback story read/redaction failed", exc_info=True)
+        return ""
+    return story[:_FALLBACK_STORY_CAP]
+
+
+def append_fallback_story(text: str, exc: BaseException, *, budget: int | None = None) -> str:
+    """Append *exc*'s chain-exhaustion story to terminal error *text*.
+
+    THE consumer for :data:`FALLBACK_STORY_ATTR` on unattended surfaces
+    (cron failure alerts, sub-agent ``info.error``, the heartbeat failure
+    log). The interactive dashboard does not use it — it rebuilds a richer
+    story from ``slot._fallback_walked``. No story ⇒ *text* is returned
+    unchanged (capped at *budget* when one is given). The story arrives
+    redacted+capped from :func:`fallback_story_of`. Never raises.
+
+    :param budget: optional total length bound for the composite. The ERROR
+        text is trimmed to leave the story room — the story is the part a
+        verbose backend error must never push out — but keeps a FLOOR of half
+        the budget: an oversized story (config-sourced ids can approach
+        :data:`_FALLBACK_STORY_CAP`, which may equal a caller's cap) must not
+        evict the actual error either, so past the floor it is the story tail
+        that truncates. Degenerate budgets (a handful of characters — no real
+        caller passes one) keep the error head and may lose the story
+        entirely. ``None`` appends unbounded (caller owns the cap); a
+        negative value is normalized to 0 (a negative slice would DROP the
+        bound instead of tightening it).
+    """
+    if budget is not None and budget < 0:
+        budget = 0
+    story = fallback_story_of(exc)
+    if not story:
+        return text if budget is None else text[:budget]
+    if budget is not None:
+        # Reserve " [" + story + "]" out of the budget, but never trim the
+        # error text below half the budget; the final cap then truncates the
+        # story tail instead.
+        text = text[: max(budget // 2, budget - len(story) - 3)]
+    out = f"{text} [{story}]" if text else story
+    return out if budget is None else out[:budget]
+
+
+def annotate_model_fallback(text: str, provider: Any) -> str:
+    """Prepend the throttle-fallback warning to a delivered unattended result.
+
+    Unattended surfaces (cron/heartbeat results, the sub-agent completion
+    event) have no chat card to announce a fallback swap on, so the delivered
+    result text itself carries the warning — the same visibility contract as
+    the interactive notice card. The marker is read from
+    :data:`TURN_FALLBACK_ATTR` (set by the shared fallback walk) and left in
+    place: the swap is sticky for the session, so every run served by the
+    fallback repeats the warning until the restore probe moves the session
+    back. Model ids come from config, which is LLM-reachable via MCP — redact
+    before they reach Slack/dashboard. One body for every surface (was two
+    spellings: ``slack/gateway`` + an inline block in ``subagent``). Never
+    raises: an annotation failure must not turn a successful run into a
+    failed one — the un-annotated *text* is returned instead.
+    """
+    try:
+        fb = getattr(provider, TURN_FALLBACK_ATTR, None)
+        if not fb:
+            return text
+        primary, candidate = fb
+        # Same threat model as _FALLBACK_STORY_CAP: the ids originate in
+        # config (LLM-reachable via MCP), so bound them as well as redacting.
+        safe_primary = redact_credentials(redact_exfiltration_urls(str(primary))[0])[0][
+            :_FALLBACK_STORY_CAP
+        ]
+        safe_candidate = redact_credentials(redact_exfiltration_urls(str(candidate))[0])[0][
+            :_FALLBACK_STORY_CAP
+        ]
+        line = (
+            f"⚠️ Model '{safe_primary}' throttled; this run was served by fallback "
+            f"'{safe_candidate}'."
+        )
+        return f"{line}\n\n{text}" if text else line
+    except Exception:  # noqa: BLE001 — annotation is best-effort visibility
+        logger.debug("fallback annotation failed", exc_info=True)
+        return text
 
 
 def provider_fallback_active(provider: Any) -> bool:
@@ -302,6 +437,37 @@ class FallbackState:
             return None
         self.pos += remaining.index(cand) + 1
         return cand
+
+    def should_retry_active(self) -> bool:
+        """Consume one more attempt on the active candidate, if budget remains.
+
+        THE single home of the per-candidate retry budget/trigger (was three
+        spellings: ``stream_and_collect`` Case 2.75, the sub-agent ladder, and
+        the dashboard's counter rewind — the last derives its counter from the
+        same constant via :func:`fallback_rewound_transient_budget`). ``True``
+        means the caller retries the active candidate once more (the attempt is
+        already recorded); ``False`` means no candidate is active or its
+        :data:`FALLBACK_CANDIDATE_ATTEMPTS` budget is spent — advance the chain
+        via :func:`advance_fallback_candidate`.
+        """
+        if self.active is None or self.attempts >= FALLBACK_CANDIDATE_ATTEMPTS:
+            return False
+        self.attempts += 1
+        return True
+
+    def exhaustion_story(self) -> str | None:
+        """One-line story of a spent chain walk, or ``None`` when none ran.
+
+        ``None`` (nothing was actually walked — e.g. every candidate was
+        skipped as unadvertised) means the error should surface exactly as it
+        did before the fallback feature existed, with no story attached.
+        """
+        if not self.walked:
+            return None
+        return (
+            f"{self.primary or 'the selected model'} throttled; "
+            f"fallbacks {', '.join(self.walked)} also unavailable"
+        )
 
 
 async def advance_fallback_candidate(
@@ -412,7 +578,10 @@ def resolve_substitute_set_model(provider: Any) -> Callable[[str], Awaitable[Non
     ``AcpClient.set_model`` / ``AcpSessionProvider.set_model`` does not fire
     for a served candidate.
     """
-    fn = getattr(provider, "set_model", None)
+    try:
+        fn = getattr(provider, "set_model", None)
+    except Exception:  # pragma: no cover - exotic property getters
+        fn = None
     if callable(fn):
         return fn
     for attr in ("client", "_client"):
@@ -420,7 +589,10 @@ def resolve_substitute_set_model(provider: Any) -> Callable[[str], Awaitable[Non
             inner = getattr(provider, attr, None)
         except Exception:  # pragma: no cover - exotic property getters
             inner = None
-        fn = getattr(inner, "set_model", None) if inner is not None else None
+        try:
+            fn = getattr(inner, "set_model", None) if inner is not None else None
+        except Exception:  # pragma: no cover - exotic property getters
+            fn = None
         if callable(fn):
             return fn
     return None
@@ -471,37 +643,89 @@ def provider_raw_model(provider: Any) -> str:
     return ""
 
 
-async def probe_fallback_restore(provider: Any, *, surface: str = "unattended") -> None:
+async def probe_fallback_restore(
+    provider: Any,
+    *,
+    surface: str = "unattended",
+    state: tuple[Any, Any] | None = None,
+    stale: bool = False,
+    clear: Callable[[], None] | None = None,
+    on_restored: Callable[[], None] | None = None,
+    log_suffix: str = "",
+) -> None:
     """One ``set_model(primary)`` restore probe at the start of a turn.
 
-    No-op unless :data:`TURN_FALLBACK_ATTR` marks an active fallback. The
-    restore only fires while the session is still on the fallback this feature
-    set (a user/session-level model change in between clears the marker without
-    touching the model — never override an explicit later pick). Success clears
-    the marker and logs (recovery is the quiet default: no chat notice);
-    failure keeps the fallback for this turn. Never raises.
+    THE single restore-probe body: the unattended surfaces call it bare (state
+    read from :data:`TURN_FALLBACK_ATTR`), and the dashboard's slot probe wraps
+    it (``chat_runner._probe_fallback_restore_for_slot_locked``) with the
+    slot-held state and hooks below, so the probe/witness/clear sequencing
+    cannot diverge across surfaces. The restore only fires while the session is
+    still on the fallback this feature set (a user/session-level model change
+    in between clears the sticky state without touching the model — never
+    override an explicit later pick). Success clears the state and logs
+    (recovery is the quiet default: no chat notice); failure keeps the fallback
+    for this turn. Never raises.
+
+    :param state: ``(primary, candidate)`` override. Default: read the
+        provider's :data:`TURN_FALLBACK_ATTR` marker (no-op when absent).
+    :param stale: caller-known extra staleness the marker cannot see (the
+        dashboard's explicit-pick generation check) — treated exactly like the
+        session having moved off the fallback.
+    :param clear: replaces the default marker clear (the dashboard drops slot
+        fields AND the marker as one logical record).
+    :param on_restored: hook running after a witnessed restore, before *clear*
+        (the dashboard's slot-model heal).
+    :param log_suffix: appended inside the log parentheses, e.g. ``", slot=k"``.
     """
-    state = getattr(provider, TURN_FALLBACK_ATTR, None)
-    if not state:
-        return
     try:
-        primary, candidate = state
+        # The whole state read is guarded: a hostile marker property, a
+        # raising ``__bool__``/``__str__``, or a malformed tuple must not
+        # break the "never raises" contract — an unreadable state simply
+        # skips the probe.
+        if state is None:
+            marker = getattr(provider, TURN_FALLBACK_ATTR, None)
+            if not marker:
+                return
+            primary, candidate = marker
+        else:
+            primary, candidate = state
+            if not candidate:
+                return
+        # Coerce ONCE; every later comparison uses the plain string. The
+        # marker path deliberately has no empty-candidate early return (a
+        # ``(primary, "")`` marker still probes and clears — pre-existing
+        # semantics), while the state path mirrors the slot probe's
+        # no-active-fallback no-op.
+        candidate = "" if candidate is None else str(candidate)
+        primary_missing = not primary
     except Exception:
+        logger.debug("fallback restore: unreadable fallback state; skipping probe", exc_info=True)
         return
+
+    def _default_clear() -> None:
+        try:
+            setattr(provider, TURN_FALLBACK_ATTR, None)
+        except Exception:
+            pass
+
+    def _run_hook(fn: Callable[[], None], what: str) -> None:
+        # Caller-supplied hooks must not break the never-raises contract: a
+        # failing heal/clear aborts the TURN it runs at the start of, which is
+        # far worse than the stale state it was tidying.
+        try:
+            fn()
+        except Exception:
+            logger.debug("fallback restore %s hook failed", what, exc_info=True)
+
+    _clear = clear if clear is not None else _default_clear
     current = provider_active_model(provider)
-    if current and candidate and current.strip().lower() != str(candidate).strip().lower():
+    if current and candidate and current.strip().lower() != candidate.strip().lower():
         # The session moved off our fallback by other means (explicit pick,
-        # session reset). The marker is stale — drop it, restore nothing.
-        try:
-            setattr(provider, TURN_FALLBACK_ATTR, None)
-        except Exception:
-            pass
+        # session reset). The sticky state is stale — drop it, restore nothing.
+        _run_hook(_clear, "clear")
         return
-    if not primary:
-        try:
-            setattr(provider, TURN_FALLBACK_ATTR, None)
-        except Exception:
-            pass
+    if stale or primary_missing:
+        _run_hook(_clear, "clear")
         return
     set_model_fn = resolve_substitute_set_model(provider)
     if set_model_fn is None:
@@ -510,11 +734,12 @@ async def probe_fallback_restore(provider: Any, *, surface: str = "unattended") 
         await set_model_fn(primary)
     except Exception as exc:
         logger.info(
-            "model fallback: primary %s still unavailable (%s); staying on %s " "(surface=%s)",
+            "model fallback: primary %s still unavailable (%s); staying on %s " "(surface=%s%s)",
             primary,
             exc,
             candidate,
             surface,
+            log_suffix,
         )
         return
     # Witness the restore before clearing: a non-raising set_model(primary)
@@ -524,24 +749,31 @@ async def probe_fallback_restore(provider: Any, *, surface: str = "unattended") 
     # backfill pin the temporary fallback permanently. Keep the marker and
     # retry at the next turn start instead.
     _raw = provider_raw_model(provider)
-    if _raw and candidate and _raw.strip().lower() == str(candidate).strip().lower():
+    if _raw and candidate and _raw.strip().lower() == candidate.strip().lower():
         logger.info(
             "model fallback: restore to %s was a silent no-op (still on %s); "
-            "keeping fallback (surface=%s)",
+            "keeping fallback (surface=%s%s)",
             primary,
             candidate,
             surface,
+            log_suffix,
         )
         return
-    try:
-        setattr(provider, TURN_FALLBACK_ATTR, None)
-    except Exception:
-        pass
+    if on_restored is not None:
+        # A failed heal does not block the clear: the two writes are one
+        # logical record, a half-cleared record is worse than a missed heal,
+        # and the stale-state paths above never heal either — retaining the
+        # record would not buy a retry of the heal. The dashboard's actual
+        # hooks are plain attribute writes that realistically cannot raise;
+        # this guard is for the "never raises" contract, not an expected path.
+        _run_hook(on_restored, "on_restored")
+    _run_hook(_clear, "clear")
     logger.warning(
-        "model fallback: restored %s -> %s (reason=primary-recovered, surface=%s)",
+        "model fallback: restored %s -> %s (reason=primary-recovered, surface=%s%s)",
         candidate,
         primary,
         surface,
+        log_suffix,
     )
 
 
@@ -1452,12 +1684,9 @@ async def stream_and_collect(
                 and acp_error_is_transient(exc)
                 and transient_attempts >= _TRANSIENT_RETRIES
             ):
-                if (
-                    _fb_state.active is not None
-                    and _fb_state.attempts < FALLBACK_CANDIDATE_ATTEMPTS
-                ):
-                    # Final attempt on the current candidate.
-                    _fb_state.attempts += 1
+                if _fb_state.should_retry_active():
+                    # Final attempt on the current candidate — the shared
+                    # budget body already recorded it.
                     delay = transient_retry_delay(1)
                     logger.warning(
                         "model fallback: candidate %s still failing (attempt %d/%d), "
@@ -1481,21 +1710,18 @@ async def stream_and_collect(
                     await asyncio.sleep(transient_retry_delay(1))
                     retrying = True
                     continue
-                if _fb_state.walked:
+                _story = _fb_state.exhaustion_story()
+                if _story:
                     # Chain exhausted: surface the ORIGINAL error class with the
                     # chain's story attached for the delivering surface, and
                     # keep the incident greppable.
-                    _story = (
-                        f"{_fb_state.primary or 'the selected model'} throttled; "
-                        f"fallbacks {', '.join(_fb_state.walked)} also unavailable"
-                    )
                     logger.warning(
                         "model fallback: chain exhausted (%s); surfacing original error: %s",
                         _story,
                         exc,
                     )
                     try:
-                        exc._kc_fallback_story = _story  # type: ignore[attr-defined]
+                        setattr(exc, FALLBACK_STORY_ATTR, _story)
                     except Exception:
                         pass
                 # Fall through to Case 2.5 / Case 3.

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1185,6 +1185,14 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # egress boundary; the modules that CALL it (mochi routes/hooks) are the
         # registered sinks.
         "apps/builtins/mochi/redact.py",
+        # Shared model-fallback text builders (fallback_story_of /
+        # annotate_model_fallback): scrub the chain-exhaustion story and the
+        # fallback-served warning line ONCE, centrally, so every consumer gets
+        # the same safe text. They own no output — the scrubbed text reaches a
+        # human only through the delivering surfaces (the cron/heartbeat alert
+        # paths in slack/gateway.py and the sub-agent completion path in
+        # subagent.py), which are the registered sinks.
+        "llm_helpers.py",
         # Redacts artifact names/metadata at the point they are STAGED (the
         # pushable list and the S3 meta sidecar), before any response exists.
         # It owns no output of its own — every HTTP response carrying that data

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -166,10 +166,11 @@ from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import HookManager, HooksConfig, hooks_config_from_config_dict
 from kiro_crew.learn import LessonStore
 from kiro_crew.llm_helpers import (
-    TURN_FALLBACK_ATTR,
     PromptBusyExhaustedError,
     ToolApprovalPolicy,
     acp_error_is_transient,
+    annotate_model_fallback,
+    append_fallback_story,
     configured_fallback_chain,
     provider_fallback_active,
     provider_last_turn_usage,
@@ -1096,32 +1097,11 @@ def _vet_at_claim_then(
     return fn(*args)
 
 
-def _annotate_model_fallback(text: str, provider: Any) -> str:
-    """Prepend the throttle-fallback warning to a delivered unattended result.
-
-    Unattended surfaces (cron/heartbeat) have no chat card to announce a
-    fallback swap on, so the delivered result text itself carries the warning —
-    the same visibility contract as the interactive notice card, and the same
-    pattern as the acquire-time ``_annotate_model_downgrade``. The marker is
-    read from :data:`TURN_FALLBACK_ATTR` (set by ``stream_and_collect``'s
-    fallback walk) and left in place: the swap is sticky for the session, so
-    every run served by the fallback repeats the warning until the restore
-    probe moves the session back. Model ids come from config, which is
-    LLM-reachable via MCP — redact before they reach Slack/dashboard.
-    """
-    fb = getattr(provider, TURN_FALLBACK_ATTR, None)
-    if not fb:
-        return text
-    try:
-        primary, candidate = fb
-    except Exception:
-        return text
-    safe_primary = redact_credentials(redact_exfiltration_urls(str(primary))[0])[0]
-    safe_candidate = redact_credentials(redact_exfiltration_urls(str(candidate))[0])[0]
-    return (
-        f"⚠️ Model '{safe_primary}' throttled; this run was served by fallback "
-        f"'{safe_candidate}'.\n\n" + text
-    )
+# One spelling of the fallback-served warning for every unattended surface
+# (issue #5447 item 4): the body lives next to TURN_FALLBACK_ATTR in
+# llm_helpers; this module-level name is kept for the cron/heartbeat call
+# sites and their tests.
+_annotate_model_fallback = annotate_model_fallback
 
 
 async def _cron_stream_with_posttoken_resume(
@@ -4772,10 +4752,28 @@ class GatewayOrchestrator:
                 if getattr(job, "_acp_retried", False):
                     raise
                 # ── Failure dedup: suppress repeated identical crash notifications ──
-                exc_summary = f"{type(exc).__name__}: {exc}"
-                exc_summary, _ = redact_exfiltration_urls(exc_summary)
-                exc_summary, _ = redact_credentials(exc_summary)
-                fh = _result_hash(exc_summary)
+                # A chain-exhaustion failure carries the fallback story on the
+                # exception (llm_helpers.FALLBACK_STORY_ATTR); append it so the
+                # alert names the whole walk, not just the last candidate's
+                # error.
+                # Redact over the FULL error text BEFORE any truncation — a cap
+                # applied first can cut a credential at the boundary, leaving a
+                # fragment the redaction regexes no longer match. The story is
+                # redacted+capped centrally in fallback_story_of.
+                _exc_text = f"{type(exc).__name__}: {exc}"
+                _exc_text, _ = redact_exfiltration_urls(_exc_text)
+                _exc_text, _ = redact_credentials(_exc_text)
+                # Delivery detail: the budget trims the ERROR part to leave the
+                # story room (a verbose backend error must not evict the walk),
+                # floored at half the cap — an oversized story trims its own
+                # tail past that point instead of evicting the error.
+                exc_detail = append_fallback_story(_exc_text, exc, budget=_CRON_FAILURE_DETAIL_CAP)
+                # Dedup hashes the STORY-FREE error text: the walk can differ
+                # between two occurrences of the same backend error (a
+                # candidate momentarily unadvertised changes `walked`; a
+                # skipped walk has no story at all), and a hash keyed on it
+                # would miss the duplicate and re-page the user.
+                fh = _result_hash(_exc_text)
                 is_dup = fh == job.last_failure_hash
                 if is_dup and time.time() - job.last_failure_at < _FAILURE_REMINDER_SECS:
                     # record_failure() is the counter's sole owner: a suppressed
@@ -4807,7 +4805,7 @@ class GatewayOrchestrator:
                             self.dashboard_state.notify(
                                 "cron",
                                 title,
-                                f"❌ Job failed (suppressed — same error):\n{exc_summary}",
+                                f"❌ Job failed (suppressed — same error):\n{exc_detail}",
                                 meta={"job_id": job.id, "failure_hash": fh},
                             )
                     except Exception:
@@ -4844,7 +4842,7 @@ class GatewayOrchestrator:
                         self.dashboard_state.notify(
                             "cron",
                             alert_title,
-                            f"❌ Job failed:\n{exc_summary[:_CRON_FAILURE_DETAIL_CAP]}",
+                            f"❌ Job failed:\n{exc_detail}",
                             meta={"job_id": job.id, "failure_hash": fh},
                         )
                 except Exception:
@@ -4869,9 +4867,7 @@ class GatewayOrchestrator:
                 # made the DM the only failure surface that still withheld what
                 # the caller already knows. Escaped and fence-neutralized for the
                 # same reasons as the script/command alert.
-                safe_reason = escape_mrkdwn(exc_summary[:_CRON_FAILURE_DETAIL_CAP]).replace(
-                    "```", "'''"
-                )
+                safe_reason = escape_mrkdwn(exc_detail).replace("```", "'''")
                 if is_dup:
                     # +1: this run's failure is recorded below, after the
                     # awaited Slack attempt, so the display count must include
@@ -4902,12 +4898,12 @@ class GatewayOrchestrator:
                     channel_fail_msg = (
                         f"⏰ Cron: {job.name} ❌ Job still failing on {host}"
                         f" ({job.consecutive_failures + 1} consecutive failures)"
-                        f" — check logs.\n{exc_summary[:_CRON_FAILURE_DETAIL_CAP]}"
+                        f" — check logs.\n{exc_detail}"
                     )
                 else:
                     channel_fail_msg = (
                         f"⏰ Cron: {job.name} ❌ Job failed on {host} — check logs.\n"
-                        f"{exc_summary[:_CRON_FAILURE_DETAIL_CAP]}"
+                        f"{exc_detail}"
                     )
                 channel_fail_msg, _ = redact_exfiltration_urls(channel_fail_msg)
                 channel_fail_msg, _ = redact_credentials(channel_fail_msg)

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -66,11 +66,13 @@ from kiro_crew.hooks import (
 )
 from kiro_crew.llm_helpers import (
     FALLBACK_CANDIDATE_ATTEMPTS,
+    FALLBACK_STORY_ATTR,
     TRANSIENT_RETRIES,
-    TURN_FALLBACK_ATTR,
     FallbackState,
     acp_error_is_transient,
     advance_fallback_candidate,
+    annotate_model_fallback,
+    append_fallback_story,
     configured_fallback_chain,
     provider_fallback_active,
     transient_retry_delay,
@@ -5113,7 +5115,14 @@ class SubagentManager:
             logger.info("Subagent %s cancelled", info.id)
         except Exception as exc:
             if not info.reaped:
-                info.error = _describe_exception(exc)
+                # Story appended INSIDE the cap: info.error reaches a WS frame
+                # and the Subagents panel, so the rendered total stays bounded
+                # by _MAX_ERROR_DETAIL_LEN exactly as before — and the budget
+                # trims the ERROR text, never the story, so a verbose chain
+                # cannot push the walk out of the terminal error.
+                info.error = append_fallback_story(
+                    _describe_exception(exc), exc, budget=_MAX_ERROR_DETAIL_LEN
+                )
                 info.done = True
                 Stats().inc_subagent_failed()
                 self._write_tombstone(info, "error")
@@ -5879,12 +5888,7 @@ class SubagentManager:
                         # llm_helpers Case 2.75 for the rationale.
                         if not _fb_state.chain:
                             raise
-                        if (
-                            _fb_state.active is not None
-                            and _fb_state.attempts < FALLBACK_CANDIDATE_ATTEMPTS
-                        ):
-                            _fb_state.attempts += 1
-                        else:
+                        if not _fb_state.should_retry_active():
                             _cand = await advance_fallback_candidate(
                                 client,
                                 _fb_state,
@@ -5892,12 +5896,8 @@ class SubagentManager:
                                 log_suffix=f", id={info.id}",
                             )
                             if _cand is None:
-                                if _fb_state.walked:
-                                    _story = (
-                                        f"{_fb_state.primary or 'the selected model'} "
-                                        f"throttled; fallbacks "
-                                        f"{', '.join(_fb_state.walked)} also unavailable"
-                                    )
+                                _story = _fb_state.exhaustion_story()
+                                if _story:
                                     logger.warning(
                                         "model fallback: chain exhausted (%s) for "
                                         "subagent %s; surfacing original error",
@@ -5905,7 +5905,7 @@ class SubagentManager:
                                         info.id,
                                     )
                                     try:
-                                        exc._kc_fallback_story = _story  # type: ignore[attr-defined]
+                                        setattr(exc, FALLBACK_STORY_ATTR, _story)
                                     except Exception:
                                         pass
                                 raise
@@ -6418,22 +6418,10 @@ class SubagentManager:
             cleaned, _ = redact_credentials(cleaned)
         # Model-fallback visibility (agent.fallback_model): a run served by a
         # fallback model must say so in the delivered result — same contract as
-        # the cron/heartbeat annotation and the dashboard notice card. Model
-        # ids come from config (LLM-reachable via MCP), so they pass the same
-        # redaction as the result body.
-        _fb_marker = getattr(client, TURN_FALLBACK_ATTR, None)
-        if _fb_marker:
-            try:
-                _fb_primary, _fb_candidate = _fb_marker
-                _fb_line = (
-                    f"⚠️ Model '{_fb_primary}' throttled; this run was served by "
-                    f"fallback '{_fb_candidate}'."
-                )
-                _fb_line, _ = redact_exfiltration_urls(_fb_line)
-                _fb_line, _ = redact_credentials(_fb_line)
-                cleaned = f"{_fb_line}\n\n{cleaned}" if cleaned else _fb_line
-            except Exception:
-                logger.debug("fallback annotation failed", exc_info=True)
+        # the cron/heartbeat annotation and the dashboard notice card. One
+        # shared spelling (llm_helpers.annotate_model_fallback) redacts the
+        # config-sourced model ids the same way as the result body.
+        cleaned = annotate_model_fallback(cleaned, client)
         info.result = cleaned or "_No response._"
         # Cap disk file and trim memory — gateway decides how much to show based on mode.
         if info.result_path:

--- a/test/test_cron_gateway_integration.py
+++ b/test/test_cron_gateway_integration.py
@@ -1228,6 +1228,106 @@ class TestThrottleFallbackCronWiring:
         setattr(provider, TURN_FALLBACK_ATTR, ("only-one",))
         assert _annotate_model_fallback("text", provider) == "text"
 
+    def test_gateway_annotator_is_the_shared_body(self):
+        """DRIFT PIN (#5447 item 4): the gateway name must BE the shared
+        helper next to TURN_FALLBACK_ATTR — not a re-spelled copy."""
+        from kiro_crew.llm_helpers import annotate_model_fallback
+        from kiro_crew.slack.gateway import _annotate_model_fallback
+
+        assert _annotate_model_fallback is annotate_model_fallback
+
+    @pytest.mark.asyncio
+    async def test_chain_exhaustion_story_reaches_the_failure_alert(self):
+        """#5447 item 1: a cron turn failing after the chain exhausted must
+        alert with the WHOLE walk (the story the walk attached to the
+        exception), not just the last candidate's error — on BOTH the
+        dashboard notify and the Slack DM legs, and even when the backend
+        error is verbose enough to hit the detail cap (a real ACP throttle
+        payload routinely exceeds it)."""
+        from kiro_crew.acp.client import AcpError
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR
+
+        gw = _make_gw_for_llm()
+        job = _make_llm_job(model="")
+        # The Slack DM leg: slack client present, no channel delivery.
+        gw.slack = MagicMock()
+        gw.slack.post_message = AsyncMock()
+        gw._open_dm_with_retry = AsyncMock(return_value="D123")
+        gw._deliver_cron_to_channel = AsyncMock(return_value=False)
+
+        # Verbose error: longer than _CRON_FAILURE_DETAIL_CAP so the story
+        # would be sliced away if it were appended after the cap.
+        exc = AcpError("Internal error: API Error: " + "x" * 700)
+        setattr(
+            exc, FALLBACK_STORY_ATTR, "primary-m throttled; fallbacks fb-1, fb-2 also unavailable"
+        )
+
+        captured_cb = None
+        provider_mock = MagicMock()
+        gw.sessions.get_or_create = AsyncMock(return_value=(provider_mock, True, False))
+        _embed_mock = AsyncMock(return_value=("full prompt", None))
+        _stream_mock = AsyncMock(side_effect=exc)
+
+        with (
+            patch("kiro_crew.slack.gateway.CronService") as mock_cron_cls,
+            patch("kiro_crew.slack.gateway.run_in_embed_pool", _embed_mock),
+            patch("kiro_crew.slack.gateway.stream_and_collect", _stream_mock),
+            patch("kiro_crew.slack.gateway.sel"),
+            patch("kiro_crew.slack.gateway.build_cron_session_context") as mock_ctx,
+        ):
+            mock_ctx.return_value = (f"cron:{job.id}", job.message)
+
+            def capture_cron(on_job=None, **kw):
+                nonlocal captured_cb
+                captured_cb = on_job
+                svc = MagicMock()
+                svc.start = AsyncMock()
+                svc.remove_job_async = AsyncMock(return_value=True)
+                return svc
+
+            mock_cron_cls.create = AsyncMock(side_effect=capture_cron)
+            await gw._init_cron()
+            assert captured_cb is not None
+            with pytest.raises(AcpError):
+                await captured_cb(job)
+
+            # Same backend error, DIFFERENT walk (a candidate momentarily
+            # unadvertised changes the story): the dedup hash keys on the
+            # story-free error text, so the repeat is suppressed instead of
+            # re-paging the user.
+            exc2 = AcpError("Internal error: API Error: " + "x" * 700)
+            setattr(
+                exc2, FALLBACK_STORY_ATTR, "primary-m throttled; fallbacks fb-2 also unavailable"
+            )
+            _stream_mock.side_effect = exc2
+            with pytest.raises(AcpError):
+                await captured_cb(job)
+
+        bodies = [
+            str(c.args[2]) for c in gw.dashboard_state.notify.call_args_list if len(c.args) >= 3
+        ]
+        assert any(
+            "primary-m throttled" in b and "fb-1, fb-2 also unavailable" in b for b in bodies
+        ), f"expected the chain story in a failure alert, got {bodies!r}"
+        # The delivered detail stays bounded by the cap even with the story
+        # appended (the budget trims the error part). +60 absorbs the fixed
+        # "❌ Job failed:\n" / "❌ Job failed (suppressed — same error):\n"
+        # prefixes around exc_detail — the bound under test is exc_detail's.
+        from kiro_crew.slack.gateway import _CRON_FAILURE_DETAIL_CAP
+
+        for b in bodies:
+            assert len(b) <= _CRON_FAILURE_DETAIL_CAP + 60, f"unbounded alert body: {len(b)} chars"
+        # The Slack DM — the surface a user actually gets paged on — carries
+        # the story too.
+        slack_texts = [str(c.args[1]) for c in gw.slack.post_message.call_args_list]
+        assert any(
+            "primary-m throttled" in t and "also unavailable" in t for t in slack_texts
+        ), f"expected the chain story in the Slack alert, got {slack_texts!r}"
+        # The second run took the dup-suppress path (story-free hash), with a
+        # bounded body that still carries its own walk.
+        assert any("suppressed — same error" in b for b in bodies), bodies
+        assert any("fb-2 also unavailable" in b for b in bodies), bodies
+
 
 class TestExecutePreservesCallbackStatus:
     """CronService._execute must not clobber a failure the callback reported by

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -16042,6 +16042,50 @@ class TestRunChatModelFallback:
         assert slot._fallback_walked == []
 
     @pytest.mark.asyncio
+    async def test_candidate_budget_routes_through_shared_rewind_body(self, tmp_path, monkeypatch):
+        """DRIFT PIN (#5447 item 2): the post-swap counter rewind must come
+        from llm_helpers.fallback_rewound_transient_budget — not a re-encoded
+        local constant. Patching the shared body to grant no extra pass drops
+        the candidate to a single attempt."""
+        from kiro_crew.acp.client import AcpError
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.llm_helpers import TRANSIENT_RETRIES
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner._agent_fallback_chain",
+            lambda: ("fallback-model",),
+        )
+        # Rewind to the exhaustion threshold: the re-queued attempt runs, and
+        # its failure immediately re-enters the fallback branch (no same-model
+        # retry pass) — one attempt on the candidate instead of two.
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.fallback_rewound_transient_budget",
+            lambda: TRANSIENT_RETRIES,
+        )
+        call_count = 0
+
+        async def _stream(msg):
+            nonlocal call_count
+            call_count += 1
+            raise AcpError(self._TRANSIENT)
+            yield  # pragma: no cover
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        # 4 on the primary + only 1 on the candidate (vs 2 unpatched — see
+        # test_chain_exhaustion_surfaces_error_with_story).
+        assert call_count == TRANSIENT_RETRIES + 2
+        client.set_model.assert_awaited_once_with("fallback-model")
+
+    @pytest.mark.asyncio
     async def test_restore_probe_fires_on_next_genuine_turn(self, tmp_path, monkeypatch):
         """A sticky fallback from an earlier cycle is probed back to the
         primary at the start of the next genuine user turn — quietly (no
@@ -16228,6 +16272,124 @@ class TestRunChatModelFallback:
         # candidate. (The unknown-primary probe clears the sticky state — the
         # pin staying empty is the property under test.)
         assert slot.model == ""
+
+
+class TestSlotProbeWrapsSharedRestoreBody:
+    """DRIFT PIN (#5447 item 3): the slot restore probe is a thin adapter over
+    llm_helpers.probe_fallback_restore — only the slot pick-gen/heal/clear
+    logic lives locally. These tests pin the delegation and the slot-specific
+    hooks it hands over; the probe mechanics themselves are pinned in
+    test_llm_helpers.py and the end-to-end behavior in
+    TestRunChatModelFallback above."""
+
+    @staticmethod
+    def _slot(**overrides):
+        from types import SimpleNamespace
+
+        defaults = dict(
+            key="s1",
+            model="",
+            _model_pick_lock=None,
+            _active_fallback_model="fb-1",
+            _fallback_primary_model="primary-m",
+            _fallback_slot_model="",
+            _model_pick_gen=3,
+            _fallback_pick_gen=3,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    @pytest.mark.asyncio
+    async def test_delegates_slot_state_to_the_shared_body(self):
+        from kiro_crew.dashboard import chat_runner
+        from kiro_crew.llm_helpers import TURN_FALLBACK_ATTR
+
+        slot = self._slot()
+        client = MagicMock()
+        setattr(client, TURN_FALLBACK_ATTR, ("primary-m", "fb-1"))
+        with patch(
+            "kiro_crew.dashboard.chat_runner.probe_fallback_restore", new_callable=AsyncMock
+        ) as probe:
+            await chat_runner._probe_fallback_restore_for_slot(slot, client)
+
+        probe.assert_awaited_once()
+        kwargs = probe.await_args.kwargs
+        assert kwargs["surface"] == "dashboard"
+        assert kwargs["state"] == ("primary-m", "fb-1")
+        assert kwargs["stale"] is False
+        assert kwargs["log_suffix"] == ", slot=s1"
+        # The handed-over clear drops slot fields AND the provider marker as
+        # one logical record.
+        kwargs["clear"]()
+        assert slot._active_fallback_model == ""
+        assert slot._fallback_primary_model == ""
+        assert getattr(client, TURN_FALLBACK_ATTR) is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_pick_generation_bump_rides_in_as_stale(self):
+        from kiro_crew.dashboard import chat_runner
+
+        slot = self._slot(_model_pick_gen=4)  # picked after the swap
+        with patch(
+            "kiro_crew.dashboard.chat_runner.probe_fallback_restore", new_callable=AsyncMock
+        ) as probe:
+            await chat_runner._probe_fallback_restore_for_slot(slot, MagicMock())
+        assert probe.await_args.kwargs["stale"] is True
+
+    @pytest.mark.asyncio
+    async def test_heal_hook_restores_the_activation_snapshot(self):
+        from kiro_crew.dashboard import chat_runner
+
+        slot = self._slot(model="fb-1", _fallback_slot_model="")  # backfilled pin
+        with patch(
+            "kiro_crew.dashboard.chat_runner.probe_fallback_restore", new_callable=AsyncMock
+        ) as probe:
+            await chat_runner._probe_fallback_restore_for_slot(slot, MagicMock())
+        probe.await_args.kwargs["on_restored"]()
+        assert slot.model == ""
+
+    @pytest.mark.asyncio
+    async def test_no_active_fallback_never_reaches_the_shared_body(self):
+        from kiro_crew.dashboard import chat_runner
+
+        slot = self._slot(_active_fallback_model="")
+        with patch(
+            "kiro_crew.dashboard.chat_runner.probe_fallback_restore", new_callable=AsyncMock
+        ) as probe:
+            await chat_runner._probe_fallback_restore_for_slot(slot, MagicMock())
+        probe.assert_not_awaited()
+
+    def test_sticky_clear_drops_marker_and_slot_fields(self):
+        from kiro_crew.dashboard import chat_runner
+        from kiro_crew.llm_helpers import TURN_FALLBACK_ATTR
+
+        slot = self._slot()
+        client = MagicMock()
+        setattr(client, TURN_FALLBACK_ATTR, ("primary-m", "fb-1"))
+        chat_runner._clear_fallback_sticky_state(slot, client)
+        assert getattr(client, TURN_FALLBACK_ATTR) is None
+        assert slot._active_fallback_model == ""
+        assert slot._fallback_primary_model == ""
+        assert slot._fallback_slot_model == ""
+
+    def test_sticky_clear_keeps_slot_record_when_marker_clear_fails(self):
+        """DRIFT PIN (review round 3): a failed provider-marker clear must NOT
+        blank the slot fields — the slot probe keys on _active_fallback_model,
+        so keeping the record is what makes the clear retryable next turn.
+        Blanking the fields around a surviving marker would orphan it."""
+        from kiro_crew.dashboard import chat_runner
+        from kiro_crew.llm_helpers import TURN_FALLBACK_ATTR
+
+        class _HostileClient:
+            @property
+            def _kc_active_fallback(self):  # TURN_FALLBACK_ATTR
+                raise RuntimeError("hostile marker")
+
+        assert TURN_FALLBACK_ATTR == "_kc_active_fallback"
+        slot = self._slot()
+        chat_runner._clear_fallback_sticky_state(slot, _HostileClient())  # must not raise
+        assert slot._active_fallback_model == "fb-1"
+        assert slot._fallback_primary_model == "primary-m"
 
 
 class TestSlotsGetWarmsGitLabAllowlist:

--- a/test/test_heartbeat_cycle_recycle.py
+++ b/test/test_heartbeat_cycle_recycle.py
@@ -61,10 +61,7 @@ class TestOnCycleEndCallback:
             order.append("cycle_end")
 
         heartbeat_file.write_text(
-            "# Heartbeat Tasks\n\n"
-            "- [ ] task A\n"
-            "- [ ] task B\n"
-            "- [ ] task C\n",
+            "# Heartbeat Tasks\n\n" "- [ ] task A\n" "- [ ] task B\n" "- [ ] task C\n",
             encoding="utf-8",
         )
 
@@ -107,9 +104,73 @@ class TestOnCycleEndCallback:
         assert cycle_end_called == [True]
 
     @pytest.mark.asyncio
+    async def test_failure_log_carries_the_fallback_story(self, heartbeat_file, caplog):
+        """#5447 item 1: the heartbeat's terminal error text (its failure log
+        line — heartbeat failures are kept + retried, never delivered) names
+        the WHOLE fallback walk carried on the exception, not just the last
+        candidate's error."""
+        import logging
+
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR
+
+        async def _on_task(text, deliver):
+            exc = RuntimeError("backend throttle 500")
+            setattr(
+                exc,
+                FALLBACK_STORY_ATTR,
+                "primary-m throttled; fallbacks fb-1, fb-2 also unavailable",
+            )
+            raise exc
+
+        heartbeat_file.write_text(
+            "# Heartbeat Tasks\n\n- [ ] some task\n",
+            encoding="utf-8",
+        )
+
+        svc = HeartbeatService(
+            memory=MagicMock(),
+            on_task=_on_task,
+        )
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.heartbeat"):
+            await svc._process_heartbeat_file()
+
+        failed = [
+            r.getMessage() for r in caplog.records if "Heartbeat task failed" in r.getMessage()
+        ]
+        assert failed, "expected the failure log line"
+        assert any("fb-1, fb-2 also unavailable" in m for m in failed)
+
+    @pytest.mark.asyncio
+    async def test_storyless_failure_log_is_unchanged(self, heartbeat_file, caplog):
+        """No story on the exception ⇒ the log line is exactly the task text
+        (byte-for-byte pre-#5447 shape)."""
+        import logging
+
+        async def _on_task(text, deliver):
+            raise RuntimeError("plain boom")
+
+        heartbeat_file.write_text(
+            "# Heartbeat Tasks\n\n- [ ] some task\n",
+            encoding="utf-8",
+        )
+
+        svc = HeartbeatService(
+            memory=MagicMock(),
+            on_task=_on_task,
+        )
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.heartbeat"):
+            await svc._process_heartbeat_file()
+
+        failed = [
+            r.getMessage() for r in caplog.records if "Heartbeat task failed" in r.getMessage()
+        ]
+        assert failed == ["Heartbeat task failed: some task"]
+
+    @pytest.mark.asyncio
     async def test_callback_failure_does_not_crash_loop(self, heartbeat_file):
         """A raising on_cycle_end must NOT propagate — the cycle is over,
         and the periodic loop must keep ticking."""
+
         async def _on_task(text, deliver):
             return None
 

--- a/test/test_llm_helpers.py
+++ b/test/test_llm_helpers.py
@@ -1342,3 +1342,500 @@ class TestRecordInteractionEvent:
 
         # Must not raise — best-effort only.
         record_interaction_event(MagicMock(), "sess-3", "dashboard")
+
+
+class TestFallbackRetryBudgetSingleBody:
+    """#5447 item 2: the per-candidate retry budget lives in ONE place."""
+
+    def test_no_active_candidate_never_retries(self) -> None:
+        st = FallbackState(("m1",))
+        assert st.should_retry_active() is False
+        assert st.attempts == 0
+
+    def test_consumes_attempts_up_to_the_budget(self) -> None:
+        st = FallbackState(("m1",), active="m1", attempts=1)
+        # attempts=1 is how advance_fallback_candidate seeds a fresh candidate.
+        for expected in range(2, FALLBACK_CANDIDATE_ATTEMPTS + 1):
+            assert st.should_retry_active() is True
+            assert st.attempts == expected
+        assert st.should_retry_active() is False
+        assert st.attempts == FALLBACK_CANDIDATE_ATTEMPTS
+
+    def test_dashboard_rewind_derives_from_the_same_constant(self) -> None:
+        """The interactive ladder's counter rewind grants a fresh candidate
+        exactly FALLBACK_CANDIDATE_ATTEMPTS - 1 further same-model passes —
+        the same budget the unattended surfaces consume via
+        should_retry_active."""
+        from kiro_crew.llm_helpers import (
+            TRANSIENT_RETRIES,
+            fallback_rewound_transient_budget,
+        )
+
+        assert fallback_rewound_transient_budget() == TRANSIENT_RETRIES - (
+            FALLBACK_CANDIDATE_ATTEMPTS - 1
+        )
+
+
+class TestFallbackExhaustionStory:
+    """The chain-exhausted story is built in ONE place (FallbackState)."""
+
+    def test_story_names_primary_and_every_walked_candidate(self) -> None:
+        st = FallbackState(("a", "b"), primary="primary-m", walked=["a", "b"])
+        assert st.exhaustion_story() == ("primary-m throttled; fallbacks a, b also unavailable")
+
+    def test_unwalked_chain_has_no_story(self) -> None:
+        """Nothing actually ran (all candidates skipped) ⇒ the error surfaces
+        exactly as before the feature — no story."""
+        assert FallbackState(("a",), primary="p").exhaustion_story() is None
+
+    def test_unknown_primary_uses_placeholder(self) -> None:
+        story = FallbackState(("a",), walked=["a"]).exhaustion_story()
+        assert story is not None and story.startswith("the selected model throttled")
+
+
+class TestFallbackStoryConsumer:
+    """#5447 item 1: append_fallback_story is THE reader of the story attr."""
+
+    def _exc_with_story(self, story: str = "primary-m throttled; fallbacks fb-1 also unavailable"):
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR
+
+        exc = AcpError("Internal server error")
+        setattr(exc, FALLBACK_STORY_ATTR, story)
+        return exc
+
+    def test_appends_story_to_terminal_error_text(self) -> None:
+        from kiro_crew.llm_helpers import append_fallback_story
+
+        out = append_fallback_story("AcpError: Internal server error", self._exc_with_story())
+        assert out == (
+            "AcpError: Internal server error "
+            "[primary-m throttled; fallbacks fb-1 also unavailable]"
+        )
+
+    def test_no_story_returns_text_byte_for_byte(self) -> None:
+        from kiro_crew.llm_helpers import append_fallback_story
+
+        assert append_fallback_story("AcpError: boom", AcpError("boom")) == "AcpError: boom"
+
+    def test_empty_text_returns_bare_story(self) -> None:
+        from kiro_crew.llm_helpers import append_fallback_story
+
+        assert append_fallback_story("", self._exc_with_story("s")) == "s"
+
+    def test_non_string_story_attr_is_ignored(self) -> None:
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR, append_fallback_story
+
+        exc = AcpError("boom")
+        setattr(exc, FALLBACK_STORY_ATTR, ["not", "a", "string"])
+        assert append_fallback_story("t", exc) == "t"
+
+    def test_stream_and_collect_sets_the_attr_this_reads(self) -> None:
+        """DRIFT PIN: the producer (Case 2.75) and this consumer agree on the
+        attribute — fallback_story_of reads back what the walk attached."""
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR, fallback_story_of
+
+        exc = AcpError("boom")
+        setattr(exc, FALLBACK_STORY_ATTR, "the story")
+        assert fallback_story_of(exc) == "the story"
+        assert fallback_story_of(AcpError("boom")) == ""
+
+
+class TestAnnotateModelFallbackSharedBody:
+    """#5447 item 4: one spelling of the fallback-served warning."""
+
+    def test_prefixes_warning_from_marker(self) -> None:
+        from types import SimpleNamespace
+
+        from kiro_crew.llm_helpers import annotate_model_fallback
+
+        provider = SimpleNamespace()
+        setattr(provider, TURN_FALLBACK_ATTR, ("primary-m", "fb-m"))
+        out = annotate_model_fallback("body text", provider)
+        assert out.startswith("⚠️ Model 'primary-m' throttled")
+        assert "fallback 'fb-m'" in out
+        assert out.endswith("\n\nbody text")
+
+    def test_empty_text_yields_bare_warning_line(self) -> None:
+        """The sub-agent call site can pass an empty result — the warning
+        stands alone rather than trailing a blank separator."""
+        from types import SimpleNamespace
+
+        from kiro_crew.llm_helpers import annotate_model_fallback
+
+        provider = SimpleNamespace()
+        setattr(provider, TURN_FALLBACK_ATTR, ("primary-m", "fb-m"))
+        out = annotate_model_fallback("", provider)
+        assert out.startswith("⚠️ Model 'primary-m' throttled")
+        assert "\n\n" not in out
+
+    def test_no_marker_and_malformed_marker_are_noops(self) -> None:
+        from types import SimpleNamespace
+
+        from kiro_crew.llm_helpers import annotate_model_fallback
+
+        assert annotate_model_fallback("text", SimpleNamespace()) == "text"
+        provider = SimpleNamespace()
+        setattr(provider, TURN_FALLBACK_ATTR, ("only-one",))
+        assert annotate_model_fallback("text", provider) == "text"
+
+
+class TestProbeFallbackRestoreSlotSeams:
+    """#5447 item 3: the parameter seams the dashboard's slot probe wraps.
+
+    The slot probe (chat_runner._probe_fallback_restore_for_slot_locked) is a
+    thin adapter over this single body; these tests pin the seams it depends
+    on: slot-held state, the extra staleness flag, the replacement clear, and
+    the pre-clear heal hook.
+    """
+
+    @staticmethod
+    def _provider(served: str = "fb-1"):
+        provider = AsyncMock()
+        provider.served_model = served
+        provider._model = served
+
+        async def _move(model_id: str) -> None:
+            provider._model = model_id
+            provider.served_model = model_id
+
+        provider.set_model = AsyncMock(side_effect=_move)
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_state_override_restores_and_runs_hooks_in_order(self) -> None:
+        provider = self._provider(served="fb-1")
+        order: list[str] = []
+        await probe_fallback_restore(
+            provider,
+            surface="dashboard",
+            state=("primary-model", "fb-1"),
+            clear=lambda: order.append("clear"),
+            on_restored=lambda: order.append("heal"),
+            log_suffix=", slot=s1",
+        )
+        provider.set_model.assert_awaited_once_with("primary-model")
+        # The heal must see the pre-clear state: heal strictly before clear.
+        assert order == ["heal", "clear"]
+
+    @pytest.mark.asyncio
+    async def test_stale_flag_clears_without_restoring(self) -> None:
+        """The dashboard's explicit-pick generation check rides in as `stale`:
+        an explicit pick must never be overridden by a restore."""
+        provider = self._provider(served="fb-1")
+        cleared: list[bool] = []
+        await probe_fallback_restore(
+            provider,
+            state=("primary-model", "fb-1"),
+            stale=True,
+            clear=lambda: cleared.append(True),
+        )
+        provider.set_model.assert_not_awaited()
+        assert cleared == [True]
+
+    @pytest.mark.asyncio
+    async def test_unknown_primary_clears_without_restoring(self) -> None:
+        provider = self._provider(served="fb-1")
+        cleared: list[bool] = []
+        await probe_fallback_restore(
+            provider,
+            state=("", "fb-1"),
+            clear=lambda: cleared.append(True),
+        )
+        provider.set_model.assert_not_awaited()
+        assert cleared == [True]
+
+    @pytest.mark.asyncio
+    async def test_empty_candidate_state_is_a_noop(self) -> None:
+        """Matches the slot probe's no-active-fallback early return: nothing
+        restored, nothing cleared."""
+        provider = self._provider()
+        cleared: list[bool] = []
+        await probe_fallback_restore(
+            provider,
+            state=("primary-model", ""),
+            clear=lambda: cleared.append(True),
+        )
+        provider.set_model.assert_not_awaited()
+        assert cleared == []
+
+    @pytest.mark.asyncio
+    async def test_failed_restore_keeps_state_and_skips_hooks(self) -> None:
+        provider = self._provider(served="fb-1")
+        provider.set_model = AsyncMock(side_effect=AcpError("throttled again"))
+        called: list[str] = []
+        await probe_fallback_restore(
+            provider,
+            state=("primary-model", "fb-1"),
+            clear=lambda: called.append("clear"),
+            on_restored=lambda: called.append("heal"),
+        )
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_silent_noop_restore_keeps_state_and_skips_hooks(self) -> None:
+        """A non-raising set_model that did not move the session (witness
+        check) must keep the sticky state — clearing would let the backfill
+        pin the fallback permanently."""
+        provider = self._provider(served="fb-1")
+        provider.set_model = AsyncMock()  # returns without syncing the model
+        called: list[str] = []
+        await probe_fallback_restore(
+            provider,
+            state=("primary-model", "fb-1"),
+            clear=lambda: called.append("clear"),
+            on_restored=lambda: called.append("heal"),
+        )
+        provider.set_model.assert_awaited_once_with("primary-model")
+        assert called == []
+
+
+class TestCase275RoutesThroughSharedBudgetBody:
+    """DRIFT PIN (#5447 item 2): Case 2.75 must consult should_retry_active.
+
+    Mutation check in reverse: forcing the shared body to refuse retries
+    changes this surface's attempt count — proof the budget is not re-encoded
+    locally. The sub-agent ladder has the mirror pin in
+    test_subagent_turn_resilience.py.
+    """
+
+    _TRANSIENT = "Prompt error: {'message': 'Internal error: API Error: Internal server error'}"
+
+    @pytest.mark.asyncio
+    async def test_forcing_the_shared_body_to_refuse_drops_candidate_retries(self) -> None:
+        from kiro_crew.llm_helpers import _TRANSIENT_RETRIES
+
+        call_count = 0
+
+        async def _stream(msg):
+            nonlocal call_count
+            call_count += 1
+            raise AcpError(self._TRANSIENT)
+            yield  # pragma: no cover
+
+        provider = AsyncMock()
+        provider.cancel = AsyncMock()
+        provider.shutdown = AsyncMock()
+        provider.stream = _stream
+        provider.available_models = MagicMock(
+            return_value=[{"modelId": "fb-1"}, {"modelId": "fb-2"}]
+        )
+        provider.served_model = "primary-model"
+        provider._model = "primary-model"
+
+        async def _move(model_id: str) -> None:
+            provider._model = model_id
+            provider.served_model = model_id
+
+        provider.set_model = AsyncMock(side_effect=_move)
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch.object(FallbackState, "should_retry_active", return_value=False),
+            pytest.raises(AcpError),
+        ):
+            await stream_and_collect(provider, "test", fallback_models=["fb-1", "fb-2"])
+
+        # Budget refused ⇒ each candidate gets only the single post-advance
+        # attempt: 4 same-model + 1 per candidate (vs 2 each normally).
+        assert call_count == (_TRANSIENT_RETRIES + 1) + 2
+
+
+class TestFallbackStorySafety:
+    """Round-2 review pins: the story is redacted+capped CENTRALLY, and the
+    consumers/annotator never raise."""
+
+    def test_story_is_capped_centrally(self) -> None:
+        """Walked ids originate in config (advertised check fails open), so an
+        arbitrarily long story must be bounded before riding any surface."""
+        from kiro_crew.llm_helpers import (
+            _FALLBACK_STORY_CAP,
+            FALLBACK_STORY_ATTR,
+            fallback_story_of,
+        )
+
+        exc = AcpError("boom")
+        setattr(exc, FALLBACK_STORY_ATTR, "m" * (_FALLBACK_STORY_CAP * 3))
+        assert len(fallback_story_of(exc)) == _FALLBACK_STORY_CAP
+
+    def test_story_is_redacted_centrally(self) -> None:
+        """A credential-shaped token in the story never reaches a consumer —
+        heartbeat logs the story with no redaction of its own."""
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR, fallback_story_of
+
+        exc = AcpError("boom")
+        setattr(
+            exc,
+            FALLBACK_STORY_ATTR,
+            "AKIAIOSFODNN7EXAMPLE throttled; fallbacks fb-1 also unavailable",
+        )
+        story = fallback_story_of(exc)
+        assert "AKIAIOSFODNN7EXAMPLE" not in story
+        assert "also unavailable" in story
+
+    def test_story_read_survives_hostile_exception_attr(self) -> None:
+        """The attribute read itself is guarded — a raising property on an
+        exotic exception type must not break the failure handler reading it."""
+        from kiro_crew.llm_helpers import append_fallback_story
+
+        class _HostileExc(Exception):
+            @property
+            def _kc_fallback_story(self):  # FALLBACK_STORY_ATTR
+                raise RuntimeError("hostile attr")
+
+        assert append_fallback_story("t", _HostileExc()) == "t"
+
+    def test_annotate_never_raises_on_hostile_marker(self) -> None:
+        """An annotation failure must not turn a successful run into a failed
+        one — the un-annotated text comes back instead (the sub-agent call
+        site relies on this; its old inline guard is gone)."""
+        from types import SimpleNamespace
+
+        from kiro_crew.llm_helpers import annotate_model_fallback
+
+        class _Boom:
+            def __str__(self) -> str:  # str(primary) raises inside the helper
+                raise RuntimeError("hostile id")
+
+        provider = SimpleNamespace()
+        setattr(provider, TURN_FALLBACK_ATTR, (_Boom(), "fb-m"))
+        assert annotate_model_fallback("the result", provider) == "the result"
+
+    @pytest.mark.asyncio
+    async def test_probe_survives_raising_hooks(self) -> None:
+        """probe_fallback_restore promises 'never raises' — caller-supplied
+        heal/clear hooks are contained, and a failed heal does not block the
+        clear (the two writes are one logical record)."""
+        provider = AsyncMock()
+        provider.served_model = "fb-1"
+        provider._model = "fb-1"
+
+        async def _move(model_id: str) -> None:
+            provider._model = model_id
+            provider.served_model = model_id
+
+        provider.set_model = AsyncMock(side_effect=_move)
+
+        cleared: list[bool] = []
+
+        def _bad_heal() -> None:
+            raise RuntimeError("heal boom")
+
+        def _clear() -> None:
+            cleared.append(True)
+
+        await probe_fallback_restore(
+            provider,
+            state=("primary-model", "fb-1"),
+            clear=_clear,
+            on_restored=_bad_heal,
+        )
+        provider.set_model.assert_awaited_once_with("primary-model")
+        assert cleared == [True]
+
+    @pytest.mark.asyncio
+    async def test_probe_survives_raising_clear_on_stale_path(self) -> None:
+        provider = AsyncMock()
+        provider.served_model = "other-model"
+        provider._model = "other-model"
+        provider.set_model = AsyncMock()
+
+        def _bad_clear() -> None:
+            raise RuntimeError("clear boom")
+
+        # Moved-off session: the stale path runs the (raising) clear — must
+        # not propagate.
+        await probe_fallback_restore(
+            provider,
+            state=("primary-model", "fb-1"),
+            clear=_bad_clear,
+        )
+        provider.set_model.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_probe_malformed_state_is_a_noop(self) -> None:
+        provider = AsyncMock()
+        provider.set_model = AsyncMock()
+        await probe_fallback_restore(provider, state=("only-one",))  # type: ignore[arg-type]
+        provider.set_model.assert_not_awaited()
+
+    def test_rewound_budget_is_clamped_at_zero(self) -> None:
+        """A future FALLBACK_CANDIDATE_ATTEMPTS above TRANSIENT_RETRIES + 1
+        cannot be expressed by the counter encoding — it clamps to zero (the
+        full same-model budget) instead of going negative."""
+        import kiro_crew.llm_helpers as lh
+
+        with patch.object(lh, "FALLBACK_CANDIDATE_ATTEMPTS", lh.TRANSIENT_RETRIES + 5):
+            assert lh.fallback_rewound_transient_budget() == 0
+
+    def test_budgeted_append_keeps_the_story_over_the_error_tail(self) -> None:
+        """With a budget, the ERROR text is trimmed to leave the story room —
+        a verbose exception must never push the walk out of the composite —
+        and the total stays within the budget."""
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR, append_fallback_story
+
+        exc = AcpError("boom")
+        setattr(exc, FALLBACK_STORY_ATTR, "primary-m throttled; fallbacks fb-1 also unavailable")
+        out = append_fallback_story("E" * 5000, exc, budget=2000)
+        assert len(out) <= 2000
+        assert out.endswith("[primary-m throttled; fallbacks fb-1 also unavailable]")
+
+    def test_budgeted_append_without_story_just_caps(self) -> None:
+        from kiro_crew.llm_helpers import append_fallback_story
+
+        assert append_fallback_story("E" * 5000, AcpError("x"), budget=2000) == "E" * 2000
+
+    def test_negative_and_zero_budgets_mean_empty_not_unbounded(self) -> None:
+        """A negative slice drops characters from the END — a negative budget
+        must tighten the bound to nothing, never loosen it."""
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR, append_fallback_story
+
+        exc = AcpError("boom")
+        setattr(exc, FALLBACK_STORY_ATTR, "s" * 50)
+        assert append_fallback_story("E" * 100, exc, budget=0) == ""
+        assert append_fallback_story("E" * 100, exc, budget=-5) == ""
+        assert append_fallback_story("E" * 100, AcpError("x"), budget=-5) == ""
+
+    def test_oversized_story_cannot_evict_the_error_text(self) -> None:
+        """The error text keeps a floor of half the budget even when the story
+        alone fills the whole budget (possible when a caller's cap equals
+        _FALLBACK_STORY_CAP): past the floor the story tail truncates, the
+        error never vanishes from the alert."""
+        from kiro_crew.llm_helpers import FALLBACK_STORY_ATTR, append_fallback_story
+
+        exc = AcpError("boom")
+        setattr(exc, FALLBACK_STORY_ATTR, "s" * 500)
+        out = append_fallback_story("E" * 400, exc, budget=500)
+        assert len(out) == 500
+        assert out.startswith("E" * 250)  # error floor = budget // 2
+        assert "sss" in out  # the story is still present, truncated
+
+    @pytest.mark.asyncio
+    async def test_probe_never_raises_on_hostile_marker_read(self) -> None:
+        """The marker property itself can raise (exotic providers) — the
+        probe skips instead of propagating."""
+
+        class _HostileProvider:
+            served_model = "fb-1"
+            _model = "fb-1"
+
+            @property
+            def _kc_active_fallback(self):  # TURN_FALLBACK_ATTR
+                raise RuntimeError("hostile marker")
+
+        await probe_fallback_restore(_HostileProvider())  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_probe_never_raises_on_hostile_candidate_str(self) -> None:
+        class _Boom:
+            def __str__(self) -> str:
+                raise RuntimeError("hostile id")
+
+            def __bool__(self) -> bool:
+                return True
+
+        provider = AsyncMock()
+        provider.served_model = "fb-1"
+        provider._model = "fb-1"
+        provider.set_model = AsyncMock()
+        await probe_fallback_restore(provider, state=("primary-model", _Boom()))
+        provider.set_model.assert_not_awaited()

--- a/test/test_subagent_turn_resilience.py
+++ b/test/test_subagent_turn_resilience.py
@@ -283,8 +283,99 @@ async def test_throttle_fallback_chain_exhausted_propagates():
 
     assert info.done is True
     assert "500" in info.error
+    # #5447 item 1: the terminal error text names the WHOLE walk, not just the
+    # last candidate's failure — the chain story is appended to info.error.
+    assert "primary-model throttled" in info.error
+    assert "fb-1" in info.error and "also unavailable" in info.error
     assert len(calls) == 1 + TRANSIENT_RETRIES + FALLBACK_CANDIDATE_ATTEMPTS
     provider.set_model.assert_awaited_once_with("fb-1")
+
+
+@pytest.mark.asyncio
+async def test_throttle_fallback_ladder_routes_through_shared_budget_body():
+    """DRIFT PIN (#5447 item 2): the ladder must consult
+    FallbackState.should_retry_active for the per-candidate budget. Forcing
+    the shared body to refuse retries changes the attempt count — proof the
+    budget is not re-encoded locally (mirror of the stream_and_collect pin in
+    test_llm_helpers.py)."""
+    from kiro_crew.llm_helpers import FallbackState
+
+    calls: list[str] = []
+
+    def stream_factory(msg: str, *a, **kw):
+        calls.append(msg)
+
+        async def _gen():
+            raise _TransientError("backend throttle 500")
+            yield  # noqa: unreachable — async generator marker
+
+        return _gen()
+
+    sessions = _mock_sessions(stream_factory)
+    provider = sessions._provider
+    provider.available_models = MagicMock(return_value=[{"modelId": "fb-1"}])
+    provider.served_model = "primary-model"
+    provider._model = "primary-model"
+
+    async def _move(model_id):
+        provider._model = model_id
+        provider.served_model = model_id
+
+    provider.set_model = AsyncMock(side_effect=_move)
+
+    mgr = _manager(sessions)
+    with (
+        patch("kiro_crew.subagent.transient_retry_delay", return_value=0.0),
+        patch("kiro_crew.subagent.configured_fallback_chain", return_value=("fb-1",)),
+        patch.object(FallbackState, "should_retry_active", return_value=False),
+    ):
+        info = await _spawn_and_wait(mgr)
+
+    assert info.done is True
+    # Budget refused ⇒ the candidate gets only its single post-advance attempt.
+    assert len(calls) == 1 + TRANSIENT_RETRIES + 1
+
+
+@pytest.mark.asyncio
+async def test_throttle_fallback_story_survives_a_verbose_error():
+    """A verbose backend error fills _describe_exception to its cap — the
+    story must still be present in info.error (the error tail is what gets
+    trimmed, never the walk), and the total stays bounded."""
+    from kiro_crew.subagent import _MAX_ERROR_DETAIL_LEN
+
+    calls: list[str] = []
+
+    def stream_factory(msg: str, *a, **kw):
+        calls.append(msg)
+
+        async def _gen():
+            raise _TransientError("backend throttle 500 " + "x" * (3 * _MAX_ERROR_DETAIL_LEN))
+            yield  # noqa: unreachable — async generator marker
+
+        return _gen()
+
+    sessions = _mock_sessions(stream_factory)
+    provider = sessions._provider
+    provider.available_models = MagicMock(return_value=[{"modelId": "fb-1"}])
+    provider.served_model = "primary-model"
+    provider._model = "primary-model"
+
+    async def _move(model_id):
+        provider._model = model_id
+        provider.served_model = model_id
+
+    provider.set_model = AsyncMock(side_effect=_move)
+
+    mgr = _manager(sessions)
+    with (
+        patch("kiro_crew.subagent.transient_retry_delay", return_value=0.0),
+        patch("kiro_crew.subagent.configured_fallback_chain", return_value=("fb-1",)),
+    ):
+        info = await _spawn_and_wait(mgr)
+
+    assert info.done is True
+    assert len(info.error) <= _MAX_ERROR_DETAIL_LEN
+    assert info.error.endswith("[primary-model throttled; fallbacks fb-1 also unavailable]")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refs #5447 — resolves items 1–4 (story consumer, single retry budget, probe dedupe, shared annotation helper); items 5–7 (picker UX, composer chip, surface-extension evaluation) remain open. Do NOT auto-close the issue.

## Problem / Motivation

Post-merge consolidation follow-ups from the review lanes on PR #5431 (model fallback chain), issue items 1–4:

1. `exc._kc_fallback_story` had **no production reader** — cron/heartbeat/sub-agent chain-exhaustion errors showed only the last candidate's failure, hiding that a whole fallback walk happened.
2. The `FALLBACK_CANDIDATE_ATTEMPTS` per-candidate retry budget/trigger was encoded in **three places** (`llm_helpers` Case 2.75, the `subagent` ladder, the `chat_runner` counter rewind).
3. `chat_runner._probe_fallback_restore_for_slot_locked` **duplicated** `llm_helpers.probe_fallback_restore` almost line-for-line.
4. `slack/gateway._annotate_model_fallback` and an inline block in `subagent.py` were **two spellings** of the same fallback-served warning.

## Why it matters

Duplicated fallback machinery drifts: a fix to one copy silently misses the others (the exact class the walk consolidation in #5431 already solved via `advance_fallback_candidate`). And an unattended failure that names only the last candidate's error sends the operator debugging the wrong model.

## What changed (motivation → approach → change)

Pure consolidation; behavior-preserving except item 1, which ADDS story text to unattended terminal errors:

- **Item 1 (story consumer):** new `FALLBACK_STORY_ATTR` constant + `fallback_story_of` / `append_fallback_story` in `llm_helpers`. The story is **redacted and capped centrally** (`_FALLBACK_STORY_CAP`) — walked ids originate in config (LLM-reachable via MCP; the advertised check fails open). Wired at all three unattended surfaces: the cron failure alert (dashboard notify + Slack DM legs), sub-agent `info.error`, and the heartbeat failure log. Budgeted composition (`budget=`) guarantees the error text a floor of half the budget and the composite never exceeds it, so a verbose backend error can't evict the story and an oversized story can't evict the error. The cron dedup hash keys on the **story-free** error text (a differing walk must not defeat dup suppression), and the dup-suppress body is now bounded by the same detail composite.
- **Item 2 (single budget body):** `FallbackState.should_retry_active()` is the one check-and-consume for the per-candidate budget (used by Case 2.75 and the sub-agent ladder); the dashboard's counter rewind derives from the same constant via `fallback_rewound_transient_budget()` (clamped at zero). `FallbackState.exhaustion_story()` is the one story builder.
- **Item 3 (probe dedupe):** `probe_fallback_restore` gained `state` / `stale` / `clear` / `on_restored` / `log_suffix` seams; `_probe_fallback_restore_for_slot_locked` is now a thin adapter handing over slot state, the explicit-pick generation check, the sticky clear, and the slot-model heal. The probe honors its never-raises contract end to end (hostile marker properties, raising `__str__`/`__bool__`, raising hooks, all three `set_model` reads guarded). `_clear_fallback_sticky_state` clears the provider marker first and retains the slot record when the marker clear fails.
- **Item 4 (shared annotator):** `annotate_model_fallback` lives next to `TURN_FALLBACK_ATTR` in `llm_helpers`; the gateway name delegates to it and the sub-agent inline block is deleted. Never-raises; ids redacted and capped.
- `docs/system-specs/features/model-fallback.md` updated to match (consumer wiring, one-place budget, delegation, central story redaction). `.gitignore` gains `.review-*.diff` + `.heartbeat` (agent-workflow scratch).

Verified against main first: none of the four consolidations had landed by another PR (branch cut from main 2df4f2d9f).

## Deliberate trade-offs (from the review rounds)

- The chain-exhaustion producer **warning logs** emit the raw story (pre-redaction) — consistent with the existing swap-warning logs, which also log raw config ids; delivery surfaces are the redaction boundary.
- A failed `on_restored` heal does not block the sticky clear (the stale paths never heal either; the dashboard's hooks are plain writes that realistically cannot raise).
- The marker-path/state-path empty-candidate asymmetry in the probe is preserved pre-existing behavior (marker `(p,"")` still probes; slot state `""` no-ops), pinned by tests.
- Gateway annotator on EMPTY text now returns the bare warning line (adopting the sub-agent spelling) instead of `line + "\n\n"`; unreachable at current call sites (`_No response._` fallback precedes it).
- Degenerate `budget` values of a few characters keep the error head and may drop the story; both real callers pass module constants (500 / 2000).
- Pre-existing (unchanged): the sub-agent tombstone leg re-redacts after truncation (`_redact(info.error)[:cap]`); noted for a follow-up rather than widened here.

## Tests

40+ new/extended tests, mutation-verified where the spec asked (break `should_retry_active` → both the `stream_and_collect` and sub-agent ladder pins fail):

- `test_llm_helpers.py`: budget consume/exhaust semantics, exhaustion story, story consumer (append/read, hostile exception attr, non-string attr), central redaction + cap, budget arithmetic (floor, negative/zero, oversized story), annotator (marker/malformed/empty-text/hostile-`__str__`), probe seams (state/stale/clear/heal ordering, raising hooks, hostile marker/candidate, malformed state), rewind derivation + clamp, and drift pins proving Case 2.75 routes through the shared bodies.
- `test_subagent_turn_resilience.py`: story lands in `info.error`; verbose error keeps the story within `_MAX_ERROR_DETAIL_LEN`; ladder routes through `should_retry_active`.
- `test_cron_gateway_integration.py`: story reaches the dashboard notify AND Slack DM legs with a >cap verbose error; bodies stay bounded; story-free dedup suppresses a repeat with a different walk; gateway annotator IS the shared body (identity pin).
- `test_dashboard_chat.py`: slot probe delegates to the shared body (state/stale/clear/heal kwargs), rewind routes through the shared derivation, sticky-clear ordering + failure-retention pins; all pre-existing restore-probe behavior tests pass unchanged.
- `test_heartbeat_cycle_recycle.py`: failure log carries the story; story-less log byte-identical to the pre-change shape.

Local gates: isort / flake8 / mypy (1152 files) / diff-scoped black gate all green. Full suite: 72,655 passed; the 96 failures + 2 errors are this host's known pre-existing environment set (AF_UNIX path length, file-explorer/design-tweak/host-isolation), zero overlap with touched modules.

## Manual verification

N/A — unit coverage sufficient: every consolidated path is exercised through its real caller harness (cron callback, sub-agent spawn loop, `_run_chat`, `HeartbeatService._process_heartbeat_file`), not just unit-level.

## Adversarial review (pre-push, blind dual-model)

5 rounds, GPT (gpt-5.6-sol) + Opus (claude-opus-5) per round on staged diffs: 36 findings total → 24 fixed, 6 documented trade-offs (above), 6 noise/pre-existing. Final round: GPT one Low (degenerate budgets, documented), Opus PASS. Notable catches: story redaction/cap centralization, cap-collision error eviction, review scratch swept into the commit by `git add -A`, dedup hash keyed on the story, residual raise paths in the never-raise helpers.

## Screenshots / video

N/A — backend-only refactor, no user-visible UI change.
