### PR TITLE
fix(auto-improvement): stop an in-flight run on gateway shutdown

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
@@ -1485,12 +1485,32 @@ def register_routes(app: web.Application) -> None:
         except Exception:  # pragma: no cover - defensive
             logger.warning("%s: watcher shutdown failed", store.APP_NAME, exc_info=True)
 
+    async def _stop_run(_app: web.Application) -> None:
+        """Wind down an in-flight run on gateway shutdown.
+
+        The supervisor's worker thread is a daemon and does not block exit, but the
+        agent/measurer SUBPROCESS it spawns is not — left running it outlives the
+        gateway, holding the clone lock and spending budget after the process that
+        owned it is gone. ``stop`` is idempotent (a no-op when idle) and bounded: it
+        signals the run and joins for at most ``STOP_JOIN_TIMEOUT_S``, since the spine
+        stops between candidates. A measurement already in flight can exceed that
+        window — the join then returns with the run still ``stopping`` — but asking it
+        to stop at all is the improvement over leaving it entirely unsignalled. Run
+        off the event loop because that join blocks.
+        """
+        try:
+
+            await asyncio.to_thread(runner.get_supervisor().stop)
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("%s: run shutdown failed", store.APP_NAME, exc_info=True)
+
     # Guarded: register_routes runs before the runner freezes its signal lists,
     # so appending is safe — but a failure here must never break gateway startup.
     try:
         app.on_startup.append(_bind_watcher_loop)
         app.on_cleanup.append(_stop_watchers)
+        app.on_cleanup.append(_stop_run)
     except Exception:  # pragma: no cover - defensive
