### PR TITLE
fix(apps): let the official catalog's repos reach the blob proxy

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -810,6 +810,22 @@ independently load-bearing:
   (scheme/host case-folded, path case preserved); a different-repo name
   collision keeps the seed, so a republished document cannot silently re-home
   an app to a new repository under a familiar name.
+- **Its repos reach the blob proxy, from process memory only.** A catalog row's
+  own icon and hero come from the CDN (`iconRef`/`heroRef`), but the store's
+  detail page and the Library card read the INSTALLED manifest's repo-relative
+  `iconPath` / `heroImageDetail` / `screenshots` — which the catalog publishes no
+  equivalent of — and every one of those resolves to an `/api/apps/blob` URL. So
+  `known_registry_repos` unions in `official_catalog.vouched_repos()`, without
+  which an app whose ONLY listing is official had all of that art refused 403.
+  The snapshot is written by `fetch_inventory_entries` alone and lives in process
+  memory, never read from the cache: an allowlist entry makes the gateway CLONE a
+  URL, which is the coordinate-shaped class the bullet above refuses to take from
+  an agent-writable file. A failed fetch keeps the previous snapshot rather than
+  clearing it — a CDN blip must not start 403ing art on an already-listed row.
+  This admits the repo to the membership test and nothing more: the clone-host
+  trust gate still applies unchanged, and `_repo_key_owner_count` enumerates the
+  bundled and external sources itself, so a catalog-only repo counts zero owners
+  and can never take the credential carve-out.
 
 **Execution consent is repository-bound for new grants.** Registry and installed
 app responses carry a server-overwritten `trustRepository`: the normalized clone

--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -822,6 +822,13 @@ independently load-bearing:
   URL, which is the coordinate-shaped class the bullet above refuses to take from
   an agent-writable file. A failed fetch keeps the previous snapshot rather than
   clearing it — a CDN blip must not start 403ing art on an already-listed row.
+  A cold load can outrun the warmup: the Library card list gates only on the
+  installed-apps query (a local read) while the catalog fetch rides the store
+  listing, so its `<img>` requests can reach the gate first and an `<img>` does
+  not retry a 403. That first paint is the residual, against a prior state where
+  the art was refused on every load; closing it needs the render gated on the
+  store listing or a second non-network source for the allowlist, both in a
+  different layer.
   This admits the repo to the membership test and nothing more: the clone-host
   trust gate still applies unchanged, and `_repo_key_owner_count` enumerates the
   bundled and external sources itself, so a catalog-only repo counts zero owners

--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -588,11 +588,17 @@ def _remember_vouched_repos(entries: list[dict[str, Any]]) -> None:
 def vouched_repos() -> frozenset[str]:
     """Clone URLs the catalog vouched for, for the ``/api/apps/blob`` SSRF gate.
 
-    Empty until a fresh catalog fetch has succeeded in this process, which is the
-    ordering that matters in practice: the store listing that renders a blob URL
-    performs that fetch before the browser requests the bytes. A surface that
-    somehow renders one first degrades to today's 403 for that one request, never
-    to a widened gate.
+    Empty until a fresh catalog fetch has succeeded in this process, and a cold
+    load CAN outrun it: the Library card list gates only on the installed-apps
+    query (``GET /api/apps``, a local read) while the catalog fetch rides the
+    separate store listing, so its ``<img>`` requests can reach the gate first.
+    Such a request 403s and an ``<img>`` does not retry, so that art stays missing
+    until the next load. Still strictly better than the state this replaces, where
+    a catalog-only app's art was refused on EVERY load rather than the first one
+    after a start — closing the window needs either the render gated on the store
+    listing or a second, non-network source for the allowlist, both of which are
+    changes to a different layer than this one. Whatever else happens, an unwarmed
+    snapshot degrades to a refusal, never to a widened gate.
     """
     return _VOUCHED_REPOS
 

--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -546,7 +546,55 @@ def fetch_inventory_entries() -> list[dict[str, Any]]:
     if problem is not None:
         raise CatalogUnavailable(problem)
     assert isinstance(doc, dict)  # narrowed by _envelope_error
-    return [a for a in doc["apps"] if isinstance(a, dict)]
+    entries = [a for a in doc["apps"] if isinstance(a, dict)]
+    _remember_vouched_repos(entries)
+    return entries
+
+
+#: Clone URLs the catalog vouched for on the most recent SUCCESSFUL fresh fetch.
+#:
+#: Process memory, deliberately, and rebound rather than mutated so a reader gets a
+#: consistent immutable snapshot without a lock. The blob proxy's SSRF gate reads
+#: this from a per-request worker thread, so it must answer without touching the
+#: network; and it must NOT come from the on-disk cache, which is agent-writable.
+#: The distinction this module already draws is the one that applies: a cached row
+#: may supply DISPLAY COPY for a row that exists anyway, and may never supply
+#: anything that makes the gateway reach a host. An allowlist entry is the second
+#: kind — planting one would buy an attacker a clone of a URL of their choosing —
+#: so it is populated only here, from a document TLS attributed to our own domain.
+_VOUCHED_REPOS: frozenset[str] = frozenset()
+
+
+def _remember_vouched_repos(entries: list[dict[str, Any]]) -> None:
+    """Record the clone URLs *entries* vouch for, for :func:`vouched_repos`.
+
+    Derived through :func:`inventory` rather than off ``entry["source"]`` directly,
+    so only a URL that already passed ``_coordinates``' validation (https, no
+    userinfo, no control characters) can enter the set — one validator, not two.
+
+    Only ever called after a fresh document validated. A FAILED fetch leaves the
+    previous snapshot in place instead of clearing it: the art on an already-listed
+    row must not start 403ing because the CDN blipped, and a stale allowlist entry
+    grants nothing a fresh one did not already grant.
+    """
+    global _VOUCHED_REPOS
+    _VOUCHED_REPOS = frozenset(
+        row["repo"]
+        for row in inventory(entries)
+        if isinstance(row.get("repo"), str) and row["repo"]
+    )
+
+
+def vouched_repos() -> frozenset[str]:
+    """Clone URLs the catalog vouched for, for the ``/api/apps/blob`` SSRF gate.
+
+    Empty until a fresh catalog fetch has succeeded in this process, which is the
+    ordering that matters in practice: the store listing that renders a blob URL
+    performs that fetch before the browser requests the bytes. A surface that
+    somehow renders one first degrades to today's 403 for that one request, never
+    to a widened gate.
+    """
+    return _VOUCHED_REPOS
 
 
 def inventory_for_install(name: str) -> dict[str, Any] | None:

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -4039,16 +4039,30 @@ def _external_registry_repos() -> set[str]:
 def known_registry_repos() -> set[str]:
     """Repo names trusted by the ``/api/apps/blob`` SSRF gate.
 
-    Union of the bundled registry and the user's external (federated)
-    registries — external-registry apps resolve an ``/api/apps/blob`` iconUrl,
-    so their repos must be allowlisted here or the App Store icon 403s.
+    Union of the bundled registry, the user's external (federated) registries, and
+    the official catalog's vouched clone URLs — each of these serves rows whose art
+    resolves to an ``/api/apps/blob`` URL, so their repos must be allowlisted here
+    or the App Store icon 403s.
+
+    The catalog half exists because an app listed ONLY in the official catalog is
+    the intended happy path and used to be the one that broke: a catalog row
+    supplies its icon and hero from the CDN, but the store's own detail page and
+    the Library card read the INSTALLED manifest's repo-relative ``iconPath`` /
+    ``screenshots`` — which the catalog publishes no equivalent of — and every one
+    of those goes through the blob proxy. With the catalog absent from this union,
+    an app whose only listing is official had all of that art refused.
+
+    ``vouched_repos`` is process memory populated only by a FRESH catalog fetch,
+    never by the agent-writable cache: an allowlist entry makes the gateway reach a
+    host, which is the class this module refuses to take from a local file.
     """
     bundled = {
         _strip_git_target_userinfo(e["repo"])
         for e in _load_registry_file()
         if isinstance(e.get("repo"), str) and e["repo"]
     }
