### PR TITLE
ci: teach UX review to catch duplicated interaction primitives

### DIFF
--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -471,12 +471,23 @@ jobs:
                  (pressed/selected/expanded) when the diff adds them.
                - Never color-only encoding: status conveyed by color pairs with
                  text, icon, or shape.
+               - Resizable panels: a drag handle is an ARIA window splitter —
+                 focusable, arrow-key operable, reporting its position — never
+                 a pointer-only div styled as a divider.
             7. CONSISTENCY & HABITUATION:
                - One term per operation everywhere — flag synonym drift
                  (Remove/Delete/Discard for the same act) against sibling code.
                - Theme tokens and existing ui/ primitives over hand-rolled
                  components or hardcoded colors; platform convention over novel
                  widgets for standard jobs.
+               - Interaction-primitive reuse: when the diff ADDS pointer/
+                 keyboard interaction machinery (drag-to-resize, splitter,
+                 sortable list, collapse/expand, roving focus), Grep hooks/ and
+                 components/ (not just ui/) for an existing shared
+                 implementation of the same gesture. A second implementation is
+                 a finding EVEN when visually identical: behavior divergence —
+                 keyboard path, hover feedback, drag physics, persistence — is
+                 what breaks habituation, and it never shows in a screenshot.
                - Habituation: flag diffs that MOVE or REORDER existing controls
                  without functional need (breaks muscle memory), and duplicate
                  new paths to an already-reachable action.

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -291,12 +291,23 @@ jobs:
                  (pressed/selected/expanded) when the diff adds them.
                - Never color-only encoding: status conveyed by color pairs with
                  text, icon, or shape.
+               - Resizable panels: a drag handle is an ARIA window splitter —
+                 focusable, arrow-key operable, reporting its position — never
+                 a pointer-only div styled as a divider.
             7. CONSISTENCY & HABITUATION:
                - One term per operation everywhere — flag synonym drift
                  (Remove/Delete/Discard for the same act) against sibling code.
                - Theme tokens and existing ui/ primitives over hand-rolled
                  components or hardcoded colors; platform convention over novel
                  widgets for standard jobs.
+               - Interaction-primitive reuse: when the diff ADDS pointer/
+                 keyboard interaction machinery (drag-to-resize, splitter,
+                 sortable list, collapse/expand, roving focus), Grep hooks/ and
+                 components/ (not just ui/) for an existing shared
+                 implementation of the same gesture. A second implementation is
+                 a finding EVEN when visually identical: behavior divergence —
+                 keyboard path, hover feedback, drag physics, persistence — is
+                 what breaks habituation, and it never shows in a screenshot.
                - Habituation: flag diffs that MOVE or REORDER existing controls
                  without functional need (breaks muscle memory), and duplicate
                  new paths to an already-reachable action.


### PR DESCRIPTION
## What

Two additions to the UX Review prompt (both `ux-review.yml` and its `fork-` twin, which carry identical lens text):

1. **Lens 7 (Consistency & Habituation) — proactive interaction-primitive reuse check.** When the diff *adds* pointer/keyboard interaction machinery (drag-to-resize, splitter, sortable list, collapse/expand, roving focus), the reviewer must grep `hooks/` and `components/` — not just `ui/` — for an existing shared implementation of the same gesture. A second implementation is a finding **even when visually identical**: what diverges is behavior (keyboard path, hover feedback, drag physics, persistence), which is exactly what breaks habituation and never shows in a screenshot.

2. **Lens 6 (Keyboard & Accessibility) — pin the splitter shape.** "Every pointer action has a keyboard path" stated abstractly did not fire on a pointer-only drag handle styled as a divider. The new bullet names the concrete rule: a drag handle is an ARIA window splitter — focusable, arrow-key operable, reporting its position.

## Why

In a recent members-page PR, a hand-rolled ninth copy of the shared `useColumnResize` drag/clamp/persist logic passed the UX lane (CONCERNS, on unrelated grounds) and was caught only by the First Principles lane via code-duplication reasoning. The user-visible consequence — a resize handle with no keyboard path and different hover behavior from the app's eight other splitters — is squarely a UX-consistency defect, and the UX lane should have a lens that sees it. The two lanes stay redundant by design: UX flags the experience divergence (advisory), First Principles adjudicates whether the duplication is justified (blocking).

## Testing

- `yaml.safe_load` passes on both files.
- Prompt-only change inside the model instruction block; no step/trigger/permission changes, and the two variants received byte-identical edits.
