### PR TITLE
fix: prepend mcp app marker so it survives acp result cuts

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -21,6 +21,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from kiro_crew import mcp_apps_render
 from kiro_crew.acp.types import (
     EVENT_PERMISSION_REQUEST,
     EVENT_TEXT_CHUNK,
@@ -1038,7 +1039,19 @@ def _build_tool_result_event(update: dict[str, Any]) -> AcpEvent | None:
                                 output_parts.append(json.dumps(j, default=str)[:4000])
     if not output_parts:
         return None
-    final_output = _redact("\n".join(output_parts)[:8000])
+    joined = "\n".join(output_parts)
+    final_output = _redact(joined[:8000])
+    # An MCP App render marker lives at offset 0 of its own text part, but the
+    # 8000-char join cut is applied to the CONCATENATION of all parts: when the
+    # marker part is preceded by other (up to 4000-char) parts, its offset in
+    # the joined string can exceed 8000 and the slice drops it, so
+    # ``mcp_apps_render.find_marker`` never sees it and the app never mounts.
+    # If the pre-slice text carried a marker that the slice removed, re-inject
+    # it at offset 0 so it stays under any cut and remains detectable. The
+    # marker is a fixed control token, not sensitive, so it needs no redaction.
+    marker_match = mcp_apps_render.MARKER_RE.search(joined)
+    if marker_match and mcp_apps_render.find_marker(final_output) is None:
+        final_output = f"{marker_match.group(0)} {final_output}"
     return AcpEvent(
         kind=EVENT_TOOL_RESULT,
         tool_call_id=tool_use_id,

--- a/src/kiro_crew/docs/mcp-apps.md
+++ b/src/kiro_crew/docs/mcp-apps.md
@@ -253,7 +253,10 @@ Useful when something renders as text and you need to find where the chain broke
    so a slow app degrades to text rather than wedging the turn.
 3. The gateway writes the payload to a spool file at
    `$KIROCREW_HOME/mcp-apps/<uuid4hex>.json` and injects an opaque marker
-   `[kirocrew-mcp-app:<uuid4hex>]` into the tool result *text*.
+   `[kirocrew-mcp-app:<uuid4hex>]` at the START of the tool result *text*. It
+   leads the text (rather than trailing it) so it survives the ACP result
+   truncation cuts before the detector below runs — a long first text block
+   would otherwise lose a trailing marker and the app would never mount.
 4. That text reaches the dashboard backend as a tool result. `mcp_apps_render.py`
    detects the marker, loads the spooled payload, pushes an `mcp_app_render`
    websocket event to the chat slot, and strips the marker from the transcript.

--- a/src/kiro_crew/mcp_gateway/apps.py
+++ b/src/kiro_crew/mcp_gateway/apps.py
@@ -410,8 +410,16 @@ def extract_declared_ui_uris(result: dict) -> dict[str, str]:
 
 
 def append_marker(result: dict, spool_id: str) -> dict:
-    """Return a copy of a ``tools/call`` result with the spool marker appended
+    """Return a copy of a ``tools/call`` result with the spool marker PREPENDED
     to its FIRST text content item (or a new text item when none exists).
+
+    The marker sits at offset 0 of the first text block so it survives the
+    downstream ACP per-part 4000-char truncation in
+    ``acp/_dispatch.py::_build_tool_result_event`` before the dashboard marker
+    detector (``mcp_apps_render.find_marker``) runs; an end-appended marker on a
+    long first block (real cases run to tens of thousands of chars) is sliced
+    off and the app never mounts. Both consumers (``find_marker`` search,
+    ``strip_marker`` sub) are position-agnostic, so leading the block is safe.
 
     Copy discipline mirrors ``backend._strip_caller_meta``: the input ``result``
     and every nested container on the mutated path are copied, never mutated in
@@ -432,10 +440,14 @@ def append_marker(result: dict, spool_id: str) -> dict:
         None,
     )
     if text_idx is None:
-        content.append({"type": "text", "text": marker})
+        # No text item exists, so create one at offset 0 to match the prepend
+        # framing: a lone new item is already the earliest content, but leading
+        # it keeps the "marker at the front" invariant true regardless of what
+        # else lands in ``content`` later.
+        content.insert(0, {"type": "text", "text": marker})
     else:
         item = dict(content[text_idx])
-        item["text"] = f"{item['text']} {marker}"
+        item["text"] = f"{marker} {item['text']}"
         content[text_idx] = item
     out["content"] = content
     return out

--- a/test/test_mcp_gateway_apps_spool.py
+++ b/test/test_mcp_gateway_apps_spool.py
@@ -30,6 +30,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from kiro_crew.mcp_apps_render import find_marker
 from kiro_crew.mcp_caller import CallerContext
 from kiro_crew.mcp_gateway import apps
 from kiro_crew.mcp_gateway.apps import (
@@ -108,13 +109,14 @@ class TestExtractUiResourceUri:
 # --------------------------------------------------------------------------
 
 class TestAppendMarker:
-    def test_appends_to_first_text_item(self):
+    def test_prepends_to_first_text_item(self):
         result = {"content": [
             {"type": "text", "text": "hello"},
             {"type": "text", "text": "second"},
         ]}
         out = append_marker(result, "abc123")
-        assert out["content"][0]["text"] == "hello [kirocrew-mcp-app:abc123]"
+        # Marker at offset 0 so it survives the downstream ACP 4000-char cut.
+        assert out["content"][0]["text"] == "[kirocrew-mcp-app:abc123] hello"
         # Only the FIRST text item is marked.
         assert out["content"][1]["text"] == "second"
 
@@ -124,12 +126,15 @@ class TestAppendMarker:
             {"type": "text", "text": "caption"},
         ]}
         out = append_marker(result, "id9")
