### PR TITLE
fix(governance): fail closed on unknown sandbox policy keys

### DIFF
--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -1878,6 +1878,29 @@ _KEY_OPEN_NAMESPACES = frozenset({"capabilities"})
 # (require_isolation, env_scrub_prefixes) kept raw under a reserved scope.
 _SANDBOX_FLAGS_SCOPE = "sandbox._flags"
 
+# The EXHAUSTIVE set of non-governed ``sandbox`` boot flags that may ride raw
+# under ``_SANDBOX_FLAGS_SCOPE``.  Anything else under ``sandbox`` fails closed
+# like every other fixed-child namespace (filesystem, folders, network).
+#
+# Why an allowlist rather than blanket tolerance: ``sandbox.min_level`` is the
+# ordinal floor with the widest blast radius in the catalog, and the reserved
+# scope is WRITE-ONLY — nothing reads it back.  Blanket tolerance therefore
+# turned a one-character typo into silent total loss of the floor:
+# ``{"sandbox": {"min_levl": "strict"}}`` parsed clean, reported OK from
+# ``kirocrew policy validate``, rendered as a governed scope in
+# ``kirocrew policy show``, and left ``sandbox.min_level`` absent — so
+# ``sandbox._governance_sandbox_floor()`` read "ungoverned" and clamped nothing.
+# Green validation with zero enforcement is precisely the failure class this
+# model exists to prevent, so an unrecognized child must be loud.
+#
+# Why not reject EVERY non-``min_level`` child: these two names are documented
+# in-code above as reserved, and a deployed policy may already carry one.
+# Rejecting them would abort boot on a policy that parses today, converting a
+# diagnostic gap into an availability regression.  Keeping the two known names
+# accepted costs nothing (they are inert either way) and confines the new
+# strictness to names nobody has been told are valid.
+_SANDBOX_RESERVED_FLAGS = frozenset({"require_isolation", "env_scrub_prefixes"})
+
 # Scope aliases: the provider doc names the profile's path scopes ``folders.read``/
 # ``folders.write`` but the policy names them ``filesystem.read``/``.write`` (App.
 # A.3 note + the worked example). They are the SAME path ceiling — both resolve
