### PR TITLE
fix(meetings): hold the opening of a meeting through agent initialization

### DIFF
--- a/src/kiro_crew/apps/builtins/meetings/backend/constants.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/constants.py
@@ -27,6 +27,20 @@ MAX_TRANSCRIPT_CHARS = 4000  # per dispatched transcription line
 #: 413; accepted segments are never silently truncated.
 MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024
 MAX_BATCH_CHARS = 60_000  # per flushed agent batch
+#: Ceiling on transcript lines held while a starting meeting initializes its
+#: agents, counted in LINES rather than bytes: the producer is one finalized
+#: speech segment at a time, so lines are what the overflow rule has to reason
+#: about, and each is already capped at ``MAX_TRANSCRIPT_CHARS``.
+#:
+#: The window is the agent-initialization span, measured at ~46s on a real
+#: meeting (issue #4610). Speech finals arrive every few seconds, so a real
+#: opening lands 15-25 lines here; 200 leaves an order of magnitude of headroom
+#: while bounding the hold at ``200 * MAX_TRANSCRIPT_CHARS`` (~800 KB) for the
+#: one meeting ``MAX_CONCURRENT_MEETINGS`` permits.
+#:
+#: A bound is REQUIRED, not a nicety: ``POST .../dispatch`` accepts untrusted
+#: text, so an unbounded hold on that path is a memory-exhaustion lever.
+MAX_INIT_BUFFER_LINES = 200
 MAX_ATTACHMENTS = 25
 MAX_DICTIONARY_TERMS = 500
 MAX_CALENDAR_EVENTS = 500
@@ -98,7 +112,17 @@ TRANSCRIPT_FILE = "transcript.jsonl"
 # a line submitted through the broadcast bar.
 TRANSCRIPT_SOURCE_SPEECH = "speech"
 TRANSCRIPT_SOURCE_TYPED = "typed"
-VALID_TRANSCRIPT_SOURCES = (TRANSCRIPT_SOURCE_SPEECH, TRANSCRIPT_SOURCE_TYPED)
+#: An app-authored transcript record — currently only the init-buffer overflow
+#: marker. It MUST be in ``VALID_TRANSCRIPT_SOURCES``: ``read_transcript_page``
+#: drops every record whose source it does not recognize, so a marker written
+#: under an unlisted source would be filtered out on read and the gap it exists
+#: to announce would be silent again.
+TRANSCRIPT_SOURCE_SYSTEM = "system"
+VALID_TRANSCRIPT_SOURCES = (
+    TRANSCRIPT_SOURCE_SPEECH,
+    TRANSCRIPT_SOURCE_TYPED,
+    TRANSCRIPT_SOURCE_SYSTEM,
+)
 
 # The always-on system agent that maintains ``tasks.json``. Not a configurable
 # entry in ``meeting_agents`` — it is a core feature of the app.
@@ -131,6 +155,19 @@ SYSTEM_MEETING_RESTARTED = (
     "Continue listening for new transcription and appending to your output."
 )
 CHAT_PREFIX = "[chat]"
+
+#: Announces that the init-window hold overflowed and dropped its OLDEST lines.
+#:
+#: Written to the durable transcript AND enqueued to the agents, because a
+#: truncation only one of them can see is the failure this marker exists to
+#: prevent: the notes would simply begin mid-sentence with nothing to show a
+#: turn was lost.
+SYSTEM_INIT_BUFFER_OVERFLOW = (
+    "[system] {count} line(s) of speech from the start of this meeting were "
+    "dropped: they arrived faster than the agents could be initialized and "
+    "exceeded the hold of {limit} lines. The transcript above is complete; the "
+    "agents did not receive the dropped lines."
+)
 
 # Task provider ids (see backend/providers/tasks.py).
 TASK_PROVIDER_LOCAL = "local"

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
@@ -411,6 +411,40 @@ class MeetingSession:
     started_at: float = field(default_factory=time.time)
     agents: dict[str, AgentQueue] = field(default_factory=dict)
     muted_agents: set[str] = field(default_factory=set)
+    #: Lines held while THIS session's agents initialize, in arrival order, each
+    #: paired with the agent names an unmuted fan-out would have reached AT THE
+    #: MOMENT IT WAS SPOKEN.
+    #:
+    #: Lives on the session, not on the holder, so it is bound to the identity
+    #: whose initialization it covers: a session that is replaced or torn down
+    #: takes its hold with it, and a later session can never inherit and replay
+    #: lines that were spoken into a meeting that no longer exists.
+    #:
+    #: The recipient set is stored rather than recomputed at drain because the
+    #: hold must change WHEN a line is delivered, never WHO it was addressed to.
+    #: Resolving it at drain let a mute applied during initialization reach
+    #: backwards and rob a line spoken while that agent was still listening —
+    #: an outcome the live path cannot produce, since it fans out immediately.
+    #:
+    #: NAMES, not queue objects: an agent disabled mid-initialization has its
+    #: queue removed from ``agents``, and holding a reference would enqueue into
+    #: a queue nothing flushes. A name that no longer resolves is simply skipped.
+    init_buffer: list[tuple[str, frozenset[str]]] = field(default_factory=list)
+    #: How many of the OLDEST held lines the cap displaced. Read at drain time
+    #: to size the marker, so a drop is announced once with an exact count
+    #: rather than per line.
+    init_dropped: int = 0
+    #: The agents that lost one of those displaced lines — the union of the
+    #: recipient sets recorded on every line the cap dropped.
+    #:
+    #: The marker's audience has to be derived from the DROPPED lines, not from
+    #: whoever is unmuted at drain time. Those two sets diverge the moment a mute
+    #: lands between the drop and the drain: the agent still receives the
+    #: surviving pre-mute lines (they carry their own arrival-time recipients) but
+    #: would fall outside a drain-time audience, so its output would begin
+    #: mid-conversation with nothing to say a turn was lost — the exact silent gap
+    #: the marker exists to prevent.
+    init_dropped_recipients: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         config = self.config if self.config is not None else store.read_config()
@@ -444,20 +478,115 @@ class MeetingSession:
         self.muted_agents.discard(agent_id)
         return queue
 
+    def _prepare_line(self, text: str) -> str:
+        """Correct and clamp one inbound line; ``""`` when it is not worth a turn.
+
+        The front half of :meth:`broadcast`, split out so the initialization hold
+        can run it at ARRIVAL rather than at delivery. Deferring it made the hold's
+        cap dishonest: recognizer filler occupied a slot until drain and only then
+        was discarded, so a burst of ``"uh"`` could evict the genuine opening
+        speech it was supposed to be counted against.
+        """
+        text = _dictionary.correct(text.strip())[: k.MAX_TRANSCRIPT_CHARS]
+        return "" if not text or is_noise(text) else text
+
+    def _recipient_names(self) -> frozenset[str]:
+        """The agents an unmuted fan-out would reach right now."""
+        return frozenset(
+            queue.name for queue in self.agents.values() if queue.name not in self.muted_agents
+        )
+
     def broadcast(self, text: str) -> int:
         """Correct, filter, and enqueue *text* for every unmuted agent.
 
         Returns the number of queues that accepted the line (0 when filtered).
         """
-        text = _dictionary.correct(text.strip())[: k.MAX_TRANSCRIPT_CHARS]
-        if not text or is_noise(text):
+        prepared = self._prepare_line(text)
+        if not prepared:
             return 0
         accepted = 0
-        for queue in self.agents.values():
-            if queue.name not in self.muted_agents:
-                queue.enqueue(text)
-                accepted += 1
+        for name in self._recipient_names():
+            self.agents[name].enqueue(prepared)
+            accepted += 1
         return accepted
