### PR TITLE
fix(gateway): drain the queued gateway.log tail before every hard exit

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -829,6 +829,38 @@ def _stop_log_queue_listener(timeout: float | None = None) -> None:
             pass  # a broken handler must not block shutdown
 
 
+async def drain_log_queue_before_hard_exit(timeout: float = 2.0) -> None:
+    """Flush the queued ``gateway.log`` tail from an ``async`` hard-exit path.
+
+    ``os._exit`` runs no ``atexit`` handler, so the drain registered by
+    :func:`_setup_cli_logging` never fires on a path that hard-exits -- every
+    record still sitting in the queue is lost, including the ones logged
+    immediately before the exit, which are the most diagnostic ones a
+    post-mortem has.
+
+    :func:`_stop_log_queue_listener` is a *synchronous* bounded drain (it
+    joins the listener thread), so calling it inline from a coroutine would
+    park the event loop for up to ``timeout``. Offload it to
+    :func:`~kiro_crew.executors.subprocess_executor` -- the pool reserved for
+    teardown work that can block on a wedged resource -- under an outer
+    deadline, exactly as the restart path already does for the SEL flush. A
+    wedged disk therefore delays neither the loop nor the exit.
+
+    Never raises: a hard exit must not be blocked, or replaced, by logging.
+    """
+    from kiro_crew.executors import subprocess_executor
+
+    try:
+        await asyncio.wait_for(
+            asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), _stop_log_queue_listener, timeout
+            ),
+            timeout=timeout + 1.0,
+        )
+    except Exception:
+        pass  # includes TimeoutError: reaching the exit is what matters
+
+
 def _setup_cli_logging(command: str | None, verbose: int) -> None:
     """Configure console echo + persistent ``gateway.log`` logging.
 

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -778,6 +778,13 @@ async def _handle_restart(
         )
     except Exception:
         logger.debug("SEL flush before restart failed", exc_info=True)
+    # Same reason, same shape, for the OTHER async log sink: gateway.log runs
+    # through a QueueListener thread, so its queued tail -- the restart
+    # decision and everything logged during the teardown above -- dies with
+    # the os._exit below unless it is drained first.
+    from kiro_crew.cli import drain_log_queue_before_hard_exit
+
+    await drain_log_queue_before_hard_exit()
     os._exit(1)
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -10382,6 +10382,15 @@ class GatewayOrchestrator:
         print("👻 Goodbye!")
         # Kill any kiro-cli processes that survived graceful shutdown
         cleanup_orphaned_sessions()
+        # This is a hard exit too: os._exit skips atexit, so the log queue's
+        # drain hook never runs here either. Without this the whole shutdown
+        # tail is lost -- including the "Graceful shutdown timed out" warning
+        # logged a few lines up, the one record a stuck-shutdown post-mortem
+        # actually needs. Bounded and off-loop so a wedged disk cannot delay
+        # the exit (see drain_log_queue_before_hard_exit).
+        from kiro_crew.cli import drain_log_queue_before_hard_exit
+
+        await drain_log_queue_before_hard_exit()
         os._exit(0)
 
     async def _start_channel_transports(

--- a/test/test_cli_logging.py
+++ b/test/test_cli_logging.py
@@ -18,6 +18,7 @@ Covers:
   ``_stop_log_queue_listener`` drains every queued record to disk
 """
 
+import ast
 import logging
 import os
 import threading
@@ -35,6 +36,7 @@ from kiro_crew.cli import (
     _redirect_fds_to,
     _setup_cli_logging,
     _stop_log_queue_listener,
+    drain_log_queue_before_hard_exit,
 )
 from kiro_crew.config import config_dir
 
@@ -465,3 +467,182 @@ class TestQueueOffLoop:
         release.set()  # unblock the daemon thread so teardown closes cleanly
         assert elapsed < 2.0
         assert cli_mod._LOG_QUEUE_LISTENER is None
