### PR TITLE
fix(installer): reject an empty exe name before the update-bypass ownership test

### DIFF
--- a/website/electron/build/installer.nsh
+++ b/website/electron/build/installer.nsh
@@ -219,8 +219,23 @@ FunctionEnd
 ; already a Kiro Crew install, which is exactly the case the executable check
 ; admits. An update that cannot prove ownership falls through to the ordinary
 ; fresh-install ownership path instead of adopting the directory.
+;
+; $KiroAppExeName is also tested for non-emptiness, BEFORE it is appended.
+; FileExists matches a directory as readily as a file, so an empty name collapses
+; the ownership proof into `FileExists "$KiroInstallDir\"` -- a bare directory
+; test, which is the same "reduce this test to a bare directory path and let the
+; bypass fire for a directory we do not own" outcome the Var declaration warns
+; about, reached by a different route. That warning covers the
+; ${APP_EXECUTABLE_FILENAME} include-time hazard; this covers the variable simply
+; never having been assigned, since only customInit assigns it. Without the test,
+; every safety property here rests on customInit having run first -- true on both
+; call paths today, and not something a page callback inserted ahead of it should
+; be able to quietly invalidate. The cost of being wrong is not a failed update:
+; the generated uninstaller removes $INSTDIR recursively, so adopting a directory
+; we did not create deletes whatever the user already had there.
 Function KiroEnsureAppInstallDir
   ${If} $KiroVisibleUpdate == 1
+  ${AndIf} $KiroAppExeName != ""
   ${AndIf} ${FileExists} "$KiroInstallDir\$KiroAppExeName"
     Return
   ${EndIf}

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -382,7 +382,7 @@ describe("first-download installer design contract", () => {
     );
     assert.match(
       ensureInstallDir,
-      /^Function KiroEnsureAppInstallDir\n\$\{If\} \$KiroVisibleUpdate == 1\n\$\{AndIf\} \$\{FileExists\} "\$KiroInstallDir\\\$KiroAppExeName"\nReturn\n\$\{EndIf\}\n/,
+      /^Function KiroEnsureAppInstallDir\n\$\{If\} \$KiroVisibleUpdate == 1\n\$\{AndIf\} \$KiroAppExeName != ""\n\$\{AndIf\} \$\{FileExists\} "\$KiroInstallDir\\\$KiroAppExeName"\nReturn\n\$\{EndIf\}\n/,
       "an update must return before any install-dir nesting can run, and only for a root it can prove is ours"
     );
     // The update bypass must stay conditional on that ownership proof. `--updated`
@@ -394,6 +394,20 @@ describe("first-download installer design contract", () => {
       /\$\{If\} \$KiroVisibleUpdate == 1\nReturn/.test(ensureInstallDir),
       false,
       "the update bypass must require proof the install root is ours, not return unconditionally"
+    );
+    // The name must be proven non-empty BEFORE it is appended. IfFileExists
+    // matches a directory as readily as a file, so an empty $KiroAppExeName
+    // collapses the ownership proof into a bare directory test -- the same
+    // failure the ${APP_EXECUTABLE_FILENAME} assertion below exists to prevent,
+    // reached by a different route: the variable never having been assigned at
+    // all. Only customInit assigns it, so without this the whole guard rests on
+    // customInit having run first, and a future page callback inserted ahead of
+    // it would silently turn the ownership proof back into "does this directory
+    // exist".
+    assert.match(
+      ensureInstallDir,
+      /\$\{AndIf\} \$KiroAppExeName != ""/,
+      "the ownership test must reject an empty executable name before appending it"
     );
     // The ownership test must read the executable name from a VARIABLE, never the
     // ${APP_EXECUTABLE_FILENAME} define. That define lives in the template's


### PR DESCRIPTION
## Why

`KiroEnsureAppInstallDir` lets an update return early — skipping the collision-nesting that would otherwise install the new version *beside* the running one — but only for a directory it can prove is one of our install roots. The proof is this app's own executable being present:

```nsis
${If} $KiroVisibleUpdate == 1
${AndIf} ${FileExists} "$KiroInstallDir\$KiroAppExeName"
  Return
${EndIf}
```

`FileExists` matches a directory as readily as a file. So when `$KiroAppExeName` is empty, the path becomes `"$KiroInstallDir\"` and the ownership proof degrades into a bare directory-existence test.

That is precisely the failure the `Var` declaration already warns about for a different cause — NSIS dropping `${APP_EXECUTABLE_FILENAME}` at include time with only `warning 6000`, which would *"silently reduce this test to a bare directory path and let the bypass fire for a directory we do not own"*. This PR closes the same hole reached by the other route: the variable never having been assigned at all.

Only `customInit` assigns it. Without this test, every safety property of the bypass rests on `customInit` having run first — true on both call paths today, enforced by nothing. A page callback inserted ahead of the install-mode leave handler would quietly turn the ownership proof back into *"does this directory exist"*.

**What it costs when it is wrong is not a failed update.** `--updated` is a command-line flag on a user-runnable installer, so it can arrive alongside `/D=<any existing directory>`. The generated uninstaller removes `$INSTDIR` recursively, so adopting a directory this installer never created means deleting whatever the user already had there.

## What changed

```nsis
${If} $KiroVisibleUpdate == 1
${AndIf} $KiroAppExeName != ""
${AndIf} ${FileExists} "$KiroInstallDir\$KiroAppExeName"
  Return
${EndIf}
```

The rationale sits with the rest of the function's reasoning **above** the `Function` line rather than inside the body. The design contract pins this guard as the first statement in the function, and `normalizedNsisBlock` keeps comments — so a comment between `Function` and the first `${If}` breaks a test that is asserting a real property, not a formatting preference. Worth knowing before moving it back.

## Contract

Two updates in `website/electron/test/packaging.test.js`:

- the pinned guard shape now carries the non-emptiness test, so the "must be the FIRST thing the function does" assertion still describes what ships;
- a dedicated assertion covers the `${AndIf} $KiroAppExeName != ""` line, so a later edit cannot drop it while the shape assertion keeps passing on the rest.

**Revert-verified**: removing the `${AndIf}` line fails `never relocates the install root on an update`, and only that test. Restored from an in-memory snapshot.

## Verification

`node --test test/packaging.test.js` → **36 pass**.

One failure remains and is environmental, not from this change: `cross-fades native pages without stalling extraction and enforces an install-time ceiling` reads `node_modules/app-builder-lib/templates/nsis/assistedInstaller.nsh`, which is not installed in this checkout (`ENOENT`). It fails identically with this diff reverted.

## Risk

Additive guard on a path that previously had none, and it only ever makes the bypass *stricter*. An update that cannot prove ownership now falls through to the ordinary fresh-install ownership path — the same branch it would have taken had the executable genuinely been absent. Undo is a revert of the single commit.

Follow-up, not in scope here: the same function's ownership proof is "a file with our executable's name exists in that directory", which a same-named file can satisfy. Reaching it needs the user to pass both `--updated` and `/D=<dir containing that name>`, so the exposure is small, but path-independent proof would be stronger.