-    return bundled | _external_registry_repos()
+    catalog = {_strip_git_target_userinfo(r) for r in official_catalog.vouched_repos()}
+    return bundled | _external_registry_repos() | catalog
 
 
 # ---------------------------------------------------------------------------

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1134,8 +1134,18 @@ def _no_live_catalog_network(monkeypatch: pytest.MonkeyPatch):
     refusal rather than failing the test with this message. Like
     ``_no_release_feed_network`` above, this is a NETWORK guard first and a
     diagnostic second.
+
+    It also pins the module's ``_VOUCHED_REPOS`` snapshot empty per test. That set
+    is PROCESS memory written by a successful ``fetch_inventory_entries``, and it
+    feeds ``registry.known_registry_repos`` — the ``/api/apps/blob`` SSRF gate — so
+    a test that drives a fetch to success would otherwise hand every later test in
+    the worker a wider allowlist than it set up. Reset here rather than in a second
+    autouse fixture because this one already resolves the module, and an autouse
+    fixture's cost is paid by all ~26k tests.
     """
     from kiro_crew.apps import official_catalog
+
+    monkeypatch.setattr(official_catalog, "_VOUCHED_REPOS", frozenset(), raising=True)
 
     original = official_catalog._open_catalog
 

--- a/test/test_apps_registry_coverage.py
+++ b/test/test_apps_registry_coverage.py
@@ -1351,6 +1351,35 @@ class TestRepoLookups:
         )
         assert registry.known_registry_repos() == {"core/a", "ext/b"}
 
+    def test_known_repos_include_the_catalog_vouched_urls(self, monkeypatch, cache_dir):
+        """An app listed ONLY in the official catalog is the intended happy path, and
+        was the one whose blob-served art 403'd: the catalog publishes no equivalent
+        of the manifest's ``screenshots``/``heroImageDetail``, so the detail page and
+        the Library card read them off the installed manifest and every one of those
+        goes through the blob proxy."""
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        _config_with(monkeypatch, [])
+        monkeypatch.setattr(
+            registry.official_catalog,
+            "vouched_repos",
+            lambda: frozenset({"https://github.com/octocat/some-app"}),
+        )
+        assert registry.known_registry_repos() == {"https://github.com/octocat/some-app"}
+
+    def test_a_vouched_url_is_stripped_of_userinfo_like_the_other_sources(
+        self, monkeypatch, cache_dir
+    ):
+        """Same normalization as the bundled and external halves, or the same repo
+        admitted by two spellings compares unequal to the handler's own query value."""
+        monkeypatch.setattr(registry, "_load_registry_file", lambda: [])
+        _config_with(monkeypatch, [])
+        monkeypatch.setattr(
+            registry.official_catalog,
+            "vouched_repos",
+            lambda: frozenset({"https://user:pw@github.com/octocat/some-app"}),
+        )
+        assert registry.known_registry_repos() == {"https://github.com/octocat/some-app"}
+
 
 class TestSourceStrings:
     def test_is_registry_source(self):

--- a/test/test_catalog_inventory.py
+++ b/test/test_catalog_inventory.py
@@ -1623,3 +1623,103 @@ class TestPinnedInstallRefusals:
         assert seen["git_url"] == URL
         # The pin must reach BOTH fetch layers: the manifest preflight and the clone.
         assert manifest_seen.get("commit") == SHA