-        assert out["content"][1]["text"] == "caption [kirocrew-mcp-app:id9]"
+        assert out["content"][1]["text"] == "[kirocrew-mcp-app:id9] caption"
 
-    def test_no_text_item_appends_new_item(self):
+    def test_no_text_item_prepends_new_item(self):
         result = {"content": [{"type": "image", "data": "..."}]}
         out = append_marker(result, "zz")
-        assert out["content"][-1] == {"type": "text", "text": "[kirocrew-mcp-app:zz]"}
+        # No text item to lead, so a fresh marker item is inserted at offset 0
+        # to match the prepend framing; the existing non-text item follows.
+        assert out["content"][0] == {"type": "text", "text": "[kirocrew-mcp-app:zz]"}
+        assert out["content"][1] == {"type": "image", "data": "..."}
 
     def test_empty_content_appends_new_item(self):
         out = append_marker({"content": []}, "q")
@@ -992,8 +997,9 @@ async def test_interception_end_to_end(apps_flag_on, spool_tmp):
     # Original stub id restored, marker injected on the first text item.
     assert delivered["id"] == 42
     text = delivered["result"]["content"][0]["text"]
-    assert text.startswith("drawn ")
-    assert text.startswith("drawn [kirocrew-mcp-app:")
+    # Marker is prepended (offset 0) and the original tool text is preserved.
+    assert text.startswith("[kirocrew-mcp-app:")
+    assert text.endswith(" drawn")
     # Structured content preserved.
     assert delivered["result"]["structuredContent"] == {"nodes": 3}
 
@@ -1008,8 +1014,10 @@ async def test_interception_end_to_end(apps_flag_on, spool_tmp):
     assert record["tool"] == "draw"
     assert record["session_key"] == "dashboard:sess-1"
     assert record["structured_content"] == {"nodes": 3}
