### PR TITLE
chore: cut 0.4.1 hotfix — fold available-update version for display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to KiroCrew are documented in this file.
 
+## [0.4.1] — 2026-08-28
+
+A display fix for stable-channel installs: the About page no longer shows the
+running build or an available update under its internal release-candidate stamp.
+
+### Notable fixes
+
+- **Available updates show their release version** — On the stable channel, the About panel's "a new version is available" line now shows the clean release number (0.4.0) instead of the internal candidate stamp it was built from (0.4.0rc14). The update mechanism itself is unchanged and keeps using the exact published version.
+- **The version chip shows the release you installed** — The About page's version badge and the Settings footer now show the clean release number on the stable channel too, instead of the candidate stamp baked into the published build.
+- **The update popup names the release, not the candidate stamp** — The "a new version is available" popup now announces the clean release number on the stable channel. Skipping or snoozing a version keeps working exactly as before.
+
+### Contributors
+
+@bolichen97
+
 ## [0.4.0] — 2026-08-25
 
 Windows and Linux stop being second-class: both get signed, self-updating native

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kirocrew"
-version = "0.4.0"
+version = "0.4.1"
 description = "Personal AI agent that runs locally — chat via CLI, dashboard, desktop app, or messaging channels like Slack and Discord"
 readme = "README.md"
 # macOS (x86_64 + arm64) and Linux (x86_64 + aarch64), CPython 3.10-3.13.

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 class _LazyShutdownEvent:

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -235,9 +235,17 @@ def status_update_fields() -> dict[str, object]:
         # the shadow-venv apply step compares it byte-for-byte against the
         # installed ``kiro_crew.__version__``, which is never folded either
         # (promotion never re-stamps the bytes). For a display-only clean
-        # version, use the ``/api/update/check`` endpoint's
-        # ``latest_version_display`` instead.
+        # version, use ``update_latest_version_display`` below (or the
+        # ``/api/update/check`` endpoint's ``latest_version_display``).
         "update_latest_version": str(_update_info.get("latest_version") or ""),
+        # DISPLAY-ONLY fold of the candidate above (clean base on the stable
+        # channel), consumed by the proactive update popup's "vX is available"
+        # text. The popup's per-version snooze/skip records and every arm
+        # path keep keying on the RAW `update_latest_version`.
+        "update_latest_version_display": _display_version(
+            str(_update_info.get("latest_version") or ""),
+            str(_update_info.get("channel") or ""),
+        ),
         "update_channel": str(_update_info.get("channel") or ""),
         # The panel needs WHO manages the update to speak honestly: a
         # command-managed host must not render the self-managed installer
@@ -250,6 +258,17 @@ def status_update_fields() -> dict[str, object]:
         # manual check. 0/0 everywhere except a successful git-checkout check.
         "update_commits_ahead": ahead if isinstance(ahead, int) else 0,
         "update_commits_behind": behind if isinstance(behind, int) else 0,
+        # The RUNNING build's version folded for display (clean base on the
+        # stable channel), so the About page's version chip can show `0.4.0`
+        # instead of the promoted candidate's baked-in `0.4.0rc14` stamp.
+        # DISPLAY-ONLY sibling of the raw `version` the WS frame and
+        # /api/status carry: that one is functional — the SPA compares it
+        # across pushes to force a reload over a gateway upgrade, and folding
+        # it would collapse e.g. `0.4.1rc1` -> `0.4.1` and `0.4.1rc2` ->
+        # `0.4.1`, masking the very upgrade the reload detection exists to
+        # catch. Falls back to the raw version until a check has resolved the
+        # channel (`_display_local_version` keys on it; only stable folds).
+        "version_display": _display_local_version(),
     }
 
 

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -229,6 +229,14 @@ def status_update_fields() -> dict[str, object]:
         # endpoint (which runs a full check per request). Empty until a check
         # has found a newer build. The changelog text stays OFF this hot-path
         # subset — consumers fetch it on demand.
+        #
+        # RAW, never folded: this is the same string ``InAppUpdateFlow``,
+        # ``api_update_arm``, and the snooze/skip persisted-record key key on —
+        # the shadow-venv apply step compares it byte-for-byte against the
+        # installed ``kiro_crew.__version__``, which is never folded either
+        # (promotion never re-stamps the bytes). For a display-only clean
+        # version, use the ``/api/update/check`` endpoint's
+        # ``latest_version_display`` instead.
         "update_latest_version": str(_update_info.get("latest_version") or ""),
         "update_channel": str(_update_info.get("channel") or ""),
         # The panel needs WHO manages the update to speak honestly: a
