### PR TITLE
docs: correct stale rotation-hash and fail-closed-gate docstrings

### DIFF
--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -17,10 +17,15 @@ auditing happen IN THE GATEWAY (``computer_use/tools.py`` →
   ``hooks._governance_denial`` — the PreToolUse gate — is fail-**OPEN** by
   deliberate repo policy (a governance glitch must not wedge every tool call on
   every surface), so it cannot be the sole authorization point for a surface that
-  can read a password field's ``AXValue``. The authoritative gate
-  (``gate.require_computer_use``) fails CLOSED and needs the OS-resolved app
-  identity and the addressed element's role — which only the gateway-side tool
-  body has.
+  can read a password field's ``AXValue``. The fail-CLOSED gate is the keystone
+  primary enable, read at the top of ``computer_use/tools.py``'s ordered
+  chokepoint: a keystone that is missing, unreadable or disabled refuses the call
+  outright. ``gate.require_computer_use`` is audit-only — it unconditionally
+  permits and records the call, retained as the one place a future edition can
+  reintroduce a decision without touching every call site — and the refusals
+  downstream of the enable (the operator's target policy, the element and pointer
+  shape checks) need the OS-resolved app identity and the addressed element's
+  role, which only the gateway-side tool body has.
 * **Governance and the audit trail live where the platform context is composed.**
   The ceiling, the profile store and the SEL trust root are all gateway state.
 * **No native code in this process.** This module imports no ctypes, loads no

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -17,9 +17,12 @@ Rotation: the live log is closed at ``_SEGMENT_MAX_BYTES`` and renamed into
 ``<config_dir>/security_events.d/``, keeping ``_SEGMENT_KEEP`` closed segments.
 Each segment is an INDEPENDENT HMAC chain (it starts from genesis), and the
 first record of every new live log is a ``sel_rotation`` event naming the
-segment just closed and its final ``entry_hash`` — so the boundary is auditable
-evidence rather than a chain break, and retention deleting an old segment leaves
-every surviving segment verifiable on its own.
+segment just closed and its size — deliberately NOT that segment's final
+``entry_hash``, which a sibling process still holding a writable fd to the
+renamed inode could invalidate, making verification report an untampered log as
+compromised. The segment NAME is what lets an investigator walk the sequence, so
+the boundary is auditable evidence rather than a chain break, and retention
+deleting an old segment leaves every surviving segment verifiable on its own.
 Retention: configurable, default 365 days per Amazon Security Event Logging Standard.
 """
 
@@ -1681,11 +1684,14 @@ class SecurityEventLog:
         new live log starts from genesis, so BOTH verify independently and
         retention deleting an old segment can never break a surviving one. The
         boundary is not lost — it is recorded as the new log's first entry, a
-        ``sel_rotation`` event naming the closed segment and its final
-        ``entry_hash``. An investigator can therefore still walk segment to
-        segment, and a segment that was deleted or swapped is visible as a
-        rotation record whose named predecessor is absent or ends on a different
-        hash.
+        ``sel_rotation`` event naming the closed segment and its size. It
+        deliberately does NOT claim that segment's final ``entry_hash``: a hash
+        captured here can be stale by the time the record is written (see
+        :meth:`_rotation_event`), which would make verification report an
+        untampered log as compromised. An investigator can therefore still walk
+        segment to segment, and a segment that was deleted or swapped is visible
+        as a rotation record whose named predecessor is absent or whose entries
+        fail their own per-record HMACs.
         """
         size = self._live_size()
         if size < _SEGMENT_MAX_BYTES:


### PR DESCRIPTION
## Problem / Motivation

Two docstrings describe behaviour the code deliberately does not have. Both are
load-bearing prose about *security* invariants, so a reader who trusts them ends up
with the wrong mental model of what the log proves and what actually refuses a call.

1. **`src/kiro_crew/sel.py`** — the module docstring and `_rotate_under_lock`'s
   docstring both state that the `sel_rotation` boundary record names the closed
   segment *and its final `entry_hash`*. It does not. `_rotation_event` writes only
   `{previous_segment, previous_bytes}` and its own docstring says the omission is
   deliberate. `_rotate_under_lock` compounded it by describing the detection
   mechanism that follows from the missing hash ("a rotation record whose named
   predecessor … ends on a different hash").
2. **`src/kiro_crew/mcp_computer.py`** — states that "the authoritative gate
   (`gate.require_computer_use`) fails CLOSED". That function is now audit-only:
   `computer_use/gate.py` documents it as "Always returns `None` (proceed). Audits
   the call. … there is no longer a governance decision to make", and
   `computer_use/tools.py` calls it "now audit-only, and unconditionally permits".

## Why it matters

Both docstrings were read as source material for a customer-facing governance
document, and both produced concrete errors in it: it asserted that the SEL rotation
boundary carries the closed segment's terminal hash (so a swapped segment is caught
by a hash mismatch), and that `require_computer_use` is the fail-closed authorization
point for computer use. Neither is true of the shipped code. The first overstates
what an integrity verification can detect; the second names a function that permits
unconditionally as the control, and omits the keystone primary enable that is the
actual refusal. Left in place, these are the docstrings the next such document,
and the next reader auditing the security posture, will be written from.

## What changed (motivation → approach → change)

**sel.py.** Symptom: two docstrings promise an `entry_hash` in the rotation record.
Root cause: an earlier revision *did* write it, `_rotation_event` removed it (a hash
captured at rename time can be stale, because a sibling process may still hold a
writable fd to the renamed inode — so the record could report an untampered log as
compromised), but the two callers' prose was never updated with it. Change: both
docstrings now say the record names the closed segment and its **size**, state
explicitly that the final `entry_hash` is deliberately not claimed, and carry the
reason forward so the omission does not read as an oversight to be "fixed" later.
`_rotate_under_lock`'s detection sentence is corrected to the mechanism that does
hold — a predecessor that is absent, or whose entries fail their own per-record
HMACs.

**mcp_computer.py.** Symptom: the docstring names a permit-only function as the
fail-closed gate. Root cause: the governance decision was removed from
`require_computer_use` and the fail-closed check now lives upstream, at step (1) of
`computer_use/tools.py`'s ordered chokepoint (`if not enable_state.is_enabled(state)`
→ `REFUSAL_DISABLED`); the module docstring still described the old arrangement.
Change: the bullet now names the keystone primary enable as the fail-CLOSED gate,
describes `require_computer_use` as audit-only (retained so a future edition can
reintroduce a decision without touching every call site), and re-attaches the
"needs OS-resolved app identity and element role" justification to the refusals that
genuinely need it — the operator's target policy and the element/pointer shape
checks. The surrounding argument for the split (`hooks._governance_denial` is
fail-OPEN, so it cannot be the sole authorization point) is unchanged.

