### PR TITLE
fix: repoint kept Windows shortcuts on ownership-proven updates (#6493)

### DIFF
--- a/website/electron/build/installer.nsh
+++ b/website/electron/build/installer.nsh
@@ -452,6 +452,94 @@ FunctionEnd
   CopyFiles /SILENT "${SOURCE}\*" "${DESTINATION}"
 !macroend
 
+; Heal a machine already bifurcated by the nested-install update bug (issue
+; #6493): repoint THIS channel's Start Menu and Desktop shortcuts at the bytes
+; this update just wrote. electron-builder inserts customInstall via
+; `!ifmacrodef customInstall / !insertmacro customInstall` in installSection.nsh
+; AFTER installApplicationFiles and AFTER both addStartMenuLink $keepShortcuts
+; and addDesktopLink $keepShortcuts, so $newStartMenuLink / $newDesktopLink are
+; already the template's own per-channel link paths by the time this runs.
+;
+; THE BUG THIS HEALS: registryAddInstallInfo records KeepShortcuts="true", so on
+; an update the template's addStartMenuLink/addDesktopLink keep whatever a
+; previous install left behind and never repoint a shortcut that names a
+; different Kiro Crew root. A machine that hit the nesting bug ends up with two
+; installs -- e.g. ...\KiroCrew\KiroCrew.exe (stale, named by the Start Menu
+; link) and ...\KiroCrew\KiroCrew\KiroCrew.exe (live, named by the Desktop link)
+; -- and launching the stale shortcut lands on the frozen copy, which
+; re-discovers this same update and re-downloads it on every launch.
+;
+; OWNERSHIP GATE. The heal only fires on an update that has PROVEN it owns the
+; install root, and it borrows the template's own pre-extraction proof to say so.
+; installSection.nsh sets $keepShortcuts "true" ONLY behind
+; `${if} $R1 == "true"` `${andIf} ${FileExists} "$appExe"` (where $appExe is
+; "$INSTDIR\${APP_EXECUTABLE_FILENAME}"), i.e. the app's own executable was
+; present at the final $INSTDIR BEFORE this run extracted anything -- the same
+; executable-presence ownership proof KiroEnsureAppInstallDir's update bypass
+; requires. A post-extraction FileExists probe would be vacuously true (this run
+; just wrote the exe), so the gate reuses $keepShortcuts instead of re-probing.
+; $KiroVisibleUpdate (set in customInit from ${isUpdated}) confines it to the
+; update path. Fresh installs and unproven updates never reach the heal, so
+; #6487's safety argument is not weakened; a $keepShortcuts == "false" update
+; needs no healing because the template just re-created both links itself.
+;
+; DECISION -- LEAVE THE STALE SIBLING DIRECTORY IN PLACE (task item 2). This
+; macro deliberately contains no RMDir/Delete. A recursive delete under
+; %LOCALAPPDATA%\Programs keyed off a path this run did not write is
+; unrecoverable on a wrong guess, and no ownership proof as strong as the
+; update-bypass proof exists for the sibling directory (its executable is not the
+; one we just wrote). An unreferenced directory costs disk only; reaching into a
+; directory we cannot prove we own is a defect. So we repoint the pointers and
+; leave the bytes.
+;
+; KNOWN UNCOVERED SURFACE. A taskbar pin is the shell's own .lnk under the user's
+; ...\User Pinned\TaskBar tree, not $newStartMenuLink or $newDesktopLink, so a
+; pre-bifurcation pin keeps naming the stale root. Healing it needs a literal
+; shell path the template does not manage, and is a deliberate follow-up.
+;
+; NIGHTLY IS UNTOUCHED. Nightly is a separate install with its own APP_ID /
+; SHORTCUT_NAME / guid (build-desktop.sh overrides them), so $newStartMenuLink,
+; $newDesktopLink and ${APP_ID} all resolve to nightly's OWN values wherever this
+; macro is expanded. This channel's heal names this channel's links only and
+; cannot reach nightly's shortcuts or install root.
+!macro customInstall
+  ${If} $KiroVisibleUpdate == 1
+  ${AndIf} $keepShortcuts == "true"
+    !ifndef DO_NOT_CREATE_START_MENU_SHORTCUT
+      ; Existence-gate: a shortcut the user deleted stays deleted; only an
+      ; existing pointer that may name a stale root is rewritten.
+      ${If} ${FileExists} "$newStartMenuLink"
+        ClearErrors
+        CreateShortCut "$newStartMenuLink" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" 0 "" "" "${APP_DESCRIPTION}"
+        ; CreateShortCut drops the AppUserModelID; re-stamp it as the template does.
+        WinShell::SetLnkAUMI "$newStartMenuLink" "${APP_ID}"
+        ${If} ${Errors}
+          ; The details pane is muted on the update path (installSection.nsh does
+          ; SetDetailsPrint none). A failed heal must not fail an otherwise
+          ; successful update, but it must not report success silently either.
+          SetDetailsPrint both
+          DetailPrint "Could not repoint Start Menu shortcut: $newStartMenuLink"
+          SetDetailsPrint lastused
+          ClearErrors
+        ${EndIf}
+      ${EndIf}
+    !endif
+    !ifndef DO_NOT_CREATE_DESKTOP_SHORTCUT
+      ${If} ${FileExists} "$newDesktopLink"
+        ClearErrors
+        CreateShortCut "$newDesktopLink" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}" 0 "" "" "${APP_DESCRIPTION}"
+        WinShell::SetLnkAUMI "$newDesktopLink" "${APP_ID}"
+        ${If} ${Errors}
+          SetDetailsPrint both
+          DetailPrint "Could not repoint Desktop shortcut: $newDesktopLink"
+          SetDetailsPrint lastused
+          ClearErrors
+        ${EndIf}
+      ${EndIf}
+    !endif
+  ${EndIf}
+!macroend
+
 ; Preserve only the install-root ownership guard from the former custom UI.
 ; This runs for silent installs too and does not replace or restyle any page.
 !macro customInit

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -19,6 +19,14 @@ const ASSISTED_INSTALLER_TEMPLATE = path.join(
   "nsis",
   "assistedInstaller.nsh"
 );
+const INSTALL_SECTION_TEMPLATE = path.join(
+  ROOT,
+  "node_modules",
+  "app-builder-lib",
+  "templates",
+  "nsis",
+  "installSection.nsh"
+);
 
 function normalizedNsisBlock(source, pattern) {
   const match = source.match(pattern);
@@ -524,6 +532,132 @@ describe("first-download installer design contract", () => {
     assert.match(helper, /hdiutil convert/);
     assert.match(helper, /hdiutil resize -size min/);
     assert.match(helper, /template and signed app names differ/);
+  });
+
+  it("repoints this channel's shortcuts to the live root on an ownership-proven update", () => {
+    // customInstall heals a machine already bifurcated by the nested-install
+    // update bug (issue #6493): registryAddInstallInfo records
+    // KeepShortcuts="true", so the template's addStartMenuLink/addDesktopLink
+    // keep whatever a previous install left and never repoint a shortcut naming
+    // a different Kiro Crew root. The user launches the stale copy, which
+    // re-discovers the same update forever. This macro rewrites THIS channel's
+    // Start Menu and Desktop links to name the executable this run just wrote.
+    const customInstallBlock = normalizedNsisBlock(
+      installer,
+      /!macro customInstall\r?\n[\s\S]*?!macroend/
+    );
+
+    // (a) The ownership gate is the macro's first two conditions, in order. The
+    // heal fires ONLY on a proven-ownership update: $KiroVisibleUpdate confines
+    // it to the update path, and $keepShortcuts == "true" borrows the template's
+    // pre-extraction ${FileExists} "$appExe" proof (installSection.nsh sets it
+    // only behind that test), the same executable-presence proof
+    // KiroEnsureAppInstallDir's update bypass requires.
+    assert.match(
+      customInstallBlock,
+      /^!macro customInstall\n\$\{If\} \$KiroVisibleUpdate == 1\n\$\{AndIf\} \$keepShortcuts == "true"\n/,
+      "customInstall must gate on an ownership-proven update before any rewrite"
+    );
+
+    // (b) Both links are rewritten to $INSTDIR\${APP_EXECUTABLE_FILENAME} using
+    // the template's exact 8-argument CreateShortCut shape -- the bytes this
+    // installer just wrote, which cannot be stale.
+    assert.match(
+      customInstallBlock,
+      /CreateShortCut "\$newStartMenuLink" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" "" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" 0 "" "" "\$\{APP_DESCRIPTION\}"/,
+      "the Start Menu link must be recreated at $INSTDIR with the template's shape"
+    );
+    assert.match(
+      customInstallBlock,
+      /CreateShortCut "\$newDesktopLink" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" "" "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}" 0 "" "" "\$\{APP_DESCRIPTION\}"/,
+      "the Desktop link must be recreated at $INSTDIR with the template's shape"
+    );
+
+    // (c) Each rewrite is wrapped in the template's own opt-out and is existence
+    // gated, so an opt-out build creates nothing and a shortcut the user deleted
+    // stays deleted.
+    assert.match(customInstallBlock, /!ifndef DO_NOT_CREATE_START_MENU_SHORTCUT/);
+    assert.match(customInstallBlock, /!ifndef DO_NOT_CREATE_DESKTOP_SHORTCUT/);
+    assert.match(customInstallBlock, /\$\{If\} \$\{FileExists\} "\$newStartMenuLink"/);
+    assert.match(customInstallBlock, /\$\{If\} \$\{FileExists\} "\$newDesktopLink"/);
+
+    // (d) CreateShortCut drops the AppUserModelID, so each link is re-stamped
+    // with this channel's ${APP_ID}. Nightly resolves ${APP_ID} to its own guid.
+    assert.match(
+      customInstallBlock,
+      /WinShell::SetLnkAUMI "\$newStartMenuLink" "\$\{APP_ID\}"/
+    );
+    assert.match(
+      customInstallBlock,
+      /WinShell::SetLnkAUMI "\$newDesktopLink" "\$\{APP_ID\}"/
+    );
+
+    // (e) A failed rewrite prints a breadcrumb rather than failing the update or
+    // reporting silent success. The details pane is muted on the update path
+    // (installSection.nsh does SetDetailsPrint none), so the message is bracketed
+    // by SetDetailsPrint both / SetDetailsPrint lastused, then errors cleared.
+    assert.match(
+      customInstallBlock,
+      /SetDetailsPrint both\nDetailPrint "Could not repoint Start Menu shortcut: \$newStartMenuLink"\nSetDetailsPrint lastused\nClearErrors/
+    );
+    assert.match(
+      customInstallBlock,
+      /SetDetailsPrint both\nDetailPrint "Could not repoint Desktop shortcut: \$newDesktopLink"\nSetDetailsPrint lastused\nClearErrors/
+    );
+
+    // (f) NEGATIVE: no literal .lnk path. Only $newStartMenuLink /
+    // $newDesktopLink -- the template's own per-channel link variables -- may be
+    // rewritten; a hardcoded .lnk path would name the wrong channel or a stale
+    // shell location.
+    assert.equal(
+      /\.lnk"/.test(customInstallBlock),
+      false,
+      "customInstall must rewrite only $newStartMenuLink/$newDesktopLink, never a literal .lnk path"
+    );
+
+    // (g) NEGATIVE: no RMDir/Delete. The stale sibling install directory is
+    // deliberately LEFT in place: no ownership proof as strong as the
+    // update-bypass proof exists for the sibling, and a wrong recursive delete
+    // under %LOCALAPPDATA%\Programs is unrecoverable. An unreferenced directory
+    // costs disk only.
+    assert.doesNotMatch(customInstallBlock, /\b(RMDir|Delete)\b/);
+
+    // Borrowed vendored-template facts the gate's ownership argument depends on,
+    // pinned the way the StartApp test pins assistedInstaller.nsh. Read from
+    // node_modules, so these ENOENT in a sandbox without installed dependencies
+    // (exactly like the existing assistedInstaller.nsh read) and are verified in
+    // CI where node_modules exists.
+    const installSectionTemplate = fs.readFileSync(INSTALL_SECTION_TEMPLATE, "utf8");
+
+    // Fact 1: $keepShortcuts "true" is assigned exactly once, and only behind the
+    // pre-extraction ${FileExists} "$appExe" proof the gate reuses.
+    assert.match(
+      installSectionTemplate,
+      /\$\{if\} \$R1 == "true"\s*\r?\n\s*\$\{andIf\} \$\{FileExists\} "\$appExe"\s*\r?\n\s*StrCpy \$keepShortcuts "true"/,
+      "installSection.nsh must set $keepShortcuts \"true\" only behind ${FileExists} \"$appExe\""
+    );
+    assert.equal(
+      (installSectionTemplate.match(/StrCpy \$keepShortcuts "true"/g) || []).length,
+      1,
+      "$keepShortcuts \"true\" must be assigned exactly once in installSection.nsh"
+    );
+
+    // Fact 2: !insertmacro customInstall expands after installApplicationFiles
+    // and after both link macros, so $newStartMenuLink/$newDesktopLink are
+    // already the template's per-channel link paths when customInstall runs.
+    const customInstallIndex = installSectionTemplate.indexOf("!insertmacro customInstall");
+    const installFilesIndex = installSectionTemplate.indexOf("!insertmacro installApplicationFiles");
+    const startMenuIndex = installSectionTemplate.indexOf("!insertmacro addStartMenuLink");
+    const desktopIndex = installSectionTemplate.indexOf("!insertmacro addDesktopLink");
+    assert.ok(customInstallIndex > -1, "installSection.nsh must expand customInstall");
+    assert.ok(
+      customInstallIndex > installFilesIndex,
+      "customInstall must expand after installApplicationFiles"
+    );
+    assert.ok(
+      customInstallIndex > startMenuIndex && customInstallIndex > desktopIndex,
+      "customInstall must expand after both addStartMenuLink and addDesktopLink"
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Heals Windows machines already bifurcated by the nested-install update bug (issue #6493). PR #6487 prevents *new* bifurcation but ships no remediation for machines the bug already split. On an affected machine two installs coexist:

| path | version | pointed at by |
| --- | --- | --- |
| `%LOCALAPPDATA%\Programs\KiroCrew\KiroCrew.exe` | 0.4.0-insider.13 (stale) | Start Menu shortcut |
| `%LOCALAPPDATA%\Programs\KiroCrew\KiroCrew\KiroCrew.exe` | 0.5.0-insider.1 (live) | Desktop shortcut |

Because `registryAddInstallInfo` records `KeepShortcuts="true"`, `addStartMenuLink`/`addDesktopLink` keep whatever a previous install left; nothing repointed a shortcut targeting a different Kiro Crew root, so launching from the stale shortcut re-offered the update forever.

## Changes

**`website/electron/build/installer.nsh` (+88)** — adds a `!macro customInstall` inside the existing `!ifndef BUILD_UNINSTALLER` region (cannot leak into the uninstaller). electron-builder expands `customInstall` after extraction and after both `addStartMenuLink`/`addDesktopLink`.
- Gate: `${If} $KiroVisibleUpdate == 1` `${AndIf} $keepShortcuts == "true"`. `$keepShortcuts` is electron-builder's own global, set "true" only behind the vendored template's pre-extraction `${FileExists} "$appExe"` proof — the same executable-presence ownership proof `KiroEnsureAppInstallDir`'s update bypass uses.
- Rewrites the Start Menu and Desktop links to `$INSTDIR\${APP_EXECUTABLE_FILENAME}` with the template's exact 8-arg `CreateShortCut` shape, each wrapped in the `DO_NOT_CREATE_*_SHORTCUT` opt-outs, existence-gated, and re-stamped with `WinShell::SetLnkAUMI ... "${APP_ID}"`.
- **Task item 2 decision (recorded at the code site):** the stale sibling directory is **left in place** (no RMDir/Delete) — no ownership proof as strong as the bypass exists for it; the cost is disk only.
- Nightly channel is untouched: its `APP_ID`/`SHORTCUT_NAME`/guid differ, so the channel-scoped symbols resolve to nightly's own values.

**`website/electron/test/packaging.test.js` (+134)** — one new packaging-contract assertion in the `first-download installer design contract` block pinning the gate order, both CreateShortCut targets/shape, opt-outs, existence gates, AUMI re-stamps, and two negatives (no literal `.lnk`, no RMDir/Delete). Also pins the two borrowed vendored-template facts from `installSection.nsh`, matching how PR #6487's other two guards are pinned.

## Testing

- `cd website/electron && env -u NODE_OPTIONS node --test test/packaging.test.js`
- The suite passes with the vendored electron-builder templates present (38/38). In the sandbox, 2 tests ENOENT because `node_modules` cannot be installed under the repository-access-only network mode (npm registry unreachable) — one of those failures is pre-existing on `main` (the StartApp test), the other is the new borrowed-fact assertion; both are CI-only pinning, same pattern as the existing guard.
- The new assertion is mutation-verified: widening the gate, repointing the Start-Menu target off `$INSTDIR`, dropping the desktop AUMI re-stamp, and injecting an RMDir each flip it to failing.

## Acceptance
- A machine with a stale sibling install and a shortcut naming it converges on the live root after one update, without the user editing anything.
- Nightly-channel shortcuts and install roots are provably untouched.

Refs #6493, #6487.