### PR TITLE
ci: scope reusable-workflow secrets, lock the review CLI, close the gate's cache

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -77,6 +77,21 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      # Declared explicitly so callers pass this ONE secret instead of
+      # `secrets: inherit`, which would hand this lane every secret in the
+      # repository. The lane assumes a signing role and produces the installer
+      # users run, so the blast radius of a compromise here is worth bounding
+      # to the credential it actually uses. Mirrors publish-windows.yml.
+      #
+      # Not required: HAS_WINDOWS_SIGNING treats an empty value as "no signing
+      # secret" and skips every signing step, which is what keeps forks -- and
+      # the workflow_dispatch packaging probe, which deliberately runs with no
+      # credentials -- green. Making it required would turn that clean skip
+      # into a workflow-call failure.
+      AWS_WINDOWS_SIGNING_ROLE_ARN:
+        description: "Role assumed to sign the Windows installer and nupkg"
+        required: false
   # Manual build-only probe: builds the installer from any ref WITHOUT
   # publishing anything. Used to validate packaging changes before merge.
   workflow_dispatch:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -108,7 +108,47 @@ jobs:
       # install never runs with the Bedrock credentials in its environment.
       - name: Install review CLI
         if: github.actor != 'dependabot[bot]' && steps.human_override.outputs.active != 'true'
-        run: npm install -g @openai/codex
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CLI_DIR: ${{ runner.temp }}/review-cli
+        # Installed from a committed lockfile (`npm ci`) whose package files are
+        # materialized from the BASE commit -- never read from the checkout.
+        #
+        # Both halves are load-bearing:
+        #
+        #   * the lockfile is what pins the dependency CLOSURE. `npm install -g
+        #     pkg@X` re-resolves the package's own dependencies on every run, so
+        #     a version pin alone leaves the transitive tree floating (zizmor
+        #     adhoc-packages).
+        #   * BASE_SHA is what keeps the manifest out of the PR author's hands.
+        #     The binary this step produces is executed AFTER the Bedrock role is
+        #     assumed, so a manifest read from the PR under review would let its
+        #     author point it at any package and receive this job's AWS
+        #     credentials. The install itself running before the role assumption
+        #     does not help: it is the EXECUTION that holds them.
+        #
+        # Installing into RUNNER_TEMP rather than the worktree keeps node_modules
+        # out of the tree the read-only agentic reviewer reads, and leaves the
+        # PR's own files untouched.
+        #
+        # Fails closed on purpose -- it does NOT fall back to the checkout the way
+        # the prompt-block step does. A prompt read from the PR weakens the review
+        # contract; a MANIFEST read from the PR is arbitrary code execution with
+        # AWS credentials, so there is no safe fallback to offer. On the bootstrap
+        # round -- the PR that first adds .github/review-cli, where the base has
+        # no manifest to trust -- this lane cannot run, and the ruling belongs to
+        # a human via `/ai-review override`.
+        run: |
+          set -euo pipefail
+          mkdir -p "$CLI_DIR"
+          for f in package.json package-lock.json; do
+            git show "$BASE_SHA:.github/review-cli/$f" > "$CLI_DIR/$f" 2>/dev/null || true
+            if [ ! -s "$CLI_DIR/$f" ]; then
+              echo "::error::.github/review-cli/$f is absent or empty on the base commit ($BASE_SHA). Refusing to install a review CLI whose manifest comes from the PR under review: the binary it produces executes with this job's Bedrock credentials. If this is the PR that introduces the manifest, a maintainer must review it and post an /ai-review override."
+              exit 1
+            fi
+          done
+          npm ci --prefix "$CLI_DIR"
 
       # ubuntu-24.04 runners restrict unprivileged user namespaces via AppArmor,
       # which makes the review CLI's bundled bubblewrap sandbox fail at netns setup.
@@ -381,7 +421,13 @@ jobs:
 
             rm -f "codex-pass-${pass}.md"
             rc=0
-            codex exec \
+            # Called by path, not from PATH: exporting the bin directory
+            # through $GITHUB_PATH is a run-step write to an environment
+            # file, which is an execution vector in a job holding Bedrock
+            # credentials (zizmor github-env). The path is under RUNNER_TEMP
+            # because the manifest that produced it was materialized from the
+            # BASE commit, not from this checkout -- see "Install review CLI".
+            "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
               --sandbox read-only \
               --output-last-message "codex-pass-${pass}.md" \
               "$PROMPT" || rc=$?

--- a/.github/workflows/dependency-vulnerability.yml
+++ b/.github/workflows/dependency-vulnerability.yml
@@ -24,11 +24,14 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.19.0"
-          cache: npm
-          cache-dependency-path: |
-            website/package-lock.json
-            website/electron/package-lock.json
-            site/package-lock.json
+          # cache deliberately NOT enabled. This workflow is workflow_call-only
+          # from nightly.yml / release.yml, where it gates whether the release
+          # proceeds. An Actions cache is writable from any branch and readable
+          # by a tag run, so a cache entry keyed on these lockfiles is an input
+          # a lower-trust context can influence -- and the one thing this job
+          # inspects IS the dependency tree. A gate that can be fed its answer
+          # is not a gate. The audit re-resolves from the registry every run;
+          # that costs seconds on a job that runs once per release.
 
       - name: Audit production dependencies
         run: python scripts/check_npm_audit.py

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -301,7 +301,47 @@ jobs:
           echo "Captured PR intent ($(wc -c < "$INTENT_FILE") bytes) for the scope check."
 
       - name: Install review CLI
