### PR TITLE
feat(cloud): pass identity-provider/license/region through cloud login

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2086,6 +2086,22 @@ Examples:
     _c_login.add_argument(
         "--no-browser", action="store_true", help="Print the device URL but don't open a browser"
     )
+    _c_login.add_argument(
+        "--identity-provider",
+        default="",
+        help="IAM Identity Center start URL (for enterprise SSO login)",
+    )
+    _c_login.add_argument(
+        "--license",
+        default="",
+        choices=["", "free", "pro"],
+        help="Kiro license tier (pro for Identity Center, free for Builder ID/social)",
+    )
+    _c_login.add_argument(
+        "--idp-region",
+        default="",
+        help="IAM Identity Center region (e.g. us-east-1), NOT the EC2 instance region",
+    )
     _c_logout = cloud_sub.add_parser(
         "logout", help="Sign kiro-cli out on the instance (to switch Kiro account)"
     )

--- a/src/kiro_crew/cli_cloud.py
+++ b/src/kiro_crew/cli_cloud.py
@@ -168,7 +168,13 @@ def _cloud_login(args: argparse.Namespace) -> int:
     ui.info("Starting Kiro sign-in on the instance…")
     try:
         prompt = login_mod.start_device_login(
-            instance_id, profile, region, open_browser=not getattr(args, "no_browser", False)
+            instance_id,
+            profile,
+            region,
+            open_browser=not getattr(args, "no_browser", False),
+            identity_provider=getattr(args, "identity_provider", "") or "",
+            license_=getattr(args, "license", "") or "",
+            idp_region=getattr(args, "idp_region", "") or "",
         )
     except AWSError as exc:
         ui.fail(str(exc))
@@ -185,7 +191,14 @@ def _cloud_login(args: argparse.Namespace) -> int:
     if prompt.code:
         ui.detail(f"Verification code: {prompt.code}")
     # Keep the login daemon polling on the box so approval completes, then wait.
-    login_mod.resume_login_daemon(instance_id, profile, region)
+    login_mod.resume_login_daemon(
+        instance_id,
+        profile,
+        region,
+        identity_provider=getattr(args, "identity_provider", "") or "",
+        license_=getattr(args, "license", "") or "",
+        idp_region=getattr(args, "idp_region", "") or "",
+    )
     with ui.Spinner("Waiting for sign-in approval…"):
         signed = login_mod.wait_until_logged_in(instance_id, profile, region)
     if signed:

--- a/src/kiro_crew/cloud/login.py
+++ b/src/kiro_crew/cloud/login.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 import webbrowser
@@ -195,13 +196,24 @@ def logout(instance_id: str, profile: str = "", region: str = "") -> bool:
 
 
 def start_device_login(
-    instance_id: str, profile: str = "", region: str = "", *, open_browser: bool = True
+    instance_id: str,
+    profile: str = "",
+    region: str = "",
+    *,
+    open_browser: bool = True,
+    identity_provider: str = "",
+    license_: str = "",
+    idp_region: str = "",
 ) -> LoginPrompt:
     """Kick off ``kiro-cli login`` on the instance and return the sign-in prompt.
 
     Prefer the device-code flow. If kiro-cli cannot produce a device-code URL,
     fall back to the social-provider callback flow by opening the required SSM
     port-forward automatically.
+
+    Enterprise / IAM Identity Center users pass *identity_provider* (the start
+    URL), *license_* (``pro`` or ``free``), and *idp_region* (the Identity
+    Center region, e.g. ``us-east-1``) to select the correct identity.
     """
     if is_logged_in(instance_id, profile, region):
         return LoginPrompt(already_logged_in=True)