@@ -258,6 +266,16 @@ async def api_update_check(request: web.Request) -> web.Response:
         {
             **_update_info,
             "current_version": _display_local_version(),
+            # DISPLAY-ONLY sibling of the raw `latest_version` above (unpacked
+            # via `**_update_info`) — folds a promoted stable candidate's
+            # insider/rc stamp to the clean release it means. `latest_version`
+            # itself MUST stay raw: it is what `InAppUpdateFlow` and
+            # `api_update_arm` arm against, compared byte-for-byte against the
+            # installed build's own never-folded `__version__`.
+            "latest_version_display": _display_version(
+                str(_update_info.get("latest_version") or ""),
+                str(_update_info.get("channel") or ""),
+            ),
             "auto_update": cfg.auto_update,
             # Surface the pin so the dashboard can say WHY an update is mandatory
             # rather than showing a bare button.
@@ -1897,6 +1915,13 @@ async def api_update_channel(request: web.Request) -> web.Response:
             # name (same helper, same https pin as the check's own path).
             "channel": stored,
             "update_command": wheel_update_command(stored),
+            # Same display-only sibling as api_update_check: this response IS
+            # the re-run check the panel adopts wholesale, so it must carry the
+            # folded version too or a channel switch would blank the clean
+            # display back to the raw stamp.
+            "latest_version_display": _display_version(
+                str(_update_info.get("latest_version") or ""), stored
+            ),
         }
     )
 

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5243,10 +5243,12 @@ class DashboardState:
         update_check_status: str = "unchecked",
         update_command: str = "",
         update_latest_version: str = "",
+        update_latest_version_display: str = "",
         update_channel: str = "",
         update_managed_by: str = "",
         update_commits_ahead: int = 0,
         update_commits_behind: int = 0,
+        version_display: str = "",
     ) -> dict[str, Any]:
         """Core status fields shared by /api/status, SSE, and WebSocket pushes."""
         uptime = int(time.time() - self.start_time)
@@ -5284,6 +5286,10 @@ class DashboardState:
             # snooze/skip on this, so it rides the hot-path subset; the
             # changelog text deliberately does not.
             "update_latest_version": update_latest_version,
+            # DISPLAY-ONLY fold of the candidate above (clean base on the
+            # stable channel); the popup's snooze/skip records key on the raw
+            # value. Empty string on emitters that don't pass it.
+            "update_latest_version_display": update_latest_version_display,
             # The release channel this INSTALL follows (the ``channel`` file
             # cli.sh wrote), empty when the layout has no channel at all (a git
             # checkout tracks a remote; a desktop bundle or container is updated
@@ -5306,6 +5312,14 @@ class DashboardState:
             # tell the two apart. 0/0 on non-git layouts and before any check.
             "update_commits_ahead": update_commits_ahead,
             "update_commits_behind": update_commits_behind,
+            # The RUNNING build's version folded for display (clean base on
+            # the stable channel; see `_display_version` in
+            # handlers/updates.py). DISPLAY-ONLY sibling of the raw `version`
+            # the WS frame appends after this snapshot — that one is what the
+            # SPA compares across pushes to force a reload over a gateway
+            # upgrade, so it must never be folded. Empty string on emitters
+            # that don't pass it (they render the raw version, as before).
+            "version_display": version_display,
             "no_crons": self.no_crons,
             "branch": branch,
             "commit": commit,

--- a/test/test_dashboard_status_snapshot.py
+++ b/test/test_dashboard_status_snapshot.py
@@ -169,10 +169,12 @@ class TestAllStatusSnapshotCallersPassTheUpdateFields:
             "update_check_status",
             "update_command",
             "update_latest_version",
+            "update_latest_version_display",
             "update_channel",
             "update_managed_by",
             "update_commits_ahead",
             "update_commits_behind",
+            "version_display",
         }
 
     def test_the_shared_reader_never_flattens_a_missing_verdict(self) -> None:
@@ -184,6 +186,37 @@ class TestAllStatusSnapshotCallersPassTheUpdateFields:
             assert status_fields_of(updates)["update_available"] is None
             updates._update_info.update({"update_available": False})
             assert status_fields_of(updates)["update_available"] is False
+        finally:
+            updates._update_info.clear()
+            updates._update_info.update(original)
+
+    def test_version_display_folds_the_running_stamp_on_stable_only(self, monkeypatch) -> None:
+        """The About page's version chip reads ``version_display`` — the
+        RUNNING build's promoted-stamp fold. The raw ``version`` the WS frame
+        appends is NOT part of this reader and stays untouched: the SPA
+        compares it across pushes to force a reload over a gateway upgrade,
+        and folding it would collapse two RCs of the same release into one
+        string, masking the very upgrade that comparison exists to catch."""
+        from kiro_crew.dashboard.handlers import updates
+
+        original = dict(updates._update_info)
+        monkeypatch.setattr(updates, "_local_version", "0.4.0rc14")
+        try:
+            updates._update_info.clear()
+            updates._update_info.update({"channel": "stable", "latest_version": "0.5.0rc3"})
+            fields = status_fields_of(updates)
+            assert fields["version_display"] == "0.4.0"
+            # The candidate's fold rides the same rule; its raw sibling (the
+            # snooze/skip key) is untouched.
+            assert fields["update_latest_version_display"] == "0.5.0"
+            assert fields["update_latest_version"] == "0.5.0rc3"
+            updates._update_info.update({"channel": "insider"})
+            fields = status_fields_of(updates)
+            assert fields["version_display"] == "0.4.0rc14"
+            assert fields["update_latest_version_display"] == "0.5.0rc3"
+            # Channel not yet resolved (no check has run): raw, never "".
+            updates._update_info.clear()
+            assert status_fields_of(updates)["version_display"] == "0.4.0rc14"
         finally:
             updates._update_info.clear()
             updates._update_info.update(original)