-    # The spool id in the marker matches the file on disk.
-    marker_id = text.split("[kirocrew-mcp-app:")[1].rstrip("]").strip()
+    # The spool id in the marker matches the file on disk. Parsed with the real
+    # consumer (find_marker) rather than a hand-rolled slice, so the assertion
+    # stays position-agnostic and cannot drift from the marker layout again.
+    marker_id = find_marker(text)
     assert (spool_tmp / f"{marker_id}.json").exists()
 
 
@@ -1040,8 +1048,7 @@ async def test_interception_blob_base64(apps_flag_on, spool_tmp):
         "result": {"contents": [{"mimeType": MCP_APPS_MIME_TYPE, "blob": blob}]},
     }) + "\n").encode("utf-8"))
     delivered = await _drain_inbox(inbox)
-    marker_id = delivered["result"]["content"][0]["text"].split(
-        "[kirocrew-mcp-app:")[1].rstrip("]").strip()
+    marker_id = find_marker(delivered["result"]["content"][0]["text"])
     record = json.loads((spool_tmp / f"{marker_id}.json").read_text())
     assert record["html"] == "<html>blob</html>"
 

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -20,6 +20,8 @@ import json
 
 from kiro_crew import session_directive as sd
 from kiro_crew.acp._dispatch import _build_tool_result_event, _mcp_content_text
+from kiro_crew.mcp_apps_render import find_marker
+from kiro_crew.mcp_gateway.apps import append_marker
 from kiro_crew.validation import build_tool_response, strip_hidden_unicode
 
 DIRECTIVE_ARGS = {"questions": [{"question": "pick one"}]}
@@ -167,3 +169,54 @@ class TestRefusalMarkerSurvivesTransport:
         assert event is not None
         assert event.tool_final is True
         assert sd.is_refusal(event.tool_output)
+
+
+class TestMcpAppMarkerSurvivesResultCuts:
+    """The MCP App render marker must survive both truncation cuts in
+    ``_build_tool_result_event`` — the per-part 4000-char cut and the 8000-char
+    join cut — or ``mcp_apps_render.find_marker`` never sees it and the app
+    never mounts (issue #6606). The gateway prepends the marker at offset 0 of
+    the first text block, and the parser re-injects it after the join cut."""
+
+    def _marker(self) -> str:
+        # A valid marker carries a 32-lowercase-hex spool id.
+        return "[kirocrew-mcp-app:" + "a" * 32 + "]"
+
+    def _id(self) -> str:
+        return "a" * 32
+
+    def test_marker_survives_long_single_block(self):
+        # Drive the marker through the real producer ``append_marker`` on a
+        # LONG (>4000-char) first block, then feed the marked envelope through
+        # the parser. The producer decides the marker's byte offset, so this
+        # regresses the fix: with the prepend it sits at offset 0 and rides the
+        # per-part 4000-char cut, but the old end-append put it past 20000 chars
+        # where the ``[:4000]`` slice drops it and ``find_marker`` returns None.
+        marked = append_marker({"content": [{"type": "text", "text": "x" * 20000}]}, self._id())
+        update = {
+            "toolCallId": "tc-long",
+            "status": "completed",
+            "rawOutput": {"items": [{"Json": marked}]},
+        }
+        event = _build_tool_result_event(update)
+        assert event is not None
+        assert find_marker(event.tool_output) == self._id()
+
+    def test_marker_survives_multi_part_join_cut(self):
+        # Two prior ~4000-char parts push the marker part's offset-0 marker
+        # past the 8000-char join cut; the parser must re-inject it so it stays
+        # detectable.
+        update = {
+            "toolCallId": "tc-multi",
+            "status": "completed",
+            "rawOutput": {
+                "items": [
+                    {"Text": "a" * 4000},
+                    {"Text": "b" * 4000},
+                    {"Json": _mcp_envelope(self._marker() + " drawn")},
+                ]
+            },
+        }
+        event = _build_tool_result_event(update)
+        assert event is not None
+        assert find_marker(event.tool_output) == self._id()


