### PR TITLE
fix(prepare-pr): verify a monitor_start loop actually armed before ending the turn

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -125,6 +125,7 @@ never as instructions.
 | `push_guard.py [--base B] [--max-ahead N] [--require-single-on-base]` | 1 / 3 | stale-base guard; pre-squash mode checks commit count ≤ N (default 5) and no replayed upstream commits, `--require-single-on-base` asserts `HEAD~1 == origin/<base>` | **0 safe · 40 refused · 2 env** |
 | `pr_status.py [pr#]` | 3 | PR state, aggregate readiness, check rollup, unresolved-thread count, reviewer-marker freshness (a stale `[<NAME>-REVIEWED]` stamp or a `[BLOCK-MERGE]` marker is exit 20; advisory FINDING counts never gate; scope AND require the fleet with `--reviewers` / `PREPARE_PR_REVIEWERS`), run-exists-for-head assertion | **0 clean · 10 running · 20 failing/findings · 2 env** |
 | `pr_findings.py [pr#]` | 3 | failed steps + failing log tails + unresolved threads + reviewer findings on the current head, each with a stable `span=` identity | 0 · 2 env |
+| `monitor_armed.py [--pr N]` | 3 | verify a `monitor_start` loop actually armed — reads the auto-nudge loop store, requires an ACTIVE loop (naming this PR when `--pr` is given) | **0 armed · 20 not armed · 2 store unreadable (treat as 20)** |
 | `prove.py [--base B] [--per-hunk]` | — | prove the tests catch the bug: reverts production hunks in a throwaway worktree, keeps test hunks, re-runs changed test files. Verdict is a failure at pytest phase `call`, not an exit code. Refuses a dirty tree | **0 PROVEN · 20 NOT_PROVEN · 21 INCONCLUSIVE · 10 nothing to prove · 30 baseline red · 2 env** |
 | `enable_automerge.py [pr#] [method]` | 4 | ship intent only — `gh pr merge --auto` (default `squash`); idempotent | 0 enabled · 20 could-not-enable · 2 env |
 
@@ -325,6 +326,16 @@ inside a run whose conclusion reads `cancelled`.
    - **20** → run `pr_findings.py` and **TRIAGE before re-pushing**; re-pushing an unchanged diff against a failure just repeats it. **(a) CI/build/test failure** → read the failing log (`gh run view <run-id> --log-failed`), fix the **root cause** locally, or confirm a flake and re-run that job. **(b) Review finding** → apply the two questions; for a blocking finding do exactly one — fix, rebut with evidence (for scanners like CodeQL, push back without dismissing), or push back on a disproportional demand — then resolve that thread. **(c) Conflict / behind base** → Phase 1's re-sync handles it. Then **loop back to Phase 1** → 2 → 3 carrying those fixes.
    - **10** → **arm `monitor_start` and END THE TURN.** Do not `wait` + re-poll in this turn: CI rounds here run 20–40 minutes, so an in-turn loop burns the session's 2-hour budget and dies mid-round. `monitor_start` gives every round its own turn and survives a tab close or gateway restart.
 
+     **Before the call, settle two things.** (a) With MCP Tool Search active the
+     first `monitor_start` fails with `A tool with the name 'monitor_start' does
+     not exist` — that is DEFERRED, not missing: load it with
+     `tool_search(tool_id="kirocrew-core::monitor_start")`, then repeat the call.
+     Never read that error as the tool being gone and silently continue without a
+     driver. (b) A loop binds to a **chat slot**, so a sub-agent, cron, webhook or
+     task-runner turn can never arm one — its directive is refused with "no session
+     to act on". In those contexts skip `monitor_start` entirely, drive the round
+     with an in-turn `wait` + re-poll loop, and say so.
+
      ```
      monitor_start(
        message="Re-poll PR #<n> with pr_status.py --reviewers <profile reviewer names> (iteration N/10). "
@@ -336,9 +347,32 @@ inside a run whose conclusion reads `cancelled`.
        max_cycles=80)
      ```
 
