### PR TITLE
fix(logging): move gateway.log I/O off the event loop

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -27,15 +27,17 @@ _ensure_ssl_certs()
 
 import argparse
 import asyncio
+import atexit
 import faulthandler
 import importlib
 import importlib.machinery
 import logging
 import os
+import queue
 import shutil
 import subprocess
 import sys
-from logging.handlers import RotatingFileHandler
+from logging.handlers import QueueHandler, QueueListener, RotatingFileHandler
 from pathlib import Path
 from typing import NoReturn
 
@@ -768,6 +770,65 @@ class _FdTrackingRotatingFileHandler(RotatingFileHandler):
         _redirect_fds_to(Path(self.baseFilename))
 
 
+class _CliLogQueueHandler(QueueHandler):
+    """Marker subclass so re-entrant setup (and tests) can find the CLI's own
+    queue handler among whatever other handlers the process accumulated."""
+
+
+# Commands that run an asyncio event loop for hours -- the ones the loop-stall
+# watchdog guards. Only these need file-handler I/O moved off the calling
+# thread, and none of them ever exec-over-self, so the atexit / bounded
+# force-exit drains cover every exit path they have. Short-lived CLI verbs
+# keep synchronous handlers: several replace the process via ``os.exec*``
+# (``logs -f`` -> tail/journalctl, ``config edit`` -> $EDITOR, ``pod exec``),
+# which skips atexit and would strand queued records -- and none of them runs
+# an event loop, so the queue buys them nothing.
+_LONG_LIVED_COMMANDS = {"serve", "gateway", "chat", None}
+
+_LOG_QUEUE_LISTENER: QueueListener | None = None
+
+
+def _stop_log_queue_listener(timeout: float | None = None) -> None:
+    """Stop the log queue listener, draining every queued record to disk.
+
+    Idempotent — registered via ``atexit`` so process shutdown flushes the
+    queued tail. Also the deterministic drain point for tests: after this
+    returns, every record logged before the call has been written by the
+    file handler.
+
+    ``timeout`` bounds the drain for force-exit paths (a second SIGINT/
+    SIGTERM hard-exits via ``os._exit``, which skips atexit): the sentinel
+    is enqueued and the listener thread joined for at most that long, so a
+    wedged disk cannot hang the force exit. When the thread does not finish
+    in time, flush/close are skipped — they would block on the same wedged
+    handler.
+    """
+    global _LOG_QUEUE_LISTENER
+    listener, _LOG_QUEUE_LISTENER = _LOG_QUEUE_LISTENER, None
+    if listener is None:
+        return
+    try:
+        if timeout is None:
+            listener.stop()
+        else:
+            listener.enqueue_sentinel()
+            # QueueListener has no bounded stop; join its (private but stable
+            # across 3.10-3.14) thread handle against the deadline.
+            thread = getattr(listener, "_thread", None)
+            if thread is not None:
+                thread.join(timeout)
+                if thread.is_alive():
+                    return  # wedged handler — do not block the force exit
+    except Exception:
+        return  # interpreter-teardown races must not raise
+    for handler in listener.handlers:
+        try:
+            handler.flush()
+            handler.close()
+        except Exception:
+            pass  # a broken handler must not block shutdown
+
+
 def _setup_cli_logging(command: str | None, verbose: int) -> None:
     """Configure console echo + persistent ``gateway.log`` logging.
 
@@ -788,6 +849,14 @@ def _setup_cli_logging(command: str | None, verbose: int) -> None:
       redirect still land, now formatted and PID-stamped;
     - after the boot rotation, fds 1/2 are re-pointed at the live log so raw
       writes (uncaught tracebacks, child stderr) do not land in ``.prev``.
+
+    In BOTH modes, for LONG-LIVED commands (``_LONG_LIVED_COMMANDS``) the file
+    handler is not attached to a logger directly: the logger gets a
+    ``QueueHandler`` and the file handler lives on a ``QueueListener`` thread,
+    so no file I/O (rollover included) ever runs on the event-loop thread.
+    Short-lived commands attach the file handler synchronously — they run no
+    event loop, and several exec-over-self (skipping atexit), where a queued
+    tail would be lost. See the inline comment at the attach site.
     """
     if verbose >= 2:
         level = logging.DEBUG
