### PR TITLE
test: name and widen the positive waits in subagent turn-resilience

### DIFF
--- a/test/test_subagent_turn_resilience.py
+++ b/test/test_subagent_turn_resilience.py
@@ -39,6 +39,44 @@ pytestmark = pytest.mark.usefixtures("healthy_host_memory")
 # Subagent-registry isolation is provided globally by the autouse
 # ``_isolate_subagents_dir`` fixture in ``conftest.py``.
 
+# Two kinds of number live here and they must not be merged.
+#
+# POSITIVE WAITS (_START_TIMEOUT, _RESPAWN_TIMEOUT) bound how long the harness waits
+# for the event loop to schedule something. Every ordering guarantee around them is
+# asserted separately, and the fixed ``asyncio.sleep`` windows that prove a respawn
+# has NOT fired yet are deliberately left alone -- those are negative assertions,
+# where the duration IS the test. Raising a positive wait cannot weaken an assertion;
+# it only stops the harness giving up before the awaited thing was ever given a
+# chance to run. 5.0s was too tight on a loaded runner: shard 4 of the Windows
+# backend job runs ~950s wall with individual tests over 38s, and
+# ``test_cancel_recovery_waits_for_slow_teardown`` timed out there while the other
+# 17,258 tests in the same shard passed.
+#
+# _RESPAWN_TIMEOUT stays BELOW the production give-up it can outlive on the FAILURE
+# path (``subagent._RECOVERY_SLOT_WAIT_SECS`` = 60.0). A passing run never reaches
+# that give-up -- ``test_cancel_recovery_waits_for_free_slot`` frees the slot while
+# the poll is still young, and every other caller finds capacity already free, so
+# the bounded wait exits on its next tick. The bound is about what a FAILING run
+# reports: if the poll outlived 60.0s, the code would have already raised "no free
+# slot for recovery respawn", ``task2`` would never appear, and the failure would
+# read as "recovery never happened" rather than naming the real cause.
+#
+# Ceiling for both: ``setup.cfg`` sets a global ``--timeout=120``. The heaviest test
+# serializes two start waits plus one respawn poll, so the failure path must stay
+# under that or a real hang surfaces as an opaque pytest-timeout kill instead of the
+# named deadline that explains it.
+_START_TIMEOUT = 30.0  # the mocked stream reaching its first yield
+_RESPAWN_TIMEOUT = 20.0  # a cancelled run's replacement task appearing in _tasks
+
+# An UPPER BOUND, not a positive wait -- do not raise it with the two above.
+# ``test_cancel_recovery_failure_emits_done_and_delivers`` patches the production
+# give-up (``subagent._RECOVERY_SLOT_WAIT_SECS``, normally 60.0) down to 0.4s, and
+# this bound is what asserts the patch actually took effect: the recovery must fail
+# FAST. Widening it opens a band in which a refactor that stops reading that module
+# global -- inlining the literal, moving it onto the instance, renaming it -- leaves
+# every terminal assertion still passing, for the wrong reason.
+_GIVE_UP_BOUND = 10.0
+
 
 class _TransientError(Exception):
     """Duck-typed AcpError carrying the structured transient verdict."""
@@ -429,7 +467,7 @@ async def test_user_cancel_is_neutral_stopped_with_partial():
     with patch("kiro_crew.subagent.Stats") as stats, patch("kiro_crew.subagent.sel"):
         info = mgr.spawn("long job")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         cancelled = await mgr.cancel(info.id)
         await asyncio.gather(*mgr._tasks.values(), return_exceptions=True)
 
@@ -461,7 +499,7 @@ async def test_unexpected_cancel_auto_continues_once():
     with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
         info = mgr.spawn("interruptible job")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         task1 = mgr._tasks[info.id]
         task1.cancel()  # UNEXPECTED cancel (not via mgr.cancel, not shutdown)
         await asyncio.gather(task1, return_exceptions=True)
@@ -474,7 +512,7 @@ async def test_unexpected_cancel_auto_continues_once():
         # teardown fully completes (explicit handshake, not a timed sleep).
         started.clear()
         task2 = None
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_event_loop().time() + _RESPAWN_TIMEOUT
         while asyncio.get_event_loop().time() < deadline:
             task2 = mgr._tasks.get(info.id)
             if task2 is not None and task2 is not task1:
@@ -484,7 +522,7 @@ async def test_unexpected_cancel_auto_continues_once():
         assert task1.done()  # respawn never races the original teardown
 
         # Second unexpected cancel → terminal (budget spent).
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         task2.cancel()
         await asyncio.gather(task2, return_exceptions=True)
 
@@ -526,7 +564,7 @@ async def test_unexpected_cancel_after_tool_activity_finalizes_without_respawn()
     with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
         info = mgr.spawn("side-effecting job")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         assert info.tool_count > 0 and info.streaming_text == ""
         task1 = mgr._tasks[info.id]
         task1.cancel()  # UNEXPECTED cancel after tool ran
@@ -563,14 +601,14 @@ async def test_cancel_recovery_text_only_respawn_gets_resume_preamble():
     with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
         info = mgr.spawn("resumable job")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         assert info.streaming_text and info.tool_count == 0
         task1 = mgr._tasks[info.id]
         task1.cancel()  # UNEXPECTED cancel after text, no tools
         await asyncio.gather(task1, return_exceptions=True)
 
         # Wait for the respawn's build_message call (second entry).
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_event_loop().time() + _RESPAWN_TIMEOUT
         while len(build_msgs) < 2 and asyncio.get_event_loop().time() < deadline:
             await asyncio.sleep(0.05)
         assert len(build_msgs) >= 2
@@ -594,7 +632,7 @@ async def test_shutdown_cancel_does_not_auto_continue():
     with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
         info = mgr.spawn("job at shutdown")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         await mgr.cancel_all()
 
     assert mgr._shutting_down is True
@@ -662,14 +700,14 @@ async def test_cancel_recovery_waits_for_slow_teardown():
     with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
         info = mgr.spawn("slow teardown job")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         task1 = mgr._tasks[info.id]
         task1.cancel()
         await asyncio.gather(task1, return_exceptions=True)
 
         # Poll for the respawn; when it appears, teardown MUST already be done.
         task2 = None
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_event_loop().time() + _RESPAWN_TIMEOUT
         while asyncio.get_event_loop().time() < deadline:
             task2 = mgr._tasks.get(info.id)
             if task2 is not None and task2 is not task1:
@@ -693,7 +731,7 @@ async def test_cancel_recovery_waits_for_free_slot():
     with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
         info = mgr.spawn("capacity job")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         task1 = mgr._tasks[info.id]
 
         # Simulate the freed slot being immediately taken by a queued spawn.
@@ -715,7 +753,7 @@ async def test_cancel_recovery_waits_for_free_slot():
         # Free the slot — recovery proceeds and count never exceeds the cap.
         mgr._running_count = 0
         task2 = None
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_event_loop().time() + _RESPAWN_TIMEOUT
         while asyncio.get_event_loop().time() < deadline:
             task2 = mgr._tasks.get(info.id)
             if task2 is not None and task2 is not task1:
@@ -753,7 +791,7 @@ async def test_cancel_recovery_failure_emits_done_and_delivers():
     ):
         info = mgr.spawn("doomed recovery job")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         task1 = mgr._tasks[info.id]
         task1.cancel()
         await asyncio.gather(task1, return_exceptions=True)
@@ -767,7 +805,7 @@ async def test_cancel_recovery_failure_emits_done_and_delivers():
         # failure path's subagent_done emit and on_done delivery run.
         rec = mgr._tasks.get(f"{info.id}:recovery")
         assert rec is not None, "pending recovery must be registered in _tasks"
-        await asyncio.wait_for(asyncio.gather(rec, return_exceptions=True), timeout=10)
+        await asyncio.wait_for(asyncio.gather(rec, return_exceptions=True), timeout=_GIVE_UP_BOUND)
 
     assert info.done is True
     assert info.error == "cancelled (recovery failed)"
@@ -796,7 +834,7 @@ async def test_cancel_all_reaches_pending_recovery_and_finalizes():
     ):
         info = mgr.spawn("job interrupted by shutdown")
         assert info is not None
-        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(started.wait(), timeout=_START_TIMEOUT)
         task1 = mgr._tasks[info.id]
         task1.cancel()
         await asyncio.gather(task1, return_exceptions=True)


### PR DESCRIPTION
## Problem / Motivation

`test_cancel_recovery_waits_for_slow_teardown` timed out on **Backend Tests (Windows) shard 4** while the other 17,258 tests in that same shard passed. It was not the test's logic: the file waited on the event loop through **fourteen hardcoded 5-second deadlines**, and that shard runs ~950s wall with individual tests over 38s. Any of the fourteen can lose the race on a loaded runner — the one that failed is simply the one that lost it this time.

## Why it matters

A time-based flake in a required check is indistinguishable from a real regression at the point where it blocks someone. Every contributor who trips it pays a re-run round and has to decide, without evidence, whether the recovery path is actually broken. The deadlines were also spelled identically to numbers that are *not* waits, so a future tuning pass had no way to tell which ones were safe to raise.

## What changed (motivation → approach → change)

Symptom: a start-wait deadline expiring on a slow Windows runner. Root cause: the file used the bare literal `5` for two kinds of number that behave in opposite ways, so raising the flaky one meant eyeballing fifteen call sites and hoping none of them was load-bearing.

The change separates the kinds and names each one:

- `_START_TIMEOUT = 30.0` — the mocked stream reaching its first yield (10 sites)
- `_RESPAWN_TIMEOUT = 20.0` — a cancelled run's replacement task appearing in `_tasks` (4 sites)
- `_GIVE_UP_BOUND = 10.0` — an **upper bound**, unchanged from the literal it replaces

Values are bounded from both directions, not just raised:

- `_RESPAWN_TIMEOUT` stays below the production give-up it can outlive on the **failure** path (`subagent._RECOVERY_SLOT_WAIT_SECS = 60.0`). A passing run never reaches that give-up — `test_cancel_recovery_waits_for_free_slot` frees the slot while the poll is still young, and every other caller finds capacity already free, so the bounded wait exits on its next tick. The bound governs what a *failing* run reports: if the poll outlived 60.0s, the code would have already raised `"no free slot for recovery respawn"`, `task2` would never appear, and the failure would read as "recovery never happened" rather than naming the real cause.
- `setup.cfg` sets a global `--timeout=120`, so the heaviest test's failure path (two start waits plus one respawn poll = 80s) must stay under it, or a real hang surfaces as an opaque pytest-timeout kill instead of the named deadline that explains it.
- `30.0` has two precedents in the suite (`_WORKER_RELEASE_TIMEOUT`, `_ANSWER_WAIT_SECS`) and sits inside the 15–60s range its siblings use.

`_GIVE_UP_BOUND` keeps `10.0` deliberately. An adversarial review of the first draft caught that this one site is not a positive wait: `test_cancel_recovery_failure_emits_done_and_delivers` patches the production give-up down to 0.4s, and the bound is what asserts the patch took effect — the recovery must fail **fast**. Routing it through a 30s constant would have opened a 10–30s band in which a refactor that stops reading that module global (inlining the literal, moving it onto the instance, renaming it) leaves every terminal assertion passing for the wrong reason. It is now named and commented as an upper bound so it does not get raised with the other two.

The three fixed `asyncio.sleep(0.2/0.5/0.6)` windows are untouched: those are **negative** assertions, where the duration IS the test.

## Tests

No new tests — this PR *is* a test change. The 28 tests in `test/test_subagent_turn_resilience.py` continue to lock in the same behavior, with the same assertions, and none of their success paths now waits for a deadline to elapse: all ten start waits return the instant the event is set, all four poll loops break on first sighting, and the patched give-up completes in ~0.4s. The change is time-neutral on the passing path.

## Manual verification

N/A — unit coverage sufficient; this is a test-only change with no production code touched.

Locally on the pushed commit: `test/test_subagent_turn_resilience.py` 28 passed; together with `test/test_llm_helpers.py` (the only other file that so much as names the module) 162 passed. `mypy src/kiro_crew/` clean over 1,170 files; `isort`, `flake8`, `black`, brand-name, focus-cue, loop-bound-locks, testpaths-coverage, changelog-history and harness-parity gates all green. The full 75k-item suite was attempted locally but the xdist workers were killed near the end under host memory pressure (8 of 16 workers, 17 GiB free), so it produced no verdict — CI's sharded matrix is the authority for it. The change cannot reach any other test file: the three constants are module-private and nothing imports them.

## Related Issues

no linked issue: the flake was observed directly on a CI run, not filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