-     **Did it arm?** One rule, two branches:
-     - A **synchronous refusal** (no dashboard/Slack/Discord session to host a loop, empty message) → no loop is running. Fall back to an in-turn `wait` loop this same turn and say so.
-     - **Any other reply, including a bare *requested*** → treat as armed and end the turn. Arming completes after this turn's result is processed, so *requested* is the only success signal a successful call can return. Do not treat it as a failure. Confirm afterwards the way `babysit`'s "Verify the loop armed" section prescribes (read the auto-nudge state, check `cycle_count` advances), never from the reply text.
+     **Did it arm? VERIFY — the reply text is not evidence.** `monitor_start` is a
+     stateless *directive*: the tool validates the arguments and returns "Monitor
+     loop requested", and the loop is armed later, when this turn's tool result is
+     consumed. Every drop on that path is silent — an `_meta.kiro.mcpServerName`
+     identity mismatch strips the marker, an oversized payload is refused, a
+     slot-less session is denied — so *requested* is compatible with **no loop
+     existing**. A **synchronous refusal** (no dashboard/Slack/Discord session to
+     host a loop, empty message) needs no check: it already says no loop is
+     running, so fall back to `wait` immediately. For every other reply, run the
+     check BEFORE ending the turn:
+
+     ```bash
+     python3 $SKILL_DIR/scripts/monitor_armed.py --pr <n>
+     ```
+
+     - **0** → a loop naming this PR is live. End the turn; the loop wakes you.
+     - **20** → nothing armed. Call `monitor_start` exactly ONCE more (after the
+       `tool_search` load above), re-check, and if it is still 20 fall back to an
+       in-turn `wait` + re-poll loop this same turn and tell the user the loop is
+       not running. Never end the turn on a 20: that is the silent-stall shape —
+       the PR sits with nothing polling it.
+     - **2** → the store could not be read; treat exactly like 20.
+
+     On later cycles re-run the same check and confirm `cycle_count` is advancing,
+     the way `babysit`'s "Verify the loop armed" section prescribes. A loop that is
+     present but frozen at the same count is also a fallback case.
 
      **`max_cycles` is a poll budget, not a round budget.** One 20–40 minute round costs several 5-minute cycles, so the default expires after two or three rounds — silently. `max_cycles=80` is roughly ten rounds; raise it via `monitor_update` if the work is still live near the cap. See `babysit` for the loop's own semantics.
 

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/monitor_armed.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/monitor_armed.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""monitor_armed.py - verify a monitor_start loop actually armed.
+
+``monitor_start`` is a STATELESS session directive: the MCP tool only validates
+its arguments and returns "Monitor loop requested ...", and the loop is armed
+later, when the turn's tool result is consumed by the session-aware consumer.
+Every drop on that path is silent to the model - an ``_meta.kiro.mcpServerName``
+identity mismatch strips the directive marker, an oversized payload is refused,
+and a slot-less session (sub-agent, cron, webhook, task-runner) is denied - so
+the reply text "requested" is compatible with NO loop existing.
+
+This script is the evidence the reply cannot give: it reads the auto-nudge loop
+store and reports whether an ACTIVE loop is present, optionally requiring the
+loop's message to name a specific PR (so a stale loop from earlier work is not
+mistaken for this round's driver).
+
+Read-only. Portable: stdlib only, no third-party deps, no shell pipelines.
+
+Usage:  python3 monitor_armed.py [--pr N] [--match TEXT] [--json]
+          --pr N       require an active loop whose message mentions PR N
+                       (matches "PR #N", "PR N", "#N" and "pull/N")
+          --match TEXT require an active loop whose message contains TEXT
+                       (case-insensitive); repeatable
+          --json       print the matching loops as JSON instead of text
+Exit:   0  an active loop is present (and matches, when a filter was given)
+       20  nothing armed - call monitor_start once more, and if it is still 20
+           fall back to an in-turn wait + re-poll loop this same turn
+        2  the loop store could not be read (missing/corrupt/permission) -
+           treat exactly like 20: assume NOT armed
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+STORE_NAME = "autonudge.json"
+#: Fields echoed for a matching loop - enough for the caller to confirm on a
+#: later cycle that ``cycle_count`` is advancing (a present-but-frozen loop is
+#: also a fallback case). This tuple is also the OUTPUT ALLOWLIST: a persisted
+#: loop additionally carries its full re-injected instruction (``message``,
+#: LLM/user-authored) and ``stop_sentinel_path``, and this script's output lands
+#: in a chat transcript, so every emitted shape - text and ``--json`` alike - is
+#: a projection of these status fields, never the stored dict.
+REPORT_FIELDS = (
+    "id",
+    "slot_key",
+    "active",
+    "cycle_count",
+    "max_cycles",
+    "idle_secs",
+    "next_due_ts",
+)
+
+
+def project(loop):
+    """Return only the allowlisted status fields of *loop* (see REPORT_FIELDS)."""
+    return {k: loop.get(k) for k in REPORT_FIELDS if k in loop}
+
+
+def err(msg):
+    sys.stderr.write(msg + "\n")
+
+
+def store_path():
+    """Return the auto-nudge store path, honouring KIROCREW_HOME."""
+    home = os.environ.get("KIROCREW_HOME", "").strip()
+    root = Path(home).expanduser() if home else Path.home() / ".kiro" / "crew"
+    return root / STORE_NAME
+
+
+def load_loops(path):
+    """Return the store's loop dicts, or raise OSError/ValueError."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, list):  # tolerate a bare-list store
+        raw = data
+    elif isinstance(data, dict):
+        raw = data.get("loops") or []
+    else:
+        raise ValueError("unexpected store shape: {}".format(type(data).__name__))
+    return [lp for lp in raw if isinstance(lp, dict)]
+
+
+def pr_patterns(pr):
+    n = re.escape(str(pr))
+    return (
+        re.compile(r"\bPR\s*#?\s*" + n + r"\b", re.IGNORECASE),
+        re.compile(r"#" + n + r"\b"),
+        re.compile(r"/pull/" + n + r"\b"),
+    )
+
+
+def matches(loop, prs, texts):
+    message = str(loop.get("message") or "")
+    for pr in prs:
+        if not any(pat.search(message) for pat in pr_patterns(pr)):
+            return False
+    low = message.lower()
+    for text in texts:
+        if text.lower() not in low:
+            return False
+    return True
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("--pr", action="append", default=[])
+    ap.add_argument("--match", action="append", default=[])
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    args = ap.parse_args(argv)
+
+    path = store_path()
+    try:
+        loops = load_loops(path)
+    except FileNotFoundError:
+        err(
+            "ERROR: no auto-nudge store at {} - nothing has ever armed a loop "
+            "on this host. Treat as NOT armed.".format(path)
+        )
+        return 2
+    except (OSError, ValueError) as exc:
+        err("ERROR: cannot read {}: {}. Treat as NOT armed.".format(path, exc))
+        return 2
+
+    active = [lp for lp in loops if lp.get("active")]
+    hits = [lp for lp in active if matches(lp, args.pr, args.match)]
+
+    if not hits:
+        if args.as_json:
+            print(json.dumps({"armed": False, "active_loops": len(active)}, indent=2))
+        elif not active:
+            err(
+                "NOT ARMED: the loop store holds no active loop ({} total entr"
+                "{}). monitor_start reported a request, but nothing was applied."
+                "".format(len(loops), "y" if len(loops) == 1 else "ies")
+            )
+        else:
+            err(
+                "NOT ARMED for this work: {} active loop(s) exist, none matching "
+                "{}. A loop from other work is not this round's driver.".format(
+                    len(active),
+                    " + ".join(["PR " + str(p) for p in args.pr] + [repr(t) for t in args.match]),
+                )
+            )
+        return 20
+
+    if args.as_json:
+        print(
+            json.dumps(
+                {"armed": True, "loops": [project(lp) for lp in hits]}, indent=2, default=str
+            )
+        )
+    else:
+        for lp in hits:
+            print(
+                "ARMED: " + " ".join("{}={}".format(k, lp.get(k)) for k in REPORT_FIELDS if k in lp)
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/test_prepare_pr_monitor_armed.py
+++ b/test/test_prepare_pr_monitor_armed.py
@@ -1,0 +1,159 @@
+"""Tests for the prepare-pr monitor_armed.py loop-arming check.
+
+``monitor_start`` is a stateless session directive: the MCP tool returns "Monitor
+loop requested" and the loop is armed later, when the turn's tool result is
+consumed. Every drop on that path is silent to the model, so prepare-pr Phase 3
+verifies arming against the loop store instead of the reply text -- and these
+tests pin the two properties that verification depends on:
+
+- the exit contract (0 armed / 20 not armed / 2 store unreadable), because the
+  skill branches on it and a wrong code either strands a PR with nothing polling
+  it or declares a loop that does not exist;
+- the output allowlist: a persisted loop carries its full re-injected instruction
+  (``message``) and ``stop_sentinel_path``, and this script's output lands in a
+  chat transcript, so neither may appear in what it prints.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MONITOR_ARMED = str(
+    REPO_ROOT
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "kirocrew-dev"
+    / "prepare-pr"
+    / "scripts"
+    / "monitor_armed.py"
+)
+
+#: Stand-in for the sensitive halves of a persisted loop: the instruction text is
+#: LLM/user-authored and the sentinel is a local path.
+CANARY = "LEAK-CANARY-b3f1"
+
+
+def _store(**overrides: object) -> dict:
+    """A loop store holding one active loop for PR 6712 and one stopped loop."""
+    active = {
+        "id": "loop-1",
+        "slot_key": "chat-1",
+        "active": True,
+        "cycle_count": 3,
+        "max_cycles": 80,
+        "idle_secs": 300,
+        "next_due_ts": 123.0,
+        "message": "Re-poll PR #6712 with pr_status.py " + CANARY,
+        "stop_sentinel_path": "/tmp/" + CANARY + "/STOP",
+    }
+    active.update(overrides)
+    stopped = {
+        "id": "loop-2",
+        "slot_key": "chat-2",
+        "active": False,
+        "cycle_count": 9,
+        "message": "Re-poll PR #999",
+    }
+    return {"version": 1, "loops": [active, stopped]}
+
+
+def _write_store(home: Path, payload: object) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "autonudge.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _run(home: Path, *args: str) -> tuple[int, str]:
+    """Run monitor_armed.py against *home*; return (rc, stdout + stderr)."""
+    env = dict(os.environ, KIROCREW_HOME=str(home))
+    proc = subprocess.run(
+        [sys.executable, MONITOR_ARMED, *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+class TestTheExitContract:
+    def test_an_active_loop_naming_the_pr_is_armed(self, tmp_path: Path) -> None:
+        _write_store(tmp_path, _store())
+        rc, out = _run(tmp_path, "--pr", "6712")
+        assert rc == 0, out
+        assert "ARMED" in out
+
+    def test_a_shorter_number_does_not_match_a_longer_one(self, tmp_path: Path) -> None:
+        # Without word-boundary anchoring, --pr 671 would match "PR #6712" and
+        # report a loop that is driving a different PR.
+        _write_store(tmp_path, _store())
+        rc, _ = _run(tmp_path, "--pr", "671")
+        assert rc == 20
+
+    def test_a_stopped_loop_is_not_armed(self, tmp_path: Path) -> None:
+        # active=False is how the service records a loop it has torn down; a
+        # stopped loop polls nothing.
+        _write_store(tmp_path, _store())
+        rc, _ = _run(tmp_path, "--pr", "999")
+        assert rc == 20
+
+    def test_no_active_loop_at_all_is_not_armed(self, tmp_path: Path) -> None:
+        _write_store(tmp_path, {"version": 1, "loops": []})
+        rc, _ = _run(tmp_path, "--pr", "6712")
+        assert rc == 20
+
+    def test_an_unfiltered_check_accepts_any_active_loop(self, tmp_path: Path) -> None:
+        _write_store(tmp_path, _store())
+        rc, _ = _run(tmp_path)
+        assert rc == 0
+
+    def test_a_missing_store_is_an_environment_error(self, tmp_path: Path) -> None:
+        # Nothing has ever armed a loop on this host: exit 2, which the skill
+        # routes to the same wait-loop fallback as 20 rather than to "armed".
+        rc, _ = _run(tmp_path, "--pr", "6712")
+        assert rc == 2
+
+    def test_a_corrupt_store_is_an_environment_error(self, tmp_path: Path) -> None:
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "autonudge.json").write_text("{not json", encoding="utf-8")
+        rc, _ = _run(tmp_path, "--pr", "6712")
+        assert rc == 2
+
+    def test_a_bare_list_store_is_still_read(self, tmp_path: Path) -> None:
+        _write_store(tmp_path, _store()["loops"])
+        rc, _ = _run(tmp_path, "--pr", "6712")
+        assert rc == 0
+
+
+class TestTheOutputCarriesNoLoopPayload:
+    def test_the_text_report_omits_the_message_and_sentinel(self, tmp_path: Path) -> None:
+        _write_store(tmp_path, _store())
+        rc, out = _run(tmp_path, "--pr", "6712")
+        assert rc == 0
+        assert CANARY not in out
+        assert "cycle_count=3" in out  # the status fields the caller does need
+
+    def test_the_json_report_is_a_projection_not_the_stored_loop(self, tmp_path: Path) -> None:
+        _write_store(tmp_path, _store())
+        rc, out = _run(tmp_path, "--pr", "6712", "--json")
+        assert rc == 0
+        assert CANARY not in out
+        payload = json.loads(out)
+        assert payload["armed"] is True
+        emitted = set(payload["loops"][0])
+        assert "message" not in emitted
+        assert "stop_sentinel_path" not in emitted
+        assert {"id", "slot_key", "cycle_count"} <= emitted
+
+    def test_an_unmatched_check_reports_only_a_count(self, tmp_path: Path) -> None:
+        _write_store(tmp_path, _store())
+        rc, out = _run(tmp_path, "--pr", "4242", "--json")
+        assert rc == 20
+        assert CANARY not in out
+        assert json.loads(out) == {"armed": False, "active_loops": 1}


### PR DESCRIPTION
## Problem / Motivation

In the `prepare-pr` skill, Phase 3 hands the CI-polling round to `monitor_start` and
ends the turn. Sometimes nothing ever polls the PR: the tool reported a loop, the
turn ended, and no round ever ran.

`monitor_start` is a *stateless session directive* (`src/kiro_crew/session_directive.py`).
The MCP tool only validates its arguments and returns `"Monitor loop requested ..."`
plus a marker; the loop is armed later, when the turn's tool result is consumed by
the session-aware consumer (`dashboard/chat_runner.py` -> `session_directive_apply.py`).
Every drop on that path is silent to the caller:

- the consumer honours a directive only when the tool CALL was recorded with
  `_meta.kiro.mcpServerName == kirocrew-core`; without that identity the marker is
  stripped and no warning is even logged (the "decode FAILED" warning fires only
  when a directive tool WAS recorded);
- an over-size payload is refused before delivery;
- a slot-less turn (sub-agent, cron, webhook, task-runner) is denied with "no
  session to act on".

The skill made this worse by prescribing the opposite of a check: *"Any other reply,
including a bare requested -> treat as armed and end the turn."* So the one shape
that means "nothing was applied" was documented as success.

## Why it matters

The failure is invisible on both sides. The agent believes a driver is armed and
stops; the PR sits with red CI or an unanswered blocking finding and nothing wakes
anyone. It surfaces only when a human notices hours later that the PR never moved —
exactly the stall the in-session loop exists to prevent. It also degrades silently in
the contexts where it can never work at all (the pr-drive task runner), where the
correct behaviour is a plain in-turn `wait` loop.

## What changed (motivation → approach → change)

Symptom: rounds stop with no poller. Root cause: arming is a second, later step whose
failures are silent, and the skill told the agent to treat the pre-arm acknowledgement
as proof. A doc-only "be careful" would not fix it — the agent has no evidence channel
other than the reply text, so the fix has to give it one.

- **New script `scripts/monitor_armed.py`** — reads the auto-nudge loop store
  (`$KIROCREW_HOME/autonudge.json`, else `~/.kiro/crew/autonudge.json`) and reports
  whether an ACTIVE loop is present, with `--pr N` requiring the loop's own
  instruction to name that PR so a leftover loop from other work cannot pass as this
  round's driver. Exit codes match the skill's existing style: **0** armed,
  **20** not armed, **2** store unreadable (documented as "treat exactly like 20").
  Read-only, stdlib only, no shell pipelines.
  Its output is a **projection of allowlisted status fields** (`REPORT_FIELDS`) on
  every path, text and `--json` alike: a persisted loop also carries its full
  re-injected instruction (`message`) and `stop_sentinel_path`, and this output lands
  in a chat transcript.
- **`SKILL.md` Phase 3, exit-10 branch** — replaces "treat any reply as armed" with a
  mandatory `monitor_armed.py --pr <n>` check before the turn ends, and says what to do
  on each code (20 -> re-arm once, re-check, then fall back to an in-turn `wait` loop
  and tell the user; never end the turn on a 20). A synchronous refusal still needs no
  check, since it already reports that no loop is running.
- **`SKILL.md`, before the call** — two pre-conditions that were silently mishandled:
  under MCP Tool Search the first call fails `A tool with the name 'monitor_start'
  does not exist` (DEFERRED, load it with `tool_search(tool_id="kirocrew-core::monitor_start")`
  and repeat), and a slot-less turn can never arm a loop, so it should skip
  `monitor_start` entirely and drive the round with `wait`.
- **`SKILL.md` script table** — one row for the new script and its exit codes.

## Tests

`test/test_prepare_pr_monitor_armed.py` (11 tests, two classes):

- **`TestTheExitContract`** — an active loop naming the PR is 0; a shorter number
  (`--pr 671` against `PR #6712`) is 20, pinning the word-boundary anchoring; a
  stopped loop (`active: False`) is 20; an empty loop list is 20; an unfiltered check
  accepts any active loop; a missing store and a corrupt store are both 2; a bare-list
  store is still read.
- **`TestTheOutputCarriesNoLoopPayload`** — neither the text report nor `--json` emits
  the loop's `message` or `stop_sentinel_path` (a canary planted in both), the `--json`
  armed payload is asserted to be a field projection, and the not-armed payload carries
  only a count. Mutation-verified: restoring the raw `hits` serialization fails exactly
  the `--json` projection test and nothing else.

## Manual verification

Ran the script against a synthetic store under a throwaway `KIROCREW_HOME`, covering
each documented exit code (0 / 20 / 2) and confirming the canary text never appears in
either output shape. Also ran it against this host's real store while no loop was
armed: exit 20 with `NOT ARMED: the loop store holds no active loop`, which is the
condition that motivated the PR.

Local gates on the pushed commit: isort, flake8, mypy (1155 files), black gate,
subprocess-encoding gate, docs-lint, and 366 tests across the skill/prepare-pr
suites (`test_prepare_pr_monitor_armed`, `test_skills`, `test_prepare_pr_profiles`,
`test_prepare_pr_status`, `test_push_guard`, `test_skill_home_paths`).

## Related Issues

no linked issue: found while driving another PR in this repo, filed directly as the fix.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