+
+    def buffer_during_init(self, text: str) -> bool:
+        """Hold *text* until initialization finishes. False when it displaced a line.
+
+        The agents cannot receive anything yet — they do not know which file they
+        own until ``init_agents`` has run — but the speaker is already talking, and
+        refusing the line is what lost the opening of every meeting (issue #4610).
+
+        Normalized and filtered HERE, at arrival, and stored with the recipients of
+        this moment: both halves of "what happens to this line" are decided when a
+        live line would have decided them, so the hold only ever shifts delivery in
+        TIME. Filler never occupies a slot it would later vacate, and a mute landing
+        mid-initialization cannot reach back to a line spoken before it.
+
+        Bounded by :data:`~..constants.MAX_INIT_BUFFER_LINES`, and the overflow
+        rule is DROP-OLDEST: an initialization slow enough to overflow is one where
+        the newest speech is the most likely to still be in play, and the tail is
+        what the agents need to pick up a conversation mid-flight. The count of
+        displaced lines is kept so :meth:`drain_init_buffer` can announce them —
+        dropping them quietly is the one outcome worse than refusing the request.
+
+        Returns whether the hold is intact: a filtered line displaces nothing, so
+        it reports True alongside a line that simply fit.
+        """
+        prepared = self._prepare_line(text)
+        if not prepared:
+            return True
+        self.init_buffer.append((prepared, self._recipient_names()))
+        overflow = len(self.init_buffer) - k.MAX_INIT_BUFFER_LINES
+        if overflow <= 0:
+            return True
+        for _line, recipients in self.init_buffer[:overflow]:
+            self.init_dropped_recipients |= recipients
+        del self.init_buffer[:overflow]
+        self.init_dropped += overflow
+        return False
+
+    def drain_init_buffer(self) -> tuple[int, int]:
+        """Fan every held line out in ARRIVAL ORDER. Returns ``(delivered, dropped)``.
+
+        Called once, immediately after initialization completes and under the same
+        ``DISPATCH_LOCK`` acquisition that reopens ingress — so a live line arriving
+        the instant ingress opens cannot overtake the held ones and reorder the
+        meeting's opening.
+
+        Each line is replayed to the recipients recorded when it was SPOKEN, not to
+        whoever is unmuted now: correction, filtering and addressing were all decided
+        at arrival, so the hold shifts delivery in time and nothing else. A recorded
+        agent whose queue is gone (disabled mid-initialization) is skipped rather
+        than resurrected.
+
+        A drop is announced FIRST, because drop-oldest puts the gap at the head of
+        what survived — so the marker sits where the missing turns actually were, and
+        it is addressed to the agents that LOST one of the dropped lines rather than
+        to whoever happens to be unmuted at drain time. Those two audiences diverge
+        under a mute landing mid-initialization, and the agent with the gap is
+        precisely the one a drain-time audience would omit.
+        """
+        held, dropped = self.init_buffer, self.init_dropped
+        deprived = self.init_dropped_recipients
+        self.init_buffer, self.init_dropped = [], 0
+        self.init_dropped_recipients = set()
+        if dropped:
+            marker = k.SYSTEM_INIT_BUFFER_OVERFLOW.format(
+                count=dropped, limit=k.MAX_INIT_BUFFER_LINES
+            )
+            for name in deprived:
+                queue = self.agents.get(name)
+                if queue is not None:
+                    queue.enqueue(marker)
+        delivered = 0
+        for line, recipients in held:
+            reached = [self.agents[name] for name in recipients if name in self.agents]
+            for queue in reached:
+                queue.enqueue(line)
+            if reached:
+                delivered += 1
+        return delivered, dropped
 
     @property
     def expired(self) -> bool:

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/_common.py
@@ -49,6 +49,19 @@ class _ActiveMeeting:
     def __init__(self) -> None:
         self.session: MeetingSession | None = None
         self.accepting_dispatches = False
+        #: The session whose ingress is closed FOR INITIALIZATION, if any.
+        #:
+        #: ``accepting_dispatches`` alone cannot answer "should this line be
+        #: refused?", because it is false for two opposite reasons: the meeting is
+        #: stopping/reviewing/expired (the line has nowhere to go — refuse it, which
+        #: is the gate issue #1981 added) or the meeting is STARTING and its agents
+        #: are not ready yet (the line is wanted — hold it). Conflating them is what
+        #: made a meeting refuse its own opening speech for ~46s.
+        #:
+        #: Stored as the SESSION rather than a bool so the state cannot outlive the
+        #: identity it describes: every install/teardown clears it, so a stale flag
+        #: can never make a later session buffer into a hold nobody drains.
+        self.buffering_session: MeetingSession | None = None
 
     def get(self, meeting_id: str = "") -> MeetingSession | None:
         """The live session, optionally requiring it to be *meeting_id*'s."""
@@ -63,15 +76,57 @@ class _ActiveMeeting:
         """The matching session only while its transcript ingress is open."""
         return self.get(meeting_id) if self.accepting_dispatches else None
 
-    def suspend_dispatches(self, session: MeetingSession | None = None) -> None:
-        """Close ingress for *session* without tearing down its agent queues."""
+    def get_for_buffering(self, meeting_id: str) -> MeetingSession | None:
+        """The matching session only while it is HOLDING speech through init.
+
+        The narrow complement of :meth:`get_for_dispatch`: a caller that was just
+        refused a direct fan-out asks this before answering 409. Returns None for
+        every other closed-ingress reason, so stop / reviewing / expired keep
+        refusing exactly as they did.
+        """
+        if self.accepting_dispatches:
+            return None
+        session = self.get(meeting_id)
+        return session if session is not None and self.buffering_session is session else None
+
+    @property
+    def buffering_dispatches(self) -> bool:
+        """Whether speech sent NOW would be held rather than refused.
+
+        Reported next to ``accepting_dispatches`` on the meeting poll: the
+        dashboard opens the microphone on "would speech land?", and during
+        initialization the answer became yes-by-holding rather than no.
+        """
+        return self.buffering_session is not None and self.buffering_session is self.session
+
+    def suspend_dispatches(
+        self, session: MeetingSession | None = None, *, buffer_speech: bool = False
+    ) -> None:
+        """Close ingress for *session* without tearing down its agent queues.
+
+        *buffer_speech* says WHY, and only the start path passes it: during agent
+        initialization the meeting wants the speech it cannot yet deliver, so the
+        dispatch endpoint holds the line instead of refusing it. Every other caller
+        (stop, reviewing, an expired session, replacing an outgoing session) leaves
+        it False and keeps the refusing behaviour.
+
+        Defaults to False so a caller added later refuses by default rather than
+        silently opting into a hold nothing drains.
+        """
         if session is not None and self.session is session:
             self.accepting_dispatches = False
+            self.buffering_session = session if buffer_speech else None
 
     def resume_dispatches(self, session: MeetingSession) -> None:
-        """Open ingress only if *session* is still the installed session."""
+        """Open ingress only if *session* is still the installed session.
+
+        Ends any hold in the same step: once direct fan-out is open, a line that
+        stayed in the buffer would be delivered out of order behind live speech.
+        The caller drains under this same lock acquisition.
+        """
         if self.session is session:
             self.accepting_dispatches = True
+            self.buffering_session = None
 
     def set(self, session: MeetingSession | None) -> None:
         """Install *session*, replacing any current one.
@@ -95,6 +150,10 @@ class _ActiveMeeting:
             previous.cancel_all()
         self.session = session
         self.accepting_dispatches = session is not None
+        # Never inherited: the outgoing session's hold belongs to a meeting that is
+        # gone, and leaving it set would make this session look like it were
+        # buffering into a list no drain will ever reach.
+        self.buffering_session = None
 
     def clear(self) -> MeetingSession | None:
         """Drop the session, CANCELLING anything still queued.
@@ -109,6 +168,7 @@ class _ActiveMeeting:
             previous.cancel_all()
         self.session = None
         self.accepting_dispatches = False
+        self.buffering_session = None
         return previous
 
     async def drain_and_clear(self) -> MeetingSession | None:

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/agents.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/agents.py
@@ -283,14 +283,59 @@ async def handle_mute_agent(request: web.Request) -> web.Response:
             {"error": "meeting not found", "code": "meeting_not_found"}, status=404
         )
 
