### PR TITLE
fix(auto-improvement): make setup_safe_clone reuse idempotent

### DIFF
--- a/docs/system-specs/modules/auto-improvement.md
+++ b/docs/system-specs/modules/auto-improvement.md
@@ -89,7 +89,7 @@ and never drive the verdict, or one flaky optional job would nudge forever.
 
 | Control | Where | Behavior |
 |---|---|---|
-| Push-disabled clone | `backend/clone_setup.py:_disable_push` + `spine/driver.py:assert_push_disabled` | **BOTH** origin urls are `DISABLED_NO_PUSH`; the run refuses to start otherwise. The real remote lives in config (`origin_url`), handed only to the trusted publishers |
+| Push-disabled clone | `backend/clone_setup.py:_disable_push` + `profiles/github_repo/profile.py:RepoIsolation.push_disabled` | **Every** configured fetch/push URL is replaced with exactly one `DISABLED_NO_PUSH` value; setup and runtime fail closed on extra values. The real remote lives in config (`origin_url`), handed only to trusted publishers |
 | Draft-only PRs | `profiles/github_repo/pr_recipe.py` | `gh pr create --draft`; never `--web`, merge, ready, or auto-merge |
 | Generated head branch | same | `auto-improvement/<kind>-<fingerprint>`; never a human's branch |
 | Protected-branch denylist | `spine/push_policy.py` | non-overridable; a hand-edited config cannot widen it |
@@ -105,6 +105,48 @@ and never drive the verdict, or one flaky optional job would nudge forever.
 | Pre-push content scan | `spine/push_policy.py:scan_content_for_secrets` | ONE scanner behind all three exits — draft-PR push, F10 direct push, one-click commit. The full pushed range is scanned; a hit **refuses** the push and the change stays in the local queue; **fail-closed** |
 | Audited subprocess agent (NOT SELECTED) | `spine/agent_runner.py:_audit_unattended_agent` | same — retained for a future caller. The `claude -p` path passes `--dangerously-skip-permissions`, so the launch is one blanket approval — logged `critical=True` before the spawn, and an unwritable audit REFUSES to launch |
 | Redacted PR prose | same, `_redact_prose` | title and description are redacted (prose survives rewriting; a diff does not) |
+
+### Clone setup and reuse contract
+
+`setup_safe_clone` derives the canonical destination from the validated GitHub
+`owner/repo`; it never treats clone contents as trusted. The improvement agent is
+expected to edit that checkout, so reuse attests only properties the host can
+enforce: the scratch root/destination and Git metadata contain no links or
+redirections, local Git config has no includes/URL rewrites/worktree override,
+and every origin fetch/push URL is exactly `DISABLED_NO_PUSH`.
+
+A documented setup re-run accepts that sentinel and reasserts the controls, which
+is the idempotency guarantee. A live mismatched or multi-valued fetch origin,
+unsafe Git metadata/config, linked scratch path, or non-repository destination is
+refused without mutation. Push URL values are instead always replaced with
+exactly one sentinel before success is reported. Initial clone ignores
+global/system Git config, pins hooks and fsmonitor off, allows only the validated
+transport, and removes partial output on failure. Branch listing, checkout, and
+runtime isolation repeat the metadata and URL-set checks. Git metadata entries must
+be regular files (object files may remain hardlinked); FIFOs, sockets, devices,
+links, and hardlinked non-object metadata are refused before host Git. Repository integrity
+is an unconditional runner startup prerequisite; direct-commit authorization can
+relax only push posture, never metadata/config validation. The attributes pin is
+published by atomic replacement, so a hardlinked path cannot truncate another
+inode. Each trusted publisher validates full repository isolation (metadata/config
+safety plus exact disabled URL sets) after the agent's final write and before its
+first trusted Git scan/mutation. Perf preflight uses the same capture → attest/retire
+→ interpret ordering before progress, archive, or HEAD reads. The one-click route holds
+the clone lock and proves the runner idle for that whole critical section; the
+driver additionally revalidates after a rebase before its retry push. Local
+configuration that can invoke host-side helpers (including diff, filter, merge,
+editor, askpass, hook, fsmonitor, proxy, signing, attributes-file, and
+excludes-file helpers) is refused; trusted Git pins both external paths to Git's
+cross-platform `/dev/null` spelling, and content scans additionally clear `diff.external` and disable external diffs. If safety
+changes after an agent/build step, the run stops before further Git, atomically
+moves the canonical clone into a private `.unsafe-*` incident directory, reports
+the retained path, and caps those incident copies at three per repository;
+ordinary setup mismatch never creates these copies.
+
+This contract deliberately makes no HMAC or clean-checkout claim: clone content
+and history remain agent-writable, while trusted publishing is contained by
+protected-branch policy, content scanning, final repository-config validation,
+and explicit config-held push destinations.
 
 ### Why the unattended runner consults the platform governance gate
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
@@ -17,13 +17,20 @@ import ipaddress
 import logging
 import os
 import re
+import secrets
 import shutil
 import socket
+import stat
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
+from kiro_crew.platform_compat import (
+    first_linked_ancestor,
+    is_link_or_junction,
+    rmtree_force,
+)
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
 from ..spine.git_safety import GIT_SAFE_CONFIG, require_pinned
@@ -46,6 +53,262 @@ _MAX_URL_LEN = 400
 
 #: The cross-cutting push-disable sentinel — matches the spine's isolation check.
 DISABLED_NO_PUSH = "DISABLED_NO_PUSH"
+
+_GIT_REPOSITORY_ENV_KEYS = frozenset(
+    {
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_CONFIG",
+        "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_GLOBAL",
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_SYSTEM",
+        "GIT_DIR",
+        "GIT_GRAFT_FILE",
+        "GIT_INDEX_FILE",
+        "GIT_NAMESPACE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_PREFIX",
+        "GIT_REPLACE_REF_BASE",
+        "GIT_SHALLOW_FILE",
+        "GIT_TEMPLATE_DIR",
+        "GIT_WORK_TREE",
+    }
+)
+
+
+def _git_env(*, network_protocol: str = "") -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _GIT_REPOSITORY_ENV_KEYS
+        and not key.startswith("GIT_CONFIG_KEY_")
+        and not key.startswith("GIT_CONFIG_VALUE_")
+    }
+    env.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_ALLOW_PROTOCOL": network_protocol,
+        }
+    )
+    if not network_protocol:
+        env.update(
+            {
+                "GIT_PROTOCOL_FROM_USER": "0",
+                "GIT_NO_LAZY_FETCH": "1",
+                "GIT_NO_REPLACE_OBJECTS": "1",
+            }
+        )
+    return env
+
+
+def _origin_urls(repo: Path, *, push: bool) -> list[str] | None:
+    key = "remote.origin.pushurl" if push else "remote.origin.url"
+    try:
+        proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                *_GIT_SAFE_CONFIG,
+                "config",
+                "--local",
+                "--no-includes",
+                "--get-all",
+                key,
+            ],
+            capture_output=True,
+            timeout=30,
+            shell=False,
+            env=_git_env(),
+            **UTF8_TEXT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode == 1:
+        return []
+    if proc.returncode != 0:
+        return None
+    return [line.strip() for line in (proc.stdout or "").splitlines() if line.strip()]
+
+
+def _repository_is_safe(repo: Path) -> bool:
+    git_dir = repo / ".git"
+    if first_linked_ancestor(git_dir) or is_link_or_junction(git_dir):
+        return False
+    if not git_dir.is_dir():
+        return False
+    for directory in (
+        git_dir / "objects",
+        git_dir / "objects" / "info",
+        git_dir / "info",
+    ):
+        if first_linked_ancestor(directory) or is_link_or_junction(directory):
+            return False
+    for forbidden in (
+        git_dir / "commondir",
+        git_dir / "config.worktree",
+        git_dir / "objects" / "info" / "alternates",
+        git_dir / "objects" / "info" / "http-alternates",
+        git_dir / "info" / "grafts",
+    ):
+        if os.path.lexists(forbidden):
+            return False
+    object_dir = git_dir / "objects"
+    errors: list[OSError] = []
+    for current, directories, files in os.walk(
+        git_dir, topdown=True, followlinks=False, onerror=errors.append
+    ):
+        current_path = Path(current)
+        for name in directories:
+            if is_link_or_junction(current_path / name):
+                return False
+        for name in files:
+            path = current_path / name
+            if is_link_or_junction(path):
+                return False
+            try:
+                metadata = path.lstat()
+            except OSError:
+                return False
+            if not stat.S_ISREG(metadata.st_mode):
+                return False
+            if not path.is_relative_to(object_dir) and metadata.st_nlink != 1:
+                return False
+    if errors:
+        return False
+
+    unsafe_keys = (
+        r"^(include\.path|includeif\..*\.path|"
+        r"url\..*\.(insteadof|pushinsteadof)|"
+        r"credential\..*|"
+        r"core\.(alternaterefscommand|askpass|attributesfile|editor|excludesfile|fsmonitor|"
+        r"gitproxy|hookspath|pager|sshcommand|worktree)|"
+        r"diff\..*|difftool\..*|"
+        r"filter\..*\.(clean|process|smudge)|gpg\..*|"
+        r"merge\..*\.driver|mergetool\..*|sequence\.editor|ssh\..*|"
+        r"https?\..*|protocol\..*|"
+        r"remote\..*\.(proxy|receivepack|uploadpack)|"
+        r"extensions\.worktreeconfig)$"
+    )
+    try:
+        proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                *_GIT_SAFE_CONFIG,
+                "config",
+                "--local",
+                "--no-includes",
+                "--name-only",
+                "--get-regexp",
+                unsafe_keys,
+            ],
+            capture_output=True,
+            timeout=30,
+            shell=False,
+            env=_git_env(),
+            **UTF8_TEXT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 1
+
+
+_UNSAFE_CLONE_RETENTION = 3
+
+
+def _prune_unsafe_clone_retirements(parent: Path, repo_name: str, current: Path) -> None:
+    """Keep the current incident plus the two newest prior retired clones."""
+    prefix = f".{repo_name}.unsafe-"
+    try:
+        candidates = [
+            path
+            for path in parent.iterdir()
+            if path.name.startswith(prefix)
+            and path != current
+            and not is_link_or_junction(path)
+            and path.is_dir()
+        ]
+        candidates.sort(key=lambda path: path.lstat().st_mtime_ns, reverse=True)
+    except OSError:
+        logger.warning("could not inventory retired clones under %s", parent)
+        return
+    for stale in candidates[_UNSAFE_CLONE_RETENTION - 1 :]:
+        if not rmtree_force(stale):
+            logger.warning("could not prune retired clone %s", stale)
+
+
+def _retire_unsafe_clone(repo: Path) -> Path | None:
+    """Atomically remove an unsafe clone from its canonical name without Git.
+
+    This is an incident boundary, not setup recovery: it runs only when a clone that
+    was safe before an agent/build step fails validation afterwards. Renaming the root
+    directory does not dereference the now-hostile Git metadata, prevents a later run
+    from adopting a rejected provisional commit, and preserves bytes for diagnosis.
+    """
+    repo = Path(repo)
+    parent = repo.parent
+    if (
+        first_linked_ancestor(parent)
+        or is_link_or_junction(parent)
+        or is_link_or_junction(repo)
+        or not repo.is_dir()
+    ):
+        return None
+    container = parent / f".{repo.name}.unsafe-{secrets.token_hex(8)}"
+    retired = container / repo.name
+    try:
+        if os.name == "nt":
+            # mkdir is the no-replace reservation. Windows rename cannot replace a
+            # non-empty destination and never follows a destination symlink.
+            container.mkdir(mode=0o700)
+            os.rename(repo, retired)
+        else:
+            flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+            parent_fd = os.open(parent, flags)
+            container_fd = -1
+            try:
+                os.mkdir(container.name, mode=0o700, dir_fd=parent_fd)
+                container_fd = os.open(container.name, flags, dir_fd=parent_fd)
+                # Both names are descriptor-relative. If a same-UID racer creates
+                # `retired` first, rename either replaces only that directory entry
+                # (never its target) or fails on a non-empty directory.
+                os.rename(
+                    repo.name,
+                    repo.name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=container_fd,
+                )
+            finally:
+                if container_fd >= 0:
+                    os.close(container_fd)
+                os.close(parent_fd)
+    except OSError:
+        logger.exception("could not retire unsafe clone %s", repo)
+        try:
+            container.rmdir()
+        except OSError:
+            pass
+        return None
+    _prune_unsafe_clone_retirements(parent, repo.name, container)
+    return retired
+
+
+def _push_disabled(repo: Path) -> bool:
+    return _origin_urls(repo, push=True) == [DISABLED_NO_PUSH] and _origin_urls(
+        repo, push=False
+    ) == [DISABLED_NO_PUSH]
+
+
+def _repository_is_isolated(repo: Path) -> bool:
+    """True only when metadata/config is safe and every origin URL is disabled."""
+    return _repository_is_safe(repo) and _push_disabled(repo)
 
 
 @dataclass