### PR DESCRIPTION
## Summary

Fixes #6606. Supersedes the closed #6617, which patched the wrong (unreachable) code site.

The MCP App render marker `[kirocrew-mcp-app:<32hex>]` was **end-appended** to the first tool-result text block by `mcp_gateway/apps.py::append_marker`, then sliced off by two upstream ACP truncation cuts in `acp/_dispatch.py::_build_tool_result_event` (a per-part `[:4000]` and a join `[:8000]`) **before** `mcp_apps_render.find_marker` ran. On long first blocks (real reported cases: 12,891 / 14,282 / 59,428 chars) the marker was truncated away, `find_marker` returned `None` (which logs nothing and early-returns), no `.rendered` sidecar was written, no `mcp_app_render` websocket frame was emitted, and the app never mounted. A 3,112-char control case with the marker at offset 3,061 survived, confirming the mechanism at the 4000 boundary.

## Why #6617 was wrong

#6617 guarded `dashboard/chat_utils.py::_redact_tool_field`'s `_MAX_TOOL_FIELD = 1_000_000` byte cap. That cap is **unreachable** on this path: every producer of `EVENT_TOOL_RESULT` caps `tool_output` at 8000 chars before `_redact_tool_field` sees it (`acp/_dispatch.py`, `acp/client.py` x2). The reported block sizes are three orders of magnitude below 1 MB. That PR is closed; this change does not touch `chat_utils.py`.

## What changed

- **`src/kiro_crew/mcp_gateway/apps.py`** — `append_marker` now **prepends** the marker (`f"{marker} {text}"`, offset 0) to the first text block so it survives the per-part `[:4000]` cut. The no-text-item branch uses `insert(0, ...)` to match the prepend invariant. Both marker consumers are position-agnostic (`find_marker` is `MARKER_RE.search`, `strip_marker` is `MARKER_RE.sub`), and nothing in `website/` references the marker string.
- **`src/kiro_crew/acp/_dispatch.py`** — `_build_tool_result_event` re-injects the marker at offset 0 after the `[:8000]` join cut when `find_marker` no longer sees it, for the multi-part case where earlier parts push the marker's offset in the joined string past 8000. It reuses `mcp_apps_render.MARKER_RE`/`find_marker` (no duplicated literal), is idempotent (guarded on `find_marker(final_output) is None`), and leaves short/single-block results untouched.
- **`src/kiro_crew/docs/mcp-apps.md`** — step 3 updated to the leading-marker, cut-surviving behavior (same commit as the code, per repo spec-sync rule).
- **`test/test_mcp_gateway_apps_spool.py`** — position-pinning tests flipped from append to prepend semantics; e2e assertion updated to `startswith("[kirocrew-mcp-app:")`.
- **`test/test_session_directive_transport.py`** — new `TestMcpAppMarkerSurvivesResultCuts` covering the long single-block case (driven through `append_marker`) and the multi-part join-cut case.

## Testing

Network mode in the sandbox is **INTEGRATIONS_ONLY** (PyPI blocked), so some tooling could not be installed. Reported honestly rather than skipped silently:

- **Ran:** targeted sync subset of the two touched test modules — 24 relevant tests pass, including the updated position pins and both new regression tests.
- **Ran:** `mypy --platform linux` on `apps.py` + `_dispatch.py` — clean.
- **Falsification (both confirmed):** reverting the sources makes `test_marker_survives_multi_part_join_cut` fail; reverting only `apps.py` makes `test_marker_survives_long_single_block` fail (marker lost to the 4000 per-part cut). Both green after restore.
- **Could NOT run here (PyPI 403):** full `python -m pytest` (conftest imports `hypothesis`; `pytest-asyncio`/`aiohttp`/`pydantic` absent), `flake8`, and the async backend e2e test in `test_mcp_gateway_apps_spool.py` (verified by inspection). CI will cover these.