## Tests

None added or changed. The diff touches only docstring prose — no statement, no
signature, no control flow — so there is no behaviour for a test to lock in. I
confirmed no test or doc asserts on the replaced wording (`grep` for
``final ``entry_hash```` and `authoritative gate` / `fails CLOSED and needs` across
`test/` and `docs/`): the only hits outside the two edited files are
`test/test_mcp_computer.py`'s own module docstring, which is prose, not an
assertion — see the known adjacent issues below.

## Manual verification

Ran the existing suites covering both modules — `test/test_sel.py`,
`test_sel_dashboard_offload.py`, `test_sel_prune_streaming.py`,
`test_mcp_computer.py`, `test_computer_use_gate.py`: **465 passed**. Gates green
on the changed files: `scripts/check_black_formatting.py` (2 files in scope),
`isort --check-only`, `flake8`, `mypy` (no issues in 2 source files). Each new
docstring claim was read back against the implementation it describes —
`_rotation_event`'s `metadata` dict for the SEL records, and
`computer_use/tools.py` step (1) plus `gate.require_computer_use`'s body for the
computer-use gate.

### Known adjacent issues, deliberately NOT in this PR

Both are the same class of defect and each deserves its own scoped change:

- `src/kiro_crew/mcp_tools/browser.py` (module docstring) claims `schemas()` returns
  `[]` when `playwright-cli` is absent; the body contradicts it.
- `test/test_mcp_computer.py` (module docstring) repeats the same
  `require_computer_use` fail-CLOSED claim corrected here in `mcp_computer.py`.

## Related Issues

no linked issue: stale docstrings found while reading these modules to write a
governance document; no tracking issue was filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