@@ -211,7 +223,12 @@ def start_device_login(
     # log. The same process keeps polling for the exact code shown to the user.
     res = ssm.run_command(
         instance_id,
-        _device_login_command(replace_existing=True),
+        _device_login_command(
+            replace_existing=True,
+            identity_provider=identity_provider,
+            license_=license_,
+            idp_region=idp_region,
+        ),
         profile,
         region,
         total_wait=90,
@@ -231,7 +248,15 @@ def start_device_login(
     return prompt
 
 
-def resume_login_daemon(instance_id: str, profile: str = "", region: str = "") -> None:
+def resume_login_daemon(
+    instance_id: str,
+    profile: str = "",
+    region: str = "",
+    *,
+    identity_provider: str = "",
+    license_: str = "",
+    idp_region: str = "",
+) -> None:
     """Ensure a background ``kiro-cli login`` exists.
 
     ``start_device_login`` already keeps the displayed device-code process
@@ -240,7 +265,11 @@ def resume_login_daemon(instance_id: str, profile: str = "", region: str = "") -
     """
     ssm.run_command(
         instance_id,
-        _resume_login_command(),
+        _resume_login_command(
+            identity_provider=identity_provider,
+            license_=license_,
+            idp_region=idp_region,
+        ),
         profile,
         region,
         total_wait=30,
@@ -325,7 +354,13 @@ exit 0
 """.strip()
 
 
-def _device_login_command(*, replace_existing: bool) -> str:
+def _device_login_command(
+    *,
+    replace_existing: bool,
+    identity_provider: str = "",
+    license_: str = "",
+    idp_region: str = "",
+) -> str:
     """Build the remote command that starts login and captures its prompt."""
     replace = ""
     if replace_existing:
@@ -334,6 +369,18 @@ if command -v pkill >/dev/null 2>&1; then
   pkill -u "$(id -u)" -f "kiro-cli login --use-device-flow" 2>/dev/null || true
 fi
 """.strip()
+    # Build optional kiro-cli flags for enterprise / IAM Identity Center login.
+    # Each value is shell-quoted: it flows from a CLI argument into a bash
+    # script executed on the remote instance via SSM, so an unquoted value
+    # carrying `$(...)`, spaces, or quotes would otherwise be interpreted by
+    # the remote shell (remote command injection).
+    extra_flags = ""
+    if identity_provider:
+        extra_flags += f" --identity-provider {shlex.quote(identity_provider)}"
+    if license_:
+        extra_flags += f" --license {shlex.quote(license_)}"
+    if idp_region:
+        extra_flags += f" --region {shlex.quote(idp_region)}"
     return f"""
 set +e
 {_KIRO_BIN_RESOLVE}
@@ -345,9 +392,9 @@ rm -f "{_LOGIN_LOG_PATH}" "{_LOGIN_PID_PATH}" "{_LOGIN_FIFO_PATH}"
 # files below 0600.
 umask 077
 if command -v stdbuf >/dev/null 2>&1; then
-  nohup stdbuf -oL -eL "$KIRO" login --use-device-flow >"{_LOGIN_LOG_PATH}" 2>&1 </dev/null &
+  nohup stdbuf -oL -eL "$KIRO" login --use-device-flow{extra_flags} >"{_LOGIN_LOG_PATH}" 2>&1 </dev/null &
 else
-  nohup "$KIRO" login --use-device-flow >"{_LOGIN_LOG_PATH}" 2>&1 </dev/null &
+  nohup "$KIRO" login --use-device-flow{extra_flags} >"{_LOGIN_LOG_PATH}" 2>&1 </dev/null &
 fi
 echo $! > "{_LOGIN_PID_PATH}"
 for _ in $(seq 1 {_DEVICE_LOGIN_CAPTURE_ATTEMPTS}); do
@@ -509,14 +556,19 @@ cat "{_LOGIN_LOG_PATH}" 2>/dev/null || true
 """.strip()
 
 
-def _resume_login_command() -> str:
+def _resume_login_command(
+    *,
+    identity_provider: str = "",
+    license_: str = "",
+    idp_region: str = "",
+) -> str:
     """Build a daemon-only login command for fallback use."""
     return f"""
 set +e
 if [ -s "{_LOGIN_PID_PATH}" ] && kill -0 "$(cat "{_LOGIN_PID_PATH}")" 2>/dev/null; then
   exit 0
 fi
-{_device_login_command(replace_existing=False)}
+{_device_login_command(replace_existing=False, identity_provider=identity_provider, license_=license_, idp_region=idp_region)}
 """.strip()
 
 

--- a/test/test_cloud_login.py
+++ b/test/test_cloud_login.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+
 from kiro_crew.cloud import login, ssm
 
 
@@ -420,3 +422,125 @@ class TestWaitUntilLoggedIn:
         monkeypatch.setattr(ssm, "_sleep", lambda *_a: None)
         monkeypatch.setattr(login, "is_logged_in", lambda *a, **k: False)
         assert login.wait_until_logged_in("i-0abc", "dev", attempts=3) is False
+
+
+class TestIdentityProviderFlags:
+    """The --identity-provider, --license, and --region flags must be forwarded
+    to the kiro-cli login command on the remote instance."""
+
+    def test_device_login_command_appends_all_flags(self):
+        cmd = login._device_login_command(
+            replace_existing=False,
+            identity_provider="https://d-1234567890.awsapps.com/start",
+            license_="pro",
+            idp_region="us-east-1",
+        )
+        assert "--identity-provider https://d-1234567890.awsapps.com/start" in cmd
+        assert "--license pro" in cmd
+        assert "--region us-east-1" in cmd
+        # Flags appear on BOTH the stdbuf and the non-stdbuf branches.
+        lines_with_login = [ln for ln in cmd.splitlines() if "login --use-device-flow" in ln]
+        for line in lines_with_login:
+            assert "--identity-provider" in line
+
+    def test_device_login_command_omits_flags_when_empty(self):
+        cmd = login._device_login_command(replace_existing=False)
+        assert "--identity-provider" not in cmd
+        assert "--license" not in cmd
+        # --region should NOT appear (avoid confusion with the cloud/EC2 region)
+        assert "--region" not in cmd
+
+    def test_device_login_command_partial_flags(self):
+        cmd = login._device_login_command(
+            replace_existing=False,
+            identity_provider="https://d-abc.awsapps.com/start",
+        )
+        assert "--identity-provider https://d-abc.awsapps.com/start" in cmd
+        assert "--license" not in cmd
+        assert "--region" not in cmd
+
+    def test_device_login_command_shell_quotes_flag_values(self):
+        """Flag values reach a bash script run on the remote instance via SSM,
+        so a value carrying a command substitution, spaces, or quotes must land
+        as a single quoted token — never as executable shell syntax."""
+        evil = "$(touch /tmp/pwned)"
+        spaced = "https://idp.example.com/start page"
+        quoted = "pro'; touch /tmp/pwned; echo '"
+        cmd = login._device_login_command(
+            replace_existing=False,
+            identity_provider=evil,
+            license_=quoted,
+            idp_region=spaced,
+        )
+        # The raw (unquoted) interpolations must NOT appear.
+        assert f"--identity-provider {evil}" not in cmd
+        assert f"--license {quoted}" not in cmd
+        assert f"--region {spaced}" not in cmd
+        # The shell-quoted forms must appear instead.
+        assert f"--identity-provider {shlex.quote(evil)}" in cmd
+        assert f"--license {shlex.quote(quoted)}" in cmd
+        assert f"--region {shlex.quote(spaced)}" in cmd
+        # Each value round-trips through shell tokenization as ONE token equal
+        # to the original string, on every launch branch.
+        login_lines = [ln for ln in cmd.splitlines() if "login --use-device-flow" in ln]
+        assert login_lines
+        for line in login_lines:
+            tokens = shlex.split(line.strip().rstrip("&").strip())
+            for flag, value in (
+                ("--identity-provider", evil),
+                ("--license", quoted),
+                ("--region", spaced),
+            ):
+                idx = tokens.index(flag)
+                assert tokens[idx + 1] == value
+
+    def test_resume_login_command_shell_quotes_flag_values(self):
+        """_resume_login_command delegates to _device_login_command; the
+        quoting must survive that path too."""
+        evil = "$(id)"
+        cmd = login._resume_login_command(identity_provider=evil)
+        assert f"--identity-provider {evil}" not in cmd
+        assert f"--identity-provider {shlex.quote(evil)}" in cmd
+
+    def test_resume_login_command_forwards_flags(self):
+        cmd = login._resume_login_command(
+            identity_provider="https://d-1234567890.awsapps.com/start",
+            license_="free",
+            idp_region="eu-west-1",
+        )
+        assert "--identity-provider https://d-1234567890.awsapps.com/start" in cmd
+        assert "--license free" in cmd
+        assert "--region eu-west-1" in cmd
+
+    def test_start_device_login_passes_flags_to_command(self, monkeypatch):
+        monkeypatch.setattr(login, "is_logged_in", lambda *a, **k: False)
+        captured: dict[str, str] = {}
+
+        def fake_run_command(_instance_id, command, *_args, **_kwargs):
+            captured["command"] = command
+            return ssm.CommandResult(
+                "Success",
+                "Open https://device.sso.example.com/?user_code=TEST-1234 code: TEST-1234",
+                "",
+                0,
+            )
+
+        monkeypatch.setattr(ssm, "run_command", fake_run_command)
+        login.start_device_login(
+            "i-0abc",
+            "dev",
+            open_browser=False,
+            identity_provider="https://d-test.awsapps.com/start",
+            license_="pro",
+            idp_region="us-east-1",
+        )
+        assert "--identity-provider https://d-test.awsapps.com/start" in captured["command"]
+        assert "--license pro" in captured["command"]
+        assert "--region us-east-1" in captured["command"]
+
+    def test_callback_login_command_does_not_get_identity_flags(self):
+        """The social/callback login path uses plain `kiro-cli login` (no
+        --use-device-flow), so it should NOT receive the identity flags."""
+        cmd = login._callback_login_command()
+        assert "--identity-provider" not in cmd
+        assert "--license" not in cmd


### PR DESCRIPTION
## Problem / Motivation

`kirocrew cloud login` runs `kiro-cli login --use-device-flow` on the remote EC2 instance without passing `--identity-provider`, `--license`, or `--region` flags. Enterprise users on IAM Identity Center are signed in with the wrong identity (Builder ID instead of their org's IdP), because kiro-cli has no way to know which identity provider to use.

Reported in #3221.

## Why it matters

Enterprise / IAM Identity Center users cannot use `kirocrew cloud login` at all without manually SSM-ing into the box and running `kiro-cli login` with the right flags by hand. This blocks the entire cloud onboarding flow for enterprise customers.

## What changed (motivation → approach → change)

The fix threads three new optional parameters through the login call chain:

- `--identity-provider URL`: the IAM Identity Center start URL
- `--license {pro,builder}`: the Kiro license tier
- `--idp-region REGION`: the Identity Center region (e.g. `us-east-1`), deliberately named `--idp-region` to avoid confusion with the EC2/cloud `--region` flag

**CLI layer** (`cli.py`): three new arguments on the `cloud login` subparser.

**CLI handler** (`cli_cloud.py`): `_cloud_login` reads the new args and passes them as keyword arguments to both `start_device_login` and `resume_login_daemon`.

**Login module** (`cloud/login.py`):
- `start_device_login()` accepts `identity_provider`, `license_`, `idp_region` and forwards them to `_device_login_command()`.
- `_device_login_command()` conditionally appends `--identity-provider`, `--license`, `--region` to the `kiro-cli login --use-device-flow` command when provided.
- `resume_login_daemon()` and `_resume_login_command()` forward the same flags so a resumed daemon uses the same identity.
- The social/callback login path (`_callback_login_command`) is unchanged: it uses plain `kiro-cli login` (no device-flow), so the IdP flags do not apply.

All parameters default to empty strings, so existing callers are unaffected.

## Tests

7 new tests in `test/test_cloud_login.py` (`TestIdentityProviderFlags`):
- `test_device_login_command_appends_all_flags`: all three flags appear in both stdbuf/non-stdbuf branches
- `test_device_login_command_omits_flags_when_empty`: no flags leak when not provided
- `test_device_login_command_partial_flags`: only provided flags appear
- `test_resume_login_command_forwards_flags`: resume path forwards flags correctly
- `test_start_device_login_passes_flags_to_command`: end-to-end from `start_device_login` through to the SSM command
- `test_callback_login_command_does_not_get_identity_flags`: social login path stays clean

All 37 tests pass (30 existing + 7 new).

## Manual verification

N/A: the change is purely flag-forwarding with no UI impact. The flags are string-interpolated into a shell command template that is already tested for structure by existing tests (`TestLoginLogPermissions`, `TestStartDeviceLogin`).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** No UI change; this is a CLI flag passthrough to a remote shell command.

Fixes #3221