@@ -152,60 +415,93 @@ def validate_target_url(url: str) -> tuple[CloneSpec | None, str]:
 
 
 def setup_safe_clone(url: str, scratch_root: Path, *, timeout_s: int = 300) -> tuple[dict, str]:
-    """Validate ``url`` and clone it into ``scratch_root`` with push disabled.
+    """Validate and install/reuse the canonical push-disabled clone.
 
-    Returns ``(result_dict, "")`` on success or ``({}, reason)`` on a user-input
-    problem. Idempotent: an existing clone of the same origin is reused after
-    re-asserting push-disabled. Never follows a symlinked destination — a
-    symlinked scratch dir must not let ``_disable_push`` rewrite a foreign repo.
+    Reuse attests only enforceable properties: canonical location, safe Git
+    metadata/config, and exactly one disabled fetch/push URL. Clone contents stay
+    agent-writable by design and are never represented as cryptographically trusted.
     """
     spec, err = validate_target_url(url)
     if not spec:
         return {}, err
+    if is_link_or_junction(scratch_root) or first_linked_ancestor(scratch_root):
+        return {}, "Clone scratch directory is under a link or junction (refused for safety)."
 
     scratch_root.mkdir(parents=True, exist_ok=True)
+    if is_link_or_junction(scratch_root) or first_linked_ancestor(scratch_root):
+        return {}, "Clone scratch directory failed safety verification."
     dest = scratch_root / spec.dir_name
 
-    if os.path.islink(dest):
-        return {}, f"Destination is a symlink (refused for safety): {dest}"
+    if is_link_or_junction(dest):
+        return {}, f"Destination is a link or junction (refused for safety): {dest}"
 
     git_dir = dest / ".git"
-    if not os.path.islink(git_dir) and git_dir.is_dir():
-        actual_origin = subprocess.run(
-            ["git", "-C", str(dest), "remote", "get-url", "origin"],
-            capture_output=True,
-            timeout=30,
-            shell=False,
-            **UTF8_TEXT,
-        ).stdout.strip()
-        if actual_origin and actual_origin != spec.clone_url:
+    if is_link_or_junction(git_dir):
+        return {}, f"Existing clone at {dest} has a linked Git directory — refusing reuse."
+    if git_dir.is_dir():
+        if not _repository_is_safe(dest):
+            return {}, f"Existing clone at {dest} failed Git metadata safety verification."
+        origins = _origin_urls(dest, push=False)
+        if origins is None or len(origins) != 1:
+            return {}, f"Existing clone at {dest} has ambiguous origin URLs — refusing reuse."
+        actual_origin = origins[0]
+        if actual_origin not in {DISABLED_NO_PUSH, spec.clone_url}:
             return {}, (
                 f"Existing clone at {dest} has origin {actual_origin!r}, which does not "
                 f"match the requested {spec.clone_url!r} — refusing to reuse it."
             )
         _disable_push(dest)
-        return _ok(spec, dest, reused=True), ""
+        result = _ok(spec, dest, reused=True)
+        if not result.get("push_disabled"):
+            return {}, "clone push could not be disabled — refusing reuse"
+        return result, ""
 
     if dest.exists():
         return {}, f"Destination already exists and is not a git repo: {dest}"
 
-    # argv list, shell=False, clone_url rebuilt from validated components.
+    protocol = "ssh" if spec.clone_url.startswith("git@") else urlparse(spec.clone_url).scheme
+    if protocol not in {"file", "https", "ssh"}:
+        return {}, "validated clone URL has no supported transport"
     try:
         proc = subprocess.run(
-            ["git", "clone", "--origin", "origin", spec.clone_url, str(dest)],
+            [
+                "git",
+                *_GIT_SAFE_CONFIG,
+                "-c",
+                "credential.helper=!gh auth git-credential",
+                "clone",
+                "--origin",
+                "origin",
+                spec.clone_url,
+                str(dest),
+            ],
             capture_output=True,
             timeout=timeout_s,
             shell=False,
+            env=_git_env(network_protocol=protocol),
             **UTF8_TEXT,
         )
     except subprocess.TimeoutExpired:
+        rmtree_force(dest)
         return {}, f"git clone timed out after {timeout_s}s."
+    except OSError as exc:
+        # No child started, so this setup attempt cannot own anything at `dest`.
+        # Do not race-delete a path another same-UID process may have created.
+        return {}, f"git clone could not start: {exc}"
     if proc.returncode != 0:
         tail = (proc.stderr or "").strip().splitlines()[-1:] or [""]
+        rmtree_force(dest)
         return {}, f"git clone failed: {tail[0][:200]}"
+    if not _repository_is_safe(dest):
+        rmtree_force(dest)
+        return {}, "cloned repository failed Git metadata safety verification"
 
     _disable_push(dest)
-    return _ok(spec, dest, reused=False), ""
+    result = _ok(spec, dest, reused=False)
+    if not result.get("push_disabled"):
+        rmtree_force(dest)
+        return {}, "clone push could not be disabled — refusing"
+    return result, ""
 
 
 #: Shape check for a user-selected branch: allowlisted charset, no leading dash
@@ -232,8 +528,12 @@ def list_clone_branches(clone: Path, *, timeout_s: int = 30) -> tuple[list[str],
     """Enumerate an existing clone's branches, default/HEAD first. Read-only, no
     network fetch, operates only on the server-controlled clone dir."""
     clone = Path(clone)
-    if not (clone / ".git").is_dir() and not (clone / ".git").is_file():
+    if not (clone / ".git").is_dir():
         return [], f"Not a git clone: {clone}"
+    if not _repository_is_safe(clone):
+        return [], "clone Git metadata failed safety verification"
+    if not _push_disabled(clone):
+        return [], "clone is not push-disabled"
     proc = subprocess.run(
         [
             "git",
@@ -247,6 +547,7 @@ def list_clone_branches(clone: Path, *, timeout_s: int = 30) -> tuple[list[str],
         capture_output=True,
         timeout=timeout_s,
         shell=False,
+        env=_git_env(),
         **UTF8_TEXT,
     )
     if proc.returncode != 0:
@@ -272,6 +573,7 @@ def list_clone_branches(clone: Path, *, timeout_s: int = 30) -> tuple[list[str],
         capture_output=True,
         timeout=timeout_s,
         shell=False,
+        env=_git_env(),
         **UTF8_TEXT,
     )
     default = (head.stdout or "").strip()
@@ -436,12 +738,43 @@ def _disable_push(repo: Path) -> None:
     Idempotent and best-effort across git versions: the caller re-verifies via
     :func:`_ok` / ``assert_push_disabled`` and fails closed if either url survives.
     """
-    for extra in (["--push"], []):
+    env = _git_env()
+    for key in ("remote.origin.pushurl", "remote.origin.url"):
         subprocess.run(
-            ["git", "-C", str(repo), "remote", "set-url", *extra, "origin", DISABLED_NO_PUSH],
+            [
+                "git",
+                "-C",
+                str(repo),
+                *_GIT_SAFE_CONFIG,
+                "config",
+                "--local",
+                "--no-includes",
+                "--unset-all",
+                key,
+            ],
             capture_output=True,
             timeout=30,
             shell=False,
+            env=env,
+            **UTF8_TEXT,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                *_GIT_SAFE_CONFIG,
+                "config",
+                "--local",
+                "--no-includes",
+                "--add",
+                key,
+                DISABLED_NO_PUSH,
+            ],
+            capture_output=True,
+            timeout=30,
+            shell=False,
+            env=env,
             **UTF8_TEXT,
         )
 
