### PR TITLE
chore: list kanban in the app registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -16,5 +16,11 @@
     "gitUrl": "https://github.com/LeTeutz/todo-txt",
     "repo": "https://github.com/LeTeutz/todo-txt",
     "branch": "main"
+  },
+  {
+    "name": "kanban",
+    "gitUrl": "https://github.com/nathanyi96/kirocrew-app-kanban",
+    "repo": "https://github.com/nathanyi96/kirocrew-app-kanban",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
## Problem / Motivation

The App Store's core registry — `src/kiro_crew/apps/app-registry.json` — is the list a
user browses in Discover and Library. An app absent from it cannot be found or
installed from the store; the only route is a manual sideload against a local
clone.

**Kanban** is a standalone agent task board that is not in that list. It also has
a second, sharper symptom: the Kanban builtin was removed from this repo when it
migrated to a standalone app, so a user who had the builtin now lands on
`/apps/migrate/kanban`. That page resolves availability by looking up the app name
in the registry (`MigrationPage.tsx` → `api.listRegistry()`, matching
`a.name === parsed`), so with no row it renders the `not-in-registry` state —
"Coming soon: this app is not yet available" — a dead end with no install action.

This PR adds the one row that closes both, following §10 of
`docs/app-kit/publishing-guide.md`.

## Why it matters

Users migrating off the Kanban builtin currently have no path forward: their
sidebar entry leads to a placeholder, and the standalone app that replaces it is
undiscoverable from the store. For everyone else, the app is simply unlistable.

## What changed (motivation → approach → change)

**Goal:** make one existing, released app installable from the store.

**Approach:** §10's registry-pointer entry, not vendoring. The app lives in its own
repo with its own CI and release cadence, so a pointer keeps that cadence
independent of the Kiro Crew release train and keeps this diff to data. `branch`
tracks `main`, matching all three existing entries and §13's update model.

**Change:** a single object appended to the JSON array — no code, schema, or guard
is touched, and the three existing entries are byte-identical after the change.
The row is appended rather than sorted, matching how the existing rows landed
(#1425 → #2901 → #4019).

```json
{
  "name": "kanban",
  "gitUrl": "https://github.com/nathanyi96/kirocrew-app-kanban",
  "repo": "https://github.com/nathanyi96/kirocrew-app-kanban",
  "branch": "main"
}
```

`repo` is set alongside `gitUrl` so the blob proxy can serve the app's committed
store art.

**What the app is:** an outcome-first agent task board. Each card is a
plain-language prompt that runs as a real agent session and moves through five
lanes with drag-and-drop plus a tap-to-move path for touch. On create you pick the
engine — Chat, Task Runner, Autopilot, or Auto routing — and the card's drawer
shows the latest outcome, verification evidence, artifacts and attempts without
having to read the whole chat. A card settles itself when its agent turn ends
(including across recoveries), and a run orphaned by a restart is reconciled on
the next page load rather than left stuck. MIT, `storage: true`, **`network:
false`**, no cron, no MCP tools, and no install script.

## Tests

No tests are added: the diff adds no code, only a data row. `_load_registry_file`
already validates row shape and drops malformed rows, and no test asserts the
bundled seed's contents by design (every registry-file test builds its own
`tmp_path` fixture), so there is no fixture to update.

Gates run locally on this commit, rebased onto `39c6952`:

| Gate | Result |
|---|---|
| `app-registry.json` parses; 3 existing rows byte-identical | pass |
| `check_brand_name.py` (diff-scoped) | pass |
| `scrub-lint.sh --no-history` | pass |
| `docs-lint.sh` | pass |

Frontend gates (website build, tsc, eslint, i18n, vitest, electron, bundle-size)
and `mypy` were not run locally: this diff touches zero TypeScript and zero Python
files, so they cannot be affected. CI covers them.

## Manual verification

The app's own CI is green on the commit this row resolves to
(`c8bcfe4`, run [33024656600](https://github.com/nathanyi96/kirocrew-app-kanban/actions/runs/33024656600)).
That workflow validates `app.json` against the installed Kiro Crew wheel's
manifest schema, byte-compiles the backend, builds and `node --check`s the UI
bundle, then does a real `kirocrew app install` → trust → enable against a booted
gateway, an API smoke pass (create / move / patch / reconcile / delete / 404), and
Playwright screenshots.

## Known follow-ups in the app repo

Stated plainly so review is not spent discovering them — both are being addressed
in the app repo and neither is in this diff:

- **`ui/dist/index.mjs` is not committed** (it is gitignored). §9 and §14 require
  the built bundle in the repo. The registry install path runs a detected build
  only for a `package.json` at the clone root, and this app's build script lives
  at `ui/package.json`, so the bundle will not be produced at install time.
- **No store art.** `iconPath`, `screenshots` and `heroImage` are undeclared, so
  every store surface falls back to the name-seeded gradient. §4's required opaque
  512×512 icon, screenshot and 16:9 hero are not yet committed.

Happy to hold this row until both land if you would rather list the app only once
it installs cleanly.

## Related Issues

No linked issue: this adds a registry row for an app developed outside this
repository, so there is no tracked issue here to close.

## Checklist

- [x] At most two commits (one here), Conventional Commits title (`chore: list kanban in the app registry`)
- [x] Existing tests pass and new tests added for new functionality — no code added; see Tests
- [x] Self-review completed; the diff is append-only and the three existing entries are unchanged
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