--- a/test/test_update_channel_and_restart.py
+++ b/test/test_update_channel_and_restart.py
@@ -127,6 +127,36 @@ class TestChannelEndpoint:
         # lane's verdict as this lane's answer.
         assert len(checked) == 1
 
+    def test_switch_response_carries_the_folded_display_sibling(self, _isolated_channel_home):
+        """The switch response is the check contract re-run against the new
+        lane, and the panel adopts it wholesale — so it must carry the same
+        display-only ``latest_version_display`` sibling as ``api_update_check``
+        (folded on stable, verbatim elsewhere) or a switch would blank the
+        clean display back to the raw promoted stamp."""
+        update_layout.set_release_channel("insider")
+
+        async def _fake_check() -> None:
+            # What the real re-check leaves behind after a stable switch finds
+            # the promoted candidate: the raw stamp, never pre-folded.
+            updates._set_update_info(
+                update_available=True, latest_version="0.4.0rc14", channel="stable"
+            )
+
+        try:
+            with (
+                patch.object(updates, "detect_install_layout", return_value=self._feed_layout()),
+                patch.object(updates, "_do_update_check", _fake_check),
+            ):
+                resp = asyncio.run(updates.api_update_channel(_request({"channel": "stable"})))
+
+            assert resp.status == 200
+            body = json.loads(resp.text)
+            # Raw for arm/apply, folded for humans — per the NEW channel.
+            assert body["latest_version"] == "0.4.0rc14"
+            assert body["latest_version_display"] == "0.4.0"
+        finally:
+            updates._set_update_info()
+
     def test_the_switch_never_reads_the_channel_file_on_the_event_loop(
         self, _isolated_channel_home
     ):

--- a/test/test_update_check_install_aware.py
+++ b/test/test_update_check_install_aware.py
@@ -57,6 +57,15 @@ def _manifest(**overrides: object) -> bytes:
     return json.dumps(body).encode()
 
 
+def _request() -> MagicMock:
+    """A request stub for ``api_update_check``: only ``.app["state"]`` is read."""
+    req = MagicMock()
+    state = MagicMock()
+    state._background_tasks = set()
+    req.app = {"state": state}
+    return req
+
+
 def _stub_feed(monkeypatch, *, status: int = 200, body: bytes | None = None, exc=None):
     """Replace the single network seam. Records the URL that was requested."""
     seen: dict[str, str] = {}
@@ -273,6 +282,71 @@ class TestWheelInstallCheck:
         assert "latest_pub_date" not in info
         assert info["check_status"] == "succeeded"  # optional field, not a hard failure
 