@@ -863,16 +932,52 @@ def _setup_cli_logging(command: str | None, verbose: int) -> None:
         # Root attach: kiro_crew records arrive once via propagation, and
         # third-party WARNINGs land formatted — replacing what the accidental
         # stderr echo used to provide unformatted.
-        logging.getLogger().addHandler(fh)
+        target_logger = logging.getLogger()
     else:
-        logging.getLogger("kiro_crew").addHandler(fh)
+        target_logger = logging.getLogger("kiro_crew")
+
+    # Never run file-handler I/O on the caller's thread of a LONG-LIVED
+    # command: the gateway invokes this from the thread that will run the
+    # asyncio event loop, and an inline emit contends for Handler.lock with
+    # every worker thread — while a size-based rollover runs the WHOLE rename
+    # chain plus the dup2 fd re-point on the loop. Blocking past the
+    # loop-stall watchdog's ``exit_after`` hard-exits the gateway mid-turn
+    # and orphans every in-flight subagent. A QueueHandler makes emit a
+    # non-blocking put; the QueueListener's thread owns the file handler, so
+    # ALL file I/O — ``doRollover()`` and ``_redirect_fds_to()`` included —
+    # happens off the loop. Secret redaction is unaffected: it hooks the
+    # log-record FACTORY (creation time, producer thread), upstream of any
+    # handler.
+    #
+    # Short-lived commands keep the synchronous handler on purpose: none of
+    # them runs an event loop (nothing to stall), and several replace the
+    # process via ``os.exec*`` (``logs -f``, ``config edit``, ``pod exec``),
+    # which skips atexit — a queue there would strand its tail records, while
+    # a sync handler has already written them by the time exec runs. See
+    # ``_LONG_LIVED_COMMANDS``.
+    if command in _LONG_LIVED_COMMANDS:
+        global _LOG_QUEUE_LISTENER
+        _stop_log_queue_listener()  # re-entrant call (tests): retire the old thread
+        for lgr in (logging.getLogger(), logging.getLogger("kiro_crew")):
+            for stale in [h for h in lgr.handlers if isinstance(h, _CliLogQueueHandler)]:
+                lgr.removeHandler(stale)  # re-entrant call: orphaned producer
+        log_queue: "queue.SimpleQueue[logging.LogRecord]" = queue.SimpleQueue()
+        queue_handler = _CliLogQueueHandler(log_queue)
+        # Gate at the producer: records the file handler would drop must not
+        # transit the queue at all.
+        queue_handler.setLevel(fh.level)
+        _LOG_QUEUE_LISTENER = QueueListener(log_queue, fh, respect_handler_level=True)
+        _LOG_QUEUE_LISTENER.start()
+        atexit.register(_stop_log_queue_listener)
+        target_logger.addHandler(queue_handler)
+    else:
+        target_logger.addHandler(fh)
 
     # Install secret redaction filter — scrubs Bearer tokens from all kiro_crew
     # log output before it reaches any handler. The filter also accepts literal
     # secret values to redact, but none are passed here: wiring resolved vault
     # secret values into the filter is a follow-up PR. Bearer token redaction is
     # active immediately with zero vault I/O.
-    _LONG_LIVED_COMMANDS = {"serve", "gateway", "chat", None}
     if command in _LONG_LIVED_COMMANDS:
         install_log_redaction([])
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -10164,6 +10164,15 @@ class GatewayOrchestrator:
             if _shutting_down:
                 print("\n👻 Force exit!")
                 cleanup_orphaned_sessions()
