### PR TITLE
refactor(chat): collapse the two scroll-anchor compensation paths onto one capture

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -450,20 +450,18 @@ export function useVirtualChat<T>(
 
   // ---- Scroll-anchor preservation ----
   //
-  // While the user is scrolled up reading history, an UPWARD window shift
-  // mounts rows above the viewport (recomputeWindow / top-sentinel expansion).
-  // Native `overflow-anchor: auto` normally holds the viewport steady, but a
-  // scroll-path recompute can UNMOUNT the browser's chosen anchor node (rows
-  // past WINDOW_UNMOUNT_HYSTERESIS), collapsing anchoring and jumping the
-  // viewport. This ref carries the topmost visible row's key + its screen
-  // offset, captured BEFORE an upward shift; a layout effect after commit
-  // re-reads that row and corrects scrollTop by the delta. This REDUCES
-  // reliance on overflow-anchor (it does not replace it — the CSS is owned by
-  // ChatPage and left alone).
-  const anchorPendingRef = useRef<{ key: string; top: number } | null>(null)
+  // While the user is scrolled up reading history, content can grow ABOVE the
+  // row they are reading, which moves that row down while scrollTop stays put —
+  // that IS the jump. Native `overflow-anchor: auto` normally holds the viewport
+  // steady, but a scroll-path recompute can UNMOUNT the browser's chosen anchor
+  // node (rows past WINDOW_UNMOUNT_HYSTERESIS), collapsing anchoring. So the
+  // hook carries its own anchor: the topmost visible row's key + screen offset,
+  // captured BEFORE the shift, re-read after commit, and the delta paid back
+  // into scrollTop. This REDUCES reliance on overflow-anchor (it does not
+  // replace it — the CSS is owned by ChatPage and left alone).
   // Anchor captured by syncHeightsNow for a spacer-repricing commit. Kept
-  // SEPARATE from anchorPendingRef: that one is consumed by the
-  // windowRange-keyed effect, and window commits land constantly while rows
+  // SEPARATE from shiftAnchorRef: that slot is consumed on a windowRange
+  // commit, and window commits land constantly while rows
   // mount — sharing the slot lets an unrelated window commit consume (and
   // clear) the anchor before the height-sync commit it was captured for,
   // leaving the repricing shift uncompensated (observed as a nondeterministic
@@ -471,22 +469,42 @@ export function useVirtualChat<T>(
   const heightAnchorPendingRef = useRef<{ key: string; top: number } | null>(null)
 
   /**
-   * Prepend compensation (load-older history).
+   * ONE compensation routine, TWO triggers, ONE capture point.
    *
-   * A prepend shifts every index up, so pre-existing rows move down by the
-   * inserted height while scrollTop stays put — that IS the jump. The snapshot
-   * must be taken in the RENDER phase (getSnapshotBeforeUpdate idiom): a layout
-   * effect runs after commit, when the row has moved and the delta reads zero.
+   *   TRIGGER 1 — prepend (load-older history): every index shifts up, so
+   *     pre-existing rows move down by the inserted height.
+   *   TRIGGER 2 — upward window shift (scroll recompute / top-sentinel
+   *     expansion): rows mount above the viewport, and they are re-measured
+   *     from the flat estimate, so the content above the reader changes height.
+   *
+   * Both are "content above the reader grew"; the correction is identical, so
+   * they share this slot and the single consumer below.
+   *
+   * The capture is in the RENDER phase (getSnapshotBeforeUpdate idiom) for BOTH.
+   * That point is canonical rather than merely convenient: a post-commit read
+   * cannot recover a pre-shift position — the row has already moved and the
+   * delta reads zero — while a pre-shift capture is valid for the window shift
+   * too, because the mounted nodes still carry the PREVIOUS commit's geometry
+   * while the new range renders. Capturing here also removes the stale-anchor
+   * hazard the callback capture had: an anchor taken when a shift was merely
+   * SCHEDULED outlived a no-op window commit and was then applied to an
+   * unrelated later one, yanking the viewport to a row nobody was reading.
    *
    * Arithmetic is no alternative: `getH` prices an unmeasured row from the
    * running MEAN of measured ones, so any measurement re-prices every unmeasured
    * row and the next sync re-reads them all (measured: a 1000px insert displaced
-   * rows by 1500). These refs stay private rather than reusing `anchorPendingRef`,
-   * which the passive itemCount recompute overwrites with its own capture.
+   * rows by 1500).
+   *
+   * Staged, because trigger 1 needs an extra commit before it can measure:
+   *   'awaiting-rebase' — prepend captured; the window must be re-based first
+   *                       (part 1) so the anchor row is still mounted to measure.
+   *   'rebased'         — re-base committed; correct, then re-derive the window.
+   *   'ready'           — window shift captured; correct only. No re-derive:
+   *                       the shift already is the window's own decision.
    */
-  const prependAnchorRef = useRef<{ key: string; top: number } | null>(null)
+  const shiftAnchorRef = useRef<{ key: string; top: number } | null>(null)
+  const shiftStageRef = useRef<'awaiting-rebase' | 'rebased' | 'ready' | null>(null)
   const prependCountRef = useRef(0)
-  const prependRefineRef = useRef(false)
   /** Previous render's identity. `items` is held because `itemsRef` has already
    *  advanced by the time the capture runs, while the mounted nodes still carry
    *  the PREVIOUS commit's indices. */
@@ -495,6 +513,9 @@ export function useVirtualChat<T>(
   })
   const prependPrev = prependPrevRef.current
   const prependFirstKey = itemCount > 0 ? getKey(items[0], 0) : null
+  // Guards the shared slot: a prepend capture in THIS render must not then be
+  // overwritten by the window-shift branch below (a re-base changes the range).
+  let anchorCapturedThisRender = false
   // A front-insert grows the count AND changes index 0's key. A slot switch does
   // both, hence the session guard; a plain append leaves index 0 alone.
   if (
@@ -518,8 +539,10 @@ export function useVirtualChat<T>(
         })
       : null
     if (prependAnchor) {
-      prependAnchorRef.current = prependAnchor
+      shiftAnchorRef.current = prependAnchor
+      shiftStageRef.current = 'awaiting-rebase'
       prependCountRef.current = itemCount - prependPrev.count
+      anchorCapturedThisRender = true
     }
   }
   prependPrevRef.current = { session: sessionId, count: itemCount, firstKey: prependFirstKey, items }
