### PR TITLE
fix: stop gateways when listener pid lookup is blind

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -1006,6 +1006,15 @@ that must not change, because the SPA's per-origin `localStorage` is keyed on it
    already has it to install it. That case carries SEL
    `reason=<tool>_outside_trusted_dirs`, distinct from `<tool>_not_found`, so
    the two are separable in the audit log.
+   When the trusted lookup tool exists but returns no pid, stop makes one
+   fixed-loopback `POST /api/shutdown` request carrying the gateway generation's
+   local secret. That handler independently requires loopback origin and a
+   constant-time secret match, then triggers the same graceful shutdown event as
+   SIGTERM. The acknowledgement body is capped at 4 KiB before JSON parsing;
+   excessive nesting is treated as malformed input. A successful acknowledgement
+   ends the stop command; a missing secret, refusal, malformed response, or
+   transport failure retains the ordinary no-gateway diagnostic. This fallback never converts the pid sidecar into
+   authority to signal a process.
 3. `platform_compat.process_command_line(pid)` to verify it's a KiroCrew process —
    `/proc/<pid>/cmdline` (Linux), `ps -o command=` (macOS), `Win32_Process.CommandLine`
    via WMI (Windows). The Windows venv `kirocrew.exe` re-execs `python.exe`, so the
@@ -1038,12 +1047,19 @@ that must not change, because the SPA's per-origin `localStorage` is keyed on it
      on Windows) to detect a running gateway. If found — OR if the lookup
      tool is absent (`not listening_pid_tool_available()`, so a missing
      tool is not mistaken for a dead gateway) — run the existing `_stop`