+                # os._exit skips atexit, so the log queue's drain hook never
+                # runs — flush the queued gateway.log tail here, bounded so a
+                # wedged disk cannot hang the force exit.
+                try:
+                    from kiro_crew.cli import _stop_log_queue_listener
+
+                    _stop_log_queue_listener(timeout=2.0)
+                except Exception:
+                    pass  # force exit must never be blocked by logging
                 os._exit(0)
             _shutting_down = True
             shutdown_event.set()

--- a/test/test_cli_logging.py
+++ b/test/test_cli_logging.py
@@ -13,21 +13,28 @@ Covers:
 - ``_fd_targets_file``  — the dev/ino detection primitive
 - ``_redirect_fds_to``  — the post-rotation fd re-point primitive
 - ``_setup_cli_logging`` — handler topology in detached vs foreground mode
+- the QueueHandler/QueueListener indirection — the file handler (rollover
+  included) runs on the listener thread, never the calling thread, and
+  ``_stop_log_queue_listener`` drains every queued record to disk
 """
 
 import logging
 import os
+import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+import kiro_crew.cli as cli_mod
 from kiro_crew.cli import (
+    _CliLogQueueHandler,
     _fd_targets_file,
     _FdTrackingRotatingFileHandler,
     _redirect_fds_to,
     _setup_cli_logging,
+    _stop_log_queue_listener,
 )
 from kiro_crew.config import config_dir
 
@@ -43,7 +50,8 @@ def _pristine_logging():
     empty handler lists, then restore the originals afterwards — closing
     any handler the test added so the tmp gateway.log file descriptor is
     released promptly (required on Windows, where an open fd blocks the
-    tmpdir cleanup).
+    tmpdir cleanup). Also stops the module's QueueListener so its drain
+    thread and the file handler's fd never leak across tests.
     """
     root = logging.getLogger()
     kc = logging.getLogger("kiro_crew")
@@ -52,6 +60,7 @@ def _pristine_logging():
     root.handlers[:] = []
     kc.handlers[:] = []
     yield
+    _stop_log_queue_listener()
     for logger, (handlers, _) in ((root, saved_root), (kc, saved_kc)):
         for handler in logger.handlers[:]:
             if handler not in handlers:
@@ -235,23 +244,32 @@ class TestSetupCliLoggingDetached:
         ]
         assert stream_handlers == []
 
-    def test_file_handler_on_root_not_kiro_crew(self):
+    def test_queue_handler_on_root_not_kiro_crew(self):
         _setup_cli_logging("gateway", 1)
-        root_fhs = [h for h in logging.getLogger().handlers if isinstance(h, RotatingFileHandler)]
-        assert len(root_fhs) == 1
-        assert Path(root_fhs[0].baseFilename) == config_dir() / "gateway.log"
-        kc_fhs = [
+        root_qhs = [h for h in logging.getLogger().handlers if isinstance(h, _CliLogQueueHandler)]
+        assert len(root_qhs) == 1
+        kc_qhs = [
             h
             for h in logging.getLogger("kiro_crew").handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, _CliLogQueueHandler)
         ]
-        assert kc_fhs == []
+        assert kc_qhs == []
+        # The file handler must never sit on a logger directly — inline emit
+        # on the event-loop thread is the loop-stall bug this fix removes.
+        for logger in (logging.getLogger(), logging.getLogger("kiro_crew")):
+            assert not any(isinstance(h, RotatingFileHandler) for h in logger.handlers)
+        listener = cli_mod._LOG_QUEUE_LISTENER
+        assert listener is not None
+        (fh,) = listener.handlers
+        # Detached mode needs the fd-tracking subclass so the WHOLE rollover
+        # (rename chain + dup2 fd re-point) rides the listener thread.
+        assert isinstance(fh, _FdTrackingRotatingFileHandler)
+        assert Path(fh.baseFilename) == config_dir() / "gateway.log"
 
     def test_kiro_crew_record_written_exactly_once(self):
         _setup_cli_logging("gateway", 1)
         logging.getLogger("kiro_crew.test_doublewrite").warning("sentinel-record")