@@ -535,6 +558,23 @@ export function useVirtualChat<T>(
   })
   // Live mirror of windowRange for imperative reads (debug probe).
   const windowRangeRef = useRef(windowRange)
+  // TRIGGER 2 capture. Read BEFORE the mirror advances, so the comparison is
+  // against the range that is still on screen. Keyed on the range having
+  // ACTUALLY moved up in committed state — not on a shift being scheduled —
+  // which is what makes a no-op window commit incapable of stranding an anchor.
+  if (!anchorCapturedThisRender && windowRange.start < windowRangeRef.current.start && !stickRef.current) {
+    const shiftEl = scrollerRef.current
+    const shiftAnchor = shiftEl
+      ? captureTopAnchorFrom(shiftEl, elIndexRef.current.entries(), (idx) => {
+          const it = items[idx]
+          return it ? getKey(it, idx) : null
+        })
+      : null
+    if (shiftAnchor) {
+      shiftAnchorRef.current = shiftAnchor
+      shiftStageRef.current = 'ready'
+    }
+  }
   windowRangeRef.current = windowRange
 
   // isAtBottom is the only render-affecting scroll state we expose (drives the
@@ -895,15 +935,10 @@ export function useVirtualChat<T>(
     } else {
       next = computeWindow(Math.max(0, el.scrollTop - leadingOffset(el)), el.clientHeight, count, getH, overscan)
     }
-    // On an upward shift (window start moving up → more rows mount above
-    // the viewport) while the user is scrolled up (stick released), record the
-    // top anchor so the post-commit layout effect can hold the viewport steady.
-    // Skipped while stick is armed — the pin path owns positioning then.
-    const cur = windowRangeRef.current
-    if (next.start < cur.start && !stickRef.current) {
-      const a = captureTopAnchor()
-      if (a) anchorPendingRef.current = a
-    }
+    // No anchor capture here. An upward shift is compensated from the
+    // render-phase capture keyed on the range actually moving up (TRIGGER 2),
+    // which cannot strand an anchor when this recompute's own update is merged
+    // away to a no-op.
     setWindowRange((prev) => {
       let merged: { start: number; end: number }
       if (expandOnly) {
@@ -931,7 +966,7 @@ export function useVirtualChat<T>(
       if (prev.start === merged.start && prev.end === merged.end) return prev
       return merged
     })
-  }, [getH, overscan, scrollerRef, captureTopAnchor, leadingOffset])
+  }, [getH, overscan, scrollerRef, leadingOffset])
 
   // ---- Pin helpers (the only code that writes el.scrollTop for follow) ----
 
