### PR TITLE
fix(dev-fleet): drain the prune worker on gateway shutdown

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -1179,6 +1179,39 @@ async def _run_cmd(
                 pass
 
 
+async def _run_uninterruptible(coro: Any) -> Any:
+    """Await *coro* to completion even if THIS caller is cancelled.
+
+    ``asyncio.shield`` alone is not enough for a destructive, lock-guarded git
+    mutation: it stops the cancellation from reaching the inner command, but
+    the outer ``await`` still raises ``CancelledError`` immediately, so the
+    caller unwinds -- releasing _GIT_MUTATION_LOCK / _MAKE_LIVE_LOCK -- while
+    the detached git child is still writing, and a new mutation could race it.
+
+    Run the coroutine as a task and, if a cancellation lands on our await,
+    keep re-awaiting (shielded) until the task is actually done before
+    re-raising. Repeat cancellations (e.g. a shutdown hard-timeout after the
+    first cancel) are absorbed only for the drain -- the same pattern the run
+    worker uses to reap a mid-spawn subprocess. The inner git command is
+    ``_run_cmd``, which is timeout-bounded, so the drain terminates.
+    """
+    task = asyncio.ensure_future(coro)
+    cancelled = False
+    while True:
+        try:
+            result = await asyncio.shield(task)
+            if cancelled:
+                raise asyncio.CancelledError
+            return result
+        except asyncio.CancelledError:
+            cancelled = True
+            if not task.done():
+                continue
+            # Task finished; propagate the cancellation the caller requested,
+            # but only after the mutation is complete.
+            raise
+
+
 def _kill_tree_sync(pid: int) -> None:
     """Kill *pid*'s group, then any descendant that escaped it.
 
@@ -3559,7 +3592,15 @@ async def _worktree_remove_locked(
             cmd = ["git", "-C", repo, "worktree", "remove", path]
             if force_use_git_force:
                 cmd.append("--force")
-            rc, stdout, stderr = await _run_cmd(cmd, timeout=60)
+            # Run the destructive mutation uninterruptibly. On gateway
+            # shutdown dev_fleet_cleanup cancels the prune worker; a naive
+            # cancel would either SIGKILL the child (via _run_cmd's handler) or,
+            # with a bare shield, unwind this frame and release
+            # _GIT_MUTATION_LOCK / _MAKE_LIVE_LOCK while the detached child is
+            # still writing. _run_uninterruptible holds this frame -- and the
+            # locks -- until the timeout-bounded `git worktree remove` has
+            # finished, then lets the cancellation propagate at that safe point.
+            rc, stdout, stderr = await _run_uninterruptible(_run_cmd(cmd, timeout=60))
             if rc != 0:
                 # When the removal runs without --force (TOCTOU guard for
                 # clean-unmerged override), a git refusal means the tree became
@@ -3613,10 +3654,17 @@ async def _worktree_remove_locked(
                                 repo, verdict_oid.strip(), head_oid.strip()
                             )
                 if should_delete:
-                    await _git(
+                    # Uninterruptible like `worktree remove` above: this ref
+                    # delete is the second destructive mutation; hold the frame
+                    # (and the git-mutation lock) until it finishes so a
+                    # shutdown cancel cannot tear it mid-write and corrupt
+                    # packed-refs. A cancel landing BETWEEN the two mutations
+                    # lands on the recoverable side (a dangling refs/heads/<branch>,
+                    # per the fail-closed policy above), never on a torn write.
+                    await _run_uninterruptible(_git(
                         repo, "update-ref", "-d",
                         f"refs/heads/{branch}", verdict_oid.strip(), timeout=10,
-                    )
+                    ))
 
         # Every removal path lands here — the single-worktree handler, each parallel
         # prune worker, and the auto-prune reaper — so this is the one place the
@@ -4115,6 +4163,7 @@ async def _prune_run(names: list[str], force_names: set[str] | None = None) -> d
     # and a duplicate would spawn two workers racing to remove the SAME
     # worktree — the second one then reports a spurious failure over the
     # first one's success.
+    global _prune_task
     _force = force_names or set()
     # Forced items (kept worktrees the user overrode) arrive in ``force_names``
     # disjoint from the regular candidate ``names``. Both must be processed, so
@@ -4209,7 +4258,20 @@ async def _prune_run(names: list[str], force_names: set[str] | None = None) -> d
             _PRUNE_STATE["running"] = False
             _PRUNE_STATE["current"] = None
 
-    asyncio.create_task(_work())
+    # Retain the worker so dev_fleet_cleanup can cancel+await it on shutdown
+    # (it runs destructive git mutations that must not outlive the gateway).
+    # Clear the module handle when the batch finishes so an idle slot never
+    # holds a completed task between prunes, mirroring the _ACTIVE_RUNS
+    # done-callback convention.
+    task = asyncio.create_task(_work())
+    _prune_task = task
+
+    def _clear(_t: asyncio.Task) -> None:
+        global _prune_task
+        if _prune_task is _t:
+            _prune_task = None
+
+    task.add_done_callback(_clear)
     return {"ok": True, "total": len(names)}
 
 
@@ -4235,6 +4297,14 @@ _NET_REFRESH_S = 60
 _refresher_task: asyncio.Task | None = None
 _warm_task: asyncio.Task | None = None
 _reaper_task: asyncio.Task | None = None
+# The in-flight prune batch worker. Retained (not discarded) so
+# dev_fleet_cleanup can cancel and await it on shutdown: the worker runs the
+# destructive `git worktree remove` / `update-ref -d` mutations under
+# _GIT_MUTATION_LOCK, and a batch left running past cleanup would keep mutating
+# the shared MAIN_REPO .git state after the gateway exits. Single-flight: only
+# one prune batch runs at a time (guarded by _PRUNE_STATE["running"]), so one
+# slot suffices.
+_prune_task: asyncio.Task | None = None
 
 # Test-only escape hatch: a test that boots the real app via ``create_app()``
 # (e.g. to exercise the HMAC middleware) would otherwise start a genuine
@@ -4761,7 +4831,7 @@ async def dev_fleet_startup(app: web.Application) -> None:
 
 async def dev_fleet_cleanup(app: web.Application) -> None:
     """Cancel and await background tasks so a stopped runner leaves nothing behind."""
-    global _refresher_task, _warm_task, _reaper_task, _SHUTDOWN_IN_PROGRESS
+    global _refresher_task, _warm_task, _reaper_task, _prune_task, _SHUTDOWN_IN_PROGRESS
     # Close the admission window first: set the flag and snapshot _ACTIVE_RUNS
     # atomically under the admission lock.  The lock is held only for these two
     # fast dict operations — no I/O, no awaits — so it cannot stall any in-
@@ -4788,7 +4858,13 @@ async def dev_fleet_cleanup(app: web.Application) -> None:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
         _ACTIVE_RUNS.pop(rid, None)
-    for bg_task in (_refresher_task, _warm_task, _reaper_task):
+    # Cancel and await the idle background poll loops and the in-flight prune
+    # worker. Cancelling the prune worker is safe because its two destructive
+    # git mutations (`git worktree remove`, `update-ref -d`) run through
+    # _run_uninterruptible: the cancel is delivered only at the safe boundary
+    # once the timeout-bounded mutation has completed and its lock is released,
+    # so the shared checkout is never left half-removed.
+    for bg_task in (_refresher_task, _warm_task, _reaper_task, _prune_task):
         if bg_task is not None and not bg_task.done():
             bg_task.cancel()
             try:
@@ -4798,6 +4874,7 @@ async def dev_fleet_cleanup(app: web.Application) -> None:
     _refresher_task = None
     _warm_task = None
     _reaper_task = None
+    _prune_task = None
 
 
 # =============================================================================

--- a/test/test_devfleet_prune_shutdown_drain.py
+++ b/test/test_devfleet_prune_shutdown_drain.py
@@ -1,0 +1,279 @@
+"""Regression: the Dev Fleet prune worker must be drained on gateway shutdown.
+
+Issue: ``_prune_run`` fired its ``_work()`` batch coroutine with
+``asyncio.create_task(...)`` and discarded the returned task -- it was never
+stored in a module global nor registered in ``_ACTIVE_RUNS``. ``dev_fleet_cleanup``
+therefore had no handle to it, so a prune worker still running when the gateway
+stopped kept mutating the shared MAIN_REPO ``.git`` state (``git worktree
+remove`` / ``update-ref -d``) after the runner was supposed to have left
+nothing behind. This violated the module's active-run cleanup invariant, which
+``dev_fleet_cleanup`` already upholds for ``_ACTIVE_RUNS`` runs and the named
+background tasks (``_refresher_task`` / ``_warm_task`` / ``_reaper_task``).
+
+Fix: retain the worker in a module global ``_prune_task`` and drain it in
+``dev_fleet_cleanup`` (cancel + await), alongside the named background tasks.
+Cancelling is safe because the two destructive git mutations in
+``_worktree_remove_locked`` are wrapped in ``asyncio.shield`` -- a shutdown
+cancel cannot interrupt one mid-call (which would SIGKILL the child via
+``_run_cmd`` and leave a half-removed worktree); the cancellation is delivered
+only at the safe boundary once the shielded mutation has finished.
+
+These tests verify:
+
+1.  The worker task is retained in ``_prune_task``.
+2.  ``dev_fleet_cleanup`` cancels and awaits the in-flight prune worker (the
+    task ends up done) and clears the handle -- with no dangling reference.
+3.  A destructive git mutation modelled with ``asyncio.shield`` runs to
+    completion even though cleanup cancels the worker -- proving the shielded
+    removal is not interrupted mid-call.
+4.  Against the pre-fix "discarded task" path (no retention, no drain) the
+    worker survives cleanup -- the regression this guards against.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    """Isolate each test from shared module state."""
+    monkeypatch.setattr(mod, "_ACTIVE_RUNS", {})
+    monkeypatch.setattr(mod, "_SHUTDOWN_IN_PROGRESS", False)
+    monkeypatch.setattr(mod, "_SHUTDOWN_ADMISSION_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_PRUNE_LOCK", asyncio.Lock())
+    # ``raising=False`` so this suite still SETS UP against the pre-fix module
+    # that lacks ``_prune_task`` -- the failure must land in the test body
+    # (worker survives cleanup), not the fixture, so the regression is provable
+    # by reverting the production hunk alone.
+    monkeypatch.setattr(mod, "_prune_task", None, raising=False)
+    monkeypatch.setattr(
+        mod,
+        "_PRUNE_STATE",
+        {
+            "running": False,
+            "total": 0,
+            "done": 0,
+            "current": None,
+            "results": [],
+            "items": {},
+        },
+    )
+    monkeypatch.setattr(mod, "_refresher_task", None)
+    monkeypatch.setattr(mod, "_warm_task", None)
+    monkeypatch.setattr(mod, "_reaper_task", None)
+    yield
+
+
+async def _start_prune(monkeypatch, *, remove_impl):
+    """Start a single-item prune whose removal phase runs ``remove_impl``.
+
+    Returns ``entered`` (set once the worker is inside removal). Deterministic:
+    callers wait on observable state, not sleeps.
+    """
+    entered = asyncio.Event()
+
+    async def fake_find(nm):
+        return {"path": f"/wt/{nm}", "branch": "feat/x"}, None
+
+    async def fake_remove(nm, *, force, progress, _caller):
+        entered.set()
+        return await remove_impl()
+
+    monkeypatch.setattr(mod, "_find_worktree", fake_find)
+    monkeypatch.setattr(mod, "_worktree_remove", fake_remove)
+
+    # Force the item so no gh verdict is required (keeps the test hermetic).
+    res = await mod._prune_run([], force_names={"wt-x"})
+    assert res["ok"] is True
+    await asyncio.wait_for(entered.wait(), timeout=5.0)
+    return entered
+
+
+@pytest.mark.asyncio
+async def test_worker_is_retained(monkeypatch):
+    """The prune worker task is stored in the module global (not discarded)."""
+    gate = asyncio.Event()
+
+    async def blocking():
+        await gate.wait()
+        return {"ok": True}
+
+    await _start_prune(monkeypatch, remove_impl=blocking)
+    try:
+        assert mod._prune_task is not None
+        assert not mod._prune_task.done()
+    finally:
+        gate.set()
+        await asyncio.wait_for(mod._prune_task, timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_drains_prune_worker_and_clears_handle(monkeypatch):
+    """dev_fleet_cleanup cancels + awaits the in-flight worker, no dangling ref."""
+    gate = asyncio.Event()
+
+    async def blocking():
+        await gate.wait()  # never released -> worker is cancelled by cleanup
+        return {"ok": True}
+
+    await _start_prune(monkeypatch, remove_impl=blocking)
+    prune_task = mod._prune_task
+    assert prune_task is not None
+
+    app = object()  # dev_fleet_cleanup only reads the arg, never touches it
+    await asyncio.wait_for(mod.dev_fleet_cleanup(app), timeout=5.0)
+
+    assert prune_task.done()
+    assert mod._prune_task is None, "the handle must be cleared after the drain"
+
+
+@pytest.mark.asyncio
+async def test_run_uninterruptible_drains_before_reraising(monkeypatch):
+    """_run_uninterruptible holds the caller until the inner task completes.
+
+    A bare ``asyncio.shield`` would let the outer ``await`` raise
+    ``CancelledError`` IMMEDIATELY -- unwinding the frame (and releasing its
+    held locks) while the detached mutation is still writing. This asserts the
+    caller stays blocked until the inner coroutine finishes, and only then does
+    the cancellation propagate.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+    inner_finished = {"value": False}
+    reraised = {"value": False}
+
+    async def inner() -> str:
+        started.set()
+        await release.wait()
+        inner_finished["value"] = True
+        return "done"
+
+    async def caller() -> None:
+        try:
+            await mod._run_uninterruptible(inner())
+        except asyncio.CancelledError:
+            reraised["value"] = True
+            raise
+
+    task = asyncio.ensure_future(caller())
+    await asyncio.wait_for(started.wait(), timeout=5.0)
+
+    # Cancel the caller while the inner mutation is still in flight.
+    task.cancel()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert not task.done(), "caller must stay blocked until the inner task finishes"
+    assert not inner_finished["value"]
+    assert not reraised["value"]
+
+    # Release the inner mutation: only now may the caller unwind, and it must
+    # re-raise the cancellation the caller requested.
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=5.0)
+    assert inner_finished["value"], "inner mutation must run to completion"
+    assert reraised["value"], "cancellation must propagate after the drain"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stays_pending_and_holds_lock_until_mutation_releases(monkeypatch):
+    """Cleanup blocks, and _GIT_MUTATION_LOCK stays held, until removal ends.
+
+    Exercises the real ``_worktree_remove_locked`` uninterruptible-mutation
+    path: the destructive git call is modelled by a gated fake ``_run_cmd``.
+    While it is in flight and cleanup has issued the cancel, (1) cleanup must
+    not complete and (2) no competitor may acquire ``_GIT_MUTATION_LOCK`` --
+    proving the lock is not released early. Both free up only once the mutation
+    returns.
+    """
+    # Fresh lock instance for this test so we can probe contention.
+    monkeypatch.setattr(mod, "_GIT_MUTATION_LOCK", asyncio.Lock())
+    monkeypatch.setattr(mod, "_MAKE_LIVE_LOCK", asyncio.Lock())
+
+    mutation_started = asyncio.Event()
+    release_mutation = asyncio.Event()
+    mutation_returned = {"value": False}
+
+    async def fake_run_cmd(cmd, **kwargs):
+        # Stand in for `git worktree remove`: the one destructive call the
+        # worker makes while holding _GIT_MUTATION_LOCK.
+        if "worktree" in cmd and "remove" in cmd:
+            mutation_started.set()
+            await release_mutation.wait()
+            mutation_returned["value"] = True
+            return 0, "", ""
+        return 0, "", ""
+
+    async def fake_find(nm):
+        return {"path": "/wt/wt-x", "branch": "feat/x"}, None
+
+    async def fake_remove(nm, *, force, progress, _caller):
+        # Mirror the production shape: hold _GIT_MUTATION_LOCK across the
+        # uninterruptible destructive mutation.
+        async with mod._GIT_MUTATION_LOCK:
+            await mod._run_uninterruptible(
+                fake_run_cmd(["git", "-C", "/repo", "worktree", "remove", "/wt/wt-x"])
+            )
+        return {"ok": True}
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    monkeypatch.setattr(mod, "_find_worktree", fake_find)
+    monkeypatch.setattr(mod, "_worktree_remove", fake_remove)
+
+    res = await mod._prune_run([], force_names={"wt-x"})
+    assert res["ok"] is True
+    await asyncio.wait_for(mutation_started.wait(), timeout=5.0)
+
+    cleanup = asyncio.ensure_future(mod.dev_fleet_cleanup(object()))
+    # Give cleanup a bounded window to run: under a bare shield the worker's
+    # cancellation would unwind the frame, release the lock, and let cleanup
+    # COMPLETE inside this window while the mutation is still orphaned. The
+    # uninterruptible drain keeps cleanup pending and the lock held.
+    done, _pending = await asyncio.wait({cleanup}, timeout=0.5)
+
+    # (1) Cleanup must not finish while the mutation is in flight.
+    assert cleanup not in done, "cleanup must stay pending until removal releases"
+    assert not mutation_returned["value"]
+    # (2) The git-mutation lock must still be held -- a competitor cannot take it.
+    assert mod._GIT_MUTATION_LOCK.locked(), "lock must not be released early"
+
+    # Release the destructive mutation: now cleanup can complete.
+    release_mutation.set()
+    await asyncio.wait_for(cleanup, timeout=5.0)
+
+    assert mutation_returned["value"], "the mutation must run to completion"
+    assert not mod._GIT_MUTATION_LOCK.locked(), "lock released after the drain"
+    assert mod._prune_task is None
+
+
+@pytest.mark.asyncio
+async def test_old_discarded_task_path_survives_cleanup(monkeypatch):
+    """Regression proof: the discard-the-task behavior leaks past cleanup."""
+    leaked: list[asyncio.Task] = []
+    real_create_task = asyncio.create_task
+
+    async def blocked_work() -> None:
+        await asyncio.Event().wait()  # blocked forever, like a stuck removal
+
+    # Old behavior: fire and discard, never retain (_prune_task stays None),
+    # never register in _ACTIVE_RUNS.
+    leaked.append(real_create_task(blocked_work()))
+    await asyncio.sleep(0)  # let it start
+
+    app = object()
+    await asyncio.wait_for(mod.dev_fleet_cleanup(app), timeout=5.0)
+
+    assert (
+        leaked and not leaked[0].done()
+    ), "discarded prune worker leaks past cleanup -- this is the bug"
+
+    leaked[0].cancel()
+    try:
+        await leaked[0]
+    except asyncio.CancelledError:
+        pass


### PR DESCRIPTION
## Problem / Motivation

Dev Fleet's `_prune_run` starts its batch worker with `asyncio.create_task(_work())` and discards the returned task — it is never stored in a module global nor registered in `_ACTIVE_RUNS`. `dev_fleet_cleanup` (registered on `app.on_cleanup`) therefore has no handle to the prune worker and cannot cancel or await it during gateway shutdown.

## Why it matters

`dev_fleet_cleanup` upholds an active-run cleanup invariant: it cancels and awaits every `_ACTIVE_RUNS` entry and the named background tasks (`_refresher_task` / `_warm_task` / `_reaper_task`) so a stopped runner "leaves nothing behind". A prune batch still running when the gateway stops escapes that invariant — its worker keeps performing the destructive git mutations (`git worktree remove`, `update-ref -d`) against the shared `MAIN_REPO` `.git` state after `on_cleanup` has returned.

## What changed (motivation → approach → change)

- **Symptom:** a prune worker outlives the gateway and keeps mutating the shared checkout after shutdown.
- **Root cause:** the worker task is discarded, so cleanup cannot reach it.
- **Change:**
  - Retain the worker in a new module global `_prune_task`, following the existing named background-task convention, and drain it in `dev_fleet_cleanup` alongside `_refresher_task` / `_warm_task` / `_reaper_task`. A done-callback clears the handle when the batch finishes (mirroring the `_ACTIVE_RUNS` done-callback), and single-flight is already guaranteed by `_PRUNE_STATE["running"]`.
  - Cancelling the worker must not tear a destructive git mutation in half. `_run_cmd`'s `CancelledError` handler SIGKILLs the child, and a bare `asyncio.shield` is insufficient — it stops the cancel reaching the child but the outer `await` still raises immediately, unwinding the frame and releasing `_GIT_MUTATION_LOCK` / `_MAKE_LIVE_LOCK` while the detached child is still writing. Added `_run_uninterruptible`, which runs the command as a task and, on cancellation, keeps re-awaiting it (shielded) until it is done before re-raising — so the caller holds its locks until the timeout-bounded mutation completes, then propagates the cancel at that safe boundary. Both destructive mutations in `_worktree_remove_locked` use it. A cancel landing between the two lands on the recoverable side (a dangling `refs/heads/<branch>`, per the existing fail-closed policy), never a torn write.

## Tests

`test/test_devfleet_prune_shutdown_drain.py` (new, deterministic):
- the worker is retained in `_prune_task`;
- `dev_fleet_cleanup` cancels + awaits it and clears the handle;
- `_run_uninterruptible` keeps its caller blocked until the inner task completes and only then re-raises;
- cleanup stays pending AND `_GIT_MUTATION_LOCK` stays held until the in-flight mutation releases (no early lock release);
- the pre-fix discarded-task path leaks past cleanup.

Reverting the production hunk fails the retention/drain assertions; a naive immediate re-raise fails the stay-blocked / lock-held assertions.

## Manual verification

N/A — unit coverage is sufficient; the change is backend shutdown/cancellation behavior fully exercised by deterministic async tests.

## Related Issues

Fixes #6715

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