@@ -468,6 +801,10 @@ def checkout_branch(clone: Path, branch: str, *, timeout_s: int = 120) -> tuple[
     bare = branch.split("/", 1)[1] if branch.startswith("origin/") else branch
     if not bare or not is_valid_branch_name(bare):
         return False, f"invalid branch name: {branch!r}"
+    if not _repository_is_safe(clone):
+        return False, "clone Git metadata failed safety verification"
+    if not _push_disabled(clone):
+        return False, "clone is not push-disabled"
 
     def _run(*args: str, tmo: int = timeout_s) -> subprocess.CompletedProcess:
         # Harden every host-side git over this clone: `checkout -B` below runs `post-checkout`
@@ -482,10 +819,18 @@ def checkout_branch(clone: Path, branch: str, *, timeout_s: int = 120) -> tuple[
         # Raised by the Opus 5 review.
         require_pinned(clone)
         return subprocess.run(
-            ["git", "-C", str(clone), *_GIT_SAFE_CONFIG, *args],
+            [
+                "git",
+                "-C",
+                str(clone),
+                f"--work-tree={clone}",
+                *_GIT_SAFE_CONFIG,
+                *args,
+            ],
             capture_output=True,
             timeout=tmo,
             shell=False,
+            env=_git_env(),
             **UTF8_TEXT,
         )
 
@@ -533,32 +878,8 @@ def checkout_branch(clone: Path, branch: str, *, timeout_s: int = 120) -> tuple[
 
 
 def _ok(spec: CloneSpec, dest: Path, *, reused: bool) -> dict:
-    """Report success only after confirming push is actually disabled (fail closed)."""
-    push = subprocess.run(
-        ["git", "-C", str(dest), "remote", "get-url", "--push", "origin"],
-        capture_output=True,
-        timeout=30,
-        shell=False,
-        **UTF8_TEXT,
-    )
-    fetch = subprocess.run(
-        ["git", "-C", str(dest), "remote", "get-url", "origin"],
-        capture_output=True,
-        timeout=30,
-        shell=False,
-        **UTF8_TEXT,
-    )
-
-    def _neutral(proc: subprocess.CompletedProcess) -> bool:
-        url = (proc.stdout or "").strip()
-        return proc.returncode == 0 and (
-            (not url) or ("DISABLED" in url.upper()) or ("NO_PUSH" in url.upper())
-        )
-
-    # BOTH urls must be neutral. A live fetch url is a live push target
-    # (`git push "$(git remote get-url origin)"`), so checking only the push url
-    # reported "disabled" for a clone that could still write to the remote.
-    push_disabled = _neutral(push) and _neutral(fetch)
+    """Report success only after every origin URL is exactly the sentinel."""
+    push_disabled = _push_disabled(dest)
     return {
         "ok": True,
         "display": spec.display,

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/commit.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/commit.py
@@ -31,7 +31,7 @@ from ..spine.push_policy import (
     scan_content_for_secrets,
 )
 from . import store
-from .clone_setup import resolve_origin_url
+from .clone_setup import _repository_is_isolated, resolve_origin_url
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +238,15 @@ def _commit_finding_locked(fp: str) -> dict[str, object]:
     ok, reason = authorize_direct_push(direct_commit=True, branch=branch)
     if not ok:
         return {"ok": False, "error": f"branch refused by push policy: {reason}"}
+    # Deliberately the sole repository-safety gate for this operation. The production
+    # route proves the runner is idle while holding `clone_lock`, then this check runs
+    # before materialization or any other Git mutation. No agent-authored step runs
+    # inside the critical section, so config/metadata cannot legitimately change before
+    # push. Rechecking only after creating the provisional commit is unsound: once that
+    # check fails, rollback Git would itself trust the repository just declared unsafe,
+    # while returning without rollback leaves a rejected commit as a future baseline.
+    if not _repository_is_isolated(clone):
+        return {"ok": False, "error": "repository isolation check failed — re-run setup"}
 
     diff_text = diff_path.read_text(encoding="utf-8")
     if not diff_text.strip():
@@ -266,7 +275,15 @@ def _commit_finding_locked(fp: str) -> dict[str, object]:
     # roll the commit back so the tree is clean for a retry or the draft-PR path, exactly
     # as the failed-apply and failed-commit branches above do.
 
-    scanned = _git(clone, "diff", f"{base_ref_local}..HEAD", timeout=_GIT_TIMEOUT_S)
+    scanned = _git(
+        clone,
+        "-c",
+        "diff.external=",
+        "diff",
+        "--no-ext-diff",
+        f"{base_ref_local}..HEAD",
+        timeout=_GIT_TIMEOUT_S,
+    )
     if scanned.returncode == 0:
         clean, code = scan_content_for_secrets(scanned.stdout or "")
         # Fixed code -> fixed literal: the message returned to the operator carries

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
@@ -341,7 +341,7 @@ async def _handle_setup_clone(request: web.Request) -> web.StreamResponse:
         return busy
 
     def _clone() -> tuple[dict, str]:
-        return clone_setup.setup_safe_clone(url, store.scratch_dir())
+        return clone_setup.setup_safe_clone(url, store.scratch_path())
 
     # `result` is a PARAMETER, not a closure read. It used to be a free variable of this
     # handler, which broke the moment clone+persist moved inside `_clone_and_persist` to take
@@ -782,6 +782,8 @@ async def _handle_draft_pr(request: web.Request) -> web.StreamResponse:
         clone = str(config.get("clone") or "").strip()
         if not clone:
             return {"ok": False, "error": "no repository configured"}
+        if not clone_setup._repository_is_isolated(Path(clone)):
+            return {"ok": False, "error": "repository isolation check failed — re-run setup"}
 
         body = body_path.read_text(encoding="utf-8")
         # The queued body leads with the summary as an H1; the recipe wants the

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
@@ -412,11 +412,24 @@ class RunSupervisor:
         clone_dir = str(config.get("clone") or "").strip()
         branch = str(config.get("branch") or "").strip() or "main"
         if clone_dir:
+            clone_path = Path(clone_dir)
+            # These preconditions precede checkout because checkout itself touches refs and
+            # the worktree. Preserve the established PermissionError contract for a live
+            # push URL instead of surfacing it later as a wrong-revision RuntimeError.
+            if not clone_setup._repository_is_safe(clone_path):
+                raise PermissionError(
+                    "refusing to start: repository metadata failed safety verification — "
+                    "re-run repository setup"
+                )
+            if not clone_setup._push_disabled(clone_path):
+                raise PermissionError(
+                    "refusing to start: the clone's push is not disabled — re-run repository setup"
+                )
             # Best-effort: log a failure but still start, EXCEPT when a diff scope was
             # requested — there, a failed checkout would compute the scope against the
             # wrong HEAD, and silently running unscoped is the outcome the operator was
             # trying to avoid by setting it.
-            ok, note = clone_setup.checkout_branch(Path(clone_dir), branch)
+            ok, note = clone_setup.checkout_branch(clone_path, branch)
             if not ok:
                 # RAISE on any failed checkout, not only when scopeDiffBase is set.
                 # `checkout_branch` already tries the remote-tracking ref AND a local ref

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/store.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/store.py
@@ -55,10 +55,15 @@ def data_dir() -> Path:
     return root
 
 
+def scratch_path() -> Path:
+    """Configured disposable root without touching the filesystem."""
+    override = os.environ.get("AUTO_IMPROVEMENT_SCRATCH")
+    return Path(override).expanduser() if override else Path.home() / ".autoimprove-scratch"
+
+
 def scratch_dir() -> Path:
     """Disposable clone/worktree root — outside ``data/`` on purpose."""
-    override = os.environ.get("AUTO_IMPROVEMENT_SCRATCH")
-    root = Path(override).expanduser() if override else Path.home() / ".autoimprove-scratch"
+    root = scratch_path()
     root.mkdir(parents=True, exist_ok=True)
     return root
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
@@ -347,10 +347,25 @@ class GitHubPRRecipe:
         try:
             if base:
                 # The full range this push would publish, against the base the PR targets.
-                proc = self._git("diff", f"{base}...HEAD", timeout=_PUSH_TIMEOUT_S)
+                proc = self._git(
+                    "-c",
+                    "diff.external=",
+                    "diff",
+                    "--no-ext-diff",
+                    f"{base}...HEAD",
+                    timeout=_PUSH_TIMEOUT_S,
+                )
             else:
                 # `--format=` prints the commit's PATCH and nothing else.
-                proc = self._git("show", "--format=", "HEAD", timeout=_PUSH_TIMEOUT_S)
+                proc = self._git(
+                    "-c",
+                    "diff.external=",
+                    "show",
+                    "--no-ext-diff",
+                    "--format=",
+                    "HEAD",
+                    timeout=_PUSH_TIMEOUT_S,
+                )
         except (OSError, subprocess.SubprocessError):
             logger.warning("could not read the pushable diff — refusing the push", exc_info=True)
             return False, "could not read the pushable diff"
@@ -370,6 +385,10 @@ class GitHubPRRecipe:
 
     def _push_fix_branch(self, *, branch: str) -> tuple[bool, str]:
         """Push HEAD to ``branch`` on the fetch url. Returns (ok, note)."""
+        from ...backend.clone_setup import _repository_is_isolated
+
+        if not _repository_is_isolated(self.clone_path):
+            return False, "repository isolation changed after review"
         url = self._resolve_fetch_url()
         if not url:
             return False, "no pushable origin fetch url (clone fully push-disabled)"

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
@@ -1384,23 +1384,9 @@ class RepoIsolation:
         `_ok` checks both, and this drifted from it. Raised by the GPT review of this branch.
         """
 
-        def _neutral(args: list[str]) -> bool:
-            try:
-                proc = _run(
-                    ["git", "-C", str(self.clone_path), *args],
-                    cwd=self.clone_path if self.clone_path.exists() else Path.cwd(),
-                    timeout=30,
-                )
-            except (OSError, subprocess.SubprocessError):
-                return False
-            if proc.returncode != 0:
-                return False
-            url = (proc.stdout or "").strip()
-            return (not url) or ("DISABLED" in url.upper()) or ("NO_PUSH" in url.upper())
+        from ...backend.clone_setup import _repository_is_isolated
 
-        return _neutral(["remote", "get-url", "--push", "origin"]) and _neutral(
-            ["remote", "get-url", "origin"]
-        )
+        return _repository_is_isolated(self.clone_path)
 
     def do_not_pollute_paths(self) -> list[Path]:
         """Host paths the spine snapshots around the (no-op) measurement boot.

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
@@ -278,8 +278,37 @@ class Driver:
             guardrail_tolerances=self.guardrail_tolerances,
             logger=self.log,
             direct_commit=self.direct_commit,
+            retire_if_unsafe=self._retire_if_unsafe,
         )
         self._stop = False
+        self._repository_retired = False
+
+    def _retire_if_unsafe(self, stage: str) -> bool:
+        """Stop and atomically retire the clone if post-agent validation fails."""
+        from ..backend.clone_setup import _repository_is_isolated, _retire_unsafe_clone
+
+        if _repository_is_isolated(self.clone):
+            return False
+        retained = _retire_unsafe_clone(self.clone)
+        self._repository_retired = True
+        self._stop = True
+        if retained is None:
+            self.log.error(
+                "repository safety changed after %s; run stopped and clone left unsafe in place",
+                stage,
+            )
+        else:
+            self.log.error(
+                "repository safety changed after %s; run stopped and clone retained at %s",
+                stage,
+                retained,
+            )
+        self._progress(
+            stage="repository_unsafe",
+            error="repository safety changed after agent-controlled execution",
+            retained_clone=str(retained or ""),
+        )
+        return True
 
     # ── boot-time safety preconditions (M0 exit criterion) ──────────────
 
@@ -296,6 +325,13 @@ class Driver:
         valid direct-commit authorization; a protected/blank branch is refused by
         :func:`.push_policy.authorize_direct_push` regardless. We fail CLOSED: any
         ambiguity → the original refusal stands."""
+        from ..backend.clone_setup import _repository_is_safe
+
+        if not _repository_is_safe(self.clone):
+            raise PushEnabledError(
+                f"SAFETY: repository metadata for clone {self.clone} failed validation — "
+                "refusing to start"
+            )
         if self.profile.isolation.push_disabled():
             return
         if self.direct_commit:
@@ -427,6 +463,65 @@ class Driver:
         except Exception:  # noqa: BLE001
             self.log.debug("on_progress sink failed", exc_info=True)
 
+    def _fan_out_checked(self, *, fresh_candidates: list, base_sha: str, cycle: int) -> list | None:
+        """Run proposer agents, then validate before re-raising any post-agent error."""
+        proposals: list = []
+        error: Exception | None = None
+        try:
+            proposals = self.proposer.fan_out(
+                profile=self.profile,
+                candidates=fresh_candidates,
+                base_sha=base_sha,
+                cycle=cycle,
+                stop_check=lambda: self._stop,
+            )
+        except Exception as exc:  # noqa: BLE001 - validate before interpreting
+            error = exc
+        if self._retire_if_unsafe("proposal"):
+            return None
+        if error is not None:
+            raise error
+        return proposals
+
+    def _work_one_proposal_checked(
+        self,
+        prop: Proposal,
+        *,
+        base_sha: str,
+        cycle: int,
+        proposals: list,
+        perf_survivors: list,
+        bug_winners: list,
+        gated_sha: dict,
+    ) -> bool:
+        """Run one candidate and validate before fallible error bookkeeping."""
+        error: Exception | None = None
+        try:
+            self._work_one_proposal(
+                prop,
+                base_sha=base_sha,
+                cycle=cycle,
+                proposals=proposals,
+                perf_survivors=perf_survivors,
+                bug_winners=bug_winners,
+                gated_sha=gated_sha,
+            )
+        except Exception as exc:  # noqa: BLE001 - one candidate must not kill the run
+            error = exc
+        if self._retire_if_unsafe("candidate gate/measure"):
+            return False
+        if error is not None:
+            self.log.error(
+                "cycle %d: candidate %s errored: %s: %s",
+                cycle,
+                prop.cand_id,
+                type(error).__name__,
+                error,
+            )
+            self.stats.errors += 1
+            self._record(prop, L.STATUS_ERROR, f"{type(error).__name__}: {error}")
+        return True
+
     def run_cycle(self, cycle: int) -> int:
         """Run one Profile→Propose→Gate→Measure→Keep pass. Returns the number of
         FRESH (not-yet-seen) candidates this cycle (drives quiescence)."""
@@ -464,6 +559,8 @@ class Driver:
             known_loci=known,
             agent_runner=self._agent_runner,
         )
+        if self._retire_if_unsafe("discovery"):
+            return 0
         self.stats.discovered += len(disc.candidates)
         fresh_candidates = []
         for cand in disc.candidates:
@@ -499,13 +596,13 @@ class Driver:
         # Phase B — propose (fan-out wide + deep; each in its own worktree).
         # The stop_check lets a clean-stop request abort the fan-out mid-loop, so we
         # don't keep spawning expensive agent subprocesses after the user clicked Stop.
-        proposals = self.proposer.fan_out(
-            profile=self.profile,
-            candidates=fresh_candidates,
+        proposals = self._fan_out_checked(
+            fresh_candidates=fresh_candidates,
             base_sha=base_sha,
             cycle=cycle,
-            stop_check=lambda: self._stop,
         )
+        if proposals is None:
+            return 0
         self._progress(
             cycle=cycle,
             stage="gate",
@@ -525,28 +622,16 @@ class Driver:
             for prop in proposals:
                 if self._stop:
                     break
-                try:
-                    self._work_one_proposal(
-                        prop,
-                        base_sha=base_sha,
-                        cycle=cycle,
-                        proposals=proposals,
-                        perf_survivors=perf_survivors,
-                        bug_winners=bug_winners,
-                        gated_sha=gated_sha,
-                    )
-                except Exception as e:  # noqa: BLE001 — one bad candidate must NEVER
-                    # kill the whole run (the original autoloop recorded status=error and
-                    # continued; without this a gate/measure exception aborts the run).
-                    self.log.error(
-                        "cycle %d: candidate %s errored: %s: %s",
-                        cycle,
-                        prop.cand_id,
-                        type(e).__name__,
-                        e,
-                    )
-                    self.stats.errors += 1
-                    self._record(prop, L.STATUS_ERROR, f"{type(e).__name__}: {e}")
+                if not self._work_one_proposal_checked(
+                    prop,
+                    base_sha=base_sha,
+                    cycle=cycle,
+                    proposals=proposals,
+                    perf_survivors=perf_survivors,
+                    bug_winners=bug_winners,
+                    gated_sha=gated_sha,
+                ):
+                    return 0
 
             # Phase E — perf keep / revert (one decision; archive all perf survivors).
             self._progress(cycle=cycle, stage="keep")
@@ -590,8 +675,11 @@ class Driver:
                 self._apply_bug_winner(cycle, prop, bug_res)
             return kept_count
         finally:
-            for prop in proposals:
-                self.proposer.teardown(prop)
+            if not self._repository_retired:
+                for prop in proposals:
+                    self.proposer.teardown(prop)
+            else:
+                self.log.warning("proposal teardown skipped because repository safety failed")
 
     def _work_one_proposal(
         self,
@@ -726,7 +814,9 @@ class Driver:
             return False
         return True
 
-    def _push_with_rebase(self, fetch_url: str, dest: str, target: str):
+    def _push_with_rebase(
+        self, fetch_url: str, dest: str, target: str
+    ) -> subprocess.CompletedProcess | None:
         """Push HEAD to ``dest``, rebasing ONCE onto the remote if it moved meanwhile.
 
         A run takes tens of minutes, so the branch can legitimately advance between the
@@ -756,6 +846,8 @@ class Driver:
         its own pre-push snapshot: a rebase rewrites HEAD, so the pre-rebase sha names a
         commit that does not exist on the remote.
         """
+        if self._retire_if_unsafe("direct-push preflight"):
+            return None
         require_pinned(self.clone)
         push = subprocess.run(
             [
@@ -784,7 +876,10 @@ class Driver:
                 _git(["rebase", "--abort"], self.clone)
                 self.log.warning("direct-push: rebase onto %s conflicted — not pushing", dest)
                 return push
-            if not self._reverify_head():
+            verified = self._reverify_head()
+            if self._retire_if_unsafe("post-rebase verification"):
+                return None
+            if not verified:
                 return push  # rebased tree is unverified — return the original rejection
             require_pinned(self.clone)
             push = subprocess.run(
@@ -937,6 +1032,9 @@ class Driver:
             diff_ref=winner_diff_ref,
             base_anchor=f"{self.branch} @ {base_sha[:12]}",
         )
+        if outcome.repository_retired:
+            self.stats.kept -= 1
+            return fresh_count
         if outcome.filed or outcome.committed_ready:
             # AMEND the provisional commit with the §2.4 attributable message, derived from
             # the SAME measured numbers as the CR (§3.2 end). The pipeline's INDEPENDENT
@@ -955,9 +1053,10 @@ class Driver:
                 # F10 direct-commit: push the verified commit to the authorized branch and
                 # record ``committed`` with the real sha (only on a successful push — a
                 # refused/failed push already recorded ``error`` and nothing left the sandbox).
-                if self._direct_push(
+                pushed = self._direct_push(
                     fp=outcome.fp, kind="perf", target=winner.candidate.target, sha=committed
-                ):
+                )
+                if pushed is True:
                     # `pushed_sha`, not `committed`: a rebase-and-retry inside the push
                     # rewrites HEAD, and recording the pre-rebase sha would point the
                     # ledger at a commit that is not in the remote's history.
@@ -980,7 +1079,7 @@ class Driver:
                         self.branch,
                         landed,
                     )
-                else:
+                elif pushed is False:
                     # ROLL BACK the refused commit. Leaving it at HEAD is a credential LEAK,
                     # not just untidy bookkeeping: the direct-push scan range is
                     # `HEAD~1..HEAD` (one commit), so the NEXT winner's scan does not see this
@@ -990,6 +1089,10 @@ class Driver:
                     # Raised by the GPT review of this branch.
                     self._reset_provisional(pre_sha)
                     self.stats.kept -= 1  # push refused/failed → not a realized outcome
+                else:
+                    # The clone was atomically retired; any Git rollback would trust
+                    # metadata that just failed validation.
+                    self.stats.kept -= 1
                 return fresh_count
             self.stats.filed += 1
             self.log.info(
@@ -1187,7 +1290,7 @@ class Driver:
             return True, "full suite green"
         return False, f"{len(failing)} failing test(s): {', '.join(failing[:3])}"
 
-    def _direct_push(self, *, fp: str, kind: str, target: str, sha: str) -> bool:
+    def _direct_push(self, *, fp: str, kind: str, target: str, sha: str) -> bool | None:
         """F10: push the just-committed verified change to the operator-authorized branch.
 
         Returns True iff the push succeeded. Re-checks authorization at push time (never
@@ -1225,6 +1328,17 @@ class Driver:
         # PRE-PUSH REVIEW GATE (fail-closed): a direct-pushed commit gets no human review,
         # so the automated reviewer must clear it before it lands on the shared branch.
         clean, note = self._prepush_review_clean(target=target, base_ref=self.branch)
+        if self._retire_if_unsafe("pre-push review"):
+            self.ledger.record(
+                L.LedgerEntry(
+                    fp=fp,
+                    kind=kind,
+                    target=target,
+                    status=L.STATUS_ERROR,
+                    note="direct-push refused: repository safety changed after review",
+                )
+            )
+            return None
         if not clean:
             self.log.warning("direct-push BLOCKED by review gate for %s: %s", target, note)
             self.ledger.record(
@@ -1296,9 +1410,23 @@ class Driver:
             _git(["rev-parse", "--verify", "--quiet", "HEAD~1"], self.clone).returncode == 0
         )
         proc = (
-            _git(["diff", "HEAD~1..HEAD"], self.clone)
+            _git(
+                ["-c", "diff.external=", "diff", "--no-ext-diff", "HEAD~1..HEAD"],
+                self.clone,
+            )
             if has_parent
-            else _git(["show", "--format=", "--root", "HEAD"], self.clone)
+            else _git(
+                [
+                    "-c",
+                    "diff.external=",
+                    "show",
+                    "--no-ext-diff",
+                    "--format=",
+                    "--root",
+                    "HEAD",
+                ],
+                self.clone,
+            )
         )
         if proc.returncode != 0:
             self.log.error(
@@ -1334,6 +1462,17 @@ class Driver:
             return False
 
         push = self._push_with_rebase(fetch_url, dest, target)
+        if push is None:
+            self.ledger.record(
+                L.LedgerEntry(
+                    fp=fp,
+                    kind=kind,
+                    target=target,
+                    status=L.STATUS_ERROR,
+                    note="direct-push refused: repository retired after safety change",
+                )
+            )
+            return None
         # Read the sha back from the clone: a rebase inside `_push_with_rebase` rewrites
         # HEAD, so the caller's pre-push snapshot would name a commit that is NOT on the
         # remote. `self.pushed_sha` is what the ledger records. Fall back to the snapshot
@@ -1597,9 +1736,10 @@ class Driver:
             if outcome.committed_ready:
                 # F10 direct-commit (bug track): push the verified RED→GREEN fix to the
                 # authorized branch; record ``committed`` only on a successful push.
-                if self._direct_push(
+                pushed = self._direct_push(
                     fp=outcome.fp, kind="bug", target=winner.candidate.target, sha=committed
-                ):
+                )
+                if pushed is True:
                     # See the perf track: record the sha that LANDED, not the pre-rebase one.
                     landed = self.pushed_sha or committed
                     self.ledger.record(
@@ -1621,7 +1761,7 @@ class Driver:
                         self.branch,
                         landed,
                     )
-                else:
+                elif pushed is False:
                     # Same rollback as the perf twin, and for the same reason: a refused
                     # commit left at HEAD is invisible to the NEXT winner's `HEAD~1..HEAD`
                     # scan but still published by its push. This branch had no `else` at
@@ -1776,6 +1916,21 @@ class Driver:
             )
         return _git(["rev-parse", "--short", "HEAD"], self.clone).stdout.strip()
 
+    def _preflight_checked(self) -> PreflightResult | None:
+        """Run perf preflight, then attest/retire before any later host Git."""
+        result: PreflightResult | None = None
+        error: Exception | None = None
+        try:
+            result = self.preflight()
+        except Exception as exc:  # noqa: BLE001 - attest before interpreting
+            error = exc
+        if self._retire_if_unsafe("perf preflight"):
+            return None
+        if error is not None:
+            raise error
+        assert result is not None
+        return result
+
     # ── the durable loop ────────────────────────────────────────────────
 
     def run(self, *, dry_run: bool = False, preflight: bool | None = None) -> Stats:
@@ -1803,7 +1958,9 @@ class Driver:
             )
             run_preflight = False
         if run_preflight:
-            res = self.preflight()  # raises (HALT/BLOCK) if the ruler is not proven
+            res = self._preflight_checked()
+            if res is None:
+                return self.stats
             # Surface the MEASURED calibration results (the band, the baseline rep
             # count, the canary's observed delta, the per-guardrail baseline medians)
             # to the progress sink so the UI's measurement battery can show real

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/git_safety.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/git_safety.py
@@ -70,14 +70,27 @@ import os
 import stat
 from pathlib import Path
 
-#: Config-named executable vectors, disabled on OUR argv (``-c`` beats any repo config).
-#: ``core.hooksPath`` to os.devnull disables every hook; ``core.fsmonitor=false`` disables the
-#: fsmonitor daemon. Both are global options and must precede the subcommand.
+from kiro_crew.atomic_write import atomic_write
+
+#: Config-named host execution/read vectors, disabled on OUR argv (``-c`` beats any repo
+#: config). Hooks and fsmonitor are disabled; external attributes/excludes files are pinned
+#: to Git's cross-platform ``/dev/null`` spelling (Git-for-Windows maps it correctly) so Git
+#: cannot open agent-selected UNC/network/FIFO paths. ``push.recurseSubmodules=no`` stops a
+#: push from recursing into submodule remotes: the egress guard validates only the SINGLE
+#: superproject origin, so an agent that set an attacker-controlled submodule remote plus
+#: recursive push could otherwise ship unscanned submodule objects to an unvalidated host.
+#: All options must precede the subcommand.
 GIT_SAFE_CONFIG: tuple[str, ...] = (
     "-c",
     f"core.hooksPath={os.devnull}",
     "-c",
     "core.fsmonitor=false",
+    "-c",
+    "core.attributesFile=/dev/null",
+    "-c",
+    "core.excludesFile=/dev/null",
+    "-c",
+    "push.recurseSubmodules=no",
 )
 
 #: What gets written to ``.git/info/attributes``.
@@ -248,7 +261,7 @@ def _pin(git_dir_owner: Path | str) -> str:
 
     Raises :class:`GitSafetyError` if a gitdir EXISTS but the pin cannot be safely written (a
     symlink swap on any component, an unwritable ``info``). Link-checks every component and
-    writes ``O_NOFOLLOW`` so a symlink swapped in at the last instant is refused by the kernel.
+    atomically replaces ``attributes`` so symlinks/hardlinks are never written through.
     """
     gitdir = _resolve_gitdir(git_dir_owner)  # may raise GitSafetyError on a linked `.git`
     if gitdir is None:
@@ -259,16 +272,16 @@ def _pin(git_dir_owner: Path | str) -> str:
         info.mkdir(parents=True, exist_ok=True)
         target = info / "attributes"
         _reject_link(target)
-        if target.is_file() and target.read_text(encoding="utf-8") == _ATTRIBUTES_PIN:
+        if (
+            target.is_file()
+            and target.lstat().st_nlink == 1
+            and target.read_text(encoding="utf-8") == _ATTRIBUTES_PIN
+        ):
             return "pinned"
-        # O_NOFOLLOW: a symlink at `target` fails the open (ELOOP) rather than being written
-        # through. O_TRUNC replaces stale/partial content. 0o600 — this is our file.
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
-        fd = os.open(str(target), flags, 0o600)
-        try:
-            os.write(fd, _ATTRIBUTES_PIN.encode("utf-8"))
-        finally:
-            os.close(fd)
+        # Replace the directory entry atomically rather than truncating it in
+        # place. If an agent hardlinked `attributes` to an external file, the
+        # external inode remains untouched and the clone receives our own file.
+        atomic_write(target, _ATTRIBUTES_PIN, mode=0o600, newline="")
         return "pinned"
     except GitSafetyError:
         raise

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/pr_pipeline.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/pr_pipeline.py
@@ -47,6 +47,7 @@ import inspect
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 from . import ledger as L
 from .contracts import BugGateResult, Measurement, Proposal, TargetProfile
@@ -84,6 +85,9 @@ class CrOutcome:
     # resulting sha after the push (so the ledger carries the real sha, not a placeholder).
     # ``filed`` stays False (no CR); ``reproduce`` is still carried for the commit message.
     committed_ready: bool = False
+    # The canonical clone was retired after untrusted build/agent execution changed
+    # repository safety. The driver must stop without commit/reset/teardown Git.
+    repository_retired: bool = False
 
 
 class CrPipeline:
@@ -106,6 +110,7 @@ class CrPipeline:
         logger: logging.Logger | None = None,
         direct_commit: bool = False,
         ruler_proven: bool = True,
+        retire_if_unsafe: Callable[[str], bool] | None = None,
     ) -> None:
         self.ledger = ledger
         self.measurer = measurer  # spine Measurer — supplies the REPRODUCE A/B
@@ -122,6 +127,7 @@ class CrPipeline:
         # verify/reproduce/RED-GREEN gates still run unchanged (they precede the draft step) —
         # direct-commit changes WHAT happens to a verified change, never WHETHER it's verified.
         self.direct_commit = bool(direct_commit)
+        self._retire_if_unsafe = retire_if_unsafe or (lambda _stage: False)
 
     # ── dedup short-circuit (§1.3 top of emit_cr; §2.1 invariant) ────────────
 
@@ -187,6 +193,13 @@ class CrPipeline:
                 gated_commit_sha=gated_commit_sha,
             )
         except Exception as e:  # noqa: BLE001
+            if self._retire_if_unsafe("reproduce"):
+                return CrOutcome(
+                    fp=fp,
+                    status=L.STATUS_ERROR,
+                    note="repository retired after reproduce",
+                    repository_retired=True,
+                )
             self.log.error("REPRODUCE errored for %s: %s", cand.target, e)
             self.ledger.record(
                 L.LedgerEntry(
@@ -199,6 +212,13 @@ class CrPipeline:
             )
             return CrOutcome(fp=fp, status=L.STATUS_ERROR, note="reproduce error")
 
+        if self._retire_if_unsafe("reproduce"):
+            return CrOutcome(
+                fp=fp,
+                status=L.STATUS_ERROR,
+                note="repository retired after reproduce",
+                repository_retired=True,
+            )
         if not self._reproduces(verify, reproduce):
             self.log.warning(
                 "did NOT reproduce (fluke): verify Δ=%s reproduce Δ=%s — no CR",

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py
@@ -1,0 +1,316 @@
+"""Offline regressions for idempotent push-disabled clone setup."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+from kiro_crew.apps.builtins.auto_improvement.backend.clone_setup import (
+    DISABLED_NO_PUSH,
+    CloneSpec,
+)
+
+
+def _seeded_bare(tmp_path: Path) -> Path:
+    bare = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True, cwd=tmp_path)
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "clone", "-q", str(bare), str(seed)], check=True, cwd=tmp_path)
+    (seed / "f.txt").write_text("hi")
+    subprocess.run(["git", "-C", str(seed), "add", "f.txt"], check=True, cwd=tmp_path)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(seed),
+            "-c",
+            "user.email=a@b.c",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-qm",
+            "seed",
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+    subprocess.run(
+        ["git", "-C", str(seed), "push", "-q", "origin", "HEAD:main"],
+        check=True,
+        cwd=tmp_path,
+    )
+    subprocess.run(
+        ["git", "--git-dir", str(bare), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+        cwd=tmp_path,
+    )
+    return bare
+
+
+def _spec(bare: Path) -> CloneSpec:
+    return CloneSpec("o/r", bare.as_uri(), "o--r")
+
+
+def _setup(bare: Path, root: Path) -> tuple[dict, str]:
+    with mock.patch.object(clone_setup, "validate_target_url", return_value=(_spec(bare), "")):
+        return clone_setup.setup_safe_clone("https://github.com/o/r", root)
+
+
+def test_second_setup_reuses_the_neutralized_clone(tmp_path: Path) -> None:
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+
+    first, first_err = _setup(bare, root)
+    second, second_err = _setup(bare, root)
+
+    assert first_err == "" and first["reused"] is False
+    assert second_err == "" and second["reused"] is True
+    assert second["push_disabled"] is True
+    clone = root / "o--r"
+    assert clone_setup._origin_urls(clone, push=False) == [DISABLED_NO_PUSH]
+    assert clone_setup._origin_urls(clone, push=True) == [DISABLED_NO_PUSH]
+
+
+def test_clone_start_failure_returns_controlled_error_without_cleanup(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    spec = CloneSpec("o/r", (tmp_path / "remote.git").as_uri(), "o--r")
+    with (
+        mock.patch.object(clone_setup, "validate_target_url", return_value=(spec, "")),
+        mock.patch.object(clone_setup.subprocess, "run", side_effect=OSError("git missing")),
+        mock.patch.object(clone_setup, "rmtree_force") as cleanup,
+    ):
+        result, err = clone_setup.setup_safe_clone("https://github.com/o/r", root)
+
+    assert result == {}
+    assert err == "git clone could not start: git missing"
+    cleanup.assert_not_called()
+    assert not (root / "o--r").exists()
+
+
+def test_failed_clone_with_no_destination_returns_controlled_error(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    spec = CloneSpec("o/r", (tmp_path / "remote.git").as_uri(), "o--r")
+    failed = subprocess.CompletedProcess(["git", "clone"], 128, "", "clone failed")
+    with (
+        mock.patch.object(clone_setup, "validate_target_url", return_value=(spec, "")),
+        mock.patch.object(clone_setup.subprocess, "run", return_value=failed),
+    ):
+        result, err = clone_setup.setup_safe_clone("https://github.com/o/r", root)
+
+    assert result == {}
+    assert err == "git clone failed: clone failed"
+    assert not (root / "o--r").exists()
+
+
+def test_extra_origin_value_refuses_reuse(tmp_path: Path) -> None:
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    first, err = _setup(bare, root)
+    assert err == "" and first["push_disabled"] is True
+    clone = root / "o--r"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(clone),
+            "config",
+            "--add",
+            "remote.origin.url",
+            bare.as_uri(),
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    branches, branch_err = clone_setup.list_clone_branches(clone)
+    checked_out, checkout_err = clone_setup.checkout_branch(clone, "main")
+    result, reuse_err = _setup(bare, root)
+
+    assert branches == []
+    assert "not push-disabled" in branch_err
+    assert checked_out is False
+    assert "not push-disabled" in checkout_err
+    assert result == {}
+    assert "ambiguous origin URLs" in reuse_err
+
+
+def test_disable_push_replaces_every_url_value(tmp_path: Path) -> None:
+    bare = _seeded_bare(tmp_path)
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", str(bare), str(clone)], check=True, cwd=tmp_path)
+    for key in ("remote.origin.url", "remote.origin.pushurl"):
+        subprocess.run(
+            ["git", "-C", str(clone), "config", "--add", key, bare.as_uri()],
+            check=True,
+            cwd=tmp_path,
+        )
+
+    clone_setup._disable_push(clone)
+
+    assert clone_setup._origin_urls(clone, push=False) == [DISABLED_NO_PUSH]
+    assert clone_setup._origin_urls(clone, push=True) == [DISABLED_NO_PUSH]
+
+
+def test_retire_unsafe_clone_preserves_bytes_off_canonical_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    (clone / "evidence.txt").write_text("preserve", encoding="utf-8")
+    # Some CI/dev temp roots live below a system symlink (for example /var on
+    # macOS). Setup tests cover ancestor refusal separately; this regression
+    # isolates the anchored no-replace rename itself.
+    monkeypatch.setattr(clone_setup, "first_linked_ancestor", lambda _path: None)
+    monkeypatch.setattr(clone_setup, "is_link_or_junction", lambda _path: False)
+
+    retired = clone_setup._retire_unsafe_clone(clone)
+
+    assert retired is not None
+
+    assert not clone.exists()
+    assert retired.parent.parent == tmp_path
+    assert retired.parent.name.startswith(".clone.unsafe-")
+    assert retired.name == "clone"
+    assert (retired / "evidence.txt").read_text(encoding="utf-8") == "preserve"
+
+    latest = retired
+    for index in range(4):
+        clone.mkdir()
+        (clone / "evidence.txt").write_text(str(index), encoding="utf-8")
+        next_retired = clone_setup._retire_unsafe_clone(clone)
+        assert next_retired is not None
+        latest = next_retired
+
+    retained = sorted(tmp_path.glob(".clone.unsafe-*"))
+    assert len(retained) == clone_setup._UNSAFE_CLONE_RETENTION
+    assert latest.exists()
+
+
+def test_linked_scratch_root_is_refused_before_mutation(tmp_path: Path) -> None:
+    bare = _seeded_bare(tmp_path)
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    root = tmp_path / "root"
+    try:
+        platform_compat.symlink_or_junction(foreign, root)
+    except OSError as exc:  # pragma: no cover - host policy may forbid links
+        pytest.skip(f"cannot create a directory link: {exc}")
+
+    result, err = _setup(bare, root)
+
+    assert result == {}
+    assert "link or junction" in err
+    assert not list(foreign.iterdir())
+
+
+@pytest.mark.parametrize(
+    "directive",
+    [
+        "include",
+        "url",
+        "worktree",
+        "diff_external",
+        "askpass",
+        "attributes_file",
+        "excludes_file",
+    ],
+)
+def test_unsafe_git_config_refuses_reuse(tmp_path: Path, directive: str) -> None:
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    first, err = _setup(bare, root)
+    assert err == "" and first["push_disabled"] is True
+    config = root / "o--r" / ".git" / "config"
+    additions = {
+        "include": "\n[include]\n\tpath = //attacker/share/config\n",
+        "url": '\n[url "https://attacker.invalid/"]\n\tinsteadOf = DISABLED_NO_PUSH\n',
+        "worktree": f"\n[core]\n\tworktree = {tmp_path / 'foreign'}\n",
+        "diff_external": "\n[diff]\n\texternal = /attacker/host-code\n",
+        "askpass": "\n[core]\n\taskpass = /attacker/credential-helper\n",
+        "attributes_file": "\n[core]\n\tattributesFile = //attacker/share/attributes\n",
+        "excludes_file": "\n[core]\n\texcludesFile = //attacker/share/excludes\n",
+    }
+    with config.open("a", encoding="utf-8") as handle:
+        handle.write(additions[directive])
+
+    result, reuse_err = _setup(bare, root)
+
+    assert result == {}
+    assert "metadata safety verification" in reuse_err
+
+
+def test_fifo_git_metadata_is_refused_without_opening_it(tmp_path: Path) -> None:
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFOs are unavailable on this platform")
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    first, err = _setup(bare, root)
+    assert err == "" and first["push_disabled"] is True
+    clone = root / "o--r"
+    index = clone / ".git" / "index"
+    index.unlink()
+    os.mkfifo(index)
+
+    assert clone_setup._repository_is_safe(clone) is False
+    result, reuse_err = _setup(bare, root)
+    assert result == {}
+    assert "metadata safety verification" in reuse_err
+
+
+def test_hardlinked_git_metadata_is_refused_without_external_write(tmp_path: Path) -> None:
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    first, err = _setup(bare, root)
+    assert err == "" and first["push_disabled"] is True
+    clone = root / "o--r"
+    external = tmp_path / "external"
+    external.write_text("keep me")
+    attributes = clone / ".git" / "info" / "attributes"
+    attributes.parent.mkdir(parents=True, exist_ok=True)
+    attributes.unlink(missing_ok=True)
+    try:
+        os.link(external, attributes)
+    except OSError as exc:  # pragma: no cover - filesystem may forbid hardlinks
+        pytest.skip(f"cannot create metadata hardlink: {exc}")
+
+    branches, branch_err = clone_setup.list_clone_branches(clone)
+    checked_out, checkout_err = clone_setup.checkout_branch(clone, "main")
+    result, reuse_err = _setup(bare, root)
+
+    assert branches == []
+    assert "safety verification" in branch_err
+    assert checked_out is False
+    assert "safety verification" in checkout_err
+    assert result == {}
+    assert "metadata safety verification" in reuse_err
+    assert external.read_text() == "keep me"
+
+
+def test_linked_git_directory_is_refused_before_target_access(tmp_path: Path) -> None:
+    bare = _seeded_bare(tmp_path)
+    root = tmp_path / "root"
+    first, err = _setup(bare, root)
+    assert err == "" and first["push_disabled"] is True
+    clone = root / "o--r"
+    real_git = clone / ".git-real"
+    (clone / ".git").rename(real_git)
+    foreign = tmp_path / "foreign-git"
+    foreign.mkdir()
+    try:
+        platform_compat.symlink_or_junction(foreign, clone / ".git")
+    except OSError as exc:  # pragma: no cover - host policy may forbid links
+        pytest.skip(f"cannot create Git directory link: {exc}")
+
+    result, reuse_err = _setup(bare, root)
+
+    assert result == {}
+    assert "linked Git directory" in reuse_err
+    assert not list(foreign.iterdir())

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_dogfood_learnings.py
@@ -120,6 +120,13 @@ class TestMetricDirectionIsPlumbed:
 class TestPushRetriesOnRace:
     """3 of 6 gate survivors were lost to a branch that moved mid-run."""
 
+    @pytest.fixture(autouse=True)
+    def _safe_repository(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+        monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: True)
+
     @staticmethod
     def _driver(clone: Path, log, *, reverify: bool = True, raises: bool = False):
         """A Driver stub whose build gate reports ``reverify`` (or explodes).
@@ -166,6 +173,7 @@ class TestPushRetriesOnRace:
 
         d = self._driver(tmp_path, logging.getLogger("t"))
         out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        assert out is not None
         assert out.returncode == 0
         assert len(pushes) == 2, "should push, rebase, push again"
         assert ["fetch", "https://x/y.git", "b"] in gits
@@ -190,6 +198,7 @@ class TestPushRetriesOnRace:
 
         d = self._driver(tmp_path, logging.getLogger("t"))
         out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        assert out is not None
         assert out.returncode == 1
         assert len(pushes) == 1, "a non-race failure must not be retried"
 
@@ -218,6 +227,7 @@ class TestPushRetriesOnRace:
 
         d = self._driver(tmp_path, logging.getLogger("t"))
         out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        assert out is not None
         assert out.returncode == 1
         assert ["rebase", "--abort"] in gits, "a conflicted rebase must be aborted"
         assert len(pushes) == 1, "must not push a half-merged tree"
@@ -236,6 +246,13 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
 
     Raised by the GPT review of this branch.
     """
+
+    @pytest.fixture(autouse=True)
+    def _safe_repository(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+        monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: True)
 
     def test_the_replayed_tree_is_re_verified_before_the_second_push(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -269,11 +286,98 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
         d.profile.build_gate.build_and_test = _counting_gate  # type: ignore[attr-defined]
 
         out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        assert out is not None
         assert out.returncode == 0
         assert verified == ["gate"], "the rebased tree must be re-verified exactly once"
         # Ordering is the whole point: the tree is verified AFTER the rebase replays it and
         # BEFORE the retry push, so what gets published is what was measured.
         assert order.index("rebase") < order.index("verify") < order.index("push", 1)
+
+    def test_post_rebase_safety_failure_retires_without_further_git(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        states = iter((True, False))
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: next(states))
+        retired: list[Path] = []
+        retired_path = tmp_path / ".clone.unsafe-test"
+
+        def _retire(clone: Path) -> Path:
+            retired.append(Path(clone))
+            return retired_path
+
+        monkeypatch.setattr(clone_setup, "_retire_unsafe_clone", _retire)
+        pushes: list[list[str]] = []
+
+        def _fake_run(argv, **_kw):
+            pushes.append(argv)
+            return subprocess.CompletedProcess(
+                args=argv, returncode=1, stdout="", stderr="(fetch first)"
+            )
+
+        gits: list[list[str]] = []
+
+        def _fake_git(args, _cwd):
+            gits.append(args)
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(D.subprocess, "run", _fake_run)
+        monkeypatch.setattr(D, "_git", _fake_git)
+        d = TestPushRetriesOnRace._driver(tmp_path / "clone", logging.getLogger("t"))
+        d._stop = False
+        d._repository_retired = False
+        d._progress = lambda **_event: None
+
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+
+        assert out is None
+        assert retired == [tmp_path / "clone"]
+        assert d._repository_retired is True and d._stop is True
+        assert len(pushes) == 1, "unsafe rebased tree must not reach the retry push"
+        assert not any(args[:1] == ["reset"] for args in gits)
+
+    @pytest.mark.parametrize("reverify,raises", [(False, False), (True, True)])
+    def test_failed_reverify_still_retires_before_failure_handling(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        reverify: bool,
+        raises: bool,
+    ) -> None:
+        from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+        from kiro_crew.apps.builtins.auto_improvement.spine import driver as D
+
+        states = iter((True, False))
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: next(states))
+        monkeypatch.setattr(
+            clone_setup, "_retire_unsafe_clone", lambda _clone: tmp_path / ".unsafe"
+        )
+        pushes: list[list[str]] = []
+
+        def _failed_push(argv, **_kw):  # noqa: ANN001
+            pushes.append(argv)
+            return subprocess.CompletedProcess(argv, 1, "", "(fetch first)")
+
+        monkeypatch.setattr(D.subprocess, "run", _failed_push)
+        monkeypatch.setattr(
+            D,
+            "_git",
+            lambda args, _cwd: subprocess.CompletedProcess(args, 0, "", ""),
+        )
+        d = TestPushRetriesOnRace._driver(
+            tmp_path / "clone", logging.getLogger("t"), reverify=reverify, raises=raises
+        )
+        d._stop = False
+        d._repository_retired = False
+        d._progress = lambda **_event: None
+
+        out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+
+        assert out is None
+        assert d._repository_retired is True
+        assert len(pushes) == 1
 
     def test_a_rebased_tree_that_fails_re_verification_is_not_pushed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -297,6 +401,7 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
 
         d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"), reverify=False)
         out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        assert out is not None
         assert out.returncode == 1, "the original rejection is returned"
         assert len(pushes) == 1, "an unverified rebased tree must never be pushed"
 
@@ -323,6 +428,7 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
 
         d = TestPushRetriesOnRace._driver(tmp_path, logging.getLogger("t"), raises=True)
         out = D.Driver._push_with_rebase(d, "https://x/y.git", "b", "tgt")
+        assert out is not None
         assert out.returncode == 1
         assert len(pushes) == 1, "a gate that raised must not be read as a pass"
 
@@ -344,6 +450,104 @@ class TestARebasedTreeIsReVerifiedBeforePublishing:
         body = inspect.getsource(Driver)
         for site in ("direct-pushed to {self.branch}", "direct-pushed bug fix to {self.branch}"):
             assert f'f"{site} ({{landed}})"' in body, f"{site} must record the landed sha"
+
+
+class TestPostAgentRepositorySafety:
+    def test_proposer_exception_retires_before_reraise(self) -> None:
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
+
+        d = object.__new__(Driver)
+        d.proposer = SimpleNamespace(  # type: ignore[assignment]
+            fan_out=lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("capture failed"))
+        )
+        d.profile = SimpleNamespace()  # type: ignore[assignment]
+        d._stop = False
+        retired: list[str] = []
+
+        def _retire(stage: str) -> bool:
+            retired.append(stage)
+            return True
+
+        d._retire_if_unsafe = _retire  # type: ignore[method-assign]
+
+        result = Driver._fan_out_checked(d, fresh_candidates=[], base_sha="abc", cycle=1)
+
+        assert result is None
+        assert retired == ["proposal"]
+
+    def test_candidate_exception_retires_before_ledger_bookkeeping(self) -> None:
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver, Stats
+
+        d = object.__new__(Driver)
+
+        def _raise(*_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+            raise RuntimeError("gate failed")
+
+        def _retire(stage: str) -> bool:
+            del stage
+            return True
+
+        def _fail_record(*_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+            pytest.fail("ledger bookkeeping ran")
+
+        d._work_one_proposal = _raise  # type: ignore[method-assign]
+        d._retire_if_unsafe = _retire  # type: ignore[method-assign]
+        d._record = _fail_record  # type: ignore[method-assign]
+        d.log = logging.getLogger("t")
+        d.stats = Stats()
+        prop = SimpleNamespace(cand_id="candidate")
+
+        result = Driver._work_one_proposal_checked(
+            d,
+            prop,  # type: ignore[arg-type]
+            base_sha="abc",
+            cycle=1,
+            proposals=[],
+            perf_survivors=[],
+            bug_winners=[],
+            gated_sha={},
+        )
+
+        assert result is False
+        assert d.stats.errors == 0
+
+    def test_each_agent_boundary_precedes_the_next_host_git_phase(self) -> None:
+        import inspect
+
+        from kiro_crew.apps.builtins.auto_improvement.spine.driver import Driver
+
+        cycle = inspect.getsource(Driver.run_cycle)
+        assert cycle.index("self.profile.discover(") < cycle.index(
+            'self._retire_if_unsafe("discovery")'
+        ) < cycle.index("self._fan_out_checked(")
+
+        fan_out = inspect.getsource(Driver._fan_out_checked)
+        assert fan_out.index("self.proposer.fan_out(") < fan_out.index(
+            'self._retire_if_unsafe("proposal")'
+        ) < fan_out.index("if error is not None:")
+
+        candidate = inspect.getsource(Driver._work_one_proposal_checked)
+        assert candidate.index("self._work_one_proposal(") < candidate.index(
+            'self._retire_if_unsafe("candidate gate/measure")'
+        ) < candidate.index("if error is not None:")
+        assert candidate.index('self._retire_if_unsafe("candidate gate/measure")') < candidate.index(
+            "self._record(prop, L.STATUS_ERROR"
+        )
+
+        push = inspect.getsource(Driver._direct_push)
+        assert push.index("self._prepush_review_clean(") < push.index(
+            'self._retire_if_unsafe("pre-push review")'
+        ) < push.index('if not sha or sha == "-"')
+        assert "elif pushed is False" in inspect.getsource(Driver._apply_verdict)
+        assert "elif pushed is False" in inspect.getsource(Driver._apply_bug_winner)
+
+        from kiro_crew.apps.builtins.auto_improvement.spine.pr_pipeline import CrPipeline
+
+        reproduce = inspect.getsource(CrPipeline.emit_perf)
+        assert reproduce.count('self._retire_if_unsafe("reproduce")') == 2
+        assert reproduce.index('self._retire_if_unsafe("reproduce")') < reproduce.index(
+            "if not self._reproduces(verify, reproduce):"
+        )
 
 
 class TestFanOutIsDisjoint:
@@ -613,6 +817,13 @@ class TestUnattendedApprovalIsAudited:
         assert calls == ["reject:r2"], "an unauditable approval must be refused"
 
 
+@pytest.fixture
+def synthetic_clone_is_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: True)
+
+
+@pytest.mark.usefixtures("synthetic_clone_is_safe")
 class TestCheckoutPrecedesProfileBuild:
     """The profile resolves ``scopeDiffBase`` in its CONSTRUCTOR, so the clone must
     already be on the configured branch when it is built.
@@ -3558,6 +3769,21 @@ class TestOneClickCommitWorksInAPushDisabledClone:
         draft_src = inspect.getsource(routes._handle_draft_pr)
         assert "clone_lock()" in draft_src, "the draft route can still race a commit"
 
+    def test_one_click_safety_gate_precedes_every_git_mutation(self) -> None:
+        """A failed safety check cannot be followed by Git rollback over that unsafe repo.
+
+        The production route holds `clone_lock` and proves the runner idle. Validate once
+        before materialization; a second post-commit check creates an impossible branch:
+        trusting Git to reset is unsafe, while not resetting leaks the rejected commit.
+        """
+        import inspect
+
+        src = inspect.getsource(commit_mod._commit_finding_locked)
+        gate = src.index("if not _repository_is_isolated(clone):")
+        assert gate < src.index("materialize_queued_diff(")
+        assert gate < src.index('"commit", "-m", message')
+        assert src.count("_repository_is_isolated(clone)") == 1
+
     def test_a_failed_push_leaves_no_commit_behind(self, tmp_path, monkeypatch) -> None:
         """One-click commit's LAST two exits returned with the commit still on the branch.
 
@@ -3950,6 +4176,7 @@ class TestAnUnprovenRulerHaltsThePerfTrack:
         )
 
 
+@pytest.mark.usefixtures("synthetic_clone_is_safe")
 class TestRunStartupSharesTheCloneLock:
     """`POST /run` mutated the shared clone without holding the clone lock.
 
@@ -4083,6 +4310,7 @@ class TestTheProfileImportStaysLazy:
         )
 
 
+@pytest.mark.usefixtures("synthetic_clone_is_safe")
 class TestRetargetIsAtomicWithRunStartup:
     """`POST /setup-clone` checked "is a run live?", then cloned (slow: network + git), then
     persisted the new `clone`/`target_url`. `POST /run` reads config independently. So a
@@ -4670,6 +4898,26 @@ class TestRepoControlledGitHooksDoNotExecuteHostSide:
         pin = (repo / ".git" / "info" / "attributes").read_text(encoding="utf-8")
         assert "-filter" in pin and " diff" in pin, "the pin content is not the driver-unbinding line"
 
+    def test_the_pin_atomically_replaces_a_hardlink(self, tmp_path) -> None:
+        from kiro_crew.apps.builtins.auto_improvement.spine import git_safety as gs
+
+        repo = tmp_path / "repo"
+        info = repo / ".git" / "info"
+        info.mkdir(parents=True)
+        external = tmp_path / "external"
+        external.write_text("PRECIOUS\n", encoding="utf-8")
+        pin = info / "attributes"
+        os.link(external, pin)
+        external_inode = external.stat().st_ino
+
+        gs.require_pinned(repo)
+
+        assert external.read_text(encoding="utf-8") == "PRECIOUS\n"
+        assert external.stat().st_ino == external_inode
+        assert pin.read_text(encoding="utf-8") == gs._ATTRIBUTES_PIN
+        assert pin.stat().st_ino != external_inode
+        assert pin.stat().st_nlink == 1
+
     def test_every_host_side_git_helper_injects_the_safe_config(self) -> None:
         """Structural: each helper that runs git over the agent-writable tree must carry the
         hook/fsmonitor overrides, so a new call site cannot quietly omit them."""
@@ -4728,6 +4976,17 @@ class TestRepoControlledGitHooksDoNotExecuteHostSide:
             cfg = " ".join(mod._GIT_SAFE_CONFIG)
             assert "core.hooksPath=" in cfg, f"{mod.__name__} does not neutralize core.hooksPath"
             assert "core.fsmonitor=false" in cfg, f"{mod.__name__} does not disable fsmonitor"
+            assert "core.attributesFile=/dev/null" in cfg, (
+                f"{mod.__name__} permits an external attributes path"
+            )
+            assert "core.excludesFile=/dev/null" in cfg, (
+                f"{mod.__name__} permits an external excludes path"
+            )
+            assert "push.recurseSubmodules=no" in cfg, (
+                f"{mod.__name__} permits recursive submodule pushes — the egress guard only "
+                f"validates the superproject origin, so a recursive push could ship unscanned "
+                f"submodule objects to an attacker-controlled submodule remote"
+            )
 
         # ONE shared definition, not a per-module copy: this finding class recurred six times
         # because each new host-side git surface re-declared its own constant and a later one
@@ -4834,7 +5093,7 @@ class TestRepoControlledGitHooksDoNotExecuteHostSide:
             "the COMMON gitdir, so the in-tree `.gitattributes` binding was never unbound"
         )
 
-    def test_clone_setup_checkout_pins_the_attributes(self, tmp_path) -> None:
+    def test_clone_setup_checkout_pins_the_attributes(self, tmp_path, monkeypatch) -> None:
         """`clone_setup.checkout_branch` runs `checkout -B <bare>` host-side over the clone, and
         `checkout` runs the SMUDGE filter as it writes the working tree — so a repo-planted
         `filter.<n>.smudge` bound by an in-tree `.gitattributes` would execute outside the
@@ -4851,6 +5110,7 @@ class TestRepoControlledGitHooksDoNotExecuteHostSide:
 
         from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup as clone_mod
 
+        monkeypatch.setattr(clone_mod, "_push_disabled", lambda _clone: True)
         clone = tmp_path / "clone"
         clone.mkdir()
         sp.run(["git", "init", "-q", "-b", "main", "."], cwd=clone, check=True)

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_github_profile.py
@@ -224,6 +224,14 @@ class TestIsolation:
         )
         assert iso.push_disabled() is True
 
+        for key in ("remote.origin.url", "remote.origin.pushurl"):
+            subprocess.run(
+                ["git", "-C", str(clone), "config", "--add", key, "https://example.invalid/x"],
+                check=True,
+                capture_output=True,
+            )
+        assert iso.push_disabled() is False
+
     def test_do_not_pollute_excludes_the_app_data_dir(self, tmp_path: Path) -> None:
         """The app writes its own ledger under the snapshot root during the boot window;
         without the exclude those writes register as a phantom leak."""

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pr_recipe.py
@@ -36,6 +36,23 @@ def _recipe(tmp_path: Path, **kw) -> pr.GitHubPRRecipe:
     )
 
 
+def test_push_refuses_before_git_when_repository_safety_changed(tmp_path: Path) -> None:
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "init", "-q", str(clone)], check=True)
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "diff.external", "/attacker/host-code"],
+        check=True,
+    )
+    recipe = _recipe(tmp_path)
+    recipe._git = MagicMock()  # type: ignore[method-assign]
+
+    ok, note = recipe._push_fix_branch(branch="auto-improvement/bug-abc")
+
+    assert ok is False
+    assert "isolation changed" in note
+    recipe._git.assert_not_called()
+
+
 def _simulate_legacy_locale(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make omitted ``Path.write_text`` encodings deterministic on every host."""
     original = Path.write_text
@@ -122,6 +139,39 @@ class TestQueueEncoding:
         )
         assert (recipe.queue_dir / "stub.diff").read_text(encoding="utf-8") == self._diff
         assert self._description in (recipe.queue_dir / "stub.pr.md").read_text(encoding="utf-8")