-    session = ACTIVE.get(meeting_id)
-    if session is not None:
-        if muted:
-            session.muted_agents.add(agent_id)
-        else:
-            session.muted_agents.discard(agent_id)
+    # Under the admission lock, because a dispatch RESOLVES its recipients from
+    # this set across an awaited transcript write. Mutating it unlocked let a mute
+    # land inside that window, so the line was addressed by the mute state of a
+    # moment AFTER it was spoken — it reached the wrong agent set, and for a line
+    # held through initialization the wrong set was recorded and replayed later.
+    #
+    # The lock belongs HERE, on the one unlocked writer, rather than on the reader:
+    # both the live fan-out and the initialization hold read this set after their
+    # own `_record_line` await, so guarding a single dispatch branch would close one
+    # window and leave its twin open. Every other writer already holds this lock
+    # (`handle_toggle_agent` takes it, and `add_agent` runs inside it).
+    #
+    # Only the in-memory mutation is covered: the metadata write above is already
+    # serialized by its own transaction, and pulling it in would hold the admission
+    # lock across disk IO that dispatch does not need to wait for.
+    async with DISPATCH_LOCK:
+        session = ACTIVE.get(meeting_id)
+        if session is not None:
+            if muted:
+                session.muted_agents.add(agent_id)
+            else:
+                session.muted_agents.discard(agent_id)
 
     return web.json_response({"ok": True, "muted_agents": meta["muted_agents"]})
+
+
+async def _record_line(
+    meeting_id: str, text: str, is_chat: bool, root: Any
+) -> tuple[str, dict[str, str]]:
+    """Redact one inbound line, append it to the transcript, build the agent line.
+
+    Shared by the live fan-out and the initialization hold so the two cannot
+    drift. The transcript append happens at ARRIVAL for both, which is what keeps
+    the durable record in spoken order and complete even when the hold later
+    overflows — the overflow then costs the agents some context, never the user
+    their transcript.
+
+    Raises :class:`BadRequest` (413) when the transcript ceiling is reached, so a
+    held line is size-checked on exactly the same terms as a live one.
+    """
+    transcript_text = redact(text)
+    source = k.TRANSCRIPT_SOURCE_TYPED if is_chat else k.TRANSCRIPT_SOURCE_SPEECH
+    segment = await asyncio.to_thread(
+        store.append_transcript, meeting_id, transcript_text, source, root
+    )
+    if segment is None:
+        raise BadRequest(
+            "meeting transcript is too large",
+            status=413,
+            code="transcript_too_large",
+        )
+    line = f"{k.CHAT_PREFIX} {transcript_text}" if is_chat else transcript_text
+    return line, segment
 
 
 async def handle_dispatch_text(request: web.Request) -> web.Response:
@@ -315,8 +360,29 @@ async def handle_dispatch_text(request: web.Request) -> web.Response:
     async with DISPATCH_LOCK:
         session = ACTIVE.get_for_dispatch(meeting_id)
         if session is None:
+            # Direct fan-out is shut. Agent INITIALIZATION is the one reason to hold
+            # the line rather than refuse it (issue #4610) — a stopping, reviewing or
+            # expired meeting has nowhere to put it and still answers 409, which is
+            # the gate issue #1981 added and this must not widen.
+            starting = ACTIVE.get_for_buffering(meeting_id)
+            if starting is None:
+                return web.json_response(
+                    {"error": "no active meeting", "code": "no_active_meeting"}, status=409
+                )
+            line, segment = await _record_line(meeting_id, text, is_chat, data_root(request))
+            if not starting.buffer_during_init(line):
+                logger.warning(
+                    "meetings: init hold for %r is full at %d line(s); "
+                    "dropped the oldest and will mark the gap on drain",
+                    meeting_id,
+                    k.MAX_INIT_BUFFER_LINES,
+                )
+            # Same shape as a live dispatch that reached nobody. The hold needs no
+            # flag of its own: no client reads one, and the line is in the durable
+            # transcript either way, so `dispatched: 0` is already the whole answer
+            # to "did this land with an agent yet".
             return web.json_response(
-                {"error": "no active meeting", "code": "no_active_meeting"}, status=409
+                {"ok": True, "dispatched": 0, "text": line, "segment": segment}
             )
         if session.expired:
             # Close admission before the slow drain. A later request can then fail
@@ -325,23 +391,7 @@ async def handle_dispatch_text(request: web.Request) -> web.Response:
             ACTIVE.suspend_dispatches(session)
             expired_session = session
         else:
-            transcript_text = redact(text)
-            source = k.TRANSCRIPT_SOURCE_TYPED if is_chat else k.TRANSCRIPT_SOURCE_SPEECH
-            segment = await asyncio.to_thread(
-                store.append_transcript,
-                meeting_id,
-                transcript_text,
-                source,
-                data_root(request),
-            )
-            if segment is None:
-                raise BadRequest(
-                    "meeting transcript is too large",
-                    status=413,
-                    code="transcript_too_large",
-                )
-
-            line = f"{k.CHAT_PREFIX} {transcript_text}" if is_chat else transcript_text
+            line, segment = await _record_line(meeting_id, text, is_chat, data_root(request))
             accepted = session.broadcast(line)
 
     if expired_session is not None:

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
@@ -142,17 +142,21 @@ async def handle_get_meeting(request: web.Request) -> web.Response:
     live_payload = None
     if live is not None:
         live_payload = live.status()
-        # Whether a dispatch sent NOW would be admitted, from the same holder flag
-        # ``get_for_dispatch`` reads. The status is persisted ``active`` before
-        # ``init_agents`` runs, so status alone overstates readiness for the whole
-        # initialization window (~tens of seconds) while every dispatch 409s. The
-        # frontend polls this endpoint to decide when to open the microphone, and
-        # this field is the only per-poll answer to "would speech land?" — the
-        # start response alone cannot be, because it can be lost in transit while
-        # the server side succeeded. Plain attribute read on the single-threaded
-        # loop, same as the ``ACTIVE.get`` above; the value is a snapshot and may
-        # change by the next poll, which is exactly what a poll is for.
+        # Whether a dispatch sent NOW would be fanned out DIRECTLY, from the same
+        # holder flag ``get_for_dispatch`` reads. The status is persisted ``active``
+        # before ``init_agents`` runs, so status alone overstates readiness for the
+        # whole initialization window (~tens of seconds). Plain attribute read on
+        # the single-threaded loop, same as the ``ACTIVE.get`` above; the value is a
+        # snapshot and may change by the next poll, which is exactly what a poll is
+        # for.
         live_payload["accepting_dispatches"] = ACTIVE.accepting_dispatches
