### PR TITLE
feat(connections): warm-mint engine — spec planning and shared-process runtime

### DIFF
--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -5,19 +5,25 @@ approval URL: ~7.5s per card. `kiro_crew.connections.warm` serves the whole gall
 process, and every rule below answers an observed failure.
 
 **Placement.** All warm code is in `src/kiro_crew/connections/warm.py`; the dashboard handler
-adds only endpoint wiring and a function-local `expire_dead_mints` import on the status path,
-keeping the mint engine off the gateway's boot path.
+adds only endpoint wiring and function-local engine imports -- `expire_dead_mints` on the status
+path, `mintable_providers` plus `warm_mint_all` on the premint path -- keeping the mint engine
+off the gateway's boot path.
 
-**Scope boundary: slice N2a ships the TABLE half; the LIFECYCLE is DEFERRED to slice N2b.**
-Shipped now: the shared row shape (`shared`/`generation`/`activation`), the liveness registry
-those stamps are read against, and `expire_dead_mints()` on the status path. Deferred to N2b:
-everything that spawns, activates, parks or kills a process -- spec planning, the spawn/respawn
-rules, tool-alias key shape, the reaper, `warm_mint_all`, and the filesystem-drift guard that
-covers their synchronous helpers. Every section below except *Measured facts* therefore
-describes N2b's half, and N2b lands those tests together with the code. With no activation
-live no row is ever `shared`, so the shipped `expire_dead_mints()` call is a no-op scan whose
-predicate is nonetheless complete for the parked case, because a reader blind to a parked
-process withdraws a URL that process can still redeem.
+**Scope boundary: the TABLE, the SPECS, the PROCESS LIFECYCLE and the ENDPOINT WIRING have
+landed.** Shipped: the shared row shape (`shared`/`generation`/`activation`), the
+liveness registry those stamps are read against, `expire_dead_mints()` on the status path, the
+spec side -- the registry-derived universe, the plan and its servability test, the tool-alias key
+shape, the spec files the plan writes, and the filesystem-drift guard covering their synchronous
+helpers -- the lifecycle: spawn/respawn, activation, park-or-kill, the reaper, and
+`warm_mint_all`, which is what gives the spec planner a caller; and the request path,
+`POST /api/connections/premint`, which the Connections page will fire once on mount -- until
+that slice lands the endpoint has no frontend caller and is reachable through the API only. The
+endpoint
+adds a handler, not a rule: it scans the mintable candidates off the loop, hands that same list
+to `warm_mint_all` so the slugs it reports and the rows the engine claims come from ONE registry
+read, and answers without awaiting the activation -- warming costs seconds, and the card's
+verdict is its own mint state rather than this list. Still deferred: proactive refresh, which
+attaches to the reaper in its own slice.
 
 ## Measured facts
 
@@ -32,6 +38,22 @@ process withdraws a URL that process can still redeem.
   questions: `generation_is_live` (the process holds the verifier) **and** `activation_is_live`
   (the session still answers the redirect). Process liveness alone passed the
   terminated-session case.
+- **A frame becomes readable only when something DRAINS the session queue.**
+  `pop_pending_oauth_requests()` reads a list that only `drain_init` appends to, and
+  `create_session` runs exactly one drain before it hands the handle over. The settle loop
+  originally slept between pops, which consumes nothing — so a provider whose `oauth_request`
+  landed after that create-time drain's idle exit was unreachable however many rounds elapsed.
+  The 3s budget was never the binding constraint; the loop had no mechanism to absorb a late
+  frame at all, and in a multi-provider activation the later providers are exactly the ones at
+  risk. Each waiting round is now a bounded `drain_init(duration=0.5, idle_exit=0.5,
+  no_report_ceiling=0.0)`. The ceiling argument is load-bearing: it arms the idle shortcut at
+  entry so the call cannot hold waiting for a "first report" this session already produced
+  during `create_session`'s own drain — which is precisely the idle-window semantics that made
+  an *unbounded* drain the wrong tool here. Bounded per round it is the right one, the total
+  wall-clock budget is unchanged, and an activation whose frames are already staged still
+  short-circuits on the first pop without opening a window. Beyond the budget the claim is
+  released and the cold path serves that provider, which is the correct fallback rather than a
+  defect.
 
 ## Specs are read once at spawn
 