+
+
+class TestReproduceRepositorySafety:
+    @pytest.mark.parametrize("raises", [False, True])
+    def test_retirement_precedes_reproduce_verdict_or_error(self, raises: bool) -> None:
+        ledger = MagicMock()
+        ledger.status_of.return_value = None
+        measurer = MagicMock()
+        if raises:
+            measurer.reproduce.side_effect = RuntimeError("gate failed")
+        else:
+            measurer.reproduce.return_value = MagicMock()
+        retire = MagicMock(return_value=True)
+        pipeline = CrPipeline(
+            ledger=ledger,
+            measurer=measurer,
+            retire_if_unsafe=retire,
+        )
+        winner = SimpleNamespace(candidate=SimpleNamespace(kind="perf", target="parser"))
+
+        outcome = pipeline.emit_perf(
+            profile=MagicMock(),
+            winner=winner,  # type: ignore[arg-type]
+            verify=MagicMock(),
+            cycle=1,
+            gated_commit_sha="abc",
+            diff_ref="diff",
+            base_anchor="main @ abc",
+        )
+
+        assert outcome.repository_retired is True
+        assert outcome.filed is False and outcome.committed_ready is False
+        retire.assert_called_once_with("reproduce")
 
 
 class TestProtocolConformance:
@@ -480,6 +530,8 @@ class TestEveryPushPathScansContent:
         ):
             src = (root / rel).read_text(encoding="utf-8")
             assert "scan_content_for_secrets" in src, f"{rel} does not scan pushed content"
+            assert "--no-ext-diff" in src, f"{rel} permits external diff execution"
+            assert "diff.external=" in src, f"{rel} does not clear the external diff helper"
             # No path may re-import the raw scanners and hand-roll the decision.
             assert "redact_credentials" not in src, f"{rel} should delegate, not re-implement"
 

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -3282,15 +3282,23 @@ def rmtree_force(path: str | os.PathLike) -> bool:
     # `onexc` replaced `onerror` in 3.12 and the old name warns; this project
     # still supports 3.9+, so pick by capability rather than by version number.
     kwarg = "onexc" if sys.version_info >= (3, 12) else "onerror"
-    if kwarg == "onerror":  # pragma: no cover - exercised on Python < 3.12
+    try:
+        if kwarg == "onerror":  # pragma: no cover - exercised on Python < 3.12
 
-        def _legacy(func: Any, target: str, exc_info: Any) -> None:
-            _clear_readonly_and_retry(func, target, exc_info[1])
+            def _legacy(func: Any, target: str, exc_info: Any) -> None:
+                _clear_readonly_and_retry(func, target, exc_info[1])
 
-        shutil.rmtree(path, onerror=_legacy)
-    else:
-        shutil.rmtree(path, onexc=_clear_readonly_and_retry)  # type: ignore[call-arg]
-    return not os.path.exists(path)
+            shutil.rmtree(path, onerror=_legacy)
+        else:
+            shutil.rmtree(path, onexc=_clear_readonly_and_retry)  # type: ignore[call-arg]
+    except FileNotFoundError:
+        # A missing ROOT is success. A nested entry can disappear during rmtree while
+        # the root survives, especially through the Python <3.12 onerror path.
+        return not os.path.lexists(path)
+    except OSError:
+        logger.warning("Cannot remove %s", path)
+        return False
+    return not os.path.lexists(path)
 
 
 def symlink_or_junction(target: str | os.PathLike, link: str | os.PathLike) -> None:

--- a/test/test_ai_backend_routes_coverage.py
+++ b/test/test_ai_backend_routes_coverage.py
@@ -507,6 +507,26 @@ class TestSetupClone:
         assert response.status == 400
         assert _json_of(response)["code"] == "url_required"
 
+    async def test_passes_noncreating_scratch_path_to_setup(
+        self, data_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scratch = data_root / "scratch"
+        monkeypatch.setattr(store, "scratch_path", lambda: scratch)
+        monkeypatch.setattr(
+            store,
+            "scratch_dir",
+            lambda: (_ for _ in ()).throw(AssertionError("scratch_dir created too early")),
+        )
+
+        def _fake(_url: str, received: Path, **_kw: Any) -> tuple[dict, str]:
+            assert received == scratch
+            assert not scratch.exists()
+            return {}, "controlled refusal"
+
+        monkeypatch.setattr(clone_setup, "setup_safe_clone", _fake)
+        response = await routes._handle_setup_clone(_request("POST", body={"url": self.URL}))
+        assert response.status == 400
+
     async def test_refuses_while_a_run_is_live(self, supervisor: FakeSupervisor) -> None:
         supervisor._status = runner.STATUS_RUNNING
         response = await routes._handle_setup_clone(_request("POST", body={"url": self.URL}))
@@ -971,6 +991,8 @@ def draft_stubs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         return mock.Mock(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(commit_mod, "_git", _git)
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: True)
     monkeypatch.setattr(
         commit_mod, "materialize_queued_diff", lambda **_kw: dict(state["materialize"])
     )

--- a/test/test_ai_github_profile_coverage.py
+++ b/test/test_ai_github_profile_coverage.py
@@ -1135,7 +1135,7 @@ def test_allowlist_reports_every_offending_path_not_just_the_first():
     ("push_url", "fetch_url", "expected"),
     [
         ("DISABLED_NO_PUSH", "DISABLED_NO_PUSH", True),
-        ("", "", True),
+        ("", "", False),
         ("DISABLED_NO_PUSH", "https://github.com/o/r.git", False),
         ("https://github.com/o/r.git", "DISABLED_NO_PUSH", False),
     ],
@@ -1143,26 +1143,50 @@ def test_allowlist_reports_every_offending_path_not_just_the_first():
 def test_isolation_push_disabled_requires_both_urls_neutral(
     tmp_path, monkeypatch, push_url, fetch_url, expected
 ):
-    """A live FETCH url is a live push target -- checking only the push url was the bug."""
+    """Only exact singleton sentinels satisfy the shared runtime isolation gate."""
+    from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
     clone = tmp_path / "clone"
     clone.mkdir()
     fake = _FakeRun(_Proc(0, push_url), _Proc(0, fetch_url))
     monkeypatch.setattr(gh, "_run", fake)
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(
+        clone_setup,
+        "_push_disabled",
+        lambda _clone: push_url == "DISABLED_NO_PUSH" and fetch_url == "DISABLED_NO_PUSH",
+    )
     iso = gh.RepoIsolation(clone_path=clone)
     assert iso.push_disabled() is expected
     assert iso.base_ref == "origin/main"
 
 
 def test_isolation_push_disabled_fails_closed_on_a_git_error(tmp_path, monkeypatch):
+    from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
     clone = tmp_path / "clone2"
     clone.mkdir()
-    monkeypatch.setattr(gh, "_run", _FakeRun(_Proc(128, "", "not a git repository")))
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(
+        clone_setup.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 128, "", "not a repo"),
+    )
     assert gh.RepoIsolation(clone_path=clone, base_ref="").push_disabled() is False
 
 
 def test_isolation_push_disabled_fails_closed_on_a_spawn_failure(tmp_path, monkeypatch):
