### PR TITLE
fix: skip a history save whose session was permanently deleted under lock

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -203,7 +203,6 @@ src/kiro_crew/cron_history.py
 src/kiro_crew/cron_script.py
 src/kiro_crew/dashboard/cautious_boot.py
 src/kiro_crew/dashboard/channel_folders.py
-src/kiro_crew/dashboard/channel_slots.py
 src/kiro_crew/dashboard/chat_auto_tag.py
 src/kiro_crew/dashboard/chat_folder_suggest.py
 src/kiro_crew/dashboard/chat_nav.py
@@ -247,7 +246,6 @@ src/kiro_crew/dashboard/routes/skills.py
 src/kiro_crew/dashboard/session_directive_apply.py
 src/kiro_crew/dashboard/session_health.py
 src/kiro_crew/dashboard/session_memory.py
-src/kiro_crew/dashboard/session_transfer.py
 src/kiro_crew/dashboard/slowloris.py
 src/kiro_crew/dashboard/stale_asset_watchdog.py
 src/kiro_crew/dashboard/system_notices.py

--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -192,6 +192,78 @@ no longer destroy older turns.
   patiently to a bounded deadline. The same discipline applies to every other
   session-JSONL writer: `clear_closed` (resume un-flags `closed` under `_locked`,
   offloaded via `asyncio.to_thread`) and all `history.py` mutators hold `_locked`.
+- **Delete-won guard**: `delete_session` unlinks the session file under the
+  same `_locked` and leaves no tombstone, and the patient off-loop acquire
+  means a save can legitimately sit waiting while a permanent delete runs to
+  completion ahead of it. Inside the lock, before any `mkdir`/`atomic_write`,
+  the save therefore aborts cleanly (no write, no error — the flush loop
+  clears `_dirty`) when the file is gone AND the slot has OBSERVED its session
+  on disk. The observation witness is `_disk_meta_created_at` — recorded
+  exactly at the hydrate sites and at each committed save, nowhere else — and
+  it is the SOLE gate: the window counters take no part in either direction,
+  because fork/transfer set `_resumed_count` optimistically after a
+  best-effort first save (a transient first-write failure must not read as a
+  deletion and eat the retry), and a restored zero-message session has
+  all-zero counters while its delete must still win against the save of its
+  first message. A delete that already
+  reported success is not silently undone. Only `FileNotFoundError` from
+  `stat` counts as the delete witness; any other failure (permissions, device
+  not ready) propagates and leaves the retry armed. A file that EXISTS can
+  also be delete-won: `delete_session` leaves no tombstone, so a foreign
+  append landing after the delete creates a fresh file — the save tells the
+  incarnations apart by the metadata `created_at` (the file's identity, which
+  a save always carries forward and which therefore never changes for a
+  continuously-existing file) against `_disk_meta_created_at`, the identity
+  the slot last observed at restore or at its own save; a known-vs-known
+  mismatch aborts rather than merging the deleted window into the new
+  transcript, while a readable-but-absent `created_at` (legacy meta) fails
+  open. The metadata is read through `get_metadata_status`, and an UNREADABLE
+  line fails CLOSED: the save raises (leaving `_dirty` armed for the flush
+  retry) and `session_was_deleted` returns True (the copy is refused,
+  retryably) — a transient read failure must not blank the identity
+  comparison and let deleted content overwrite a replacement session. A brand-new slot's first
+  save has none of that evidence and creates the file normally. The abort
+  returns `False` (every other completion returns `True`), and
+  `save_slot_off_loop` forwards it — for BOTH `best_effort` modes the skip
+  raises nothing, so a clean return no longer proves a committed write.
+  Callers that republish the slot's content elsewhere check it: the fork
+  aborts with 409 and the transfer export refuses the bundle, because a copy
+  made from the surviving in-memory window would resurrect the destroyed
+  conversation under a fresh key whose own save carries no delete evidence.
+  Because the periodic 5s flush can hit the guard FIRST and clear `_dirty` —
+  after which fork/transfer skip their dirty-gated flush arms and never see
+  the `False` — both also call `session_was_deleted(state, slot)` directly at
+  their copy choke points: the same evidence + stat-ENOENT witness, answered
+  independently of flush ordering (lock-free, safe because a permanent delete
+  never un-happens). Being lock-free also means the delete can land INSIDE the
+  probe, between its stat and its metadata read, and `get_metadata_status`
+  reports a vanished file as a genuine `({}, True)` -- so an empty `created_at`
+  is re-stated before it is trusted, which is what tells "legacy metadata"
+  (fails open) from "deleted a moment ago" (refuses). The save's guard needs no
+  equivalent: it reads the metadata and stats the path inside `_locked`, the
+  lock `delete_session` unlinks under, so no delete can interleave between its
+  two reads.
+  A single pre-copy probe is not enough, because writing the copy is itself an
+  await that does not serialise against the source's delete: the transfer
+  re-probes after bundle assembly, and the fork re-probes after its DESTINATION
+  save, both before the copy is acknowledged. The boundary a handler owns is
+  ACKNOWLEDGMENT — a delete committing before it wins, and the fork therefore
+  removes the destination transcript it had already written (`delete_session`
+  on the destination key, off-loop) and pops the never-broadcast slot before
+  answering 409; a delete committing after the copy is acknowledged is out of
+  scope and the copy survives its source, the way a repo fork outlives what it
+  came from. Rolling the destination back cannot harm the source (different
+  key, different lock), so the fail-closed probe costs at worst a retryable
+  409. If that removal itself fails the copy stays on disk and is logged at
+  ERROR — the one case that still needs a human.
+  Archival callers (close/cleanup) ignore it — the delete already disposed of
+  what they were archiving. Residuals: a slot that never observed its session
+  on disk (fresh slot adopting an existing key whose file is deleted while it
+  waits) still recreates — the writer-recreates case `delete_session`'s
+  docstring already accepts; and for a slot the delete's cleanup cannot pop
+  (e.g. a cron-linked tab whose slot key matches none of the spellings the
+  cleanup probes), the abort latches — every later save of new activity is
+  skipped, which is why the skip logs at WARNING with the slot key.
 - **Turn persistence is offloaded through ONE choke point**
   (`save_conversation_turn_off_loop`, `llm_helpers.py`): `save_conversation_turn`
   makes TWO `append` calls, so an on-loop caller pays ~24 ms of loop time per turn

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -245,9 +245,7 @@ def needs_default_filing(meta: dict[str, Any]) -> bool:
     first surface happens exactly once per conversation.
     """
     return not (
-        meta.get("folder_id")
-        or meta.get("channel_folder_filed")
-        or meta.get("channel_origin")
+        meta.get("folder_id") or meta.get("channel_folder_filed") or meta.get("channel_origin")
     )
 
 
@@ -300,9 +298,7 @@ def surface_channel_session(
         )
         session_key = ""
     if not session_key:
-        logger.info(
-            "channel surface: %s has no mapped session key; surfacing unbound", stem
-        )
+        logger.info("channel surface: %s has no mapped session key; surfacing unbound", stem)
     try:
         slot = state.get_or_create_slot(
             name=slot_name,
@@ -321,6 +317,12 @@ def surface_channel_session(
     slot._titled = bool(raw_title)
     if meta.get("created_at"):
         slot.created_at = meta["created_at"]
+    # The identity of the transcript this surfacing read — lets a later save
+    # recognize a file recreated by another writer after a permanent delete
+    # (the delete-won guard in ``_save_slot_to_history``). Channel slots adopt
+    # append-created transcripts, so the observed on-disk value is the only
+    # honest anchor (the slot's own construction time never matches it).
+    slot._disk_meta_created_at = str(meta.get("created_at") or "")
     if meta.get("model"):
         slot.model = meta["model"]
     if meta.get("workspace"):
@@ -424,7 +426,7 @@ def _window_matches_disk(slot: "_ChatSlot", messages: list[dict[str, Any]]) -> b
     window = slot.messages
     if older + len(window) > len(messages):
         return False
-    expected = messages[older:older + len(window)]
+    expected = messages[older : older + len(window)]
     for mem, disk in zip(window, expected):
         if (
             mem.get("role") != disk.get("role")
@@ -435,9 +437,7 @@ def _window_matches_disk(slot: "_ChatSlot", messages: list[dict[str, Any]]) -> b
     return True
 
 
-def refresh_channel_window(
-    slot: "_ChatSlot", messages: list[dict[str, Any]], mtime: float
-) -> int:
+def refresh_channel_window(slot: "_ChatSlot", messages: list[dict[str, Any]], mtime: float) -> int:
     """Bring a bound slot's in-memory window up to date with its transcript.
 
     The tab and the channel write one file, but the tab's window is a snapshot
