### PR TITLE
perf(dashboard): coalesce chat_thinking dispatches to one per frame

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -243,7 +243,11 @@ export function useWebSocket() {
   // index-map recomputes each dispatch triggers) happen ~per frame instead of
   // ~per token. lastSeq is carried across flushes so cross-batch gap detection
   // mirrors the reducer's per-chunk "N chunk(s) missed" marker.
-  const chunkBufRef = useRef<Map<string, { content: string; lastSeq: number | undefined }>>(new Map())
+  // `thinking` buffers reasoning-stream text (chat_thinking) in the SAME entry
+  // so both content types share one flush cycle and one lifecycle (reconnect
+  // clear, chat_done delete, unmount cancel); the flush dispatches thinking
+  // before content, matching a turn's thought-then-answer arrival order.
+  const chunkBufRef = useRef<Map<string, { content: string; lastSeq: number | undefined; thinking: string }>>(new Map())
   const chunkFlushScheduledRef = useRef(false)
   const chunkRafRef = useRef<number | null>(null)
   const chunkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -547,6 +551,12 @@ export function useWebSocket() {
     const activeSlot = store.getState().chat.activeSlot
     let dispatchedActive = false
     for (const [slot, entry] of buf) {
+      // Thinking first: within a turn the reasoning stream precedes the answer
+      // stream, so a frame holding both must land them in that order.
+      if (entry.thinking) {
+        dispatch(sseThinkingChunk({ slot, content: entry.thinking }))
+        entry.thinking = ''
+      }
       if (!entry.content) continue
       dispatch(sseChatMessage({ slot, role: 'chunk', content: entry.content, seq: entry.lastSeq, batched: true }))
       entry.content = ''
@@ -585,6 +595,22 @@ export function useWebSocket() {
     if (typeof requestAnimationFrame === 'function') chunkRafRef.current = requestAnimationFrame(() => flushChunks())
     else chunkTimerRef.current = setTimeout(() => flushChunks(), 16)
   }, [flushChunks])
+
+  /** Salvage buffered reasoning before the chunk buffer is dropped. Buffered
+   *  CONTENT may be discarded — refreshSlot recovers it from the server — but
+   *  reasoning is client-only (the backend never persists it), so anything
+   *  still buffered when the buffer is cleared (reconnect) or the hook unmounts
+   *  would be permanently lost. A hidden tab makes that window unbounded:
+   *  requestAnimationFrame is suspended there, so the scheduled flush never
+   *  runs while thinking keeps accumulating. */
+  const flushBufferedThinking = useCallback(() => {
+    for (const [slot, entry] of chunkBufRef.current) {
+      if (entry.thinking) {
+        dispatch(sseThinkingChunk({ slot, content: entry.thinking }))
+        entry.thinking = ''
+      }
+    }
+  }, [dispatch])
 
   /** Flush buffered slot-recency bumps: one touchSlotActivity per slot, not per
    *  event. Cancels any pending frame first, mirroring flushChunks. */
@@ -720,6 +746,9 @@ export function useWebSocket() {
         chunkRafRef.current = null
         chunkTimerRef.current = null
         chunkFlushScheduledRef.current = false
+        // Reasoning first: it is client-only, so unlike content the refresh
+        // below cannot recover it — land it in the store before the drop.
+        flushBufferedThinking()
         chunkBufRef.current.clear()  // drop pre-disconnect partial chunks; refreshSlot recovers state
         // Same for subagent chunks: pre-disconnect text must not cross a reconnect.
         if (subagentChunkRafRef.current != null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(subagentChunkRafRef.current)
@@ -1245,7 +1274,7 @@ export function useWebSocket() {
             if (cs) {
               const buf = chunkBufRef.current
               let entry = buf.get(cs)
-              if (!entry) { entry = { content: '', lastSeq: undefined }; buf.set(cs, entry) }
+              if (!entry) { entry = { content: '', lastSeq: undefined, thinking: '' }; buf.set(cs, entry) }
               // Cross-chunk gap detection via the shared missedChunkMarker,
               // single-sourced with the reducer so the two copies can't drift.
               if (entry.lastSeq !== undefined && data.seq !== undefined) {
@@ -1527,7 +1556,18 @@ export function useWebSocket() {
             break
           case 'chat_thinking': {
             // kiro-cli/ACP reasoning (agent_thought_chunk) -> collapsible block.
-            dispatch(sseThinkingChunk({ slot: data.slot, content: (data as { content?: string }).content || '' }))
+            // Buffered into the shared chunk buffer and flushed once per frame
+            // (see flushChunks): reasoning streams run for hundreds of tokens,
+            // and a per-token dispatch recomputes the O(N) displayItems on each.
+            const thinkSlot = data.slot as string | undefined
+            const thinkText = (data as { content?: string }).content || ''
+            if (thinkSlot && thinkText) {
+              const buf = chunkBufRef.current
+              let entry = buf.get(thinkSlot)
+              if (!entry) { entry = { content: '', lastSeq: undefined, thinking: '' }; buf.set(thinkSlot, entry) }
+              entry.thinking += thinkText
+              scheduleChunkFlush()
+            }
             // Dispatch the status detail only on a genuine kind TRANSITION into
             // 'thinking'. Guarding merely on `!== 'streaming'` would not
             // self-limit — 'thinking' is itself `!== 'streaming'`, so it would
@@ -1773,7 +1813,7 @@ export function useWebSocket() {
     }
 
     ws.onerror = () => { /* onclose will fire */ }
-  }, [dispatch, flushChunks, scheduleChunkFlush, bufferSlotActivity, bufferSubagentChunk, flushSubagentChunks, playNextVoiceChunk, queryClient, stopVoice, syncPendingApprovals, syncPendingQuestions, seedGoalLoops, recordRetiredId])
+  }, [dispatch, flushChunks, flushBufferedThinking, scheduleChunkFlush, bufferSlotActivity, bufferSubagentChunk, flushSubagentChunks, playNextVoiceChunk, queryClient, stopVoice, syncPendingApprovals, syncPendingQuestions, seedGoalLoops, recordRetiredId])
 
   /**
    * Force an immediate reconnect: cancels any pending backoff timer, closes
@@ -1852,6 +1892,9 @@ export function useWebSocket() {
       // otherwise leave a stale sidebar tint. The flush also cancels the scheduled frame.
       flushSlotActivity()
       flushSubagentChunks()
+      // Same for buffered reasoning: it is client-only and unrecoverable, unlike
+      // buffered content (which the next mount's refresh restores from the server).
+      flushBufferedThinking()
       wsRef.current?.close()
       wsRef.current = null
       window.removeEventListener('voice-stop', onVoiceStop)
@@ -1860,7 +1903,7 @@ export function useWebSocket() {
       unsubFocus()
       sendSlotFocusedImpl = () => {}
     }
-  }, [connect, stopVoice, flushSlotActivity, flushSubagentChunks])
+  }, [connect, stopVoice, flushSlotActivity, flushSubagentChunks, flushBufferedThinking])
 
   /** Subscribe to log events — call with callback on mount, null on unmount. */
   const subscribeLogs = useCallback((cb: LogCallback) => {

--- a/website/src/test/useWebSocket.thinkingChunkCoalesce.test.ts
+++ b/website/src/test/useWebSocket.thinkingChunkCoalesce.test.ts
@@ -1,0 +1,261 @@
+/**
+ * `chat_thinking` must buffer into the shared chunk buffer and flush once per
+ * frame, not dispatch per token. Reasoning streams run for hundreds of tokens,
+ * so a per-token dispatch recomputes the O(N) displayItems on every one.
+ * Mirrors the chat_chunk / subagent_chunk coalescing pattern.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store as globalStore } from '../store'
+import { setActiveSlot, clearSlotState } from '../store/chatSlice'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockReturnValue(new Promise(() => {})),  // never resolves
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+/** Deliberately the SINGLETON store: useWebSocket dispatches via useAppDispatch()
+ *  but reads state off the imported singleton, so a separate Provider store would
+ *  let reads and writes diverge. */
+function seedStore() {
+  globalStore.dispatch(clearSlotState())
+  globalStore.dispatch(setActiveSlot('slot-1'))
+  return globalStore
+}
+
+const thinkingRows = () =>
+  globalStore.getState().chat.messages.filter(m => m.role === 'thinking' && m.content)
+
+const streamingText = () =>
+  globalStore.getState().chat.messages.find(m => m.role === 'streaming')?.content ?? ''
+
+const thinking = (slot: string, content: string) => ({
+  type: 'chat_thinking',
+  data: { slot, content },
+})
+
+const chunk = (slot: string, content: string, seq?: number) => ({
+  type: 'chat_chunk',
+  data: { slot, content, ...(seq !== undefined ? { seq } : {}) },
+})
+
+describe('useWebSocket chat_thinking coalescing', () => {
+  let queryClient: QueryClient
+  let rafQueue: FrameRequestCallback[]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    rafQueue = []
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // Hand-driven frames: nothing flushes until runFrames() is called
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { rafQueue.push(cb); return rafQueue.length })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => { rafQueue[id - 1] = () => {} })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalStore.dispatch(clearSlotState())
+    globalStore.dispatch(setActiveSlot(null))
+  })
+
+  function runFrames() {
+    const pending = rafQueue
+    rafQueue = []
+    act(() => { pending.forEach(cb => cb(performance.now())) })
+  }
+
+  function mount() {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store: globalStore },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return { hook, ws }
+  }
+
+  it('does not dispatch synchronously on each thinking event', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => { ws.simulateMessage(thinking('slot-1', 'hmm ')) })
+
+    // Unbuffered code would insert a thinking row here; buffered code has not flushed.
+    expect(thinkingRows()).toHaveLength(0)
+
+    runFrames()
+    expect(thinkingRows()).toHaveLength(1)
+    expect(thinkingRows()[0].content).toBe('hmm ')
+  })
+
+  it('collapses a burst into one thinking row with all text concatenated', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => {
+      for (let i = 0; i < 40; i++) ws.simulateMessage(thinking('slot-1', `t${i} `))
+    })
+
+    expect(thinkingRows()).toHaveLength(0)
+
+    runFrames()
+
+    const expected = Array.from({ length: 40 }, (_, i) => `t${i} `).join('')
+    expect(thinkingRows()).toHaveLength(1)
+    expect(thinkingRows()[0].content).toBe(expected)
+  })
+
+  it('lands thinking before answer chunks when one frame holds both', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => {
+      ws.simulateMessage(thinking('slot-1', 'reasoning '))
+      ws.simulateMessage(chunk('slot-1', 'answer'))
+      ws.simulateMessage(thinking('slot-1', 'more'))
+    })
+    runFrames()
+
+    // One thinking row carrying the full reasoning text, positioned before the
+    // streaming answer row.
+    const msgs = globalStore.getState().chat.messages
+    const thinkIdx = msgs.findIndex(m => m.role === 'thinking' && m.content)
+    const streamIdx = msgs.findIndex(m => m.role === 'streaming')
+    expect(thinkIdx).toBeGreaterThanOrEqual(0)
+    expect(streamIdx).toBeGreaterThan(thinkIdx)
+    expect(msgs[thinkIdx].content).toBe('reasoning more')
+    expect(streamingText()).toBe('answer')
+  })
+
+  it('flushes buffered thinking synchronously before a chat_message lands', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => {
+      ws.simulateMessage(thinking('slot-1', 'buffered thought'))
+      ws.simulateMessage({ type: 'chat_message', data: { slot: 'slot-1', role: 'assistant', content: 'final' } })
+    })
+
+    // No frame ran, yet the thinking row exists and precedes the final message:
+    // chat_message's synchronous flushChunks() must drain the thinking buffer.
+    const msgs = globalStore.getState().chat.messages
+    const thinkIdx = msgs.findIndex(m => m.role === 'thinking' && m.content === 'buffered thought')
+    const finalIdx = msgs.findIndex(m => m.role === 'assistant' && m.content === 'final')
+    expect(thinkIdx).toBeGreaterThanOrEqual(0)
+    expect(finalIdx).toBeGreaterThan(thinkIdx)
+  })
+
+  it('keeps per-slot thinking independent and ignores inactive-slot rows in the transcript', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => {
+      ws.simulateMessage(thinking('slot-1', 'active '))
+      ws.simulateMessage(thinking('slot-2', 'other '))
+    })
+    runFrames()
+
+    // The reducer only renders the active slot's transcript; slot-2's text must
+    // not bleed into it.
+    expect(thinkingRows()).toHaveLength(1)
+    expect(thinkingRows()[0].content).toBe('active ')
+  })
+
+  it('keeps the messages array reference stable across a burst until the frame lands', () => {
+    const { ws } = mount()
+    const store = seedStore()
+    const before = store.getState().chat.messages
+
+    act(() => {
+      for (let i = 0; i < 12; i++) ws.simulateMessage(thinking('slot-1', 'x'))
+    })
+    expect(store.getState().chat.messages).toBe(before)
+
+    runFrames()
+    expect(store.getState().chat.messages).not.toBe(before)
+  })
+
+  it('salvages buffered thinking on reconnect instead of dropping it', () => {
+    // Fake ONLY setTimeout (the reconnect backoff): default fake timers also
+    // fake requestAnimationFrame, and advanceTimersByTime would then run the
+    // scheduled flush — emptying the buffer before the reconnect this test is
+    // about. The hand-driven rafQueue stub must stay in control so the buffer
+    // is genuinely unflushed when the socket reopens (as in a hidden tab).
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const { ws } = mount()
+      seedStore()
+
+      // Reasoning arrives but the frame never runs (a hidden tab suspends rAF).
+      act(() => { ws.simulateMessage(thinking('slot-1', 'unflushed reasoning')) })
+      expect(thinkingRows()).toHaveLength(0)
+
+      // Disconnect -> reconnect. Reasoning is client-only (never persisted
+      // server-side), so unlike buffered content the reconnect refresh cannot
+      // recover it: the reconnect branch must land it in the store before
+      // clearing the buffer.
+      act(() => { ws.onclose?.(new CloseEvent('close')) })
+      act(() => { vi.advanceTimersByTime(2000) })
+      const ws2 = WS_INSTANCES[1]
+      act(() => { ws2.simulateOpen() })
+
+      expect(thinkingRows()).toHaveLength(1)
+      expect(thinkingRows()[0].content).toBe('unflushed reasoning')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('salvages buffered thinking on unmount', () => {
+    const { hook, ws } = mount()
+    seedStore()
+
+    act(() => { ws.simulateMessage(thinking('slot-1', 'tail reasoning')) })
+    expect(thinkingRows()).toHaveLength(0)
+
+    // The store outlives the hook; buffered reasoning must not die with it.
+    hook.unmount()
+
+    expect(thinkingRows()).toHaveLength(1)
+    expect(thinkingRows()[0].content).toBe('tail reasoning')
+  })
+})