-        for h in logging.getLogger().handlers:
-            h.flush()
+        _stop_log_queue_listener()  # deterministic drain to disk
         text = (config_dir() / "gateway.log").read_text(encoding="utf-8")
         assert text.count("sentinel-record") == 1
         # And it is the PID-stamped file-handler copy, not the console format.
@@ -262,8 +280,7 @@ class TestSetupCliLoggingDetached:
         # stderr echo; the root-attached handler must keep them flowing.
         _setup_cli_logging("gateway", 1)
         logging.getLogger("somelib.test_doublewrite").warning("thirdparty-record")
-        for h in logging.getLogger().handlers:
-            h.flush()
+        _stop_log_queue_listener()  # deterministic drain to disk
         text = (config_dir() / "gateway.log").read_text(encoding="utf-8")
         assert text.count("thirdparty-record") == 1
 
@@ -290,8 +307,12 @@ class TestSetupCliLoggingDetached:
         cfg.agent.log_level = "ERROR"
         monkeypatch.setattr("kiro_crew.cli.KiroCrewConfig.load", staticmethod(lambda: cfg))
         _setup_cli_logging("gateway", 0)
-        fh = next(h for h in logging.getLogger().handlers if isinstance(h, RotatingFileHandler))
+        (fh,) = cli_mod._LOG_QUEUE_LISTENER.handlers
         assert fh.level == logging.WARNING
+        # The producer-side gate mirrors the file handler's level, so records
+        # the handler would drop never transit the queue.
+        (qh,) = [h for h in logging.getLogger().handlers if isinstance(h, _CliLogQueueHandler)]
+        assert qh.level == logging.WARNING
         assert logging.getLogger("kiro_crew").level == logging.ERROR
 
 
@@ -304,23 +325,31 @@ class TestSetupCliLoggingForeground:
         self.redirect = MagicMock()
         monkeypatch.setattr("kiro_crew.cli._redirect_fds_to", self.redirect)
 
-    def test_file_handler_on_kiro_crew_logger(self):
+    def test_queue_handler_on_kiro_crew_logger(self):
         _setup_cli_logging("gateway", 1)
-        kc_fhs = [
+        kc_qhs = [
             h
             for h in logging.getLogger("kiro_crew").handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, _CliLogQueueHandler)
         ]
-        assert len(kc_fhs) == 1
-        assert kc_fhs[0].level == logging.INFO
-        root_fhs = [h for h in logging.getLogger().handlers if isinstance(h, RotatingFileHandler)]
-        assert root_fhs == []
+        assert len(kc_qhs) == 1
+        assert kc_qhs[0].level == logging.INFO
+        assert not any(
+            isinstance(h, _CliLogQueueHandler) for h in logging.getLogger().handlers
+        )
+        # No inline file handler on either logger.
+        for logger in (logging.getLogger(), logging.getLogger("kiro_crew")):
+            assert not any(isinstance(h, RotatingFileHandler) for h in logger.handlers)
+        (fh,) = cli_mod._LOG_QUEUE_LISTENER.handlers
+        # Foreground keeps the plain handler: no fds were redirected, so
+        # there is nothing to re-point on rollover.
+        assert type(fh) is RotatingFileHandler
+        assert fh.level == logging.INFO
 
     def test_record_written_once_to_file(self):
         _setup_cli_logging("gateway", 1)
         logging.getLogger("kiro_crew.test_foreground").warning("fg-sentinel")
-        for h in logging.getLogger("kiro_crew").handlers:
-            h.flush()
+        _stop_log_queue_listener()  # deterministic drain to disk
         text = (config_dir() / "gateway.log").read_text(encoding="utf-8")
         assert text.count("fg-sentinel") == 1
 
