### PR TITLE
perf(runtime): reclaim retained Linux gateway heap

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -765,6 +765,24 @@ runtime that still ships the API keeps the mitigation. Without that guard the
 Linux pidfd branch raised `AttributeError` and `kirocrew gateway` died before
 binding its port, while every other subcommand kept working.
 
+### Linux gateway heap reclamation
+
+The event-loop heartbeat offers a self-gating maintenance object a tick every
+five seconds. At most once every ten minutes on Linux, it reads current RSS
+directly from procfs. When RSS is at least 1.5 GiB, it asks glibc
+`malloc_trim(0)` to return wholly-free heap pages to the OS and logs reductions
+of at least 16 MiB. The probe and allocator call run in a worker thread, after
+the dashboard socket has bound, so maintenance cannot delay readiness or block
+the event loop. Healthy gateways remain below the threshold and do no
+allocator-wide work.
+
+The heartbeat waits at most two seconds for a pass. A timed-out worker keeps the
+single in-flight slot until it exits, preventing repeated submissions or a
+watchdog-triggering wait when the executor is saturated. Missing `ctypes`,
+non-glibc libc, failed current-RSS probes, and rejected trim calls are
+best-effort no-ops: reclamation must never stop the liveness heartbeat or make
+the gateway unavailable. macOS and Windows are unchanged.
+
 ### Live-target bootstrap
 
 On the `gateway` command path only, immediately after `_JAILED_COMMANDS`

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -3536,6 +3536,7 @@ async def start_dashboard(
         # the process while its config filesystem is itself under pressure.
         _exit_after = float(resolve_loop_stall_exit_after(environ=_launch_environment))
     _loop_watchdog = LoopStallWatchdog(dump_file=_dump_file, exit_after=_exit_after)
+    _heap_trim_maintainer = platform_compat.HeapTrimMaintainer()
 
     async def _loop_heartbeat() -> None:
         # 5s (not 10s) so the watchdog's armed dump-then-exit timer is re-petted
@@ -3558,6 +3559,12 @@ async def start_dashboard(
             # block the loop this heartbeat exists to watch. After the lag
             # read so the await can't register as loop lag.
             await state.resource_pressure_notifier.maybe_sample()
+            released = await _heap_trim_maintainer.maybe_trim()
+            if released >= platform_compat.HEAP_TRIM_LOG_THRESHOLD_BYTES:
+                logger.info(
+                    "Gateway heap trim returned %.0f MiB to the OS",
+                    released / (1024 * 1024),
+                )
             if lag > 1.0:
                 logger.warning("event-loop heartbeat: lag %.1fs (loop was blocked)", lag)
             else:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -4363,6 +4363,111 @@ def proc_rss_bytes() -> int:
     return 0 if counters is None else int(counters.WorkingSetSize)
 
 
+HEAP_TRIM_INTERVAL_SECONDS = 10 * 60.0
+HEAP_TRIM_RSS_THRESHOLD_BYTES = 1536 * 1024 * 1024
+HEAP_TRIM_LOG_THRESHOLD_BYTES = 16 * 1024 * 1024
+# Must remain below the heartbeat interval.  A queued or wedged default-executor
+# worker forfeits this maintenance pass instead of starving the liveness beat.
+HEAP_TRIM_TIMEOUT_SECONDS = 2.0
+
+
+def _malloc_trim() -> bool:
+    """Ask glibc to return wholly-free heap pages, or no-op elsewhere."""
+    try:
+        libc = ctypes.CDLL(None)
+        getattr(libc, "gnu_get_libc_version")
+        trim = libc.malloc_trim
+        trim.argtypes = [ctypes.c_size_t]
+        trim.restype = ctypes.c_int
+        return bool(trim(0))
+    except (AttributeError, OSError):
+        return False
+
+
+def trim_heap_if_needed(
+    *,
+    rss_reader: Callable[[], int | None] | None = None,
+    trimmer: Callable[[], bool] | None = None,
+) -> int:
+    """Return bytes released from a large Linux gateway heap.
+
+    A high threshold avoids allocator-wide work on healthy gateways. This must
+    use Linux's current RSS directly: :func:`proc_rss_bytes` deliberately falls
+    back to peak RSS when procfs is unavailable, which would turn one historic
+    spike into repeated trim attempts. Unsupported libc and probe failures are
+    harmless because reclamation is optional.
+    """
+    if not IS_LINUX:
+        return 0
+    try:
+        read_rss = rss_reader or _linux_current_rss_bytes
+        before = read_rss()
+        if before is None:
+            return 0
+        if before < HEAP_TRIM_RSS_THRESHOLD_BYTES:
+            return 0
+        if not (trimmer or _malloc_trim)():
+            return 0
+        after = read_rss()
+        if after is None:
+            return 0
+    except Exception:  # noqa: BLE001 - optional maintenance must not stop the heartbeat
+        return 0
+    return max(0, before - after)
+
+
+class HeapTrimMaintainer:
+    """Self-gate bounded, best-effort heap reclamation for the gateway.
+
+    The heartbeat calls :meth:`maybe_trim` on every tick. Cadence and in-flight
+    ownership live here so the heartbeat stays cadence-free. A timed-out worker
+    may continue running because Python cannot cancel native work already in a
+    thread; ``_inflight`` prevents another from being submitted until that
+    worker returns. If cancellation wins before the worker starts, maintenance
+    remains disabled for this object, which is the safe failure mode.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        trim: Callable[[], int] = trim_heap_if_needed,
+    ) -> None:
+        self._clock = clock
+        self._trim = trim
+        self._next_trim = clock() + HEAP_TRIM_INTERVAL_SECONDS
+        self._inflight = False
+
+    async def maybe_trim(self) -> int:
+        """Return bytes released, or zero when skipped, timed out, or failed."""
+        try:
+            if not IS_LINUX:
+                return 0
+            now = self._clock()
+            if now < self._next_trim or self._inflight:
+                return 0
+            self._next_trim = now + HEAP_TRIM_INTERVAL_SECONDS
+            self._inflight = True
+            try:
+                return await asyncio.wait_for(
+                    asyncio.to_thread(self._run_trim),
+                    timeout=HEAP_TRIM_TIMEOUT_SECONDS,
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                logger.debug("gateway heap trim timed out; maintenance pass skipped")
+                return 0
+        except Exception:  # noqa: BLE001 - maintenance must not stop the heartbeat
+            logger.debug("gateway heap trim failed", exc_info=True)
+            return 0
+
+    def _run_trim(self) -> int:
+        """Worker-thread wrapper that releases the single in-flight slot."""
+        try:
+            return self._trim()
+        finally:
+            self._inflight = False
+
+
 def proc_peak_rss_bytes() -> int:
     """Return this process's PEAK resident set size in bytes, or 0 on failure.
 

--- a/test/test_runtime_memory.py
+++ b/test/test_runtime_memory.py
@@ -1,0 +1,179 @@
+"""Regression coverage for conservative Linux gateway heap reclamation."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import platform_compat
+
+
+def test_large_linux_heap_is_trimmed(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+    readings = iter([2 * 1024**3, 1200 * 1024**2])
+    trims: list[bool] = []
+
+    released = platform_compat.trim_heap_if_needed(
+        rss_reader=lambda: next(readings),
+        trimmer=lambda: trims.append(True) or True,
+    )
+
+    assert released == 848 * 1024**2
+    assert trims == [True]
+
+
+def test_small_heap_is_not_trimmed(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+
+    def forbidden() -> bool:
+        raise AssertionError("trim must not run")
+
+    assert (
+        platform_compat.trim_heap_if_needed(
+            rss_reader=lambda: 512 * 1024**2,
+            trimmer=forbidden,
+        )
+        == 0
+    )
+
+
+def test_non_linux_heap_is_not_trimmed(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+
+    def forbidden() -> bool:
+        raise AssertionError("trim must not run")
+
+    assert (
+        platform_compat.trim_heap_if_needed(
+            rss_reader=lambda: 2 * 1024**3,
+            trimmer=forbidden,
+        )
+        == 0
+    )
+
+
+def test_trim_failure_never_escapes(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+    assert (
+        platform_compat.trim_heap_if_needed(
+            rss_reader=lambda: 2 * 1024**3,
+            trimmer=lambda: (_ for _ in ()).throw(OSError("unsupported")),
+        )
+        == 0
+    )
+
+
+def test_missing_current_rss_never_falls_back_to_peak(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+    monkeypatch.setattr(platform_compat, "_linux_current_rss_bytes", lambda: None)
+    monkeypatch.setattr(
+        platform_compat,
+        "proc_rss_bytes",
+        lambda: 4 * 1024**3,
+    )
+    trims: list[bool] = []
+
+    released = platform_compat.trim_heap_if_needed(
+        trimmer=lambda: trims.append(True) or True,
+    )
+
+    assert released == 0
+    assert trims == []
+
+
+def test_missing_post_trim_rss_never_inflates_release(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+    readings = iter([2 * 1024**3, None])
+
+    assert (
+        platform_compat.trim_heap_if_needed(
+            rss_reader=lambda: next(readings),
+            trimmer=lambda: True,
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_maintainer_owns_its_cadence(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+    now = [0.0]
+    trims: list[bool] = []
+
+    async def inline_to_thread(fn):
+        return fn()
+
+    monkeypatch.setattr(platform_compat.asyncio, "to_thread", inline_to_thread)
+    maintainer = platform_compat.HeapTrimMaintainer(
+        clock=lambda: now[0],
+        trim=lambda: trims.append(True) or 123,
+    )
+
+    now[0] = platform_compat.HEAP_TRIM_INTERVAL_SECONDS - 1
+    assert await maintainer.maybe_trim() == 0
+    now[0] = platform_compat.HEAP_TRIM_INTERVAL_SECONDS
+    assert await maintainer.maybe_trim() == 123
+    assert await maintainer.maybe_trim() == 0
+    now[0] = 2 * platform_compat.HEAP_TRIM_INTERVAL_SECONDS
+    assert await maintainer.maybe_trim() == 123
+    assert trims == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_non_linux_maintainer_never_submits_worker(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+
+    async def forbidden_to_thread(_fn):
+        raise AssertionError("non-Linux maintenance must not submit a worker")
+
+    monkeypatch.setattr(platform_compat.asyncio, "to_thread", forbidden_to_thread)
+    maintainer = platform_compat.HeapTrimMaintainer(clock=lambda: 999999.0)
+
+    assert await maintainer.maybe_trim() == 0
+
+
+@pytest.mark.asyncio
+async def test_maintainer_bounds_executor_wait_and_does_not_resubmit(monkeypatch) -> None:
+    monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+    now = [0.0]
+    submissions: list[bool] = []
+
+    async def stalled_to_thread(_fn):
+        submissions.append(True)
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(platform_compat.asyncio, "to_thread", stalled_to_thread)
+    monkeypatch.setattr(platform_compat, "HEAP_TRIM_TIMEOUT_SECONDS", 0.001)
+    maintainer = platform_compat.HeapTrimMaintainer(clock=lambda: now[0])
+
+    now[0] = platform_compat.HEAP_TRIM_INTERVAL_SECONDS
+    assert await maintainer.maybe_trim() == 0
+    now[0] = 2 * platform_compat.HEAP_TRIM_INTERVAL_SECONDS
+    assert await maintainer.maybe_trim() == 0
+    assert submissions == [True]
+
+
+def test_gateway_trim_maintainer_is_created_after_socket_bind() -> None:
+    source = Path(__file__).parents[1] / "src" / "kiro_crew" / "dashboard" / "server.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    start_site_line = next(
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_start_site"
+    )
+    maintainer_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "platform_compat"
+        and node.func.attr == "HeapTrimMaintainer"
+    ]
+    assert len(maintainer_calls) == 1
+    assert maintainer_calls[0].lineno > start_site_line


### PR DESCRIPTION
## Problem / Motivation

Long-lived Linux gateways can retain glibc heap pages after transient high-memory work, leaving RSS above the live allocation set.

## Why it matters

That retained heap makes healthy long-running gateways look like they are leaking memory and can amplify memory pressure on WSL, VM, and service hosts even after the workload has ended.

## What changed

- Add a Linux-only heap maintainer after the dashboard socket binds.
- Every ten minutes, read current RSS directly from `/proc`; never substitute peak RSS.
- At 1.5 GiB or above, run glibc `malloc_trim(0)` in the default executor.
- Bound the heartbeat wait to two seconds.
- Keep one in-flight slot so a timed-out worker cannot cause repeated submissions.
- Log only measured reductions of at least 16 MiB.
- Treat unsupported libc, failed probes, timeouts, and trim failures as no-ops.
- Leave allocator arena counts, child processes, macOS, and Windows unchanged.

This supersedes the earlier arena-cap implementation. It adds no synchronous work to the gateway boot path and does not trade allocator concurrency for memory.

## Measurement

A controlled glibc reproducer kept eight worker threads alive after each allocated and freed 4,096 blocks of 16 KiB:

- Before trim: 470.6 MiB RSS
- After trim: 11.6 MiB RSS
- Returned: 459.1 MiB
- Duration: 10.40 ms

This validates the retained-page mechanism and reclamation path; it is not presented as a production incident measurement.

## Tests

All local validation ran in Docker capped at 4 CPUs and 4 GiB RAM.

- Black, isort, flake8, and mypy: pass.
- Runtime-memory tests: 10 passed.
- Existing current-RSS tests: 8 passed.
- Resource-pressure and loop-watchdog tests: 39 passed.
- CLI lazy-import and config metadata tests: 63 passed.
- Diff whitespace check: pass.

The upstream current-head CI matrix for the previous revision otherwise passed; this revision specifically adds regression coverage for the two review findings.

## Checklist

- [x] One Conventional Commit
- [x] Focused regression coverage
- [x] Runtime documentation updated
- [x] No secrets or internal references
