### PR TITLE
refactor(core): migrate the two remaining inline atomic writes onto the shared helper

### DIFF
--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 
 logger = logging.getLogger(__name__)
@@ -482,14 +483,32 @@ class ChannelManager:
         self._load_all()
 
     def _save_channel(self, channel: Channel) -> None:
-        """Persist channel state to disk."""
+        """Persist channel state to disk.
+
+        Routed through the shared :func:`atomic_write` helper rather than a
+        hand-rolled temp-write-and-rename. The hand-rolled form derived its temp
+        name from the destination (``<id>.json.tmp``), so two writers persisting
+        the same channel raced on one filename: the loser could publish a
+        half-written payload, or fail outright when its rename found the temp
+        already moved. It also missed the helper's bounded retry for the Windows
+        rename window, where a scanner holding the temp file makes a correct
+        write lose its payload.
+
+        Durability and permission semantics are deliberately unchanged: no
+        ``fsync`` (the pre-existing best-effort contract for channel state) and
+        no explicit ``mode``, so the file still lands at the umask default.
+        ``json.dumps`` is ASCII-only by default, so the helper's UTF-8 encoding
+        puts the same bytes on disk as the previous locale-default text handle.
+
+        ``os.makedirs`` stays OUTSIDE the ``try`` on purpose. The helper creates
+        the parent itself, so this call is now belt-and-braces -- but moving
+        directory creation inside the ``try`` would newly swallow a "cannot
+        create the channels directory" failure that callers see raised today.
+        """
         os.makedirs(self._CHANNELS_DIR, exist_ok=True)
         path = os.path.join(self._CHANNELS_DIR, f"{channel.id}.json")
-        tmp = path + ".tmp"
         try:
-            with open(tmp, "w") as f:
-                json.dump(channel.serialize(), f)
-            os.replace(tmp, path)
+            atomic_write(path, json.dumps(channel.serialize()))
         except Exception:
             logger.exception("Failed to save channel %s", channel.id)
 

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -37,6 +37,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.atomic_write import atomic_write
+
 logger = logging.getLogger(__name__)
 
 _REGISTRY_FILE = Path(__file__).resolve().parent / "model_registry.json"
@@ -228,8 +230,18 @@ def persist_kiro_windows() -> None:
 
     Separated from :func:`refresh_kiro_windows` so an async caller can offload
     ONLY this filesystem step to an executor while keeping the in-memory update
-    synchronous. Atomic (tmp + ``os.replace``); a persist failure is logged, not
-    raised — the in-memory cache is authoritative for this process either way.
+    synchronous. Atomic via the shared :func:`kiro_crew.atomic_write.atomic_write`
+    helper; a persist failure is logged, not raised — the in-memory cache is
+    authoritative for this process either way.
+
+    The helper replaces a hand-rolled temp-write-and-rename whose temp name was
+    derived from the destination (``model_windows.json.tmp``), so two processes
+    persisting the cache raced on one filename, and which missed the helper's
+    bounded retry for the Windows rename window. Durability and permission
+    semantics are unchanged: no ``fsync`` (best-effort by contract, per the note
+    above) and no explicit ``mode``, so the sidecar still lands at the umask
+    default. The helper creates the parent directory itself and raises ``OSError``
+    on failure — the same class the ``except`` below already absorbed.
 
     Thread-safety: this runs on an executor thread while ``refresh_kiro_windows``
     mutates ``_KIRO_WINDOWS`` on the event-loop thread. Snapshot with ``dict(...)``
@@ -240,11 +252,7 @@ def persist_kiro_windows() -> None:
     try:
         snapshot = dict(_KIRO_WINDOWS)  # atomic under the GIL; safe vs. concurrent mutation
         path = _kiro_windows_cache_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(snapshot, f)
-        tmp.replace(path)
+        atomic_write(path, json.dumps(snapshot))
     except OSError:  # pragma: no cover - disk full / perms
         logger.debug("Could not persist kiro window cache", exc_info=True)
 

