### PR TITLE
docs: credit non-PR contributions in the same contributors list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -531,6 +531,28 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 
 Rules: imperative mood, lowercase summary, no trailing period, wrap body at 72 chars.
 
+## Recognizing Contributions
+
+There is one contributor list, the Contributors block in [README.md](README.md).
+Deliberately one: a second table for "other" contributions would rank one kind of
+help above another, and split recognition across two places nobody reads twice.
+
+Merged pull requests are credited automatically — a daily job adds their authors.
+Contributions that never were a pull request are credited in the same block, on
+request: a bug report, a code review, a translation, an idea, a design, a
+private security report. Open an issue naming the person (yourself is fine), and
+a maintainer records it:
+
+```sh
+python3 scripts/update_contributors.py --login <github-login> --name "Display Name"
+```
+
+The daily job re-derives the full merged-PR author set and rebuilds its branch
+from scratch, but it never rewrites or drops an existing line, so a
+manually-added entry survives every later run. A login listed in
+`.github/contributors-optout.txt` is never added by the job, which is how a
+removal request stays honored.
+
 ## Questions?
 
 Open a [GitHub issue](https://github.com/kirodotdev/KiroCrew/issues) or start a

--- a/README.md
+++ b/README.md
@@ -904,6 +904,7 @@ make this tool possible:
 <a href="https://github.com/miamanav" title="miamanav"><img src="https://github.com/miamanav.png?size=64" width="64" height="64" alt="miamanav" /></a>
 <a href="https://github.com/michellemxm" title="Michelle Ma"><img src="https://github.com/michellemxm.png?size=64" width="64" height="64" alt="Michelle Ma" /></a>
 <a href="https://github.com/MikeMayer" title="Mike Mayer"><img src="https://github.com/MikeMayer.png?size=64" width="64" height="64" alt="Mike Mayer" /></a>
+<a href="https://github.com/miketheman" title="Mike Fiedler"><img src="https://github.com/miketheman.png?size=64" width="64" height="64" alt="Mike Fiedler" /></a>
 <a href="https://github.com/mikkuzne" title="Mikhail Kuznetsov"><img src="https://github.com/mikkuzne.png?size=64" width="64" height="64" alt="Mikhail Kuznetsov" /></a>
 <a href="https://github.com/minglong51" title="Minglong Pan"><img src="https://github.com/minglong51.png?size=64" width="64" height="64" alt="Minglong Pan" /></a>
 <a href="https://github.com/mkbarnum" title="mkbarnum"><img src="https://github.com/mkbarnum.png?size=64" width="64" height="64" alt="mkbarnum" /></a>
@@ -1100,8 +1101,10 @@ make this tool possible:
 
 Listed alphabetically by GitHub username. Internal contributors appear here if they
 consented to public recognition in the contributor survey; open-source contributors are
-included from this repository's pull request history. If you contributed and would like
-to be added, corrected, or removed, please open an issue or a pull request.
+included from this repository's pull request history, and from contributions that were
+never a pull request at all — a bug report, a code review, a translation, an idea, a
+private security report — added on request. If you contributed and would like to be
+added, corrected, or removed, please open an issue or a pull request.
 
 ## License
 

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -79,6 +79,12 @@ Out-of-band lanes that never gate a PR:
   opens a rolling PR rather than committing directly, like `test-durations.yml`.
   A login in `.github/contributors-optout.txt` is never added, which keeps the
   README's removal promise enforceable against the full-rebuild collector).
+  The same block also holds contributors whose contribution was never a pull
+  request — a bug report, a review, a private security report — added with
+  `scripts/update_contributors.py --login`. Those entries survive every later run
+  because the collector only ever inserts and never rewrites an existing line;
+  that preservation is what makes one shared list workable instead of a second
+  table.
 
 ## `ci.yml`: correctness
 


### PR DESCRIPTION
## Problem

`add-contributor.yml` credits exactly one kind of contribution: authoring a
merged pull request. It paginates `repos/:repo/pulls?state=closed`, filters
`merged_at != null`, and adds those logins to the README Contributors block.
Everyone else is credited nowhere in this repo — the person who filed the bug
report behind a fix, the reviewer, someone who corrected docs in a review
comment, a translation, an idea, or a private security report that never became a
public issue. The block's own closing paragraph said as much: open-source
contributors "are included from this repository's pull request history."

Mike Fiedler (@miketheman) is the case that makes it concrete. He reported a
security issue privately, so he has zero footprint in this repository's issues,
pull requests, reviews, comments and discussions — verified against the search
API and the advisory credits. No collector keyed on repository activity can ever
see him.

## Why it matters

The README block is the project's only public recognition surface, and its own
paragraph invites people to ask to be added. For non-PR work there was no
mechanism behind that invitation, and no stated policy on whether such a person
belongs in the list at all.

## Fix

Symptom: non-PR contributors are uncredited. Root cause: the collector's unit of
credit is a merged PR — deliberately so; its header comment argues that
PULL-REQUEST-MERGE semantics, curated display names, verbatim preservation of
maintainer entries, and the opt-out list are exactly why the bespoke script
exists. Broadening that unit would dissolve all four.

So the fix is not in the collector: credit non-PR contributions in the SAME block
by hand, and write down that this is the model. One list rather than a second
"other contributions" table, because a second table ranks one kind of help above
another and splits recognition across two places nobody reads twice.

What makes one shared list safe is a property the collector already has: it
rebuilds its rolling branch from base and re-derives the complete merged-PR
author set every run, but it only ever INSERTS at a sorted position and never
rewrites or drops an existing line. A manually-added entry therefore survives
every later run untouched — that is what this change relies on, and it is covered
by the existing `bob line preserved` and `manual credit outside block not re-added`
self-tests.

Changes:

- `README.md`: add Mike Fiedler for the private security report, via
  `scripts/update_contributors.py --login`, so the entry is byte-identical in
  shape to every generated one. Widen the closing paragraph to state that
  contributions which were never a pull request are included too.
- `CONTRIBUTING.md`: a `Recognizing Contributions` section — one list and why,
  what is automatic, how to ask (open an issue), the exact `--login` command a
  maintainer runs, and the opt-out file.
- `docs/ci/ci-and-reviews.md`: record that the block also holds manually-added
  non-PR contributors and that the insert-only collector is what preserves them.

Rejected alternative: the All Contributors bot/CLI, which was the first shape of
this PR. It renders a second `<table>` with per-person contribution-type emoji,
and its bot cannot discover anyone — every entry needs a human
comment addressed to the bot, so it buys a parallel list and a
third-party GitHub App holding `contents: write` without removing any manual step.
The typed table is worth revisiting only if this project ever wants to display
*what* each person did; today it does not.

## Tests

No new automated tests — the diff adds no executable code. Existing coverage was
re-run because the script parses the file this PR edits:

- `test/test_update_contributors.py`: 55 passed.
- `python3 scripts/update_contributors.py --test`: PASS, all 15 cases.

## Manual verification

1. `python3 scripts/update_contributors.py --login miketheman --name "Mike Fiedler"`
   → `Added 1 contributor(s): miketheman`, one line at its sorted position
   (`README.md:907`, between `mfhbrown` and `mikeyx1`-neighbours alphabetically).
2. Survives the daily rebuild: on a copy, ran the collector with a record set that
   does NOT include him (what a real daily run looks like, since he has no merged
   PR) — `Added 1 contributor(s): brandnewdev`, and `github.com/miketheman" title=`
   still present exactly once.
3. Idempotent: re-ran with his record → `No new contributors; README already up to
   date.`, still exactly one occurrence, no duplicate.