@@ -736,9 +736,7 @@ async def _reconcile_channel_slots_locked(state: "DashboardState", window_minute
     # fails the next pass re-qualifies them from the same (now-unflagged)
     # state.
     reactivated = [
-        s.get("key", "")
-        for s in pending
-        if (metadata.get(s.get("key", "")) or {}).get("closed")
+        s.get("key", "") for s in pending if (metadata.get(s.get("key", "")) or {}).get("closed")
     ]
     if reactivated:
 
@@ -820,9 +818,7 @@ async def _reconcile_channel_slots_locked(state: "DashboardState", window_minute
             # now existing is the evidence that happened — filing over it would
             # restore the default folder after the next restart.
             if channel_slot_name(key) in state._slots:
-                logger.debug(
-                    "channel reconcile: %s surfaced while this pass ran; not filing", key
-                )
+                logger.debug("channel reconcile: %s surfaced while this pass ran; not filing", key)
                 to_file = ""
         if to_file:
             # Persist the placement BEFORE the slot becomes visible.
@@ -857,7 +853,8 @@ async def _reconcile_channel_slots_locked(state: "DashboardState", window_minute
                 # filed again by the next pass. Leave the conversation unfiled
                 # and let a later pass retry.
                 logger.warning(
-                    "channel reconcile: could not persist folder filing for %s", key,
+                    "channel reconcile: could not persist folder filing for %s",
+                    key,
                     exc_info=True,
                 )
                 to_file = ""

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -8,7 +8,7 @@ import logging
 from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig
-from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop, session_was_deleted
 from kiro_crew.dashboard.chat_utils import (
     _sync_dashboard_slots,
     effective_session_key,
@@ -257,7 +257,9 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                         # (``test_a_first_entry_pending_rewrite_save_archives_as_
                         # before`` pins that). Stating it here removes the dependence
                         # on that promotion, which is the thing that silently failed.
-                        await save_slot_off_loop(state, slot, rewrite=True, best_effort=False)
+                        saved = await save_slot_off_loop(
+                            state, slot, rewrite=True, best_effort=False
+                        )
                     except Exception:
                         logger.warning(
                             "chat_fork: could not persist the pending rewrite for "
@@ -272,6 +274,24 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                                 "code": "fork_snapshot_unstable",
                             },
                             status=503,
+                        )
+                    if not saved:
+                        # Delete-won: the source session was permanently deleted
+                        # while this flush awaited the lock. Do not fork — the
+                        # copy would republish the destroyed conversation under
+                        # a fresh key (see the identical check at the plain
+                        # flush site below).
+                        logger.warning(
+                            "chat_fork: source slot=%s was permanently deleted "
+                            "during the pending-rewrite flush; aborting fork",
+                            slot.key,
+                        )
+                        return web.json_response(
+                            {
+                                "error": "the source session was permanently deleted",
+                                "code": "fork_source_deleted",
+                            },
+                            status=409,
                         )
                     # A moved generation means a genuine re-dirty landed across the
                     # await -- i.e. a rewind, whose ``_pending_rewrite`` this save
@@ -510,7 +530,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             # abort the fork (leaving ``_dirty`` set) rather than fork from a
             # partially-persisted source.
             try:
-                await save_slot_off_loop(state, slot, best_effort=False)
+                saved = await save_slot_off_loop(state, slot, best_effort=False)
             except Exception:
                 logger.warning(
                     "chat_fork: durable save of source slot=%s failed; "
@@ -522,10 +542,51 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
                     {"error": "could not persist source session before fork; " "please retry"},
                     status=503,
                 )
+            if not saved:
+                # The delete-won guard skipped the write: the source session was
+                # permanently deleted while the flush awaited the lock. Forking
+                # now would republish the destroyed conversation under a fresh
+                # key (a brand-new slot carries no delete evidence, so ITS save
+                # would proceed) — the exact resurrection the guard exists to
+                # prevent, laundered through a copy. Abort instead; the delete's
+                # reported success stands.
+                logger.warning(
+                    "chat_fork: source slot=%s was permanently deleted during "
+                    "the pre-fork flush; aborting fork",
+                    slot.key,
+                )
+                return web.json_response(
+                    {
+                        "error": "the source session was permanently deleted",
+                        "code": "fork_source_deleted",
+                    },
+                    status=409,
+                )
             slot._resumed_count = len(slot.messages)
             slot._dirty = False
         if not all_messages:
             all_messages = list(slot.messages)
+        # Direct delete check, independent of the flush arms above: if the
+        # periodic 5s flush hit the delete-won guard first, it cleared
+        # ``_dirty`` and this handler's own flush arms never ran — the disk
+        # read came back empty and ``all_messages`` just fell back to the
+        # in-memory window of a permanently deleted conversation. The two
+        # ``saved``-checks above only cover a delete observed by THIS
+        # handler's flush; this probe answers regardless of who consumed the
+        # signal.
+        if session_was_deleted(state, slot):
+            logger.warning(
+                "chat_fork: source slot=%s belongs to a permanently deleted "
+                "session; refusing to fork it",
+                slot.key,
+            )
+            return web.json_response(
+                {
+                    "error": "the source session was permanently deleted",
+                    "code": "fork_source_deleted",
+                },
+                status=409,
+            )
     visible = [m for m in all_messages if m.get("role") in ("user", "assistant")]
     if not visible:
         return web.json_response({"error": "no messages to fork"}, status=400)
@@ -630,6 +691,85 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
             error="fork finalisation failed",
         )
         raise
+    # Acknowledgment boundary. The destination save above is the last await
+    # before this fork is answered, and it takes the DESTINATION's history lock
+    # -- nothing in it serialises against the SOURCE's permanent delete. So a
+    # delete that began after the pre-copy probe passed can commit inside that
+    # await, and the copy now on disk is a conversation the user has since
+    # destroyed. ``build_transfer_bundle_async`` already closes its equivalent
+    # window by re-probing after bundle assembly and before the peer send is
+    # acknowledged; this is the same rule at the same boundary, for the copy
+    # this handler makes.
+    #
+    # A delete that commits AFTER this point is deliberately out of scope: a
+    # fork acknowledged while its source was alive is its own session and
+    # survives the source, the way a repo fork outlives what it came from.
+    # Acknowledgment is the only boundary a handler owns, so it is the line
+    # drawn here.
+    if session_was_deleted(state, slot):
+        # Roll the destination back. It has been neither acknowledged nor
+        # broadcast (``push_slots_update`` is below, and every ``append`` above
+        # passed ``broadcast=False``), so nothing outside this handler has seen
+        # it: removing it leaves no trace of the deleted conversation instead of
+        # a fresh key holding a full copy. Removing the destination cannot harm
+        # the source -- different key, different lock -- so a false positive
+        # here (``session_was_deleted`` fails CLOSED when a stat or metadata
+        # read is unverifiable) costs a retryable 409 against a still-live
+        # source, not data.
+        removed = False
+        if state.conversation_log is not None:
+            try:
+                removed = bool(
+                    await asyncio.to_thread(
+                        state.conversation_log.delete_session,
+                        slot_history_key(new_slot),
+                    )
+                )
+            except Exception:
+                removed = False
+                logger.warning(
+                    "chat_fork: removing the unacknowledged fork transcript for %s raised",
+                    new_slot.key,
+                    exc_info=True,
+                )
+        state._slots.pop(new_slot.key, None)
+        if removed:
+            logger.warning(
+                "chat_fork: source slot=%s was permanently deleted during the "
+                "destination save; removed the unacknowledged fork %s",
+                slot.key,
+                new_slot.key,
+            )
+        else:
+            # The copy is still on disk and WILL be listed in Older Sessions.
+            # Loud, because this is the resurrection the guard exists to
+            # prevent and it now needs a human -- but still a 409: reporting
+            # success would additionally hide it.
+            logger.error(
+                "chat_fork: source slot=%s was permanently deleted during the "
+                "destination save, but the fork transcript for %s could not be "
+                "removed; a copy of the deleted conversation remains on disk",
+                slot.key,
+                new_slot.key,
+            )
+        sel().log_api_access(
+            caller=request_app or "dashboard",
+            operation="chat.slot_fork",
+            outcome="denied",
+            source="dashboard",
+            resources=(
+                f"from={slot.key},to={new_slot.key},"
+                f"rollback={'removed' if removed else 'failed'}"
+            ),
+            error="source session permanently deleted during the destination save",
+        )
+        return web.json_response(
+            {
+                "error": "the source session was permanently deleted",
+                "code": "fork_source_deleted",
+            },
+            status=409,
+        )
     sel().log_api_access(
         caller=request_app or "dashboard",
         operation="chat.slot_fork",

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -5766,6 +5766,10 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
     # so the auto-titler can still name it on the next turn.
     if meta.get("created_at"):
         slot.created_at = meta["created_at"]
+    # The identity of the transcript this resume read — lets a later save
+    # recognize a file recreated by another writer after a permanent delete
+    # (the delete-won guard in ``_save_slot_to_history``).
+    slot._disk_meta_created_at = str(meta.get("created_at") or "")
     # On a member key the pin came from the BINDING at slot creation above and
     # metadata may not override it (same tamperable file the guard refused to
     # trust). On an ordinary key, mode="member" may not ride in either — the

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -897,6 +897,10 @@ def _rehydrate_slot_from_history(
         )
         if meta.get("created_at"):
             slot.created_at = meta["created_at"]
+        # The identity of the file this restore just read — lets a later save
+        # recognize a file recreated by another writer after a permanent
+        # delete (delete-won guard).
+        slot._disk_meta_created_at = str(meta.get("created_at") or "")
         # Member keys keep the binding-derived agent/mode: transcript metadata
         # is the operator-editable file the pin must not re-derive from.
         if meta.get("agent") and _member_identity is None:
@@ -1363,6 +1367,10 @@ def _apply_recent_session(
     )
     if meta.get("created_at"):
         slot.created_at = meta["created_at"]
+    # The identity of the file this restore just read — lets a later save
+    # recognize a file recreated by another writer after a permanent delete
+    # (delete-won guard).
+    slot._disk_meta_created_at = str(meta.get("created_at") or "")
     # Member keys keep the binding-derived agent/mode: transcript metadata is
     # the operator-editable file the pin must not re-derive from.
     if meta.get("agent") and _member_identity is None:
@@ -2341,7 +2349,7 @@ def _save_slot_to_history(
     closed_at: float | None = None,
     force: bool = False,
     rewrite: bool = False,
-) -> None:
+) -> bool:
     """Persist slot messages to JSONL history (append-safe).
 
     The session file is modeled as **frozen prefix + live window**:
@@ -2376,9 +2384,14 @@ def _save_slot_to_history(
     tab_id chaining is 1:1 (a slot's tab_id maps to exactly one file — fork makes
     a fresh slot with its own file), so this never reads/writes a sibling and
     legacy no-tab_id sessions stay isolated.
+
+    Returns ``False`` only when the delete-won guard aborted the save because
+    the session was permanently deleted while this save awaited the lock — the
+    in-memory window was NOT persisted and must not be treated as durable.
+    Every other completion (including the benign no-op skips) returns ``True``.
     """
     if not state.conversation_log:
-        return
+        return True
     # An explicit message snapshot always means "this is the full authoritative
     # window state" → rewrite. Edit paths (rewind/regenerate/fork) pass a snapshot.
     # A slot left in _pending_rewrite by a failed inline rewrite also takes
@@ -2457,7 +2470,7 @@ def _save_slot_to_history(
             note_auth_key,
         )
     if not window:
-        return
+        return True
     # Skip a pure no-op: a freshly resumed slot with no new AND no edited
     # messages. ``slot._dirty`` is set by both append and in-place edits
     # (update_message / _resolve_stop_event / file-change + mcp_oauth patches),
@@ -2472,7 +2485,7 @@ def _save_slot_to_history(
         and not force
         and not rewrite
     ):
-        return
+        return True
     try:
         # Hold the SAME per-session cross-process lock that ``append`` /
         # ``append_off_loop`` / rotate / rewrite / metadata mutations take, across
@@ -2488,9 +2501,101 @@ def _save_slot_to_history(
         # ``save_slot_off_loop`` helper routes on-loop callers to a worker thread
         # so they take the patient acquire path instead of dropping the save.
         with state.conversation_log._locked(history_key):
-            existing_meta = state.conversation_log.get_metadata(history_key)
+            # Status form, not bare ``get_metadata``: the delete-won identity
+            # comparison below is exactly the "empty result triggers something
+            # destructive" case that ``get_metadata_status`` exists for — a
+            # transient read failure returns ``{}`` from the bare getter,
+            # indistinguishable from "no metadata", which would blank the
+            # identity check and let a pending save overwrite a replacement
+            # session with deleted content.
+            existing_meta, _meta_readable = state.conversation_log.get_metadata_status(history_key)
 
             path = state.conversation_log._path(history_key)
+            # ── Delete-won guard ────────────────────────────────────────────
+            # ``delete_session`` unlinks the session file under the SAME
+            # ``_locked`` region and deliberately leaves no tombstone (its
+            # docstring notes a concurrent writer can recreate the session
+            # once it releases the lock). ``save_slot_off_loop`` routes
+            # on-loop callers to a worker thread that takes the PATIENT
+            # acquire, so this save can legitimately sit waiting while a
+            # permanent delete runs to completion ahead of it — writing now
+            # would silently undo a delete that already reported success,
+            # resurrecting the conversation in Older Sessions. A missing
+            # file alone is NOT that signal: a brand-new slot's first save
+            # also starts with no file. The abort therefore requires
+            # evidence that this slot's session HAS been on disk before —
+            # it was resumed from history (``_resumed_count``), its window
+            # has older lines on disk (``disk_older``), or one of this
+            # slot's own saves already committed (``_disk_window_len``).
+            # A fresh slot has none of these and proceeds with a normal
+            # first create. (``path`` is resolved after the delete, so for a
+            # legacy-aliased Slack key it may name the canonical file rather
+            # than the legacy one the delete unlinked — both are gone, so
+            # the answer is the same.) Returning cleanly (no mkdir, no
+            # write, no raise) lets the flush loop clear ``_dirty`` so the
+            # delete's reported success stands; the ``False`` return lets
+            # callers that must CONFIRM durability (fork, transfer export)
+            # distinguish this skip from a committed write. Only a missing
+            # file counts as the delete witness — any other ``stat`` failure
+            # (permissions, device not ready) propagates to the outer
+            # handler, which re-raises and leaves the retry armed.
+            _delete_won = False
+            # Evidence is the slot having OBSERVED its file on disk, and
+            # ``_disk_meta_created_at`` is that observation: recorded exactly
+            # at the hydrate sites and at each committed save, nowhere else.
+            # Identity ALONE is the gate. The window counters take no part in
+            # it, in either direction: fork/transfer set ``_resumed_count``
+            # optimistically after a best-effort first save (a transient
+            # failure would read as "was on disk, now gone" and eat the retry
+            # best-effort re-armed), and a restored ZERO-message session has
+            # all-zero counters while its delete must still win against the
+            # save of its first message.
+            _known = slot._disk_meta_created_at
+            if _known:
+                try:
+                    path.stat()
+                except FileNotFoundError:
+                    _delete_won = True
+                else:
+                    # The file EXISTS but may not be the one this slot knows: a
+                    # permanent delete followed by another writer's append (a
+                    # channel/cron ``append_off_loop``) creates a FRESH file
+                    # with a new metadata ``created_at``. Merging this slot's
+                    # window into that file would restore the deleted
+                    # conversation into the new transcript. ``created_at`` is
+                    # the file's identity — the save always carries the on-disk
+                    # value forward, so for a continuously-existing file it
+                    # never changes. An UNREADABLE metadata line fails CLOSED:
+                    # the identity cannot be verified, so the save must not
+                    # proceed — raising (rather than returning False) leaves
+                    # ``_dirty`` armed via the outer handler, so the flush
+                    # retries once the transient read failure clears, instead
+                    # of the delete-won path discarding the content. A
+                    # readable-but-absent ``created_at`` (legacy meta) fails
+                    # open to the pre-guard behavior.
+                    if not _meta_readable:
+                        raise OSError(
+                            f"history metadata for {history_key} is transiently "
+                            "unreadable; cannot verify the session's identity "
+                            "before writing — save deferred for retry"
+                        )
+                    _current = str(existing_meta.get("created_at") or "")
+                    if _current and _current != _known:
+                        _delete_won = True
+            if _delete_won:
+                # WARNING, with the slot key: for a slot the delete's cleanup
+                # could not pop (e.g. a cron-linked tab whose slot key does not
+                # match any spelling the cleanup probes), every later save of
+                # new activity aborts here — the slot's in-memory content is
+                # no longer durable, and this line is the only operator-visible
+                # evidence of that.
+                logger.warning(
+                    "Skipping history save for %s (slot=%s): the session was "
+                    "permanently deleted while this save awaited the lock",
+                    history_key,
+                    slot.key,
+                )
+                return False
             path.parent.mkdir(parents=True, exist_ok=True)
             meta_line: dict = {
                 "_type": "metadata",
@@ -2780,6 +2885,11 @@ def _save_slot_to_history(
             # Record how many window messages are now on disk so memory trimming
             # can safely fold leading window messages into the frozen prefix.
             slot._disk_window_len = len(window)
+            # Record the disk identity this save just wrote (carried forward
+            # from ``existing_meta`` when present), so the delete-won guard can
+            # recognize a file recreated by another writer after a permanent
+            # delete on the NEXT save.
+            slot._disk_meta_created_at = str(meta_line.get("created_at") or "")
             # Record the post-write mtime in the frozen-prefix cache (even when
             # there is no frozen prefix, ``disk_older == 0``). The cache doubles
             # as the "did another process touch this file since we last wrote
@@ -2805,9 +2915,108 @@ def _save_slot_to_history(
                 slot._frozen_prefix_cache = None
             state.conversation_log._invalidate_cache(history_key)
             state.conversation_log.note_tab_id(history_key, tab_id)
+            return True
     except Exception:
         logger.error("Failed to save slot %s to history", slot.key, exc_info=True)
         raise
+
+
+def session_was_deleted(state: DashboardState, slot: _ChatSlot) -> bool:
+    """True when this slot's session was permanently deleted out from under it.
+
+    The same delete witness as the delete-won guard in
+    :func:`_save_slot_to_history`, exposed for callers that REPUBLISH a slot's
+    content (fork, transfer export) and cannot rely on observing the guard's
+    ``False`` return: the periodic 5s flush can hit the guard first and clear
+    ``_dirty``, after which those callers skip their own flush arm entirely and
+    would copy from the in-memory window. This probe answers directly, however
+    the flush ordering fell out. Same evidence rule: the slot must have
+    OBSERVED its file on disk (``_disk_meta_created_at`` non-empty — recorded
+    at the hydrate sites and at committed saves, nowhere else), so a fresh
+    slot is never "deleted". Witnesses, in order: a missing file
+    (``FileNotFoundError``; any other ``stat`` failure also refuses — the
+    file's existence is unverifiable, same fail-closed rule as the metadata
+    read), and an on-disk ``created_at`` that no longer matches the observed one (a
+    fresh incarnation created after the delete). An UNREADABLE metadata line
+    returns True — identity unverifiable, so the copy is refused (fork 409 /
+    transfer ``SnapshotUnstable``, both retryable) rather than republishing.
+    An EMPTY ``created_at`` is re-stated before it is trusted: being lock-free,
+    this probe can have the delete land between its stat and its metadata read,
+    and a file that has just vanished reads back as a genuine ``({}, True)``,
+    so the empty answer alone cannot tell "legacy metadata" (fails open) from
+    "deleted a moment ago" (must refuse).
+    Lock-free: a permanent delete never un-happens, so a True is stable; a
+    False can race a delete landing right after, which is the same residual
+    as a delete landing right after the copy itself completed.
+    """
+    if not state.conversation_log:
+        return False
+    # Same evidence rule as the guard: the slot must have OBSERVED its file on
+    # disk, and ``_disk_meta_created_at`` is that observation (recorded at the
+    # hydrate sites and at committed saves, nowhere else). Identity alone is
+    # the gate — the window counters take no part (fork/transfer set
+    # ``_resumed_count`` optimistically after a best-effort save that may have
+    # failed, and a restored zero-message session has all-zero counters).
+    known = str(getattr(slot, "_disk_meta_created_at", "") or "")
+    if not known:
+        return False
+    path_fn = getattr(state.conversation_log, "_path", None)
+    if path_fn is None:
+        # A log without a path resolver (stub/alternate store) cannot witness a
+        # delete — same fail-open-is-fail-safe rule as the OSError arm below.
+        return False
+    try:
+        path_fn(slot_history_key(slot)).stat()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        # Any other stat failure fails CLOSED, like the metadata read below:
+        # the file's existence cannot be verified, so the copy is refused
+        # (retryably) rather than republishing what may be a deleted
+        # conversation from the surviving in-memory window.
+        return True
+    # The file exists but may be a fresh incarnation created by another writer
+    # AFTER the delete (e.g. a channel/cron append) — same identity rule as the
+    # save's own guard: the observed ``created_at`` no longer matching the
+    # on-disk one means this slot's session was deleted and the file belongs
+    # to a new one. Status form for the same reason as the guard: a transient
+    # metadata read failure must not blank the comparison. UNREADABLE fails
+    # CLOSED here too — the copy is refused (fork 409 / transfer
+    # SnapshotUnstable, both retryable) rather than republishing content whose
+    # identity cannot be verified.
+    meta_fn = getattr(state.conversation_log, "get_metadata_status", None)
+    if meta_fn is not None:
+        try:
+            current_meta, readable = meta_fn(slot_history_key(slot))
+        except Exception:
+            return True  # cannot verify identity — refuse the copy
+        if not readable:
+            return True
+        current = str((current_meta or {}).get("created_at") or "")
+        if not current:
+            # An empty ``created_at`` is ambiguous, and this probe is
+            # deliberately lock-free, so the delete can land BETWEEN the stat
+            # above and this read: ``get_metadata_status`` reports a file that
+            # no longer exists as ``({}, True)`` -- by its own contract a
+            # GENUINE empty answer, not an unreadable one -- which would blank
+            # the comparison below and answer "not deleted" for a session that
+            # is gone. Re-stat to tell the two empties apart. The save's own
+            # guard needs no equivalent: it reads the metadata and stats the
+            # path inside ``_locked``, the lock ``delete_session`` unlinks
+            # under, so no delete can interleave between its two reads.
+            try:
+                path_fn(slot_history_key(slot)).stat()
+            except OSError:
+                # Gone (``FileNotFoundError``) is the delete witness; any other
+                # stat failure leaves existence unverifiable. Both refuse the
+                # copy, exactly as the first stat's arms do.
+                return True
+            # Still there, so the empty ``created_at`` is a genuine legacy-
+            # metadata answer, which fails OPEN by the documented rule.
+            return False
+        if current != known:
+            return True
+    return False
 
 
 async def save_slot_off_loop(
@@ -2820,7 +3029,7 @@ async def save_slot_off_loop(
     force: bool = False,
     rewrite: bool = False,
     best_effort: bool = True,
-) -> None:
+) -> bool:
     """Persist a slot from the event loop without blocking or dropping the save.
 
     :func:`_save_slot_to_history` holds the per-session cross-process
@@ -2846,10 +3055,18 @@ async def save_slot_off_loop(
     close/cleanup) that must CONFIRM the durable write succeeded before removing
     the session: the save still runs off-loop (patient acquire), but any
     exception propagates so the caller can roll back and keep the slot.
+
+    Returns ``False`` only when the save was skipped because the session was
+    permanently deleted while the save awaited the lock (the delete-won guard
+    in :func:`_save_slot_to_history`) — that skip raises nothing, for either
+    ``best_effort`` mode, so a clean return NO LONGER proves a committed write.
+    Callers that go on to republish the slot's content elsewhere (fork, the
+    transfer export) must check the return; archival callers (close/cleanup)
+    may ignore it — the delete already disposed of what they were archiving.
     """
 
-    def _do() -> None:
-        _save_slot_to_history(
+    def _do() -> bool:
+        return _save_slot_to_history(
             state,
             slot,
             messages,
@@ -2866,7 +3083,7 @@ async def save_slot_off_loop(
     if loop is None:
         if best_effort:
             try:
-                _do()
+                return _do()
             except Exception:  # noqa: BLE001 - best-effort durable copy
                 # A swallowed failure must NOT be silently final: mark the slot
                 # dirty so the periodic flush retries the write. Metadata-only
@@ -2878,12 +3095,11 @@ async def save_slot_off_loop(
                 logger.warning(
                     "save_slot_off_loop: inline save failed slot=%s", slot.key, exc_info=True
                 )
-            return
-        _do()
-        return
+                return True
+        return _do()
     if best_effort:
         try:
-            await loop.run_in_executor(None, _do)
+            return await loop.run_in_executor(None, _do)
         except Exception:  # noqa: BLE001 - best-effort durable copy
             # See the inline branch above: re-arm the periodic flush so a
             # swallowed metadata/message save is retried rather than lost.
@@ -2891,10 +3107,10 @@ async def save_slot_off_loop(
             logger.warning(
                 "save_slot_off_loop: offloaded save failed slot=%s", slot.key, exc_info=True
             )
-        return
+            return True
     # Non-best-effort: propagate so the caller can roll back (do NOT remove the
     # session until the durable write is confirmed).
-    await loop.run_in_executor(None, _do)
+    return await loop.run_in_executor(None, _do)
 
 
 def _build_history_prefix(slot: _ChatSlot) -> str:

--- a/src/kiro_crew/dashboard/session_transfer.py
+++ b/src/kiro_crew/dashboard/session_transfer.py
@@ -70,7 +70,7 @@ from kiro_crew.config.paths import kiro_sessions_dir
 # move _append_unflushed_tail and its collaborators down to chat_persistence
 # first rather than creating the cycle.
 from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
-from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop, session_was_deleted
 from kiro_crew.dashboard.chat_utils import (
     _sync_dashboard_slots,
     effective_session_key,
@@ -612,16 +612,25 @@ async def build_transfer_bundle_async(
             # across this await and spend an attempt rather than trusting it.
             gen_before_save = slot._dirty_gen
             try:
-                await save_slot_off_loop(state, slot, best_effort=False)
+                saved = await save_slot_off_loop(state, slot, best_effort=False)
             except Exception as exc:
                 logger.warning(
                     "session_transfer: could not persist slot=%s before bundling",
                     slot.key,
                     exc_info=True,
                 )
-                raise SnapshotUnstable(
-                    "the session could not be persisted before copying"
-                ) from exc
+                raise SnapshotUnstable("the session could not be persisted before copying") from exc
+            if not saved:
+                # Delete-won: the session was permanently deleted while the
+                # flush awaited the lock. Bundling would ship the destroyed
+                # conversation to the peer (or an empty shell of it), so the
+                # transfer fails instead of answering success.
+                logger.warning(
+                    "session_transfer: slot=%s was permanently deleted during "
+                    "the pre-bundle flush; refusing the transfer",
+                    slot.key,
+                )
+                raise SnapshotUnstable("the session was permanently deleted")
             if slot._dirty_gen != gen_before_save:
                 continue
             _guard_snapshot(slot)
@@ -640,6 +649,19 @@ async def build_transfer_bundle_async(
         # kept because this snapshot has already been wrong twice by assuming a
         # single field told the whole story.
         count_before = len(slot.messages)
+        # Direct delete check, independent of the flush arm above: if the
+        # periodic 5s flush hit the delete-won guard first, it cleared
+        # ``_dirty``, the flush arm here never ran, and the disk read below
+        # would assemble a bundle from a permanently deleted session (its
+        # in-memory tail plus an empty transcript). The ``saved``-check above
+        # only covers a delete observed by THIS builder's own flush.
+        if session_was_deleted(state, slot):
+            logger.warning(
+                "session_transfer: slot=%s belongs to a permanently deleted "
+                "session; refusing the transfer",
+                slot.key,
+            )
+            raise SnapshotUnstable("the session was permanently deleted")
         # Snapshot the unpersisted tail (and the slot fields the bundle needs) ON
         # THE LOOP, so the thread below never touches the slot while the loop
         # could be appending to it. Everything past this point is plain data.
@@ -675,6 +697,18 @@ async def build_transfer_bundle_async(
         # while ``_disk_window_len`` stays put, which would otherwise read as
         # "stable" and copy turns the user just discarded.
         _guard_snapshot(slot)
+        # The deletion check too: the assembly read above is the longest await
+        # in this builder (redaction regexes over the whole transcript), so a
+        # permanent delete can complete inside it — after the pre-read probe
+        # passed — and the bundle in hand is the destroyed conversation. A
+        # delete is permanent, so this is a refusal, not a retry.
+        if session_was_deleted(state, slot):
+            logger.warning(
+                "session_transfer: slot=%s was permanently deleted during "
+                "bundle assembly; refusing the transfer",
+                slot.key,
+            )
+            raise SnapshotUnstable("the session was permanently deleted")
         if (
             slot._dirty_gen == gen_before
             and slot._disk_window_len == boundary_before
@@ -685,9 +719,7 @@ async def build_transfer_bundle_async(
             "session_transfer: slot %s flushed during the transcript read; retrying",
             slot.key,
         )
-    raise SnapshotUnstable(
-        f"transcript snapshot did not settle in {_SNAPSHOT_ATTEMPTS} attempts"
-    )
+    raise SnapshotUnstable(f"transcript snapshot did not settle in {_SNAPSHOT_ATTEMPTS} attempts")
 
 
 def _guard_snapshot(slot: _ChatSlot) -> None:
@@ -711,8 +743,7 @@ def _guard_snapshot(slot: _ChatSlot) -> None:
     # not.)
     if slot._disk_window_len > len(slot.messages):
         raise SnapshotUnstable(
-            "the persisted boundary is ahead of the resident window "
-            "(a flush landed mid-stream)"
+            "the persisted boundary is ahead of the resident window " "(a flush landed mid-stream)"
         )
 
 
@@ -1191,9 +1222,7 @@ async def api_chat_slot_import(request: web.Request) -> web.Response:
             # Files in a thread (blocking IO), join on the loop (the live map's
             # whole-file write is unsynchronised against concurrent session
             # starts). See _write_layer_b_files / _join_layer_b.
-            written_sid = await asyncio.to_thread(
-                _write_layer_b_files, layer_b, new_slot.agent
-            )
+            written_sid = await asyncio.to_thread(_write_layer_b_files, layer_b, new_slot.agent)
             layer_b_sid = written_sid or ""
             resumable = bool(layer_b_sid) and _join_layer_b(sessions, sm_key, layer_b_sid)
             if not resumable:
@@ -1283,8 +1312,11 @@ async def api_chat_slot_import(request: web.Request) -> web.Response:
                 exc_info=True,
             )
             sel().log_api_access(
-                caller=caller, operation="chat.slot_import", outcome="error",
-                source="dashboard", resources=f"to={new_slot.key}",
+                caller=caller,
+                operation="chat.slot_import",
+                outcome="error",
+                source="dashboard",
+                resources=f"to={new_slot.key}",
                 error="durable save failed",
             )
             return web.json_response(

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2794,6 +2794,7 @@ class _ChatSlot:
         "_disk_older_count",
         "_disk_older_durable_count",
         "_disk_window_len",
+        "_disk_meta_created_at",
         "_disk_tail_ts",
         "_frozen_prefix_cache",
         "_pending_rewrite",
@@ -3249,6 +3250,17 @@ class _ChatSlot:
         # watermark is what makes the #8 trim credit safe. It is NOT a fragile
         # "what to append" counter — saves always re-serialize the WHOLE window.
         self._disk_window_len: int = 0
+        # The ``created_at`` of the on-disk metadata line this slot LAST
+        # OBSERVED (at restore or at its own save). This is the session file's
+        # identity: ``delete_session`` removes the file and a later writer
+        # (e.g. a channel/cron ``append_off_loop``) creates a FRESH one with a
+        # new ``created_at``, so a pending save comparing the current on-disk
+        # value against this field can tell "the same file I knew" from "a
+        # different file born after my session was permanently deleted" — the
+        # delete-won guard in ``_save_slot_to_history`` refuses to merge the
+        # deleted window into the latter. Empty means "never observed a disk
+        # identity" (fresh slot), which the guard treats as no evidence.
+        self._disk_meta_created_at: str = ""
         # The newest ``ts`` seen on disk at the last save, INCLUDING rows this
         # slot never observed. A subagent, cron, or CLI appending to a session a
         # live tab also has open writes rows that ``_save_slot_to_history``

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -2566,6 +2566,561 @@ class TestHistoryPersistence:
             assert data["has_more"] is False
 
 
+# ── Save vs. permanent delete ──
+
+
+class TestSaveDoesNotResurrectDeletedSession:
+    """#6677: a save must not recreate a session whose permanent delete committed.
+
+    ``delete_session`` unlinks under the same ``_locked`` region the save
+    holds, leaves no tombstone, and reports success. A save routed through
+    ``save_slot_off_loop`` takes the patient acquire, so it can sit waiting
+    while the delete runs to completion ahead of it — the sequential
+    delete-then-save below exercises exactly the code path such a save takes
+    once the lock is finally granted (file gone, slot still carrying its
+    in-memory window).
+    """
+
+    def test_save_after_committed_delete_does_not_recreate_the_file(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("gone")
+        slot.append("user", "hello")
+        slot.append("assistant", "hi")
+        slot.drain()
+        # First save through the real path: the session now exists on disk and
+        # the slot has learned it (``_disk_window_len`` > 0).
+        assert _save_slot_to_history(state, slot, force=True) is True
+        path = state.conversation_log._path("dashboard:gone")
+        assert path.exists()
+        assert slot._disk_window_len > 0
+
+        # The permanent delete commits and reports success…
+        assert state.conversation_log.delete_session("dashboard:gone") is True
+        assert not path.exists()
+
+        # …so a save that acquires the lock afterwards must NOT undo it, even
+        # though its window still holds the whole conversation. The ``False``
+        # return is the caller-visible signal that nothing was persisted.
+        assert _save_slot_to_history(state, slot, force=True) is False
+        assert not path.exists(), (
+            "a save that lost the race to a committed permanent delete "
+            "recreated the session file"
+        )
+
+    def test_resumed_slot_save_after_delete_does_not_recreate_the_file(self, tmp_path, monkeypatch):
+        """The ``_resumed_count`` evidence arm: a slot restored from history
+        (no save of its own yet) must also honor a committed delete."""
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        log.append("dashboard:revived", "user", "old turn")
+        slot = state.get_or_create_slot("revived")
+        slot.append("user", "old turn")
+        slot.drain()
+        # As the restore path records them: the resumed count AND the observed
+        # disk identity (every hydrate site records both).
+        slot._resumed_count = 1
+        slot._disk_meta_created_at = str(log.get_metadata("dashboard:revived")["created_at"])
+        assert slot._disk_window_len == 0
+
+        assert log.delete_session("dashboard:revived") is True
+        path = log._path("dashboard:revived")
+        assert not path.exists()
+
+        _save_slot_to_history(state, slot, force=True)
+        assert not path.exists(), "a resumed slot's save recreated a permanently deleted session"
+
+    @pytest.mark.asyncio
+    async def test_fork_aborts_even_after_a_flush_consumed_the_delete_signal(
+        self, tmp_path, monkeypatch
+    ):
+        """The flush-ordering bypass: a NON-dirty deleted slot must still not fork.
+
+        The periodic 5s flush can hit the delete-won guard first and clear
+        ``_dirty``. The fork then skips its own flush arms entirely (they are
+        gated on ``slot._dirty``), the disk read comes back empty, and
+        ``all_messages`` falls back to the in-memory window — republishing the
+        deleted conversation with no save ever returning ``False`` to the fork.
+        The direct ``session_was_deleted`` probe must refuse it anyway.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("forkclean")
+        slot.append("user", "keep me?", "msg msg-u")
+        slot.append("assistant", "sure", "msg msg-a")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        assert state.conversation_log.delete_session("dashboard:forkclean") is True
+        # Model the flush having consumed the delete-won signal already.
+        slot._dirty = False
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/forkclean/fork",
+                json={"prompt": "forked"},
+            )
+            payload = await resp.json()
+
+        assert (
+            resp.status == 409
+        ), f"non-dirty fork of a deleted session must abort, got {resp.status} {payload}"
+        session_files = [p.name for p in tmp_path.glob("*.jsonl")]
+        assert (
+            session_files == []
+        ), f"a fork of the deleted conversation was published: {session_files}"
+
+    @pytest.mark.asyncio
+    async def test_transfer_bundle_refuses_a_deleted_session(self, tmp_path, monkeypatch):
+        """Same bypass on the export path: a non-dirty deleted slot must not bundle."""
+        from kiro_crew.dashboard import session_transfer as st
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("bundlegone")
+        slot.append("user", "ship me?", "msg msg-u")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+
+        assert state.conversation_log.delete_session("dashboard:bundlegone") is True
+        slot._dirty = False
+
+        with pytest.raises(st.SnapshotUnstable, match="permanently deleted"):
+            await st.build_transfer_bundle_async(state, slot, origin="test")
+
+    @pytest.mark.asyncio
+    async def test_transfer_refuses_a_delete_landing_during_assembly(self, tmp_path, monkeypatch):
+        """A delete completing INSIDE the threaded bundle read must still refuse.
+
+        The assembly read is the builder's longest await, so the pre-read probe
+        can pass and the permanent delete complete before the bundle returns —
+        the bundle in hand is the destroyed conversation. The post-assembly
+        re-check must catch it.
+        """
+        from kiro_crew.dashboard import session_transfer as st
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("midassembly")
+        slot.append("user", "racing", "msg msg-u")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+        slot._dirty = False
+
+        real_assemble = st._read_and_assemble
+
+        def _assemble_with_delete_landing_inside(*args, **kwargs):
+            bundle = real_assemble(*args, **kwargs)
+            # The permanent delete commits while the worker thread is still
+            # inside the assembly (after the pre-read probe passed).
+            assert state.conversation_log.delete_session("dashboard:midassembly") is True
+            return bundle
+
+        monkeypatch.setattr(st, "_read_and_assemble", _assemble_with_delete_landing_inside)
+
+        with pytest.raises(st.SnapshotUnstable, match="permanently deleted"):
+            await st.build_transfer_bundle_async(state, slot, origin="test")
+
+    def test_save_does_not_merge_into_a_file_recreated_after_the_delete(
+        self, tmp_path, monkeypatch
+    ):
+        """Delete -> foreign append recreates the file -> pending save must skip.
+
+        ``delete_session`` leaves no tombstone, so a channel/cron
+        ``append_off_loop`` landing after the delete creates a FRESH session
+        file (new metadata ``created_at``). A pending save that only checked
+        file existence would merge the deleted window into that new transcript
+        — resurrecting the destroyed conversation inside someone else's rows.
+        The guard must recognize the new incarnation by its identity and skip.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("reborn")
+        slot.append("user", "the deleted conversation", "msg msg-u")
+        slot.drain()
+        assert _save_slot_to_history(state, slot, force=True) is True
+        assert slot._disk_meta_created_at, "save must record the disk identity"
+
+        log = state.conversation_log
+        assert log.delete_session("dashboard:reborn") is True
+        # A foreign writer recreates the session file with a fresh identity.
+        log.append("dashboard:reborn", "assistant", "foreign row in the new file")
+        path = log._path("dashboard:reborn")
+        assert path.exists()
+
+        assert _save_slot_to_history(state, slot, force=True) is False
+        content = path.read_text(encoding="utf-8")
+        assert (
+            "the deleted conversation" not in content
+        ), "the pending save merged the deleted window into the recreated file"
+        assert (
+            "foreign row in the new file" in content
+        ), "the guard must leave the new incarnation untouched"
+
+    def test_channel_surfaced_slot_records_the_disk_identity(self, tmp_path, monkeypatch):
+        """The channel surfacing path must arm the delete-won identity too.
+
+        ``surface_channel_session`` adopts an append-created transcript — its
+        slot never runs the dashboard rehydrate paths, so without recording
+        ``_disk_meta_created_at`` here the identity arm of the delete-won
+        guard fails open for every channel tab: delete -> inbound append
+        recreates the file -> the pending save merges the deleted window into
+        the new transcript.
+        """
+        from kiro_crew.dashboard import channel_slots
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        key = "slack:thread-77"
+        log.append(key, "user", "channel turn")
+        meta = log.get_metadata(key)
+        assert meta.get("created_at"), "fixture transcript must carry an identity"
+
+        slot = channel_slots.surface_channel_session(
+            state,
+            {"key": key, "title": "chan"},
+            meta,
+            log.read_messages_chained(key),
+            session_key=key,
+        )
+        assert slot is not None
+        assert slot._disk_meta_created_at == str(
+            meta["created_at"]
+        ), "channel surfacing must record the observed disk identity"
+
+        # Delete, then a foreign append recreates the file with a new identity:
+        # the surviving slot's pending save must skip, not merge.
+        assert log.delete_session(key) is True
+        log.append(key, "assistant", "new incarnation row")
+        assert _save_slot_to_history(state, slot, force=True) is False
+        content = log._path(key).read_text(encoding="utf-8")
+        assert (
+            "channel turn" not in content
+        ), "the channel slot's save merged the deleted window into the recreated file"
+
+    def test_failed_first_save_is_not_mistaken_for_deletion(self, tmp_path, monkeypatch):
+        """A fork whose best-effort first save failed must still persist on retry.
+
+        ``chat_fork`` saves the destination slot best-effort and then sets
+        ``_resumed_count`` unconditionally — a transient first-write failure is
+        swallowed (dirty re-armed) and leaves a slot with resumed evidence but
+        NO file and NO observed identity. An evidence gate built on the
+        counters alone would misread that as "was on disk, now deleted", skip
+        the retry, clear ``_dirty``, and lose the acknowledged fork at the next
+        restart. The gate must require an observed disk identity
+        (``_disk_meta_created_at``), which only a real hydrate or a committed
+        save records.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("forkchild")
+        slot.append("user", "the forked conversation", "msg msg-u")
+        slot.drain()
+        # As chat_fork leaves the slot when its best-effort save failed: the
+        # optimistic counter is set, no write ever committed, no identity.
+        slot._resumed_count = len(slot.messages)
+        assert slot._disk_meta_created_at == ""
+
+        assert (
+            _save_slot_to_history(state, slot, force=True) is True
+        ), "the retry of a failed first save was misread as delete-won"
+        path = state.conversation_log._path("dashboard:forkchild")
+        assert path.exists(), "the acknowledged fork never reached disk"
+        assert "the forked conversation" in path.read_text(encoding="utf-8")
+
+    def test_zero_message_resumed_session_delete_still_wins(self, tmp_path, monkeypatch):
+        """A restored EMPTY session's delete must beat the save of its first message.
+
+        A zero-message restore leaves every window counter at 0, so an
+        evidence gate that requires the counters alongside the identity skips
+        the guard for exactly this slot — the save of the session's first
+        message would recreate the deleted history. Identity alone must gate.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        # A session file with metadata but no message rows — e.g. a titled
+        # session whose turns were all trimmed/consolidated away.
+        log.update_metadata("dashboard:empty", {"title": "empty but real"})
+        meta = log.get_metadata("dashboard:empty")
+        assert meta.get("created_at")
+
+        slot = state.get_or_create_slot("empty")
+        # As a restore of that session records it: identity observed, all
+        # window counters zero (nothing to load).
+        slot._disk_meta_created_at = str(meta["created_at"])
+        assert slot._resumed_count == 0
+        assert slot._disk_older_count == 0
+        assert slot._disk_window_len == 0
+
+        # First message arrives, then the permanent delete wins the lock.
+        slot.append("user", "first message", "msg msg-u")
+        slot.drain()
+        assert log.delete_session("dashboard:empty") is True
+
+        assert _save_slot_to_history(state, slot, force=True) is False
+        assert not log._path(
+            "dashboard:empty"
+        ).exists(), "the first-message save recreated a deleted zero-message session"
+
+    def test_unreadable_metadata_defers_the_save_instead_of_writing(self, tmp_path, monkeypatch):
+        """A transient metadata read failure must fail CLOSED, not blank the check.
+
+        ``get_metadata`` returns ``{}`` for both "no metadata" and "read
+        failed"; blanking the identity comparison on a transient failure would
+        let a pending save overwrite a replacement session with deleted
+        content. The save must refuse to write (raising, so ``_dirty`` stays
+        armed and the flush retries) until the metadata is readable again.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        slot = state.get_or_create_slot("flaky")
+        slot.append("user", "hello", "msg msg-u")
+        slot.drain()
+        assert _save_slot_to_history(state, slot, force=True) is True
+        before = log._path("dashboard:flaky").read_text(encoding="utf-8")
+
+        monkeypatch.setattr(log, "get_metadata_status", lambda key: ({}, False))
+        with pytest.raises(OSError, match="unreadable"):
+            _save_slot_to_history(state, slot, force=True)
+        assert (
+            log._path("dashboard:flaky").read_text(encoding="utf-8") == before
+        ), "the save wrote through an unverifiable identity"
+
+    def test_probe_refuses_the_copy_when_metadata_is_unreadable(self, tmp_path, monkeypatch):
+        """``session_was_deleted`` must fail closed on an unreadable metadata line."""
+        from kiro_crew.dashboard.chat_persistence import (
+            _save_slot_to_history,
+            session_was_deleted,
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        slot = state.get_or_create_slot("murky")
+        slot.append("user", "hello", "msg msg-u")
+        slot.drain()
+        assert _save_slot_to_history(state, slot, force=True) is True
+        assert session_was_deleted(state, slot) is False
+
+        monkeypatch.setattr(log, "get_metadata_status", lambda key: ({}, False))
+        assert (
+            session_was_deleted(state, slot) is True
+        ), "an unverifiable identity must refuse the copy, not allow it"
+
+    def test_first_save_of_a_fresh_slot_still_creates_the_file(self, tmp_path, monkeypatch):
+        """Control: the guard must not break the normal first create — a
+        brand-new slot has no on-disk evidence and starts with no file."""
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("fresh")
+        slot.append("user", "first message")
+        slot.drain()
+
+        _save_slot_to_history(state, slot, force=True)
+        assert state.conversation_log._path(
+            "dashboard:fresh"
+        ).exists(), "the delete-won guard aborted a legitimate first save"
+
+    @pytest.mark.asyncio
+    async def test_fork_aborts_when_the_source_was_deleted(self, tmp_path, monkeypatch):
+        """A fork must not republish a permanently deleted conversation.
+
+        The fork's pre-copy flush runs with ``best_effort=False`` and used to
+        treat any non-raising return as a confirmed durable write. A delete-won
+        skip raises nothing, and the fork's DESTINATION slot is brand new — it
+        carries no delete evidence, so its save would proceed and the destroyed
+        conversation would come back under a fresh key. The fork must abort
+        instead.
+        """
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("forkgone")
+        slot.append("user", "keep me?", "msg msg-u")
+        slot.append("assistant", "sure", "msg msg-a")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+        # New unpersisted activity keeps the slot dirty, so the fork takes its
+        # durable-flush arm.
+        slot.append("user", "one more", "msg msg-u")
+        slot._dirty = True
+
+        assert state.conversation_log.delete_session("dashboard:forkgone") is True
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/forkgone/fork",
+                json={"prompt": "forked"},
+            )
+            payload = await resp.json()
+
+        assert (
+            resp.status == 409
+        ), f"fork of a deleted session must abort, got {resp.status} {payload}"
+        assert not state.conversation_log._path(
+            "dashboard:forkgone"
+        ).exists(), "the fork's flush recreated the deleted source session"
+        # No fork session file may exist either — the copy was refused.
+        session_files = [
+            p.name for p in tmp_path.glob("*.jsonl") if "forkgone" in p.name or "fork" in p.name
+        ]
+        assert (
+            session_files == []
+        ), f"a fork of the deleted conversation was published: {session_files}"
+
+    @pytest.mark.asyncio
+    async def test_fork_rolls_back_a_delete_landing_during_the_destination_save(
+        self, tmp_path, monkeypatch
+    ):
+        """A delete committing INSIDE the destination save must still win.
+
+        The pre-copy probe passes (the source is alive when it runs) and the
+        destination save takes the DESTINATION's history lock, which does not
+        serialise against the source's delete. So the delete can commit inside
+        that await, and the fork would be acknowledged holding a full copy of a
+        conversation the user destroyed. The handler must refuse at the
+        acknowledgment boundary and remove the copy it had already written --
+        the same rule ``build_transfer_bundle_async`` applies by re-probing
+        after assembly.
+        """
+        from kiro_crew.dashboard import chat_fork as fork_mod
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("forkrace")
+        slot.append("user", "delete me", "msg msg-u")
+        slot.append("assistant", "noted", "msg msg-a")
+        slot.drain()
+        _save_slot_to_history(state, slot, force=True)
+        # Not dirty: the handler's pre-copy flush arms are gated on ``_dirty``,
+        # so the ONLY save in this fork is the destination's — which is exactly
+        # where the race lives.
+        slot._dirty = False
+        source_path = state.conversation_log._path("dashboard:forkrace")
+        assert source_path.exists()
+        before = {p.resolve() for p in tmp_path.rglob("*.jsonl")}
+
+        real_save = fork_mod.save_slot_off_loop
+        dest_keys: list[str] = []
+
+        async def _save_then_delete(st, target, *args, **kwargs):
+            result = await real_save(st, target, *args, **kwargs)
+            if target is not slot:
+                dest_keys.append(target.key)
+                # The permanent delete commits while the destination save is in
+                # flight, i.e. after the pre-copy probe has already passed.
+                assert st.conversation_log.delete_session("dashboard:forkrace") is True
+            return result
+
+        monkeypatch.setattr(fork_mod, "save_slot_off_loop", _save_then_delete)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/forkrace/fork",
+                json={"prompt": "forked"},
+            )
+            payload = await resp.json()
+
+        assert (
+            resp.status == 409
+        ), f"the delete must win over an unacknowledged fork, got {resp.status} {payload}"
+        assert payload.get("code") == "fork_source_deleted"
+        assert not source_path.exists()
+        # No transcript may survive the rollback: comparing against the
+        # pre-fork set keeps this independent of how the fork mints its key.
+        leftover = sorted(p.name for p in tmp_path.rglob("*.jsonl") if p.resolve() not in before)
+        assert leftover == [], f"a copy of the deleted conversation remains on disk: {leftover}"
+        # …and the destination slot must be gone from the live set too. The key
+        # comes from the save the handler actually made, not the 409 body.
+        assert dest_keys, "the destination save never ran, so this pins nothing"
+        assert state._slots.get(dest_keys[0]) is None, "the rolled-back fork is still a live slot"
+
+    def test_probe_catches_a_delete_landing_between_its_stat_and_metadata_read(
+        self, tmp_path, monkeypatch
+    ):
+        """The probe is lock-free, so a delete can land in the middle of it.
+
+        ``get_metadata_status`` reports a file that no longer exists as
+        ``({}, True)`` -- by its own contract a GENUINE empty answer, not an
+        unreadable one. So a delete committing between the probe's ``stat`` and
+        its metadata read leaves an empty ``created_at`` that must not be read
+        as "legacy metadata, fail open": that would answer "not deleted" for a
+        session that is gone and let fork/transfer republish it. The save's own
+        guard cannot hit this -- it reads both inside ``_locked``, the lock
+        ``delete_session`` unlinks under.
+        """
+        from kiro_crew.dashboard.chat_persistence import session_was_deleted
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        log.append("dashboard:midprobe", "user", "delete me")
+        slot = state.get_or_create_slot("midprobe")
+        slot._disk_meta_created_at = str(log.get_metadata("dashboard:midprobe")["created_at"])
+        # Control: the session is alive, so the probe must not refuse the copy.
+        assert session_was_deleted(state, slot) is False
+
+        real_status = log.get_metadata_status
+
+        def _delete_then_read(key):
+            # The permanent delete commits after the probe's stat() has already
+            # seen the file and before the probe reads its metadata.
+            log.delete_session("dashboard:midprobe")
+            return real_status(key)
+
+        monkeypatch.setattr(log, "get_metadata_status", _delete_then_read)
+        assert (
+            session_was_deleted(state, slot) is True
+        ), "the probe missed a delete landing between its stat and its metadata read"
+
+    def test_probe_still_fails_open_on_legacy_metadata_without_created_at(
+        self, tmp_path, monkeypatch
+    ):
+        """The other empty: a live file whose metadata carries no ``created_at``.
+
+        The re-stat must not turn the documented fail-open for legacy metadata
+        into a refusal -- the file is there, so the copy proceeds.
+        """
+        from kiro_crew.dashboard.chat_persistence import session_was_deleted
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        log.append("dashboard:legacymeta", "user", "keep me")
+        slot = state.get_or_create_slot("legacymeta")
+        slot._disk_meta_created_at = str(log.get_metadata("dashboard:legacymeta")["created_at"])
+
+        monkeypatch.setattr(log, "get_metadata_status", lambda key: ({}, True))
+        assert (
+            session_was_deleted(state, slot) is False
+        ), "legacy metadata with no created_at must still fail open while the file exists"
+
+
 # ── Slot lifecycle ──
 
 
@@ -11298,6 +11853,13 @@ class TestFolderAssignmentPersistence:
         slot = state.get_or_create_slot("resumedslot")
         slot.append("user", "old message from before restart")
         slot.drain()
+        # A genuinely resumed slot's file exists on disk (the restore read it).
+        # Persist first so the fixture matches reality — a slot claiming
+        # on-disk history whose file is missing is the delete-won state the
+        # save now refuses to recreate (#6677).
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        _save_slot_to_history(state, slot, force=True)
         # Mark slot as a resumed session (simulates being restored from disk).
         # The guard fires when _resumed_count >= len(messages).
         slot._resumed_count = len(slot.messages)
@@ -11310,7 +11872,7 @@ class TestFolderAssignmentPersistence:
             )
             assert resp.status == 200
             path = tmp_path / "dashboard_resumedslot.jsonl"
-            assert path.exists(), "folder_id save must reach disk on resumed session"
+            assert path.exists(), "fixture save should have created the session file"
             import json
 
             meta = json.loads(path.read_text(encoding="utf-8").split("\n")[0])
@@ -11332,13 +11894,19 @@ class TestFolderAssignmentPersistence:
         slot = state.get_or_create_slot("pinslot")
         slot.append("user", "old message")
         slot.drain()
+        # Persist first: a resumed slot's file exists on disk (see the folder
+        # regression above — the missing-file variant is the delete-won state
+        # the save refuses to recreate, #6677).
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        _save_slot_to_history(state, slot, force=True)
         slot._resumed_count = len(slot.messages)
         app = _make_folder_app(state)
         async with TestClient(TestServer(app)) as client:
             resp = await client.patch("/api/chat/slots/pinslot/pin", json={"pinned": True})
             assert resp.status == 200
             path = tmp_path / "dashboard_pinslot.jsonl"
-            assert path.exists(), "pinned save must reach disk on resumed session"
+            assert path.exists(), "fixture save should have created the session file"
             import json
 
             meta = json.loads(path.read_text(encoding="utf-8").split("\n")[0])
@@ -11360,6 +11928,12 @@ class TestFolderAssignmentPersistence:
         slot = state.get_or_create_slot("forceslot")
         slot.append("user", "hello")
         slot.drain()
+        # Persist first: a genuinely resumed slot's file exists on disk. (The
+        # missing-file variant is the delete-won state the save refuses to
+        # recreate, #6677.)
+        _save_slot_to_history(state, slot, force=True)
+        path = tmp_path / "dashboard_forceslot.jsonl"
+        assert path.exists()
         slot._resumed_count = len(slot.messages)
         # Model a genuinely-resumed, UNCHANGED slot: restore sets _dirty=False.
         # (A dirty slot — e.g. an in-place stop-event edit — must NOT be skipped;
@@ -11367,15 +11941,16 @@ class TestFolderAssignmentPersistence:
         slot._dirty = False
         slot.folder_id = "f-force"
 
-        # Without force — save is skipped by the guard, no file written.
-        _save_slot_to_history(state, slot)
-        path = tmp_path / "dashboard_forceslot.jsonl"
-        assert not path.exists(), "guard must skip save when not forced"
-
-        # With force — save bypasses the guard, file is written with folder_id.
-        _save_slot_to_history(state, slot, force=True)
-        assert path.exists(), "force=True must bypass the guard"
         import json
+
+        # Without force — the resumed-count guard skips the save, so the
+        # metadata mutation must NOT reach disk.
+        _save_slot_to_history(state, slot)
+        meta = json.loads(path.read_text(encoding="utf-8").split("\n")[0])
+        assert meta.get("folder_id") is None, "guard must skip save when not forced"
+
+        # With force — save bypasses the guard, folder_id is written.
+        _save_slot_to_history(state, slot, force=True)
 
         meta = json.loads(path.read_text(encoding="utf-8").split("\n")[0])
         assert meta.get("folder_id") == "f-force"

--- a/test/test_fork_reconciles_after_flush.py
+++ b/test/test_fork_reconciles_after_flush.py
@@ -319,6 +319,7 @@ async def test_a_boundary_ahead_of_the_window_does_not_duplicate_persisted_turns
         flushes["n"] += 1
         s._disk_window_len = len(s.messages)
         s._dirty = False
+        return True
 
     monkeypatch.setattr("kiro_crew.dashboard.chat_fork.save_slot_off_loop", fake_flush)
 
@@ -859,8 +860,8 @@ async def test_a_rewind_landing_during_the_pending_rewrite_save_is_not_erased(
             # flag -- including the rewind's, which it never owned.
             await real_save(state_, slot_, stale_snapshot, rewrite=True, best_effort=False)
             slot_._pending_rewrite = False
-            return
-        await real_save(state_, slot_, *a, **kw)
+            return True
+        return await real_save(state_, slot_, *a, **kw)
 
     monkeypatch.setattr(chat_fork_mod, "save_slot_off_loop", _save_with_a_rewind_landing_inside)
 
@@ -1047,8 +1048,8 @@ async def test_the_pending_rewrite_retry_still_archives_the_discarded_turns(tmp_
             slot_._pending_rewrite = True
             await real_save(state_, slot_, stale_snapshot, rewrite=True, best_effort=False)
             slot_._pending_rewrite = False
-            return
-        await real_save(state_, slot_, *a, **kw)
+            return True
+        return await real_save(state_, slot_, *a, **kw)
 
     monkeypatch.setattr(chat_fork_mod, "save_slot_off_loop", _save_with_a_rewind_landing_inside)
 

--- a/test/test_session_transfer.py
+++ b/test/test_session_transfer.py
@@ -286,6 +286,7 @@ async def test_send_handler_sends_each_turn_exactly_once(monkeypatch):
         disk["messages"] = list(s.messages)
         s._dirty = False
         s._disk_window_len = len(s.messages)
+        return True
 
     monkeypatch.setattr(st, "save_slot_off_loop", _save)
 
@@ -829,6 +830,7 @@ async def test_bundle_flushes_a_dirty_slot_so_in_place_edits_travel(monkeypatch)
         disk["messages"] = list(s.messages)
         s._dirty = False
         s._disk_window_len = len(s.messages)
+        return True
 
     monkeypatch.setattr(st, "save_slot_off_loop", _save)
     bundle = await st.build_transfer_bundle_async(
@@ -1028,6 +1030,7 @@ async def test_bundle_refuses_when_the_slot_never_settles(monkeypatch):
         # edit leaves the slot dirty, so the next attempt flushes again.
         s._dirty = True
         s._dirty_gen += 1
+        return True
 
     monkeypatch.setattr(st, "save_slot_off_loop", _save_then_edit)
 
@@ -1059,6 +1062,7 @@ async def test_retry_reflushes_so_it_cannot_serialize_a_superseded_variant(monke
         disk[:] = [dict(m) for m in s.messages]
         s._disk_window_len = len(s.messages)
         s._dirty = False
+        return True
 
     monkeypatch.setattr(st, "save_slot_off_loop", _save)
 
@@ -1389,7 +1393,7 @@ async def test_import_creates_a_new_slot_with_no_project(monkeypatch):
     state.end_slot_construction = state._slots_under_construction.discard
 
     async def _save(*_a, **_k):
-        return None
+        return True
 
     monkeypatch.setattr(st, "save_slot_off_loop", _save)
     monkeypatch.setattr(st, "_sync_dashboard_slots", lambda _s: None)
@@ -2341,6 +2345,7 @@ async def test_layer_b_lands_before_the_transcript_is_persisted(monkeypatch):
 
     async def _save(*_a, **_k):
         order.append("save")
+        return True
 
     monkeypatch.setattr(st, "_write_layer_b_files", _mat)
     monkeypatch.setattr(st, "_join_layer_b", lambda *_a, **_k: True)
@@ -2543,7 +2548,7 @@ def _stub_state(st, monkeypatch, save=None):
     slot = _Slot()
 
     async def _save(*_a, **_k):
-        return None
+        return True
 
     monkeypatch.setattr(st, "save_slot_off_loop", save or _save)
     monkeypatch.setattr(st, "_sync_dashboard_slots", lambda _s: None)


### PR DESCRIPTION
## Problem / Motivation

A session the user permanently deleted can reappear on disk in Older Sessions. `_save_slot_to_history` takes the per-session `_locked` for its whole read-modify-`atomic_write`, and `delete_session` unlinks the file under the same lock -- but the save never re-checked, inside the lock, that the session still existed. `save_slot_off_loop` routes on-loop callers to a worker thread that takes the PATIENT lock acquire, so a save can legitimately sit waiting while a permanent delete runs to completion ahead of it; when the save finally gets the lock it goes straight to `mkdir` + `atomic_write` and silently recreates the session the delete had already reported destroyed. `delete_session` deliberately leaves no tombstone, so nothing downstream catches it.

## Why it matters

Permanent delete is the user's strongest promise in the product: "this conversation is gone." A save losing the lock race breaks that promise silently -- the conversation the user destroyed comes back, with no error anywhere and only the delete's success answer on record. For a user deleting sensitive content, resurrection is a real harm, not a cosmetic bug.

## What changed (motivation -> approach -> change)

Symptom: deleted session reappears -> root cause: the save could not tell "never existed here (normal first create)" from "existed and was permanently deleted under this lock", and its content could also escape through copies (fork, transfer). The shipped mechanism, converged over nine review rounds (all dispositions in the PR comments):

- **Identity is the sole delete-evidence.** Each slot records `_disk_meta_created_at` -- the metadata `created_at` of the transcript it last OBSERVED, written exactly at the hydrate sites (dashboard rehydrate x2, channel surfacing, resume handler) and at each committed save, nowhere else. `created_at` is carried forward by every save, so it never changes for a continuously-existing file: it is the file's identity. The window counters (`_resumed_count` etc.) take no part in the evidence -- fork/transfer set them optimistically after a best-effort first save (a transient first-write failure must not read as a deletion and eat the retry), and a restored zero-message session has all-zero counters while its delete must still win.
- **The delete-won guard.** Inside `_locked`, before any `mkdir`/`atomic_write`: with a known identity, a missing file (stat `FileNotFoundError` only) or an on-disk `created_at` that no longer matches (a fresh incarnation created by a foreign append after the delete) aborts the save cleanly -- no write, no error, WARNING log with the slot key, and the flush loop clears `_dirty` so the delete's reported success stands. The abort returns `False` (every other completion `True`), threaded through `save_slot_off_loop`, so callers that must confirm durability can tell the skip from a committed write.
- **Unreadable metadata fails CLOSED.** The save reads metadata via `get_metadata_status`; a transiently unreadable line makes the save raise (deferral: `_dirty` stays armed, the flush retries) instead of blanking the identity comparison and overwriting a replacement session with deleted content.
- **Copies are guarded directly.** Fork and transfer export call `session_was_deleted(state, slot)` at their copy choke points -- the periodic 5s flush can consume the guard's signal first by clearing `_dirty`, so the copy paths cannot rely on their own flush arms observing it. The probe applies the same identity rule, and unreadable metadata refuses the copy retryably. Fork refuses with 409; transfer raises `SnapshotUnstable`. Being lock-free, the probe can also have the delete land INSIDE it, between its stat and its metadata read: `get_metadata_status` reports a vanished file as a genuine `({}, True)`, so an empty `created_at` is re-stated before it is trusted -- gone means refuse, still-there means this is legacy metadata and fails open as documented. The save's guard needs no equivalent, because it does both reads inside `_locked`, the lock `delete_session` unlinks under.
- **The copy is re-checked at the ACKNOWLEDGMENT boundary.** One pre-copy probe is not enough, because writing the copy is itself an await that does not serialise against the source's delete: the transfer re-probes after bundle assembly, and the fork re-probes after its DESTINATION save (which takes the destination's lock, so nothing in it orders against the source's). Acknowledgment is the boundary a handler owns, so a delete committing before it wins: the fork removes the destination transcript it had already written (`delete_session` on the destination key, off-loop) and pops the never-broadcast slot before answering 409. Rolling the destination back cannot harm the source (different key, different lock), so the fail-closed probe costs at worst a retryable 409 against a still-live source. A delete committing AFTER the copy is acknowledged is deliberately out of scope: a fork acknowledged while its source was alive is its own session and survives the source. If the rollback removal itself fails, the copy stays on disk and is logged at ERROR -- the one case that still needs a human, and no worse than the unconditional persistence this replaces.

Doc sync: `docs/system-specs/modules/history.md` documents the guard, the identity rule, the fail-closed behavior, the return contract, the acknowledgment boundary and its rollback, and the residuals (fresh-slot adoption; the latched cron-linked-slot case). Three pre-existing tests fabricated a resumed slot with no on-disk file (now indistinguishable from delete-won) and were fixed to persist first with their original contracts preserved; save fakes in the fork/transfer test modules return `True` per the new contract. `session_transfer.py` and `channel_slots.py` were reformatted and graduated from the black baseline: the black gate itself fails with "graduated entr(y/ies) to prune" until the baseline shrinks, so the prune must ride in the same change.

## Tests

`TestSaveDoesNotResurrectDeletedSession` (test_dashboard_chat.py), 16 tests, each guard/probe mechanism mutation-verified red without its fix:
- save after committed delete does not recreate the file (returns `False`); the `_resumed_count` arm; first save of a fresh slot still creates (control).
- fork aborts 409 when the source was deleted (mid-flush AND after a flush consumed the signal); transfer bundle refuses (pre-read AND a delete landing during assembly).
- a delete landing INSIDE the fork's destination save is rolled back: 409, the source stays deleted, no new transcript survives, and the destination slot is gone from the live set. Mutation-verified: without the boundary re-check the fork answers 200 and a full copy of the deleted conversation persists under a fresh key.
- a delete landing inside the probe itself (between its stat and its metadata read) is caught, with a companion control pinning that legacy metadata carrying no `created_at` still fails open while the file exists.
- a file recreated by a foreign append after the delete is not merged into (identity mismatch); channel-surfaced slots record the identity and honor it.
- a failed best-effort first save is not mistaken for deletion; a zero-message resumed session's delete still wins; unreadable metadata defers the save and makes the probe refuse the copy.

Gates: isort/flake8/mypy clean; black gate passes; docs lint passes; 859 tests green across the dashboard-chat/fork/transfer suites, and the full backend suite is green apart from failure families proven pre-existing on this environment by an A/B run with the change stashed (`test_artifact_source`, `test_file_explorer_app`, `test_design_tweak_backend`, `test_host_isolation_floor`, `test_dashboard_peer_auth` and siblings -- none in the files this PR touches).

## Manual verification

N/A -- the race windows are deterministic to pin in unit tests (a delete committing before the save's lock acquire, and a delete committing inside the fork's destination save, both exercise the identical code paths), and the fork/transfer refusals are pinned at the endpoint level.

Closes #6677
