### PR TITLE
fix(test): replace fixed sleeps with deterministic polling in session sharing tests

### DIFF
--- a/test/test_session_sharing.py
+++ b/test/test_session_sharing.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.usefixtures("healthy_host_memory")
 # ``_isolate_subagents_dir`` fixture in ``conftest.py`` — no per-file fixture needed.
 
 
-async def _wait_until_done(info, *, timeout: float = 5.0) -> None:
+async def _wait_until_done(info, *, timeout: float = 30.0) -> None:
     """Wait for a spawned subagent to finish, deterministically.
 
     ``manager.spawn`` runs the subagent as a background asyncio task that flips
@@ -47,7 +47,7 @@ async def _wait_until_done(info, *, timeout: float = 5.0) -> None:
         await asyncio.sleep(0.01)
 
 
-async def _wait_until_awaited(mock_attr, label: str, *, timeout: float = 5.0) -> None:
+async def _wait_until_awaited(mock_attr, label: str, *, timeout: float = 30.0) -> None:
     """Wait for an async mock to have been awaited, deterministically.
 
     Companion to :func:`_wait_until_done`, for assertions about TEARDOWN rather
@@ -477,7 +477,8 @@ class TestSessionSharingMultiAgent:
              patch("kiro_crew.subagent.sel"):
             info1 = manager.spawn("task A", parent_session_key="dashboard:slot1")
             info2 = manager.spawn("task B", parent_session_key="dashboard:slot1")
-            await asyncio.sleep(1.0)
+            await _wait_until_done(info1)
+            await _wait_until_done(info2)
 
         # Both should use session sharing
         assert info1._session_sharing is True
@@ -505,7 +506,8 @@ class TestSessionSharingMultiAgent:
              patch("kiro_crew.subagent.sel"):
             info1 = manager.spawn("task A", parent_session_key="dashboard:slot1")
             info2 = manager.spawn("task B", parent_session_key="dashboard:slot2")
-            await asyncio.sleep(1.0)
+            await _wait_until_done(info1)
+            await _wait_until_done(info2)
 
         assert info1._session_sharing is True
         assert info2._session_sharing is True


### PR DESCRIPTION
## Summary

Fixes #6537 — the flaky `test_subagent_gets_unique_session_id` assertion.

### Changes

Per `docs/system-specs/common/testing-conventions.md` § Determinism (class 2: Wall-clock races):

1. **Raised `_wait_until_done` default timeout** from 5.0s → 30.0s — generous outer bound for loaded CI runners while still failing loudly if the condition is never met.

2. **Raised `_wait_until_awaited` default timeout** from 5.0s → 30.0s — consistent with the companion helper.

3. **Converted two sibling tests from fixed sleep to polling:**
   - `test_two_subagents_share_same_runtime`: replaced `await asyncio.sleep(1.0)` with `await _wait_until_done(info1)` + `await _wait_until_done(info2)`
   - `test_two_subagents_different_parents_get_separate_runtimes`: same conversion

### Testing

Test-only change. The polling pattern is already used by every other test in the same file. No functional code modified.