### PR TITLE
feat: AgentCore core interfaces and governance schema

### DIFF
--- a/docs/request-for-change/README.md
+++ b/docs/request-for-change/README.md
@@ -20,7 +20,8 @@ not been re-audited since 2026-08-03. The durable-run-coordinator row was added
 `c4f253891`; the `rfc-token-efficient-monitors` row was added 2026-08-22 and
 verified against `6d3e30bbbd`. The `rfc-global-workflow-library` row was added
 2026-08-25 and audited against `749468d42`; its implementation exists only in
-the active detached worktree. The `rfc-crew-agent-sdk-boundary` row was added 2026-08-28 and verified against `dc88f142b`. The `rfc-transcript-section-markers` row was added 2026-08-30 and verified against `202770d13`.
+the active detached worktree. The `rfc-agentcore-identity-gateway` row
+was added 2026-08-27. The `rfc-crew-agent-sdk-boundary` row was added 2026-08-28 and verified against `dc88f142b`. The `rfc-transcript-section-markers` row was added 2026-08-30 and verified against `202770d13`.
 
 | Document | Status | What is actually on main |
 |---|---|---|
@@ -55,6 +56,7 @@ the active detached worktree. The `rfc-crew-agent-sdk-boundary` row was added 20
 | [rfc-amend-tenets-everything-is-an-app.md](rfc-amend-tenets-everything-is-an-app.md) | `draft` | Nothing. `TENETS.md` still carries seven tenets on main. `git log --follow` on it shows two commits and no prior amendment, and `grep -i tenet` returns zero hits in `GOVERNANCE.md` |
 | [rfc-crew-projects.md](rfc-crew-projects.md) | `draft` | Nothing. Verified at `5cd92ff99`: no project manifest format exists, `slot.project` is a bare directory path, and `grep -ril "confluence\|servicenow" src/kiro_crew` returns zero hits |
 | [rfc-tool-derived-diff-cards.md](rfc-tool-derived-diff-cards.md) | `in-progress` | Ships with [#5012](https://github.com/kirodotdev/KiroCrew/pull/5012): dashboard diff-card/summary promotion + runtime-selected prompt rule. The messaging `OutputEvent` extension (§3.3) is unstarted |
+| [rfc-agentcore-identity-gateway.md](rfc-agentcore-identity-gateway.md) | `in-progress` | First stack PR lands the `agent_identity` CPP slot, `DefaultAgentIdentityProvider` no-op, `capabilities.agentcore` catalog row, and AWS-free policy validators. No AWS extra, no Gateway inject, no login attach, no Settings UI |
 
 Nothing in this directory is `implemented` or `superseded` today.
 

--- a/docs/request-for-change/rfc-agentcore-identity-gateway.md
+++ b/docs/request-for-change/rfc-agentcore-identity-gateway.md
@@ -1,0 +1,1120 @@
+---
+title: AgentCore Identity and Gateway — Crew agent identity and token vending
+status: draft
+author: kyle
+created: 2026-08-27
+last-audited: 2026-08-27
+audited-at: 152c00e99
+doc-pr:
+implementation-prs: []
+tracking-issues: []
+supersedes: []
+superseded-by: []
+---
+
+# RFC: AgentCore Identity and Gateway — Crew agent identity and token vending
+
+## Summary
+
+Give each Kiro Crew agent a first-class **Amazon Bedrock AgentCore
+Identity** workload identity, and use **AgentCore Gateway** as the
+outbound token-vending plane for MCP tools. Crew does not implement
+OAuth, RFC 8693, or a token vault. The companion edition registers the
+workload, vends tokens, and contributes the Gateway MCP endpoint. The
+public core grows generic, default-off seams so a standalone install
+stays byte-identical and never imports AWS.
+
+A fleet picks **exactly one** posture in `security_policy.json`, and
+that posture is what the copyable cloud **Policy.json pair** must
+match — the launcher document (`iam.policy_json()` / `kirocrew cloud
+iam-policy`) plus the instance-role fragment
+(`iam.agentcore_instance_policy_document`):
+
+- **`workload`** — a deployed Crew instance has an IAM identity and
+  can invoke Gateway at boot. No user login required to start.
+- **`login`** — only Gateway-approved MCP is vended. That catalog
+  **overrides Kiro's default MCP merge**. Tools stay absent until
+  the operator logs in.
+
+This is the **identity and credential** plane. It is not the sandbox /
+execution plane in the sibling AgentCore sandboxes design.
+
+**Implementation plan:**
+[`../superpowers/plans/2026-08-27-agentcore-identity-gateway.md`](../superpowers/plans/2026-08-27-agentcore-identity-gateway.md)
+
+## Motivation
+
+### Current state (verified at `152c00e99`)
+
+Crew has an operator-identity seam and no agent-identity or token-vending
+seam.
+
+| Surface | What exists | What it is not |
+|---|---|---|
+| `IdentityProvider` (`platform/interfaces.py:306`) | SSO status, preflight, MCP credential-watch paths | Not consumed as a principal. `whoami` / `issuer` are **RESERVED** (`platform/context.py:150`) |
+| `DefaultIdentityProvider` | Delegates to `sso_status.py` stubs (`available: false`) | No SSO, no JWT, no workload |
+| `McpToolingProvider.extra_mcp_servers()` | ADD-only MCP specs merged into `kirocrew.json` | Static at rebuild time. No per-session `Authorization` |
+| `kiro_oauth_wire_entry` (`mcp_utils.py:160`) | Translates remote MCP OAuth hints for kiro-cli | Operator-managed client credentials, not AgentCore |
+| MCP `headers` on URL servers (`mcp_discovery.py`) | Static headers from config | A baked bearer is a live credential in an agent-readable file |
+| Dashboard tokens (`dashboard/token_auth.py`) | HMAC-SHA256, IP-pinned, single-use | Not an OIDC JWT. Cannot satisfy Gateway `CUSTOM_JWT` |
+| Channel session keys (`session.md`) | `slack:…`, `dashboard:…`, cron keys | Surface routing, not a cryptographic user identity |
+| Governance `SCOPE_CATALOG` | `mcp`, `network.egress`, `capabilities.*` | No AgentCore / token-vend row |
+| Credential redaction | AKIA/ASIA floor + bearer-header heuristics | No AgentCore workload-token shape |
+
+Grep of `src/`, `website/src/`, and `docs/` at `152c00e99` finds **no**
+`AgentCore`, `bedrock-agentcore`, `GetWorkloadAccessToken`, or
+`GetResourceOauth2Token` symbol.
+
+### Problems
+
+1. **The Crew agent has no identity AgentCore can name.** Gateway policy,
+   CloudTrail, and the Identity token vault key on a workload identity.
+   Today the caller is "whatever IAM role the host has," which cannot
+   distinguish `kirocrew` from a sibling agent, a cron job, or a
+   compromised local process.
+2. **Outbound tool credentials are operator-local secrets.** Slack bot
+   tokens, GitHub PATs, and static MCP `Authorization` headers live on
+   disk or in env. There is no on-behalf-of exchange, no per-user vault
+   binding, and no short-lived scoped token.
+3. **A static Gateway URL is not an integration.** An operator can paste
+   a Gateway MCP URL into `~/.kiro/crew/mcp.json` today. That carries no
+   agent identity, no refresh, no per-session principal, and no 3LO
+   consent surface. It also puts a bearer in an agent-readable spec.
+4. **Unattended work has no honest principal.** Cron, TaskRunner, and
+   subagents are not the operator at a keyboard. ForUserId without a
+   trusted derivation is impersonation.
+
+### What AgentCore actually is (product shape)
+
+Two AWS services, not one:
+
+**AgentCore Identity** is the workload identity directory and token
+vault.
+
+- A **workload identity** names an agent (`kirocrew`, later
+  `kirocrew-<agent_id>`).
+- `GetWorkloadAccessToken` / `ForJWT` / `ForUserId` mint an opaque
+  **workload access token** bound to `(workload, user)`.
+- That token is **first-party only**. It authorizes AgentCore Identity
+  APIs (`GetResourceOauth2Token`, vault reads). It is not a Gateway
+  inbound credential and must never be sent to a downstream MCP server.
+- `GetResourceOauth2Token` vends an OAuth token for a named credential
+  provider (`M2M`, authorization-code / 3LO, or `TOKEN_EXCHANGE` /
+  on-behalf-of).
+- Runtime-managed and Gateway-managed workload identities **cannot**
+  call `GetWorkloadAccessToken` themselves. A Crew-owned identity must
+  be a **standalone** workload, not the Gateway's.
+
+**AgentCore Gateway** is a hosted MCP endpoint.
+
+- Inbound: `CUSTOM_JWT` (OIDC discovery + JWKS) or `AWS_IAM`. JWT is
+  required for OBO; IAM is machine-to-machine and has no user `sub`.
+- The Gateway obtains its **own** workload access token and asks
+  Identity to vend the outbound credential for the target.
+- Outbound grant types: client credentials, authorization code, RFC 8693
+  token exchange (`TOKEN_EXCHANGE`).
+- Optional Cedar policy engine and request interceptors.
+
+The official [Kiro IDE + AgentCore Gateway](https://builder.aws.com/content/3CS1jTWHngGW3IxFXCjcP2T9l8B/govern-mcp-tools-at-scale-with-kiro-and-agentcore-gateway)
+pattern is "IDE presents a developer OIDC JWT; Gateway vends outbound
+tokens." Crew is a **local orchestrator**, not Kiro IDE and not AgentCore
+Runtime. Runtime auto-injects `WorkloadAccessToken` into hosted agent
+code; Crew never runs there, so it must mint its own workload token when
+it calls Identity APIs.
+
+## Goals
+
+- Register one standalone AgentCore workload identity for the Crew
+  agent, visible in Identity status, CloudTrail, and vault bindings.
+- Use AgentCore Gateway as the token-vending plane for approved MCP
+  targets. Crew does not implement RFC 8693.
+- Bind vault entries to a **trusted** `(workload, user)` pair. Prefer
+  `GetWorkloadAccessTokenForJWT`. Use `ForUserId` only with a
+  core-derived, partitioned subject.
+- Inject Gateway inbound credentials **per session**, never into
+  `~/.kiro/agents/kirocrew.json`.
+- Public edition remains complete standalone: no AWS SDK, no AgentCore
+  import, no new default-on egress, no Cognito/SSO reintroduction.
+- Fail closed. A missing companion, expired JWT, or Identity error
+  denies the Gateway call. It does not fall back to a shared token.
+- Work with the existing cloud Policy.json pair: the launcher
+  document (`iam.policy_json`) and the instance permissions
+  boundary (`iam.boundary_policy_document`). A deployed Crew can
+  only reach Gateway when **both** the grant and the boundary
+  ceiling allow it.
+- Two exclusive postures (`workload` | `login`), selected by
+  `security_policy.json`. `login` withholds Kiro-global and
+  crew-store MCP at rebuild time, not only at the tool gate.
+
+## Non-goals
+
+- Hosting Crew on AgentCore Runtime, or treating Gateway as an
+  `agent.provider`. `agent.provider` stays `acp`.
+- A new OS-sandbox backend or Instances `connection_method`. That is
+  the sibling sandboxes RFC.
+- Re-adding enterprise SSO, Cognito, Midway, or device-posture tunnels
+  to the public core. `sso_status.py` stays a stub. Companion SSO lands
+  through the existing `IdentityProvider` slot.
+- Crew-side `GetResourceOauth2Token` for arbitrary local tools in v1.
+  Gateway vends. Direct Identity vending is a later, narrowly-scoped
+  follow-on.
+- Making `IdentityProvider.whoami` / `issuer` live. Those stay
+  RESERVED. Surface principal data through wired `status()` payloads.
+- Bumping `CONTRACT_VERSION`. Pre-launch field and method adds stay at
+  `1`, matching `knowledge` / `dashboard` / `jail`.
+- A public `config.json` AgentCore block. Agent-writable config cannot
+  be the trust root for workload name, gateway URL, or region.
+- Re-versioning the immutable `kirocrew-ec2-boundary` in place.
+  Widening that document is a new named boundary, opt-in at launch.
+- Running both postures at once. `workload` and `login` are
+  alternatives, not layers.
+
+## Design
+
+### Target architecture
+
+```
+Operator / channel user
+        │  dashboard token, Slack user id, companion SSO JWT
+        ▼
+Kiro Crew gateway (local, ACP → kiro-cli)
+        │
+        ├─ AgentIdentityProvider.workload_identity()
+        │     standalone AgentCore workload "kirocrew"
+        │
+        ├─ AgentIdentityProvider.vend_workload_access_token(principal)
+        │     Identity: GetWorkloadAccessToken*  (see posture)
+        │     first-party token; never leaves the gateway process
+        │
+        └─ inbound to AgentCore Gateway  (MCP)
+              posture=workload → instance IAM  (InvokeGateway)
+              posture=login    → user OIDC JWT after ensure-login
+                    │
+                    ▼
+         AgentCore Gateway
+                    │  Gateway's own workload token
+                    ▼
+         AgentCore Identity token vault
+                    │  GetResourceOauth2Token (M2M / 3LO / OBO)
+                    ▼
+         Gateway target (Slack, GitHub, internal API, MCP server)
+```
+
+The diagram branches on `capabilities.agentcore.posture`. `workload`
+is the deployed-box path (IAM inbound, no login). `login` is the
+ensure-login path (CUSTOM_JWT, Gateway catalog only).
+
+Two tokens, two audiences, never interchangeable:
+
+| Token | Audience | Who mints it | Who holds it |
+|---|---|---|---|
+| Workload access token | AgentCore Identity APIs only | Identity (`GetWorkloadAccessToken*`) | Crew gateway process, in memory |
+| Gateway inbound JWT | Gateway `customJWTAuthorizer` | Companion IdP / SSO | Injected as `Authorization` on the Gateway MCP transport for that session |
+| Outbound resource token | Downstream API | Identity, **called by Gateway** | Gateway; Crew never sees it in v1 |
+
+### Two postures, one Policy.json
+
+The operator-facing document today is `iam.policy_json()` — the
+indented JSON the dashboard copies (`GET /api/cloud/iam-policy`) and
+`kirocrew cloud iam-policy` prints. It is the **launcher** policy
+(CloudFormation, tagged EC2, PassRole, SSM, source bucket, STS). It
+is **not** what the running instance can do.
+
+A deployed Crew process assumes the instance role. That role is
+capped by the content-fixed permissions boundary
+`kirocrew-ec2-boundary` (`iam.boundary_policy_document`): SSM-core +
+`s3:GetObject` on `kirocrew-src-<account>-*`. A boundary is a
+ceiling, not a grant. Adding `bedrock-agentcore:InvokeGateway` to
+the launcher Policy.json alone does nothing for a box that is
+already running: the boundary still denies it. The boundary is
+create-once and never re-versioned on purpose (a leaked launcher
+credential must not be able to `CreatePolicyVersion` it permissive).
+
+So "works with our Policy.json" means three documents stay in
+agreement, not one:
+
+| Document | Who applies it | What it is |
+|---|---|---|
+| `iam.policy_json()` | Operator pastes into IAM for the **launch** principal | Must be able to PassRole an instance role that *may* carry AgentCore |
+| Instance role grant (inline or attached) | Launch template / companion | The actual `InvokeGateway` / `GetWorkloadAccessToken*` allow |
+| `kirocrew-ec2-boundary` (or a new named successor) | Admin, once per account | Ceiling. Must list any AgentCore action the grant uses |
+| `security_policy.json` | Fleet trust root (keystone) | Picks the posture. Agent cannot weaken it |
+
+`capabilities.agentcore` grows an inner posture, still a data row
+(`SCOPE_CATALOG` append-only, evaluator untouched):
+
+```json
+{
+  "capabilities": {
+    "agentcore": {
+      "enabled": true,
+      "posture": "workload"
+    }
+  }
+}
+```
+
+`posture` is `"workload"` or `"login"`. Absent / unknown with
+`enabled: true` fails closed (boot abort if `boot.fail_closed`,
+else treat as disabled). The two postures are exclusive.
+
+#### Deploy assigns the AgentCore identity
+
+A remote Crew launch **creates** the standalone AgentCore identity
+in the same CloudFormation stack that creates the instance.
+
+- Resource: `AWS::BedrockAgentCore::WorkloadIdentity` (CDK L2:
+  `aws_bedrockagentcore.WorkloadIdentity`). Same resource, two
+  front-ends. The public wheel does not depend on `aws-cdk-lib`.
+- Name: `kirocrew-<StackTag>` so two crews in one account do not
+  collide. Hand-rolled fleets may still use the bare name
+  `kirocrew`.
+- The instance role receives the posture grant automatically
+  (`AWS::IAM::Policy`). Operators do not paste the instance
+  Policy.json onto a CFN-launched box.
+- systemd gets `KIROCREW_AGENTCORE_POSTURE`,
+  `KIROCREW_AGENTCORE_WORKLOAD_NAME`, and optional
+  `KIROCREW_AGENTCORE_GATEWAY_URL`. A non-`none` posture installs
+  `kirocrew[agentcore]` (`boto3`) via `install.sh --agentcore`.
+  Settings PUT and standalone boot also `ensure_extra()` when the
+  home policy or env posture is already `workload`/`login`, so a
+  box that skipped the CFN flag still gets boto3. The in-repo extra
+  (`platform/agentcore_aws.py`) reads those env vars (workload name
+  defaults to `kirocrew` when only the policy is set) and the
+  Gateway MCP URL from `capabilities.agentcore.gateway_url` (Settings
+  / policy first) or `KIROCREW_AGENTCORE_GATEWAY_URL`. It calls
+  `GetWorkloadAccessToken*` through a lazy boto3 client.
+  Public core never imports the `bedrock-agentcore` SDK package and
+  never registers `kirocrew.plugins`.
+- Opt-in: `AgentCorePosture=none` (default) is the historical
+  launch. `kirocrew cloud launch --agentcore-posture workload`
+  creates the AWS identity at deploy time. See-and-configure
+  lives on **that crew's** Settings → Security → Agent identity
+  (`GET`/`PUT /api/agentcore/identity`), not on the hub's Remote
+  Crew launcher. The same pane verifies the Gateway, lists targets
+  and the data-plane tool catalog, and can Sync a DEFAULT target
+  (`GET`/`POST /api/agentcore/gateway`, owner-only). Instance IAM
+  grants inspect on `gateway/*`; Invoke stays on `kirocrew-*`.
+  `ListOauth2CredentialProviders` is not on this pane. A fleet
+  override or signed policy is refused.
+- Stack delete removes the identity. The launcher Policy.json
+  grows `CreateWorkloadIdentity` / `DeleteWorkloadIdentity` /
+  `GetWorkloadIdentity` / tag verbs, still scoped to
+  `kirocrew` / `kirocrew-*`. It still does **not** grow
+  `InvokeGateway`.
+
+#### Posture `workload` — deployed Crew can start
+
+Use this on a `kirocrew cloud launch` box (or any companion-managed
+host) that should reach Gateway **without** an interactive login.
+
+- Register a standalone workload identity `kirocrew-<StackTag>`
+  (not Gateway-managed) via the CloudFormation resource above.
+- Gateway inbound is **IAM** (`authorizerType: AWS_IAM`). The
+  instance role is the caller. Action:
+  `bedrock-agentcore:InvokeGateway` on the Gateway ARN.
+- The instance role also needs
+  `bedrock-agentcore:GetWorkloadAccessToken` (and, for unattended
+  job-owner binding only,
+  `GetWorkloadAccessTokenForUserId`) scoped to
+  `workload-identity-directory/default/workload-identity/kirocrew`.
+- **Deny** `GetWorkloadAccessTokenForJWT` on this role: there is no
+  user JWT in this posture, and leaving ForJWT allowed invites a
+  planted-token confused deputy.
+- Kiro MCP defaults **still merge** (`~/.kiro/settings/mcp.json`,
+  crew store, apps). The fleet can still deny them with the
+  existing `mcp` ruleset. This posture answers "can the box start,"
+  not "is the catalog empty."
+- Cron / TaskRunner / injected envelopes run as the workload
+  identity. They may call M2M Gateway targets. They must not OBO as
+  an arbitrary user.
+
+The copyable **launcher** Policy.json (`iam.policy_json()`) does
+**not** grow `InvokeGateway` or `GetWorkloadAccessToken*`. Those
+belong on the instance role, not the laptop/CI principal that
+pastes the document. The launcher document grows only the verbs
+needed to *stand up* an AgentCore-capable box:
+
+- `iam:CreatePolicy` + `iam:GetPolicy` on the **new** boundary
+  ARN (`kirocrew-ec2-boundary-agentcore`), still no
+  `CreatePolicyVersion` / `Delete*`.
+- `iam:CreateRole` `ArnLike` on **either**
+  `kirocrew-ec2-boundary` or `kirocrew-ec2-boundary-agentcore`.
+- `bedrock-agentcore:CreateWorkloadIdentity` (and Get/Delete/Tag)
+  on `workload-identity/kirocrew` and `kirocrew-*`.
+- Existing tag-gated `PassRole` of `kirocrew-ec2-*` roles.
+
+The dashboard / `kirocrew cloud iam-policy` grows a **second,
+labeled** document — the instance-role fragment — from
+`iam.agentcore_instance_policy_document(posture)`. Copying the
+launcher JSON onto the instance role, or the instance JSON onto
+the launch principal, is a misconfiguration the copy UI must
+not invite.
+
+The instance boundary does **not** silently grow. A new named
+boundary (`kirocrew-ec2-boundary-agentcore`) is the **union**
+ceiling: existing SSM-core + source-bucket read, plus every
+AgentCore action either posture's instance grant may use
+(`GetWorkloadAccessToken`, `ForUserId`, `ForJWT`,
+`InvokeGateway`). A boundary does not grant; the instance
+document is still what turns a verb on. One successor name
+covers both postures so a fleet can switch `security_policy.json`
+without minting a third boundary. New launches opt in; existing
+instances stay on `kirocrew-ec2-boundary` and cannot reach
+Gateway. No `CreatePolicyVersion` of the original document.
+
+#### Posture `login` — Gateway catalog only, user must sign in
+
+Use this when the approved tool catalog *is* the Gateway, and a
+human has to be present.
+
+- Gateway inbound is **CUSTOM_JWT**. Crew attaches the operator's
+  IdP JWT after login. The instance role does **not** receive
+  `InvokeGateway` or `GetWorkloadAccessTokenForUserId`.
+- If Crew must mint a workload token after login, the role may have
+  `GetWorkloadAccessTokenForJWT` only, scoped to `kirocrew`.
+  ForUserId is **denied** in IAM.
+- **Override Kiro defaults at rebuild time.** When posture is
+  `login` and `capabilities.agentcore` is enabled,
+  `rebuild_agent_config()` withholds:
+
+  - `~/.kiro/settings/mcp.json` (Kiro global)
+  - seam-contributed provider globals
+  - `~/.kiro/crew/mcp.json` user servers
+  - leftover non-managed entries in the merge base
+
+  It still emits the managed Crew servers (`kirocrew-core`,
+  `kirocrew-cron`, `kirocrew-computer` when its spec_gate is open)
+  and the Gateway URL-only spec. Those are not "Kiro defaults";
+  they are Crew's own process. A `@server` ref whose entry was
+  withheld mounts nothing — same control as the computer-use
+  spec_gate (`mcp.md`).
+- Until `vend_gateway_inbound_token` returns a live JWT, the
+  Gateway server is **absent** (fail closed). The dashboard/CLI
+  login prompt is the only way to make it appear. Companion SSO
+  already owns `IdentityProvider` / `/api/sso-login`; this posture
+  consumes that login, it does not re-add Cognito to the core.
+- Unattended jobs cannot see Gateway tools. Cron on a login-posture
+  host is M2M-less and stays on managed Crew servers only.
+
+The login-mode instance document **omits** `InvokeGateway` and
+`GetWorkloadAccessTokenForUserId`. Copying the workload-mode
+fragment onto a login-mode fleet is a misconfiguration: the
+instance could IAM-invoke Gateway and skip the login. The core
+detects the mismatch (posture `login` but a successful IAM
+InvokeGateway probe, or vice versa) and refuses to emit the
+Gateway server, SEL-audited.
+
+#### How the two Policy.json shapes differ
+
+Workload-mode excerpt (instance grant + matching boundary ceiling;
+ARNs are fleet-pinned, never `*`):
+
+```json
+{
+  "Sid": "AgentCoreIdentity",
+  "Effect": "Allow",
+  "Action": [
+    "bedrock-agentcore:GetWorkloadAccessToken",
+    "bedrock-agentcore:GetWorkloadAccessTokenForUserId"
+  ],
+  "Resource": [
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default",
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default/workload-identity/kirocrew"
+  ]
+},
+{
+  "Sid": "AgentCoreGateway",
+  "Effect": "Allow",
+  "Action": ["bedrock-agentcore:InvokeGateway"],
+  "Resource": "arn:aws:bedrock-agentcore:*:*:gateway/kirocrew-*"
+},
+{
+  "Sid": "DenyJwtPathOnWorkloadPosture",
+  "Effect": "Deny",
+  "Action": "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+  "Resource": "*"
+}
+```
+
+Login-mode excerpt:
+
+```json
+{
+  "Sid": "AgentCoreIdentityForJwt",
+  "Effect": "Allow",
+  "Action": ["bedrock-agentcore:GetWorkloadAccessTokenForJWT"],
+  "Resource": [
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default",
+    "arn:aws:bedrock-agentcore:*:*:workload-identity-directory/default/workload-identity/kirocrew"
+  ]
+},
+{
+  "Sid": "DenyUserIdAndIamGateway",
+  "Effect": "Deny",
+  "Action": [
+    "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
+    "bedrock-agentcore:InvokeGateway"
+  ],
+  "Resource": "*"
+}
+```
+
+`iam.policy_json()` stays the launcher document. A new helper
+`iam.agentcore_instance_policy_document(posture)` emits the
+instance-role fragment above so the dashboard can copy **the
+right Policy.json for the posture in `security_policy.json`**,
+not a single kitchen-sink document.
+
+### Edition split
+
+The public core defines the protocol, the session-principal derivation,
+the MCP header-injection site, governance, redaction, and SEL. It ships
+`DefaultAgentIdentityProvider` (all methods empty / `enabled() ==
+False`).
+
+An **opt-in extra** (`kirocrew[agentcore]`, boto3 only) implements
+`AgentIdentityProvider` in-tree as `AwsAgentIdentityProvider` so a
+deployed box can vend. IaC (`install.sh --agentcore`, the EC2
+template) installs it; a later policy or Settings configure
+force-installs the same extra into the gateway interpreter.
+Bootstrap swaps only `agent_identity` on a standalone profile — it
+does not flip to a companion and does not register
+`kirocrew.plugins`.
+
+The enterprise companion (separate package, `kirocrew.plugins` entry
+point) remains the home for operator IdP JWT annotation, Cognito /
+SSO, and Gateway/target control-plane registration.
+
+Dependency stays one-way: companion depends on core. Core never imports
+`bedrock_agentcore`, never names Cognito, never hardcodes a discovery
+URL. boto3 is imported only inside the extra module's methods.
+
+### New CPP slot: `agent_identity`
+
+A new `AgentIdentityProvider` Protocol on `PlatformContext`, not more
+methods on `IdentityProvider`.
+
+`IdentityProvider` is operator SSO (status line, preflight, credential
+watch). Agent workload identity and token vending are a different
+edition concern. The same reason `AgentCatalogProvider` is not folded
+into `McpToolingProvider` applies here.
+
+Pre-launch, a new `PlatformContext` field does **not** bump
+`CONTRACT_VERSION` (pinned at `1`; `knowledge` / `dashboard` / `jail`
+landed the same way). `DefaultAgentIdentityProvider` keeps a standalone
+process byte-identical.
+
+```python
+@dataclass(frozen=True)
+class WorkloadIdentity:
+    name: str
+    arn: str
+
+@dataclass(frozen=True)
+class SessionPrincipal:
+    """Trusted caller. Core-derived; never taken from tool input."""
+    surface: str          # dashboard | slack | discord | telegram | …
+    subject: str          # already partitioned: "{surface}+{id}"
+    session_key: str
+    user_jwt: str | None  # set only by the companion after IdP verify
+
+@dataclass(frozen=True)
+class InboundToken:
+    scheme: str           # "bearer"
+    token: str
+    expires_at: float     # unix epoch seconds
+    audience: str
+
+class AgentIdentityProvider(Protocol):
+    def enabled(self) -> bool: ...
+    def workload_identity(self) -> WorkloadIdentity | None: ...
+    def status(self) -> dict[str, object]: ...
+    def gateway_mcp_spec(self) -> dict[str, object] | None: ...
+    async def annotate_principal(
+        self, principal: SessionPrincipal
+    ) -> SessionPrincipal: ...
+    async def vend_workload_access_token(
+        self, principal: SessionPrincipal
+    ) -> str | None: ...
+    async def vend_gateway_inbound_token(
+        self, principal: SessionPrincipal
+    ) -> InboundToken | None: ...
+```
+
+`status()` is display-only: `{enabled, workloadName, gatewayConfigured,
+principalBound}` and never token material. The dashboard merges it next
+to the existing `IdentityProvider.status()` payload (or a sibling
+`GET /api/agent-identity` if merging would confuse the SSO TTL probe).
+
+`whoami` / `issuer` on `IdentityProvider` stay RESERVED. Do not consume
+them to satisfy this RFC.
+
+### Session principal (core, trusted)
+
+The core builds `SessionPrincipal` from ground truth it already has.
+The adapter may **annotate** (attach a verified JWT). It may not
+replace `subject` with a client-supplied user id.
+
+| Surface | `subject` | JWT available? |
+|---|---|---|
+| Dashboard (companion SSO) | `dashboard+{idp_sub}` | Yes — `ForJWT` (`login` posture) |
+| Dashboard (OSS token auth) | `dashboard+{local_owner}` | No JWT. `ForUserId` only in `workload` posture, and only if the local owner is the host principal |
+| Slack / Discord / … | `{channel}+{provider_user_id}` | JWT only if companion SSO has bound that channel user (`login`). Else `ForUserId` only in `workload` |
+| CLI | `cli+{os_user}` | Same as local owner |
+| Cron / TaskRunner | `cron+{job_owner}` (the operator who created the job, persisted at create time) | No interactive JWT. `workload`: M2M Gateway only. `login`: Gateway absent |
+| Subagent | inherit parent principal | Same token audience as parent |
+| Injected cron / subagent-completion envelopes | **not a user** | Do not mint a user-bound token for an injected message |
+
+`ForUserId` subjects are partitioned `provider_id+user_id` per the
+Identity docs, so `slack+U0123` and `dashboard+U0123` cannot collide in
+the vault.
+
+IAM on the instance role denies the path the other posture uses
+(`ForJWT` denied in `workload`; `ForUserId` and `InvokeGateway`
+denied in `login`). The core still prefers `user_jwt` when
+`annotate_principal` set one.
+
+### Gateway attach and per-session header injection
+
+`gateway_mcp_spec()` / `extra_mcp_servers()` contribute a **URL-only**
+remote MCP entry: endpoint, protocol, no `Authorization`. In
+`login` posture the rest of the MCP merge is withheld first
+(see *Two postures, one Policy.json*); Gateway is then the only
+non-managed remote server that rebuild may emit.
+
+The missing core seam is per-session header injection at MCP spawn,
+analogous to `mcp_gateway` declared-env forwarding
+(`security.md` § pooled-backend declared-env):
+
+1. Session start resolves `SessionPrincipal` and calls
+   `vend_gateway_inbound_token`.
+2. On miss or expiry, the Gateway server is **absent** for that session
+   (not present with an empty header). Fail closed.
+3. The bearer is written to a `0600` session sidecar that kiro-cli /
+   the MCP stub reads as transport headers. It is never merged into
+   `~/.kiro/agents/kirocrew.json`.
+4. The Gateway server is **unpooled** in v1 (`pool_identity` would have
+   to include the bearer, which re-partitions on every refresh and
+   leaks a credential into a hash input). Per-session spawn is the
+   honest cost.
+5. `IdentityProvider.credential_watch_paths()` stays the mcp_gateway
+   pooled-backend watcher. Gateway is unpooled, so inbound-token expiry
+   drains that session's ACP child (`drain_expired_gateway_transport` →
+   `SessionManager.remove`) instead of `pool.drain_all_to_bluegreen`.
+
+A local token-proxy MCP (Crew attaches the header, then forwards) is
+the unused fallback. Phase 0 did not run a live kiro-cli header probe;
+v1 ships the `0600` session sidecar and injects it on `session/new`,
+the same pattern as MCP-gateway env sidecars. Tokens never enter the
+agent file. The header-proxy MCP is not implemented.
+
+### Token vending path (Gateway, not Crew)
+
+v1 outbound vending is entirely Gateway + Identity:
+
+- Companion registers Gateway targets and OAuth credential providers
+  (M2M, 3LO, `TOKEN_EXCHANGE`) in the AgentCore control plane.
+- Crew presents the inbound JWT. Gateway exchanges and calls the
+  target.
+- Crew never calls `GetResourceOauth2Token` in v1.
+- Crew never logs, transcripts, or redacts the outbound token because
+  it never holds it.
+
+3LO / consent: when Identity returns `authorizationUrl` + `sessionUri`
+instead of a token, Gateway fails the MCP call. The companion must
+surface that URL on a **human** channel (dashboard modal or the
+originating chat thread), never as model-visible "click this" text.
+Reuse the existing operator-OAuth allowlist
+(`security.py` `_load_operator_oauth_endpoints` /
+`oauth_endpoints.json` keystone) so a consent URL to an unknown host
+is refused.
+
+### Unattended jobs
+
+Cron and TaskRunner have no interactive JWT. Posture decides whether
+they can see Gateway at all.
+
+v1 policy:
+
+- **`workload`.** Gateway targets whose credential provider is
+  **M2M** (client credentials, no user) may run unattended, under
+  the job-owner / instance identity. OBO / 3LO targets are
+  **denied** on unattended sessions unless a still-valid vaulted
+  user token already exists for that `(workload, job_owner)` pair.
+  There is no silent refresh via a guessed user id.
+- **`login`.** Unattended sessions never receive a Gateway inbound
+  JWT, so the Gateway server stays absent. Cron stays on managed
+  Crew servers only. That is the point of the posture: a human had
+  to log in.
+- Injected `[Cron notification]` / `[Subagent completion event]`
+  messages do not mint a new principal. They run as the job/parent
+  already bound.
+
+### Governance, keystone, redaction
+
+- New `SCOPE_CATALOG` row `capabilities.agentcore` with
+  `capability_default=False` (opt-in, like `capabilities.publish` /
+  `capabilities.messaging`). The inner `posture` field
+  (`workload` | `login`) is policy data, not a second scope.
+  Data row only; evaluator untouched; `CONTRACT_VERSION` untouched.
+- The capability gates: contributing the Gateway MCP server, calling
+  either vend method, and surfacing 3LO consent. `login` also
+  withholds the default MCP merge at rebuild. `network.egress` still
+  bounds the Gateway host. `mcp` still bounds the server/tool identity.
+- No `agentcore.json` in public `config.json`. Companion configuration
+  lives in the companion. If a later public opt-in needs a file, it is
+  a keystone path in `security._SENSITIVE_HOME_DIRS` (read **and**
+  write, including extract verbs), next to `oauth_endpoints.json`.
+- Workload access tokens and Gateway inbound JWTs are bearer material.
+  Existing HTTP-bearer redaction covers the wire shape; the companion
+  `CredentialPolicy` overlay may add AgentCore-specific prefixes. Tokens
+  never enter SEL payloads, transcripts, or `status()`.
+- SEL events (grant and deny): `agentcore.workload_token`,
+  `agentcore.gateway_inbound`, `agentcore.consent_url`,
+  `agentcore.unattended_denied`, `agentcore.posture_mismatch`.
+  No token bytes, no raw JWT.
+
+### Dashboard and CLI
+
+- Status only in v1: workload name, enabled, posture, whether this
+  session has a bound principal, Gateway configured. No token
+  display, no "copy bearer."
+- Copy Policy JSON offers the launcher document and, when
+  `capabilities.agentcore` is enabled, the posture-correct
+  instance fragment. Never one kitchen-sink document.
+- 3LO consent is a modal / channel prompt with the allowlisted URL.
+- User-facing strings go through the i18n catalog
+  (`website/docs/i18n-catalog.md`). Backend non-2xx bodies carry a
+  machine-readable `code`.
+- No emojis. `lucide-react` + `lucide-inline`.
+
+## Migration plan
+
+Each phase is independently shippable and abandonable. Exit criteria
+are assertions, not dates.
+
+### Phase 0 — Probe (this repo, no product surface)
+
+Answer two questions and write the verdict into this RFC:
+
+1. Can kiro-cli take per-session `Authorization` headers for a URL MCP
+   server without writing them into the rendered agent JSON?
+2. Does a standalone (non-Gateway-managed) workload identity in the
+   target account accept `GetWorkloadAccessTokenForJWT` from the
+   companion's IAM principal?
+
+**Verdict (1):** sidecar path. A live kiro-cli per-session header probe
+did not run. Crew already writes `0600` env sidecars for pooled MCP
+and injects servers on `session/new` without touching
+`~/.kiro/agents/`. Inbound JWTs use that same contract: URL-only spec
+at rebuild for `workload`; login vends onto
+`<data home>/agentcore-inbound/<digest>.json` and
+`AcpClient._pooled_mcp_servers` appends the entry. The local
+header-proxy MCP is not implemented.
+
+**Verdict (2):** in-repo extra when opted in. Public Default stays a
+no-op. `AwsAgentIdentityProvider` calls `GetWorkloadAccessToken` /
+`GetWorkloadAccessTokenForJWT` through boto3 (`bedrock-agentcore`
+client name, not the `bedrock-agentcore` SDK). CFN creates the
+standalone `AWS::BedrockAgentCore::WorkloadIdentity`. WAT is still
+first-party only — never Gateway inbound. Login inbound is the
+operator IdP JWT on `principal.user_jwt`. Workload Gateway inbound
+is IAM: `gateway_mcp_spec()` returns a `127.0.0.1` SigV4 proxy
+(`platform/agentcore_sigv4.py`, service `bedrock-agentcore`) so
+kiro-cli never presents an unsigned Gateway URL. A WAT is still
+never a Gateway bearer. Login without a companion JWT attaches a
+URL-only sidecar so kiro-cli can run its MCP OAuth challenge.
+
+Exit: both answers recorded here. Phase 3 is blocked on (1). Phase 2
+is blocked on (2). If (1) is no, implement the local header-proxy MCP
+instead of kiro-cli header injection.
+
+### Phase 1 — Core seams, public no-ops
+
+Add `AgentIdentityProvider`, `DefaultAgentIdentityProvider`,
+`PlatformContext.agent_identity`, bootstrap wiring, CPP coverage tests,
+`capabilities.agentcore` (default off, with a `posture` field), and
+spec updates (`platform-context.md`, `governance.md`). No AWS
+dependency. Standalone behavior byte-identical.
+
+Exit: `test_platform_cpp_seam_coverage.py` lists the new slot;
+`enabled()` is False; unknown/absent posture with `enabled: true`
+fails closed; no `bedrock-agentcore` SDK import under
+`src/kiro_crew/` (boto3 stays inside the opt-in extra).
+
+### Phase 1b — Policy.json pair, boundary successor, login withhold
+
+Public-core JSON only (no AgentCore SDK):
+
+- `iam.agentcore_instance_policy_document(posture)` emits the
+  instance-role fragment for `workload` or `login`.
+- New named boundary `kirocrew-ec2-boundary-agentcore` (SSM-core +
+  source-bucket read + the AgentCore ceiling for that posture).
+  Original `kirocrew-ec2-boundary` stays byte-identical.
+- Launcher Policy.json / CloudFormation `AllowedPattern` accept
+  **either** boundary name. Still no `CreatePolicyVersion`.
+- Dashboard / `kirocrew cloud iam-policy` can copy the
+  posture-correct instance document as a labeled sibling of the
+  launcher document.
+- `rebuild_agent_config()` withholds Kiro-global, seam-global,
+  crew-store, and leftover non-managed servers when posture is
+  `login` and the capability is on. Managed `kirocrew-*` still
+  emit. Gateway stays out of the agent file; attach writes a session
+  sidecar (bearer JWT or URL-only OAuth challenge).
+- Posture-vs-IAM mismatch probe fails closed (no Gateway emit,
+  SEL-audited).
+
+Exit: copying `iam.policy_json()` never grants `InvokeGateway`;
+the instance helper for `login` denies `InvokeGateway` and
+`ForUserId`; a login-posture rebuild fixture contains no Kiro
+global server; the original boundary document is unchanged.
+
+### Phase 2 — Session principal + Identity vend (in-repo extra)
+
+Core derives `SessionPrincipal` at session start and never accepts a
+tool-supplied user id. `AwsAgentIdentityProvider` (opt-in extra)
+implements `vend_workload_access_token` / `status()` /
+`gateway_mcp_spec()`. `annotate_principal` stays a pass-through
+until a companion fills `user_jwt`.
+
+Exit: extra tests (mocked boto3) mint a workload token; `status()`
+has no token keys; injected messages do not vend.
+
+### Phase 3 — Gateway MCP attach + inbound token injection
+
+Companion (or the in-repo extra) contributes the Gateway URL. Core
+injects inbound per session: a JWT sidecar, a URL-only OAuth-challenge
+sidecar, or — on workload — the localhost SigV4 proxy URL in the
+rebuilt agent file. Unpooled. Expiry drains a bearer sidecar's ACP
+child (not the mcp_gateway pool). Fail closed on a missing URL.
+
+Exit: a login session with a Gateway URL lists the server (bearer or
+OAuth challenge); a session without a URL does not; `kirocrew.json`
+contains no `Authorization` header.
+
+### Phase 4 — Human 3LO consent + unattended policy
+
+Consent URL allowlist + dashboard/channel prompt. Unattended jobs
+restricted to M2M or vaulted-owner tokens. SEL events land.
+
+v1 implementation: `security.allow_agentcore_consent_url` reuses
+`oauth_endpoints.json` (no second keystone). Settings → Security shows
+an allowlisted GET `/api/agentcore/consent` link; unknown hosts return
+403 `consent_host_refused`. Login never attaches Gateway for `cron:` /
+`taskrunner:` keys. Workload user/OBO without
+`status().vaultedOwnerToken` writes a deny sidecar (`disabled: true`).
+SEL `agentcore.consent_url` / `agentcore.unattended_denied` log
+host+path / session+subject only — never token bytes.
+`GetWorkloadAccessToken*` is the `kirocrew[agentcore]` extra
+(Task 7), not Phase 5 `GetResourceOauth2Token`.
+
+Exit: an unknown consent host is refused; a cron job cannot OBO as an
+arbitrary user.
+
+### Phase 5 (follow-on, not v1) — Crew-direct `GetResourceOauth2Token`
+
+Only if a local tool cannot sit behind Gateway. Same workload token,
+same principal rules, same redaction. Do not start this phase to
+"complete" v1.
+
+## Backward compatibility
+
+- Standalone / public wheel: no new default imports, no new MCP server,
+  no new default-on capability, no config migration. The `agentcore`
+  extra is opt-in (`pip install kirocrew[agentcore]` / IaC).
+- Companion: additive. A companion that does not override
+  `agent_identity` inherits the Default (disabled).
+- Existing static remote MCP servers and `kiro_oauth_wire_entry` are
+  unchanged.
+- `IdentityProvider` signatures unchanged. RESERVED methods stay
+  reserved.
+
+## Security considerations
+
+- **Do not send a workload access token to Gateway.** Identity docs:
+  first-party only. Gateway inbound is a user JWT or IAM.
+- **Do not register a Gateway-managed workload as the Crew identity.**
+  Those identities refuse `GetWorkloadAccessToken` from the caller
+  ("WorkloadIdentity is linked to a service…").
+- **Do not put tokens in agent JSON, transcripts, SEL, or `status()`.**
+  Sidecar `0600`, process memory, then drop.
+- **Do not take `userId` from the model, a tool argument, or a query
+  string.** Core-derived principal only.
+- **Do not fail open** to a shared service-account token when JWT
+  vending fails.
+- **Do not re-introduce Cognito / RUM ids / enterprise SSO** into
+  `src/kiro_crew/`. Discovery URLs live in the companion.
+- Computer use stays ungoverned and in-band. This RFC does not add
+  `computer_use.*` scopes.
+- Sensitive-path matchers must cover any later keystone file on both
+  read and write/extract verbs.
+
+## Live verification findings (2026-08-28)
+
+Verified in a scratch AWS account in `us-east-1` against a tagged
+`kirocrew:e2e=true` stack: an AWS_IAM Gateway (READY), a standalone
+workload identity, a Lambda target, and an MCP_SERVER target.
+
+Verified live:
+
+- Control-plane catalog + Settings verify: READY, AWS_IAM, URL match,
+  `kirocrew-*` invoke scope, tools/list `echo-hello___echo_hello`.
+- Workload SigV4 localhost proxy: MCP initialize, `tools/list`, and
+  `tools/call` (`{"message":"hello proxy"}`).
+- Unsigned Gateway and WAT-as-`Authorization` both 401. WAT vends
+  (opaque). `vend_gateway_inbound_token` without a user JWT is `None`.
+- Policy `gateway_url` wins over `KIROCREW_AGENTCORE_GATEWAY_URL`.
+- Identity GET/PUT and catalog GET/verify (owner); app tokens 403.
+  Lambda Sync returns `not_syncable`.
+- Workload rebuild emits the proxy URL only. Login rebuild withholds.
+  Unattended login does not attach.
+
+Closed after the run:
+
+- GetGatewayTarget omits `targetType`; `mcp.lambda` was labeled `MCP`.
+  Catalog now infers `LAMBDA`.
+- Settings-only default name `kirocrew` does not match a created
+  `kirocrew-e2e` (`AccessDenied`: identity does not belong to caller
+  account). Settings now authors `capabilities.agentcore.workload_name`.
+- Login attach used `gateway_mcp_spec()`, which rewrites to the proxy
+  when env posture is still `workload`. Login sidecars now always use
+  the https Gateway URL.
+- Catalog/verify now probes `GetWorkloadAccessToken` and discards the
+  body. A standalone `kirocrew-e2e` is `ok`; a Gateway-linked
+  service identity is `service_linked`; the default
+  `kirocrew` is `identity_denied`. Login skips the probe
+  (`login_needs_sign_in`). The token never enters the snapshot.
+- Login sidecar `Authorization` is RFC 6750 `Bearer` (live-checked).
+- `resolved_posture()` is policy-first like URL and name. Leftover
+  env `workload` no longer hides a Settings `login` from catalog
+  (authorizer mismatch against this AWS_IAM Gateway is now visible).
+
+Closed on the production-ready pass:
+
+- Owner-dashboard PUT hot-applies the home file onto the running
+  ceiling and AWS adapter (`apply_agentcore_runtime`) and rebuilds
+  the agent config. `restart_required` stays true only when that
+  apply cannot attach the extra.
+- Settings-only empty no longer invents `kirocrew`. PUT posture-on
+  without a name is 400 `workload_name_required`; the UI disables
+  Save until a name is set. Launch env posture without a systemd
+  name still uses the RFC default.
+- Successor-boundary Invoke stays `kirocrew-*`. Catalog
+  `invoke_scope` is now credential-proved: tools/list through the
+  SigV4 proxy greens any Gateway this crew can actually call, so a
+  pasted existing Gateway is not falsely red. Prefix is the
+  fallback when tools were not proved. A data-plane 401/403 is
+  `invoke_denied` even on a `kirocrew-*` id.
+- Instance-role-only IAM (`kirocrew-e2e-instance` assumed from a
+  named IAM user, policy from `agentcore_instance_policy_document(
+  "workload")`): WAT `ok`, all nine catalog checks green, tools/list
+  and `SynchronizeGatewayTargets` accepted. Admin keys were not in
+  that process.
+- MCP_SERVER target `public-docs` (DEFAULT listing)
+  is READY. GetGatewayTarget still omits `targetType`; catalog
+  infers `MCP_SERVER`, marks it `syncable`, and lists
+  `public-docs___ask_question` / `read_wiki_contents` /
+  `read_wiki_structure` next to the Lambda tool. A hostname that
+  does not resolve fails as `FAILED` with `statusReasons`; Settings
+  now shows those reasons on the target row.
+
+Closed on the agent-path honesty pass:
+
+- Catalog / Verify `tools/list` uses `ensure_workload_proxy` and an
+  unsigned localhost POST — the same path rebuild writes into
+  `kirocrew.json`. A green tools check is no longer a direct SigV4
+  to the Gateway hostname. Proxy start failure is
+  `proxy_unavailable`. Isolated rebuild of a workload spec persists
+  `http://127.0.0.1:<port>/mcp`. Live under assumed-role
+  `kirocrew-e2e-instance`: snapshot `via=proxy`, both targets'
+  tools listed, `gateway_mcp_spec()` listen URL
+  `http://127.0.0.1:<port>/mcp`, and `tools/call`
+  `echo-hello___echo_hello` succeeded through that listener.
+
+Closed on the OOTB session-inject pass:
+
+- Workload `attach_gateway_inbound` still clears the sidecar (IAM,
+  no JWT). `session_gateway_servers` now injects the live loopback
+  SigV4 listen URL when identity is on, so `session/new` outranks a
+  stale agent-file port after a gateway restart. A companion https
+  spec (unsigned Gateway hostname) still injects `[]`.
+- The proxy prefers `127.0.0.1:18765` so a rebuilt `kirocrew.json`
+  survives a restart when that port is free.
+  `KIROCREW_AGENTCORE_PROXY_PORT` overrides; bind failure falls
+  back to ephemeral and session inject carries the live URL.
+- Isolated kiro-cli 2.20.1 `session/new` rejects `{name, url}` and
+  `{name, disabled: true}` (`untagged enum McpServer`). HTTP inject
+  is now `{name, type: "http", url, headers}` (empty headers when
+  there is no bearer). Deny retracts with a disabled HTTP
+  placeholder. Confirmed: `type: http` + `headers: []` accepts
+  `session/new`; the earlier shape closed the connection. Live
+  inject+MCP under assumed-role `kirocrew-e2e-instance` bound
+  `127.0.0.1:18765`, listed both targets' tools, and
+  `echo-hello___echo_hello` returned `hello ootb`.   Isolated
+  `KIRO_HOME` did not write `~/.kiro/agents`. Isolated kiro-cli
+  2.20.1 then accepted `session/new`, overrode the stale agent-file
+  port, launched `agentcore-gateway` over unauthenticated HTTP to
+  the SigV4 proxy, and emitted
+  `_kiro.dev/mcp/server_initialized`.
+
+Closed on the existing-Gateway honesty pass:
+
+- Catalog `invoke_scope` no longer fails a working non-`kirocrew-*`
+  Gateway. If tools/list just succeeded via the SigV4 proxy, this
+  credential invoked it. Prefix remains the unproved fallback.
+  Settings copy is credential-honest (this crew's AWS credentials),
+  not "instance role only." `invoke_denied` names a 401/403 on
+  Invoke. IAM documents are unchanged.
+
+Still open (not v1 blockers):
+
+- kiro-cli's hosted MCP OAuth challenge (`Authorize` /
+  `_kiro.dev/mcp/oauth_request`) against a `CUSTOM_JWT` Gateway was
+  not driven. The product sidecar + a real IdP JWT were.
+- MCP initialize on this Gateway does not return `mcp-session-id`;
+  `tools/list` still works without one.
+- Creating a Gateway also creates a service-linked identity that
+  refuses caller WAT. Crew must use a standalone workload identity.
+  Settings now names that failure `service_linked`.
+- Phase 5 `GetResourceOauth2Token` stays follow-on.
+- Lambda targets stay `not_syncable`.
+- Desktop/PEP 668 extra install and widening Invoke to `gateway/*`
+  stay out of v1.
+
+Closed on the leftover-validation pass (live, 2026-08-28):
+
+- **Desktop / PEP 668.** Host Homebrew Python 3.14 is
+  `EXTERNALLY-MANAGED`, not a venv, and has no boto3.
+  `python3 -m pip install kirocrew[agentcore]` exits 1 with the
+  PEP 668 error (no `--break-system-packages`). The worktree venv
+  reports `extra_available` / `extra_code=ok`. Settings
+  `no_install_channel` is the correct desktop answer.
+- **Phase 5 `GetResourceOauth2Token`.**
+  `ListOauth2CredentialProviders` is empty in this account. A WAT
+  for standalone `kirocrew-e2e` vends. `GetResourceOauth2Token`
+  against a missing provider is `ValidationException` ("invalid
+  type or does not exist"). Gateway MCP tools already list and
+  call without Crew becoming a token broker. Phase 5 stays out.
+- **Invoke `gateway/*`.** Created IAM Gateway
+  an existing-customer Gateway (not `kirocrew-*`) + public MCP
+  target. Admin/laptop credentials: catalog `invoke_scope` green
+  via proxy (`via=proxy`, 3 tools). Assumed
+  `kirocrew-e2e-instance`: inspect `ok`, tools `tools_denied`,
+  `invoke_denied`. Settings customers with their own creds do not
+  need a wider CFN grant. A CFN-launched box still cannot Invoke a
+  non-`kirocrew-*` Gateway unless the operator attaches that ARN.
+  Successor boundary stays `kirocrew-*`.
+- **Login / CUSTOM_JWT.** Tagged Cognito pool `kirocrew-e2e-oidc`
+  (test IdP, not product SSO) + Gateway `kirocrew-e2e-jwt`.
+  Discovery URL is public. Unsigned initialize is 401. A Cognito
+  **IdToken** with Gateway `allowedAudience` = app client id
+  initializes 200 and `tools/list` returns the three
+  `public-docs___` tools. A Cognito **access** token (no `aud`,
+  `token_use=access`) is 403 `insufficient_scope`. Product login
+  catalog: authorizer `CUSTOM_JWT`, tools `login_needs_sign_in`.
+  Attach without JWT: https sidecar + `oauth_challenge`. Attach
+  with the IdToken: `Authorization: Bearer` + session/new HTTP
+  inject carries the header. The operator IdP must issue a JWT
+  the Gateway's audience/client allow-list accepts — Cognito's
+  IdToken does; its access token does not.
+
+## Alternatives considered
+
+### A. Companion-only, no core seam (rejected as the long-term shape)
+
+The companion could inject a Gateway MCP server with a static header
+via `extra_mcp_servers()` today. That cannot do per-session OBO,
+refresh, or keep the bearer out of `kirocrew.json`. Acceptable as a
+manual operator escape hatch; not the integration.
+
+### B. boto3 AgentCore client in the public core (rejected)
+
+Violates the de-Amazoned fork rule, adds an AWS dependency to the
+public wheel, and invites hardcoded Cognito/discovery values. The CPP
+seam exists so the core never imports this.
+
+### C. Deploy Crew onto AgentCore Runtime (rejected for this RFC)
+
+Runtime auto-vends `WorkloadAccessToken` in the invocation payload.
+Crew is a local multi-surface gateway (dashboard, Slack, cron,
+subagents) that drives kiro-cli over ACP. Runtime has no inbound
+dashboard TCP and is a different product. Revisit only if a hosted
+Crew edition is separately designed.
+
+### D. Extend `IdentityProvider` instead of a new slot (viable, not recommended)
+
+v1 method adds on `IdentityProvider` would work and avoid a
+`PlatformContext` field. The slot is already SSO-shaped
+(`status_line`, `preflight_checks`). Token vending would overload it.
+A dedicated protocol matches "one edition concern, one interface."
+
+### E. Crew calls `GetResourceOauth2Token` and skips Gateway (rejected for v1)
+
+Puts OAuth, 3LO, and per-target credential-provider config in Crew.
+Gateway already does this, plus Cedar policy and interceptors. Crew
+should present identity, not become a token broker.
+
+### F. IAM inbound to Gateway, no JWT (adopted as posture `workload`)
+
+This is no longer a fallback: it **is** the deployed-box posture.
+IAM inbound lets a `kirocrew cloud launch` instance invoke Gateway
+at boot with no login. The public-core `probe_instance_invoke_gateway()`
+is a no-op that returns False; a companion must override it.
+Fail-closed there means no mismatch was detected, not that IAM inbound
+is impossible. It drops user `sub`, so OBO and per-user
+vault binding are unavailable on that path — cron is M2M-only, and
+the instance Policy.json **Denies** `ForJWT`. Interactive
+per-user vending is the other posture (`login` / CUSTOM_JWT),
+not a layer on top of this one. A fleet that wants both must
+run two hosts (or switch `security_policy.json` and relaunch
+with the matching boundary + instance grant).
+
+## Open questions
+
+1. **kiro-cli per-session headers (Phase 0).** Resolved: sidecar path.
+   Tokens never enter the rendered agent JSON. `session/new` injects
+   the inbound sidecar. Header-proxy MCP not implemented.
+2. **One workload vs per-agent-config workloads.** v1 is one
+   `kirocrew` workload. A later `kirocrew-<agent_id>` split is
+   additive (new identities, same protocol).
+3. **Dashboard route.** Resolved: sibling
+   `GET`/`PUT /api/agentcore/identity` on **this crew's** Settings →
+   Security. Not `GET /api/sso-ttl`, and not the hub Remote Crew
+   launcher. SSO TTL stays an SSO probe.
+4. **Channel-user SSO binding.** How the companion proves a Slack user
+   *is* the IdP `sub` is a companion concern. This RFC only requires
+   that the proof happen before `user_jwt` is set.
+5. **Sibling sandboxes RFC.** If that design lands a Crew-driven
+   Code Interpreter session, it must use this RFC's workload identity
+   rather than minting a second one.
+6. **Boundary successor vs parameterized name.** v1 uses a second
+   exact name (`kirocrew-ec2-boundary-agentcore`) so the original
+   document stays immutable. Confirm the CloudFormation
+   `PermissionsBoundaryArn` `AllowedPattern` can list both names
+   without weakening the create-once story.
+7. **Launcher document vs instance document in the dashboard.**
+   Today `GET /api/cloud/iam-policy` returns one blob. v1 adds a
+   labeled sibling rather than merging AgentCore actions into the
+   launcher JSON. Confirm the copy UI copy can show two documents
+   without operators pasting the instance grant onto the launch
+   principal.
+
+## Related
+
+- [`platform-context.md`](../system-specs/modules/platform-context.md) —
+  CPP seam, RESERVED methods, `CONTRACT_VERSION` pin
+- [`security.md`](../system-specs/modules/security.md) — keystone,
+  redaction, MCP env forwarding
+- [`governance.md`](../system-specs/modules/governance.md) —
+  `SCOPE_CATALOG` append-only
+- [`mcp.md`](../architecture/mcp.md) — MCP merge, `spec_gate`
+  withhold, stateless tools
+- [`cloud.md`](../system-specs/modules/cloud.md) — launcher
+  Policy.json, immutable `kirocrew-ec2-boundary`, create-once
+  `CreatePolicy` (never `CreatePolicyVersion`)
+- [`injected-messages.md`](../system-specs/common/injected-messages.md)
+  — cron / subagent envelopes are not the user
+- [Get workload access token](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/get-workload-access-token.html)
+- [GetResourceOauth2Token](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_GetResourceOauth2Token.html)
+- [On-behalf-of token exchange](https://aws.amazon.com/blogs/machine-learning/implement-on-behalf-of-token-exchange-for-multi-tenant-agents-with-amazon-bedrock-agentcore-gateway/)

--- a/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
+++ b/docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md
@@ -1,0 +1,576 @@
+# AgentCore Identity and Gateway Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Crew agent a standalone AgentCore Identity workload
+and use AgentCore Gateway as the outbound token-vending plane, behind
+default-off CPP seams so the public edition stays byte-identical. A
+fleet picks exactly one `security_policy.json` posture, and the
+copyable cloud Policy.json pair must match it.
+
+**Architecture:** A new `AgentIdentityProvider` slot on
+`PlatformContext` holds workload identity and token vending. The public
+`Default` is empty. The companion talks to Identity (`GetWorkloadAccessToken*`)
+and contributes the Gateway MCP URL. The core derives a trusted
+`SessionPrincipal` and leaves outbound OAuth to Gateway.
+`CONTRACT_VERSION` stays `1`.
+
+Two exclusive postures, selected by `capabilities.agentcore.posture`:
+
+- **`workload`** — deployed box. Instance IAM invokes Gateway at
+  boot. No login. Kiro MCP defaults still merge. Instance Policy.json
+  allows `InvokeGateway` + `GetWorkloadAccessToken` / `ForUserId` and
+  Denies `ForJWT`.
+- **`login`** — Gateway catalog only. Rebuild withholds Kiro-global,
+  seam-global, crew-store, and leftover non-managed MCP. Tools stay
+  absent until `ensure` login vends a CUSTOM_JWT. Instance Policy.json
+  allows `ForJWT` only and Denies `ForUserId` + `InvokeGateway`.
+
+The launcher `iam.policy_json()` never grows those instance actions.
+A new helper emits the instance fragment; a new named boundary
+(`kirocrew-ec2-boundary-agentcore`) is the ceiling. The original
+`kirocrew-ec2-boundary` is not re-versioned.
+
+**Tech Stack:** Python 3.10+, existing CPP (`platform/`), MCP gateway
+rewriter, governance `SCOPE_CATALOG`, pytest-asyncio. Companion-only:
+`boto3` / `bedrock-agentcore` (not a public-wheel dependency).
+
+**Spec:**
+[`../../request-for-change/rfc-agentcore-identity-gateway.md`](../../request-for-change/rfc-agentcore-identity-gateway.md)
+
+## Global Constraints
+
+- Core never imports `bedrock_agentcore`, `boto3` AgentCore clients, or
+  names Cognito / Midway / a discovery URL.
+- Do not consume `IdentityProvider.whoami` or `issuer` (RESERVED).
+- Do not write tokens into `~/.kiro/agents/kirocrew.json`, transcripts,
+  SEL payloads, or `status()`.
+- Do not take `userId` from the model, a tool argument, or a query
+  string.
+- Fail closed: missing companion, expired JWT, vend error, unknown
+  posture, or posture-vs-IAM mismatch means the Gateway server is
+  absent for that session.
+- `capabilities.agentcore` defaults **off**. No new default-on egress.
+- Postures are exclusive. Do not layer `workload` IAM inbound on top
+  of `login` JWT inbound.
+- Do not `CreatePolicyVersion` `kirocrew-ec2-boundary`. AgentCore
+  ceiling is a new named boundary, opt-in at launch.
+- Do not put `InvokeGateway` / `GetWorkloadAccessToken*` on the
+  launcher Policy.json. Those belong on
+  `iam.agentcore_instance_policy_document(posture)`.
+- `login` withholds Kiro defaults at `rebuild_agent_config()` emit
+  time (same control as `kirocrew-computer` `spec_gate`), not only
+  at the tool gate.
+- `sso_status.py` stays a stub. No `CHANGELOG.md` edit.
+- Computer use stays ungoverned. No `computer_use.*` scopes.
+- Update the owning spec in the same commit as the code it covers.
+- Run `scripts/docs-lint.sh` after every docs change.
+- Frontend user-facing strings go through the i18n catalog. No emojis.
+
+---
+
+## Stack and file map
+
+| PR | Branch suffix | Primary files |
+|---|---|---|
+| 1 | `plan` (this PR) | RFC, this plan, RFC + plans indexes |
+| 2 | `seams` | `platform/interfaces.py`, `defaults.py`, `context.py`, `bootstrap.py`, CPP coverage tests, `SCOPE_CATALOG` + `posture`, `platform-context.md`, `governance.md` |
+| 2b | `iam` | `cloud/iam.py` helper + new boundary name, launcher CreateRole pin widening, dashboard/CLI copy of the instance fragment, login-mode rebuild withhold, posture-mismatch probe, `cloud.md`, `mcp.md` |
+| 3 | `principal` | session-principal derivation, injected-message guard, unit tests, `session.md` |
+| 4 | `probe` | Phase 0 verdict written back into the RFC (kiro-cli headers + standalone workload) |
+| 5 | `inject` | per-session Gateway header sidecar **or** header-proxy MCP; unpooled Gateway server |
+| 6 | `consent-unattended` | 3LO allowlist + dashboard/channel prompt + posture-aware cron/M2M policy + SEL; `security.md` |
+| 7 | extra + IaC (this repo) | `kirocrew[agentcore]` (`AwsAgentIdentityProvider`), CFN Gateway URL, `install.sh --agentcore`, systemd env |
+
+PRs 2, 2b, 3, 5, 6, and 7 are this repository. PR 4 is a research commit
+that only edits the RFC. Operator IdP JWT annotation and Gateway/target
+control-plane stay companion-owned; token fetch on a launched box does not.
+PR 2b can land right after PR 2: the IAM helpers and the rebuild
+withhold do not need a live vend path.
+
+### Stable interfaces
+
+```python
+@dataclass(frozen=True)
+class WorkloadIdentity:
+    name: str
+    arn: str
+
+@dataclass(frozen=True)
+class SessionPrincipal:
+    surface: str
+    subject: str
+    session_key: str
+    user_jwt: str | None = None
+
+@dataclass(frozen=True)
+class InboundToken:
+    scheme: str
+    token: str
+    expires_at: float
+    audience: str
+
+class AgentIdentityProvider(Protocol):
+    def enabled(self) -> bool: ...
+    def workload_identity(self) -> WorkloadIdentity | None: ...
+    def status(self) -> dict[str, object]: ...
+    def gateway_mcp_spec(self) -> dict[str, object] | None: ...
+    async def annotate_principal(
+        self, principal: SessionPrincipal
+    ) -> SessionPrincipal: ...
+    async def vend_workload_access_token(
+        self, principal: SessionPrincipal
+    ) -> str | None: ...
+    async def vend_gateway_inbound_token(
+        self, principal: SessionPrincipal
+    ) -> InboundToken | None: ...
+```
+
+`DefaultAgentIdentityProvider`: `enabled() -> False`; all other methods
+return `None` / `{}` / the input principal unchanged.
+
+---
+
+### Task 1: PR 1 — record the design and this plan
+
+**Files:**
+
+- Create: `docs/request-for-change/rfc-agentcore-identity-gateway.md`
+- Create: `docs/superpowers/plans/2026-08-27-agentcore-identity-gateway.md`
+- Modify: `docs/request-for-change/README.md`
+- Modify: `docs/superpowers/plans/README.md`
+
+**Interfaces:**
+
+- Consumes: CPP slot table, RESERVED identity methods, MCP merge rules,
+  AgentCore Identity/Gateway product shape.
+- Produces: locked design + PR-sized implementation map.
+
+- [x] **Step 1: Write the RFC and this plan.**
+
+- [x] **Step 2: Index both documents.**
+
+  Add a `draft` row to `docs/request-for-change/README.md` naming the
+  commit they were verified against (`152c00e99`). Link this plan from
+  `docs/superpowers/plans/README.md`.
+
+- [x] **Step 3: Verify documentation.**
+
+  Run: `bash scripts/docs-lint.sh && git diff --check`
+  Expected: both exit zero.
+
+- [x] **Step 4: Commit.**
+
+  ```
+  docs: add AgentCore identity and gateway plan
+  ```
+
+---
+
+### Task 2: PR 2 — CPP slot and governance row (public no-ops)
+
+**Files:**
+
+- Modify: `src/kiro_crew/platform/interfaces.py` (add dataclasses + Protocol)
+- Modify: `src/kiro_crew/platform/defaults.py` (add `DefaultAgentIdentityProvider`)
+- Modify: `src/kiro_crew/platform/context.py` (add `agent_identity` field)
+- Modify: `src/kiro_crew/platform/bootstrap.py` (wire Default)
+- Modify: `src/kiro_crew/platform/__init__.py` (exports)
+- Modify: `src/kiro_crew/platform/governance.py` (`capabilities.agentcore`)
+- Modify: `test/test_platform_cpp_seam_coverage.py` (and any bootstrap/context tests the coverage file names)
+- Modify: `docs/system-specs/modules/platform-context.md`
+- Modify: `docs/system-specs/modules/governance.md`
+
+**Interfaces:**
+
+- Consumes: the Protocol above.
+- Produces: a composed `ctx.agent_identity` that is disabled in
+  standalone.
+
+- [ ] **Step 1: Write the failing coverage test.**
+
+  Assert `PlatformContext` has `agent_identity`, the default adapter's
+  `enabled()` is False, `workload_identity()` is None,
+  `gateway_mcp_spec()` is None, `status()` is a dict with no token-like
+  keys, and `capabilities.agentcore` exists with
+  `capability_default=False`. An `enabled: true` document with a
+  missing or unknown `posture` fails closed (treated as disabled,
+  or boot-abort when `boot.fail_closed`).
+
+- [ ] **Step 2: Run the test and verify RED.**
+
+  Run: `python -m pytest test/test_platform_cpp_seam_coverage.py -n0 -q -k agent_identity`
+  Expected: FAIL because the field / scope does not exist.
+
+- [ ] **Step 3: Implement Default + catalog row.**
+
+  Follow existing v1 addition comments (`no CONTRACT_VERSION bump`).
+  `safe_context_call` fallback for every new method must be the disabled
+  answer (False / None / `{}` / unchanged principal), never a raised
+  error that degrades to "enabled."
+
+- [ ] **Step 4: Grep the public tree for AWS leakage.**
+
+  Run: `rg -n "bedrock.agentcore|bedrock_agentcore|GetWorkloadAccessToken|cognito-idp" src/kiro_crew website/src`
+  Expected: no matches.
+
+- [ ] **Step 5: Update specs and run gates.**
+
+  `platform-context.md` table gets an `agent_identity` row.
+  `governance.md` documents the new capability as opt-in and names
+  the inner `posture` field (`workload` | `login`).
+  Run: `black --target-version py310 <touched py>` then
+  `python3 scripts/check_black_formatting.py` and
+  `mypy --platform linux src/kiro_crew`.
+
+- [ ] **Step 6: Commit.**
+
+  ```
+  feat: add agent_identity CPP slot and agentcore capability
+  ```
+
+---
+
+### Task 2b: PR 2b — Policy.json pair, boundary successor, login withhold
+
+**Files:**
+
+- Modify: `src/kiro_crew/cloud/iam.py`
+  (`agentcore_instance_policy_document(posture)`,
+  `AGENTCORE_BOUNDARY_NAME = "kirocrew-ec2-boundary-agentcore"`,
+  `agentcore_boundary_policy_document(account, posture)`,
+  launcher `CreateRole` / `CreatePolicy` statements accept either
+  boundary name)
+- Modify: `src/kiro_crew/cloud/source.py` (create-once helper for the
+  new boundary name; still never `CreatePolicyVersion`)
+- Modify: `src/kiro_crew/cloud/templates/kirocrew-ec2.yaml`
+  (`PermissionsBoundaryArn` `AllowedPattern` lists both names;
+  `AgentCorePosture` creates `AWS::BedrockAgentCore::WorkloadIdentity`
+  named `kirocrew-<StackTag>` and attaches the instance grant)
+- Modify: dashboard cloud IAM copy + `cli_cloud` `iam-policy` (labeled
+  sibling document; query/flag `--instance --posture`)
+- Modify: `src/kiro_crew/agent.py` / MCP merge (`rebuild_agent_config`
+  withholds Kiro-global, seam-global, crew-store, leftover non-managed
+  when posture is `login` and the capability is on)
+- Create: `test/test_agentcore_iam_posture.py`
+- Modify: existing `test/test_cloud_*` / rebuild tests that pin
+  `BOUNDARY_NAME` or merge order
+- Modify: `docs/system-specs/modules/cloud.md`
+- Modify: `docs/architecture/mcp.md` (login withhold = emit-time
+  `spec_gate`, same as `kirocrew-computer`)
+
+**Interfaces:**
+
+- Consumes: `capabilities.agentcore.{enabled,posture}` from PR 2.
+- Produces: posture-correct instance Policy.json; a new immutable
+  boundary name; login-mode rebuild that emits only managed
+  `kirocrew-*` plus (later) a URL-only Gateway spec.
+
+- [ ] **Step 1: Write failing IAM + rebuild tests.**
+
+  ```python
+  def test_launcher_policy_json_has_no_invoke_gateway():
+      assert "InvokeGateway" not in iam.policy_json()
+      assert "GetWorkloadAccessToken" not in iam.policy_json()
+
+  def test_workload_instance_document_denies_for_jwt():
+      doc = iam.agentcore_instance_policy_document("workload")
+      ...
+
+  def test_login_instance_document_denies_userid_and_invoke():
+      doc = iam.agentcore_instance_policy_document("login")
+      ...
+
+  def test_original_boundary_document_unchanged():
+      # byte-compare the SSM-core + source-bucket shape; no AgentCore
+
+  def test_login_rebuild_withholds_kiro_global(tmp_path):
+      # seed ~/.kiro/settings/mcp.json with a dummy server
+      # posture=login + capability on → rebuilt kirocrew.json
+      # has kirocrew-core / kirocrew-cron, no dummy, no Gateway yet
+
+  def test_workload_rebuild_still_merges_kiro_global(tmp_path):
+      ...
+
+  def test_login_probe_succeeds_iam_invoke_fails_closed():
+      # posture=login + mock IAM InvokeGateway success
+      # → Gateway spec absent, SEL agentcore.posture_mismatch
+  ```
+
+- [ ] **Step 2: Run tests, verify RED.**
+
+  Run: `python -m pytest test/test_agentcore_iam_posture.py -n0 -q`
+
+- [ ] **Step 3: Implement helper, successor boundary, withhold, probe.**
+
+  Keep `BOUNDARY_NAME = "kirocrew-ec2-boundary"` as the default
+  launch path. AgentCore launches pass the successor ARN. The
+  successor document is the **union** ceiling (SSM-core +
+  source-bucket + every AgentCore action either posture may grant).
+  Resource ARNs in the instance fragment are fleet-pinned (workload
+  name `kirocrew`, gateway `kirocrew-*`), never `*`, except on the
+  explicit Deny SIDs.
+
+- [ ] **Step 4: Update cloud.md + mcp.md and run gates.**
+
+  Run: `bash scripts/docs-lint.sh` then
+  `black --target-version py310 <touched py>` then
+  `python3 scripts/check_black_formatting.py`.
+
+- [ ] **Step 5: Commit.**
+
+  ```
+  feat: add agentcore policy.json postures and login mcp withhold
+  ```
+
+---
+
+### Task 3: PR 3 — trusted session principal
+
+**Files:**
+
+- Create: `src/kiro_crew/platform/agent_identity.py` (dataclasses if not
+  already in interfaces; `derive_session_principal(slot_or_session)`)
+- Create: `test/test_agent_identity_principal.py`
+- Modify: session start site(s) — the smallest existing hook that already
+  knows `session_key` + surface (likely `session` / chat runner / channel
+  dispatch). Do **not** invent a second session key.
+- Modify: `docs/system-specs/modules/session.md`
+
+**Interfaces:**
+
+- Consumes: existing session key and channel identity.
+- Produces: `SessionPrincipal` with partitioned `subject`.
+
+- [ ] **Step 1: Write failing derivation tests.**
+
+  ```python
+  def test_dashboard_owner_is_partitioned():
+      p = derive_session_principal(surface="dashboard", raw_id="alice", session_key="dashboard:1")
+      assert p.subject == "dashboard+alice"
+      assert p.user_jwt is None
+
+  def test_tool_input_cannot_supply_subject():
+      # whatever helper rejects kwargs from tool_input
+      ...
+
+  def test_injected_cron_envelope_does_not_derive_a_user():
+      assert derive_session_principal_for_injected("[Cron notification from \"job\"]") is None
+  ```
+
+- [ ] **Step 2: Run tests, verify RED, then implement.**
+
+  Run: `python -m pytest test/test_agent_identity_principal.py -n0 -q`
+
+- [ ] **Step 3: Call `annotate_principal` through `safe_context_call`.**
+
+  Fallback = the core-derived principal unchanged. Companion may set
+  `user_jwt`. It must not change `subject`. Add a test that a stub
+  adapter attempting to rewrite `subject` is ignored or rejected.
+
+- [ ] **Step 4: Commit.**
+
+  ```
+  feat: derive partitioned AgentCore session principals
+  ```
+
+---
+
+### Task 4: PR 4 — Phase 0 probe verdict
+
+**Files:**
+
+- Modify: `docs/request-for-change/rfc-agentcore-identity-gateway.md`
+  (Open question 1 + Phase 0)
+
+No product code. Record:
+
+1. Whether kiro-cli accepts per-session MCP headers without persisting
+   them in the rendered agent file (experiment against current kiro-cli;
+   cite version).
+2. Whether a standalone workload identity accepts
+   `GetWorkloadAccessTokenForJWT` from the companion IAM role (companion
+   repo or a scratch account; paste only the error string, no tokens).
+
+- [ ] **Step 1: Run the two probes.**
+
+- [ ] **Step 2: Write the verdict into the RFC Open questions section.**
+
+- [ ] **Step 3: Commit.**
+
+  ```
+  docs: record AgentCore Phase 0 header and workload verdicts
+  ```
+
+Phase 5 implements **exactly one** of: kiro-cli sidecar headers, or the
+local header-proxy MCP. Do not implement both.
+
+---
+
+### Task 5: PR 5 — Gateway attach and inbound injection
+
+**Files (sidecar path, if Phase 0 said yes):**
+
+- Modify: `src/kiro_crew/mcp_gateway/` rewriter / session spawn
+- Modify: `src/kiro_crew/agent.py` (`_extra_mcp_servers` merge of
+  `gateway_mcp_spec()`, URL only)
+- Create: `test/test_agentcore_gateway_inject.py`
+- Modify: `docs/architecture/mcp.md` only if the inject path needs a
+  new header-sidecar note (login withhold already landed in PR 2b)
+
+**Files (proxy path, if Phase 0 said no):**
+
+- Create: `src/kiro_crew/mcp_gateway/agentcore_proxy.py` (stdio MCP that
+  forwards to the Gateway URL with the session inbound token)
+- Same tests and `mcp.md` update
+
+**Either path:**
+
+- [x] **Step 1: Write failing tests.**
+
+  - `enabled() is False` → no Gateway server in the rebuilt agent config.
+  - `enabled() is True` / posture `login` but `vend_gateway_inbound_token`
+    returns None → server still absent (fail closed). Operator must
+    complete ensure-login.
+  - `enabled() is True` / posture `workload` → IAM inbound, no JWT
+    sidecar. Gateway URL-only spec is present at boot.
+  - Successful `login` vend → transport has `Authorization: Bearer …`
+    and `~/.kiro/agents/kirocrew.json` does not.
+  - Two sessions with different principals do not share a backend
+    (unpooled).
+  - Token bytes never appear in a captured log / SEL fixture.
+
+- [x] **Step 2: Implement the Phase 0-chosen path only.**
+
+  Gate contribution on `capabilities.agentcore` (fail closed when the
+  capability is off, even if the companion `enabled()` is True).
+
+- [x] **Step 3: Commit.**
+
+  ```
+  feat: inject per-session AgentCore Gateway inbound tokens
+  ```
+
+---
+
+### Task 6: PR 6 — consent surface and unattended policy
+
+**Files:**
+
+- Modify: `src/kiro_crew/security.py` (consent-host allowlist reuse of
+  `oauth_endpoints.json`; do not add a second file unless the existing
+  keystone cannot express AgentCore consent hosts)
+- Modify: dashboard handler + a small Settings / modal component
+  (`website/src/…`) with i18n keys
+- Modify: cron / task start path: `login` never attaches Gateway
+  (already withheld). `workload` refuses OBO targets without a
+  vaulted owner token (companion reports "m2m" vs "user" on
+  `gateway_mcp_spec()` or status)
+- Modify: SEL event names from the RFC
+- Modify: `docs/system-specs/modules/security.md`
+- Test: `test/test_agentcore_consent.py`, `test/test_agentcore_unattended.py`
+
+- [x] **Step 1: Write failing tests for unknown consent host, injected
+  envelope, and cron-without-JWT.**
+
+- [x] **Step 2: Implement allowlist + fail-closed unattended policy.**
+
+  User-facing copy is cataloged. Backend errors include `code`.
+  No model-visible "click this URL" injection.
+
+- [x] **Step 3: Verify dashboard strings and the unattended path.**
+
+  `cd website && npm run test` for the new modal/copy.
+  Backend: `python -m pytest test/test_agentcore_consent.py test/test_agentcore_unattended.py -n0 -q`
+
+- [x] **Step 4: Commit.**
+
+  ```
+  feat: gate AgentCore 3LO consent and unattended vending
+  ```
+
+---
+
+### Task 7: In-repo extra + IaC (this repository)
+
+Landed in Kiro Crew as an opt-in extra, not a `kirocrew.plugins`
+companion. A launched box that opted into AgentCore actually vends.
+
+- Extra: `kirocrew[agentcore]` = `boto3>=1.34,<2` (`setup.cfg`)
+- Adapter: `platform/agentcore_aws.py` `AwsAgentIdentityProvider`
+- Bootstrap (standalone only): `dataclasses.replace` of
+  `agent_identity` when `opted_in()` — home-policy or env posture
+  `workload`/`login`, or a named workload plus
+  `KIROCREW_AGENTCORE_AWS=1`. `ensure_extra()` pips
+  `kirocrew[agentcore]` on that path and on Settings PUT
+  (not on GET; not uninstalled when posture returns to `none`)
+- Settings/policy `capabilities.agentcore.gateway_url` is the
+  this-crew Gateway MCP URL (https); runtime prefers that over
+  `KIROCREW_AGENTCORE_GATEWAY_URL`
+- IaC: `install.sh --agentcore`; CFN `AgentCoreGatewayUrl`; systemd
+  `KIROCREW_AGENTCORE_GATEWAY_URL`
+- CLI: `kirocrew cloud launch --agentcore-gateway-url https://…`
+- Calls: `GetWorkloadAccessToken` / `GetWorkloadAccessTokenForJWT`
+  via boto3 client name `bedrock-agentcore`
+- Gateway spec: URL-only; never a WAT bearer. Workload posture
+  rewrites the URL to a `127.0.0.1` SigV4 proxy
+  (`platform/agentcore_sigv4.py`, service `bedrock-agentcore`)
+- Login inbound: companion IdP JWT on `principal.user_jwt` when
+  present; otherwise a URL-only sidecar so kiro-cli can start its
+  MCP OAuth challenge (`_kiro.dev/mcp/oauth_request`)
+- `status()` contains no token material
+- Settings catalog: `platform/agentcore_inspect.py` + owner-only
+  `GET`/`POST /api/agentcore/gateway` (verify, targets, tools/list,
+  optional Sync). Instance inspect SID on `gateway/*`. Launcher
+  Policy.json still has no inspect / Invoke verbs.
+- Do **not** register `kirocrew.plugins` (that flips enterprise
+  profile / fail-closed)
+
+Still companion-owned (other repo):
+
+- Operator IdP JWT → `annotate_principal.user_jwt` (optional now;
+  public login uses kiro-cli MCP OAuth when the JWT is absent)
+- Gateway + target + OAuth provider control plane
+
+---
+
+## Execution order and stop points
+
+1. Land PR 1 (this documentation).
+2. Land PR 2 before anything consumes the slot.
+3. Land PR 2b next (Policy.json + boundary + login withhold). It
+   does not wait on a vend path.
+4. Land PR 3 before any vend call.
+5. Run PR 4 **before** writing PR 5 code. If the header probe is
+   inconclusive, stop and update the RFC rather than guessing.
+   PR 5's `workload` IAM path does not depend on the header probe;
+   only the `login` JWT sidecar / proxy does.
+6. PR 6 can overlap PR 5 once the injection tests exist, but do not
+   merge consent UI that points at a server the inject path cannot
+   attach.
+7. Task 7 (this extra) can land on the same Protocol as PR 2. Do not
+   start a companion package to fetch tokens.
+
+**Do not implement Phase 5 of the RFC** (Crew-direct
+`GetResourceOauth2Token`) in this stack.
+
+## Verification before calling a phase done
+
+- Public tree still has zero `bedrock-agentcore` SDK imports (boto3
+  in the extra module only, lazy).
+- `DefaultAgentIdentityProvider.enabled()` is False and no Gateway
+  server appears in a standalone `rebuild_agent_config()`.
+- `iam.policy_json()` still has no `InvokeGateway` /
+  `GetWorkloadAccessToken*` action.
+- `iam.boundary_policy_document()` is byte-stable vs the pre-PR
+  SSM-core + source-bucket shape.
+- Login-posture rebuild fixtures contain managed `kirocrew-*` only
+  (no Kiro global, no crew-store leftover).
+- `kirocrew.json` fixtures contain no `Authorization` header.
+- Injected cron / subagent envelopes cannot vend a user token.
+- `scripts/docs-lint.sh` and
+  `BRAND_BASE_REF=origin/main python3 scripts/check_brand_name.py`
+  are clean on the files you added.

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -2,3 +2,6 @@
 
 - [2026-08-22-durable-run-coordinator.md](2026-08-22-durable-run-coordinator.md)
   — additive durable run coordinator and subagent lifecycle extraction.
+- [2026-08-27-agentcore-identity-gateway.md](2026-08-27-agentcore-identity-gateway.md)
+  — AgentCore Identity workload for the Crew agent and Gateway token
+  vending, with exclusive `workload` / `login` Policy.json postures.

--- a/docs/system-specs/common/code-style.md
+++ b/docs/system-specs/common/code-style.md
@@ -40,6 +40,7 @@ Paths below are relative to `src/kiro_crew/`.
 | Process-wide shutdown signal | `__init__.py` | `shutdown_event`. Background loops `await shutdown_event.wait()` with a timeout instead of a plain `asyncio.sleep`, so they wake instantly on Ctrl-C. |
 | Base agent config | `config/defaults.json` | `tools`, `allowedTools`, `resources`, `hooks`, model. Packaged as package data, so editing it needs no code change. |
 | Managed MCP server specs | `agent.py` | `_MANAGED_MCP_SERVERS`: which servers are auto-registered and refreshed while preserving user customizations. |
+| AgentCore policy-field validators | `platform/agentcore_schema.py` | `AGENTCORE_GATEWAY_URL_MAX`, `WORKLOAD_NAME_MIN` / `WORKLOAD_NAME_MAX`, `normalize_agentcore_gateway_url`, `normalize_agentcore_workload_name`. AWS-free so governance can parse a policy without the optional extra. |
 | Built-in skills | `builtin_skills/<name>/SKILL.md` | Frontmatter (`always`, `triggers`, `dir`) is the skill's own contract. This is the only tree copied into a user's `~/.kiro/crew/skills/`. |
 
 Other style rules:

--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -2076,6 +2076,8 @@ default on; a deny makes the tool refuse outright, and it does NOT fall back to
 the `commands` scope, so denying browsing wholesale means denying both this
 capability AND the `playwright-cli` command),
 `capabilities.publish` (artifact publish chokepoint — see below),
+`capabilities.agentcore` (opt-in agent workload identity + Gateway MCP —
+see below),
 `capabilities.theme_persona` / `capabilities.theme_install`,
 `capabilities.mobile_connect` (phone-connection methods: filters the
 `GET /api/mobile-connect/methods` listing AND is re-checked fail-closed inside
@@ -2134,6 +2136,48 @@ surface-agnostic Settings > Security snapshot + the builtin-toggle 409 check, so
 a rule pinned by any profile renders locked and rejects a disable rather than
 surfacing a no-op opt-out (UI success while the bound-profile gate still denies).
 Display-only union — it does not widen enforcement.
+
+`capabilities.agentcore` is a `CapabilityGate` (opt-in: `capability_default=False`,
+like `capabilities.publish` / `capabilities.messaging`). It is a catalog data row
+only — the evaluator is untouched. The inner `posture` field is policy data, not
+a second scope and not a `CapabilityGate` field (`additionalProperties: false`
+stays `enabled` + `scopes`): `workload` or `login`. An `enabled: true` document
+with a missing or unknown `posture` fails closed — the row is treated as
+disabled, or boot aborts when `boot.fail_closed`. A disabled or omitted row
+does not require `posture`.
+
+`CapabilityGate.from_dict` rejects a non-boolean `enabled` the same way
+`ScopedRuleset.mode` rejects an unknown mode: `enabled: "false"` is not
+coerced with `bool()`, and a present `enabled: null` is not treated as
+absent. The default applies only when the key is omitted. The raise is
+unconditional (including `boot.fail_closed=false`) and applies to every
+capability row, not just `agentcore` — six catalog scopes default ON, so
+a stringly-typed or null disable must not turn into a permit.
+
+The composed posture is a **policy-only** ceiling side field
+(`GovernanceCeiling.agentcore_identity_posture`, Rule 6 — same shape as Slack
+`channels.posture` and `updates`). A profile may enable or disable the
+capability (tightest-wins on `enabled`) but cannot carry `posture`,
+`gateway_url`, or `workload_name`: those keys are rejected at parse, the same
+fail-closed raise as `ScopedMap.posture` / `updates` / `fallback`.
+Enable-without-posture is the legal profile shape; it cannot turn the seam on
+alone, because an omitted policy has no stored posture. Read the composed
+value through the public helper
+`agentcore_posture(ceiling) -> "workload" | "login" | None` — do not re-parse
+raw policy JSON. The helper returns the stored posture only when the
+capability is enabled with a known value; `None` when the ceiling is missing,
+the capability is omitted, disabled, or fail-closed-disabled.
+
+`gateway_url` (https MCP URL, no credentials, no fragment, no internal
+whitespace) and `workload_name`
+(3–255 of `[A-Za-z0-9_.-]`) are the same policy-only shape. Validators live
+in `platform/agentcore_schema.py` so policy parse does not import AWS.
+Consumption ANDs three conjuncts: the `agent_identity` adapter is on,
+governance permits `capabilities.agentcore`, and `agentcore_posture(ceiling)`
+is a known value. The public `DefaultAgentIdentityProvider` is disabled, so a
+standalone host with no policy is unchanged. Later stack PRs consult this row
+at rebuild / Gateway injection; naming it here is what lets a policy pin the
+capability before those chokepoints land.
 
 `capabilities.publish` is a `CapabilityGate` (opt-in: `capability_default=False`)
 with an inner `destinations` `ScopedRuleset` (`identifier` matcher) bounding

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -43,6 +43,7 @@ interface, the public edition is complete standalone.
 | `governance` | **concrete carrier** | `load_security_policy()` result or `None` | bundled Level-1 ceiling |
 | `slack_gate` | adapter | `DefaultSlackEnterpriseGate` (default-open) | fail-closed enterprise allowlist |
 | `identity` | adapter | `DefaultIdentityProvider` (`sso_status.py` stub; `whoami`/`issuer` **RESERVED**) | enterprise SSO / directory |
+| `agent_identity` | adapter | `DefaultAgentIdentityProvider` (disabled: `enabled() -> False`; no workload, no Gateway spec, no tokens). Distinct from operator-SSO `identity`. `IdentityProvider.whoami` / `issuer` stay RESERVED and are not consumed to satisfy this seam. A later stack PR may swap this adapter when an optional extra opts in; this PR composes only the Default. | edition workload identity + token vending |
 | `embeddings` | adapter | **RESERVED** — `DefaultEmbeddingSource`; the public runtime is the bundled in-process llama-cpp model, so no method is consumed (swap via `embeddings.register_embedding_backend`) | — (slot inert) |
 | `mcp_tooling` | adapter | `DefaultMcpToolingProvider` (all methods empty) | enterprise MCP server + skills + provider MCP scopes |
 | `agent_catalog` | adapter | `DefaultAgentCatalogProvider` (`builtin_agents()` → `[]`) | edition agent-catalog rows |
@@ -309,6 +310,8 @@ added pre-launch landed under this same `1`, with no bump:
   before the core applies its sandbox);
 - the `knowledge` (connector registry), `dashboard` (route/service/login-handler
   contributor), and `jail` (process-isolation) extension points;
+- the `agent_identity` slot (`AgentIdentityProvider` — agent workload identity
+  and token vending, distinct from operator-SSO `identity`);
 - wiring an *existing* but previously-unconsumed Protocol method into a call site
   (e.g. `ProviderRegistry.create_factory` going live, `AppsLoader` bundling
   feature apps) — no shape change, so no bump regardless;

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -86,9 +86,11 @@ from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.platform import safe_context_call
 from kiro_crew.platform.governance import (
     CU_MCP_SERVER,
+    agentcore_posture,
     may_skip_gate_now,
     strip_ungoverned_auto_approve,
 )
+from kiro_crew.platform.governance_profiles import governance_permits
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import (  # circular import: sel imports config which imports agent
     SecurityEvent,
@@ -97,6 +99,62 @@ from kiro_crew.sel import (  # circular import: sel imports config which imports
 from kiro_crew.validation import _AGENT_NAME_RE
 
 logger = logging.getLogger(__name__)
+
+
+def _agentcore_capability_permitted() -> bool:
+    """Whether the governance ceiling permits ``capabilities.agentcore``.
+
+    Independent of the CPP adapter. An omitted capability is ungoverned
+    (permitted); a transient lookup degrades to False. Used by the
+    three-conjunct identity probe (adapter AND this AND known posture).
+    """
+    return bool(
+        safe_context_call(
+            lambda: getattr(
+                governance_permits(
+                    "capabilities.agentcore",
+                    "",
+                    fail_closed=True,
+                    log_warning=False,
+                ),
+                "permitted",
+                False,
+            ),
+            fallback=False,
+            log_message="agentcore governance lookup failed; treating as disabled",
+        )
+    )
+
+
+def _agent_identity_enabled() -> bool:
+    """Whether the composed agent-identity seam is on.
+
+    True only when the adapter is on AND governance permits
+    ``capabilities.agentcore`` AND the ceiling stores a known posture.
+    Standalone Default returns False without consulting governance, so
+    Gateway/token work stays off. An omitted capability is ungoverned
+    (permitted), so the known-posture conjunct is what keeps a forced-on
+    adapter off when no row is present. A transient adapter/governance
+    error degrades to False (never to enabled) via ``safe_context_call``.
+    """
+    adapter_on = bool(
+        safe_context_call(
+            lambda: current_context().agent_identity.enabled(),
+            fallback=False,
+            log_message="agent_identity.enabled lookup failed; treating as disabled",
+        )
+    )
+    if not adapter_on:
+        return False
+    if not _agentcore_capability_permitted():
+        return False
+    return bool(
+        safe_context_call(
+            lambda: agentcore_posture(current_context().governance) is not None,
+            fallback=False,
+            log_message="agentcore posture lookup failed; treating as disabled",
+        )
+    )
 
 
 def _atomic_json_write(path: Path, data: dict) -> None:

--- a/src/kiro_crew/platform/agentcore_schema.py
+++ b/src/kiro_crew/platform/agentcore_schema.py
@@ -1,0 +1,66 @@
+"""AWS-free AgentCore policy-field validators.
+
+These live beside governance, not the optional AWS extra, so a policy
+document can be parsed on a host that never installed ``kirocrew[agentcore]``.
+The extra (a later PR) reuses the same functions; it must not re-define them.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+# Policy / launch-env Gateway MCP URL ceiling. A longer value is almost
+# certainly a paste error or a credential stuffed into the query.
+AGENTCORE_GATEWAY_URL_MAX = 512
+
+# AgentCore CreateWorkloadIdentity name bounds.
+WORKLOAD_NAME_MIN = 3
+WORKLOAD_NAME_MAX = 255
+_WORKLOAD_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def normalize_agentcore_gateway_url(value: str | None) -> str:
+    """Return a stripped https Gateway MCP URL, or empty.
+
+    Rejects credentials-in-URL, non-https, fragments, and over-long values
+    so a policy write or launch Environment= line cannot carry an arbitrary
+    credentialed URL.
+    """
+    url = (value or "").strip()
+    if not url:
+        return ""
+    if len(url) > AGENTCORE_GATEWAY_URL_MAX:
+        raise ValueError(f"agentcore_gateway_url exceeds {AGENTCORE_GATEWAY_URL_MAX} characters")
+    # Internal whitespace (including newlines) survives urlparse's scheme
+    # check and would land unquoted in a systemd Environment= line.
+    if any(ch.isspace() for ch in url):
+        raise ValueError("agentcore_gateway_url must be an https URL without credentials")
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        raise ValueError("agentcore_gateway_url must be an https URL without credentials")
+    return url
+
+
+def normalize_agentcore_workload_name(value: str | None) -> str:
+    """Return a stripped workload identity name, or empty.
+
+    Empty is legal (env / RFC default still apply). A present value must
+    match AgentCore CreateWorkloadIdentity: 3–255 of ``[A-Za-z0-9_.-]``.
+    """
+    name = (value or "").strip()
+    if not name:
+        return ""
+    if (
+        len(name) < WORKLOAD_NAME_MIN
+        or len(name) > WORKLOAD_NAME_MAX
+        or _WORKLOAD_NAME_RE.fullmatch(name) is None
+    ):
+        raise ValueError("agentcore_workload_name is not a usable workload identity name")
+    return name

--- a/src/kiro_crew/platform/bootstrap.py
+++ b/src/kiro_crew/platform/bootstrap.py
@@ -25,6 +25,7 @@ from kiro_crew.platform.context import (
 from kiro_crew.platform.defaults import (
     DefaultAgentCatalogProvider,
     DefaultAgentExecutableResolver,
+    DefaultAgentIdentityProvider,
     DefaultAgentRuntime,
     DefaultAppRegistryPolicy,
     DefaultAppsLoader,
@@ -134,6 +135,7 @@ def build_default_context(
         security=PolicyAuthority(),  # _NullOverlay → baseline only
         slack_gate=DefaultSlackEnterpriseGate(),
         identity=DefaultIdentityProvider(),
+        agent_identity=DefaultAgentIdentityProvider(),
         embeddings=DefaultEmbeddingSource(),
         mcp_tooling=DefaultMcpToolingProvider(),
         agent_catalog=DefaultAgentCatalogProvider(),

--- a/src/kiro_crew/platform/context.py
+++ b/src/kiro_crew/platform/context.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:  # avoid import cycles — config.loader imports heavy modules
     from kiro_crew.platform.interfaces import (
         AgentCatalogProvider,
         AgentExecutableResolver,
+        AgentIdentityProvider,
         AgentRuntime,
         AppRegistryPolicy,
         AppsLoader,
@@ -65,7 +66,7 @@ if TYPE_CHECKING:  # avoid import cycles — config.loader imports heavy modules
 # incrementing this only after the first public release, when a separately-built
 # companion can pin against a frozen contract.  (Every seam added pre-launch —
 # the ``governance`` carrier, then the ``knowledge``/``dashboard``/``jail``
-# extension points — landed under this same v1, no bump.)
+# extension points, then ``agent_identity`` — landed under this same v1, no bump.)
 CONTRACT_VERSION = 1
 
 _logger = logging.getLogger(__name__)
@@ -284,6 +285,9 @@ class PlatformContext:
     slack_gate: "SlackEnterpriseGate"
     # ``whoami``/``issuer`` are [RESERVED] — see RESERVED_METHODS.
     identity: "IdentityProvider"
+    # Agent workload identity / token vending. Distinct from ``identity``
+    # (operator SSO). v1 addition (no CONTRACT_VERSION bump).
+    agent_identity: "AgentIdentityProvider"
     embeddings: "EmbeddingSource"  # [RESERVED] — see RESERVED_SLOTS
     mcp_tooling: "McpToolingProvider"
     agent_catalog: "AgentCatalogProvider"

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -16,7 +16,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 if TYPE_CHECKING:
-    from kiro_crew.platform.interfaces import ImportSource, McpScope
+    from kiro_crew.platform.interfaces import (
+        ImportSource,
+        InboundToken,
+        McpScope,
+        SessionPrincipal,
+        WorkloadIdentity,
+    )
 
 from kiro_crew import security, sso_status
 from kiro_crew.platform.interfaces import (
@@ -204,6 +210,41 @@ class DefaultIdentityProvider:
         # daemon runs with no rotation watcher. A companion returns its
         # rotated-credential file path(s) here.
         return []
+
+
+class DefaultAgentIdentityProvider:
+    """Disabled agent-identity seam — standalone has no workload or Gateway.
+
+    ``enabled()`` is False so every public call site is a no-op. Other methods
+    return the disabled answer (``None`` / ``{}`` / the input principal) so a
+    ``safe_context_call`` fallback that degrades to the same values cannot
+    flip the seam on.
+    """
+
+    def enabled(self) -> bool:
+        return False
+
+    def workload_identity(self) -> "WorkloadIdentity | None":
+        return None
+
+    def status(self) -> Dict[str, object]:
+        # Display-only. Never token material — a token-like key here would
+        # leak bearer into the dashboard status payload.
+        return {}
+
+    def gateway_mcp_spec(self) -> Dict[str, object] | None:
+        return None
+
+    async def annotate_principal(self, principal: "SessionPrincipal") -> "SessionPrincipal":
+        return principal
+
+    async def vend_workload_access_token(self, principal: "SessionPrincipal") -> str | None:
+        return None
+
+    async def vend_gateway_inbound_token(
+        self, principal: "SessionPrincipal"
+    ) -> "InboundToken | None":
+        return None
 
 
 class DefaultEmbeddingSource:

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -943,9 +943,17 @@ class CapabilityGate:
             for k, v in raw_scopes.items()
             if isinstance(v, dict)
         }
-        enabled = d.get("enabled")
+        if "enabled" not in d:
+            enabled_flag = default_enabled
+        else:
+            enabled = d["enabled"]
+            if not isinstance(enabled, bool):
+                raise PlatformCompositionError(
+                    f"CapabilityGate.enabled must be a boolean, got {enabled!r}"
+                )
+            enabled_flag = enabled
         return CapabilityGate(
-            enabled=bool(enabled) if enabled is not None else default_enabled,
+            enabled=enabled_flag,
             scopes=scopes,
         )
 
@@ -1170,6 +1178,13 @@ SCOPE_CATALOG: Dict[str, ScopeSpec] = {
     "capabilities.script_hooks": ScopeSpec(CAPABILITY, capability_default=False),
     "capabilities.cron": ScopeSpec(CAPABILITY, capability_default=False),
     "capabilities.messaging": ScopeSpec(CAPABILITY, capability_default=False),
+    # Agent workload identity + Gateway MCP (opt-in, like messaging/publish).
+    # Inner ``posture`` is policy data (``workload`` | ``login``), not a second
+    # scope and not an evaluator input. An ``enabled: true`` document with a
+    # missing or unknown posture fails closed — treated as disabled, or
+    # boot-abort when ``boot.fail_closed``. Data row only; CONTRACT_VERSION
+    # and the evaluator are untouched.
+    "capabilities.agentcore": ScopeSpec(CAPABILITY, capability_default=False),
     # Publishing an artifact's bytes to an external destination is an
     # exfil/external-side-effect surface (like messaging), so it is opt-in
     # (capability_default=False): a policy that names ``publish`` while omitting
@@ -1813,6 +1828,22 @@ class GovernanceCeiling:
     # fallback is still intersected with this ceiling, so it can only ever narrow
     # it — it trades strict fail-closed for keeping the unlisted planes available.
     fallback_profile: "Optional[Profile]" = None
+    # Policy-only composed posture for ``capabilities.agentcore``
+    # (``workload`` | ``login``). Not a CapabilityGate field — that type stays
+    # ``enabled`` + ``scopes``. Read through :func:`agentcore_posture`, which
+    # returns ``None`` when the capability is off, omitted, or fail-closed
+    # disabled. A profile cannot compose a different posture onto this field
+    # (policy-wins).
+    agentcore_identity_posture: Optional[str] = None
+    # Policy-only Gateway MCP URL (``capabilities.agentcore.gateway_url``).
+    # Empty when omitted or the capability is off. Not a CapabilityGate field.
+    # A profile cannot carry this key. Read through
+    # :func:`agentcore_gateway_url`.
+    agentcore_gateway_url: str = ""
+    # Policy-only workload identity name (``capabilities.agentcore.workload_name``).
+    # Empty when omitted — runtime then uses env or a later default. A profile
+    # cannot carry this key. Read through :func:`agentcore_workload_name`.
+    agentcore_workload_name: str = ""
 
     def get(self, scope: str) -> Optional[object]:
         return self.controls.get(scope)
@@ -1933,6 +1964,173 @@ def _command_deny_patterns(control: object) -> Tuple[str, ...]:
     return ()
 
 
+_AGENTCORE_SCOPE = "capabilities.agentcore"
+_AGENTCORE_POSTURES = frozenset({"workload", "login"})
+_AGENTCORE_POLICY_ONLY = frozenset({"posture", "gateway_url", "workload_name"})
+
+
+def _capability_raw_for_gate(
+    scope: str, raw: Mapping[str, object], *, is_policy: bool
+) -> Mapping[str, object]:
+    """Drop inner policy data that is not a CapabilityGate field.
+
+    ``capabilities.agentcore.posture``, ``gateway_url``, and
+    ``workload_name`` are policy data, not a second scope and not an
+    evaluator input. Strip them on a policy document so
+    ``CapabilityGate.from_dict`` stays ``additionalProperties: false``.
+    A profile (or policy fallback body) that carries either key is
+    rejected — Rule 6, same fail-closed raise as ``ScopedMap.posture``.
+    """
+    if scope != _AGENTCORE_SCOPE:
+        return raw
+    extra = _AGENTCORE_POLICY_ONLY.intersection(raw)
+    if not extra:
+        return raw
+    if not is_policy:
+        name = "posture" if "posture" in extra else next(iter(extra))
+        raise PlatformCompositionError(
+            f"capabilities.agentcore.{name} is policy-only; not allowed on a profile"
+        )
+    return {key: value for key, value in raw.items() if key not in _AGENTCORE_POLICY_ONLY}
+
+
+def _apply_agentcore_posture(
+    data: Mapping[str, object],
+    controls: Dict[str, object],
+    boot: "BootControls",
+) -> Optional[str]:
+    """Validate agentcore posture and return the value to persist on the ceiling.
+
+    Missing or unknown ``posture`` with ``enabled: true`` aborts when
+    ``boot.fail_closed``; otherwise the row is treated as disabled. Disabled
+    (or unnamed) rows do not require a posture and yield ``None``.
+    """
+    raw_caps = data.get("capabilities")
+    if not isinstance(raw_caps, dict):
+        return None
+    raw = raw_caps.get("agentcore")
+    if not isinstance(raw, dict):
+        return None
+    control = controls.get(_AGENTCORE_SCOPE)
+    if not isinstance(control, CapabilityGate) or not control.enabled:
+        return None
+    posture = raw.get("posture")
+    if isinstance(posture, str) and posture in _AGENTCORE_POSTURES:
+        return posture
+    reason = (
+        f"capabilities.agentcore is enabled but posture is {posture!r}; "
+        "expected 'workload' or 'login'"
+    )
+    if boot.fail_closed:
+        raise PlatformCompositionError(reason)
+    controls[_AGENTCORE_SCOPE] = CapabilityGate(enabled=False, scopes=control.scopes)
+    return None
+
+
+def agentcore_posture(ceiling: Optional[GovernanceCeiling]) -> Optional[str]:
+    """Return the policy posture if ``capabilities.agentcore`` is enabled.
+
+    ``\"workload\"`` or ``\"login\"`` when the ceiling enables the capability
+    with a known posture. ``None`` when there is no ceiling, the capability is
+    omitted, disabled, or fail-closed-disabled. The single reader later work
+    must use — do not re-parse raw policy JSON for this field.
+    """
+    if ceiling is None:
+        return None
+    stored = ceiling.agentcore_identity_posture
+    if stored not in _AGENTCORE_POSTURES:
+        return None
+    control = ceiling.controls.get(_AGENTCORE_SCOPE)
+    if not isinstance(control, CapabilityGate) or not control.enabled:
+        return None
+    return stored
+
+
+def _apply_agentcore_gateway_url(
+    data: Mapping[str, object],
+    controls: Dict[str, object],
+    boot: "BootControls",
+) -> str:
+    """Validate and return the policy Gateway URL, or empty.
+
+    Missing / empty is legal (the crew may still name a posture and add
+    the URL later). A present but unusable value aborts when
+    ``boot.fail_closed``; otherwise it is ignored.
+    """
+    from kiro_crew.platform.agentcore_schema import normalize_agentcore_gateway_url
+
+    raw_caps = data.get("capabilities")
+    if not isinstance(raw_caps, dict):
+        return ""
+    raw = raw_caps.get("agentcore")
+    if not isinstance(raw, dict):
+        return ""
+    control = controls.get(_AGENTCORE_SCOPE)
+    if not isinstance(control, CapabilityGate) or not control.enabled:
+        return ""
+    value = raw.get("gateway_url")
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        reason = "capabilities.agentcore.gateway_url must be a string"
+        if boot.fail_closed:
+            raise PlatformCompositionError(reason)
+        return ""
+    try:
+        return normalize_agentcore_gateway_url(value)
+    except ValueError as exc:
+        if boot.fail_closed:
+            raise PlatformCompositionError(str(exc)) from exc
+        return ""
+
+
+def agentcore_gateway_url(ceiling: Optional[GovernanceCeiling]) -> str:
+    """Return the policy Gateway URL if ``capabilities.agentcore`` is enabled."""
+    if ceiling is None or agentcore_posture(ceiling) is None:
+        return ""
+    return str(ceiling.agentcore_gateway_url or "")
+
+
+def _apply_agentcore_workload_name(
+    data: Mapping[str, object],
+    controls: Dict[str, object],
+    boot: "BootControls",
+) -> str:
+    """Validate and return the policy workload name, or empty."""
+    from kiro_crew.platform.agentcore_schema import normalize_agentcore_workload_name
+
+    raw_caps = data.get("capabilities")
+    if not isinstance(raw_caps, dict):
+        return ""
+    raw = raw_caps.get("agentcore")
+    if not isinstance(raw, dict):
+        return ""
+    control = controls.get(_AGENTCORE_SCOPE)
+    if not isinstance(control, CapabilityGate) or not control.enabled:
+        return ""
+    value = raw.get("workload_name")
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        reason = "capabilities.agentcore.workload_name must be a string"
+        if boot.fail_closed:
+            raise PlatformCompositionError(reason)
+        return ""
+    try:
+        return normalize_agentcore_workload_name(value)
+    except ValueError as exc:
+        if boot.fail_closed:
+            raise PlatformCompositionError(str(exc)) from exc
+        return ""
+
+
+def agentcore_workload_name(ceiling: Optional[GovernanceCeiling]) -> str:
+    """Return the policy workload name if ``capabilities.agentcore`` is enabled."""
+    if ceiling is None or agentcore_posture(ceiling) is None:
+        return ""
+    return str(ceiling.agentcore_workload_name or "")
+
+
 def _parse_control(scope: str, spec: ScopeSpec, raw: object, *, is_policy: bool) -> object:
     """Parse one raw JSON control value into its archetype, per the catalog."""
     if not isinstance(raw, dict):
@@ -1949,8 +2147,9 @@ def _parse_control(scope: str, spec: ScopeSpec, raw: object, *, is_policy: bool)
             raise PlatformCompositionError(f"ordinal scope {scope!r} needs a string value")
         return OrdinalControl(scale=spec.ordinal_scale, value=value)
     if spec.kind == CAPABILITY:
+        gate_raw: Mapping[str, object] = _capability_raw_for_gate(scope, raw, is_policy=is_policy)
         return CapabilityGate.from_dict(
-            raw, default_enabled=spec.capability_default, scope_matchers=spec.scope_matchers
+            gate_raw, default_enabled=spec.capability_default, scope_matchers=spec.scope_matchers
         )
     if spec.kind == SCOPEDMAP:
         return ScopedMap.from_dict(raw, allow_posture=is_policy)
@@ -2218,6 +2417,9 @@ def parse_policy(
         fail_closed=bool(boot_raw.get("fail_closed", True)),
     )
     controls = _parse_controls(data, is_policy=True)
+    composed_posture = _apply_agentcore_posture(data, controls, boot)
+    composed_gateway_url = _apply_agentcore_gateway_url(data, controls, boot)
+    composed_workload_name = _apply_agentcore_workload_name(data, controls, boot)
     identity = data.get("identity") or {}
     issuer = str(identity.get("issuer", "")) if isinstance(identity, dict) else ""
     signature = str(identity.get("signature", "")) if isinstance(identity, dict) else ""
@@ -2265,6 +2467,9 @@ def parse_policy(
         updates=UpdatePins.from_dict(raw_updates or {}),
         distribution=PolicyDistribution.from_dict(raw_distribution or {}),
         fallback_profile=fallback_profile,
+        agentcore_identity_posture=composed_posture,
+        agentcore_gateway_url=composed_gateway_url,
+        agentcore_workload_name=composed_workload_name,
     )
 
 

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -14,7 +14,7 @@ deny decision must be ``@final`` to enforce the ADD-only floor.
 from __future__ import annotations
 
 import enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -380,6 +380,81 @@ class IdentityProvider(Protocol):
         ...
 
     def credential_watch_paths(self) -> List[Path]: ...
+
+
+@dataclass(frozen=True)
+class WorkloadIdentity:
+    """The agent process's registered workload (name + ARN).
+
+    Public Default never has one. A companion fills this from the edition's
+    workload registration; core code must not invent an ARN.
+    """
+
+    name: str
+    arn: str
+
+
+@dataclass(frozen=True)
+class SessionPrincipal:
+    """Trusted caller for agent-identity token vending.
+
+    Core-derived (surface + already-partitioned subject + session key). Never
+    taken from tool input. ``user_jwt`` is set only by a companion after IdP
+    verify; the public Default leaves it ``None``.
+    """
+
+    surface: str
+    subject: str
+    session_key: str
+    user_jwt: str | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True)
+class InboundToken:
+    """A short-lived inbound credential a companion vends for Gateway MCP.
+
+    ``token`` is bearer material: it must never enter ``status()``, SEL
+    payloads, or transcripts. Public Default never vends one.
+    """
+
+    scheme: str
+    token: str = field(repr=False)
+    expires_at: float
+    audience: str
+
+
+class AgentIdentityProvider(Protocol):
+    """Agent workload identity and token vending — not operator SSO.
+
+    ``IdentityProvider`` is the operator-SSO slot (status line, preflight,
+    credential watch). This slot is the edition concern for a process-level
+    workload identity and for vending tokens *as that workload*. Same reason
+    ``AgentCatalogProvider`` is not folded into ``McpToolingProvider``.
+
+    Public Default is disabled (``enabled() -> False``; every other method
+    returns ``None`` / ``{}`` / the input principal unchanged) so a standalone
+    process stays byte-identical. ``IdentityProvider.whoami`` / ``issuer`` stay
+    RESERVED — do not consume them to satisfy this seam.
+
+    v1 field addition (no ``CONTRACT_VERSION`` bump); same landing as
+    ``knowledge`` / ``dashboard`` / ``jail``.
+    """
+
+    def enabled(self) -> bool: ...
+
+    def workload_identity(self) -> WorkloadIdentity | None: ...
+
+    def status(self) -> dict[str, object]: ...
+
+    def gateway_mcp_spec(self) -> dict[str, object] | None: ...
+
+    async def annotate_principal(self, principal: SessionPrincipal) -> SessionPrincipal: ...
+
+    async def vend_workload_access_token(self, principal: SessionPrincipal) -> str | None: ...
+
+    async def vend_gateway_inbound_token(
+        self, principal: SessionPrincipal
+    ) -> InboundToken | None: ...
 
 
 class EmbeddingSource(Protocol):

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5268,6 +5268,13 @@ _CREW_SECRET_LEAVES: list[str] = [
     # directly, not through this gate; the operator hand-edits it out-of-band
     # (there is deliberately no dashboard writer).
     "oauth_endpoints.json",
+    # Per-session AgentCore Gateway inbound JWTs (directory name reserved
+    # before the writer lands). Owner-only ``0600`` does not isolate another
+    # process running as the same UID, so the directory belongs behind the
+    # shared floor like every other credential store. Classified as the
+    # whole DIRECTORY so atomic-write temps and every sidecar file are
+    # covered.
+    "agentcore-inbound",
     # Which checkout the gateway executes (Dev Fleet "Make live"). The pointer is
     # resolved during startup and exec'd into, so a writable one is arbitrary
     # code execution in the gateway's own identity — the agent must not be able

--- a/test/test_agentcore_schema.py
+++ b/test/test_agentcore_schema.py
@@ -1,0 +1,89 @@
+"""Direct coverage of AWS-free AgentCore policy-field validators.
+
+Governance parse re-exports these; later stack PRs import them from the AWS
+extra. A host that never installed ``kirocrew[agentcore]`` still has to reject
+a credentialed, fragmented, over-long, or whitespace-bearing Gateway URL
+before it can land in Policy.json or a systemd Environment= line.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.platform.agentcore_schema import (
+    AGENTCORE_GATEWAY_URL_MAX,
+    WORKLOAD_NAME_MAX,
+    WORKLOAD_NAME_MIN,
+    normalize_agentcore_gateway_url,
+    normalize_agentcore_workload_name,
+)
+
+_VALID_URL = "https://gateway.example.test/mcp"
+
+
+class TestNormalizeAgentcoreGatewayUrl:
+    def test_empty_and_none_are_legal(self) -> None:
+        assert normalize_agentcore_gateway_url(None) == ""
+        assert normalize_agentcore_gateway_url("") == ""
+        assert normalize_agentcore_gateway_url("   ") == ""
+
+    def test_valid_https_url_is_stripped(self) -> None:
+        assert normalize_agentcore_gateway_url(f"  {_VALID_URL}  ") == _VALID_URL
+
+    @pytest.mark.parametrize(
+        "url",
+        (
+            "http://gateway.example.test/mcp",
+            "https://user:pass@gateway.example.test/mcp",
+            "https://user@gateway.example.test/mcp",
+            "https://gateway.example.test/mcp#frag",
+            "https://",
+            "not-a-url",
+            "ftp://gateway.example.test/mcp",
+        ),
+    )
+    def test_rejects_insecure_or_credentialed_urls(self, url: str) -> None:
+        with pytest.raises(ValueError, match="https URL without credentials"):
+            normalize_agentcore_gateway_url(url)
+
+    def test_rejects_over_long_url(self) -> None:
+        url = "https://gateway.example.test/" + ("a" * AGENTCORE_GATEWAY_URL_MAX)
+        assert len(url) > AGENTCORE_GATEWAY_URL_MAX
+        with pytest.raises(ValueError, match="exceeds"):
+            normalize_agentcore_gateway_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        (
+            "https://gateway.example.test/mcp\nExecStartPre=/bin/true",
+            "https://gateway.example.test/mcp\t$(id)",
+            "https://gateway.example.test/mcp extra",
+        ),
+    )
+    def test_rejects_internal_whitespace(self, url: str) -> None:
+        with pytest.raises(ValueError, match="https URL without credentials"):
+            normalize_agentcore_gateway_url(url)
+
+
+class TestNormalizeAgentcoreWorkloadName:
+    def test_empty_and_none_are_legal(self) -> None:
+        assert normalize_agentcore_workload_name(None) == ""
+        assert normalize_agentcore_workload_name("") == ""
+        assert normalize_agentcore_workload_name("   ") == ""
+
+    def test_valid_name_is_stripped(self) -> None:
+        assert normalize_agentcore_workload_name("  crew.one_2-3  ") == "crew.one_2-3"
+
+    def test_rejects_too_short(self) -> None:
+        with pytest.raises(ValueError, match="usable workload identity name"):
+            normalize_agentcore_workload_name("ab")
+        assert WORKLOAD_NAME_MIN == 3
+
+    def test_rejects_too_long(self) -> None:
+        with pytest.raises(ValueError, match="usable workload identity name"):
+            normalize_agentcore_workload_name("a" * (WORKLOAD_NAME_MAX + 1))
+
+    @pytest.mark.parametrize("name", ("has space", "slash/name", "at@name", "bang!"))
+    def test_rejects_charset(self, name: str) -> None:
+        with pytest.raises(ValueError, match="usable workload identity name"):
+            normalize_agentcore_workload_name(name)

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -233,6 +233,21 @@ class TestCapabilityGate:
         g2 = CapabilityGate.from_dict({}, default_enabled=False)
         assert not g2.enabled
 
+    def test_from_dict_rejects_non_boolean_enabled(self):
+        # bool("false") is True — a stringly-typed disable must not permit.
+        # A present null is not "absent": default-ON scopes must not stay on.
+        for bogus in ("false", "true", 1, 0, ["yes"], None):
+            with pytest.raises(PlatformCompositionError, match="boolean"):
+                CapabilityGate.from_dict({"enabled": bogus}, default_enabled=True)
+
+    def test_known_capability_rejects_non_boolean_enabled(self):
+        # Default-ON siblings (memory_writes, browse, …) used to coerce
+        # enabled: "false" through bool() and stay on.
+        with pytest.raises(PlatformCompositionError, match="boolean"):
+            parse_profile(
+                {"name": "host", "capabilities": {"memory_writes": {"enabled": "false"}}}
+            )
+
     def test_scopes_compose_independently(self):
         a = CapabilityGate(
             enabled=True,
@@ -1727,6 +1742,8 @@ class TestValidateReportsUngovernedCapabilities:
 
     def test_fully_enumerated_block_reports_no_gap(self, capsys):
         body = {scope.split(".", 1)[1]: {"enabled": True} for scope in _capability_scopes()}
+        # agentcore requires a known inner posture when enabled.
+        body["agentcore"] = {"enabled": True, "posture": "workload"}
         out = self._validate(capsys, parse_policy(_policy_body(capabilities=body)))
         assert "UNGOVERNED" not in out
         assert "✅ valid" in out

--- a/test/test_platform_cpp_seam_coverage.py
+++ b/test/test_platform_cpp_seam_coverage.py
@@ -45,7 +45,10 @@ from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.platform import (
     RESERVED_METHODS,
     RESERVED_SLOTS,
+    PlatformCompositionError,
     build_default_context,
+    reset_context,
+    set_context,
 )
 from kiro_crew.platform.context import (
     _RESERVED_DEFAULT_ADAPTERS,
@@ -53,6 +56,14 @@ from kiro_crew.platform.context import (
     PlatformContext,
     _reserved_slot_is_default,
 )
+from kiro_crew.platform.governance import (
+    CAPABILITY,
+    SCOPE_CATALOG,
+    parse_policy,
+    parse_profile,
+    resolve,
+)
+from kiro_crew.platform.interfaces import InboundToken, SessionPrincipal
 
 # ── Static-analysis configuration ──
 
@@ -560,3 +571,266 @@ class TestReservedDefaultAdapterMap:
         ctx = build_default_context(KiroCrewConfig())
         for field in RESERVED_SLOTS:
             assert _reserved_slot_is_default(field, getattr(ctx, field)) is True
+
+
+# ── Agent identity CPP slot + capabilities.agentcore (public no-ops) ──
+
+_TOKEN_LIKE_STATUS_NEEDLES = (
+    "token",
+    "jwt",
+    "bearer",
+    "authorization",
+    "secret",
+    "password",
+    "credential",
+)
+
+
+def _agentcore_policy_body(
+    *,
+    fail_closed: bool = True,
+    agentcore: Optional[dict] = None,
+) -> dict:
+    body: dict = {
+        "version": 1,
+        "boot": {"fail_closed": fail_closed},
+    }
+    if agentcore is not None:
+        body["capabilities"] = {"agentcore": agentcore}
+    return body
+
+
+class TestAgentIdentitySeam:
+    """Public no-op slot: disabled Default + opt-in catalog row + fail-closed posture."""
+
+    def test_platform_context_has_agent_identity_slot(self) -> None:
+        names = {f.name for f in dataclasses.fields(PlatformContext)}
+        assert "agent_identity" in names
+        ctx = build_default_context(KiroCrewConfig())
+        assert hasattr(ctx, "agent_identity")
+
+    def test_default_agent_identity_is_disabled(self) -> None:
+        ctx = build_default_context(KiroCrewConfig())
+        adapter = ctx.agent_identity
+        assert adapter.enabled() is False
+        assert adapter.workload_identity() is None
+        assert adapter.gateway_mcp_spec() is None
+        status = adapter.status()
+        assert isinstance(status, dict)
+        for key in status:
+            lowered = str(key).lower()
+            assert not any(
+                needle in lowered for needle in _TOKEN_LIKE_STATUS_NEEDLES
+            ), f"agent_identity.status() must not expose token-like key {key!r}"
+
+    def test_bearer_fields_are_omitted_from_repr(self) -> None:
+        principal = SessionPrincipal(
+            surface="dashboard",
+            subject="user-1",
+            session_key="dashboard:main",
+            user_jwt="secret.jwt.token",
+        )
+        inbound = InboundToken(
+            scheme="Bearer",
+            token="secret-inbound",
+            expires_at=0.0,
+            audience="gateway",
+        )
+        assert "secret.jwt.token" not in repr(principal)
+        assert "secret-inbound" not in repr(inbound)
+        assert principal.user_jwt == "secret.jwt.token"
+        assert inbound.token == "secret-inbound"
+
+    def test_agent_identity_capability_is_opt_in(self) -> None:
+        spec = SCOPE_CATALOG["capabilities.agentcore"]
+        assert spec.kind == CAPABILITY
+        assert spec.capability_default is False
+
+    def test_agent_identity_enabled_without_posture_aborts_when_fail_closed(self) -> None:
+        with pytest.raises(PlatformCompositionError, match="posture"):
+            parse_policy(_agentcore_policy_body(agentcore={"enabled": True}))
+
+    def test_agent_identity_enabled_unknown_posture_aborts_when_fail_closed(self) -> None:
+        with pytest.raises(PlatformCompositionError, match="posture"):
+            parse_policy(
+                _agentcore_policy_body(agentcore={"enabled": True, "posture": "federated"})
+            )
+
+    def test_agent_identity_non_boolean_enabled_aborts_when_fail_closed(self) -> None:
+        with pytest.raises(PlatformCompositionError, match="boolean"):
+            parse_policy(
+                _agentcore_policy_body(
+                    agentcore={"enabled": "false", "posture": "workload"},
+                )
+            )
+
+    def test_agent_identity_null_enabled_aborts_when_fail_closed(self) -> None:
+        """A present ``enabled: null`` must not default the row on."""
+        with pytest.raises(PlatformCompositionError, match="boolean"):
+            parse_policy(
+                _agentcore_policy_body(
+                    agentcore={"enabled": None, "posture": "workload"},
+                )
+            )
+
+    def test_agent_identity_non_boolean_enabled_raises_when_not_fail_closed(
+        self,
+    ) -> None:
+        # CapabilityGate.from_dict rejects unconditionally; fail_closed
+        # cannot salvage a stringly-typed enabled into a disabled row.
+        with pytest.raises(PlatformCompositionError, match="boolean"):
+            parse_policy(
+                _agentcore_policy_body(
+                    fail_closed=False,
+                    agentcore={"enabled": "false", "posture": "workload"},
+                )
+            )
+
+    def test_agent_identity_enabled_without_posture_disables_when_not_fail_closed(
+        self,
+    ) -> None:
+        ceiling = parse_policy(
+            _agentcore_policy_body(fail_closed=False, agentcore={"enabled": True})
+        )
+        decision = resolve(ceiling, None, "capabilities.agentcore", "")
+        assert not decision.permitted
+
+    def test_agent_identity_enabled_with_known_posture_parses(self) -> None:
+        for posture in ("workload", "login"):
+            ceiling = parse_policy(
+                _agentcore_policy_body(
+                    agentcore={"enabled": True, "posture": posture},
+                )
+            )
+            decision = resolve(ceiling, None, "capabilities.agentcore", "")
+            assert decision.permitted, f"posture={posture!r} must remain enabled"
+
+    def test_agent_identity_known_posture_is_stored_on_ceiling(self) -> None:
+        from kiro_crew.platform.governance import agentcore_posture
+
+        for posture in ("workload", "login"):
+            ceiling = parse_policy(
+                _agentcore_policy_body(agentcore={"enabled": True, "posture": posture})
+            )
+            assert agentcore_posture(ceiling) == posture
+
+    def test_agent_identity_omitted_capability_has_no_stored_posture(self) -> None:
+        from kiro_crew.platform.governance import agentcore_posture
+
+        ceiling = parse_policy(_agentcore_policy_body())
+        assert agentcore_posture(ceiling) is None
+        assert agentcore_posture(None) is None
+
+    def test_agent_identity_disabled_row_does_not_require_posture(self) -> None:
+        from kiro_crew.platform.governance import agentcore_posture
+
+        ceiling = parse_policy(_agentcore_policy_body(agentcore={"enabled": False}))
+        assert not resolve(ceiling, None, "capabilities.agentcore", "").permitted
+        assert agentcore_posture(ceiling) is None
+
+    def test_agent_identity_fail_closed_disabled_has_no_stored_posture(self) -> None:
+        from kiro_crew.platform.governance import agentcore_posture
+
+        ceiling = parse_policy(
+            _agentcore_policy_body(fail_closed=False, agentcore={"enabled": True})
+        )
+        assert agentcore_posture(ceiling) is None
+
+    def test_agent_identity_profile_enabled_without_posture_parses(self) -> None:
+        """A profile may toggle enabled; posture is policy-only and not required."""
+        from kiro_crew.platform.governance import CapabilityGate
+
+        profile = parse_profile({"name": "host", "capabilities": {"agentcore": {"enabled": True}}})
+        gate = profile.controls["capabilities.agentcore"]
+        assert isinstance(gate, CapabilityGate)
+        assert gate.enabled is True
+
+    def test_agent_identity_profile_non_boolean_enabled_is_rejected(self) -> None:
+        """``enabled: "false"`` must not coerce to a permit through ``bool()``."""
+        with pytest.raises(PlatformCompositionError, match="boolean"):
+            parse_profile({"name": "host", "capabilities": {"agentcore": {"enabled": "false"}}})
+
+    def test_agent_identity_profile_carrying_posture_is_rejected(self) -> None:
+        """Carrying posture on a profile is a silent lie — reject like ScopedMap.posture."""
+        with pytest.raises(PlatformCompositionError, match="posture"):
+            parse_profile(
+                {
+                    "name": "host",
+                    "capabilities": {
+                        "agentcore": {"enabled": True, "posture": "login"},
+                    },
+                }
+            )
+
+    def test_agent_identity_policy_gateway_url_is_stored(self) -> None:
+        from kiro_crew.platform.governance import agentcore_gateway_url
+
+        ceiling = parse_policy(
+            _agentcore_policy_body(
+                agentcore={
+                    "enabled": True,
+                    "posture": "workload",
+                    "gateway_url": "https://gw.example.test/mcp",
+                }
+            )
+        )
+        assert agentcore_gateway_url(ceiling) == "https://gw.example.test/mcp"
+
+    def test_agent_identity_policy_rejects_http_gateway_url(self) -> None:
+        with pytest.raises(PlatformCompositionError, match="https"):
+            parse_policy(
+                _agentcore_policy_body(
+                    agentcore={
+                        "enabled": True,
+                        "posture": "workload",
+                        "gateway_url": "http://insecure.example/mcp",
+                    }
+                )
+            )
+
+    def test_agent_identity_profile_carrying_gateway_url_is_rejected(self) -> None:
+        with pytest.raises(PlatformCompositionError, match="gateway_url"):
+            parse_profile(
+                {
+                    "name": "host",
+                    "capabilities": {
+                        "agentcore": {
+                            "enabled": True,
+                            "gateway_url": "https://gw.example.test/mcp",
+                        },
+                    },
+                }
+            )
+
+    def test_agent_identity_profile_disabled_row_does_not_require_posture(self) -> None:
+        profile = parse_profile({"name": "host", "capabilities": {"agentcore": {"enabled": False}}})
+        gate = profile.controls["capabilities.agentcore"]
+        assert gate.enabled is False
+
+    def test_agent_identity_seam_stays_off_when_capability_is_off(self) -> None:
+        """Adapter-on is not enough: capability off / no posture keeps the seam off."""
+        from kiro_crew.agent import _agent_identity_enabled
+        from kiro_crew.platform.defaults import DefaultAgentIdentityProvider
+
+        class _ForcedOn(DefaultAgentIdentityProvider):
+            def enabled(self) -> bool:
+                return True
+
+        base = build_default_context(KiroCrewConfig())
+        off_ceiling = parse_policy(_agentcore_policy_body(agentcore={"enabled": False}))
+        on_ceiling = parse_policy(
+            _agentcore_policy_body(agentcore={"enabled": True, "posture": "workload"})
+        )
+        try:
+            set_context(dataclasses.replace(base, agent_identity=_ForcedOn(), governance=None))
+            assert _agent_identity_enabled() is False
+            set_context(
+                dataclasses.replace(base, agent_identity=_ForcedOn(), governance=off_ceiling)
+            )
+            assert _agent_identity_enabled() is False
+            set_context(
+                dataclasses.replace(base, agent_identity=_ForcedOn(), governance=on_ceiling)
+            )
+            assert _agent_identity_enabled() is True
+        finally:
+            reset_context()


### PR DESCRIPTION
## Problem / Motivation

The AgentCore identity + Gateway work landed as one ~18k-line PR (#6387, 111 files). That form mixes independent security boundaries and is too large to review. This is **PR 1 of 6** in a stacked split by trust boundary. Each PR is merge-safe and inert by default.

## Why it matters

Reviewers of governance and the CPP contract should not also have to review SigV4, OAuth consent, or Settings UI. A schema-only first PR lets that review happen on a small, AWS-free surface.

## What changed (motivation → approach → change)

Goal: land the contract later PRs attach to, without turning anything on.

- `AgentIdentityProvider` Protocol + `WorkloadIdentity` / `SessionPrincipal` / `InboundToken` types
- `DefaultAgentIdentityProvider` no-op (`enabled() -> False`; no tokens, no Gateway spec)
- `PlatformContext.agent_identity` slot (CONTRACT_VERSION stays 1)
- Bootstrap composes **only** the Default — no AWS swap
- `capabilities.agentcore` catalog row (`capability_default=False`)
- Policy-only `posture` / `gateway_url` / `workload_name` with fail-closed unknown posture
- AWS-free validators in `platform/agentcore_schema.py` so governance never imports boto3
- `_agent_identity_enabled()` three-conjunct probe (adapter AND capability AND known posture)
- `agentcore-inbound` reserved on the keystone leaf list (writer comes later)
- `CapabilityGate.from_dict` now rejects a non-boolean `enabled` the same way `ScopedRuleset.mode` already does. A profile or policy that previously coerced `"false"` / `1` / `"0"` will fail composition instead of silently permitting. This is the existing gate parser, not AgentCore-only.
- RFC + plan + system-spec updates for this slice

Unrelated Node/theming/Discord reversions from #6387 are **not** in this stack.

Later PRs (stacked on this one):

2. Principal propagation (default-off)
3. AWS extra + CFN/IAM adapter
4. Workload Gateway integration (SigV4 proxy, MCP inject)
5. Login attach and consent
6. Dashboard Settings UI

#6387 will be closed as superseded once the stack is up.

## Tests

- `TestAgentIdentitySeam` in `test_platform_cpp_seam_coverage.py`: Default disabled, opt-in catalog, fail-closed posture, policy-only keys rejected on profiles, https-only gateway URL, three-conjunct probe stays off without capability/posture
- `test_fully_enumerated_block_reports_no_gap` supplies a known agentcore posture
- Local: 213 passed (`test_platform_cpp_seam_coverage.py` + `test_governance_policy.py`)

## Manual verification

N/A — this PR is inert. No Settings UI, no AWS calls, no Gateway inject. Unit coverage is the verification.

## Related Issues

Supersedes the schema/CPP portion of #6387.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated
- [x] No secrets, credentials, or internal references in the diff
