### PR TITLE
docs: correct stale browser visibility and computer-use gate docstrings

### DIFF
--- a/src/kiro_crew/mcp_tools/browser.py
+++ b/src/kiro_crew/mcp_tools/browser.py
@@ -17,13 +17,20 @@ Deliberately OUT of scope: this handler never runs ``playwright-cli`` itself and
 carries no op->verb map. When no native panel is serving the session it returns
 guidance text pointing at the ``playwright-cli`` verbs, and stops there.
 
-Visibility follows the browse capability: ``schemas()`` returns ``[]`` while
-``playwright-cli`` is not installed, so a machine where browsing was never set
-up does not advertise a tool that cannot work. Presence of the CLI is the
-availability signal for browsing on this host (see ``browser_cli.install``), not
-consent to bypass the approval path. The native panel is another expression of
-that same capability. The handler re-checks because kiro-cli caches
-``tools/list`` for the life of a session.
+Visibility does NOT follow the browse capability: ``schemas()`` advertises the
+tool unconditionally. The registry requires every ``HANDLERS`` entry to have a
+descriptor and vice versa, so an env-gated ``[]`` would fail
+``test_mcp_tool_registry`` on any host without ``playwright-cli`` (CI included).
+Both gates are therefore CALL-time, and they are deliberately opposite
+polarities: availability fails **closed** -- no ``playwright-cli`` and no native
+panel yields an "install it from Settings -> Browser" error -- while a
+``capabilities.browse`` denial refuses **outright** with no playwright fallback,
+because a fallback would let browsing continue and defeat the control. The
+handler re-checks availability rather than trusting the advertisement because
+kiro-cli caches ``tools/list`` for the life of a session, so a session that
+started with the CLI installed keeps offering the tool after it is removed.
+Presence of the CLI is the availability signal for browsing on this host (see
+``browser_cli.install``), not consent to bypass the approval path.
 """
 
 from __future__ import annotations

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -8,9 +8,13 @@ accessibility / capture work and all SEL auditing happen in the GATEWAY.
 That split exists because ``hooks._governance_denial`` — the PreToolUse gate — is
 fail-**OPEN** by deliberate repo policy (a governance glitch must not wedge every
 tool call on every surface), so it cannot be the sole authorization point for a
-surface that can read a password field's ``AXValue``. The authoritative gate
-(``computer_use/gate.py::require_computer_use``) fails CLOSED and needs the
-OS-resolved app identity and the addressed element's role, which only the
+surface that can read a password field's ``AXValue``. The fail-CLOSED gate is the
+keystone primary enable, read at the top of ``computer_use/tools.py``'s ordered
+chokepoint: a keystone that is missing, unreadable or disabled refuses the call
+outright. ``computer_use/gate.py::require_computer_use`` is audit-only — it
+unconditionally permits and records the call — and the refusals downstream of the
+enable (the operator's target policy, the element and pointer shape checks) need
+the OS-resolved app identity and the addressed element's role, which only the
 gateway-side tool body has.
 
 Two halves are tested here:


### PR DESCRIPTION
## Problem / Motivation

Two module docstrings assert the opposite of what their own code does.

**1. `src/kiro_crew/mcp_tools/browser.py`** — the module docstring claims:

> Visibility follows the browse capability: `schemas()` returns `[]` while `playwright-cli` is not installed, so a machine where browsing was never set up does not advertise a tool that cannot work.

`schemas()` sits 60 lines below and says the opposite, with its reason:

> Always advertised (never gated on `_browsing_available()`): the tool registry requires every `HANDLERS` entry to have a descriptor, and vice versa, so an env-gated `[]` here would fail `test_mcp_tool_registry` on any host without `playwright-cli` (e.g. CI).

**2. `test/test_mcp_computer.py`** — the module docstring carries the same
`require_computer_use` fails-CLOSED claim that #6604 corrects in
`src/kiro_crew/mcp_computer.py`:

> The authoritative gate (`computer_use/gate.py::require_computer_use`) fails CLOSED …

`computer_use/gate.py` states that it "Always returns `None` (proceed). Audits the
call. … there is no longer a governance decision to make. The keystone primary
enable, checked upstream in `:mod:`tools``, is the whole gate", and
`computer_use/tools.py` calls it "now audit-only, and unconditionally permits".

Both were named as adjacent, out-of-scope findings in #6604; this PR closes them.

## Why it matters

These are not cosmetic. Both docstrings have already produced wrong statements in
a customer-facing enterprise governance document, because they are the primary
source a reader consults for the security posture of these two surfaces:

- The browser paragraph asserts an availability-gated tool surface, which invites
  the conclusion that a host without `playwright-cli` advertises nothing. The real
  posture is that the tool is always advertised and both checks are CALL-time, with
  deliberately opposite polarities — that difference is what a security reviewer
  asks about.
- The computer-use paragraph names a fail-CLOSED governance decision point that no
  longer exists, so a reader documents a refusal the code does not perform.

A docstring that contradicts its own function is worse than a missing one: it is
read as authoritative and it propagates.

## What changed (motivation → approach → change)

**Symptom:** two module docstrings whose claims are contradicted by code in the
same file (browser) or in the module under test (computer-use).

**Root cause:** both describe an earlier design. `schemas()` was gated on
availability before the registry parity requirement forced it to be
unconditional, and `require_computer_use` held a governance decision before that
moved to the keystone enable. In each case the implementation moved and the
docstring did not.

**Change — docstrings only, no behaviour:**

- `browser.py`: the visibility paragraph is rewritten to state that `schemas()`
  advertises unconditionally and to name the registry-parity reason, then to
  describe the two CALL-time gates and their opposite polarities — availability
  fails **closed** (an "install it from Settings → Browser" error), a
  `capabilities.browse` denial refuses **outright** with no playwright fallback,
  because a fallback would defeat the control. The kiro-cli `tools/list` caching
  rationale for re-checking is kept and attached to the availability check, which
  is what it actually explains.
- `test/test_mcp_computer.py`: the gate paragraph now names the keystone primary
  enable in `computer_use/tools.py` as the fail-CLOSED gate and describes
  `require_computer_use` as audit-only, matching #6604's correction to the
  production module so the test file and the module it pins agree.

Adjacent and deliberately NOT touched: `src/kiro_crew/mcp_computer.py` carries the
same claim and is fixed by #6604. This branch is off `origin/main`, so that file
still shows the old wording here; the two PRs touch disjoint files and do not
conflict.

## Tests

None added — this is a docstring-only diff with no behaviour to lock in.

Verified no test asserts the replaced wording (`grep` for
`Visibility follows the browse capability` and the `returns []` phrasing across
`test/` and `src/` returns nothing).

Ran the suites covering both touched files and the parity guarantee the new
browser wording cites: `test_mcp_computer.py` (164 passed),
`test_browser_command_bus.py` + `test_mcp_tool_registry.py` (74 passed,
including `test_every_handler_is_advertised`) — **238 passed, 0 failed**.

## Manual verification

N/A — unit coverage sufficient. There is no runtime behaviour in the diff; the
claims are verified by reading the functions they describe (`schemas()`,
`browser()`, `computer_use/gate.py::require_computer_use`,
`computer_use/tools.py`) and by the parity test above.

## Related Issues

no linked issue: follow-up to the two adjacent findings recorded in #6604's body.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
