### PR TITLE
test(sidebar): defuse the effective-agent fixture time bomb

### DIFF
--- a/website/src/test/ChatSidebar.effectiveAgent.test.tsx
+++ b/website/src/test/ChatSidebar.effectiveAgent.test.tsx
@@ -85,7 +85,13 @@ import ChatSidebar from '../pages/ChatSidebar'
 import type { RootState } from '../store'
 import type { ChatSlot } from '../types'
 
-const LAST_TS = '2026-08-26T18:00:00Z'
+// RELATIVE, not a literal date: the sidebar's dormant-session collapse
+// (staleCollapse.ts, default threshold 2 days) hides any row whose last
+// activity is older than the threshold, and these tests address rows by
+// title, so a hardcoded date turns into a time bomb — the fixture aged past
+// the threshold two days after it was written and all ten tests started
+// failing on every PR at once. A minute ago is always fresh.
+const LAST_TS = new Date(Date.now() - 60_000).toISOString()
 
 const SLOTS: ChatSlot[] = [
   // The divergence: bound to a `mochi` that nothing dispatches, so `kirocrew`


### PR DESCRIPTION
## Problem
All ten tests in `ChatSidebar.effectiveAgent.test.tsx` are failing on **every open PR's merge CI** (Frontend Tests shard 3) since 2026-08-28 ~18:00 UTC, and on pure `main` — e.g. the failures on #6507's merge run. Neither recently-merged PR broke the other: this is a **fixture time bomb**.

## Root cause
The test pins its rows to a literal date:
```ts
const LAST_TS = '2026-08-26T18:00:00Z'
```
#6473's dormant-session collapse (default threshold **2 days**, `staleCollapse.ts`) hides any non-exempt row older than the threshold, and these tests address rows by title. #6473 merged while the fixture was still fresh (its own CI was green), and exactly two days after the fixture's date — today 18:00 UTC — every row aged past the threshold, collapsed behind the "Dormant sessions" expander, and all ten tests went red at once, repo-wide.

Verified by bisect: `2cc8270d3` (#6473) fails 10/10, its parent passes 10/10, and the failure reproduces on a pristine `origin/main` checkout.

## Fix
Use a relative timestamp (one minute before the run) so the fixture can never age out, with a comment naming the trap for the next fixture author.

Note: 27 other test files carry old literal dates (`2026-01-01`) but currently pass — their rows are exempt or asserted differently. Only this file is red today; a broader sweep can be a follow-up.

## Verified
- `ChatSidebar.effectiveAgent.test.tsx`: 10/10 pass on this branch (was 0/10 on main)
- eslint clean on the touched file
