### PR TITLE
feat(apps): durable job runtime and the shared _jobs surface

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -155,7 +155,6 @@ src/kiro_crew/apps/dependencies.py
 src/kiro_crew/apps/dependency_ledger.py
 src/kiro_crew/apps/dev_mode.py
 src/kiro_crew/apps/execution.py
-src/kiro_crew/apps/hooks_integration.py
 src/kiro_crew/apps/install_receipt.py
 src/kiro_crew/apps/manager.py
 src/kiro_crew/apps/manifest.py

--- a/src/kiro_crew/apps/context.py
+++ b/src/kiro_crew/apps/context.py
@@ -16,6 +16,7 @@ from typing import Any
 from kiro_crew.apps.app_storage import AppStorage
 from kiro_crew.apps.cron_sdk import CronSDK
 from kiro_crew.apps.event_bus import EventBus
+from kiro_crew.apps.job_sdk import JobSDK
 from kiro_crew.apps.spawn_sdk import SpawnSDK
 
 
@@ -64,6 +65,7 @@ class AppContext:
     events: EventBus | None = None
     storage: AppStorage | None = None
     spawn: SpawnSDK | None = None
+    job: JobSDK | None = None
     health: AppHealthStatus = field(default_factory=AppHealthStatus)
 
 
@@ -119,6 +121,17 @@ def build_app_context(
     if perms.get("storage"):
         app_storage = AppStorage(app_name, data_dir)
 
+    # Build JobSDK if permitted. Unlike cron/spawn there is no host service to
+    # inject: the run store IS the app's own data dir, so the permission alone
+    # decides. Registering it in the process-wide lookup the shared routes read
+    # is deliberately NOT done here -- that is the gateway wiring's job (see
+    # hooks_integration._build_app_context_from_info), so this factory stays
+    # free of process-global side effects and a test can build a context
+    # without publishing an SDK to every route.
+    job_sdk = None
+    if perms.get("jobs"):
+        job_sdk = JobSDK(app_name, data_dir)
+
     return AppContext(
         name=app_name,
         data_dir=data_dir,
@@ -128,4 +141,5 @@ def build_app_context(
         events=event_bus,
         storage=app_storage,
         spawn=spawn_sdk,
+        job=job_sdk,
     )

--- a/src/kiro_crew/apps/hooks_integration.py
+++ b/src/kiro_crew/apps/hooks_integration.py
@@ -28,6 +28,8 @@ from kiro_crew.apps.execution import (
     app_execution_denied,
     shipped_builtin_app_root,
 )
+from kiro_crew.apps.job_routes import register_job_routes
+from kiro_crew.apps.job_sdk import forget_sdk, get_sdk, reconcile_all, register_sdk
 from kiro_crew.apps.lifecycle import LifecycleDispatcher
 from kiro_crew.apps.manager import app_dir, list_apps
 from kiro_crew.apps.route_registry import RouteRegistry
@@ -88,6 +90,11 @@ def init_hooks_system(
     """
     global _route_registry, _lifecycle_dispatcher
 
+    # BEFORE the catch-all, not after: aiohttp matches in registration order, so
+    # /api/apps/{app_name}/{path:.*} would otherwise swallow every _jobs request
+    # and answer it from the app's own dispatch table.
+    register_job_routes(app)
+
     _route_registry = RouteRegistry(app)
     _route_registry.ensure_catch_all()
 
@@ -110,16 +117,12 @@ def get_lifecycle_dispatcher() -> LifecycleDispatcher | None:
     return _lifecycle_dispatcher
 
 
-async def stop_retained_startup_hooks(
-    app_name: str, *, bounded: bool
-) -> bool:
+async def stop_retained_startup_hooks(app_name: str, *, bounded: bool) -> bool:
     """Wait for retained startup execution, failing closed on ownership errors."""
     if _lifecycle_dispatcher is None:
         return True
     try:
-        return await _lifecycle_dispatcher.stop_detached_startup_hooks(
-            app_name, bounded=bounded
-        )
+        return await _lifecycle_dispatcher.stop_detached_startup_hooks(app_name, bounded=bounded)
     except Exception:  # noqa: BLE001 - destructive lifecycle work must fail closed
         logger.exception("Could not verify detached startup-hook cleanup for %s", app_name)
         return False
@@ -142,7 +145,7 @@ def _build_app_context_from_info(
     permissions = manifest.get("permissions", {})
     data_path = app_dir(name) / "data"
     data_path.mkdir(parents=True, exist_ok=True)
-    return build_app_context(
+    ctx = build_app_context(
         app_name=name,
         data_dir=data_path,
         permissions=permissions,
@@ -151,6 +154,13 @@ def _build_app_context_from_info(
         spawn_impl=spawn_impl,
         app_config=manifest.get("extra", {}),
     )
+    # The shared _jobs routes are mounted once for every app and resolve the app
+    # from the URL, so they need a name -> SDK lookup. Publishing happens here,
+    # in the gateway wiring, rather than inside build_app_context, so building a
+    # context in a test does not put an SDK behind the live routes.
+    if ctx.job is not None:
+        register_sdk(ctx.job)
+    return ctx
 
 
 async def on_app_enable(
@@ -231,19 +241,38 @@ async def on_app_enable(
     routes_hook = hooks.get("routes", "")
     if routes_hook and _route_registry:
         app_root = _app_hook_root(app_name)
-        registered = await _route_registry.register_app_routes(
-            app_name, app_root, routes_hook, ctx
-        )
+        registered = await _route_registry.register_app_routes(app_name, app_root, routes_hook, ctx)
         if registered:
             result["hooks_routes"] = registered
 
     # Invoke on_startup hook if declared
     startup_hook = hooks.get("on_startup", "")
     if startup_hook and _lifecycle_dispatcher:
-        success = await _lifecycle_dispatcher._invoke(
-            app_name, startup_hook, ctx, phase="startup"
-        )
+        success = await _lifecycle_dispatcher._invoke(app_name, startup_hook, ctx, phase="startup")
         result["hooks_startup"] = "ok" if success else "failed"
+
+    # Reconcile this app's job records now that its startup hook has registered
+    # the runners. The boot-time pass runs once, after the enable LOOP, so an app
+    # enabled later in the gateway's life never got one -- and reconciliation is
+    # only decidable once the runners are known, since "no runner for this kind"
+    # is one of the two outcomes it reports. Without this a record left
+    # non-terminal by a previous process stayed that way until the next restart,
+    # and `list_active` kept reporting work that had already stopped, which is the
+    # exact symptom this SDK exists to remove.
+    #
+    # Scoped to the hooks path on purpose: an app with no backend hooks returned
+    # above, and it can register no runners, so there is nothing here to decide
+    # against -- the boot-time pass already owns that case.
+    if getattr(ctx, "job", None) is not None:
+        try:
+            flipped = await asyncio.to_thread(ctx.job.reconcile)
+            if flipped:
+                result["job_reconcile"] = f"resolved {flipped} interrupted run(s)"
+        except Exception as exc:  # noqa: BLE001 - enable must not fail on this
+            logger.warning(
+                "App %s: job reconciliation after enable did not complete: %s", app_name, exc
+            )
+            result["job_reconcile"] = "failed: stale run records may remain"
 
     # Report health status
     health_snapshot = _publish_hook_health(app_name, ctx)
@@ -259,15 +288,69 @@ async def on_app_enable(
     return result
 
 
-async def stop_app_startup_hooks(
-    app_name: str, *, bounded: bool = False
-) -> bool:
+async def stop_app_startup_hooks(app_name: str, *, bounded: bool = False) -> bool:
     """Prove retained startup ownership clear before teardown mutates state."""
     if not _lifecycle_dispatcher:
         return True
-    return await _lifecycle_dispatcher.stop_detached_startup_hooks(
-        app_name, bounded=bounded
-    )
+    return await _lifecycle_dispatcher.stop_detached_startup_hooks(app_name, bounded=bounded)
+
+
+async def _cleanup_app_jobs(app_name: str, result: dict[str, Any]) -> None:
+    """Stop and drop an app's durable job runs, mirroring the cron contract:
+    idempotent, and a failure is REPORTED rather than crashing the disable.
+
+    Signalling is all the SDK can do about the WORK -- a runner that never polls
+    its handle within the deadline is reported -- and the RECORDS stay deleted:
+    the SDK marks every live handle discarded under the same lock its guarded
+    writer takes, so a worker returning mid-cleanup cannot write its record back,
+    and a partial delete is reported rather than read as clean.
+
+    Keyed off the REGISTRY, not the manifest grant. Gating this on
+    ``permissions.get("jobs")`` meant revoking the grant and then disabling took
+    the one path that skips it entirely: the SDK stays registered from the enable
+    that DID have the grant, its workers keep executing, and the lookup entry is
+    dropped afterwards -- so nothing can ever reach them again. The grant governs
+    whether an app may START jobs; whether it HAS any running is a fact about the
+    registry, and that is what teardown has to ask.
+
+    A separate function so that grant-independence is testable on its own; it was
+    unreachable while the logic sat inline behind the condition it must ignore.
+    """
+    job_sdk = get_sdk(app_name)
+    if job_sdk is None:
+        return
+    try:
+        cleanup = await job_sdk.remove_all_async()
+        if not cleanup.is_clean:
+            # Reported, not swallowed: a cleanup that left records behind OR left
+            # app code executing must not read as clean.
+            parts = []
+            if cleanup.failed:
+                parts.append(f"{cleanup.failed} run record(s) remain")
+            if cleanup.still_running:
+                parts.append(f"{cleanup.still_running} worker(s) still running")
+            result["job_cleanup"] = f"partial: removed {cleanup.removed}, " + "; ".join(parts)
+            sel().log_api_access(
+                caller="gateway",
+                operation="jobs.deregister",
+                outcome="partial",
+                resources=(
+                    f"app={app_name} removed={cleanup.removed} "
+                    f"failed={cleanup.failed} running={cleanup.still_running}"
+                ),
+            )
+        elif cleanup.removed:
+            result["job_cleanup"] = f"removed {cleanup.removed} run record(s)"
+    except OSError as exc:
+        logger.warning("App %s: job cleanup could not complete on disable: %s", app_name, exc)
+        result["job_cleanup"] = "failed: run records may remain"
+        sel().log_api_access(
+            caller="gateway",
+            operation="jobs.deregister",
+            outcome="failed",
+            resources=app_name,
+            error=str(exc),
+        )
 
 
 async def on_app_disable(
@@ -305,9 +388,7 @@ async def on_app_disable(
     # task becomes a hard teardown failure; callers keep trust in place rather
     # than falsely claiming all app code stopped.
     if startup_stopped is None:
-        startup_stopped = await stop_app_startup_hooks(
-            app_name, bounded=bounded_startup_cleanup
-        )
+        startup_stopped = await stop_app_startup_hooks(app_name, bounded=bounded_startup_cleanup)
     if not startup_stopped:
         result["startup_cleanup"] = (
             "failed: detached startup hook is still running; teardown not started"
@@ -367,14 +448,11 @@ async def on_app_disable(
                 # above forbids. Reported rather than retried: an unreadable store
                 # does not heal on its own.
                 logger.warning(
-                    "App %s: cron cleanup could not complete on disable — "
-                    "store unreadable: %s",
+                    "App %s: cron cleanup could not complete on disable — " "store unreadable: %s",
                     app_name,
                     exc,
                 )
-                result["cron_cleanup"] = (
-                    "failed: cron store unreadable — jobs may still be enabled"
-                )
+                result["cron_cleanup"] = "failed: cron store unreadable — jobs may still be enabled"
                 sel().log_api_access(
                     caller="gateway",
                     operation="app_crons_deregister",
@@ -396,6 +474,18 @@ async def on_app_disable(
                     resources=app_name,
                     error=str(exc),
                 )
+
+    # Stop and drop this app's durable job runs. Keyed off the registry, not
+    # the manifest grant -- see _cleanup_app_jobs for why that distinction is
+    # load-bearing on a revoked grant.
+    await _cleanup_app_jobs(app_name, result)
+
+    # Drop the lookup entry unconditionally, for the same reason the cleanup
+    # above ignores the grant: a revoked capability must not survive in the
+    # registry, and a conditional forget would leave the SDK published for the
+    # rest of the gateway's life. The route guard re-reads the manifest so it
+    # would refuse anyway, but the registry must not disagree with it.
+    forget_sdk(app_name)
 
     return result
 
@@ -480,16 +570,12 @@ async def on_gateway_startup(
         # Register routes (if declared)
         routes_hook = hooks.get("routes", "")
         if routes_hook and _route_registry:
-            await _route_registry.register_app_routes(
-                name, _app_hook_root(name), routes_hook, ctx
-            )
+            await _route_registry.register_app_routes(name, _app_hook_root(name), routes_hook, ctx)
 
         # Invoke on_startup hook (if declared)
         startup_hook = hooks.get("on_startup", "")
         if startup_hook and _lifecycle_dispatcher:
-            success = await _lifecycle_dispatcher._invoke(
-                name, startup_hook, ctx, phase="startup"
-            )
+            success = await _lifecycle_dispatcher._invoke(name, startup_hook, ctx, phase="startup")
             if success:
                 logger.info("Startup hook invoked for: %s", name)
 
@@ -501,6 +587,31 @@ async def on_gateway_startup(
         # _mark_cancelled_startup_residual at lifecycle.py:66), so an aggregate
         # would only re-log them, and only ever for this one caller.
         _publish_hook_health(name, ctx)
+
+    # AFTER the loop, deliberately: only here has every enabled app registered
+    # its runners, so a run whose kind has no runner can be told apart from an
+    # app that has simply not loaded yet. Reconciliation resolves runs that a
+    # previous gateway process left mid-flight -- a run must never be left
+    # `running` forever, and must never silently vanish.
+    try:
+        interrupted = await asyncio.to_thread(reconcile_all)
+        if interrupted:
+            logger.info("Startup: reconciled %d interrupted job run(s)", interrupted)
+            sel().log_api_access(
+                caller="gateway",
+                operation="jobs.reconcile",
+                outcome="completed",
+                resources=f"interrupted={interrupted}",
+            )
+    except Exception as exc:  # noqa: BLE001 - boot must not fail on a bad run store
+        logger.exception("Startup: job reconciliation failed")
+        sel().log_api_access(
+            caller="gateway",
+            operation="jobs.reconcile",
+            outcome="failed",
+            resources="startup",
+            error=str(exc),
+        )
 
 
 async def on_gateway_shutdown() -> None:

--- a/src/kiro_crew/apps/job_routes.py
+++ b/src/kiro_crew/apps/job_routes.py
@@ -1,0 +1,331 @@
+"""The shared ``_jobs/*`` HTTP surface for the Job SDK.
+
+Mounted ONCE for every app rather than per app: the routes carry ``{app}`` as a
+path segment and resolve that app's :class:`JobSDK` from the process registry —
+the same shape the Route Registry catch-all and the app API proxy already use.
+A per-app loop would need the app list at registration time, which is not known
+until the enable loop runs.
+
+Registration must happen BEFORE ``RouteRegistry.ensure_catch_all()`` installs
+``/api/apps/{app_name}/{path:.*}``, because aiohttp matches in registration
+order and that catch-all would otherwise swallow ``_jobs`` and answer with the
+app's own dispatch table instead.
+
+Authorization. These paths sit inside ``/api/apps/{app}``, which
+``_app_owns_path`` grants to that app's own token unconditionally, and the
+conventional ``/api/apps/<app>/*`` manifest grant covers them too — so a
+consuming app needs no new ``permissions.api`` entry. On top of that this
+surface is deliberately OWNER-GATED like the account portal: ``start`` runs real
+work with real side effects, and P1 ships with no consumer that needs an
+app-token caller, so the narrower gate is the one that ships. Opening it to app
+tokens is a later, deliberate change with its own review, not a default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from functools import wraps
+from typing import Any, Awaitable, Callable
+
+from aiohttp import web
+
+from kiro_crew.apps.job_sdk import JobError, JobRun, JobSDK, UnknownJobKind, get_sdk
+from kiro_crew.apps.manager import get_app_manifest, is_app_enabled
+from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
+
+# The dashboard owner/session guards are imported lazily, INSIDE the request
+# path, on purpose. Importing them at module scope pulls in
+# ``kiro_crew.dashboard.handlers``, whose package init reaches
+# ``handlers.security -> apps.routes -> apps.hooks_integration`` -- and
+# ``hooks_integration`` is what imports this module to mount the routes, so a
+# module-scope import closes the cycle and breaks gateway boot with a partially
+# initialized module. Same reason ``cron_sdk`` defers its ``mcp_cron`` vetting
+# imports. Per-request cost is a dict lookup in ``sys.modules``; by the time a
+# request arrives the dashboard package is long since loaded.
+
+Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
+
+#: Mounted under each app's own namespace.
+_PREFIX = "/api/apps/{app}/_jobs"
+
+#: Cap on a single ``recent`` page, so a caller cannot ask the gateway to read
+#: an app's entire run history into one response.
+_RECENT_MAX = 100
+
+
+def _audit(app: str, operation: str, resources: str, outcome: str, *, error: str = "") -> None:
+    """Best-effort SEL audit; never blocks the response."""
+    try:
+        sel().log_api_access(
+            caller="dashboard-owner",
+            operation=f"jobs.{operation}",
+            outcome=outcome,
+            source=app or "jobs",
+            resources=resources[:200],
+            error=error[:200],
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("jobs SEL audit failed", exc_info=True)
+
+
+def _safe(text: str) -> str:
+    """Scrub an SDK error before it becomes a response body.
+
+    The SDK already redacts what a runner produces; this covers the message the
+    SDK itself raises, which can quote a path or a kind name supplied by the
+    caller.
+    """
+    try:
+        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+        out, _ = redact_credentials(text)
+        out, _ = redact_exfiltration_urls(out)
+        return out[:500]
+    except Exception:  # noqa: BLE001 - redaction must not mask the error
+        return text[:500]
+
+
+def _public_view(run: JobRun) -> dict[str, Any]:
+    """The record as the browser sees it.
+
+    ``origin`` and ``pid`` are host facts with no client meaning, so they are
+    withheld. Everything else the record holds is served: P1's record has no
+    caller- or runner-supplied payload to decide about, which is why there is no
+    per-field withholding rule here any more.
+    """
+    return {
+        "run_id": run.run_id,
+        "kind": run.kind,
+        "status": run.status,
+        "cancellable": run.cancellable,
+        "created_at": run.created_at,
+        "updated_at": run.updated_at,
+        "finished_at": run.finished_at,
+        "error": run.error,
+    }
+
+
+def _enabled_and_permitted(app_name: str) -> tuple[bool, bool]:
+    """Read enablement AND the declared ``jobs`` grant. Call off the loop.
+
+    Authorization must NOT rest on the process registry: an SDK is published at
+    enable time and lives for the gateway's life, so a grant revoked in the
+    manifest afterwards would otherwise keep serving through the stale entry.
+    The manifest is the authority; the registry only says where the runs are.
+    """
+    if not is_app_enabled(app_name):
+        return False, False
+    manifest = get_app_manifest(app_name)
+    return True, bool(manifest and manifest.permissions.jobs)
+
+
+def _guarded(
+    handler: Callable[[web.Request, str, JobSDK], Awaitable[web.StreamResponse]],
+) -> Handler:
+    """Enabled + grant + owner check, then hand the app and SDK to the handler."""
+
+    @wraps(handler)
+    async def _wrapped(request: web.Request) -> web.StreamResponse:
+        from kiro_crew.dashboard.handlers._shared import _owner_denial_response
+        from kiro_crew.dashboard.handlers.source_providers import (
+            is_owner_dashboard_request,
+        )
+
+        app_name = request.match_info.get("app", "")
+        if not app_name:
+            return web.json_response(
+                {"error": "app name missing from path", "code": "app_name_required"},
+                status=400,
+            )
+        # Reads installed.json and the manifest from disk -- off the loop.
+        enabled, permitted = await asyncio.to_thread(_enabled_and_permitted, app_name)
+        if not enabled:
+            _audit(app_name, "access", request.path, "denied", error="app_disabled")
+            return web.json_response(
+                {"error": "app is disabled", "code": "app_disabled"}, status=403
+            )
+        if not permitted:
+            _audit(app_name, "access", request.path, "denied", error="jobs_not_granted")
+            return web.json_response(
+                {"error": "app has no job runtime", "code": "jobs_not_enabled"},
+                status=404,
+            )
+        if not is_owner_dashboard_request(request):
+            _audit(app_name, "access", request.path, "denied", error="non-owner")
+            return _owner_denial_response(
+                request, "dashboard owner required", "dashboard_owner_required"
+            )
+        sdk = get_sdk(app_name)
+        if sdk is None:
+            # Granted but nothing published: the app declared the permission and
+            # is enabled, yet its context was never built (a failed enable). A
+            # 404 rather than a 403 -- there is nothing here to be denied.
+            return web.json_response(
+                {"error": "app has no job runtime", "code": "jobs_not_enabled"},
+                status=404,
+            )
+        # An ALLOW is a permission decision too. Auditing only denials leaves an
+        # incident review able to see who was refused and not who got through.
+        _audit(app_name, "access", request.path, "allowed")
+        return await handler(request, app_name, sdk)
+
+    return _wrapped
+
+
+def _mutating(
+    operation: str,
+) -> Callable[
+    [Callable[[web.Request, str, JobSDK], Awaitable[web.StreamResponse]]],
+    Callable[[web.Request, str, JobSDK], Awaitable[web.StreamResponse]],
+]:
+    """Refuse a restricted session, then audit the outcome of a mutation."""
+
+    def _decorate(
+        handler: Callable[[web.Request, str, JobSDK], Awaitable[web.StreamResponse]],
+    ) -> Callable[[web.Request, str, JobSDK], Awaitable[web.StreamResponse]]:
+        @wraps(handler)
+        async def _wrapped(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
+            state = request.app.get("state")
+            if state is not None:
+                from kiro_crew.dashboard.handlers._shared import _is_restricted_session
+
+                if _is_restricted_session(state, request):
+                    _audit(app_name, operation, request.path, "denied", error="restricted session")
+                    return web.json_response(
+                        {
+                            "error": "this session may not start or stop work",
+                            "code": "restricted_session",
+                        },
+                        status=403,
+                    )
+            response = await handler(request, app_name, sdk)
+            _audit(
+                app_name,
+                operation,
+                request.path,
+                "success" if response.status < 400 else "refused",
+            )
+            return response
+
+        return _wrapped
+
+    return _decorate
+
+
+async def _body(request: web.Request) -> dict[str, Any]:
+    try:
+        data = await request.json()
+    except Exception:  # noqa: BLE001 - a malformed body is an empty one
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+# ── Handlers ──
+
+
+async def _handle_start(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
+    kind = request.match_info.get("kind", "")
+    body = await _body(request)
+    dedupe_key = body.get("dedupe_key", "")
+    if not isinstance(dedupe_key, str):
+        return web.json_response(
+            {"error": "dedupe_key must be a string", "code": "invalid_dedupe_key"},
+            status=400,
+        )
+    try:
+        run_id = await sdk.start_async(kind, dedupe_key=dedupe_key)
+    except UnknownJobKind as exc:
+        # Not 400: the request is well-formed, the named kind simply does not
+        # exist on this app -- and a kind with no runner must never queue a run
+        # nothing will ever service.
+        #
+        # Scrubbed like every other outbound error here. The message quotes the
+        # `kind` the CALLER chose, so an unregistered kind carrying a credential
+        # was reflected into the response verbatim -- the one error path on this
+        # surface that skipped `_safe`.
+        return web.json_response({"error": _safe(str(exc)), "code": "unknown_job_kind"}, status=404)
+    except JobError as exc:
+        # The SDK refused to start: it could not persist the initial record, or
+        # the host refused a thread. Without this the JobError would reach
+        # aiohttp's default handler as a bare 500 carrying no machine-readable
+        # code, which no client can switch on.
+        return web.json_response({"error": _safe(str(exc)), "code": "job_start_failed"}, status=503)
+    run = await asyncio.to_thread(sdk.get, run_id)
+    if run is None:
+        return web.json_response(
+            {"error": "the run record could not be read back", "code": "run_unreadable"},
+            status=500,
+        )
+    return web.json_response({"run": _public_view(run)})
+
+
+async def _handle_active(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
+    kind = request.query.get("kind", "")
+    runs = await asyncio.to_thread(sdk.list_active, kind)
+    return web.json_response({"runs": [_public_view(r) for r in runs]})
+
+
+async def _handle_recent(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
+    kind = request.query.get("kind", "")
+    raw_limit = request.query.get("limit", "20")
+    try:
+        limit = int(raw_limit)
+    except ValueError:
+        return web.json_response(
+            {"error": "limit must be an integer", "code": "invalid_limit"}, status=400
+        )
+    limit = max(1, min(limit, _RECENT_MAX))
+    runs = await asyncio.to_thread(sdk.list_recent, kind, limit)
+    return web.json_response({"runs": [_public_view(r) for r in runs]})
+
+
+async def _handle_get(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
+    run_id = request.match_info.get("run_id", "")
+    run = await asyncio.to_thread(sdk.get, run_id)
+    if run is None:
+        return web.json_response({"error": "no such run", "code": "job_not_found"}, status=404)
+    return web.json_response({"run": _public_view(run)})
+
+
+async def _handle_cancel(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
+    run_id = request.match_info.get("run_id", "")
+    run = await asyncio.to_thread(sdk.get, run_id)
+    if run is None:
+        return web.json_response({"error": "no such run", "code": "job_not_found"}, status=404)
+    accepted = await sdk.cancel_async(run_id)
+    if not accepted:
+        # Deliberately not an error: the run is finished, was never declared
+        # cancellable, or belongs to a process that is gone. Saying so beats a
+        # 200 that implies the run is stopping when nothing can reach it.
+        return web.json_response(
+            {
+                "error": "this run cannot be cancelled",
+                "code": "job_not_cancellable",
+                "run": _public_view(run),
+            },
+            status=409,
+        )
+    fresh = await asyncio.to_thread(sdk.get, run_id)
+    return web.json_response({"cancelling": True, "run": _public_view(fresh or run)})
+
+
+# ── Registration ──
+
+
+def register_job_routes(app: web.Application) -> None:
+    """Mount the shared ``_jobs`` family. Call before the app catch-all.
+
+    ``active`` and ``recent`` are registered BEFORE ``{run_id}``: aiohttp
+    matches in registration order, so the literal segments would otherwise be
+    captured as run ids and every list request would 404 as an unknown run.
+    """
+    r = app.router
+    r.add_get(f"{_PREFIX}/active", _guarded(_handle_active))
+    r.add_get(f"{_PREFIX}/recent", _guarded(_handle_recent))
+    r.add_get(_PREFIX + "/{run_id}", _guarded(_handle_get))
+    r.add_post(_PREFIX + "/{kind}/start", _guarded(_mutating("start")(_handle_start)))
+    r.add_post(_PREFIX + "/{run_id}/cancel", _guarded(_mutating("cancel")(_handle_cancel)))
+    logger.info("Job SDK routes registered under %s", _PREFIX)

--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -1,0 +1,963 @@
+"""Job SDK — app-scoped durable runs for long, user-initiated foreground work.
+
+``CronSDK`` schedules work for later; this owns work a human started and is
+watching NOW. The gap it closes is that the product had no server-side
+representation of "a task of mine is running": the fact lived only in the React
+component that started it, so navigating away destroyed the fact while the work
+kept going, and the UI then reported the task as stopped. See
+``docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md``.
+
+Five design points are load-bearing rather than incidental.
+
+**P1 records that a run EXISTS and how it ended — nothing it produced.** There
+is no ``params`` a caller passes in, and no ``progress`` or ``result`` a runner
+reports out. A run's record holds its identity, its lifecycle and, if it failed,
+one error string. That is deliberate and is the whole of what the originating
+problem needs: the UI's question is "is my task still running", not "how far
+along is it". The payload channels are structured data that must be sanitized
+before it can be written or served, and P1 has NO consumer that reads them, so
+they were carrying that cost for capability nobody calls. They return in P2,
+designed against a real consumer, as types that are sanitized by construction
+rather than by a rule each writer has to remember.
+
+**A runner is REGISTERED, not passed per call.** ``register(kind, fn)`` binds a
+kind to the callable that services it, once, at app init. ``start(kind, ...)``
+then names the kind only. This is what lets a caller that cannot hold a Python
+callable — the browser, and the startup reconciliation pass — address a run.
+
+**Cancellation is cooperative and DECLARED.** A worker thread cannot be killed,
+so ``cancel()`` can only ask. The SDK cannot inspect an arbitrary ``fn`` to find
+out whether it ever checks, so cancellability is the app's assertion at
+``register(..., cancellable=True)`` and defaults to False. A run recorded
+``cancellable: false`` answers ``cancel()`` with ``False`` rather than
+pretending, and the UI hides the control instead of offering a button that does
+nothing.
+
+**One writer per run file.** There is no lock helper beside ``atomic_write`` and
+concurrent read-modify-write of one document is last-writer-wins, so each run is
+its own file and writers never share a path: ``start`` writes the initial record
+BEFORE handing off, the worker thread is the sole writer from then on, and
+``cancel`` writes nothing at all (it sets an in-memory event; the worker records
+the outcome at its next checkpoint). Reconciliation writes only records from a
+process that is already gone.
+
+**Claiming a run and LAUNCHING it are separate, and the interval between them is
+named.** That interval contains a disk write, so it is not instantaneous, and the
+run is already in the live table while its thread does not yet exist. Three
+defects came from code that had no name for that state: cleanup joined a thread
+that was never started, which raised and escaped the disable so the records were
+never deleted; a start that had already claimed launched into an app being
+disabled; and the record said ``running`` while no worker existed. So the record
+starts at ``STARTING`` and the worker itself completes the transition to
+``RUNNING``, the live entry carries ``started`` as the one authority on whether
+there is a thread to join, and the launch is a GUARDED transition performed under
+the same lock cleanup marks with -- not an unconditional call. Each of the three
+questions is now answered by reading state rather than by assuming it.
+
+That discipline settles writer-vs-WRITER, not reader-vs-writer: a reader still
+races the one writer's temp-file-plus-rename. POSIX hides this because rename is
+atomic for a reader, so the reads go through ``atomic_write``'s
+``read_bytes_with_retry`` -- on Windows the same instant raises
+``PermissionError`` at the reader, and a record read is not optional here
+(``get`` answers the HTTP surface, and ``iter_runs`` feeds reconciliation).
+
+Staleness is decided by ``_ORIGIN``, a token minted once per gateway process —
+not by pid, which can be reused by the very process doing the reconciling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from kiro_crew.atomic_write import atomic_write, read_bytes_with_retry
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
+
+#: Identity of THIS gateway process. A run record carrying a different origin
+#: belongs to a process that no longer exists, which is what makes staleness
+#: decidable without trusting a pid (pids are reused, and the reconciling
+#: process could hold the very pid a stale record names).
+_ORIGIN = uuid.uuid4().hex
+
+QUEUED = "queued"
+#: Claimed, durable, and NOT yet executing: the record is on disk and the run
+#: owns its dedupe key, but its worker thread has not been started. This state
+#: exists because the interval between claiming a run and launching it is real --
+#: it contains a disk write -- and three separate defects came from code that had
+#: no way to name it. Cleanup joined a thread that was never started; a start that
+#: had already claimed launched into an app that was being disabled; and the
+#: record said ``running`` while no worker existed. A state that can be READ under
+#: the same lock the transitions take makes each of those decidable instead of
+#: guessable.
+STARTING = "starting"
+RUNNING = "running"
+DONE = "done"
+FAILED = "failed"
+CANCELLED = "cancelled"
+INTERRUPTED = "interrupted"
+
+#: A run in a terminal state is never resumed and never reconciled.
+TERMINAL_STATES = frozenset({DONE, FAILED, CANCELLED, INTERRUPTED})
+
+#: Length of an SDK-minted run id (``uuid.uuid4().hex``). Validated, not just
+#: assumed: a caller reaches ``{run_id}`` on the HTTP surface directly, and a
+#: hex string of any other length is not a run this SDK ever minted. Checking
+#: only the ALPHABET let a very long id through, and the oversized filename it
+#: built raised ``ENAMETOOLONG`` -- an ``OSError`` no read handler names -- which
+#: surfaced as a 500 where a 404 is the honest answer.
+_RUN_ID_LEN = 32
+
+#: How long disable waits for one worker to notice its cancel signal. Bounded:
+#: a runner that never polls its handle must not be able to block an app's
+#: disable indefinitely, so it is reported instead.
+_CLEANUP_JOIN_SECS = 5.0
+
+_RUNS_DIRNAME = "jobs"
+
+
+class JobError(RuntimeError):
+    """Base class for Job SDK refusals."""
+
+
+class UnknownJobKind(JobError):
+    """Raised when starting a kind that has no registered runner."""
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _redact(text: str) -> str:
+    """Scrub the ONE runner-produced string a record carries: its error.
+
+    A failing runner's exception text can quote back a command line carrying a
+    credential, so the same chain the app route boundaries apply runs here, at
+    the point the text stops being local. Applied at INGEST rather than on the
+    way out, so the record on disk is clean too.
+    """
+    try:
+        out, _ = redact_credentials(text)
+        out, _ = redact_exfiltration_urls(out)
+        return out
+    except Exception:  # noqa: BLE001 - redaction must never mask the error itself
+        logger.debug("job text redaction failed", exc_info=True)
+        return text
+
+
+@dataclass
+class JobRun:
+    """One run's durable record. Serialized whole; never partially updated.
+
+    ``error`` is the ONLY field a runner supplies. Everything else is minted by
+    the SDK, which is what makes the sanitize rule one line rather than a list
+    somebody has to remember to extend.
+    """
+
+    run_id: str
+    app: str
+    kind: str
+    status: str = QUEUED
+    origin: str = ""
+    pid: int = 0
+    dedupe_key: str = ""
+    cancellable: bool = False
+    created_at: str = ""
+    updated_at: str = ""
+    finished_at: str = ""
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> JobRun:
+        """Build a record from disk, tolerating a hand-edited or older file.
+
+        Unknown keys are dropped rather than raising: a run record is data the
+        gateway re-reads across upgrades, so one unexpected field must not make
+        an app's whole run history unreadable.
+
+        A body that is not an OBJECT breaks that promise from the other side. A
+        file holding ``[]`` or ``"x"`` or ``5`` is valid JSON, so it survives the
+        parse, and then ``.items()`` raises ``AttributeError`` -- which neither
+        reader's handler names, so it escaped as a 500 from the route and
+        ABANDONED the whole reconciliation scan, stranding every later record of
+        that app. Refused as ``ValueError`` because that is the failure both
+        readers already treat as "this one record is unusable", so the blast
+        radius is the one file rather than the pass.
+
+        A WRONG-TYPED field does the same damage one level in: a record whose
+        ``error`` is a number reached ``_persist``, where the slice after the
+        redaction raised ``TypeError`` outside that method's own try. So each
+        known field is coerced to its declared type HERE, at the single point
+        foreign data enters, and a value that cannot be coerced falls back to the
+        field's default. Every consumer downstream then gets the type it is
+        written against, instead of each one needing its own defence.
+        """
+        if not isinstance(data, dict):
+            raise ValueError(f"job record is {type(data).__name__}, not an object")
+        kwargs: dict[str, Any] = {}
+        for name, spec in cls.__dataclass_fields__.items():
+            if name not in data:
+                continue
+            value = data[name]
+            want = spec.type
+            # ``bool`` before ``int``: bool IS an int subclass, so testing int
+            # first would silently accept True for a pid.
+            if want == "bool":
+                if isinstance(value, bool):
+                    kwargs[name] = value
+            elif want == "int":
+                if isinstance(value, int) and not isinstance(value, bool):
+                    kwargs[name] = value
+            elif isinstance(value, str):
+                kwargs[name] = value
+        kwargs.setdefault("run_id", "")
+        kwargs.setdefault("app", "")
+        kwargs.setdefault("kind", "")
+        return cls(**kwargs)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATES
+
+
+class JobHandle:
+    """What a runner is handed: the cancel signal it must poll.
+
+    ``cancelled`` is a ``threading.Event`` and checking it is the runner's own
+    responsibility — the SDK has no way to interrupt a thread that never looks.
+
+    There is deliberately no ``progress()`` in P1. With no progress channel the
+    worker writes its record exactly ONCE, terminally, so the record has a
+    single writer over its whole life instead of a stream of mid-run mutations
+    each needing the discard check to be right.
+    """
+
+    def __init__(self, run: JobRun) -> None:
+        self.cancelled = threading.Event()
+        #: Set when this run's record has been deliberately dropped (app
+        #: disable). Checked INSIDE the guarded writer, under the same lock the
+        #: discard is set with -- checking it here and writing afterwards was a
+        #: check-then-act race: cleanup could delete the file in between and the
+        #: write would recreate it, because ``JobStore.write`` mkdirs and writes
+        #: unconditionally and cannot tell a first write from a resurrection.
+        self.discarded = threading.Event()
+        self._run = run
+
+    @property
+    def run_id(self) -> str:
+        return self._run.run_id
+
+
+#: A runner receives its handle and nothing else. P1 has no parameter channel:
+#: caller-supplied ``params`` was the other half of what made a record hold
+#: arbitrary nested data, and it returns in P2 with the payload channels.
+JobFn = Callable[["JobHandle"], Any]
+
+
+@dataclass
+class CleanupResult:
+    """What a disable actually achieved.
+
+    ``still_running`` is a field rather than a log line because a cleanup that
+    left app code executing must not be reportable as clean -- the caller has to
+    be able to say so in the disable result.
+    """
+
+    removed: int = 0
+    failed: int = 0
+    still_running: int = 0
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.failed and not self.still_running
+
+
+@dataclass
+class _Runner:
+    fn: JobFn
+    cancellable: bool
+
+
+@dataclass
+class _Live:
+    handle: JobHandle
+    thread: threading.Thread
+    #: Whether ``thread.start()` has actually run. The ONE authority on "is there
+    #: a thread to wait for", flipped only inside the lock, because cleanup makes
+    #: a decision from it and a bool it has to infer is what it got wrong before:
+    #: it joined every entry it snapshotted, and ``Thread.join()`` on a thread that
+    #: was never started raises ``RuntimeError``, which escaped the disable and
+    #: left the app's records in place with its worker running. Kept here rather
+    #: than read off the record because cleanup never reads the record, and the
+    #: two answers must not be able to disagree.
+    started: bool = False
+
+
+class JobStore:
+    """One JSON file per run under ``<app data dir>/jobs/``.
+
+    File-per-run rather than one document: ``atomic_write`` gives crash-safety
+    (no reader sees a torn file) but not mutual exclusion, so two writers on one
+    path would silently drop the loser's update. Separate paths remove the race
+    instead of needing a lock the tree does not offer.
+    """
+
+    def __init__(self, data_dir: Path) -> None:
+        self.dir = Path(data_dir) / _RUNS_DIRNAME
+
+    def _path(self, run_id: str) -> Path:
+        # run ids are SDK-minted hex; reject anything else rather than letting a
+        # caller-supplied id become a path. LENGTH is checked as well as the
+        # alphabet: `{run_id}` is reachable on the HTTP surface, and a very long
+        # all-hex id passed the alphabet check, built a filename over the OS
+        # limit, and raised ENAMETOOLONG -- an OSError no read handler names, so
+        # it left as a 500 instead of the 404 an unknown id deserves.
+        if len(run_id) != _RUN_ID_LEN or not all(c in "0123456789abcdef" for c in run_id):
+            raise ValueError(f"invalid run id: {run_id!r}")
+        return self.dir / f"{run_id}.json"
+
+    def write(self, run: JobRun) -> None:
+        run.updated_at = _now()
+        path = self._path(run.run_id)
+        self.dir.mkdir(parents=True, exist_ok=True)
+        atomic_write(path, json.dumps(run.to_dict(), indent=1))
+
+    def read(self, run_id: str) -> JobRun | None:
+        try:
+            # ``read_bytes_with_retry``, not ``read_text``, for two reasons a
+            # POSIX-only run never shows. A worker replacing this file races a
+            # reader here, and on Windows ``os.replace`` makes that reader fail
+            # with ``PermissionError`` while a plain rename does not -- the
+            # read-side twin of the retry ``atomic_write`` already applies to the
+            # write. And the decode is explicit because ``atomic_write`` emits
+            # UTF-8 while ``read_text`` would decode in the host LOCALE, so a
+            # non-UTF-8 Windows console would mis-read a redacted non-ASCII
+            # string. Reached only off the loop (the routes offload every call),
+            # which is what lets the helper's sleep apply at all.
+            raw = read_bytes_with_retry(self._path(run_id)).decode("utf-8")
+        except (FileNotFoundError, NotADirectoryError, ValueError):
+            return None
+        try:
+            return JobRun.from_dict(json.loads(raw))
+        except (TypeError, ValueError):
+            logger.warning("unreadable job run record: %s", run_id)
+            return None
+
+    def iter_runs(self) -> Iterator[JobRun]:
+        if not self.dir.is_dir():
+            return
+        for path in sorted(self.dir.glob("*.json")):
+            try:
+                # Same Windows window as ``read``, but here it failed SILENTLY
+                # rather than loudly: ``PermissionError`` subclasses ``OSError``,
+                # so a record being replaced by its own worker was skipped as
+                # "unreadable" and simply vanished from this listing -- and a
+                # record missed here is a record reconciliation does not resolve,
+                # so a stale ``running`` would survive the boot meant to clear it.
+                raw = read_bytes_with_retry(path).decode("utf-8")
+                run = JobRun.from_dict(json.loads(raw))
+            except (OSError, TypeError, ValueError):
+                logger.warning("skipping unreadable job record: %s", path.name)
+                continue
+            yield run
+
+    def remove_all(self) -> tuple[int, int]:
+        """Delete every record. Returns ``(removed, failed)``.
+
+        The failure count is returned rather than swallowed: reporting only the
+        successes let a partial delete read as a clean one, so disable would
+        claim the app's runs were gone while records remained. The cron contract
+        this mirrors reports a failed cleanup, and so does this.
+        """
+        removed = 0
+        failed = 0
+        if not self.dir.is_dir():
+            return 0, 0
+        for path in list(self.dir.glob("*.json")):
+            try:
+                path.unlink()
+                removed += 1
+            except OSError:
+                failed += 1
+                logger.warning("could not remove job record: %s", path.name)
+        return removed, failed
+
+
+class JobSDK:
+    """App-scoped durable runs. One instance per app, for the gateway's life."""
+
+    def __init__(self, app_name: str, data_dir: Path) -> None:
+        self._app_name = app_name
+        self._store = JobStore(data_dir)
+        self._runners: dict[str, _Runner] = {}
+        self._live: dict[str, _Live] = {}
+        #: (kind, dedupe_key) -> run_id for runs live in THIS process. Held in
+        #: memory rather than derived from the store so the dedupe check and the
+        #: claim can happen in ONE critical section: the previous version read
+        #: the disk between them, so two near-simultaneous starts both saw no
+        #: owner and both ran -- exactly the double-click case dedupe exists to
+        #: stop.
+        self._keys: dict[tuple[str, str], str] = {}
+        # A plain threading lock: it guards two small dicts with no awaits
+        # inside, and an asyncio primitive here would bind this SDK to the loop
+        # that happened to construct it.
+        self._lock = threading.Lock()
+        #: Set by ``remove_all_async``, under the lock, BEFORE it snapshots the
+        #: live table. Disable has to be terminal for this SDK instance: the
+        #: route guard re-reads the manifest, but an app's own code holds a
+        #: reference to this object, so without this flag a ``start`` racing
+        #: cleanup could claim and spawn a worker after the snapshot was taken
+        #: and leave a disabled app doing real work with no record. Checked in
+        #: the SAME critical section as the dedupe claim, so there is no window
+        #: between the check and the claim.
+        self._closed = False
+
+    @property
+    def app_name(self) -> str:
+        return self._app_name
+
+    @property
+    def store(self) -> JobStore:
+        return self._store
+
+    # ── The one writer ──
+
+    def _persist(self, run: JobRun, handle: JobHandle | None = None) -> bool:
+        """Write a run's record. The ONLY path that writes one.
+
+        Three callers used to write directly -- start, the worker's terminal
+        write, and reconcile (a fourth, progress, is gone with the progress
+        channel) -- and each had to remember the same three rules. Two review
+        rounds found a different one missed each time, so the rules live here
+        instead:
+
+        * the discard check and the write happen under ONE lock acquisition, the
+          same lock ``remove_all_async`` sets ``discarded`` with, so cleanup can
+          no longer land between a caller's check and its write and have the
+          record recreated;
+        * a serialization or I/O failure returns ``False`` instead of raising, so
+          a caller's bookkeeping (the live table, the dedupe claim) can never be
+          skipped by an exception escaping mid-cleanup;
+        * the record is JSON-safe by construction: every field except ``error``
+          is minted by the SDK from a str, an int or a bool.
+
+        Returns True when the record is on disk.
+        """
+        # INVARIANT: nothing a runner supplied reaches disk unsanitized. This is
+        # ONE line because ``error`` is the only field a runner supplies, and
+        # that is the point: the earlier backstop scrubbed a hand-written LIST
+        # (step, error, lines, params, result), and four rounds each found a
+        # different member missing. A funnel with one input cannot.
+        run.error = _redact(run.error)[:2000]
+        with self._lock:
+            if handle is not None and handle.discarded.is_set():
+                return False
+            try:
+                self._store.write(run)
+                return True
+            except Exception:  # noqa: BLE001 - a write failure is a result, not a crash
+                logger.exception("could not persist job record %s", run.run_id)
+                return False
+
+    # ── Registration ──
+
+    def register(self, kind: str, fn: JobFn, *, cancellable: bool = False) -> None:
+        """Bind ``kind`` to the callable that services it.
+
+        Call from the app's ``on_startup`` hook. ``cancellable=True`` is the
+        app's assertion that ``fn`` polls ``handle.cancelled`` at checkpoints;
+        the SDK cannot verify it, so the consumer's migration checklist has to
+        name those checkpoints.
+        """
+        if not kind:
+            raise ValueError("job kind must be a non-empty string")
+        with self._lock:
+            self._runners[kind] = _Runner(fn=fn, cancellable=cancellable)
+        logger.info("App %s registered job kind: %s", self._app_name, kind)
+
+    def kinds(self) -> list[str]:
+        with self._lock:
+            return sorted(self._runners)
+
+    def is_cancellable(self, kind: str) -> bool:
+        with self._lock:
+            runner = self._runners.get(kind)
+        return bool(runner and runner.cancellable)
+
+    # ── Start ──
+
+    def start(self, kind: str, *, dedupe_key: str = "") -> str:
+        """Start a run of ``kind`` and return its run id.
+
+        With a ``dedupe_key``, a second start while a run of the same kind and
+        key is still in flight ADOPTS that run instead of beginning another —
+        which is what stops a double click, or two tabs, from doing the paid
+        work twice.
+
+        There is no ``params`` in P1: a runner takes its handle and nothing
+        else. Caller-supplied arguments are structured data that has to be
+        sanitized before it can be written or served, and that channel returns
+        in P2 together with the progress and result channels.
+
+        Synchronous, and safe on the event loop: the only blocking work is one
+        small ``atomic_write``. Unlike ``CronSDK``'s mutators there is no
+        bounded store-lock spin to park the loop on, so this does not refuse an
+        on-loop caller. :meth:`start_async` exists for callers who would rather
+        not touch the disk from the loop thread at all.
+        """
+        with self._lock:
+            runner = self._runners.get(kind)
+        if runner is None:
+            raise UnknownJobKind(
+                f"app {self._app_name} has no registered runner for job kind {kind!r}"
+            )
+
+        run = JobRun(
+            run_id=uuid.uuid4().hex,
+            app=self._app_name,
+            kind=kind,
+            # STARTING, not RUNNING: no worker exists yet, and the initial write
+            # below happens before one does. Claiming `running` here made the
+            # record assert something untrue for the length of a disk write, which
+            # `list_active` then served. The worker flips it as its first act.
+            status=STARTING,
+            origin=_ORIGIN,
+            pid=os.getpid(),
+            dedupe_key=dedupe_key,
+            cancellable=runner.cancellable,
+            created_at=_now(),
+        )
+        handle = JobHandle(run)
+        thread = threading.Thread(
+            target=self._execute,
+            args=(run, runner, handle),
+            name=f"job:{self._app_name}:{run.kind}",
+            daemon=True,
+        )
+
+        # CHECK AND CLAIM IN ONE CRITICAL SECTION. Building the record, handle
+        # and (unstarted) thread first keeps every await-free line above out of
+        # the lock, so the section below holds no I/O at all -- which is what
+        # makes it safe to be atomic. Splitting the check from the claim is what
+        # let two concurrent starts both win. The closed check belongs in this
+        # same section for the same reason: cleanup sets the flag under this lock
+        # before snapshotting, so a start that gets here after that cannot claim.
+        key = (kind, dedupe_key) if dedupe_key else None
+        with self._lock:
+            if self._closed:
+                raise JobError(
+                    f"app {self._app_name} is no longer accepting jobs; its job "
+                    "runtime was shut down"
+                )
+            if key is not None:
+                existing = self._keys.get(key)
+                if existing is not None:
+                    # The key itself is NOT logged: it is caller-supplied and can
+                    # carry a credential or an account id, and the gateway log is
+                    # durable and served by /api/logs. The run id and the kind
+                    # identify the adoption without quoting the caller's string.
+                    logger.info(
+                        "App %s adopted in-flight job %s for kind=%s",
+                        self._app_name,
+                        existing,
+                        kind,
+                    )
+                    return existing
+                self._keys[key] = run.run_id
+            self._live[run.run_id] = _Live(handle=handle, thread=thread)
+
+        # Outside the lock, and BEFORE the worker exists, so this write still has
+        # no competing writer. If it fails the claim must not leak, or the kind's
+        # dedupe key would stay owned by a run that never started.
+        if not self._persist(run):
+            with self._lock:
+                self._live.pop(run.run_id, None)
+                if key is not None:
+                    self._keys.pop(key, None)
+            raise JobError(f"could not persist the initial record for job kind {kind!r}")
+
+        # LAUNCH AS A GUARDED TRANSITION, not as an unconditional call. Everything
+        # above happened outside the lock, including a disk write, so by now the
+        # app may have been disabled -- and this run is ALREADY in `_live`, which
+        # is the case `_closed` alone cannot cover: that flag refuses a start that
+        # reaches the claim section after cleanup, and this one got there first.
+        # Cleanup marks the handle discarded under this same lock, so re-reading
+        # both here is what makes "may I start" answerable rather than assumed.
+        with self._lock:
+            entry = self._live.get(run.run_id)
+            if self._closed or handle.discarded.is_set() or entry is None:
+                # Refused: unwind the claim so the key is not owned by a run that
+                # will never exist.
+                self._live.pop(run.run_id, None)
+                if key is not None:
+                    self._keys.pop(key, None)
+                refused = True
+                start_error: Exception | None = None
+            else:
+                refused = False
+                try:
+                    thread.start()
+                except RuntimeError as exc:
+                    # The OS refused a thread. Unwind under the lock we hold; the
+                    # record is dealt with below, outside it.
+                    self._live.pop(run.run_id, None)
+                    if key is not None:
+                        self._keys.pop(key, None)
+                    start_error = exc
+                else:
+                    # The transition, recorded where cleanup will read it.
+                    entry.started = True
+                    start_error = None
+
+        if refused:
+            # The record is the discarded handle's problem, not ours: `_persist`
+            # refuses a discarded run by design, and writing one anyway is how a
+            # record cleanup had already deleted came back. Cleanup's own
+            # `remove_all` owns the file.
+            raise JobError(
+                f"app {self._app_name} stopped accepting jobs while {kind!r} was starting"
+            )
+        if start_error is not None:
+            # A terminal record so this is not a ghost nothing will ever resolve:
+            # its origin is ours and reconcile spares a live entry, so without
+            # this it would sit non-terminal for the process's whole life. Routed
+            # through the handle so a cleanup that landed first still refuses it
+            # rather than having the file recreated.
+            run.status = FAILED
+            run.error = "the host refused a new thread for this job"
+            run.finished_at = _now()
+            self._persist(run, handle)
+            self._audit("job_start", run.run_id, "failed", error=str(start_error))
+            raise JobError(
+                f"could not start a worker for job kind {kind!r}: {start_error}"
+            ) from start_error
+        self._audit("job_start", run.run_id, "ok")
+        return run.run_id
+
+    async def start_async(self, kind: str, *, dedupe_key: str = "") -> str:
+        """Loop-native :meth:`start` — the initial record write is offloaded so
+        an on-loop caller never touches the disk on the loop thread."""
+        return await asyncio.to_thread(self.start, kind, dedupe_key=dedupe_key)
+
+    def _execute(self, run: JobRun, runner: _Runner, handle: JobHandle) -> None:
+        """The worker body. Sole writer of this run's record from here on.
+
+        The runner's return value is DISCARDED. P1 records that a run finished,
+        not what it produced: a return value is arbitrary nested data, and
+        holding it is what required a recursive sanitizer over channels no P1
+        consumer reads. It returns in P2 on a type that is safe by construction.
+        """
+        # Completing the STARTING -> RUNNING transition is the worker's first act,
+        # because the worker is the only party that knows it is actually running.
+        # Through the guarded writer, so a disable that landed between the launch
+        # and this line refuses it rather than recreating a deleted record.
+        run.status = RUNNING
+        self._persist(run, handle)
+        try:
+            runner.fn(handle)
+            run.status = CANCELLED if handle.cancelled.is_set() else DONE
+        except Exception as exc:  # noqa: BLE001 - a runner's failure is data, not a crash
+            run.status = FAILED
+            run.error = _redact(str(exc))[:2000]
+            logger.warning(
+                "App %s job %s (%s) failed: %s",
+                self._app_name,
+                run.run_id,
+                run.kind,
+                run.error,
+            )
+        finally:
+            run.finished_at = _now()
+            # The guarded writer owns the discard check, so a cleanup landing
+            # mid-write cannot have this record recreated, and a failure comes
+            # back as False rather than as an exception that would skip the
+            # bookkeeping below. That skip is what leaked a dedupe claim no
+            # later start could release.
+            self._write_terminal(run, handle)
+            with self._lock:
+                self._live.pop(run.run_id, None)
+                if run.dedupe_key:
+                    self._keys.pop((run.kind, run.dedupe_key), None)
+            self._audit(f"job_{run.status}", run.run_id, "ok")
+
+    def _write_terminal(self, run: JobRun, handle: JobHandle) -> None:
+        """Persist a run's final state, retrying once.
+
+        A lost terminal write is not cosmetic: the record stays ``running`` and
+        the UI keeps reporting work that has finished. One retry covers a
+        transient failure. If it still fails the run has already been dropped
+        from the live table, so ``reconcile`` resolves it -- immediately if
+        anything calls it, and at the next gateway start regardless, since by
+        then the record's origin is foreign. That residue is bounded but real,
+        and a periodic sweep is deliberately out of scope here.
+
+        A discarded run is not retried: ``_persist`` refuses it by design, and
+        retrying would only burn the delay before refusing again.
+        """
+        if handle.discarded.is_set():
+            return
+        for attempt in (1, 2):
+            if self._persist(run, handle):
+                return
+            if attempt == 1:
+                time.sleep(0.05)
+        logger.error(
+            "could not persist terminal state for job %s; it will be reconciled "
+            "as interrupted rather than left running",
+            run.run_id,
+        )
+
+    # ── Read ──
+
+    def get(self, run_id: str) -> JobRun | None:
+        return self._store.read(run_id)
+
+    def list_active(self, kind: str = "") -> list[JobRun]:
+        """Runs that are not in a terminal state — what a fresh mount adopts."""
+        return [
+            r for r in self._store.iter_runs() if not r.is_terminal and (not kind or r.kind == kind)
+        ]
+
+    def list_recent(self, kind: str = "", limit: int = 20) -> list[JobRun]:
+        """Most recently updated runs first, terminal ones included."""
+        runs = [r for r in self._store.iter_runs() if not kind or r.kind == kind]
+        runs.sort(key=lambda r: (r.updated_at, r.created_at), reverse=True)
+        return runs[: max(0, limit)]
+
+    # ── Cancel ──
+
+    def cancel(self, run_id: str) -> bool:
+        """Ask a live, cancellable run to stop. Writes nothing.
+
+        Returns False — rather than pretending — when the run is not live in
+        this process or was never declared cancellable. The worker records the
+        outcome itself at its next checkpoint, which keeps this run's file to a
+        single writer.
+        """
+        with self._lock:
+            live = self._live.get(run_id)
+        if live is None:
+            return False
+        run = self._store.read(run_id)
+        if run is None or not run.cancellable or run.is_terminal:
+            return False
+        live.handle.cancelled.set()
+        self._audit("job_cancel", run_id, "ok")
+        return True
+
+    async def cancel_async(self, run_id: str) -> bool:
+        """Loop-native :meth:`cancel`. Present so an on-loop caller does not
+        have to know which methods happen to touch the disk."""
+        return await asyncio.to_thread(self.cancel, run_id)
+
+    # ── Reconciliation ──
+
+    def reconcile(self) -> int:
+        """Resolve records left non-terminal by a process that is gone.
+
+        A run must never be left ``running`` forever and must never silently
+        vanish — the two directions the hand-rolled predecessors got wrong. The
+        reason distinguishes a lost process from a kind whose runner is no
+        longer registered (the app was disabled, or the kind was removed), which
+        is why this runs only after every app has registered.
+
+        This is the ONE path that consumes records it did not write -- a file
+        left by an older build, or hand-edited during an incident -- so a single
+        unusable record must cost only itself. ``JobStore._path`` raises
+        ``ValueError`` on a run id it will not turn into a path, and letting that
+        escape would abandon every remaining run of this app, leaving exactly the
+        stuck-``running`` state the pass exists to clear.
+        """
+        flipped = 0
+        for run in self._store.iter_runs():
+            if run.is_terminal:
+                continue
+            with self._lock:
+                live = run.run_id in self._live
+                known = run.kind in self._runners
+            # Skip only a run this process is ACTUALLY executing. Matching on
+            # origin alone would spare a record this process wrote and then lost
+            # (a terminal write that failed twice), which is the stuck-`running`
+            # state the pass exists to clear.
+            if run.origin == _ORIGIN and live:
+                continue
+            run.status = INTERRUPTED
+            run.finished_at = _now()
+            run.error = (
+                "the gateway restarted while this was running"
+                if known
+                else f"the gateway restarted and no runner is registered for {run.kind!r}"
+            )
+            if not self._persist(run):
+                continue
+            flipped += 1
+            self._audit("job_interrupted", run.run_id, "ok")
+        if flipped:
+            logger.info("App %s: reconciled %d interrupted job run(s)", self._app_name, flipped)
+        return flipped
+
+    # ── Cleanup ──
+
+    async def remove_all_async(self) -> CleanupResult:
+        """Stop this app's runs and drop their records.
+
+        Called on disable, mirroring ``CronSDK.remove_all_async``, and it now
+        does what "disable" implies: every live handle is marked discarded and
+        cancelled under the lock the guarded writer checks, and then each worker
+        is **bounded-joined**. Signalling alone left the threads running -- a
+        disabled app kept doing real, side-effecting work with its records
+        already deleted. Waiting is the only correct answer: a thread cannot be
+        killed, and abandoning it is the defect rather than the fix.
+
+        A worker that outlives the deadline is reported, not waited on forever.
+        Gateway shutdown is a separate case left as accepted residue: these are
+        daemon threads, so the interpreter reaps them at exit without a chance
+        to finish, and draining every app's runs there would delay shutdown for
+        work nobody is waiting on.
+        """
+        with self._lock:
+            # Set BEFORE the snapshot, under the lock ``start``'s claim section
+            # takes. Marking and snapshotting were previously the whole of this
+            # section, so a start that had already read the runner table could
+            # still claim afterwards and spawn a worker this cleanup would never
+            # see -- a disabled app doing real work with its records deleted.
+            # Disable is terminal for this instance; a re-enable builds a new one.
+            self._closed = True
+            live = list(self._live.values())
+            # Marked and cleared under the SAME lock the guarded writer takes,
+            # so a worker cannot slip a write in between this and the delete.
+            # The dedupe index goes too, or a key would stay owned by a run
+            # whose record no longer exists and the next start would adopt a
+            # ghost.
+            for entry in live:
+                entry.handle.discarded.set()
+                entry.handle.cancelled.set()
+            self._live.clear()
+            self._keys.clear()
+
+        # Joined OFF THE LOOP and outside the lock. Off the loop because a
+        # blocking join in an async method parks the whole gateway for its
+        # deadline -- the exact hazard CronSDK's docstring spells out, which this
+        # method walked into while fixing the previous round. Outside the lock
+        # because a worker's final write needs that lock, so holding it here
+        # would deadlock against the thread being waited on.
+        stubborn = await asyncio.to_thread(self._join_workers, live)
+        if stubborn:
+            logger.warning(
+                "App %s: %d job worker(s) did not stop within %.0fs and are still "
+                "running with their records removed: %s",
+                self._app_name,
+                len(stubborn),
+                _CLEANUP_JOIN_SECS,
+                ", ".join(stubborn),
+            )
+
+        removed, failed = await asyncio.to_thread(self._store.remove_all)
+        if removed or failed:
+            self._audit(
+                "job_remove_all",
+                f"removed={removed} failed={failed} stubborn={len(stubborn)}",
+                "ok" if not failed and not stubborn else "partial",
+            )
+            logger.info(
+                "App %s removed %d job record(s), %d failed", self._app_name, removed, failed
+            )
+        return CleanupResult(removed=removed, failed=failed, still_running=len(stubborn))
+
+    def _join_workers(self, live: list[_Live]) -> list[str]:
+        """Wait for each STARTED worker, bounded. Runs on a worker thread, never
+        the loop.
+
+        An entry whose thread never started is skipped rather than joined, and it
+        cannot be stubborn: no code of the app is executing, so there is nothing
+        to outlive a deadline. Joining it instead raised ``RuntimeError``, which
+        escaped the disable entirely -- so the records were never deleted and any
+        worker that HAD started kept going. Reading ``started`` is what removes
+        the guess; the flag is set under the same lock the snapshot is taken with,
+        so this list cannot contain an entry whose state changed underneath it.
+        """
+        stubborn = []
+        for entry in live:
+            if not entry.started:
+                continue
+            entry.thread.join(timeout=_CLEANUP_JOIN_SECS)
+            if entry.thread.is_alive():
+                stubborn.append(entry.thread.name)
+        return stubborn
+
+    # ── Audit ──
+
+    def _audit(self, operation: str, resources: str, outcome: str, *, error: str = "") -> None:
+        try:
+            sel().log_api_access(
+                caller=f"app:{self._app_name}",
+                operation=f"jobs.{operation}",
+                outcome=outcome,
+                source=self._app_name,
+                resources=resources[:200],
+                error=error[:200],
+            )
+        except Exception:  # noqa: BLE001 - an audit failure must not fail the job
+            logger.debug("job SEL audit failed", exc_info=True)
+
+
+# ── Process-wide registry ──
+#
+# The shared ``_jobs/*`` route family is mounted ONCE for every app and resolves
+# the app from the URL, so it needs a name -> SDK lookup; startup reconciliation
+# needs the same table. That makes this registry part of the design rather than
+# a shortcut around passing the SDK around.
+
+_SDKS: dict[str, JobSDK] = {}
+_SDKS_LOCK = threading.Lock()
+
+
+def register_sdk(sdk: JobSDK) -> None:
+    with _SDKS_LOCK:
+        _SDKS[sdk.app_name] = sdk
+
+
+def get_sdk(app_name: str) -> JobSDK | None:
+    with _SDKS_LOCK:
+        return _SDKS.get(app_name)
+
+
+def forget_sdk(app_name: str) -> None:
+    with _SDKS_LOCK:
+        _SDKS.pop(app_name, None)
+
+
+def registered_apps() -> list[str]:
+    with _SDKS_LOCK:
+        return sorted(_SDKS)
+
+
+def reconcile_all() -> int:
+    """Reconcile every registered app's runs. Call once, after startup.
+
+    Placed after the enable loop deliberately: before it, a kind with no runner
+    is indistinguishable from an app that has not loaded yet, so an early pass
+    would blame the app for the gateway's own boot order.
+    """
+    with _SDKS_LOCK:
+        sdks = list(_SDKS.values())
+    total = 0
+    for sdk in sdks:
+        try:
+            total += sdk.reconcile()
+        except Exception:  # noqa: BLE001 - one app's bad store must not stop the rest
+            logger.exception("job reconciliation failed for app %s", sdk.app_name)
+    return total

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -636,6 +636,11 @@ class Permissions:
     #: Declared rather than implicit so "which apps can start an agent" is
     #: auditable from the manifest instead of from an app's import graph.
     spawn: bool = False
+    #: May run durable background jobs through the host's Job SDK, and gains the
+    #: shared ``_jobs/*`` HTTP surface under its own namespace. Declared for the
+    #: same reason as ``spawn``: "which apps can start work that outlives the
+    #: page that started it" must be answerable from the manifest.
+    jobs: bool = False
     # WS cross-app visibility opt-in: app names (or ["*"]) allowed to use
     # slots:app:<this-app> / subagent:app:<this-app> declarations to observe
     # this app's slots and subagents. Empty list = no cross-app visibility.
@@ -659,6 +664,8 @@ class Permissions:
             d["cron"] = True
         if self.spawn:
             d["spawn"] = True
+        if self.jobs:
+            d["jobs"] = True
         if self.exposeToApps:
             d["exposeToApps"] = self.exposeToApps
         return d
@@ -685,6 +692,7 @@ class Permissions:
             memory=str(data.get("memory", "")),
             cron=data.get("cron") is True,
             spawn=data.get("spawn") is True,
+            jobs=data.get("jobs") is True,
             exposeToApps=_granted_list(data.get("exposeToApps")),  # noqa: N815
         )
 

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1171,6 +1171,17 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "chokepoint that applies the deploy handlers' credential + "
         "exfiltration-URL chain before the text reaches the dashboard.",
     ),
+    (
+        "Job runtime error responses",
+        "apps/job_routes.py",
+        "Error text returned by the shared `_jobs/*` HTTP surface that every app's "
+        "job runtime is served through. The SDK scrubs what a RUNNER produces, but "
+        "the refusal this surface raises itself quotes caller-supplied material -- "
+        "a job kind name, a dedupe key, or a path carried out of the SDK's own "
+        "exception -- so the `job_start_failed` body funnels through one `_safe` "
+        "chokepoint that applies the credential + exfiltration-URL chain before the "
+        "text reaches the dashboard.",
+    ),
 )
 
 # Modules that call a redactor but are NOT an output egress boundary, so they do
@@ -1235,6 +1246,14 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # the account snapshot is BUILT. It owns no output — the snapshot is
         # served only through routes.py, the registered sink for this app.
         "apps/builtins/aws_control/backend/accounts.py",
+        # Same shape, one layer earlier: scrubs runner-supplied job payload as the
+        # run record is BUILT and persisted. `_redact` covers `step`, `error` and
+        # each progress line, and `_json_safe` recurses through nested structures
+        # (dict KEYS as well as values) before `_persist` writes the record. It
+        # owns no output -- the record reaches a human only through
+        # apps/job_routes.py, the registered sink for this surface. The on-disk
+        # file is not the egress boundary the panel counts.
+        "apps/job_sdk.py",
         # Same shape: hosts _redact_memory_field, the shared recursive scrubber
         # for memory fields. It owns no output of its own — the handler modules
         # that call it (memory.py, cron.py) are the covered surfaces.

--- a/test/test_job_routes.py
+++ b/test/test_job_routes.py
@@ -1,0 +1,571 @@
+"""Coverage tests for kiro_crew.apps.job_routes — the shared ``_jobs/*`` HTTP
+surface mounted once for every app.
+
+Everything runs in-process against ``aiohttp``'s ``TestServer`` with
+``KIROCREW_HOME`` pointed at ``tmp_path`` and the guards monkeypatched — no
+network, no subprocess. The routes resolve the app from the URL and look its
+:class:`JobSDK` up in a process-global registry, so a fixture forgets the SDK
+on teardown to keep tests from leaking into the rest of the suite.
+
+The two guards the handler consults are patched on their ORIGINATING modules,
+because the module imports them lazily inside the request:
+``is_owner_dashboard_request`` / ``_owner_denial_response`` on the dashboard
+handler modules, and ``_is_restricted_session`` on ``_shared`` — patching a
+copy on ``job_routes`` would never be reached. ``is_app_enabled`` is imported
+at ``job_routes`` module scope, so it is patched there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import kiro_crew.apps.job_routes as jr
+import kiro_crew.apps.job_sdk as js
+import kiro_crew.dashboard.handlers._shared as shared
+import kiro_crew.dashboard.handlers.source_providers as sp
+from kiro_crew.apps.job_sdk import JobError, JobSDK, forget_sdk, get_sdk, register_sdk
+
+APP = "jobs-cov-app"
+
+# A terminal-state poll deadline: runs are real daemon threads, so we wait for
+# the worker to reach a terminal state rather than sleeping a fixed amount.
+_DEADLINE = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sdk(tmp_path: Path) -> Any:
+    """A registered JobSDK for APP whose store lives under tmp_path.
+
+    Registered in the process-global registry so the routes resolve it, and
+    forgotten on teardown so it never leaks into another test.
+
+    Teardown also STOPS the app's work, not just the registry entry. A route test
+    that starts a run and then fails an assertion used to leave that worker
+    executing: forgetting the SDK makes it unreachable but does not end it, so it
+    kept holding the SDK's lock and writing records while later tests ran. Done
+    through the SDK's own ``remove_all_async``, which already discards every
+    handle under the writer's lock and bounded-joins each worker -- a hand-rolled
+    join here would be a second, drifting copy of that contract.
+    """
+    instance = JobSDK(APP, tmp_path / "app-data")
+    register_sdk(instance)
+    try:
+        yield instance
+    finally:
+        # OSError only. A broad `except Exception` here silently swallowed a
+        # NameError from a missing import, so this teardown did nothing at all
+        # while the suite stayed green -- the failure mode a bare except invites.
+        # A store that cannot be deleted is the one thing teardown may shrug at.
+        try:
+            asyncio.run(instance.remove_all_async())
+        except OSError:
+            pass
+        forget_sdk(APP)
+
+
+def _setup_guards(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enabled: bool = True,
+    owner: bool = True,
+    granted: bool = True,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    monkeypatch.setattr(jr, "is_app_enabled", lambda name: enabled)
+
+    # The guard re-reads the manifest rather than trusting the process registry,
+    # so authorization survives a grant revoked after the SDK was published.
+    # `granted=False` is that revoked case.
+    class _Perms:
+        jobs = granted
+
+    class _Manifest:
+        permissions = _Perms()
+
+    monkeypatch.setattr(jr, "get_app_manifest", lambda name: _Manifest())
+    monkeypatch.setattr(sp, "is_owner_dashboard_request", lambda r: owner)
+    monkeypatch.setattr(
+        shared,
+        "_owner_denial_response",
+        lambda r, m="dashboard owner required", c="dashboard_owner_required": web.json_response(
+            {"error": m, "code": c}, status=403
+        ),
+    )
+
+
+def _make_app(*, state: Any = None) -> web.Application:
+    app = web.Application()
+    if state is not None:
+        app["state"] = state
+    jr.register_job_routes(app)
+    return app
+
+
+def _base(app: str = APP) -> str:
+    return f"/api/apps/{app}/_jobs"
+
+
+def _wait_terminal(sdk: JobSDK, run_id: str, deadline: float = _DEADLINE) -> js.JobRun:
+    """Poll until the run reaches a terminal state or the deadline passes."""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        run = sdk.get(run_id)
+        if run is not None and run.is_terminal:
+            return run
+        time.sleep(0.02)
+    run = sdk.get(run_id)
+    raise AssertionError(f"run {run_id} did not reach a terminal state: {run and run.status}")
+
+
+def _wait_status(sdk: JobSDK, run_id: str, status: str, deadline: float = _DEADLINE) -> js.JobRun:
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        run = sdk.get(run_id)
+        if run is not None and run.status == status:
+            return run
+        time.sleep(0.02)
+    run = sdk.get(run_id)
+    raise AssertionError(f"run {run_id} never reached {status!r}: {run and run.status}")
+
+
+# ---------------------------------------------------------------------------
+# 1-3: the guard chain (enabled -> owner -> SDK present)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_app_is_403_app_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _setup_guards(tmp_path, monkeypatch, enabled=False)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/active")
+        assert resp.status == 403
+        assert (await resp.json())["code"] == "app_disabled"
+
+
+@pytest.mark.asyncio
+async def test_non_owner_is_owner_denial_with_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _setup_guards(tmp_path, monkeypatch, owner=False)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/active")
+        assert resp.status == 403
+        body = await resp.json()
+        assert body["code"]  # the denial carries a machine-readable code
+
+
+@pytest.mark.asyncio
+async def test_enabled_owner_but_no_sdk_is_404_jobs_not_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Enabled + owner, but no SDK registered for this app.
+    _setup_guards(tmp_path, monkeypatch)
+    forget_sdk(APP)  # make sure nothing is registered
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/active")
+        assert resp.status == 404
+        assert (await resp.json())["code"] == "jobs_not_enabled"
+
+
+@pytest.mark.asyncio
+async def test_missing_app_name_is_400(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The ``{app}`` segment cannot be empty via the router, but the guard's
+    # empty-name branch is still worth pinning: register a route with a blank
+    # app captured and drive the guarded handler directly.
+    _setup_guards(tmp_path, monkeypatch)
+
+    async def _passthrough(request: web.Request, app_name: str, sdk: Any) -> web.StreamResponse:
+        return web.json_response({"ok": True})
+
+    app = web.Application()
+    app.router.add_get("/probe/{app}/x", jr._guarded(_passthrough))
+
+    # aiohttp will not match an empty path segment, so exercise the branch by
+    # patching match_info via a middleware that blanks the app name.
+    @web.middleware
+    async def _blank(request: web.Request, handler: Any) -> web.StreamResponse:
+        request.match_info["app"] = ""
+        return await handler(request)
+
+    app2 = web.Application(middlewares=[_blank])
+    app2.router.add_get("/probe/{app}/x", jr._guarded(_passthrough))
+    async with TestClient(TestServer(app2)) as client:
+        resp = await client.get("/probe/anything/x")
+        assert resp.status == 400
+        assert (await resp.json())["code"] == "app_name_required"
+
+
+# ---------------------------------------------------------------------------
+# 4-6: POST {kind}/start
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_registered_kind_returns_run_without_params(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+
+    def _runner(handle: Any, **params: Any) -> dict[str, Any]:
+        return {"done": True}
+
+    sdk.register("quick", _runner)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/quick/start", json={"params": {"a": 1}})
+        assert resp.status == 200
+        body = await resp.json()
+    run = body["run"]
+    # The public view withholds params (and origin/pid) on purpose.
+    assert "params" not in run
+    assert "origin" not in run
+    assert "pid" not in run
+    # ...and carries the fields the UI renders.
+    for field in ("run_id", "kind", "status", "cancellable"):
+        assert field in run
+    assert run["kind"] == "quick"
+    assert run["cancellable"] is False
+    _wait_terminal(sdk, run["run_id"])
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_error_is_scrubbed_before_it_is_reflected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """The 404 body quotes the caller's own `kind`, so it must be scrubbed.
+
+    This was the one error path on the surface that skipped `_safe`: a kind
+    carrying a credential came straight back in the response. A path parameter is
+    caller-controlled, so the reflection is reachable by anyone who can reach the
+    surface at all.
+    """
+    _setup_guards(tmp_path, monkeypatch)
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/aws_secret_access_key{secret}/start")
+        assert resp.status == 404
+        body = await resp.json()
+        assert body["code"] == "unknown_job_kind"
+        assert secret not in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_start_with_non_string_dedupe_key_is_400(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    sdk.register("k", lambda handle, **p: None)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/k/start", json={"dedupe_key": 42})
+        assert resp.status == 400
+        assert (await resp.json())["code"] == "invalid_dedupe_key"
+
+
+@pytest.mark.asyncio
+async def test_start_with_malformed_body_is_treated_as_empty_not_500(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    sdk.register("k", lambda handle, **p: {"ok": True})
+    async with TestClient(TestServer(_make_app())) as client:
+        # A body that is not JSON at all must not 500 — it is treated as {}.
+        resp = await client.post(
+            f"{_base()}/k/start",
+            data="not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 200
+        run = (await resp.json())["run"]
+    _wait_terminal(sdk, run["run_id"])
+
+
+@pytest.mark.asyncio
+async def test_start_run_unreadable_is_500(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    # start_async succeeds but the record cannot be read back — the defensive
+    # 500 branch. start_async is stubbed so no real thread is spawned, and get
+    # returns None.
+    _setup_guards(tmp_path, monkeypatch)
+    sdk.register("k", lambda handle, **p: None)
+
+    async def _start_async(kind: str, *, params: Any = None, dedupe_key: str = "") -> str:
+        return "deadbeef" * 4
+
+    monkeypatch.setattr(sdk, "start_async", _start_async)
+    monkeypatch.setattr(sdk, "get", lambda run_id: None)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/k/start", json={})
+        assert resp.status == 500
+        assert (await resp.json())["code"] == "run_unreadable"
+
+
+@pytest.mark.asyncio
+async def test_start_unknown_kind_is_404_unknown_job_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    # No runner registered for "ghost".
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/ghost/start", json={})
+        assert resp.status == 404
+        assert (await resp.json())["code"] == "unknown_job_kind"
+
+
+# ---------------------------------------------------------------------------
+# 7: GET active / recent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_active_and_recent_return_runs_array(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    sdk.register("k", lambda handle, **p: {"ok": True})
+    rid = sdk.start("k")
+    _wait_terminal(sdk, rid)
+    async with TestClient(TestServer(_make_app())) as client:
+        active = await client.get(f"{_base()}/active")
+        recent = await client.get(f"{_base()}/recent")
+        assert active.status == 200
+        assert recent.status == 200
+        assert isinstance((await active.json())["runs"], list)
+        recent_runs = (await recent.json())["runs"]
+    assert isinstance(recent_runs, list)
+    assert any(r["run_id"] == rid for r in recent_runs)
+
+
+@pytest.mark.asyncio
+async def test_recent_non_integer_limit_is_400_invalid_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/recent", params={"limit": "abc"})
+        assert resp.status == 400
+        assert (await resp.json())["code"] == "invalid_limit"
+
+
+@pytest.mark.asyncio
+async def test_recent_limit_above_cap_is_clamped_not_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    seen: dict[str, int] = {}
+
+    def _capture(kind: str, limit: int) -> list[Any]:
+        seen["limit"] = limit
+        return []
+
+    monkeypatch.setattr(sdk, "list_recent", _capture)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/recent", params={"limit": "10000"})
+        assert resp.status == 200
+    # Clamped to the module cap rather than refused.
+    assert seen["limit"] == jr._RECENT_MAX
+
+
+# ---------------------------------------------------------------------------
+# 8: GET {run_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_missing_run_is_404_job_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    async with TestClient(TestServer(_make_app())) as client:
+        # A valid-shaped but unknown hex run id.
+        resp = await client.get(f"{_base()}/{'a' * 32}")
+        assert resp.status == 404
+        assert (await resp.json())["code"] == "job_not_found"
+
+
+@pytest.mark.asyncio
+async def test_get_existing_run_is_200(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    sdk.register("k", lambda handle, **p: {"ok": True})
+    rid = sdk.start("k")
+    _wait_terminal(sdk, rid)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/{rid}")
+        assert resp.status == 200
+        assert (await resp.json())["run"]["run_id"] == rid
+
+
+# ---------------------------------------------------------------------------
+# 9: POST {run_id}/cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_missing_run_is_404_job_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/{'b' * 32}/cancel")
+        assert resp.status == 404
+        assert (await resp.json())["code"] == "job_not_found"
+
+
+@pytest.mark.asyncio
+async def test_cancel_non_cancellable_run_is_409_with_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    # A terminal, non-cancellable run: cancel_async returns False.
+    sdk.register("k", lambda handle, **p: {"ok": True})
+    rid = sdk.start("k")
+    _wait_terminal(sdk, rid)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/{rid}/cancel")
+        assert resp.status == 409
+        body = await resp.json()
+        assert body["code"] == "job_not_cancellable"
+        # The body still carries the run.
+        assert body["run"]["run_id"] == rid
+
+
+@pytest.mark.asyncio
+async def test_cancel_live_cancellable_run_is_200_cancelling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    started = threading.Event()
+
+    def _blocking(handle: Any, **params: Any) -> None:
+        started.set()
+        # Block until asked to cancel; poll rather than sleep a fixed amount.
+        handle.cancelled.wait(timeout=_DEADLINE)
+
+    sdk.register("blocker", _blocking, cancellable=True)
+    rid = sdk.start("blocker")
+    assert started.wait(timeout=_DEADLINE), "runner never started"
+    _wait_status(sdk, rid, js.RUNNING)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post(f"{_base()}/{rid}/cancel")
+        assert resp.status == 200
+        assert (await resp.json())["cancelling"] is True
+    # The worker observes the signal and settles into CANCELLED.
+    run = _wait_terminal(sdk, rid)
+    assert run.status == js.CANCELLED
+
+
+# ---------------------------------------------------------------------------
+# 10: restricted session refused on a mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restricted_session_is_403_restricted_session_on_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    _setup_guards(tmp_path, monkeypatch)
+    sdk.register("k", lambda handle, **p: None)
+    # _mutating consults request.app["state"]; give it any truthy state and
+    # patch the restricted-session predicate on its originating module.
+    monkeypatch.setattr(shared, "_is_restricted_session", lambda state, request: True)
+    app = _make_app(state=object())
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post(f"{_base()}/k/start", json={})
+        assert resp.status == 403
+        assert (await resp.json())["code"] == "restricted_session"
+
+
+# ---------------------------------------------------------------------------
+# 11: route-ordering regression — /active is not a run id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_active_is_not_matched_as_a_run_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    # If ``{run_id}`` were registered before ``active``, GET /_jobs/active would
+    # be captured as run_id="active" and 404 as job_not_found. It must return
+    # the active list instead.
+    _setup_guards(tmp_path, monkeypatch)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/active")
+        assert resp.status == 200
+        body = await resp.json()
+        assert "runs" in body
+        assert "code" not in body
+
+
+@pytest.mark.asyncio
+async def test_revoked_grant_is_refused_even_with_an_sdk_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A grant revoked AFTER the SDK was published must stop serving.
+
+    The SDK is registered at enable time and lives for the gateway's life, so if
+    authorization rested on the registry a revoked `jobs` permission would keep
+    serving through the stale entry. The guard re-reads the manifest instead --
+    pinned here with the SDK deliberately still registered.
+    """
+    _setup_guards(tmp_path, monkeypatch, granted=False)
+    sdk = JobSDK(APP, tmp_path / "data")
+    sdk.register("k", lambda h, **kw: {})
+    register_sdk(sdk)
+    try:
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"{_base()}/active")
+            assert resp.status == 404
+            assert (await resp.json())["code"] == "jobs_not_enabled"
+        # The registry entry is still there: the refusal came from the manifest
+        # re-read, not from a missing SDK.
+        assert get_sdk(APP) is sdk
+    finally:
+        forget_sdk(APP)
+
+
+@pytest.mark.asyncio
+async def test_sdk_refusal_becomes_a_coded_503_not_a_bare_500(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A JobError must not reach aiohttp's default handler.
+
+    `start` raises JobError when it cannot persist the initial record or the host
+    refuses a thread. Uncaught, that surfaces as a bare 500 with no
+    machine-readable code -- nothing a client can switch on, and a violation of
+    the error contract every other branch here follows.
+    """
+    _setup_guards(tmp_path, monkeypatch)
+    sdk = JobSDK(APP, tmp_path / "data")
+    sdk.register("k", lambda h, **kw: {})
+    register_sdk(sdk)
+
+    def refuse(*_a: Any, **_kw: Any) -> str:
+        raise JobError("could not persist the initial record for job kind 'k'")
+
+    monkeypatch.setattr(sdk, "start", refuse)
+    try:
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.post(f"{_base()}/k/start", json={})
+            assert resp.status == 503
+            assert (await resp.json())["code"] == "job_start_failed"
+    finally:
+        forget_sdk(APP)

--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -1,0 +1,1746 @@
+"""Tests for the Job SDK — app-scoped durable runs.
+
+Covers the runner registry, per-run JSON records, cooperative cancellation via
+a threading.Event, the startup reconciliation pass, and the process-wide SDK
+registry.
+
+Runs execute on real daemon threads, so terminal state is awaited with a
+bounded poll (``_wait_terminal``) rather than a fixed sleep — a fixed sleep is
+what makes such a suite flaky on a loaded runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.apps import job_sdk
+from kiro_crew.apps.job_sdk import (
+    _CLEANUP_JOIN_SECS,
+    CANCELLED,
+    DONE,
+    FAILED,
+    INTERRUPTED,
+    QUEUED,
+    RUNNING,
+    STARTING,
+    TERMINAL_STATES,
+    CleanupResult,
+    JobError,
+    JobHandle,
+    JobRun,
+    JobSDK,
+    JobStore,
+    UnknownJobKind,
+    forget_sdk,
+    get_sdk,
+    reconcile_all,
+    register_sdk,
+    registered_apps,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _wait_terminal(sdk: JobSDK, run_id: str, timeout: float = 5.0) -> JobRun:
+    """Poll until the run reaches a terminal status, or fail with what we saw."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = sdk.get(run_id)
+        if last is not None and last.is_terminal:
+            return last
+        time.sleep(0.01)
+    observed = last.status if last is not None else "<no record>"
+    raise AssertionError(f"run {run_id} not terminal within {timeout}s; observed status={observed}")
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"condition not met within {timeout}s")
+
+
+@pytest.fixture
+def sdk(tmp_path: Path):
+    """A fresh SDK over a tmp data dir, unregistered from the global registry
+    on teardown so it never leaks into another test in the session.
+
+    Teardown also SIGNALS and WAITS for any run still executing. Runs are real
+    daemon threads: one still alive when pytest removes ``tmp_path`` would
+    mkdir and write into the deleted tree at its next progress or terminal
+    write, which is a real file mutation racing the fixture. Waiting (bounded,
+    and loud on timeout) is the only correct answer -- cancelling the wrapper
+    would leave the thread running, which is the defect, not the fix.
+    """
+    s = JobSDK("test-app", tmp_path)
+    yield s
+    with s._lock:  # noqa: SLF001 - teardown needs the live table the SDK owns
+        live = list(s._live.values())
+    for entry in live:
+        entry.handle.discarded.set()
+        entry.handle.cancelled.set()
+    for entry in live:
+        entry.thread.join(timeout=5.0)
+        assert not entry.thread.is_alive(), (
+            "a job worker outlived its test and would write into the removed "
+            f"tmp_path: {entry.thread.name}"
+        )
+    forget_sdk(s.app_name)
+
+
+# ---------------------------------------------------------------------------
+# 1. register / kinds / is_cancellable
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register_and_kinds(self, sdk: JobSDK) -> None:
+        sdk.register("build", lambda h: {"ok": True})
+        sdk.register("deploy", lambda h: {"ok": True}, cancellable=True)
+        assert sdk.kinds() == ["build", "deploy"]  # sorted
+
+    def test_is_cancellable(self, sdk: JobSDK) -> None:
+        sdk.register("plain", lambda h: {})
+        sdk.register("stoppable", lambda h: {}, cancellable=True)
+        assert sdk.is_cancellable("plain") is False
+        assert sdk.is_cancellable("stoppable") is True
+        # Unknown kind is not cancellable.
+        assert sdk.is_cancellable("nope") is False
+
+    def test_register_empty_kind_raises(self, sdk: JobSDK) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            sdk.register("", lambda h: {})
+
+
+# ---------------------------------------------------------------------------
+# 2. start() on an unregistered kind
+# ---------------------------------------------------------------------------
+
+
+class TestStartUnknown:
+    def test_start_unknown_kind_raises(self, sdk: JobSDK) -> None:
+        with pytest.raises(UnknownJobKind, match="no registered runner"):
+            sdk.start("ghost")
+
+
+# ---------------------------------------------------------------------------
+# 3. Happy run: reaches done; the runner's return value is not recorded
+# ---------------------------------------------------------------------------
+
+
+class TestHappyRun:
+    def test_run_reaches_done(self, sdk: JobSDK) -> None:
+        sdk.register("work", lambda h: {"answer": 42})
+        run_id = sdk.start("work")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+        assert run.finished_at != ""
+        assert run.error == ""
+
+    def test_the_runner_gets_its_handle_and_nothing_else(self, sdk: JobSDK) -> None:
+        """P1 has no params channel, so a runner is a one-argument callable.
+
+        Pinned because the signature IS the contract a P2 consumer writes
+        against: reintroducing kwargs is a deliberate P2 change, not something
+        that should be able to drift back in unnoticed.
+        """
+        seen: list[object] = []
+
+        def runner(h):
+            seen.append(h)
+
+        sdk.register("work", runner)
+        run_id = sdk.start("work")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+        assert len(seen) == 1 and seen[0].run_id == run_id
+
+    def test_a_returned_value_is_not_persisted_anywhere(self, sdk: JobSDK) -> None:
+        """The return value is discarded, and no field appears to hold it.
+
+        Asserting on the SERIALIZED record rather than on an attribute, so this
+        fails if a result-shaped field is added back without a design decision.
+        """
+        sdk.register("work", lambda h: {"secret": "AKIAIOSFODNN7EXAMPLE"})
+        run_id = sdk.start("work")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+        assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(run.to_dict())
+        assert set(run.to_dict()) == {
+            "run_id",
+            "app",
+            "kind",
+            "status",
+            "origin",
+            "pid",
+            "dedupe_key",
+            "cancellable",
+            "created_at",
+            "updated_at",
+            "finished_at",
+            "error",
+        }
+
+
+# ---------------------------------------------------------------------------
+# 4. Raising runner -> failed with truncated, recorded error
+# ---------------------------------------------------------------------------
+
+
+class TestFailingRun:
+    def test_raising_runner_reaches_failed_with_error(self, sdk: JobSDK) -> None:
+        def boom(h, **kw):
+            raise RuntimeError("kaboom happened")
+
+        sdk.register("boom", boom)
+        run_id = sdk.start("boom")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == FAILED
+        assert "kaboom happened" in run.error
+
+    def test_error_is_truncated_to_2000_chars(self, sdk: JobSDK) -> None:
+        def boom(h, **kw):
+            raise RuntimeError("x" * 5000)
+
+        sdk.register("boom", boom)
+        run_id = sdk.start("boom")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == FAILED
+        assert len(run.error) == 2000
+
+
+# ---------------------------------------------------------------------------
+# 5. Cancellation
+# ---------------------------------------------------------------------------
+
+
+class TestCancellation:
+    def test_polling_runner_reaches_cancelled(self, sdk: JobSDK) -> None:
+        started = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            # Poll the cancel signal cooperatively.
+            for _ in range(500):
+                if h.cancelled.is_set():
+                    return
+                time.sleep(0.01)
+
+        sdk.register("loop", runner, cancellable=True)
+        run_id = sdk.start("loop")
+        assert started.wait(5.0)
+        assert sdk.cancel(run_id) is True
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == CANCELLED
+
+    def test_cancel_unknown_run_id_returns_false(self, sdk: JobSDK) -> None:
+        assert sdk.cancel("deadbeef" * 4) is False
+
+    def test_cancel_non_cancellable_run_returns_false(self, sdk: JobSDK) -> None:
+        release = threading.Event()
+        started = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            release.wait(5.0)
+            return {}
+
+        # Registered cancellable=False (the default).
+        sdk.register("plain", runner)
+        run_id = sdk.start("plain")
+        assert started.wait(5.0)
+        # Live but not declared cancellable -> False.
+        assert sdk.cancel(run_id) is False
+        release.set()
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+
+    def test_cancel_already_terminal_run_returns_false(self, sdk: JobSDK) -> None:
+        sdk.register("quick", lambda h, **kw: {"done": True}, cancellable=True)
+        run_id = sdk.start("quick")
+        _wait_terminal(sdk, run_id)
+        # Popped from _live once terminal, so cancel returns False.
+        assert sdk.cancel(run_id) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. dedupe_key
+# ---------------------------------------------------------------------------
+
+
+class TestDedupe:
+    def test_second_start_with_same_key_adopts_run(self, sdk: JobSDK) -> None:
+        release = threading.Event()
+        started = threading.Event()
+        calls = []
+
+        def runner(h, **kw):
+            calls.append(1)
+            started.set()
+            release.wait(5.0)
+            return {}
+
+        sdk.register("work", runner)
+        first = sdk.start("work", dedupe_key="k1")
+        assert started.wait(5.0)
+        second = sdk.start("work", dedupe_key="k1")
+        assert second == first  # adopted, not a new run
+        release.set()
+        _wait_terminal(sdk, first)
+        assert calls == [1]  # body ran exactly once
+
+    def test_two_starts_without_key_produce_two_ids(self, sdk: JobSDK) -> None:
+        sdk.register("work", lambda h, **kw: {})
+        a = sdk.start("work")
+        b = sdk.start("work")
+        assert a != b
+        _wait_terminal(sdk, a)
+        _wait_terminal(sdk, b)
+
+
+# ---------------------------------------------------------------------------
+# 7. JobHandle.progress and bounded line tail
+# ---------------------------------------------------------------------------
+
+
+def _handle_over(tmp_path: Path, run: JobRun) -> tuple[JobHandle, JobStore, JobSDK]:
+    """A handle plus the REAL SDK whose guarded writer owns the discard check.
+
+    The handle no longer carries a writer: with the progress channel gone the
+    only mid-life write is the worker's terminal one, so the discard check lives
+    entirely in ``JobSDK._persist``. Handing back the SDK lets a test exercise
+    that real guard rather than a stand-in copy of it.
+    """
+    sdk = JobSDK("handle-test", tmp_path)
+    return JobHandle(run), sdk.store, sdk
+
+
+# ---------------------------------------------------------------------------
+# 8. get / list_active / list_recent
+# ---------------------------------------------------------------------------
+
+
+class TestReadViews:
+    def test_get_missing_returns_none(self, sdk: JobSDK) -> None:
+        assert sdk.get("c" * 32) is None
+
+    def test_list_active_excludes_terminal_and_filters_kind(self, sdk: JobSDK) -> None:
+        release = threading.Event()
+
+        def blocker(h, **kw):
+            release.wait(5.0)
+            return {}
+
+        sdk.register("live", blocker)
+        sdk.register("fast", lambda h, **kw: {})
+
+        live_id = sdk.start("live")
+        fast_id = sdk.start("fast")
+        _wait_terminal(sdk, fast_id)
+
+        active = sdk.list_active()
+        active_ids = {r.run_id for r in active}
+        assert live_id in active_ids
+        assert fast_id not in active_ids  # terminal excluded
+
+        # kind filter
+        assert [r.run_id for r in sdk.list_active(kind="live")] == [live_id]
+        assert sdk.list_active(kind="fast") == []
+
+        release.set()
+        _wait_terminal(sdk, live_id)
+
+    def test_list_recent_limit_and_ordering(self, sdk: JobSDK) -> None:
+        # Write records directly with controlled, distinct updated_at values.
+        # (_now() is second-granularity, so real runs in the same second cannot
+        # be ordered by wall clock — the ordering CONTRACT is what we pin here.)
+        store = sdk.store
+        specs = [
+            ("a" * 32, "2026-01-01T00:00:01Z"),
+            ("b" * 32, "2026-01-01T00:00:03Z"),  # newest
+            ("c" * 32, "2026-01-01T00:00:02Z"),
+        ]
+        store.dir.mkdir(parents=True, exist_ok=True)
+        for rid, ts in specs:
+            run = JobRun(run_id=rid, app="test-app", kind="work", status=DONE)
+            run.updated_at = ts
+            run.created_at = ts
+            (store.dir / f"{rid}.json").write_text(json.dumps(run.to_dict(), indent=1))
+
+        recent = sdk.list_recent(limit=2)
+        assert len(recent) == 2
+        # Most-recently-updated first.
+        assert [r.run_id for r in recent] == ["b" * 32, "c" * 32]
+
+    def test_list_recent_limit_zero_returns_empty(self, sdk: JobSDK) -> None:
+        sdk.register("work", lambda h, **kw: {})
+        rid = sdk.start("work")
+        _wait_terminal(sdk, rid)
+        assert sdk.list_recent(limit=0) == []
+
+    def test_list_recent_kind_filter(self, sdk: JobSDK) -> None:
+        sdk.register("a", lambda h, **kw: {})
+        sdk.register("b", lambda h, **kw: {})
+        a_id = sdk.start("a")
+        b_id = sdk.start("b")
+        _wait_terminal(sdk, a_id)
+        _wait_terminal(sdk, b_id)
+        recent_a = sdk.list_recent(kind="a")
+        assert [r.run_id for r in recent_a] == [a_id]
+
+
+# ---------------------------------------------------------------------------
+# 9. JobRun.from_dict / JobStore.read / _path / iter_runs
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_from_dict_drops_unknown_keys(self) -> None:
+        run = JobRun.from_dict(
+            {"run_id": "x1", "app": "a", "kind": "k", "bogus": "nope", "status": DONE}
+        )
+        assert run.run_id == "x1"
+        assert run.status == DONE
+        assert not hasattr(run, "bogus")
+
+    def test_from_dict_tolerates_missing_required(self) -> None:
+        run = JobRun.from_dict({})
+        assert run.run_id == ""
+        assert run.app == ""
+        assert run.kind == ""
+
+    def test_read_missing_file_returns_none(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path)
+        assert store.read("d" * 32) is None
+
+    def test_read_corrupt_file_returns_none(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path)
+        store.dir.mkdir(parents=True, exist_ok=True)
+        (store.dir / ("abcdef" * 4 + ".json")).write_text("{ not json")
+        assert store.read("abcdef" * 4) is None
+
+    def test_read_invalid_run_id_returns_none(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path)
+        # ValueError from _path is swallowed into None by read.
+        assert store.read("NOT-HEX!") is None
+
+    def test_path_rejects_non_hex_id(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path)
+        with pytest.raises(ValueError, match="invalid run id"):
+            store._path("zzz")
+        with pytest.raises(ValueError, match="invalid run id"):
+            store._path("")
+
+    def test_path_rejects_an_all_hex_id_of_the_wrong_length(self, tmp_path: Path) -> None:
+        """Length is checked, not just the alphabet.
+
+        A very long all-hex id passed the alphabet check and built a filename
+        over the OS limit, so the read raised ENAMETOOLONG -- an ``OSError`` no
+        handler names -- and the route answered 500 where an unknown id deserves
+        404. Short ids are rejected for the same reason they are not run ids.
+        """
+        store = JobStore(tmp_path)
+        for bad in ("a" * 31, "a" * 33, "a" * 5000, "abcdef"):
+            with pytest.raises(ValueError, match="invalid run id"):
+                store._path(bad)
+
+    def test_an_overlong_id_reads_as_none_not_an_oserror(self, tmp_path: Path) -> None:
+        """The route's 404 path depends on this being None rather than a raise."""
+        store = JobStore(tmp_path)
+        assert store.read("f" * 5000) is None
+
+    def test_iter_runs_skips_unreadable_file(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path)
+        store.dir.mkdir(parents=True, exist_ok=True)
+        good = JobRun(run_id="a" * 32, app="x", kind="k", status=DONE)
+        store.write(good)
+        (store.dir / "corrupt.json").write_text("{ broken")
+        runs = list(store.iter_runs())
+        assert [r.run_id for r in runs] == ["a" * 32]
+
+    def test_iter_runs_empty_when_dir_absent(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path / "does-not-exist")
+        assert list(store.iter_runs()) == []
+
+
+class TestRecordReadSurvivesTheWriterRace:
+    """Both readers go through the Windows-safe helper and decode UTF-8 explicitly.
+
+    A reader racing the single writer's temp-file-plus-rename is invisible on
+    POSIX, where rename is atomic for a reader, and raises ``PermissionError`` on
+    Windows -- which is why this reddened only the Windows matrix. These pin the
+    helper and the encoding so a later "simplify back to read_text" fails here,
+    on Linux, instead of on one Windows shard.
+    """
+
+    @staticmethod
+    def _spy(monkeypatch) -> list[Path]:
+        seen: list[Path] = []
+        real = job_sdk.read_bytes_with_retry
+
+        def spy(path):
+            seen.append(Path(path))
+            return real(path)
+
+        monkeypatch.setattr(job_sdk, "read_bytes_with_retry", spy)
+        return seen
+
+    def test_read_routes_through_the_retrying_reader(self, tmp_path: Path, monkeypatch) -> None:
+        store = JobStore(tmp_path)
+        store.write(JobRun(run_id="b" * 32, app="x", kind="k", status=DONE))
+        seen = self._spy(monkeypatch)
+        assert store.read("b" * 32) is not None
+        assert [p.name for p in seen] == [f"{'b' * 32}.json"]
+
+    def test_iter_runs_routes_through_the_retrying_reader(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        store = JobStore(tmp_path)
+        store.write(JobRun(run_id="c" * 32, app="x", kind="k", status=DONE))
+        seen = self._spy(monkeypatch)
+        assert [r.run_id for r in store.iter_runs()] == ["c" * 32]
+        assert [p.name for p in seen] == [f"{'c' * 32}.json"]
+
+    def test_non_ascii_record_round_trips_regardless_of_host_locale(self, tmp_path: Path) -> None:
+        """``atomic_write`` emits UTF-8, so the reader must decode UTF-8.
+
+        ``read_text()`` decodes in the host LOCALE, so a redacted string holding a
+        non-ASCII character survived only where the console happened to be UTF-8.
+        Escapes rather than literals keep this file ASCII while still carrying
+        multi-byte content through the round trip.
+        """
+        text = "resum\u00e9 \u4f5c\u4e1a"
+        store = JobStore(tmp_path)
+        store.write(JobRun(run_id="d" * 32, app="x", kind="k", status=DONE, error=text))
+        got = store.read("d" * 32)
+        assert got is not None and got.error == text
+
+
+# ---------------------------------------------------------------------------
+# 10. reconcile()
+# ---------------------------------------------------------------------------
+
+
+class TestReconcile:
+    def _write_raw(self, store: JobStore, run: JobRun) -> None:
+        store.dir.mkdir(parents=True, exist_ok=True)
+        path = store.dir / f"{run.run_id}.json"
+        path.write_text(json.dumps(run.to_dict(), indent=1))
+
+    def test_foreign_origin_nonterminal_flips_to_interrupted_known_runner(
+        self, sdk: JobSDK
+    ) -> None:
+        sdk.register("work", lambda h, **kw: {})
+        run = JobRun(
+            run_id="a" * 32,
+            app="test-app",
+            kind="work",
+            status=RUNNING,
+            origin="foreign-origin-token",
+        )
+        self._write_raw(sdk.store, run)
+        flipped = sdk.reconcile()
+        assert flipped == 1
+        reread = sdk.get(run.run_id)
+        assert reread.status == INTERRUPTED
+        assert "gateway restarted while this was running" in reread.error
+
+    def test_foreign_origin_unknown_runner_error_names_kind(self, sdk: JobSDK) -> None:
+        run = JobRun(
+            run_id="b" * 32,
+            app="test-app",
+            kind="gone-kind",
+            status=RUNNING,
+            origin="foreign-origin-token",
+        )
+        self._write_raw(sdk.store, run)
+        flipped = sdk.reconcile()
+        assert flipped == 1
+        reread = sdk.get(run.run_id)
+        assert reread.status == INTERRUPTED
+        assert "no runner is registered" in reread.error
+        assert "gone-kind" in reread.error
+
+    def test_terminal_record_left_alone(self, sdk: JobSDK) -> None:
+        run = JobRun(
+            run_id="c" * 32,
+            app="test-app",
+            kind="work",
+            status=DONE,
+            origin="foreign-origin-token",
+        )
+        self._write_raw(sdk.store, run)
+        assert sdk.reconcile() == 0
+        assert sdk.get(run.run_id).status == DONE
+
+    def test_own_origin_record_is_resolved_when_nothing_is_executing_it(self, sdk: JobSDK) -> None:
+        """Own origin alone is NOT a reason to spare a record.
+
+        A record this process wrote and then lost -- a terminal write that failed
+        twice -- carries this origin while nothing is running it, and sparing it
+        would leave exactly the stuck-`running` state the pass exists to clear.
+        The live table, not the origin, is what says a run is still executing.
+        """
+        run = JobRun(
+            run_id="d" * 32,
+            app="test-app",
+            kind="work",
+            status=RUNNING,
+            origin=job_sdk._ORIGIN,
+        )
+        self._write_raw(sdk.store, run)
+        assert sdk.reconcile() == 1
+        assert sdk.get(run.run_id).status == INTERRUPTED
+
+    def test_a_run_this_process_is_actually_executing_is_left_alone(self, sdk: JobSDK) -> None:
+        """The other half: a genuinely live run must survive a reconcile.
+
+        Reconciliation runs after the enable loop, and an app's on_startup may
+        already have started a run, so this is a real ordering, not a hypothetical.
+        """
+        release = threading.Event()
+        started = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            release.wait(5.0)
+            return {}
+
+        sdk.register("work", runner)
+        run_id = sdk.start("work")
+        assert started.wait(5.0)
+
+        assert sdk.reconcile() == 0
+        assert sdk.get(run_id).status == RUNNING
+
+        release.set()
+        _wait_terminal(sdk, run_id)
+
+
+# ---------------------------------------------------------------------------
+# 11. remove_all_async
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveAll:
+    def test_signals_live_and_deletes_records_idempotent(self, sdk: JobSDK) -> None:
+        release = threading.Event()
+        started = threading.Event()
+        cancelled_seen = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            for _ in range(500):
+                if h.cancelled.is_set():
+                    cancelled_seen.set()
+                    return
+                time.sleep(0.01)
+            release.wait(5.0)
+            return {}
+
+        sdk.register("live", runner, cancellable=True)
+        run_id = sdk.start("live")
+        assert started.wait(5.0)
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup == CleanupResult(1, 0, 0)
+        # The live run was signalled to stop.
+        assert cancelled_seen.wait(5.0)
+        release.set()
+        _wait_until(lambda: not any(t.name.startswith("job:") for t in threading.enumerate()))
+        # The signalled worker cannot write its record back, so the deletion
+        # holds and a second cleanup is a no-op.
+        assert sdk.get(run_id) is None
+        assert asyncio.run(sdk.remove_all_async()) == CleanupResult(0, 0, 0)
+
+    def test_remove_all_deletes_records_of_finished_runs(self, sdk: JobSDK) -> None:
+        """With no live worker to race, remove_all_async deletes the record and
+        the second call is a no-op."""
+        sdk.register("work", lambda h, **kw: {"ok": True})
+        run_id = sdk.start("work")
+        _wait_terminal(sdk, run_id)
+        # No live worker remains, so nothing can rewrite the file.
+        assert asyncio.run(sdk.remove_all_async()) == CleanupResult(1, 0, 0)
+        assert sdk.get(run_id) is None
+        assert asyncio.run(sdk.remove_all_async()) == CleanupResult(0, 0, 0)
+
+    def test_remove_all_is_not_resurrected_by_worker(self, sdk: JobSDK) -> None:
+        """A worker returning AFTER cleanup must not write its record back.
+
+        Regression pin. JobStore.write mkdirs and writes unconditionally, so it
+        cannot tell a first write from a resurrection; the guarantee comes from
+        remove_all_async marking every live handle discarded BEFORE deleting,
+        and both write paths honouring that mark. Without it this run reappears
+        on disk as `cancelled` and the second remove_all_async returns 1.
+        """
+        started = threading.Event()
+        removed_done = threading.Event()
+        finally_done = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            # Do not exit (and thus do not reach the finally-block write) until
+            # remove_all has finished deleting the record — this makes the
+            # ordering deterministic rather than timing-dependent.
+            removed_done.wait(5.0)
+            try:
+                return
+            finally:
+                finally_done.set()
+
+        sdk.register("live", runner, cancellable=True)
+        run_id = sdk.start("live")
+        assert started.wait(5.0)
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        # Only `removed` is asserted here. Whether this worker is still alive
+        # when cleanup returns is a race between its own wait and the join
+        # deadline, so pinning it would make this test flaky for a reason that
+        # has nothing to do with resurrection. TestCleanupDoesNotBlockTheLoop
+        # covers the still-running report deterministically, with a runner that
+        # ignores its cancel signal outright.
+        assert cleanup.removed == 1
+        assert sdk.get(run_id) is None  # deleted at this instant
+        removed_done.set()
+        # Let the worker's finally-block write complete.
+        assert finally_done.wait(5.0)
+        _wait_until(lambda: not any(t.name.startswith("job:") for t in threading.enumerate()))
+        time.sleep(0.05)
+        # The record stays deleted, and idempotency still holds -- a resurrected
+        # record would make this second call report 1.
+        assert sdk.get(run_id) is None
+        assert asyncio.run(sdk.remove_all_async()) == CleanupResult(0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# 12. Process-wide registry
+# ---------------------------------------------------------------------------
+
+
+class TestProcessRegistry:
+    def test_register_get_forget_registered_apps(self, tmp_path: Path) -> None:
+        a = JobSDK("app-a", tmp_path / "a")
+        b = JobSDK("app-b", tmp_path / "b")
+        try:
+            register_sdk(a)
+            register_sdk(b)
+            assert get_sdk("app-a") is a
+            assert get_sdk("app-b") is b
+            assert "app-a" in registered_apps()
+            assert "app-b" in registered_apps()
+            forget_sdk("app-a")
+            assert get_sdk("app-a") is None
+            assert "app-a" not in registered_apps()
+        finally:
+            forget_sdk("app-a")
+            forget_sdk("app-b")
+
+    def test_get_sdk_unknown_returns_none(self) -> None:
+        assert get_sdk("never-registered-app") is None
+
+    def test_reconcile_all_sums_across_sdks_and_survives_raise(self, tmp_path: Path) -> None:
+        good = JobSDK("good-app", tmp_path / "good")
+        bad = JobSDK("bad-app", tmp_path / "bad")
+
+        # good has one foreign non-terminal record to flip.
+        good.store.dir.mkdir(parents=True, exist_ok=True)
+        run = JobRun(
+            run_id="e" * 32,
+            app="good-app",
+            kind="work",
+            status=RUNNING,
+            origin="foreign-origin-token",
+        )
+        (good.store.dir / f"{run.run_id}.json").write_text(json.dumps(run.to_dict(), indent=1))
+
+        # bad raises from reconcile — reconcile_all must survive it.
+        def boom() -> int:
+            raise RuntimeError("store is broken")
+
+        bad.reconcile = boom  # type: ignore[method-assign]
+
+        try:
+            register_sdk(good)
+            register_sdk(bad)
+            total = reconcile_all()
+            assert total == 1  # good's one flip; bad's raise swallowed
+        finally:
+            forget_sdk("good-app")
+            forget_sdk("bad-app")
+
+
+# ---------------------------------------------------------------------------
+# 13. start_async / cancel_async match sync twins
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncTwins:
+    def test_start_async_runs_and_reaches_done(self, sdk: JobSDK) -> None:
+        sdk.register("work", lambda h: {"async": True})
+        run_id = asyncio.run(sdk.start_async("work"))
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+
+    def test_cancel_async_matches_sync(self, sdk: JobSDK) -> None:
+        started = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            for _ in range(500):
+                if h.cancelled.is_set():
+                    return
+                time.sleep(0.01)
+
+        sdk.register("loop", runner, cancellable=True)
+        run_id = sdk.start("loop")
+        assert started.wait(5.0)
+        assert asyncio.run(sdk.cancel_async(run_id)) is True
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == CANCELLED
+
+    def test_cancel_async_unknown_returns_false(self, sdk: JobSDK) -> None:
+        assert asyncio.run(sdk.cancel_async("f" * 32)) is False
+
+
+# ---------------------------------------------------------------------------
+# Misc invariants
+# ---------------------------------------------------------------------------
+
+
+class TestMisc:
+    def test_terminal_states_membership(self) -> None:
+        assert DONE in TERMINAL_STATES
+        assert FAILED in TERMINAL_STATES
+        assert CANCELLED in TERMINAL_STATES
+        assert INTERRUPTED in TERMINAL_STATES
+        assert RUNNING not in TERMINAL_STATES
+
+    def test_is_terminal_property(self) -> None:
+        assert JobRun(run_id="x", app="a", kind="k", status=DONE).is_terminal is True
+        assert JobRun(run_id="x", app="a", kind="k", status=RUNNING).is_terminal is False
+
+
+# ---------------------------------------------------------------------------
+# Defensive branches: redaction fallback, audit swallow, OSError paths
+# ---------------------------------------------------------------------------
+
+
+class TestDefensiveBranches:
+    def test_redact_falls_back_to_raw_when_security_raises(self, sdk: JobSDK, monkeypatch) -> None:
+        """If the redaction chain itself raises, the raw error text survives
+        (redaction must never mask the error)."""
+        import kiro_crew.security as security
+
+        def boom(_text):
+            raise RuntimeError("redaction backend down")
+
+        monkeypatch.setattr(security, "redact_credentials", boom)
+
+        def failer(h, **kw):
+            raise ValueError("SENTINEL-ERR-TEXT")
+
+        sdk.register("boom", failer)
+        run_id = sdk.start("boom")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == FAILED
+        assert "SENTINEL-ERR-TEXT" in run.error
+
+    def test_audit_failure_is_swallowed(self, sdk: JobSDK, monkeypatch) -> None:
+        """A SEL audit failure must not fail the job."""
+        import kiro_crew.apps.job_sdk as m
+
+        def boom():
+            raise RuntimeError("sel down")
+
+        monkeypatch.setattr(m, "sel", boom)
+        sdk.register("work", lambda h, **kw: {"ok": True})
+        run_id = sdk.start("work")  # _audit("job_start") swallows the raise
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+
+    def test_reconcile_survives_write_oserror(self, sdk: JobSDK, monkeypatch) -> None:
+        """A write failure during reconcile is logged and skipped, not raised."""
+        run = JobRun(
+            run_id="a" * 32,
+            app="test-app",
+            kind="work",
+            status=RUNNING,
+            origin="foreign-origin-token",
+        )
+        sdk.store.dir.mkdir(parents=True, exist_ok=True)
+        (sdk.store.dir / f"{run.run_id}.json").write_text(json.dumps(run.to_dict(), indent=1))
+
+        def boom(_run):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(sdk.store, "write", boom)
+        # Does not raise; the un-writable record is not counted as flipped.
+        assert sdk.reconcile() == 0
+
+    def test_remove_all_survives_unlink_oserror(self, tmp_path: Path, monkeypatch) -> None:
+        store = JobStore(tmp_path)
+        run = JobRun(run_id="b" * 32, app="x", kind="k", status=DONE)
+        store.write(run)
+
+        real_unlink = Path.unlink
+
+        def boom(self, *a, **k):
+            raise OSError("locked")
+
+        monkeypatch.setattr(Path, "unlink", boom)
+        # Counted as a FAILURE, not silently dropped: reporting only successes
+        # let a partial delete read as a clean one, so disable would claim the
+        # app's runs were gone while records remained.
+        assert store.remove_all() == (0, 1)
+        monkeypatch.setattr(Path, "unlink", real_unlink)
+
+    def test_remove_all_empty_dir_returns_zero(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path / "absent")
+        assert store.remove_all() == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# The discard guard — the other half of the resurrection fix
+# ---------------------------------------------------------------------------
+
+
+class TestDiscardGuard:
+    """``JobHandle`` has TWO write paths and cleanup must silence both.
+
+    ``TestRemoveAll`` pins the worker's terminal write. This pins the guarded
+    writer directly: a write arriving after the record was dropped would
+    recreate the file just as surely, because ``JobStore.write`` mkdirs and
+    writes unconditionally and cannot tell a first write from a resurrection.
+    """
+
+    def test_the_guarded_writer_refuses_a_discarded_handle(self, tmp_path: Path) -> None:
+        run = JobRun(run_id="ab" * 16, app="demo", kind="work", status=RUNNING)
+        handle, store, sdk = _handle_over(tmp_path, run)
+
+        assert sdk._persist(run, handle) is True  # noqa: SLF001 - the guard under test
+        assert store.read(run.run_id) is not None
+
+        assert store.remove_all() == (1, 0)
+        handle.discarded.set()
+
+        # The worker still tries to write its outcome; it must not land. The
+        # writer refuses under the same lock the discard was set with, so there
+        # is no check-then-act window for cleanup to slip through -- and the
+        # refusal is a False return, not an exception, so the caller's live-table
+        # and dedupe bookkeeping still runs.
+        run.status = DONE
+        assert sdk._persist(run, handle) is False  # noqa: SLF001 - the guard under test
+        assert store.read(run.run_id) is None
+
+    def test_handle_exposes_its_run_id(self, tmp_path: Path) -> None:
+        run = JobRun(run_id="cd" * 16, app="demo", kind="work")
+        handle, _store, _sdk = _handle_over(tmp_path, run)
+        assert handle.run_id == run.run_id
+
+
+class TestReconcilePoisonRecord:
+    """One unusable record must cost only itself.
+
+    Found by a pod end-to-end pass: a hand-written record whose run_id was not
+    hex made ``JobStore._path`` raise ``ValueError``, which escaped ``reconcile``
+    (it caught only ``OSError``) and abandoned every remaining run of that app.
+    The symptom was the exact one the pass exists to clear -- runs stuck at
+    ``running`` forever -- and it was invisible except as a logged traceback.
+    """
+
+    def test_a_record_with_an_unwritable_id_does_not_abandon_the_rest(
+        self, sdk: JobSDK, tmp_path: Path
+    ) -> None:
+        jobs_dir = tmp_path / "jobs"
+        jobs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Sorted first, so it is reached BEFORE the healthy record: if it aborts
+        # the loop, the sibling below is never reconciled and the test fails.
+        (jobs_dir / "0-bad-id.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "not-hex-at-all",
+                    "app": "demo",
+                    "kind": "work",
+                    "status": RUNNING,
+                    "origin": "f" * 32,
+                }
+            )
+        )
+        healthy_id = "ab" * 16
+        (jobs_dir / f"{healthy_id}.json").write_text(
+            json.dumps(
+                {
+                    "run_id": healthy_id,
+                    "app": "demo",
+                    "kind": "work",
+                    "status": RUNNING,
+                    "origin": "f" * 32,
+                }
+            )
+        )
+
+        # The poison record is skipped; the healthy one is still resolved.
+        assert sdk.reconcile() == 1
+        assert sdk.get(healthy_id).status == INTERRUPTED
+
+
+class TestConcurrentDedupe:
+    """Two simultaneous starts with one key must produce ONE run.
+
+    The double-click / two-tabs case is the whole point of `dedupe_key`, and the
+    first version checked the key and claimed it in two separate critical
+    sections with a disk read in between, so both callers could see no owner and
+    both run -- paying the cost twice, which is exactly the hazard dedupe exists
+    to remove.
+    """
+
+    def test_two_racing_starts_yield_one_run(self, sdk: JobSDK) -> None:
+        bodies = threading.Semaphore(0)
+        entered: list[str] = []
+
+        def runner(h, **kw):
+            entered.append(h.run_id)
+            bodies.acquire(timeout=5.0)
+            return {}
+
+        sdk.register("work", runner, cancellable=False)
+
+        gate = threading.Barrier(3, timeout=5.0)
+        ids: list[str] = []
+        errors: list[BaseException] = []
+
+        def racer() -> None:
+            try:
+                gate.wait()
+                ids.append(sdk.start("work", dedupe_key="one"))
+            except BaseException as exc:  # noqa: BLE001 - surfaced by the assert below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=racer, name=f"racer-{i}") for i in range(2)]
+        for t in threads:
+            t.start()
+        gate.wait()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        assert not errors, errors
+        assert len(ids) == 2
+        assert ids[0] == ids[1], f"dedupe let both starts win: {ids}"
+        # And only one body ever ran. Waited for rather than assumed: the worker's
+        # first act is now the STARTING -> RUNNING write, so a body enters strictly
+        # after a lock acquisition and a small disk write. This assertion used to
+        # read `entered` the instant both starts returned, which was only ever true
+        # because that gap was short -- a latent timing assumption, not a property.
+        # `ids[0] == ids[1]` above already proves ONE run exists, so nothing else
+        # can append here.
+        _wait_until(lambda: len(entered) >= 1)
+        assert len(entered) == 1, entered
+
+        bodies.release()
+        _wait_terminal(sdk, ids[0])
+
+
+class TestRunnerOutputIsRedacted:
+    """Runner-produced text is scrubbed at INGEST, so the record on disk is
+    clean too -- not only the HTTP response. A runner that shells out can quote
+    back a command line carrying a credential.
+
+    In P1 there is exactly one such field: the error of a failed run. The
+    progress and result channels this class used to cover are out of P1, so the
+    surface that needs scrubbing is a single string rather than arbitrary nested
+    data.
+    """
+
+    def test_a_failed_runners_error_is_scrubbed_on_disk_and_in_the_record(
+        self, sdk: JobSDK
+    ) -> None:
+        secret = "AKIAIOSFODNN7EXAMPLE"
+
+        def runner(h):
+            raise RuntimeError(f"upload failed: aws_secret_access_key={secret}")
+
+        sdk.register("leaky", runner)
+        run_id = sdk.start("leaky")
+        run = _wait_terminal(sdk, run_id)
+
+        assert run.status == FAILED
+        on_disk = (sdk.store.dir / f"{run_id}.json").read_text()
+        assert secret not in on_disk, "the credential reached the record on disk"
+        assert secret not in run.error
+        # Scrubbed, not blanked: the operator still learns what failed.
+        assert "upload failed" in run.error
+
+
+class TestClaimAndWriteFailurePaths:
+    """The two failure paths the atomicity and persistence fixes introduced."""
+
+    def test_a_failed_initial_write_releases_the_dedupe_claim(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Otherwise the key stays owned by a run that never started, and every
+        later start with that key would adopt a run that does not exist."""
+        sdk.register("work", lambda h, **kw: {})
+
+        def boom(_run):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(sdk.store, "write", boom)
+        # The guarded writer turns any write failure into a False return, so
+        # start refuses with a JobError rather than leaking the raw OSError --
+        # and, crucially, without skipping the claim release below.
+        with pytest.raises(JobError):
+            sdk.start("work", dedupe_key="k")
+
+        # Claim released: with a working store the same key starts a real run.
+        monkeypatch.undo()
+        run_id = sdk.start("work", dedupe_key="k")
+        assert run_id
+        assert _wait_terminal(sdk, run_id).status == DONE
+
+    def test_a_transient_terminal_write_is_retried(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A lost terminal write leaves the record reading `running` while the
+        work is finished, so one retry covers the transient case."""
+        real_write = sdk.store.write
+        calls: list[int] = []
+
+        def flaky(run):
+            calls.append(1)
+            # Fail only the terminal write (the initial one is call 1).
+            if len(calls) == 2:
+                raise OSError("transient")
+            return real_write(run)
+
+        sdk.register("work", lambda h, **kw: {"ok": True})
+        monkeypatch.setattr(sdk.store, "write", flaky)
+        run_id = sdk.start("work")
+        run = _wait_terminal(sdk, run_id)
+        assert run.status == DONE
+        assert len(calls) >= 3, f"the retry did not happen: {len(calls)} write(s)"
+
+
+class TestRecordIsAlwaysWritable:
+    """A runner cannot make its own record unserializable.
+
+    `json.dumps` raises TypeError on a set, a Path, or any object, and that
+    exception used to escape the terminal write and skip the live-table and
+    dedupe-key cleanup that follows it -- leaking a claim no later start could
+    release. In P1 that failure is impossible by CONSTRUCTION rather than
+    prevented by a sanitizer: every field is minted by the SDK from a str, an int
+    or a bool, and the one runner-supplied field is a string. The tests that used
+    to feed a Path and a set through the result and params channels went with
+    those channels.
+    """
+
+    def test_no_runner_can_put_a_non_json_value_in_its_record(self, sdk: JobSDK) -> None:
+        """A runner returning unserializable junk still lands a readable record.
+
+        The return value is discarded, so this holds no matter what the runner
+        produces -- and it is the property that keeps the claim from leaking,
+        because the terminal write cannot raise on serialization.
+        """
+        sdk.register("weird", lambda h: {"path": Path("/tmp/x"), "s": {1, 2}, "n": 3})
+        run_id = sdk.start("weird", dedupe_key="k")
+        run = _wait_terminal(sdk, run_id)
+
+        assert run.status == DONE
+        # Readable back off disk, so the write really happened.
+        assert sdk.get(run_id) is not None
+        # Bookkeeping was NOT skipped: the key is free, so a new start with the
+        # same key begins a new run rather than adopting a finished one.
+        second = sdk.start("weird", dedupe_key="k")
+        assert second != run_id
+        _wait_terminal(sdk, second)
+
+    def test_every_field_of_a_live_record_is_json_serializable(self, sdk: JobSDK) -> None:
+        """Pinned on the record's own shape, so a future field cannot slip in
+        holding something ``json.dumps`` refuses."""
+        sdk.register("work", lambda h: None)
+        run_id = sdk.start("work")
+        run = _wait_terminal(sdk, run_id)
+        for name, value in run.to_dict().items():
+            assert isinstance(value, (str, int, bool)), f"{name} is {type(value).__name__}"
+
+
+class TestDisableStopsTheWork:
+    """Disable must STOP the runs, not merely forget them.
+
+    Signalling alone left the threads running: a disabled app kept doing real,
+    side-effecting work with its records already deleted. Cleanup now
+    bounded-joins each worker.
+    """
+
+    def test_remove_all_waits_for_a_cooperating_worker(self, sdk: JobSDK) -> None:
+        started = threading.Event()
+        finished = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            while not h.cancelled.is_set():
+                time.sleep(0.01)
+            finished.set()
+            return {}
+
+        sdk.register("slow", runner, cancellable=True)
+        sdk.start("slow")
+        assert started.wait(5.0)
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup == CleanupResult(1, 0, 0)
+        # The worker is already done by the time cleanup returns -- that is the
+        # difference between stopping the work and forgetting it.
+        assert finished.is_set()
+        assert not any(t.name.startswith("job:") for t in threading.enumerate())
+
+
+class TestSanitizeInvariant:
+    """Nothing a runner supplied reaches disk unsanitized.
+
+    Four review rounds each found a different channel the scrub did not cover --
+    top-level result values, then ``step`` and nested values, then dict KEYS,
+    then ``progress_pct`` past the float guard -- because the writer's backstop
+    was a hand-written LIST of fields and a list is a thing to forget. P1 has one
+    runner-supplied field instead of five, so the funnel has one input and
+    cannot have a member missing. The channels those rounds found are out of P1
+    and return in P2 on types that are safe by construction.
+    """
+
+    def test_the_writer_scrubs_an_error_set_behind_its_back(self, sdk: JobSDK) -> None:
+        """The backstop. A field assigned directly, skipping the ingest site, is
+        still scrubbed because the single writer re-scrubs before writing."""
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        run = JobRun(run_id="ef" * 16, app="test-app", kind="work", status=RUNNING)
+        run.error = f"failed with aws_secret_access_key={secret}"
+        assert sdk._persist(run) is True  # noqa: SLF001 - the invariant under test
+        on_disk = (sdk.store.dir / f"{run.run_id}.json").read_text()
+        assert secret not in on_disk
+        assert secret not in run.error
+
+    def test_error_is_the_only_runner_supplied_field(self) -> None:
+        """The claim the one-line backstop rests on, pinned.
+
+        If a future field lands that a runner or caller can set, this fails and
+        whoever added it has to decide how it is sanitized -- which is the review
+        conversation the hand-written list kept losing.
+        """
+        sdk_minted = {
+            "run_id",
+            "app",
+            "kind",
+            "status",
+            "origin",
+            "pid",
+            "dedupe_key",
+            "cancellable",
+            "created_at",
+            "updated_at",
+            "finished_at",
+        }
+        fields = set(JobRun.__dataclass_fields__)
+        assert fields - sdk_minted == {"error"}
+
+
+class TestDisableIsTerminalForTheSDK:
+    """Cleanup must close the SDK, not merely snapshot what was live.
+
+    Marking and snapshotting used to be the whole of cleanup's critical section,
+    so a ``start`` that had already read the runner table could claim AFTER the
+    snapshot and spawn a worker cleanup would never see -- a disabled app doing
+    real, side-effecting work with its records already deleted. The route guard
+    does not cover this: it re-reads the manifest, but the app's own code holds a
+    reference to the SDK object and calls it directly.
+    """
+
+    def test_start_after_disable_is_refused(self, sdk: JobSDK) -> None:
+        sdk.register("work", lambda h: None)
+        asyncio.run(sdk.remove_all_async())
+        with pytest.raises(JobError, match="no longer accepting jobs"):
+            sdk.start("work")
+
+    def test_a_start_racing_cleanup_cannot_claim_after_the_snapshot(self, sdk: JobSDK) -> None:
+        """The window itself: close, then start, and no worker may exist.
+
+        Asserted on the THREAD table rather than on the refusal, because the
+        defect was not a missing error message -- it was app code still running.
+        """
+        sdk.register("work", lambda h: time.sleep(30))
+        asyncio.run(sdk.remove_all_async())
+        for _ in range(5):
+            with pytest.raises(JobError):
+                sdk.start("work")
+        assert not [t for t in threading.enumerate() if t.name.startswith("job:")]
+        assert sdk.list_active() == []
+
+
+class TestDedupeKeyIsNotLogged:
+    """A caller-supplied dedupe key must not reach the gateway log.
+
+    The adoption line used to quote it. The gateway log is durable and is served
+    by ``/api/logs``, and a dedupe key is whatever the caller chose -- an account
+    id, a path, or a credential -- so quoting it turned a de-duplication aid into
+    an output boundary nobody had classified as one.
+    """
+
+    def test_the_adoption_line_names_the_run_not_the_key(
+        self, sdk: JobSDK, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        gate = threading.Semaphore(0)
+        sdk.register("slow", lambda h: gate.acquire(timeout=10))
+
+        first = sdk.start("slow", dedupe_key=secret)
+        with caplog.at_level(logging.INFO, logger="kiro_crew.apps.job_sdk"):
+            second = sdk.start("slow", dedupe_key=secret)
+        assert second == first, "the second start should have adopted the first"
+
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        assert secret not in logged, "the dedupe key reached the gateway log"
+        # Still useful: the line has to identify WHAT was adopted.
+        assert first in logged and "slow" in logged
+
+        gate.release()
+        _wait_terminal(sdk, first)
+
+
+class TestEnableReconcilesStaleRecords:
+    """A mid-life enable must reconcile, not wait for the next gateway start.
+
+    The boot-time pass runs ONCE, after the enable loop, so an app enabled later
+    never got one -- and reconciliation is only decidable after the app's startup
+    hook registers its runners, since "no runner for this kind" is one of the two
+    outcomes it reports. Without a pass here a record left non-terminal by a
+    previous process stayed ``running`` until the next restart, and
+    ``list_active`` kept reporting work that had already stopped: the exact
+    symptom this SDK exists to remove.
+    """
+
+    def test_on_app_enable_flips_a_foreign_running_record(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from types import SimpleNamespace
+
+        from kiro_crew.apps import hooks_integration as hi
+
+        sdk = JobSDK("enable-app", tmp_path)
+        sdk.register("work", lambda h: None)
+        # Written by a process that is gone: a foreign origin with a live status.
+        stale = JobRun(
+            run_id="1a" * 16,
+            app="enable-app",
+            kind="work",
+            status=RUNNING,
+            origin="a-process-that-no-longer-exists",
+        )
+        sdk.store.write(stale)
+        assert sdk.get(stale.run_id).status == RUNNING
+
+        async def _no_crons(*_a, **_k):
+            return 0
+
+        monkeypatch.setattr(hi, "app_execution_denied", lambda *a, **k: "")
+        monkeypatch.setattr(hi, "register_app_crons_with_service", _no_crons)
+        monkeypatch.setattr(hi, "sel", lambda: MagicMock())
+        monkeypatch.setattr(hi, "_publish_hook_health", lambda *a, **k: None)
+        monkeypatch.setattr(hi, "_lifecycle_dispatcher", None)
+        monkeypatch.setattr(hi, "_route_registry", None)
+        monkeypatch.setattr(
+            hi,
+            "_build_app_context_from_info",
+            lambda *a, **k: SimpleNamespace(job=sdk),
+        )
+
+        app_info = {"manifest": {"backend": {"hooks": {"on_startup": "app.py:start"}}}}
+        result = asyncio.run(hi.on_app_enable("enable-app", app_info))
+
+        assert sdk.get(stale.run_id).status == INTERRUPTED
+        assert "1" in result.get("job_reconcile", ""), result
+
+    def test_a_reconcile_failure_does_not_fail_the_enable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Enable must survive it: a stale record is worth less than the app."""
+        from types import SimpleNamespace
+
+        from kiro_crew.apps import hooks_integration as hi
+
+        sdk = JobSDK("enable-app", tmp_path)
+
+        def boom() -> int:
+            raise OSError("the runs directory is unreadable")
+
+        monkeypatch.setattr(sdk, "reconcile", boom)
+
+        async def _no_crons(*_a, **_k):
+            return 0
+
+        monkeypatch.setattr(hi, "app_execution_denied", lambda *a, **k: "")
+        monkeypatch.setattr(hi, "register_app_crons_with_service", _no_crons)
+        monkeypatch.setattr(hi, "sel", lambda: MagicMock())
+        monkeypatch.setattr(hi, "_publish_hook_health", lambda *a, **k: None)
+        monkeypatch.setattr(hi, "_lifecycle_dispatcher", None)
+        monkeypatch.setattr(hi, "_route_registry", None)
+        monkeypatch.setattr(
+            hi,
+            "_build_app_context_from_info",
+            lambda *a, **k: SimpleNamespace(job=sdk),
+        )
+
+        app_info = {"manifest": {"backend": {"hooks": {"on_startup": "app.py:start"}}}}
+        result = asyncio.run(hi.on_app_enable("enable-app", app_info))
+        assert result["job_reconcile"].startswith("failed:")
+
+
+class TestNonObjectRecordCostsOnlyItself:
+    """A file holding valid JSON that is not an OBJECT must not strand the scan.
+
+    ``[]``, ``"x"`` and ``5`` all survive ``json.loads``, and then ``.items()``
+    raises ``AttributeError`` -- which neither reader's handler named, so it
+    escaped as a 500 from the route and abandoned the whole reconciliation pass,
+    stranding every later record of that app. Refused as ``ValueError`` at
+    ``from_dict``, which is the failure both readers already treat as "this one
+    record is unusable".
+    """
+
+    def test_from_dict_refuses_a_non_object_body(self) -> None:
+        for body in ([], "x", 5, None, 1.5):
+            with pytest.raises(ValueError, match="not an object"):
+                JobRun.from_dict(body)  # type: ignore[arg-type]
+
+    def test_read_returns_none_for_a_non_object_record(self, tmp_path: Path) -> None:
+        store = JobStore(tmp_path)
+        store.dir.mkdir(parents=True, exist_ok=True)
+        (store.dir / ("9a" * 16 + ".json")).write_text("[]")
+        assert store.read("9a" * 16) is None
+
+    def test_iter_runs_skips_it_and_keeps_going(self, tmp_path: Path) -> None:
+        """The blast radius: the GOOD record after it must still be yielded."""
+        store = JobStore(tmp_path)
+        store.dir.mkdir(parents=True, exist_ok=True)
+        # Named to sort BEFORE the good one, so a raise would hide the good one.
+        (store.dir / ("0b" * 16 + ".json")).write_text('"just a string"')
+        good = JobRun(run_id="ff" * 16, app="x", kind="k", status=DONE)
+        store.write(good)
+        assert [r.run_id for r in store.iter_runs()] == [good.run_id]
+
+    def test_reconcile_is_not_abandoned_by_one(self, tmp_path: Path) -> None:
+        sdk = JobSDK("poison-app", tmp_path)
+        sdk.store.dir.mkdir(parents=True, exist_ok=True)
+        (sdk.store.dir / ("0c" * 16 + ".json")).write_text("[1, 2, 3]")
+        stale = JobRun(
+            run_id="ee" * 16,
+            app="poison-app",
+            kind="work",
+            status=RUNNING,
+            origin="a-process-that-is-gone",
+        )
+        sdk.store.write(stale)
+        # The unusable file must not stop the stale one from being resolved.
+        assert sdk.reconcile() == 1
+        assert sdk.get(stale.run_id).status == INTERRUPTED
+
+
+class TestDisableCleansUpRegardlessOfTheGrant:
+    """Teardown asks the REGISTRY, not the manifest.
+
+    Gating cleanup on the `jobs` grant meant revoking the grant and then
+    disabling took the one path that skips it: the SDK stays registered from the
+    enable that DID have the grant, its workers keep executing, and the lookup
+    entry is dropped afterwards -- so nothing can reach them again.
+    """
+
+    def test_cleanup_runs_for_an_app_whose_grant_was_revoked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.apps import hooks_integration as hi
+
+        sdk = JobSDK("revoked-app", tmp_path)
+        started = threading.Event()
+        sdk.register("work", lambda h: (started.set(), h.cancelled.wait(10)), cancellable=True)
+        sdk.start("work")
+        assert started.wait(5.0)
+
+        register_sdk(sdk)
+        try:
+            monkeypatch.setattr(hi, "get_sdk", lambda name: sdk if name == "revoked-app" else None)
+            monkeypatch.setattr(hi, "sel", lambda: MagicMock())
+
+            result: dict = {}
+            # No manifest and no grant are consulted at all: the helper takes only
+            # the app name, which is the point of the fix.
+            asyncio.run(hi._cleanup_app_jobs("revoked-app", result))
+
+            assert sdk.list_active() == []
+            assert not [t for t in threading.enumerate() if t.name.startswith("job:")]
+            assert "job_cleanup" in result
+        finally:
+            forget_sdk("revoked-app")
+
+
+class TestStartingStateClosesTheLaunchWindow:
+    """The interval between CLAIMING a run and LAUNCHING it is real and named.
+
+    It contains a disk write, and three defects came from code with no way to name
+    it: cleanup joined a thread that was never started (RuntimeError, which
+    escaped the disable so the records were never deleted); a start that had
+    already claimed launched into an app being disabled; and the record said
+    `running` while no worker existed. `_Live.started` and the `STARTING` status
+    make each decidable, and both transitions happen under the one lock.
+    """
+
+    def test_cleanup_does_not_crash_on_an_unstarted_entry(self, sdk: JobSDK) -> None:
+        """The exact crash: join() on a thread that was never started.
+
+        Driven by putting the state in directly, because that IS the state cleanup
+        snapshotted -- and the assertion is that the records still get deleted,
+        since the real damage was the RuntimeError escaping so `remove_all` never
+        ran and a disabled app kept its records AND its worker.
+        """
+        run = JobRun(run_id="7a" * 16, app=sdk.app_name, kind="work", status=STARTING)
+        sdk.store.write(run)
+        never_started = threading.Thread(target=lambda: None, name="job:never-started")
+        sdk._live[run.run_id] = job_sdk._Live(  # noqa: SLF001 - the state under test
+            handle=JobHandle(run), thread=never_started, started=False
+        )
+
+        result = asyncio.run(sdk.remove_all_async())
+
+        assert result.removed == 1, "the record was not deleted -- cleanup did not finish"
+        assert result.still_running == 0, "an unstarted thread cannot be stubborn"
+        assert result.is_clean
+        assert sdk.get(run.run_id) is None
+
+    def test_a_disable_landing_inside_the_window_refuses_the_launch(self, sdk: JobSDK) -> None:
+        """The window `_closed` alone cannot cover: this start claimed FIRST.
+
+        Cleanup is triggered from inside the initial record write, which is
+        precisely where the window is, so no sleep is involved and the ordering is
+        not left to the scheduler.
+        """
+        ran: list[str] = []
+        sdk.register("work", lambda h: ran.append(h.run_id))
+
+        real_persist = sdk._persist  # noqa: SLF001 - driving the real writer
+        fired: list[bool] = []
+
+        def persist_then_disable(run, handle=None):
+            ok = real_persist(run, handle)
+            if not fired:
+                fired.append(True)
+                # The app is disabled while this start sits between its claim and
+                # its launch. Its live entry is already in the table.
+                asyncio.run(sdk.remove_all_async())
+            return ok
+
+        sdk._persist = persist_then_disable  # type: ignore[method-assign]
+        with pytest.raises(JobError, match="stopped accepting jobs"):
+            sdk.start("work")
+
+        assert ran == [], "a worker was launched for an app that was being disabled"
+        assert not [t for t in threading.enumerate() if t.name.startswith("job:")]
+        assert sdk.list_active() == []
+
+    def test_the_first_write_says_starting_not_running(self, sdk: JobSDK) -> None:
+        """Observed at the write itself, because that is where the lie was.
+
+        Asserting only what the WORKER sees cannot detect a regression: if the
+        initial status went back to `running`, the worker would still report
+        `running` and such a test would stay green while the record was again
+        claiming a worker existed during the initial disk write.
+        """
+        statuses: list[str] = []
+        real_persist = sdk._persist  # noqa: SLF001 - observing the real writer
+
+        def record_status(run, handle=None):
+            statuses.append(run.status)
+            return real_persist(run, handle)
+
+        sdk._persist = record_status  # type: ignore[method-assign]
+        sdk.register("work", lambda h: None)
+        run_id = sdk.start("work")
+        _wait_terminal(sdk, run_id)
+
+        assert statuses[0] == STARTING, f"the first write claimed {statuses[0]!r}"
+        assert RUNNING in statuses, "the worker never recorded that it was running"
+        assert statuses[-1] == DONE
+
+    def test_the_record_says_starting_until_the_worker_says_running(self, sdk: JobSDK) -> None:
+        """The record must not assert a worker exists before one does."""
+        seen: list[str] = []
+        release = threading.Semaphore(0)
+
+        def runner(h):
+            # By now the worker has completed the STARTING -> RUNNING transition.
+            got = sdk.get(h.run_id)
+            seen.append(got.status if got else "<gone>")
+            release.acquire(timeout=5.0)
+
+        sdk.register("work", runner)
+        run_id = sdk.start("work")
+        _wait_until(lambda: bool(seen))
+        assert seen == [RUNNING]
+
+        release.release()
+        assert _wait_terminal(sdk, run_id).status == DONE
+
+    def test_starting_is_not_terminal_so_reconcile_resolves_it(self, tmp_path: Path) -> None:
+        """A process that died mid-launch leaves `starting` behind; it must not
+        be mistaken for a finished run."""
+        assert STARTING not in TERMINAL_STATES
+        sdk = JobSDK("mid-launch", tmp_path)
+        sdk.store.write(
+            JobRun(
+                run_id="7b" * 16,
+                app="mid-launch",
+                kind="work",
+                status=STARTING,
+                origin="a-process-that-is-gone",
+            )
+        )
+        assert sdk.reconcile() == 1
+        assert sdk.get("7b" * 16).status == INTERRUPTED
+
+
+class TestForeignRecordFieldsAreCoerced:
+    """A wrong-TYPED field must not abort the scan either.
+
+    A record whose `error` is a number reached `_persist`, where the slice after
+    the redaction raised `TypeError` outside that method's own try -- the same
+    blast radius as a non-object body, one level in. Coerced at `from_dict`, the
+    single point foreign data enters, so every consumer downstream gets the type
+    it is written against.
+    """
+
+    def test_wrong_typed_fields_fall_back_to_defaults(self) -> None:
+        run = JobRun.from_dict(
+            {
+                "run_id": "8a" * 16,
+                "app": "x",
+                "kind": "k",
+                "error": 12345,  # not a string
+                "pid": "not-a-number",
+                "cancellable": "yes",  # not a bool
+                "status": ["running"],  # not a string
+            }
+        )
+        assert run.error == ""
+        assert run.pid == 0
+        assert run.cancellable is False
+        assert run.status == QUEUED
+
+    def test_a_true_bool_is_not_accepted_as_a_pid(self) -> None:
+        """bool IS an int subclass, so an int check alone would take True."""
+        assert JobRun.from_dict({"run_id": "8b" * 16, "pid": True}).pid == 0
+
+    def test_reconcile_survives_a_numeric_error_field(self, tmp_path: Path) -> None:
+        sdk = JobSDK("typed-app", tmp_path)
+        sdk.store.dir.mkdir(parents=True, exist_ok=True)
+        (sdk.store.dir / ("8c" * 16 + ".json")).write_text(
+            json.dumps(
+                {
+                    "run_id": "8c" * 16,
+                    "app": "typed-app",
+                    "kind": "work",
+                    "status": RUNNING,
+                    "origin": "gone",
+                    "error": 999,
+                }
+            )
+        )
+        assert sdk.reconcile() == 1
+        assert sdk.get("8c" * 16).status == INTERRUPTED
+
+
+class TestCleanupDoesNotBlockTheLoop:
+    """An async SDK method must never park the event loop.
+
+    `remove_all_async` bounded-joins workers, and doing that inline made every
+    disable stall the whole gateway for the deadline -- the exact hazard
+    CronSDK's docstring spells out. The join runs on a worker thread now.
+    """
+
+    def test_the_loop_keeps_running_while_cleanup_waits(self, sdk: JobSDK) -> None:
+        started = threading.Event()
+        stop = threading.Event()
+        # Held so this deliberately uncooperative worker can be joined at the end.
+        # It is the one test that WANTS a thread to outlive cleanup's deadline, so
+        # it is also the one that has to clean up after itself -- left running it
+        # would still hold the SDK's lock and write files while later tests ran.
+        worker: list[threading.Thread] = []
+
+        def runner(h, **kw):
+            worker.append(threading.current_thread())
+            started.set()
+            # Ignores the cancel signal, so cleanup must wait out its deadline.
+            stop.wait(_CLEANUP_JOIN_SECS + 2.0)
+            return {}
+
+        sdk.register("stubborn", runner, cancellable=True)
+        sdk.start("stubborn")
+        assert started.wait(5.0)
+
+        async def drive() -> int:
+            ticks = 0
+
+            async def ticker() -> None:
+                nonlocal ticks
+                while True:
+                    await asyncio.sleep(0.02)
+                    ticks += 1
+
+            spin = asyncio.ensure_future(ticker())
+            try:
+                result = await sdk.remove_all_async()
+            finally:
+                spin.cancel()
+            # The worker never cooperated, so cleanup reports it rather than
+            # claiming a clean teardown.
+            assert result.still_running == 1
+            assert not result.is_clean
+            return ticks
+
+        ticks = asyncio.run(drive())
+        stop.set()
+        # A blocking join would have starved the ticker for the whole deadline.
+        assert ticks > 5, f"the loop was parked during cleanup (only {ticks} ticks)"
+        # Released, then actually waited for: the assertion above is about the
+        # LOOP not stalling, which says nothing about the thread still running.
+        for t in worker:
+            t.join(timeout=5.0)
+            assert not t.is_alive(), "the stubborn worker outlived its test"
+
+
+class TestThreadStartFailure:
+    """A refused thread must not leave a claimed run nothing will finish."""
+
+    def test_a_refused_thread_leaves_no_ghost(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sdk.register("work", lambda h, **kw: {}, cancellable=False)
+
+        def refuse(self):  # noqa: ANN001 - patching threading.Thread.start
+            raise RuntimeError("can't start new thread")
+
+        monkeypatch.setattr(threading.Thread, "start", refuse)
+        with pytest.raises(JobError):
+            sdk.start("work", dedupe_key="k")
+        monkeypatch.undo()
+
+        # No run is left claiming to be active, and the key is free again.
+        assert sdk.list_active() == []
+        again = sdk.start("work", dedupe_key="k")
+        assert _wait_terminal(sdk, again).status == DONE


### PR DESCRIPTION
## What is the problem?

The product has no server-side representation of "a task of mine is running".

A long task started from the dashboard -- AWS Control's backup, Dev Fleet's pull --
exists only as state inside the React component that started it. Navigate away and
that state is destroyed while the work keeps going, so the UI reports the task as
stopped. It was reported three times as three bugs; it is one app-wide
architectural gap, and no app can fix it alone because none of them owns a durable
place to record a run.

## Why this issue matters to the user

The user cannot trust what the UI tells them about their own work. They either sit
on the page babysitting a backup, or they navigate away, see "stopped", and start it
again -- doing paid work twice against the same destination. There is also no way to
answer "did last night's run finish?", because nothing outlives the tab.

## How our fix solves it

This is P1 of the merged spec `docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md`.
It adds the durable run registry the gap needs, and **ships with no consumers on
purpose** -- migrating an app is P2, so P1 can be reviewed as a foundation rather
than as a feature.

**`ctx.job` -- an app-scoped Job SDK** (`src/kiro_crew/apps/job_sdk.py`), gated on a
new `jobs` manifest permission. A runner is REGISTERED against a kind at app init,
not passed per call, which is what lets a caller that cannot hold a Python callable
-- the browser, and the startup reconciliation pass -- address a run.

**Shared `_jobs/*` routes** (`src/kiro_crew/apps/job_routes.py`), mounted once for
every app with `{app}` as a path segment, so no app registers its own. Registered
before `RouteRegistry.ensure_catch_all()` because aiohttp matches in registration
order and the app catch-all would otherwise swallow every `_jobs` request.
Authorization does not trust the process registry: the guard re-reads the manifest
off the loop, so a grant revoked after enable refuses even while the SDK is still
published.

**P1 records that a run EXISTS and how it ended -- nothing it produced.** There is
no `params` a caller passes in and no `progress` or `result` a runner reports out. A
record holds identity, lifecycle, and one error string if it failed. This is the
scope decision that makes the rest defensible: those channels are arbitrary nested
data that must be sanitized before it can be written or served, they needed a
recursive sanitizer to do it, and P1 has no consumer that reads them. They return in
P2 designed against a real consumer, as types that are sanitized by construction
rather than by a rule each writer has to remember.

Four invariants, each enforced in ONE place rather than by convention at each call
site:

- **Nothing runner-supplied reaches disk unsanitized.** One line in the single
  writer, because `error` is the only field a runner supplies. Everything else is
  minted by the SDK from a str, an int or a bool, so a record is JSON-safe by
  construction and the terminal write cannot raise on serialization -- which is what
  used to skip the live-table and dedupe-key cleanup and leak a claim forever.
- **One writer per run file.** Each run is its own file, so concurrent writers never
  share a path; `atomic_write` gives crash-safety but no mutual exclusion, and the
  tree has no lock helper. Reads go through `atomic_write.read_bytes_with_retry`,
  because file-per-run settles writer-vs-writer and NOT reader-vs-writer: on Windows
  a reader racing the writer's rename fails with `PermissionError`.
- **An async SDK method never parks the loop.** Worker joins go through
  `asyncio.to_thread`, and every route reads the record off the loop.
- **Cleanup reports the truth, and disable is terminal.** `remove_all_async` returns
  a result that cannot hide a worker it failed to stop, and it closes the SDK under
  the same lock `start` claims in -- so a start racing cleanup cannot spawn a worker
  after the snapshot and leave a disabled app doing real work.

Reconciliation resolves records left non-terminal by a process that is gone.
Staleness is decided by a per-process origin token, not a pid, because a pid can be
reused by the very process doing the reconciling. It runs after the enable loop at
boot, and again after an app's startup hook registers its runners, so an app enabled
later in the gateway's life is not left reporting work that already stopped.

## What tests we did

95 tests across `test/test_job_sdk.py` and `test/test_job_routes.py`, at 98%
coverage of `job_sdk.py` and 97% of `job_routes.py`. `flake8`, `isort` and the
baselined `black` gate are clean, and `mypy` is clean over 1178 files.

Every behaviour that a review round established is pinned, and the pins are
mutation-verified -- reverting the fix turns its own test red, checked one fix at a
time:

- a `start` after disable is refused, and no worker thread survives the attempt;
- an all-hex run id of the wrong length is rejected, so an oversized filename cannot
  reach the filesystem and surface `ENAMETOOLONG` as a 500 where 404 is the answer;
- a caller-supplied dedupe key does not reach the gateway log;
- the unknown-kind 404 body is scrubbed, since it reflects a path parameter;
- enabling an app reconciles its stale records, and a reconcile failure does not fail
  the enable;
- both record readers go through the Windows-safe helper, and a non-ASCII error
  round-trips as UTF-8 rather than in the host locale.

Verified by a real gateway boot in an isolated pod, 9 of 9, for the two wiring
points unit tests structurally cannot reach: `GET /_jobs/active` returned the job
handler rather than a 404 from the app catch-all, proving route ordering; and
foreign-origin `running` records written while the pod was down flipped to
`interrupted` on boot with different text for a known versus an unknown kind,
proving reconciliation runs after the enable loop.

## Any other suggestions on the work

Two exceptions are deliberate. The dashboard owner-guard imports inside
`job_routes._guarded` stay function-local because module scope closes a
boot-breaking import cycle -- the same exemption `cron_sdk` documents for
`mcp_cron`. And gateway shutdown does not drain runs: these are daemon threads the
interpreter reaps at exit, and draining every app's runs would delay shutdown for
work nobody is waiting on.

Two items are accepted and tracked rather than fixed here. Revoking the `jobs` grant
and then disabling skips live-worker cleanup, and a worker that outlives the join
deadline does not fail trust withdrawal; both are in `hooks_integration.py` on the
disable path, and both want the same fix, which is for cleanup to run off the grant
rather than off the permission read.

P2 owes the payload channels on typed constructors, and a docs follow-up owes one
correction to the merged spec: it says the routes are registered through the Route
Registry so the existing `permissions.api` gate applies. Builtins register directly
on the aiohttp app, the Route Registry cannot register on another app's behalf, and
no new `permissions.api` entry is needed because `_app_owns_path` already covers an
app's own namespace.
