### PR TITLE
fix(identity): single canonical identity-store table replaces six drifting copies

### DIFF
--- a/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
+++ b/src/kiro_crew/dashboard/handlers/kiro_usage_api.py
@@ -92,6 +92,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from kiro_crew import hooks
+from kiro_crew.identity_stores import Trust, sqlite_dbs
 
 logger = logging.getLogger(__name__)
 
@@ -164,12 +165,7 @@ _JSON_TOKEN_READ_IDS = (
 # ``~/Library/Application Support`` on macOS, both matching the entries
 # above). ``AppData/Roaming`` is retained for layouts that used the roaming
 # location; a path that does not exist on the running host is inert.
-_CLI_SQLITE_DBS = (
-    Path.home() / ".local" / "share" / "kiro-cli" / "data.sqlite3",
-    Path.home() / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3",
-    Path.home() / "AppData" / "Local" / "kiro-cli" / "data.sqlite3",
-    Path.home() / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3",
-)
+_CLI_SQLITE_DBS = sqlite_dbs(Trust.TRUSTED)
 
 # Auth stores belonging to OTHER products (amazon-q). Readable, and often the same
 # account, but NOT kiro-cli's own credential — so a token from here can only be
@@ -183,12 +179,7 @@ _CLI_SQLITE_DBS = (
 # fenced -- a store every writer treats as a secret and this reader treats as
 # absent. Untrusted either way (``from_cli_store=False``), so this widens what
 # can be READ for credit reporting, never what is believed.
-_OTHER_SQLITE_DBS = (
-    Path.home() / ".local" / "share" / "amazon-q" / "data.sqlite3",
-    Path.home() / "Library" / "Application Support" / "amazon-q" / "data.sqlite3",
-    Path.home() / "AppData" / "Local" / "amazon-q" / "data.sqlite3",
-    Path.home() / "AppData" / "Roaming" / "amazon-q" / "data.sqlite3",
-)
+_OTHER_SQLITE_DBS = sqlite_dbs(Trust.OTHER)
 _SQLITE_TOKEN_KEYS = ("kirocli:odic:token", "codewhisperer:odic:token", "kirocli:social:token", "kirocli:external-idp:token")
 
 # SEL audit label for the SQLite live-token read. Not an allowlist entry (that

--- a/src/kiro_crew/identity_stores.py
+++ b/src/kiro_crew/identity_stores.py
@@ -1,0 +1,327 @@
+"""The single canonical table of kiro-cli / amazon-q identity-store locations.
+
+Six places in the tree used to resolve these stores, each with its own hardcoded
+per-platform list and no shared helper, so they drifted apart one reader at a
+time (#6352). This module is that shared source of truth: an ordered table of
+``(platform, home_relative_dir, product, trust)`` rows, plus the small set of
+projections every reader needs. Every other reader is now a thin wrapper over a
+projection here, so a new location is added ONCE.
+
+Two properties are enforced by the table's shape, not by scattered convention:
+
+* **TRUSTED implies FENCED.** A store is trusted (``from_cli_store=True`` at the
+  usage reader) only when an agent file tool cannot write it, and that fence is
+  home-anchored at exactly these directories. So every row is fenced; the
+  ``trust`` column only distinguishes kiro-cli's OWN credential (``TRUSTED``)
+  from another product's readable-but-not-owned store (``OTHER``).
+* **Ordering is preserved.** The projections emit rows in the table's order,
+  which is the exact order the pre-refactor readers used
+  (``.local/share`` -> ``Library/Application Support`` -> ``AppData/Local`` ->
+  ``AppData/Roaming``). Golden tests freeze that order.
+
+LEAF module: stdlib-only imports so any module (including ``security.py``, which
+is imported very early) can depend on it without a cycle.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+# The on-disk filename of every identity/state SQLite database. One constant so
+# the six sites that used to spell ``"data.sqlite3"`` inline cannot drift.
+AUTH_SQLITE_DB = "data.sqlite3"
+
+
+class Platform(enum.Enum):
+    """The three platform families the stores are laid out for."""
+
+    DARWIN = "darwin"
+    WIN32 = "win32"
+    POSIX = "posix"
+
+
+class Product(enum.Enum):
+    """The two products whose identity stores are resolved here."""
+
+    KIRO_CLI = "kiro-cli"
+    AMAZON_Q = "amazon-q"
+
+
+class Trust(enum.Enum):
+    """Whether a store is kiro-cli's OWN credential or another product's."""
+
+    TRUSTED = "trusted"
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class StoreRoot:
+    """One identity-store location, as a home-relative directory.
+
+    ``home_relative_dir`` is a forward-slash POSIX string (e.g.
+    ``".local/share/kiro-cli"``); callers join it under a concrete home. It is
+    the value the fence (``_SENSITIVE_HOME_DIRS``) is expressed in, so
+    :func:`fenced_home_dirs` returns these strings verbatim.
+
+    ``env_var`` names the environment variable the CLI resolves this location's
+    ROOT from (``XDG_DATA_HOME`` / ``LOCALAPPDATA`` / ``APPDATA``), or ``None``
+    when the location is a fixed home anchor (macOS). It is honoured only on the
+    SOURCE side of staging and state-db discovery -- never for the fenced /
+    trusted lists, which stay anchored so a redirected path cannot become a
+    forgeable trusted path.
+
+    ``trust`` is DERIVED, not stored: kiro-cli's own stores are TRUSTED, every
+    other product's are OTHER. One bit lives in one place (``product``), so the
+    two axes cannot drift apart -- storing trust as an independent column would
+    re-seed exactly the redundancy this table exists to remove -- while trust
+    remains a real, consumable concept (:func:`sqlite_dbs` keys on it).
+    """
+
+    platform: Platform
+    home_relative_dir: str
+    product: Product
+    env_var: Optional[str] = None
+
+    @property
+    def trust(self) -> Trust:
+        return Trust.TRUSTED if self.product is Product.KIRO_CLI else Trust.OTHER
+
+
+# The canonical, ordered table. Order is load-bearing: the projections emit in
+# this order, matching every pre-refactor reader.
+#
+# TRUSTED implies FENCED holds by construction -- every row is a fenced store
+# directory, and only kiro-cli rows are TRUSTED.
+#
+# Within each platform: Local before Roaming (Windows), kiro-cli before amazon-q.
+IDENTITY_STORE_ROOTS: tuple[StoreRoot, ...] = (
+    # ── POSIX (Linux): ~/.local/share/<product>, root from XDG_DATA_HOME ──
+    StoreRoot(Platform.POSIX, ".local/share/kiro-cli", Product.KIRO_CLI, "XDG_DATA_HOME"),
+    StoreRoot(Platform.POSIX, ".local/share/amazon-q", Product.AMAZON_Q, "XDG_DATA_HOME"),
+    # ── macOS: ~/Library/Application Support/<product>, fixed anchor (env None) ──
+    StoreRoot(
+        Platform.DARWIN,
+        "Library/Application Support/kiro-cli",
+        Product.KIRO_CLI,
+        None,
+    ),
+    StoreRoot(Platform.DARWIN, "Library/Application Support/amazon-q", Product.AMAZON_Q, None),
+    # ── Windows Local: ~/AppData/Local/<product>, root from LOCALAPPDATA ──
+    StoreRoot(Platform.WIN32, "AppData/Local/kiro-cli", Product.KIRO_CLI, "LOCALAPPDATA"),
+    StoreRoot(Platform.WIN32, "AppData/Local/amazon-q", Product.AMAZON_Q, "LOCALAPPDATA"),
+    # ── Windows Roaming: ~/AppData/Roaming/<product>, root from APPDATA ──
+    StoreRoot(Platform.WIN32, "AppData/Roaming/kiro-cli", Product.KIRO_CLI, "APPDATA"),
+    StoreRoot(Platform.WIN32, "AppData/Roaming/amazon-q", Product.AMAZON_Q, "APPDATA"),
+)
+
+
+def fenced_home_dirs() -> tuple[str, ...]:
+    """Every store directory, home-relative, in table order.
+
+    Spliced into ``security._SENSITIVE_HOME_DIRS`` so agent file tools cannot
+    read any identity store (or its WAL/SHM/journal sidecars). Returns all eight
+    directories -- both products, all platform layouts -- because the fence is
+    the floor under both the TRUSTED and OTHER read lists.
+    """
+
+    return tuple(root.home_relative_dir for root in IDENTITY_STORE_ROOTS)
+
+
+def _rows_for_product(product: Product) -> tuple[StoreRoot, ...]:
+    return tuple(root for root in IDENTITY_STORE_ROOTS if root.product is product)
+
+
+def sqlite_dbs(trust: Trust, home: Optional[Path] = None) -> tuple[Path, ...]:
+    """Absolute ``<home>/<dir>/data.sqlite3`` paths for one trust class, table order.
+
+    Keyed on :class:`Trust` -- the consumer's real question is "which stores are
+    kiro-cli's own credential vs another product's" -- so the module's headline
+    TRUSTED-implies-FENCED invariant is load-bearing here, not documentary.
+    Order is ``.local/share`` -> ``Library/Application Support`` ->
+    ``AppData/Local`` -> ``AppData/Roaming`` -- the exact order the read lists
+    (``_CLI_SQLITE_DBS`` / ``_OTHER_SQLITE_DBS``) used before the refactor, so
+    the resulting tuples are byte-identical. ``home`` defaults to
+    :meth:`Path.home` so the module-level tuples match the old ``Path.home()``
+    idiom.
+    """
+
+    base = Path.home() if home is None else home
+    if not isinstance(trust, Trust):
+        # Loud misuse guard: Trust and Product are distinct enums, so a Product
+        # member silently matches no row and the projection returns an EMPTY
+        # tuple -- a subset test over it would pass vacuously (this exact
+        # mistake shipped once). Tests are not mypy-checked; this is.
+        raise TypeError(f"sqlite_dbs is keyed on Trust, got {trust!r}")
+    return tuple(
+        base.joinpath(*root.home_relative_dir.split("/")) / AUTH_SQLITE_DB
+        for root in IDENTITY_STORE_ROOTS
+        if root.trust is trust
+    )
+
+
+def _store_write_time(db: Path) -> float:
+    """Newest write across a store's main file and its WAL sidecar.
+
+    The store runs in SQLite WAL mode: a commit lands in the ``-wal`` sidecar and
+    the main file's mtime does not advance until a checkpoint, so the main file
+    alone under-reports recency on exactly the side being written. The ``-shm``
+    index is not consulted -- it is mapped shared memory, not a write record.
+    Raises ``OSError`` if the main file vanished; a missing sidecar is normal.
+    """
+
+    newest = db.stat().st_mtime
+    wal = db.with_name(db.name + "-wal")
+    try:
+        newest = max(newest, wal.stat().st_mtime)
+    except OSError:
+        pass
+    return newest
+
+
+def selected_store(
+    platform: str,
+    home: Path,
+) -> Path:
+    """The single live kiro-cli store path on ``platform``, from fixed anchors.
+
+    Hardwired to kiro-cli: the logout-detection fingerprint is deliberately NOT
+    amazon-q's (a recorded pre-refactor decision), and every caller selects the
+    CLI's own store -- so no product knob is offered that could loosen that.
+
+    Candidates are PROJECTED from :data:`IDENTITY_STORE_ROOTS` (filtered to this
+    platform's kiro-cli rows), so a relocated row reaches live-store selection
+    the same way it reaches the fence, the sqlite tuples, staging, and state-db
+    discovery. No environment variable is consulted -- and none is accepted --
+    because the fence that makes these stores unwritable by agent file tools is
+    anchored at exactly these paths, so a redirected location either resolves
+    here or falls outside the fence where an agent could forge the rows.
+
+    On Windows, when BOTH the Local and Roaming stores exist the most recently
+    written one wins (WAL-aware, per store), so a leftover in the abandoned root
+    never masks the live account; equal timestamps prefer Local (the first
+    table row -- the current layout); and when neither exists the Local anchor
+    is returned as the safe default.
+    """
+
+    plat = Platform(platform) if platform in {"darwin", "win32"} else Platform.POSIX
+    candidates = [
+        home.joinpath(*root.home_relative_dir.split("/")) / AUTH_SQLITE_DB
+        for root in _rows_for_product(Product.KIRO_CLI)
+        if root.platform is plat
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    # Windows: table order is Local (current layout) then Roaming (legacy).
+    local, roaming = candidates
+    if not roaming.exists():
+        return local
+    if not local.exists():
+        return roaming
+    try:
+        if _store_write_time(roaming) > _store_write_time(local):
+            return roaming
+    except OSError:
+        pass
+    return local
+
+
+@dataclass(frozen=True)
+class StoreMapping:
+    """One source store directory mapped to its fixed staged-relative directory.
+
+    ``env_var`` on the row governs the SOURCE side only: when set and present in
+    ``environ`` it re-roots the source, since that is where this host's real
+    store lives. The staged side is always the fixed default layout the staged
+    environment re-points those variables at.
+    """
+
+    source: Path
+    staged_relative: Path
+    product: Product
+
+
+def _source_root(root: StoreRoot, home: Path, environ: Mapping[str, str]) -> Path:
+    """Resolve one row's SOURCE directory, honouring its env var if set.
+
+    macOS rows carry ``env_var=None`` (fixed anchor). Windows/POSIX rows re-root
+    only their FIRST path segment from the env var (``AppData/Local`` ->
+    ``<LOCALAPPDATA>``, ``.local/share`` -> ``<XDG_DATA_HOME>``), keeping the
+    product-name tail; an unset variable falls back to the home anchor.
+    """
+
+    segments = root.home_relative_dir.split("/")
+    tail = segments[-1]
+    default_root = home.joinpath(*segments[:-1])
+    if root.env_var:
+        override = environ.get(root.env_var)
+        if override:
+            return Path(override) / tail
+    return default_root / tail
+
+
+def store_mappings(
+    platform: str,
+    home: Path,
+    environ: Mapping[str, str],
+) -> tuple[StoreMapping, ...]:
+    """Source->staged directory mappings for one platform, both products.
+
+    Emitted PRODUCT-MAJOR (all kiro-cli mappings, then all amazon-q), matching
+    the exact order the pre-refactor ``_auth_store_mappings`` loop produced --
+    on Windows that is kiro-cli Local, kiro-cli Roaming, amazon-q Local,
+    amazon-q Roaming. The env var is honoured on the SOURCE side only;
+    ``staged_relative`` is the fixed default layout regardless of redirection.
+    """
+
+    plat = Platform(platform) if platform in {"darwin", "win32"} else Platform.POSIX
+    mappings: list[StoreMapping] = []
+    for product in Product:
+        for root in IDENTITY_STORE_ROOTS:
+            if root.platform is not plat or root.product is not product:
+                continue
+            mappings.append(
+                StoreMapping(
+                    source=_source_root(root, home, environ),
+                    staged_relative=Path(*root.home_relative_dir.split("/")),
+                    product=root.product,
+                )
+            )
+    return tuple(mappings)
+
+
+def state_db_candidates(
+    platform: str,
+    home: Path,
+    environ: Mapping[str, str],
+) -> tuple[Path, ...]:
+    """Candidate kiro-cli state-database paths, most likely first.
+
+    Hardwired to kiro-cli (every caller probes the CLI's own state database;
+    see :func:`selected_store` for the recorded not-amazon-q decision).
+    Mirrors the per-platform data directories the readiness probe stages from,
+    honouring ``XDG_DATA_HOME`` (POSIX) and ``LOCALAPPDATA`` (the current Windows
+    layout) on the source side, so a host with a relocated data dir is not
+    silently treated as having no store. The Windows Roaming candidate is a FIXED
+    home anchor -- ``APPDATA`` is deliberately NOT followed here (matching the
+    pre-refactor ``kiro_cli.kiro_cli_state_dbs``): the current generation writes
+    the ``LOCALAPPDATA`` location, and the roaming default is retained only as a
+    legacy fallback. Deduped while preserving first-seen order (Local before
+    Roaming on Windows).
+    """
+
+    plat = Platform(platform) if platform in {"darwin", "win32"} else Platform.POSIX
+    roots: list[Path] = []
+    for root in _rows_for_product(Product.KIRO_CLI):
+        if root.platform is not plat:
+            continue
+        # Roaming (APPDATA) is a fixed anchor for state-db discovery; every other
+        # row follows its env var when set.
+        if root.env_var == "APPDATA":
+            roots.append(home.joinpath(*root.home_relative_dir.split("/")))
+        else:
+            roots.append(_source_root(root, home, environ))
+    unique = list(dict.fromkeys(roots))
+    return tuple(root / AUTH_SQLITE_DB for root in unique)

--- a/src/kiro_crew/kiro_cli.py
+++ b/src/kiro_crew/kiro_cli.py
@@ -9,15 +9,16 @@ import urllib.request
 from collections.abc import Mapping
 from pathlib import Path
 
-from kiro_crew import platform_compat
+from kiro_crew import identity_stores, platform_compat
 from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.env import augmented_path
 
 KIRO_CLI_NAME = "kiro-cli"
 
 # kiro-cli's own local state database. Holds identity-describing rows next to
-# credential rows, so every reader here is read-only and key-scoped.
-KIRO_CLI_STATE_DB = "data.sqlite3"
+# credential rows, so every reader here is read-only and key-scoped. Alias of
+# the single canonical filename constant so the six former copies cannot drift.
+KIRO_CLI_STATE_DB = identity_stores.AUTH_SQLITE_DB
 
 # Non-secret rows kiro-cli writes when the signed-in identity came from IAM
 # Identity Center. Presence is the whole signal: the values (a start URL and a
@@ -44,24 +45,11 @@ def kiro_cli_state_dbs(
 
     Mirrors the per-platform data directories the readiness probe stages from,
     including the ``XDG_DATA_HOME`` / ``LOCALAPPDATA`` redirections, so a host
-    with a relocated data dir is not silently treated as having no store.
+    with a relocated data dir is not silently treated as having no store. Thin
+    wrapper over :func:`identity_stores.state_db_candidates`, which owns the
+    canonical per-platform table and the dedupe.
     """
-    if platform_name == "darwin":
-        roots = [home / "Library" / "Application Support" / KIRO_CLI_NAME]
-    elif platform_name == "win32":
-        local_app_data = Path(environ.get("LOCALAPPDATA") or home / "AppData" / "Local")
-        roots = [
-            local_app_data / KIRO_CLI_NAME,
-            home / "AppData" / "Roaming" / KIRO_CLI_NAME,
-        ]
-    else:
-        data_home = Path(environ.get("XDG_DATA_HOME") or home / ".local" / "share")
-        roots = [data_home / KIRO_CLI_NAME]
-    return tuple(root / KIRO_CLI_STATE_DB for root in _unique_paths(roots))
-
-
-def _unique_paths(items: list[Path]) -> list[Path]:
-    return list(dict.fromkeys(items))
+    return identity_stores.state_db_candidates(platform_name, home, environ)
 
 
 def api_key_configured(environ: Mapping[str, str] | None = None) -> bool:

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -51,7 +51,7 @@ from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import hooks, platform_compat
+from kiro_crew import hooks, identity_stores, platform_compat
 from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.agent_files import AGENT_FILENAME
 from kiro_crew.atomic_write import atomic_write
@@ -195,7 +195,7 @@ _AUTH_STORE_READ_ERROR = "Kiro identity file could not be read safely"
 # "no such table: history" on first use. Copying every table's DDL (and indexes)
 # while withholding non-identity ROWS keeps the CLI's queries valid and still
 # hands the sandboxed process no transcript content.
-_AUTH_SQLITE_DB = "data.sqlite3"
+_AUTH_SQLITE_DB = identity_stores.AUTH_SQLITE_DB
 _AUTH_IDENTITY_TABLES = ("auth_kv", "migrations")
 # `state` is a mixed key/value table: a few rows describe WHICH identity is signed
 # in (Identity Center region + start URL, CodeWhisperer profile) and the rest is
@@ -803,64 +803,6 @@ def _atomic_write_secret_bytes(path: Path, content: bytes) -> None:
     atomic_write(path, content, fsync=True, restrict_to_owner=True)
 
 
-def _store_write_time(db: Path) -> float:
-    """Newest write across a store's main file and its WAL sidecar.
-
-    The store runs in SQLite WAL mode: a commit lands in the ``-wal`` sidecar
-    and the main file's mtime does not advance until a checkpoint, so the main
-    file alone under-reports recency on exactly the side being written. The
-    ``-shm`` index file is not consulted -- it is mapped shared memory, not a
-    write record. Raises ``OSError`` if the main file vanished; a missing
-    sidecar is normal (checkpointed or non-WAL store).
-    """
-
-    newest = db.stat().st_mtime
-    wal = db.with_name(db.name + "-wal")
-    try:
-        newest = max(newest, wal.stat().st_mtime)
-    except OSError:
-        pass
-    return newest
-
-
-def _win32_identity_store_path(home: Path) -> Path:
-    """Pick between the Local anchor and the legacy Roaming store on Windows.
-
-    Current kiro-cli writes ``AppData/Local/kiro-cli``; older layouts used
-    ``AppData/Roaming/kiro-cli``. When only one store exists it is the store.
-    When BOTH exist, the most recently written one wins: an upgraded host
-    carries a stale Roaming leftover next to its live Local store (upgrades do
-    not clean up the old directory), while a downgraded host writes Roaming
-    next to a stale Local leftover -- and preferring either fixed side reads
-    the leftover on the other shape, yielding a confident fingerprint of an
-    account nobody is signed into. Reporting both-present as absent instead
-    would silently disable identity tracking on every upgraded host, the
-    common shape. The mtime signal is as trustworthy as the stores
-    themselves: both paths sit inside the ``_SENSITIVE_HOME_DIRS`` fence, so
-    anything that could move their timestamps could already author the rows
-    outright -- no new forgeable surface. Equal timestamps prefer Local, the
-    current layout.
-    """
-
-    local = home / "AppData" / "Local" / "kiro-cli" / _AUTH_SQLITE_DB
-    roaming = home / "AppData" / "Roaming" / "kiro-cli" / _AUTH_SQLITE_DB
-    if not roaming.exists():
-        return local
-    if not local.exists():
-        return roaming
-    try:
-        # Recency is per STORE, not per file: in WAL mode a commit advances
-        # the -wal sidecar while the main file's mtime stays frozen until a
-        # checkpoint, so each side reports the newest of the pair.
-        if _store_write_time(roaming) > _store_write_time(local):
-            return roaming
-    except OSError:
-        # A store vanished between the existence probe and the stat; the
-        # Local anchor is the current layout and the safe default.
-        pass
-    return local
-
-
 def kiro_identity_store_path(
     platform_name: str,
     home: Path,
@@ -888,8 +830,9 @@ def kiro_identity_store_path(
     directory (``AppData/Local/kiro-cli``); older layouts used the roaming one
     (``AppData/Roaming/kiro-cli``). When only one store exists it is chosen;
     when both exist the most recently written one wins, so a leftover from
-    the other layout never masks the live store's account (see
-    :func:`_win32_identity_store_path`). Both anchors sit inside the
+    the other layout never masks the live store's account (the WAL-aware
+    mtime tie-break lives in :func:`identity_stores.selected_store`). Both
+    anchors sit inside the
     ``_SENSITIVE_HOME_DIRS`` fence, so neither choice widens what an agent
     can forge. This branch stats the filesystem, so callers on the event loop
     should resolve the path inside the same worker thread as the read itself.
@@ -901,11 +844,7 @@ def kiro_identity_store_path(
     that genuinely requires it does not change every call site.
     """
 
-    if platform_name == "darwin":
-        return home / "Library" / "Application Support" / "kiro-cli" / _AUTH_SQLITE_DB
-    if platform_name == "win32":
-        return _win32_identity_store_path(home)
-    return home / ".local" / "share" / "kiro-cli" / _AUTH_SQLITE_DB
+    return identity_stores.selected_store(platform_name, home)
 
 
 def identity_store_is_relocated(
@@ -943,24 +882,33 @@ def identity_store_is_relocated(
     :meth:`KiroPrerequisiteService.current_identity_fingerprint` makes it
     diagnosable. A variable set to exactly the default location is not a
     relocation.
+
+    The (variable, default root) pairs are PROJECTED from
+    :data:`identity_stores.IDENTITY_STORE_ROOTS` -- each kiro-cli row's
+    ``env_var`` against the parent of its home-relative directory -- so this
+    check learns about a new or relocated store row the same way the fence,
+    staging, and state-db discovery do. macOS falls out naturally: its rows
+    carry no ``env_var`` (no standard variable relocates
+    ``~/Library/Application Support``), so no pair is checked there.
     """
 
-    if platform_name == "win32":
-        for variable, default in (
-            ("LOCALAPPDATA", home / "AppData" / "Local"),
-            ("APPDATA", home / "AppData" / "Roaming"),
+    plat = (
+        identity_stores.Platform(platform_name)
+        if platform_name in ("darwin", "win32")
+        else identity_stores.Platform.POSIX
+    )
+    for root in identity_stores.IDENTITY_STORE_ROOTS:
+        if (
+            root.platform is not plat
+            or root.product is not identity_stores.Product.KIRO_CLI
+            or root.env_var is None
         ):
-            configured = environ.get(variable, "").strip()
-            if configured and Path(configured) != default:
-                return True
-        return False
-    if platform_name == "darwin":
-        # No standard variable relocates ~/Library/Application Support.
-        return False
-    configured = environ.get("XDG_DATA_HOME", "").strip()
-    if not configured:
-        return False
-    return Path(configured) != home / ".local" / "share"
+            continue
+        default = home.joinpath(*root.home_relative_dir.split("/")).parent
+        configured = environ.get(root.env_var, "").strip()
+        if configured and Path(configured) != default:
+            return True
+    return False
 
 
 def identity_fingerprint(path: Path) -> str:
@@ -1097,7 +1045,17 @@ def _auth_store_mappings(
     home: Path,
     environ: MutableMapping[str, str],
 ) -> tuple[_AuthStoreMapping, ...]:
-    """Return only Kiro identity stores, never the surrounding credential dirs."""
+    """Return only Kiro identity stores, never the surrounding credential dirs.
+
+    Built over the canonical :func:`identity_stores.store_mappings` projection so
+    the source directories, the env-var source-side honouring
+    (``LOCALAPPDATA`` / ``APPDATA`` / ``XDG_DATA_HOME``), the fixed staged side,
+    and the Local-before-Roaming ordering all come from the single table. This
+    wrapper keeps staging's own concerns: the ``.aws/sso/cache`` token mapping
+    (not an identity store, so not in the table), the ``_AuthStoreMapping`` shape
+    with ``filenames=_AUTH_SQLITE_FILES``, and the ``win32:{app}`` group that
+    defers the abort across a product's two alternate AppData roots.
+    """
 
     mappings = [
         _AuthStoreMapping(
@@ -1106,57 +1064,25 @@ def _auth_store_mappings(
             filenames=("kiro-auth-token*.json",),
         )
     ]
-    app_names = ("kiro-cli", "amazon-q")
-    if platform_name == "darwin":
-        for app_name in app_names:
-            mappings.append(
-                _AuthStoreMapping(
-                    source=home / "Library" / "Application Support" / app_name,
-                    staged_relative=Path("Library") / "Application Support" / app_name,
-                    filenames=_AUTH_SQLITE_FILES,
-                )
+    for row in identity_stores.store_mappings(platform_name, home, environ):
+        # Both AppData roots of one Windows product are alternates: only one is
+        # this host's live store, so a stale leftover in the unused root must
+        # not abort staging from the used one. A shared group defers the abort
+        # across them; distinct ``staged_relative`` values (from the table) keep
+        # them from overwriting each other. macOS/Linux have a single location
+        # per product, so no group. (The env-var source-side honouring and the
+        # fixed staged side are already applied by ``store_mappings``.)
+        group = (
+            f"win32:{row.product.value}" if platform_name == "win32" else None
+        )
+        mappings.append(
+            _AuthStoreMapping(
+                source=row.source,
+                staged_relative=row.staged_relative,
+                filenames=_AUTH_SQLITE_FILES,
+                group=group,
             )
-    elif platform_name == "win32":
-        # Both AppData roots, because the installed CLI is observed using either
-        # one and every OTHER reader of this store already covers both: the fence
-        # (``_SENSITIVE_HOME_DIRS``), the trusted live-store list
-        # (``_CLI_SQLITE_DBS``), the logout fingerprint
-        # (``_win32_identity_store_path``) and ``kiro_cli_state_dbs``. Staging
-        # was the last reader still naming Local alone, so on a host whose CLI
-        # keeps its store under Roaming it staged NOTHING and the staged home
-        # looked signed-out. ``LOCALAPPDATA``/``APPDATA`` are honoured for the
-        # source side (that is where this host's real store lives), while the
-        # staged side is the fixed default layout the staged env re-points those
-        # variables at.
-        local_app_data = Path(environ.get("LOCALAPPDATA") or home / "AppData" / "Local")
-        roaming_app_data = Path(environ.get("APPDATA") or home / "AppData" / "Roaming")
-        for app_name in app_names:
-            for source_root, staged_root in (
-                (local_app_data, "Local"),
-                (roaming_app_data, "Roaming"),
-            ):
-                mappings.append(
-                    _AuthStoreMapping(
-                        source=source_root / app_name,
-                        staged_relative=Path("AppData") / staged_root / app_name,
-                        filenames=_AUTH_SQLITE_FILES,
-                        # The two roots of one product are alternates, so a stale
-                        # store in the unused root cannot abort staging from the
-                        # used one. Distinct ``staged_relative`` values keep them
-                        # from overwriting each other when a host has both.
-                        group=f"win32:{app_name}",
-                    )
-                )
-    else:
-        data_home = Path(environ.get("XDG_DATA_HOME") or home / ".local" / "share")
-        for app_name in app_names:
-            mappings.append(
-                _AuthStoreMapping(
-                    source=data_home / app_name,
-                    staged_relative=Path(".local") / "share" / app_name,
-                    filenames=_AUTH_SQLITE_FILES,
-                )
-            )
+        )
     return tuple(mappings)
 
 

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, NamedTuple
 from urllib.parse import parse_qs, unquote, unquote_plus, urlparse
 
 from kiro_crew.executors import maintenance_executor
+from kiro_crew.identity_stores import fenced_home_dirs
 from kiro_crew.sel import SecurityEvent, SecurityEventLog
 from kiro_crew.trust_patterns import ENV_ASSIGNMENT_RE
 from kiro_crew.vector_memory_constants import _contains_injection
@@ -4798,21 +4799,21 @@ _SENSITIVE_HOME_DIRS: list[str] = [
     # The internal reader opens the DB read-only + SEL-audited (NOT via
     # is_sensitive_path), so it still works; the sandbox bind-mount list
     # (sandbox.py) is SEPARATE, so kiro-cli's own auth is unaffected.
-    ".local/share/kiro-cli",
-    ".local/share/amazon-q",
-    "Library/Application Support/kiro-cli",
-    "Library/Application Support/amazon-q",
-    # Windows layouts of the same stores. Current kiro-cli writes the local,
-    # non-roaming app-data directory (%LOCALAPPDATA% defaults to
-    # ~/AppData/Local); the Roaming entries cover layouts that used
-    # %APPDATA% (defaults to ~/AppData/Roaming). These matchers are
-    # home-anchored, so a profile redirected outside the home directory is not
-    # covered -- the default location is what agent file tools can reach by a
-    # fixed relative path.
-    "AppData/Local/kiro-cli",
-    "AppData/Local/amazon-q",
-    "AppData/Roaming/kiro-cli",
-    "AppData/Roaming/amazon-q",
+    # The identity-store directories come from the single canonical table
+    # (``identity_stores.IDENTITY_STORE_ROOTS``) so this fence and the five other
+    # readers cannot drift apart (#6352). The splice emits all eight in table
+    # order (``.local/share`` -> ``Library/Application Support`` ->
+    # ``AppData/Local`` -> ``AppData/Roaming``, kiro-cli before amazon-q), which
+    # is the exact order this list carried before the refactor -- a golden test
+    # freezes that the final list is unchanged.
+    #
+    # Windows layouts: current kiro-cli writes the local, non-roaming app-data
+    # directory (%LOCALAPPDATA% defaults to ~/AppData/Local); the Roaming entries
+    # cover layouts that used %APPDATA% (defaults to ~/AppData/Roaming). These
+    # matchers are home-anchored, so a profile redirected outside the home
+    # directory is not covered -- the default location is what agent file tools
+    # can reach by a fixed relative path.
+    *fenced_home_dirs(),
 ]
 
 # ── KiroCrew's own data-home secrets & governance trust-root ──

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -436,15 +436,13 @@ class TestTheSharedKiroPathRatchet:
         # longer matches the thing it protects -- weakening the guard to satisfy an
         # isolation ratchet, which is backwards.
         ("kiro_crew/security.py", "_EXTRACT_INTO_TRUST_ROOT_RE"): "security anchor: must name the REAL home",
-        # Also not redirectable: the home-anchoring IS the security property. These name
-        # OTHER products' credential stores (kiro-cli, amazon-q), and the module's own
-        # comment records that an entry either equals the home-anchored path inside
-        # `_SENSITIVE_HOME_DIRS`' fence or falls outside it and must not be trusted --
-        # so a redirected value would manufacture a forgeable "trusted" path. They are
-        # only ever READ, and `test_kiro_usage_api.py` stubs the tuples per test, which
-        # is the right seam: stub the READER, never move the anchor.
-        ("kiro_crew/dashboard/handlers/kiro_usage_api.py", "_CLI_SQLITE_DBS"): "security anchor: must name the REAL home",
-        ("kiro_crew/dashboard/handlers/kiro_usage_api.py", "_OTHER_SQLITE_DBS"): "security anchor: must name the REAL home",
+        # The kiro-cli/amazon-q sqlite tuples that used to sit here as direct
+        # ``Path.home()`` bindings are now PROJECTIONS over the canonical table in
+        # ``kiro_crew/identity_stores.py`` (``sqlite_dbs(...)`` resolves the home
+        # inside the call), so they no longer match this tripwire's import-time
+        # shape and need no exclusion. Their anchor rule ("must name the REAL
+        # home"; stub the READER, never move the anchor) is carried forward by
+        # ``test_identity_stores.py::TestUsageTuplesAnchorTheRealHome``.
         # An ALLOW-LIST root, so the same rule applies from the other direction: the
         # file browser's first permitted root is the operator's real home BY DESIGN,
         # since that is the directory the user is entitled to browse. Redirecting it

--- a/test/test_identity_stores.py
+++ b/test/test_identity_stores.py
@@ -1,0 +1,349 @@
+"""The single canonical identity-store table and its projections (#6352).
+
+These tests pin two things: the table's structural invariants (every projection
+stays a subset of the table; TRUSTED implies FENCED), and GOLDEN freezes of the
+pre-refactor outputs so a future edit that changes an order or drops a location
+fails here rather than shipping. The six former readers are now thin wrappers
+over these projections; their own behaviour is pinned in their own suites.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import identity_stores as ids
+from kiro_crew.identity_stores import (
+    IDENTITY_STORE_ROOTS,
+    Platform,
+    Product,
+    Trust,
+    fenced_home_dirs,
+    selected_store,
+    sqlite_dbs,
+    state_db_candidates,
+    store_mappings,
+)
+
+
+class TestTableInvariants:
+    def test_every_row_dir_is_in_fenced_home_dirs(self) -> None:
+        fenced = fenced_home_dirs()
+        for root in IDENTITY_STORE_ROOTS:
+            assert root.home_relative_dir in fenced
+
+    def test_trusted_implies_kiro_cli_and_every_row_is_fenced(self) -> None:
+        # TRUSTED-implies-FENCED holds by construction: every row is a fenced
+        # store dir, and only kiro-cli rows are TRUSTED.
+        fenced = set(fenced_home_dirs())
+        for root in IDENTITY_STORE_ROOTS:
+            assert root.home_relative_dir in fenced
+            if root.trust is Trust.TRUSTED:
+                assert root.product is Product.KIRO_CLI
+
+    def test_fenced_dirs_are_unique(self) -> None:
+        dirs = fenced_home_dirs()
+        assert len(dirs) == len(set(dirs))
+
+
+class TestProjectionsAreSubsetsOfTable:
+    def _table_dirs(self) -> set[str]:
+        return {root.home_relative_dir for root in IDENTITY_STORE_ROOTS}
+
+    def test_sqlite_dbs_dirs_subset(self) -> None:
+        home = Path("/home/u")
+        for trust in (Trust.TRUSTED, Trust.OTHER):
+            dbs = sqlite_dbs(trust, home)
+            # Non-vacuous: each trust class must project real rows. (A prior
+            # revision passed Product members here, matched nothing, and this
+            # loop asserted over an empty tuple.)
+            assert len(dbs) == 4
+            for db in dbs:
+                rel = db.parent.relative_to(home).as_posix()
+                assert rel in self._table_dirs()
+
+    def test_sqlite_dbs_rejects_a_product_member(self) -> None:
+        with pytest.raises(TypeError):
+            sqlite_dbs(Product.KIRO_CLI)  # type: ignore[arg-type]
+
+    def test_store_mappings_staged_dirs_subset(self) -> None:
+        for platform in ("darwin", "win32", "posix"):
+            for mapping in store_mappings(platform, Path("/home/u"), {}):
+                assert mapping.staged_relative.as_posix() in self._table_dirs()
+
+    def test_state_db_candidates_dirs_subset(self) -> None:
+        home = Path("/home/u")
+        for platform in ("darwin", "win32", "posix"):
+            for db in state_db_candidates(platform, home, {}):
+                rel = db.parent.relative_to(home).as_posix()
+                assert rel in self._table_dirs()
+
+    def test_selected_store_dir_subset(self) -> None:
+        """Live-store selection is table-derived like every other projection.
+
+        This is the projection logout detection fingerprints from -- if it ever
+        re-hardcodes a path, a relocated table row would update the fence,
+        tuples, staging, and state-db candidates while selection silently kept
+        the old path."""
+        home = Path("/home/u")
+        for platform in ("darwin", "win32", "posix"):
+            store = selected_store(platform, home)
+            rel = store.parent.relative_to(home).as_posix()
+            assert rel in self._table_dirs()
+
+
+class TestGoldenFencedDirs:
+    def test_exactly_eight_dirs_in_frozen_order(self) -> None:
+        assert fenced_home_dirs() == (
+            ".local/share/kiro-cli",
+            ".local/share/amazon-q",
+            "Library/Application Support/kiro-cli",
+            "Library/Application Support/amazon-q",
+            "AppData/Local/kiro-cli",
+            "AppData/Local/amazon-q",
+            "AppData/Roaming/kiro-cli",
+            "AppData/Roaming/amazon-q",
+        )
+
+
+class TestGoldenSqliteTuples:
+    def test_kiro_cli_tuple_exact_order(self) -> None:
+        home = Path("/home/u")
+        assert sqlite_dbs(Trust.TRUSTED, home) == (
+            home / ".local" / "share" / "kiro-cli" / "data.sqlite3",
+            home / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3",
+            home / "AppData" / "Local" / "kiro-cli" / "data.sqlite3",
+            home / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3",
+        )
+
+    def test_amazon_q_tuple_exact_order(self) -> None:
+        home = Path("/home/u")
+        assert sqlite_dbs(Trust.OTHER, home) == (
+            home / ".local" / "share" / "amazon-q" / "data.sqlite3",
+            home / "Library" / "Application Support" / "amazon-q" / "data.sqlite3",
+            home / "AppData" / "Local" / "amazon-q" / "data.sqlite3",
+            home / "AppData" / "Roaming" / "amazon-q" / "data.sqlite3",
+        )
+
+    def test_default_home_matches_explicit(self) -> None:
+        assert sqlite_dbs(Trust.TRUSTED) == sqlite_dbs(Trust.TRUSTED, Path.home())
+
+
+class TestGoldenSelectedStore:
+    def test_darwin_fixed_anchor(self) -> None:
+        home = Path("/home/u")
+        assert selected_store("darwin", home) == (
+            home / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3"
+        )
+
+    def test_posix_fixed_anchor(self) -> None:
+        home = Path("/home/u")
+        assert selected_store("linux", home) == (
+            home / ".local" / "share" / "kiro-cli" / "data.sqlite3"
+        )
+
+    def test_win32_neither_exists_prefers_local(self, tmp_path: Path) -> None:
+        assert selected_store("win32", tmp_path) == (
+            tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        )
+
+    def test_win32_only_roaming_exists(self, tmp_path: Path) -> None:
+        roaming = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        roaming.parent.mkdir(parents=True)
+        roaming.write_bytes(b"x")
+        assert selected_store("win32", tmp_path) == roaming
+
+    def test_win32_both_exist_newer_roaming_wins(self, tmp_path: Path) -> None:
+        import os
+
+        local = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        roaming = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        for db in (local, roaming):
+            db.parent.mkdir(parents=True)
+            db.write_bytes(b"x")
+        os.utime(local, (1000, 1000))
+        os.utime(roaming, (2000, 2000))
+        assert selected_store("win32", tmp_path) == roaming
+
+    def test_win32_equal_mtime_prefers_local(self, tmp_path: Path) -> None:
+        import os
+
+        local = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        roaming = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        for db in (local, roaming):
+            db.parent.mkdir(parents=True)
+            db.write_bytes(b"x")
+            os.utime(db, (1500, 1500))
+        assert selected_store("win32", tmp_path) == local
+
+    def test_win32_wal_sidecar_counts_as_recency(self, tmp_path: Path) -> None:
+        import os
+
+        local = tmp_path / "AppData" / "Local" / "kiro-cli" / "data.sqlite3"
+        roaming = tmp_path / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3"
+        for db in (local, roaming):
+            db.parent.mkdir(parents=True)
+            db.write_bytes(b"x")
+        # Local main file is newest, but Roaming's WAL sidecar is newer still,
+        # so Roaming (the actually-written store) must win.
+        os.utime(local, (3000, 3000))
+        os.utime(roaming, (1000, 1000))
+        wal = roaming.with_name(roaming.name + "-wal")
+        wal.write_bytes(b"x")
+        os.utime(wal, (4000, 4000))
+        assert selected_store("win32", tmp_path) == roaming
+
+
+class TestGoldenStoreMappings:
+    def test_linux_source_and_staged(self) -> None:
+        home = Path("/home/u")
+        mappings = store_mappings("linux", home, {})
+        assert [(m.source, m.staged_relative, m.product) for m in mappings] == [
+            (
+                home / ".local" / "share" / "kiro-cli",
+                Path(".local/share/kiro-cli"),
+                Product.KIRO_CLI,
+            ),
+            (
+                home / ".local" / "share" / "amazon-q",
+                Path(".local/share/amazon-q"),
+                Product.AMAZON_Q,
+            ),
+        ]
+
+    def test_darwin_source_and_staged(self) -> None:
+        home = Path("/home/u")
+        mappings = store_mappings("darwin", home, {})
+        assert [(m.source, m.staged_relative) for m in mappings] == [
+            (
+                home / "Library" / "Application Support" / "kiro-cli",
+                Path("Library/Application Support/kiro-cli"),
+            ),
+            (
+                home / "Library" / "Application Support" / "amazon-q",
+                Path("Library/Application Support/amazon-q"),
+            ),
+        ]
+
+    def test_win32_product_major_order_matches_pre_refactor(self) -> None:
+        """PRODUCT-MAJOR: the exact emission order of the pre-refactor
+        ``_auth_store_mappings`` win32 loop (all kiro-cli, then all amazon-q).
+        Order-sensitive on purpose -- a reorder must fail here, not slide by."""
+        home = Path("/home/u")
+        mappings = store_mappings("win32", home, {})
+        assert [(m.source, m.staged_relative) for m in mappings] == [
+            (home / "AppData" / "Local" / "kiro-cli", Path("AppData/Local/kiro-cli")),
+            (home / "AppData" / "Roaming" / "kiro-cli", Path("AppData/Roaming/kiro-cli")),
+            (home / "AppData" / "Local" / "amazon-q", Path("AppData/Local/amazon-q")),
+            (home / "AppData" / "Roaming" / "amazon-q", Path("AppData/Roaming/amazon-q")),
+        ]
+
+    def test_win32_env_vars_honoured_on_source_only(self) -> None:
+        home = Path("/home/u")
+        mappings = store_mappings("win32", home, {"LOCALAPPDATA": "/loc", "APPDATA": "/roam"})
+        kiro = {m.source: m.staged_relative for m in mappings if m.source.name == "kiro-cli"}
+        assert kiro == {
+            Path("/loc/kiro-cli"): Path("AppData/Local/kiro-cli"),
+            Path("/roam/kiro-cli"): Path("AppData/Roaming/kiro-cli"),
+        }
+
+    def test_linux_xdg_data_home_honoured_on_source_only(self) -> None:
+        home = Path("/home/u")
+        mappings = store_mappings("linux", home, {"XDG_DATA_HOME": "/xdg"})
+        kiro = [m for m in mappings if m.product is Product.KIRO_CLI][0]
+        assert kiro.source == Path("/xdg/kiro-cli")
+        assert kiro.staged_relative == Path(".local/share/kiro-cli")
+
+
+class TestGoldenStateDbCandidates:
+    def test_darwin(self) -> None:
+        home = Path("/home/u")
+        assert state_db_candidates("darwin", home, {}) == (
+            home / "Library" / "Application Support" / "kiro-cli" / "data.sqlite3",
+        )
+
+    def test_linux(self) -> None:
+        home = Path("/home/u")
+        assert state_db_candidates("linux", home, {}) == (
+            home / ".local" / "share" / "kiro-cli" / "data.sqlite3",
+        )
+
+    def test_win32_local_before_roaming(self) -> None:
+        home = Path("/home/u")
+        assert state_db_candidates("win32", home, {}) == (
+            home / "AppData" / "Local" / "kiro-cli" / "data.sqlite3",
+            home / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3",
+        )
+
+    def test_linux_xdg_data_home_honoured(self) -> None:
+        home = Path("/home/u")
+        assert state_db_candidates("linux", home, {"XDG_DATA_HOME": "/xdg"}) == (
+            Path("/xdg/kiro-cli/data.sqlite3"),
+        )
+
+    def test_win32_localappdata_honoured_roaming_fixed(self) -> None:
+        # Matches the pre-refactor kiro_cli_state_dbs: LOCALAPPDATA moves the
+        # Local candidate, APPDATA is NOT followed (Roaming stays anchored).
+        home = Path("/home/u")
+        assert state_db_candidates(
+            "win32",
+            home,
+            {"LOCALAPPDATA": "/loc", "APPDATA": "/roam"},
+        ) == (
+            Path("/loc/kiro-cli/data.sqlite3"),
+            home / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3",
+        )
+
+    def test_win32_localappdata_equal_to_default_dedupes(self) -> None:
+        home = Path("/home/u")
+        # When LOCALAPPDATA points at the default Local root, no duplicate.
+        result = state_db_candidates(
+            "win32",
+            home,
+            {"LOCALAPPDATA": str(home / "AppData" / "Local")},
+        )
+        assert result == (
+            home / "AppData" / "Local" / "kiro-cli" / "data.sqlite3",
+            home / "AppData" / "Roaming" / "kiro-cli" / "data.sqlite3",
+        )
+
+
+class TestConstants:
+    def test_auth_sqlite_db_filename(self) -> None:
+        assert ids.AUTH_SQLITE_DB == "data.sqlite3"
+
+    def test_platform_product_trust_values(self) -> None:
+        assert Platform.DARWIN.value == "darwin"
+        assert Platform.WIN32.value == "win32"
+        assert Platform.POSIX.value == "posix"
+        assert Product.KIRO_CLI.value == "kiro-cli"
+        assert Product.AMAZON_Q.value == "amazon-q"
+        assert {t.value for t in Trust} == {"trusted", "other"}
+
+
+class TestUsageTuplesAnchorTheRealHome:
+    """Replacement pin for the host-isolation ratchet's deleted exclusions.
+
+    ``kiro_usage_api._CLI_SQLITE_DBS`` / ``_OTHER_SQLITE_DBS`` used to be direct
+    import-time ``Path.home()`` bindings, tracked by
+    ``test_host_isolation_floor.py``'s ratchet as excluded-with-reason security
+    anchors ("must name the REAL home"). As projections they no longer match
+    that tripwire's AST shape, so THIS test carries the property forward: the
+    tuples must anchor the operator's real home at import, because an entry is
+    trusted precisely when it equals a home-anchored path inside the
+    ``_SENSITIVE_HOME_DIRS`` fence -- a redirected value would manufacture a
+    forgeable "trusted" path. Tests that need different paths must stub the
+    READER (as ``test_kiro_usage_api.py`` does per test), never move the anchor.
+    """
+
+    def test_import_time_tuples_are_real_home_anchored(self) -> None:
+        from kiro_crew.dashboard.handlers import kiro_usage_api as api
+
+        real_home = Path.home()
+        for db in (*api._CLI_SQLITE_DBS, *api._OTHER_SQLITE_DBS):
+            assert real_home in db.parents, (
+                f"{db} is not anchored at the real home -- the trusted-store "
+                "anchor property regressed (stub the reader, never the anchor)"
+            )
+            assert db.name == ids.AUTH_SQLITE_DB

--- a/test/test_windows_identity_store_paths.py
+++ b/test/test_windows_identity_store_paths.py
@@ -22,8 +22,10 @@ from pathlib import Path, PurePosixPath
 
 import pytest
 
+from kiro_crew import identity_stores as ids
 from kiro_crew import kiro_prerequisite as kp
 from kiro_crew.dashboard.handlers import kiro_usage_api as usage_api
+from kiro_crew.identity_stores import Trust
 from kiro_crew.security import _SENSITIVE_HOME_DIRS
 
 # The two roots the installed CLI is observed using, for each product whose store
@@ -249,3 +251,55 @@ class TestStagingToleratesTheUnusedAppDataRoot:
 
         staged_db = Path(workspace.root) / "AppData" / "Roaming" / "kiro-cli" / kp._AUTH_SQLITE_DB
         assert staged_db.exists()
+
+
+class TestReadersAgreeWithCanonicalTable:
+    """The six former copies are now projections of ``identity_stores`` (#6352).
+
+    These re-point the ratchet at the single canonical table: every reader must
+    equal the projection it now wraps, so drift is impossible by construction
+    rather than by remembering to update N hardcoded lists.
+    """
+
+    def test_fence_identity_dirs_come_from_the_table(self) -> None:
+        """Every fenced identity dir is a canonical row, and vice versa."""
+
+        fenced_identity = {
+            entry for entry in _SENSITIVE_HOME_DIRS if entry in set(ids.fenced_home_dirs())
+        }
+        assert fenced_identity == set(ids.fenced_home_dirs())
+
+    def test_usage_read_lists_are_the_projections(self) -> None:
+        assert usage_api._CLI_SQLITE_DBS == ids.sqlite_dbs(Trust.TRUSTED)
+        assert usage_api._OTHER_SQLITE_DBS == ids.sqlite_dbs(Trust.OTHER)
+
+    def test_identity_store_path_matches_selected_store(self, tmp_path: Path) -> None:
+        for platform in ("darwin", "linux", "win32"):
+            assert kp.kiro_identity_store_path(platform, tmp_path, {}) == (
+                ids.selected_store(platform, tmp_path)
+            )
+
+    def test_state_dbs_match_the_projection(self, tmp_path: Path) -> None:
+        from kiro_crew import kiro_cli
+
+        for platform in ("darwin", "linux", "win32"):
+            assert kiro_cli.kiro_cli_state_dbs(platform, tmp_path, {}) == (
+                ids.state_db_candidates(platform, tmp_path, {})
+            )
+
+    def test_auth_sqlite_db_constant_is_the_alias(self) -> None:
+        assert kp._AUTH_SQLITE_DB == ids.AUTH_SQLITE_DB
+        from kiro_crew import kiro_cli
+
+        assert kiro_cli.KIRO_CLI_STATE_DB == ids.AUTH_SQLITE_DB
+
+    def test_staging_sources_track_the_table_on_win32(self, tmp_path: Path) -> None:
+        """Staging's win32 source dirs are the table's win32 mapping sources."""
+
+        staged = {
+            m.source.relative_to(tmp_path).as_posix()
+            for m in kp._auth_store_mappings("win32", tmp_path, {})
+            if m.source.is_relative_to(tmp_path / "AppData")
+        }
+        table = {m.staged_relative.as_posix() for m in ids.store_mappings("win32", tmp_path, {})}
+        assert staged == table


### PR DESCRIPTION
## Problem / Motivation

Six sites hardcode the kiro-cli/amazon-q identity-store locations independently, and they keep drifting apart (#6352): the `_SENSITIVE_HOME_DIRS` fence in `security.py`, the `_CLI_SQLITE_DBS`/`_OTHER_SQLITE_DBS` trust tuples in `kiro_usage_api.py`, the fingerprint path selection in `kiro_prerequisite.py` (`_win32_identity_store_path` / `kiro_identity_store_path`), the sign-in staging mappings (`_auth_store_mappings`), and the CLI state-db candidates in `kiro_cli.py`. Each holds its own representation (home-relative strings, absolute paths, selected path, source/staged pairs, env-aware candidates) plus three separate copies of the `"data.sqlite3"` filename constant. History shows the drift is real: the Windows `AppData/Local` entries reached different sites at different times, leaving windows where a token was fenced but unreadable.

## Why it matters

The fence's security claim (every trusted store location is also a fenced location) currently rests on six lists agreeing by hand. Any new reader or a missed platform entry silently re-opens the gap #5251 closed. Making TRUSTED-implies-FENCED a *structural property of one table* removes the class of bug instead of policing instances of it — the direction the maintainer prescribed on the issue.

## What changed (motivation → approach → change)

- **New leaf module `src/kiro_crew/identity_stores.py`** (stdlib-only, nothing imports from the consumers): a single ordered table `IDENTITY_STORE_ROOTS` of `(platform, home_relative_dir, product, trust, env_var)` rows, plus the one `AUTH_SQLITE_DB = "data.sqlite3"` constant.
- **Per-consumer projections** over the table: `fenced_home_dirs()`, `sqlite_dbs(product)`, `selected_store(...)` (keeps the win32 Local/Roaming WAL-aware mtime tie-break), `store_mappings(...)` (env vars honoured on the source side only, exactly as before), `state_db_candidates(...)` (Local follows `LOCALAPPDATA`, Roaming stays a fixed anchor — the pre-existing asymmetry is preserved and pinned by golden tests).
- **Six sites re-pointed**: `security.py` splices `*fenced_home_dirs()` in place of the 8 literals; `kiro_usage_api.py` builds both tuples from `sqlite_dbs(...)`; `kiro_prerequisite.py` delegates path selection and staging mappings (keeping `_AuthStoreMapping`, `group="win32:{app}"`, and the `.aws/sso/cache` mapping); `kiro_cli.py` delegates `kiro_cli_state_dbs` and aliases `KIRO_CLI_STATE_DB` (module stays import-light).
- **Behaviour-preserving by construction**: golden tests freeze the exact pre-refactor outputs (8 fence dirs, both 4-entry sqlite tuples in order, staging mappings per platform, state-db candidates with/without env vars).

## Tests

- New `test/test_identity_stores.py`: table invariants (every row's dir is fenced; every projection's dirs are a subset of the table — a new hardcoded literal in any consumer can no longer bypass the table unnoticed) plus the golden equivalence freeze.
- `test/test_windows_identity_store_paths.py` (the #5251 ratchet) re-pointed at the projections — every existing case kept, new `TestReadersAgreeWithCanonicalTable` added.
- Targeted runs: 264 passed (`test_identity_stores`, `test_windows_identity_store_paths`, `test_external_logout_detection` unchanged, `test_kiro_usage_api`, `test_security_posture`) + 242 passed (`test_security.py -k "sensitive or home"`).
- Lint floor: repo black gate (26.3.1) passed with no baseline change; isort and flake8 clean over src/ and test/ changes.

## Manual verification

Verified the projections reproduce the previous literals byte-for-byte via the golden tests (fence list, sqlite tuples, staging mappings, candidate order), and that `kiro_cli.py` gains no heavy transitive import (the new module is stdlib-only).

## Screenshots / video

Not applicable — backend-only change, no UI surface.

## Related Issues

Fixes #6352

## Checklist

- [x] Tests added/updated and passing locally (targeted suites listed above)
- [x] Lint/format gates pass (black gate, isort, flake8)
- [x] No breaking behaviour change (golden equivalence tests pin prior outputs)
- [x] Docs not required (internal refactor; module docstring documents the table contract)

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
