### PR TITLE
fix: surface tailscale serve output on timeout and stdout paths (#6583)

### DIFF
--- a/src/kiro_crew/dashboard/tailnet_serve.py
+++ b/src/kiro_crew/dashboard/tailnet_serve.py
@@ -23,10 +23,13 @@ Two consequences of never having seen this daemon's real output on a live tailne
 (this repo's dev host has no Tailscale) shape the code, and both are deliberate
 rather than provisional:
 
-**The daemon's own stderr is always passed through verbatim.** ``code`` is a
+**The daemon's own output is always passed through verbatim.** ``code`` is a
 best-effort classification for the UI to branch on; ``detail`` carries what
-Tailscale actually said. If the classification is wrong or the phrasing changes
-upstream, the operator still sees the real reason instead of our guess at it.
+Tailscale actually said — stderr first, but stdout too, because upstream prints
+some of its most actionable messages there (the Serve enablement URL among
+them), and a timeout hands over whatever was captured before the deadline. If
+the classification is wrong or the phrasing changes upstream, the operator
+still sees the real reason instead of our guess at it.
 
 **Published-state detection does not depend on the JSON schema.** Rather than
 reading key paths from ``tailscale serve status --json`` that are unverified here,
@@ -97,9 +100,9 @@ class ServeResult:
     """Outcome of a publish/unpublish attempt.
 
     ``code`` is for branching, ``detail`` is for the human. ``detail`` includes
-    the daemon's own stderr whenever there was any, because this module's whole
-    reason to exist separately from the read path is that it must not invent a
-    reason or hide the real one.
+    the daemon's own output whenever there was any — stderr first, stdout when it
+    carries the reason — because this module's whole reason to exist separately
+    from the read path is that it must not invent a reason or hide the real one.
     """
 
     ok: bool
@@ -133,6 +136,51 @@ class ServeState:
     detail: str
 
 
+def _stream_text(stream: str | bytes | None) -> str:
+    """Normalize a ``TimeoutExpired`` stream attribute to ``str``.
+
+    ``subprocess.run(text=True)`` decodes the streams on the success path, but a
+    ``TimeoutExpired`` carries whatever ``communicate`` had at the deadline:
+    ``None`` when nothing was captured, ``bytes`` on POSIX (the exception is
+    raised below the text layer), ``str`` on Windows (``run`` re-reads the pipes
+    after killing the child). Decoded with ``errors="replace"`` because the
+    deadline can split a multibyte sequence, and a mangled character beats a
+    dropped reason.
+    """
+    if stream is None:
+        return ""
+    if isinstance(stream, bytes):
+        return stream.decode("utf-8", errors="replace")
+    return stream
+
+
+#: Ceiling on how much recovered daemon output is spliced into a ``detail``
+#: string. The interesting part (a refusal, the Serve enablement URL) leads the
+#: stream, while the pathological case — a status read that timed out mid-way
+#: through a multi-KB JSON document — would otherwise turn a one-line refusal
+#: into a raw dump in the CLI and the mobile handler's JSON response.
+_DETAIL_MAX_CHARS = 1000
+
+
+def _daemon_output(*, out: str, err: str) -> str:
+    """Whatever the daemon said, wherever it said it.
+
+    stderr leads because that is where failure text belongs, but upstream prints
+    some of its most actionable messages to STDOUT — on a tailnet where Serve is
+    not enabled, ``tailscale serve`` prints the enablement URL there and then
+    blocks — so stdout is kept too: it follows stderr when both carry text and
+    stands alone when stderr is empty. Building ``detail`` from stderr alone
+    dropped exactly that URL. Keyword-only, because with two same-typed string
+    parameters a swapped call site would silently invert the precedence.
+    """
+    err = (err or "").strip()
+    out = (out or "").strip()
+    text = f"{err}\n{out}" if err and out else (err or out)
+    if len(text) > _DETAIL_MAX_CHARS:
+        return text[:_DETAIL_MAX_CHARS] + " …"
+    return text
+
+
 def _run(args: list[str], timeout: float) -> tuple[int, str, str]:
     """Run the CLI. Returns ``(returncode, stdout, stderr)``.
 
@@ -141,7 +189,10 @@ def _run(args: list[str], timeout: float) -> tuple[int, str, str]:
     different words to the operator:
 
     * ``-1`` — no binary at any vetted path. "Tailscale is not installed here."
-    * ``-2`` — timed out.
+    * ``-2`` — timed out, with whatever the child wrote before the deadline in
+      ``stdout``/``stderr``. On a Serve-disabled tailnet the command prints the
+      enablement URL and then blocks forever, so the timeout is the only
+      reachable outcome and the captured output IS the diagnosis.
     * ``-3`` — the binary exists but could not be launched (``OSError``), with the
       OS's own message in ``stderr``. Collapsing this into ``-1`` told the operator
       "tailscale was not found" about a binary that is right there — the misleading
@@ -167,25 +218,28 @@ def _run(args: list[str], timeout: float) -> tuple[int, str, str]:
             check=False,
             env=scrub_env(),
         )
-    except subprocess.TimeoutExpired:
-        return -2, "", ""
+    except subprocess.TimeoutExpired as exc:
+        return -2, _stream_text(exc.stdout), _stream_text(exc.stderr)
     except (OSError, subprocess.SubprocessError) as exc:
         logger.debug("tailscale %s failed to run: %s", " ".join(args), exc)
         return -3, "", str(exc)
     return proc.returncode, proc.stdout or "", proc.stderr or ""
 
 
-def _classify(stderr: str) -> ResultCode:
+def _classify(output: str) -> ResultCode:
     """Best-effort code for a non-zero exit. Never the only thing reported.
 
     Matching on message text is inherently fragile — upstream owns this wording
     and can change it — so this only ever *adds* a hint on top of the verbatim
-    stderr the caller also surfaces. The two codes worth separating are the ones
-    with different remedies: a permission problem needs ``sudo`` or an
-    ``--operator`` grant, while an unreachable daemon needs it started or logged
-    in.
+    output the caller also surfaces. Callers feed it the LEADING stream only
+    (stderr, or stdout when stderr is empty), never the concatenation: with both
+    streams in view, incidental stdout text containing "operator" would flip a
+    daemon-down failure to ``no_permission`` and attach a confidently wrong
+    remedy. The two codes worth separating are the ones with different remedies:
+    a permission problem needs ``sudo`` or an ``--operator`` grant, while an
+    unreachable daemon needs it started or logged in.
     """
-    low = stderr.lower()
+    low = output.lower()
     if any(
         s in low
         for s in ("access denied", "permission denied", "must be run as root", "operator")
@@ -283,14 +337,18 @@ def serve_state(port: int) -> ServeState:
             None, None, "The tailscale CLI was not found in a standard install location."
         )
     if rc == -2:
-        return ServeState(None, None, "The tailscale CLI did not respond in time.")
+        said = _daemon_output(out=out, err=err)
+        detail = "The tailscale CLI did not respond in time."
+        if said:
+            detail += f" Before the deadline it printed: {said}"
+        return ServeState(None, None, detail)
     if rc == -3:
         return ServeState(
             None, None, f"The tailscale CLI could not be launched: {(err or '').strip()}"
         )
     if rc != 0:
         return ServeState(
-            None, None, (err or "").strip() or f"tailscale serve status exited {rc}"
+            None, None, _daemon_output(out=out, err=err) or f"tailscale serve status exited {rc}"
         )
     try:
         doc = json.loads(out or "")
@@ -413,7 +471,7 @@ def publish(port: int, *, audit_tool: str = "tailnet_publish") -> ServeResult:
             f"sure, run `tailscale serve --bg --https={SERVE_HTTPS_PORT} "
             f"http://127.0.0.1:{port}` yourself.",
         )
-    rc, _out, err = _run(
+    rc, out, err = _run(
         ["serve", "--bg", f"--https={SERVE_HTTPS_PORT}", f"http://127.0.0.1:{port}"],
         _WRITE_TIMEOUT_SECS,
     )
@@ -426,12 +484,18 @@ def publish(port: int, *, audit_tool: str = "tailnet_publish") -> ServeResult:
             "yourself and set dashboard.url instead.",
         )
     if rc == -2:
-        return ServeResult(
-            False,
-            "timeout",
+        # The most common way to land here is a Serve-disabled tailnet: the CLI
+        # prints the enablement URL to stdout and then blocks waiting for the
+        # capability, so the captured output carries the one thing the operator
+        # needs and the timeout heading alone would hide it.
+        said = _daemon_output(out=out, err=err)
+        detail = (
             "tailscale serve did not respond in time. It may still have applied — "
-            "check `kirocrew tailnet status` before retrying.",
+            "check `kirocrew tailnet status` before retrying."
         )
+        if said:
+            detail += f" Before the deadline it printed: {said}"
+        return ServeResult(False, "timeout", detail)
     if rc == -3:
         return ServeResult(
             False,
@@ -440,8 +504,8 @@ def publish(port: int, *, audit_tool: str = "tailnet_publish") -> ServeResult:
             + (err or "").strip(),
         )
     if rc != 0:
-        code = _classify(err)
-        said = (err or "").strip()
+        said = _daemon_output(out=out, err=err)
+        code = _classify(err.strip() or out.strip())
         hint = ""
         if code == "no_permission":
             # The single most likely refusal on Linux, and the one an operator
@@ -560,7 +624,7 @@ def unpublish(port: int, *, audit_tool: str = "tailnet_unpublish") -> ServeResul
             f"you are sure, run `tailscale serve --https {SERVE_HTTPS_PORT} "
             f"--set-path={SERVE_MOUNT} off` yourself.",
         )
-    rc, _out, err = _run(
+    rc, out, err = _run(
         [
             "serve",
             "--https",
@@ -573,14 +637,19 @@ def unpublish(port: int, *, audit_tool: str = "tailnet_unpublish") -> ServeResul
     if rc == -1:
         return ServeResult(False, "no_cli", "The tailscale CLI was not found; nothing to do.")
     if rc == -2:
-        return ServeResult(False, "timeout", "tailscale serve did not respond in time.")
+        said = _daemon_output(out=out, err=err)
+        detail = "tailscale serve did not respond in time."
+        if said:
+            detail += f" Before the deadline it printed: {said}"
+        return ServeResult(False, "timeout", detail)
     if rc == -3:
         return ServeResult(
             False, "failed", "The tailscale CLI could not be launched: " + (err or "").strip()
         )
     if rc != 0:
-        code = _classify(err)
-        return ServeResult(False, code, (err or "").strip() or f"tailscale serve exited {rc}")
+        said = _daemon_output(out=out, err=err)
+        code = _classify(err.strip() or out.strip())
+        return ServeResult(False, code, said or f"tailscale serve exited {rc}")
     return ServeResult(
         True, "ok", "The dashboard is no longer published on this machine's tailnet."
     )

--- a/test/test_tailnet_serve.py
+++ b/test/test_tailnet_serve.py
@@ -4,11 +4,12 @@ The sibling suite (``test_tailnet_origin.py``) pins the opposite property — th
 the READ path swallows everything and degrades to "contributes nothing". Here the
 weighting is inverted, because a publish that fails silently is the bug:
 
-* :class:`TestFailureReporting` pins that the daemon's own stderr reaches the
-  caller **verbatim**, and that the two refusals with different remedies
-  (permission vs. daemon down) are told apart. The classifier matches on upstream
-  wording we do not own, so the tests assert the raw text is present regardless of
-  whether the classification lands.
+* :class:`TestFailureReporting` pins that the daemon's own output reaches the
+  caller **verbatim** — stderr first, stdout when the reason lives there, and a
+  timeout's captured streams too — and that the two refusals with different
+  remedies (permission vs. daemon down) are told apart. The classifier matches on
+  upstream wording we do not own, so the tests assert the raw text is present
+  regardless of whether the classification lands.
 * :class:`TestGovernance` pins the ASYMMETRY that makes the ceiling coherent:
   publishing is refused when pinned and does not spawn the CLI at all, while
   *withdrawing* is never gated — a fail-closed control that could not un-expose a
@@ -66,7 +67,12 @@ def _patch_cli(**run_kwargs):
     )
 
 
-def _patch_cli_write_fails(returncode: int = 1, stderr: str = "", exc: BaseException | None = None):
+def _patch_cli_write_fails(
+    returncode: int = 1,
+    stderr: str = "",
+    stdout: str = "",
+    exc: BaseException | None = None,
+):
     """CLI installed; `serve status` SUCCEEDS with a free mount, the WRITE fails.
 
     A single mock answering every invocation identically is not how a daemon behaves —
@@ -81,7 +87,7 @@ def _patch_cli_write_fails(returncode: int = 1, stderr: str = "", exc: BaseExcep
             return _proc("{}")
         if exc is not None:
             raise exc
-        return _proc(returncode=returncode, stderr=stderr)
+        return _proc(stdout=stdout, returncode=returncode, stderr=stderr)
 
     return (
         patch.object(tailnet_serve, "_cli_path", return_value=_CLI),
@@ -251,6 +257,181 @@ class TestFailureReporting:
             result = tailnet_serve.publish(_PORT)
         assert result.code == "no_cli"
         assert not result.ok
+
+
+class TestTimeoutOutputIsNotDiscarded:
+    """The timeout's captured streams ARE the diagnosis, so they must survive it.
+
+    On a tailnet where Serve is not enabled (the default), ``tailscale serve``
+    prints the enablement URL to stdout and then blocks waiting for the
+    capability — a timeout is the only reachable outcome, and dropping the
+    exception's ``.stdout``/``.stderr`` rendered the one actionable line as a
+    bare "did not respond in time".
+    """
+
+    _URL = "https://login.tailscale.com/f/serve?node=nTEST"
+
+    @staticmethod
+    def _timeout_exc(
+        stdout: str | bytes | None = None, stderr: str | bytes | None = None
+    ) -> subprocess.TimeoutExpired:
+        return subprocess.TimeoutExpired("tailscale", 15, output=stdout, stderr=stderr)
+
+    def test_run_returns_the_captured_streams(self) -> None:
+        cli, run = _patch_cli(side_effect=self._timeout_exc(stdout="from out", stderr="from err"))
+        with cli, run:
+            rc, out, err = tailnet_serve._run(["serve"], 1.0)
+        assert (rc, out, err) == (-2, "from out", "from err")
+
+    def test_none_streams_become_empty_strings(self) -> None:
+        """A timeout that captured nothing must not grow a dangling suffix."""
+        cli, run = _patch_cli(side_effect=self._timeout_exc())
+        with cli, run:
+            rc, out, err = tailnet_serve._run(["serve"], 1.0)
+        assert (rc, out, err) == (-2, "", "")
+
+    def test_bytes_streams_are_decoded(self) -> None:
+        """POSIX raises the exception below the text layer, so streams arrive as bytes.
+
+        An invalid sequence (a multibyte character split by the deadline) must
+        degrade to a replacement character, never to a decode error that eats the
+        rest of the reason.
+        """
+        cli, run = _patch_cli(
+            side_effect=self._timeout_exc(stdout=self._URL.encode() + b"\xff", stderr=b"warn")
+        )
+        with cli, run:
+            rc, out, err = tailnet_serve._run(["serve"], 1.0)
+        assert rc == -2
+        assert self._URL in out
+        assert "\ufffd" in out
+        assert err == "warn"
+
+    def test_publish_timeout_surfaces_the_enablement_url(self) -> None:
+        cli, run = _patch_cli_write_fails(exc=self._timeout_exc(stdout=self._URL))
+        with cli, run, patch.object(
+            tailnet_serve, "is_governance_pinned_off", return_value=False
+        ):
+            result = tailnet_serve.publish(_PORT)
+        assert result.code == "timeout"
+        # The ambiguity warning is kept — the config may still have applied.
+        assert "may still have applied" in result.detail
+        assert self._URL in result.detail
+
+    def test_publish_timeout_without_output_has_no_dangling_suffix(self) -> None:
+        cli, run = _patch_cli_write_fails(exc=self._timeout_exc())
+        with cli, run, patch.object(
+            tailnet_serve, "is_governance_pinned_off", return_value=False
+        ):
+            result = tailnet_serve.publish(_PORT)
+        assert result.code == "timeout"
+        assert "it printed" not in result.detail
+
+    def test_unpublish_timeout_surfaces_output(self) -> None:
+        cli, run = _patch_cli(side_effect=self._timeout_exc(stderr="context deadline exceeded"))
+        with cli, run, patch.object(
+            tailnet_serve, "serve_state", return_value=ServeState(True, True, "ours")
+        ):
+            result = tailnet_serve.unpublish(_PORT)
+        assert result.code == "timeout"
+        assert "did not respond in time" in result.detail
+        assert "context deadline exceeded" in result.detail
+
+    def test_serve_state_timeout_surfaces_output(self) -> None:
+        cli, run = _patch_cli(side_effect=self._timeout_exc(stdout="partial status text"))
+        with cli, run:
+            state = tailnet_serve.serve_state(_PORT)
+        assert state.published is None
+        assert "did not respond in time" in state.detail
+        assert "partial status text" in state.detail
+
+
+class TestStdoutCarriedReasons:
+    """A fast non-zero exit whose reason went to stdout must not report blank.
+
+    Upstream does not reserve stderr for its refusals, and ``detail`` built from
+    stderr alone rendered a stdout-only message as the bare fallback string.
+    """
+
+    def test_a_stdout_only_reason_reaches_the_detail(self) -> None:
+        cli, run = _patch_cli_write_fails(stdout="Serve is not enabled; visit https://x")
+        with cli, run, patch.object(
+            tailnet_serve, "is_governance_pinned_off", return_value=False
+        ):
+            result = tailnet_serve.publish(_PORT)
+        assert not result.ok
+        assert "Serve is not enabled; visit https://x" in result.detail
+
+    def test_a_stdout_only_reason_feeds_classification(self) -> None:
+        cli, run = _patch_cli_write_fails(stdout="access denied: serve config")
+        with cli, run, patch.object(
+            tailnet_serve, "is_governance_pinned_off", return_value=False
+        ):
+            result = tailnet_serve.publish(_PORT)
+        assert result.code == "no_permission"
+
+    def test_stderr_leads_when_both_streams_carry_text(self) -> None:
+        cli, run = _patch_cli_write_fails(stderr="the refusal", stdout="the context")
+        with cli, run, patch.object(
+            tailnet_serve, "is_governance_pinned_off", return_value=False
+        ):
+            result = tailnet_serve.publish(_PORT)
+        assert "the refusal" in result.detail
+        assert "the context" in result.detail
+        assert result.detail.index("the refusal") < result.detail.index("the context")
+
+    def test_stdout_never_flips_a_correct_stderr_classification(self) -> None:
+        """Classification reads the leading stream, never the concatenation.
+
+        Incidental stdout text containing "operator" beside a daemon-down stderr
+        would otherwise flip the code to ``no_permission`` and attach a sudo /
+        --operator remedy to a stopped daemon — a confidently wrong hint, which is
+        the defect class this module exists to avoid. The verbatim detail still
+        carries both streams.
+        """
+        cli, run = _patch_cli_write_fails(
+            stderr="tailscaled is not running",
+            stdout="run `tailscale set --operator=$USER` to allow serve",
+        )
+        with cli, run, patch.object(
+            tailnet_serve, "is_governance_pinned_off", return_value=False
+        ):
+            result = tailnet_serve.publish(_PORT)
+        assert result.code == "daemon_unavailable"
+        assert "tailscaled is not running" in result.detail
+
+    def test_recovered_output_is_capped_not_dumped(self) -> None:
+        """A status read that dies mid-document must not paste multi-KB JSON.
+
+        The leading slice survives (the actionable line comes first), the tail is
+        elided — a raw serve-config dump in a refusal string is worse for the
+        operator than no detail at all.
+        """
+        blob = "x" * 5000
+        cli, run = _patch_cli(return_value=_proc(blob, returncode=1))
+        with cli, run:
+            state = tailnet_serve.serve_state(_PORT)
+        assert len(state.detail) < 1200
+        assert state.detail.endswith("…")
+
+    def test_unpublish_keeps_a_stdout_only_reason(self) -> None:
+        def _dispatch(argv, *_a, **_k):
+            if argv[1:4] == ["serve", "status", "--json"]:
+                return _proc(_doc(f"http://127.0.0.1:{_PORT}"))
+            return _proc(stdout="cannot remove: reason on stdout", returncode=1)
+
+        cli, run = _patch_cli(side_effect=_dispatch)
+        with cli, run:
+            result = tailnet_serve.unpublish(_PORT)
+        assert not result.ok
+        assert "cannot remove: reason on stdout" in result.detail
+
+    def test_serve_state_keeps_a_stdout_only_reason(self) -> None:
+        cli, run = _patch_cli(return_value=_proc("health warning on stdout", returncode=1))
+        with cli, run:
+            state = tailnet_serve.serve_state(_PORT)
+        assert state.published is None
+        assert "health warning on stdout" in state.detail
 
 
 class TestSpawnHardening:


### PR DESCRIPTION
# Summary

Publishing the dashboard to a tailnet could fail with an empty, unactionable error: `_run` caught `subprocess.TimeoutExpired` and returned `-2, "", ""`, discarding the `.stdout`/`.stderr` the exception carries under `capture_output=True`. All three `rc == -2` branches then rendered a fixed "did not respond in time" string. On a Serve-disabled tailnet (the default), `tailscale serve` prints the enablement URL to **stdout** and then blocks forever — so the timeout is the only reachable outcome and the one actionable line was dropped, violating the module's own "output passed through verbatim" contract.

## Changes

- `_run`'s `TimeoutExpired` handler returns the captured streams, normalized by a new `_stream_text` helper (`None` → `""`, `bytes` → decoded with `errors="replace"` — POSIX raises the exception below the text layer, Windows re-reads post-kill as `str`).
- All three `rc == -2` branches (`serve_state`, `publish`, `unpublish`) keep their existing heading (including publish's "may still have applied" ambiguity warning) and append the recovered output to `detail`.
- Secondary stdout gap closed: `detail` is built from the combined output via `_daemon_output` (stderr leads, stdout follows or stands alone when stderr is empty), so a fast non-zero exit whose reason went to stdout no longer renders the bare fallback string.
- `_classify` is fed the **leading stream only** (stderr, or stdout when stderr is empty), never the concatenation — incidental stdout text containing "operator" beside a daemon-down stderr must not flip the code to `no_permission` and attach a confidently wrong sudo/`--operator` remedy.
- Recovered output is capped at `_DETAIL_MAX_CHARS` so a status read that dies mid-way through a multi-KB JSON document does not paste the dump into a refusal string.
- Docstrings updated where they said "stderr" only (module head, `ServeResult`, `_classify`).

Deliberately NOT done, per the issue: no `_WRITE_TIMEOUT_SECS` tuning and no retry logic — on a Serve-disabled tailnet the command blocks forever, so the fix is surfacing the reason, not avoiding the timeout.

## Testing

- 15 new/extended pins in `test/test_tailnet_serve.py` (mocked `subprocess.run`, no real tailscale binary): timeout streams propagate into `_run`'s tuple and all three branch details; `bytes`/`None`/invalid-sequence normalization; no dangling suffix when nothing was captured; stdout-only reasons reach detail and classification; stderr leads when both streams carry text; stdout never flips a correct stderr classification; oversized output is capped.
- Local gates green: isort, flake8, mypy (1153 files), black/subprocess-encoding/brand/harness diff gates, targeted tailnet suites (214 tests), full backend suite (73k passed; 94 failures are the known host-env set — file-explorer, isolation-floor, AF_UNIX path length — none touching tailnet).

## Pre-push review

Dual blind model-pinned review: GPT lane PASS (0 findings); Opus lane PASS (0 blocking, 6 advisories — the High classification-inversion and Medium unbounded-detail findings adopted with pin tests, keyword-only `_daemon_output` and test annotation adopted; locale-based decoding declined because the repo's subprocess-encoding gate pushes away from locale code pages, newline-splice declined because verbatim multi-line stderr already flowed into `detail` before this change).

No UI change — no screenshots.

Closes #6583