-        logger.warning("%s: could not register watcher lifecycle hooks", store.APP_NAME)
+        logger.warning("%s: could not register lifecycle hooks", store.APP_NAME)
 
     logger.info("%s backend routes registered", store.APP_NAME)

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_shutdown_stops_run.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_shutdown_stops_run.py
@@ -1,0 +1,111 @@
+"""Gateway shutdown must stop an in-flight run, not orphan it.
+
+The supervisor's worker thread is a daemon, so it does not block interpreter exit —
+but the agent/measurer SUBPROCESS it spawns is not a daemon and can outlive the
+gateway, holding the clone lock and continuing to spend budget after the process
+that owned it is gone. ``RunSupervisor.stop`` exists to wind a run down cleanly and
+bounded, but nothing invoked it on shutdown: ``register_routes`` wired an
+``on_cleanup`` hook for the PR watchers and none for the run supervisor.
+
+This test drives the real ``register_routes`` on a bare aiohttp application, starts a
+run that parks in ``driver.run`` (so the supervisor genuinely owns a live thread),
+then fires the app's ``on_cleanup`` signal exactly as ``aiohttp`` does at shutdown.
+The run must be stopped afterwards. It fails before the lifecycle hook is added.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+from kiro_crew.apps.builtins.auto_improvement.backend import routes as R
+from kiro_crew.apps.builtins.auto_improvement.backend import runner
+
+
+class _BlockingDriver:
+    """Parks in ``run`` until stopped, so the supervisor has a genuinely live thread."""
+
+    def __init__(self) -> None:
+        self._release = threading.Event()
+
+    def run(self, **_kw: Any) -> Any:
+        self._release.wait(timeout=10.0)
+        return _FakeStats()
+
+    def request_stop(self) -> None:
+        self._release.set()
+
+
+class _FakeStats:
+    cycles = 0
+    discovered = 0
+    deduped = 0
+    gated_out = 0
+    not_kept = 0
+    kept = 0
+    filed = 0
+    errors = 0
+    cost_usd = 0.0
+
+
+@pytest.fixture
+def _fresh_singleton(monkeypatch: pytest.MonkeyPatch) -> runner.RunSupervisor:
+    """A fresh process-wide supervisor for the duration of the test.
+
+    The cleanup hook resolves the supervisor through ``runner.get_supervisor()``, so
+    the test must drive that same singleton — but a run leaked into the real module
+    singleton would make unrelated tests' "already active" refusal fire. Swapping the
+    module global for a fresh instance keeps both true.
+    """
+    sup = runner.RunSupervisor()
+    monkeypatch.setattr(runner, "_SUPERVISOR", sup)
+    return sup
+
+
+@pytest.mark.asyncio
+async def test_gateway_shutdown_stops_an_active_run(
+    _fresh_singleton: runner.RunSupervisor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    driver = _BlockingDriver()
+    monkeypatch.setattr(_fresh_singleton, "_build_driver", lambda _cfg: driver)
+
+    app = web.Application()
+    R.register_routes(app)
+    # aiohttp freezes the signal lists during startup; a signal can only be sent once
+    # frozen, so mirror that here before firing shutdown.
+    app.freeze()
+
+    started = _fresh_singleton.start({"clone": "/does/not/matter"})
+    try:
+        assert started["status"] == runner.STATUS_RUNNING
+        assert _fresh_singleton.status()["status"] == runner.STATUS_RUNNING
+
+        # Fire the shutdown signals exactly as aiohttp does when the gateway stops.
+        await app.on_cleanup.send(app)
+
+        # The load-bearing assertion: before the fix `request_stop` is never called,
+        # so this is False and the run is orphaned.
+        assert (
+            driver._release.is_set()
+        ), "shutdown did not ask the driver to stop — the run was orphaned"
+        # The released driver returns at once, so the join inside `stop` observes a
+        # finished thread and the terminal status is DONE. (STOPPING would be the
+        # honest answer only if a real measurement outran the join timeout.)
+        assert (
+            _fresh_singleton.status()["status"] == runner.STATUS_DONE
+        ), "the run supervisor was not stopped on gateway shutdown"
+    finally:
+        driver.request_stop()
+        _fresh_singleton.stop()
+
+
+def test_register_routes_wires_a_supervisor_cleanup_hook() -> None:
+    """A structural guard: the run-supervisor stop must be an on_cleanup hook, so a
+    future edit that drops it fails here rather than silently orphaning runs."""
+    app = web.Application()
+    R.register_routes(app)
+    names = {getattr(h, "__name__", "") for h in app.on_cleanup}
+    assert "_stop_run" in names, sorted(names)


### PR DESCRIPTION
## Problem / Motivation

An active Auto-Improvement run is not wound down when the gateway shuts down or the app is disabled. `register_routes` wires an `on_cleanup` hook for the PR watchers (`_stop_watchers`) but no lifecycle hook invokes `RunSupervisor.stop`.

## Why it matters

The supervisor's worker thread is a daemon and does not block interpreter exit, but the agent/measurer **subprocess** it spawns is not a daemon. Left unsignalled on shutdown, that subprocess can outlive the gateway — holding the clone lock and continuing to spend run budget after the process that owned it is gone.

## What changed (motivation → approach → change)

- Symptom: a run keeps a subprocess alive past gateway shutdown / app disable.
- Root cause: nothing calls the already-bounded `RunSupervisor.stop` from a shutdown path; only the watchers get an `on_cleanup` hook.
- Change: register a parallel `_stop_run` `on_cleanup` hook that invokes `runner.get_supervisor().stop` via `asyncio.to_thread` (the join blocks, so it runs off the event loop). This mirrors the existing `_stop_watchers` convention rather than introducing a new mechanism. `stop` is idempotent (a no-op when idle) and bounded (it signals the run and joins for at most `STOP_JOIN_TIMEOUT_S`, since the spine stops between candidates), so it is safe to call unconditionally on every shutdown. A measurement already in flight can still exceed the join window — the join then returns with the run `stopping` — but signalling the run at all is the improvement over leaving it entirely unsignalled; the residual subprocess-lifecycle gap is pre-existing and out of scope.

## Tests

- `test_gateway_shutdown_stops_an_active_run` — starts a run parked in a blocking driver, fires the app's `on_cleanup` signal exactly as aiohttp does at shutdown, and asserts the driver was asked to stop and the run reached a terminal state. Fails before the hook is added (the run is orphaned).
- `test_register_routes_wires_a_supervisor_cleanup_hook` — a structural guard that the `_stop_run` hook stays registered, so a future edit that drops it fails here rather than silently orphaning runs.

## Manual verification

N/A — unit coverage sufficient. The change is a backend lifecycle hook exercised directly by firing the real `on_cleanup` signal against a started run.

## Related Issues

Fixes #6700

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I have read the CLA Document and I hereby sign the CLA.