+
+
+class TestDrainBeforeHardExit:
+    """``os._exit`` runs no ``atexit`` handler, so every ``async`` path that
+    hard-exits the gateway must drain the log queue itself - bounded, and off
+    the event loop."""
+
+    @pytest.fixture(autouse=True)
+    def _foreground(self, monkeypatch):
+        monkeypatch.setattr("kiro_crew.cli._fd_targets_file", lambda fd, path: False)
+        monkeypatch.setattr("kiro_crew.cli._redirect_fds_to", MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_queued_tail_reaches_disk(self):
+        """The records logged immediately before a hard exit - the ones a
+        post-mortem actually needs - are on disk when the drain returns."""
+        _setup_cli_logging("gateway", 1)
+        logging.getLogger("kiro_crew.shutdown").warning("shutdown-tail-record")
+        await drain_log_queue_before_hard_exit()
+        text = (config_dir() / "gateway.log").read_text(encoding="utf-8")
+        assert "shutdown-tail-record" in text
+        assert cli_mod._LOG_QUEUE_LISTENER is None
+
+    @pytest.mark.asyncio
+    async def test_join_runs_off_the_event_loop_thread(self):
+        """The synchronous listener join happens on an executor thread: doing
+        it inline would park the loop for up to the drain deadline."""
+        _setup_cli_logging("gateway", 1)
+        join_threads: list[threading.Thread] = []
+        real_stop = cli_mod._stop_log_queue_listener
+
+        def recording_stop(timeout=None):
+            join_threads.append(threading.current_thread())
+            real_stop(timeout)
+
+        cli_mod._stop_log_queue_listener = recording_stop  # type: ignore[assignment]
+        try:
+            await drain_log_queue_before_hard_exit()
+        finally:
+            cli_mod._stop_log_queue_listener = real_stop  # type: ignore[assignment]
+        assert join_threads, "drain never reached the listener stop"
+        assert all(t is not threading.current_thread() for t in join_threads)
+
+    @pytest.mark.asyncio
+    async def test_wedged_handler_does_not_delay_the_exit(self):
+        """A wedged disk must not hold the loop past the deadline: the drain
+        returns bounded, and the exit proceeds without it."""
+        import time
+
+        _setup_cli_logging("gateway", 1)
+        (fh,) = cli_mod._LOG_QUEUE_LISTENER.handlers
+        release = threading.Event()
+        orig_emit = fh.emit
+
+        def wedged_emit(record):
+            release.wait(10.0)  # simulate blocking handler I/O
+            orig_emit(record)
+
+        fh.emit = wedged_emit  # type: ignore[method-assign]
+        logging.getLogger("kiro_crew.wedged").warning("wedged-shutdown-record")
+        t0 = time.monotonic()
+        await drain_log_queue_before_hard_exit(timeout=0.2)
+        elapsed = time.monotonic() - t0
+        release.set()  # unblock the daemon thread so teardown closes cleanly
+        assert elapsed < 3.0
+
+    @pytest.mark.asyncio
+    async def test_no_listener_is_a_silent_no_op(self):
+        """Short-lived verbs never start a listener; the drain must still be
+        safe to await, and must never raise into a hard-exit path."""
+        _setup_cli_logging("status", 1)
+        assert cli_mod._LOG_QUEUE_LISTENER is None
+        await drain_log_queue_before_hard_exit()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_drain_never_blocks_the_exit(self):
+        """Logging must not be able to abort a shutdown: a stop that raises is
+        swallowed, not propagated to the caller about to ``os._exit``."""
+        _setup_cli_logging("gateway", 1)
+        real_stop = cli_mod._stop_log_queue_listener
+
+        def exploding_stop(timeout=None):
+            raise RuntimeError("interpreter teardown race")
+
+        cli_mod._stop_log_queue_listener = exploding_stop  # type: ignore[assignment]
+        try:
+            await drain_log_queue_before_hard_exit()
+        finally:
+            cli_mod._stop_log_queue_listener = real_stop  # type: ignore[assignment]
+
+
+class TestEveryGatewayHardExitDrainsTheQueue:
+    """Ratchet: the queue only helps if EVERY hard exit in the gateway process
+    drains it. ``src/kiro_crew/slack/gateway.py`` and ``.../events.py`` are the
+    two modules that call ``os._exit`` from inside the long-lived gateway
+    process - the other ``os._exit`` sites in the tree (``sandbox.py``,
+    ``_process_group_supervisor.py``) run in forked/pre-exec children that
+    never install the CLI's queue listener.
+
+    The check is per-function and does NOT look inside nested functions, so a
+    drain in a sibling closure cannot vouch for its parent."""
+
+    _MODULES = (
+        Path(__file__).resolve().parents[1] / "src/kiro_crew/slack/gateway.py",
+        Path(__file__).resolve().parents[1] / "src/kiro_crew/slack/events.py",
+    )
+    _DRAINS = {"_stop_log_queue_listener", "drain_log_queue_before_hard_exit"}
+
+    @staticmethod
+    def _own_body_names(fn):
+        """Every Name/Attribute identifier in ``fn``'s own body, skipping the
+        bodies of functions nested inside it."""
+        names: set[str] = set()
+
+        class _Walk(ast.NodeVisitor):
+            def visit_FunctionDef(self, node):  # nested def: not fn's own body
+                if node is fn:
+                    self.generic_visit(node)
+
+            visit_AsyncFunctionDef = visit_FunctionDef
+
+            def visit_Name(self, node):
+                names.add(node.id)
+
+            def visit_Attribute(self, node):
+                names.add(node.attr)
+                self.generic_visit(node)
+
+        _Walk().visit(fn)
+        return names
+
+    def _hard_exit_functions(self, tree):
+        """(function node, line) for each ``os._exit(...)`` call, attributed to
+        the nearest enclosing function."""
+        parents: "dict[ast.AST, ast.AST]" = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                parents[child] = node
+        found = []
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "_exit"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "os"
+            ):
+                continue
+            cur = parents.get(node)
+            while cur is not None and not isinstance(
+                cur, (ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                cur = parents.get(cur)
+            if cur is not None:
+                found.append((cur, node.lineno))
+        return found
+
+    def test_the_ratchet_actually_finds_the_hard_exits(self):
+        """A scan that matches nothing would pass vacuously."""
+        total = 0
+        for path in self._MODULES:
+            total += len(
+                self._hard_exit_functions(ast.parse(path.read_text(encoding="utf-8")))
+            )
+        assert total >= 3, f"expected the known os._exit sites, found {total}"
+
+    def test_no_hard_exit_strands_the_queued_log_tail(self):
+        violations = []
+        for path in self._MODULES:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for fn, lineno in self._hard_exit_functions(tree):
+                if not (self._own_body_names(fn) & self._DRAINS):
+                    violations.append(f"{path.name}:{lineno} in {fn.name}()")
+        assert not violations, (
+            "os._exit skips atexit, so these hard exits drop the queued "
+            "gateway.log tail; await drain_log_queue_before_hard_exit() (or "
+            "call _stop_log_queue_listener(timeout=...) from a sync handler) "
+            "first: " + ", ".join(violations)
+        )


### PR DESCRIPTION
## Problem / Motivation

`#6632` moved `gateway.log` I/O off the event loop onto a `QueueListener` thread and
registered `_stop_log_queue_listener` via `atexit`. `os._exit` runs no `atexit` handler,
so that PR added an explicit bounded drain to the double-SIGINT force-exit path
(`gateway.py:10173`). The gateway process's two **other** `os._exit` sites were left
without one, and both still strand whatever is sitting in the queue:

- **`slack/gateway.py:10385` — the NORMAL shutdown path.** Every record logged during
  teardown is dropped, including `"Graceful shutdown timed out — force exiting"`, logged
  four lines above the exit. That warning is the single record a stuck-shutdown
  post-mortem needs, and it is the one guaranteed to still be in flight when the process
  dies.
- **`slack/events.py:781` — the `/kirocrew restart` path.** This site already hand-flushes
  the SEL audit queue, with a comment giving exactly this reason ("logging is async … and
  `os._exit()` runs neither atexit handlers nor finalizers, so the approved-restart audit
  event above would be lost"). `gateway.log` is the other async log sink on that path and
  was not flushed, so the restart decision and the whole teardown trace are lost.

The residual was named by the Design review on `#6632` ("Unfixed siblings: `slack/gateway.py:10388`
— the **normal** shutdown path … and the `"Graceful shutdown timed out"` warning at 10383 can
itself be lost; `slack/events.py:781` — the restart path, which already hand-flushes SEL for
exactly this reason").

`cli.py`'s own comment on `_LONG_LIVED_COMMANDS` asserts the invariant this PR restores:
"none of them ever exec-over-self, so the atexit / bounded force-exit drains cover every exit
path they have." On current `main` they do not.

## Why it matters

The queue was introduced to stop synchronous logging stalling the event loop. The trade it
made is that a record is durable only once the listener thread has written it — so any exit
that skips the drain converts a latency win into silent log loss. The lost window is exactly
the shutdown, which is when the log is read: an operator debugging "the gateway hung on
shutdown" or "it restarted and I don't know why" gets a log that ends before the interesting
part. Loss is invisible — no error, no gap marker, just a truncated file.

## What changed (motivation → approach → change)

Symptom: the `gateway.log` tail vanishes on normal shutdown and on `/kirocrew restart`.
Root cause: `os._exit` bypasses the `atexit`-registered `_stop_log_queue_listener`, and only
one of the three hard-exit sites compensates. The change adds the missing drain at the other
two, at the same layer as the existing one.

Both new sites are inside coroutines, where the existing site is a synchronous signal handler.
`_stop_log_queue_listener` is a *synchronous* bounded drain (it joins the listener thread), so
calling it inline from a coroutine would park the event loop for the length of the drain.
The fix therefore offloads it to `subprocess_executor()` — the pool this repo reserves for
teardown work that can block on a wedged resource — under an outer deadline, which is the
idiom `_handle_restart` already uses for its SEL flush three lines earlier. A wedged disk
delays neither the loop nor the exit.

- `cli.py`: new `drain_log_queue_before_hard_exit(timeout=2.0)` — one coroutine wrapping the
  existing `_stop_log_queue_listener` in that executor + deadline shape. It never raises:
  logging must not be able to abort, or replace, a shutdown.
- `slack/gateway.py`: `await` it before the normal-shutdown `os._exit(0)`.
- `slack/events.py`: `await` it before the restart `os._exit(1)`, beside the existing SEL flush.

Deliberately **not** changed: the force-exit site at `gateway.py:10173` keeps its synchronous
call — it runs in a signal handler and cannot await. The `os._exit` sites in `sandbox.py` and
`_process_group_supervisor.py` are forked / pre-exec children that never install the CLI's
queue listener, and `loop_watchdog`'s exit is `faulthandler`'s C-level `_exit`, which no Python
code runs before. Those are excluded by construction, and the ratchet below is scoped to say so.

## Tests

`test/test_cli_logging.py`, 7 new tests, 2 classes:

`TestDrainBeforeHardExit` — behavior of the drain itself:
- `test_queued_tail_reaches_disk` — a record logged immediately before the drain is on disk
  when it returns (the defect, at the primitive).
- `test_join_runs_off_the_event_loop_thread` — the synchronous listener join happens on an
  executor thread, never the calling thread. This is what makes the fix safe to `await` from
  the loop.
- `test_wedged_handler_does_not_delay_the_exit` — with a handler that blocks for 10s, the
  drain returns bounded; a wedged disk cannot hold the exit.
- `test_no_listener_is_a_silent_no_op` — short-lived verbs start no listener; awaiting the
  drain there is safe.
- `test_a_failing_drain_never_blocks_the_exit` — a stop that raises is swallowed, not
  propagated to the caller about to `os._exit`.

`TestEveryGatewayHardExitDrainsTheQueue` — an AST ratchet over `slack/gateway.py` and
`slack/events.py`: every `os._exit(...)` must have a drain in its **own** enclosing function
body, with nested-function bodies excluded, so a drain in a sibling closure cannot vouch for
its parent (without that exclusion `run()` would falsely pass on the strength of the
`_on_signal` closure nested inside it). Plus `test_the_ratchet_actually_finds_the_hard_exits`,
so a scan that matched nothing could not pass vacuously.

Red-before, with only the two production hunks reverted, tests as shipped:

```
AssertionError: os._exit skips atexit, so these hard exits drop the queued gateway.log tail;
await drain_log_queue_before_hard_exit() (or call _stop_log_queue_listener(timeout=...) from
a sync handler) first: gateway.py:10385 in run(), events.py:781 in _handle_restart()
```

Green after: `test/test_cli_logging.py` 32 passed, 1 skipped.

Adjacent suites (`test_cli.py`, `test_log_redaction.py`, `test_events_base.py`,
`test_events_forward.py`, `test_events_backfill.py`, `test_cli_gateway_flags.py`):
555 passed, 15 skipped, 3 failed — all 3 reproduce identically on clean `origin/main` on this
machine and are host-locale artifacts, not regressions
(`TestDenialNoticeEncoding::…[cp950]`, `…[cp950:strict]`, and
`test_events_backfill.py::test_pathological_json_counts_as_parse_failure`).

`flake8` clean on all four files. `black` is not run: both `slack/events.py` and
`test_cli_logging.py` are already non-conformant against the pinned `black==26.3.1` on
unmodified `origin/main`, so reformatting either would bury this diff in unrelated churn.
Every added line is within the configured 100-column limit and matches the wrapping style of
the surrounding code.

## Manual verification

N/A — unit coverage sufficient: the drain's contract (records land, join runs off-loop,
bounded under a wedged handler, never raises) is fully exercised in-process, and the two
call sites are pinned by the AST ratchet rather than by reaching a real `os._exit`, which a
test process cannot survive.

## Related Issues

Follow-up to #6632 (residual named in its Design review). Original loop-stall issue: #6631.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no spec under `docs/system-specs/` documents the
      log-queue drain contract, and no API, schema, or documented behavior changes
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