+
+
+class TestVouchedRepos:
+    """The catalog's contribution to the ``/api/apps/blob`` SSRF gate.
+
+    An allowlist entry is the kind of value this module refuses to take from a
+    local file: it makes the gateway CLONE a URL. So the whole point of this
+    snapshot is WHERE it may come from, and every test here is about that rather
+    than about the set's contents.
+    """
+
+    def test_a_fresh_fetch_records_the_urls_it_vouched_for(self, monkeypatch):
+        monkeypatch.setattr(oc, "_read_cache", lambda: None)
+        monkeypatch.setattr(
+            oc,
+            "fetch_document",
+            lambda url, *a, **k: {"schemaVersion": 1, "apps": [catalog_git()]},
+        )
+        oc.fetch_inventory_entries()
+        assert oc.vouched_repos() == frozenset({URL})
+
+    def test_the_agent_writable_cache_can_never_introduce_one(self, monkeypatch):
+        """The reason the snapshot is process memory rather than a cache read.
+
+        ``_read_cache`` is a file the agent's own tools can write, so a planted entry
+        there must not become a host the blob proxy will reach. The fetch SUCCEEDS
+        here on purpose: a test where it fails never reaches the recording line at
+        all, so it cannot tell a cache read from a fetch read.
+        """
+        planted = {
+            "schemaVersion": 1,
+            "apps": [
+                catalog_git(
+                    name="planted",
+                    source={"type": "git", "url": "https://evil.example/x", "ref": SHA},
+                )
+            ],
+        }
+        monkeypatch.setattr(oc, "_read_cache", lambda: planted)
+        monkeypatch.setattr(
+            oc,
+            "fetch_document",
+            lambda url, *a, **k: {"schemaVersion": 1, "apps": [catalog_git()]},
+        )
+        oc.fetch_inventory_entries()
+        assert oc.vouched_repos() == frozenset({URL}), "the FETCHED document decides"
+        assert "https://evil.example/x" not in oc.vouched_repos()
+
+    def test_a_failed_fetch_keeps_the_previous_snapshot(self, monkeypatch):
+        """A CDN blip must not start 403ing the art on an already-listed row, and a
+        stale entry grants nothing a fresh one did not already grant."""
+        monkeypatch.setattr(oc, "_read_cache", lambda: None)
+        monkeypatch.setattr(
+            oc,
+            "fetch_document",
+            lambda url, *a, **k: {"schemaVersion": 1, "apps": [catalog_git()]},
+        )
+        oc.fetch_inventory_entries()
+        monkeypatch.setattr(oc, "fetch_document", lambda url, *a, **k: None)
+        monkeypatch.setattr(oc, "_write_failure", lambda: None)
+        with pytest.raises(oc.CatalogUnavailable):
+            oc.fetch_inventory_entries()
+        assert oc.vouched_repos() == frozenset({URL})
+
+    def test_an_entry_whose_coordinates_do_not_validate_vouches_for_nothing(self, monkeypatch):
+        """Routed through ``inventory`` so one validator decides, not two: a URL that
+        cannot supply install coordinates must not become a reachable host either."""
+        monkeypatch.setattr(oc, "_read_cache", lambda: None)
+        monkeypatch.setattr(
+            oc,
+            "fetch_document",
+            lambda url, *a, **k: {
+                "schemaVersion": 1,
+                # http:// is refused by `_coordinates`, so `inventory` drops the row.
+                "apps": [catalog_git(source={"type": "git", "url": "http://plain.example/x", "ref": SHA})],
+            },
+        )
+        oc.fetch_inventory_entries()
+        assert oc.vouched_repos() == frozenset()
+
+    def test_the_snapshot_is_replaced_not_accumulated(self, monkeypatch):
+        """A URL the catalog has since dropped must stop being a reachable host."""
+        monkeypatch.setattr(oc, "_read_cache", lambda: None)
+        monkeypatch.setattr(
+            oc,
+            "fetch_document",
+            lambda url, *a, **k: {"schemaVersion": 1, "apps": [catalog_git()]},
+        )
+        oc.fetch_inventory_entries()
+        other = "https://github.com/org/other-app"
+        monkeypatch.setattr(
+            oc,
+            "fetch_document",
+            lambda url, *a, **k: {
+                "schemaVersion": 1,
+                "apps": [catalog_git(name="other", source={"type": "git", "url": other, "ref": SHA})],
+            },
+        )
+        oc.fetch_inventory_entries()
+        assert oc.vouched_repos() == frozenset({other})


### PR DESCRIPTION
An app whose only listing is the **official catalog** — the intended happy path —
was the one whose artwork silently 403'd.

## What broke

A catalog row supplies its own icon and hero from the CDN (`iconRef` / `heroRef`).
But the store's **detail page** and the **Library card** read the *installed*
manifest's repo-relative `iconPath` / `heroImageDetail` / `screenshots`, which the
catalog publishes no equivalent of — `official_catalog.inventory()` / `annotate()`
map only `iconRef`, `iconRefDark`, `heroRef`. Every one of those paths resolves to
an `/api/apps/blob` URL, and `InstalledAppCard` never consults the store row at
all:

