### PR TITLE
ci: lead the UX review with a product-coherence lens

### DIFF
--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -379,6 +379,23 @@ jobs:
             only to surface findings. If a lens raises no finding, it produces
             NO output. Lenses 11–12 apply only when their surface is present.)
 
+            0. PRODUCT COHERENCE (run FIRST, before every other lens): put the
+               change next to the product it is joining. Open the sibling
+               surfaces that already do the closest job (Grep/Read
+               website/src; committed screenshots of existing pages when
+               present) and compare:
+               - LOOK — the new surface matches the product's established
+                 look: spacing, container shapes, elevation, typography,
+                 tokens.
+               - INFORMATION ARCHITECTURE — the same jobs use the same
+                 patterns: panel/sidebar toggles, close affordances, header
+                 layout, list rows, iconography. A user who has learned the
+                 rest of the product must not find this page strange.
+               - EARN EVERY ELEMENT — every button, label, and line of copy
+                 has a job a user needs done. Anything present without one is
+                 a finding.
+               Divergence from the product's established look or patterns is
+               a finding unless the PR states why this surface must differ.
             1. FIRST-TIME COMPREHENSION (the cold-read test): would a user
                seeing this for the first time understand what each label says
                and what each feature does?

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -199,6 +199,23 @@ jobs:
             only to surface findings. If a lens raises no finding, it produces
             NO output. Lenses 11–12 apply only when their surface is present.)
 
+            0. PRODUCT COHERENCE (run FIRST, before every other lens): put the
+               change next to the product it is joining. Open the sibling
+               surfaces that already do the closest job (Grep/Read
+               website/src; committed screenshots of existing pages when
+               present) and compare:
+               - LOOK — the new surface matches the product's established
+                 look: spacing, container shapes, elevation, typography,
+                 tokens.
+               - INFORMATION ARCHITECTURE — the same jobs use the same
+                 patterns: panel/sidebar toggles, close affordances, header
+                 layout, list rows, iconography. A user who has learned the
+                 rest of the product must not find this page strange.
+               - EARN EVERY ELEMENT — every button, label, and line of copy
+                 has a job a user needs done. Anything present without one is
+                 a finding.
+               Divergence from the product's established look or patterns is
+               a finding unless the PR states why this surface must differ.
             1. FIRST-TIME COMPREHENSION (the cold-read test): would a user
                seeing this for the first time understand what each label says
                and what each feature does?


### PR DESCRIPTION
## What

One addition to the UX Review prompt (both `ux-review.yml` and its `fork-` twin, which carry identical lens text): **lens 0, PRODUCT COHERENCE**, run before every other lens.

The lens is one principle — *put the change next to the product it is joining* — with three faces:

- **LOOK** — the new surface matches the product's established visual language (spacing, container shapes, elevation, typography, tokens).
- **INFORMATION ARCHITECTURE** — the same jobs use the same patterns (panel/sidebar toggles, close affordances, header layout, list rows, iconography). A user who has learned the rest of the product must not find this page strange.
- **EARN EVERY ELEMENT** — every button, label, and line of copy has a job a user needs done.

The evidence-gathering step (open the sibling surfaces that already do the closest job) is embedded in the principle itself, and deliberate divergence stays legal when the PR states why.

## Why

A recent members-page PR shipped a surface that diverged from the product on all three faces — list rows styled unlike the app's other conversation list, header iconography and layout matching no sibling page, and a chip announcing an invariant no user needs told — and the UX lane flagged none of it (the defects were caught by the PM reviewing the live build, and by other lanes on unrelated grounds).

The miss was a missing *frame*, not a missing rule: consistency lived as one lens among twelve, applied to the diff in isolation, and nothing directed the reviewer to look at the product first. Leading with coherence makes the comparison the reference frame for everything after it, and keeps the prompt principle-shaped instead of accreting one instance rule per postmortem. Lens 7 keeps its fine-grained consistency bullets (term drift, habituation, modes) as the complement.

## Testing

- `yaml.safe_load` passes on both files.
- The inserted section is byte-identical across the two variants (diff-verified).
- Prompt-only change inside the model instruction block; no step/trigger/permission changes. Lens numbering is untouched (the new lens is 0), so the preamble's "Lenses 11–12" reference stays correct.
