### PR TITLE
feat: pinnable browser live-view port via dashboard.browser_view_port (#6655)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -522,7 +522,6 @@ test/test_bootstrap.py
 test/test_brand_name_gate.py
 test/test_browser_cli_launch.py
 test/test_browser_cli_snapshots.py
-test/test_browser_cli_view.py
 test/test_browser_recording_skill.py
 test/test_bug_proposal_skip_status_default.py
 test/test_bug_validation_send_message_schema.py

--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5664,6 +5664,7 @@
         "cautious_boot": true,
         "widget_density": "more",
         "use_builtin_browser": true,
+        "browser_view_port": 0,
         "verbosity": "default",
         "link_previews": false,
         "usage_text_scrape_enabled": false,
@@ -6004,6 +6005,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": true
+    },
+    {
+      "path": "dashboard.browser_view_port",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Browser Live-View Port",
+      "help": "Pin the browser live-view server (playwright-cli show) to this loopback port. 0 (the default) picks a fresh OS-assigned ephemeral port on every start. Set a fixed port when the dashboard is viewed remotely through an SSH tunnel that forwards a fixed set of ports, so the Browser panel can always reach the view. The server binds loopback-only either way. A value outside 1-65535 is treated as unset. A changed pin applies the next time the view server (re)starts; an already-running server keeps its current port.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 0
     },
     {
       "path": "dashboard.verbosity",

--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -302,7 +302,15 @@ rather than relative to whatever working directory an agent happened to have.
 ### Dashboard integration
 
 `playwright-cli show --port <n> --host 127.0.0.1` serves the CLI's own dashboard
-over loopback HTTP, and the panel embeds that in an iframe. The served dashboard
+over loopback HTTP, and the panel embeds that in an iframe. The port is
+OS-assigned by default; `dashboard.browser_view_port` pins the public port, for
+remote-gateway deployments where the viewer reaches loopback through an SSH
+tunnel that forwards a fixed set of ports. The pin is never handed to the
+child: the supervisor claims the pinned port itself with a bound listener it
+keeps holding, an atomic ownership proof that makes the deterministic,
+operator-named port race-free, and relays byte-for-byte to the child's own
+ephemeral port. The child's OS-assigned port keeps the unpinned path's
+advisory bind window (unpredictable, loopback-local); both bind loopback only. The served dashboard
 provides the session grid with live screencast, a session detail view with tab bar
 and navigation controls, and full remote mouse and keyboard input, so a human can
 take over a session directly: this is the path for a CAPTCHA or a 2FA prompt that

--- a/src/kiro_crew/browser_cli/view.py
+++ b/src/kiro_crew/browser_cli/view.py
@@ -19,7 +19,15 @@ getting any of them wrong presents as a broken feature rather than as an error:
 
 The port is chosen by bind-probe rather than hardcoded: a fixed port collides
 with whatever else the operator runs, and the collision would surface as an
-unexplained dead panel.
+unexplained dead panel. An operator who NEEDS predictability — the dashboard
+viewed through an SSH tunnel that forwards a fixed set of ports — can pin the
+public port via ``dashboard.browser_view_port``. The pin is never handed to
+the child: this module claims the pinned port itself with a bound listener it
+keeps holding (an atomic ownership proof, so the deterministic, operator-named
+port is race-free) and relays byte-for-byte to the child's own ephemeral port.
+The child's OS-assigned port keeps the same advisory bind window as the
+unpinned path — unpredictable and loopback-local. Both the relay and the
+child bind loopback only.
 """
 
 from __future__ import annotations
@@ -32,7 +40,7 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from kiro_crew import platform_compat
 from kiro_crew.browser_cli.install import cli_env, cli_path
@@ -49,6 +57,13 @@ _POLL_INTERVAL_S = 0.25
 _HEALTH_TIMEOUT_S = 2.0
 _TERMINATE_GRACE_S = 5.0
 
+# Concurrent connections the pinned-port relay will carry. The panel needs a
+# handful (page, assets, one screencast/input WebSocket per session view);
+# 32 leaves generous headroom while bounding the threads and sockets a local
+# process can force the relay to hold — a local-DoS bound, not an auth control
+# (the view server itself is equally reachable by any local process).
+_RELAY_MAX_CONNS = 32
+
 
 @dataclass(frozen=True)
 class ShowInfo:
@@ -61,6 +76,12 @@ class ShowInfo:
 _lock = threading.Lock()
 _proc: subprocess.Popen[bytes] | None = None
 _info: ShowInfo | None = None
+_relay: "_Relay | None" = None
+# Why the last start attempt failed, surfaced through ``status()``. With an
+# ephemeral port a failed bind was a near-impossible edge; with a pinned port
+# "already in use" becomes the most likely operator misconfiguration, and a
+# silent ``stopped`` presents as a broken panel rather than as an error.
+_last_reason: str | None = None
 
 
 def _free_port() -> int:
@@ -75,6 +96,194 @@ def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind((LOOPBACK_HOST, 0))
         return int(sock.getsockname()[1])
+
+
+def _claim_listener(port: int) -> socket.socket | None:
+    """Atomically claim *port* with a bound, listening socket, or ``None``.
+
+    Split out of :class:`_Relay` so :func:`ensure_running` can claim the pin
+    BEFORE choosing the child's ephemeral port: while the pin is bound,
+    ``_free_port()`` structurally cannot hand the same number back, so the
+    "child port equals the pin" collision cannot arise by construction.
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if platform_compat.IS_POSIX:
+        # Allow rebinding through TIME_WAIT after a restart. POSIX-only:
+        # on Windows SO_REUSEADDR permits stealing an ACTIVE listener,
+        # which is the exact hole the held-listener design exists to close.
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    elif hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+        # Windows: merely NOT setting SO_REUSEADDR is not enough — another
+        # local process can still bind the same port by setting SO_REUSEADDR
+        # on ITS socket. SO_EXCLUSIVEADDRUSE is the opt-in that makes our
+        # bind exclusive, so the ownership proof holds on Windows too.
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+    try:
+        listener.bind((LOOPBACK_HOST, port))
+        listener.listen(16)
+    except OSError:
+        with contextlib.suppress(Exception):
+            listener.close()
+        return None
+    return listener
+
+
+class _Relay:
+    """Holds a pinned loopback port and pumps bytes to the child's real port.
+
+    The pin cannot be handed to the child directly without a race: any probe
+    closes its socket before the child binds, and in that window a local
+    squatter can take the port — after which :func:`_healthy` would accept the
+    squatter's response and the panel would frame arbitrary content WITH remote
+    input forwarding. Holding the bound listener ourselves is the only atomic
+    ownership proof: ``bind()`` either succeeds (the port is ours until we
+    close it) or raises (occupied). This makes the DETERMINISTIC, operator-named
+    port race-free; the child then binds an OS-assigned ephemeral port exactly
+    as on the unpinned path, which keeps that path's advisory window
+    (unpredictable, loopback-local). This relay forwards
+    each accepted connection byte-for-byte, which carries HTTP and WebSocket
+    traffic alike. Both sockets stay loopback-only.
+    """
+
+    def __init__(self, listener: socket.socket, target_port: int) -> None:
+        self._listener = listener
+        self._target_port = target_port
+        self._closed = threading.Event()
+        # Live sockets, guarded by _conn_lock: bounds what a local process can
+        # force us to hold, and lets close() tear down in-flight connections
+        # instead of leaving them to die with their daemon threads.
+        self._conn_lock = threading.Lock()
+        self._conns: set[socket.socket] = set()
+        self._thread = threading.Thread(
+            target=self._accept_loop, name="browser-view-relay", daemon=True
+        )
+        self._thread.start()
+
+    @classmethod
+    def open(cls, port: int, target_port: int) -> "_Relay | None":
+        """Claim *port* and relay it to *target_port*, or ``None`` if taken."""
+        listener = _claim_listener(port)
+        if listener is None:
+            return None
+        return cls(listener, target_port)
+
+    @classmethod
+    def from_listener(cls, listener: socket.socket, target_port: int) -> "_Relay":
+        """Start relaying on an already-claimed listener (see _claim_listener)."""
+        return cls(listener, target_port)
+
+    def close(self) -> None:
+        """Stop accepting and wait for the accept thread to exit.
+
+        ``shutdown`` before ``close`` is what reliably unblocks a thread
+        parked in ``accept()`` — closing the descriptor alone is not
+        guaranteed to wake it on every platform. The bounded ``join`` makes
+        teardown deterministic instead of leaving a daemon thread to die on
+        its own schedule (a test-visible side effect).
+        """
+        self._closed.set()
+        with contextlib.suppress(Exception):
+            self._listener.shutdown(socket.SHUT_RDWR)
+        with contextlib.suppress(Exception):
+            self._listener.close()
+        self._thread.join(timeout=_TERMINATE_GRACE_S)
+        # Tear down in-flight connections. shutdown() before close(), same as
+        # the listener above: the pump threads hold these sockets, and close()
+        # alone does not reliably interrupt them or deliver the FIN while
+        # another thread is blocked in recv() — shutdown() does both.
+        with self._conn_lock:
+            conns = list(self._conns)
+            self._conns.clear()
+        for sock in conns:
+            with contextlib.suppress(Exception):
+                sock.shutdown(socket.SHUT_RDWR)
+            with contextlib.suppress(Exception):
+                sock.close()
+
+    def _track(self, sock: socket.socket) -> bool:
+        """Register a live socket; ``False`` when the cap refuses it."""
+        with self._conn_lock:
+            if len(self._conns) >= _RELAY_MAX_CONNS:
+                return False
+            self._conns.add(sock)
+            return True
+
+    def _untrack(self, sock: socket.socket) -> None:
+        with self._conn_lock:
+            self._conns.discard(sock)
+
+    def _accept_loop(self) -> None:
+        while not self._closed.is_set():
+            try:
+                client, _addr = self._listener.accept()
+            except OSError:
+                return  # listener closed
+            if not self._track(client):
+                # At capacity: refuse instead of queueing unbounded threads. A
+                # local flooder is bounded; the panel's handful of connections
+                # never gets near the cap.
+                with contextlib.suppress(Exception):
+                    client.close()
+                continue
+            threading.Thread(
+                target=self._serve, args=(client,), name="browser-view-relay-conn", daemon=True
+            ).start()
+
+    def _serve(self, client: socket.socket) -> None:
+        try:
+            upstream = socket.create_connection(
+                (LOOPBACK_HOST, self._target_port), timeout=_HEALTH_TIMEOUT_S
+            )
+        except OSError:
+            self._untrack(client)
+            with contextlib.suppress(Exception):
+                client.close()
+            return
+        upstream.settimeout(None)
+        # Release the cap slot only when BOTH directions have terminated. A
+        # half-closed connection (one pump exited, the other still parked in
+        # recv on a peer that stays silent) must keep holding its slot:
+        # freeing it on the first exit would let a local flooder accumulate
+        # live pump threads beyond the accounting bound. Teardown still
+        # reaches a lingering pump: a client-blocked pump is unblocked by
+        # close() shutting down the tracked client socket, and an
+        # upstream-blocked pump by the supervised child being reaped, which
+        # accompanies every relay teardown path in ensure_running/stop.
+        remaining = [2]
+        remaining_lock = threading.Lock()
+
+        def on_done() -> None:
+            with remaining_lock:
+                remaining[0] -= 1
+                finished = remaining[0] == 0
+            if finished:
+                self._untrack(client)
+
+        a = threading.Thread(target=_pump, args=(client, upstream, on_done), daemon=True)
+        b = threading.Thread(target=_pump, args=(upstream, client, on_done), daemon=True)
+        a.start()
+        b.start()
+
+
+def _pump(
+    src: socket.socket, dst: socket.socket, on_done: "Callable[[], None] | None" = None
+) -> None:
+    """Copy bytes from *src* to *dst* until either side closes."""
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        with contextlib.suppress(Exception):
+            dst.shutdown(socket.SHUT_WR)
+        with contextlib.suppress(Exception):
+            src.close()
+        if on_done is not None:
+            on_done()
 
 
 def _healthy(port: int) -> bool:
@@ -155,7 +364,7 @@ def _spawn(cli: str, port: int) -> subprocess.Popen[bytes] | None:
         return None
 
 
-def ensure_running() -> ShowInfo | None:
+def ensure_running(port: int | None = None) -> ShowInfo | None:
     """Return the running dashboard, starting it if needed.
 
     Idempotent: a process that is alive and answering is reused, so repeated
@@ -163,10 +372,20 @@ def ensure_running() -> ShowInfo | None:
     that has died or stopped answering is reaped first, because leaving it
     would make every later call reuse a corpse.
 
-    ``None`` means no dashboard is available: the CLI is not installed, or the
-    server did not become healthy within the startup budget.
+    *port* pins the port the dashboard is reachable on; ``None`` (or ``0``)
+    keeps the OS-assigned ephemeral default. A pin is never handed to the
+    child directly — the module claims the pinned port itself with a bound
+    listener (:class:`_Relay`, the atomic ownership proof) and relays to the
+    child's own ephemeral port, so the operator-named port itself has no
+    probe-to-bind window to race. The pin applies when a server is (re)started —
+    an already-healthy server is reused as-is, on whatever port it holds.
+    The bind host stays :data:`LOOPBACK_HOST` regardless.
+
+    ``None`` means no dashboard is available: the CLI is not installed, the
+    pinned port is already taken by something else, or the server did not
+    become healthy within the startup budget. ``status()`` carries the reason.
     """
-    global _proc, _info
+    global _proc, _info, _relay, _last_reason
     with _lock:
         if _alive(_proc) and _info is not None and _healthy(_info.port):
             return _info
@@ -174,32 +393,65 @@ def ensure_running() -> ShowInfo | None:
             _reap(_proc)
             _proc = None
             _info = None
+        if _relay is not None:
+            _relay.close()
+            _relay = None
+        _last_reason = None
 
         cli = cli_path()
         if cli is None:
             return None
 
-        port = _free_port()
-        proc = _spawn(cli, port)
+        relay: _Relay | None = None
+        if port:
+            # Claim the pin BEFORE choosing the child's port. Two things follow
+            # by construction: bind() either makes the pin ours until we close
+            # it or raises because someone else holds it (no window in which a
+            # squatter can be mistaken for us), and while the pin is bound
+            # _free_port() cannot hand the same number back, so the child's
+            # ephemeral port can never collide with the pin.
+            pin_listener = _claim_listener(port)
+            if pin_listener is None:
+                logger.warning("configured browser view port %d is already in use", port)
+                _last_reason = f"configured port {port} is already in use"
+                return None
+            child_port = _free_port()
+            relay = _Relay.from_listener(pin_listener, child_port)
+        else:
+            child_port = _free_port()
+        proc = _spawn(cli, child_port)
         if proc is None:
+            if relay is not None:
+                relay.close()
+            _last_reason = "playwright-cli show could not be started"
             return None
 
+        public_port = port if port else child_port
         deadline = time.monotonic() + _STARTUP_TIMEOUT_S
         while time.monotonic() < deadline:
             if proc.poll() is not None:
                 logger.warning(
                     "playwright-cli show exited during startup (rc=%s) on port %d",
                     proc.returncode,
-                    port,
+                    child_port,
                 )
+                if relay is not None:
+                    relay.close()
+                _last_reason = f"playwright-cli show exited during startup on port {child_port}"
                 return None
-            if _healthy(port):
+            if _healthy(child_port):
                 _proc = proc
-                _info = ShowInfo(url=f"http://{LOOPBACK_HOST}:{port}", port=port)
+                _relay = relay
+                _info = ShowInfo(url=f"http://{LOOPBACK_HOST}:{public_port}", port=public_port)
                 return _info
             time.sleep(_POLL_INTERVAL_S)
 
-        logger.warning("playwright-cli show did not answer on port %d within the budget", port)
+        logger.warning(
+            "playwright-cli show did not answer on port %d within the budget", child_port
+        )
+        if relay is not None:
+            relay.close()
+        _last_reason = f"playwright-cli show did not answer on port {child_port} within the budget"
         _reap(proc)
         return None
 
@@ -215,19 +467,27 @@ def stop() -> None:
     independently-launched ``playwright-cli show`` session, destroying their
     unsaved work.
     """
-    global _proc, _info
+    global _proc, _info, _relay, _last_reason
     with _lock:
         if _proc is not None:
             _reap(_proc)
+        if _relay is not None:
+            _relay.close()
         _proc = None
         _info = None
+        _relay = None
+        _last_reason = None
 
 
 def status() -> dict[str, Any]:
     """Current dashboard state, without starting or stopping anything.
 
     ``unavailable`` is reported when the CLI is absent, and is distinct from
-    ``stopped``: the first cannot be fixed by starting the server.
+    ``stopped``: the first cannot be fixed by starting the server. A
+    ``stopped`` state carries the last start attempt's failure reason when
+    one is recorded — with a pinned port, "already in use" is the most likely
+    misconfiguration, and reporting it is what separates a fixable setting
+    from a mysteriously dead panel.
     """
     with _lock:
         if cli_path() is None:
@@ -244,4 +504,4 @@ def status() -> dict[str, Any]:
                 "port": _info.port,
                 "reason": None,
             }
-        return {"status": "stopped", "url": None, "port": None, "reason": None}
+        return {"status": "stopped", "url": None, "port": None, "reason": _last_reason}

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -467,6 +467,18 @@ def _safe_nonnegative_int(value: object, default: int) -> int:
     return result if result >= 0 else default
 
 
+def _port_or_unset(value: object) -> int:
+    """A TCP port, or 0 (unset) when the value is malformed or out of range.
+
+    Deliberately NOT the clamp convention used for bounded knobs: a clamped
+    port is as wrong as a malformed one — a tunnel that forwards 8080 does not
+    forward 65535 either — so anything outside 1..65535 falls back to unset
+    (ephemeral) rather than becoming a live pin the operator never named.
+    """
+    result = _safe_int(value, 0)
+    return result if 0 < result <= 65535 else 0
+
+
 #: Bounds of a context-threshold percentage, and the single statement of the range.
 #: The floor is 1, not 0, because a 0% threshold means "always over" and would fire the
 #: notice/compaction on every turn. Public because the dashboard's channel-config
@@ -3151,6 +3163,20 @@ class DashboardConfig:
             "Use Built-in Browser",
             "When on, the browser tool opens pages in Kiro Crew's built-in panel "
             "(desktop app only). When off, the agent browses via playwright-cli.",
+        ),
+    )
+    browser_view_port: int = field(
+        default=0,
+        metadata=_meta(
+            "Browser Live-View Port",
+            "Pin the browser live-view server (playwright-cli show) to this "
+            "loopback port. 0 (the default) picks a fresh OS-assigned ephemeral "
+            "port on every start. Set a fixed port when the dashboard is viewed "
+            "remotely through an SSH tunnel that forwards a fixed set of ports, "
+            "so the Browser panel can always reach the view. The server binds "
+            "loopback-only either way. A value outside 1-65535 is treated as "
+            "unset. A changed pin applies the next time the view server "
+            "(re)starts; an already-running server keeps its current port.",
         ),
     )
     verbosity: str = field(
@@ -7894,6 +7920,7 @@ class KiroCrewConfig:
                 auto_open_git_panel=_safe_bool(dashboard_data.get("auto_open_git_panel"), False),
                 widget_density=dashboard_data.get("widget_density", "more"),
                 use_builtin_browser=_safe_bool(dashboard_data.get("use_builtin_browser"), True),
+                browser_view_port=_port_or_unset(dashboard_data.get("browser_view_port", 0)),
                 verbosity=dashboard_data.get("verbosity", "default"),
                 link_previews=_safe_bool(dashboard_data.get("link_previews"), False),
                 usage_text_scrape_enabled=_safe_bool(

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -3214,7 +3214,9 @@ async def api_browser_view_start(request: web.Request) -> web.Response:
 
     Idempotent, and off-loaded to a thread because starting the dashboard waits on
     a child process becoming healthy, which would otherwise stall the event loop
-    and with it every other dashboard request.
+    and with it every other dashboard request. Honors
+    ``dashboard.browser_view_port`` when set, so a remote-gateway operator can
+    keep the port inside their tunnel's forwarded set.
 
     App-token denied: this both LAUNCHES a browser process and returns the
     unauthenticated dashboard URL, so it is the stronger half of the same hole
@@ -3223,7 +3225,14 @@ async def api_browser_view_start(request: web.Request) -> web.Response:
     denied = _deny_non_owner_browser_request(request, "browser_view_start")
     if denied is not None:
         return denied
-    await asyncio.to_thread(browser_cli_view.ensure_running)
+
+    def _start_view() -> None:
+        # Config read stays in the worker thread with the child-process wait:
+        # both are blocking I/O that must not run on the event loop.
+        pinned = KiroCrewConfig.load().dashboard.browser_view_port
+        browser_cli_view.ensure_running(pinned or None)
+
+    await asyncio.to_thread(_start_view)
     return web.json_response(await asyncio.to_thread(browser_cli_view.status))
 
 

--- a/test/test_browser_cli_view.py
+++ b/test/test_browser_cli_view.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import http.server
 import socket
 import threading
+import time
 from collections.abc import Iterator
 
 import pytest
@@ -60,6 +62,8 @@ def reset_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[int]]:
     signalled: list[int] = []
     monkeypatch.setattr(mod, "_proc", None)
     monkeypatch.setattr(mod, "_info", None)
+    monkeypatch.setattr(mod, "_relay", None)
+    monkeypatch.setattr(mod, "_last_reason", None)
     monkeypatch.setattr(
         platform_compat,
         "kill_process_tree",
@@ -68,6 +72,8 @@ def reset_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[int]]:
     yield signalled
     mod._proc = None
     mod._info = None
+    mod._relay = None
+    mod._last_reason = None
 
 
 def _free_port() -> int:
@@ -174,14 +180,314 @@ def test_ensure_running_spawns_with_loopback_host(monkeypatch: pytest.MonkeyPatc
     assert argv[argv.index("--port") + 1] == str(info.port)
 
 
+def test_ensure_running_pins_the_configured_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pin is served by a held relay listener; the child stays ephemeral.
+
+    The pinned port must never appear in the child argv — handing it to the
+    child would reopen the probe-to-bind window a local squatter can win. The
+    module claims the pin itself and the child binds its own ephemeral port.
+    """
+    recorded: list[list[str]] = []
+    opened: list[tuple[object, int]] = []
+    claimed: list[int] = []
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_free_port", lambda: 51515)
+
+    sentinel_listener = object()
+    monkeypatch.setattr(
+        mod, "_claim_listener", lambda port: claimed.append(port) or sentinel_listener
+    )
+
+    class FakeRelay:
+        def __init__(self) -> None:
+            self.closed = False
+
+        @classmethod
+        def from_listener(cls, listener: object, target_port: int) -> "FakeRelay":
+            opened.append((listener, target_port))
+            return cls()
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(mod, "_Relay", FakeRelay)
+
+    def fake_spawn(cli: str, port: int) -> FakeProc:
+        recorded.append(mod._show_argv(cli, port))
+        return FakeProc()
+
+    monkeypatch.setattr(mod, "_spawn", fake_spawn)
+
+    info = mod.ensure_running(port=45613)
+
+    assert info is not None
+    assert info.port == 45613
+    assert info.url == "http://127.0.0.1:45613"
+    assert claimed == [45613]
+    assert opened == [(sentinel_listener, 51515)]
+    argv = recorded[0]
+    # The child binds its own ephemeral port; the pin never reaches its argv.
+    assert argv[argv.index("--port") + 1] == "51515"
+    # Pinning the port must not loosen the loopback bind.
+    assert argv[argv.index("--host") + 1] == "127.0.0.1"
+
+
+def test_pinned_start_claims_the_pin_before_choosing_the_child_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pin is bound before _free_port() runs, so an ephemeral-range pin can
+    never be handed back as the child's port (bind collision by construction)."""
+    order: list[str] = []
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: FakeProc())
+
+    pin = _free_port()
+    real_claim = mod._claim_listener
+
+    def tracking_claim(port: int) -> object:
+        order.append("claim")
+        return real_claim(port)
+
+    real_free = mod._free_port
+
+    def tracking_free() -> int:
+        order.append("free_port")
+        got = real_free()
+        assert got != pin, "kernel handed out a port that is supposed to be bound"
+        return got
+
+    monkeypatch.setattr(mod, "_claim_listener", tracking_claim)
+    monkeypatch.setattr(mod, "_free_port", tracking_free)
+
+    try:
+        info = mod.ensure_running(port=pin)
+        assert info is not None and info.port == pin
+        assert order == ["claim", "free_port"]
+    finally:
+        mod.stop()
+
+
+def test_relay_forwards_http_to_the_target_port(redirecting_server: int) -> None:
+    """The held listener relays real HTTP byte-for-byte to the child's port."""
+    public = _free_port()
+    relay = mod._Relay.open(public, redirecting_server)
+    assert relay is not None
+    try:
+        assert mod._healthy(public)  # the 302 travels through the relay
+    finally:
+        relay.close()
+
+
+def test_relay_close_joins_the_accept_thread(redirecting_server: int) -> None:
+    """close() must not leave the accept thread running (test-visible side
+    effect otherwise: a daemon thread outliving the test that spawned it)."""
+    relay = mod._Relay.open(_free_port(), redirecting_server)
+    assert relay is not None
+    try:
+        assert relay._thread.is_alive()
+    finally:
+        relay.close()
+    assert not relay._thread.is_alive()
+
+
+def test_relay_caps_concurrent_connections(
+    monkeypatch: pytest.MonkeyPatch, redirecting_server: int
+) -> None:
+    """Connections beyond the cap are refused; finished ones free their slot."""
+    monkeypatch.setattr(mod, "_RELAY_MAX_CONNS", 2)
+    public = _free_port()
+    relay = mod._Relay.open(public, redirecting_server)
+    assert relay is not None
+    held: list[socket.socket] = []
+    try:
+        held = [socket.create_connection(("127.0.0.1", public), timeout=2) for _ in range(2)]
+        # Give the accept loop a moment to register both.
+        deadline = time.time() + 5
+        while time.time() < deadline and len(relay._conns) < 2:
+            time.sleep(0.05)
+        assert len(relay._conns) == 2
+        # The third is accepted at the OS level then closed by the cap: reads EOF.
+        extra = socket.create_connection(("127.0.0.1", public), timeout=2)
+        try:
+            extra.settimeout(5)
+            assert extra.recv(1) == b""
+        finally:
+            extra.close()
+        # Closing a held connection frees its slot.
+        held[0].close()
+        deadline = time.time() + 5
+        while time.time() < deadline and len(relay._conns) > 1:
+            time.sleep(0.05)
+        assert len(relay._conns) == 1
+    finally:
+        for sock in held:
+            with contextlib.suppress(OSError):
+                sock.close()
+        relay.close()
+
+
+def test_relay_close_tears_down_live_connections(redirecting_server: int) -> None:
+    """close() closes tracked sockets instead of leaving pumps to linger."""
+    public = _free_port()
+    relay = mod._Relay.open(public, redirecting_server)
+    assert relay is not None
+    client: socket.socket | None = None
+    try:
+        client = socket.create_connection(("127.0.0.1", public), timeout=2)
+        deadline = time.time() + 5
+        while time.time() < deadline and not relay._conns:
+            time.sleep(0.05)
+        assert relay._conns
+    finally:
+        relay.close()
+    assert not relay._conns
+    try:
+        client.settimeout(5)
+        assert client.recv(1) == b""  # our side was closed
+    finally:
+        client.close()
+
+
+def test_relay_slot_held_until_both_pumps_finish() -> None:
+    """A half-closed connection keeps its cap slot: one pump exiting while the
+    other stays parked must not free the accounting bound."""
+    # A silent upstream that accepts and then neither sends nor closes, so the
+    # upstream->client pump stays parked after the client half-closes. (The
+    # redirecting HTTP fixture would close on EOF and end BOTH pumps.)
+    silent = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    silent.bind(("127.0.0.1", 0))
+    silent.listen(4)
+    accepted: list[socket.socket] = []
+
+    def _hold() -> None:
+        with contextlib.suppress(OSError):
+            conn, _ = silent.accept()
+            accepted.append(conn)
+
+    holder = threading.Thread(target=_hold, daemon=True)
+    holder.start()
+
+    public = _free_port()
+    relay = mod._Relay.open(public, int(silent.getsockname()[1]))
+    assert relay is not None
+    client: socket.socket | None = None
+    try:
+        client = socket.create_connection(("127.0.0.1", public), timeout=2)
+        deadline = time.time() + 5
+        while time.time() < deadline and not relay._conns:
+            time.sleep(0.05)
+        assert relay._conns
+        # Half-close: our write side closes, so the client->upstream pump sees
+        # EOF and exits, while the upstream->client pump stays parked on the
+        # silent server.
+        client.shutdown(socket.SHUT_WR)
+        time.sleep(0.5)  # give the exited pump time to run on_done
+        assert relay._conns, "slot was released while one pump was still live"
+    finally:
+        relay.close()
+        for sock in [client, silent, *accepted]:
+            if sock is not None:
+                with contextlib.suppress(OSError):
+                    sock.close()
+        holder.join(timeout=5)
+    assert not relay._conns
+
+
+def test_claim_listener_sets_the_platform_exclusivity_option(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POSIX gets SO_REUSEADDR (TIME_WAIT rebind); Windows gets
+    SO_EXCLUSIVEADDRUSE (without it another local process can rebind our held
+    port by setting SO_REUSEADDR on ITS socket, defeating the ownership proof)."""
+    calls: list[tuple[int, int, int]] = []
+    real_setsockopt = socket.socket.setsockopt
+
+    def spy(self: socket.socket, level: int, opt: int, value: int) -> None:
+        calls.append((level, opt, value))
+        real_setsockopt(self, level, opt, value)
+
+    monkeypatch.setattr(socket.socket, "setsockopt", spy)
+
+    listener = mod._claim_listener(_free_port())
+    assert listener is not None
+    listener.close()
+
+    if platform_compat.IS_POSIX:
+        assert (socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) in calls
+    elif hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+        assert (socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1) in calls
+
+
+def test_relay_open_returns_none_when_port_is_taken(redirecting_server: int) -> None:
+    """bind() is the atomic ownership proof: an occupied pin is refused."""
+    assert mod._Relay.open(redirecting_server, 51515) is None
+
+
+def test_ensure_running_falls_back_to_ephemeral_when_unpinned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``None`` and ``0`` both mean "unset": today's OS-assigned behavior."""
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_free_port", lambda: 51515)
+    spawns: list[int] = []
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc())
+
+    for unset in (None, 0):
+        mod._proc = None
+        mod._info = None
+        info = mod.ensure_running(port=unset)
+        assert info is not None and info.port == 51515, unset
+
+    assert spawns == [51515, 51515]
+
+
+def test_ensure_running_refuses_an_occupied_pinned_port(
+    monkeypatch: pytest.MonkeyPatch, redirecting_server: int
+) -> None:
+    """An occupied pin must fail BEFORE spawning: the doomed child would lose
+    the bind and exit while ``_healthy`` accepts the unrelated occupant's
+    response, recording a corpse as running and iframing a stranger."""
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    spawns: list[int] = []
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc())
+
+    info = mod.ensure_running(port=redirecting_server)
+
+    assert info is None
+    assert spawns == []
+    st = mod.status()
+    assert st["status"] == "stopped"
+    assert st["reason"] is not None and str(redirecting_server) in st["reason"]
+
+
+def test_status_reason_cleared_after_a_successful_start(
+    monkeypatch: pytest.MonkeyPatch, redirecting_server: int
+) -> None:
+    """A stale failure reason must not outlive a later successful start."""
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: FakeProc())
+    # First attempt fails on the occupied pin and records a reason.
+    assert mod.ensure_running(port=redirecting_server) is None
+    assert mod.status()["reason"] is not None
+
+    # Second attempt (unpinned, healthy) succeeds; then stop() clears state.
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_free_port", lambda: 51515)
+    assert mod.ensure_running() is not None
+    assert mod.status()["reason"] is None
+    mod.stop()
+    assert mod.status() == {"status": "stopped", "url": None, "port": None, "reason": None}
+
+
 def test_ensure_running_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
     """A healthy server is reused, not duplicated by a second panel mount."""
     spawns: list[int] = []
     monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
     monkeypatch.setattr(mod, "_healthy", lambda port: True)