-    monkeypatch.setattr(gh, "_run", _FakeRun(OSError("git missing")))
-    iso = gh.RepoIsolation(clone_path=tmp_path / "absent", base_ref="origin/dev")
+    from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
+    clone = tmp_path / "absent"
+    clone.mkdir()
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(
+        clone_setup.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("git missing")),
+    )
+    iso = gh.RepoIsolation(clone_path=clone, base_ref="origin/dev")
     assert iso.push_disabled() is False
     assert iso.base_ref == "origin/dev"
 

--- a/test/test_ai_runner_coverage.py
+++ b/test/test_ai_runner_coverage.py
@@ -192,6 +192,12 @@ def _no_real_checkout(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Path, str]]
     return seen
 
 
+@pytest.fixture(autouse=True)
+def _synthetic_clone_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: True)
+
+
 @pytest.fixture()
 def sup() -> Any:
     """A fresh supervisor whose worker thread is always joined."""
@@ -629,7 +635,10 @@ class TestBuildDriver:
             self._locked(sup, config, _profile(tmp_path / "clone"))
         assert "scopeDiffBase would resolve against the wrong HEAD" in str(excinfo.value)
 
-    def test_refuses_when_push_is_not_disabled(self, sup: Any, tmp_path: Path) -> None:
+    def test_refuses_when_push_is_not_disabled(
+        self, sup: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: False)
         profile = _profile(tmp_path / "clone", push_disabled=False)
         with pytest.raises(PermissionError) as excinfo:
             self._locked(sup, self._config(tmp_path), profile)

--- a/test/test_ai_spine_driver_coverage.py
+++ b/test/test_ai_spine_driver_coverage.py
@@ -86,7 +86,16 @@ class _Git:
         return seq.pop(0) if len(seq) > 1 else seq[0]
 
     def git(self, args, cwd):
-        joined = " ".join(str(a) for a in args)
+        toks = [str(a) for a in args]
+        clean: list[str] = []
+        index = 0
+        while index < len(toks):
+            if toks[index] == "-c":
+                index += 2
+                continue
+            clean.append(toks[index])
+            index += 1
+        joined = " ".join(clean)
         self.calls.append(joined)
         rc, out, err = self._take(joined)
         return subprocess.CompletedProcess(args=list(args), returncode=rc, stdout=out, stderr=err)
@@ -369,6 +378,10 @@ DIFF = "--- a/m.py\n+++ b/m.py\n@@ -1 +1 @@\n-old\n+new\n"
 @pytest.fixture(autouse=True)
 def _isolate_env(tmp_path, monkeypatch):
     """No real home, no inherited fan-out overrides, no leaked log handlers."""
+    from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: True)
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
     for var in ("AUTO_IMPROVEMENT_WIDE", "AUTO_IMPROVEMENT_DEEP"):
         monkeypatch.delenv(var, raising=False)
@@ -474,6 +487,19 @@ def test_live_push_is_tolerated_under_an_authorized_direct_commit(tmp_path):
     d.assert_push_disabled()  # scoped push exception
 
 
+def test_direct_commit_never_bypasses_unsafe_repository(tmp_path, monkeypatch):
+    from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: False)
+    d = _make(
+        tmp_path,
+        profile=_Profile(isolation=_Isolation(disabled=False)),
+        direct_commit=True,
+    )
+    with pytest.raises(drv.PushEnabledError, match="repository metadata"):
+        d.assert_push_disabled()
+
+
 def test_live_push_on_a_protected_branch_still_refuses(tmp_path):
     d = _make(tmp_path, profile=_Profile(isolation=_Isolation(disabled=False)), direct_commit=True)
     d.branch = "main"
@@ -574,6 +600,37 @@ def test_preflight_uses_an_explicitly_injected_boot_verbatim(tmp_path, monkeypat
     d = _make(tmp_path, profile=_Profile(isolation=_Isolation(boot=lambda: None)), boot_callable=boot)
     d.preflight()
     assert seen["boot"] is boot
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_preflight_retires_before_interpreting_success_or_failure(tmp_path, monkeypatch, raises):
+    d = _make(tmp_path)
+    result = PreflightResult(ok=True, noise_band=1.0)
+
+    def _preflight():
+        if raises:
+            raise RuntimeError("preflight failed")
+        return result
+
+    retired: list[str] = []
+    d.preflight = _preflight
+    d._retire_if_unsafe = lambda stage: retired.append(stage) or True
+
+    assert d._preflight_checked() is None
+    assert retired == ["perf preflight"]
+
+
+def test_post_execution_live_urls_retire_the_clone(tmp_path, monkeypatch):
+    from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+
+    d = _make(tmp_path)
+    monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _clone: True)
+    monkeypatch.setattr(clone_setup, "_push_disabled", lambda _clone: False)
+    retained = tmp_path / ".clone.unsafe" / "clone"
+    monkeypatch.setattr(clone_setup, "_retire_unsafe_clone", lambda _clone: retained)
+
+    assert d._retire_if_unsafe("agent") is True
+    assert d._repository_retired is True and d._stop is True
 
 
 def test_measurement_boot_comes_from_the_isolation_recipe_when_not_injected(tmp_path):