+        # And whether it would be HELD rather than refused (issue #4610). The
+        # frontend polls this endpoint to decide when to open the microphone, and
+        # "would speech land?" is now these two ORed: during initialization the
+        # answer is yes-by-holding. Reported separately rather than folded into the
+        # flag above, because that one is also the gate ``get_for_dispatch`` reads —
+        # making it true here would send lines to agents that are not ready.
+        live_payload["buffering_dispatches"] = ACTIVE.buffering_dispatches
     return web.json_response(
         {
             "meta": meta,
@@ -320,9 +324,16 @@ async def handle_start_meeting(request: web.Request) -> web.Response:
         outgoing = await ACTIVE.drain_and_clear()
         async with DISPATCH_LOCK:
             ACTIVE.set(session)
-            # Agent initialization may await several model turns. Keep ingress
-            # closed until every enabled agent knows its output contract.
-            ACTIVE.suspend_dispatches(session)
+            # Agent initialization may await several model turns. Keep DIRECT
+            # fan-out closed until every enabled agent knows its output contract —
+            # but HOLD what is said meanwhile instead of refusing it.
+            #
+            # Refusing was measured at ~46s of a real meeting (issue #4610): the
+            # speaker opens with the agenda, every line 409s, and the notes and
+            # tasks begin partway through the first topic with nothing to show a
+            # turn was lost. The hold is bounded and drains in arrival order right
+            # after `init_agents` returns, below.
+            ACTIVE.suspend_dispatches(session, buffer_speech=True)
 
         # A replacement of a DIFFERENT meeting is a teardown of that meeting, so its
         # metadata needs the same terminal status every other teardown writes.
@@ -370,6 +381,30 @@ async def handle_start_meeting(request: web.Request) -> web.Response:
             await sess.broadcast_system(session, k.SYSTEM_MEETING_RESTARTED)
         async with DISPATCH_LOCK:
             ACTIVE.resume_dispatches(session)
+            # Drain under the SAME acquisition that reopened ingress. A live
+            # dispatch needs this lock too, so nothing spoken after the reopen can
+            # overtake speech that was held while it was shut — releasing between
+            # the two would let the meeting's opening land after its second topic.
+            buffered, dropped = session.drain_init_buffer()
+        if buffered or dropped:
+            logger.info(
+                "meetings: %r delivered %d line(s) held during agent init, %d dropped",
+                meeting_id,
+                buffered,
+                dropped,
+            )
+        if dropped:
+            # Off the lock (this is disk IO) but still inside START_LOCK. Recorded
+            # so the human transcript states the loss too: the agents were told by
+            # `drain_init_buffer`, and a gap only one reader can see is the silent
+            # truncation the bound exists to avoid.
+            await asyncio.to_thread(
+                store.append_transcript,
+                meeting_id,
+                k.SYSTEM_INIT_BUFFER_OVERFLOW.format(count=dropped, limit=k.MAX_INIT_BUFFER_LINES),
+                k.TRANSCRIPT_SOURCE_SYSTEM,
+                root,
+            )
 
     audit("meetings.start", meeting_id, outcome="ok")
     return web.json_response(

--- a/test/test_meetings_routes.py
+++ b/test/test_meetings_routes.py
@@ -3282,3 +3282,477 @@ class TestATeardownNeverClearsAReplacement:
         drained = await active.drain_and_clear()
         assert drained is session
         assert active.get() is None
+
+
+def _held_lines(session) -> list[str]:
+    """Just the text of an init hold, dropping each entry's recipient snapshot."""
+    return [line for line, _recipients in session.init_buffer]
+
+
+class TestSpeechDuringAgentInitIsHeldNotRefused:
+    """Issue #4610: the opening of a meeting must survive agent initialization.
+
+    ``handle_start_meeting`` persists ``active``, installs the session, then awaits
+    ``init_agents`` — a sequence of model turns measured at ~46s. Ingress is shut
+    for that whole span, so every line spoken into it was answered 409 and lost:
+    the notes and tasks began partway through the first topic with nothing to show
+    a turn had been dropped.
+
+    Speech in that window is now HELD and replayed in arrival order. The hold is
+    bounded by line count, overflows by dropping the OLDEST, and announces a drop
+    to both readers — the agents and the durable transcript.
+    """
+
+    @staticmethod
+    async def _start_paused_in_init(
+        client, monkeypatch: pytest.MonkeyPatch, meeting_id: str = "standup"
+    ):
+        """Begin a start that blocks INSIDE ``init_agents``.
+
+        Returns ``(start_task, release)``: the in-flight request, and the event that
+        lets initialization finish. Mirrors the real window — the session is
+        installed and the meeting reads ``active``, but no agent knows its output
+        file yet.
+        """
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        real_init_agents = sess.init_agents
+
+        async def blocking_init(session, meta, root=None):
+            entered.set()
+            await release.wait()
+            await real_init_agents(session, meta, root)
+
+        monkeypatch.setattr(sess, "init_agents", blocking_init)
+        await client.post(f"{BASE}/meetings/{meeting_id}/init", json={"title": "Standup"})
+        start = asyncio.create_task(
+            client.post(f"{BASE}/meetings/{meeting_id}/start", json={})
+        )
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        return start, release
+
+    @pytest.mark.asyncio
+    async def test_speech_mid_init_is_buffered_and_delivered_in_order(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The core regression: three lines spoken during init reach the agents.
+
+        RED on origin/main — each dispatch answers 409 ``no_active_meeting`` and the
+        lines never enter a queue at all.
+        """
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+
+            for line in ("first the agenda", "then the blockers", "and the owners"):
+                resp = await client.post(
+                    f"{BASE}/meetings/standup/dispatch", json={"text": line}
+                )
+                assert resp.status == 200, await resp.text()
+                body = await resp.json()
+                # Held, not fanned out — and already durable either way. The hold is
+                # observed on the session below; the response says only that nothing
+                # reached an agent yet.
+                assert body["dispatched"] == 0
+                assert body["segment"]["source"] == k.TRANSCRIPT_SOURCE_SPEECH
+
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            assert _held_lines(session) == [
+                "first the agenda",
+                "then the blockers",
+                "and the owners",
+            ]
+
+            release.set()
+            assert (await start).status == 200
+
+            # Drained into every unmuted queue, in the order they were spoken.
+            assert session.init_buffer == []
+            for agent_id in ("note-taker", "sketch-artist", k.TASK_EXTRACTOR_ID):
+                assert session.agents[agent_id].queue == [
+                    "first the agenda",
+                    "then the blockers",
+                    "and the owners",
+                ]
+
+    @pytest.mark.asyncio
+    async def test_the_transcript_holds_every_line_spoken_during_init(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The durable record is written at ARRIVAL, so a reader loses nothing."""
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+            await client.post(
+                f"{BASE}/meetings/standup/dispatch", json={"text": "opening remarks"}
+            )
+            # Readable BEFORE initialization finishes — the user sees their own words.
+            body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
+            assert [s["text"] for s in body["segments"]] == ["opening remarks"]
+
+            release.set()
+            assert (await start).status == 200
+
+    @pytest.mark.asyncio
+    async def test_a_typed_line_mid_init_keeps_its_chat_marking(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A held line goes through the same recorder as a live one."""
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+            body = await (
+                await client.post(
+                    f"{BASE}/meetings/standup/dispatch",
+                    json={"text": "the owner is Bob", "chat": True},
+                )
+            ).json()
+            assert body["dispatched"] == 0
+            assert body["text"].startswith(k.CHAT_PREFIX)
+            assert body["segment"]["source"] == k.TRANSCRIPT_SOURCE_TYPED
+
+            release.set()
+            assert (await start).status == 200
+
+    @pytest.mark.asyncio
+    async def test_a_held_line_is_still_redacted(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The hold must not become a way for a credential to reach an agent unredacted."""
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+            body = await (
+                await client.post(
+                    f"{BASE}/meetings/standup/dispatch",
+                    json={"text": "rotate AKIAIOSFODNN7EXAMPLE today"},
+                )
+            ).json()
+            assert "AKIAIOSFODNN7EXAMPLE" not in body["text"]
+            assert "AKIAIOSFODNN7EXAMPLE" not in body["segment"]["text"]
+
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            assert not any("AKIAIOSFODNN7EXAMPLE" in line for line in _held_lines(session))
+
+            release.set()
+            assert (await start).status == 200
+
+    @pytest.mark.asyncio
+    async def test_the_hold_is_bounded_and_drops_the_oldest(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The cap holds, and overflow discards the OLDEST lines — never the newest.
+
+        The bound is the security property: ``POST .../dispatch`` takes untrusted
+        text, so an unbounded hold on that path would be a memory-exhaustion lever.
+        """
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 3)
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+
+            for index in range(5):
+                resp = await client.post(
+                    f"{BASE}/meetings/standup/dispatch", json={"text": f"line number {index}"}
+                )
+                assert resp.status == 200
+
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            # Never more than the cap, and it is the TAIL that survived.
+            assert len(session.init_buffer) == 3
+            assert _held_lines(session) == ["line number 2", "line number 3", "line number 4"]
+            assert session.init_dropped == 2
+
+            release.set()
+            assert (await start).status == 200
+
+    @pytest.mark.asyncio
+    async def test_an_overflow_marks_the_gap_for_the_agents_and_the_transcript(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A drop is announced to BOTH readers — a silent truncation is the real bug.
+
+        The marker leads the drained lines, because drop-oldest puts the gap at the
+        head of what survived.
+        """
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 2)
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+            for index in range(4):
+                await client.post(
+                    f"{BASE}/meetings/standup/dispatch", json={"text": f"line number {index}"}
+                )
+
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            release.set()
+            assert (await start).status == 200
+
+            expected_marker = k.SYSTEM_INIT_BUFFER_OVERFLOW.format(count=2, limit=2)
+            # The agents are told first, then given what survived.
+            assert session.agents["note-taker"].queue == [
+                expected_marker,
+                "line number 2",
+                "line number 3",
+            ]
+            assert session.init_dropped == 0  # the tally is consumed by the drain
+
+            # And the human transcript states it too, under a source the reader
+            # keeps: `read_transcript_page` drops unrecognized sources, so a marker
+            # written outside `VALID_TRANSCRIPT_SOURCES` would vanish on read.
+            body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
+            markers = [
+                s for s in body["segments"] if s["source"] == k.TRANSCRIPT_SOURCE_SYSTEM
+            ]
+            assert len(markers) == 1
+            assert markers[0]["text"] == expected_marker
+            # Every spoken line is still in the transcript — only the AGENTS lost two.
+            assert [s["text"] for s in body["segments"] if s["source"] != "system"] == [
+                "line number 0",
+                "line number 1",
+                "line number 2",
+                "line number 3",
+            ]
+
+    @pytest.mark.asyncio
+    async def test_no_marker_when_the_hold_did_not_overflow(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A meeting that fits inside the bound gets no system noise at all."""
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+            await client.post(
+                f"{BASE}/meetings/standup/dispatch", json={"text": "just the one line"}
+            )
+            release.set()
+            assert (await start).status == 200
+
+            body = await (await client.get(f"{BASE}/meetings/standup/transcript")).json()
+            assert [s["source"] for s in body["segments"]] == [k.TRANSCRIPT_SOURCE_SPEECH]
+
+    @pytest.mark.asyncio
+    async def test_the_poll_reports_the_hold_so_the_microphone_can_open(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``buffering_dispatches`` is the flag the dashboard's mic gate needs.
+
+        Without it the client keeps the microphone shut for the whole window (its
+        gate reads ``accepting_dispatches``), so nothing would ever reach the hold
+        and the server-side fix would be unreachable.
+        """
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+            live = (await (await client.get(f"{BASE}/meetings/standup")).json())["live"]
+            # Direct fan-out is shut, but speech LANDS — held.
+            assert live["accepting_dispatches"] is False
+            assert live["buffering_dispatches"] is True
+
+            release.set()
+            assert (await start).status == 200
+
+            live = (await (await client.get(f"{BASE}/meetings/standup")).json())["live"]
+            assert live["accepting_dispatches"] is True
+            assert live["buffering_dispatches"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_reviewing_meeting_still_refuses_instead_of_buffering(
+        self, app, fake_sessions
+    ):
+        """The #1981 gate is untouched: only INITIALIZATION holds a line.
+
+        A reviewing meeting has nowhere to put the line — its agents were told to
+        finalize — so it must keep answering 409 rather than quietly accumulating
+        speech nothing will drain.
+        """
+        async with client_for(app) as client:
+            await _start(client)
+            status = await client.post(
+                f"{BASE}/meetings/standup/status", json={"status": k.STATUS_REVIEWING}
+            )
+            assert status.status == 200
+
+            resp = await client.post(
+                f"{BASE}/meetings/standup/dispatch", json={"text": "too late"}
+            )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "no_active_meeting"
+
+            live = (await (await client.get(f"{BASE}/meetings/standup")).json())["live"]
+            assert live["accepting_dispatches"] is False
+            assert live["buffering_dispatches"] is False
+
+    @pytest.mark.asyncio
+    async def test_an_outgoing_session_being_replaced_does_not_buffer(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Replacing a lapsed meeting suspends the OUTGOING session to refuse, not hold.
+
+        Its transcript is being flushed and its session dropped; a line held against
+        it would be drained by nobody.
+        """
+        async with client_for(app) as client:
+            await _start(client, "the-old-one")
+            outgoing = _common.ACTIVE.get("the-old-one")
+            assert outgoing is not None
+            monkeypatch.setattr(
+                type(outgoing), "expired", property(lambda _self: True)
+            )
+
+            start, release = await self._start_paused_in_init(
+                client, monkeypatch, "the-new-one"
+            )
+            # The replaced meeting refuses; only the starting one holds.
+            stale = await client.post(
+                f"{BASE}/meetings/the-old-one/dispatch", json={"text": "orphan line"}
+            )
+            assert stale.status == 409
+            held = await client.post(
+                f"{BASE}/meetings/the-new-one/dispatch", json={"text": "live line"}
+            )
+            assert held.status == 200
+            starting = _common.ACTIVE.get("the-new-one")
+            assert starting is not None
+            assert _held_lines(starting) == ["live line"]
+
+            release.set()
+            assert (await start).status == 200
+
+    @pytest.mark.asyncio
+    async def test_filler_does_not_consume_a_slot_and_evict_real_speech(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Recognizer filler must not push the opening out of a bounded hold.
+
+        Filtering ran at DRAIN, so ``"uh"`` occupied a slot until initialization
+        finished and only then was discarded — meaning a burst of filler could
+        evict the genuine speech the cap was supposed to be protecting. A live
+        line is filtered the instant it arrives; a held one must be too.
+        """
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 3)
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+
+            await client.post(
+                f"{BASE}/meetings/standup/dispatch", json={"text": "the real agenda"}
+            )
+            for filler in ("uh", "um", "ok so uh", "hmm"):
+                resp = await client.post(
+                    f"{BASE}/meetings/standup/dispatch", json={"text": filler}
+                )
+                assert resp.status == 200
+
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            # Four filler lines went in and none of them displaced anything.
+            assert _held_lines(session) == ["the real agenda"]
+            assert session.init_dropped == 0
+
+            release.set()
+            assert (await start).status == 200
+            assert session.agents["note-taker"].queue == ["the real agenda"]
+
+    @pytest.mark.asyncio
+    async def test_a_mute_during_init_does_not_rob_earlier_speech(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Recipients are the ones the line HAD, not the ones it finds at drain.
+
+        Resolving recipients at drain let a mute applied mid-initialization reach
+        backwards: a line spoken while the agent was listening silently vanished
+        from its output. The live path cannot produce that, because it fans out
+        before the mute exists.
+        """
+        async with client_for(app) as client:
+            start, release = await self._start_paused_in_init(client, monkeypatch)
+            await client.post(
+                f"{BASE}/meetings/standup/dispatch", json={"text": "said while listening"}
+            )
+
+            mute = await client.post(
+                f"{BASE}/meetings/standup/mute",
+                json={"agent_id": "note-taker", "muted": True},
+            )
+            assert mute.status == 200
+
+            await client.post(
+                f"{BASE}/meetings/standup/dispatch", json={"text": "said after the mute"}
+            )
+
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+            release.set()
+            assert (await start).status == 200
+
+            # The note-taker keeps what it was addressed, and gains nothing after.
+            assert session.agents["note-taker"].queue == ["said while listening"]
+            # An agent unmuted throughout got both lines.
+            assert session.agents["sketch-artist"].queue == [
+                "said while listening",
+                "said after the mute",
+            ]
+
+
+class TestMuteCannotLandInsideADispatch:
+    """A mute may not change the audience of a line already being recorded.
+
+    `handle_mute_agent` wrote `session.muted_agents` with no lock, while both
+    dispatch paths resolve their recipients from that set AFTER an awaited
+    transcript write. A mute arriving inside that window re-addressed a line to
+    the mute state of a moment after it was spoken — delivered to the wrong agent
+    set on the live path, and recorded-then-replayed to the wrong set on the
+    initialization hold (issue #4610).
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_mute_racing_the_transcript_write_keeps_the_line_s_audience(
+        self, app, fake_sessions, monkeypatch: pytest.MonkeyPatch
+    ):
+        async with client_for(app) as client:
+            start, release = await (
+                TestSpeechDuringAgentInitIsHeldNotRefused._start_paused_in_init(
+                    client, monkeypatch
+                )
+            )
+            session = _common.ACTIVE.get("standup")
+            assert session is not None
+
+            entered_append = threading.Event()
+            allow_append = threading.Event()
+            real_append = store.append_transcript
+
+            def blocking_append(*args, **kwargs):
+                """Hold the worker thread inside the transcript write."""
+                entered_append.set()
+                allow_append.wait(5)
+                return real_append(*args, **kwargs)
+
+            monkeypatch.setattr(store, "append_transcript", blocking_append)
+
+            dispatch = asyncio.create_task(
+                client.post(
+                    f"{BASE}/meetings/standup/dispatch",
+                    json={"text": "said while the note-taker was listening"},
+                )
+            )
+            # The dispatch now holds DISPATCH_LOCK and is parked in the append.
+            await asyncio.to_thread(entered_append.wait, 5)
+
+            mute = asyncio.create_task(
+                client.post(
+                    f"{BASE}/meetings/standup/mute",
+                    json={"agent_id": "note-taker", "muted": True},
+                )
+            )
+            # It must not be able to apply while the dispatch holds admission.
+            await asyncio.sleep(0.05)
+            assert not mute.done(), "the mute applied inside the dispatch's window"
+
+            allow_append.set()
+            assert (await dispatch).status == 200
+            assert (await mute).status == 200
+
+            # The held line kept the audience it had when it was spoken.
+            recipients = [names for _line, names in session.init_buffer]
+            assert len(recipients) == 1
+            assert "note-taker" in recipients[0]
+
+            release.set()
+            assert (await start).status == 200

--- a/test/test_meetings_session.py
+++ b/test/test_meetings_session.py
@@ -676,3 +676,173 @@ class TestDispatchThreadsGovernanceIdentity:
             names = {kw.arg for kw in call.keywords}
             assert "app" in names, "on_tool_call is invoked without `app`, so no profile resolves"
             assert "session_key" in names and "agent" in names
+
+
+class TestTheInitWindowHoldIsBounded:
+    """Unit-level arithmetic for the #4610 hold, without the HTTP surface."""
+
+    @staticmethod
+    def _session() -> sess.MeetingSession:
+        return sess.MeetingSession(
+            meeting_id="standup",
+            sessions=None,
+            config={"meeting_agents": []},
+        )
+
+    def test_it_accepts_up_to_the_cap_without_dropping(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 3)
+        session = self._session()
+        assert [session.buffer_during_init(f"line {i}") for i in range(3)] == [
+            True,
+            True,
+            True,
+        ]
+        assert session.init_dropped == 0
+        assert len(session.init_buffer) == 3
+
+    def test_the_line_past_the_cap_displaces_the_oldest(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 3)
+        session = self._session()
+        for index in range(4):
+            accepted = session.buffer_during_init(f"line {index}")
+        # The fourth reports the displacement so the caller can log it.
+        assert accepted is False
+        assert [line for line, _ in session.init_buffer] == ["line 1", "line 2", "line 3"]
+        assert session.init_dropped == 1
+
+    def test_a_lowered_cap_sheds_the_whole_excess_at_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The trim is by ARITHMETIC, not one entry per call.
+
+        A `pop(0)` per append would leave the buffer permanently over a cap that
+        shrank — the bound has to hold for the buffer it is applied to, not only
+        for the line that triggered it.
+        """
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 5)
+        session = self._session()
+        for index in range(5):
+            session.buffer_during_init(f"line {index}")
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 2)
+        assert session.buffer_during_init("newest") is False
+        assert [line for line, _ in session.init_buffer] == ["line 4", "newest"]
+        assert session.init_dropped == 4
+
+    def test_the_drain_empties_the_hold_and_resets_the_tally(self) -> None:
+        session = self._session()
+        assert session.buffer_during_init("first") is True
+        assert session.buffer_during_init("second") is True
+        delivered, dropped = session.drain_init_buffer()
+        assert (delivered, dropped) == (2, 0)
+        assert session.init_buffer == []
+        assert session.init_dropped == 0
+        # The always-on task extractor received them in order.
+        assert session.agents[k.TASK_EXTRACTOR_ID].queue == ["first", "second"]
+
+    def test_noise_is_filtered_at_arrival_and_never_occupies_a_slot(self) -> None:
+        """A held line takes the same path in; the hold changes WHEN, not WHAT.
+
+        Filtering at arrival is what makes the cap honest — filler that would be
+        discarded anyway must not be counted against the bound in the meantime.
+        """
+        session = self._session()
+        assert session.buffer_during_init("uh") is True
+        assert session.init_buffer == []  # consumed no slot at all
+        session.buffer_during_init("real content here")
+        assert [line for line, _ in session.init_buffer] == ["real content here"]
+
+        delivered, dropped = session.drain_init_buffer()
+        assert (delivered, dropped) == (1, 0)
+        assert session.agents[k.TASK_EXTRACTOR_ID].queue == ["real content here"]
+
+    def test_each_line_keeps_the_recipients_it_had_when_spoken(self) -> None:
+        """A mute landing mid-hold does not reach backwards."""
+        session = self._session()
+        session.agents["late-joiner"] = session._make_queue("late-joiner", "")
+        session.buffer_during_init("everyone hears this")
+        session.muted_agents.add("late-joiner")
+        session.buffer_during_init("only the extractor hears this")
+
+        delivered, dropped = session.drain_init_buffer()
+        assert (delivered, dropped) == (2, 0)
+        assert session.agents["late-joiner"].queue == ["everyone hears this"]
+        assert session.agents[k.TASK_EXTRACTOR_ID].queue == [
+            "everyone hears this",
+            "only the extractor hears this",
+        ]
+
+    def test_an_agent_removed_mid_hold_is_skipped_not_resurrected(self) -> None:
+        """A recorded name whose queue is gone must not be re-created at drain.
+
+        Names are stored rather than queue objects precisely so a disabled agent
+        cannot be fed into a queue nothing flushes.
+        """
+        session = self._session()
+        session.agents["doomed"] = session._make_queue("doomed", "")
+        session.buffer_during_init("spoken while it existed")
+        del session.agents["doomed"]
+
+        delivered, dropped = session.drain_init_buffer()
+        # Still counts as delivered — the extractor received it.
+        assert (delivered, dropped) == (1, 0)
+        assert "doomed" not in session.agents
+        assert session.agents[k.TASK_EXTRACTOR_ID].queue == ["spoken while it existed"]
+
+    def test_a_line_addressed_to_nobody_is_not_counted_as_delivered(self) -> None:
+        """Every recipient muted at arrival means the line reached no one."""
+        session = self._session()
+        session.muted_agents.add(k.TASK_EXTRACTOR_ID)
+        session.buffer_during_init("into the void")
+        delivered, dropped = session.drain_init_buffer()
+        assert (delivered, dropped) == (0, 0)
+        assert session.agents[k.TASK_EXTRACTOR_ID].queue == []
+
+    def test_the_marker_reaches_an_agent_muted_after_its_lines_were_dropped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The marker follows the LOSS, not the drain-time mute set.
+
+        Addressing it to whoever is unmuted at drain omitted exactly the agent the
+        marker is for: one that lost an opening line to the cap and was muted before
+        the drain still receives its surviving pre-mute lines, so without the notice
+        its output begins mid-conversation with nothing to show a turn was lost.
+        """
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 1)
+        session = self._session()
+        session.agents["muted-later"] = session._make_queue("muted-later", "")
+        # Cap of 1: the first line is dropped by the second, and both were
+        # addressed to `muted-later` while it was still listening.
+        session.buffer_during_init("dropped opening")
+        session.buffer_during_init("surviving line")
+        assert session.init_dropped == 1
+        assert "muted-later" in session.init_dropped_recipients
+
+        session.muted_agents.add("muted-later")
+        delivered, dropped = session.drain_init_buffer()
+        assert (delivered, dropped) == (1, 1)
+
+        marker = k.SYSTEM_INIT_BUFFER_OVERFLOW.format(count=1, limit=1)
+        # It gets the surviving line AND the notice that one is missing.
+        assert session.agents["muted-later"].queue == [marker, "surviving line"]
+        # The tally is consumed by the drain.
+        assert session.init_dropped_recipients == set()
+
+    def test_no_marker_reaches_an_agent_that_lost_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An agent muted while the dropped lines were spoken has no gap to announce."""
+        monkeypatch.setattr(k, "MAX_INIT_BUFFER_LINES", 1)
+        session = self._session()
+        session.agents["late-joiner"] = session._make_queue("late-joiner", "")
+        session.muted_agents.add("late-joiner")
+        session.buffer_during_init("dropped while muted")
+        session.buffer_during_init("also while muted")
+        session.muted_agents.discard("late-joiner")
+
+        delivered, dropped = session.drain_init_buffer()
+        assert dropped == 1
+        assert session.agents["late-joiner"].queue == []

--- a/website/src/apps/meetings/api.ts
+++ b/website/src/apps/meetings/api.ts
@@ -13,7 +13,7 @@ const API = '/api/apps/meetings'
 export type MeetingStatus = 'idle' | 'active' | 'paused' | 'reviewing' | 'ended'
 export type WidgetType = 'markdown' | 'html' | 'chat'
 export type TaskPriority = 'high' | 'medium' | 'low'
-export type TranscriptSource = 'speech' | 'typed'
+export type TranscriptSource = 'speech' | 'typed' | 'system'
 
 /**
  * Full literal catalog keys per enum value, not a suffix interpolated at the call
@@ -122,10 +122,15 @@ export interface LiveStatus {
   agents: Record<string, AgentQueueStatus>
   agents_paused: boolean
   expired: boolean
-  /** Whether a dispatch sent now would be admitted (transcript ingress open).
+  /** Whether a dispatch sent now would be fanned out to the agents directly.
    *  Present on the meeting poll (`GET /meetings/{id}`), whose consumer gates
    *  the microphone on it; absent from the bare `/status` endpoint. */
   accepting_dispatches?: boolean
+  /** Whether a dispatch sent now would be HELD until the agents finish
+   *  initializing, rather than refused with a 409. Speech lands either way, so
+   *  the microphone gate is this OR `accepting_dispatches` — see
+   *  `canOpenTranscription`. */
+  buffering_dispatches?: boolean
 }
 
 export interface Task {

--- a/website/src/apps/meetings/hooks/useMeetingSession.ts
+++ b/website/src/apps/meetings/hooks/useMeetingSession.ts
@@ -197,16 +197,23 @@ export function canTransition(from: MeetingStatus, to: MeetingStatus): boolean {
  *
  * `status === 'active'` alone is NOT dispatch readiness. `POST /start` persists
  * `active` up front and then initializes agents with transcript ingress
- * SUSPENDED — every dispatch in that window is rejected with a 409
- * (`no_active_meeting`, see the backend's `get_for_dispatch`). The fast start
- * poll exists to observe `active` early, so without a readiness gate it opened
- * the microphone tens of seconds before ingress: early finals burned through
- * the short dispatch retry schedule (~4.6s) against a ~46s initialization and
- * were PERMANENTLY lost from the notes and tasks.
+ * SUSPENDED for direct fan-out. The fast start poll exists to observe `active`
+ * early, so without a readiness gate it opened the microphone tens of seconds
+ * before ingress: early finals burned through the short dispatch retry schedule
+ * (~4.6s) against a ~46s initialization and were PERMANENTLY lost from the notes
+ * and tasks.
  *
- * `ingressReady` is the server's own admission flag, `accepting_dispatches`,
- * reported on every meta poll — the same holder flag the dispatch endpoint
- * itself checks. Gating on the POLLED value rather than on the start
+ * That gate cost the opening of every meeting instead — the mic simply stayed
+ * shut for those ~46s and the speech was never captured at all (issue #4610).
+ * The server now HOLDS speech through initialization, so there are two states in
+ * which a line lands: fanned out immediately (`accepting_dispatches`) or held and
+ * replayed in order when the agents are ready (`buffering_dispatches`). Capture
+ * must open for BOTH, and a server that reports neither is still the closed case
+ * this gate was written for — stopping, reviewing, expired, or no live session.
+ *
+ * `ingressReady` is that pair of server flags, reported on every meta poll — the
+ * same holder state the dispatch endpoint itself checks. Gating on the POLLED
+ * value rather than on the start
  * mutation's lifecycle makes every client-side inference hole unreachable at
  * once, because the mutation's outcome is not evidence about ingress in either
  * direction: an error settlement can hide a server-side success (the ~46s
@@ -298,11 +305,14 @@ export function useMeetingSession({ eventId, fallbackTitle, config, notify }: Op
   const meta: MeetingMeta | undefined = metaQuery.data?.meta
   const status: MeetingStatus = meta?.status ?? 'idle'
   const live = metaQuery.data?.live ?? null
-  // The server's own dispatch-admission flag, straight off the poll. `=== true`
-  // rather than truthy-or-default: a missing `live` (no session installed — a
-  // gateway restart left the meeting `active` on disk with nothing live) means a
-  // dispatch CANNOT land, so unknown must read as not-ready.
-  const ingressReady = live?.accepting_dispatches === true
+  // The server's own dispatch-admission state, straight off the poll. Either flag
+  // means a line sent now LANDS: directly, or held for the agents that are still
+  // initializing (issue #4610). `=== true` rather than truthy-or-default: a
+  // missing `live` (no session installed — a gateway restart left the meeting
+  // `active` on disk with nothing live) means a dispatch CANNOT land, so unknown
+  // must read as not-ready.
+  const ingressReady =
+    live?.accepting_dispatches === true || live?.buffering_dispatches === true
 
   const outputsQuery = useQuery({
     queryKey: [...scope, 'outputs'],

--- a/website/src/test/UseMeetingSessionCoverage.test.tsx
+++ b/website/src/test/UseMeetingSessionCoverage.test.tsx
@@ -330,6 +330,35 @@ describe('useMeetingSession transcription binding', () => {
     expect(stt.start).not.toHaveBeenCalled()
   })
 
+  it('starts the microphone while the server is HOLDING speech through agent init', async () => {
+    // The server buffers speech for the initializing agents instead of refusing
+    // it (issue #4610), so a line sent now lands — it is just replayed in order
+    // once they are ready. Keeping the mic shut here is what cost every meeting
+    // its opening ~46s, so capture must follow the hold as well as the direct
+    // fan-out.
+    apiMocks.meeting.mockResolvedValue({
+      meta: meta({ status: 'active' }),
+      live: { accepting_dispatches: false, buffering_dispatches: true },
+    })
+    await mountLoaded()
+
+    await waitFor(() => expect(stt.start).toHaveBeenCalled())
+    expect(stt.stop).not.toHaveBeenCalled()
+  })
+
+  it('keeps the microphone closed when the server neither admits nor holds', async () => {
+    // Both flags false is the genuinely closed case — stopping, reviewing, or an
+    // expired session. The hold must not widen this into "always open".
+    apiMocks.meeting.mockResolvedValue({
+      meta: meta({ status: 'active' }),
+      live: { accepting_dispatches: false, buffering_dispatches: false },
+    })
+    const view = await mountLoaded()
+    await waitFor(() => expect(view.result.current.status).toBe('active'))
+
+    expect(stt.start).not.toHaveBeenCalled()
+  })
+
   it('keeps the microphone closed when the meeting is active with no live session', async () => {
     // `active` on disk with `live: null` (a gateway restart dropped the
     // session) means a dispatch CANNOT land; unknown must read as not-ready.


### PR DESCRIPTION
Fixes #4610.

<!-- no-visual-delta -->

**Why no screenshot:** this change adds no UI element, style, or layout. Its only frontend effect is that an existing state — the microphone being open — activates ~46s earlier, because the server now holds speech through agent initialization instead of refusing it. There is no new pixel to photograph; the behaviour is pinned by two `canOpenTranscription` tests instead (mic opens on the hold, stays shut when the server reports neither open state). The "Preparing agents…" badge, which *would* be a visual delta, is deliberately not in this PR.

## The bug

`handle_start_meeting` persists `active`, installs the live session, then awaits `init_agents` — a sequence of model turns the reporter measured at **~46s**. Ingress was suspended across that whole span, so every line spoken into it answered `409 no_active_meeting` and reached no agent. The notes and tasks began partway through the first topic, with nothing in either to show a turn had been dropped.

## The fix

Speech in the init window is **held on the session** and replayed **in arrival order** the moment initialization completes.

**Two closed-ingress reasons, told apart.** `accepting_dispatches` was false for two opposite reasons: the meeting is stopping / reviewing / expired (the line has nowhere to go — refuse it, the gate #1981 added) or the meeting is *starting* (the line is wanted — hold it). The holder now records **which**, as the session being initialized rather than a bare flag, so the state cannot outlive the identity it describes. `suspend_dispatches` grows a `buffer_speech` keyword that **only the start path passes**; stop, reviewing, expiry and outgoing-session replacement keep refusing, untouched.

**Filtered and addressed at arrival.** Each line is normalized, noise-filtered, and paired with the recipient names it had *at the moment it was spoken*, then stored. Both halves of "what happens to this line" are decided when a live line would have decided them, so the hold only ever shifts delivery in **time**. Names rather than queue objects, so an agent disabled mid-initialization is skipped instead of being fed a queue nothing flushes.

**Bounded, by line count.** `MAX_INIT_BUFFER_LINES = 200`. The producer is one finalized speech segment at a time and each is already capped at `MAX_TRANSCRIPT_CHARS`, so lines are what the overflow rule has to reason about. A real opening lands 15–25 lines here; the cap bounds the hold at ~800 KB for the one meeting `MAX_CONCURRENT_MEETINGS` permits. The bound is **required, not a nicety** — `POST …/dispatch` accepts untrusted text, so an unbounded hold there is a memory-exhaustion lever.

**Overflow drops the OLDEST, and tells the agents that actually lost something.** A slow initialization is one where the newest speech is still in play, and the tail is what an agent needs to pick up a conversation mid-flight. The agent-facing marker is addressed to the union of the recipient sets recorded on the **dropped** lines — not to whoever is unmuted at drain, because those two audiences diverge under a mute landing between the drop and the drain, and the agent with the gap is exactly the one a drain-time audience omits. The transcript gets the same marker under a new `system` source, added to `VALID_TRANSCRIPT_SOURCES` deliberately: `read_transcript_page` drops records whose source it does not recognize, so a marker outside that tuple would be filtered out on read and the gap would be silent again.

**The transcript is never truncated.** Held and live lines are both appended at *arrival*, through one shared `_record_line`, so the human record stays complete and in spoken order even when the hold overflows. An overflow costs the agents context, never the user their transcript.

**Nothing observability-only rides along.** The hold's counters and a `buffered` response flag were carried in the first two rounds and had no reader — see the First Principles disposition below. They are left out; they belong with the "Preparing agents…" badge.

## Why the frontend change is load-bearing, not cosmetic

`canOpenTranscription` on `main` gates the microphone on the polled `accepting_dispatches`. That gate was itself a mitigation for this window — it stopped early finals from burning the retry schedule, at the cost of not capturing the opening at all. **With the server change alone the mic would still stay shut for those ~46s and nothing would ever reach the hold**, so the backend fix would be dead code.

The meeting poll now reports a second flag, `buffering_dispatches`, and the gate opens on either. A server reporting *neither* is still the genuinely-closed case the gate was written for (stopping, reviewing, expired, or no live session) — that path is pinned by its own test.

## Review rounds

Both rounds of findings were accepted in full; neither was rebutted.

**Round 1 — GPT: filtering and addressing happened at drain, not arrival.** Verified by reverting only `session.py` to `c4ea94cdc`: **6 cases fail**.

| Divergence from the live path | Consequence | Fix |
|---|---|---|
| noise filtered at drain | filler occupied a cap slot until drain, so a burst of `"uh"` could **evict the genuine opening speech** the bound protects | `_prepare_line` runs at arrival; a filtered line consumes no slot |
| recipients resolved at drain | a mute landing mid-initialization reached **backwards** and robbed a line spoken while that agent was still listening | each line stores `_recipient_names()` from its own arrival moment |

**Round 2 — GPT: the overflow marker still used the drain-time audience.** The sibling of the same asymmetry, in my own round-1 fix: the lines moved to arrival-time recipients but the marker did not. An agent that lost an opening line and was muted before the drain received its surviving pre-mute lines with **no notice of the gap** — the silent truncation the marker exists to prevent. Fixed by recording the dropped lines' recipient union (`init_dropped_recipients`) and addressing the marker to it. Verified by reverting only the marker audience: **2 cases fail**.

**Round 2 — First Principles: three zero-consumer fields.** Correct, and confirmed by grep: `init_buffered` / `init_dropped` on the status payload and `buffered` on the dispatch response had no reader — not the fix path, not the mic gate (which reads `buffering_dispatches`), not the client (`dispatchWithRetry` reads only `response.segment`). The defect is gone without them and the drain already logs delivered/dropped counts. All three are subtracted, along with the `agents.py` idle default and the `LiveStatus` / `DispatchResponse` type members. The pinned `/status` idle shape is back to its base form, so this PR no longer touches that contract at all.

Opus 4.8 and UX Review returned no findings.

## Tests — red-before proven

Against the base commit: **17 backend cases and 1 frontend case fail**, the headline one with the exact 409:

```
FAILED TestSpeechDuringAgentInitIsHeldNotRefused::test_speech_mid_init_is_buffered_and_delivered_in_order
  - AssertionError: {"error": "no active meeting", "code": "no_active_meeting"}
```

Coverage, per the issue's requirements:

| Requirement | Test |
|---|---|
| delivered after init | `test_speech_mid_init_is_buffered_and_delivered_in_order` |
| order preserved | same (asserts the exact queue contents of all three agents) |
| the cap holds | `test_the_hold_is_bounded_and_drops_the_oldest`, `test_it_accepts_up_to_the_cap_without_dropping` |
| overflow drops oldest | same, plus `test_the_line_past_the_cap_displaces_the_oldest`, `test_a_lowered_cap_sheds_the_whole_excess_at_once` |
| marker in the transcript | `test_an_overflow_marks_the_gap_for_the_agents_and_the_transcript` |
| marker reaches the agents that lost a line | `test_the_marker_reaches_an_agent_muted_after_its_lines_were_dropped`, `test_no_marker_reaches_an_agent_that_lost_nothing` |
| #1981 gate intact | `test_a_reviewing_meeting_still_refuses_instead_of_buffering`, `test_an_outgoing_session_being_replaced_does_not_buffer`, and the pre-existing `test_stop_closes_dispatch_admission_before_a_slow_agent_flush` |
| no gratuitous markers | `test_no_marker_when_the_hold_did_not_overflow` |
| held lines still redacted | `test_a_held_line_is_still_redacted` |
| arrival-time filter + addressing | `test_filler_does_not_consume_a_slot_and_evict_real_speech`, `test_a_mute_during_init_does_not_rob_earlier_speech`, `test_noise_is_filtered_at_arrival_and_never_occupies_a_slot`, `test_each_line_keeps_the_recipients_it_had_when_spoken` |
| mic follows the hold | `starts the microphone while the server is HOLDING speech through agent init` |

## Verification

- 991 backend tests green (all `test_meetings_*` + `test_apps_registry_coverage` + `test_app_manager` + `test_ci_surface_tests`)
- Full frontend suite green: 25,858 passed
- `isort` / `flake8` on `src/kiro_crew test conftest.py xdist_budget.py` — clean
- `mypy src/kiro_crew/` — no issues in 1,157 files
- `tsc --noEmit` — clean
- Baselined gates: black, subprocess-encoding, lockdown-before-publish — all pass
- `push_guard.py --require-single-on-base` — SAFE (single commit on base)

## Notes for review

- **Ordering.** The reopen and the drain share **one** `DISPATCH_LOCK` acquisition. A live dispatch needs that lock too, so nothing spoken after the reopen can overtake the held lines. Releasing between the two would let a meeting's opening land after its second topic.
- **A failed `init_agents`.** `_init_agents_plan` can raise out of its `to_thread`, leaving ingress closed and the hold un-drained. That is the behaviour on `main` too (ingress simply stays shut), and it is exactly why the bound is not optional — the hold stops at 200 lines instead of growing. I deliberately did not add a `finally` that reopens ingress: that would fan speech out to agents that were never initialized, which is a worse outcome and wider scope than this issue.
- **Diff scope.** Confined to the ingress/buffer path. The only pre-existing lines touched are one stale comment that said "every dispatch 409s" (no longer true) and the split of `broadcast` into `_prepare_line` + `_recipient_names` — same behaviour, now shared with the hold so the two cannot drift.
- Rebased onto `41cc5a83b`.