-     kill-by-port path. If not (e.g. the user runs `restart` after a
-     crash), skip the stop step rather than erroring — the user expects to
-     end up with a running gateway either way. The `_stop` call is wrapped
-     in a `try / except SystemExit` so a TOCTOU race (gateway exits between
-     the listener check and `_stop`'s own lookup → `_stop` calls
-     `sys.exit(1)`) does not abort the restart before the spawn.
+     path. When the trusted lookup tool exists but returns no pid, restart
+     independently attempts the authenticated shutdown request. An acknowledged
+     request always refuses the immediate replacement and tells the operator to
+     retry after shutdown completes: neither an absent pid sidecar nor a live
+     same-user pid from that sidecar can prove singleton-lock release, because a
+     stale pid may be recycled and exit before the incumbent. The second restart
+     sees no incumbent and safely starts the replacement.
+   - If no incumbent evidence exists (e.g. the user runs `restart` after a
+     crash), skip the stop step rather than erroring — the user expects to end
+     up with a running gateway either way. The `_stop` call is wrapped in a
+     `try / except SystemExit` so a TOCTOU race (gateway exits between the
+     listener check and `_stop`'s own lookup → `_stop` calls `sys.exit(1)`)
+     does not abort the restart before the spawn.
    - Spawn a detached `kirocrew gateway` via `subprocess.Popen`, stdin set
      to `subprocess.DEVNULL`, and stdout + stderr redirected to
      `~/.kiro/crew/gateway.log` (the same file the `kirocrew logs` command

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -317,6 +317,67 @@ def _logout(port: int) -> None:
         sys.exit(1)
 
 
+_SHUTDOWN_RESPONSE_MAX_BYTES = 4096
+
+
+def _request_gateway_shutdown(port: int) -> bool:
+    """Request graceful shutdown through the gateway's self-authenticating API.
+
+    This is the safe fallback when the platform listener lookup is available but
+    returns no pid. The request targets a fixed IPv4 loopback URL and presents
+    the per-generation local secret; the handler independently requires both
+    loopback origin and a constant-time secret match before setting the same
+    shutdown event as SIGTERM.
+
+    A stale secret cannot authorize another gateway generation, and no process
+    identity is guessed or signaled on this path. Any missing credential,
+    refusal, malformed response, or transport failure returns ``False`` so the
+    caller retains the existing no-target diagnostic.
+    """
+    secret = run_marker.read_secret(port)
+    if not secret:
+        return False
+    request = urllib.request.Request(
+        f"http://{_CLI_LOOPBACK}:{port}/api/shutdown",
+        method="POST",
+        headers={"X-Local-Secret": secret, "Content-Type": "application/json"},
+        data=b"{}",
+    )
+    try:
+        with loopback_urlopen(request, timeout=5) as response:
+            if int(response.status) != 200:
+                return False
+            raw = response.read(_SHUTDOWN_RESPONSE_MAX_BYTES + 1)
+            if len(raw) > _SHUTDOWN_RESPONSE_MAX_BYTES:
+                return False
+            payload = json.loads(raw)
+    except (
+        http.client.HTTPException,
+        OSError,
+        RecursionError,
+        UnicodeError,
+        ValueError,
+        urllib.error.URLError,
+    ):
+        return False
+    return bool(isinstance(payload, dict) and payload.get("ok") and payload.get("shutting_down"))
+
+
+def _report_authenticated_shutdown(port: int) -> bool:
+    """Request, audit, and report an authenticated graceful shutdown."""
+    if not _request_gateway_shutdown(port):
+        return False
+    sel().log_api_access(
+        caller="cli",
+        operation="gateway_stop",
+        outcome="allowed",
+        source="cli",
+        resources=f"port={port} via=api reason=listener_lookup_empty",
+    )
+    print(f"✅ Requested graceful shutdown from gateway on port {port}.")
+    return True
+
+
 def _stop(cli_port: int | None = None) -> None:
     """Stop a running KiroCrew gateway.
 
@@ -380,6 +441,8 @@ def _stop(cli_port: int | None = None) -> None:
                     f"port {port}. Install {_tool} and retry."
                 )
             sys.exit(1)
+        if _report_authenticated_shutdown(port):
+            return
         sel().log_api_access(
             caller="cli",
             operation="gateway_stop",
@@ -878,6 +941,7 @@ def _restart(cli_port: int | None = None) -> None:
     prior_marker_pid = run_marker.read_pid(port)
     listeners = platform_compat.find_listening_pids(port)
     incumbents = [p for p in listeners if _is_kirocrew_process(p)]
+    wait_for_incumbents = False
     if listeners or not platform_compat.listening_pid_tool_available():
         # TOCTOU: the gateway can exit between the check above and _stop()'s own
         # lookup. _stop() raises SystemExit(1) when it finds nothing — for restart
@@ -888,7 +952,24 @@ def _restart(cli_port: int | None = None) -> None:
             _stop(cli_port)
         except SystemExit:
             pass
+        wait_for_incumbents = True
+    elif _report_authenticated_shutdown(port):
+        sel().log_api_access(
+            caller="cli",
+            operation="gateway_restart",
+            outcome="denied",
+            source="cli",
+            resources=f"port={port} reason=shutdown_ack_listener_lookup_blind",
+        )
+        print(
+            f"❌ Gateway accepted graceful shutdown on port {port}, but listener PID "
+            "lookup is unavailable. Not starting a replacement because safe lock "
+            "release cannot be proven.\n   Wait for shutdown to finish, then run: "
+            "kirocrew restart"
+        )
+        sys.exit(1)
 
+    if wait_for_incumbents:
         alive = _wait_for_pids_exit(incumbents, _RESTART_STOP_TIMEOUT)
         if alive:
             # Refuse rather than spawn a replacement that the lock would reject.

--- a/test/test_cli_restart_marker_fallback.py
+++ b/test/test_cli_restart_marker_fallback.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_authenticated_shutdown_request_uses_fixed_loopback_endpoint() -> None:
+    from kiro_crew import cli_server
+
+    assert hasattr(cli_server, "_request_gateway_shutdown")
+    _request_gateway_shutdown = cli_server._request_gateway_shutdown
+
+    response = MagicMock(status=200)
+    response.read.return_value = json.dumps({"ok": True, "shutting_down": True}).encode()
+    context = MagicMock()
+    context.__enter__.return_value = response
+
+    with (
+        patch("kiro_crew.cli_server.run_marker.read_secret", return_value="local-secret"),
+        patch("kiro_crew.cli_server.loopback_urlopen", return_value=context) as mock_open,
+    ):
+        assert _request_gateway_shutdown(7777) is True
+
+    request = mock_open.call_args.args[0]
+    assert request.full_url == "http://127.0.0.1:7777/api/shutdown"
+    assert request.method == "POST"
+    assert request.get_header("X-local-secret") == "local-secret"
+
+
+def test_authenticated_shutdown_request_fails_closed_without_secret() -> None:
+    from kiro_crew import cli_server
+
+    assert hasattr(cli_server, "_request_gateway_shutdown")
+    _request_gateway_shutdown = cli_server._request_gateway_shutdown
+
+    with (
+        patch("kiro_crew.cli_server.run_marker.read_secret", return_value=""),
+        patch("kiro_crew.cli_server.loopback_urlopen") as mock_open,
+    ):
+        assert _request_gateway_shutdown(7777) is False
+    mock_open.assert_not_called()
+
+
+def test_authenticated_shutdown_request_rejects_non_object_response() -> None:
+    from kiro_crew import cli_server
+
+    assert hasattr(cli_server, "_request_gateway_shutdown")
+    _request_gateway_shutdown = cli_server._request_gateway_shutdown
+
+    response = MagicMock(status=200)
+    response.read.return_value = b"[]"
+    context = MagicMock()
+    context.__enter__.return_value = response
+
+    with (
+        patch("kiro_crew.cli_server.run_marker.read_secret", return_value="local-secret"),
+        patch("kiro_crew.cli_server.loopback_urlopen", return_value=context),
+    ):
+        assert _request_gateway_shutdown(7777) is False
+
+
+def test_stop_uses_authenticated_shutdown_when_listener_lookup_is_blind(capsys) -> None:
+    from kiro_crew import cli_server
+
+    assert hasattr(cli_server, "_report_authenticated_shutdown")
+    _stop = cli_server._stop
+
+    mock_sel = MagicMock()
+    with (
+        patch("kiro_crew.cli_server.service_controller.stop_service", return_value=False),
+        patch(
+            "kiro_crew.cli_server.platform_compat.find_listening_pids",
+            return_value=[],
+        ),
+        patch(
+            "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
+            return_value=True,
+        ),
+        patch("kiro_crew.cli_server._request_gateway_shutdown", return_value=True),
+        patch("kiro_crew.cli_server.sel", return_value=mock_sel),
+    ):
+        _stop(7777)
+
+    assert "graceful shutdown" in capsys.readouterr().out
+    audit = mock_sel.log_api_access.call_args.kwargs
+    assert audit["outcome"] == "allowed"
+    assert "via=api" in audit["resources"]
+
+
+def test_authenticated_shutdown_request_rejects_oversized_response() -> None:
+    from kiro_crew import cli_server
+
+    response = MagicMock(status=200)
+    response.read.return_value = b"x" * (cli_server._SHUTDOWN_RESPONSE_MAX_BYTES + 1)
+    context = MagicMock()
+    context.__enter__.return_value = response
+
+    with (
+        patch("kiro_crew.cli_server.run_marker.read_secret", return_value="local-secret"),
+        patch("kiro_crew.cli_server.loopback_urlopen", return_value=context),
+    ):
+        assert cli_server._request_gateway_shutdown(7777) is False
+
+    response.read.assert_called_once_with(cli_server._SHUTDOWN_RESPONSE_MAX_BYTES + 1)
+
+
+def test_authenticated_shutdown_request_rejects_recursive_json() -> None:
+    from kiro_crew import cli_server
+
+    response = MagicMock(status=200)
+    response.read.return_value = b"[" * 1500 + b"]" * 1500
+    context = MagicMock()
+    context.__enter__.return_value = response
+
+    with (
+        patch("kiro_crew.cli_server.run_marker.read_secret", return_value="local-secret"),
+        patch("kiro_crew.cli_server.loopback_urlopen", return_value=context),
+    ):
+        assert cli_server._request_gateway_shutdown(7777) is False
+
+
+@pytest.mark.parametrize("marker_pid", [None, 1234])
+def test_restart_refuses_spawn_after_blind_authenticated_shutdown(
+    capsys, marker_pid: int | None
+) -> None:
+    from kiro_crew import cli_server
+
+    mock_sel = MagicMock()
+    with (
+        patch("kiro_crew.cli_server.resolve_client_port", return_value=7777),
+        patch(
+            "kiro_crew.cli_server.service_controller.restart_service",
+            return_value=False,
+        ),
+        patch("kiro_crew.cli_server.run_marker.read_pid", return_value=marker_pid),
+        patch(
+            "kiro_crew.cli_server.platform_compat.find_listening_pids",
+            return_value=[],
+        ),
+        patch(
+            "kiro_crew.cli_server.platform_compat.listening_pid_tool_available",
+            return_value=True,
+        ),
+        patch("kiro_crew.cli_server._report_authenticated_shutdown", return_value=True),
+        patch("kiro_crew.cli_server._spawn_detached_gateway") as mock_spawn,
+        patch("kiro_crew.cli_server.sel", return_value=mock_sel),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            cli_server._restart(None)
+
+    assert exc.value.code == 1
+    mock_spawn.assert_not_called()
+    assert "listener PID lookup is unavailable" in capsys.readouterr().out
+    audit = mock_sel.log_api_access.call_args.kwargs
+    assert audit["outcome"] == "denied"
+    assert "reason=shutdown_ack_listener_lookup_blind" in audit["resources"]


### PR DESCRIPTION
## Problem / Motivation

On some POSIX hosts, the trusted listener lookup tool exists but returns no PID even while a healthy Kiro Crew gateway is listening. `kirocrew stop` then reports that no gateway is running, and `kirocrew restart` skips shutdown, launches a duplicate, and loses to the incumbent gateway's singleton lock.

## Why it matters

Operators cannot reliably apply configuration changes or updates through the documented lifecycle commands. The false no-gateway result also sends them toward manual process termination even though the gateway already exposes a safe graceful-shutdown API.

## What changed (motivation → approach → change)

When listener lookup returns no PID, `stop` now makes one fixed-IPv4-loopback `POST /api/shutdown` request using only the per-port, per-generation secret. The existing handler independently requires loopback origin and a constant-time secret match before triggering the same graceful shutdown event as SIGTERM.

The acknowledgement body is capped at 4 KiB before JSON parsing; oversized, recursively nested, malformed, refused, or unreachable responses fail closed. The legacy shared-secret fallback is deliberately excluded because listener identity is unverified on this path and that credential may still authorize a different port.

For `restart`, authenticated shutdown is attempted independently of PID-sidecar availability. If the gateway acknowledges shutdown while listener lookup is blind, restart always refuses an immediate replacement and tells the operator to retry after shutdown completes. Neither a missing sidecar nor a live same-user sidecar PID is treated as proof of singleton-lock release: a stale PID can be recycled and exit before the real gateway releases the lock. On the retry, the stopped gateway is absent and the replacement starts safely.

The CLI system specification documents the authenticated fallback, response bound, and fail-closed two-invocation restart contract.

## Tests

- Added eight focused regressions covering fixed-loopback routing, missing-secret refusal, non-object JSON, oversized bodies, recursive JSON, blind-listener `stop`, and blind-listener `restart` refusal with both absent and stale PID-sidecar values.
- Focused lifecycle suite: 63 passed, including existing stop, restart, readiness, ownership, and bounded-wait tests.
- Formatting, isort, flake8, mypy, documentation lint, brand, harness-parity, lock, changelog, focus-cue, vendor-manifest, scrub, and credential scans pass.
- Node 24 Electron suite: 1,421 passed, zero failures or cancellations.
- Full backend suite was attempted locally in a container: 73,219 passed; 48 environment-dependent tests remained red because the minimal container lacks host facilities such as a user database entry, AWS CLI, IPv6, service management, and process-group behavior. GitHub CI remains the authoritative full-fleet result.
- GPT focused verification: `VERIFIED CLOSED` for both duplicate-spawn race paths.
- Final Opus/AUTOSDE local review: `NO FINDINGS`.

## Manual verification

Reproduced the original condition on Linux: the gateway process was healthy, `ss` showed its loopback listener, `kirocrew status` succeeded, and the trusted `lsof` query returned no PID. Before this fix, restart launched a duplicate that the singleton lock rejected. With the fix, the first restart invocation requests authenticated graceful shutdown and refuses the unsafe immediate spawn; rerunning restart after shutdown starts the replacement safely.

## Pattern harvest

Rule candidate: lifecycle regression test.

Pattern: An empty listener-PID lookup must not be treated as proof that no listener exists when the lookup can be blind. Authenticated shutdown must be independent of PID-sidecar availability, and replacement startup must fail closed whenever singleton-lock release cannot be proven.

## Related Issues

no linked issue: the defect was reproduced directly and no matching open issue or pull request exists.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality — focused and static gates pass; refreshed GitHub CI pending
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
