### PR TITLE
test(feedback): deracify the pulse-survey onLayoutChange assertions

### DIFF
--- a/website/src/test/SessionPulseSurveyCard.test.tsx
+++ b/website/src/test/SessionPulseSurveyCard.test.tsx
@@ -173,18 +173,26 @@ describe('SessionPulseSurveyCard (collapsed disclosure)', () => {
   it('calls onLayoutChange on show, on expand, and on collapse -- so the parent can re-anchor scroll for every height change', async () => {
     const onLayoutChange = vi.fn()
     const { rerenderWithTurnCount } = renderCard(onLayoutChange)
+    // The baseline must be captured while the card is still hidden — if the
+    // show already happened, `callsBeforeShow` silently includes the show's
+    // own call and the delta assertion below can never pass.
+    expect(screen.queryByText(RATING_QUESTION)).not.toBeInTheDocument()
     const callsBeforeShow = onLayoutChange.mock.calls.length
 
     await showCard(rerenderWithTurnCount)
-    expect(onLayoutChange.mock.calls.length).toBeGreaterThan(callsBeforeShow)
+    // The callback fires from a layout effect, one commit AFTER the text the
+    // show waits on is queryable — poll the condition instead of asserting
+    // the instant count (raced on slow runners: the count was read before
+    // the effect flushed).
+    await waitFor(() => expect(onLayoutChange.mock.calls.length).toBeGreaterThan(callsBeforeShow))
     const callsAfterShow = onLayoutChange.mock.calls.length
 
     fireEvent.click(screen.getByRole('button', { name: RATING_QUESTION }))
-    expect(onLayoutChange.mock.calls.length).toBeGreaterThan(callsAfterShow)
+    await waitFor(() => expect(onLayoutChange.mock.calls.length).toBeGreaterThan(callsAfterShow))
     const callsAfterExpand = onLayoutChange.mock.calls.length
 
     fireEvent.click(screen.getByRole('button', { name: RATING_QUESTION }))
-    expect(onLayoutChange.mock.calls.length).toBeGreaterThan(callsAfterExpand)
+    await waitFor(() => expect(onLayoutChange.mock.calls.length).toBeGreaterThan(callsAfterExpand))
   })
 })
 


### PR DESCRIPTION
## Problem
`SessionPulseSurveyCard.test.tsx` › "calls onLayoutChange on show, on expand, and on collapse" flaked on #6610's merge run (Frontend Tests shard 4) with `expected 1 to be greater than 1` — the show visibly happened (the card's text was in the DOM) but the assertion read the callback count before it moved. Local runs pass 3/3; this is a race, not a behavior change.

## Root cause
`onLayoutChange` fires from an effect keyed on `[visible, expanded, submitted]`, one commit AFTER the rating-question text that `showCard`'s `waitFor` polls for becomes queryable. Asserting `mock.calls.length` synchronously right after `showCard` resolves races the effect flush on a slow runner.

## Fix (per testing-conventions: wait on the condition, never rerun or sleep)
- Poll each call-count delta with `waitFor` instead of asserting the instant count.
- Guard the baseline capture with an explicit not-yet-shown assertion, so an early show fails loudly instead of silently folding the show's own call into `callsBeforeShow` (the one interleaving `waitFor` alone cannot save).

## Verified
- 21/21 pass on this branch; eslint warning count unchanged (2 pre-existing).
