### PR TITLE
fix: repoint kept Windows shortcuts on ownership-proven updates (#6493)

### DIFF
--- a/website/electron/build/installer.nsh
+++ b/website/electron/build/installer.nsh
@@ -93,6 +93,11 @@ Var KiroVisibleUpdate
 ; variable and the Function reads it. (${APP_FILENAME} is fine at include time --
 ; it comes from the generated header, not common.nsh.)
 Var KiroAppExeName
+; Bifurcation evidence for the shortcut heal in customInstall: whether a
+; sibling install root (the shape the former collision-nesting produced)
+; physically exists beside the root this update writes.
+Var KiroStaleSibling
+Var KiroStaleSiblingProbe
 
 ; The fade operates on the top-level dialog, the only window type for which
 ; AW_BLEND is supported. It runs once per page boundary and leaves the native
@@ -450,6 +455,123 @@ FunctionEnd
     ${EndIf}
   ${EndIf}
   CopyFiles /SILENT "${SOURCE}\*" "${DESTINATION}"
+!macroend
+
+; Heal a PERSISTED shortcut left naming a stale sibling install root.
+;
+; The relaunch half of that staleness is already handled: StartApp launches
+; $INSTDIR\${APP_EXECUTABLE_FILENAME} directly (see customFinishPage). What that
+; cannot reach is the shortcut a user clicks by hand later: with
+; KeepShortcuts="true", addStartMenuLink / addDesktopLink preserve whatever .lnk
+; a previous install left behind, so on a machine carrying two sibling install
+; roots both links can still name the stale one. Launching it lands on the
+; frozen copy, which re-discovers the update and re-runs a full download +
+; install on every launch.
+;
+; GATE. $keepShortcuts, not another FileExists probe, carries the ownership
+; proof here: this macro expands after installApplicationFiles, where
+; "$INSTDIR\${APP_EXECUTABLE_FILENAME}" exists unconditionally because this run
+; just wrote it. installSection.nsh sets $keepShortcuts to "true" only after
+; testing ${FileExists} "$appExe" BEFORE extraction -- the same
+; executable-presence proof KiroEnsureAppInstallDir's update bypass requires --
+; so ($KiroVisibleUpdate == 1) AND ($keepShortcuts == "true") is exactly "an
+; update whose install root was proven ours pre-extraction, and whose shortcuts
+; were preserved rather than recreated". A fresh install never reaches this,
+; and the $keepShortcuts == "false" branch needs no healing: the template
+; itself just re-created both links at $appExe there.
+;
+; REWRITE, NOT READ-AND-COMPARE. Reading a .lnk target needs the ShellLink
+; plugin, which this build does not bundle (the template ships only WinShell /
+; StdUtils / UAC), so an existing link is re-created at the root this run just
+; wrote without reading its current target. CreateShortCut resets any
+; arguments, icon or working directory a user edited onto a link, so the
+; rewrite must never touch a healthy machine: it additionally requires
+; PHYSICAL EVIDENCE OF BIFURCATION -- a sibling Kiro Crew install root in one
+; of the two shapes the former collision-nesting produced (this app's
+; executable directly in $INSTDIR's parent, or in an ${APP_FILENAME} child of
+; $INSTDIR). $KiroStaleSibling defaults to 0 and only the two existence probes
+; can set it, so a machine with a single install root keeps its customized
+; shortcuts untouched on every update. On a bifurcated machine the rewrite
+; discards customization on the two links it heals; a customized link naming a
+; frozen copy is already broken, and that loss is the accepted cost of not
+; bundling ShellLink. The ${FileExists} link gates keep a shortcut the user
+; deleted deleted. Arguments mirror the template's own CreateShortCut calls
+; ($appExe is "$INSTDIR\${APP_EXECUTABLE_FILENAME}"), and $newStartMenuLink /
+; $newDesktopLink are the template's own resolved names (setLinkVars), so a
+; template upgrade that renames a link moves this code with it.
+;
+; The AppUserModelID is re-stamped because CreateShortCut writes a fresh .lnk
+; without one. This does not contradict customFinishPage's "costs nothing"
+; note: main.js's app.setAppUserModelId() covers the running PROCESS identity,
+; which is why the relaunch can name the executable directly, while the stamp
+; here keeps the persisted .lnk itself carrying the id the shell groups and
+; pins by. The two cover different surfaces; neither substitutes for the other.
+;
+; KNOWN UNCOVERED SURFACE: a taskbar PIN is the shell's own .lnk copy under
+; the user's "User Pinned\TaskBar" tree, not either link rewritten here, so a
+; pin created before the machine bifurcated keeps naming the stale root.
+; Healing it would mean writing a literal shell path this template does not
+; manage; that is a deliberate follow-up, not part of this change.
+;
+; A failed rewrite is surfaced, not swallowed: the details pane is muted on
+; this path (installSection.nsh runs SetDetailsPrint none), and a silent
+; failure here would mean the update reports success while the shortcut still
+; names the stale root, with no trace to diagnose. The template's own
+; unconditional ClearErrors covers a cosmetic "already exists" create; here
+; the write IS the fix, so failure gets a breadcrumb first.
+;
+; THE STALE SIBLING DIRECTORY IS DELIBERATELY LEFT IN PLACE. Removing it would
+; be a recursive delete under %LOCALAPPDATA%\Programs keyed off a path this run
+; did not write; a wrong deletion there is unrecoverable for the user, and an
+; ownership proof for a DELETE would have to be at least as strong as the one
+; guarding the update bypass -- no such proof exists for the sibling. An
+; unreferenced directory costs disk only.
+!macro customInstall
+  ; Default-deny: only the two probes below may arm the heal. Probe 1 catches
+  ; a stale PARENT root (this update runs in the nested child); probe 2
+  ; catches a stale NESTED child (this update runs in the parent). Both are
+  ; the executable-presence test, the same evidence standard as the update
+  ; bypass in KiroEnsureAppInstallDir.
+  StrCpy $KiroStaleSibling 0
+  ${GetParent} "$INSTDIR" $KiroStaleSiblingProbe
+  ${If} $KiroStaleSiblingProbe != ""
+  ${AndIf} $KiroStaleSiblingProbe != "$INSTDIR"
+  ${AndIf} ${FileExists} "$KiroStaleSiblingProbe\${APP_EXECUTABLE_FILENAME}"
+    StrCpy $KiroStaleSibling 1
+  ${EndIf}
+  ${If} ${FileExists} "$INSTDIR\${APP_FILENAME}\${APP_EXECUTABLE_FILENAME}"
+    StrCpy $KiroStaleSibling 1
+  ${EndIf}
+  ${If} $KiroVisibleUpdate == 1
+  ${AndIf} $keepShortcuts == "true"
+  ${AndIf} $KiroStaleSibling == 1
+    !ifndef DO_NOT_CREATE_START_MENU_SHORTCUT
+      ${If} ${FileExists} "$newStartMenuLink"
+        ClearErrors
+        CreateShortCut "$newStartMenuLink" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" 0 "" "" "${APP_DESCRIPTION}"
+        ${If} ${Errors}
+          SetDetailsPrint both
+          DetailPrint "Could not rewrite the Start Menu shortcut; it keeps its old target."
+          SetDetailsPrint lastused
+          ClearErrors
+        ${EndIf}
+        WinShell::SetLnkAUMI "$newStartMenuLink" "${APP_ID}"
+      ${EndIf}
+    !endif
+    !ifndef DO_NOT_CREATE_DESKTOP_SHORTCUT
+      ${If} ${FileExists} "$newDesktopLink"
+        ClearErrors
+        CreateShortCut "$newDesktopLink" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" 0 "" "" "${APP_DESCRIPTION}"
+        ${If} ${Errors}
+          SetDetailsPrint both
+          DetailPrint "Could not rewrite the Desktop shortcut; it keeps its old target."
+          SetDetailsPrint lastused
+          ClearErrors
+        ${EndIf}
+        WinShell::SetLnkAUMI "$newDesktopLink" "${APP_ID}"
+      ${EndIf}
+    !endif
+  ${EndIf}
 !macroend
 
 ; Preserve only the install-root ownership guard from the former custom UI.

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -436,6 +436,147 @@ describe("first-download installer design contract", () => {
     );
   });
 
+  it("repoints kept shortcuts once an update has proven install-root ownership", () => {
+    // KeepShortcuts="true" makes addStartMenuLink / addDesktopLink preserve
+    // whatever .lnk a previous install left behind, so a machine carrying two
+    // sibling install roots keeps launching the stale one from its shortcuts
+    // even though updates land on the live root. The customInstall hook
+    // rewrites this channel's own links at the root the update just wrote.
+    const heal = normalizedNsisBlock(installer, /!macro customInstall\r?\n[\s\S]*?!macroend/);
+    // The gate must stay exactly (visible update) AND (kept shortcuts) AND
+    // (physical bifurcation evidence). The $keepShortcuts assignment carries
+    // the pre-extraction ${FileExists} "$appExe" ownership proof -- a
+    // FileExists probe inside this macro would be vacuously true, because
+    // customInstall expands after installApplicationFiles wrote the
+    // executable. $KiroStaleSibling keeps the rewrite off healthy machines:
+    // CreateShortCut resets a link's arguments/icon/working directory, so a
+    // machine with a single install root must never have its customized
+    // shortcuts rewritten. Pinning all three conditions means deleting any
+    // one, or widening the gate to unproven installs or healthy machines,
+    // fails here.
+    assert.match(
+      heal,
+      /\$\{If\} \$KiroVisibleUpdate == 1\n\$\{AndIf\} \$keepShortcuts == "true"\n\$\{AndIf\} \$KiroStaleSibling == 1\n/,
+      "shortcut healing must be gated on visible-update + kept-shortcuts ownership proof + bifurcation evidence"
+    );
+    // The bifurcation flag is default-deny: it starts 0, and only the two
+    // sibling existence probes (stale parent root / stale nested child) may
+    // arm it -- both use the same executable-presence evidence standard as
+    // the update bypass.
+    assert.match(
+      heal,
+      /^!macro customInstall\n(?:;[^\n]*\n)*StrCpy \$KiroStaleSibling 0\n/,
+      "the bifurcation flag must default to 0 before any probe runs"
+    );
+    assert.match(
+      heal,
+      /\$\{AndIf\} \$\{FileExists\} "\$KiroStaleSiblingProbe\\\$\{APP_EXECUTABLE_FILENAME\}"\nStrCpy \$KiroStaleSibling 1/,
+      "the stale-parent probe must require this app's executable at the parent root"
+    );
+    assert.match(
+      heal,
+      /\$\{If\} \$\{FileExists\} "\$INSTDIR\\\$\{APP_FILENAME\}\\\$\{APP_EXECUTABLE_FILENAME\}"\nStrCpy \$KiroStaleSibling 1/,
+      "the stale-child probe must require this app's executable in the nested ${APP_FILENAME} child"
+    );
+    assert.equal(
+      heal.match(/StrCpy \$KiroStaleSibling 1/g).length,
+      2,
+      "only the two sibling probes may arm the bifurcation flag"
+    );
+    // The rewrite target must name the install root THIS run wrote. Any
+    // registry-derived path could itself be the stale sibling. Each rewrite is
+    // existence-gated so a shortcut the user deleted stays deleted, and the
+    // CreateShortCut arguments mirror the template's own calls.
+    assert.match(
+      heal,
+      /\$\{If\} \$\{FileExists\} "\$newStartMenuLink"\nClearErrors\nCreateShortCut "\$newStartMenuLink" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" "" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" 0 "" "" "\$\{APP_DESCRIPTION\}"/,
+      "the Start Menu link must be re-created at $INSTDIR with the template's own arguments"
+    );
+    assert.match(
+      heal,
+      /\$\{If\} \$\{FileExists\} "\$newDesktopLink"\nClearErrors\nCreateShortCut "\$newDesktopLink" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" "" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" 0 "" "" "\$\{APP_DESCRIPTION\}"/,
+      "the Desktop link must be re-created at $INSTDIR with the template's own arguments"
+    );
+    // A failed rewrite must leave a breadcrumb: the details pane is muted on
+    // this path, and a silent failure means the update reports success while
+    // the shortcut still names the stale root.
+    assert.match(
+      heal,
+      /\$\{If\} \$\{Errors\}\nSetDetailsPrint both\nDetailPrint "Could not rewrite the Start Menu shortcut[\s\S]*?SetDetailsPrint lastused\nClearErrors/,
+      "a failed Start Menu rewrite must print a breadcrumb before clearing the error flag"
+    );
+    // CreateShortCut drops the AppUserModelID stamp; the template re-stamps
+    // after every creation and the heal must too, or the rewritten shortcut
+    // loses its taskbar/notification identity registration.
+    assert.match(heal, /WinShell::SetLnkAUMI "\$newStartMenuLink" "\$\{APP_ID\}"/);
+    assert.match(heal, /WinShell::SetLnkAUMI "\$newDesktopLink" "\$\{APP_ID\}"/);
+    // Each branch reproduces the template's own compile-time opt-outs, so a
+    // future createStartMenuShortcut/createDesktopShortcut=false config change
+    // cannot leave this macro as the only code still writing that link.
+    assert.match(
+      heal,
+      /!ifndef DO_NOT_CREATE_START_MENU_SHORTCUT\n\$\{If\} \$\{FileExists\} "\$newStartMenuLink"/
+    );
+    assert.match(
+      heal,
+      /!ifndef DO_NOT_CREATE_DESKTOP_SHORTCUT\n\$\{If\} \$\{FileExists\} "\$newDesktopLink"/
+    );
+    // Only the template's own resolved link variables (setLinkVars) may be
+    // rewritten -- an invented .lnk literal would orphan the heal on a template
+    // upgrade and could reach another channel's or application's shortcut.
+    assert.doesNotMatch(
+      heal,
+      /\.lnk/,
+      "the heal must use $newStartMenuLink / $newDesktopLink, never a literal shortcut path"
+    );
+    // The stale sibling install directory is left in place: no ownership proof
+    // exists for a recursive delete under %LOCALAPPDATA%\Programs.
+    assert.doesNotMatch(heal, /RMDir|\bDelete\b/);
+    // The gate's ownership argument rests on two facts in the vendored
+    // template, and this platform's NSIS code cannot run in CI, so pin them
+    // the way the StartApp test pins assistedInstaller.nsh: an
+    // electron-builder bump that breaks either must fail here, not ship a
+    // silently dead (or silently widened) heal.
+    const installSection = fs.readFileSync(
+      path.join(
+        ROOT,
+        "node_modules",
+        "app-builder-lib",
+        "templates",
+        "nsis",
+        "installSection.nsh"
+      ),
+      "utf8"
+    );
+    // (a) $keepShortcuts can only become "true" behind the pre-extraction
+    // ${FileExists} "$appExe" ownership proof -- the fact the macro's gate
+    // borrows.
+    assert.match(
+      installSection,
+      /\$\{andIf\} \$\{FileExists\} "\$appExe"\r?\n\s*StrCpy \$keepShortcuts "true"/,
+      "the template must still assign keepShortcuts only behind the pre-extraction $appExe existence proof"
+    );
+    assert.equal(
+      installSection.match(/StrCpy \$keepShortcuts "true"/g).length,
+      1,
+      "a second keepShortcuts assignment would bypass the ownership proof the heal's gate borrows"
+    );
+    // (b) customInstall must still expand after extraction and after both link
+    // macros, or the heal reads pre-install state / gets overwritten.
+    const extractionAt = installSection.indexOf("!insertmacro installApplicationFiles");
+    const startMenuAt = installSection.indexOf("!insertmacro addStartMenuLink");
+    const desktopAt = installSection.indexOf("!insertmacro addDesktopLink");
+    const healAt = installSection.indexOf("!insertmacro customInstall");
+    assert.ok(
+      extractionAt !== -1 && startMenuAt !== -1 && desktopAt !== -1 && healAt !== -1,
+      "the template must still contain the extraction, link, and customInstall insertion points"
+    );
+    assert.ok(
+      extractionAt < startMenuAt && startMenuAt < desktopAt && desktopAt < healAt,
+      "customInstall must expand after extraction and after both link macros"
+    );
+  });
+
   it("keeps install-root ownership and legacy startup cleanup without custom pages", () => {
     assert.match(installer, /Function KiroEnsureAppInstallDir[\s\S]*?FunctionEnd/);
     assert.match(installer, /!macro customInit[\s\S]*?Call KiroEnsureAppInstallDir/);


### PR DESCRIPTION
## Problem / Motivation

A machine already bifurcated by the former Windows nested-install update bug carries two sibling install roots: a stale `%LOCALAPPDATA%\Programs\KiroCrew\KiroCrew.exe` and a live `%LOCALAPPDATA%\Programs\KiroCrew\KiroCrew\KiroCrew.exe`. The merged nesting guard (#6487) prevents NEW bifurcation but ships no remediation for machines already split: `registryAddInstallInfo` records `KeepShortcuts="true"`, so `addStartMenuLink` / `addDesktopLink` preserve whatever `.lnk` a previous install left behind, and nothing repoints a Start Menu or Desktop shortcut whose target root differs from the root an update just wrote.

## Why it matters

A user launching from the stale shortcut lands on the frozen copy, which re-discovers the update and re-runs a full download + install on every launch — the "re-offer forever" symptom persisting on exactly the machines that motivated the nesting guard. The relaunch half is already fixed (`StartApp` launches `$INSTDIR\${APP_EXECUTABLE_FILENAME}` directly); the persisted shortcut a user clicks by hand later is the remaining half.

## What changed (motivation → approach → change)

Symptom: shortcuts keep naming the stale sibling root after successful updates. Root cause: with `KeepShortcuts="true"` and unchanged link names, the template's `addStartMenuLink` / `addDesktopLink` are deliberate no-ops, so a stale pointer is never corrected.

The change adds a `customInstall` macro to `website/electron/build/installer.nsh` (that hook expands in `installSection.nsh` after extraction and after both link macros) that re-creates this channel's own two shortcuts at `$INSTDIR`:

- **Gate — ownership-proven updates on physically bifurcated machines only:** `$KiroVisibleUpdate == 1` AND `$keepShortcuts == "true"` AND `$KiroStaleSibling == 1`. The template assigns `$keepShortcuts` `"true"` only behind a pre-extraction `${FileExists} "$appExe"` test at the final `$INSTDIR` — the same executable-presence proof `KiroEnsureAppInstallDir`'s update bypass requires. A post-extraction `FileExists` probe would be vacuously true (this run just wrote the executable), so the gate borrows the template's pre-extraction proof instead. `$KiroStaleSibling` is default-deny: it starts 0 and only two physical bifurcation probes may arm it — this app's executable present at `$INSTDIR`'s parent, or in an `${APP_FILENAME}` child of `$INSTDIR` (the two shapes the former collision-nesting produced). Fresh installs, unproven updates, and healthy single-root machines never reach the heal, so the safety argument of #6487 is not weakened and a customized shortcut on a healthy machine is never rewritten. The `$keepShortcuts == "false"` branch needs no healing: the template itself just re-created both links.
- **Rewrite, not read-and-compare:** reading a `.lnk` target needs the `ShellLink` NSIS plugin, which this build does not bundle (the template ships only WinShell / StdUtils / UAC). Rather than add a plugin dependency, an existing link is re-created at `$INSTDIR\${APP_EXECUTABLE_FILENAME}` with the template's own `CreateShortCut` arguments, existence-gated so a shortcut the user deleted stays deleted, wrapped in the template's own `!ifndef DO_NOT_CREATE_*` opt-outs, and re-stamped with the AppUserModelID (`WinShell::SetLnkAUMI`) that `CreateShortCut` drops. Residual trade-off stated in the code comment: on a bifurcated machine the rewrite discards customization on the two healed links (a customized link naming a frozen copy is already broken) — the accepted cost of not bundling ShellLink.
- **Failure is surfaced, not swallowed:** the details pane is muted on this path, so a failed rewrite prints a breadcrumb (`SetDetailsPrint both` → `DetailPrint` → `SetDetailsPrint lastused`) before clearing the error flag, instead of reporting a successful update while the shortcut still names the stale root.
- **The stale sibling directory is deliberately NOT deleted.** A recursive delete under `%LOCALAPPDATA%\Programs` keyed off a path this run did not write is unrecoverable on a wrong guess, and no ownership proof as strong as the update-bypass proof exists for the sibling. The decision and reason are recorded at the code site. An unreferenced directory costs disk only.
- **Known uncovered surface (recorded in the comment):** a taskbar pin is the shell's own `.lnk` copy under the user's `User Pinned\TaskBar` tree, not either link rewritten here; a pre-bifurcation pin keeps naming the stale root. Healing it would mean writing a literal shell path the template does not manage — a deliberate follow-up, not part of this change.

No changes to update-feed logic, no changes to `KiroEnsureAppInstallDir`'s branches, no nightly-channel logic (nightly has its own `SHORTCUT_NAME`/`APP_ID`/guid, so this channel's heal cannot reach its links).

## Tests

One packaging-contract test added to `website/electron/test/packaging.test.js`, in the same style as the existing `KiroEnsureAppInstallDir` pins:

- Pins all three gate conditions, the default-deny `$KiroStaleSibling` flag, both bifurcation-probe shapes, and that exactly two arm sites exist, so deleting any condition or widening the heal to unproven installs or healthy machines fails.
- Pins both `CreateShortCut` calls to `$INSTDIR` with the template's exact argument shape, the existence gates, the `!ifndef` opt-outs, the AUMI re-stamps, and the failure breadcrumb.
- Forbids literal `.lnk` paths (only the template's own `$newStartMenuLink` / `$newDesktopLink` may be rewritten) and forbids `RMDir`/`Delete` (the no-deletion decision).
- Pins the two vendored-template facts the gate's ownership argument borrows, the way the existing `StartApp` test pins `assistedInstaller.nsh`: `$keepShortcuts` `"true"` is assigned exactly once and only behind the pre-extraction `${FileExists} "$appExe"` proof, and `!insertmacro customInstall` expands after extraction and after both link macros. An electron-builder bump that breaks either fails this test instead of shipping a silently dead or silently widened heal.

All assertions were mutation-verified: 13 mutants (gate deletions/widenings, bifurcation-condition drop, default-armed flag, third arm site, weakened parent probe, target repoint, AUMI drop, breadcrumb drop, `!ifndef` drop, template proof drop, unguarded template assignment, insertion-point move) each fail the test; the unmutated tree passes.

## Manual verification

Windows-only NSIS code cannot be executed by this repo's gates, so the packaging-contract test IS the verification surface. What is pinned by the test is listed above; what remains unverifiable without a Windows machine is the runtime behavior itself — the acceptance criterion from the issue (a machine with a stale sibling install and a shortcut naming it converges on the live root after one update) needs a bifurcated Windows machine to confirm end to end.

Local gates: backend pytest 73,219 passed (6 pre-existing env-dependent failures reproduce identically on pristine `main`), isort/flake8/mypy clean (CI-pinned versions), `tsc -b` clean, vitest 25,797 passed, electron `node --test` lane 1,422 passed including the new test, brand gate clean.

<!-- no-visual-delta -->
**Why no screenshot:** installer script + a Node test assertion; nothing renders in the browser or the app UI.

## Related Issues

Closes #6493

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior documented at the code site
- [x] No secrets, credentials, or internal references in the diff