```ts
const artRepo = m?.repo || app.sourceUrl || ''
const iconUrl = manifestArt(m?.iconUrl, artRepo) || manifestArt(m?.iconPath, artRepo)
```

`known_registry_repos`, the blob proxy's SSRF gate, unioned only the bundled seed
and the user's external registries. A catalog-only app is in neither, so the gate
answered `repo not in registry` (403) for its icon, its detail hero, and every
screenshot.

Observed end to end on a real install: an app moved from a user-added registry
into the official catalog lost its store banner, its screenshots, and its Library
icon at the exact moment the user removed their own registry — that listing had
been the only thing keeping its repo in the union. Its blob cache still holds the
bytes from when it worked.

## The change

Union in the catalog's clone URLs, from a snapshot written **only** by
`fetch_inventory_entries` (the fresh HTTPS fetch) and held in **process memory**.

Deliberately *not* read from the on-disk cache. That file is agent-writable, and
an allowlist entry makes the gateway **clone a URL** — the coordinate-shaped class
this module already refuses to take from a local file. The module's own rule is the
one that applies: a cached document may re-dress a row that exists anyway, and may
never supply anything that makes the gateway reach a host.

A failed fetch keeps the previous snapshot rather than clearing it: a CDN blip must
not start 403ing the art on a row that is already listed, and a stale entry grants
nothing a fresh one did not already grant.

**This admits the repo to the membership test and nothing more.**

- The **clone-host trust gate** (`is_clone_host_trusted`) applies unchanged — a
  catalog repo on a non-public-forge host still fails closed.
- `_repo_key_owner_count` enumerates the bundled and external sources itself, so a
  catalog-only repo counts **zero** owners, never "exactly one" — it can never take
  the owner-designated credential carve-out. Its clone stays anonymous + strict
  sandbox.
- The **external-registry half is untouched**; the diff on `registry.py` is the
  docstring plus one `| catalog` term.

## Trust basis, by source

| Source | Authorized by | Read from | Agent-writable |
|---|---|---|---|
| bundled seed | ships in the wheel | package file | no |
| user's external registry | the owner typed the URL into config | index sync cache | **yes** (pre-existing) |
| official catalog (new) | first-party doc, TLS to `apps.crew.kiro.dev` | fresh-fetch-only process memory | no |

The middle row is a pre-existing asymmetry, left alone on purpose: it has its own
authorization basis (an explicit owner opt-in) that the catalog cannot borrow, and
changing it would turn this from "add a missing source" into "rework the gate's
trust model".

## Verification

Six mutations, each killed by its intended test:

| Mutation | Reddens |
|---|---|
| drop `\| catalog` from the union | both new gate tests |
| skip `_strip_git_target_userinfo` on the vouched URLs | the userinfo test |
| record from `_read_cache()` instead of the fetched doc | the agent-writable-cache test |
| clear the snapshot before each fetch | the failed-fetch test |
| bypass `inventory()` and read `source.url` directly | the invalid-coordinates test |
| accumulate instead of replace | the replaced-not-accumulated test |

The cache test was **inert on the first attempt** — it asserted on a path where
the fetch fails, so the recording line never executed and it could not tell a
cache read from a fetch read. Rewritten to let the fetch succeed while the cache
holds a different planted URL, which is what actually kills that mutation.

`test/conftest.py` pins the snapshot empty per test in the existing autouse
catalog-network fixture: it is process memory feeding an SSRF gate, so a test that
drives a fetch to success would otherwise hand every later test in the worker a
wider allowlist than it set up.

Local: `isort` / `flake8` clean, `mypy` clean over 1166 files, `black` clean
(`official_catalog.py` is outside the baseline), `docs-lint` clean, and 807 passed
across `test_catalog_inventory.py`, `test_apps_registry_coverage.py`,
`test_external_registry.py`, `test_apps_routes_coverage.py`. The full suite is left
to CI.

Spec updated in the same commit — `docs/system-specs/modules/app-kit-platform.md`
§14 gains a posture bullet for this, next to the cache rule it inherits.

**Why no screenshot:** backend-only; no file under `website/` changed. The visible
effect is an image that already had markup rendering instead of 403ing, and
capturing it needs a published catalog entry for a real third-party app, which no
isolated instance can stand up.
