### PR TITLE
fix(doctor): gate missing-MCP-server checks on spec_gate (#6548)

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -147,6 +147,11 @@ and asymmetrically on purpose:
 - `_refresh_dynamic_fields()` **retracts** an entry a previous pass wrote while
   the gate was open, because a skip-only refresh would mean turning a feature off
   never reclaims the process turning it on started;
+
+`kirocrew doctor` is a third, read-only consumer: its MCP sections resolve the
+same registry gate (`cli_doctor._spec_gate_closed`) so a gated-off server's
+absence reads as informational rather than as a missing entry — the drift where
+doctor demanded what emission deliberately omitted was #6548.
 **The `@server` refs in `tools` / `allowedTools` are left exactly as they are.**
 Withholding the entry is the whole control: a `@server` ref resolves against the
 agent's own `mcpServers` plus the global `mcp.json`, so with no entry in either
@@ -192,7 +197,8 @@ signed in to, not a user preference, and because the client's filter is
 symmetric: outside registry mode a marked entry is the one that gets dropped.
 `command`/`args` stay either way, since the registry path is not the only
 consumer of this spec (doctor's handshake probe and the CC sidecar sync both
-launch from it). See
+launch from it — though doctor skips the probe for a server whose spec gate is
+closed, since no emitted spec defines it). See
 [../guides/enterprise-mcp-governance.md](../guides/enterprise-mcp-governance.md).
 
 `kirocrew-computer` carries **no `autoApprove` key and none may ever be added.**

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -18,6 +18,7 @@ import urllib.request
 from pathlib import Path
 
 from kiro_crew import __version__ as _mc_version
+from kiro_crew import agent as _agent
 from kiro_crew import agent_state, dep_sync, diagnostics, platform_compat, sandbox, stt
 from kiro_crew._bootstrap import _source_checkout_root
 from kiro_crew.acp.client import KIRO_CLI_BIN
@@ -480,17 +481,85 @@ def _format_model_pin_problem(name: str, pin: str, correction: str) -> tuple[str
     )
 
 