--- a/website/src/test/useWebSocket.thinkingStatusChurn.test.ts
+++ b/website/src/test/useWebSocket.thinkingStatusChurn.test.ts
@@ -137,7 +137,7 @@ describe('useWebSocket chat_thinking status-detail churn', () => {
     expect(store.getState().chat.slotStatusDetail).toBe(mapAfterFirst)
   })
 
-  it('still accumulates the reasoning text on every frame', () => {
+  it('still accumulates the reasoning text once the frame flush lands', async () => {
     const store = storeOnSlot1()
     const { ws } = mount(store)
 
@@ -146,6 +146,9 @@ describe('useWebSocket chat_thinking status-detail churn', () => {
       ws.simulateMessage(thinking('beta '))
       ws.simulateMessage(thinking('gamma'))
     })
+
+    // Thinking text is frame-buffered (see flushChunks); wait one frame for it.
+    await act(async () => { await new Promise(r => requestAnimationFrame(() => r(undefined))) })
 
     const think = store.getState().chat.messages.find(m => m.role === 'thinking')
     expect(think).toBeDefined()


### PR DESCRIPTION
## Problem / Motivation

During a streaming turn the dashboard animations stutter. Regular answer chunks (`chat_chunk`) and subagent chunks are already frame-buffered, but reasoning-stream tokens (`chat_thinking`) still dispatch `sseThinkingChunk` per token. Reasoning models emit hundreds to thousands of thought tokens per turn — often more than the answer itself — and each dispatch mutates `chat.messages`, which recomputes the O(N) transcript displayItems and re-renders subscribers on every token.

## Why it matters

Reasoning-heavy models make the thinking stream the dominant per-token dispatch source left in the hot path. On busy dashboards (many open sessions, long transcripts) this burns most of a frame budget per token, which users perceive as janky animations and sluggish scrolling for the entire duration of the model's reasoning.

## What changed (motivation → approach → change)

Symptom: per-token store commits during reasoning. Root cause: `chat_thinking` bypassed the existing chunk-coalescing path. Change: buffer thinking text into the SAME per-slot chunk buffer used by `chat_chunk` and flush once per animation frame. Reusing the shared buffer (rather than adding a parallel one) means thinking inherits the exact lifecycle already proven for content: synchronous flush before `chat_message` / `chat_segment` / `chat_done`, buffer clear on reconnect, cancel on unmount. Within a flush, thinking dispatches before answer content, matching a turn's thought-then-answer arrival order. The `setSlotStatusDetail` transition guard is unchanged (already idempotent per the churn tests).

Because reasoning is client-only (the backend never persists it — see the preserveThinking notes in `chatSlice.ts`), buffered thinking cannot be recovered by the reconnect refresh the way buffered content can. A `flushBufferedThinking()` salvage therefore lands any buffered reasoning in the store immediately before the reconnect buffer clear and on unmount — closing the loss window a hidden tab would otherwise make unbounded (rAF is suspended there). This was caught by pre-push blind review and fixed before opening this PR.

## Tests

- New `useWebSocket.thinkingChunkCoalesce.test.ts` (8 tests, mirrors the subagent coalescing harness): no synchronous dispatch per event; a 40-token burst lands as one thinking row with all text; thinking lands before answer chunks when one frame holds both; `chat_message` synchronously flushes buffered thinking before the final message; per-slot independence; `chat.messages` reference stability across a burst; reconnect and unmount salvage of buffered reasoning (fake timers restricted to setTimeout so the rAF stub keeps the buffer genuinely unflushed at reconnect). Mutation-verified: reverting to a synchronous flush fails 3 tests, and removing either salvage call fails its pinning test.
- Adapted `useWebSocket.thinkingStatusChurn.test.ts`'s content-accumulation test to await one frame (its intent — status-churn suppression must not suppress content — is unchanged, and its other 4 tests pass untouched).

## Manual verification

N/A — unit coverage sufficient: the buffered path is exercised end-to-end through the mocked WebSocket harness, and the flush lifecycle (message/segment/done/reconnect) is shared with the already-shipped `chat_chunk` coalescing.

## Related Issues

no linked issue: found during a live jank investigation; no issue was filed for it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, internal rendering path
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** frame-buffering of store dispatches; rendered transcript content is identical, only dispatch frequency changes.