-    monkeypatch.setattr(
-        mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc()
-    )
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc())
 
     first = mod.ensure_running()
     second = mod.ensure_running()
@@ -195,9 +501,7 @@ def test_ensure_running_replaces_a_dead_process(monkeypatch: pytest.MonkeyPatch)
     spawns: list[int] = []
     monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
     monkeypatch.setattr(mod, "_healthy", lambda port: True)
-    monkeypatch.setattr(
-        mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc()
-    )
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc())
 
     mod.ensure_running()
     mod._proc = FakeProc(alive=False)
@@ -342,9 +646,7 @@ def test_status_does_not_start_anything(monkeypatch: pytest.MonkeyPatch) -> None
     spawns: list[int] = []
     monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
     monkeypatch.setattr(mod, "_healthy", lambda port: True)
-    monkeypatch.setattr(
-        mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc()
-    )
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: spawns.append(port) or FakeProc())
 
     assert mod.status()["status"] == "stopped"
     assert spawns == []

--- a/test/test_browser_view_port_config.py
+++ b/test/test_browser_view_port_config.py
@@ -1,0 +1,143 @@
+"""Tests for the dashboard.browser_view_port config field (issue #6655).
+
+The field pins the browser live-view server (``playwright-cli show``) to a fixed
+loopback port so remote-gateway users can forward it through an SSH tunnel.
+The tests pin the contract: it defaults to 0 (OS-assigned ephemeral, today's
+behavior), round-trips through save/load, a malformed value falls back to 0
+rather than crashing the load, out-of-range values fall back to unset (never
+clamping into a pin the operator did not name), and the view-start handler
+passes the configured pin through to
+``ensure_running`` — with 0 mapped to ``None`` so the module keeps its
+ephemeral default.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
+
+from kiro_crew.config.loader import KiroCrewConfig
+
+
+@pytest.fixture()
+def cfg_file(tmp_path):
+    p = tmp_path / "config.json"
+    p.write_text("{}", encoding="utf-8")
+    with patch("kiro_crew.config.loader.config_path", return_value=p):
+        yield p
+
+
+def test_browser_view_port_default_is_ephemeral():
+    """0 means "unset": the view keeps binding an OS-assigned ephemeral port."""
+    assert KiroCrewConfig().dashboard.browser_view_port == 0
+
+
+def test_browser_view_port_save_load(cfg_file):
+    cfg = KiroCrewConfig()
+    cfg.dashboard.browser_view_port = 45613
+    cfg.save()
+
+    raw = json.loads(cfg_file.read_text(encoding="utf-8"))
+    assert raw["dashboard"]["browser_view_port"] == 45613
+    assert KiroCrewConfig.load().dashboard.browser_view_port == 45613
+
+
+def test_browser_view_port_absent_key_stays_zero(cfg_file):
+    cfg_file.write_text(json.dumps({"dashboard": {}}), encoding="utf-8")
+    assert KiroCrewConfig.load().dashboard.browser_view_port == 0
+
+
+def test_browser_view_port_malformed_falls_back_to_zero(cfg_file):
+    """A broken value must never crash the load or invent a pin."""
+    for bad in ("not-a-port", True, None, [8080], 1.5):
+        cfg_file.write_text(
+            json.dumps({"dashboard": {"browser_view_port": bad}}),
+            encoding="utf-8",
+        )
+        assert KiroCrewConfig.load().dashboard.browser_view_port == 0, bad
+
+
+def test_browser_view_port_out_of_range_falls_back_to_unset(cfg_file):
+    """An out-of-range port must revert to unset, never clamp into a live pin:
+    a tunnel that forwards 8080 does not forward 65535 either, so a clamped
+    value is as wrong as a malformed one."""
+    for raw, expected in ((-5, 0), (0, 0), (70000, 0), (65536, 0), ("8080", 8080), (65535, 65535)):
+        cfg_file.write_text(
+            json.dumps({"dashboard": {"browser_view_port": raw}}),
+            encoding="utf-8",
+        )
+        assert KiroCrewConfig.load().dashboard.browser_view_port == expected, raw
+
+
+# ── Handler end-to-end: the pin reaches ensure_running ──
+
+
+@pytest.fixture()
+def mock_sel():
+    try:
+        import kiro_crew.dashboard.handlers  # noqa: F401
+    except ImportError:
+        pytest.skip("dashboard handler deps not available locally")
+    m = MagicMock()
+    m.log_api_access = MagicMock()
+    with patch("kiro_crew.dashboard.handlers.sel", return_value=m):
+        yield m
+
+
+@pytest.fixture()
+def view_start_app(cfg_file, mock_sel):
+    from kiro_crew.dashboard.handlers.messaging import api_browser_view_start
+
+    app = web.Application()
+    app.router.add_post("/api/browser/view/start", api_browser_view_start)
+    return as_owner(app)
+
+
+async def _post_start(app: web.Application) -> None:
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/api/browser/view/start")
+        assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_view_start_passes_the_configured_pin(cfg_file, view_start_app):
+    """browser_view_port=N in config reaches ensure_running(N) end-to-end."""
+    cfg_file.write_text(json.dumps({"dashboard": {"browser_view_port": 45613}}), encoding="utf-8")
+    calls: list[int | None] = []
+    with (
+        patch(
+            "kiro_crew.browser_cli.view.ensure_running",
+            side_effect=lambda port=None: calls.append(port),
+        ),
+        patch(
+            "kiro_crew.browser_cli.view.status",
+            return_value={"status": "stopped", "url": None, "port": None, "reason": None},
+        ),
+    ):
+        await _post_start(view_start_app)
+
+    assert calls == [45613]
+
+
+@pytest.mark.asyncio
+async def test_view_start_unset_pin_maps_to_none(cfg_file, view_start_app):
+    """0 (the default) must reach ensure_running as None, keeping ephemeral."""
+    calls: list[int | None] = []
+    with (
+        patch(
+            "kiro_crew.browser_cli.view.ensure_running",
+            side_effect=lambda port=None: calls.append(port),
+        ),
+        patch(
+            "kiro_crew.browser_cli.view.status",
+            return_value={"status": "stopped", "url": None, "port": None, "reason": None},
+        ),
+    ):
+        await _post_start(view_start_app)
+
+    assert calls == [None]


### PR DESCRIPTION
## Problem / Motivation

The browser live-view server (`playwright-cli show`, supervised by `src/kiro_crew/browser_cli/view.py`) always binds an OS-assigned ephemeral port via `_free_port()`. There is no configuration key, environment variable, or API parameter to pin it.

## Why it matters

On a remote-gateway deployment the dashboard Browser panel loads the live view from the viewer's own loopback through an SSH tunnel that forwards a fixed set of ports. Because the port changes on every start it is never in the forwarded set, so the panel shows "connection refused" for every remote-gateway user -- the feature is unusable out of the box on that topology. The reporter verified a gateway-spawned instance landed on a random port (panel dead) while a manual `playwright-cli show --port <forwarded> --host 127.0.0.1` worked perfectly.

## What changed

Chain from symptom to root cause: dead panel -> iframe targets a loopback port the tunnel does not forward -> `ensure_running()` unconditionally calls `_free_port()` with no way to influence the choice. The fix makes the public port configurable while keeping the child's own bind behavior exactly as it was:

- **`dashboard.browser_view_port`** (int, default 0 = unset): new config key. 0 keeps today's ephemeral behavior byte-for-byte; a value in 1-65535 pins the public port. Out-of-range values are treated as **unset** rather than clamped -- a tunnel that forwards 8080 does not forward 65535 either, so a clamped value would be a live pin the operator never named (`_port_or_unset`).
- **Held-listener relay for the pin**: the pin is never handed to the child. `ensure_running(port)` claims the pinned port itself with a bound listener it keeps holding (`_Relay.open`: `bind()` either makes the port ours until we close it, or raises because someone else holds it -- an atomic ownership proof with no probe-to-bind window on the operator-named port), then relays byte-for-byte to the child, which binds its own OS-assigned ephemeral port exactly as on the unpinned path. An occupied pin is therefore refused before spawn, with the reason surfaced. Scope of the guarantee: the deterministic, operator-named port is race-free; the child's ephemeral port keeps the unpinned path's advisory bind window (unpredictable, loopback-local) -- parity with today's baseline, not elimination.
- **Loopback invariant untouched**: `_show_argv` still unconditionally appends `--host 127.0.0.1`, the module still exposes no host parameter, and both the relay listener and the child bind loopback only. `SO_REUSEADDR` on the relay is POSIX-only (TIME_WAIT rebinding); it is skipped on Windows where it would permit stealing an active listener.
- **Failure reason surfaced**: start failures record a `_last_reason` reported through `status()`'s existing `reason` key ("configured port N is already in use", startup exit, health timeout). With a pin, "port occupied" is the most likely misconfiguration and previously surfaced as a silently dead panel. The frontend hook already carries the `reason` field.
- The `api_browser_view_start` handler reads the config inside the existing worker thread (no new event-loop blocking) and maps 0 -> `None`.
- `config-baseline.json` regenerated for the new schema entry; spec `docs/system-specs/modules/browser.md` updated in the same commit. `test_browser_cli_view.py` was black-formatted while being extended and so graduates from `.github/black-baseline.txt` (the gate demands the prune in the same change; PR Hygiene enforces a single commit per PR, so it cannot ride separately).

## Tests

- `test_browser_cli_view.py` (+7): the pin never reaches the child argv (child stays ephemeral, `--host 127.0.0.1` intact); the relay is opened pin->child; a real `_Relay` forwards HTTP end-to-end to a live server; `_Relay.open` refuses an occupied port (real bind); `None`/`0` fall back to ephemeral; a failure reason surfaces in `status()` and does not outlive a later successful start; existing lifecycle tests unchanged and passing.
- `test_browser_view_port_config.py` (new): default 0; save/load round-trip; absent key; malformed values fall back to 0; out-of-range values fall back to unset (never clamp into a pin); handler end-to-end -- configured pin reaches `ensure_running(N)`, unset reaches `None`.
- Full impacted set green locally (866 tests across browser_cli, config loader/schema/baseline, dashboard handlers, settings-registry fixture). `isort` / `flake8` / `black` gate / `mypy` (no new errors) / brand / subprocess-encoding / loop-bound-locks / focus-cue gates all pass. Two pre-push model-pinned reviews (GPT 5.6 + Opus) ran before opening; every finding fixed (stale config baseline, occupied-pin adoption, clamp-to-pin, silent failure reason). The server GPT lane's r1 finding (probe-to-bind race on the pin) drove the probe's replacement with the held-listener relay described above.

## Anything else

The pin applies when the view server (re)starts; an already-running server keeps its port (documented in the field help). No settings UI control is added -- the key is reachable via config file / CLI, which matches the remote-operator audience. The residual pre-existing class (child/ephemeral bind race + any-responder health probe, identical on main) is tracked for a cause-level fix outside this PR; a listener-ownership check such as the existing `_spawn_owns_listener` in `apps/backend.py` is a candidate mechanism for that follow-up.

Closes #6655