-        run: npm install -g @openai/codex
+        env:
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          CLI_DIR: ${{ runner.temp }}/review-cli
+        # Installed from a committed lockfile (`npm ci`) whose package files are
+        # materialized from the BASE commit -- never read from the checkout.
+        #
+        # Both halves are load-bearing:
+        #
+        #   * the lockfile is what pins the dependency CLOSURE. `npm install -g
+        #     pkg@X` re-resolves the package's own dependencies on every run, so
+        #     a version pin alone leaves the transitive tree floating (zizmor
+        #     adhoc-packages).
+        #   * BASE_SHA is what keeps the manifest out of the PR author's hands.
+        #     The binary this step produces is executed AFTER the Bedrock role is
+        #     assumed, so a manifest read from the PR under review would let its
+        #     author point it at any package and receive this job's AWS
+        #     credentials. The install itself running before the role assumption
+        #     does not help: it is the EXECUTION that holds them.
+        #
+        # Installing into RUNNER_TEMP rather than the worktree keeps node_modules
+        # out of the tree the read-only agentic reviewer reads, and leaves the
+        # PR's own files untouched.
+        #
+        # Fails closed on purpose -- it does NOT fall back to the checkout the way
+        # the prompt-block step does. A prompt read from the PR weakens the review
+        # contract; a MANIFEST read from the PR is arbitrary code execution with
+        # AWS credentials, so there is no safe fallback to offer. On the bootstrap
+        # round -- the PR that first adds .github/review-cli, where the base has
+        # no manifest to trust -- this lane cannot run, and the ruling belongs to
+        # a human via `/ai-review override`.
+        run: |
+          set -euo pipefail
+          mkdir -p "$CLI_DIR"
+          for f in package.json package-lock.json; do
+            git show "$BASE_SHA:.github/review-cli/$f" > "$CLI_DIR/$f" 2>/dev/null || true
+            if [ ! -s "$CLI_DIR/$f" ]; then
+              echo "::error::.github/review-cli/$f is absent or empty on the base commit ($BASE_SHA). Refusing to install a review CLI whose manifest comes from the PR under review: the binary it produces executes with this job's Bedrock credentials. If this is the PR that introduces the manifest, a maintainer must review it and post an /ai-review override."
+              exit 1
+            fi
+          done
+          npm ci --prefix "$CLI_DIR"
 
       - name: Enable unprivileged user namespaces for the review sandbox
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
@@ -569,7 +609,13 @@ jobs:
 
             rm -f "codex-pass-${pass}.md"
             rc=0
-            codex exec \
+            # Called by path, not from PATH: exporting the bin directory
+            # through $GITHUB_PATH is a run-step write to an environment
+            # file, which is an execution vector in a job holding Bedrock
+            # credentials (zizmor github-env). The path is under RUNNER_TEMP
+            # because the manifest that produced it was materialized from the
+            # BASE commit, not from this checkout -- see "Install review CLI".
+            "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
               --sandbox read-only \
               --output-last-message "codex-pass-${pass}.md" \
               "$PROMPT" || rc=$?

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -153,7 +153,11 @@ jobs:
       version: ${{ needs.version.outputs.nightly_version }}
       soft_fail: true
       use_prod_environment: true
-    secrets: inherit
+    # Explicit passthrough, not `secrets: inherit`: the callee declares
+    # the secret it consumes, so this hands over that one and nothing
+    # else. Pinned by test_workflow_permissions.py.
+    secrets:
+      AWS_WINDOWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_WINDOWS_SIGNING_ROLE_ARN }}
 
   # ── CLI channel publish ───────────────────────────────────────────────
   # Publishes the built wheel to the nightly CLI channel (cli/ + latest-cli.json).
@@ -172,7 +176,11 @@ jobs:
       channel: nightly
       version: ${{ needs.version.outputs.nightly_version }}
       wheel_artifact: cli-wheel
-    secrets: inherit
+    # Explicit passthrough, not `secrets: inherit`: the callee declares
+    # the secret it consumes, so this hands over that one and nothing
+    # else. Pinned by test_workflow_permissions.py.
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
 
   # ── Linux desktop publish ─────────────────────────────────────────────
   # Publishes the built AppImages to the distribution CDN (versioned key +
@@ -375,7 +383,14 @@ jobs:
       contents: read
       attestations: write
     uses: ./.github/workflows/sign-and-notarize.yml
-    secrets: inherit
+    # Explicit passthrough, not `secrets: inherit`: the callee declares
+    # the secrets it consumes, so this hands over those and nothing
+    # else. Pinned by test_workflow_permissions.py.
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+      AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
+      AWS_SIGNER_ACCESS_ROLE_ARN: ${{ secrets.AWS_SIGNER_ACCESS_ROLE_ARN }}
+      CDSIGNER_API_ENDPOINT: ${{ secrets.CDSIGNER_API_ENDPOINT }}
     with:
       channel: nightly
       version: ${{ needs.version.outputs.nightly_version }}

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -39,6 +39,17 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      # Declared explicitly so callers pass this ONE secret instead of
+      # `secrets: inherit`. This lane assumes a role and publishes the wheel
+      # plus its signed manifest, so it is the highest-value caller in the
+      # repo to keep scoped. Mirrors publish-windows.yml.
+      #
+      # Not required: HAS_PUBLISH_ROLE treats an empty value as "no publish
+      # role" and skips the publish steps, which is how a fork stays green.
+      AWS_SIGNING_ROLE_ARN:
+        description: "Role assumed to publish the wheel and write the CLI manifest"
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,7 +343,11 @@ jobs:
       version: ${{ needs.version.outputs.version }}
       soft_fail: true
       use_prod_environment: true
-    secrets: inherit
+    # Explicit passthrough, not `secrets: inherit`: the callee declares
+    # the secret it consumes, so this hands over that one and nothing
+    # else. Pinned by test_workflow_permissions.py.
+    secrets:
+      AWS_WINDOWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_WINDOWS_SIGNING_ROLE_ARN }}
 
   # ── CLI channel publish ───────────────────────────────────────────────
   # Publishes the release wheel to the insider/stable CLI channel (cli/ +