@@ -906,7 +963,7 @@ def test_direct_push_refuses_a_disabled_remote_url(tmp_path, git):
 
 def test_direct_push_refuses_an_unreadable_pushable_diff(tmp_path, git):
     git.script("rev-parse --verify", 0)
-    git.script("diff HEAD~1..HEAD", (128, "", "fatal"))
+    git.script("diff --no-ext-diff HEAD~1..HEAD", (128, "", "fatal"))
     d = _direct_push_driver(tmp_path)
     assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is False
     assert d.ledger._seen["fp"].note == (
@@ -916,18 +973,18 @@ def test_direct_push_refuses_an_unreadable_pushable_diff(tmp_path, git):
 
 def test_direct_push_scans_a_root_commit_with_show(tmp_path, git, monkeypatch):
     git.script("rev-parse --verify", 1)  # no parent → root commit
-    git.script("show --format=", (0, DIFF, ""))
+    git.script("show --no-ext-diff --format=", (0, DIFF, ""))
     git.script("rev-parse HEAD", (0, "landedsha\n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path)
     assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is True
-    assert git.seen("show --format=")
+    assert git.seen("show --no-ext-diff --format=")
 
 
 def test_direct_push_refuses_content_the_scanner_flags(tmp_path, git, monkeypatch):
     monkeypatch.setattr(PP, "scan_content_for_secrets", lambda text: (False, PP.SCAN_HIT))
     git.script("rev-parse --verify", 0)
-    git.script("diff HEAD~1..HEAD", (0, DIFF, ""))
+    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
     d = _direct_push_driver(tmp_path)
     assert d._direct_push(fp="fp", kind="perf", target="t", sha="abc") is False
     assert d.ledger._seen["fp"].note == (
@@ -938,7 +995,7 @@ def test_direct_push_refuses_content_the_scanner_flags(tmp_path, git, monkeypatc
 
 def test_direct_push_records_a_failed_push(tmp_path, git):
     git.script("rev-parse --verify", 0)
-    git.script("diff HEAD~1..HEAD", (0, DIFF, ""))
+    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
     git.script("rev-parse HEAD", (0, "headsha\n", ""))
     git.script("push", (1, "", "remote rejected"))
     d = _direct_push_driver(tmp_path)
@@ -949,7 +1006,7 @@ def test_direct_push_records_a_failed_push(tmp_path, git):
 
 def test_direct_push_reports_the_sha_that_actually_landed(tmp_path, git):
     git.script("rev-parse --verify", 0)
-    git.script("diff HEAD~1..HEAD", (0, DIFF, ""))
+    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
     git.script("rev-parse HEAD", (0, "rebasedsha\n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path)
@@ -959,7 +1016,7 @@ def test_direct_push_reports_the_sha_that_actually_landed(tmp_path, git):
 
 def test_direct_push_falls_back_to_the_snapshot_sha_when_rev_parse_blanks(tmp_path, git):
     git.script("rev-parse --verify", 0)
-    git.script("diff HEAD~1..HEAD", (0, DIFF, ""))
+    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
     git.script("rev-parse HEAD", (0, "   \n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path)
@@ -970,7 +1027,7 @@ def test_direct_push_falls_back_to_the_snapshot_sha_when_rev_parse_blanks(tmp_pa
 def test_direct_push_reads_the_fetch_url_off_the_clone_when_the_profile_has_none(tmp_path, git):
     git.script("remote get-url", (0, "https://example.invalid/from-clone.git\n", ""))
     git.script("rev-parse --verify", 0)
-    git.script("diff HEAD~1..HEAD", (0, DIFF, ""))
+    git.script("diff --no-ext-diff HEAD~1..HEAD", (0, DIFF, ""))
     git.script("rev-parse HEAD", (0, "sha\n", ""))
     git.script("push", 0)
     d = _direct_push_driver(tmp_path, profile=_Profile(fetch_url=""))

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -1303,6 +1303,31 @@ class TestRmtreeForce:
         monkeypatch.setattr(pc.shutil, "rmtree", lambda *_a, **_k: None)
         assert pc.rmtree_force(root) is False
 
+    def test_missing_tree_is_already_removed(self, tmp_path):
+        assert pc.rmtree_force(tmp_path / "missing") is True
+
+    def test_nested_missing_race_does_not_hide_a_surviving_root(self, monkeypatch, tmp_path):
+        root = tmp_path / "tree"
+        root.mkdir()
+
+        def _nested_missing(*_args: Any, **_kwargs: Any) -> None:
+            raise FileNotFoundError("nested entry disappeared")
+
+        monkeypatch.setattr(pc.shutil, "rmtree", _nested_missing)
+        assert pc.rmtree_force(root) is False
+        assert root.exists()
+
+    def test_delete_error_is_reported_without_raising(self, monkeypatch, tmp_path):
+        root = tmp_path / "tree"
+        root.mkdir()
+
+        def _boom(*_args: Any, **_kwargs: Any) -> None:
+            raise OSError("denied")
+
+        monkeypatch.setattr(pc.shutil, "rmtree", _boom)
+        assert pc.rmtree_force(root) is False
+        assert root.exists()
+
     def test_readonly_hook_retries_the_operation(self, tmp_path):
         victim = tmp_path / "ro.txt"
         victim.write_text("x")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -346,8 +346,9 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # worktree of a push-disabled clone, which is where its blast radius is
         # contained; these calls are the harness around it, not the agent's hands.
         "apps/builtins/auto_improvement/backend/clone_setup.py::_disable_push",
+        "apps/builtins/auto_improvement/backend/clone_setup.py::_origin_urls",
+        "apps/builtins/auto_improvement/backend/clone_setup.py::_repository_is_safe",
         "apps/builtins/auto_improvement/backend/clone_setup.py::_gh_prefers_ssh",
-        "apps/builtins/auto_improvement/backend/clone_setup.py::_ok",
         "apps/builtins/auto_improvement/backend/clone_setup.py::_run",
         "apps/builtins/auto_improvement/backend/clone_setup.py::list_clone_branches",
         "apps/builtins/auto_improvement/backend/clone_setup.py::setup_safe_clone",
@@ -361,6 +362,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "::test_approval_is_logged_then_granted",
         "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"
         "::test_audit_failure_denies_instead_of_approving",
+        # Offline clone-setup regressions use only fixed Git argv against pytest
+        # tmp_path repositories; no agent/model input reaches command or cwd.
+        "apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py::_seeded_bare",
+        "apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py"
+        "::test_extra_origin_value_refuses_reuse",
+        "apps/builtins/auto_improvement/tests/test_clone_setup_idempotent.py"
+        "::test_disable_push_replaces_every_url_value",
         # A FIXED argv of `[sys.executable, "-c", <literal>]` — the interpreter running the
         # test plus a constant source string with no interpolation, so neither the command
         # nor its args are agent-influenced. The child only imports a module and prints
@@ -453,6 +461,10 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "::test_a_recipe_holding_the_config_url_can_still_push",
         "apps/builtins/auto_improvement/tests/test_pr_recipe.py"
         "::test_without_the_config_url_the_neutralized_clone_degrades_to_the_queue",
+        # Same basis: fixed `git init/config` argv against a tmp_path repo, proving an
+        # agent-planted external diff helper is refused before any publisher Git call.
+        "apps/builtins/auto_improvement/tests/test_pr_recipe.py"
+        "::test_push_refuses_before_git_when_repository_safety_changed",
         # Same basis: a fixed `git init/add/commit` against a tmp_path, asserting a diff
         # that cannot apply is refused BEFORE the pipeline drafts.
         "apps/builtins/auto_improvement/tests/test_dogfood_learnings.py"


### PR DESCRIPTION
## Problem / Motivation

`setup_safe_clone` is documented as idempotent, but successful setup rewrites both
origin URLs to `DISABLED_NO_PUSH`. A later setup compared that sentinel with the
requested URL and refused the clone that setup itself had neutralized.

## Why it matters

Re-running repository setup is the documented recovery path. It must succeed for
the canonical push-disabled clone without weakening the app's primary safety
control or claiming that agent-writable clone contents are trusted.

## What changed (motivation → approach → change)

- Existing canonical clones may be reused when their sole fetch URL is either the
  validated requested remote or `DISABLED_NO_PUSH`; mismatched or multi-valued
  fetch origins remain fail-closed refusals, while push URL values are always
  replaced with exactly one sentinel.
- Reuse makes no cryptographic or clean-checkout claim. Clone contents and history
  remain agent-writable by design; setup attests only enforceable location,
  metadata/config, and push-isolation properties. Non-object Git metadata must
  also have a single link, preventing host writes through hardlinks. Every
  metadata entry must be a regular file; FIFOs, sockets, and devices are refused
  before trusted Git can open them. Branch
  listing, checkout, and runtime isolation all require the same singleton
  sentinel URL sets before touching refs or worktrees.
- Every configured fetch and push URL is removed and replaced with exactly one
  `DISABLED_NO_PUSH` value. Setup and runtime isolation inspect all values and
  reject extras.
- The setup route passes a non-creating scratch path; scratch roots and
  destinations reject linked ancestors, symlinks, and Windows junctions before
  any directory creation or mutation. Git metadata rejects `commondir`, grafts,
  local/HTTP alternates, linked metadata nodes, local includes, URL rewrites,
  `core.worktree`, and worktree config.
- Local Git operations ignore inherited repository selectors and global/system
  config. Initial clone pins hooks/fsmonitor off, uses the validated transport,
  and supplies the trusted `gh auth git-credential` helper for private HTTPS
  repositories. Branch checkout pins the canonical work tree.
- Trusted one-click, direct-driver, and draft-PR publishers validate complete
  repository isolation—metadata/config safety and exact disabled URL sets—after
  agent work and before their first trusted Git mutation. Perf preflight uses the
  same capture → attest/retire → interpret ordering before progress, archive, or
  HEAD reads. The one-click route holds the clone lock and proves the runner idle through
  push; the driver revalidates after rebase before a retry push. These gates
  refuse URL rewrites, credential helpers, SSH commands, proxies, custom
  receive/upload-pack commands, protocol overrides, and host-side diff,
  filter, merge, editor, pager, askpass, hook, fsmonitor, proxy, signing,
  attributes-file, or excludes-file helpers. Trusted Git pins both external
  paths to Git's cross-platform `/dev/null` spelling. Startup validates repository integrity independently and
  unconditionally before considering the direct-commit push-posture exception.
  Every content scan also clears `diff.external` and passes
  `--no-ext-diff` in defense in depth. If repository safety changes after an
  agent/build step, the run stops before further Git, atomically retires the
  canonical clone into a private `.unsafe-*` incident directory, reports the
  retained path, and caps incident copies at three per repository; both direct-push callers skip rollback Git for that distinct
  outcome.
- Git's `.git/info/attributes` safety pin is atomically replaced rather than
  truncated in place, so a planted hardlink cannot overwrite an external inode.
- Failed clone output is removed with the repository's Windows-safe Git-tree
  remover, including read-only Git objects and already-missing destinations;
  a process-launch failure does not delete a path this setup attempt never owned.
- The authoritative Auto-Improvement module specification now documents this
  reuse contract explicitly.

## Tests

Offline local-bare-repository regressions cover:

- first setup followed by successful sentinel-based reuse;
- refusal of ambiguous/multi-valued origin state;
- replacement of every fetch/push URL value with one sentinel;
- linked scratch-root refusal before foreign-directory mutation;
- hardlinked writable Git metadata refusal without external-file truncation;
- branch listing and checkout refusal when origin URL sets are live or ambiguous;
- refusal of local include, URL rewrite, and `core.worktree` config;
- controlled errors when Git cannot start or a failed clone leaves no destination;
- missing-path and deletion-error behavior for Windows-safe tree cleanup;
- atomic unsafe-clone retirement with retained-path reporting;
- repository validation after discovery, proposal, every candidate gate/measure,
  reproduce, and pre-push review — including failed/raised outcomes and before
  fallible ledger/error bookkeeping;
- post-rebase safety refusal performs no retry push or rollback Git;
- trusted publisher refusal before Git when repository safety changes after agent
  work, including URL rewrites and execution-bearing transport config;
- runtime isolation rejecting secondary live URLs;
- spawn-audit coverage for every fixed-argv Git call.

Validation: full Auto-Improvement suite — 1,012 passed, 46 skipped. Targeted
setup-route, clone-safety, cleanup, retirement, attribute-pin, publisher-refusal,
one-click/candidate/reproduce ordering, and spawn-audit suite — 73 passed.
Repository-level draft-route, GitHub-profile, and Driver coverage — 500 passed.
Runner construction/startup coverage — 97 passed.
Black, isort, flake8, mypy, and subprocess-encoding checks pass.

## Manual verification

N/A — deterministic local bare repositories exercise setup, reuse, refusal, and
push neutralization without external network dependencies. This is backend-only
and has no rendered UI delta.

## Related Issues

Fixes #6704

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Placeholder retained as required by the repository template; exact CLA wording
will be supplied by OSPO.