@@ -55,7 +77,7 @@ so respawn frequency is the dominant design pressure:
 
 `mint.py` (PR #3154) is the reviewed engine and owns the row table, the row identity token,
 grant detection, spec emission and the manifest sweep; warm imports all of it and adds only
-what is genuinely per-process. Two adaptations:
+what is genuinely per-process. Three adaptations:
 
 - `_mint_holder_alive` is deliberately **not** reused -- it reads the row's own `client`, which
   a shared row does not own, so it answers False for every warm row. `_warm_row_alive` asks the
@@ -66,6 +88,35 @@ what is genuinely per-process. Two adaptations:
   refuses anything matching the cold name shape, and both patterns must share one **character
   class**: while warm accepted `[A-Za-z]` and cold only `[a-z]`, a mixed-case alias produced a
   live cold spec the warm sweep read as its own and unlinked.
+- **A name is not ownership.** Those fixed names are predictable and they live in the user's own
+  agents directory, next to the agents they hand-write, so a name says where a spec of ours
+  would *go* and never that the file already there is one. Trusting the name shape alone was a
+  defect in both directions: the write-time sweep unlinked a user's own agent spec sitting at
+  such a path, and the write then clobbered one at a path the current plan wanted.
+  `_warm_spec_is_foreign` proves ownership from the file's CONTENTS, and it takes two halves.
+  The fields the spec body fixes (`model`, `includeMcpJson`, `prompt`, `allowedTools`) are read
+  off `_mint_spec_body` so a change to the body cannot leave the module unable to recognise its
+  own files -- but they are also **stock defaults** a hand-written or scaffolded agent plausibly
+  carries, so on their own they still read a wholly user-authored spec as ours. The
+  discriminating half is `_WARM_SPEC_SENTINEL`, stamped as the description prefix of every spec
+  written here. `description` is the only field free enough to carry a marker while staying
+  schema-legal: kiro-cli rejects an unknown spec key, and the agent-spec migration sweep strips
+  bookkeeping keys. Requiring it orphans nothing, since no warm-spec writer has ever shipped --
+  and a hypothetical unsentinelled file of ours would read as foreign, which means refused and
+  left in place. It fails closed, because the mistakes are not symmetric: reading our own file
+  as foreign leaves one stale spec as clutter, while reading a user's file as ours destroys it.
+  A refusal is audited and skipped -- never raised -- so an occupied path costs one unwarmed
+  provider, not a failed spawn.
+- **The ownership checks guard one directory; kiro-cli reads two.** Everything above protects
+  the user's agents directory, but kiro-cli also resolves PROJECT-LOCAL specs from
+  `<cwd>/.kiro/agents`, and the process is activated BY NAME -- so a spec planted under the
+  warm process's own working directory shadows the guarded one, and its `mcpServers` is what
+  gets initialized and authorized against. No ownership check looks there. The working
+  directory is therefore `<data home>/run/connections-warm`: `run/` is already on
+  `security._SENSITIVE_HOME_DIRS` (it holds the sandbox launchers and run markers the gateway
+  execs outside the sandbox), while `connections/` carries no entry and an agent file tool
+  could write it. The property is asserted through `security.is_sensitive_write_path` rather
+  than a path literal, so a later rename cannot silently leave the fence.
 
 ## Tool-alias key shape
 
@@ -81,22 +132,185 @@ the pre-#3260 rule and those assertions were not carried forward.
 ## Filesystem work never runs on the loop
 
 Every flow reads the user's config, the shared agents directory, or kiro-cli's OAuth cache, any
-of which can sit on a network mount where a stat is unbounded, so the synchronous helpers are
-reached through `asyncio.to_thread` -- enforced by a fixed-point drift guard in
-`test/test_connections_warm.py` that reuses the mint engine's own primitive sets so the two
-cannot drift apart.
+of which can sit on a network mount where a stat is unbounded, so all of that work lives in
+SYNCHRONOUS helpers and a coroutine reaches them through `asyncio.to_thread` -- enforced by a
+fixed-point drift guard in `test/test_connections_warm.py` that reuses the mint engine's own
+primitive sets so the two cannot drift apart. What the guard pins today is the exact set of
+helpers doing filesystem work, so the lifecycle slice can neither call one from a coroutine nor
+quietly drop the filesystem work the guard's coverage rests on without failing it.
 
 ## Seams and residuals
 
-**Revocation** is PR #5899's, through `_expire_shared_mints`; **proactive refresh** attaches in
-`_warm_mint_reaper`; **a supervisor/watchdog** is absent, as are the accessors it would need.
-Two residuals:
+**Shared-mint expiry** has landed with the lifecycle, keyed on the fact that a minting process is
+gone rather than on a cause, which is what covers a process that went away by a route no expiry
+path anticipated. PR #5899 is a different cause and a different table: it owns
+**Disconnect-driven grant revocation**, and the two meet only where a revoke should re-warm.
+**Proactive refresh** attaches to `_warm_mint_reaper`, which now exists; **a
+supervisor/watchdog** is absent, as are the accessors it would need.
 
-- **A cancel between the claim and the activation leaks the claim.** `warm_mint_all` takes its
-  claim outside any `try`/`finally` and `_warm_activate` catches `Exception`, not
-  `BaseException`, so a `CancelledError` in that window leaves rows `minting` with no watcher:
-  nothing expires them, `_shared_mints_pending` stays true, and the process is never retired.
-  Unreachable while `warm_mint_all` has no caller, and **must be closed before N2b wires it up.**
+Three residuals the lifecycle slice was required to close, and did:
+
+- **A cancel between the claim and the activation leaked the claim.** The entry point took its
+  claim outside any `try`/`finally` and the activation catches `Exception`, not `BaseException`,
+  so a `CancelledError` in that window left rows `minting` with no watcher: nothing expires them
+  (`expire_dead_mints` judges `waiting` rows only), the pending check stays true, and the process
+  is never retired. `warm_mint_all` now holds every claim inside a `try` whose `except
+  BaseException` releases them and re-raises, so cancellation still propagates -- the activation
+  deliberately does NOT swallow it, because reporting a clean stand-down to a caller being torn
+  down is the worse failure. The window after the activation returns is covered by the same
+  block. **The claim loop itself was a second copy of this window**, since the claim is taken
+  *before* that `try`: it awaited `_dispose_mint` on each row it replaced, which suspends on a
+  client teardown and again on the shielded spec removal in that function's `finally`. The claim
+  loop is now await-free and atomic by construction -- it returns the displaced rows for the
+  caller to dispose *inside* the protected region, which also moves the dispose outside the
+  table lock, where the mint engine's own rule wants it. Pinned by an AST guard, not just by a
+  behavioural test.
+- **A shared row's fence was a batch clock reading, not a row identity** (issue #6110). Rows were
+  separated by `entry["started"] == started`, one `time.monotonic()` value per `warm_mint_all`
+  call. The clock has ~15.6ms granularity on Windows -- the reason `_new_mint_token` exists for
+  the cold engine -- so two Connects for one provider inside a tick read as the same row and a
+  late absorb wrote its URL over the newer claim. Claiming now returns `{slug: token}` and
+  absorb and release both verify that opaque per-row token; `started` is kept as information and
+  is never a fence.
+- **An approval URL was stored without being screened for a credential.** `_absorb_warm_requests`
+  wrote the popped `oauth_request` URL straight onto the row. It now passes every popped URL
+  through `security.oauth_url_contains_credential` -- the same gate the cold mint and the chat
+  consent banner apply, called, not re-implemented -- *before* the table lock, since the verdict
+  is a pure function of the URL and the gate can read the operator's on-disk endpoint extension.
+  A refused URL never reaches the store: the claim is released so the card asks for a fresh mint,
+  and the refusal is audited without the value.
+
+Two more the same slice closed, both about **withdrawal and retirement following the
+generation** rather than anything else:
+
+- **The retry's expiry pass was unscoped.** `_WarmMintDied` is raised only after the stand-down
+  inside `mint_for` has already run `_expire_shared_mints(generation=<the dead one>)` through
+  `_kill_generation`, so the rows whose verifier died are withdrawn before the retry ever sees
+  the exception. A second pass in `_warm_activate`, narrowed only by the caller's own row
+  tokens, therefore expired every *other* live shared row: a parked generation's URL is still
+  redeemable (its process holds the verifier and its session still answers the redirect), and a
+  concurrent batch's claims are another activation's to fill. The pass is gone, and
+  `_expire_shared_mints` now takes `generation` as its only narrowing, because withdrawal
+  follows the verifier.
+- **A parked generation was stranded when the current process died.** `sweep_retiring` is the
+  only thing that retires a parked process, and every route to it runs off a NEW mint -- which
+  is exactly what the leak does not have. The reaper used to `return` as soon as the current
+  process was gone, and the stand-down before a *failed* respawn cancelled the reaper without
+  creating one, so in both cases the parked process, its sessions and their loopback servers
+  stayed resident forever once its last card completed. `_drain_parked_generations` now keeps
+  sweeping until nothing is parked, and both routes run it.
+
+And one the second review round found, which is not a cancellation bug at all:
+
+- **A refused spec was still activated by name.** The writer declines to overwrite a file at
+  a planned spec path whose contents this module did not write — which protects the file and
+  nothing else, because the spawn is handed `agent=<fixed name>` and kiro-cli resolves that
+  name off the same agents directory. A hand-written agent parked at
+  `kirocrew-mint-warm-base.json` would therefore have been executed, with its own
+  `mcpServers` commands initialized, by the very code that had just refused to own it.
+  `_unowned_plan_specs` now re-verifies, off the loop, that every planned spec exists *and*
+  is sentinel-owned before the runtime is constructed; any refusal aborts warming entirely
+  and is audited. Aborting is safe because the cold path still serves every Connect — it
+  just spawns per provider.
+
+One residual remains:
+
+## Session-handle ownership, made explicit
+
+Three review rounds kept producing findings in this area because the ownership transfers were
+*implicit* — a handle moved between "the backend has it", "we have it", and "the registry has
+it" with no stated rule about who is responsible if an await in between is interrupted. The
+rule is now one sentence: **a handle is registered before anything can interrupt, and
+forgotten only once its destroy has completed.** Every touchpoint:
+
+| # | Point | Transfer | How it is cancellation-safe |
+|---|---|---|---|
+| 1 | `runtime.create_session` in `_activate_locked` | backend → us | Run as a SHIELDED task we keep a reference to, so the handle stays reachable when the wait is abandoned. `except BaseException` → `_abandon_session_creation_locked` → re-raise. |
+| 2 | `_sessions[activation] = _WarmSession(...)` | us → registry | No await between the handle arriving and the registration (counter bump + dataclass are sync). Atomic by construction. |
+| 3 | abandoned create, handle recovered | backend → registry | Registered settled-and-expired *before* the destroy, so it enters rule 6 rather than being a special case. |
+| 4 | abandoned create, no handle recovered | — | `create.cancel()`, then the generation is **quarantined** (`_plan`/`_digest` cleared) so the next activation stands it down and the orphan dies with the process. See the bound below. |
+| 5 | oauth-poll failure in `_activate_locked` | registry → destroyed | Record marked settled + `expires_at = 0` BEFORE the destroy, popped after. An interrupted destroy leaves a sweepable record. |
+| 6 | `_sweep_sessions_locked` | registry → destroyed | `try/finally` popping only when `destroyed` is true. Held across the await on purpose: a lock-free reader then over-reports liveness briefly, which keeps a row waiting rather than withdrawing a URL. |
+| 7 | `_drop_generation_sessions` | registry → dropped, no destroy | Sync, and correct: the process is dead, so its sessions died with it. |
+| 8 | `_retire_locked`'s `_sessions.clear()` | registry → dropped, no destroy | Sync. Every runtime is being killed, so every session dies with its process; on this path withdrawing the rows is the intent. |
+| 9 | `_destroy_session_quietly` | — | Swallows `Exception`, propagates `CancelledError` **by design** — that is what lets callers 5, 6 and 3 retain the record and retry. |
+
+Two awaits in `_activate_locked`'s own `except BaseException` handler are the cleanup rather
+than a window, and their safety is state ordering (rule 5) rather than a nested handler, so
+they are pinned by behavioural tests instead of the AST guard.
+
+That guard is now bound to **specific (function, await-target) pairs**, not to "this function
+contains some protected try" — the coarse form is what let a bare sibling await in
+`_activate_locked` pass by association, and it omitted `_sweep_sessions_locked` entirely.
+
+**The residual, and its bound.** A `session/new` the backend accepts *after* we cancel the
+create carries no id we hold, so nothing can address it directly. The first version of this
+note claimed that was fine because "it is reaped when the runtime is retired" — and a review
+round falsified exactly that argument: retirement is not guaranteed to arrive. Any card
+holding a URL keeps `_shared_mints_pending` true, which resets the reaper's idle clock on
+every cycle, while `_ensure_locked`'s digest-equality fast path keeps the same generation
+reusable — so each repetition parked another orphan session and its callback children on ONE
+live process, unbounded until listener or memory exhaustion.
+
+So the generation is now **quarantined** instead: row 4 clears `_plan` and `_digest`, which
+makes the next activation find the resident plan unservable and stand the generation down
+through the ordinary path — parked for the drain when a card still needs it, killed outright
+otherwise. Either way the process dies and takes the orphan with it. **The bound is therefore
+at most one generation's sessions, released on the next activation or on idle retirement,
+whichever comes first.** The cost is a respawn (~5s) on the next warm call after a transient
+session timeout, which is the right trade: correctness over a warm-cache hit. Closing the
+residual entirely would need the backend to expose a session id at request time rather than at
+response time.
+
 - **A hard gateway kill strands warm spec files.** They carry no manifest row, so the cold
   engine's aged-row sweep cannot see them. The next spawn's write-time sweep removes them, so
   the exposure is bounded, but it is not a clean teardown.
+
+## The one bug class, and the uniform shape that closes it
+
+Two independent review rounds on the lifecycle slice produced seven findings between them,
+and **six were the same defect wearing different clothes**: an `await` sitting between a
+state mutation and that mutation's settlement or cleanup, guarded only by an
+`except Exception` — which a `CancelledError` walks straight past, because it inherits from
+`BaseException`. Each instance leaks something different, which is why they read as
+unrelated:
+
+| Mutation | The await in the window | What leaked |
+|---|---|---|
+| rows installed as `minting` | `_dispose_mint` on a replaced row, inside the claim loop | rows nothing withdraws, process never retired |
+| rows installed as `minting` | the activation and the absorb | same |
+| a generation parked, its reaper cancelled | the spec write and `runtime.spawn()` | parked process with no sweeper, forked child, orphan specs |
+| a session registered | the credential screen's thread hop | session + its loopback callback servers, for the process's life |
+| generations moved out of `_retiring` | `_kill_generation` per generation | processes with no reference left anywhere |
+| `_runtime` cleared, reaper cancelled | `_kill_generation` in the stand-down | the same |
+| `_retiring` emptied, `_runtime` cleared | the hard teardown's kill loop | the same |
+
+One further finding was NOT a cancellation window but the same *implicitness* — a state that
+had always been reachable and became routine. `generation_is_live` denied liveness on the
+equality branch: `generation == self._generation` answered `is_alive()`, which reads
+`self._runtime`. But only a successful spawn bumps the counter, so a stood-down process sits
+in `_retiring` under the number that is still `self._generation` with `self._runtime` already
+cleared. A lock-free status scan in that window read a live parked process as dead, withdrew
+its redeemable URLs, and the withdrawal then made `_generation_holds_live_rows` false so the
+next sweep killed it. The ordinary incompatible-plan respawn always had this window; the
+re-park fixes above *widened* it by adding a second route (an interrupted kill re-parks under
+the current number). The equality test now confirms liveness and never denies it, falling
+through to the parked list.
+
+Fixing them one at a time is what produced two rounds, so the module now states the
+invariant instead: **a mutation is either atomic by construction, or its cleanup runs in a
+`finally` / `except BaseException` that re-raises.** In practice that is three shapes —
+make the loop await-free so there is no window (the claim), settle in a `finally` that
+takes its own fresh snapshot (the session), or re-park what a teardown did not finish and
+arm the drain synchronously before any further await (every process path). An AST guard
+asserts the functions owning these windows carry a bare-`finally` or `BaseException`
+handler rather than only `except Exception`, so the class cannot silently return; the
+remaining awaits are covered by a written audit rather than a test, because "this await has
+no mutation behind it" is not mechanically checkable.
+
+Three awaits are deliberately left unprotected, and each is a judgement rather than an
+oversight: `_dispose_displaced_rows` can be interrupted partway, but the rows are already
+evicted and their watchers are token-fenced, so a survivor writes nothing;
+`_expire_shared_mints` and `expire_dead_mints` flip a row to `expired` before awaiting its
+dispose, which the reaper's next pass re-scans and completes; and the reaper and drain
+treat their own cancellation as the signal that a replacement is taking over.

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -1,14 +1,20 @@
-"""The shared warm-mint TABLE: which shared rows still hold a redeemable URL.
+"""The shared warm mint: the specs one kiro-cli process serves, and the rows it holds.
 
 The cold path (:mod:`kiro_crew.connections.mint`) pays a full kiro-cli spawn PER provider
-for one approval URL. The warm design serves every card's URL from ONE process instead, and
-splits in two: the TABLE (this module) and the LIFECYCLE that fills it.
+for one approval URL. The warm design serves every card's URL from ONE process instead:
+mode activation costs a FIXED ~5.18s whether the spec carries one remote server or six, so
+a spec holding every mintable provider yields every ``oauth_request`` in a SINGLE
+activation.
 
-This slice ships the TABLE half only -- the row shape a shared mint uses (``shared`` /
-``generation`` / ``activation`` on :class:`~kiro_crew.connections.mint.MintState`), the
-liveness registry those stamps are read against (:class:`_WarmMintRuntime`), and the
-withdrawal chokepoint the dashboard's status path calls (:func:`expire_dead_mints`).
-Nothing here spawns, activates, parks or kills a process.
+Three halves have landed. The TABLE: the row shape a shared mint uses (``shared`` /
+``generation`` / ``activation`` on :class:`~kiro_crew.connections.mint.MintState`) and the
+withdrawal chokepoint the dashboard's status path calls (:func:`expire_dead_mints`). The
+SPECS: the registry scan deciding which providers a warm process could serve
+(:func:`warm_spec_providers`), the plan it would spawn on (:func:`_warm_spec_plan`), and
+the spec files that plan writes (:func:`_write_warm_mint_specs`). The RUNTIME: the one
+process every card shares (:class:`_WarmMintRuntime`) -- spawned, activated, parked, killed
+and reaped (:func:`_warm_mint_reaper`) -- and the flow that turns one activation into a
+whole table of URLs (:func:`warm_mint_all`).
 
 Redeemability takes TWO questions and they die independently: the PKCE verifier lives in
 the PROCESS (``generation_is_live``) while the loopback listener answering the redirect
@@ -16,23 +22,671 @@ belongs to the SESSION (``activation_is_live``). Process liveness alone passed a
 terminated-session row, which is how a card kept serving an unredeemable URL. Both
 failures are recorded in ``docs/architecture/design-notes/connections-warm-table.md``.
 
-DEFERRED to slice N2b: the entire lifecycle -- spec planning, spawn, activation, parking,
-the reaper, and ``warm_mint_all``. Until it lands nothing sets ``shared`` on a row, so
-:func:`expire_dead_mints` is a no-op scan and the registry below stays empty. Both are
-written to answer correctly the moment N2b starts filling them, parked generations
-included: a reader blind to a parked process withdraws a code that process can still
-redeem, so completing the predicate later would mean revisiting this decision under a
-live bug.
+Four rules are load-bearing and recorded in that same note: the SESSION is HELD (see
+:func:`_warm_row_alive`), specs are enumerated ONCE at spawn -- which fixes the mode's
+mounted server set for the life of the process, so a plan that merely SHRANK is servable but
+NOT reusable and respawns, with a process still holding a consent PARKED rather than killed
+(:func:`_plan_is_servable`,
+:func:`_resident_roster_is_asked_for`, :meth:`_WarmMintRuntime._park_or_kill_locked`), the
+spec universe is registry-derived and BLIND to grant and cancel state because a plan
+tracking who needs a URL now retires a process holding other cards' listeners, and a warm
+session injects an EMPTY ``mcp_servers`` list because remote servers passed through
+``session/new`` kill the process with every pending verifier in it
+(:func:`_warm_session_mcp_servers`).
+
+IDENTITY: a row is fenced by its own opaque ``token``, never by the batch clock reading in
+``started``. ``time.monotonic()`` has ~15.6ms granularity on Windows, so two Connects for
+one provider inside a tick read as one row and a late absorb overwrites the newer claim --
+the same reasoning
+:func:`~kiro_crew.connections.mint._new_mint_token` records for the cold engine. WITHDRAWAL
+is the other axis and does NOT use the token: a row is expired because the process that
+holds its verifier is gone, so :func:`_expire_shared_mints` narrows by ``generation`` only.
+
+ATOMICITY: :func:`_claim_shared_mints` contains no await, so a caller either holds every
+claim it asked for or none -- the claim is taken before :func:`warm_mint_all` enters the
+``try`` that rolls it back, which makes any await in that loop an unprotected cancel window.
+The rows a claim displaced come back to the caller and are disposed inside that ``try``.
+
+CANCELLATION SAFETY is the invariant this module is written around, because two review
+rounds found the same bug class: an await sitting between a state mutation and that
+mutation's settlement or cleanup, guarded only by an ``except Exception`` that a
+``CancelledError`` walks straight past. Every such window is closed the same way -- the
+mutation is either atomic by construction (no await in it) or its cleanup is a ``finally``
+/ ``except BaseException`` that re-raises. Concretely: a claim rolls back
+(:func:`warm_mint_all`), an activation's session is ALWAYS settled so the sweep can collect
+it (:func:`_absorb_warm_requests`), and a process whose teardown did not finish stays
+PARKED with a drain armed rather than losing its only reference
+(:meth:`_WarmMintRuntime._park_or_kill_locked`, ``_sweep_retiring_locked``,
+``_retire_locked``, ``_abandon_spawn_locked``). Pinned by an AST guard in
+``test/test_connections_warm.py``, not merely described here.
+
+SESSION OWNERSHIP is explicit at every transfer, because the handle is the ONLY way to
+terminate a backend session and the loopback callback children it owns. One rule covers
+every point: a handle is REGISTERED in ``_sessions`` before anything can be interrupted, and
+FORGOTTEN only once its destroy has completed -- so an interrupted teardown leaves a record
+the ordinary sweep retries. The create is run as a shielded task so its handle stays
+reachable even when the wait for it is abandoned
+(:meth:`_WarmMintRuntime._abandon_session_creation_locked`). When no handle can be recovered
+at all the generation is QUARANTINED rather than trusted to retire on its own, which bounds
+the unaddressable residual to one generation's sessions -- retirement is not guaranteed to
+arrive, because a card holding a URL keeps the reaper's idle clock reset while the digest fast
+path keeps the same process reusable.
+
+LIVENESS is asked of the parked list too. A generation keeps its NUMBER while parked -- only
+a successful spawn bumps the counter -- so ``generation_is_live`` uses the equality test to
+CONFIRM liveness and never to deny it, then falls through to ``_retiring``. Denying on
+equality reported a stood-down-but-alive process dead, which withdrew redeemable URLs and
+then let the next sweep kill the process the park existed to preserve.
+
+OWNERSHIP is checked twice, because a spec is activated BY NAME. The writer refuses a path
+whose contents this module did not write, which protects the FILE; :func:`_unowned_plan_specs`
+then re-verifies every planned spec exists and is ours BEFORE the runtime is constructed,
+which protects the SPAWN. Without the second check the refusal would hand kiro-cli a
+stranger's spec at our fixed name and initialize its ``mcpServers``. A refusal aborts
+warming entirely, audited: the cold path still serves every Connect.
+
+OWNERSHIP: these specs carry FIXED, predictable names in the user's own agents directory,
+so a name is where a spec of ours would GO and never proof that the file there is one.
+Every spec written here is stamped with :data:`_WARM_SPEC_SENTINEL` on its description --
+the stock defaults a spec body also fixes are values a user's own agent plausibly carries,
+so the sentinel is what actually discriminates. Neither :func:`_write_warm_mint_specs` nor
+:func:`_remove_warm_mint_specs` unlinks or overwrites a path whose contents this module did
+not write -- see :func:`_warm_spec_is_foreign`.
+
+INVARIANT: no coroutine here touches the filesystem directly. The spec helpers read the
+user's config, the shared agents dir, or kiro-cli's OAuth cache, and the credential gate
+reads the operator's OAuth-endpoint extension -- any of which can sit on a network mount
+where a stat is unbounded -- so they are synchronous, and a coroutine reaches them through
+``asyncio.to_thread``. Enforced by a fixed-point drift guard in
+``test/test_connections_warm.py``, not merely described here.
+
+REQUEST PATH: :func:`warm_mint_all` is driven by ``POST /api/connections/premint``, which the
+Connections page WILL fire once on mount -- no frontend caller exists yet, so today the endpoint
+is reachable through the API only. It scans the candidates and hands them over, so the slugs it
+reports and the rows the engine claims come from one registry read. Proactive refresh attaches
+in :func:`_warm_mint_reaper` when slice N3 lands.
 """
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
 import logging
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
-from kiro_crew.connections.mint import MintState, _dispose_mint, _mints, _mints_lock
+from kiro_crew import agent as _agent
+from kiro_crew.agent_discovery import _read_agent_spec
+from kiro_crew.agent_files import AGENT_FILENAME
+from kiro_crew.config.loader import data_home
+from kiro_crew.connections.mint import (
+    _MINT_AGENT_PREFIX,
+    _MINT_GRANT_POLL_SECONDS,
+    _MINT_NAME_RE,
+    _MINT_TTL_SECONDS,
+    MintState,
+    _dispose_mint,
+    _mint_spec_body,
+    _mint_watcher,
+    _mints,
+    _mints_lock,
+    _new_mint_token,
+)
+from kiro_crew.connections.registry import Provider, get_visible_providers
+from kiro_crew.connections.tool_aliases import declared_tool_aliases, resolve_tool_aliases
+from kiro_crew.mcp_discovery import list_servers
+from kiro_crew.mcp_grant import grant_presence as grant_present
+from kiro_crew.mcp_utils import (
+    kiro_entry_client_id,
+    kiro_entry_scopes,
+    kiro_oauth_wire_entry,
+    mcp_server_alias,
+)
+from kiro_crew.security import oauth_url_contains_credential
+from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
+
+#: Warm specs are FIXED names under the cold mint's prefix, so one glob finds them all. They
+#: carry no ``-<pid>-<8hex>`` suffix, which keeps them out of the cold engine's manifest sweep
+#: -- and is the only thing telling a warm spec from a cold one whose server is literally named
+#: ``warm-*`` (see ``_is_stale_warm_spec``). The character class MUST match the cold engine's: a
+#: case only ONE pattern accepts reads as ours and gets its live spec unlinked.
+_WARM_AGENT_PREFIX = f"{_MINT_AGENT_PREFIX}warm-"
+_WARM_NAME_RE = re.compile(rf"^{re.escape(_WARM_AGENT_PREFIX)}[a-z0-9_.-]+$")
+_WARM_BASE_AGENT = f"{_WARM_AGENT_PREFIX}base"
+_WARM_ALL_AGENT = f"{_WARM_AGENT_PREFIX}all"
+#: Prefixed onto the ``description`` of every spec this module writes, and the mark that makes
+#: ownership provable. The other fields the writer fixes (``model``, ``includeMcpJson``,
+#: ``prompt``, ``allowedTools``) are STOCK DEFAULTS a hand-written or scaffolded agent
+#: plausibly carries, so on their own they judged a user's own spec at a warm path as ours.
+#: ``description`` is the only schema-legal field free enough to carry a marker: kiro-cli
+#: rejects an unknown spec key, and the agent-spec migration sweep strips bookkeeping keys.
+_WARM_SPEC_SENTINEL = "Kiro Crew warm mint spec (machine-written; safe to delete)"
+_WARM_SPAWN_TIMEOUT_SECONDS = 90.0
+_WARM_SESSION_TIMEOUT_SECONDS = 90.0
+_WARM_SESSION_DESTROY_TIMEOUT_SECONDS = 10.0
+#: How long to keep waiting for a handle whose create we already gave up on. Short, because
+#: this only buys back a session already on its way; see ``_abandon_session_creation``.
+_WARM_SESSION_REAP_TIMEOUT_SECONDS = 10.0
+_WARM_KILL_TIMEOUT_SECONDS = 20.0
+#: The oauth_request frame lands a beat AFTER set_mode returns (~0.35s measured),
+#: beyond drain_init's idle window for a slow provider. Poll rather than race it.
+_WARM_OAUTH_SETTLE_SECONDS = 0.5
+_WARM_OAUTH_SETTLE_ROUNDS = 6
+#: A tenth of the mint TTL: long enough that reopening the gallery reuses the
+#: process, short enough that an abandoned visit leaves no kiro-cli resident.
+_WARM_IDLE_GRACE_SECONDS = _MINT_TTL_SECONDS / 10
+#: One respawn, then the cold path -- a second death means the process cannot stay
+#: up, and a Connect is better served by its own dedicated spawn.
+_WARM_ACTIVATION_ATTEMPTS = 2
+#: Generation key for a process that never became ``self._runtime`` -- an abandoned spawn,
+#: which owns no rows. NEGATIVE because generations only ever increment from zero, so no row
+#: can carry it: ``_generation_holds_live_rows`` reads it as needed by nobody, and the sweep
+#: retries its kill instead of parking it forever behind a row that will never appear.
+_WARM_UNKEYED_GENERATION = -1
+
+#: The row states a shared mint is still working on. ``minting`` counts: a claim with no
+#: URL yet is exactly what a cancelled activation must not leave behind.
+_LIVE_STATES = ("minting", "waiting")
+
+
+class _WarmMintUnsafe(RuntimeError):
+    """A warm mint was about to be issued in a way that kills the shared process."""
+
+
+class _WarmMintDied(RuntimeError):
+    """The shared process was gone by the end of an activation."""
+
+    def __init__(self, cause: str) -> None:
+        super().__init__(cause)
+        self.cause = cause
+
+
+def _acp_runtime_factory() -> Any:
+    """The agent-runtime class, resolved through the session manager's own loader.
+
+    Still the indirection tests substitute a fake runtime class for, and now also why
+    this module carries no ``kiro_crew.acp`` import: application code may not reach the
+    ACP layer (``scripts/check_agent_sdk_boundary.py``), and the sanctioned surface
+    ``kiro_crew.agent_sdk`` is deliberately EMPTY -- its RFC schedules runtime ownership
+    for the supervisor phase, with ``connections/`` migrating in the consumer wave after
+    it. Until then ``session._load_bg_runtime_types`` is the tree's single accessor for
+    the class, already consumed that way by ``session_background`` and
+    ``session_allocation`` through an injected callable; when the supervisor takes the
+    pool, this one call site moves with it.
+
+    Imported inside the call for the same reason that loader is itself lazy: it crosses
+    the ``session -> acp.runtime -> acp.client -> session`` import cycle.
+    """
+    from kiro_crew.session import _load_bg_runtime_types
+
+    return _load_bg_runtime_types()[0]
+
+
+def _warm_session_mcp_servers() -> list[dict[str, Any]]:
+    """The session-injected MCP servers for a warm mint: ALWAYS empty.
+
+    A remote server passed through ``session/new`` kills the process together with every
+    pending verifier in it, so the spec -- never the session -- is what mounts servers.
+    """
+    return []
+
+
+def _log_warm_event(operation: str, resources: str, outcome: str = "ok") -> None:
+    """Record a warm-table event. Never carries a URL or an exception message."""
+    sel().log_api_access(
+        caller="dashboard",
+        operation=operation,
+        outcome=outcome,
+        source="dashboard",
+        resources=resources,
+    )
+
+
+def connections_tool_aliases(server_aliases: list[str]) -> dict[str, str]:
+    """``toolAliases`` for a spec mounting ``server_aliases``, or ``{}``.
+
+    kiro-cli exposes MCP tool names RAW, so two mounted servers exporting the same
+    name leave only one reachable. The collision set is DECLARED by the registry and
+    resolved by :func:`resolve_tool_aliases`, so it is known before consent -- the
+    MCP inventory carries no tool list for a server that never authorized.
+
+    KEY SHAPE. The resolver keys by registry SLUG (``@slug/tool``) while this spec mounts
+    servers under ``mcp_server_alias(slug)``, and where the two differ kiro-cli applies no
+    rename and the collision comes back silently -- so keys are re-pointed at the MOUNTED
+    alias here. Every registry slug is slash-free today, making this an identity map that
+    holds the shape contract of the spec we WRITE rather than fixing a reachable bug; the
+    design note's "Tool-alias key shape" carries the full reasoning.
+    """
+    declared = declared_tool_aliases()
+    wanted = set(server_aliases)
+    mounted = {slug: alias for slug in declared if (alias := mcp_server_alias(slug)) in wanted}
+    resolved = resolve_tool_aliases(
+        {slug: set(tools) for slug, tools in declared.items() if slug in mounted}
+    )
+    aliased: dict[str, str] = {}
+    for ref, alias in resolved.items():
+        # rpartition, not partition: a registry slug may itself contain a slash while a tool
+        # name never does, so the LAST separator reliably splits server from tool.
+        slug, _, tool = ref.lstrip("@").rpartition("/")
+        aliased[f"@{mounted.get(slug, slug)}/{tool}"] = alias
+    return dict(sorted(aliased.items()))
+
+
+def _warm_spec_description(detail: str) -> str:
+    """Every description this module writes: the sentinel, then the caller's detail.
+
+    Sentinel-FIRST rather than appended, so the judge tests a prefix. A suffix could be
+    truncated by any writer that clips the field, and a prefix a user would have to type
+    verbatim to impersonate.
+    """
+    detail = detail.strip()
+    return f"{_WARM_SPEC_SENTINEL} {detail}" if detail else _WARM_SPEC_SENTINEL
+
+
+def _warm_spec_body(name: str, servers: dict[str, Any], description: str) -> dict[str, Any]:
+    """A mint spec body, sentinel-stamped, plus the ``toolAliases`` its mounted set needs.
+
+    THE writer chokepoint: every spec this module puts on disk comes through here, which is
+    what lets :func:`_warm_spec_is_foreign` treat the sentinel as present-or-not-ours.
+    """
+    body = _mint_spec_body(name, servers, _warm_spec_description(description))
+    aliases = connections_tool_aliases(list(servers))
+    if aliases:
+        body["toolAliases"] = aliases
+    return body
+
+
+def _registry_server_entry(provider: Provider) -> dict[str, Any] | None:
+    """The remote MCP entry the registry implies for ``provider``, in wire shape."""
+    entry: dict[str, Any] = {"url": provider["mcp_url"]}
+    scopes = provider.get("recommended_scopes") or []
+    if scopes:
+        entry["scopes"] = list(scopes)
+    client_id = provider.get("client_id")
+    if client_id:
+        entry["clientId"] = client_id
+    # store_entry=None: registry-derived, so no store owns it.
+    return kiro_oauth_wire_entry(entry, store_entry=None, server=str(provider["slug"]))
+
+
+def _disabled_provider_slugs() -> set[str]:
+    """Registry slugs whose configured MCP entry the user turned OFF."""
+    disabled = {server.name for server in list_servers() if server.disabled}
+    return {
+        provider["slug"]
+        for provider in get_visible_providers()
+        if provider["slug"] in disabled or mcp_server_alias(provider["slug"]) in disabled
+    }
+
+
+def warm_spec_providers() -> list[Provider]:
+    """The spec UNIVERSE: every provider the shared process ENUMERATES at spawn."""
+    disabled = _disabled_provider_slugs()
+    return [
+        provider
+        for provider in get_visible_providers()
+        if provider["slug"] not in disabled and _warm_mintable_entry(provider, None) is not None
+    ]
+
+
+def _warm_activation_candidates(universe: list[Provider]) -> list[Provider]:
+    """The subset of ``universe`` an activation should actually ask a URL for.
+
+    A DEFINITIVE absence -- ``is False`` -- never a falsy answer. ``grant_present`` is
+    tri-state and ``None`` means the grant cache could not be read at all, which a
+    truthiness test reads as "no grant": consent is then initiated on an absence nobody
+    confirmed, and the card is flipped to waiting behind an approval URL for a provider
+    that may already be connected. L1 collapses the same third answer deliberately because
+    it never initiates consent; this path does, so it must not.
+
+    Each provider is stat-ed exactly ONCE here. Re-reading presence to classify the skip is
+    the two-pass race :func:`~kiro_crew.mcp_grant.grant_presence` refuses -- a failure that
+    cleared between the passes would read as a definitive absence and warm anyway.
+
+    An indeterminate provider is skipped for this activation, not dropped forever: the cold
+    path still serves its Connect, and the next scan re-reads the cache.
+    """
+    presence = [(provider, grant_present(provider["mcp_url"])) for provider in universe]
+    unknown = sorted(provider["slug"] for provider, verdict in presence if verdict is None)
+    if unknown:
+        logger.warning(
+            "Not warming %d provider(s) whose grant cache could not be read, so absence is "
+            "unconfirmed: %s. The cold path still serves their Connect.",
+            len(unknown),
+            ", ".join(unknown),
+        )
+    return [provider for provider, verdict in presence if verdict is False]
+
+
+def _warm_candidate_scan() -> tuple[list[Provider], list[Provider]]:
+    """``(spec universe, activation candidates)`` from one pass over the registry."""
+    try:
+        universe = warm_spec_providers()
+    except Exception:  # noqa: BLE001 — reads user config; degrade to warming nothing
+        logger.debug("warm mint inventory read failed", exc_info=True)
+        return [], []
+    return universe, _warm_activation_candidates(universe)
+
+
+def mintable_providers() -> list[Provider]:
+    """Providers an activation should warm right now, registry order."""
+    return _warm_candidate_scan()[1]
+
+
+def _wanted_aliases(providers: list[Provider]) -> frozenset[str]:
+    """The server aliases an activation must produce a challenge for."""
+    return frozenset(mcp_server_alias(provider["slug"]) for provider in providers)
+
+
+def _auth_shape(entry: dict[str, Any]) -> tuple[str, tuple[str, ...], str]:
+    """The fields of an MCP entry that decide what an authorization asks for."""
+    return (
+        str(entry.get("url") or ""),
+        tuple(kiro_entry_scopes(entry)),
+        kiro_entry_client_id(entry),
+    )
+
+
+def _warm_mintable_entry(
+    provider: Provider, configured: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """The REGISTRY entry the warm process would activate, or None if it cannot.
+
+    Registry-derived on purpose: a plan built from the user's config changed on every
+    Connect click, respawning a process holding other cards' live listeners.
+
+    None in two cases: no usable auth configuration (no DCR and no pre-registered public
+    client id -- GitHub is the standing example), or a CONFIGURED entry asking for
+    something different from the registry, which only the cold path can honour without
+    handing back a grant the user did not ask for.
+    """
+    entry = _registry_server_entry(provider)
+    if entry is None:
+        return None
+    expectations: dict[str, Any] = dict(provider.get("l0_expectations") or {})
+    # Through the accessor: the wire shape nests the client id under ``oauth``, so a
+    # bare ``clientId`` lookup reads every registered non-DCR provider as unregistered.
+    if not bool(expectations.get("dcr")) and not kiro_entry_client_id(entry):
+        return None
+    if isinstance(configured, dict) and _auth_shape(configured) != _auth_shape(entry):
+        return None
+    return entry
+
+
+@dataclass(frozen=True)
+class _WarmSpecPlan:
+    """Every agent spec the warm process needs, plus a digest of their contents.
+
+    ``entries`` is the plan's roster, keyed by ``mcp_server_alias`` -- the identity this whole
+    module works in (``_wanted_aliases`` activates by alias, and both reuse tests compare
+    these keys), so it is also what says whether a candidate survived the scan's vetoes.
+    """
+
+    all_agent: str
+    specs: dict[str, dict[str, Any]]
+    entries: dict[str, dict[str, Any]]
+    digest: str
+
+
+def _plan_is_servable(resident: _WarmSpecPlan, wanted: _WarmSpecPlan) -> bool:
+    """True when the RUNNING process's specs can still serve ``wanted``.
+
+    Digest equality is the wrong test alone: it reads a set that SHRANK as a set that
+    changed. The only thing a respawn can fix is a server the process was never told
+    about, so a plan whose every entry is already resident with an identical authorization
+    ask is servable -- and replacing the process would strand its peers' listeners for
+    nothing. A changed url/scopes/client id is genuine incompatibility: authorizing the
+    resident ask would hand back the wrong grant.
+
+    Reuse is only sound for an activation whose MODE mounts nothing this scan excluded --
+    see :func:`_resident_roster_is_asked_for`. Servability answers "can this process serve
+    these servers at all"; it deliberately says nothing about what else the mode mounts.
+    """
+    if not resident.all_agent:
+        return False
+    return all(resident.entries.get(alias) == entry for alias, entry in wanted.entries.items())
+
+
+def _resident_roster_is_asked_for(resident: _WarmSpecPlan, wanted: _WarmSpecPlan) -> bool:
+    """True when the resident ALL-AGENT mode mounts nothing ``wanted`` excluded.
+
+    THE reason this is separate from servability. Specs are enumerated ONCE at spawn and a
+    warm session injects an empty ``mcp_servers`` list, so the servers an activation
+    initializes are fixed by the spec the NAMED mode carried when the process started --
+    rewriting the file afterwards moves nothing, and passing the wanted subset through
+    ``session/new`` kills the process with every pending verifier in it. The mounted set is
+    therefore not a thing an activation can narrow: the only way to stop initializing a
+    provider is to stop using the mode that lists it.
+
+    So a plan that merely SHRANK is servable but not reusable IN BULK: the resident
+    all-agent mode still lists the excluded provider, ``set_mode`` initializes its MCP
+    server, and an authorization request goes out for exactly the provider
+    :func:`_warm_mintable_entry` vetoed -- filtering the RESULT leaves that request made.
+    A strict shrink therefore respawns, which is not the same as stranding a peer: a process
+    still holding a redeemable code is PARKED, keeps its generation live, and is retired by
+    the drain once its rows are gone.
+
+    Paired with -- never a substitute for -- :func:`_plan_is_servable`. Servability alone
+    reuses a shrink, which is the defect this exists to close; the two together admit reuse
+    only for a roster that is neither more nor less than what the scan asked for.
+    """
+    return resident.entries.keys() <= wanted.entries.keys()
+
+
+def _warm_spec_plan(providers: list[Provider]) -> _WarmSpecPlan:
+    """Build (but do not write) the warm process's spec set."""
+    agents_dir = _agent.kiro_agents_dir_path()
+    # Through the hardened reader (#6736's migration): the agents dir is user-writable and
+    # shared with other tools, so a symlink planted at this path pointed a raw ``_load_json``
+    # at a file outside it -- followed, parsed, uncapped and unaudited -- and the contents
+    # then DECIDED the plan, because a configured entry vetoes its provider below. A refusal
+    # reads as an absent file: planning proceeds with nothing configured, which vetoes
+    # nothing, rather than failing the warm path.
+    spec = _read_agent_spec(
+        agents_dir / AGENT_FILENAME,
+        operation="connections_warm_mint",
+        source="dashboard",
+    )
+    configured = (spec or {}).get("mcpServers") or {}
+    entries: dict[str, dict[str, Any]] = {}
+    for provider in providers:
+        alias = mcp_server_alias(provider["slug"])
+        entry = _warm_mintable_entry(provider, configured.get(alias))
+        if entry is None:
+            continue
+        entries[alias] = entry
+
+    # The BASE spec carries zero servers on purpose: it is what the process spawns on, so
+    # anything it declared would be initialized -- and challenged for -- before any mint.
+    specs: dict[str, dict[str, Any]] = {
+        _WARM_BASE_AGENT: _warm_spec_body(
+            _WARM_BASE_AGENT, {}, "Zero-server base spec for the shared approval-URL mint."
+        )
+    }
+    if entries:
+        specs[_WARM_ALL_AGENT] = _warm_spec_body(
+            _WARM_ALL_AGENT, entries, "Every mintable provider: one activation warms every card."
+        )
+    digest = hashlib.sha256(
+        json.dumps(specs, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return _WarmSpecPlan(
+        all_agent=_WARM_ALL_AGENT if entries else "",
+        specs=specs,
+        entries=entries,
+        digest=digest,
+    )
+
+
+def _is_stale_warm_spec(stem: str, plan_names: frozenset[str]) -> bool:
+    """Whether ``stem`` is a warm spec from a previous plan, safe to unlink.
+
+    Three conjuncts, and the third is not redundant: a COLD mint spec for a server
+    literally named ``warm-*`` shares this module's prefix
+    (``kirocrew-mint-warm-foo-4821-9ab3c1de``), so prefix plus not-in-plan alone would
+    delete a live cold mint's spec and strand a user mid-consent. Only the
+    ``-<pid>-<8hex>`` suffix separates the two, over one shared character class.
+
+    Necessary but NOT sufficient to unlink: the name says where a spec of ours would go,
+    and :func:`_warm_spec_is_foreign` is what says the file there is one.
+    """
+    return (
+        stem not in plan_names
+        and _WARM_NAME_RE.match(stem) is not None
+        and _MINT_NAME_RE.match(f"{stem}.json") is None
+    )
+
+
+def _warm_ownership_marks(name: str) -> dict[str, Any]:
+    """The fields a warm spec named ``name`` carries no matter which plan wrote it.
+
+    Read off the WRITER rather than restated, so a change to the spec body cannot leave
+    this module unable to recognise its own files -- which would turn every rewrite into a
+    refusal and hand the process a stale spec. ``mcpServers`` and ``tools`` vary with the
+    plan, so neither can carry ownership.
+
+    NECESSARY BUT NOT SUFFICIENT: every value here is a stock default, so a user's own spec
+    plausibly matches all four. ``description`` is what discriminates -- not because its
+    detail is fixed (it is not) but because its PREFIX is :data:`_WARM_SPEC_SENTINEL`, which
+    :func:`_warm_spec_is_foreign` requires on top of these marks.
+    """
+    probe = _mint_spec_body(name, {}, "")
+    return {key: probe[key] for key in ("model", "includeMcpJson", "prompt", "allowedTools")}
+
+
+def _warm_spec_is_foreign(path: Path) -> bool:
+    """True when ``path`` exists but no warm plan wrote it, so this module must not touch it.
+
+    Warm spec names are FIXED and predictable and they sit in the user's OWN agents
+    directory, so the name shape :func:`_is_stale_warm_spec` checks says where a spec of
+    ours would GO -- never that the file already there is one. Ownership is proved from the
+    contents instead, and it takes BOTH halves: the declared ``name`` matches the file with
+    every field the writer fixes still holding, AND the description carries the sentinel.
+    The marks alone are generic defaults, so a wholly user-authored spec that happens to
+    carry them was read as ours and clobbered; the sentinel is the half that discriminates.
+
+    Fails closed, because the two mistakes are not symmetric. Reading a file of ours as
+    foreign costs one stale spec left as clutter; reading a user's hand-written agent as
+    ours deletes it, or overwrites it with a spec they never asked for. So a file that is
+    unreadable, not a JSON object, or shaped like anything but our own is foreign.
+    """
+    # Through the hardened reader, like the planner read: a raw ``_load_json`` FOLLOWS a
+    # symlink planted at this warm path and parses whatever it lands on, so a link aimed at
+    # a sensitive file was read uncapped and unaudited -- and the ownership verdict this
+    # function returns is what decides whether that path gets unlinked or overwritten.
+    body = _read_agent_spec(
+        path,
+        operation="connections_warm_mint",
+        source="dashboard",
+    )
+    if not body:
+        # A refusal reads as an empty body: absent, unreadable, non-object, oversized and a
+        # sensitive-target symlink all land here, and only the ABSENT one is a path we may
+        # write -- which is what the presence check separates. A dangling symlink resolves
+        # to nothing, so ``exists()`` alone would report the path free and the writer would
+        # replace the link (and the sweep unlink it) -- destroying a path occupant this
+        # module does not own; the link itself occupying the path is what counts. Every
+        # refusal therefore reads as foreign, which is refused and left in place: the safe
+        # direction.
+        return path.is_symlink() or path.exists()
+    marks = _warm_ownership_marks(path.stem)
+    if body.get("name") != path.stem or any(body.get(key) != value for key, value in marks.items()):
+        return True
+    # No legacy exposure: no warm-spec writer has ever shipped, so no unsentinelled file of
+    # ours exists anywhere to be orphaned by requiring this. Were one to exist it would read
+    # as foreign, which means refused and left in place -- the safe direction.
+    return not str(body.get("description") or "").startswith(_WARM_SPEC_SENTINEL)
+
+
+def _write_warm_mint_specs(plan: _WarmSpecPlan) -> None:
+    """Write the whole spec set, removing warm specs no longer in it.
+
+    Every unlink and every write is gated on ownership, so a file this module did not write
+    survives both. A refusal is audited and skipped, never raised: a provider whose spec
+    path is occupied is a provider that goes unwarmed, not a failed spawn.
+    """
+    agents_dir = _agent.kiro_agents_dir_path()
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    plan_names = frozenset(plan.specs)
+    try:
+        for path in agents_dir.glob(f"{_WARM_AGENT_PREFIX}*.json"):
+            if not _is_stale_warm_spec(path.stem, plan_names):
+                continue
+            if _warm_spec_is_foreign(path):
+                _log_warm_event("warm_mint_spec_sweep", path.name, outcome="refused")
+                continue
+            path.unlink(missing_ok=True)
+    except OSError:
+        logger.debug("warm mint spec sweep failed", exc_info=True)
+    for name, spec in plan.specs.items():
+        path = agents_dir / f"{name}.json"
+        if _warm_spec_is_foreign(path):
+            _log_warm_event("warm_mint_spec_write", path.name, outcome="refused")
+            continue
+        _agent._atomic_json_write(path, spec)
+
+
+def _unowned_plan_specs(plan: _WarmSpecPlan) -> list[str]:
+    """The planned spec names whose file is missing, or is not one this module wrote.
+
+    Activation happens BY NAME: the runtime is handed ``agent=<fixed name>`` and kiro-cli
+    resolves that name off this same agents directory. So the write's refusal protects the
+    FILE and nothing else -- a hand-written agent sitting at a name we declined to
+    overwrite would be spawned, and its ``mcpServers`` commands would initialize. This is
+    what protects the SPAWN.
+
+    Existence is tested as well as ownership, because :func:`_warm_spec_is_foreign` answers
+    False for an absent path: a spec that is not there is equally not ours to activate.
+    """
+    agents_dir = _agent.kiro_agents_dir_path()
+    unowned: list[str] = []
+    for name in plan.specs:
+        path = agents_dir / f"{name}.json"
+        if not path.is_file() or _warm_spec_is_foreign(path):
+            unowned.append(name)
+    return unowned
+
+
+def _remove_warm_mint_specs() -> None:
+    """Unlink every warm spec THIS module wrote. Called when the process is retired."""
+    try:
+        for path in _agent.kiro_agents_dir_path().glob(f"{_WARM_AGENT_PREFIX}*.json"):
+            if not _is_stale_warm_spec(path.stem, frozenset()):
+                continue
+            if _warm_spec_is_foreign(path):
+                _log_warm_event("warm_mint_spec_removal", path.name, outcome="refused")
+                continue
+            path.unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001 — spec files; the write-time sweep catches leftovers
+        logger.debug("warm mint spec removal failed", exc_info=True)
+
+
+def _warm_work_dir() -> Path:
+    """The shared process's working directory, inside the agent-write-protected run tree.
+
+    NOT under ``connections/``, and the reason is the spawn. kiro-cli resolves PROJECT-LOCAL
+    agent specs from ``<cwd>/.kiro/agents`` as well as the user's agents dir, and this module
+    activates BY NAME -- so a spec planted at ``<cwd>/.kiro/agents/<mode>.json`` shadows the
+    warm spec :func:`_write_warm_mint_specs` wrote, on a path every ownership check here
+    (:func:`_warm_spec_is_foreign`, :func:`_unowned_plan_specs`) looks straight past. The
+    injected body's ``mcpServers`` would then be what the process initializes and authorizes
+    against.
+
+    ``connections/`` carries no entry in ``security._SENSITIVE_HOME_DIRS``, so an agent file
+    tool could write that tree; ``run/`` is already fenced read+write for precisely this
+    class of reason -- it holds the sandbox launchers and run markers the gateway execs
+    outside the sandbox. Putting the cwd there makes the injection unwritable through any
+    Kiro Crew-mediated channel instead of merely unlikely.
+
+    No ``mkdir`` here: the runtime creates its work dir at spawn.
+    """
+    return data_home() / "run" / "connections-warm"
 
 
 def _runtime_alive(runtime: Any) -> bool:
@@ -46,35 +700,104 @@ def _runtime_alive(runtime: Any) -> bool:
         return False
 
 
-class _WarmMintRuntime:
-    """The liveness registry a shared row's ``generation``/``activation`` are read against.
+def _live_row_count(generation: int) -> int:
+    """How many cards are still mid-consent on ``generation``."""
+    return sum(
+        1
+        for entry in _mints.values()
+        if entry.get("shared")
+        and entry.get("generation") == generation
+        and entry.get("state") in _LIVE_STATES
+    )
 
-    Both containers are filled by the deferred lifecycle (slice N2b) and are empty until it
-    lands. They are READ here rather than in N2b because the reader is what decides whether
-    a card's URL is withdrawn, and the parked case is exactly the one where a wrong answer
-    destroys a code the user could still redeem.
+
+def _generation_holds_live_rows(generation: int) -> bool:
+    """True while killing ``generation`` would strand a redeemable code."""
+    return _live_row_count(generation) > 0
+
+
+def _activations_in_use() -> set[int]:
+    """Activation ids a live shared row still points at -- the sweep's keep-set."""
+    return {
+        int(entry["activation"])
+        for entry in _mints.values()
+        if entry.get("shared") and entry.get("activation") and entry.get("state") in _LIVE_STATES
+    }
+
+
+@dataclass
+class _WarmSession:
+    """One live ACP session on the shared process, and what it owns.
+
+    Held because the session owns the loopback callback servers for its challenges.
+    ``settled`` flips once the URLs are absorbed into the mint table, which is what makes
+    the sweep safe -- an activation still in flight is referenced by no row. ``expires_at``
+    is why a session outlives the rows that pointed at it: a replaced URL may still be open
+    on the provider's consent page, and one mint TTL is exactly the window in which that
+    code is still redeemable.
+    """
+
+    generation: int
+    handle: Any
+    expires_at: float
+    settled: bool = False
+
+
+@dataclass(frozen=True)
+class _WarmMintResult:
+    """One activation's product, plus the snapshot and process it ran on."""
+
+    generation: int
+    activation: int
+    providers: list[Provider]
+    requests: list[dict[str, str]]
+
+
+class _WarmMintRuntime:
+    """One kiro-cli process shared by every card's approval-URL mint.
+
+    Also the liveness registry a shared row's ``generation``/``activation`` are read
+    against: the reader is what decides whether a card's URL is withdrawn, and the parked
+    case is exactly the one where a wrong answer destroys a code the user could still
+    redeem.
     """
 
     def __init__(self) -> None:
         self._runtime: Any = None
+        self._plan: _WarmSpecPlan | None = None
+        self._digest = ""
         #: Bumped on every spawn. Rows record the generation that minted them, letting a
         #: stand-down tell "nothing needs this" from "killing it strands a user mid-consent".
         self._generation = 0
         #: Generations kept alive ONLY because a card still holds one of their URLs.
+        #: New mints never route here; the reaper kills each once its rows are gone.
         self._retiring: list[tuple[int, Any]] = []
         #: Live sessions by activation id -- each owns the loopback servers for its
         #: challenges, so one is held while a card points at one of its URLs.
-        self._sessions: dict[int, Any] = {}
+        self._sessions: dict[int, _WarmSession] = {}
+        self._activation_seq = 0
+        self._lock = asyncio.Lock()
+        self._reaper: Any = None
 
     def is_alive(self) -> bool:
         return _runtime_alive(self._runtime)
 
     def generation_is_live(self, generation: int) -> bool:
-        """True while the process that minted ``generation`` can still redeem."""
+        """True while the process that minted ``generation`` can still redeem.
+
+        A generation keeps its NUMBER while it is parked: only a successful spawn bumps the
+        counter, so between a stand-down and its replacement the CURRENT number names a
+        process that lives in ``_retiring`` with ``self._runtime`` already cleared. The
+        equality test therefore CONFIRMS liveness but never denies it -- a miss falls
+        through to the parked list. Answering False there withdrew redeemable URLs, and the
+        withdrawal then made ``_generation_holds_live_rows`` false, so the next sweep killed
+        the very process the park existed to preserve. Readers reach this without the
+        runtime lock (the dashboard status path does), so the window is observable.
+        """
         if generation <= 0:
             return False
-        if generation == self._generation:
-            return self.is_alive()
+        if generation == self._generation and self.is_alive():
+            return True
         return any(
             parked == generation and _runtime_alive(runtime) for parked, runtime in self._retiring
         )
@@ -84,6 +807,546 @@ class _WarmMintRuntime:
         if activation <= 0:
             return False
         return activation in self._sessions
+
+    def parked_count(self) -> int:
+        """How many generations are parked -- alive only for a card still mid-consent.
+
+        Read by :func:`_drain_parked_generations`, which is what retires them once the
+        current process is gone and no new mint will sweep them.
+        """
+        return len(self._retiring)
+
+    async def settle_activation(self, activation: int, in_use: set[int]) -> None:
+        """Mark ``activation`` absorbed, then collect the sessions nothing needs."""
+        async with self._lock:
+            record = self._sessions.get(activation)
+            if record is not None:
+                record.settled = True
+            await self._sweep_sessions_locked(in_use)
+
+    async def sweep_sessions(self, in_use: set[int]) -> None:
+        """Collect settled sessions no live row points at."""
+        async with self._lock:
+            await self._sweep_sessions_locked(in_use)
+
+    async def _sweep_sessions_locked(self, in_use: set[int]) -> None:
+        """Collect settled sessions no row needs AND whose TTL has run out."""
+        now = time.monotonic()
+        doomed = [
+            activation
+            for activation, record in self._sessions.items()
+            if record.settled and activation not in in_use and record.expires_at <= now
+        ]
+        for activation in doomed:
+            record = self._sessions.get(activation)
+            if record is None:
+                continue
+            destroyed = False
+            try:
+                destroyed = await _destroy_session_quietly(record.handle)
+            finally:
+                # Forgotten only once the destroy actually TOOK. The record is the only
+                # reference left to the handle, so losing it while the session is still
+                # listening leaves it -- and the loopback servers it owns -- with nothing
+                # that could ever retry; the record stays settled and expired, so the next
+                # reaper sweep is that retry. Held across the await deliberately: a reader
+                # without the lock then over-reports the session as live for a moment, which
+                # keeps a row waiting a beat longer rather than withdrawing a URL, the safe
+                # direction.
+                if destroyed:
+                    self._sessions.pop(activation, None)
+
+    def _drop_generation_sessions(self, generation: int) -> None:
+        """Forget one generation's sessions. Its process death already reaped them."""
+        for activation in [
+            activation
+            for activation, record in self._sessions.items()
+            if record.generation == generation
+        ]:
+            self._sessions.pop(activation, None)
+
+    async def mint_for(self) -> _WarmMintResult | None:
+        """Ensure a live process, activate it, return its challenges."""
+        async with self._lock:
+            await self._sweep_retiring_locked()
+            universe, candidates = await asyncio.to_thread(_warm_candidate_scan)
+            # The UNIVERSE decides what the process must have enumerated; the CANDIDATES
+            # decide what this activation asks for. Apart, a grant moves the second only.
+            plan = await self._ensure_locked(universe)
+            if plan is None:
+                return None
+            agent = plan.all_agent
+            if not agent:
+                return None
+            # Keyed on the plan's own roster, which is what the activated mode will mount:
+            # a candidate the plan vetoed must not be asked for even though the scan found
+            # it. Alias, not slug, because the roster and the activation both work in
+            # aliases (``_wanted_aliases`` below).
+            wanted = [
+                provider
+                for provider in candidates
+                if mcp_server_alias(provider["slug"]) in plan.entries
+            ]
+            if not wanted:
+                return None
+            generation = self._generation
+            try:
+                activation, requests = await self._activate_locked(agent, _wanted_aliases(wanted))
+            except Exception as exc:
+                if self.is_alive():
+                    # One activation failed but the process still serves: its other verifiers
+                    # are intact, so killing it here destroys still-completable consent flows.
+                    raise
+                await self._park_or_kill_locked()
+                raise _WarmMintDied(type(exc).__name__) from exc
+            return _WarmMintResult(
+                generation=generation,
+                activation=activation,
+                providers=wanted,
+                requests=requests,
+            )
+
+    async def _ensure_locked(self, providers: list[Provider]) -> _WarmSpecPlan | None:
+        """Guarantee a process whose specs can serve ``providers``, and return THAT plan.
+
+        The returned plan -- never ``self._plan`` -- is what an activation must be driven
+        from. The two differ on the reuse path: ``self._plan`` is what the running process
+        ENUMERATED, which a shrink leaves a SUPERSET of what this scan wants, so it still
+        names providers the scan excluded. ``_warm_mintable_entry`` excludes a provider
+        whose CONFIGURED entry diverges from the registry precisely because only the cold
+        path can honour it without handing back a grant the user did not ask for -- and an
+        activation driven from the resident plan asked for that provider's URL anyway, with
+        the registry's scopes and client id, bypassing the exclusion entirely.
+
+        So the two reads are split by job: servability decides whether to RESPAWN, this plan
+        decides what to ASK FOR. ``None`` when nothing can be warmed.
+
+        Reuse takes BOTH tests. Servability says the resident process can answer for every
+        provider this scan wants; :func:`_resident_roster_is_asked_for` says it will not also
+        mount one the scan excluded. Nothing narrows a mode's mounted set after the spawn that
+        enumerated it, so this decision is the only place the exclusion can be enforced.
+        """
+        try:
+            plan = await asyncio.to_thread(_warm_spec_plan, providers)
+        except Exception:  # noqa: BLE001 — reads user-editable JSON; never fail a mint
+            logger.debug("warm mint spec plan failed", exc_info=True)
+            return None
+        if not plan.all_agent:
+            return None
+
+        if self.is_alive() and self._digest == plan.digest:
+            # Digest equality is spec-set equality, so every mode's roster is asked for.
+            return plan
+        resident = self._plan
+        if (
+            self.is_alive()
+            and resident is not None
+            and _plan_is_servable(resident, plan)
+            and _resident_roster_is_asked_for(resident, plan)
+        ):
+            logger.info(
+                "Shared mint generation %d already serves the new candidate set; "
+                "re-activating instead of respawning",
+                self._generation,
+            )
+            return plan
+        if self._runtime is not None:
+            logger.info(
+                "Starting a new shared mint generation (%s)",
+                "specs are incompatible" if self.is_alive() else "process is gone",
+            )
+        await self._park_or_kill_locked()
+
+        runtime: Any = None
+        handed_over = False
+        try:
+            await asyncio.to_thread(_write_warm_mint_specs, plan)
+            # The write REFUSES a path it does not own rather than clobbering it, and the
+            # spawn below activates by NAME -- so without this the refusal would hand
+            # kiro-cli a stranger's spec to execute. Aborting is safe and honest: the cold
+            # path still serves every Connect, it just spawns per provider.
+            unowned = await asyncio.to_thread(_unowned_plan_specs, plan)
+            if unowned:
+                logger.warning(
+                    "Not warming: %d planned mint spec(s) are not ours to activate", len(unowned)
+                )
+                await asyncio.to_thread(
+                    _log_warm_event,
+                    "connections_warm_mint_spawn",
+                    f"unowned_specs:{len(unowned)}",
+                    "refused",
+                )
+                return None
+            runtime = _acp_runtime_factory()(
+                work_dir=await asyncio.to_thread(_warm_work_dir),
+                agent=_WARM_BASE_AGENT,
+                sandbox_mode="auto",
+            )
+            await asyncio.wait_for(runtime.spawn(), timeout=_WARM_SPAWN_TIMEOUT_SECONDS)
+            # No await between the spawn returning and the flag: the handover is a run of
+            # plain assignments plus a synchronous ``create_task``, so there is no window
+            # in which the process is ours but the ``finally`` would still tear it down.
+            self._runtime, self._plan, self._digest = runtime, plan, plan.digest
+            self._generation += 1
+            self._reaper = asyncio.get_running_loop().create_task(
+                _warm_mint_reaper(self._generation)
+            )
+            handed_over = True
+        except Exception as exc:  # noqa: BLE001 — degrade to the cold path
+            logger.warning("Shared mint process spawn failed: %s", type(exc).__name__)
+            return None
+        finally:
+            # A ``finally``, not an ``except Exception``: the stand-down above has already
+            # parked the old generation AND cancelled its reaper, so a CancelledError in the
+            # spec write or the spawn would otherwise leave that process with nothing that
+            # will ever sweep it -- the parked-generation leak by a third route -- plus a
+            # forked child and a set of specs nobody owns.
+            if not handed_over:
+                await self._abandon_spawn_locked(runtime)
+        await asyncio.to_thread(
+            _log_warm_event,
+            "connections_warm_mint_spawn",
+            f"providers:{len(plan.entries)} generation:{self._generation}",
+        )
+        return plan
+
+    async def _abandon_spawn_locked(self, runtime: Any) -> None:
+        """Undo a spawn attempt that never became this object's process.
+
+        Reached from a ``finally``, so it covers cancellation as well as failure.
+        """
+        if self._retiring:
+            # Armed BEFORE any await, because ``create_task`` is synchronous: the parked
+            # generation then has its sweeper even if the teardown below is interrupted.
+            # Stored as the reaper so a later spawn's own reaper replaces it.
+            self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
+        if runtime is not None and not await _kill_quietly(runtime):
+            # This attempt never became ``self._runtime``, so it owns no generation and no
+            # rows. Tracked under a key no row can carry, which makes every sweep read it as
+            # needed by nobody and retry the kill until it takes -- rather than dropping the
+            # last reference to a child that outlived the spawn we gave up on.
+            self._retain_unkilled_locked(_WARM_UNKEYED_GENERATION, runtime)
+        if not self._retiring:
+            await asyncio.to_thread(_remove_warm_mint_specs)
+
+    async def _abandon_session_creation_locked(self, create: Any) -> None:
+        """Reap a session the backend may have created after we stopped waiting for it.
+
+        ``create`` was shielded from our own cancellation precisely so its result stays
+        reachable here: the handle is the ONLY way to terminate the session and the loopback
+        callback children it owns. A handle that does arrive is REGISTERED before it is
+        destroyed -- settled and already expired -- so it enters the same ownership rule the
+        rest of this class uses, and an interrupted destroy is retried by the ordinary sweep
+        instead of being lost.
+        """
+        handle: Any = None
+        try:
+            # Bounded: this only buys back a session already on its way.
+            handle = await asyncio.wait_for(
+                asyncio.shield(create), timeout=_WARM_SESSION_REAP_TIMEOUT_SECONDS
+            )
+        except BaseException:  # noqa: BLE001 — best-effort reap; the caller re-raises its own
+            handle = None
+        if handle is None:
+            # Nothing addressable exists to destroy: the backend may still accept a session
+            # carrying an id we never received. QUARANTINE the generation rather than trust
+            # retirement to arrive on its own -- it is not guaranteed to. Any card holding a
+            # URL keeps ``_shared_mints_pending`` true, which resets the reaper's idle clock
+            # every cycle, while ``_ensure_locked``'s digest fast path keeps this same
+            # process reusable; so without this, every repetition of this path parked another
+            # unaddressable session and its callback children on ONE live runtime, without
+            # bound. Clearing the resident plan makes the next activation find it unservable,
+            # which stands this generation down through the ordinary path (parked for the
+            # drain when a card still needs it, killed outright otherwise) and takes the
+            # orphan with it. The residual is therefore at most ONE generation's sessions.
+            #
+            # Scoped deliberately to this branch: the recovered-handle path below repairs
+            # itself completely, so quarantining there would cost a respawn on every
+            # transient timeout for nothing.
+            self._plan, self._digest = None, ""
+            logger.warning(
+                "Quarantining shared mint generation %d: a session was created that we "
+                "cannot address, so the process is stood down at the next activation",
+                self._generation,
+            )
+            create.cancel()
+            return
+        self._activation_seq += 1
+        activation = self._activation_seq
+        self._sessions[activation] = _WarmSession(
+            generation=self._generation, handle=handle, expires_at=0.0, settled=True
+        )
+        destroyed = False
+        try:
+            destroyed = await _destroy_session_quietly(handle)
+        finally:
+            # Registered settled and already expired above, so a record kept here because
+            # the destroy did not take is picked up by the next sweep rather than lost.
+            if destroyed:
+                self._sessions.pop(activation, None)
+
+    async def _activate_locked(
+        self, agent: str, wanted: frozenset[str]
+    ) -> tuple[int, list[dict[str, str]]]:
+        """Activate ``agent`` on the shared process and return its challenges."""
+        runtime = self._runtime
+        if runtime is None or not self.is_alive():
+            raise _WarmMintUnsafe("the shared mint process is not alive")
+        servers = _warm_session_mcp_servers()
+        if servers:
+            # Never reachable from our own code -- the guard exists because the failure is
+            # silent and total: session/new-injected servers kill the process and its verifiers.
+            raise _WarmMintUnsafe("session-injected MCP servers would kill the shared process")
+
+        # OWNERSHIP TRANSFER, and the one that has no second chance: the returned handle is
+        # the ONLY way to terminate a session and the loopback callback children it owns, so
+        # a wait we abandon after the backend already accepted `session/new` would leak them
+        # until the whole runtime is retired. The create runs as a task we keep a reference
+        # to and shield, so the handle stays REACHABLE even when we stop waiting for it.
+        create = asyncio.get_running_loop().create_task(
+            runtime.create_session(agent=agent, mcp_servers=servers)
+        )
+        try:
+            handle = await asyncio.wait_for(
+                asyncio.shield(create), timeout=_WARM_SESSION_TIMEOUT_SECONDS
+            )
+        except BaseException:
+            await self._abandon_session_creation_locked(create)
+            raise
+        # No await between the handle arriving and its registration, so there is no window
+        # in which the session exists and nothing in this object knows about it.
+        self._activation_seq += 1
+        activation = self._activation_seq
+        self._sessions[activation] = _WarmSession(
+            generation=self._generation,
+            handle=handle,
+            expires_at=time.monotonic() + _MINT_TTL_SECONDS,
+        )
+        collected: dict[str, dict[str, str]] = {}
+        try:
+            for round_index in range(_WARM_OAUTH_SETTLE_ROUNDS):
+                for request in handle.pop_pending_oauth_requests():
+                    name = str(request.get("serverName") or "")
+                    if name and request.get("oauthUrl"):
+                        collected[name] = request
+                if wanted and wanted <= collected.keys():
+                    break
+                if round_index + 1 < _WARM_OAUTH_SETTLE_ROUNDS:
+                    # CONSUME the queue rather than sleep past it. This is the whole
+                    # mechanism: ``pop_pending_oauth_requests`` reads a list that only
+                    # ``drain_init`` appends to, and ``create_session`` runs exactly one
+                    # drain before handing the handle over -- so a bare sleep here moved
+                    # nothing, and a frame arriving after that drain's idle exit was
+                    # unreachable however many rounds elapsed. The budget was never the
+                    # binding constraint; the loop had no way to absorb a late frame at all.
+                    #
+                    # ``no_report_ceiling=0.0`` is load-bearing: it arms the idle shortcut at
+                    # entry, so this call cannot hold waiting for a "first report" that this
+                    # session already produced during ``create_session``'s own drain. That is
+                    # precisely the idle-window semantics that made an unbounded drain the
+                    # wrong tool here -- bounded per round, it is the right one. Each round is
+                    # therefore a window of at most ``_WARM_OAUTH_SETTLE_SECONDS`` that
+                    # returns as soon as the queue goes quiet, so the total budget is
+                    # unchanged and a satisfied activation still short-circuits on the pop
+                    # above without opening a window at all.
+                    await handle.drain_init(
+                        duration=_WARM_OAUTH_SETTLE_SECONDS,
+                        idle_exit=_WARM_OAUTH_SETTLE_SECONDS,
+                        no_report_ceiling=0.0,
+                    )
+        except BaseException:
+            # Nothing will ever be stamped with this activation, so the session it
+            # registered would leak past the sweep's settled-only rule. Marked settled and
+            # already expired FIRST, so that if the destroy below is interrupted -- or does
+            # not take -- the sweep is a real retry; and popped only once the destroy
+            # actually completed, because the record is the only reference left to the
+            # handle.
+            record = self._sessions.get(activation)
+            if record is not None:
+                record.settled = True
+                record.expires_at = 0.0
+            if await _destroy_session_quietly(handle):
+                self._sessions.pop(activation, None)
+            raise
+        return activation, list(collected.values())
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            await self._retire_locked()
+
+    async def sweep_retiring(self) -> None:
+        """Kill parked generations nothing is waiting on any more."""
+        async with self._lock:
+            await self._sweep_retiring_locked()
+
+    async def _sweep_retiring_locked(self) -> None:
+        keep: list[tuple[int, Any]] = []
+        drop: list[tuple[int, Any]] = []
+        for pair in self._retiring:
+            generation, runtime = pair
+            needed = _runtime_alive(runtime) and _generation_holds_live_rows(generation)
+            (keep if needed else drop).append(pair)
+        self._retiring = keep
+        try:
+            while drop:
+                generation, runtime = drop[0]
+                logger.info("Retiring parked shared mint generation %d", generation)
+                if not await self._kill_generation(generation, runtime):
+                    # The child may still be running, so this generation is NOT retired:
+                    # left in ``drop`` for the ``finally`` to put back and a later sweep to
+                    # retry. Stopping here rather than continuing keeps the list's order.
+                    break
+                # Popped only once its kill has actually completed.
+                drop.pop(0)
+        finally:
+            if drop:
+                # Whatever this sweep did not finish stays PARKED. Removing it from the list
+                # without killing it would make ``parked_count()`` read zero, so the drain
+                # would exit and no later sweep would retry -- the process, its sessions and
+                # their loopback servers would simply leak.
+                self._retiring = drop + self._retiring
+
+    async def _park_or_kill_locked(self) -> None:
+        """Stand the current process down: PARKED when a card still needs it."""
+        runtime, generation = self._runtime, self._generation
+        reaper, self._reaper = self._reaper, None
+        self._runtime, self._plan, self._digest = None, None, ""
+        # The reaper is the caller on the idle path; cancelling the current task
+        # would abandon the kill it is in the middle of awaiting.
+        if reaper is not None and reaper is not asyncio.current_task():
+            reaper.cancel()
+        if runtime is None:
+            return
+        if _runtime_alive(runtime) and _generation_holds_live_rows(generation):
+            self._retiring.append((generation, runtime))
+            logger.info(
+                "Parking shared mint generation %d: %d card(s) still mid-consent on it",
+                generation,
+                _live_row_count(generation),
+            )
+            return
+        try:
+            if not await self._kill_generation(generation, runtime):
+                # The kill did not take. Same reasoning as the handler below, reached for a
+                # plain failure (a timeout) rather than a cancellation.
+                self._retain_unkilled_locked(generation, runtime)
+        except BaseException:
+            # ``_runtime`` and the reaper were cleared synchronously above, so this list is
+            # now the ONLY reference to a process the kill did not finish with. Park it and
+            # arm the drain rather than dropping it: an untracked child never gets retired.
+            self._retain_unkilled_locked(generation, runtime)
+            raise
+
+    async def _kill_generation(self, generation: int, runtime: Any) -> bool:
+        """Kill one process and expire the links only it could have redeemed.
+
+        ``False`` when the kill did not take, and the caller must keep the pair tracked. The
+        rows are expired either way -- this generation is being retired, so its URLs must
+        stop being served -- but the spec sweep is WITHHELD: a spec removed under a process
+        that is still running strands it without the file it was spawned on, which is the
+        same rule the parked path follows.
+        """
+        killed = await _kill_quietly(runtime)
+        self._drop_generation_sessions(generation)
+        await _expire_shared_mints("mint_process_gone", generation=generation)
+        if killed and self._runtime is None and not self._retiring:
+            await asyncio.to_thread(_remove_warm_mint_specs)
+        return killed
+
+    def _retain_unkilled_locked(self, generation: int, runtime: Any) -> None:
+        """Keep a process whose kill did not take, and make sure something retries it.
+
+        Every caller clears ``_runtime`` and cancels the reaper synchronously BEFORE the
+        kill, so this list is then the only reference to a child that may still be alive.
+        Arming the drain is what performs the retry: it re-sweeps while anything is parked.
+        """
+        self._retiring.append((generation, runtime))
+        if self._reaper is None:
+            self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
+
+    async def _retire_locked(self) -> None:
+        """Hard teardown: every generation, parked ones included."""
+        reaper, runtime, generation = self._reaper, self._runtime, self._generation
+        # Parked generations first, then the current one -- a parked process is the one a
+        # card may still be mid-consent on, so it is retired before the live one.
+        pending = list(self._retiring)
+        if runtime is not None:
+            pending.append((generation, runtime))
+        had_work = bool(pending)
+        self._retiring = []
+        self._reaper = self._runtime = None
+        self._plan, self._digest = None, ""
+        self._sessions.clear()
+        if reaper is not None and reaper is not asyncio.current_task():
+            reaper.cancel()
+        try:
+            while pending:
+                doomed_generation, doomed_runtime = pending[0]
+                killed = await _kill_quietly(doomed_runtime)
+                await _expire_shared_mints("mint_process_gone", generation=doomed_generation)
+                if not killed:
+                    # A hard teardown that could not kill a child must not report it retired:
+                    # left in ``pending`` for the ``finally`` below to re-track.
+                    break
+                # Popped only once this generation is fully retired.
+                pending.pop(0)
+        finally:
+            if pending:
+                # Same rule as everywhere else in this class: a process whose teardown did
+                # not complete stays tracked, with something scheduled to retire it. The
+                # lists above were emptied synchronously, so this is the only reference left.
+                self._retiring = pending
+                self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
+        if had_work and not self._retiring:
+            # Only once nothing is left: a spec removed under a still-running parked process
+            # strands it without the file it was spawned on.
+            await asyncio.to_thread(_remove_warm_mint_specs)
+
+
+async def _destroy_session_quietly(handle: Any) -> bool:
+    """Terminate one warm session. ``False`` when it may still be listening.
+
+    The return value is the point, and it is the same contract as :func:`_kill_quietly`. A
+    destroy that TIMES OUT leaves a live session and the loopback callback servers it owns,
+    and reporting that as success let every caller drop the record -- which is the ONLY
+    remaining reference to the handle, so the session became unaddressable and nothing could
+    ever retry it. ``asyncio.TimeoutError`` IS an ``Exception``, so the retention the three
+    call sites already had -- each written for a ``CancelledError``, which is not -- never
+    saw the case it matters most for.
+
+    Still no raise: teardown is best-effort by design and runs from ``finally`` blocks where
+    raising would mask the original failure. The callers RETAIN instead of propagating, and
+    the reaper's periodic session sweep is what performs the retry.
+    """
+    try:
+        await asyncio.wait_for(handle.destroy(), timeout=_WARM_SESSION_DESTROY_TIMEOUT_SECONDS)
+    except Exception:  # noqa: BLE001 — best-effort teardown of our own session
+        logger.warning("warm mint session destroy failed; the session stays tracked for a retry")
+        logger.debug("warm mint session destroy failed", exc_info=True)
+        return False
+    return True
+
+
+async def _kill_quietly(runtime: Any) -> bool:
+    """Kill one process. ``False`` when it may still be running.
+
+    The return value is the point. A kill that TIMES OUT leaves a live child, and reporting
+    that as success let every caller discard the only reference to it -- the generation was
+    forgotten while the process, its sessions and their loopback listeners stayed resident,
+    so repeated activations accumulated them with nothing left that could retire them.
+    ``asyncio.TimeoutError`` IS an ``Exception``, so the three retention paths this class
+    already has -- all built for a ``CancelledError``, which is not -- never saw it.
+
+    Still no raise: teardown is best-effort by design and runs from ``finally`` blocks where
+    raising would mask the original failure. The callers RETAIN instead of propagating.
+    """
+    try:
+        await asyncio.wait_for(runtime.kill(), timeout=_WARM_KILL_TIMEOUT_SECONDS)
+    except Exception:  # noqa: BLE001 — best-effort teardown of our own child
+        logger.warning("warm mint runtime kill failed; the process stays tracked for a retry")
+        logger.debug("warm mint runtime kill failed", exc_info=True)
+        return False
+    return True
 
 
 _warm_mint = _WarmMintRuntime()
@@ -103,6 +1366,38 @@ def _warm_row_alive(entry: MintState) -> bool:
     return _warm_mint.activation_is_live(int(entry.get("activation") or 0))
 
 
+def _shared_mints_pending() -> bool:
+    """True while any card still needs the shared process alive."""
+    return any(
+        entry.get("shared") and entry.get("state") in _LIVE_STATES for entry in _mints.values()
+    )
+
+
+async def _expire_shared_mints(reason: str, *, generation: int | None = None) -> list[str]:
+    """Flip live shared mints stale. Called when a process is gone.
+
+    ``generation`` is the only narrowing there is, and every caller passes it: the rows a
+    dead process can no longer redeem are exactly the ones it minted. A pass narrowed by
+    the CALLER's own row tokens instead used to exist here; it read as "spare my retry" but
+    meant "expire every other generation", which withdrew a parked generation's redeemable
+    URL. Withdrawal follows the verifier, so it follows the generation.
+    """
+    flipped: list[str] = []
+    async with _mints_lock:
+        for slug, entry in _mints.items():
+            if not entry.get("shared") or entry.get("state") not in _LIVE_STATES:
+                continue
+            if generation is not None and entry.get("generation") != generation:
+                continue
+            entry["state"] = "expired"
+            entry["reason"] = reason
+            await _dispose_mint(entry)
+            flipped.append(slug)
+    if flipped:
+        logger.info("Shared mint process gone; %d pending mint(s) flipped stale", len(flipped))
+    return flipped
+
+
 async def expire_dead_mints() -> list[str]:
     """Withdraw every shared row whose holding process is gone. THE chokepoint."""
     doomed: list[str] = []
@@ -119,3 +1414,320 @@ async def expire_dead_mints() -> list[str]:
     if doomed:
         logger.info("Withdrew %d approval URL(s) whose minting process is gone", len(doomed))
     return doomed
+
+
+async def _warm_activate() -> _WarmMintResult | None:
+    """Activate the shared process, surviving one death of it.
+
+    The death path does NOT expire anything itself. The stand-down inside ``mint_for`` --
+    reached only when the process is already gone -- has just run
+    ``_expire_shared_mints(generation=<the dead one>)`` through ``_kill_generation``, so the
+    rows whose verifier died are already withdrawn, scoped to that generation. A second,
+    unscoped pass here withdrew every other live shared row instead: a PARKED generation's
+    URL is still redeemable (its process holds the verifier and its session still answers
+    the redirect) and a concurrent batch's claims are another activation's to fill.
+
+    ``CancelledError`` is deliberately NOT caught: swallowing it would report a successful
+    stand-down to a caller that is being torn down. The caller releases its claims and
+    re-raises (see ``warm_mint_all``).
+    """
+    for attempt in range(_WARM_ACTIVATION_ATTEMPTS):
+        try:
+            return await _warm_mint.mint_for()
+        except _WarmMintDied as died:
+            last = attempt + 1 >= _WARM_ACTIVATION_ATTEMPTS
+            logger.warning(
+                "Shared mint process died mid-activation (%s); %s",
+                died.cause,
+                "falling back to the cold path" if last else "respawning it",
+            )
+        except Exception as exc:  # noqa: BLE001 — the process lives; degrade to cold
+            logger.warning(
+                "Shared mint activation failed on a live process (%s); "
+                "falling back to the cold path",
+                type(exc).__name__,
+            )
+            return None
+    return None
+
+
+async def _drain_parked_generations() -> None:
+    """Keep sweeping until no parked generation is left, then return.
+
+    A parked generation is a process kept alive ONLY because a card still holds one of its
+    URLs, so it can be retired the moment that card grants, cancels or times out -- and
+    ``sweep_retiring`` is the only thing that retires it. Every other route to that sweep
+    runs off a NEW mint (``mint_for``, or the reaper a fresh spawn creates), which is
+    precisely what the leak does not have: once the current process is gone and no further
+    Connect arrives, nothing calls it again and the parked process, its sessions and their
+    loopback servers stay resident indefinitely.
+
+    Returns immediately when nothing is parked, so the callers can invoke it unconditionally.
+    """
+    while _warm_mint.parked_count():
+        await asyncio.sleep(_MINT_GRANT_POLL_SECONDS)
+        await _warm_mint.sweep_retiring()
+        # A parked process can also die while parked, which withdraws its cards' URLs.
+        await expire_dead_mints()
+        async with _mints_lock:
+            in_use = _activations_in_use()
+        await _warm_mint.sweep_sessions(in_use)
+
+
+async def _warm_mint_reaper(generation: int) -> None:
+    """Retire the shared process once no card is waiting on it.
+
+    Outlives its own generation on the death path: standing the current process down does
+    not release the generations parked behind it, so the reaper drains those before it
+    returns (see :func:`_drain_parked_generations`).
+    """
+    idle_since = 0.0
+    try:
+        while True:
+            await asyncio.sleep(_MINT_GRANT_POLL_SECONDS)
+            await _warm_mint.sweep_retiring()
+            # Every generation, parked ones included: a card pointing at a process that is
+            # gone must not keep its URL until this reaper's own generation is the dead one.
+            await expire_dead_mints()
+            # Sessions outlive the rows that needed them on every path ending a mint without
+            # a new activation (grant, cancel, TTL). Collected here, not for the process life.
+            async with _mints_lock:
+                in_use = _activations_in_use()
+            await _warm_mint.sweep_sessions(in_use)
+            if not _warm_mint.is_alive():
+                await _expire_shared_mints("mint_process_gone", generation=generation)
+                await _drain_parked_generations()
+                return
+            if _shared_mints_pending():
+                idle_since = 0.0
+                continue
+            now = time.monotonic()
+            if idle_since == 0.0:
+                idle_since = now
+            elif now - idle_since >= _WARM_IDLE_GRACE_SECONDS:
+                logger.info("Retiring the idle shared mint process")
+                # Hard teardown, parked generations included -- so no drain is needed after.
+                await _warm_mint.shutdown()
+                return
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 — the reaper must never take the gateway down
+        logger.debug("warm mint reaper failed", exc_info=True)
+
+
+def _mint_is_cold_held(entry: MintState | None) -> bool:
+    """True when a dedicated client -- not the shared process -- holds this URL."""
+    return entry is not None and entry.get("state") == "waiting" and entry.get("client") is not None
+
+
+async def _claim_shared_mints(slugs: list[str]) -> tuple[dict[str, str], list[MintState]]:
+    """Claim ``slugs`` for the shared process. Returns ``({slug: row token}, displaced rows)``.
+
+    The token is the row's OWN identity and it is what every later step fences on. A batch
+    ``time.monotonic()`` reading cannot do that job: it has ~15.6ms granularity on Windows,
+    so two Connects for one provider inside a single tick read as the same row and a late
+    absorb writes its URL over the newer claim (see ``_new_mint_token``, which records the
+    same reasoning for the cold engine).
+
+    ATOMIC BY CONSTRUCTION: the loop contains NO await, so the caller either gets every
+    claim or none. It used to await ``_dispose_mint`` on each replaced row, which suspends
+    on a client teardown and again on the shielded spec removal in that function's
+    ``finally`` -- and the claim is taken BEFORE ``warm_mint_all`` enters the try that rolls
+    it back, so a cancellation there left earlier slugs installed as ``minting`` with no
+    caller holding their tokens. Nothing withdraws such a row (``expire_dead_mints`` judges
+    ``waiting`` only) and it keeps ``_shared_mints_pending`` true, so the process is never
+    retired either. The replaced rows come back for the caller to dispose INSIDE that try
+    instead -- which also puts the dispose outside the table lock, where the mint engine's
+    own rule wants it.
+    """
+    claimed: dict[str, str] = {}
+    displaced: list[MintState] = []
+    started = time.monotonic()
+    async with _mints_lock:
+        for slug in slugs:
+            prior = _mints.get(slug)
+            if _mint_is_cold_held(prior):
+                # A dedicated client owns this provider's verifier. Leave its URL on
+                # the card rather than replace a working link.
+                continue
+            if prior is not None:
+                # Hand it back, don't just drop it: the replaced row may own a watcher, and
+                # a watcher outliving its row expires the NEW mint on the OLD mint's
+                # deadline. Recorded only alongside the claim that displaced it, so a
+                # non-empty list always implies a non-empty claim set.
+                displaced.append(prior)
+            token = _new_mint_token()
+            _mints[slug] = {
+                "state": "minting",
+                # Informational only -- when the claim was taken. Never a fence.
+                "started": started,
+                "shared": True,
+                "token": token,
+            }
+            claimed[slug] = token
+    return claimed, displaced
+
+
+async def _dispose_displaced_rows(rows: list[MintState]) -> None:
+    """Release the holdings of the rows a claim replaced -- watcher, client, PID, spec.
+
+    Split out of the claim itself because it awaits: see ``_claim_shared_mints``. Called
+    from inside the caller's protected region, so a cancellation here rolls the claims back
+    rather than stranding them.
+    """
+    for row in rows:
+        await _dispose_mint(row)
+
+
+async def _release_shared_claims(claims: dict[str, str]) -> None:
+    """Drop unfulfilled claims so the card asks for a fresh mint.
+
+    Keyed on the row token, so a claim already superseded by a newer one at the same slug
+    is left alone rather than dropped out from under the activation now filling it.
+    """
+    async with _mints_lock:
+        for slug, token in claims.items():
+            entry = _mints.get(slug)
+            if entry is not None and entry.get("token") == token and entry.get("shared"):
+                await _dispose_mint(entry)
+                _mints.pop(slug, None)
+
+
+def _credential_bearing_slugs(urls: dict[str, str]) -> set[str]:
+    """The slugs in ``{slug: url}`` whose approval URL carries a credential.
+
+    The gate is :func:`~kiro_crew.security.oauth_url_contains_credential` -- the same
+    predicate the cold mint and the chat consent banner apply -- and it is synchronous
+    because it can consult the operator's on-disk OAuth-endpoint extension, an unbounded
+    stat on a network mount. Never returns or logs the value it judged.
+    """
+    return {slug for slug, url in urls.items() if url and oauth_url_contains_credential(url)}
+
+
+async def _absorb_warm_requests(result: _WarmMintResult, claims: dict[str, str]) -> list[str]:
+    """Move popped challenges into the mint table. Returns the slugs now waiting."""
+    popped = {
+        str(request.get("serverName") or ""): str(request.get("oauthUrl") or "")
+        for request in result.requests
+    }
+    # An activation names its challenges by the alias the SPEC mounted; the table is keyed by
+    # registry slug. Resolved once, here, so the screen and the store judge the same string.
+    resolved = {
+        slug: popped.get(mcp_server_alias(slug)) or popped.get(slug) or ""
+        for slug in (provider["slug"] for provider in result.providers)
+    }
+    minted: list[str] = []
+    unfulfilled: dict[str, str] = {}
+    tainted: set[str] = set()
+    try:
+        # Screened BEFORE the table lock: the verdict is a pure function of the URL, and the
+        # gate can read the operator's endpoint extension off disk. A refused URL never
+        # reaches the store, so no card can be handed one.
+        tainted = await asyncio.to_thread(_credential_bearing_slugs, resolved)
+        loop = asyncio.get_running_loop()
+        async with _mints_lock:
+            for provider in result.providers:
+                slug = provider["slug"]
+                token = claims.get(slug, "")
+                entry = _mints.get(slug)
+                if entry is None or not token or entry.get("token") != token:
+                    # Superseded while the activation ran. Its challenge stays alive in the
+                    # session that produced it and nothing points at it; the sweep collects
+                    # that session.
+                    continue
+                url = resolved.get(slug, "")
+                if not url or slug in tainted:
+                    # Released either way, not failed: the card asks for a fresh mint rather
+                    # than sitting on a claim nothing will ever fill.
+                    unfulfilled[slug] = token
+                    continue
+                entry.update(
+                    {
+                        "state": "waiting",
+                        "oauth_url": url,
+                        "generation": result.generation,
+                        "activation": result.activation,
+                        "watcher": loop.create_task(
+                            _mint_watcher(slug, provider["mcp_url"], token)
+                        ),
+                    }
+                )
+                minted.append(slug)
+    finally:
+        # Settlement on EVERY post-activation exit, which is why it is a ``finally``. The
+        # session was registered by ``_activate_locked`` before this function ran, and the
+        # sweep only ever collects a SETTLED session -- so a raise anywhere above (the
+        # screen's thread hop is a cancellation point, and the gate itself can fail on an
+        # unreadable file) would leave the session, and the loopback callback servers it
+        # owns, resident for the life of the process. The in-use snapshot is taken HERE,
+        # under the lock, so it reflects whatever the loop above actually installed rather
+        # than what it intended to.
+        async with _mints_lock:
+            in_use = _activations_in_use()
+        await _warm_mint.settle_activation(result.activation, in_use)
+    for slug in tainted:
+        logger.warning("Shared mint for %r produced a URL with a credential pattern", slug)
+        await asyncio.to_thread(
+            _log_warm_event, "connections_warm_mint_url", f"provider:{slug}", "refused"
+        )
+    if unfulfilled:
+        await _release_shared_claims(unfulfilled)
+    return minted
+
+
+async def warm_mint_all(providers: list[Provider] | None = None) -> list[str]:
+    """Warm every mintable provider's approval URL in ONE activation.
+
+    Returns the slugs now holding a URL. Never raises for a mint failure -- that leaves the
+    cards exactly as they were, asking for a mint. CANCELLATION does propagate, after the
+    claims are released.
+
+    The claim is taken BEFORE the process is ensured, because ensuring and activating are
+    one locked step (see ``mint_for``) and nothing may run between them. ``providers``
+    therefore only decides which rows are CLAIMED; what gets activated is the snapshot the
+    lock holder computes, so a claim the activation did not cover is released rather than
+    left minting forever.
+
+    ``POST /api/connections/premint`` passes the candidates it scanned, so an explicit
+    ``providers`` is the ordinary call shape; ``None`` re-scans for a caller that has no
+    list of its own.
+    """
+    candidates = (
+        await asyncio.to_thread(mintable_providers) if providers is None else list(providers)
+    )
+    if not candidates:
+        return []
+
+    claims, displaced = await _claim_shared_mints([provider["slug"] for provider in candidates])
+    if not claims:
+        # A displaced row is only ever recorded alongside the claim that displaced it, so an
+        # empty claim set means there is nothing to dispose either.
+        return []
+    try:
+        # Inside the protected region on purpose: this is the awaiting half of the claim, so
+        # a cancellation here must roll the whole claim set back rather than strand it.
+        await _dispose_displaced_rows(displaced)
+        result = await _warm_activate()
+        if result is None:
+            await _release_shared_claims(claims)
+            return []
+
+        minted = await _absorb_warm_requests(result, claims)
+        activated = {provider["slug"] for provider in result.providers}
+        stranded = {slug: token for slug, token in claims.items() if slug not in activated}
+        if stranded:
+            await _release_shared_claims(stranded)
+    except BaseException:
+        # BaseException, not Exception: a CancelledError landing between the claim and the
+        # activation would otherwise leave every row ``minting`` with no watcher and no
+        # activation. ``expire_dead_mints`` judges ``waiting`` rows only, so nothing would
+        # ever withdraw them -- and they keep ``_shared_mints_pending`` true, so the reaper
+        # never retires the process either. The release awaits to completion: a task is
+        # handed its cancellation once, so this cleanup runs before the raise resumes it.
+        await _release_shared_claims(claims)
+        raise
+    await asyncio.to_thread(
+        _log_warm_event, "connections_warm_mint", f"activated:{len(claims)} minted:{len(minted)}"
+    )
+    logger.info("Shared mint activation warmed %d of %d card(s)", len(minted), len(claims))
+    return minted

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -92,6 +92,7 @@ from kiro_crew.dashboard.handlers.connections import (  # noqa: E402, F401
     api_connections_disconnect,
     api_connections_mint,
     api_connections_mint_state,
+    api_connections_premint,
     api_connections_status,
     api_mcp_oauth_relay,
 )

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,11 +12,14 @@ from urllib.parse import parse_qs, urlsplit
 
 from aiohttp import web
 
+from kiro_crew import hooks
 from kiro_crew.connections import get_provider
 from kiro_crew.connections.ownership import remove_provider_entry
 from kiro_crew.connections.registry import Provider
 from kiro_crew.dashboard.handlers.mcp import _is_valid_mcp_name
 from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
 
 _MAX_RETURN_ADDRESS_BYTES = 8192
 _MAX_REQUEST_TARGET_BYTES = 6144
@@ -259,6 +263,16 @@ async def api_mcp_oauth_relay(request: web.Request) -> web.Response:
 
 # Fire-and-forget mint tasks, held so the loop cannot collect one mid-flight.
 _mint_tasks: set[asyncio.Task] = set()
+
+# The same keepalive for the premint activation, kept separate so a page open cannot
+# be mistaken for a card-initiated mint when either set is inspected.
+_premint_tasks: set[asyncio.Task] = set()
+
+#: SEL read-id for the grant observation the premint endpoint acts on. Distinct from
+#: the mint engine's and the status module's ids so the trail says which surface
+#: looked; registered in ``hooks._AUDIT_ONLY_READ_IDS``, which fail-closes on an
+#: unregistered id and would record nothing.
+_GRANT_PRESENCE_READ_ID = "connections_premint.oauth_grant_presence"
 
 
 def _requested_provider(slug: str) -> Provider | None:
@@ -586,3 +600,91 @@ async def api_connections_disconnect(request: web.Request) -> web.Response:
             "grantCensusUnreadable": list(scope.census_unreadable),
         }
     )
+
+
+async def api_connections_premint(request: web.Request) -> web.Response:
+    """POST /api/connections/premint — warm every mintable provider's URL in one activation.
+
+    The page fires this once on mount, ahead of any click, so that a Connect
+    serves a URL the warm table already holds instead of paying a cold spawn.
+    Takes no body: what is mintable is a fact about the user's registry and grant
+    state, never a caller's choice, and the bound on what may be spawned has to
+    stay on this side of the wire.
+
+    ``preminting`` names the providers warming was STARTED for, which is why the
+    response can precede any of them holding a URL. Warming one provider costs
+    seconds and the whole activation is a single shared process, so awaiting it
+    would stall the page's first paint for the sake of a report the card already
+    gets from its own mint feed. A slug reported here can still end up without a
+    URL -- the activation snapshot is the engine's to compute -- so the card's
+    verdict remains the mint state, not this list.
+    """
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    # Owner-gated for the same reason as the mint POST: warming spawns a kiro-cli
+    # process, so the caller has to be the owner rather than merely authenticated.
+    owner_denied = await require_owner_dashboard_request(request, "connections_premint")
+    if owner_denied is not None:
+        return owner_denied
+
+    # Function-local by DESIGN, not for a cycle: the handlers package is imported on
+    # the gateway boot path, and the warm engine imports the cold mint at module
+    # scope then adds the ACP runtime and the MCP inventory on top -- the heaviest
+    # half of Connections. test_the_handlers_package_does_not_import_the_warm_engine
+    # enforces it in a subprocess; hoisting this to module scope turns that red.
+    from kiro_crew.connections.warm import mintable_providers, warm_mint_all
+
+    # Off the loop: the scan reads the user's MCP config and stats kiro-cli's OAuth
+    # artifact directory, either of which can sit on a network mount where a stat is
+    # unbounded. warm.py routes the same call through a thread for this reason and
+    # pins it with a drift guard.
+    candidates = await asyncio.to_thread(mintable_providers)
+    slugs = [str(provider["slug"]) for provider in candidates]
+    if not slugs:
+        # Nothing to warm: an activation with an empty claim set would spawn a
+        # process, pay the fixed activation cost and hold nothing. Nothing was acted
+        # on either, so the scan owes no audit -- see below.
+        return web.json_response({"ok": True, "preminting": []})
+
+    # The credential-store observation this endpoint ACTS on: the scan above stats
+    # kiro-cli's OAuth artifacts per provider, and reaching this line means the answer
+    # is about to spawn a warm activation. ONE event for the whole sweep, matching
+    # ``connections.status``: a single scan pass yields N answers but exactly one act
+    # decision, so per-candidate events would over-count one observation, and the
+    # per-URL ``mcp_grant.grant_observed`` wrapper would additionally have to break the
+    # scan's synchronous shape that warm.py pins with a drift guard.
+    #
+    # Off the loop because the entry point marks its events critical, which drains the
+    # SEL queue synchronously -- the same reason the log_api_access calls here are
+    # threaded. Best-effort, NOT fail-closed: the artifacts are stat-ed and never
+    # opened, so no credential material crosses this boundary, and refusing to warm on
+    # an SEL outage would make every Connect pay a cold spawn instead. An unaudited
+    # boolean is the lesser failure, and it leaves a warning behind.
+    if not await asyncio.to_thread(
+        hooks.emit_internal_read_audit, _GRANT_PRESENCE_READ_ID, "success"
+    ):
+        logger.warning(
+            "grant-presence audit for the premint scan could not be recorded; "
+            "proceeding unaudited"
+        )
+
+    # The candidates are PASSED rather than re-derived inside the engine, so the
+    # claim set and this response come from one scan. Two independent scans can
+    # disagree -- a consent completing between them drops a provider -- and the
+    # response would then name a slug nothing ever claimed.
+    task = asyncio.create_task(warm_mint_all(candidates))
+    _premint_tasks.add(task)
+    task.add_done_callback(_premint_tasks.discard)
+
+    # Off the loop for the same reason as api_connections_mint: this handler can be
+    # the first state-changing request a fresh gateway serves, and the FIRST sel()
+    # of a process constructs the log.
+    await asyncio.to_thread(
+        lambda: sel().log_api_access(
+            caller="dashboard",
+            operation="connections_premint",
+            outcome="started",
+            resources=f"providers:{len(slugs)}",
+        )
+    )
+    return web.json_response({"ok": True, "preminting": slugs})

--- a/src/kiro_crew/dashboard/routes/agent_config.py
+++ b/src/kiro_crew/dashboard/routes/agent_config.py
@@ -78,6 +78,7 @@ def register(app: web.Application) -> None:
     app.router.add_post("/api/mcp/oauth/relay", handlers.api_mcp_oauth_relay)
     app.router.add_post("/api/connections/mint", handlers.api_connections_mint)
     app.router.add_get("/api/connections/mint", handlers.api_connections_mint_state)
+    app.router.add_post("/api/connections/premint", handlers.api_connections_premint)
     app.router.add_get("/api/connections/status", handlers.api_connections_status)
     app.router.add_post("/api/connections/cancel", handlers.api_connections_cancel)
     app.router.add_post("/api/connections/disconnect", handlers.api_connections_disconnect)

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -3005,6 +3005,23 @@ _AUDIT_ONLY_READ_IDS: dict[str, str] = {
     # ``status.reconcile_connected_since`` for why that boundary is
     # best-effort rather than fail-closed (stats only, no bytes returned).
     "connections_status.oauth_grant_presence": ".aws/sso/cache/<sha256(mcp_url)>.token.json",
+    # Class 2, same artifacts and same posture again: the premint endpoint
+    # (``dashboard.handlers.connections.api_connections_premint``) reaches the warm
+    # engine's candidate scan, which STATS the paired grant artifacts for every
+    # registry provider to decide which ones still need a URL minted.
+    #
+    # A separate id from the mint's and the status module's, so the trail names the
+    # surface that looked. ONE event per activation rather than one per candidate:
+    # the scan is a single pass whose N answers feed exactly one act decision (spawn
+    # the shared warm process, or do not), so per-candidate events would over-count
+    # one observation and, because this entry point marks its events critical, drain
+    # the queue N times for a single page mount. Audited only when the endpoint ACTS
+    # -- an empty candidate set returns early without spawning, persisting, or
+    # reporting any grant answer, so a page mounted against a fully-authorized
+    # gallery writes nothing. Best-effort rather than fail-closed for the same reason
+    # as the two entries above (stats only, no bytes returned); see
+    # ``api_connections_premint`` for why refusing would be the worse failure.
+    "connections_premint.oauth_grant_presence": ".aws/sso/cache/<sha256(mcp_url)>.token.json",
 }
 
 

--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -787,6 +787,10 @@ _EXPECTED_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
         ("connections_mint", "dashboard"),
         ("connections_mint", "dashboard"),
     ],
