### PR TITLE
test(sidebar): pin the stale collapse off in the effective-agent test

### DIFF
--- a/website/src/test/ChatSidebar.effectiveAgent.test.tsx
+++ b/website/src/test/ChatSidebar.effectiveAgent.test.tsx
@@ -146,7 +146,18 @@ function markerFor(container: HTMLElement, title: string): HTMLElement | null {
   return metaLineFor(container, title).querySelector('[data-testid="session-effective-agent"]')
 }
 
-beforeEach(() => localStorage.clear())
+// `LAST_TS` is a fixed wall-clock instant while the stale-session collapse
+// measures age against `Date.now()`, so this file's rows drift into dormancy on
+// their own: they were 1.6 days old when the collapse shipped and passed, then
+// crossed the 2-day default at 2026-08-28T18:00Z and every row-by-title lookup
+// below started throwing `no row titled ...` with no code change in between.
+// Pinning the threshold off keeps the rows queryable and makes the file's age
+// irrelevant; the collapse's own behavior is pinned in
+// ChatSidebar.staleCollapse.test.tsx, which is where it belongs.
+beforeEach(() => {
+  localStorage.clear()
+  localStorage.setItem('mc-session-stale-collapse-ms', '0')
+})
 afterEach(() => vi.clearAllMocks())
 
 describe('chat sidebar — effective-agent marker', () => {


### PR DESCRIPTION
## Problem / Motivation

`website/src/test/ChatSidebar.effectiveAgent.test.tsx` is red on `main` with no commit in between — ten tests, all in that one file, all failing as `Error: no row titled "diverged"`.

It is not a stale test that someone forgot to update. It is a **clock-dependent** one that went red on its own.

## Why it matters

It blocks `Frontend Tests (3)` and, downstream of that, `Frontend Coverage Merge` — so it fails **every** open PR that lands on a shard-3 run, regardless of what that PR changed. It is currently red on my own unrelated composer PR ([#6551](https://github.com/kirodotdev/KiroCrew/pull/6551)), which is how I found it.

The failure mode is also the kind that erodes trust in the suite: it appears without a diff to blame, so the natural first guess is "my branch broke it".

## What changed (motivation → approach → change)

**Root cause.** The fixtures share one hardcoded `LAST_TS = '2026-08-26T18:00:00Z'`, while the dormant-session collapse from #6473 measures age against `Date.now()`. So the rows aged into dormancy with no code moving:

| moment | fixture age | result |
|---|---|---|
| 2cc8270d3 authored (2026-08-28T09:14Z) | 1.63 days | under the 2-day default → **green in that PR's own CI** |
| 2026-08-28T18:00Z | 2.00 days | crosses the threshold |
| now | > 2 days | rows collapse behind the `Dormant sessions (N)` expander → every row-by-title lookup throws |

That timing is also why the commit did not catch it. `2cc8270d3` swept the sibling suites it saw fail — `channelOriginGlyph`, `chevronGrammar`, `digitBadges`, `flatView`, `metaLine`, `offline`, `openInTab`, `dragFreezeOrder` and the integration suite — and this file was simply **not failing yet**, so it was not in the sweep.

**Fix.** The same pattern that commit already established for the identical cause in `ChatSidebar.metaLine.test.tsx`: pin the threshold to `0` in `beforeEach`, so the rows stay queryable and the file's age stops mattering. The collapse's own behavior is pinned in `ChatSidebar.staleCollapse.test.tsx`, so nothing here needs to assert it.

**Scope is one file, and that is measured rather than assumed.** Seven other guard-less `ChatSidebar.*` tests hardcode far older dates (`2026-01-01`, `2020-01-01`) and pass anyway — they do not look rows up by title — and CI's other shards were green. There is nothing else to sweep, so nothing else is touched.

## Tests

No new test. This repairs an existing one, and the repair is verified by the failure it removes:

- before: **10 failed** in that file;
- after: **10 passed**;
- deleting the pinned line returns **exactly those 10 failures** — so the one line is load-bearing and the fix is not incidental;
- the whole `ChatSidebar` family: **62 files / 493 passed, 1 skipped**, so no sibling is disturbed.

`npx tsc -b` clean.

## Manual verification

Reproduced on a pristine `origin/main` checkout (`1129ef110`) before changing anything — 10 failures, byte-identical to CI's annotations — which is what established that it is a `main` regression and not a branch artifact.

## Related Issues

No linked issue: found while babysitting an unrelated PR's CI, filed directly as the fix.

Cause is #6473 (`2cc8270d3`), which is correct in itself — the sweep just could not see a test that had not aged into failure yet.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — N/A, repairs an existing test
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
