### PR TITLE
fix(test): anchor effective-agent sidebar rows to a relative timestamp

### DIFF
--- a/website/src/test/ChatSidebar.effectiveAgent.test.tsx
+++ b/website/src/test/ChatSidebar.effectiveAgent.test.tsx
@@ -85,7 +85,13 @@ import ChatSidebar from '../pages/ChatSidebar'
 import type { RootState } from '../store'
 import type { ChatSlot } from '../types'
 
-const LAST_TS = '2026-08-26T18:00:00Z'
+// Relative to now, not a fixed date: ChatSidebar collapses rows idle for more
+// than DEFAULT_STALE_COLLAPSE_MS (2 days) behind a hidden "Dormant sessions"
+// expander under the default date-desc sort. A hard-coded past timestamp is a
+// time-bomb — it reads "fresh" until wall-clock time crosses the threshold, then
+// every row collapses out of the DOM and the whole file fails with "no row
+// titled …" for reasons unrelated to the effective-agent marker under test.
+const LAST_TS = new Date().toISOString()
 
 const SLOTS: ChatSlot[] = [
   // The divergence: bound to a `mochi` that nothing dispatches, so `kirocrew`


### PR DESCRIPTION
## Problem / Motivation

`ChatSidebar.effectiveAgent.test.tsx` pins every slot's `last_ts` to the fixed date `2026-08-26T18:00:00Z`. The sidebar collapses rows idle for more than two days behind the dormant-sessions expander, so the fixture read as "fresh" only until wall-clock time crossed `2026-08-28T18:00Z`. Past that moment every row ages out of the DOM and all ten tests in the file fail with `no row titled "..."` — on any branch, for any diff. Main's own CI ran this file green at ~17:04 UTC on 2026-08-28 and would fail it on the next run; two unrelated fork PRs already fail `Frontend Tests (3)` deterministically on it.

## Why it matters

Every CI run repo-wide is now red on this shard regardless of the change under test, which also freezes the fork AI-review pipeline (Stage-2 reviews dispatch only from green CI).

## What changed

One fixture line: `LAST_TS` is computed relative to `Date.now()` instead of a hardcoded date, with a comment explaining the dormant-collapse interaction so the next fixture author doesn't reintroduce the bomb. No product code touched.

## Tests

- Reproduced at the pristine base `23d02c227` with a clean `npm ci`: all 10 tests fail with the hardcoded date, 10/10 pass with the relative timestamp.
- `npx vitest run src/test/ChatSidebar.effectiveAgent.test.tsx`: 10 passed.

Fixes #6618
