### PR TITLE
fix(trash): replace _rewrite_manifest tmp-write with atomic_write(fsync=True)

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -79,6 +79,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import IO, Any
 
 from kiro_crew import hooks, platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import (
     CONFIG_DIR_LEAF,
     KIRO_BASE_DIR_NAME,
@@ -1540,13 +1541,10 @@ def _summarize_manifest(batch: Path) -> tuple[dict[str, Any], int, int] | None:
 
 
 def _rewrite_manifest(batch: Path, header: dict[str, Any], entries: list[dict[str, Any]]) -> None:
-    """Replace a manifest atomically after a partial restore."""
-    tmp = batch / f"{MANIFEST_NAME}.tmp"
-    with tmp.open("w", encoding="utf-8") as handle:
-        handle.write(json.dumps(header) + "\n")
-        for entry in entries:
-            handle.write(json.dumps(entry) + "\n")
-    os.replace(tmp, batch / MANIFEST_NAME)
+    """Replace and sync a manifest after a partial restore."""
+    header_line = json.dumps(header) + "\n"
+    entry_lines = "".join(json.dumps(entry) + "\n" for entry in entries)
+    atomic_write(batch / MANIFEST_NAME, header_line + entry_lines, fsync=True)
 
 
 def _entry_bytes(entry: dict[str, Any]) -> int:

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -765,6 +765,40 @@ class TestManifestPersistenceFailure:
         assert (crew_home / "sessions" / "dashboard_chat-1.jsonl").is_file()
         assert session_storage.list_trash() == []
 
+    def test_rewrite_fsyncs_before_publishing_manifest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash after publish must not expose manifest bytes still only in cache."""
+        from kiro_crew import atomic_write as atomic_write_module
+
+        batch = tmp_path / "batch"
+        batch.mkdir()
+        events: list[str] = []
+        real_fsync = atomic_write_module.os.fsync
+        real_replace = atomic_write_module.replace_with_retry
+
+        def tracking_fsync(fd: int) -> None:
+            events.append("fsync")
+            real_fsync(fd)
+
+        def tracking_replace(src: str | Path, dst: str | Path) -> None:
+            events.append("replace")
+            real_replace(src, dst)
+
+        monkeypatch.setattr(atomic_write_module.os, "fsync", tracking_fsync)
+        monkeypatch.setattr(atomic_write_module, "replace_with_retry", tracking_replace)
+        header = {"schema": session_storage.MANIFEST_SCHEMA, "batch_id": "batch"}
+        entries = [{"uid": "aaaa1111", "files": []}]
+
+        session_storage._rewrite_manifest(batch, header, entries)
+
+        assert events.index("fsync") < events.index("replace")
+        manifest = batch / session_storage.MANIFEST_NAME
+        assert [json.loads(line) for line in manifest.read_text(encoding="utf-8").splitlines()] == [
+            header,
+            *entries,
+        ]
+
 
 class TestBatchIdentityIsTheDirectory:
     def test_a_header_naming_another_batch_is_not_offered(self, stores: tuple[Path, Path]) -> None:


### PR DESCRIPTION
## Problem / Motivation

`_rewrite_manifest` wrote a tmp file and called `os.replace` without an
intermediate `fsync`. A power loss (or OS crash) between the rename and the
flush could publish a manifest directory entry whose data pages were still only
in the page cache. A subsequent restore scan would read a corrupt or
zero-length manifest and miscount surviving sessions.

## Why it matters

The trash manifest is the source of truth for which sessions a batch contains.
Silent data loss here causes a restore to silently skip sessions the user
expects to recover. The bug is rare (requires a crash in a narrow window) but
silent and unrecoverable without manual intervention.

## What changed (motivation → approach → change)

Root cause: the tmp-write path called `os.replace` immediately after closing
the file handle — no flush, no fsync.

`atomic_write(path, content, fsync=True)` already implements the correct
sequence: write to tmp, call `os.fdatasync`, then `replace_with_retry`
(which adds a Windows-safe retry loop around `os.replace`). The fix removes
the hand-rolled tmp-file plumbing from `_rewrite_manifest` and delegates to
`atomic_write` with `fsync=True`.

No behaviour change on the happy path (same tmp → replace sequence). On
Windows the caller now benefits from `replace_with_retry`'s backoff, which
the old `os.replace` lacked.

Deferred / not in this PR (gated or design work):
- Directory fsync (fsync of the parent directory after replace) — design
  decision still open in #6291.
- Cross-filesystem moves and all other sub-claims in #6291 beyond this slice.

## Tests

`test_rewrite_fsyncs_before_publishing_manifest`
(`TestManifestPersistenceFailure`) — patches `atomic_write.os.fsync` and
`atomic_write.replace_with_retry`, calls `_rewrite_manifest`, then asserts:
1. `fsync` appears in the event list before `replace` (ordering invariant).
2. The written manifest round-trips to the expected header + entries lines
   (output-preservation invariant).

Red-before verification: running the test against the unpatched production
code produces `ValueError: 'fsync' is not in list` because `os.replace` was
called directly with no fsync. The test passes only after the fix.

84 existing manifest/trash tests continue to pass.

## Manual verification

N/A — unit coverage sufficient. The fsync ordering and replace semantics are
both verified by the added test; there is no user-visible UI surface.

## Related Issues

Part of #6291 (mechanical `_rewrite_manifest` sub-claim only; directory fsync
and other sub-claims remain gated/design work)

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
