### PR TITLE
fix(knowledge): carry the gate's text hash so a transformed duplicate stays owned

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -48,6 +48,19 @@ FTS5 search via `~/.kiro/crew/memory_index.db` (SQLite via `pysqlite3-binary` on
 
 Context injection includes source citations per section. Agent can update memory files via kiro-cli's file tools.
 
+### Knowledge library duplicate ownership
+
+Folder ingestion tracks two identities for each file: `content_hash` is the hash
+of the file's raw bytes, while `text_hash` is the hash of the text extracted by
+the reader and stored on knowledge items. They are equal for plain text but not
+for transformed formats such as PDF, DOCX, and HTML. The pre-ingest duplicate
+gate passes its exact extracted-text hash to the caller's in-transaction
+`on_duplicate` finalizer. `FolderWatcher` stores that value on the deduped state
+row before the gate commits, so a later source deletion can reassign and adopt
+the surviving item into the correct file row. Deriving the value only from a
+byte-identical sibling is a fallback for older direct state writes, not the
+ingestion contract.
+
 ### Decaying Memory (`read_recent_history`)
 
 History context uses natural decay: recent days in full detail, older days

--- a/src/kiro_crew/knowledge/agent_source.py
+++ b/src/kiro_crew/knowledge/agent_source.py
@@ -374,7 +374,7 @@ async def _add_agent_document(
             # The duplicate-branch sibling of on_committed, and inside the gate's
             # hop for the same reason: the gate has already committed the delete
             # and the location claim by the time it reports back.
-            on_duplicate=lambda: _record_deduped_state(
+            on_duplicate=lambda _text_hash: _record_deduped_state(
                 store, source_id, slug, content_hash, title),
         )
     finally:

--- a/src/kiro_crew/knowledge/artifact_ingest.py
+++ b/src/kiro_crew/knowledge/artifact_ingest.py
@@ -467,7 +467,7 @@ async def ingest_artifact(
             # it has already committed the delete and the location claim, and a
             # cancellation between here and a post-hoc write would leave both
             # durable with nothing naming them.
-            on_duplicate=lambda: _record_deduped_state(
+            on_duplicate=lambda _text_hash: _record_deduped_state(
                 kstore, source_id, slug, content_hash, title, art.kind),
         )
     finally:

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -495,8 +495,8 @@ class FolderWatcher:
 
             item_ids, outcome = await self._ingest_file(
                 file_path, source_id, namespace, props, old_ids, root=uri,
-                on_duplicate=lambda: self._record_deduped_state(
-                    source_id, file_path, content_hash, mtime, now))
+                on_duplicate=lambda text_hash: self._record_deduped_state(
+                    source_id, file_path, content_hash, mtime, now, text_hash))
             if item_ids is None:
                 # Ingestion failed. The 'scanning' marker above is only a crash hint,
                 # so it has to be replaced with a terminal status here rather than
@@ -709,24 +709,16 @@ class FolderWatcher:
         Never on the event loop, and only inside the caller's write transaction.
 
         Returning empty is not proof that this source owns nothing for the
-        document. ``_adopt_reassigned_item`` matches a folder row on
-        ``COALESCE(text_hash, content_hash)``, and a refused row's ``text_hash``
-        is derived from a byte-identical sibling row -- so for a transformed file
-        (PDF, DOCX, HTML, where the bytes hash and the text hash differ) with no
-        such sibling, the adoption matches nothing and this read cannot see the
-        item. That gap predates this change: the terminal write was previously an
-        unconditional empty group, so the row never named the item either. Closing
-        it needs the incoming document's TEXT hash carried out of the gate rather
-        than guessed from a sibling, which is a change to what the gate reports and
-        does not belong here. ``test_deduped_state_write_recovers_a_transformed_
-        files_reassigned_item`` is an xfail pinning it. The aggregate tables store
-        the text hash in ``content_hash`` directly and do not have this gap.
+        document. The duplicate finalizer stores the gate's extracted-text hash
+        before commit, so a later cascade can adopt a transformed document into
+        this exact row. This read preserves an adoption that already landed.
         """
         return self.store.surviving_group_in_txn(
             "folder_file_state", source_id, file_path)
 
     def _record_deduped_state(self, source_id: str, file_path: str, content_hash: str,
-                              mtime: float, now: str) -> None:
+                              mtime: float, now: str,
+                              text_hash: str | None = None) -> None:
         """Terminal write for a file the pre-ingest gate refused.
 
         Invoked BY the gate as its ``on_duplicate`` finalizer, from inside the
@@ -746,9 +738,9 @@ class FolderWatcher:
         adopted = self._surviving_group(source_id, file_path)
         self._write_state_row(
             source_id, file_path, content_hash, mtime, json.dumps(adopted), now,
-            "done" if adopted else "deduped")
+            "done" if adopted else "deduped", known_text_hash=text_hash)
 
-    def _write_state_row(self, source_id: str, file_path: str, content_hash: str, mtime: float, item_ids: str, now: str, status: str = "done", error_message: str | None = None, *, attempts: int = 0):
+    def _write_state_row(self, source_id: str, file_path: str, content_hash: str, mtime: float, item_ids: str, now: str, status: str = "done", error_message: str | None = None, *, attempts: int = 0, known_text_hash: str | None = None):
         # Record the EXTRACTED-TEXT hash alongside the file-bytes one. Ownership
         # lookups have to relate this row to items, and items are keyed by the text
         # hash -- for a PDF or HTML file that is a different string from the bytes
@@ -756,17 +748,17 @@ class FolderWatcher:
         # (one document's items share its hash) so nothing has to be plumbed through
         # the ingest path, and left alone when the row owns nothing: there is then
         # nothing to derive it from, and guessing is what makes documents collide.
-        text_hash: str | None = None
+        text_hash = known_text_hash
         try:
             ids = json.loads(item_ids or "[]")
         except (TypeError, ValueError):
             ids = []
-        if ids:
+        if ids and text_hash is None:
             row = self.store.db.execute(
                 "SELECT content_hash FROM items WHERE id = ?", (ids[0],)).fetchone()
             if row:
                 text_hash = row["content_hash"]
-        elif status == "deduped":
+        elif status == "deduped" and text_hash is None:
             text_hash = self._deduped_text_hash(content_hash)
         # ``attempts`` defaults to 0, so every terminal write ('done', 'deduped',
         # 'failed') clears the retry budget as a side effect of not passing it: the
@@ -858,7 +850,7 @@ class FolderWatcher:
     async def _ingest_file(self, file_path: str, source_id: str, namespace: str, props: dict,
                            old_item_ids: list[str],
                            root: str = "",
-                           on_duplicate: Callable[[], None] | None = None,
+                           on_duplicate: Callable[[str], None] | None = None,
                            ) -> tuple[list[str] | None, str]:
         """Ingest one file.
 

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -277,7 +277,7 @@ class IngestionPipeline:
 
     def _skip_as_duplicate(self, content_hash: str, source_id: str | None,
                            old_item_ids: list[str] | None = None,
-                           on_duplicate: Callable[[], None] | None = None) -> str | None:
+                           on_duplicate: Callable[[str], None] | None = None) -> str | None:
         """Terminal job id when this exact document is already in the Library.
 
         Returns ``None`` when the write should proceed.
@@ -373,7 +373,11 @@ class IngestionPipeline:
             # rolls the gate back too, which is the correct pairing: the delete,
             # the claim and the record land together or not at all.
             if on_duplicate is not None:
-                on_duplicate()
+                # The caller may track file identity in a different hash domain
+                # (folder rows use raw bytes while items use extracted text).
+                # Hand it the exact text hash the gate matched so transformed
+                # documents can remain adoptable after this transaction commits.
+                on_duplicate(content_hash)
             self.store.db.execute("COMMIT")
         except Exception:
             self.store.db.execute("ROLLBACK")
@@ -450,7 +454,7 @@ class IngestionPipeline:
         except Exception:
             logger.debug("Post-ingest dedup skipped", exc_info=True)
 
-    async def ingest_file(self, path: str, on_progress=None, original_name: str = "", namespace: str = "default", source_id: str = "", old_item_ids: list[str] | None = None, on_committed: Callable[[list[str]], None] | None = None, on_duplicate: Callable[[], None] | None = None) -> str | None:
+    async def ingest_file(self, path: str, on_progress=None, original_name: str = "", namespace: str = "default", source_id: str = "", old_item_ids: list[str] | None = None, on_committed: Callable[[list[str]], None] | None = None, on_duplicate: Callable[[str], None] | None = None) -> str | None:
         """Full pipeline. Returns job_id, or None if content hash unchanged.
 
         If source_id is provided, ingests into that existing source instead of
@@ -470,9 +474,9 @@ class IngestionPipeline:
         the same run-to-completion guarantee as the delete it belongs with.
 
         ``on_duplicate`` is that same bargain for the branch where the pre-ingest
-        gate REFUSES the write. It runs inside the gate's own hop, after its
-        transaction commits, and records whatever terminal state the caller keys by
-        document. Leaving it to the caller is not merely riskier here than on the
+        gate REFUSES the write. It receives the extracted-text hash matched by the
+        gate and runs inside the gate's transaction, recording whatever terminal
+        state the caller keys by document. Leaving it to the caller is not merely riskier here than on the
         success branch, it is unsound: ``run_to_completion`` guarantees the gate
         finishes and then re-raises the cancellation, so a shutdown lands with the
         deletion and the location claim durable and the caller's write never
@@ -783,7 +787,7 @@ class IngestionPipeline:
     async def ingest_text(self, text: str, title: str, source_type: str = 'manual',
                           source_id: str | None = None,
                           old_item_ids: list[str] | None = None,
-                          on_duplicate: Callable[[], None] | None = None) -> str | None:
+                          on_duplicate: Callable[[str], None] | None = None) -> str | None:
         """Ingest raw text (dashboard drop, chat, or a shared aggregate source).
 
         Without ``source_id`` the source is found-or-created by a

--- a/test/test_knowledge_delete_off_loop.py
+++ b/test/test_knowledge_delete_off_loop.py
@@ -623,15 +623,6 @@ def test_deduped_state_write_drops_the_group_the_gate_just_deleted(tmp_path):
         store.close()
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "Pre-existing on main, not introduced here: a transformed file's ownership "
-    "bookkeeping is inert because _adopt_reassigned_item matches a folder row on "
-    "COALESCE(text_hash, content_hash) and a refused row's text_hash is derived "
-    "from a byte-identical SIBLING row, which a lone PDF does not have. main "
-    "writes an unconditional empty group here, so the row never named the item "
-    "either. Closing it needs the incoming document's TEXT hash carried out of "
-    "the gate instead of guessed, which changes what the gate reports. Strict, so "
-    "this starts failing the moment someone lands that and the xfail goes stale."))
 @pytest.mark.asyncio
 async def test_deduped_state_write_recovers_a_transformed_files_reassigned_item(tmp_path):
     """A transformed file must not be stranded when adoption silently matched nothing.
@@ -923,7 +914,7 @@ async def test_duplicate_gate_records_terminal_state_even_when_cancelled(tmp_pat
         started = asyncio.Event()
         release = threading.Event()
 
-        def finalizer() -> None:
+        def finalizer(_text_hash: str) -> None:
             recorded.append("terminal state written")
 
         real_gate = pipeline._skip_as_duplicate
@@ -1015,7 +1006,7 @@ async def test_duplicate_gate_and_terminal_state_are_one_transaction(tmp_path):
             "SELECT id FROM items WHERE source_id = ?", (target,)).fetchall()]
         assert superseded, "nothing to supersede -- the delete under test is a no-op"
 
-        def exploding_finalizer() -> None:
+        def exploding_finalizer(_text_hash: str) -> None:
             raise RuntimeError("terminal state write failed")
 
         with pytest.raises(RuntimeError, match="terminal state write failed"):


### PR DESCRIPTION
## Problem / Motivation

`main` already pins this defect itself, as a `strict` xfail:
`test_deduped_state_write_recovers_a_transformed_files_reassigned_item` in
`test/test_knowledge_delete_off_loop.py`. This PR does not add that test — it removes the
xfail and makes it pass.

Folder ingestion tracks a file under two identities:

- `content_hash` — the hash of the file's **raw bytes**, stored on the `folder_file_state` row;
- `text_hash` — the hash of the **extracted text**, which is what knowledge `items` are keyed by.

For plain text these are the same string. For a transformed format — PDF, DOCX, HTML — they
are not.

When the pre-ingest duplicate gate refuses a write, `FolderWatcher._record_deduped_state` runs
as the gate's in-transaction finalizer and writes the terminal state row. It had no way to
learn the text hash the gate had just matched, so `_write_state_row` guessed: it derived one
from a byte-identical **sibling** row. A lone PDF has no such sibling, so the row was written
with `text_hash = NULL`.

That NULL is load-bearing. `_adopt_reassigned_item` matches a folder row on
`COALESCE(text_hash, content_hash)`, so for a transformed document it compares the item's text
hash against the file's **bytes** hash and matches nothing. The item survives a later
cross-source reassignment and is adopted by the folder source, but no state row names it —
an orphan: the data is present and the delete path cannot find it.

## Why it matters

Orphaned items are invisible in both directions. Nothing surfaces them as owned by the folder
source, and removing the source does not remove them, so a document a user believes they
deleted stays in the Library and keeps coming back in search results and injected context.
The set it affects is exactly the ingested-document formats a knowledge library is for — PDF,
DOCX, HTML — while plain text, where hashing happens to agree, is unaffected. That is why the
gap survived: it is silent, format-dependent, and only observable after a reassignment.

## What changed (motivation → approach → change)

Root cause: the terminal write needed a value only the gate knew, and inferred it instead of
being told. Fix: have the gate report it.

- `knowledge/ingestion.py` — `on_duplicate` becomes `Callable[[str], None]` and
  `_skip_as_duplicate` invokes it with the exact `content_hash` it matched (which, at that
  point in the pipeline, *is* the extracted-text hash). Still inside the gate's own
  transaction, so the delete, the location claim and the state row commit or roll back
  together — the existing bargain is unchanged, only its payload grows.
- `knowledge/folder_watcher.py` — `_record_deduped_state` accepts that hash and passes it to
  `_write_state_row` as `known_text_hash`. The sibling-derivation and the item-row lookup are
  kept, demoted to fallbacks for direct state writes that have no gate to hear from; the
  known value simply wins when present.
- `knowledge/agent_source.py`, `knowledge/artifact_ingest.py` — the two other `on_duplicate`
  finalizers take the new parameter and ignore it (`lambda _text_hash: ...`). Neither has this
  problem: the aggregate tables store the text hash in `content_hash` directly.
- `docs/system-specs/modules/memory-skills-hooks.md` — documents the two-hash contract and
  states that sibling derivation is a fallback, not the ingestion contract. Same commit, per
  the spec-management rule.

No schema change, no new column, no new public surface, and no change to which rows are
written or to the transaction boundary — only to what one already-written column contains.

## Tests

`test_deduped_state_write_recovers_a_transformed_files_reassigned_item` — **already on `main`,
byte-for-byte unchanged by this PR.** The only edits to the test file are the removal of its
`@pytest.mark.xfail(strict=True, ...)` marker and two test-local finalizer signatures updated
to the new callback arity. The assertions were authored by whoever pinned the defect, not
fitted to this fix, and the xfail was `strict` precisely so it would start failing the moment
someone landed this.

Red-before, with only the production hunks reverted and the test as shipped:

```
>           assert sorted(named) == sorted(owned), (
E               assert [] == ['4347cc64-5d...27f290033fd7']
```

— the state row names nothing while the item is owned. That is the orphan, reproduced
directly.

Green after:
- `test/test_knowledge_delete_off_loop.py` — 18 passed (0 xfail remaining)
- with `test/test_knowledge_ingest_scan_off_loop.py` — 32 passed

Gates: `scripts/check_black_formatting.py` passes; `flake8` clean on `src/kiro_crew/knowledge/`
and the changed test; `scripts/docs-lint.sh` passes.

`mypy 1.14.1 --platform linux` clean on the two changed modules. Worth naming, because the
arity change had a second call site that is easy to miss: `FolderWatcher._ingest_file` merely
forwards the callback, and leaving its annotation at `Callable[[], None]` produced

```
folder_watcher.py:498: error: Argument "on_duplicate" to "_ingest_file" of "FolderWatcher"
has incompatible type "Callable[[Any], None]"; expected "Callable[[], None] | None"
```

with a second error on the forward. Both are fixed by widening that one annotation, and mypy
is green with it.

## Manual verification

N/A — unit coverage sufficient: the defect is a value in one database column and its effect on
one `COALESCE` join, and the pre-existing test drives the real ingestion gate, the real state
write, and the real reassignment/adoption path against a real store rather than mocking any of
them.

## Related Issues

No issue — the defect was pinned in-tree on `main` as a `strict` xfail rather than filed, and
this PR retires that pin.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/system-specs/modules/memory-skills-hooks.md` updated in the same commit
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