+
+class TestAvailableUpdateDisplayFold:
+    """The promoted-stable display fold on the available-update version.
+
+    Backported to the 0.4.1 hotfix line: only the display sibling, none of
+    the later feed-floor machinery."""
+
+    def test_available_update_on_stable_stays_raw_for_arm_but_folds_for_display(
+        self, monkeypatch, tmp_path
+    ):
+        """The feed check's `_update_info["latest_version"]` MUST stay the raw
+        stamp (``0.4.0rc14``): `api_update_arm` arms against it verbatim, and
+        the shadow-venv apply step compares it byte-for-byte against the
+        installed build's own `__version__`, which is never folded either
+        (promotion never re-stamps the bytes). A folded value there would make
+        every stable in-app apply fail with a version mismatch.
+
+        The clean release version for the About panel comes from a SEPARATE
+        display-only field on the `/api/update/check` response,
+        `latest_version_display`, folded the same way `_display_local_version`
+        folds the running build."""
+        (tmp_path / "channel").write_text("stable\n")
+        _stub_feed(
+            monkeypatch,
+            body=_manifest(channel="stable", version="0.4.0rc14"),
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+
+        info = updates.get_update_info()
+        assert info["channel"] == "stable"
+        assert info["check_status"] == "succeeded"
+        assert info["latest_version"] == "0.4.0rc14"  # RAW -- what arm/apply use
+
+        resp = asyncio.run(updates.api_update_check(_request()))
+        payload = json.loads(resp.body.decode())
+        assert payload["latest_version"] == "0.4.0rc14"  # still raw on the wire
+        assert payload["latest_version_display"] == "0.4.0"  # folded for display
+
+        # Same fold applies on the unparseable-local-version failure branch,
+        # and `latest_version` there stays raw too.
+        monkeypatch.setattr(updates, "_local_version", "not-a-version")
+        asyncio.run(updates._do_update_check())
+        info = updates.get_update_info()
+        assert info["check_status"] == "failed"
+        assert info["latest_version"] == "0.4.0rc14"
+        resp = asyncio.run(updates.api_update_check(_request()))
+        payload = json.loads(resp.body.decode())
+        assert payload["latest_version_display"] == "0.4.0"
+
+        # An insider feed keeps its full stamp everywhere -- the fold is
+        # stable-only, both raw and display agree.
+        (tmp_path / "channel").write_text("insider\n")
+        _stub_feed(
+            monkeypatch,
+            body=_manifest(channel="insider", version="0.4.0-insider.14"),
+        )
+        monkeypatch.setattr(updates, "_local_version", "0.3.0")
+        asyncio.run(updates._do_update_check())
+        info = updates.get_update_info()
+        assert info["channel"] == "insider"
+        assert info["latest_version"] == "0.4.0-insider.14"
+        resp = asyncio.run(updates.api_update_check(_request()))
+        payload = json.loads(resp.body.decode())
+        assert payload["latest_version_display"] == "0.4.0-insider.14"
 
 class TestWheelInstallFailuresAreHonest:
     """Every failure must set ``error`` and leave ``checked`` False."""

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Kiro Crew \u2014 AI agent desktop app",
   "homepage": "https://github.com/kirodotdev/KiroCrew",
   "desktopName": "kirocrew-desktop.desktop",

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -2738,7 +2738,7 @@ export const api = {
    * check compares against; it never installs anything, so the response is the
    * re-run check against the NEW channel.
    */
-  setUpdateChannel: (channel: string) => post('/api/update/channel', { channel }).then(j),
+  setUpdateChannel: (channel: string) => post('/api/update/channel', { channel }).then(j) as Promise<UpdateCheckResult>,
   /**
    * Restart the gateway without updating. The connection drops as the process
    * image is replaced, so callers must treat a network failure after a 200 as

--- a/website/src/components/UpdateFoundModal.test.tsx
+++ b/website/src/components/UpdateFoundModal.test.tsx
@@ -276,6 +276,37 @@ describe('UpdateFoundModal — desktop source', () => {
 })
 
 describe('UpdateFoundModal — gateway source', () => {
+  it('prints the folded display version but keys snooze/skip on the raw stamp', async () => {
+    // A promoted stable candidate: the popup's text must show the clean
+    // release, while the persisted per-version verdict keys on the raw stamp
+    // (folding the key would make dismissing `0.4.0` swallow the next
+    // release's rc candidate too).
+    mockedApi.checkUpdate.mockResolvedValue({ changes: '' } as never)
+    let resolvePatch: (v: unknown) => void = () => {}
+    mockedApi.patchConfig.mockReturnValue(new Promise(r => { resolvePatch = r }) as never)
+    await mount(undefined, gatewayStore({
+      update_available: true, update_latest_version: '0.4.0rc14',
+      update_latest_version_display: '0.4.0', update_command: 'x-update',
+    }))
+    await waitFor(() => expect(dialog()).toBeInTheDocument())
+    expect(screen.getByText('0.4.0')).toBeInTheDocument()
+    expect(screen.queryByText('0.4.0rc14')).not.toBeInTheDocument()
+    fireEvent.click(byName('components.updateFoundModal.skip_this_version'))
+    await waitFor(() => expect(mockedApi.patchConfig).toHaveBeenCalledTimes(1))
+    expect(mockedApi.patchConfig).toHaveBeenCalledWith('dashboard.update_nudge',
+      expect.objectContaining({ version: '0.4.0rc14', skipped: true }))
+    await act(async () => { resolvePatch({}) })
+  })
+
+  it('falls back to the raw version when an older gateway sends no display field', async () => {
+    mockedApi.checkUpdate.mockResolvedValue({ changes: '' } as never)
+    await mount(undefined, gatewayStore({
+      update_available: true, update_latest_version: '0.4.0rc14', update_command: 'x-update',
+    }))
+    await waitFor(() => expect(dialog()).toBeInTheDocument())
+    expect(screen.getByText('0.4.0rc14')).toBeInTheDocument()
+  })
+
   it('opens with Update now when the gateway can apply in-process', async () => {
     mockedApi.checkUpdate.mockResolvedValue({ changes: 'zzq gw notes' } as never)
     await mount(undefined, gatewayStore({

--- a/website/src/components/UpdateFoundModal.tsx
+++ b/website/src/components/UpdateFoundModal.tsx
@@ -11,6 +11,7 @@ import { i18nT } from '../i18n/t'
 import { copyToClipboard } from '../utils/clipboard'
 import { updateAffordance } from '../utils/updateAffordance'
 import { shouldNudge, snoozeRecord, skipRecord, type UpdateNudgeRecord } from '../utils/updateNudge'
+import { foldStableStamp } from '../utils/displayVersion'
 import type { UpdateState } from '../hooks/useUpdateSubscription'
 
 /**
@@ -59,6 +60,11 @@ function desktopCanDownload(): boolean {
 type Candidate = {
   source: 'desktop' | 'gateway'
   version: string
+  /** What the popup PRINTS — the promoted-stamp fold of `version` on the
+   *  stable channel. `version` itself stays raw: it keys the per-version
+   *  snooze/skip records, and a fold there would make dismissing `0.4.0`
+   *  swallow the next release's `0.4.0rcN` candidate too. */
+  displayVersion: string
   notes?: string
   /** Gateway only: which action the primary slot offers. */
   affordance?: 'apply' | 'command'
@@ -78,6 +84,9 @@ export default function UpdateFoundModal() {
 
   const gwAvailable = useAppSelector(s => s.dashboard.status?.update_available === true)
   const gwVersion = useAppSelector(s => s.dashboard.status?.update_latest_version) || ''
+  // Backend-folded sibling for DISPLAY (clean base on the stable channel).
+  // Raw fallback below covers a gateway that predates the field.
+  const gwVersionDisplay = useAppSelector(s => s.dashboard.status?.update_latest_version_display) || ''
   const gwCanApply = useAppSelector(s => s.dashboard.status?.update_can_apply)
   const gwCommand = useAppSelector(s => s.dashboard.status?.update_command) || ''
 
@@ -90,7 +99,7 @@ export default function UpdateFoundModal() {
   const { data: bridgeInfo } = useQuery({
     queryKey: ['update-info'],
     queryFn: async () =>
-      (window as unknown as { updateAPI?: { getInfo?: () => Promise<{ autoDownload?: boolean }> } })
+      (window as unknown as { updateAPI?: { getInfo?: () => Promise<{ autoDownload?: boolean; channel?: string | null }> } })
         .updateAPI?.getInfo?.() ?? null,
     enabled: !!desktop && (desktop.state === 'found' || desktop.state === 'available'),
     staleTime: Infinity,
@@ -104,11 +113,21 @@ export default function UpdateFoundModal() {
   // vanishes when an auto-download preference lands.
   let candidate: Candidate | null = null
   if (desktop && (desktop.state === 'found' || desktop.state === 'available') && !desktop.replayed && desktop.version && desktopCanDownload() && bridgeInfo !== undefined && bridgeInfo?.autoDownload !== true) {
-    candidate = { source: 'desktop', version: desktop.version, notes: desktop.notes }
+    // Desktop-reported version never crosses the gateway, so the fold is
+    // computed locally, keyed on the followed channel like the backend's.
+    candidate = {
+      source: 'desktop', version: desktop.version,
+      displayVersion: foldStableStamp(desktop.version, bridgeInfo?.channel),
+      notes: desktop.notes,
+    }
   } else if (gwAvailable && gwVersion) {
     const afford = updateAffordance({ updateAvailable: true, canApply: gwCanApply, command: gwCommand })
     if (afford !== 'none') {
-      candidate = { source: 'gateway', version: gwVersion, affordance: afford, command: gwCommand }
+      candidate = {
+        source: 'gateway', version: gwVersion,
+        displayVersion: gwVersionDisplay || gwVersion,
+        affordance: afford, command: gwCommand,
+      }
     }
   }
 
@@ -312,7 +331,7 @@ export default function UpdateFoundModal() {
                 letter-named closing tags in values. */}
             <Trans
               i18nKey="components.updateFoundModal.version_is_available"
-              values={{ version: candidate.version }}
+              values={{ version: candidate.displayVersion }}
               components={[<span key="v" className="font-semibold" />]}
             />
           </p>

--- a/website/src/pages/SettingsPage.tsx
+++ b/website/src/pages/SettingsPage.tsx
@@ -83,7 +83,10 @@ function buildTabs() {
 }
 
 export default function SettingsPage() {
-  const version = useAppSelector(s => s.dashboard.status?.version) || '—'
+  // Folded for display on the stable channel (`version_display`), raw
+  // `version` fallback for a gateway that predates the field. Display-only:
+  // nothing here compares or arms on it.
+  const version = useAppSelector(s => s.dashboard.status?.version_display || s.dashboard.status?.version) || '—'
   useSettingHighlight()
   const [params, setParams] = useSearchParams()
 

--- a/website/src/pages/settings/AboutPanel.tsx
+++ b/website/src/pages/settings/AboutPanel.tsx
@@ -17,6 +17,7 @@ import { copyToClipboard } from '../../utils/clipboard'
 import { i18nT } from '../../i18n/t'
 import { fmtDateTimeNumeric, fmtList } from '../../i18n/format'
 import type { UpdateState } from '../../hooks/useUpdateSubscription'
+import { foldStableStamp } from '../../utils/displayVersion'
 
 /** Human-readable transfer rate for the progress label. */
 function formatRate(bps: number): string {
@@ -355,7 +356,16 @@ export function AboutPanel() {
     onSettled: () => queryClient.invalidateQueries({ queryKey: ['update-info'] }),
   })
 
-  const version = info?.version || gatewayVersion || '—'
+  // The version chip's DISPLAY text. For a gateway install the fold is the
+  // backend's (`version_display`, raw `version` fallback for a gateway that
+  // predates the field); for a desktop build it is computed locally, because
+  // the Electron-reported version never crosses the gateway. Every functional
+  // reader (`versionLooksPrerelease`, the updater compare gate, the SPA's
+  // reload-on-upgrade comparison) keeps its raw source.
+  const gatewayVersionDisplay = useAppSelector(s => s.dashboard.status?.version_display) || ''
+  const versionDisplay = info?.version
+    ? foldStableStamp(info.version, info.channel)
+    : (gatewayVersionDisplay || gatewayVersion || '—')
   const channel = info?.channel
   const updatesDisabled = info?.disabled
   // An externally-managed install (a distro/enterprise package) has no channel
@@ -793,7 +803,7 @@ export function AboutPanel() {
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2.5 flex-wrap">
               <span className="text-[19px] font-extrabold tracking-tight text-text-strong">{botName || 'Kiro Crew'}</span>
-              <span className="text-[12px] font-mono font-semibold text-accent rounded-full px-2.5 py-0.5 border" style={ACCENT_TINT}>{i18nT('pages.settings.aboutPanel.v')}{version}</span>
+              <span className="text-[12px] font-mono font-semibold text-accent rounded-full px-2.5 py-0.5 border" style={ACCENT_TINT}>{i18nT('pages.settings.aboutPanel.v')}{versionDisplay}</span>
               {!isDesktop && (heroDiverged
                 // Diverged outranks BOTH other verdicts: `update_available` is
                 // false here BY DESIGN (the no-auto-apply property), and a

--- a/website/src/pages/settings/AboutPanel.tsx
+++ b/website/src/pages/settings/AboutPanel.tsx
@@ -547,6 +547,9 @@ export function AboutPanel() {
   // changelog confirm because applying restarts the gateway.
   const [gwChanges, setGwChanges] = useState('')
   const [gwTarget, setGwTarget] = useState('')
+  // Display-only sibling of gwTarget, folded to the clean release version on
+  // stable. Never fed to InAppUpdateFlow or /api/update/arm.
+  const [gwTargetDisplay, setGwTargetDisplay] = useState('')
   const [gwFound, setGwFound] = useState(false)
   // Commit distance from the tracked upstream, straight from the check payload.
   // Only a git checkout ever reports non-zero values; both stay 0 elsewhere.
@@ -592,6 +595,9 @@ export function AboutPanel() {
       // read as a fallback only because it is what some older payloads carried.
       const target = d?.latest_version || d?.version
       if (target) setGwTarget(String(target))
+      // Same contract as the channel-switch handler below: adopt the
+      // display-only folded sibling (empty when the gateway predates it).
+      setGwTargetDisplay(typeof d?.latest_version_display === 'string' ? d.latest_version_display : '')
       // Derive availability from the check response itself, not only the redux
       // status flag (which refreshes on a slower WS status push). Otherwise a
       // check that finds an update could still show "You're on the latest
@@ -661,7 +667,7 @@ export function AboutPanel() {
       // one and fall back to the generic line when it did not.
       setGwChannelError(e instanceof ApiError ? (e.message || '') : '')
     },
-    onSuccess: (d: any) => {
+    onSuccess: (d) => {
       // The response is the re-run check against the new channel, so adopt it
       // wholesale rather than leaving the previous lane's verdict on screen.
       //
@@ -680,6 +686,7 @@ export function AboutPanel() {
       setGwCommand(typeof d?.update_command === 'string' ? d.update_command : '')
       setGwCommandCopied(false)
       setGwTarget(typeof d?.latest_version === 'string' ? d.latest_version : '')
+      setGwTargetDisplay(typeof d?.latest_version_display === 'string' ? d.latest_version_display : '')
       if (typeof d?.can_apply === 'boolean') setGwSelfUpdatable(d.can_apply)
     },
   })
@@ -1146,7 +1153,7 @@ export function AboutPanel() {
               <>
                 {showUpdate && (
                   <p className="text-sm text-muted flex items-center gap-1.5">
-                    <ArrowUp size={13} className="lucide-inline text-accent" /> {i18nT('pages.settings.aboutPanel.a_new_version')}{gwTarget ? ` (v${gwTarget})` : ''} {i18nT('pages.settings.aboutPanel.is_available')}
+                    <ArrowUp size={13} className="lucide-inline text-accent" /> {i18nT('pages.settings.aboutPanel.a_new_version')}{(gwTargetDisplay || gwTarget) ? ` (v${gwTargetDisplay || gwTarget})` : ''} {i18nT('pages.settings.aboutPanel.is_available')}
                   </p>
                 )}
                 {showManualUpdate ? (

--- a/website/src/test/AboutPanel.gatewayCheck.test.tsx
+++ b/website/src/test/AboutPanel.gatewayCheck.test.tsx
@@ -298,6 +298,52 @@ describe('AboutPanel gateway update check', () => {
     expect(screen.getByRole('button', { name: /copy command/i })).toBeTruthy()
   })
 
+  it('the available-version line shows the folded display value, keeping the raw stamp off screen', async () => {
+    // A promoted stable candidate keeps its rc stamp in latest_version (that is
+    // what arm/apply key on); the check response carries the folded sibling
+    // latest_version_display for the human-facing line. The manual-check
+    // handler must adopt it -- this is the path the About panel's "a new
+    // version (vX) is available" text renders from.
+    stubFetch({
+      check_status: 'succeeded',
+      update_available: true,
+      error_code: null,
+      managed_by: 'kirocrew',
+      can_apply: false,
+      channel: 'stable',
+      latest_version: '0.4.0rc14',
+      latest_version_display: '0.4.0',
+      remediation: { kind: 'command', message: '', command: 'kirocrew update' },
+    })
+    mountWeb()
+    await pressCheck()
+
+    await waitFor(() => {
+      const body = document.body.textContent || ''
+      expect(body).toContain('(v0.4.0)')
+      expect(body).not.toContain('0.4.0rc14')
+    })
+  })
+
+  it('falls back to the raw version when an older gateway omits the display sibling', async () => {
+    stubFetch({
+      check_status: 'succeeded',
+      update_available: true,
+      error_code: null,
+      managed_by: 'kirocrew',
+      can_apply: false,
+      channel: 'stable',
+      latest_version: '0.4.0rc14',
+      remediation: { kind: 'command', message: '', command: 'kirocrew update' },
+    })
+    mountWeb()
+    await pressCheck()
+
+    await waitFor(() => {
+      expect(document.body.textContent || '').toContain('(v0.4.0rc14)')
+    })
+  })
+
   it('a command-managed gateway shows the policy note, never installer copy', async () => {
     // A check-only policy pin: an update is available but there is no in-app
     // apply. The self-managed installer instructions would tell the user to

--- a/website/src/test/AboutPanel.gatewayCheck.test.tsx
+++ b/website/src/test/AboutPanel.gatewayCheck.test.tsx
@@ -79,6 +79,26 @@ describe('AboutPanel gateway update check', () => {
     store.dispatch(sseStatus({ ...BLANK_STATUS } as never))
   })
 
+  it('the version chip shows the folded running version, raw fallback for an older gateway', async () => {
+    // A promoted stable build's bytes keep the RC stamp; the gateway folds it
+    // into `version_display` and the chip must render THAT, never the raw
+    // `version` (which stays raw for the SPA's reload-on-upgrade comparison).
+    stubFetch({ check_status: 'succeeded', update_available: false, error_code: null })
+    store.dispatch(sseStatus({
+      ...BLANK_STATUS, version: '0.4.0rc14', version_display: '0.4.0',
+    } as never))
+    mountWeb()
+    expect(await screen.findByText('v0.4.0')).toBeTruthy()
+    expect(screen.queryByText('v0.4.0rc14')).toBeNull()
+    cleanup()
+
+    // An older gateway sends no `version_display`: the chip falls back to the
+    // raw version rather than rendering an empty chip.
+    store.dispatch(sseStatus({ ...BLANK_STATUS, version: '0.4.0rc14' } as never))
+    mountWeb()
+    expect(await screen.findByText('v0.4.0rc14')).toBeTruthy()
+  })
+
   it('a check that could not run reports the failure, not "up to date"', async () => {
     stubFetch({ check_status: 'failed', update_available: null, error_code: 'feed_unreachable', managed_by: 'kirocrew' })
     mountWeb()

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -37,6 +37,12 @@ export interface StatusData {
    */
   update_latest_version?: string
   /**
+   * DISPLAY-ONLY fold of `update_latest_version` (clean base on the stable
+   * channel). The popup's snooze/skip keys and every arm path keep reading
+   * the raw field. Optional: an older gateway does not send it.
+   */
+  update_latest_version_display?: string
+  /**
    * The release channel this INSTALL follows (the `channel` file `cli.sh` wrote).
    * "" when the layout has no channel at all — a git checkout tracks a remote, a
    * desktop bundle and a container are updated by something else — which is what
@@ -58,6 +64,15 @@ export interface StatusData {
   update_commits_behind?: number
   update_progress?: { step: string; detail: string } | null
   version?: string
+  /**
+   * The RUNNING build's version folded for display — the clean base on the
+   * stable channel (`0.4.0` for bytes stamped `0.4.0rc14`), the raw version
+   * on every other channel. DISPLAY-ONLY sibling of `version` above, which
+   * stays raw because the SPA compares it across pushes to force a reload
+   * over a gateway upgrade. Optional: an older gateway does not send it —
+   * fall back to `version`.
+   */
+  version_display?: string
   /**
    * Which release lane these bytes came from. The gateway resolves it (see
    * `src/kiro_crew/release_channel.py`) rather than leaving the dashboard to

--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -125,6 +125,23 @@ export interface UpdateCheckResult {
   requires_restart?: boolean
   channel?: string
   latest_version?: string
+  /**
+   * DISPLAY-ONLY sibling of `latest_version`, folded to the clean release
+   * version on the stable channel (a promoted candidate keeps its insider/rc
+   * stamp in the bytes, e.g. "0.4.0rc14" for the "0.4.0" release). Never pass
+   * this to `InAppUpdateFlow`'s `version` prop, `/api/update/arm`, or a
+   * snooze/skip key — those must use the raw `latest_version`, which is
+   * compared byte-for-byte against the installed build's own never-folded
+   * `__version__` during apply.
+   */
+  latest_version_display?: string
+  /**
+   * Copyable upgrade command ("" when none). Carried by the channel-switch
+   * response (POST /api/update/channel, which answers with this same contract
+   * re-run against the new lane); the check endpoint itself carries the
+   * command inside `remediation` instead.
+   */
+  update_command?: string
   changes?: string
   check_status?: 'unchecked' | 'checking' | 'succeeded' | 'failed' | 'deferred'
   update_available?: boolean | null

--- a/website/src/utils/displayVersion.ts
+++ b/website/src/utils/displayVersion.ts
@@ -1,0 +1,21 @@
+/**
+ * Mirrors the backend's `_display_version` (handlers/updates.py) for version
+ * strings that never cross the gateway (the Electron updater's own reports):
+ * a promoted STABLE build keeps its soaked candidate's prerelease stamp in
+ * the bytes (promotion never re-stamps), so fold the stamp to its clean base
+ * for DISPLAY on the stable channel only. Keys on the FOLLOWED channel, same
+ * as the backend. Lenient like the backend's `running_release` rule — any
+ * SemVer prerelease label folds onto its numeric base, because release.yml
+ * passes every `v1.2.3-<label>` tag's label through unchanged.
+ *
+ * DISPLAY ONLY. Every functional reader keeps the raw string: the updater's
+ * compare gate, `versionLooksPrerelease`, the arm target, and the update
+ * popup's per-version snooze/skip keys. Gateway-reported versions should
+ * prefer the backend-folded `*_display` sibling fields and use this only as
+ * a fallback shape for desktop-local values.
+ */
+export function foldStableStamp(version: string, channel: string | null | undefined): string {
+  if (channel !== 'stable') return version
+  const m = /^([0-9]+(?:\.[0-9]+)*)-.+$/.exec(version.trim())
+  return m ? m[1] : version
+}


### PR DESCRIPTION
Hotfix release cut for **0.4.1** on the release line.

## What
- Cherry-picks the display-only fold of a promoted stable candidate's rc stamp from [PR #6507](https://github.com/kirodotdev/KiroCrew/pull/6507) (`latest_version` stays raw everywhere; a new `latest_version_display` sibling on `/api/update/check` and the channel-switch response feeds only the About panel's text).
- Bumps `src/kiro_crew/__init__.py`, `pyproject.toml`, `website/electron/package.json` to **0.4.1**.
- Prepends the `## [0.4.1]` CHANGELOG section (required by the stable promotion gate; shipped sections byte-identical, verified by `check_changelog_history.py` against `origin/release/0.4.0`).

## Backport notes
- `test_update_stepup.py` and `AboutPanel.inAppApply.test.tsx` are **not** backported: `api_update_arm` / the in-app arm flow do not exist on this line.
- The display regression test is extracted into its own class (`TestAvailableUpdateDisplayFold`) because the feed `min_version` machinery is also post-0.4.0.

## Scope
All three display surfaces are folded on the stable channel: the "A new version (vX) is available" line, the running-version chip (About badge + Settings footer, via a display-only `version_display` status field), and the proactive update popup (via `update_latest_version_display`; its per-version snooze/skip records keep keying on the raw stamp). The raw `version` the SPA's reload-on-upgrade comparison reads stays untouched. After this hotfix ships, About shows a clean `v0.4.1` everywhere on stable; insider installs keep their full stamp by design.

## Verified on this branch
- 187 backend tests green (update check / channel / coverage suites)
- 203 frontend tests green, `tsc --noEmit` clean
- changelog-history gate green

## Release plan (after merge)
1. Tag `v0.4.1-insider.1` on the merge commit → full Release run (build+sign+notarize)
2. After that run is green, tag bare `v0.4.1` on the same commit → stable promotion (republishes the verified bytes, no rebuild)


