### PR TITLE
fix(desktop): keep the dashboard session token out of chromium.log

### DIFF
--- a/website/electron/native-logging.js
+++ b/website/electron/native-logging.js
@@ -112,6 +112,140 @@ function nativeLoggingSwitches(logPath) {
   ];
 }
 
+/** Mode for a file that may contain a bearer credential: owner read/write only. */
+const SECRET_FILE_MODE = 0o600;
+
+/**
+ * Redaction cap. Reading the file to rewrite it costs its size in memory, and
+ * this runs during boot on a host that may already be under pressure. One
+ * session of Chromium logging is small (see `rotateNativeLog`) — a file past
+ * this bound means something looped, and the honest trade is to keep the
+ * evidence unredacted rather than risk an out-of-memory at launch.
+ */
+const MAX_REDACT_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Query-string bearer tokens, as Chromium writes them.
+ *
+ * Chromium's `INFO:CONSOLE` lines append the document URL, and the desktop app
+ * loads the dashboard as `?token=<jwt>` — so every renderer console message from
+ * that document records the session token verbatim. The value ends at the next
+ * URL/log delimiter; `&` matters because the real URL continues with `&sid=`.
+ *
+ * Deliberately narrow: only the query parameter shape that was observed. A
+ * broad "anything JWT-shaped" pattern would start eating legitimate log content.
+ */
+const TOKEN_QUERY_RE = /([?&](?:token|access_token)=)[^&\s"'`)\]]+/gi;
+
+/**
+ * Replace query-string token values with a marker, preserving everything else.
+ *
+ * Pure so the pattern is testable without touching a filesystem. The marker is
+ * left in place of the value rather than removing the parameter, so a log reader
+ * can still see that a tokened URL was involved.
+ */
+function redactTokensInText(text) {
+  return String(text == null ? "" : text).replace(TOKEN_QUERY_RE, "$1[REDACTED]");
+}
+
+/**
+ * Best-effort `chmod` to {@link SECRET_FILE_MODE}. Never throws.
+ *
+ * Separate from creation because it applies to BOTH generations: the file this
+ * boot creates and the one the previous boot left behind at an inherited 0644.
+ * On Windows the POSIX mode is largely advisory — the call is still made rather
+ * than platform-gated, because it is harmless there and gating it would be one
+ * more branch that only ever runs on one OS.
+ */
+function tightenLogMode(filePath, { fs, log = () => {} } = {}) {
+  if (!fs || typeof fs.chmodSync !== "function") return false;
+  try {
+    fs.chmodSync(filePath, SECRET_FILE_MODE);
+    return true;
+  } catch (e) {
+    log(`native log chmod failed at ${filePath}: ${e && e.message}`);
+    return false;
+  }
+}
+
+/**
+ * Strip credentials from a log file in place, and tighten its mode.
+ *
+ * Only ever called on the ROTATED generation, which this process owns outright
+ * after `renameSync` — the live file belongs to Chromium's own file handle and
+ * rewriting under it would race the writer. That split is why mode bits alone
+ * are not enough: they stop another local account reading the file, but the
+ * retained log is also the artifact users are asked to attach to a bug report,
+ * and that copy has to be clean on its own.
+ *
+ * Fail-soft in every direction, matching this module's posture: losing a
+ * redaction pass is worth a log line, never a failed launch. An `fs` double
+ * without the read/write/stat members simply opts out.
+ */
+function redactNativeLogSecrets(filePath, { fs, log = () => {} } = {}) {
+  if (!fs || typeof fs.readFileSync !== "function" || typeof fs.writeFileSync !== "function") {
+    return { scanned: false, redacted: false, skipped: "unsupported-fs" };
+  }
+  try {
+    if (typeof fs.statSync === "function") {
+      const size = Number(fs.statSync(filePath).size);
+      if (Number.isFinite(size) && size > MAX_REDACT_BYTES) {
+        log(`native log redaction skipped at ${filePath}: ${size} bytes over cap`);
+        return { scanned: false, redacted: false, skipped: "too-large" };
+      }
+    }
+    const raw = fs.readFileSync(filePath, "utf8");
+    const cleaned = redactTokensInText(raw);
+    if (cleaned === raw) return { scanned: true, redacted: false, skipped: null };
+    // Mode is passed for the create case; `writeFileSync` leaves an existing
+    // file's mode alone, which is why tightenLogMode runs regardless below.
+    fs.writeFileSync(filePath, cleaned, { mode: SECRET_FILE_MODE });
+    return { scanned: true, redacted: true, skipped: null };
+  } catch (e) {
+    log(`native log redaction failed at ${filePath}: ${e && e.message}`);
+    return { scanned: false, redacted: false, skipped: "error" };
+  }
+}
+
+/**
+ * Pre-create the live log with a tight mode, so Chromium opens an inode that is
+ * already owner-only.
+ *
+ * Chromium creates `--log-file` itself at the process's default umask, which on
+ * a normal macOS install is 0644 — world-readable, for a file that records the
+ * dashboard session token on every renderer console line. Nothing on this side
+ * can filter what Chromium writes into that handle, so the mode has to be set
+ * on the inode BEFORE Chromium opens it.
+ *
+ * `wx` (fail-if-exists) rather than `w`: truncating here would destroy exactly
+ * the evidence `rotateNativeLog` just went to the trouble of preserving in the
+ * blocked-rotation case. Creating the file empty keeps the module's existing
+ * "starts clean either way" property intact — Chromium appending to a
+ * zero-length file and truncating one are indistinguishable in the result.
+ *
+ * Never throws. An EEXIST still falls through to the `chmod`, which is the
+ * upgrade path for a log left at 0644 by an earlier build.
+ */
+function createTightLogFile(logPath, { fs, log = () => {} } = {}) {
+  if (!fs) return { created: false, tightened: false };
+  let created = false;
+  try {
+    if (typeof fs.openSync === "function" && typeof fs.closeSync === "function") {
+      fs.closeSync(fs.openSync(logPath, "wx", SECRET_FILE_MODE));
+      created = true;
+    } else if (typeof fs.writeFileSync === "function") {
+      fs.writeFileSync(logPath, "", { flag: "wx", mode: SECRET_FILE_MODE });
+      created = true;
+    }
+  } catch (e) {
+    if (!e || e.code !== "EEXIST") {
+      log(`native log pre-create failed at ${logPath}: ${e && e.message}`);
+      return { created: false, tightened: tightenLogMode(logPath, { fs, log }) };
+    }
+  }
+  return { created, tightened: tightenLogMode(logPath, { fs, log }) };
+}
+
 /**
  * Start-of-boot rotation, which is what bounds this file's size.
  *
@@ -160,6 +294,10 @@ function rotateNativeLog(logPath, { fs, log = () => {} } = {}) {
     // Search-indexer touch is enough); see `replace_with_retry` in
     // `src/kiro_crew/atomic_write.py`.
     fs.renameSync(logPath, previousPath);
+    // The retained generation is ours now, and it is the copy users hand over.
+    // Strip credentials from it and tighten its mode before anything reads it.
+    redactNativeLogSecrets(previousPath, { fs, log });
+    tightenLogMode(previousPath, { fs, log });
     return { rotated: true, blocked: false, previousPath };
   } catch (e) {
     // A read-only directory or a Windows sharing violation reaches here. The
@@ -201,6 +339,13 @@ function initNativeLogging({
   // previous generation has to be moved aside first or it is appended to (or
   // clobbered) instead of preserved.
   if (fs) ({ rotated, blocked, previousPath } = rotateNativeLog(logPath, { fs, log }));
+
+  // Chromium creates `--log-file` at the process umask (0644 on a normal macOS
+  // install) and records the dashboard session token on every renderer console
+  // line, so the inode has to be owner-only BEFORE Chromium opens it. Skipped
+  // when rotation was blocked: the un-rotated file still holds the session we
+  // are trying to preserve, and the sink is not armed for it either (below).
+  if (fs && !blocked) createTightLogFile(logPath, { fs, log });
 
   // Fail SAFE, not fail open. A blocked rotation means the un-rotated live log
   // still holds the session we were trying to preserve — and Chromium's own
@@ -258,6 +403,12 @@ module.exports = {
   previousNativeLogPath,
   nativeLoggingSwitches,
   rotateNativeLog,
+  redactTokensInText,
+  redactNativeLogSecrets,
+  createTightLogFile,
+  tightenLogMode,
   NATIVE_LOG_BASENAME,
   NATIVE_LOG_PREVIOUS_BASENAME,
+  SECRET_FILE_MODE,
+  MAX_REDACT_BYTES,
 };

--- a/website/electron/native-logging.js
+++ b/website/electron/native-logging.js
@@ -197,9 +197,32 @@ function redactNativeLogSecrets(filePath, { fs, log = () => {} } = {}) {
     const raw = fs.readFileSync(filePath, "utf8");
     const cleaned = redactTokensInText(raw);
     if (cleaned === raw) return { scanned: true, redacted: false, skipped: null };
-    // Mode is passed for the create case; `writeFileSync` leaves an existing
-    // file's mode alone, which is why tightenLogMode runs regardless below.
-    fs.writeFileSync(filePath, cleaned, { mode: SECRET_FILE_MODE });
+    // Atomic replace, NOT an in-place rewrite. `writeFileSync` truncates before
+    // it writes, so a write that fails partway (ENOSPC, EIO, a Windows sharing
+    // violation) would leave the retained log partial or empty — destroying the
+    // one generation this module exists to preserve. An unredacted log is a
+    // hygiene problem; a truncated one is the loss of the crash evidence, which
+    // is strictly worse. So: write a sibling at the tight mode, then rename over
+    // the original only once the write returned. `renameSync` carries the temp
+    // file's mode across, so the replacement is owner-only by construction.
+    // Mirrors `src/kiro_crew/atomic_write.py`, already cited by the rotation
+    // comment above for the same class of failure.
+    const tmpPath = `${filePath}.redact.tmp`;
+    try {
+      fs.writeFileSync(tmpPath, cleaned, { mode: SECRET_FILE_MODE });
+      fs.renameSync(tmpPath, filePath);
+    } catch (e) {
+      // The original is untouched on this path — that is the whole point of the
+      // sibling. Clean up the partial temp so it cannot be mistaken for a log,
+      // and report the miss rather than raising: this runs during boot.
+      try {
+        if (typeof fs.unlinkSync === "function") fs.unlinkSync(tmpPath);
+      } catch {
+        /* the temp may never have been created; nothing to clean up */
+      }
+      log(`native log redaction not applied at ${filePath}: ${e && e.message}`);
+      return { scanned: true, redacted: false, skipped: "replace-failed" };
+    }
     return { scanned: true, redacted: true, skipped: null };
   } catch (e) {
     log(`native log redaction failed at ${filePath}: ${e && e.message}`);

--- a/website/electron/native-logging.js
+++ b/website/electron/native-logging.js
@@ -207,9 +207,25 @@ function redactNativeLogSecrets(filePath, { fs, log = () => {} } = {}) {
     // file's mode across, so the replacement is owner-only by construction.
     // Mirrors `src/kiro_crew/atomic_write.py`, already cited by the rotation
     // comment above for the same class of failure.
+    // The temp path is predictable, so the write has to be exclusive-create:
+    // `writeFileSync`'s default `w` follows a symlink planted at that path and
+    // would land this log's contents on the link's target. `wx` (O_EXCL) refuses
+    // any pre-existing entry, symlink included, which is the same reason
+    // `createTightLogFile` below opens with `wx` rather than `w`. A stale temp
+    // from a crashed earlier pass would otherwise disable redaction forever, so
+    // EEXIST gets exactly one retry: unlink removes the entry itself — never
+    // whatever it points at — and the retry is still exclusive, so an attacker
+    // re-planting inside that window loses the race into the skip path below
+    // instead of winning a write.
     const tmpPath = `${filePath}.redact.tmp`;
     try {
-      fs.writeFileSync(tmpPath, cleaned, { mode: SECRET_FILE_MODE });
+      try {
+        fs.writeFileSync(tmpPath, cleaned, { mode: SECRET_FILE_MODE, flag: "wx" });
+      } catch (e) {
+        if (!e || e.code !== "EEXIST" || typeof fs.unlinkSync !== "function") throw e;
+        fs.unlinkSync(tmpPath);
+        fs.writeFileSync(tmpPath, cleaned, { mode: SECRET_FILE_MODE, flag: "wx" });
+      }
       fs.renameSync(tmpPath, filePath);
     } catch (e) {
       // The original is untouched on this path — that is the whole point of the

--- a/website/electron/test/native-logging.test.js
+++ b/website/electron/test/native-logging.test.js
@@ -10,8 +10,13 @@ const {
   previousNativeLogPath,
   nativeLoggingSwitches,
   rotateNativeLog,
+  redactTokensInText,
+  redactNativeLogSecrets,
+  createTightLogFile,
   NATIVE_LOG_BASENAME,
   NATIVE_LOG_PREVIOUS_BASENAME,
+  SECRET_FILE_MODE,
+  MAX_REDACT_BYTES,
 } = require("../native-logging");
 
 const LIVE = path.join("/logs", NATIVE_LOG_BASENAME);
@@ -20,19 +25,65 @@ const PREV = path.join("/logs", NATIVE_LOG_PREVIOUS_BASENAME);
 /**
  * fs double over an in-memory file set, recording renames.
  * `present` lists paths that exist; `throwOn` makes renameSync fail.
+ *
+ * Also models the three things the credential-hygiene path needs: file CONTENT
+ * (so a redaction can be observed), file MODE (so a tightening can be), and
+ * `wx` create semantics (so "must not truncate an existing log" is testable).
+ * `contents` seeds bodies for paths in `present`; `throwReadOn` makes a read of
+ * that path fail, which is the fail-soft case.
  */
-function fakeFs({ present = [], throwOn = null } = {}) {
+function fakeFs({ present = [], throwOn = null, contents = {}, throwReadOn = null } = {}) {
   const files = new Set(present);
   const renames = [];
+  const body = new Map(Object.entries(contents));
+  const modes = new Map();
+  for (const p of present) modes.set(p, 0o644); // what Chromium's umask leaves
   return {
     files,
     renames,
+    body,
+    modes,
     existsSync: (p) => files.has(p),
     renameSync(from, to) {
       if (throwOn) throw new Error(throwOn);
       renames.push({ from, to });
       files.delete(from);
       files.add(to);
+      if (body.has(from)) {
+        body.set(to, body.get(from));
+        body.delete(from);
+      }
+      if (modes.has(from)) {
+        modes.set(to, modes.get(from));
+        modes.delete(from);
+      }
+    },
+    openSync(p, flag, mode) {
+      if (String(flag).includes("x") && files.has(p)) {
+        const err = new Error(`EEXIST: file already exists, open '${p}'`);
+        err.code = "EEXIST";
+        throw err;
+      }
+      files.add(p);
+      body.set(p, "");
+      if (mode !== undefined) modes.set(p, mode);
+      return 1;
+    },
+    closeSync() {},
+    chmodSync(p, mode) {
+      modes.set(p, mode);
+    },
+    statSync(p) {
+      return { size: Buffer.byteLength(body.get(p) || "", "utf8") };
+    },
+    readFileSync(p) {
+      if (throwReadOn && p === throwReadOn) throw new Error("EIO");
+      return body.get(p) || "";
+    },
+    writeFileSync(p, data, opts) {
+      files.add(p);
+      body.set(p, String(data));
+      if (opts && opts.mode !== undefined && !modes.has(p)) modes.set(p, opts.mode);
     },
   };
 }
@@ -166,7 +217,17 @@ describe("initNativeLogging", () => {
   it("rotates before arming the switches", () => {
     const { fs } = harness();
     assert.deepEqual(fs.renames, [{ from: LIVE, to: PREV }]);
-    assert.equal(fs.files.has(LIVE), false);
+  });
+
+  // The live path is deliberately re-created after the rotation (empty, 0600) so
+  // Chromium opens an inode that is already owner-only. Before that, Chromium
+  // created it at the process umask — 0644 for a file that records the session
+  // token on every renderer console line.
+  it("leaves the live log pre-created at an owner-only mode", () => {
+    const { fs } = harness();
+    assert.equal(fs.files.has(LIVE), true, "Chromium must open an inode we already tightened");
+    assert.equal(fs.modes.get(LIVE), 0o600);
+    assert.equal(fs.body.get(LIVE), "", "pre-creation must not add content of its own");
   });
 
   // A boot-path helper must never be the reason the app fails to start.
@@ -220,6 +281,21 @@ describe("initNativeLogging", () => {
     assert.ok(lines.some((l) => /NOT armed/.test(l)));
   });
 
+  // The pre-create is skipped on the same fail-safe reasoning as the sink: the
+  // un-rotated file still holds the session we were trying to preserve, so this
+  // boot must not open it, tighten it, or write a byte into it.
+  it("does not pre-create or rewrite the live log when rotation was blocked", () => {
+    const fs = fakeFs({
+      present: [LIVE],
+      contents: { [LIVE]: "prior session evidence" },
+      throwOn: "EPERM",
+    });
+    const { result } = harness({ fs });
+    assert.equal(result.blocked, true);
+    assert.equal(fs.body.get(LIVE), "prior session evidence");
+    assert.equal(fs.modes.get(LIVE), 0o644, "an untouched file keeps the mode it had");
+  });
+
   // Minidumps go to their own directory and are unaffected by the log file, so a
   // blocked rotation must not leave a crash this boot completely undocumented.
   it("still arms minidumps when the file sink is skipped", () => {
@@ -254,6 +330,163 @@ describe("initNativeLogging", () => {
       lines.find((l) => /native logging armed/.test(l)),
       /previous=none/
     );
+  });
+});
+
+// A real line, as Chromium writes it: the token is not something the app logs
+// deliberately — `INFO:CONSOLE` appends the document URL, and the desktop app
+// loads the dashboard as `?token=<jwt>`, so every renderer console message from
+// that document records the session token.
+const TOKENED_LINE =
+  '[123:0828/122558.487579:INFO:CONSOLE:0] "ResizeObserver loop completed with undelivered ' +
+  'notifications.", source: http://localhost:5476/chat/gateway?token=eyJzdWIiOiJVMEJRQTNYUkI4RCJ9' +
+  ".MgrpIEuHoX7bVuGcQSmK7xqK4tytvtrZiXvy7NtEesw&sid=chat-155-1787945035 (0)";
+
+describe("redactTokensInText", () => {
+  it("replaces the token value and stops at the next parameter", () => {
+    const out = redactTokensInText(TOKENED_LINE);
+    assert.match(out, /\?token=\[REDACTED\]&sid=chat-155-1787945035/);
+    assert.ok(!/eyJzdWIi/.test(out), "no part of the JWT may survive");
+  });
+
+  it("keeps everything around the token intact", () => {
+    const out = redactTokensInText(TOKENED_LINE);
+    assert.match(out, /INFO:CONSOLE:0/);
+    assert.match(out, /ResizeObserver loop completed/);
+    assert.match(out, /http:\/\/localhost:5476\/chat\/gateway/);
+  });
+
+  it("redacts every occurrence, not just the first", () => {
+    const out = redactTokensInText("a?token=AAA b\nc?token=BBB d");
+    assert.equal(out, "a?token=[REDACTED] b\nc?token=[REDACTED] d");
+  });
+
+  it("covers the &token= and access_token= spellings", () => {
+    assert.equal(redactTokensInText("x?a=1&token=ZZZ"), "x?a=1&token=[REDACTED]");
+    assert.equal(redactTokensInText("x?access_token=ZZZ"), "x?access_token=[REDACTED]");
+  });
+
+  // The pattern is deliberately narrow. A broad "anything JWT-shaped" rule would
+  // start eating legitimate log content, which is the opposite of the goal.
+  it("leaves a line with no query token untouched", () => {
+    const line = "[1:0828/1:INFO:CONSOLE:0] plain message, source: http://localhost:5476/ (0)";
+    assert.equal(redactTokensInText(line), line);
+  });
+
+  it("does not throw on nullish input", () => {
+    assert.equal(redactTokensInText(null), "");
+    assert.equal(redactTokensInText(undefined), "");
+  });
+});
+
+describe("redactNativeLogSecrets", () => {
+  it("rewrites the retained log in place and tightens its mode", () => {
+    const fs = fakeFs({ present: [PREV], contents: { [PREV]: TOKENED_LINE } });
+    const out = redactNativeLogSecrets(PREV, { fs });
+    assert.deepEqual(out, { scanned: true, redacted: true, skipped: null });
+    assert.match(fs.body.get(PREV), /token=\[REDACTED\]/);
+    assert.ok(!/eyJzdWIi/.test(fs.body.get(PREV)));
+  });
+
+  it("does not rewrite a log that carries no credential", () => {
+    const clean = "[1:0828/1:INFO:CONSOLE:0] nothing to see, source: http://localhost:5476/ (0)";
+    const fs = fakeFs({ present: [PREV], contents: { [PREV]: clean } });
+    assert.deepEqual(redactNativeLogSecrets(PREV, { fs }), {
+      scanned: true,
+      redacted: false,
+      skipped: null,
+    });
+    assert.equal(fs.body.get(PREV), clean, "an untouched log must stay byte-identical");
+  });
+
+  // Reading the file costs its size in memory, at boot, on a host that may
+  // already be under pressure. Past the cap the honest trade is unredacted
+  // evidence over an out-of-memory launch.
+  it("skips a log past the size cap rather than reading it into memory", () => {
+    const fs = fakeFs({ present: [PREV], contents: { [PREV]: TOKENED_LINE } });
+    fs.statSync = () => ({ size: MAX_REDACT_BYTES + 1 });
+    const lines = [];
+    const out = redactNativeLogSecrets(PREV, { fs, log: (m) => lines.push(m) });
+    assert.equal(out.skipped, "too-large");
+    assert.equal(out.redacted, false);
+    assert.ok(lines.some((l) => /over cap/.test(l)));
+  });
+
+  // Boot-path posture: losing a redaction pass is worth a log line, never a
+  // failed launch.
+  it("survives an unreadable log without throwing", () => {
+    const fs = fakeFs({ present: [PREV], contents: { [PREV]: TOKENED_LINE }, throwReadOn: PREV });
+    const lines = [];
+    const out = redactNativeLogSecrets(PREV, { fs, log: (m) => lines.push(m) });
+    assert.equal(out.skipped, "error");
+    assert.ok(lines.some((l) => /redaction failed/.test(l)));
+  });
+
+  it("opts out of an fs double that cannot read or write", () => {
+    const out = redactNativeLogSecrets(PREV, { fs: { existsSync: () => true } });
+    assert.equal(out.skipped, "unsupported-fs");
+  });
+});
+
+describe("createTightLogFile", () => {
+  it("creates the log empty at owner-only mode", () => {
+    const fs = fakeFs({ present: [] });
+    const out = createTightLogFile(LIVE, { fs });
+    assert.deepEqual(out, { created: true, tightened: true });
+    assert.equal(fs.modes.get(LIVE), SECRET_FILE_MODE);
+    assert.equal(fs.body.get(LIVE), "");
+  });
+
+  // `wx`, not `w`. Truncating here would destroy exactly the evidence
+  // rotateNativeLog preserves in the blocked-rotation case.
+  it("never truncates an existing log, but still tightens it", () => {
+    const fs = fakeFs({ present: [LIVE], contents: { [LIVE]: "prior session evidence" } });
+    const out = createTightLogFile(LIVE, { fs });
+    assert.equal(out.created, false, "an existing file must not be re-created");
+    assert.equal(fs.body.get(LIVE), "prior session evidence");
+    assert.equal(fs.modes.get(LIVE), SECRET_FILE_MODE, "0644 left by an older build is upgraded");
+  });
+
+  it("survives an fs whose create fails, and still reports the chmod attempt", () => {
+    const lines = [];
+    const fs = fakeFs({ present: [] });
+    fs.openSync = () => {
+      throw new Error("EROFS");
+    };
+    const out = createTightLogFile(LIVE, { fs, log: (m) => lines.push(m) });
+    assert.equal(out.created, false);
+    assert.ok(lines.some((l) => /pre-create failed/.test(l)));
+  });
+
+  it("does nothing at all without an fs", () => {
+    assert.deepEqual(createTightLogFile(LIVE, {}), { created: false, tightened: false });
+  });
+});
+
+describe("rotateNativeLog credential hygiene", () => {
+  it("redacts and tightens the generation it just took ownership of", () => {
+    const fs = fakeFs({ present: [LIVE], contents: { [LIVE]: TOKENED_LINE } });
+    assert.equal(rotateNativeLog(LIVE, { fs }).rotated, true);
+    assert.match(fs.body.get(PREV), /token=\[REDACTED\]/);
+    assert.equal(fs.modes.get(PREV), SECRET_FILE_MODE);
+  });
+
+  // The live file belongs to Chromium's own open handle; rewriting under it would
+  // race the writer. Only the renamed copy is ours.
+  it("leaves the live file alone when there is nothing to rotate", () => {
+    const fs = fakeFs({ present: [], contents: {} });
+    assert.equal(rotateNativeLog(LIVE, { fs }).rotated, false);
+    assert.deepEqual(fs.renames, []);
+  });
+
+  it("does not touch the retained log when a needed rotation was blocked", () => {
+    const fs = fakeFs({
+      present: [LIVE],
+      contents: { [LIVE]: TOKENED_LINE },
+      throwOn: "EPERM",
+    });
+    assert.equal(rotateNativeLog(LIVE, { fs }).blocked, true);
+    assert.equal(fs.body.get(LIVE), TOKENED_LINE, "the evidence must survive untouched");
   });
 });
 

--- a/website/electron/test/native-logging.test.js
+++ b/website/electron/test/native-logging.test.js
@@ -32,15 +32,23 @@ const PREV = path.join("/logs", NATIVE_LOG_PREVIOUS_BASENAME);
  * `contents` seeds bodies for paths in `present`; `throwReadOn` makes a read of
  * that path fail, which is the fail-soft case.
  */
-function fakeFs({ present = [], throwOn = null, contents = {}, throwReadOn = null } = {}) {
+function fakeFs({
+  present = [],
+  throwOn = null,
+  contents = {},
+  throwReadOn = null,
+  throwWriteOn = null,
+} = {}) {
   const files = new Set(present);
   const renames = [];
+  const unlinked = [];
   const body = new Map(Object.entries(contents));
   const modes = new Map();
   for (const p of present) modes.set(p, 0o644); // what Chromium's umask leaves
   return {
     files,
     renames,
+    unlinked,
     body,
     modes,
     existsSync: (p) => files.has(p),
@@ -57,6 +65,12 @@ function fakeFs({ present = [], throwOn = null, contents = {}, throwReadOn = nul
         modes.set(to, modes.get(from));
         modes.delete(from);
       }
+    },
+    unlinkSync(p) {
+      unlinked.push(p);
+      files.delete(p);
+      body.delete(p);
+      modes.delete(p);
     },
     openSync(p, flag, mode) {
       if (String(flag).includes("x") && files.has(p)) {
@@ -81,6 +95,7 @@ function fakeFs({ present = [], throwOn = null, contents = {}, throwReadOn = nul
       return body.get(p) || "";
     },
     writeFileSync(p, data, opts) {
+      if (throwWriteOn && p === throwWriteOn) throw new Error("ENOSPC");
       files.add(p);
       body.set(p, String(data));
       if (opts && opts.mode !== undefined && !modes.has(p)) modes.set(p, opts.mode);
@@ -380,12 +395,52 @@ describe("redactTokensInText", () => {
 });
 
 describe("redactNativeLogSecrets", () => {
+  const TMP = `${PREV}.redact.tmp`;
+
   it("rewrites the retained log in place and tightens its mode", () => {
     const fs = fakeFs({ present: [PREV], contents: { [PREV]: TOKENED_LINE } });
     const out = redactNativeLogSecrets(PREV, { fs });
     assert.deepEqual(out, { scanned: true, redacted: true, skipped: null });
     assert.match(fs.body.get(PREV), /token=\[REDACTED\]/);
     assert.ok(!/eyJzdWIi/.test(fs.body.get(PREV)));
+  });
+
+  // NOT an in-place rewrite: writeFileSync truncates first, so a partial write
+  // would destroy the one retained generation. The sibling+rename is what makes
+  // the failure path lose the redaction instead of the evidence.
+  it("goes through an owner-only sibling and renames over the original", () => {
+    const fs = fakeFs({ present: [PREV], contents: { [PREV]: TOKENED_LINE } });
+    redactNativeLogSecrets(PREV, { fs });
+    assert.deepEqual(fs.renames, [{ from: TMP, to: PREV }]);
+    assert.equal(fs.modes.get(PREV), SECRET_FILE_MODE, "the mode rides across the rename");
+    assert.equal(fs.files.has(TMP), false, "no temp may be left behind");
+  });
+
+  it("leaves the original intact when the sibling write fails", () => {
+    const fs = fakeFs({
+      present: [PREV],
+      contents: { [PREV]: TOKENED_LINE },
+      throwWriteOn: TMP,
+    });
+    const lines = [];
+    const out = redactNativeLogSecrets(PREV, { fs, log: (m) => lines.push(m) });
+    assert.equal(out.skipped, "replace-failed");
+    assert.equal(out.redacted, false);
+    assert.equal(fs.body.get(PREV), TOKENED_LINE, "the retained evidence must survive verbatim");
+    assert.deepEqual(fs.renames, [], "nothing may be renamed over the original");
+    assert.ok(lines.some((l) => /not applied/.test(l)));
+  });
+
+  it("cleans up the temp when the rename fails", () => {
+    const fs = fakeFs({
+      present: [PREV],
+      contents: { [PREV]: TOKENED_LINE },
+      throwOn: "EPERM",
+    });
+    const out = redactNativeLogSecrets(PREV, { fs });
+    assert.equal(out.skipped, "replace-failed");
+    assert.equal(fs.body.get(PREV), TOKENED_LINE);
+    assert.ok(fs.unlinked.includes(TMP), "a partial temp must not be left looking like a log");
   });
 
   it("does not rewrite a log that carries no credential", () => {

--- a/website/electron/test/native-logging.test.js
+++ b/website/electron/test/native-logging.test.js
@@ -28,7 +28,10 @@ const PREV = path.join("/logs", NATIVE_LOG_PREVIOUS_BASENAME);
  *
  * Also models the three things the credential-hygiene path needs: file CONTENT
  * (so a redaction can be observed), file MODE (so a tightening can be), and
- * `wx` create semantics (so "must not truncate an existing log" is testable).
+ * `wx` create semantics on BOTH `openSync` and `writeFileSync` (so "must not
+ * truncate an existing log" and "must not follow a planted temp path" are
+ * testable). Every write is recorded in `writes` with its flag, so the
+ * exclusive-create contract can be asserted directly rather than inferred.
  * `contents` seeds bodies for paths in `present`; `throwReadOn` makes a read of
  * that path fail, which is the fail-soft case.
  */
@@ -42,6 +45,7 @@ function fakeFs({
   const files = new Set(present);
   const renames = [];
   const unlinked = [];
+  const writes = [];
   const body = new Map(Object.entries(contents));
   const modes = new Map();
   for (const p of present) modes.set(p, 0o644); // what Chromium's umask leaves
@@ -49,6 +53,7 @@ function fakeFs({
     files,
     renames,
     unlinked,
+    writes,
     body,
     modes,
     existsSync: (p) => files.has(p),
@@ -96,6 +101,13 @@ function fakeFs({
     },
     writeFileSync(p, data, opts) {
       if (throwWriteOn && p === throwWriteOn) throw new Error("ENOSPC");
+      const flag = opts && opts.flag !== undefined ? String(opts.flag) : "w";
+      writes.push({ path: p, flag, mode: opts && opts.mode });
+      if (flag.includes("x") && files.has(p)) {
+        const err = new Error(`EEXIST: file already exists, open '${p}'`);
+        err.code = "EEXIST";
+        throw err;
+      }
       files.add(p);
       body.set(p, String(data));
       if (opts && opts.mode !== undefined && !modes.has(p)) modes.set(p, opts.mode);
@@ -441,6 +453,43 @@ describe("redactNativeLogSecrets", () => {
     assert.equal(out.skipped, "replace-failed");
     assert.equal(fs.body.get(PREV), TOKENED_LINE);
     assert.ok(fs.unlinked.includes(TMP), "a partial temp must not be left looking like a log");
+  });
+
+  // The temp path is derived from the log path, so it is predictable. A default
+  // `w` write would follow a symlink planted there and land log contents on the
+  // link's target; O_EXCL is what refuses that.
+  it("creates the temp exclusively so a planted path is refused, not followed", () => {
+    const fs = fakeFs({ present: [PREV], contents: { [PREV]: TOKENED_LINE } });
+    redactNativeLogSecrets(PREV, { fs });
+    const tmpWrites = fs.writes.filter((w) => w.path === TMP);
+    assert.ok(tmpWrites.length > 0, "the redaction must go through the temp");
+    for (const w of tmpWrites) {
+      assert.equal(w.flag, "wx", "every temp write must be exclusive-create");
+      assert.equal(w.mode, SECRET_FILE_MODE);
+    }
+  });
+
+  // Exclusive create alone would let one crashed pass disable redaction forever,
+  // so EEXIST gets a single retry. Unlink removes the entry itself, never what it
+  // points at, and the retry is still exclusive.
+  it("clears a stale temp and retries rather than abandoning the redaction", () => {
+    const fs = fakeFs({ present: [PREV, TMP], contents: { [PREV]: TOKENED_LINE } });
+    const out = redactNativeLogSecrets(PREV, { fs });
+    assert.deepEqual(out, { scanned: true, redacted: true, skipped: null });
+    assert.ok(fs.unlinked.includes(TMP), "the stale entry must be removed, not written through");
+    assert.equal(fs.writes.filter((w) => w.path === TMP && w.flag === "wx").length, 2);
+    assert.match(fs.body.get(PREV), /token=\[REDACTED\]/);
+    assert.equal(fs.modes.get(PREV), SECRET_FILE_MODE);
+  });
+
+  it("keeps the log verbatim when the temp cannot be created exclusively", () => {
+    const fs = fakeFs({ present: [PREV, TMP], contents: { [PREV]: TOKENED_LINE } });
+    delete fs.unlinkSync; // no way to clear the blocking entry, so no retry is possible
+    const out = redactNativeLogSecrets(PREV, { fs });
+    assert.equal(out.skipped, "replace-failed");
+    assert.equal(out.redacted, false);
+    assert.equal(fs.body.get(PREV), TOKENED_LINE, "refusing to write beats writing somewhere else");
+    assert.deepEqual(fs.renames, []);
   });
 
   it("does not rewrite a log that carries no credential", () => {


### PR DESCRIPTION
## Problem / Motivation

The desktop app loads the dashboard as `?token=<jwt>`, and Chromium appends the
document URL to every `INFO:CONSOLE` line. So each renderer console message
records the live session credential verbatim in `chromium.log`. Chromium also
creates `--log-file` at the process umask — 0644 on a normal macOS install — so
that file is world-readable on a shared machine, and it is the artifact users are
asked to attach to a bug report.

## Why it matters

Two exposures, both on the default path with no user action:

- **Local, for the duration of the install.** Any other account on the machine can
  read a live bearer credential out of `~/Library/Logs/…/chromium.log`.
- **Off the machine, deliberately.** The retained log is what a user hands over
  with a bug report, so the credential travels with it.

The value is a working session token, not a fingerprint, and nothing on this side
can filter what Chromium writes into that handle.

## What changed (motivation → approach → change)

**Symptom → cause.** The credential reaches the file through Chromium's own
writer, and the file is readable because Chromium creates it at the umask. Those
are two separate causes and neither fix covers the other, so both are addressed:
content for the generation we own, mode for the generation Chromium owns.

**Approach.** Split by who owns the file handle.

- The **rotated** generation (`chromium.previous.log`) belongs to this process
  outright after `renameSync`, so its content can be rewritten. It is redacted
  through an atomic replace — write a sibling at 0600, then rename over the
  original — because `writeFileSync` truncates before writing, and a write that
  fails partway would destroy the crash evidence rotation exists to preserve. The
  temp is opened `wx` so a symlink planted at that predictable path cannot
  redirect the log's contents.
- The **live** file belongs to Chromium's handle, so only its mode can be
  touched. It is pre-created empty at 0600 with `wx` before the switches are
  armed, so Chromium opens an inode that is already owner-only.

**The pre-create alone is not sufficient, which is what the latest revision
addresses.** This side cannot pin down Chromium's open mode for `--log-file` —
the same limit the module's blocked-rotation branch already reasons from — and one
of the possibilities is unlink-then-create, which would discard the pre-created
inode and recreate the path at the umask. Rather than assert what Chromium does,
the fix removes the dependency on knowing: `initNativeLogging` now returns a
`tightenLiveLog` callback and `main.js` runs it on `app.whenReady()`, after
Chromium has opened the file. The pre-create wins when Chromium opens the existing
inode (append or truncate); the post-open pass covers the case where it does not.
The end state is owner-only under all three open semantics.

`tightenLiveLog` is idempotent — on the ordinary path the chmod is a no-op — and
fail-soft, returning `false` and logging rather than throwing.

**Everything that touches a path this module does not own goes through one
identity-checked descriptor.** `renameSync` moves a symlink rather than resolving
it, so a `chromium.log` link planted before boot would arrive at the redaction step
as the retained generation, and a path-based `chmod` or read would follow it.
`openRegularFile` refuses anything `lstat` does not call a regular file and
re-checks the opened descriptor with `fstat`, so a swap landing between the two
loses into a refusal; callers then act on the descriptor (`fchmodSync`, `readSync`).
A link to a character device is the case that makes this load-bearing: it reports
size 0, so it lands on the small-file branch, where an unbounded read would exhaust
memory at launch.

**Redaction is byte-exact, never a string round-trip.** A crash truncates the log
mid-write, so its tail is very often invalid UTF-8 — and a decode would turn that
into U+FFFD, which the atomic replace then makes permanent. `redactTokensInBuffer`
replaces token values byte-wise and copies every other byte verbatim. This is safe
on arbitrary bytes because every byte it scans for is ASCII, and a UTF-8 multi-byte
sequence consists entirely of bytes `>= 0x80`, so a match can never land inside one.

**Redaction runs before the rename, and a failure aborts rather than deletes.** The
rename overwrites the older retained generation, so a redaction failing after it
would leave one file and a choice between keeping a live credential in the copy
users attach or destroying the last crash evidence. Doing it in this order costs
neither: both files stay untouched and rotation simply does not happen that boot,
reported as `blocked` so the sink is not armed over a file we could not clean.
Rewriting the live path here is safe because rotation runs before the switches are
appended and only in the single-instance lock winner, so nothing holds that file.

Redaction switches strategy rather than giving up past 32 MB: over the bound the
same pass runs a chunk at a time, splitting on the newline byte and carrying the
unterminated tail, because exceeding the bound means the console looped — which is
precisely the run a user reports, and so the log most likely to be attached.

## Tests

`website/electron/test/native-logging.test.js`, 97 assertions passing across this
file and the two source-order suites it shares `main.js` with.

Mode, on both generations:

- `re-tightens a live log Chromium unlinked and recreated at the umask` — the case
  a pre-create alone cannot cover; the `fakeFs` models the whole sequence.
- `is a no-op when the pre-created inode survived` — idempotence, which is what
  makes the post-open pass safe to run unconditionally on boot.
- `refuses a rotated log that is a symlink instead of chmodding its target` —
  asserts the link target's mode is untouched.
- `refuses when the path changes identity between the stat and the open`, and
  `closes the descriptor when the identity check rejects it`.

Redaction, byte-exact:

- `preserves invalid UTF-8 bytes while redacting` on both the whole-file and the
  streaming path — a lone `0xE4` beside a token must still be `0xE4` afterwards,
  not U+FFFD. The double accounts in `latin1` so a non-UTF-8 byte survives its own
  in-memory representation.
- `leaves a non-UTF-8 log with no token byte-identical`, asserting no rename.
- `agrees with the string form on every ASCII case` — twelve inputs covering the
  grammar, so the byte and string forms cannot drift apart.
- `redacts a log past the size cap by streaming instead of skipping it`,
  `redacts a token that straddles a chunk boundary`, and
  `holds no more than one chunk while streaming a multi-chunk log` — the memory
  bound is measured by wrapping `readSync`, not asserted.
- `survives a short write while losing no bytes`, and
  `reports rather than spins when a write makes no progress`.

Rotation ordering:

- `aborts the rotation without touching either generation when redaction fails` —
  both generations byte-identical, nothing renamed, neither unlinked.
- `redacts before renaming, not after` — asserted on the recorded rename order,
  since the end state alone cannot distinguish the two.

Already covered: the exclusive-create contract on the pre-create and both redaction
temps (asserted on recorded flags, not inferred), rotation ordering relative to the
switches, the blocked-rotation fail-safe, and the exact Chromium switch spellings.

## Manual verification

No packaged launch was performed, and the change is shaped so that it is not the
evidence this rests on. The design concern offered two routes — prove Chromium
opens the existing inode, or stop depending on it. This takes the second: the
post-open `chmod` makes the end state mode-correct whether Chromium appends,
truncates, or unlinks and recreates, so there is no open-mode claim left to verify.
The unlink-and-recreate branch a real launch would have been needed to rule on is
covered by a unit test instead.

Two files in the `electron` suite fail locally for a reason unrelated to this
diff: `packaging.test.js` and `store-rename-migration.test.js` both fail on
missing modules (`electron-store`, `app-builder-lib`) because
`website/electron/node_modules` is not installed in this checkout. Neither file is
in the diff. Those gates are delegated to CI.

## Related Issues

Fixes #6629

Residual gap deferred out of scope, tracked separately: #11189 — the **live**
`chromium.log` still records the session token, because Chromium owns that file
handle and nothing on this side can filter what goes into it. This PR closes the
retained generation and sets `0600` on the live one; keeping the bearer out of the
document URL, or revealing a sanitized export instead of the directory, are design
decisions in other subsystems.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a value that crosses a trust or process boundary is asserted, never
assumed. Six blocking findings on this one file were the same defect wearing
different clothes — a pre-created inode assumed to survive a foreign process's
open, a path assumed not to be a symlink, a `writeSync` count assumed complete, a
byte→string→byte round-trip assumed lossless, a callee's failure status assumed
irrelevant, and an ordering assumed safe because the end state looked right. The
prompt-level rule that catches all six: where code prepares state for another
process, or reads a value another layer produced, require the check *after* the
boundary rather than the preparation *before* it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the module's own comments carry the
      reasoning; no user-facing docs describe log file modes
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The template carries an OSPO placeholder rather than published wording; I agree to
the CLA text once it is added there.