+    "kiro_crew/connections/warm.py": [
+        ("connections_warm_mint", "dashboard"),
+        ("connections_warm_mint", "dashboard"),
+    ],
     "kiro_crew/context.py": [("steering_resources", "unknown")],
     "kiro_crew/cron_script.py": [("cron_resolve_mcp_server", "cron")],
     "kiro_crew/dashboard/handlers/agents.py": [

--- a/test/test_connections_premint.py
+++ b/test/test_connections_premint.py
@@ -1,0 +1,327 @@
+"""Premint endpoint tests: the route, the report it makes, and what it must not wait for.
+
+``POST /api/connections/premint`` is the warm engine's only request-path caller. Its
+contract is narrow -- ``{"ok": true, "preminting": [<slug>, ...]}`` -- and the whole point
+is that the slugs are reported BEFORE any provider process exists, so the tests here pin
+the non-blocking property directly rather than trusting the handler's shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
+
+from kiro_crew.connections.registry import Provider
+from kiro_crew.dashboard.handlers import connections
+
+
+def _provider(slug: str) -> Provider:
+    return {  # type: ignore[typeddict-item]
+        "slug": slug,
+        "mcp_url": f"https://{slug}.example/mcp",
+        "l0_expectations": {"dcr": True},
+    }
+
+
+async def _client() -> TestClient:
+    app = web.Application()
+    app.router.add_post("/api/connections/premint", connections.api_connections_premint)
+    as_owner(app)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+@pytest.fixture
+def warm_engine(monkeypatch: pytest.MonkeyPatch):
+    """Stub the warm engine's two entry points. NEVER a real provider spawn.
+
+    Patched on the engine module, which is the namespace the handler's
+    function-local import resolves against -- patching a name on the handler
+    module would miss, and the real activation would spawn kiro-cli.
+    """
+    from kiro_crew.connections import warm
+
+    calls: dict[str, object] = {"warmed": None, "invocations": 0}
+    candidates: list[Provider] = [_provider("linear"), _provider("vercel")]
+
+    async def _warm_mint_all(providers: list[Provider] | None = None) -> list[str]:
+        calls["invocations"] = int(calls["invocations"]) + 1
+        calls["warmed"] = providers
+        return [str(provider["slug"]) for provider in providers or []]
+
+    monkeypatch.setattr(warm, "mintable_providers", lambda: list(candidates))
+    monkeypatch.setattr(warm, "warm_mint_all", _warm_mint_all)
+    calls["candidates"] = candidates
+    return calls
+
+
+async def _premint(client: TestClient) -> tuple[int, dict]:
+    resp = await client.post("/api/connections/premint")
+    return resp.status, await resp.json()
+
+
+# ── the wire contract ──
+
+
+@pytest.mark.asyncio
+async def test_premint_reports_every_mintable_provider(warm_engine):
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body == {"ok": True, "preminting": ["linear", "vercel"]}
+
+
+@pytest.mark.asyncio
+async def test_premint_drives_the_warm_engine_with_the_slugs_it_reported(warm_engine):
+    """The response and the claim set come from ONE registry scan, not two.
+
+    The handler passes the candidates it just scanned rather than letting the engine
+    re-scan: two independent scans can disagree (a consent completing between them
+    drops a provider), and the response would then name a slug nothing claimed.
+    """
+    client = await _client()
+    try:
+        _status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    # The task is fired, not awaited, so give the loop one pass to start it.
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 1
+    warmed = warm_engine["warmed"]
+    assert warmed is not None
+    assert [str(provider["slug"]) for provider in warmed] == body["preminting"]
+
+
+@pytest.mark.asyncio
+async def test_premint_with_no_eligible_provider_warms_nothing(
+    monkeypatch: pytest.MonkeyPatch, warm_engine
+):
+    """An empty candidate set must not activate a process to warm nothing."""
+    from kiro_crew.connections import warm
+
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [])
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body == {"ok": True, "preminting": []}
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 0
+
+
+@pytest.mark.asyncio
+async def test_premint_answers_before_the_activation_settles(
+    monkeypatch: pytest.MonkeyPatch, warm_engine
+):
+    """The page fires this on mount; an activation costs seconds, so it cannot be awaited.
+
+    A handler that awaited the engine would hang here for the whole test timeout
+    instead of answering, which is exactly the regression this pins.
+    """
+    from kiro_crew.connections import warm
+
+    released = asyncio.Event()
+    started = asyncio.Event()
+
+    async def _never_settles(providers: list[Provider] | None = None) -> list[str]:
+        started.set()
+        await released.wait()
+        return []
+
+    monkeypatch.setattr(warm, "warm_mint_all", _never_settles)
+    client = await _client()
+    try:
+        status, body = await asyncio.wait_for(_premint(client), timeout=5)
+        assert status == 200
+        assert body["preminting"] == ["linear", "vercel"]
+        # The engine really was entered -- the response overtook it rather than the
+        # handler having skipped the call altogether.
+        await asyncio.wait_for(started.wait(), timeout=5)
+    finally:
+        released.set()
+        await client.close()
+
+
+# ── the gate ──
+
+
+@pytest.mark.asyncio
+async def test_premint_is_owner_gated(warm_engine):
+    """Same gate as the sibling POSTs: warming spawns a kiro-cli process."""
+    client = await _client()
+    try:
+        resp = await client.post(
+            "/api/connections/premint", headers={"X-Test-User": "someone-else"}
+        )
+        assert resp.status in (401, 403)
+        body = await resp.json()
+    finally:
+        await client.close()
+    assert body.get("code")
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 0
+
+
+# ── the acted-on grant observation is SEL-audited ──
+
+
+def test_the_premint_read_id_is_registered_with_the_audit_gate():
+    """``emit_internal_read_audit`` fail-closes on an unregistered read_id, and the
+    audit tests below monkeypatch the hook, so only this un-mocked check can catch a
+    registration gap that silently disables the audit."""
+    from kiro_crew import hooks
+
+    assert connections._GRANT_PRESENCE_READ_ID in hooks._AUDIT_ONLY_READ_IDS
+
+
+@pytest.mark.asyncio
+async def test_premint_audits_the_grant_observation_it_acts_on(warm_engine, monkeypatch):
+    """The scan stats kiro-cli's OAuth artifacts and this handler SPAWNS on the answer.
+
+    One event per activation, not one per candidate: the scan is a single pass that
+    yields N candidates and exactly one act decision, so N events would over-count one
+    observation.
+    """
+    from kiro_crew import hooks
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        hooks,
+        "emit_internal_read_audit",
+        lambda read_id, outcome: (calls.append((read_id, outcome)), True)[1],
+    )
+
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body["preminting"] == ["linear", "vercel"]
+    assert calls == [(connections._GRANT_PRESENCE_READ_ID, "success")]
+
+
+@pytest.mark.asyncio
+async def test_premint_still_warms_when_the_audit_cannot_be_recorded(
+    warm_engine, monkeypatch, caplog
+):
+    """Best-effort, not fail-closed: the artifacts are stat-ed, never opened.
+
+    Denying here would turn an SEL outage into a page that pays a cold spawn on every
+    Connect, so an unaudited boolean is the lesser failure -- and it leaves a warning.
+    """
+    from kiro_crew import hooks
+
+    monkeypatch.setattr(hooks, "emit_internal_read_audit", lambda read_id, outcome: False)
+
+    client = await _client()
+    try:
+        with caplog.at_level(logging.WARNING, logger=connections.__name__):
+            status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body["preminting"] == ["linear", "vercel"]
+    # The activation is not gated on the trail.
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 1
+    assert any(
+        "proceeding unaudited" in record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    )
+
+
+@pytest.mark.asyncio
+async def test_premint_with_no_candidates_audits_nothing(warm_engine, monkeypatch):
+    """An empty scan is not an acted-on observation, so it owes no trail.
+
+    Same rule as ``connections.status``: the event records the observation a caller
+    ACTS on. Here the handler returns early -- no process is spawned, nothing is
+    persisted, and no grant answer reaches the user -- so a page mounted against a
+    fully-authorized gallery must not write an event on every poll.
+    """
+    from kiro_crew import hooks
+    from kiro_crew.connections import warm
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        hooks,
+        "emit_internal_read_audit",
+        lambda read_id, outcome: (calls.append((read_id, outcome)), True)[1],
+    )
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [])
+
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body == {"ok": True, "preminting": []}
+    assert calls == []
+
+
+# ── the route is reachable, not merely defined ──
+
+
+def test_the_premint_route_is_wired_into_the_dashboard():
+    """A handler the route table never registers is unreachable from the page."""
+    from kiro_crew.dashboard.routes import agent_config
+
+    app = web.Application()
+    agent_config.register(app)
+    wired = {
+        (route.method, route.resource.canonical)
+        for route in app.router.routes()
+        if route.resource is not None
+    }
+    assert ("POST", "/api/connections/premint") in wired
+
+
+# ── the boot path stays free of the engine ──
+
+
+def test_the_handlers_package_does_not_import_the_warm_engine():
+    """The gateway imports the handlers package at boot; the warm engine must not ride along.
+
+    The warm engine imports the cold mint at module scope and adds the ACP runtime and the
+    MCP inventory on top, so a module-scope import in the premint handler would put the
+    heaviest half of Connections on every gateway start. Run in a subprocess because this
+    test module reaches the engine directly, so an in-process ``sys.modules`` check would
+    always find it.
+    """
+    probe = (
+        "import sys; import kiro_crew.dashboard.handlers;"
+        " leaked = [m for m in ('kiro_crew.connections.warm', 'kiro_crew.connections.mint')"
+        " if m in sys.modules];"
+        " print('LEAKED:' + ','.join(leaked) if leaked else 'CLEAN')"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=180,
+    )
+    assert out.returncode == 0, out.stderr[-2000:]
+    assert out.stdout.strip().endswith("CLEAN"), out.stdout

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -1,11 +1,26 @@
-"""Warm-table tests: the row-liveness registry and the withdrawal chokepoint."""
+"""Warm-mint tests: the spec plan and its files, the row-liveness registry, the chokepoint."""
 
 from __future__ import annotations
 
-import pytest
+import ast
+import asyncio
+import inspect
+import json
+import logging
+import textwrap
+import time
+from pathlib import Path
+from typing import Any
 
-from kiro_crew.connections import warm
+import pytest
+from test_connections_mint import _FS_ATTRS, _FS_NAMES, _called_names
+
+from conftest import requires_symlinks
+from kiro_crew import security
+from kiro_crew.agent_files import AGENT_FILENAME
+from kiro_crew.connections import tool_aliases, warm
 from kiro_crew.connections.mint import _mints
+from kiro_crew.connections.registry import Provider
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +28,60 @@ def _clean_mint_table():
     _mints.clear()
     yield
     _mints.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_warm_runtime():
+    """Restore the module-level ``_warm_mint`` singleton around every test.
+
+    The engine is a module singleton, so a test that drives ``_ensure_locked`` all the way to
+    a successful spawn leaves a live runtime, a matching spec digest and a sleeping reaper on
+    it -- and ``monkeypatch`` cannot undo state it never patched. A later test then reads its
+    neighbour's process, which is one leak wearing three faces: the digest fast path returns
+    before the test's own factory is ever constructed (no ``CancelledError`` raised, no kill
+    recorded), a stand-down kills the neighbour's runtime first and inflates the kill count,
+    and ``_park_or_kill_locked`` cancels a reaper task whose loop has since closed, which is
+    a ``RuntimeError: Event loop is closed``. Which face appears depends only on which tests
+    share a worker, so it moves whenever the file gains or loses a test.
+
+    The containers are copied, not aliased: a test that appends to ``_retiring`` in place
+    would otherwise leave the mutation behind in the very object being restored.
+
+    ``_lock`` is reset to a FRESH lock rather than restored, because an ``asyncio.Lock``
+    binds to the loop that first has to wait on it: the uncontended fast path never calls
+    ``_get_loop``, so today's tests pass, but the first CONTENDED acquire in a later test's
+    loop raises ``RuntimeError: ... is bound to a different event loop``. A new lock per test
+    cannot carry a dead loop into the next one.
+    """
+    tracked = (
+        "_runtime",
+        "_plan",
+        "_digest",
+        "_generation",
+        "_retiring",
+        "_sessions",
+        "_activation_seq",
+        "_reaper",
+    )
+    saved: dict[str, Any] = {name: getattr(warm._warm_mint, name) for name in tracked}
+    saved["_retiring"] = list(saved["_retiring"])
+    saved["_sessions"] = dict(saved["_sessions"])
+    warm._warm_mint._lock = asyncio.Lock()
+    yield
+    reaper = warm._warm_mint._reaper
+    if reaper is not None and reaper is not saved["_reaper"] and not reaper.done():
+        try:
+            # Cancelled HERE, while the loop that owns it is still this test's. Cancelling it
+            # from a later test's loop is the "Event loop is closed" face above, not the cure.
+            reaper.cancel()
+        except RuntimeError:
+            # The loop is already gone; dropping the reference below is what matters.
+            pass
+    for name, value in saved.items():
+        setattr(warm._warm_mint, name, value)
+    # Fresh again on the way out: a lock left bound to THIS test's loop is exactly what the
+    # next test must not inherit.
+    warm._warm_mint._lock = asyncio.Lock()
 
 
 class _Runtime:
@@ -128,3 +197,2476 @@ async def test_a_row_whose_process_and_session_both_live_keeps_its_url(
     }
     assert await warm.expire_dead_mints() == []
     assert _mints["linear"]["state"] == "waiting"
+
+
+def _provider(slug: str, url: str = "") -> Provider:
+    return {  # type: ignore[typeddict-item]
+        "slug": slug,
+        "mcp_url": url or f"https://{slug}.example/mcp",
+        "l0_expectations": {"dcr": True},
+    }
+
+
+# ── the loop/filesystem invariant (mirrors the mint engine's own guard) ──
+#
+# Reuses the mint guard's primitive sets so the two cannot drift apart, plus the names that
+# reach the filesystem only from THIS module: the MCP inventory read, the grant stat, and the
+# credential gate -- which consults the operator's on-disk OAuth-endpoint extension for any
+# host outside the builtin set, so it is an unbounded stat like the rest.
+_WARM_FS_NAMES = _FS_NAMES | {"list_servers", "grant_present", "oauth_url_contains_credential"}
+
+
+def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
+    tree = ast.parse(inspect.getsource(warm))
+    sync: dict[str, Any] = {}
+    coros: dict[str, Any] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            sync[node.name] = node
+        elif isinstance(node, ast.AsyncFunctionDef):
+            coros[node.name] = node
+    assert sync and coros, "module shape changed; this guard is reading the wrong tree"
+
+    touches = {
+        name: bool(_called_names(node) & (_FS_ATTRS | _WARM_FS_NAMES))
+        for name, node in sync.items()
+    }
+    changed = True
+    while changed:
+        changed = False
+        for name, node in sync.items():
+            if touches[name]:
+                continue
+            if any(touches.get(callee) for callee in _called_names(node)):
+                touches[name] = changed = True
+    fs_helpers = {name for name, hit in touches.items() if hit}
+    # The known set, so a helper silently losing its filesystem work -- and with it
+    # this guard's coverage -- is visible rather than a quietly weaker test.
+    assert fs_helpers == {
+        "_log_warm_event",
+        "_disabled_provider_slugs",
+        "warm_spec_providers",
+        "_warm_activation_candidates",
+        "_warm_candidate_scan",
+        "mintable_providers",
+        "_warm_spec_plan",
+        "_warm_spec_is_foreign",
+        "_unowned_plan_specs",
+        "_write_warm_mint_specs",
+        "_remove_warm_mint_specs",
+        "_warm_work_dir",
+        "_credential_bearing_slugs",
+    }
+
+    offenders = {
+        f"{coro} -> {callee}"
+        for coro, node in coros.items()
+        for callee in _called_names(node) & (fs_helpers | _FS_ATTRS | _WARM_FS_NAMES)
+    }
+    assert not offenders, (
+        "filesystem work on the event loop: "
+        + ", ".join(sorted(offenders))
+        + " -- route it through asyncio.to_thread"
+    )
+
+
+# ── defect: tool-alias key shape ──
+#
+# The resolver de-collides by registry SLUG and keys ``@slug/tool``, but a warm spec mounts
+# servers under ``mcp_server_alias(slug)``. Where the two differ a slug-keyed entry names a
+# server the spec never mounted, so kiro-cli applies no rename and the collision returns.
+
+
+@pytest.fixture
+def _slash_bearing_registry(monkeypatch: pytest.MonkeyPatch):
+    """Two providers whose slugs contain a slash, so slug and mounted alias differ."""
+    declared = {
+        "ns/alpha": {"shared_tool": "alpha_shared_tool"},
+        "ns/beta": {"shared_tool": "beta_shared_tool"},
+    }
+    monkeypatch.setattr(tool_aliases, "declared_tool_aliases", lambda: declared)
+    monkeypatch.setattr(warm, "declared_tool_aliases", lambda: declared)
+    return declared
+
+
+def test_alias_keys_name_the_server_the_spec_actually_mounts(_slash_bearing_registry):
+    """RED before the re-key: the emitted keys were ``@ns/alpha/...``, a server the
+    spec -- which mounts ``ns-alpha`` -- never declared, so no rename applied."""
+    aliases = warm.connections_tool_aliases(["ns-alpha", "ns-beta"])
+    assert aliases == {
+        "@ns-alpha/shared_tool": "alpha_shared_tool",
+        "@ns-beta/shared_tool": "beta_shared_tool",
+    }
+    mounted = {"ns-alpha", "ns-beta"}
+    assert {key.lstrip("@").rpartition("/")[0] for key in aliases} == mounted
+
+
+def test_the_spec_a_warm_plan_writes_only_mounts_aliased_servers(_slash_bearing_registry):
+    body = warm._warm_spec_body(
+        "probe", {"ns-alpha": {"url": "https://a"}, "ns-beta": {"url": "https://b"}}, "probe"
+    )
+    assert set(body["toolAliases"]) <= {f"@{alias}/shared_tool" for alias in body["mcpServers"]}
+
+
+# ── defect: alias semantics are #3260's, not the pre-#3260 first-server rule ──
+#
+# The draft asserted that the FIRST mounted server keeps the bare name and only later ones are
+# renamed. #3260 shipped rename-EVERY-claimant, slug-keyed: when two mounted servers claim a
+# tool, both are renamed and neither keeps the bare name.
+
+
+def test_every_claimant_of_a_collision_is_renamed_not_just_the_later_one():
+    aliases = warm.connections_tool_aliases(["linear", "vercel"])
+    assert aliases == {
+        "@linear/get_project": "linear_get_project",
+        "@linear/list_projects": "linear_list_projects",
+        "@linear/list_teams": "linear_list_teams",
+        "@vercel/get_project": "vercel_get_project",
+        "@vercel/list_projects": "vercel_list_projects",
+        "@vercel/list_teams": "vercel_list_teams",
+    }
+    # Tools only one of the mounted pair declares keep their natural names.
+    assert not any(key.endswith(("list_issues", "get_issue")) for key in aliases)
+
+
+def test_a_single_mounted_provider_needs_no_aliases():
+    assert warm.connections_tool_aliases(["linear"]) == {}
+    assert warm.connections_tool_aliases(["vercel"]) == {}
+
+
+def test_a_warm_spec_declares_tool_aliases_only_when_a_collision_is_mounted():
+    single = warm._warm_spec_body("m", {"vercel": {"url": "https://v"}}, "probe")
+    assert "toolAliases" not in single
+    both = warm._warm_spec_body(
+        "m", {"linear": {"url": "https://l"}, "vercel": {"url": "https://v"}}, "probe"
+    )
+    assert both["toolAliases"]["@linear/list_teams"] == "linear_list_teams"
+    assert both["toolAliases"]["@vercel/list_teams"] == "vercel_list_teams"
+
+
+# ── spec sweep: never unlink a live COLD mint's spec ──
+
+
+def test_the_warm_sweep_refuses_a_cold_mint_spec_that_shares_the_prefix():
+    """A cold spec for a server named ``warm-*`` matches the warm prefix. Deleting it
+    would strand a user mid-consent, so the cold ``-<pid>-<8hex>`` shape is refused --
+    including a MIXED-CASE alias, which only a shared character class catches."""
+    for cold in ("kirocrew-mint-warm-foo-4821-9ab3c1de", "kirocrew-mint-warm-Foo-4821-9ab3c1de"):
+        assert warm._is_stale_warm_spec(cold, frozenset()) is False
+
+
+def test_the_warm_sweep_drops_a_warm_spec_absent_from_the_plan_and_keeps_the_rest():
+    assert warm._is_stale_warm_spec("kirocrew-mint-warm-notion", frozenset()) is True
+    assert (
+        warm._is_stale_warm_spec(
+            "kirocrew-mint-warm-notion", frozenset({"kirocrew-mint-warm-notion"})
+        )
+        is False
+    )
+    assert warm._is_stale_warm_spec("some-user-agent", frozenset()) is False
+
+
+# ── defect: the sweep trusted a NAME, so it deleted and overwrote files it never wrote ──
+#
+# Warm spec names are FIXED and predictable (``kirocrew-mint-warm-<alias>``), and they live in
+# the user's own agents directory alongside the agents they hand-write. Name shape alone made
+# every such path fair game: a user's agent spec sitting at one was unlinked by the sweep and
+# clobbered by the write. Ownership is now proved from the file's CONTENTS, and a path that
+# cannot be proved ours is left exactly as it is -- audited and skipped, never raised.
+
+
+@pytest.fixture
+def _agents_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """An isolated agents directory, through the module's own override hook."""
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    monkeypatch.setattr(warm._agent, "KIRO_AGENTS_DIR", agents)
+    monkeypatch.setattr(warm, "_log_warm_event", lambda *a, **k: None)
+    return agents
+
+
+def _foreign_spec(agents: Path, stem: str) -> tuple[Path, str]:
+    """A user's OWN agent spec, planted at a path a warm plan would claim."""
+    path = agents / f"{stem}.json"
+    body = json.dumps(
+        {
+            "name": "my-own-research-agent",
+            "description": "hand-written by the user",
+            "prompt": "You are my research agent.",
+            "mcpServers": {"private": {"command": "my-server"}},
+            "allowedTools": ["@private"],
+        },
+        indent=2,
+    )
+    path.write_text(body, encoding="utf-8")
+    return path, body
+
+
+def test_the_sweep_refuses_to_unlink_a_foreign_file_at_a_warm_spec_path(_agents_dir: Path):
+    """RED before the ownership check: ``_is_stale_warm_spec`` matched the NAME, so the
+    write-time sweep unlinked a user's own agent spec that happened to sit there."""
+    planted, body = _foreign_spec(_agents_dir, "kirocrew-mint-warm-notion")
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+
+    assert planted.is_file(), "the sweep deleted a file no warm plan ever wrote"
+    assert planted.read_text(encoding="utf-8") == body
+
+
+# ── defect: the ownership marks alone are GENERIC DEFAULTS, so a mimic passed as ours ──
+#
+# `model: "auto"`, `includeMcpJson: false`, `prompt: ""` and `allowedTools: []` are stock
+# values any hand-written or scaffolded agent plausibly carries, so name-plus-marks judged a
+# wholly user-authored spec at a warm path as ours and clobbered it. That falsified the claim
+# that CONTENTS prove ownership. A sentinel prefix on the description is what discriminates.
+
+
+def _mimic_spec(agents: Path, stem: str) -> tuple[Path, str]:
+    """A user's own spec at a warm path that COPIES every generic default we fix.
+
+    Everything the user actually authored -- description, mcpServers, tools -- is theirs;
+    only the four stock marks and the name coincide with ours.
+    """
+    path = agents / f"{stem}.json"
+    body = json.dumps(
+        {
+            "name": stem,
+            "description": "my own scratch agent that happens to sit here",
+            "model": "auto",
+            "includeMcpJson": False,
+            "prompt": "",
+            "mcpServers": {"private": {"command": "my-server"}},
+            "tools": ["@private"],
+            "allowedTools": [],
+        },
+        indent=2,
+    )
+    path.write_text(body, encoding="utf-8")
+    return path, body
+
+
+def test_a_mimic_carrying_only_our_generic_defaults_survives_the_write(_agents_dir: Path):
+    """RED before the sentinel: name plus four stock defaults read as ours, so the write
+    clobbered a spec whose description, mcpServers and tools were entirely the user's."""
+    planted, body = _mimic_spec(_agents_dir, warm._WARM_BASE_AGENT)
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+
+    assert planted.read_text(encoding="utf-8") == body, "the write clobbered a mimic"
+
+
+def test_a_mimic_carrying_only_our_generic_defaults_survives_sweep_and_teardown(
+    _agents_dir: Path,
+):
+    """RED before the sentinel: the same mimic at a path no plan wants was unlinked by both
+    the write-time sweep and teardown."""
+    planted, body = _mimic_spec(_agents_dir, "kirocrew-mint-warm-notion")
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    assert planted.is_file(), "the sweep deleted a mimic"
+
+    warm._remove_warm_mint_specs()
+
+    assert planted.is_file(), "teardown deleted a mimic"
+    assert planted.read_text(encoding="utf-8") == body
+
+
+def test_the_judge_reads_a_mimic_as_foreign_and_our_own_writer_output_as_ours(
+    _agents_dir: Path,
+):
+    """The predicate itself, so the discriminator is pinned independently of the callers."""
+    mimic, _ = _mimic_spec(_agents_dir, "kirocrew-mint-warm-mimic")
+    assert warm._warm_spec_is_foreign(mimic) is True
+
+    ours = _agents_dir / "kirocrew-mint-warm-ours.json"
+    ours.write_text(
+        json.dumps(warm._warm_spec_body("kirocrew-mint-warm-ours", {}, "probe")),
+        encoding="utf-8",
+    )
+    assert warm._warm_spec_is_foreign(ours) is False
+
+
+@requires_symlinks
+def test_a_dangling_symlink_at_the_spec_path_reads_as_foreign(_agents_dir: Path):
+    """A dangling link resolves to nothing, so ``exists()`` alone reports the path free and
+    the writer would replace the link (the sweep would unlink it) -- destroying a path
+    occupant this module does not own. The occupied verdict keeps every write and unlink
+    away from it."""
+    planted = _agents_dir / "kirocrew-mint-warm-notion.json"
+    planted.symlink_to(_agents_dir / "nowhere" / "target.json")
+
+    assert warm._warm_spec_is_foreign(planted) is True
+
+
+def test_every_spec_a_warm_plan_writes_carries_the_ownership_sentinel(_agents_dir: Path):
+    """Whole-plan coverage: the base spec and the all-providers spec alike."""
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+
+    written = list(_agents_dir.glob(f"{warm._WARM_AGENT_PREFIX}*.json"))
+    assert written
+    for path in written:
+        body = json.loads(path.read_text(encoding="utf-8"))
+        assert body["description"].startswith(warm._WARM_SPEC_SENTINEL)
+        assert warm._warm_spec_is_foreign(path) is False
+
+
+def test_the_write_refuses_to_clobber_a_foreign_file_at_a_planned_spec_path(_agents_dir: Path):
+    """RED before the ownership check: the write was unconditional, so a user's file at a
+    path the CURRENT plan wants was overwritten rather than skipped."""
+    planted, body = _foreign_spec(_agents_dir, warm._WARM_BASE_AGENT)
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+
+    assert planted.read_text(encoding="utf-8") == body, "the write clobbered a foreign file"
+
+
+def test_the_teardown_refuses_to_unlink_a_foreign_file_at_a_warm_spec_path(_agents_dir: Path):
+    """RED before the ownership check: teardown swept the whole warm glob by name."""
+    planted, body = _foreign_spec(_agents_dir, "kirocrew-mint-warm-notion")
+
+    warm._remove_warm_mint_specs()
+
+    assert planted.is_file(), "teardown deleted a file no warm plan ever wrote"
+    assert planted.read_text(encoding="utf-8") == body
+
+
+def test_the_sweep_still_unlinks_a_stale_spec_a_warm_plan_did_write(_agents_dir: Path):
+    """The refusal must not cost the sweep its job: our own leftovers still go."""
+    stale = _agents_dir / "kirocrew-mint-warm-gone.json"
+    stale.write_text(
+        json.dumps(warm._warm_spec_body("kirocrew-mint-warm-gone", {}, "stale")),
+        encoding="utf-8",
+    )
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+
+    assert not stale.exists(), "a spec this module wrote survived the sweep"
+    assert (_agents_dir / f"{warm._WARM_BASE_AGENT}.json").is_file()
+
+
+def test_teardown_unlinks_every_spec_a_warm_plan_did_write(_agents_dir: Path):
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    assert (_agents_dir / f"{warm._WARM_BASE_AGENT}.json").is_file()
+
+    warm._remove_warm_mint_specs()
+
+    assert not list(_agents_dir.glob(f"{warm._WARM_AGENT_PREFIX}*.json"))
+
+
+def test_a_spec_this_module_wrote_is_rewritten_in_place(_agents_dir: Path):
+    """Ownership must be recognized across a plan change, or the process gets a stale spec."""
+    path = _agents_dir / f"{warm._WARM_BASE_AGENT}.json"
+    path.write_text(
+        json.dumps(warm._warm_spec_body(warm._WARM_BASE_AGENT, {}, "an older description")),
+        encoding="utf-8",
+    )
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+
+    description = json.loads(path.read_text(encoding="utf-8"))["description"]
+    assert description.startswith(warm._WARM_SPEC_SENTINEL)
+    assert "Zero-server" in description and "an older description" not in description
+
+
+def test_an_unreadable_file_at_a_warm_spec_path_is_left_alone(_agents_dir: Path):
+    """Fail closed: a path we cannot prove is ours is not ours. The cost is clutter."""
+    path = _agents_dir / "kirocrew-mint-warm-notion.json"
+    path.write_text("{ this is not json", encoding="utf-8")
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._remove_warm_mint_specs()
+
+    assert path.read_text(encoding="utf-8") == "{ this is not json"
+
+
+def test_a_refusal_is_audited_rather_than_raised(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """The caller sees no exception, and the refusal is not silent either."""
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    monkeypatch.setattr(warm._agent, "KIRO_AGENTS_DIR", agents)
+    events: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        warm,
+        "_log_warm_event",
+        lambda operation, resources, outcome="ok": events.append((operation, resources, outcome)),
+    )
+    _foreign_spec(agents, warm._WARM_BASE_AGENT)
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+
+    assert events, "a refusal to touch a user's file was silent"
+    assert all(outcome == "refused" for _, _, outcome in events)
+    # The audit names the spec, never the file's contents.
+    assert all(warm._WARM_AGENT_PREFIX in resources for _, resources, _ in events)
+
+
+# ── the plan's own read of the user's spec goes through the hardened reader ──
+#
+# ``_warm_spec_plan`` read ``kirocrew.json`` with a raw ``_load_json``, which follows a
+# symlink and parses whatever it lands on -- so a link planted at the agent-spec path
+# pointed the planner at a file outside the agents dir, and that file's contents then
+# DECIDED the plan: a configured entry whose auth shape differs from the registry's vetoes
+# the provider (``_warm_mintable_entry``). No size cap, no sensitive-target refusal, no SEL
+# denial. #6736 migrated the other ``kirocrew.json`` readers; this one was added after.
+
+
+@requires_symlinks
+def test_a_sensitive_symlink_at_the_spec_path_never_reaches_the_plan(
+    _agents_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """RED before the migration: the linked file's veto excluded the provider."""
+    from kiro_crew import agent_discovery
+
+    target = tmp_path / "protected.json"
+    # A DIVERGENT auth shape, so being read is observable: it would veto the provider.
+    target.write_text(
+        json.dumps({"mcpServers": {"acme": {"url": "https://attacker.example/mcp"}}}),
+        encoding="utf-8",
+    )
+    (_agents_dir / AGENT_FILENAME).symlink_to(target)
+    monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda p: str(target) in str(p))
+
+    plan = warm._warm_spec_plan([_provider("acme")])
+
+    assert plan.entries["acme"]["url"] == "https://acme.example/mcp"
+    assert plan.all_agent == warm._WARM_ALL_AGENT
+    assert "attacker.example" not in json.dumps(plan.specs)
+
+
+def test_a_refused_spec_plans_as_though_nothing_were_configured(
+    _agents_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Refusal degrades exactly like an absent file -- it never fails the planner."""
+    from kiro_crew import hooks
+
+    monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 256)
+    (_agents_dir / AGENT_FILENAME).write_text(
+        json.dumps(
+            {"mcpServers": {"acme": {"url": "https://attacker.example/mcp"}}, "pad": "x" * 1024}
+        ),
+        encoding="utf-8",
+    )
+
+    plan = warm._warm_spec_plan([_provider("acme")])
+
+    assert plan.entries["acme"]["url"] == "https://acme.example/mcp"
+
+
+# ── the OWNERSHIP judge reads a warm spec path, and it decides an unlink ──
+#
+# ``_warm_spec_is_foreign`` was the second raw ``_load_json`` read, and the more dangerous
+# one: its verdict is what licenses the sweep to unlink that path and the writer to overwrite
+# it. A symlink planted at a warm spec path was FOLLOWED, so a file outside the agents dir --
+# a sensitive one included -- was read uncapped and unaudited, and if its contents happened to
+# be ours-shaped it was judged OURS and destroyed through the link. Both cases below are
+# differential: under the raw read the planted body parses and reads as ours (False).
+
+
+def _ours_shaped_spec_text(stem: str, *, pad: int = 0) -> str:
+    """A body the ownership judge accepts as ours: right name, marks and sentinel.
+
+    ``pad`` grows the file through a key the judge does NOT inspect. Padding one of the four
+    marks (``prompt`` is one) would make the body read as foreign on its SHAPE, so the
+    oversized test would pass without the cap ever being consulted.
+    """
+    body = warm._warm_spec_body(stem, {}, "planted")
+    if pad:
+        body["pad"] = "x" * pad
+    return json.dumps(body)
+
+
+@requires_symlinks
+def test_a_sensitive_symlink_at_a_warm_spec_path_is_never_judged_ours(
+    _agents_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """RED before the migration: the link was followed, read as ours, and swept."""
+    from kiro_crew import agent_discovery
+
+    target = tmp_path / "protected.json"
+    stem = f"{warm._WARM_AGENT_PREFIX}notion"
+    target.write_text(_ours_shaped_spec_text(stem), encoding="utf-8")
+    link = _agents_dir / f"{stem}.json"
+    link.symlink_to(target)
+    monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda p: str(target) in str(p))
+
+    assert warm._warm_spec_is_foreign(link) is True
+
+    # The verdict's whole purpose: the sweep must leave both the link and its target alone.
+    warm._remove_warm_mint_specs()
+
+    assert link.is_symlink(), "the sweep unlinked a symlink it was refused"
+    assert target.is_file(), "the sweep reached a file outside the agents dir"
+
+
+def test_an_oversized_spec_at_a_warm_spec_path_is_never_judged_ours(
+    _agents_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The cap is consulted here too: past it, ours-shaped contents still read as foreign."""
+    from kiro_crew import hooks
+
+    monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 256)
+    stem = f"{warm._WARM_AGENT_PREFIX}notion"
+    planted = _agents_dir / f"{stem}.json"
+    planted.write_text(_ours_shaped_spec_text(stem, pad=1024), encoding="utf-8")
+
+    assert warm._warm_spec_is_foreign(planted) is True
+
+    warm._remove_warm_mint_specs()
+
+    assert planted.is_file(), "the sweep unlinked a file it could not read"
+
+
+def test_a_readable_spec_of_ours_is_still_judged_ours_under_the_same_cap(_agents_dir: Path):
+    """The refusal must not cost the judge its job -- guards the vacuous pass above."""
+    stem = f"{warm._WARM_AGENT_PREFIX}notion"
+    planted = _agents_dir / f"{stem}.json"
+    planted.write_text(_ours_shaped_spec_text(stem), encoding="utf-8")
+
+    assert warm._warm_spec_is_foreign(planted) is False
+
+
+# ── the work dir: an agent-writable cwd is a second spec path, unguarded ──
+#
+# Every ownership check in this module guards the USER's agents dir. kiro-cli also resolves
+# PROJECT-LOCAL specs from ``<cwd>/.kiro/agents``, and the spawn activates by NAME, so a spec
+# planted under the process's own cwd shadows the guarded one and its ``mcpServers`` is what
+# gets initialized and authorized against. The cwd therefore has to be a tree an agent file
+# tool cannot write.
+
+
+def test_the_warm_process_cwd_is_inside_the_agent_write_protected_tree():
+    """RED before the fix: the cwd was ``<data home>/connections/warm-mint``.
+
+    Asserted through ``security``'s own predicate rather than a path literal, because the
+    property is "the gate refuses an agent write here" -- which a later rename must keep and a
+    path literal would not notice losing.
+    """
+    planted = warm._warm_work_dir() / ".kiro" / "agents" / f"{warm._WARM_ALL_AGENT}.json"
+
+    assert security.is_sensitive_write_path(str(planted)) is True
+
+
+def test_the_gate_that_test_relies_on_is_not_true_of_every_crew_home_path():
+    """Guards the vacuous pass above: the old cwd's tree really is agent-writable."""
+    writable = warm.data_home() / "connections" / "warm-mint" / ".kiro" / "agents" / "all.json"
+
+    assert security.is_sensitive_write_path(str(writable)) is False
+
+
+# ── servability: a set that SHRANK is still servable ──
+
+
+def _plan(entries: dict[str, dict[str, Any]]) -> warm._WarmSpecPlan:
+    return warm._WarmSpecPlan(
+        all_agent="all" if entries else "",
+        specs={},
+        entries=entries,
+        digest=repr(sorted(entries.items())),
+    )
+
+
+def test_a_shrunk_candidate_set_is_served_by_the_running_process():
+    resident = _plan({"linear": {"url": "https://l"}, "vercel": {"url": "https://v"}})
+    assert warm._plan_is_servable(resident, _plan({"linear": {"url": "https://l"}})) is True
+
+
+def test_a_changed_authorization_ask_is_not_servable():
+    resident = _plan({"linear": {"url": "https://l"}})
+    assert warm._plan_is_servable(resident, _plan({"linear": {"url": "https://other"}})) is False
+    assert warm._plan_is_servable(resident, _plan({"notion": {"url": "https://n"}})) is False
+
+
+def test_a_process_that_enumerated_nothing_serves_nothing():
+    assert warm._plan_is_servable(_plan({}), _plan({"linear": {"url": "https://l"}})) is False
+
+
+# ── candidates: a granted provider is warmed into the spec but asked for no URL ──
+
+
+def test_a_granted_provider_is_not_an_activation_candidate(monkeypatch: pytest.MonkeyPatch):
+    universe = [_provider("granted"), _provider("fresh")]
+    monkeypatch.setattr(warm, "grant_present", lambda url: "granted" in url)
+    assert [p["slug"] for p in warm._warm_activation_candidates(universe)] == ["fresh"]
+
+
+def test_an_unreadable_inventory_warms_nothing_rather_than_raising(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        warm, "warm_spec_providers", lambda: (_ for _ in ()).throw(OSError("config unreadable"))
+    )
+    assert warm._warm_candidate_scan() == ([], [])
+
+
+def test_a_warm_session_never_injects_mcp_servers():
+    """A remote server through ``session/new`` kills the process and every verifier."""
+    assert warm._warm_session_mcp_servers() == []
+
+
+# ── one activation fills the whole table ──
+
+
+@pytest.fixture
+def _stub_activation(monkeypatch: pytest.MonkeyPatch):
+    """Neutralize the process, the audit log and the grant watcher."""
+
+    async def _no_watcher(slug: str, mcp_url: str, token: str) -> None:
+        return None
+
+    async def _no_settle(activation: int, in_use: set[int]) -> None:
+        return None
+
+    monkeypatch.setattr(warm, "_mint_watcher", _no_watcher)
+    monkeypatch.setattr(warm, "_log_warm_event", lambda *a, **k: None)
+    monkeypatch.setattr(warm._warm_mint, "settle_activation", _no_settle)
+
+
+def _result(
+    providers: list[Provider],
+    requests: list[dict[str, str]],
+    *,
+    generation: int = 7,
+    activation: int = 3,
+) -> warm._WarmMintResult:
+    return warm._WarmMintResult(
+        generation=generation, activation=activation, providers=providers, requests=requests
+    )
+
+
+def _returns(result: warm._WarmMintResult | None):
+    async def _activate(*, slug: str = ""):
+        return result
+
+    return _activate
+
+
+async def _claim(*slugs: str) -> dict[str, str]:
+    """Claim helper for the tests that do not exercise the displaced-row half."""
+    claims, displaced = await warm._claim_shared_mints(list(slugs))
+    assert not displaced, "these tests claim into empty slots"
+    return claims
+
+
+@pytest.mark.asyncio
+async def test_one_activation_stamps_every_row_with_its_generation_and_activation(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    providers = [_provider("linear"), _provider("vercel")]
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result(
+                providers,
+                [
+                    {"serverName": "linear", "oauthUrl": "https://l/consent"},
+                    {"serverName": "vercel", "oauthUrl": "https://v/consent"},
+                ],
+            )
+        ),
+    )
+
+    minted = await warm.warm_mint_all(providers)
+
+    assert sorted(minted) == ["linear", "vercel"]
+    for slug in ("linear", "vercel"):
+        row = _mints[slug]
+        assert row["state"] == "waiting"
+        assert row["generation"] == 7 and row["activation"] == 3
+        assert row["shared"] is True
+        # Every row carries the cold engine's row identity, which is what the grant
+        # watcher re-checks before it writes a verdict.
+        assert row["token"]
+    assert len({_mints["linear"]["token"], _mints["vercel"]["token"]}) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_claim_the_activation_did_not_cover_is_released_not_left_minting(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    claimed = [_provider("linear"), _provider("stranded")]
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result([claimed[0]], [{"serverName": "linear", "oauthUrl": "https://l/consent"}])
+        ),
+    )
+
+    assert await warm.warm_mint_all(claimed) == ["linear"]
+    assert "stranded" not in _mints, "an uncovered claim must not sit in the table forever"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_activation_releases_every_claim(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    monkeypatch.setattr(warm, "_warm_activate", _returns(None))
+    assert await warm.warm_mint_all([_provider("linear")]) == []
+    assert _mints == {}
+
+
+@pytest.mark.asyncio
+async def test_a_cold_held_row_is_never_replaced_by_a_warm_claim():
+    _mints["linear"] = {"state": "waiting", "client": object(), "oauth_url": "https://cold"}
+    assert await warm._claim_shared_mints(["linear"]) == ({}, [])
+    assert _mints["linear"]["oauth_url"] == "https://cold"
+
+
+@pytest.mark.asyncio
+async def test_expiry_is_narrowed_to_the_one_generation_whose_verifier_died():
+    """Withdrawal follows the verifier, so it follows the generation. A row on any OTHER
+    generation is redeemable on a process this expiry is not about."""
+    _mints["a"] = {"state": "waiting", "shared": True, "generation": 1, "token": "tok-a"}
+    _mints["b"] = {"state": "waiting", "shared": True, "generation": 2, "token": "tok-b"}
+    # A claim not yet stamped with a generation belongs to an activation still in flight.
+    _mints["c"] = {"state": "minting", "shared": True, "token": "tok-c"}
+    assert await warm._expire_shared_mints("mint_process_gone", generation=1) == ["a"]
+    assert _mints["b"]["state"] == "waiting"
+    assert _mints["c"]["state"] == "minting"
+
+
+# ── defect #6110: a batch timestamp is not a row identity ──
+#
+# The fence separating one activation's rows from the next at the SAME slug was
+# ``entry["started"] == started``, a ``time.monotonic()`` reading taken once per
+# ``warm_mint_all`` call. ``_new_mint_token``'s own docstring records why that is not a row
+# identity: the clock has ~15.6ms granularity on Windows, so two Connects for one provider
+# inside a single tick read as the same row and every guard built on it fails OPEN.
+
+
+@pytest.mark.asyncio
+async def test_a_late_absorb_does_not_write_its_url_over_a_newer_claim(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """Two overlapping activations at one slug. The first one's absorb lands last, and it
+    must not replace the second's claim -- the URL it carries belongs to a session the
+    second Connect is not waiting on."""
+    # A coarse clock, as Windows has: both claims are taken inside one tick, so a fence
+    # reading ``started`` cannot tell the two rows apart.
+    monkeypatch.setattr(warm.time, "monotonic", lambda: 100.0)
+    provider = _provider("linear")
+
+    first = await _claim("linear")
+    second, displaced = await warm._claim_shared_mints(["linear"])
+    assert first and second
+    assert first["linear"] != second["linear"], "each claim needs its own row identity"
+    assert [row["token"] for row in displaced] == [
+        first["linear"]
+    ], "the row the second claim replaced comes back for the caller to dispose"
+
+    stale = _result(
+        [provider], [{"serverName": "linear", "oauthUrl": "https://stale/consent"}], activation=1
+    )
+    assert await warm._absorb_warm_requests(stale, first) == []
+    row = _mints["linear"]
+    assert row.get("oauth_url") != "https://stale/consent"
+    assert row["state"] == "minting", "the newer claim is still the activation's to fill"
+    assert row["token"] == second["linear"]
+
+
+@pytest.mark.asyncio
+async def test_a_release_leaves_a_newer_claim_at_the_same_slug_alone(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The release path needs the same identity: dropping the row a newer activation is
+    filling would strand that Connect on a card with no claim and no URL."""
+    monkeypatch.setattr(warm.time, "monotonic", lambda: 100.0)
+    first = await _claim("linear")
+    second, _ = await warm._claim_shared_mints(["linear"])
+
+    await warm._release_shared_claims(first)
+
+    assert _mints["linear"]["token"] == second["linear"]
+
+
+# ── defect: a credential-bearing URL must be refused before it is stored ──
+
+
+@pytest.mark.asyncio
+async def test_a_url_carrying_a_credential_is_refused_rather_than_stored(_stub_activation):
+    """The same gate the cold mint and the chat consent banner apply. A refused URL is
+    never written to the row, so nothing can serve it to a card."""
+    provider = _provider("linear")
+    claims = await _claim("linear")
+    assert claims
+
+    bearing = _result(
+        [provider],
+        [
+            {
+                "serverName": "linear",
+                "oauthUrl": "https://linear.example/authorize?state=AKIA" + "IOSFODNN7EXAMPLE1",
+            }
+        ],
+    )
+    assert await warm._absorb_warm_requests(bearing, claims) == []
+    assert "linear" not in _mints, "the claim is released so the card asks for a fresh mint"
+
+
+@pytest.mark.asyncio
+async def test_the_screen_is_the_shared_security_gate_not_a_local_copy(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """A second implementation of the predicate would drift from the one the rest of the
+    product enforces, so the module must call through to security's."""
+    assert warm.oauth_url_contains_credential is security.oauth_url_contains_credential
+
+    monkeypatch.setattr(warm, "oauth_url_contains_credential", lambda url: True)
+    claims = await _claim("linear")
+    plain = _result(
+        [_provider("linear")], [{"serverName": "linear", "oauthUrl": "https://l/consent"}]
+    )
+    assert await warm._absorb_warm_requests(plain, claims) == []
+
+
+@pytest.mark.asyncio
+async def test_a_clean_url_still_lands_on_the_row(_stub_activation):
+    """The screen must not refuse the ordinary case it exists to let through."""
+    claims = await _claim("linear")
+    clean = _result(
+        [_provider("linear")],
+        [{"serverName": "linear", "oauthUrl": "https://linear.example/oauth/authorize?state=xyz"}],
+    )
+    assert await warm._absorb_warm_requests(clean, claims) == ["linear"]
+    assert _mints["linear"]["state"] == "waiting"
+
+
+# ── defect: a cancel between claim and activation strands every claimed row ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_between_claim_and_activation_releases_every_row(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """``minting`` rows are invisible to ``expire_dead_mints`` (it judges ``waiting`` only)
+    and they keep ``_shared_mints_pending`` true, so a row left behind here is never
+    withdrawn AND the process is never retired."""
+
+    async def _cancelled(*, slug: str = ""):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_warm_activate", _cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm.warm_mint_all([_provider("linear"), _provider("vercel")])
+
+    assert _mints == {}, "a cancelled activation must not leave a claim minting with no watcher"
+    assert warm._shared_mints_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_a_real_task_cancel_mid_activation_still_completes_the_release(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """The stronger form: not a raised ``CancelledError`` but a real ``Task.cancel()`` while
+    the coroutine is suspended. The cleanup awaits a lock and a dispose, so this is what
+    proves those awaits run rather than being interrupted a second time."""
+    entered = asyncio.Event()
+
+    async def _hangs(*, slug: str = ""):
+        entered.set()
+        await asyncio.Event().wait()  # never completes; the cancel lands here
+
+    monkeypatch.setattr(warm, "_warm_activate", _hangs)
+
+    task = asyncio.get_running_loop().create_task(warm.warm_mint_all([_provider("linear")]))
+    await entered.wait()
+    assert _mints["linear"]["state"] == "minting", "the claim is taken before the activation"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert _mints == {}
+    assert warm._shared_mints_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_after_the_activation_lands_releases_the_rows_too(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """The window does not close when the activation returns: an absorb interrupted
+    mid-flight leaves the same orphaned claims."""
+
+    async def _cancelling_absorb(result, claims):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result(
+                [_provider("linear")], [{"serverName": "linear", "oauthUrl": "https://l/consent"}]
+            )
+        ),
+    )
+    monkeypatch.setattr(warm, "_absorb_warm_requests", _cancelling_absorb)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm.warm_mint_all([_provider("linear")])
+
+    assert _mints == {}
+
+
+# ── defect: the claim loop's own await is a cancel window OUTSIDE the protected region ──
+#
+# ``warm_mint_all`` takes its claims BEFORE entering the try whose ``except BaseException``
+# rolls them back, so any await inside the claim loop is unprotected. Replacing an existing
+# row awaits ``_dispose_mint``, which suspends on a client teardown and again on the
+# shielded spec removal in its ``finally`` -- so a cancellation there unwinds with earlier
+# slugs already installed as ``minting`` and no caller holding their tokens.
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_while_replacing_a_row_does_not_strand_the_earlier_claims(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """``vercel`` is claimed first and needs no dispose; ``linear`` already holds a row, so
+    replacing it is the await the cancellation lands in. ``vercel`` must not survive it."""
+    real_dispose = warm._dispose_mint
+
+    async def _cancel_on_the_displaced_row(entry):
+        # Only the row being REPLACED carries a URL; our own fresh claims do not, so the
+        # rollback's own disposes still run for real.
+        if entry.get("oauth_url"):
+            raise asyncio.CancelledError()
+        await real_dispose(entry)
+
+    monkeypatch.setattr(warm, "_dispose_mint", _cancel_on_the_displaced_row)
+    _mints["linear"] = {
+        "state": "waiting",
+        "shared": True,
+        "oauth_url": "https://l/consent",
+        "generation": 5,
+        "activation": 1,
+        "token": "older-linear-row",
+    }
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm.warm_mint_all([_provider("vercel"), _provider("linear")])
+
+    assert _mints == {}, "an interrupted claim must not leave a row minting with no owner"
+    # `minting` rows are invisible to expire_dead_mints and keep the pending check true, so
+    # a survivor here is never withdrawn AND stops the process from ever being retired.
+    assert warm._shared_mints_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_the_claim_loop_itself_contains_no_await():
+    """The structural invariant behind the test above: with no await between the first row
+    being installed and the loop ending, there is no window to be cancelled in."""
+    body = ast.parse(inspect.getsource(warm._claim_shared_mints)).body[0]
+    loops = [node for node in ast.walk(body) if isinstance(node, ast.For)]
+    assert loops, "guard is reading the wrong tree"
+    offenders = [
+        type(node).__name__
+        for loop in loops
+        for node in ast.walk(loop)
+        if isinstance(node, ast.Await)
+    ]
+    assert not offenders, f"awaits inside the claim loop: {offenders} -- move them out"
+
+
+# ── defect: the retry's expiry pass is unscoped ──
+
+
+@pytest.mark.asyncio
+async def test_a_retry_does_not_withdraw_a_parked_generations_live_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A parked generation's process still holds its verifier and its session still answers
+    the redirect, so its URL is redeemable. An expiry pass not scoped to the DEAD generation
+    withdraws a working link."""
+    _mints["parked"] = {
+        "state": "waiting",
+        "shared": True,
+        "oauth_url": "https://p/consent",
+        "generation": 3,
+        "activation": 1,
+        "token": "tok-parked",
+    }
+
+    attempts: list[str] = []
+
+    async def _dies_then_declines(*, slug: str = ""):
+        attempts.append(slug)
+        if len(attempts) == 1:
+            raise warm._WarmMintDied("ProcessGone")
+        return None
+
+    monkeypatch.setattr(warm._warm_mint, "mint_for", _dies_then_declines)
+
+    assert await warm._warm_activate() is None
+    assert len(attempts) == 2, "the death is retried once"
+    assert _mints["parked"]["state"] == "waiting"
+    assert _mints["parked"]["oauth_url"] == "https://p/consent"
+
+
+@pytest.mark.asyncio
+async def test_a_dead_generations_rows_are_expired_by_the_kill_itself(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Why the retry needs no expiry pass of its own: the stand-down that precedes
+    ``_WarmMintDied`` already withdrew exactly the rows whose verifier died, scoped to that
+    generation and leaving every other generation alone."""
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    _mints["dead"] = {"state": "waiting", "shared": True, "generation": 4, "token": "t4"}
+    _mints["parked"] = {"state": "waiting", "shared": True, "generation": 3, "token": "t3"}
+
+    await warm._warm_mint._park_or_kill_locked()
+
+    assert _mints["dead"]["state"] == "expired"
+    assert _mints["dead"]["reason"] == "mint_process_gone"
+    assert _mints["parked"]["state"] == "waiting"
+
+
+# ── defect: a parked generation is stranded when the current process dies ──
+
+
+def _parked_session(generation: int) -> warm._WarmSession:
+    """An unsettled session, so the sweep holds it exactly as a live activation's would be."""
+    return warm._WarmSession(
+        generation=generation, handle=object(), expires_at=time.monotonic() + 600
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_reaper_drains_parked_generations_after_the_current_process_dies(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Nothing else on any path reaches a parked generation once the current process is gone:
+    a new mint would sweep it, and the leak is exactly the case where none arrives. So the
+    process and its sessions stay resident forever after its last card completes."""
+    parked_runtime = _Runtime(True)
+    killed: list[Any] = []
+
+    async def _record_kill(runtime):
+        killed.append(runtime)
+        return True
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 6)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, parked_runtime)])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {9: _parked_session(5)})
+    # Generation 5 is parked because this card still points at it.
+    _mints["parked"] = {
+        "state": "waiting",
+        "shared": True,
+        "generation": 5,
+        "activation": 9,
+        "token": "t5",
+    }
+
+    sweeps = 0
+    real_sweep = warm._warm_mint.sweep_retiring
+
+    async def _counting_sweep():
+        nonlocal sweeps
+        sweeps += 1
+        if sweeps == 2:
+            # The card completes, so nothing needs generation 5 any more.
+            _mints.pop("parked", None)
+        await real_sweep()
+
+    monkeypatch.setattr(warm._warm_mint, "sweep_retiring", _counting_sweep)
+
+    await asyncio.wait_for(warm._warm_mint_reaper(6), timeout=5)
+
+    assert killed == [parked_runtime], "the parked generation's process was never retired"
+    assert warm._warm_mint._retiring == []
+    assert warm._warm_mint._sessions == {}, "its sessions own the loopback servers"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_respawn_still_drains_the_generation_it_parked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The same leak by the other route: the stand-down cancels the old reaper, so a spawn
+    that then fails leaves a parked generation with no reaper at all."""
+    parked_runtime = _Runtime(True)
+    killed: list[Any] = []
+
+    async def _record_kill(runtime):
+        killed.append(runtime)
+        return True
+
+    def _explode(*a, **k):
+        raise OSError("kiro-cli is not installed")
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _explode)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, parked_runtime)])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is None
+
+    drain = warm._warm_mint._reaper
+    assert drain is not None, "a parked generation with no process needs a drain task"
+    await asyncio.wait_for(drain, timeout=5)
+    assert killed == [parked_runtime]
+    assert warm._warm_mint._retiring == []
+
+
+# ── defect: a refused spec is still activated BY NAME ──
+#
+# The writer audits and SKIPS a foreign file at a planned spec path, which protects the
+# file. It does not protect the ACTIVATION: the runtime is handed `agent=<fixed name>` and
+# kiro-cli resolves that name off the same directory, so a hand-written agent sitting at
+# the name we declined to own gets executed and its `mcpServers` commands initialize.
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_spec_at_a_planned_path_aborts_warming_instead_of_being_activated(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """The refusal has to reach the SPAWN, not just the write."""
+    _foreign_spec(_agents_dir, warm._WARM_BASE_AGENT)
+    constructed: list[str] = []
+
+    def _factory():
+        def _build(**kwargs):
+            constructed.append(str(kwargs.get("agent")))
+            raise AssertionError("a refused spec must never be activated")
+
+        return _build
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", _factory)
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is None
+    assert constructed == [], "the runtime was constructed on a spec we refused to own"
+
+
+@pytest.mark.asyncio
+async def test_a_missing_planned_spec_also_aborts_warming(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """Absence and foreignness are the same answer here: an unreadable spec path is not a
+    spec of ours, and `_warm_spec_is_foreign` answers False for an absent file, so the
+    verification has to test existence as well as ownership."""
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)  # writes nothing
+    constructed: list[str] = []
+
+    def _factory():
+        def _build(**kwargs):
+            constructed.append(str(kwargs.get("agent")))
+            raise AssertionError("a missing spec must never be activated")
+
+        return _build
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", _factory)
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is None
+    assert constructed == []
+
+
+@pytest.mark.asyncio
+async def test_a_spec_set_this_module_owns_is_activated_normally(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """The verification must not refuse the ordinary case it exists to let through."""
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
+    built: list[str] = []
+
+    class _Spawnable:
+        def __init__(self, **kwargs):
+            built.append(str(kwargs.get("agent")))
+
+        async def spawn(self):
+            return None
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _Spawnable)
+
+    served = await warm._warm_mint._ensure_locked([_provider("linear")])
+    assert served is not None and served.all_agent == warm._WARM_ALL_AGENT
+    assert built == [warm._WARM_BASE_AGENT]
+    reaper = warm._warm_mint._reaper
+    assert reaper is not None
+    reaper.cancel()
+
+
+# ── defect: the stand-down -> spawn transition is not BaseException-safe ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_spec_write_still_arms_the_drain(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """Third route into the parked-generation leak. The park has already cancelled the old
+    reaper, so a cancellation before a replacement exists leaves the parked process with
+    nothing that will ever sweep it."""
+    parked_runtime = _Runtime(True)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, parked_runtime)])
+
+    def _cancel(plan):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", _cancel)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._ensure_locked([_provider("linear")])
+
+    drain = warm._warm_mint._reaper
+    assert drain is not None, "a park with no replacement reaper needs a drain armed"
+    drain.cancel()
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_spawn_kills_the_partial_runtime(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """A runtime that was constructed and may have forked a child must not be dropped on
+    the floor when the spawn await is cancelled."""
+    killed: list[Any] = []
+
+    async def _record_kill(runtime):
+        killed.append(runtime)
+        return True
+
+    class _CancelsOnSpawn:
+        def __init__(self, **kwargs):
+            pass
+
+        async def spawn(self):
+            raise asyncio.CancelledError()
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _CancelsOnSpawn)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._ensure_locked([_provider("linear")])
+
+    assert len(killed) == 1, "the constructed runtime was leaked"
+
+
+# ── defect: settlement is not reached on every post-activation exit ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_credential_screen_still_settles_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The screen's `to_thread` await sits between the session's creation and its
+    settlement. A session left `settled=False` is permanently ineligible for the sweep, so
+    it and its loopback callback servers accumulate for the life of the process."""
+    settled: list[int] = []
+
+    async def _record_settle(activation: int, in_use: set[int]) -> None:
+        settled.append(activation)
+
+    def _cancel(urls):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm._warm_mint, "settle_activation", _record_settle)
+    monkeypatch.setattr(warm, "_credential_bearing_slugs", _cancel)
+
+    claims = await _claim("linear")
+    result = _result(
+        [_provider("linear")],
+        [{"serverName": "linear", "oauthUrl": "https://l/consent"}],
+        activation=11,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._absorb_warm_requests(result, claims)
+
+    assert settled == [11], "an unsettled session can never be collected"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_absorb_still_settles_the_session(monkeypatch: pytest.MonkeyPatch):
+    """Not only cancellation: any raise after the activation exists has the same
+    consequence, so the settlement belongs in a finally rather than on one branch."""
+    settled: list[int] = []
+
+    async def _record_settle(activation: int, in_use: set[int]) -> None:
+        settled.append(activation)
+
+    def _explode(urls):
+        raise OSError("the operator endpoint file is unreadable")
+
+    monkeypatch.setattr(warm._warm_mint, "settle_activation", _record_settle)
+    monkeypatch.setattr(warm, "_credential_bearing_slugs", _explode)
+
+    claims = await _claim("linear")
+    result = _result(
+        [_provider("linear")], [{"serverName": "linear", "oauthUrl": "https://l/consent"}]
+    )
+
+    with pytest.raises(OSError):
+        await warm._absorb_warm_requests(result, claims)
+
+    assert settled == [3]
+
+
+# ── defect (found by the systematic audit, not the lane): the retiring sweep drops
+# generations from its own list before killing them ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_mid_sweep_leaves_the_unkilled_generations_parked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`_sweep_retiring_locked` assigns the keep-list before it kills the drop-list, so a
+    cancellation partway through used to remove BOTH generations from `_retiring` while only
+    one was actually killed -- `parked_count()` then reads zero and the drain exits, so
+    nothing ever retries. A generation whose kill completed is gone; one whose kill was
+    interrupted stays parked for a later sweep."""
+    first, second = _Runtime(False), _Runtime(False)
+    killed: list[Any] = []
+
+    async def _kill_then_cancel(runtime):
+        killed.append(runtime)
+        if len(killed) == 2:
+            raise asyncio.CancelledError()
+        return True
+
+    monkeypatch.setattr(warm, "_kill_quietly", _kill_then_cancel)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(1, first), (2, second)])
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint.sweep_retiring()
+
+    assert killed == [first, second]
+    assert warm._warm_mint.parked_count() == 1, "the ungathered generation must stay parked"
+    assert warm._warm_mint._retiring == [(2, second)]
+
+
+# ── a kill that TIMES OUT is not a kill ──
+#
+# ``_kill_quietly`` swallowed every ``Exception`` and returned None, so a kill that timed out
+# was indistinguishable from one that worked: each caller then dropped the only reference to
+# a child that is still running. ``asyncio.TimeoutError`` IS an ``Exception``, so none of the
+# three retention paths above -- all built for a ``CancelledError``, which is not -- ever saw
+# it. Repeated activations therefore accumulated live kiro-cli processes, their sessions and
+# their loopback listeners, with nothing left that could ever retire them.
+
+
+class _UnkillableRuntime:
+    """A process whose kill fails the way a timeout does: a plain ``Exception``.
+
+    Fails ``failures`` times and then succeeds, so one test can pin both halves of the
+    contract -- retained while the kill does not take, released once it does.
+    """
+
+    def __init__(self, failures: int = 1) -> None:
+        self._failures = failures
+        self.kill_attempts = 0
+
+    def is_alive(self) -> bool:
+        return True
+
+    async def kill(self) -> None:
+        self.kill_attempts += 1
+        if self.kill_attempts <= self._failures:
+            raise TimeoutError("kill timed out")
+
+
+@pytest.fixture
+def _no_drain(monkeypatch: pytest.MonkeyPatch):
+    """Neutralize the drain task and the spec sweep, keeping the arming observable."""
+
+    async def _noop() -> None:
+        return None
+
+    monkeypatch.setattr(warm, "_drain_parked_generations", _noop)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_a_sweep_whose_kill_times_out_keeps_the_generation_parked(
+    monkeypatch: pytest.MonkeyPatch, _no_drain: None
+):
+    """RED before the fix: the pair was popped and the surviving child forgotten."""
+    doomed = _UnkillableRuntime(failures=1)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, doomed)])
+
+    await warm._warm_mint.sweep_retiring()
+
+    assert doomed.kill_attempts == 1
+    assert warm._warm_mint._retiring == [(5, doomed)], "a surviving child must stay tracked"
+    assert warm._warm_mint.parked_count() == 1
+
+    # The next pass is what retires it -- and only then does the list clear.
+    await warm._warm_mint.sweep_retiring()
+
+    assert doomed.kill_attempts == 2
+    assert warm._warm_mint._retiring == []
+
+
+@pytest.mark.asyncio
+async def test_a_stand_down_whose_kill_times_out_re_parks_the_process(
+    monkeypatch: pytest.MonkeyPatch, _no_drain: None
+):
+    """``_park_or_kill_locked`` clears ``_runtime`` first, so this list is the last reference."""
+    doomed = _UnkillableRuntime(failures=1)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", doomed)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 7)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_reaper", None)
+
+    await warm._warm_mint._park_or_kill_locked()
+
+    assert warm._warm_mint._retiring == [(7, doomed)]
+    assert warm._warm_mint._reaper is not None, "nothing was scheduled to retry the kill"
+
+
+@pytest.mark.asyncio
+async def test_a_hard_teardown_whose_kill_times_out_keeps_the_child_tracked(
+    monkeypatch: pytest.MonkeyPatch, _no_drain: None
+):
+    """``shutdown()`` empties both lists up front; an unkilled child must come back."""
+    doomed = _UnkillableRuntime(failures=1)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", doomed)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 9)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_reaper", None)
+
+    await warm._warm_mint.shutdown()
+
+    assert warm._warm_mint._retiring == [(9, doomed)]
+    assert warm._warm_mint._reaper is not None
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_spawn_whose_kill_times_out_is_tracked_not_dropped(
+    monkeypatch: pytest.MonkeyPatch, _no_drain: None
+):
+    """The one path with no generation of its own: tracked under a key no row can carry, so
+    every sweep reads it as needed by nobody and retries the kill until it takes."""
+    doomed = _UnkillableRuntime(failures=1)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_reaper", None)
+
+    await warm._warm_mint._abandon_spawn_locked(doomed)
+
+    assert warm._warm_mint._retiring == [(warm._WARM_UNKEYED_GENERATION, doomed)]
+    assert warm._WARM_UNKEYED_GENERATION < 0, "a real generation would collide with its rows"
+    assert not warm._generation_holds_live_rows(warm._WARM_UNKEYED_GENERATION)
+
+
+@pytest.mark.asyncio
+async def test_a_spec_sweep_is_withheld_while_an_unkilled_child_still_needs_its_spec():
+    """A spec removed under a process that is still running strands it -- the same rule the
+    parked path follows, and the reason the sweep is gated on the kill having taken."""
+    removed: list[bool] = []
+    doomed = _UnkillableRuntime(failures=1)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(warm, "_remove_warm_mint_specs", lambda: removed.append(True))
+        patch.setattr(warm._warm_mint, "_runtime", None)
+        patch.setattr(warm._warm_mint, "_retiring", [])
+
+        assert await warm._warm_mint._kill_generation(3, doomed) is False
+        assert not removed, "the surviving child's spec was unlinked underneath it"
+
+        assert await warm._warm_mint._kill_generation(3, doomed) is True
+        assert removed == [True]
+
+
+# ── the invariant itself, pinned where it is mechanically checkable ──
+
+
+def _await_protections(func: Any) -> list[tuple[str, list[str]]]:
+    """Every await in ``func`` as ``(source text, enclosing try protections)``.
+
+    A protection reads ``finally`` or ``except BaseException`` -- the only two shapes a
+    ``CancelledError`` cannot walk past. An ``except Exception`` is recorded so the guard can
+    say what WAS there rather than only that nothing qualified.
+    """
+    source = textwrap.dedent(inspect.getsource(func))
+    tree = ast.parse(source)
+    found: list[tuple[str, list[str]]] = []
+
+    def label(node: ast.Try) -> str:
+        kinds = ["finally"] if node.finalbody else []
+        for handler in node.handlers:
+            if handler.type is None:
+                kinds.append("except BaseException")
+            elif isinstance(handler.type, ast.Name):
+                kinds.append(f"except {handler.type.id}")
+            else:
+                kinds.append("except <expr>")
+        return "+".join(kinds)
+
+    def walk(node: ast.AST, stack: list[str]) -> None:
+        if isinstance(node, ast.Try):
+            here = label(node)
+            for child in node.body:
+                walk(child, stack + [here])
+            for handler in node.handlers:
+                for child in handler.body:
+                    walk(child, stack)
+            for child in node.finalbody + node.orelse:
+                walk(child, stack)
+            return
+        if isinstance(node, ast.Await):
+            found.append((ast.get_source_segment(source, node) or "", list(stack)))
+        for child in ast.iter_child_nodes(node):
+            walk(child, stack)
+
+    for child in ast.iter_child_nodes(tree):
+        walk(child, [])
+    return found
+
+
+#: The awaits that sit between a state mutation and that mutation's settlement or cleanup.
+#: Named individually rather than "this function has SOME protected try", because the coarse
+#: form passed while a sibling await in the same function was still bare.
+_MUST_BE_PROTECTED = [
+    ("warm_mint_all", "_warm_activate", warm.warm_mint_all),
+    ("warm_mint_all", "_absorb_warm_requests", warm.warm_mint_all),
+    ("warm_mint_all", "_dispose_displaced_rows", warm.warm_mint_all),
+    ("_absorb_warm_requests", "_credential_bearing_slugs", warm._absorb_warm_requests),
+    (
+        "_activate_locked",
+        "asyncio.shield(create)",
+        warm._WarmMintRuntime._activate_locked,
+    ),
+    ("_activate_locked", "handle.drain_init", warm._WarmMintRuntime._activate_locked),
+    (
+        "_abandon_session_creation_locked",
+        "_destroy_session_quietly",
+        warm._WarmMintRuntime._abandon_session_creation_locked,
+    ),
+    (
+        "_sweep_sessions_locked",
+        "_destroy_session_quietly",
+        warm._WarmMintRuntime._sweep_sessions_locked,
+    ),
+    ("_ensure_locked", "_write_warm_mint_specs", warm._WarmMintRuntime._ensure_locked),
+    ("_ensure_locked", "runtime.spawn()", warm._WarmMintRuntime._ensure_locked),
+    ("_sweep_retiring_locked", "_kill_generation", warm._WarmMintRuntime._sweep_retiring_locked),
+    ("_park_or_kill_locked", "_kill_generation", warm._WarmMintRuntime._park_or_kill_locked),
+    ("_retire_locked", "_kill_quietly", warm._WarmMintRuntime._retire_locked),
+]
+
+_PROTECTING = ("finally", "except BaseException")
+
+
+def test_every_post_mutation_await_is_individually_protected():
+    """Both review rounds found the same class: an await between a state mutation and its
+    settlement or cleanup, guarded only by an `except Exception` that a CancelledError walks
+    straight past. Bound to the SPECIFIC await rather than the function, so a newly-added
+    sibling await in an already-protected function cannot pass by association."""
+    for name, target, func in _MUST_BE_PROTECTED:
+        awaits = _await_protections(func)
+        matching = [(text, stack) for text, stack in awaits if target in text]
+        assert matching, (
+            f"{name}: no await matching {target!r} -- the guard is reading the wrong code, "
+            "so update this table rather than deleting the entry"
+        )
+        for text, stack in matching:
+            assert any(any(kind in entry for kind in _PROTECTING) for entry in stack), (
+                f"{name}: `{text}` is guarded only by {stack or ['nothing']} -- a "
+                "CancelledError walks past every `except Exception`, which is exactly the "
+                "bug class three review rounds found"
+            )
+
+
+# ── two more of the same class, found by the systematic audit ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_stand_down_kill_re_parks_the_process(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`_park_or_kill_locked` clears `_runtime` and cancels the reaper BEFORE it awaits the
+    kill, so a cancellation inside that kill used to drop the only reference to a process
+    that is still running -- neither registered, nor parked, nor dead."""
+    doomed = _Runtime(False)
+
+    async def _cancel(runtime):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_kill_quietly", _cancel)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", doomed)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 7)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_reaper", None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._park_or_kill_locked()
+
+    assert warm._warm_mint._retiring == [(7, doomed)], "an unkilled process must stay tracked"
+    drain = warm._warm_mint._reaper
+    assert drain is not None, "and something must be scheduled to retire it"
+    drain.cancel()
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_hard_teardown_re_parks_what_is_left(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`_retire_locked` empties `_retiring` and clears `_runtime` up front, so a
+    cancellation partway through its kill loop used to leak every remaining process with no
+    reference left anywhere."""
+    parked, current = _Runtime(False), _Runtime(False)
+    killed: list[Any] = []
+
+    async def _kill_then_cancel(runtime):
+        killed.append(runtime)
+        if len(killed) == 2:
+            raise asyncio.CancelledError()
+        return True
+
+    monkeypatch.setattr(warm, "_kill_quietly", _kill_then_cancel)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", current)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 9)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(8, parked)])
+    monkeypatch.setattr(warm._warm_mint, "_reaper", None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._retire_locked()
+
+    # The parked one was killed first and is gone; the current one was interrupted.
+    assert killed == [parked, current]
+    assert warm._warm_mint._retiring == [(9, current)]
+    drain = warm._warm_mint._reaper
+    assert drain is not None
+    drain.cancel()
+
+
+# ── defect: the CURRENT generation number can name a PARKED process ──
+#
+# Only a successful spawn bumps `_generation`, so a stand-down leaves the live process in
+# `_retiring` under the number that is still `self._generation`, with `self._runtime`
+# cleared. The equality branch answered `is_alive()` for that number and so reported the
+# parked process dead -- withdrawing redeemable URLs, and then letting the next sweep kill
+# the very process the park existed to preserve.
+
+
+@pytest.mark.asyncio
+async def test_a_generation_parked_mid_respawn_keeps_its_rows(monkeypatch: pytest.MonkeyPatch):
+    """A status scan runs without the runtime lock, so it sees the window between the
+    stand-down and its replacement spawn."""
+    live = _Runtime(True)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    # Exactly the mid-respawn state: stood down, replacement not yet spawned, so the
+    # parked entry still carries the CURRENT number.
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(4, live)])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {2: _parked_session(4)})
+    _mints["linear"] = {
+        "state": "waiting",
+        "shared": True,
+        "oauth_url": "https://l/consent",
+        "generation": 4,
+        "activation": 2,
+        "token": "t4",
+    }
+
+    assert warm._warm_mint.generation_is_live(4) is True
+    assert await warm.expire_dead_mints() == []
+    assert _mints["linear"]["state"] == "waiting"
+
+
+def test_a_dead_current_runtime_is_still_dead_when_nothing_is_parked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The fall-through must not turn a genuinely dead generation live."""
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    assert warm._warm_mint.generation_is_live(4) is False
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(4, _Runtime(False))])
+    assert warm._warm_mint.generation_is_live(4) is False
+
+
+# ── defect: session-handle ownership transfers are not cancellation-safe ──
+
+
+class _SessionHandle:
+    """A backend session. Records that it exists, and whether it was terminated."""
+
+    def __init__(self, created: list[Any]) -> None:
+        self.destroyed = False
+        created.append(self)
+
+    async def destroy(self) -> None:
+        self.destroyed = True
+
+    def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_create_still_destroys_the_session_the_backend_made(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The backend's session/new has already succeeded when our wait is abandoned. The
+    handle is the ONLY way to terminate that session and its loopback callback children, so
+    dropping it leaks them until the whole runtime is retired."""
+    created: list[Any] = []
+    exists = asyncio.Event()
+
+    class _SlowToReturn:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            handle = _SessionHandle(created)  # the backend session now EXISTS
+            exists.set()
+            await asyncio.sleep(0.2)  # ...and our wait is abandoned during this
+            return handle
+
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _SlowToReturn())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    task = asyncio.get_running_loop().create_task(
+        warm._warm_mint._activate_locked("agent", frozenset())
+    )
+    await exists.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(created) == 1
+    assert created[0].destroyed is True, "an abandoned session must still be terminated"
+    assert warm._warm_mint._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_mid_session_destroy_keeps_the_record_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The sweep popped the record before awaiting the destroy, so a cancellation there lost
+    the only reference to a session that is still listening."""
+
+    async def _cancels(handle: Any) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_destroy_session_quietly", _cancels)
+    record = warm._WarmSession(generation=1, handle=object(), expires_at=0.0, settled=True)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {5: record})
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint.sweep_sessions(set())
+
+    assert warm._warm_mint._sessions == {5: record}, "the only retry record must survive"
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_destroying_an_unstamped_session_leaves_it_sweepable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The activation's own failure path has the same shape: it popped the record, so a
+    cancellation mid-destroy lost it. Retained instead -- and marked settled and expired, so
+    the next sweep is the retry rather than nothing being."""
+    created: list[Any] = []
+
+    class _PollExplodes:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            return _SessionHandle(created)
+
+    async def _cancels(handle: Any) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_destroy_session_quietly", _cancels)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _PollExplodes())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    monkeypatch.setattr(warm, "_WARM_OAUTH_SETTLE_ROUNDS", 1)
+    # The oauth poll raises, which is what sends the activation down its teardown path.
+    monkeypatch.setattr(
+        _SessionHandle,
+        "pop_pending_oauth_requests",
+        lambda self: (_ for _ in ()).throw(RuntimeError("frame decode failed")),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    sessions = warm._warm_mint._sessions
+    assert len(sessions) == 1, "an undestroyed session must stay tracked"
+    record = next(iter(sessions.values()))
+    assert (
+        record.settled is True and record.expires_at <= time.monotonic()
+    ), "and must be eligible for the sweep, or retaining it just moves the leak"
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_destroying_an_abandoned_session_leaves_it_sweepable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The reaped handle enters the SAME ownership rule as every other session: registered
+    settled-and-expired before the destroy, so an interrupted destroy is retried by the
+    ordinary sweep rather than losing the only reference."""
+    created: list[Any] = []
+    exists = asyncio.Event()
+
+    class _SlowToReturn:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            handle = _SessionHandle(created)
+            exists.set()
+            await asyncio.sleep(0.2)
+            return handle
+
+    async def _cancels(handle: Any) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_destroy_session_quietly", _cancels)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _SlowToReturn())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    task = asyncio.get_running_loop().create_task(
+        warm._warm_mint._activate_locked("agent", frozenset())
+    )
+    await exists.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    sessions = warm._warm_mint._sessions
+    assert len(sessions) == 1, "an undestroyed reaped session must stay tracked"
+    record = next(iter(sessions.values()))
+    assert record.settled is True and record.expires_at <= time.monotonic()
+
+
+# ── defect: an unaddressable abandoned session accumulated without bound ──
+#
+# The no-handle abandon path's acceptance was "reaped when the runtime is retired". But
+# retirement is not guaranteed to arrive: any card holding a URL keeps `_shared_mints_pending`
+# true, which resets the reaper's idle clock every cycle, while `_ensure_locked`'s
+# digest-equality fast path keeps the SAME generation reusable -- so every repetition parked
+# another orphan session and its callback children on one live process.
+
+
+@pytest.mark.asyncio
+async def test_an_unaddressable_abandoned_session_quarantines_its_generation(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """Quarantining bounds the residual to ONE generation's worth: the next activation finds
+    the resident plan unservable, stands the generation down, and the orphan dies with the
+    process."""
+    monkeypatch.setattr(warm, "_WARM_SESSION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(warm, "_WARM_SESSION_REAP_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)
+    monkeypatch.setattr(warm, "_unowned_plan_specs", lambda plan: [])
+
+    class _NeverReturnsAHandle:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            # No handle ever becomes reachable to us, so nothing is addressable to destroy.
+            await asyncio.Event().wait()
+
+    stale = _NeverReturnsAHandle()
+    # The REAL resident plan, so the digest fast path is genuinely reachable -- otherwise the
+    # test would respawn for an unrelated reason and prove nothing.
+    resident = warm._warm_spec_plan([_provider("linear")])
+    monkeypatch.setattr(warm._warm_mint, "_runtime", stale)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_plan", resident)
+    monkeypatch.setattr(warm._warm_mint, "_digest", resident.digest)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+
+    with pytest.raises(BaseException):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    assert warm._warm_mint._plan is None, "the generation must be quarantined"
+    assert warm._warm_mint._digest == ""
+
+    # A subsequent activation must stand the quarantined generation DOWN, not reuse it.
+    killed: list[Any] = []
+
+    async def _record_kill(runtime: Any) -> bool:
+        killed.append(runtime)
+        return True
+
+    class _Spawnable:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def spawn(self) -> None:
+            return None
+
+        def is_alive(self) -> bool:
+            return True
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _Spawnable)
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is not None
+    assert killed == [stale], "the process holding the orphan session was reused instead"
+    reaper = warm._warm_mint._reaper
+    if reaper is not None:
+        reaper.cancel()
+
+
+@pytest.mark.asyncio
+async def test_a_recovered_handle_does_not_quarantine_the_generation(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """The opposite failure mode: the RECOVERED-handle path registers and destroys cleanly,
+    so it needs no stand-down. Quarantining there would cost a respawn on every transient
+    timeout that the reap already fully repaired."""
+    monkeypatch.setattr(warm, "_WARM_SESSION_TIMEOUT_SECONDS", 0.01)
+    created: list[Any] = []
+
+    class _SlowToReturn:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            handle = _SessionHandle(created)
+            await asyncio.sleep(0.05)
+            return handle
+
+    resident = warm._warm_spec_plan([_provider("linear")])
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _SlowToReturn())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_plan", resident)
+    monkeypatch.setattr(warm._warm_mint, "_digest", resident.digest)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    with pytest.raises(BaseException):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    assert created and created[0].destroyed is True, "the reap must still have worked"
+    assert warm._warm_mint._plan is resident, "a fully repaired reap must not force a respawn"
+    assert warm._warm_mint._digest == resident.digest
+
+
+# ── defect: the settle loop never CONSUMED the session queue ──
+#
+# `pop_pending_oauth_requests()` reads a list that only `drain_init` appends to, and
+# `create_session` runs exactly one drain before returning the handle. So `asyncio.sleep`
+# between pops moved nothing: a frame arriving after that create-time drain's idle exit was
+# unreachable no matter how many rounds elapsed. The budget was never the binding
+# constraint -- the loop had no mechanism to absorb a late frame at all.
+
+
+class _QueuedOauthHandle:
+    """A session handle with the real contract: a frame is poppable only after a DRAIN.
+
+    ``available_after_drains`` is how many ``drain_init`` calls must have happened before
+    that provider's frame moves onto the poppable list -- 0 models a frame staged during
+    ``session/new`` and already drained by ``create_session``.
+    """
+
+    def __init__(self, schedule: dict[str, int]) -> None:
+        self._schedule = dict(schedule)
+        self._poppable: list[dict[str, str]] = []
+        self.drains = 0
+        self.destroyed = False
+        self._promote()
+
+    def _promote(self) -> None:
+        for name, due in sorted(self._schedule.items()):
+            if due <= self.drains:
+                self._poppable.append({"serverName": name, "oauthUrl": f"https://{name}/consent"})
+                del self._schedule[name]
+
+    def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+        out, self._poppable = list(self._poppable), []
+        return out
+
+    async def drain_init(self, **kwargs) -> None:
+        self.drains += 1
+        self._promote()
+
+    async def destroy(self) -> None:
+        self.destroyed = True
+
+
+def _queued_runtime(handle: Any) -> Any:
+    class _Runtime:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            return handle
+
+    return _Runtime()
+
+
+@pytest.mark.asyncio
+async def test_a_frame_arriving_after_the_create_drain_is_still_absorbed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`linear`'s frame was staged during session/new; `vercel`'s lands three windows later.
+    Sleeping past it consumed nothing, so it was never poppable."""
+    handle = _QueuedOauthHandle({"linear": 0, "vercel": 3})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    activation, requests = await warm._warm_mint._activate_locked(
+        "agent", frozenset({"linear", "vercel"})
+    )
+
+    names = sorted(str(request["serverName"]) for request in requests)
+    assert names == ["linear", "vercel"], "a late frame must be consumed, not slept past"
+    assert activation in warm._warm_mint._sessions
+    assert handle.destroyed is False
+
+
+@pytest.mark.asyncio
+async def test_the_settle_loop_stops_as_soon_as_every_wanted_frame_is_in(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Consuming must not cost latency when the frames are already staged: the loop still
+    short-circuits on the first pop and opens no drain window at all."""
+    handle = _QueuedOauthHandle({"linear": 0})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    _, requests = await warm._warm_mint._activate_locked("agent", frozenset({"linear"}))
+
+    assert [str(r["serverName"]) for r in requests] == ["linear"]
+    assert handle.drains == 0, "an already-satisfied activation must open no drain window"
+
+
+@pytest.mark.asyncio
+async def test_the_settle_loop_consumes_on_every_round_it_waits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The budget is only meaningful if every waiting round is a CONSUMING round -- one
+    bare sleep anywhere in the loop is a window a frame can land in unseen."""
+    handle = _QueuedOauthHandle({"linear": 0, "never": 99})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    await warm._warm_mint._activate_locked("agent", frozenset({"linear", "never"}))
+
+    assert (
+        handle.drains == warm._WARM_OAUTH_SETTLE_ROUNDS - 1
+    ), "every round that waits must consume; the last round pops and does not wait"
+
+
+@pytest.mark.asyncio
+async def test_a_frame_past_the_whole_budget_releases_its_claim_cleanly(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """Beyond the budget the cold path is the correct answer, so the claim must be RELEASED
+    -- no row left minting, and the token fence still refuses a late absorb."""
+    provider = _provider("slowpoke")
+    claims = await _claim("slowpoke")
+    token = claims["slowpoke"]
+
+    # The activation produced no frame for it at all.
+    empty = _result([provider], [])
+    assert await warm._absorb_warm_requests(empty, claims) == []
+    assert "slowpoke" not in _mints, "an unfulfilled claim must not sit in the table"
+
+    # A later activation re-claims the slug; the first claim's token must not resurrect it.
+    fresh = await _claim("slowpoke")
+    assert fresh["slowpoke"] != token
+    late = _result([provider], [{"serverName": "slowpoke", "oauthUrl": "https://s/consent"}])
+    assert await warm._absorb_warm_requests(late, claims) == []
+    assert _mints["slowpoke"]["state"] == "minting"
+    assert _mints["slowpoke"]["token"] == fresh["slowpoke"]
+
+
+# ── defect: reuse activated the RESIDENT plan, which still names excluded providers ──
+#
+# Servability deliberately reuses a process whose spec set is a SUPERSET of what the current
+# scan wants, so a shrink does not strand a peer's listeners. But the bulk activation names
+# the resident ALL-AGENT mode, and a mode's mounted server set is fixed by the spec it
+# carried at spawn -- specs are enumerated ONCE, and the wanted subset cannot travel through
+# `session/new` because injected servers kill the process. So `set_mode` initializes the
+# excluded provider's MCP server and an authorization request goes out for exactly the
+# provider `_warm_mintable_entry` vetoed. Filtering the activation's RESULT leaves that
+# request made, which is why these tests assert what the process MOUNTS, not what the mint
+# returns.
+
+
+def _divergent_config(agents: Path, alias: str) -> None:
+    """The user's own agent spec, asking for a DIFFERENT endpoint than the registry does."""
+    (agents / AGENT_FILENAME).write_text(
+        json.dumps({"mcpServers": {alias: {"url": "https://elsewhere.example/mcp"}}}),
+        encoding="utf-8",
+    )
+
+
+class _SpecEnumeratingRuntime:
+    """A process that mounts what kiro-cli mounts: the specs on disk AT SPAWN, by name.
+
+    kiro-cli enumerates the agents directory once at spawn and ``set_mode`` then activates one
+    of THOSE modes, so the servers an activation initializes are the ones the named spec listed
+    when the process started -- not whatever the file says later. Modelling that is the whole
+    point: a fake that re-read the spec at ``create_session`` time would make the defect these
+    tests exist for invisible.
+    """
+
+    def __init__(self, agents_dir: Path, mounted: list[tuple[str, frozenset[str]]], **kwargs: Any):
+        self._agents_dir = agents_dir
+        self._mounted = mounted
+        self._modes: dict[str, frozenset[str]] = {}
+
+    async def spawn(self) -> None:
+        for path in self._agents_dir.glob("*.json"):
+            try:
+                body = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            self._modes[path.stem] = frozenset((body.get("mcpServers") or {}))
+
+    def is_alive(self) -> bool:
+        return True
+
+    async def create_session(self, *, agent: str, mcp_servers: list[Any]) -> Any:
+        assert mcp_servers == [], "a warm session must inject no servers"
+        # What `set_mode` would initialize: the roster this mode carried at spawn.
+        self._mounted.append((agent, self._modes.get(agent, frozenset())))
+        return _SessionHandle([])
+
+
+@pytest.fixture
+def _mount_spy(monkeypatch: pytest.MonkeyPatch, _agents_dir: Path):
+    """Every activation's ``(mode, mounted servers)``, observed at the spawn/set_mode seam."""
+    mounted: list[tuple[str, frozenset[str]]] = []
+
+    def _factory():
+        def _build(**kwargs: Any) -> _SpecEnumeratingRuntime:
+            return _SpecEnumeratingRuntime(_agents_dir, mounted, **kwargs)
+
+        return _build
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", _factory)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
+    monkeypatch.setattr(warm, "_WARM_OAUTH_SETTLE_ROUNDS", 1)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    return mounted
+
+
+async def _spawned_on(agents_dir: Path, plan: warm._WarmSpecPlan, mounted: list[Any]) -> Any:
+    """A live process that enumerated ``plan``'s specs, the way a resident one did."""
+    warm._write_warm_mint_specs(plan)
+    runtime = _SpecEnumeratingRuntime(agents_dir, mounted)
+    await runtime.spawn()
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_an_excluded_provider_is_never_mounted_by_a_bulk_activation(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path, _mount_spy: list[Any]
+):
+    """THE test: assert what the activation INITIALIZES, not what the mint returns.
+
+    RED before the fix -- the resident all-agent mode was reused, so `notion`'s MCP server
+    was still mounted and challenged for even though its URL was discarded."""
+    linear, notion = _provider("linear"), _provider("notion")
+    resident = warm._warm_spec_plan([linear, notion])
+    assert set(resident.entries) == {"linear", "notion"}
+    stale = await _spawned_on(_agents_dir, resident, _mount_spy)
+    _mount_spy.clear()
+
+    # notion's configured entry now diverges, which vetoes it in every fresh plan.
+    _divergent_config(_agents_dir, "notion")
+
+    async def _kills(runtime: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(warm, "_kill_quietly", _kills)
+    monkeypatch.setattr(warm, "_warm_candidate_scan", lambda: ([linear, notion], [linear, notion]))
+    monkeypatch.setattr(warm._warm_mint, "_runtime", stale)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    monkeypatch.setattr(warm._warm_mint, "_plan", resident)
+    monkeypatch.setattr(warm._warm_mint, "_digest", resident.digest)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    result = await warm._warm_mint.mint_for()
+
+    assert result is not None
+    assert len(_mount_spy) == 1, "exactly one activation"
+    mode, servers = _mount_spy[0]
+    assert mode == warm._WARM_ALL_AGENT
+    assert servers == frozenset({"linear"}), "the vetoed provider's server was initialized"
+    assert [provider["slug"] for provider in result.providers] == ["linear"]
+
+
+@pytest.mark.asyncio
+async def test_a_shrink_parks_a_process_a_card_still_needs_rather_than_killing_it(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path, _mount_spy: list[Any]
+):
+    """The other half of the constraint: re-mounting an exact roster must not strand a peer.
+
+    A process holding a redeemable code is PARKED, keeps its generation live, and the drain
+    retires it once its rows are gone -- so the excluded provider stops being mounted without
+    any card losing its URL."""
+    linear, notion = _provider("linear"), _provider("notion")
+    resident = warm._warm_spec_plan([linear, notion])
+    stale = await _spawned_on(_agents_dir, resident, _mount_spy)
+    _mount_spy.clear()
+    _divergent_config(_agents_dir, "notion")
+
+    killed: list[Any] = []
+
+    async def _record_kill(runtime: Any) -> bool:
+        killed.append(runtime)
+        return True
+
+    # A peer is mid-consent on the resident generation, so killing it would strand its URL.
+    _mints["vercel"] = {"state": "waiting", "shared": True, "generation": 4, "token": "t"}
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_warm_candidate_scan", lambda: ([linear, notion], [linear, notion]))
+    monkeypatch.setattr(warm._warm_mint, "_runtime", stale)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    monkeypatch.setattr(warm._warm_mint, "_plan", resident)
+    monkeypatch.setattr(warm._warm_mint, "_digest", resident.digest)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    assert await warm._warm_mint.mint_for() is not None
+
+    assert killed == [], "a process a card is still mid-consent on must be parked, not killed"
+    assert [generation for generation, _ in warm._warm_mint._retiring] == [4]
+    assert warm._warm_mint.generation_is_live(4) is True, "the parked URL must stay redeemable"
+    assert _mount_spy[0][1] == frozenset({"linear"})
+
+
+@pytest.mark.asyncio
+async def test_a_roster_that_only_changed_ORDER_reuses_the_process_instead_of_parking_it(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """The reuse branch's surviving case, now that the slug-scoped modes are gone.
+
+    The digest is order-sensitive (a spec's ``tools`` is a LIST built in scan order), so a
+    registry that hands the same providers back in a different order produces a different
+    digest for an IDENTICAL roster. Only the two predicates catch that: servability says the
+    resident process can answer for everything wanted, and
+    ``_resident_roster_is_asked_for`` says it mounts nothing extra. Without them a bare
+    reorder would park a live process and respawn for no gain.
+
+    This is also the guard on the tempting simplification: collapsing the pair into the
+    digest comparison alone.
+    """
+    linear, notion = _provider("linear"), _provider("notion")
+    resident = warm._warm_spec_plan([linear, notion])
+    reordered = warm._warm_spec_plan([notion, linear])
+    assert resident.entries == reordered.entries, "same roster"
+    assert resident.digest != reordered.digest, "a reorder must not be caught by the digest"
+
+    def _never_respawn():
+        raise AssertionError("an identical roster in a new order must reuse the process")
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", _never_respawn)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(True))
+    monkeypatch.setattr(warm._warm_mint, "_plan", resident)
+    monkeypatch.setattr(warm._warm_mint, "_digest", resident.digest)
+
+    served = await warm._warm_mint._ensure_locked([notion, linear])
+
+    assert served is not None
+    assert set(served.entries) == {"linear", "notion"}
+    # The enumerated superset is what the next scan is judged against, so it must survive
+    # a reuse untouched.
+    assert warm._warm_mint._plan is resident
+
+
+# ── a session destroy that TIMES OUT is not a destroy ──
+#
+# `_destroy_session_quietly` swallowed every `Exception` and returned None, so a destroy that
+# timed out was indistinguishable from one that worked. The record each caller then dropped
+# is the ONLY reference to the handle, so a session that is still listening -- and the
+# loopback callback children it owns -- became unaddressable, with nothing that could retry.
+# `asyncio.TimeoutError` IS an `Exception`, so the retention every call site already had --
+# each written for a `CancelledError`, which is not -- never covered the case. The same class
+# as `_kill_quietly` above, one layer down.
+
+
+class _UndestroyableHandle:
+    """A session whose destroy fails the way a timeout does: a plain ``Exception``.
+
+    Fails ``failures`` times and then succeeds, so one test pins both halves of the
+    contract -- retained while the destroy does not take, forgotten once it does.
+    """
+
+    def __init__(self, failures: int = 1) -> None:
+        self._failures = failures
+        self.destroy_attempts = 0
+
+    async def destroy(self) -> None:
+        self.destroy_attempts += 1
+        if self.destroy_attempts <= self._failures:
+            raise TimeoutError("session destroy timed out")
+
+    def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_a_session_destroy_that_times_out_reports_false():
+    """The verdict itself: without it no caller can tell the two outcomes apart."""
+    handle = _UndestroyableHandle(failures=1)
+
+    assert await warm._destroy_session_quietly(handle) is False
+    assert await warm._destroy_session_quietly(handle) is True
+
+
+@pytest.mark.asyncio
+async def test_a_session_sweep_whose_destroy_times_out_keeps_the_record(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """RED before the fix: the record was popped and the live session forgotten."""
+    handle = _UndestroyableHandle(failures=1)
+    record = warm._WarmSession(generation=1, handle=handle, expires_at=0.0, settled=True)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {5: record})
+
+    await warm._warm_mint.sweep_sessions(set())
+
+    assert handle.destroy_attempts == 1
+    assert warm._warm_mint._sessions == {5: record}, "the last reference left must survive"
+
+    # The next sweep is the retry -- and only then is the record forgotten.
+    await warm._warm_mint.sweep_sessions(set())
+
+    assert handle.destroy_attempts == 2
+    assert warm._warm_mint._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_an_activation_teardown_whose_destroy_times_out_leaves_it_sweepable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The activation's own failure path popped unconditionally, so the sweep it marks the
+    record for could never run."""
+    handle = _UndestroyableHandle(failures=99)
+
+    class _PollExplodes:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            return handle
+
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _PollExplodes())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    monkeypatch.setattr(warm, "_WARM_OAUTH_SETTLE_ROUNDS", 1)
+    # The oauth poll raises, which is what sends the activation down its teardown path.
+    monkeypatch.setattr(
+        _UndestroyableHandle,
+        "pop_pending_oauth_requests",
+        lambda self: (_ for _ in ()).throw(RuntimeError("frame decode failed")),
+    )
+
+    with pytest.raises(RuntimeError):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    sessions = warm._warm_mint._sessions
+    assert len(sessions) == 1, "a session that may still be listening must stay tracked"
+    record = next(iter(sessions.values()))
+    assert record.handle is handle
+    assert (
+        record.settled is True and record.expires_at <= time.monotonic()
+    ), "and must be eligible for the sweep, or retaining it just moves the leak"
+
+
+@pytest.mark.asyncio
+async def test_a_reaped_session_whose_destroy_times_out_stays_tracked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The recovered-handle path registers the reaped session settled-and-expired for exactly
+    this reason, so a destroy that does not take must leave the record for the sweep."""
+    handle = _UndestroyableHandle(failures=99)
+
+    class _SlowToReturn:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            await asyncio.sleep(0.05)
+            return handle
+
+    monkeypatch.setattr(warm, "_WARM_SESSION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _SlowToReturn())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    with pytest.raises(asyncio.TimeoutError):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    sessions = warm._warm_mint._sessions
+    assert len(sessions) == 1, "the reaped session may still be listening; keep it tracked"
+    record = next(iter(sessions.values()))
+    assert record.handle is handle
+    assert record.settled is True and record.expires_at <= time.monotonic()
+
+
+# ── an unreadable grant cache is not an absent grant ──
+#
+# `grant_present` is tri-state and `None` means the cache could not be read at all, so
+# `not grant_present(...)` selected an indeterminate provider for a warm mint: consent was
+# initiated on an absence nobody confirmed, and the card was flipped to waiting behind an
+# approval URL for a provider that may already be connected. L1 collapses the same third
+# answer on purpose because it never initiates consent; this path does.
+
+
+def test_an_indeterminate_grant_is_not_read_as_an_absent_one(monkeypatch: pytest.MonkeyPatch):
+    """RED before the fix: `not None` is True, so `unreadable` was warmed."""
+    universe = [_provider("fresh"), _provider("unreadable"), _provider("granted")]
+
+    def _presence(url: str) -> bool | None:
+        if "unreadable" in url:
+            return None
+        return "granted" in url
+
+    monkeypatch.setattr(warm, "grant_present", _presence)
+
+    assert [p["slug"] for p in warm._warm_activation_candidates(universe)] == ["fresh"]
+
+
+def test_an_indeterminate_provider_is_named_and_read_exactly_once(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Skipped is not dropped: the provider is named, so its absence from the batch is
+    accountable. Read ONCE -- a re-stat to classify the skip is the two-pass race
+    `grant_presence` refuses, where a failure clearing between passes reads as absence."""
+    reads: list[str] = []
+
+    def _unreadable(url: str) -> bool | None:
+        reads.append(url)
+        return None
+
+    monkeypatch.setattr(warm, "grant_present", _unreadable)
+
+    with caplog.at_level(logging.WARNING, logger=warm.logger.name):
+        assert warm._warm_activation_candidates([_provider("notion")]) == []
+
+    assert len(reads) == 1, "presence was read more than once per provider"
+    assert "notion" in caplog.text


### PR DESCRIPTION
## Problem / Motivation

Opening the Connections gallery pays a full kiro-cli process spawn (~7.5s) per card the moment a user clicks Connect, because every approval URL is minted cold. #6045 landed the warm-mint TABLE (the row shape a shared mint uses, and the withdrawal chokepoint `expire_dead_mints`), but nothing planned what a shared warm process should serve, wrote the specs it would activate, or ran the process itself.

**Scope note:** this PR now carries BOTH halves of the warm-mint engine. It began as the spec-plan slice; the runtime slice ([#6720](https://github.com/kirodotdev/KiroCrew/pull/6720), reviewed separately through its own five-lane rounds) was merged into this branch on 2026-08-29, so what merges here is the complete engine. The earlier description's "lifecycle deferred" framing is superseded by this one.

## Why it matters

One shared process activation yields every card's approval URL, replacing the ~7.5s-per-card cold spawn with a fixed ~5.18s activation shared across all providers.

## What changed (motivation → approach → change)

The engine lives in `src/kiro_crew/connections/warm.py` (extending #6045's table module) with its test file and the design note; the branch also carries its first consumer, absorbed by the maintainer from #6968: `POST /api/connections/premint` (handler in `dashboard/handlers/connections.py`, route registration, a `hooks.py` read-id, and `test/test_connections_premint.py`).

**Spec-plan half** (reviewed as this PR's original scope):
- Provider scan and candidates: enumerate registry providers that are remote, enabled, and not already granted; an unreadable inventory warms nothing rather than raising.
- Tool aliasing: every claimant of a tool-name collision is renamed, so a spec mounting several providers stays activatable.
- Spec plan + servability: a resident process keeps serving a shrunk candidate set; a changed authorization ask is not servable.
- Spec file IO with ownership proof: files at warm paths are touched only when their contents prove we wrote them — every description starts with a sentinel (the only schema-legal carrier; kiro-cli rejects unknown keys), and the judge fails closed. A hand-written agent at a warm path survives write, sweep, and teardown; each refusal is audited.

**Runtime half** (merged from [#6720](https://github.com/kirodotdev/KiroCrew/pull/6720)):
- Process lifecycle on `_WarmMintRuntime`: spawn, activation settlement, session sweep, park-or-kill on plan changes, generation retirement, a reaper, and a parked-generation drain covering reaper-death, spawn-failure, and cancellation routes.
- Claim/absorb/expire for shared rows, and the entry point `warm_mint_all`.
- The three #6110 gating fixes, red-first and mutation-checked: rows fenced by opaque per-row uuid4 tokens instead of a wall-clock value (whose ~15.6ms Windows granularity made the donor's fence fail open); every approval URL screened by `security.oauth_url_contains_credential` off-loop BEFORE it is stored on a row (a credential-bearing URL is refused and audited); a cancellation between claim and activation releases every installed token.
- A cancellation-safety campaign (four local review rounds plus the server round): activation only runs on specs re-verified as sentinel-owned (a refused foreign spec is never executed — warming aborts to the cold path); stand-down→spawn, session settlement, retiring sweep, and hard teardown are all `BaseException`-safe under one uniform pattern; liveness consults the retiring table so a parked-mid-respawn generation is not misread as dead; an abandoned session creation quarantines its generation, bounding the orphan residual to one generation; the OAuth settle loop actively drains frames each round instead of sleep-polling a list nothing fed. The invariant ("registered before anything can interrupt, forgotten only once its destroy completed") is documented as an ownership table in the design note and enforced by an AST test bound to specific awaits plus 19 compile-verified mutation checks.
- New SEL audit events for spec refusals and warm spawns.

**Endpoint scope**: the `POST /api/connections/premint` endpoint originally planned as the next slice was merged into this branch by the maintainer (#6968), so this PR ships the engine together with its first caller. The endpoint performs bulk warm mints only; a per-provider `mint_for(slug=)` variant that had no production caller was removed from this PR, and per-provider activation will land with the connections page slice that actually calls it.

## Tests

`test/test_connections_warm.py` grows 30 → **77** (sync plan-half tests plus async lifecycle tests): the foreign-file refusal suite including the stock-defaults mimic; sweep/plan/servability/alias coverage; the seven donor lifecycle tests; red-first regressions for all three #6110 fixes and for every review-round fix (claim-window cancel, scoped expiry, parked drain both routes, refused-spec activation gate, spawn-transition abandon, settlement-on-every-exit, sweep retain-until-destroyed, liveness fall-through, abandoned-create reap, generation quarantine, settle-loop drain); the AST invariant guards; and the session-never-injects-mcp-servers pin. Full `test_connections_*.py` surface: 779 passing.

## Manual verification

N/A — unit coverage sufficient: backend-only. The engine is exercised directly by the suite (including under injected cancellation at every audited window) and through its endpoint consumer's tests in `test/test_connections_premint.py`.

## Screenshots / video

N/A — backend + docs only; no user-visible UI change.

## Related Issues

The dashboard wiring (premint endpoint) follows as the next slice.

Fixes #6110

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