@@ -331,3 +360,108 @@ class TestSetupCliLoggingForeground:
         assert (config_dir() / "gateway.log.prev").exists()
         # … but a foreground console must never be dup2'd into the log file.
         self.redirect.assert_not_called()
+
+
+class TestQueueOffLoop:
+    """The point of the queue: file-handler I/O never runs on the calling
+    thread (in the gateway that thread runs the asyncio event loop, and an
+    inline emit or rollover blocking >25s trips the loop-stall watchdog,
+    which hard-exits the process and orphans every in-flight subagent)."""
+
+    @pytest.fixture(autouse=True)
+    def _foreground(self, monkeypatch):
+        monkeypatch.setattr("kiro_crew.cli._fd_targets_file", lambda fd, path: False)
+        monkeypatch.setattr("kiro_crew.cli._redirect_fds_to", MagicMock())
+
+    def test_file_emit_runs_on_listener_thread(self):
+        _setup_cli_logging("gateway", 1)
+        (fh,) = cli_mod._LOG_QUEUE_LISTENER.handlers
+        emit_threads: list[threading.Thread] = []
+        orig_emit = fh.emit
+
+        def recording_emit(record):
+            emit_threads.append(threading.current_thread())
+            orig_emit(record)
+
+        fh.emit = recording_emit  # type: ignore[method-assign]
+        logging.getLogger("kiro_crew.offloop").warning("off-loop-sentinel")
+        _stop_log_queue_listener()  # drains the queue through recording_emit
+        assert emit_threads, "record never reached the file handler"
+        caller = threading.current_thread()
+        assert all(t is not caller for t in emit_threads)
+
+    def test_stop_drains_pending_records(self):
+        _setup_cli_logging("gateway", 1)
+        log = logging.getLogger("kiro_crew.drain")
+        for i in range(50):
+            log.warning("drain-record-%d", i)
+        _stop_log_queue_listener()
+        text = (config_dir() / "gateway.log").read_text(encoding="utf-8")
+        assert text.count("drain-record-") == 50
+
+    def test_reentrant_setup_leaves_single_queue_handler(self):
+        _setup_cli_logging("gateway", 1)
+        _setup_cli_logging("gateway", 1)
+        kc_qhs = [
+            h
+            for h in logging.getLogger("kiro_crew").handlers
+            if isinstance(h, _CliLogQueueHandler)
+        ]
+        assert len(kc_qhs) == 1
+        assert cli_mod._LOG_QUEUE_LISTENER is not None
+
+    def test_short_lived_command_keeps_sync_handler(self):
+        """Short-lived verbs get NO queue: several replace the process via
+        os.exec* (``logs -f``, ``config edit``), which skips atexit — a queued
+        tail there would be lost, while a sync handler has already written it.
+        They also run no event loop, so there is nothing for the queue to
+        protect."""
+        _setup_cli_logging("status", 1)
+        assert cli_mod._LOG_QUEUE_LISTENER is None
+        kc = logging.getLogger("kiro_crew")
+        assert not any(isinstance(h, _CliLogQueueHandler) for h in kc.handlers)
+        sync_fhs = [h for h in kc.handlers if isinstance(h, RotatingFileHandler)]
+        assert len(sync_fhs) == 1
+        logging.getLogger("kiro_crew.short").warning("short-lived-record")
+        for h in kc.handlers:
+            h.flush()
+        text = (config_dir() / "gateway.log").read_text(encoding="utf-8")
+        assert "short-lived-record" in text
+
+    def test_stop_is_idempotent(self):
+        _setup_cli_logging("gateway", 1)
+        _stop_log_queue_listener()
+        _stop_log_queue_listener()  # second stop must be a silent no-op
+        assert cli_mod._LOG_QUEUE_LISTENER is None
+
+    def test_bounded_stop_still_drains_when_healthy(self):
+        """The force-exit path (timeout=) must still flush a healthy queue."""
+        _setup_cli_logging("gateway", 1)
+        logging.getLogger("kiro_crew.bounded").warning("bounded-record")
+        _stop_log_queue_listener(timeout=5.0)
+        text = (config_dir() / "gateway.log").read_text(encoding="utf-8")
+        assert "bounded-record" in text
+        assert cli_mod._LOG_QUEUE_LISTENER is None
+
+    def test_bounded_stop_gives_up_on_wedged_handler(self):
+        """A wedged disk must not hang the force exit: the bounded stop
+        returns within the deadline and skips flush/close."""
+        import time
+
+        _setup_cli_logging("gateway", 1)
+        (fh,) = cli_mod._LOG_QUEUE_LISTENER.handlers
+        release = threading.Event()
+        orig_emit = fh.emit
+
+        def wedged_emit(record):
+            release.wait(5.0)  # simulate blocking handler I/O
+            orig_emit(record)
+
+        fh.emit = wedged_emit  # type: ignore[method-assign]
+        logging.getLogger("kiro_crew.wedged").warning("wedged-record")
+        t0 = time.monotonic()
+        _stop_log_queue_listener(timeout=0.2)
+        elapsed = time.monotonic() - t0
+        release.set()  # unblock the daemon thread so teardown closes cleanly
+        assert elapsed < 2.0
+        assert cli_mod._LOG_QUEUE_LISTENER is None