-def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
+def _spec_gate_closed(name: str) -> bool:
+    """Whether *name*'s spec-emission gate reports CLOSED right now.
+
+    Spec emission consults each managed server's ``spec_gate``
+    (``agent._MANAGED_MCP_SERVERS``): a closed gate means the ``mcpServers``
+    entry is deliberately omitted from every emitted spec — and retracted from
+    an existing one on refresh — so on such a host the entry's absence is the
+    HEALTHY state, not a broken install. Doctor's static checks must consult
+    the same predicate or the two sides drift apart, producing the unfixable
+    "missing from mcpServers (re-run `kirocrew setup`)" loop on every host
+    where the gate is closed (#6548). Resolving the gate through the registry
+    keeps them pinned together: a future server gaining a gate needs no edit
+    here, and a server without one reports open, exactly as emission treats it.
+
+    The ``except`` covers gate-CONTRACT failures only — a registry entry that
+    is not a dict, or a gate callable that raises past its own handling. For
+    those, the fail direction is deliberately the OPPOSITE of emission's
+    ``agent._gated_off_servers()``: there, a gate that raises is treated as
+    closed, because the open position hands out a backend the operator may not
+    want running; here it reports NOT closed, because "closed" is what
+    silences the missing-entry error. Each side fails toward its own safe
+    state. Note the scope honestly: the shipped computer-use gate catches its
+    own internal errors and ANSWERS ``False`` (its documented fail-closed
+    posture — an unreadable keystone must never hand out the desktop), so an
+    unreadable keystone is indistinguishable from policy-closed through the
+    boolean, by the gate's own design. That answer is still the
+    emission-CONSISTENT one to report: in that state the entry genuinely is
+    omitted from every emitted spec, so the ℹ️ line describes what the system
+    actually does, even when the underlying cause is a broken enable-state
+    read rather than a decision.
+
+    Never loads a native driver: the computer-use gate reads only the enable
+    keystone and platform flags (see ``agent._computer_use_spec_gate``), which
+    is what makes it safe to evaluate on doctor's diagnostic path.
+    """
+    try:
+        spec = _agent._MANAGED_MCP_SERVERS.get(name) or {}
+        gate = spec.get("spec_gate")
+        if gate is None:
+            return False
+        return not gate()
+    except Exception:
+        logger.debug("spec gate for %s unreadable; doctor treats it as open", name, exc_info=True)
+        return False
+
+
+def _doctor_gated_off_mcps() -> frozenset[str]:
+    """Doctor's per-run snapshot of managed servers whose spec gate is closed.
+
+    Evaluated ONCE per doctor run and threaded into both MCP sections, for the
+    same reason ``agent._gated_off_servers()`` snapshots once per rebuild: the
+    reads are cheap, agreeing is the point. A keystone flip landing between
+    the `MCP Tools` and `MCP Governance` sections would otherwise produce a
+    self-contradicting report — one saying "gated off by design", the other
+    "markers missing — re-run `kirocrew setup --agent-only`". Not reused from
+    ``_gated_off_servers()`` itself because the two snapshots fail in opposite
+    directions on an unreadable gate (see :func:`_spec_gate_closed`).
+    """
+    return frozenset(name for name in _MANAGED_MCPS if _spec_gate_closed(name))
+
+
+def _doctor_mcp_tools(
+    agent_path: Path, issues: list[str], *, gated_off: "frozenset[str] | None" = None
+) -> None:
     """Render the `MCP Tools` section of `kirocrew doctor`.
 
     Two passes scoped to the managed servers (`kirocrew-core`,
     `kirocrew-cron`, `kirocrew-computer`):
 
-    1. Static sanity check of the agent config: each server must be present
-       in ``mcpServers`` and ``tools``. Missing ``tools`` entries — and
-       ``allowedTools`` entries for every server outside
-       :data:`_NO_BLANKET_ALLOW_MCPS` — are auto-appended and the file is
-       rewritten atomically. A missing ``mcpServers`` entry cannot be
+    1. Static coherence check of the agent config: each always-on server whose
+       ``spec_gate`` is open — or that has no gate — must be present in
+       ``mcpServers`` and ``tools``. A gated-off server (feature disabled, or
+       no driver for this platform) is deliberately absent from every emitted
+       spec, so its absence is reported as informational, never as an issue —
+       and a stale entry left from when the gate was open is neither mounted
+       into ``tools`` nor probed (see :func:`_spec_gate_closed`). Missing
+       ``tools`` entries — and ``allowedTools`` entries for every server
+       outside :data:`_NO_BLANKET_ALLOW_MCPS` — are auto-appended and the file
+       is rewritten atomically. A missing ``mcpServers`` entry cannot be
        auto-added because the command path is install-specific.
     2. Live handshake probe via :func:`mcp_discovery.probe_server`. Reports
        per-server status with tool count on success, and on failure shows
@@ -520,8 +589,11 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
     config_changed = False
 
     probe_targets = []
+    if gated_off is None:
+        gated_off = _doctor_gated_off_mcps()
     for name in _MANAGED_MCPS:
         ref = f"@{name}"
+        gate_closed = name in gated_off
         if name not in mcps:
             # An opt-in set is granted per agent, so its absence from THIS spec is
             # the normal state, not a broken install. Say nothing and probe
@@ -537,6 +609,27 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
                         "— add the server entry, or drop the ref"
                     )
                 continue
+            if gate_closed:
+                # Spec emission consults this same gate and deliberately omits
+                # the entry, so absence is the healthy state here — the hard
+                # error below would be unfixable ("re-run setup" writes the
+                # same gated spec back). Informational, never an issue. A stale
+                # `@ref` in ``tools`` is NOT the opt-in "half a grant" warning:
+                # emission deliberately leaves the ref alone when it retracts
+                # the entry (a dangling ref mounts nothing, and dropping it
+                # would destroy a grant the user may have narrowed by hand), so
+                # ref-present-entry-absent is the designed steady state on a
+                # gated-off host and advising "add the server entry" would
+                # defeat the gate. No governance-ceiling revoke is needed on
+                # this path either: with no ``mcpServers`` entry kiro-cli has
+                # nothing to launch, so a leftover ``allowedTools`` ref cannot
+                # auto-approve anything — the stale-ENTRY branch below is the
+                # one window where a grant is live, and the revoke runs there.
+                print(
+                    f"  {ref}: ℹ️  gated off on this host (feature disabled or "
+                    "no driver for this platform) — absent from mcpServers by design"
+                )
+                continue
             print(f"  {ref}: ❌ missing from mcpServers (re-run `kirocrew setup`)")
             issues.append(f"{ref} config")
             continue
@@ -550,7 +643,21 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
             if name not in _OPT_IN_MCPS:
                 issues.append(f"{ref} config")
             continue
-        if ref not in tools and name not in _OPT_IN_MCPS:
+        if gate_closed:
+            # A stale entry from before the gate closed (feature turned off, or
+            # a config copied from a host that has a driver). The next config
+            # refresh retracts it; until then doctor must not deepen the hole:
+            # no mounting the ref (kiro-cli would spawn a backend emission
+            # decided against), no minting `allowedTools`, no probe (nothing
+            # SHOULD launch). The governance-ceiling revoke below still runs —
+            # the entry is live in this spec until the retraction, so an
+            # auto-approve exemption would be real for exactly that window.
+            print(
+                f"  {ref}: ℹ️  gated off on this host (feature disabled or no "
+                "driver for this platform) — stale mcpServers entry is "
+                "retracted on the next `kirocrew setup` or gateway start"
+            )
+        elif ref not in tools and name not in _OPT_IN_MCPS:
             # Mounting an opt-in server IS granting it: the `@` ref is what makes
             # kiro-cli load it. Doctor repairs a broken always-on mount, but it
             # must never hand an agent a set the user did not assign.
@@ -606,13 +713,20 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
             # enabled still prompts on every call — say it once, here, so
             # `kirocrew doctor` explains it.
             print(f"  {ref}: 🔒 auto-approve withheld by security policy — calls will prompt")
-        elif ref not in allowed and name not in _NO_BLANKET_ALLOW_MCPS:
+        elif ref not in allowed and name not in _NO_BLANKET_ALLOW_MCPS and not gate_closed:
             # Computer use is never blanket-allowed here: see _NO_BLANKET_ALLOW_MCPS.
             # A pre-existing user-made grant is left alone (doctor never REMOVES a
-            # decision the user owns); doctor simply never mints one.
+            # decision the user owns); doctor simply never mints one. A gated-off
+            # server never gets one minted either: granting auto-approve to a
+            # server emission has decided against is the wrong direction.
             allowed.append(ref)
             config_changed = True
 
+        if gate_closed:
+            # Nothing should launch: no emitted spec defines this server, so a
+            # handshake probe would spawn a backend for a capability that is off
+            # or has no driver here — and report its result either way.
+            continue
         spec = mcps[name]
         probe_targets.append(
             McpServerInfo(
@@ -687,7 +801,9 @@ def _doctor_mcp_tools(agent_path: Path, issues: list[str]) -> None:
 # Non-secret rows kiro-cli writes when the signed-in identity came from IAM
 # Identity Center. Presence is the signal; the values (a start URL and a region)
 # are never read into a message, and no token key is touched.
-def _doctor_mcp_governance(agent_path: Path, issues: list[str]) -> None:
+def _doctor_mcp_governance(
+    agent_path: Path, issues: list[str], *, gated_off: "frozenset[str] | None" = None
+) -> None:
     """Render the `MCP Governance` section of `kirocrew doctor`.
 
     Speaks up in two situations: governance can reach this identity (Identity
@@ -725,10 +841,20 @@ def _doctor_mcp_governance(agent_path: Path, issues: list[str]) -> None:
     # would report every governed install as half-marked; dropping the always-on
     # ones from the denominator would make a spec that declares NOTHING — a
     # malformed or emptied ``mcpServers`` — read as fully marked, which is the
-    # exact failure this section exists to catch.
-    expected = list(_ALWAYS_ON_MCPS) + [
-        name for name in _OPT_IN_MCPS if isinstance(servers.get(name), dict)
-    ]
+    # exact failure this section exists to catch. One exception, same rule as
+    # the MCP Tools section above: an always-on server whose spec gate is
+    # closed is deliberately absent from every emitted spec, so demanding a
+    # registry marker for it would re-create the unfixable "re-run setup" loop
+    # (#6548). A STALE entry still counts while it exists — kiro-cli drops an
+    # unmarked entry at session assembly, so the marker matters for exactly as
+    # long as the entry does.
+    if gated_off is None:
+        gated_off = _doctor_gated_off_mcps()
+    expected = [
+        name
+        for name in _ALWAYS_ON_MCPS
+        if isinstance(servers.get(name), dict) or name not in gated_off
+    ] + [name for name in _OPT_IN_MCPS if isinstance(servers.get(name), dict)]
     marked = sorted(
         name
         for name in expected
@@ -2525,10 +2651,14 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     # ── MCP Tools ──
     print("\nMCP Tools")
     if agent_path.exists():
-        _doctor_mcp_tools(agent_path, issues)
+        # One gate snapshot for both sections, so a keystone flip landing
+        # between them cannot make the report contradict itself (see
+        # _doctor_gated_off_mcps).
+        gated_off = _doctor_gated_off_mcps()
+        _doctor_mcp_tools(agent_path, issues, gated_off=gated_off)
         # After the probe, deliberately: the probe reporting green is the exact
         # condition this section exists to explain.
-        _doctor_mcp_governance(agent_path, issues)
+        _doctor_mcp_governance(agent_path, issues, gated_off=gated_off)
 
     # ── Python Runtime ──
     print("\nRuntime")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3564,7 +3564,12 @@ class TestDoctorMcpTools:
         this reason; a diagnostic command silently undoing it would be a complete
         Plane-A bypass.  The ``tools`` entry is still repaired — that only makes the
         server's tools reachable, never pre-approved.
+
+        The spec gate is pinned OPEN: this guard is about what doctor does to a
+        server it repairs, and a closed gate (the CI default — feature disabled)
+        would skip the repair entirely and assert nothing.
         """
+        from kiro_crew import agent
         from kiro_crew.cli_doctor import _doctor_mcp_tools
 
         agent_path = tmp_path / "kirocrew.json"
@@ -3576,8 +3581,13 @@ class TestDoctorMcpTools:
         data["allowedTools"] = []
         agent_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
+        gated_open = dict(agent._MANAGED_MCP_SERVERS["kirocrew-computer"])
+        gated_open["spec_gate"] = lambda: True
         issues: list[str] = []
-        with self._mock_probe({}):
+        with (
+            patch.dict(agent._MANAGED_MCP_SERVERS, {"kirocrew-computer": gated_open}),
+            self._mock_probe({}),
+        ):
             _doctor_mcp_tools(agent_path, issues)
 
         updated = json.loads(agent_path.read_text(encoding="utf-8"))
@@ -3594,13 +3604,22 @@ class TestDoctorMcpTools:
         A user who deliberately added the ref owns that decision; silently
         reverting their config on a diagnostic run would be its own surprise. The
         two rules are independent and both matter.
+
+        Gate pinned OPEN like the mint test above: the preservation rule is
+        exercised on the path where doctor walks the full entry.
         """
+        from kiro_crew import agent
         from kiro_crew.cli_doctor import _doctor_mcp_tools
 
         agent_path = tmp_path / "kirocrew.json"
         _healthy_agent_file(agent_path)
+        gated_open = dict(agent._MANAGED_MCP_SERVERS["kirocrew-computer"])
+        gated_open["spec_gate"] = lambda: True
         issues: list[str] = []
-        with self._mock_probe({}):
+        with (
+            patch.dict(agent._MANAGED_MCP_SERVERS, {"kirocrew-computer": gated_open}),
+            self._mock_probe({}),
+        ):
             _doctor_mcp_tools(agent_path, issues)
         updated = json.loads(agent_path.read_text(encoding="utf-8"))
         assert "@kirocrew-computer" in updated["allowedTools"]
@@ -3718,6 +3737,246 @@ class TestDoctorMcpTools:
         # persists the coerced empty config over the user's original file.
         assert agent_path.read_text() == content
         assert "Auto-fixed" not in out
+
+
+class TestDoctorMcpSpecGate:
+    """Doctor's MCP checks consult the same ``spec_gate`` emission does (#6548).
+
+    Spec emission (``agent.build_agent_config`` / ``_refresh_dynamic_fields``)
+    deliberately omits — and retracts — the ``mcpServers`` entry of a managed
+    server whose ``spec_gate`` is closed (feature disabled, or no driver for
+    this platform). Before this gate, doctor demanded the entry's presence
+    unconditionally, so every non-macOS host reported an unfixable
+    ``@kirocrew-computer: missing from mcpServers`` and `kirocrew setup` could
+    never clear it: the two sides drifted because only one consulted the gate.
+
+    Each test pins the gate through the same registry doctor resolves it from
+    (``agent._MANAGED_MCP_SERVERS``), so the resolution seam is exercised too,
+    and no test depends on the host's real enable-state or platform.
+    """
+
+    def _mock_probe(self, seen: list[str]):
+        """Patch ``probe_server`` to record which servers doctor launches."""
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        async def fake(target: McpServerInfo) -> McpServerInfo:
+            seen.append(target.name)
+            target.status = "ok"
+            target.tools = []
+            target.error = ""
+            return target
+
+        return patch("kiro_crew.cli_doctor.probe_server", side_effect=fake)
+
+    def _pin_gate(self, gate):
+        """Return a patch pinning ``kirocrew-computer``'s spec gate to *gate*."""
+        from kiro_crew import agent
+
+        pinned = dict(agent._MANAGED_MCP_SERVERS["kirocrew-computer"])
+        pinned["spec_gate"] = gate
+        return patch.dict(agent._MANAGED_MCP_SERVERS, {"kirocrew-computer": pinned})
+
+    def _config_without_computer(self, path: Path) -> None:
+        """Servers as spec emission writes them on a gated-off host: every
+        managed always-on server EXCEPT the gated one, refs for all of them
+        (emission deliberately leaves the ``tools`` ref alone when it retracts
+        the entry, so ref-present-entry-absent is the designed steady state)."""
+        from kiro_crew.mcp_cleanup import ALWAYS_ON_BIN_MCP_SERVERS
+
+        present = [n for n in ALWAYS_ON_BIN_MCP_SERVERS if n != "kirocrew-computer"]
+        _write_agent_config(
+            path,
+            tools=[f"@{n}" for n in ALWAYS_ON_BIN_MCP_SERVERS],
+            allowed=[f"@{n}" for n in present],
+            servers={
+                n: {"command": sys.executable, "args": [f"mcp-{n.split('-', 1)[1]}"]}
+                for n in present
+            },
+        )
+
+    def test_gate_closed_absent_entry_is_informational_not_an_issue(self, tmp_path, capsys):
+        """Gate closed + entry absent = the healthy state on this host.
+
+        The exact #6548 report: no hard error, no ``issues`` entry (so doctor
+        exits 0), no auto-mount of the ref, and the line says WHY the server is
+        absent rather than looking like a silent skip.
+        """
+        from kiro_crew.cli_doctor import _doctor_mcp_tools
+
+        agent_path = tmp_path / "kirocrew.json"
+        self._config_without_computer(agent_path)
+        before = agent_path.read_text(encoding="utf-8")
+        issues: list[str] = []
+        probed: list[str] = []
+        with self._pin_gate(lambda: False), self._mock_probe(probed):
+            _doctor_mcp_tools(agent_path, issues)
+        out = capsys.readouterr().out
+        assert "@kirocrew-computer: ℹ️  gated off on this host" in out
+        assert "feature disabled or no driver" in out
+        assert "@kirocrew-computer: ❌" not in out
+        assert issues == []
+        # Nothing mounted, minted, or probed for the gated-off server — and the
+        # stale ref emission leaves behind is not reported as "half a grant".
+        assert "kirocrew-computer" not in probed
+        assert "referenced in tools but absent" not in out
+        assert agent_path.read_text(encoding="utf-8") == before
+
+    def test_gate_open_absent_entry_keeps_the_hard_error(self, tmp_path, capsys):
+        """Gate open + entry absent is still a broken install and MUST fail."""
+        from kiro_crew.cli_doctor import _doctor_mcp_tools
+
+        agent_path = tmp_path / "kirocrew.json"
+        self._config_without_computer(agent_path)
+        issues: list[str] = []
+        with self._pin_gate(lambda: True), self._mock_probe([]):
+            _doctor_mcp_tools(agent_path, issues)
+        out = capsys.readouterr().out
+        assert "@kirocrew-computer: ❌ missing from mcpServers (re-run `kirocrew setup`)" in out
+        assert "@kirocrew-computer config" in issues
+
+    def test_gate_raising_is_treated_as_open(self, tmp_path, capsys):
+        """A gate that raises PAST ITS OWN HANDLING must not silence the error.
+
+        This pins the helper's contract-level fail direction — deliberately
+        the opposite of emission's ``_gated_off_servers()`` (which treats a
+        raising gate as closed, because its open position spawns a backend):
+        here "closed" is what suppresses the error, so a gate the helper
+        cannot evaluate reports the missing entry. Note the shipped
+        computer-use gate catches its own internal errors and ANSWERS False,
+        so this path covers registry/contract failures and any future gate
+        without an internal handler; the shipped gate's swallowed-error case
+        is pinned separately below.
+        """
+        from kiro_crew.cli_doctor import _doctor_mcp_tools
+
+        def explode() -> bool:
+            raise RuntimeError("gate unreadable")
+
+        agent_path = tmp_path / "kirocrew.json"
+        self._config_without_computer(agent_path)
+        issues: list[str] = []
+        with self._pin_gate(explode), self._mock_probe([]):
+            _doctor_mcp_tools(agent_path, issues)
+        out = capsys.readouterr().out
+        assert "@kirocrew-computer: ❌ missing from mcpServers" in out
+        assert "@kirocrew-computer config" in issues
+        assert "gated off" not in out
+
+    def test_shipped_gate_swallowing_internal_errors_reads_as_closed(self, tmp_path, capsys):
+        """The shipped gate's own fail-closed answer is reported as-is.
+
+        ``agent._computer_use_spec_gate`` catches its internal errors and
+        answers False (its documented posture: an unreadable keystone must
+        never hand out the desktop), so doctor cannot distinguish "unreadable
+        internals" from "policy closed" through the boolean — and reporting
+        closed is the emission-CONSISTENT answer: in that same state the entry
+        genuinely is omitted from every emitted spec, so the ℹ️ line describes
+        what the system actually does. This test pins that DELIVERED semantic
+        so the helper's docstring cannot silently overclaim again; if the
+        gate's exception contract ever changes, this test and the one above
+        say exactly which behavior moved.
+        """
+        from kiro_crew.cli_doctor import _doctor_mcp_tools
+
+        agent_path = tmp_path / "kirocrew.json"
+        self._config_without_computer(agent_path)
+        issues: list[str] = []
+        with (
+            patch(
+                "kiro_crew.computer_use.enable_state.is_enabled",
+                side_effect=RuntimeError("keystone unreadable"),
+            ),
+            self._mock_probe([]),
+        ):
+            # No _pin_gate: the REAL registry gate runs, swallows the raise,
+            # and answers False — the exact production shape.
+            _doctor_mcp_tools(agent_path, issues)
+        out = capsys.readouterr().out
+        assert "@kirocrew-computer: ℹ️  gated off on this host" in out
+        assert issues == []
+
+    def test_gate_closed_stale_entry_is_not_mounted_or_probed(self, tmp_path, capsys):
+        """A leftover entry from when the gate was open must not deepen the hole.
+
+        Doctor must not mount its ref into ``tools`` (kiro-cli would spawn a
+        backend emission decided against), must not probe it (nothing should
+        launch), and must not count it as an issue — the next config refresh
+        retracts it.
+        """
+        from kiro_crew.cli_doctor import _doctor_mcp_tools
+        from kiro_crew.mcp_cleanup import ALWAYS_ON_BIN_MCP_SERVERS
+
+        agent_path = tmp_path / "kirocrew.json"
+        present = list(ALWAYS_ON_BIN_MCP_SERVERS)
+        _write_agent_config(
+            agent_path,
+            tools=[f"@{n}" for n in present if n != "kirocrew-computer"],
+            allowed=[],
+            servers={
+                n: {"command": sys.executable, "args": [f"mcp-{n.split('-', 1)[1]}"]}
+                for n in present
+            },
+        )
+        issues: list[str] = []
+        probed: list[str] = []
+        with self._pin_gate(lambda: False), self._mock_probe(probed):
+            _doctor_mcp_tools(agent_path, issues)
+        out = capsys.readouterr().out
+        assert "stale mcpServers entry" in out
+        assert issues == []
+        assert "kirocrew-computer" not in probed
+        # The other always-on servers were still probed — the skip is scoped.
+        assert "kirocrew-core" in probed and "kirocrew-cron" in probed
+        updated = json.loads(agent_path.read_text(encoding="utf-8"))
+        assert "@kirocrew-computer" not in updated["tools"]
+        assert "@kirocrew-computer" not in updated["allowedTools"]
+
+    def test_governance_denominator_skips_an_absent_gated_off_server(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """The MCP Governance section applies the same rule to its marker count.
+
+        On a governed non-macOS host the gated-off server has no entry to mark,
+        so counting it as expected would re-create the same unfixable
+        "re-run `kirocrew setup --agent-only`" loop in this section.
+        """
+        from kiro_crew import cli_doctor
+        from kiro_crew.mcp_cleanup import ALWAYS_ON_BIN_MCP_SERVERS
+
+        monkeypatch.setattr(cli_doctor, "mcp_governance_may_apply", lambda: True)
+
+        class _Agent:
+            mcp_registry_mode = True
+
+        class _Cfg:
+            agent = _Agent()
+
+        monkeypatch.setattr(cli_doctor.KiroCrewConfig, "load", staticmethod(lambda: _Cfg()))
+        spec_path = tmp_path / "kirocrew.json"
+        spec_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        n: {"command": "kirocrew", "args": [f"mcp-{n.split('-', 1)[1]}"], "type": "registry"}
+                        for n in ALWAYS_ON_BIN_MCP_SERVERS
+                        if n != "kirocrew-computer"
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        issues: list[str] = []
+        with self._pin_gate(lambda: False):
+            cli_doctor._doctor_mcp_governance(spec_path, issues)
+        out = capsys.readouterr().out
+        assert issues == []
+        assert "markers missing" not in out
+        # The gate-open direction keeps the failure: a genuinely missing
+        # always-on server still reads as unmarked.
+        issues2: list[str] = []
+        with self._pin_gate(lambda: True):
+            cli_doctor._doctor_mcp_governance(spec_path, issues2)
+        assert issues2 == ["MCP registry markers"]
 
 
 class TestDoctorStt:


### PR DESCRIPTION
## Summary

On a non-macOS host `kirocrew doctor` permanently failed with `@kirocrew-computer: missing from mcpServers (re-run kirocrew setup)`. Spec emission consults the server's `spec_gate` (`agent._MANAGED_MCP_SERVERS`) and deliberately omits the entry where the gate is closed (feature disabled, or no driver for the platform) — but doctor demanded the entry unconditionally, and its remedy re-runs the same gated emission, so the error could never clear.

Doctor now resolves the same gate through the registry (`_spec_gate_closed`, general over server names — no hardcoded OS or server-name check), snapshotted once per run (`_doctor_gated_off_mcps`) and threaded into both MCP sections so a keystone flip mid-run cannot make the report contradict itself:

- **gate closed + entry absent** → informational ℹ️ naming the reason; no `issues` entry; the stale `tools` ref emission deliberately leaves behind is not reported as "half a grant" (no revoke needed here: with no entry, kiro-cli has nothing to launch, so a leftover `allowedTools` ref is inert)
- **gate closed + stale entry present** → not mounted into `tools`, not minted into `allowedTools`, not probed; the governance-ceiling revoke (and its SEL event) still runs, since the entry is live in this spec until the next refresh retracts it
- **gate open + entry absent** → the existing hard error survives verbatim
- **gate contract unreadable** (registry lookup fails, or a gate raises past its own handling) → treated as OPEN, the opposite fail direction from emission's `_gated_off_servers()`: each side fails toward its own safe state
- the **MCP Governance** marker denominator applies the same rule, closing the identical re-run-setup loop on governed gated-off hosts

`docs/architecture/mcp.md` now names doctor as the gate's third (read-only) consumer and qualifies the probe claim.

## Review adjudication (pre-push, dual model-pinned)

GPT 5.6 and Opus 5 independently converged on one point: the shipped `_computer_use_spec_gate` catches its own internal errors and answers `False`, so doctor's raising-gate→open protection cannot fire through it — an unreadable keystone reads as "gated off by design". **Adopted as Opus recommended** (docstring scoped to gate-contract failures + a test pinning the delivered semantics). **Declined GPT's smallest-fix** (make the gate propagate): the gate's swallow is pre-existing emission-side design whose fail-closed posture is documented and pinned ("the open position of this gate hands out the operator's whole desktop"), `agent.py` is read-only for this fix, and the answer doctor reports in that state is emission-consistent — the entry genuinely is omitted from every emitted spec, so the ℹ️ line describes what the system actually does; the pre-fix behavior in that same state was the unfixable ❌ loop this issue exists to remove, not a useful signal. Opus advisories A2 (per-run snapshot), A3 (absent-path revoke rationale), A4 (doc currency), A5 (import hoist) all adopted.

## Testing

- New `TestDoctorMcpSpecGate` (6 tests): gate closed+absent → informational/no issue/nothing mounted/nothing probed; gate open+absent → hard error survives; gate raising past handling → treated as open; shipped gate swallowing internal errors → reads closed (delivered-semantics pin); stale entry → not mounted/minted/probed, scoped skip; governance denominator both directions
- Two existing computer-use doctor tests now pin the gate open (hermetic against the host's real enable state; guards preserved verbatim)
- Red-on-old verified: the three gate-closed tests fail on pristine main; survival-direction tests pass on main by design
- End-to-end on this Linux host with the REAL gate and a spec built by real emission: `issues == []`, informational line printed
- Full backend suite vs clean-main control at the same base SHA (7389db990): failure-set delta is exactly one pre-existing order-dependent flake in `test_search_sessions_cost.py` that fails identically on pristine main; zero new failures
- Lint battery green: black (baselined), subprocess-encoding, lockdown, isort, flake8, mypy

Closes #6548
