### PR TITLE
fix(mcp-apps): preserve MCP App marker when _redact_tool_field truncates large tool output

### DIFF
--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -152,6 +152,13 @@ def _redact_deep(obj):
 _MAX_TOOL_FIELD = 1_000_000
 _MAX_TOOL_PURPOSE = 8_000  # purpose is a short label — no scenario for more
 
+# Local copy of the MCP App marker pattern (same as MARKER_RE in
+# kiro_crew.mcp_apps_render) to avoid a cross-module import that could become
+# circular in the future.  The marker is appended to the END of tool result
+# text by the gateway's append_marker; we need to detect it here so truncation
+# does not silently destroy it.
+_MCP_APP_MARKER_RE = re.compile(r"\[kirocrew-mcp-app:[0-9a-f]{32}\]")
+
 
 def _redact_tool_field(text: str | None, *, limit: int = _MAX_TOOL_FIELD) -> str:
     """Redact + apply 1 MB safety cap to a tool input/output field. Used for
@@ -162,9 +169,25 @@ def _redact_tool_field(text: str | None, *, limit: int = _MAX_TOOL_FIELD) -> str
     if len(text) * 4 > limit:
         encoded = text.encode("utf-8")
         if len(encoded) > limit:
+            # Before truncating, check whether the text carries an MCP App
+            # marker at or near the end.  The marker is always appended as
+            # the very last token (``text + " " + marker``) by the gateway,
+            # so we only need to inspect the tail.  If truncation would
+            # remove it we re-append it after the sentinel so that
+            # handle_tool_result / find_marker can still detect and render
+            # the associated MCP App.
+            marker_match = _MCP_APP_MARKER_RE.search(text, pos=max(0, len(text) - 80))
+            marker_suffix = ""
+            if marker_match:
+                marker_suffix = " " + marker_match.group(0)
+
             # errors="ignore" cleanly drops a partial trailing multi-byte
             # sequence at the cut point.
-            text = encoded[:limit].decode("utf-8", errors="ignore") + f"\n… [truncated at {limit:,} bytes]"
+            text = (
+                encoded[:limit].decode("utf-8", errors="ignore")
+                + f"\n… [truncated at {limit:,} bytes]"
+                + marker_suffix
+            )
     text, _ = redact_exfiltration_urls(text)
     text, _ = redact_credentials(text)
     return text

--- a/test/test_chat_utils.py
+++ b/test/test_chat_utils.py
@@ -226,3 +226,30 @@ class TestRedactToolField:
     def test_purpose_limit(self):
         result = _redact_tool_field("x" * 10_000, limit=8_000)
         assert "[truncated at 8,000 bytes]" in result
+
+    def test_preserves_mcp_marker_on_truncation(self):
+        """When text exceeds the limit and carries a trailing MCP App marker,
+        the marker must survive truncation so find_marker can still detect it."""
+        marker = "[kirocrew-mcp-app:606dfdf4abcd1234567890abcdef1234]"
+        # Build text that is well over the limit once the marker is appended.
+        body = "x" * 200  # 200 bytes ASCII
+        text = body + " " + marker
+        # Use a limit smaller than the total text so truncation fires.
+        result = _redact_tool_field(text, limit=100)
+        assert "[truncated at 100 bytes]" in result
+        assert marker in result
+
+    def test_mcp_marker_no_truncation_unchanged(self):
+        """When text is under the limit the marker is left in place naturally."""
+        marker = "[kirocrew-mcp-app:abcdef01234567890abcdef012345678]"
+        text = "short output " + marker
+        result = _redact_tool_field(text, limit=1_000_000)
+        assert marker in result
+        assert "truncated" not in result
+
+    def test_no_marker_truncation_unchanged(self):
+        """When text has no MCP App marker, truncation behaviour is unchanged."""
+        text = "y" * 300
+        result = _redact_tool_field(text, limit=100)
+        assert "[truncated at 100 bytes]" in result
+        assert "[kirocrew-mcp-app:" not in result


### PR DESCRIPTION
## Summary

Fixes #6606 (Candidate A from triage).

The MCP App render marker `[kirocrew-mcp-app:<32hex>]` was being silently destroyed by `_redact_tool_field` truncation. The gateway appends the marker to the **end** of tool result text, but `_redact_tool_field` in `chat_utils.py` truncates at 1,000,000 bytes **before** `find_marker` runs in `handle_tool_result`. Large tool outputs (like meeting transcripts exceeding 1MB) therefore lost their marker to truncation and could never render — explaining why no `.rendered` sidecar is written and no `mcp_app_render` websocket frame is emitted.

## What changed

**`src/kiro_crew/dashboard/chat_utils.py`:**
- Added a local `_MCP_APP_MARKER_RE` regex (avoids circular import with `mcp_apps_render`)
- Before truncation, searches the last 80 characters of the original text for the marker
- If found and truncation would remove it, re-appends the marker after the truncation sentinel
- Downstream `find_marker` can then detect it as usual

**`test/test_chat_utils.py`:**
- `test_preserves_mcp_marker_on_truncation` — marker survives when text exceeds the limit
- `test_mcp_marker_no_truncation_unchanged` — marker left in place when text is under limit
- `test_no_marker_truncation_unchanged` — no marker means no change to truncation behavior

## Why this was the root cause

The triage comment on #6606 narrows to three candidates. Candidate A is confirmed:

1. The gateway's `append_marker` appends the marker to the **end** of the first text content item
2. `_redact_tool_field` runs a hard cap (`_MAX_TOOL_FIELD = 1_000_000` bytes) **before** `handle_tool_result` sees the text
3. `find_marker` returning `None` logs nothing at all — matching the "no failure-path lines" observation
4. `get_meeting_transcript` is exactly the shape of tool that crosses the 1MB line
5. Two earlier (presumably shorter) renders mounted; later (longer) ones did not

## Testing

- Python AST validation passes on both modified files
- Fix logic verified with standalone script covering 7 scenarios including realistic 3MB output
- Full pytest suite could not run in sandbox due to network constraints (missing `aiohttp` dependency)

## Remaining candidates from triage

Candidates B (divergent spool directories) and C (stale session binding after gateway restart) from the triage comment may contribute to the reporter's specific environment but are orthogonal to this code defect. This PR fixes the product bug; the reporter's environment-specific factors can be addressed separately if they persist after this fix.