### PR TITLE
fix(chat): stop a trimmed paste vanishing when execCommand only claims success

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -2210,6 +2210,7 @@ function ChatInput({
     // the browser so the paste is never a silent no-op.
     if (cleaned !== pasted && cleaned !== '') {
       e.preventDefault()
+      const next = before + cleaned + after
       // Insert through the native input path so the textarea's own onChange runs:
       // that fires the /, @, $ picker detection, marks the edit user-driven, and
       // keeps native undo. Fall back to a controlled-value splice where
@@ -2218,9 +2219,19 @@ function ChatInput({
       try {
         inserted = typeof document.execCommand === 'function' && document.execCommand('insertText', false, cleaned)
       } catch { inserted = false }
-      if (inserted) return
+      // That boolean is not evidence on its own. iOS Safari's native paste
+      // callout reports success on a <textarea> and can leave the field
+      // untouched, and this branch has ALREADY called preventDefault() — so
+      // trusting the return value drops the paste with no visible trace at all.
+      // Read the DOM back instead, and reconcile the controlled value either
+      // way: after a real insert this is the same string the textarea's own
+      // onChange already pushed up (React bails), while an insert React never
+      // saw would otherwise be reverted to the stale `value` prop on the next
+      // render — the same silent vanish by a different route.
+      const nativeOk = inserted && ta.value === next
       valueFromUserRef.current = true
-      onChange(before + cleaned + after)
+      onChange(next)
+      if (nativeOk) return // the native insert placed the caret itself
       requestAnimationFrame(() => {
         if (ta && document.activeElement === ta) {
           const pos = before.length + cleaned.length

--- a/website/src/test/ChatInput.paste.test.tsx
+++ b/website/src/test/ChatInput.paste.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useState } from 'react'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
 import ChatInput from '../components/ChatInput'
@@ -332,18 +333,87 @@ describe('ChatInput paste: strip trailing blank lines', () => {
     expect(elapsed).toBeLessThan(1000)
   })
 
-  it('uses the native execCommand insertText path when available (fires the real onChange, not a direct splice)', () => {
+  it('uses the native execCommand insertText path when it verifiably inserted (keeps the real input pipeline)', () => {
     const onChange = vi.fn()
-    const exec = vi.fn(() => true)
+    const textarea = () => screen.getByRole('textbox') as HTMLTextAreaElement
+    // A truthful stub: the real execCommand mutates the field. Anything that
+    // only returns true without touching the DOM is the iOS shape covered below.
+    const exec = vi.fn((_cmd: unknown, _ui: unknown, text: unknown) => {
+      textarea().value = String(text)
+      return true
+    })
+    ;(document as unknown as { execCommand: (...a: unknown[]) => boolean }).execCommand = exec
+    renderWithProviders(
+      <ChatInput value="" onChange={onChange} onSend={vi.fn()} onPasteBlocksChange={vi.fn()} />,
+    )
+    pasteText(textarea(), 'just one line\n\n\n')
+    // Inserted via the native input pipeline with the trimmed text …
+    expect(exec).toHaveBeenCalledWith('insertText', false, 'just one line')
+    // … and the controlled value is reconciled to exactly what landed in the
+    // DOM. In a browser the textarea's own onChange has already reported this
+    // same string, so React bails; asserting it here is what keeps a native
+    // insert React never saw from being reverted to the stale `value` prop.
+    expect(onChange).toHaveBeenCalledWith('just one line')
+  })
+
+  it('still lands the paste when execCommand reports success but inserts NOTHING (iOS native paste callout)', () => {
+    // The regression this guards: handlePaste has already called
+    // preventDefault(), so returning on the strength of the boolean alone means
+    // the tap on iOS's "Paste" produces no text and no error — the paste just
+    // vanishes. Verified against the DOM, the controlled splice must still run.
+    const onChange = vi.fn()
+    const exec = vi.fn(() => true) // reports success, leaves the field empty
     ;(document as unknown as { execCommand: (...a: unknown[]) => boolean }).execCommand = exec
     renderWithProviders(
       <ChatInput value="" onChange={onChange} onSend={vi.fn()} onPasteBlocksChange={vi.fn()} />,
     )
     pasteText(screen.getByRole('textbox'), 'just one line\n\n\n')
-    // Inserted via the native input pipeline with the trimmed text …
-    expect(exec).toHaveBeenCalledWith('insertText', false, 'just one line')
-    // … so handlePaste does NOT splice onChange itself (the textarea's own
-    // onChange handles state + picker detection + user-edit flag).
-    expect(onChange).not.toHaveBeenCalled()
+    expect(exec).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('just one line')
+  })
+
+  it('positions the caret itself when the native insert only CLAIMED to work (the DOM read-back is load-bearing)', async () => {
+    // The other two cases pin that the text lands. This one pins the read-back
+    // that decides it: `inserted && ta.value === next`. Trusting the boolean
+    // alone still lands the text (onChange runs before the early return) but
+    // skips our caret placement, leaving the caret wherever the browser left
+    // it — so without a caret assertion that half of the fix is untested.
+    //
+    // The paste goes at the START of existing text on purpose. Assigning to
+    // `.value` parks the caret at the end, which is exactly where our own
+    // placement would land for an end-of-field paste — the two outcomes would
+    // coincide and the assertion would prove nothing.
+    const Host = () => {
+      const [v, setV] = useState('AB')
+      return <ChatInput value={v} onChange={setV} onSend={vi.fn()} onPasteBlocksChange={vi.fn()} />
+    }
+    // The iOS shape: reports success, never touches the field.
+    ;(document as unknown as { execCommand: (...a: unknown[]) => boolean }).execCommand = vi.fn(() => true)
+    renderWithProviders(<Host />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    ta.focus() // the rAF is gated on document.activeElement === ta
+    ta.setSelectionRange(0, 0)
+    pasteText(ta, 'x\n\n')
+    await vi.waitFor(() => expect(ta.value).toBe('xAB'))
+    // Caret sits after the inserted text, not at the end of the field.
+    await vi.waitFor(() => expect(ta.selectionStart).toBe(1))
+    expect(ta.selectionEnd).toBe(1)
+  })
+
+  it('reconciles against the DOM, not the requested text (a partial native insert is not success)', () => {
+    // A native path that inserts something OTHER than what was asked for must
+    // not be treated as authoritative either — the controlled value is the one
+    // the send path reads, so it has to be written explicitly.
+    const onChange = vi.fn()
+    const textarea = () => screen.getByRole('textbox') as HTMLTextAreaElement
+    ;(document as unknown as { execCommand: (...a: unknown[]) => boolean }).execCommand = vi.fn(() => {
+      textarea().value = 'just one'
+      return true
+    })
+    renderWithProviders(
+      <ChatInput value="" onChange={onChange} onSend={vi.fn()} onPasteBlocksChange={vi.fn()} />,
+    )
+    pasteText(textarea(), 'just one line\n\n\n')
+    expect(onChange).toHaveBeenCalledWith('just one line')
   })
 })


### PR DESCRIPTION
## Problem / Motivation

Paste text that carries trailing blank lines into the chat composer on iOS Safari and you can get **no text at all** — no error, nothing in the field, no trace that anything happened.

## Why it happens

`handlePaste` deliberately intercepts that clipboard shape so the trailing run can be stripped. Interception means it has already called `preventDefault()`, so **the browser will not insert anything itself**. It then re-inserts through `document.execCommand('insertText', …)` — on purpose, so the textarea's own `onChange` runs, which is what fires the `/`, `@`, `$` picker detection, marks the edit user-driven, and keeps native undo.

It then returned early on the strength of that call's return value:

```ts
inserted = document.execCommand('insertText', false, cleaned)
if (inserted) return
```

**That boolean is not evidence.** iOS Safari's native paste callout reports success on a `<textarea>` and can leave the field untouched. The browser's own insert was already cancelled, the early return skipped the fallback, and the paste was gone.

The same silent vanish had a second route: a native insert React never observed would be reverted to the stale `value` prop on the next render.

## What changed

Read the DOM back instead of trusting the return value, and reconcile the controlled value unconditionally:

```ts
const next = before + cleaned + after
const nativeOk = inserted && ta.value === next
valueFromUserRef.current = true
onChange(next)
if (nativeOk) return // the native insert placed the caret itself
```

After a real insert, that `onChange` writes the string the textarea's own onChange already pushed up, so React bails and the native path keeps owning the caret. When the insert did not happen — or landed something other than what was asked for — the controlled splice and our own caret placement still run.

Two independent parts, and the ordering matters: `onChange` moving **above** the early return is what lands the text; the `ta.value === next` read-back is what decides whether we also place the caret.

## Tests

Three cases in `website/src/test/ChatInput.paste.test.tsx`, **each mutation-verified**:

| Mutation | Result |
|---|---|
| move `onChange(next)` back below the early return | the two text-landing cases go red |
| `nativeOk = inserted` (drop the DOM read-back) | the caret case goes red |
| both reverted | back to 23 passing |

The caret case pastes at the **start** of existing text on purpose. Assigning to `.value` parks the caret at the end, which is exactly where our own placement would land for an end-of-field paste — the two outcomes would coincide and the assertion would prove nothing. Writing it the obvious way produces an inert test; this was caught by the mutation run, not by reading it.

One existing case was rewritten rather than added to: its `execCommand` stub returned `true` without touching the DOM, which is *the iOS shape itself*, so it was asserting the buggy behaviour was correct. The stub now mutates the field like the real API does.

## Manual verification

`npx vitest run src/test/ChatInput.paste.test.tsx` → 23 passed. Whole composer surface (`src/test/ChatInput*`) → 19 files / 392 passed. `npx tsc -b` clean. `npx eslint src/ --max-warnings 664` (CI's own ratchet) → rc=0, warning count identical to `origin/main`; the one warning in this file (`promptOptimizer` dep at :2130) is present unchanged on main and is not in this diff.

Not reproduced on a physical iPhone — the failing path is a WebKit-specific `execCommand` behaviour that neither jsdom nor headless Chromium exhibits. The tests pin the shape (reports success, field untouched) rather than the engine.

<!-- no-visual-delta -->

**Why no screenshot:** nothing rendered changes — the fix decides whether pasted
text *arrives* in the textarea, not how any pixel is styled, and the failing path
is a WebKit-only `execCommand` behaviour. A Chromium or jsdom capture shows the
same successful paste before and after the change, so a before/after image here
would assert the bug is absent on the one engine that never had it. The falsifiable
evidence is the mutation table above: revert either half and a named test reddens.

## Related Issues

no linked issue: found while auditing unlanded work in a local worktree, filed directly as the fix.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff

