### PR TITLE
fix: serve the logo at /favicon.ico instead of SPA HTML

### DIFF
--- a/src/kiro_crew/dashboard/routes/realtime.py
+++ b/src/kiro_crew/dashboard/routes/realtime.py
@@ -20,6 +20,11 @@ def register(app: web.Application) -> None:
     """Register the realtime routes on *app*."""
     app.router.add_get("/", handlers.index)
     app.router.add_get("/logo.png", handlers.logo)
+    # A long tail of clients (bookmark managers, in-app browsers, uptime
+    # monitors) never parse <link rel="icon"> and fetch /favicon.ico directly.
+    # Without this route the request falls through to the SPA fallback and
+    # returns 200 text/html, which fails image decoding downstream.
+    app.router.add_get("/favicon.ico", handlers.logo)
     app.router.add_get(
         "/{name:manifest\\.json|sw\\.js|icon-\\d+\\.png|pcm-worklet\\.js}", handlers.pwa_file
     )

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -439,6 +439,9 @@ _BYPASS_PREFIXES = (
 )
 _BYPASS_EXACT = {
     "/logo.png",
+    # Alias of /logo.png for clients that hardcode the favicon path instead of
+    # parsing <link rel="icon"> — same handler, same static-asset exposure.
+    "/favicon.ico",
     "/manifest.json",
     "/sw.js",
     "/pcm-worklet.js",

--- a/test/test_dashboard_handlers_core_coverage.py
+++ b/test/test_dashboard_handlers_core_coverage.py
@@ -238,6 +238,21 @@ class TestPageAndAssets:
         assert resp.status == 404
 
     @pytest.mark.asyncio
+    async def test_favicon_route_resolves_to_logo_handler(self) -> None:
+        """/favicon.ico must serve the logo, not fall through to the SPA
+        fallback: clients that hardcode the path and never parse
+        <link rel="icon"> otherwise receive text/html and show no icon."""
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.dashboard.routes import realtime
+
+        app = web.Application()
+        realtime.register(app)
+        for path in ("/logo.png", "/favicon.ico"):
+            match = await app.router.resolve(make_mocked_request("GET", path))
+            assert match.handler is core_mod.logo, path
+
+    @pytest.mark.asyncio
     async def test_pwa_file_serves_dist_child(self, monkeypatch, tmp_path) -> None:
         dist = tmp_path / "dist"
         dist.mkdir()

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -603,6 +603,7 @@ async def test_cookie_server_port_name_denied_when_host_differs() -> None:
         "/fonts/AWSDiatype-Regular.woff2",
         "/vendor/tailwindcss-browser.js",
         "/logo.png",
+        "/favicon.ico",
         "/manifest.json",
         "/sw.js",
         "/icon-192.png",


### PR DESCRIPTION
## Problem / Motivation

`GET /favicon.ico` falls through to the SPA catch-all route and returns **200 with `text/html`** (the dashboard index page). The SPA declares its icon via `<link rel="icon" href="/logo.png">`, which works for browsers that parse link tags — but a long tail of clients (bookmark/favorites managers, in-app browsers, RSS readers, uptime monitors) hardcode `<origin>/favicon.ico` and never read the HTML. For them, image decoding fails and the gateway shows a generic placeholder icon.

Measured on a running gateway:

    /logo.png     -> 200 image/png  82941 bytes
    /icon-192.png -> 200 image/png  21490 bytes
    /favicon.ico  -> 200 text/html  22073 bytes   <- SPA fallback, not an image

## Why it matters

Every icon surface that hardcodes the path shows a wrong/placeholder icon for KiroCrew gateways. Returning 200 + HTML is worse than a 404: clients may cache the bogus payload, and the response wastes ~22 KB per fetch.

## What changed (motivation → approach → change)

Symptom: HTML at `/favicon.ico`. Root cause: no route is registered for the path, so it lands in the SPA fallback. Fix: register `/favicon.ico` on the **existing logo handler** in `routes/realtime.py`, inserted in the literal-route cluster ahead of the PWA pattern route and the SPA fallback. The handler already serves the configured avatar (with the `is_sensitive_path` + `validate_file_path` guards) or the bundled logo PNG; serving PNG bytes at an `.ico` path is fine — modern clients sniff content. `/favicon.ico` is also added to `_BYPASS_EXACT` in `token_auth.py` so unauthenticated icon fetchers reach it, exactly mirroring `/logo.png` (same handler, same static-asset exposure class — no new surface).

## Tests

- `test_favicon_route_resolves_to_logo_handler` (`test_dashboard_handlers_core_coverage.py`): asserts `/favicon.ico` and `/logo.png` both resolve to the logo handler, locking in that the path no longer falls through to the SPA.
- `/favicon.ico` added to the `test_static_assets_bypass_auth` parametrize list (`test_token_auth.py`): locks in the auth bypass.

Both tests were revert-verified: they fail with the src change reverted and pass with it.

## Manual verification

Verified on a live gateway that `/logo.png` and `/icon-192.png` serve PNGs while `/favicon.ico` served the SPA HTML (the numbers above). N/A beyond that — unit coverage exercises the route resolution and the auth bypass directly.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend route + auth-bypass change only; no frontend file touched and no rendered pixel changes.

## Related Issues

Fixes #6671

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface for route internals
- [x] No secrets, credentials, or internal references in the diff

---
_This PR was prepared by Ember, an AI agent acting on behalf of @helenastafford. Local gates run before push: diff-scoped pytest (394 passed), flake8, black, isort, mypy, brand gate; two-lane local AI review (GPT + Opus mirrors) returned zero findings._