--- a/test/test_atomic_write_migrated_sites.py
+++ b/test/test_atomic_write_migrated_sites.py
@@ -1,0 +1,171 @@
+"""Regression tests for the two writers migrated onto the shared atomic helper.
+
+``ChannelManager._save_channel`` and ``model_registry.persist_kiro_windows`` both
+hand-rolled a temp-write-and-rename whose temp filename was DERIVED FROM THE
+DESTINATION (``<id>.json.tmp`` / ``model_windows.json.tmp``). Two writers
+targeting the same file therefore shared one temp name, so a payload could be
+published half-written or a rename could fail outright, and neither site got the
+bounded retry ``atomic_write`` applies to the Windows rename window.
+
+The load-bearing assertions here are the "occupied temp name" ones. They occupy
+the deterministic temp path with a DIRECTORY, which is that collision expressed
+deterministically: the hand-rolled ``open(tmp, "w")`` raises ``IsADirectoryError``
+and — because both sites swallow their own write errors — the destination
+silently never appears. ``atomic_write`` picks a unique ``mkstemp`` name and is
+unaffected. Reverting either site to the hand-rolled form fails those tests, so
+they cannot pass by accident.
+
+The remaining assertions pin the semantics the migration had to PRESERVE, since a
+shared helper makes it easy to change them by accident: the umask default file
+mode (neither narrowed to ``0o600`` nor widened) and no leftover temp file.
+Durability is unchanged too — both sites are best-effort by contract and neither
+passed ``fsync``, which is asserted by requiring ``fsync`` to stay absent from
+the recorded call kwargs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+import kiro_crew.channel as channel_mod
+from kiro_crew import model_registry as mr
+from kiro_crew.channel import ChannelManager
+
+
+def _umask_default_mode() -> int:
+    """The mode ``open(path, "w")`` would have produced under this umask."""
+    current = os.umask(0)
+    os.umask(current)
+    return 0o666 & ~current
+
+
+def _mode_of(path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+class TestChannelSaveUsesSharedHelper:
+    @pytest.fixture(autouse=True)
+    def _channels_dir(self, tmp_path):
+        self._root = tmp_path / "channels"
+        self._root.mkdir()
+        self._dir = str(self._root)
+
+    def test_save_routes_through_atomic_write(self, monkeypatch):
+        """The persist path must call the shared helper, not its own rename."""
+        calls: list[tuple[str, dict]] = []
+        original = channel_mod.atomic_write
+
+        def recording(path, content, **kwargs):
+            calls.append((str(path), kwargs))
+            original(path, content, **kwargs)
+
+        monkeypatch.setattr(channel_mod, "atomic_write", recording)
+
+        mgr = ChannelManager(channels_dir=self._dir)
+        ch = mgr.create("topic")
+        assert ch is not None
+        assert ch.add_agent(role="Tester", agent_name="a", task="t") is not None
+
+        assert calls, "channel persist did not go through atomic_write"
+        assert all(p.endswith(f"{ch.id}.json") for p, _ in calls)
+        # Durability/permissions come from the helper's defaults: the hand-rolled
+        # site passed neither fsync nor an explicit mode, so neither may appear.
+        for _, kwargs in calls:
+            assert "fsync" not in kwargs
+            assert "mode" not in kwargs
+
+    def test_save_survives_an_occupied_deterministic_temp_name(self):
+        """A directory squatting on ``<id>.json.tmp`` must not lose the write.
+
+        This is the collision the shared helper exists to remove. The
+        hand-rolled writer opened that exact path, so this fails on revert.
+        """
+        mgr = ChannelManager(channels_dir=self._dir)
+        ch = mgr.create("topic")
+        assert ch is not None
+        target = self._root / f"{ch.id}.json"
+        squatter = self._root / f"{ch.id}.json.tmp"
+        squatter.mkdir()
+
+        assert ch.add_agent(role="Tester", agent_name="a", task="t") is not None
+
+        assert target.is_file(), "the persist was lost to the occupied temp name"
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert data["id"] == ch.id
+        assert any(m["role"] == "Tester" for m in data["members"].values())
+        assert squatter.is_dir(), "the helper must not have touched the squatter"
+
+    def test_save_keeps_umask_default_mode_and_leaves_no_temp(self):
+        """The migration must not widen or narrow the published file mode."""
+        mgr = ChannelManager(channels_dir=self._dir)
+        ch = mgr.create("topic")
+        assert ch is not None
+        assert ch.add_agent(role="Tester", agent_name="a", task="t") is not None
+        target = self._root / f"{ch.id}.json"
+
+        assert target.is_file()
+        if os.name != "nt":  # POSIX permission bits only
+            assert _mode_of(target) == _umask_default_mode()
+        assert list(self._root.glob("*.tmp")) == []
+
+
+class TestPersistKiroWindowsUsesSharedHelper:
+    @pytest.fixture(autouse=True)
+    def _isolated_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        saved = dict(mr._KIRO_WINDOWS)
+        mr._KIRO_WINDOWS.clear()
+        mr._KIRO_WINDOWS["probe-model-zzz"] = 272_000
+        yield
+        mr._KIRO_WINDOWS.clear()
+        mr._KIRO_WINDOWS.update(saved)
+
+    def test_persist_routes_through_atomic_write(self, monkeypatch):
+        calls: list[tuple[str, dict]] = []
+        original = mr.atomic_write
+
+        def recording(path, content, **kwargs):
+            calls.append((str(path), kwargs))
+            original(path, content, **kwargs)
+
+        monkeypatch.setattr(mr, "atomic_write", recording)
+
+        mr.persist_kiro_windows()
+
+        assert calls, "persist_kiro_windows did not go through atomic_write"
+        assert calls[0][0].endswith("model_windows.json")
+        assert "fsync" not in calls[0][1]
+        assert "mode" not in calls[0][1]
+
+    def test_persist_survives_an_occupied_deterministic_temp_name(self):
+        """A directory on ``model_windows.json.tmp`` must not lose the cache.
+
+        The hand-rolled writer wrote ``path.with_suffix(".json.tmp")`` and
+        swallowed the resulting ``IsADirectoryError`` as an ``OSError``, so the
+        sidecar never appeared. This fails on revert.
+        """
+        path = mr._kiro_windows_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        squatter = path.with_suffix(".json.tmp")
+        squatter.mkdir()
+
+        mr.persist_kiro_windows()
+
+        assert path.is_file(), "the persist was lost to the occupied temp name"
+        assert json.loads(path.read_text(encoding="utf-8"))["probe-model-zzz"] == 272_000
+        assert squatter.is_dir(), "the helper must not have touched the squatter"
+
+    def test_persist_creates_the_parent_and_keeps_umask_default_mode(self):
+        """The helper owns the ``mkdir`` the site used to perform by hand."""
+        path = mr._kiro_windows_cache_path()
+
+        mr.persist_kiro_windows()
+
+        assert path.is_file()
+        if os.name != "nt":
+            assert _mode_of(path) == _umask_default_mode()
+        assert list(path.parent.glob("*.json.tmp")) == []


### PR DESCRIPTION
## Problem / Motivation

`atomic_write` in `src/kiro_crew/atomic_write.py` exists so every tmp-file-plus-rename writer in the codebase gets one correct implementation: a unique `mkstemp` temp name, a bounded retry for the Windows rename window, and temp-file cleanup under `BaseException` (Ctrl-C included).

Two writers still hand-rolled that sequence, and both derived their temp filename **from the destination**:

| Site | Hand-rolled temp name |
|---|---|
| `ChannelManager._save_channel` (`src/kiro_crew/channel.py`) | `<channel-id>.json.tmp` |
| `model_registry.persist_kiro_windows` (`src/kiro_crew/model_registry.py`) | `model_windows.json.tmp` |

A destination-derived temp name is shared by every writer targeting that file, which is the defect. Two concurrent writers interleave on one temp path, so the loser can publish a half-written payload or fail its rename outright. Both sites swallow their own write errors — `_save_channel` logs `Exception`, `persist_kiro_windows` logs `OSError` — so the failure mode is **a persist that silently does not happen**.

Neither site got the Windows rename retry either: on Windows `os.replace` raises `PermissionError` while any other handle is open on either path, so a Search-indexer or AV scanner touching the freshly written temp file is enough to lose a correct write.

## Why it matters

Channel state is what a restart restores from (`ChannelManager._load_all`), and the kiro-window sidecar is the cache `model_window()` consults before falling back to the static registry. A silently dropped write means restored state, or a resolved context window, that does not reflect what the process actually decided.

## What changed (motivation → approach → change)

Both call sites now delegate to `atomic_write`. This is a **mechanical migration**: durability and permission semantics are carried through exactly, not re-chosen.

- Neither site passed `fsync`, so neither passes it now — both remain best-effort by their own documented contract.
- Neither site set an explicit `mode`, so both keep `mode=None` and still land at the **umask default**. Nothing is narrowed to `0o600`, nothing is widened. (`mkstemp` creates at `0o600` and the helper's `fchmod_safe` widens it to the umask default before publish, so the transient window is strictly *tighter* than the hand-rolled `open()`; the published file is identical.)
- `channel.py` previously used a locale-default text handle (`open(tmp, "w")`, no `encoding`). `json.dumps` is ASCII-only by default, so the helper's UTF-8 encoding puts the same bytes on disk.
- `channel.py` keeps its `os.makedirs` **outside** the `try`. The helper creates the parent itself, so the call is now belt-and-braces — but moving directory creation inside the `try` would newly swallow a "cannot create the channels directory" failure that callers see raised today.
- `model_registry.py` drops its explicit `path.parent.mkdir`, which sat **inside** the `try`. The helper's own `mkdir` raises the same `OSError` class into the same `except`, so error coverage there is unchanged.

Both docstrings now state the race the migration removes and the semantics it preserves, so the next reader does not have to re-derive either.

`model_registry.py` gains a module-scope import of `atomic_write`. That is cycle-free: `atomic_write` reaches only `platform_compat` at import time, whose own Kiro Crew imports (`windows_acl`, `executors`, `subprocess_utf8`) are stdlib-only leaves. The file's lazy `config.paths` import is untouched.

### Scope, and what is deliberately left alone

This carries forward the **un-superseded remainder of #2169**, which targeted five sites. Three of those — in `deploy/pending.py` and `deploy/profiles.py` — were independently migrated onto `replace_with_retry` on main since that PR was opened, so only these two were still hand-rolled. Those three are **not** touched here: re-migrating them would be churn against a settled decision. #2169 sat 1899 commits behind main on exactly the files main rewrote, so a fresh two-site change is cheaper and clearer than a rebase. Original author credited via `Co-authored-by:`.

## Tests

`test/test_atomic_write_migrated_sites.py` (new, 6 tests) covers both sites:

- **the collision, deterministically** — a directory occupies the exact temp path each site used to derive (`<id>.json.tmp`, `model_windows.json.tmp`). The hand-rolled `open(tmp, "w")` raises `IsADirectoryError`, which both sites swallow, so the destination silently never appears; the helper's unique `mkstemp` name is unaffected. These are the load-bearing assertions.
- **routing** — the persist path is asserted to go through the module's `atomic_write`, with `fsync` and `mode` asserted **absent** from the call kwargs, so a later change cannot quietly add durability or narrow permissions.
- **preservation** — the published file's mode equals the umask default on POSIX, and no temp file is left behind.

**Mutation-verified.** With both production hunks reverted and the tests kept: the two collision tests fail with `the persist was lost to the occupied temp name`, and the two routing tests fail with `module has no attribute 'atomic_write'`. The two preservation tests pass either way *by design* — they pin semantics rather than detect the defect, and the module docstring says so explicitly.

## Manual verification

N/A — unit coverage is sufficient. Both sites are pure filesystem writers with no user-visible surface, and the tests exercise the real filesystem via `tmp_path` rather than a mock.

### Gates run locally

- `test/test_channel.py`, `test/test_model_registry.py`, `test/test_model_registry_parity.py`, the three `test_atomic_write_*` suites and the new file — **124 passed**.
- `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1153 files), `scripts/check_black_formatting.py` — all clean.
- No frontend files, no new user-facing strings and no new JSON error responses, so the i18n parity gate and the error-code contract are out of scope. `test/test_error_code_contract.py` was run to **confirm** rather than assumed — 6 passed.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change; no rendered surface is touched.

## Related Issues

Supersedes #2169 (carries its remaining two sites forward), which is now closed.

no linked issue: #2169 tracked this work as a pull request rather than an issue, so there is nothing for a closing keyword to close.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — both migrated docstrings state the race removed and the semantics preserved
- [x] No secrets, credentials, or internal references in the diff