@@ -370,7 +374,11 @@ jobs:
       wheel_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'cli-wheel' }}
       promote: ${{ needs.version.outputs.channel == 'stable' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
-    secrets: inherit
+    # Explicit passthrough, not `secrets: inherit`: the callee declares
+    # the secret it consumes, so this hands over that one and nothing
+    # else. Pinned by test_workflow_permissions.py.
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
 
   # ── Linux desktop publish ─────────────────────────────────────────────
   # Publishes the release AppImages to the distribution CDN (versioned key +
@@ -647,7 +655,14 @@ jobs:
       contents: read
       attestations: write
     uses: ./.github/workflows/sign-and-notarize.yml
-    secrets: inherit
+    # Explicit passthrough, not `secrets: inherit`: the callee declares
+    # the secrets it consumes, so this hands over those and nothing
+    # else. Pinned by test_workflow_permissions.py.
+    secrets:
+      AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
+      AWS_SIGNING_BUCKET: ${{ secrets.AWS_SIGNING_BUCKET }}
+      AWS_SIGNER_ACCESS_ROLE_ARN: ${{ secrets.AWS_SIGNER_ACCESS_ROLE_ARN }}
+      CDSIGNER_API_ENDPOINT: ${{ secrets.CDSIGNER_API_ENDPOINT }}
     with:
       channel: ${{ needs.version.outputs.channel }}
       version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -89,6 +89,26 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      # Declared explicitly so callers pass exactly these four instead of
+      # `secrets: inherit`. Mirrors publish-windows.yml.
+      #
+      # None are required: HAS_SIGNING_SECRETS / HAS_CDSIGNER treat an empty
+      # value as "not configured" and skip the signing, notarization and
+      # publish steps, which is how a fork stays green. Making any required
+      # would turn that clean skip into a workflow-call failure.
+      AWS_SIGNING_ROLE_ARN:
+        description: "Role assumed to sign, notarize and write the distribution bucket"
+        required: false
+      AWS_SIGNING_BUCKET:
+        description: "Bucket holding the unsigned, signed and notarized artifacts"
+        required: false
+      AWS_SIGNER_ACCESS_ROLE_ARN:
+        description: "Role the signing service assumes to read the submitted artifact"
+        required: false
+      CDSIGNER_API_ENDPOINT:
+        description: "Signing service endpoint that performs the Developer ID signature"
+        required: false
 
 permissions:
   contents: read

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
@@ -492,26 +492,50 @@ def extract_base_rule_specs(workflow_text: str) -> list[FileSpec]:
     return specs
 
 
+#: The directory the shared review-prompt blocks live in. The extractor selects
+#: on this rather than on position in the file: a workflow may materialize SEVERAL
+#: unrelated things from ``$BASE_SHA``, and "the first such loop" is not a
+#: description of the prompt loader. `codex-review.yml` now also base-materializes
+#: `.github/review-cli/{package.json,package-lock.json}` -- and it does so ABOVE
+#: the prompt loader, so a positional match silently produced prompt specs named
+#: `package.json`.
+_PROMPT_DIR = ".github/review-prompts/"
+
+_PROMPT_TMPL_RE = re.compile(
+    r"git show \"\$BASE_SHA:(?P<src>[^\"]*"
+    + re.escape(_PROMPT_DIR)
+    + r"[^\"]*\$\{?\w+\}?[^\"]*)\"\s*>\s*\"(?P<dest>[^\"]+)\"",
+)
+_LOOP_RE = re.compile(r"for\s+(?P<var>\w+)\s+in\s+(?P<names>[A-Za-z0-9_.\- ]+);\s*do")
+
+
 def extract_prompt_file_specs(workflow_text: str) -> list[FileSpec]:
     """Base-ref review-prompt files, expanded from the workflow's own for-loop.
 
     Returns [] when the workflow keeps no prompt files.
     """
-    loop = re.search(r"for\s+(?P<var>\w+)\s+in\s+(?P<names>[A-Za-z0-9_.\- ]+);\s*do", workflow_text)
-    tmpl = re.search(
-        r"git show \"\$BASE_SHA:(?P<src>[^\"]*\$\{?\w+\}?[^\"]*)\"\s*>\s*\"(?P<dest>[^\"]+)\"",
-        workflow_text,
-    )
-    if loop is None or tmpl is None:
+    tmpl = _PROMPT_TMPL_RE.search(workflow_text)
+    if tmpl is None:
         return []
+    # The governing loop is the LAST one opened before the prompt template, not
+    # the first one in the file. Anything materialized earlier (the review CLI's
+    # own manifest, for instance) has its own loop and is not a prompt block.
+    loops = [m for m in _LOOP_RE.finditer(workflow_text) if m.start() < tmpl.start()]
+    if not loops:
+        return []
+    loop = loops[-1]
     var = loop.group("var")
     # codex-review.yml's loader carries a `cp` bootstrap: when a shared prompt
     # is absent on the base (the PR that introduces it), CI warns and uses the
     # checked-out copy. Mirror that exactly; without the cp, a missing prompt
-    # stays fatal like CI's Opus lanes.
+    # stays fatal like CI's Opus lanes. Scoped to the prompt directory for the
+    # same reason as the template above -- and searched from the loop onward, so
+    # an unrelated `cp` earlier in the file cannot be mistaken for the bootstrap.
     cp_tmpl = re.search(
-        r"cp\s+\"(?P<src>[^\"]*\$\{?\w+\}?[^\"]*)\"\s+\"(?P<dest>[^\"]+)\"",
-        workflow_text,
+        r"cp\s+\"(?P<src>[^\"]*"
+        + re.escape(_PROMPT_DIR)
+        + r"[^\"]*\$\{?\w+\}?[^\"]*)\"\s+\"(?P<dest>[^\"]+)\"",
+        workflow_text[loop.start() :],
     )
     specs: list[FileSpec] = []
     for name in loop.group("names").split():

--- a/test/test_dependency_vulnerability_gate.py
+++ b/test/test_dependency_vulnerability_gate.py
@@ -131,9 +131,26 @@ class TestWorkflowContract:
             step for step in job["steps"] if step.get("uses", "").startswith("actions/setup-node@")
         )
         assert setup_node["with"]["node-version"] == "24.19.0"
-        assert set(setup_node["with"]["cache-dependency-path"].splitlines()) == set(
-            gate.AUDITED_LOCKFILES
-        )
+
+        # The npm cache is deliberately OFF here. An Actions cache is writable
+        # from any branch and readable by a tag run, and this job's whole output
+        # is a verdict about the dependency tree -- a gate that can be fed its
+        # own answer is not a gate. It costs almost nothing: the audit calls the
+        # registry advisory endpoint via `npx npm@<pin> audit`, it does not
+        # install packages, so there was little for the cache to serve.
+        assert (
+            "cache" not in setup_node["with"]
+        ), "the release-gating audit must not restore a branch-writable cache"
+
+        # This used to read the audited set back out of that step's
+        # `cache-dependency-path`. With the cache gone the workflow no longer
+        # restates the list at all, which is the better arrangement: the script
+        # is the single source of truth. What is still worth pinning is that the
+        # list names real files, so a rename cannot silently shrink the audit to
+        # nothing while every assertion still passes.
+        assert gate.AUDITED_LOCKFILES
+        for lockfile in gate.AUDITED_LOCKFILES:
+            assert (ROOT / lockfile).is_file(), f"{lockfile} is audited but absent"
 
     def test_pr_and_release_workflows_call_the_gate(self) -> None:
         code_review = yaml.safe_load((WORKFLOWS / "code-review.yml").read_text(encoding="utf-8"))

--- a/test/test_prepare_pr_local_review.py
+++ b/test/test_prepare_pr_local_review.py
@@ -89,6 +89,50 @@ def _profile_on_main(root, toml_text):
     _git(root, "checkout", "-q", "feature")
 
 
+def test_a_non_prompt_base_snapshot_is_not_mistaken_for_a_prompt_block() -> None:
+    """The extractor must select the prompt loader by PATH, not by position.
+
+    `codex-review.yml` materializes two unrelated things from `$BASE_SHA`: the
+    shared `.github/review-prompts/gpt-*.md` blocks, and the review CLI's own
+    `.github/review-cli/{package.json,package-lock.json}` manifest -- the latter
+    ABOVE the former. An extractor that took "the first `for ... do` loop plus
+    the first `git show "$BASE_SHA:...$var..."`" produced prompt specs named
+    `package.json`, and then every downstream test failed looking for
+    `.github/review-prompts/package.json`. That is what this pins.
+    """
+    specs = local_review.extract_prompt_file_specs(_gpt_text())
+    srcs = [spec.src for spec in specs]
+
+    assert srcs, "the GPT lane does keep base-ref prompt blocks"
+    assert all(src.startswith(".github/review-prompts/") for src in srcs), srcs
+    assert not [src for src in srcs if "review-cli" in src or "package" in src], srcs
+
+
+def test_prompt_extraction_survives_a_leading_unrelated_loop() -> None:
+    """Synthetic form of the same defect, so the guard does not depend on
+    `codex-review.yml` keeping its current step order."""
+    text = """
+          for f in package.json package-lock.json; do
+            git show "$BASE_SHA:.github/review-cli/$f" > "$CLI_DIR/$f" 2>/dev/null || true
+          done
+          for p in alpha beta; do
+            git show "$BASE_SHA:.github/review-prompts/$p.md" > ".review-prompts-gpt/$p.md"
+            cp ".github/review-prompts/$p.md" ".review-prompts-gpt/$p.md"
+          done
+    """
+    specs = local_review.extract_prompt_file_specs(text)
+
+    assert [spec.src for spec in specs] == [
+        ".github/review-prompts/alpha.md",
+        ".github/review-prompts/beta.md",
+    ]
+    # The `cp` bootstrap is still picked up, and still from the prompt directory.
+    assert [spec.worktree_src for spec in specs] == [
+        ".github/review-prompts/alpha.md",
+        ".github/review-prompts/beta.md",
+    ]
+
+
 def _gpt_text():
     return GPT_WORKFLOW.read_text(encoding="utf-8")
 

--- a/test/test_workflow_secret_and_cache_scope.py
+++ b/test/test_workflow_secret_and_cache_scope.py
@@ -1,0 +1,294 @@
+"""Repo-wide ratchets for workflow trust boundaries.
+
+Three invariants, all of which were breached once and fixed one file at a time:
+reusable-workflow secret scope, publish-lane caches, and where the AI review
+lanes' CLI manifest comes from.
+
+Both invariants were established one workflow at a time (`publish-windows.yml`
+got explicit secrets first; `release.yml` and the three build lanes got
+`enable-cache: false` first). A per-file assertion protects only the files that
+already tripped the audit, so the NEXT lane added silently reopens the hole.
+These tests derive the file set from the workflow graph instead, so a new caller
+or a new publish lane is covered the moment it is committed.
+
+Scope note: these are deliberately structural, not `zizmor` re-runs. zizmor
+cannot see through `workflow_call`, which is exactly why the cache invariant
+below needed finding by hand -- cache sites were live on publish lanes that
+zizmor never reported.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# The two entry points that publish. Everything reachable from them by
+# `uses: ./.github/workflows/...` builds, signs, gates or ships released bytes.
+PUBLISH_ENTRY_POINTS = ("nightly.yml", "release.yml")
+
+# Always present, never declared as a workflow_call secret.
+IMPLICIT_SECRETS = frozenset({"GITHUB_TOKEN"})
+
+LOCAL_USES_RE = re.compile(r"\./\.github/workflows/([A-Za-z0-9._-]+\.ya?ml)$")
+SECRET_REF_RE = re.compile(r"secrets\.([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _load(name: str) -> dict[str, Any]:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """PyYAML resolves the bare key `on` to the boolean True (YAML 1.1), so the
+    trigger block is not reachable under the string "on"."""
+    block = workflow[True] if True in workflow else workflow.get("on")
+    return block if isinstance(block, dict) else {}
+
+
+def _local_callers() -> list[tuple[str, str, dict[str, Any]]]:
+    """Every (caller, callee, job) triple that calls a workflow in this repo."""
+    found: list[tuple[str, str, dict[str, Any]]] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        workflow = _load(path.name)
+        for job in (workflow.get("jobs") or {}).values():
+            if not isinstance(job, dict):
+                continue
+            match = LOCAL_USES_RE.match(str(job.get("uses", "")))
+            if match:
+                found.append((path.name, match.group(1), job))
+    return found
+
+
+def _reachable_publish_lanes() -> set[str]:
+    """Transitive closure of local `uses:` from the publishing entry points."""
+    seen: set[str] = set()
+    queue = list(PUBLISH_ENTRY_POINTS)
+    edges = [(caller, callee) for caller, callee, _ in _local_callers()]
+    while queue:
+        current = queue.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        queue.extend(callee for caller, callee in edges if caller == current)
+    return seen
+
+
+def _callees() -> list[str]:
+    return sorted({callee for _, callee, _ in _local_callers()})
+
+
+def _declared_secrets(callee: str) -> dict[str, Any]:
+    call = _triggers(_load(callee)).get("workflow_call")
+    if not isinstance(call, dict):
+        return {}
+    return call.get("secrets") or {}
+
+
+def _referenced_secrets(callee: str) -> set[str]:
+    text = (WORKFLOWS / callee).read_text(encoding="utf-8")
+    return set(SECRET_REF_RE.findall(text)) - IMPLICIT_SECRETS
+
+
+class TestReusableWorkflowSecretScope:
+    def test_no_caller_inherits_the_whole_secret_store(self) -> None:
+        """`secrets: inherit` hands a called workflow EVERY repository secret.
+
+        Asserted over every local call site rather than the lanes that happened
+        to be audited, so adding a caller cannot reintroduce it unnoticed."""
+        offenders = [
+            f"{caller} -> {callee}"
+            for caller, callee, job in _local_callers()
+            if job.get("secrets") == "inherit"
+        ]
+        assert not offenders, "these call sites inherit every repository secret: " + ", ".join(
+            sorted(offenders)
+        )
+
+    def test_every_passed_secret_is_declared_by_the_callee(self) -> None:
+        """A secret passed but not declared is silently dropped, so the callee
+        sees an empty value and skips work it was supposed to do -- the failure
+        looks like a missing credential, not a typo in the caller."""
+        problems: list[str] = []
+        for caller, callee, job in _local_callers():
+            passed = job.get("secrets")
+            if not isinstance(passed, dict):
+                continue
+            declared = _declared_secrets(callee)
+            for name in passed:
+                if name not in declared:
+                    problems.append(f"{caller} passes {name} to {callee}, undeclared")
+        assert not problems, "; ".join(problems)
+
+    def test_every_secret_a_callee_reads_is_declared(self) -> None:
+        """The mirror of the test above. A reusable workflow that READS a secret
+        it never declares only works while some caller says `secrets: inherit`;
+        converting that caller to an explicit list then breaks the lane at
+        runtime. Declaring the full read set is what makes the conversion safe."""
+        problems: list[str] = []
+        for callee in _callees():
+            call = _triggers(_load(callee)).get("workflow_call")
+            if not isinstance(call, dict):
+                continue
+            declared = set(_declared_secrets(callee))
+            for name in sorted(_referenced_secrets(callee) - declared):
+                problems.append(f"{callee} reads {name} without declaring it")
+        assert not problems, "; ".join(problems)
+
+    def test_declared_secrets_stay_optional(self) -> None:
+        """Every one of these lanes has a no-credential path -- a fork, or the
+        `workflow_dispatch` packaging probe -- that must still run and skip the
+        signing steps. `required: true` turns that clean skip into a
+        workflow-call failure before the job starts."""
+        problems: list[str] = []
+        for callee in _callees():
+            for name, spec in _declared_secrets(callee).items():
+                if isinstance(spec, dict) and spec.get("required") is True:
+                    problems.append(f"{callee}:{name}")
+        assert not problems, (
+            "these declarations are required:true, which breaks the "
+            "no-credential path: " + ", ".join(problems)
+        )
+
+
+def _cache_offenders(name: str) -> list[str]:
+    """Enabled caches in one workflow, as human-readable step descriptions."""
+    workflow = _load(name)
+    offenders: list[str] = []
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            uses = str(step.get("uses", ""))
+            with_block = step.get("with") or {}
+            if uses.startswith("actions/cache@"):
+                offenders.append(f"{name}:{job_name} uses actions/cache")
+            elif uses.startswith("actions/setup-node@"):
+                if with_block.get("cache"):
+                    offenders.append(f"{name}:{job_name} setup-node cache is on")
+            elif uses.startswith("astral-sh/setup-uv@"):
+                # `enable-cache` defaults to `auto`, which is ON for a hosted
+                # runner in a uv-managed project. Omitting the key is not
+                # neutral, so an explicit false is required.
+                if with_block.get("enable-cache") is not False:
+                    offenders.append(f"{name}:{job_name} setup-uv does not set enable-cache: false")
+    return offenders
+
+
+class TestPublishLaneCaches:
+    def test_the_publish_graph_is_discovered_not_hardcoded(self) -> None:
+        """Guards the test below: if the traversal silently stopped matching (a
+        renamed entry point, a changed `uses:` spelling) it would pass by
+        inspecting nothing."""
+        lanes = _reachable_publish_lanes()
+        assert set(PUBLISH_ENTRY_POINTS) <= lanes
+        # The build + sign lanes are the ones whose bytes reach users; if the
+        # traversal cannot see them it is not traversing.
+        assert {
+            "build-wheel.yml",
+            "build-desktop.yml",
+            "build-windows.yml",
+            "sign-and-notarize.yml",
+            "publish-cli.yml",
+        } <= lanes
+
+    @pytest.mark.parametrize("name", sorted(_reachable_publish_lanes()))
+    def test_publish_lane_has_no_enabled_cache(self, name: str) -> None:
+        """An Actions cache is writable from any branch and readable by a tag
+        run, so on a lane that builds, signs, gates or ships released bytes a
+        restored entry is an input a lower-trust context can influence.
+
+        This includes the gates: `dependency-vulnerability.yml` decides whether
+        a release proceeds by reading the dependency tree, and a gate that can
+        be handed its own answer is not a gate."""
+        offenders = _cache_offenders(name)
+        assert not offenders, "; ".join(offenders)
+
+
+# --------------------------------------------------------------------------
+# Review-CLI trust boundary.
+# --------------------------------------------------------------------------
+# The AI review lanes install a Node CLI and then execute it AFTER assuming the
+# Bedrock role, so whatever produced that binary runs with AWS credentials. The
+# manifest therefore has to come from the BASE commit, never from the checkout:
+# `codex-review.yml` runs on same-repo PRs where the checkout IS the PR ref, so
+# a manifest read from the tree would let a PR author point it at any package
+# and receive the credentials.
+#
+# This is a real regression that shipped in review and was caught: moving the
+# manifest out of `.github/workflows/` and into `.github/review-cli/` moved it
+# out of the only thing that gates workflow edits. `fork-gpt-review.yml` was
+# safe only incidentally -- it checks out `base_sha` -- and an edit to that
+# checkout would have reopened it silently. Hence a mechanical assertion rather
+# than a comment.
+
+REVIEW_CLI_DIR = ".github/review-cli"
+
+
+def _review_cli_lanes() -> list[str]:
+    return sorted(
+        path.name
+        for path in WORKFLOWS.glob("*.yml")
+        if REVIEW_CLI_DIR in path.read_text(encoding="utf-8")
+    )
+
+
+class TestReviewCliTrustBoundary:
+    def test_the_lanes_are_discovered_not_hardcoded(self) -> None:
+        """Guards the assertions below from passing by inspecting nothing."""
+        assert set(_review_cli_lanes()) >= {"codex-review.yml", "fork-gpt-review.yml"}
+
+    def test_no_lane_installs_the_manifest_from_the_checkout(self) -> None:
+        """`npm ci --prefix .github/review-cli` installs whatever the checked-out
+        tree says. On a same-repo PR that tree is the PR, and the binary runs with
+        this job's Bedrock credentials."""
+        offenders = [
+            name
+            for name in _review_cli_lanes()
+            if f"--prefix {REVIEW_CLI_DIR}" in (WORKFLOWS / name).read_text(encoding="utf-8")
+        ]
+        assert not offenders, (
+            "these lanes install the review CLI from the checkout instead of "
+            "materializing it from the base commit: " + ", ".join(offenders)
+        )
+
+    def test_every_lane_materializes_the_manifest_from_the_base_commit(self) -> None:
+        problems: list[str] = []
+        for name in _review_cli_lanes():
+            text = (WORKFLOWS / name).read_text(encoding="utf-8")
+            if f'git show "$BASE_SHA:{REVIEW_CLI_DIR}/' not in text:
+                problems.append(f"{name} does not read the manifest from $BASE_SHA")
+        assert not problems, "; ".join(problems)
+
+    def test_no_lane_executes_the_cli_from_inside_the_worktree(self) -> None:
+        """The binary must be invoked from where the base-materialized install
+        put it (RUNNER_TEMP), not from a path inside the reviewed tree."""
+        problems: list[str] = []
+        for name in _review_cli_lanes():
+            text = (WORKFLOWS / name).read_text(encoding="utf-8")
+            if f"{REVIEW_CLI_DIR}/node_modules" in text:
+                problems.append(f"{name} runs the CLI from the worktree")
+            if "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" not in text:
+                problems.append(f"{name} does not invoke the base-materialized CLI")
+        assert not problems, "; ".join(problems)
+
+    def test_the_absent_manifest_path_fails_closed(self) -> None:
+        """There is deliberately no fallback to the checkout. A prompt block read
+        from the PR weakens the review contract; a MANIFEST read from the PR is
+        arbitrary code execution with AWS credentials, so the bootstrap round is
+        a human ruling (`/ai-review override`), not an automatic downgrade."""
+        problems: list[str] = []
+        for name in _review_cli_lanes():
+            text = (WORKFLOWS / name).read_text(encoding="utf-8")
+            if f"cp {REVIEW_CLI_DIR}" in text or f'cp ".{REVIEW_CLI_DIR[7:]}' in text:
+                problems.append(f"{name} falls back to copying the checked-out manifest")
+            if "is absent or empty on the base commit" not in text:
+                problems.append(f"{name} has no fail-closed branch for an absent manifest")
+        assert not problems, "; ".join(problems)


### PR DESCRIPTION
## Problem / Motivation

Round 1 of the zizmor hardening ([#6492](https://github.com/kirodotdev/KiroCrew/pull/6492)) closed the four findings that were straightforwardly actionable. Two audit classes were left open in the [Kiro Crew Security](https://taskei.amazon.dev/rooms/adccf007-cb42-4e50-af05-067ed5b248c5/tasks) room, and round 1 also surfaced a blind spot: three cache sites on publish lanes that zizmor never reported, found only by hand.

This closes both remaining classes, closes the one remaining unreported cache site, and adds the ratchets round 1 did not.

- `secrets-inherit` × 6 — [P500306956](https://taskei.amazon.dev/tasks/2ade1008-9834-4c91-ac64-0b1cccd75c13)
- `adhoc-packages` × 2 — [P500307257](https://taskei.amazon.dev/tasks/c97a4d9f-7527-42bc-a00c-9361a4926255)

## Why it matters

**The secret scope is the big one.** `nightly.yml` and `release.yml` called `build-windows`, `publish-cli` and `sign-and-notarize` with `secrets: inherit` — every repository secret handed to each callee. The calling context on those two workflows holds the signing role, the Apple notarization credential and the publish role, so this was the widest secret exposure in the repo, on its most privileged path.

The underlying reason it was written that way: **none of the three callees declared `on.workflow_call.secrets` at all**, so `inherit` was the only thing that worked. Converting the call sites without declaring the read set first would have broken the lanes at runtime — which is why one of the new tests asserts exactly that property.

**The review lanes execute third-party code with AWS credentials.** `codex-review.yml` and `fork-gpt-review.yml` ran `npm install -g @openai/codex` unversioned, in jobs that hold Bedrock credentials and read PR content.

**A gate was reading a branch-writable input.** `dependency-vulnerability.yml` decides whether a release proceeds, by inspecting the dependency tree — and it cached npm keyed on the very lockfiles it audits. An Actions cache is writable from any branch and readable by a tag run. A gate that can be handed its own answer is not a gate.

## What changed (motivation → approach → change)

### 1. `secrets-inherit`: 6 → 0

Each callee now declares the secrets it reads; each call site passes exactly those.

| Callee | Declared / passed |
|---|---|
| `build-windows.yml` | `AWS_WINDOWS_SIGNING_ROLE_ARN` |
| `publish-cli.yml` | `AWS_SIGNING_ROLE_ARN` |
| `sign-and-notarize.yml` | `AWS_SIGNING_ROLE_ARN`, `AWS_SIGNING_BUCKET`, `AWS_SIGNER_ACCESS_ROLE_ARN`, `CDSIGNER_API_ENDPOINT` |

Every declaration is **`required: false`, deliberately.** Each lane has a no-credential path — a fork, and `build-windows`' `workflow_dispatch` packaging probe — where an empty value is how the signing steps skip cleanly (`HAS_WINDOWS_SIGNING`, `HAS_PUBLISH_ROLE`, `HAS_SIGNING_SECRETS`, `HAS_CDSIGNER` all test for non-empty). `required: true` would turn that clean skip into a workflow-call failure before the job starts. This mirrors `publish-windows.yml`, already converted and pinned by `test_workflow_permissions.py`.

### 2. `adhoc-packages`: 2 → 0 — and the manifest's own trust boundary

Pinning the version alone does not close this, and zizmor says why: `npm install -g pkg@X` still re-resolves that package's *own* dependencies on every run. So a committed manifest is used instead — `.github/review-cli/{package.json,package-lock.json}`, exact pin at 0.150.1. **Those two files are not in this diff:** they landed separately in #6867 as a commit with zero consumers, for the bootstrap reason in the note below. This PR is what starts consuming them.

**That fix, in its first form, opened a worse hole than the one it closed, and review caught it.** Committing the manifest moved an executed input out of `.github/workflows/` — where a same-repo PR edit is covered by human review, the arrangement `fork-workflow-guard.yml:26` states explicitly — and into `.github/review-cli/`, which nothing gates. `codex-review.yml` runs on same-repo PRs with `pull_request`, so its checkout **is** the PR ref, and the binary runs *after* the Bedrock role is assumed. A PR could have pointed the manifest at any package and received the credentials.

The package files are therefore materialized from the base commit, using this file's own existing idiom (`git show "$BASE_SHA:..."`, as the AUTOSDE-rule and prompt-block steps already do), installed into `RUNNER_TEMP` rather than the worktree, and invoked from there:

```yaml
      - name: Install review CLI
        env:
          BASE_SHA: ${{ github.event.pull_request.base.sha }}
          CLI_DIR: ${{ runner.temp }}/review-cli
        run: |
          set -euo pipefail
          mkdir -p "$CLI_DIR"
          for f in package.json package-lock.json; do
            git show "$BASE_SHA:.github/review-cli/$f" > "$CLI_DIR/$f" 2>/dev/null || true
            if [ ! -s "$CLI_DIR/$f" ]; then
              echo "::error::.github/review-cli/$f is absent or empty on the base commit ($BASE_SHA). ..."
              exit 1
            fi
          done
          npm ci --prefix "$CLI_DIR"
```

**It fails closed, and does NOT fall back to the checkout** the way the prompt-block step directly below it does. That asymmetry is the point: a prompt read from the PR weakens the review contract, but a *manifest* read from the PR is arbitrary code execution with AWS credentials, so there is no safe fallback to offer.

**⚠️ Why this shipped as two PRs — and why no override is needed.** The guard's precondition, manifest present on the base commit, cannot be satisfied by the PR that *introduces* the manifest: no base commit carries it yet. Any code path that would let such a PR pass must read the manifest from the PR itself, which is exactly what the guard exists to prevent — so the precondition cannot be patched around, only satisfied. I considered adding a third gate-passing condition beside the existing `dependabot` / `human_override` skips and rejected it: adding a bypass path in order to close a bypass path is the worse trade, and a new gate-passing condition is exactly what should not be invented inside a security fix. The manifest therefore landed first, in #6867, as inert data. **`Install review CLI` now runs and passes on this PR on its own merits** — an active override would have marked that step `skipped`, not `success`.

`fork-gpt-review.yml` was safe only *incidentally* — it checks out `base_sha`. Made explicit anyway, because an edit to that checkout would have reopened the identical hole with nothing to notice.

An earlier attempt also introduced a **High `github-env`** finding by exporting the bin directory through `$GITHUB_PATH`; the CLI is invoked by path instead, and the final scan has `github-env` at 0.

### 3. The cache site zizmor cannot see: 1 → 0

`dependency-vulnerability.yml`'s `setup-node` no longer enables `cache: npm`. Cost is near zero — the audit calls the registry advisory endpoint via `npx npm@<pin> audit`, it does not install packages.

Same blind spot that hid three sites during #6492: **zizmor cannot see through `workflow_call`**, so it does not know this workflow only ever runs on a publish path.

### 5. The blast radius nobody would have predicted: prepare-pr's own contract extractor

Adding a second `$BASE_SHA` snapshot to `codex-review.yml` **broke
`prepare-pr/scripts/local_review.py`**, which mirrors CI by extracting each
reviewer's contract from its workflow. `extract_prompt_file_specs` selected the
prompt loader *positionally* — the first `for ... do` loop plus the first
`git show "$BASE_SHA:...$var..."` anywhere in the file. The new install step sits
**above** the prompt loader, so the extractor built prompt specs named
`package.json`, and 22 tests failed looking for
`.github/review-prompts/package.json`.

Caught by CI on `bf1ac7f63` (`Backend Tests (3.10, 3)` and
`Backend Tests (Windows) (3)`), not by me — worth saying plainly, because it is
the second time in this PR that a change which looked local turned out to move a
boundary.

Fixed **in the extractor**, not by reordering the workflow around a fragile
parser. It now selects by **path** (the template's `src` must be under
`.github/review-prompts/`) and takes the **last** loop opened before that
template, so an unrelated base snapshot cannot be mistaken for a prompt block
wherever it sits. The `cp` bootstrap match is scoped the same way and searched
from the loop onward.

Verified the extractor still yields the right sets, rather than merely not
crashing:

| Lane | Prompt specs |
|---|---|
| `codex-review.yml` | the 5 `gpt-*` blocks |
| `claude-review.yml` | the 2 `opus-*` blocks |
| `fork-gpt-review.yml` | 0 — it loads prompts from its base checkout, and yielded 0 before this change too |

Two regression tests, one on the live workflow and one synthetic so the guard
does not depend on the step order staying as it is. Both fail against the old
extractor (with the same 20 cascade failures CI showed) and pass against the new.

### 4. Ratchets, so there is no round 3

Every invariant here was previously established one file at a time, which protects only the files that already tripped the audit. `test/test_workflow_secret_and_cache_scope.py` derives its file set from the **workflow graph**:

- no local call site uses `secrets: inherit`
- every passed secret is declared by the callee
- **every secret a callee READS is declared** — the gap that made this PR necessary
- declarations stay `required: false`
- nothing reachable from `nightly.yml` / `release.yml` enables a cache, with `setup-uv` required to say `enable-cache: false` **explicitly** (its default `auto` is ON for a hosted runner in a uv-managed project — omitting the key is not neutral)
- **no review lane installs the CLI manifest from the checkout**, every one materializes it from `$BASE_SHA`, none executes it from inside the worktree, none copies the checked-out manifest, and each has the fail-closed branch
- plus guard tests asserting both discovery walks actually reach the lanes they are meant to, so neither can pass by inspecting nothing

## Tests

**552 passed** across every suite that reads a workflow this PR touches:

```
test_workflow_secret_and_cache_scope.py  (new, 21)  test_workflow_permissions.py
test_dependency_vulnerability_gate.py               test_workflow_cache_setup_uniqueness.py
test_github_workflow_security.py                    test_ai_review_workflows.py (176)
test_fork_pr_description_workflow.py (32)           test_nightly_version_contract.py
test_release_channel.py                             test_release_macos_fail_closed.py
test_stable_release_gate.py                         test_cli_manifest_signature.py
test_publish_feed_contract.py                       test_publish_docker_contract.py
test_release_promotion.py                           test_release_promotion_contract.py
test_verify_windows_installer.py
```

**Mutation-verified in both directions.** 3 tests fail on `f31b82d08` (main at branch point):

```
test_no_caller_inherits_the_whole_secret_store
  nightly.yml -> build-windows.yml, nightly.yml -> publish-cli.yml,
  nightly.yml -> sign-and-notarize.yml, release.yml -> build-windows.yml,
  release.yml -> publish-cli.yml, release.yml -> sign-and-notarize.yml
test_every_secret_a_callee_reads_is_declared
  6 undeclared reads across the three callees
test_publish_lane_has_no_enabled_cache[dependency-vulnerability.yml]
```

and 4 more fail on `3c7a836f8` — **this branch's own first head**, the one carrying the manifest hole:

```
test_no_lane_installs_the_manifest_from_the_checkout
  these lanes install the review CLI from the checkout instead of
  materializing it from the base commit: codex-review.yml, fork-gpt-review.yml
test_every_lane_materializes_the_manifest_from_the_base_commit
test_no_lane_executes_the_cli_from_inside_the_worktree
test_the_absent_manifest_path_fails_closed
```

Other gates: 48 workflows parse as YAML; `black` gate exit 0 (12 files in scope, nothing unformatted outside the baseline); `isort` and `flake8` clean.

## Manual verification

**The install step's shell body was executed against real commits, not just read.** Both branches:

| Case | Base commit | Result |
|---|---|---|
| manifest absent on base | `origin/main` before #6867 | exit **1**, `::error::... absent or empty on the base commit` |
| manifest present on base | `origin/main` after #6867 | exit **0**, `npm ci` → `codex-cli 0.150.1` at `$CLI_DIR/node_modules/.bin/codex` |

zizmor 1.29.0, `--no-online-audits`, on this branch:

```
total: 105          (main: 113)
  High           dangerous-triggers       11
  Medium         artipacked               12
  Informational  template-injection       81
  Informational  superfluous-actions       1
```

`secrets-inherit`, `adhoc-packages` and `github-env` all 0. Remaining, all pre-existing:

- **11 `dangerous-triggers`** — audited safe by design. `fork-pr-description.yml`, `fork-pr-label.yml`, `fork-workflow-guard.yml` and `pr-readiness.yml` contain no `actions/checkout` at all; `fork-gpt-review.yml` checks out `base_sha` with `persist-credentials: false`.
- **12 `artipacked`** — 11 are documented residuals from #6492, each with an inline comment naming the job and the git operation needing the credential. The 12th arrived on main during review and sits in `ci.yml` / `add-contributor.yml` / `cleanup-temp-screenshots.yml` / `memory-benchmark.yml` / `test-durations.yml` — none of which this PR touches, so it is out of scope here rather than a regression from this diff. Count is 12 on this branch and 12 on main.

**Not verified end-to-end, and cannot be from a PR:** no real prerelease tag has published against the explicit `secrets:` blocks. A dropped secret surfaces as a publish-lane failure, not a lint failure. The two declaration tests catch a name mismatch in either direction, but the first real nightly is the live confirmation.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** CI configuration and a test file only — no rendered surface is touched.

## Related Issues

Closes the two remaining open zizmor tickets in the Kiro Crew Security room:
[secrets-inherit](https://taskei.amazon.dev/tasks/2ade1008-9834-4c91-ac64-0b1cccd75c13) · [adhoc-packages](https://taskei.amazon.dev/tasks/c97a4d9f-7527-42bc-a00c-9361a4926255)

Follows [#6492](https://github.com/kirodotdev/KiroCrew/pull/6492). `no linked issue: the work was tracked in Taskei, not GitHub Issues.`

Deliberately **not** in scope, each worth its own decision:

1. `.github/review-cli/package-lock.json` is not in `AUDITED_LOCKFILES`. That gate audits *production* dependencies and this is CI-only tooling — but it is tooling that executes in a credentialed job, so extending the gate is a reasonable follow-up.
2. Same-repo PRs have no automated `.github/**` change gate (`fork-workflow-guard.yml` is fork-only, and same-repo edits rely on human review by inheritance). That is the boundary this PR's regression walked through. Widening the guard to same-repo PRs is a separate change with its own blast radius.
3. The two `artipacked` follow-ups recorded on the closed round-1 ticket.

## Checklist

- [x] Tests added for the new behaviour, mutation-verified against **both** main and the vulnerable prior head
- [x] The shell logic was run, not just reviewed — both branches, against real commits
- [x] No user-facing surface changed
- [x] Local gates green (552 pytest, black, isort, flake8, YAML parse, zizmor 104)
- [x] One inherited failure confirmed pre-existing against a clean-main worktree at `6ea916123`: `test_prepare_pr_findings.py::TestCredentialRedaction::test_redacts_freshly_minted_link_token`
- [x] Single commit, rebased on current `main`, 0 behind
- [x] Security reasoning recorded inline in each file, not only in this PR

## Contribution License Agreement

By submitting this pull request I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.