@@ -1398,19 +1433,11 @@ export function useVirtualChat<T>(
         for (const entry of entries) {
           if (!entry.isIntersecting) continue
           if (entry.target === topSentinelRef.current) {
-            // Upward expansion mounts rows above the viewport. Capture
-            // the top anchor first (while stick is released — reading history)
-            // so the compensation layout effect can hold the viewport steady.
-            //
-            // Only when there is actually room to expand: at start === 0
-            // expandWindowUp is a no-op, so a captured anchor would never be
-            // consumed by an upward shift and would instead be applied to the
-            // NEXT layout pass — a downward expansion — yanking the viewport
-            // back to a stale row.
-            if (!stickRef.current && windowRangeRef.current.start > 0) {
-              const a = captureTopAnchor()
-              if (a) anchorPendingRef.current = a
-            }
+            // Upward expansion mounts rows above the viewport, and TRIGGER 2
+            // compensates it from the render phase. Nothing to capture here:
+            // at start === 0 expandWindowUp is a no-op, and keying the capture
+            // on the committed range moving up makes that case a non-event
+            // instead of something this site has to screen for.
             setWindowRange((prev) => expandWindowUp(prev, overscan))
             onTopReachedRef.current?.()
           } else if (entry.target === bottomSentinelRef.current) {
@@ -1424,62 +1451,24 @@ export function useVirtualChat<T>(
     if (topSentinelRef.current) io.observe(topSentinelRef.current)
     if (bottomSentinelRef.current) io.observe(bottomSentinelRef.current)
     return () => io.disconnect()
-  }, [overscan, scrollerEl, captureTopAnchor])
-
-  // ---- Scroll-anchor preservation: hold the viewport steady across an
-  //      upward window shift ----
-  //
-  // Runs after every windowRange commit. If recomputeWindow / top-sentinel
-  // expansion captured a top anchor (only on an upward shift while stick is
-  // released), re-read that row's screen position in the freshly-committed DOM
-  // and correct scrollTop by the delta so the row the user is looking at does
-  // not jump when rows mount/unmount above it. Skipped when stick is armed (the
-  // pin path owns positioning) or nothing was captured. The scrollTop write is
-  // recorded in lastWriteTopRef so the passive scroll listener classifies it as
-  // a self-scroll (isSelfScroll / SELF_SCROLL_EPSILON) and does not release
-  // stick or treat it as a user scroll.
-  useLayoutEffect(() => {
-    const pending = anchorPendingRef.current
-    anchorPendingRef.current = null
-    if (!pending) return
-    const el = scrollerRef.current
-    if (!el || stickRef.current || typeof el.getBoundingClientRect !== 'function') return
-    let node: HTMLElement | null = null
-    for (const [n, idx] of elIndexRef.current.entries()) {
-      const it = itemsRef.current[idx]
-      if (it && getKeyRef.current(it, idx) === pending.key) {
-        node = n as HTMLElement
-        break
-      }
-    }
-    if (!node) return
-    const srTop = el.getBoundingClientRect().top
-    const newTop = node.getBoundingClientRect().top - srTop
-    const delta = newTop - pending.top
-    if (Math.abs(delta) > 0.5) {
-      // Instant, and accounted as a 'pin' write: this is our own correction, so
-      // the follow guard must recognise the resulting scroll event as self-scroll
-      // rather than user input. Routed through the chokepoint so the accounting
-      // cannot be forgotten here (see writeScrollTop).
-      writeScrollTop(el, el.scrollTop + delta, 'auto', 'pin')
-    }
-  }, [windowRange, scrollerRef, writeScrollTop])
+  }, [overscan, scrollerEl])
 
   /**
-   * Prepend compensation, part 1: re-base the window by the inserted count so
-   * the rows being read stay mounted — including the anchor row, which part 2
-   * has to measure. Runs pre-paint, so the shifted-but-uncorrected frame is
-   * never shown.
+   * Part 1 — TRIGGER 1 only: re-base the window by the inserted count so the
+   * rows being read stay mounted, including the anchor row that part 2 has to
+   * measure. Runs pre-paint, so the shifted-but-uncorrected frame is never
+   * shown. A window shift needs no equivalent: it IS a range change already.
    */
   useLayoutEffect(() => {
     const inserted = prependCountRef.current
     if (inserted <= 0) return
     prependCountRef.current = 0
-    if (stickRef.current || !prependAnchorRef.current) {
-      prependAnchorRef.current = null
+    if (stickRef.current || !shiftAnchorRef.current) {
+      shiftAnchorRef.current = null
+      shiftStageRef.current = null
       return
     }
-    prependRefineRef.current = true
+    shiftStageRef.current = 'rebased'
     setWindowRange((r) => ({
       start: Math.min(itemCount, r.start + inserted),
       end: Math.min(itemCount, r.end + inserted),
@@ -1487,24 +1476,34 @@ export function useVirtualChat<T>(
   }, [itemCount])
 
   /**
-   * Prepend compensation, part 2: re-read the anchor row in the shifted DOM and
-   * move scrollTop by however far it travelled, which holds the user's place
-   * whatever mix of inserted rows and re-estimated heights caused the shift.
+   * Part 2 — the single consumer for BOTH triggers: re-read the anchor row in
+   * the shifted DOM and move scrollTop by however far it travelled, which holds
+   * the user's place whatever mix of inserted rows and re-estimated heights
+   * caused the shift.
    *
-   * INVARIANT — the passive itemCount recompute runs BETWEEN these two layout
-   * effects; part 2 must re-derive the window after correcting scrollTop.
+   * Gated on the stage, not on this effect having run: the deps include
+   * `recomputeWindow`, whose identity changes as heights are measured, so an
+   * ungated read here would consume a prepend anchor before part 1 had re-based
+   * the window to keep its row mounted.
    *
-   * Then recompute the window, because the passive itemCount recompute has
-   * already run by this point — React flushes it between these two layout
-   * effects — so it sized the window from the PRE-correction offset and its
-   * update lands after this write. Re-deriving from the corrected scrollTop is
-   * what stops that stale range being the one left committed.
+   * The scrollTop write is recorded in lastWriteTopRef so the passive scroll
+   * listener classifies it as a self-scroll (isSelfScroll / SELF_SCROLL_EPSILON)
+   * and does not release stick or treat it as user input.
+   *
+   * After a 'rebased' correction only, re-derive the window: the passive
+   * itemCount recompute has already run by this point — React flushes it between
+   * these two layout effects — so it sized the window from the PRE-correction
+   * offset and its update lands after this write. Re-deriving from the corrected
+   * scrollTop is what stops that stale range being the one left committed. A
+   * 'ready' (window-shift) correction must NOT re-derive: that range is the
+   * window's own decision, and recomputing it here would fight the scroll.
    */
   useLayoutEffect(() => {
-    if (!prependRefineRef.current) return
-    prependRefineRef.current = false
-    const pending = prependAnchorRef.current
-    prependAnchorRef.current = null
+    const stage = shiftStageRef.current
+    if (stage !== 'rebased' && stage !== 'ready') return
+    shiftStageRef.current = null
+    const pending = shiftAnchorRef.current
+    shiftAnchorRef.current = null
     const el = scrollerRef.current
     if (!pending || !el || stickRef.current) return
     const newTop = rowTopFrom(el, elIndexRef.current.entries(), (idx) => {
@@ -1513,8 +1512,12 @@ export function useVirtualChat<T>(
     }, pending.key)
     if (newTop === null) return
     const delta = newTop - pending.top
+    // Instant, and accounted as a 'pin' write: this is our own correction, so
+    // the follow guard must recognise the resulting scroll event as self-scroll
+    // rather than user input. Routed through the chokepoint so the accounting
+    // cannot be forgotten here (see writeScrollTop).
     if (Math.abs(delta) > 0.5) writeScrollTop(el, el.scrollTop + delta, 'auto', 'pin')
-    recomputeWindow()
+    if (stage === 'rebased') recomputeWindow()
   }, [windowRange, scrollerRef, writeScrollTop, recomputeWindow])
 
   // Same correction for a HEIGHT-SYNC commit (spacer repricing), keyed on the

--- a/website/src/test/useVirtualChat.prependAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.prependAnchor.test.tsx
@@ -261,4 +261,67 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     // unmodified hook (verified), so that drift is not this path's to fix.
     expect(screenTopOf(el, before!.key)).not.toBeNull()
   })
+
+  // ---- Reader-row immobility: ONE invariant, both compensation triggers ----
+  //
+  // A prepend and an upward window shift are two ways the content above the
+  // reader grows. The user-visible contract is identical for both: the row
+  // being read does not move. These cases pin that contract per TRIGGER,
+  // independent of which internal slot carries the anchor, so collapsing the
+  // capture paths cannot silently drop one of them.
+
+  it('INVARIANT holds the reader row across the PREPEND trigger', () => {
+    const { el, view, scrollerRef } = mountScrolledUp()
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+
+    act(() => {
+      view.rerender(
+        <Harness items={[...mkItems(10, 'p'), ...mkItems(30)]} scrollerRef={scrollerRef} />,
+      )
+    })
+
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  /** Lowest mounted virtual index — proves an upward shift actually happened,
+   *  so the invariant case cannot pass vacuously on a window that never moved. */
+  function lowestMountedIndex(el: HTMLElement): number {
+    let min = Number.POSITIVE_INFINITY
+    el.querySelectorAll('[data-index]').forEach((n) => {
+      min = Math.min(min, Number((n as HTMLElement).getAttribute('data-index')))
+    })
+    return min
+  }
+
+  it('INVARIANT holds the reader row across the upward WINDOW-SHIFT trigger', () => {
+    const { el } = mountScrolledUp()
+
+    // A reading-scroll UP, not a far jump: the window shifts up by a couple of
+    // rows while the row being read stays mounted. The scroll is the user's;
+    // the shift it provokes is ours, so the reference position is read AFTER
+    // the scroll lands and BEFORE the rAF that mounts rows above.
+    const mountedBefore = lowestMountedIndex(el)
+    act(() => {
+      el.scrollTop = 1960
+      el.dispatchEvent(new Event('scroll'))
+    })
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+    // Not vacuous: rows really did mount above the reader.
+    expect(lowestMountedIndex(el)).toBeLessThan(mountedBefore)
+    // Those rows are REAL_H while the offset index had credited them the flat
+    // estimate, so without compensation the reader's row is pushed down by the
+    // difference. Assert the ROW, not scrollTop: holding the row IS the
+    // contract, and it is held by moving the viewport under it.
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
 })


### PR DESCRIPTION
## Problem / Motivation

`useVirtualChat` carried one rule -- *content grew above the row the user is reading, so pay the delta back into `scrollTop`* -- spelled twice, as two independent compensation paths with two anchors, two capture moments and two consumers:

| | captured | consumed |
|---|---|---|
| `anchorPendingRef` | in `recomputeWindow` and the top-sentinel `IntersectionObserver`, at the moment an upward window shift was **scheduled** | its own `windowRange`-keyed layout effect |
| `prependAnchorRef` | in the **render phase**, when older history arrived | the prepend part-1 / part-2 pair |

The two spellings sat 1000 lines apart with comments at each site asserting the separation was deliberate, and no test stated the shared contract, so nothing pinned them as one rule.

## Why it matters

Two implementations of one rule drift. Concretely, capturing at *schedule* time rather than at *shift* time is not equivalent: an anchor taken for a window shift that then merged away to a no-op outlived its commit and was applied to an unrelated later one, yanking the viewport to a row nobody was reading. The top-sentinel site needed an explicit `start > 0` screen for exactly that hazard -- a workaround for the capture point, not for anything intrinsic. The `recomputeWindow` site had no equivalent screen.

Two open issues are queued to extend this routine (an append trigger, and pinned-jump glide ownership). Extending two divergent copies is where the real cost lands.

## What changed (motivation → approach → change)

**Approach: unify on the render-phase capture as canonical.** This is the correctness argument, not a preference: a post-commit read cannot recover a pre-shift position -- the row has already moved and the delta reads zero -- while a pre-shift capture *is* valid for the upward-window-shift trigger too, because the mounted nodes still carry the previous commit's geometry while the new range renders. The render phase is therefore the only point that serves both triggers.

Changes, all in `website/src/hooks/virtualizer/useVirtualChat.ts`:

- **One slot.** `anchorPendingRef` and `prependAnchorRef` collapse into `shiftAnchorRef`. Both triggers write it; one layout effect consumes it.
- **Trigger 2 moves into the render phase**, keyed on the committed range having *actually* moved up (`windowRange.start < windowRangeRef.current.start`, read before the mirror advances) rather than on a shift being scheduled. The two callback captures -- in `recomputeWindow` and in the top-sentinel observer -- are deleted, along with the now-unnecessary `start > 0` screen: a no-op window commit is now incapable of stranding an anchor, so there is nothing for that site to screen for.
- **A stage replaces `prependRefineRef`.** `shiftStageRef` carries the only genuine difference between the triggers: a prepend needs one extra commit to re-base the window before its anchor row can be measured (`awaiting-rebase` → `rebased`), and only that path re-derives the window afterwards; a window shift is already the window's own decision and is corrected in place (`ready`). The stage also keeps the shared consumer from eating a prepend anchor early -- its deps include `recomputeWindow`, whose identity changes as heights are measured.
- **A render-local guard** stops trigger 2 overwriting a trigger-1 capture taken in the same render (part 1's re-base changes the range).

**`heightAnchorPendingRef` is deliberately left alone.** Its comment records a measured 170-190px lurch caused by sharing a slot with the window path: height commits and window commits interleave, so a window commit consumes and clears an anchor captured for a spacer-repricing commit. It keeps its own slot and its own `heightCommit`-keyed effect. Folding it in is a known-bad move, not an oversight.

Net: 108 lines deleted, 174 added -- the growth is comment, because the unified routine now documents both triggers, the staging, and why the height slot stays out.

## Tests

`website/src/test/useVirtualChat.prependAnchor.test.tsx`, written before the production change:

- **`INVARIANT holds the reader row across the PREPEND trigger`** and **`INVARIANT ... across the upward WINDOW-SHIFT trigger`** -- the same assertion, once per trigger: the row being read does not move. Stating it per trigger, rather than per code path, is what makes the contract independent of which internal slot carries the anchor, so the queued append trigger cannot silently drop one.
- The window-shift case first asserts the lowest mounted index actually decreased, so it cannot pass vacuously on a window that never moved. It uses a reading-scroll rather than a far jump, so the anchor row stays mounted and the assertion is about position rather than existence.

Full `vitest` suite on the branch: **1629 files, 25779 passed, 0 failures** (1 expected-fail, 3 skipped). `tsc -b`, `eslint`, and the theme-colors / phantom-classes / i18n script gates all clean.

**Honest note on red-before.** Both invariant cases pass on `origin/main` as well as on this branch. That is the correct result for this issue and worth stating plainly rather than manufacturing a failure: each trigger *was* individually compensated before this change -- #4307 is a duplication defect, not a broken-behaviour defect. The tests are a regression pin for the collapse, not proof of a prior user-visible break.

While probing for a red I did find one real defect, and it is **not** this PR's: when a *pending* upward shift collides with a prepend in the same frame, the reader's row unmounts entirely. It reproduces **identically on `origin/main` and on this branch**, so the unification neither causes nor fixes it; the mechanism is height re-estimation, which is the root cause tracked by the separate append/height-estimation issue. I did not absorb it here, and did not ship a test asserting behaviour this PR does not change.

## Manual verification

N/A -- unit coverage sufficient. The compensation paths are pure scroll arithmetic over a deterministic layout harness (the suite installs the same fake layout engine the integration tests use, so the rows genuinely move rather than being asserted against source text), and there is no rendered pixel change to inspect.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** internal refactor of scroll-compensation bookkeeping -- the corrected scroll position is byte-identical for each trigger in isolation, so a before/after capture would show the same frame.

## Related Issues

Fixes #4307

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