### PR DESCRIPTION
Fixes #6631

## Root cause

`_setup_cli_logging` attached the `RotatingFileHandler` / `_FdTrackingRotatingFileHandler` directly to the root (detached) or `kiro_crew` (foreground) logger. Every `logger.info()` on the gateway's event-loop thread performed handler I/O inline and contended for `Handler.lock` with 20-30 worker threads; on the rollover path the loop thread ran the ENTIRE `doRollover()` — the rename chain plus `_redirect_fds_to()` (dup2 on raw fds 1/2) — synchronously. Blocking past the loop-stall watchdog's `exit_after=25s` hard-exits the gateway, orphaning every in-flight subagent ("lost to gateway restart"). Crash dumps from macOS and Linux consistently show the MainThread blocking leaf inside `logging` (`Handler.acquire`, `emit`, or `doRollover`).

## Change

- Logger gets a `_CliLogQueueHandler` (marker `QueueHandler` subclass, backed by `queue.SimpleQueue`) — emit is a non-blocking put, level-gated at the producer so dropped records never transit the queue
- The file handler runs inside a `QueueListener` thread (`respect_handler_level=True`) — ALL file I/O including the whole rollover + fd re-point now happens off the loop
- `_stop_log_queue_listener()` drains and closes on shutdown (atexit), is idempotent, and is the deterministic drain point for tests
- Re-entrant setup retires the old listener and removes stale queue handlers, so no duplicate producers

Handler topology is otherwise unchanged: detached still attaches to root with the fd-tracking subclass and WARNING cap; foreground still attaches to the `kiro_crew` logger. Secret redaction is unaffected (it hooks the log-record factory on the producing thread, upstream of any handler). The foreground console `StreamHandler` stays synchronous by design — the stall mode is the detached gateway, which has no console handler.

## Testing

- `test/test_cli_logging.py`: 23 passed — existing topology/behavior tests updated to the queue topology, plus new `TestQueueOffLoop` (file emit runs on the listener thread, stop drains 50 pending records, re-entrant setup leaves a single queue handler, stop is idempotent)
- Adjacent suites (`test_cli.py`, `test_cli_mcp_builtin_verbs.py`, `test_update_wheel_dispatch.py`, `test_host_isolation_floor.py`, `test_log_redaction.py`): 494 passed, 2 skipped, 1 failed — the failure (`TestTheWorkerBudgetIsMemoryBounded`) reproduces identically on clean `origin/main` on this machine (memory-dependent bound), unrelated to this change

## Follow-ups (out of scope, tracked in #6631)

- Offload `vector_memory._try_embed` and subagent cold-start sync sections via `run_in_executor`