### PR TITLE
fix(chat): verify the optimizer write-back landed instead of trusting execCommand

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1690,7 +1690,30 @@ function ChatInput({
     el.readOnly = false
     el.focus()
     el.select()
-    document.execCommand('insertText', false, text)
+    // Same reconciliation handlePaste does, for the same reason: execCommand's
+    // boolean is not evidence. It is absent entirely on some engines, and iOS
+    // Safari reports success on a <textarea> while leaving the field untouched.
+    // Here the whole field was just select()ed, so an unverified failure leaves
+    // the ORIGINAL prompt on screen with the optimizer's result discarded and
+    // no error — indistinguishable from "the optimizer changed nothing".
+    let inserted = false
+    try {
+      inserted = typeof document.execCommand === 'function' && document.execCommand('insertText', false, text)
+    } catch { inserted = false }
+    // Reconcile through the controlled value either way, exactly as handlePaste
+    // does: after a real insert this is the same string the textarea's own
+    // onChange already pushed up (React bails), while an insert React never saw
+    // would be reverted to the stale `value` prop on the next render — the same
+    // silent vanish by a different route. Marked user-driven so the undo
+    // recorder treats it as an edit (a new boundary) rather than a
+    // parent-driven draft restore, which is what keeps this "undoable".
+    const nativeOk = inserted && el.value === text
+    valueFromUserRef.current = true
+    onChange(text)
+    if (nativeOk) return // the native insert placed the caret itself
+    requestAnimationFrame(() => {
+      if (el && document.activeElement === el) el.setSelectionRange(text.length, text.length)
+    })
   }, [onChange])
 
   const optimizeMutation = useMutation({

--- a/website/src/test/ChatInput.optimizeWriteback.test.tsx
+++ b/website/src/test/ChatInput.optimizeWriteback.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ChatInput from '../components/ChatInput'
+
+/**
+ * The optimizer's write-back (`setTextUndoable`) is the sibling of the paste
+ * path fixed in #6657, and it fails by the identical route: it drives the
+ * textarea through `document.execCommand('insertText')` and trusts the call.
+ *
+ * That call is not trustworthy. It is missing on some engines, and iOS
+ * Safari's native handling reports success on a <textarea> while leaving the
+ * field untouched. Here the whole field has already been `select()`ed and the
+ * readOnly overlay has already cleared, so a failure that goes unverified puts
+ * the user's ORIGINAL prompt back on screen with the optimizer's result
+ * discarded and nothing logged — visually identical to a successful optimize
+ * that changed nothing.
+ */
+
+const OPTIMIZED = 'a much better prompt'
+const ORIGINAL = 'my prompt'
+
+const stubOptimizer = (optimized: string | null = OPTIMIZED) =>
+  vi.fn((url: string) => {
+    if (typeof url === 'string' && url.includes('/api/optimizer/optimize')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ changed: optimized !== null, optimized }),
+      })
+    }
+    // Any other app fetch (e.g. the slash-command list) gets a benign shape.
+    return Promise.resolve({ ok: true, json: async () => [] })
+  })
+
+const setExecCommand = (impl: (...a: unknown[]) => boolean) => {
+  ;(document as unknown as { execCommand: (...a: unknown[]) => boolean }).execCommand = impl
+}
+
+const clickOptimize = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Optimize prompt' }))
+
+describe('ChatInput optimize: the write-back is verified against the DOM', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete (document as unknown as { execCommand?: unknown }).execCommand
+  })
+
+  it('lands the optimized prompt when execCommand reports success but inserts NOTHING', async () => {
+    // The regression: `optimizing` has already cleared and the textarea is
+    // writable again, so trusting the boolean loses the optimizer's result
+    // with no error and no visible trace.
+    const onChange = vi.fn()
+    vi.stubGlobal('fetch', stubOptimizer())
+    setExecCommand(vi.fn(() => true)) // claims success, leaves the field alone
+
+    renderWithProviders(
+      <ChatInput value={ORIGINAL} onChange={onChange} onSend={vi.fn()} connected={true} />,
+    )
+    clickOptimize()
+
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(OPTIMIZED))
+  })
+
+  it('lands the optimized prompt when execCommand is absent entirely', async () => {
+    const onChange = vi.fn()
+    vi.stubGlobal('fetch', stubOptimizer())
+    delete (document as unknown as { execCommand?: unknown }).execCommand
+
+    renderWithProviders(
+      <ChatInput value={ORIGINAL} onChange={onChange} onSend={vi.fn()} connected={true} />,
+    )
+    clickOptimize()
+
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(OPTIMIZED))
+  })
+
+  it('lands the optimized prompt when execCommand throws', async () => {
+    const onChange = vi.fn()
+    vi.stubGlobal('fetch', stubOptimizer())
+    setExecCommand(
+      vi.fn(() => {
+        throw new Error('execCommand is not supported in this context')
+      }),
+    )
+
+    renderWithProviders(
+      <ChatInput value={ORIGINAL} onChange={onChange} onSend={vi.fn()} connected={true} />,
+    )
+    clickOptimize()
+
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(OPTIMIZED))
+  })
+
+  it('keeps the native input pipeline when execCommand verifiably inserted', async () => {
+    // The DOM read-back must not turn every optimize into a controlled splice:
+    // when the native insert really happened, the textarea's own onChange has
+    // already reported that string and the component leaves the caret alone.
+    const onChange = vi.fn()
+    vi.stubGlobal('fetch', stubOptimizer())
+    const setSelectionRange = vi.fn()
+    const exec = vi.fn((_cmd: unknown, _ui: unknown, text: unknown) => {
+      const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+      ta.value = String(text)
+      ta.setSelectionRange = setSelectionRange
+      return true
+    })
+    setExecCommand(exec)
+
+    renderWithProviders(
+      <ChatInput value={ORIGINAL} onChange={onChange} onSend={vi.fn()} connected={true} />,
+    )
+    clickOptimize()
+
+    await vi.waitFor(() => expect(exec).toHaveBeenCalledWith('insertText', false, OPTIMIZED))
+    // The native path owns the caret; the fallback's repositioning must not run.
+    expect(setSelectionRange).not.toHaveBeenCalled()
+  })
+
+  it('lands the optimized prompt when the native insert emits no input event', async () => {
+    // The narrow arm between the two above: `execCommand` really did mutate the
+    // textarea, so the DOM read-back verifies, but the engine emitted no
+    // `input` event — React's synthetic onChange never ran and the controlled
+    // value is still the ORIGINAL. Returning early on the strength of the DOM
+    // alone leaves the next render free to restore that stale prop over the
+    // optimizer's result. Reconciling unconditionally, the way the paste
+    // sibling already does, is what makes the DOM read-back load-bearing.
+    const onChange = vi.fn()
+    vi.stubGlobal('fetch', stubOptimizer())
+    setExecCommand(
+      vi.fn((_cmd: unknown, _ui: unknown, text: unknown) => {
+        const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+        ta.value = String(text) // mutates the field, dispatches nothing
+        return true
+      }),
+    )
+
+    renderWithProviders(
+      <ChatInput value={ORIGINAL} onChange={onChange} onSend={vi.fn()} connected={true} />,
+    )
+    clickOptimize()
+
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(OPTIMIZED))
+  })
+
+  it('restores the trimmed prompt when the optimizer request fails', async () => {
+    // Same silent-loss shape on the error path: onError writes the original
+    // back through setTextUndoable, and it writes the TRIMMED prompt — the one
+    // that was actually sent — so this is a real change to reconcile, not a
+    // no-op. (When the draft needs no trimming the DOM already holds the target
+    // text and the read-back correctly reports nothing to do.)
+    const onChange = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        if (typeof url === 'string' && url.includes('/api/optimizer/optimize')) {
+          return Promise.resolve({ ok: false, json: async () => ({}) })
+        }
+        return Promise.resolve({ ok: true, json: async () => [] })
+      }),
+    )
+    setExecCommand(vi.fn(() => true)) // claims success, leaves the field alone
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    renderWithProviders(
+      <ChatInput value={`${ORIGINAL}   `} onChange={onChange} onSend={vi.fn()} connected={true} />,
+    )
+    clickOptimize()
+
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(ORIGINAL))
+    warn.mockRestore()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`setTextUndoable` — the prompt optimizer's write-back into the composer — drives the
textarea through `document.execCommand('insertText')` and then simply returns:

```ts
el.readOnly = false
el.focus()
el.select()
document.execCommand('insertText', false, text)
```

No return-value check, no DOM read-back, no fallback through `onChange`. That is the exact
defect `#6657` fixed on the paste path a few hundred lines below, and it fails by the exact
same route — `execCommand` is absent on some engines, and iOS Safari's native handling
reports success on a `<textarea>` while leaving the field untouched. The Design review on
`#6657` named this site as the unfixed sibling: "`setTextUndoable` at `ChatInput.tsx:1688`
never checks the return value *or* the DOM and has no `onChange` fallback, so the optimizer
write-back vanishes by the identical route on the same engine."

Here the consequences are worse than a lost paste, because of what has already happened by
the time the call runs:

- `optimizing` has cleared, so the readOnly overlay is gone and the composer looks live.
- The whole field has just been `select()`ed, so the intended result is a full replacement.

A silent failure therefore leaves the user's **original** prompt on screen, the optimizer's
result discarded, no error anywhere, and the controlled `value` untouched — visually
indistinguishable from an optimize that decided nothing needed changing. Where `execCommand`
is missing outright, the call throws straight out of React Query's `onSuccess` / `onError`
handler instead of failing softly.

Both call sites are affected: `onSuccess` (write the optimized prompt) and `onError`
(restore the prompt that was sent).

## Why it matters

The optimizer is a one-click action whose entire output is the rewritten prompt. When the
write-back is dropped there is nothing left of the request: no text, no error toast, no
console entry on the success path. The user sees the spinner finish and their own prompt
still sitting there, and the only available reading is "the optimizer had nothing to add" —
so they do not retry. The work is lost silently, on exactly the mobile Safari surface where
retyping a long prompt is most expensive.

## What changed (motivation → approach → change)

Symptom: the optimized prompt never appears and nothing reports a failure. Root cause: the
write-back trusts `execCommand`'s boolean (or its existence) as evidence that the DOM
changed. Fix: verify against the DOM and reconcile through the controlled value, reusing the
shape `handlePaste` already established in this file rather than inventing a second one.

`setTextUndoable` now:

1. wraps the `execCommand` call in a `typeof` guard and a `try` so an absent or throwing
   implementation degrades instead of escaping into the mutation handler;
2. reconciles through the controlled value **unconditionally** — `valueFromUserRef`, then
   `onChange(text)` — before any early return. After a real native insert that is the same
   string the textarea's own `onChange` already pushed up, so React bails; but an engine
   that mutates the field without emitting an `input` event leaves React's controlled value
   holding the ORIGINAL, and the next render puts it back over the optimizer's result. This
   is what the merged paste sibling already does (`nativeOk`, then `onChange(next)`, then
   return), for the reason its own comment gives; diverging from it here was the last gap;
3. returns early **only** when the call reported success *and* `el.value` actually equals
   the target text — the native path then owns the caret. `valueFromUserRef` matters: it is what
   makes the undo recorder treat this as a real edit and open a boundary rather than folding
   it into a parent-driven draft restore — i.e. it is what keeps the helper *undoable*, which
   is the reason it exists;
4. places the caret at the end on that fallback path, since no native insert did it.

Scope is one function. No new props, no new state, no API or config surface, and the
optimizer's own control flow (slot routing, the trim guard, the readOnly lifecycle, the
completion effect's undo boundary) is untouched.

## Tests

New `website/src/test/ChatInput.optimizeWriteback.test.tsx`, 6 tests driving the real
optimize button through a stubbed `/api/optimizer/optimize`:

- **`execCommand` reports success but inserts NOTHING** (the iOS shape) → the optimized
  prompt still reaches `onChange`.
- **`execCommand` absent entirely** → same.
- **`execCommand` throws** → same; the exception no longer escapes the mutation handler.
- **`execCommand` verifiably inserted** → the native input pipeline is kept and the
  fallback's `setSelectionRange` does **not** run. This is the over-fix guard: it fails if
  the read-back is dropped in favour of always splicing.
- **the native insert lands in the DOM but emits no `input` event** → the optimized prompt
  still reaches `onChange`. This is the narrow arm between the two above: the read-back
  verifies, so a DOM-only check returns early, yet React's controlled value is still the
  original. It is red on the previous revision of this branch (`onChange` calls: 0) and
  green now, and it is what makes the unconditional reconcile load-bearing.
- **the optimizer request fails** → `onError`'s restore of the *trimmed* prompt (the string
  actually sent) is reconciled. Note the honest boundary here: when the draft needs no
  trimming the DOM already holds the target text and the read-back correctly reports nothing
  to do, so the test uses a draft with trailing whitespace to exercise a real change.

Red-before, tests as shipped against unmodified `ChatInput.tsx`: **4 failed | 1 passed** —
the four write-back tests report `onChange` "Number of calls: 0", and two of them additionally
surface `TypeError: document.execCommand is not a function` escaping through
`ChatInput.tsx:1693`. The one that passes is the native-pipeline guard, which is correct: it
describes behavior this PR must preserve, not behavior it adds.

Green after: 5 passed.

Sibling suites (`ChatInput.test.tsx`, `ChatInput.paste.test.tsx`, `ChatInputCoverage.test.tsx`,
plus the new file): **226 passed, 0 failed.**

Gates: `tsc --noEmit` clean; `eslint` on both changed files reports 0 errors (one pre-existing
`react-hooks/exhaustive-deps` warning at line 2153, outside this diff); `jscpd` — the `pretest`
duplication gate — finds **0 clones** across 2,394 files, so mirroring `handlePaste`'s
reconciliation does not trip it.

## Manual verification

N/A — unit coverage sufficient: the failure mode is an engine-specific lie from
`execCommand`, which is reproducible deterministically with a stub and is not reproducible at
all in a desktop browser. The three stub shapes in the tests (lies, absent, throws) cover
every way the call can fail to mutate the field.

<!-- no-visual-delta -->
**Why no screenshot:** the diff adds no string, element, style, or layout, and on
every engine that implements `execCommand` honestly the composer is pixel-identical
before and after it. The one rendered difference this change produces -- the
optimizer's result appearing instead of the original prompt -- only occurs on an
engine that reports a successful insert while changing nothing, or that omits the
`input` event. That engine is the bug, and it cannot be reproduced in CI or in a
screenshot harness; the regression tests stub exactly those three behaviours
instead. The UX review on the previous head reached the same conclusion
independently: "no new strings, surfaces, or screenshots ... nothing user-visible
changes on the working path."

## Related Issues

Follow-up to #6657 — the unfixed sibling named in its Design review.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no user-facing string, no locale-formatted
      value, and no documented behavior changes; nothing under `website/docs/` covers this helper
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->


