### PR TITLE
test: poll session-sharing completion on a generous bound (#6537)

### DIFF
--- a/test/test_session_sharing.py
+++ b/test/test_session_sharing.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.usefixtures("healthy_host_memory")
 # ``_isolate_subagents_dir`` fixture in ``conftest.py`` — no per-file fixture needed.
 
 
-async def _wait_until_done(info, *, timeout: float = 5.0) -> None:
+async def _wait_until_done(info, *, timeout: float = 30.0) -> None:
     """Wait for a spawned subagent to finish, deterministically.
 
     ``manager.spawn`` runs the subagent as a background asyncio task that flips
@@ -47,7 +47,7 @@ async def _wait_until_done(info, *, timeout: float = 5.0) -> None:
         await asyncio.sleep(0.01)
 
 
-async def _wait_until_awaited(mock_attr, label: str, *, timeout: float = 5.0) -> None:
+async def _wait_until_awaited(mock_attr, label: str, *, timeout: float = 30.0) -> None:
     """Wait for an async mock to have been awaited, deterministically.
 
     Companion to :func:`_wait_until_done`, for assertions about TEARDOWN rather
@@ -477,7 +477,8 @@ class TestSessionSharingMultiAgent:
              patch("kiro_crew.subagent.sel"):
             info1 = manager.spawn("task A", parent_session_key="dashboard:slot1")
             info2 = manager.spawn("task B", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(1.0)
+            await _wait_until_done(info1)
+            await _wait_until_done(info2)
 
         # Both should use session sharing
         assert info1._session_sharing is True
@@ -505,7 +506,8 @@ class TestSessionSharingMultiAgent:
              patch("kiro_crew.subagent.sel"):
             info1 = manager.spawn("task A", parent_session_key="dashboard:slot1")
             info2 = manager.spawn("task B", parent_session_key="dashboard:slot2")
-            await asyncio.sleep(1.0)
+            await _wait_until_done(info1)
+            await _wait_until_done(info2)
 
         assert info1._session_sharing is True
         assert info2._session_sharing is True


### PR DESCRIPTION
## Problem / Motivation

`test/test_session_sharing.py::TestSessionSharingMultiAgent::test_subagent_gets_unique_session_id` fails intermittently on loaded CI runners (observed on Backend Tests 3.12 shard 3, PR #6531 head cc203632f, run 33171028700) with:

```
AssertionError: subagent 0667ea3c did not complete within 5.0s
```

1 failed / 18206 passed in that shard; the failing PR's diff did not touch session sharing, and the Coverage Gate red in the same run was the fail-closed consequence of this one shard. The module's poll helpers `_wait_until_done` / `_wait_until_awaited` already poll the completion condition correctly, but cap the poll at a fixed `timeout=5.0` — on a contended runner the correct completion lands just after that deadline, so the poll raises even though nothing is wrong.

## Why it matters

This is the determinism class named in `docs/system-specs/common/testing-conventions.md` § Determinism: a wall-clock deadline that races the scheduler. Every flake costs a full CI round on an unrelated PR (and drags the Coverage Gate red with it), plus a human/agent triage cycle to conclude "not my diff".

## What changed (motivation → approach → change)

Symptom: a correct subagent completion trips a too-tight fixed deadline under load. Root cause: the poll helpers' outer bound (5.0s) encodes an assumption about runner speed, not about correctness. Fix, test-only, per the testing conventions ("poll for the condition with a generous deadline"):

- Raised the default poll bound on both module-local helpers (`_wait_until_done`, `_wait_until_awaited`) from `5.0` to `30.0` seconds. The polling structure is unchanged — the helpers return as soon as the condition holds, so the happy path pays nothing; the larger bound only stops a contended runner from expiring the deadline before a correct completion lands. The failure mode stays fail-closed: a genuinely hung subagent still raises at the bound.
- Swept the module for sibling fixed-deadline waits: `test_two_subagents_share_same_runtime` and `test_two_subagents_different_parents_get_separate_runtimes` used a bare `await asyncio.sleep(1.0)` as a completion proxy — the same class, one step worse (a fixed sleep both races under load and always pays the full second). Replaced both with `_wait_until_done(info1/info2)` polls.

No production code changed — the subagent completion behaviour is correct; only the tests' timing bounds were too tight.

## Tests

This PR is itself a test change; no new tests are added. What the changed tests now lock in:

- All 22 tests in `test/test_session_sharing.py` pass (module runs in ~4s locally).
- Happy path is not slowed: with the poll bound at 30s, the three `TestSessionSharingMultiAgent` tests complete in 0.11–0.15s each (`--durations`), and the two converted tests are now ~0.9s *faster* than before (they no longer sleep a mandatory fixed 1.0s).
- Verification note for the flake itself: a single green run cannot prove a load-dependent flake fixed, and a mutation check has no power here. Correctness is by mechanism — the bound no longer gates a correct completion (30s of headroom vs the observed just-over-5s completion), and the poll returns immediately on completion, per the testing-conventions precedent.

## Manual verification

N/A — unit coverage sufficient: the change is confined to test timing bounds; the module's own suite plus the full backend suite exercise it directly.

## Related Issues

Closes #6537

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, test-only
- [x] No secrets, credentials, or internal references in the diff