@@ -2042,8 +2065,11 @@ def _parse_controls(
                 dotted = f"{key}.{sub}"
                 if dotted in SCOPE_CATALOG:
                     take(dotted, sub_raw)
-                elif key == "sandbox":
-                    # Non-governed boot flags ride raw under a reserved scope.
+                elif key == "sandbox" and sub in _SANDBOX_RESERVED_FLAGS:
+                    # A KNOWN non-governed boot flag rides raw under a reserved
+                    # scope.  The membership test is what keeps a typo'd
+                    # ``min_level`` from being swallowed here instead of
+                    # reaching the fail-closed raise below.
                     controls.setdefault(_SANDBOX_FLAGS_SCOPE, {})  # type: ignore[arg-type]
                     controls[_SANDBOX_FLAGS_SCOPE][sub] = sub_raw  # type: ignore[index]
                 else:

--- a/test/test_governance_policy.py
+++ b/test/test_governance_policy.py
@@ -378,6 +378,55 @@ class TestLoader:
         with pytest.raises(PlatformCompositionError):
             parse_policy(_policy_body(bogus_scope={"mode": "allow"}))
 
+    def test_typod_sandbox_child_fails_closed(self):
+        """A typo'd ``min_level`` must RAISE, not vanish into the reserved scope.
+
+        ``sandbox`` used to accept ANY child into the write-only
+        ``sandbox._flags`` scope, so ``min_levl`` parsed clean and left the
+        floor absent — green validation, zero enforcement, on the ordinal with
+        the widest blast radius.  The message names the key so the operator can
+        see WHICH key was rejected.
+        """
+        with pytest.raises(PlatformCompositionError) as exc:
+            parse_policy(_policy_body(sandbox={"min_levl": "strict"}))
+        assert "sandbox.min_levl" in str(exc.value)
+        assert "fail-closed" in str(exc.value)
+
+    def test_typod_sandbox_child_does_not_silently_drop_the_floor(self):
+        """The regression's CONSEQUENCE: it must not parse to an absent floor.
+
+        Pinned separately from the raise so a future change that re-tolerates
+        the key cannot pass by merely raising somewhere else — what must never
+        happen again is a ceiling that reports success while
+        ``sandbox.min_level`` is unset.
+        """
+        try:
+            ceiling = parse_policy(_policy_body(sandbox={"min_levl": "strict"}))
+        except PlatformCompositionError:
+            return
+        pytest.fail(f"parsed clean with sandbox.min_level={ceiling.get('sandbox.min_level')!r}")
+
+    def test_reserved_sandbox_boot_flags_still_parse(self):
+        """The compatibility half: the documented reserved flags must still load."""
+        ceiling = parse_policy(
+            _policy_body(
+                sandbox={
+                    "min_level": "strict",
+                    "require_isolation": True,
+                    "env_scrub_prefixes": ["AWS_SECRET"],
+                }
+            )
+        )
+        assert isinstance(ceiling.get("sandbox.min_level"), OrdinalControl)
+        flags = ceiling.controls["sandbox._flags"]
+        assert flags == {"require_isolation": True, "env_scrub_prefixes": ["AWS_SECRET"]}
+
+    def test_sandbox_min_level_alone_still_parses(self):
+        """The overwhelmingly common shape must be untouched by the new check."""
+        ceiling = parse_policy(_policy_body(sandbox={"min_level": "strict"}))
+        assert isinstance(ceiling.get("sandbox.min_level"), OrdinalControl)
+        assert "sandbox._flags" not in ceiling.controls
+
 
 # ──────────────────────────────────────────────────────────────────────────
 # Policy / Profile parsing


### PR DESCRIPTION
## Problem / Motivation

`_parse_controls` in `src/kiro_crew/platform/governance.py` accepted **any**
child of the `sandbox` policy namespace into the reserved `sandbox._flags`
scope, instead of rejecting names it does not recognize:

```python
elif key == "sandbox":
    # Non-governed boot flags ride raw under a reserved scope.
    controls.setdefault(_SANDBOX_FLAGS_SCOPE, {})
    controls[_SANDBOX_FLAGS_SCOPE][sub] = sub_raw
```

That reserved scope is **write-only**: `sandbox._flags` is assigned here and
read nowhere in the repository (`grep` finds it only at its definition, line
1879, and at these two assignments). So an unrecognized `sandbox` child was
not "kept raw for later" — it was discarded, silently.

Every sibling fixed-child namespace (`filesystem`, `folders`, `network`)
already raises `PlatformCompositionError` on an unknown child a few lines
below. `sandbox` was the sole exception, and it is the namespace carrying
`sandbox.min_level`.

## Why it matters

A one-character typo silently disabled the sandbox floor entirely. This
policy:

```json
{"version": 1, "boot": {"fail_closed": true},
 "sandbox": {"min_levl": "strict"}}
```

behaved as follows on `origin/main` before this change (measured, not
inferred):

- `parse_policy` returned successfully, with `controls == {"sandbox._flags": ...}`
- `ceiling.get("sandbox.min_level")` was `None`
- **`kirocrew policy validate` printed `Policy: v1 OK (1 governed scopes)` and `✅ valid`**
- `kirocrew policy show` rendered `sandbox._flags` as a governed scope, so the
  policy *looked* enforced
- `sandbox.py::_governance_sandbox_floor()` read `governance_floor_ordinal("sandbox.min_level")`
  → `None` → "ungoverned" → `_clamp_sandbox_mode` clamped nothing

The operator sees a green validation, a governed-looking `policy show`, and no
warning anywhere, while the host runs with **no sandbox floor at all**. Green
validation with zero enforcement is the exact failure class the governance
model exists to prevent, and this was it on the ordinal with the widest blast
radius in the catalog.

The typo does not even have to be in `min_level`: any misspelling
(`sandbox.mode`, `sandbox.level`, `sandbox.minimum_level`) had the same
outcome.

## What changed (motivation → approach → change)

**Symptom** → a policy naming `sandbox.min_levl` boots clean, validates
green, and enforces no floor.

**Root cause** → the `elif key == "sandbox"` branch is unconditional on the
child name, so it intercepts every unrecognized child *before* control reaches
the `else: raise PlatformCompositionError(...)` that the sibling namespaces
rely on. The destination scope is never read, so the interception is a
discard.

**Change** → restrict that branch to an explicit allowlist so an unrecognized
child falls through to the existing fail-closed raise:

```python
_SANDBOX_RESERVED_FLAGS = frozenset({"require_isolation", "env_scrub_prefixes"})
...
elif key == "sandbox" and sub in _SANDBOX_RESERVED_FLAGS:
```

No new error path is introduced — the rejection reuses the raise the sibling
namespaces already use, so the message reads consistently:

```
unknown governed key 'sandbox.min_levl' (fail-closed)   ← new
unknown governed key 'network.egres' (fail-closed)      ← pre-existing sibling
```

### ⚠️ Compatibility decision — allowlist, not blanket rejection

Rejecting **every** non-`min_level` child would be simpler and stricter, but
it would abort boot for any deployed policy that already carries a reserved
flag — turning a diagnostic gap into an availability regression, under
`fail_closed: true`. I chose the allowlist. The two names in it were
established from evidence, not assumption:

| Evidence source | `require_isolation` | `env_scrub_prefixes` | any other name |
|---|---|---|---|
| Named as reserved by the in-code comment at governance.py:1877-1878 | yes | yes | no |
| Present in a test fixture | yes — `test_governance_policy.py:389` (`_policy_body(sandbox={"min_level": "cc", "require_isolation": True})`) | no | no |
| Present in a shipped policy JSON / template / doc example | no | no | no |
| Read by any consumer | no | no | no |

Findings behind that table:

- Every `sandbox` policy block anywhere in the repo — 18 occurrences across 5
  governance test files, plus every doc example — uses **only** `min_level`,
  with the single exception of `test_governance_policy.py:389`.
- `env_scrub_prefixes` appears **nowhere** as a sandbox policy child. The
  `ENV_SCRUB_PREFIXES` hits in `mcp_gateway/hashing.py` are an unrelated
  MCP-gateway constant that happens to share the name. It is allowlisted purely
  because the same in-code comment declares it reserved, and an operator who
  read that comment may have written it.
- Neither flag has a consumer, so allowlisting them is inert with respect to
  enforcement — it preserves parse compatibility and nothing else.

The new strictness is therefore confined to names nobody has ever been told
are valid, which is where the typos live.

**No existing test pinned the silent-swallow behavior.** No test anywhere
asserts on `sandbox._flags` contents or on an arbitrary `sandbox` child
parsing, so no test encoded the old intent and none needed rewriting.
`test_full_policy_parses` (line 389) exercises `require_isolation` but asserts
nothing about it; it passes unmodified under the allowlist. Had I chosen
blanket rejection, that test would have had to change — which is a second
reason the allowlist is the lower-risk shape here.

## Tests

Four tests added to `TestLoader` in `test/test_governance_policy.py`:

| Test | Locks in | On unmodified code |
|---|---|---|
| `test_typod_sandbox_child_fails_closed` | `sandbox.min_levl` raises `PlatformCompositionError`, and the message names the offending key plus `fail-closed` | **RED** — `Failed: DID NOT RAISE PlatformCompositionError` |
| `test_typod_sandbox_child_does_not_silently_drop_the_floor` | the *consequence*: it must never parse to a ceiling whose `sandbox.min_level` is absent | **RED** — `Failed: parsed clean with sandbox.min_level=None` |
| `test_reserved_sandbox_boot_flags_still_parse` | the compatibility half — both allowlisted flags load, and `sandbox.min_level` still parses alongside them | green before and after (pins behavior that must not change) |
| `test_sandbox_min_level_alone_still_parses` | the common shape is untouched, and no empty `sandbox._flags` is created | green before and after |

The two RED tests were proven red by reverting **only** the production hunk
(`git stash push -- src/kiro_crew/platform/governance.py`) while keeping the
test hunk, then re-running: `2 failed, 2 passed`. With the fix applied:
`4 passed`.

The second test is deliberately separate from the first: pinning only the
raise would let a future change pass by raising somewhere else while
reintroducing the absent-floor ceiling, which is the actual defect.

Suite results (Python 3.12.13):

- `test/test_governance*.py` (all 10 files) — **1014 passed, 3 skipped**
- `test/test_sandbox_first_party_exec.py` + `test/test_platform_context.py` — **44 passed**

## Manual verification

Verified the before/after parse behavior directly against the loader, since
the defect is that validation *reports success* — an outcome no assertion in
the old suite could have surfaced.

Before (origin/main @ 1129ef110):

```
PARSED CLEAN (defect present)
  controls keys: ['sandbox._flags']
  sandbox.min_level control: None
```

After:

```
typo min_levl        : REJECTED -> unknown governed key 'sandbox.min_levl' (fail-closed)
typo sandbox.mode    : REJECTED -> unknown governed key 'sandbox.mode' (fail-closed)
min_level only       : parsed; min_level=OrdinalControl(scale='sandbox', value='strict'); keys=['sandbox.min_level']
min_level + reserved : parsed; min_level=OrdinalControl(scale='sandbox', value='strict'); keys=['sandbox._flags', 'sandbox.min_level']
reserved only        : parsed; min_level=None; keys=['sandbox._flags']
sibling (network)    : REJECTED -> unknown governed key 'network.egres' (fail-closed)
```

The last line is the error-shape comparison against a pre-existing sibling
namespace, confirming the new rejection reads identically to the ones already
shipped.

Gates run on the changed files, each exit code captured from the checker
itself (never after a pipe):

| Gate | Exit |
|---|---|
| `python3 scripts/check_black_formatting.py` | 0 — `2 changed file(s)` in scope, passed |
| `isort --check-only` | 0 |
| `flake8` | 0 |
| `mypy src/kiro_crew/platform/governance.py` | 0 — `Success: no issues found in 1 source file` |

## Related Issues

no linked issue: found by direct audit of the `sandbox` namespace's
fail-closed posture, not filed beforehand.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the in-code comment block documenting the reserved-flag contract is updated in the diff; no user-facing doc names these flags
- [x] No secrets, credentials, or internal references in the diff
