### PR TITLE
fix(auto-improvement): serialize the manual filed write under the ledger lock

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/ledger_admin.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/ledger_admin.py
@@ -42,10 +42,17 @@ import json
 import logging
 import os
 import re
-import threading
 import time
 from typing import Any
 
+# The ONE process-wide lock that serializes read → decide → append against the ledger
+# file, SHARED with the loop's own filing writer: :meth:`spine.ledger.Ledger.record`
+# acquires the SAME object, so an operator forget / purge / manual-filed / commit here
+# cannot interleave with the loop's `record()` on the same file (#6716). It lives in the
+# stdlib-only leaf :mod:`spine.ledger_lock` precisely so both layers share one object
+# without this module pulling the spine engine (the driver / agent runner / PR pipeline).
+# Aliased to the historical name so the four `with _LEDGER_LOCK:` sites read unchanged.
+from ..spine.ledger_lock import LEDGER_WRITE_LOCK as _LEDGER_LOCK
 from . import store
 
 logger = logging.getLogger(__name__)
@@ -85,10 +92,6 @@ _PR_URL_RE = re.compile(r"^https://[^\s]+/(?:pull|merge_requests)/\d+", re.IGNOR
 #: Anchored with ``\Z``, not ``$``: ``$`` also matches immediately BEFORE a trailing
 #: newline, so ``"abc\n"`` would pass and reach a path interpolation.
 _FP_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}\Z")
-
-#: Serializes read → decide → append against the ledger file. Module-level because
-#: the ledger is a process-wide singleton; the gateway runs these in worker threads.
-_LEDGER_LOCK = threading.Lock()
 
 #: Artifact families addressed by fingerprint. ``results/candidates/*`` is NOT here:
 #: those files are named after the ``cand_id``, not the fingerprint, so removing them
@@ -464,26 +467,88 @@ def record_committed(fp: str, *, branch: str, sha: str) -> bool:
         # `validate_fingerprint` RAISES on a bad shape rather than returning falsy.
         logger.warning("ledger: refusing to record a commit for a malformed fingerprint")
         return False
-    prior = {}
-    for record in latest_records():
-        if str(record.get("fp")) == safe_fp:
-            prior = record
-            break
+    with _LEDGER_LOCK:
+        kind, target = _prior_kind_target(_load_events(), safe_fp)
+        try:
+            _append_event(
+                {
+                    "fp": safe_fp,
+                    # Carried over so the row stays identifiable rather than becoming an
+                    # anonymous fingerprint in the timeline (as in `_purged_event`).
+                    "kind": kind,
+                    "target": target,
+                    "status": STATUS_COMMITTED,
+                    "cr": sha,
+                    "note": f"committed to {branch} ({sha})"[:200],
+                    "ts": time.time(),
+                }
+            )
+        except OSError as exc:
+            logger.error("ledger: could not record the commit of %s: %s", safe_fp, exc)
+            return False
+    return True
+
+
+def _prior_kind_target(events: list[dict[str, Any]], fp: str) -> tuple[str, str]:
+    """The ``kind`` and ``target`` from ``fp``'s most recent event, or empty strings.
+
+    Both are REQUIRED fields on ``spine.ledger.LedgerEntry``; a row missing either
+    raises ``TypeError`` inside ``_load()``'s torn-line handler and is silently dropped,
+    so every writer must carry them forward. Reading from the already-loaded ``events``
+    (rather than ``latest_records()``) keeps the read inside the caller's ``_LEDGER_LOCK``
+    critical section — one consistent read → decide → append, not a second file scan that
+    could observe a row a concurrent writer appended in between.
+    """
+    latest = _latest_event(events, fp)
+    if latest is None:
+        return "", ""
+    return str(latest.get("kind") or ""), str(latest.get("target") or "")
+
+
+def record_filed(fp: str, pr_ref: str) -> bool:
+    """Append a ``filed`` ledger row carrying a pull-request reference, under the lock.
+
+    The manual-draft path (``backend/routes.ledger_admin_record``) records a filed PR the
+    same way the loop's own filing does. It MUST share ``_LEDGER_LOCK`` with
+    :func:`forget` / :func:`purge`: those read the latest event, decide, and append while
+    holding the lock, so a filed write in a DIFFERENT lock domain can slip its row in
+    between a ``forget``'s read and its ``purged`` append. That interleaving lands
+    ``filed(real PR)`` then ``purged`` — last-write-wins makes ``purged`` current, which
+    hides the live pull request and re-opens the locus, so the loop drafts a SECOND PR for
+    a change already up for review. Serialized here, ``forget`` instead either runs before
+    this write (and this row supersedes its purge) or after it (and refuses on
+    ``has_pull_request``).
+
+    The reference goes in ``cr`` (never ``pr``) and ``kind``/``target`` are always present
+    for the reason in :func:`_purged_event`: ``LedgerEntry(**row)`` is a fixed-field
+    dataclass, so a row spelled ``pr`` or missing either field raises ``TypeError`` in
+    ``_load()``'s torn-line handler and the ``filed`` marker never enters the dedup index.
+    Readers accept both spellings, so the UI link still renders.
+
+    Returns True iff the row was written; a write failure is logged, never raised — the
+    pull request already exists, so a bookkeeping problem must not surface as an error the
+    operator might act on.
+    """
     try:
-        _append_event(
-            {
-                "fp": safe_fp,
-                # Carried over so the row stays identifiable rather than becoming an
-                # anonymous fingerprint in the timeline (as in `_purged_event`).
-                "kind": prior.get("kind") or "",
-                "target": prior.get("target") or "",
-                "status": STATUS_COMMITTED,
-                "cr": sha,
-                "note": f"committed to {branch} ({sha})"[:200],
-                "ts": time.time(),
-            }
-        )
-    except OSError as exc:
-        logger.error("ledger: could not record the commit of %s: %s", safe_fp, exc)
+        safe_fp = validate_fingerprint(fp)
+    except ValueError:
+        logger.warning("ledger: refusing to record a filed PR for a malformed fingerprint")
         return False
+    with _LEDGER_LOCK:
+        kind, target = _prior_kind_target(_load_events(), safe_fp)
+        try:
+            _append_event(
+                {
+                    "fp": safe_fp,
+                    "kind": kind,
+                    "target": target,
+                    "status": STATUS_FILED,
+                    "cr": pr_ref,
+                    "note": "manually drafted from the queued change",
+                    "ts": time.time(),
+                }
+            )
+        except OSError as exc:
+            logger.error("ledger: could not record the filed PR of %s: %s", safe_fp, exc)
+            return False
     return True

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import time
 from functools import wraps
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -945,59 +944,22 @@ async def _handle_draft_pr(request: web.Request) -> web.StreamResponse:
 
 
 def ledger_admin_record(fp: str, pr_ref: str) -> None:
-    """Append a ``filed`` ledger row carrying the pull-request reference.
+    """Record a manually-drafted ``filed`` pull request in the ledger.
 
-    Append-only rather than a rewrite: the ledger is the run's audit trail, and
-    the latest row for a fingerprint is what readers treat as current, so adding
-    a row records the new fact without mutating history.
+    Delegates to :func:`ledger_admin.record_filed`, which appends the row while holding
+    the module's ``_LEDGER_LOCK`` — the SAME lock ``forget`` / ``purge`` hold across their
+    read → decide → append. Sharing that one lock domain is load-bearing: a filed write
+    that appended outside it could land its row between a concurrent ``forget``'s read and
+    its ``purged`` append, and ``purged`` (last-write-wins) would then hide the just-filed
+    pull request and re-open the locus, so the loop drafts a SECOND PR for a change already
+    up for review. The helper also carries ``kind``/``target`` and writes ``cr`` (never
+    ``pr``) so the row survives ``spine.ledger.LedgerEntry(**row)`` and enters the dedup
+    index; see its docstring for why that shape matters.
 
-    The reference goes in ``cr``, and ``kind``/``target`` are always present, because
-    ``spine.ledger.Ledger._load()`` does ``LedgerEntry(**row)`` inside a bare
-    ``except: continue`` that exists to tolerate a torn final line. ``LedgerEntry`` is a
-    fixed-field dataclass with ``cr`` and REQUIRED ``kind``/``target``, so a row spelled
-    ``pr``, or one missing either field, raises ``TypeError`` and is silently discarded:
-    this ``filed`` marker would never enter the dedup index, and after the retry cooldown
-    the loop would re-discover the locus and draft a SECOND pull request for a change
-    already filed. ``backend/ledger_admin.py`` documents the same hazard for its purge
-    event, and ``_purged_event`` is the shape followed here. Readers accept both
-    spellings (``progress.read_findings``, ``prUrlOf``), so the UI link still renders.
+    A write failure is logged inside the helper and swallowed here: the pull request is
+    already published, so a bookkeeping miss must not surface as a caller error.
     """
-
-    row: dict[str, Any] = {
-        "fp": fp,
-        "status": "filed",
-        "cr": pr_ref,
-        "note": "manually drafted from the queued change",
-        "ts": time.time(),
-    }
-    path = store.ledger_path()
-    existing = ""
-    if path.exists():
-        try:
-            existing = path.read_text(encoding="utf-8")
-        except OSError:
-            existing = ""
-    # Preserve the target/kind from the finding's prior rows so the new row is
-    # still identifiable in the list view.
-    for line in reversed(existing.splitlines()):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            prior = json.loads(line)
-        except ValueError:
-            continue
-        if isinstance(prior, dict) and str(prior.get("fp") or "") == fp:
-            row.setdefault("kind", prior.get("kind") or "")
-            row.setdefault("target", prior.get("target") or "")
-            break
-    # Unconditionally, even when no prior row was found: `kind` and `target` are
-    # REQUIRED dataclass fields, so omitting them fails `LedgerEntry(**row)` exactly
-    # like the wrong key spelling would, and the row would be dropped just as silently.
-    row.setdefault("kind", "")
-    row.setdefault("target", "")
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(row) + "\n")
+    ledger_admin.record_filed(fp, pr_ref)
 
 
 # ── per-PR watcher sessions ──────────────────────────────────────────────────
@@ -1381,6 +1343,7 @@ async def _handle_run_start(_request: web.Request) -> web.StreamResponse:
     repo or a wider budget than what the config endpoints allow. Building the driver
     is blocking (git, provider probe), so the whole call runs off the event loop.
     """
+
     # Read the config INSIDE the lock, together with the start it feeds. Read outside, a
     # retarget landing between the read and the start means the run operates on the repo
     # that was just replaced while the UI shows the new one. `_build_driver` re-enters the

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger.py
@@ -26,6 +26,8 @@ import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from .ledger_lock import LEDGER_WRITE_LOCK
+
 # The outcome statuses a finding can land on. Mirrors the source ledger so the
 # morning-collection step (``grep '"status": "filed"'``) is unchanged (M5).
 STATUS_SEEN = "seen"
@@ -279,7 +281,14 @@ class Ledger:
     def record(self, entry: LedgerEntry) -> None:
         if entry.ts == 0.0:
             entry.ts = time.time()
-        with self._lock:
+        # The process-wide ledger write lock, NOT this instance's own lock: the same
+        # file is written by the operator's forget / purge / manual-filed / commit
+        # paths in `backend.ledger_admin`, which hold `LEDGER_WRITE_LOCK` across their
+        # read → decide → append. Sharing one lock makes this append atomic against a
+        # concurrent `forget`'s read → decide → `purged`, so a just-filed row can no
+        # longer be superseded by a stale purge (#6716). `self._lock` still guards the
+        # in-memory `_seen` map for readers on this instance.
+        with LEDGER_WRITE_LOCK, self._lock:
             self._seen[entry.fp] = entry
             with self.path.open("a") as f:
                 f.write(json.dumps(asdict(entry)) + "\n")

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger_lock.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/ledger_lock.py
@@ -1,0 +1,53 @@
+"""The one process-wide lock that serializes every write to the dedup ledger file.
+
+The ledger (``store.ledger_path()`` → ``<workspace>/ledger.jsonl``) is a single
+append-only JSONL file, and it is written from THREE code paths that all run on
+gateway worker threads in one process:
+
+  * the loop's own filing — :meth:`spine.ledger.Ledger.record`, driven by
+    :mod:`spine.pr_pipeline` on the active-run worker thread;
+  * the operator's manual draft / commit — ``backend.ledger_admin.record_filed`` /
+    ``record_committed``;
+  * the operator's forget / purge — ``backend.ledger_admin.forget`` / ``purge``,
+    which read the latest event, DECIDE on it, and append, all as one step.
+
+``known()`` resolves a fingerprint by its LATEST event (last-write-wins). If any two
+of those paths hold DIFFERENT locks, their read → decide → append sequences
+interleave: a ``forget`` that read a ``QUEUED`` placeholder can append ``purged``
+AFTER a concurrent path appended the real ``filed(<pr-url>)`` row, so ``purged``
+wins, the pull request is hidden, and the loop drafts a second PR for a change
+already up for review (#6716). One lock shared by all three writers makes each
+sequence atomic against the others and removes the interleaving.
+
+WHY A DEDICATED LEAF MODULE, not a lock defined in ``spine.ledger`` or
+``backend.ledger_admin``: the lock must be the SAME object in both layers, but
+``backend.ledger_admin`` is deliberately kept off the spine engine (importing
+``spine`` eagerly loads the driver/agent-runner/PR-pipeline). This module imports
+only :mod:`threading`, so either layer can import it for the shared object without
+pulling the engine, and it belongs in ``spine`` because the ledger it guards is
+spine-owned durable state.
+
+WHY ``RLock``: :meth:`spine.ledger.Ledger.record` already serialized on the
+instance's own lock; folding that into a re-entrant process lock means a future
+caller that already holds it (a guarded helper calling another) cannot
+self-deadlock. It is only ever acquired for a bounded file append, never around a
+subprocess, network call, or a wait — so it cannot starve other writers.
+
+LOCK ORDERING: this is an INNER lock. The manual-draft route holds
+``commit.clone_lock`` (the clone-mutation lock) across its whole
+materialize → commit → draft sequence and only briefly takes this lock at the
+final ledger append; the reverse — taking ``clone_lock`` while holding this — never
+happens (neither ``spine.ledger`` nor ``ledger_admin`` imports ``commit``), so the
+two locks have a single consistent order and cannot deadlock. All acquisitions are
+on worker threads (``asyncio.to_thread`` for the operator paths, the run thread for
+the loop), never on the asyncio event loop.
+"""
+
+from __future__ import annotations
+
+import threading
+
+#: Serializes every read → decide → append against ``store.ledger_path()`` across
+#: all three writer paths. Module-level because the ledger file is process-wide
+#: shared state; the gateway runs these paths on worker threads.
+LEDGER_WRITE_LOCK = threading.RLock()

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_ledger_admin.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_ledger_admin.py
@@ -19,7 +19,8 @@ from typing import Any
 import pytest
 
 from kiro_crew.apps.builtins.auto_improvement.backend import ledger_admin as la
-from kiro_crew.apps.builtins.auto_improvement.backend import store
+from kiro_crew.apps.builtins.auto_improvement.backend import routes, store
+from kiro_crew.apps.builtins.auto_improvement.spine import ledger as spine_ledger
 
 REAL_PR = "https://github.com/o/r/pull/7"
 
@@ -148,8 +149,6 @@ class TestForget:
         so an event carrying an unexpected key is DROPPED, the fingerprint never
         enters the index as purged, and the locus stays deduped. The purge would look
         like it worked and change nothing."""
-        from kiro_crew.apps.builtins.auto_improvement.spine import ledger as spine_ledger
-
         _write_ledger(data_home, [_row("f1", "failed_gate")])
         assert spine_ledger.Ledger(store.ledger_path()).known("f1") is True
 
@@ -161,8 +160,6 @@ class TestForget:
     def test_status_purged_matches_the_spine_constant(self) -> None:
         """The literal here mirrors the spine's constant to avoid importing the whole
         engine on a request path. Pin them together so the mirror cannot drift."""
-        from kiro_crew.apps.builtins.auto_improvement.spine import ledger as spine_ledger
-
         assert la.STATUS_PURGED == spine_ledger.STATUS_PURGED
 
     def test_unknown_fingerprint_is_refused(self, data_home: Path) -> None:
@@ -577,9 +574,6 @@ class TestManualDraftRowSurvivesReload:
     """
 
     def test_filed_marker_enters_the_dedup_index(self, data_home: Path) -> None:
-        from kiro_crew.apps.builtins.auto_improvement.backend import routes
-        from kiro_crew.apps.builtins.auto_improvement.spine import ledger as spine_ledger
-
         # A prior soft-terminal row, as after an automatic draft failed (no gh/network).
         _write_ledger(data_home, [_row("f9", "error")])
         routes.ledger_admin_record("f9", "https://github.com/o/r/pull/7")
@@ -594,12 +588,212 @@ class TestManualDraftRowSurvivesReload:
     def test_row_is_loadable_even_with_no_prior_row(self, data_home: Path) -> None:
         """``kind``/``target`` are required, so they must be present unconditionally —
         not only on the path where a prior row supplied them."""
-        from kiro_crew.apps.builtins.auto_improvement.backend import routes
-        from kiro_crew.apps.builtins.auto_improvement.spine import ledger as spine_ledger
-
         store.ledger_path().parent.mkdir(parents=True, exist_ok=True)
         routes.ledger_admin_record("f10", "https://github.com/o/r/pull/8")
 
         reloaded = spine_ledger.Ledger(store.ledger_path())
         assert "f10" in reloaded._seen
         assert reloaded._seen["f10"].cr.endswith("/8")
+
+
+class TestManualFiledWriteSharesTheForgetLockDomain:
+    """The manual-draft ``filed`` write must serialize against ``forget`` under the
+    SAME ``_LEDGER_LOCK`` that ``forget`` / ``purge`` hold — not a different lock domain.
+
+    The regression this pins: a finding sits ``filed`` with a ``QUEUED:<fp>`` placeholder
+    (queued, no real pull request yet). A ``forget`` reads that placeholder and decides it
+    is safe to clear (``is_real_pr_reference`` is False), then appends ``purged``.
+    Concurrently the manual draft opens a real pull request and records a ``filed`` row
+    carrying its URL. When the two writes live in DIFFERENT lock domains they interleave
+    as ``filed(real PR)`` THEN ``purged`` — the later ``purged`` wins last-write-wins, so
+    ``known()`` reports the locus unknown, the findings list drops the row, and the next
+    discovery cycle drafts a SECOND pull request for a change already up for review.
+
+    Unifying both under ``_LEDGER_LOCK`` makes each caller's read→decide→append atomic:
+    ``forget`` runs either entirely before the filed write (then the filed write
+    supersedes the purge with the real PR) or entirely after it (then, seeing the real
+    PR, ``forget`` REFUSES with ``has_pull_request``). Both serialized outcomes leave the
+    real pull request as the current state; the interleaved one does not.
+
+    Determinism without sleeps: the ``forget`` thread is paused at its DECISION point
+    (right after it reads the ledger and before it appends ``purged``) and there released
+    the filed writer. If the writes share one lock, the filed writer is parked on
+    ``_LEDGER_LOCK`` — which ``forget`` still holds — so it cannot append until ``forget``
+    finishes and releases; the shared lock, not the test, orders them. If they do NOT
+    share the lock (the bug), the filed writer runs to completion inside ``forget``'s
+    critical section and lands its ``filed`` row BEFORE ``forget``'s ``purged`` — the
+    interleaving the invariant below rejects. A timeout bounds the pause so a fixed build
+    (where the writer is correctly blocked) never hangs.
+    """
+
+    def test_forget_and_manual_filed_write_do_not_interleave(
+        self, data_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A queued-but-not-yet-drafted finding: filed, reference is a QUEUED placeholder.
+        _write_ledger(data_home, [_row("fp1", "filed", cr="QUEUED:fp1")])
+
+        forget_decided = threading.Event()  # forget has read+decided, is about to append
+        filed_may_start = threading.Event()  # release the filed writer
+        filed_done = threading.Event()  # the filed writer's record() has returned
+
+        # Hook forget's decision point: `_purged_event` is built inside forget AFTER the
+        # read and BEFORE the append, while `_LEDGER_LOCK` is held. Releasing the filed
+        # writer here means it must contend for the lock against a holder that has already
+        # decided — exactly the window the bug exploited.
+        original_purged_event = la._purged_event
+
+        def _hooked_purged_event(prior: dict[str, Any], note: str) -> dict[str, Any]:
+            forget_decided.set()
+            filed_may_start.set()
+            # Wait for the filed writer to fully COMPLETE its record. On the BUGGY build it
+            # is not under this lock, so it runs to completion here and `filed_done` is set
+            # → forget then appends `purged` AFTER the real filed row (the interleaving).
+            # On the FIXED build it is blocked on the shared `_LEDGER_LOCK` that forget
+            # still holds, so `filed_done` never sets within the timeout, forget proceeds
+            # and releases the lock, and the filed row lands cleanly afterwards — no hang.
+            filed_done.wait(timeout=1.0)
+            return original_purged_event(prior, note)
+
+        monkeypatch.setattr(la, "_purged_event", _hooked_purged_event)
+
+        results: dict[str, Any] = {}
+
+        def _forget() -> None:
+            results["forget"] = la.forget("fp1")
+
+        def _filed() -> None:
+            filed_may_start.wait(timeout=5.0)
+            # Drive the PUBLIC route entry point, not the helper directly: it is what the
+            # dashboard's manual-draft path calls, and reverting the production fix returns
+            # it to a lock-free append — which is exactly what must turn this test red.
+            routes.ledger_admin_record("fp1", REAL_PR)
+            results["filed"] = True
+            filed_done.set()
+
+        threads = [threading.Thread(target=_forget), threading.Thread(target=_filed)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10.0)
+        assert not any(t.is_alive() for t in threads), "a writer deadlocked"
+        assert forget_decided.is_set(), "forget never reached its decision point"
+
+        # THE INVARIANT: the current state of fp1 must reflect the real pull request. A
+        # `purged` row sitting on top of the real `filed(REAL_PR)` row is the exact bug —
+        # it hides a live PR and re-opens the locus for duplicate drafting.
+        latest = {r["fp"]: r for r in la.latest_records()}["fp1"]
+        statuses = [r.get("status") for r in _events(data_home)]
+        assert latest["status"] == "filed", f"the manual filed PR was hidden; tail = {statuses}"
+        assert la.pr_reference(latest) == REAL_PR
+
+        # The dedup index agrees: the locus stays known, so no second PR is drafted.
+        reloaded = spine_ledger.Ledger(store.ledger_path())
+        assert reloaded.known("fp1") is True
+
+        # If forget ran AFTER the real PR was recorded, it must have REFUSED rather than
+        # purged — a forget that clears a locus with a live PR is itself the defect.
+        if results["forget"].get("ok"):
+            assert results["filed"] is True  # forget ran first; the filed write superseded
+            assert "purged" in statuses
+        else:
+            assert results["forget"]["reason"] == "has_pull_request"
+
+    def test_record_filed_is_a_public_shared_helper(self, data_home: Path) -> None:
+        """The manual filed write is a named ``ledger_admin`` helper, not a hand-rolled
+        append in the route — so it shares the module's lock and prior-row handling."""
+        _write_ledger(data_home, [_row("fp2", "seen")])
+        assert la.record_filed("fp2", REAL_PR) is True
+        latest = {r["fp"]: r for r in la.latest_records()}["fp2"]
+        assert latest["status"] == "filed"
+        assert la.pr_reference(latest) == REAL_PR
+        # kind/target carried from the prior row so the timeline row stays identifiable
+        # AND the spine dataclass load does not drop it.
+        reloaded = spine_ledger.Ledger(store.ledger_path())
+        assert "fp2" in reloaded._seen
+        assert reloaded._seen["fp2"].kind == "bug"
+        assert reloaded._seen["fp2"].target == "src/x.py::f"
+
+    def test_forget_cannot_hide_the_loops_own_in_run_filed_write(
+        self, data_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`forget`/`purge` must serialize against the LOOP'S OWN filing writer too —
+        ``spine.ledger.Ledger.record`` — not only the operator's manual write.
+
+        The loop files a finding by constructing a ``spine.ledger.Ledger`` on the same
+        ``store.ledger_path()`` and calling ``record()`` on a run worker thread (via
+        ``spine.pr_pipeline``). Before the shared lock, ``Ledger.record`` appended under the
+        instance's OWN ``self._lock`` — a third lock domain — so an operator ``forget``
+        concurrent with the loop filing that locus could still land ``filed(real PR)`` then
+        ``purged`` and re-open the locus for a duplicate PR. Both now hold
+        ``spine.ledger_lock.LEDGER_WRITE_LOCK``, so the sequences serialize.
+
+        Deterministic, no sleeps: ``forget`` is paused at its decision point (hooking
+        ``_purged_event``, built under the lock) and there releases the spine writer. If the
+        two share the lock, the spine ``record()`` is parked on ``LEDGER_WRITE_LOCK`` that
+        ``forget`` still holds and cannot append until ``forget`` finishes — the shared lock,
+        not the test, orders them (``spine_done`` times out, ``forget`` proceeds, no hang). If
+        they did NOT share it (the pre-fix third domain), ``record()`` runs to completion
+        inside ``forget``'s critical section and lands ``filed(real PR)`` before ``purged`` —
+        the interleaving the invariant rejects.
+        """
+        _write_ledger(data_home, [_row("fp3", "filed", cr="QUEUED:fp3")])
+
+        forget_decided = threading.Event()
+        spine_may_start = threading.Event()
+        spine_done = threading.Event()
+
+        original_purged_event = la._purged_event
+
+        def _hooked_purged_event(prior: dict[str, Any], note: str) -> dict[str, Any]:
+            forget_decided.set()
+            spine_may_start.set()
+            spine_done.wait(timeout=1.0)
+            return original_purged_event(prior, note)
+
+        monkeypatch.setattr(la, "_purged_event", _hooked_purged_event)
+
+        results: dict[str, Any] = {}
+
+        def _forget() -> None:
+            results["forget"] = la.forget("fp3")
+
+        def _loop_file() -> None:
+            spine_may_start.wait(timeout=5.0)
+            # The loop's own filing path: a Ledger on the SAME file, record() on a worker
+            # thread — exactly what spine.pr_pipeline does when it files a finding.
+            ledger = spine_ledger.Ledger(store.ledger_path())
+            ledger.record(
+                spine_ledger.LedgerEntry(
+                    fp="fp3",
+                    kind="bug",
+                    target="src/x.py::f",
+                    status=spine_ledger.STATUS_FILED,
+                    cr=REAL_PR,
+                )
+            )
+            spine_done.set()
+
+        threads = [threading.Thread(target=_forget), threading.Thread(target=_loop_file)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10.0)
+        assert not any(t.is_alive() for t in threads), "a writer deadlocked"
+        assert forget_decided.is_set(), "forget never reached its decision point"
+
+        latest = {r["fp"]: r for r in la.latest_records()}["fp3"]
+        statuses = [r.get("status") for r in _events(data_home)]
+        assert latest["status"] == "filed", f"the loop's filed PR was hidden; tail = {statuses}"
+        assert la.pr_reference(latest) == REAL_PR
+        reloaded = spine_ledger.Ledger(store.ledger_path())
+        assert reloaded.known("fp3") is True
+
+        if results["forget"].get("ok"):
+            assert "purged" in statuses  # forget ran first; the loop's record superseded it
+        else:
+            assert results["forget"]["reason"] == "has_pull_request"
+
+    def test_manual_and_spine_writers_share_one_lock_object(self) -> None:
+        """The unified fix is one lock OBJECT across both layers — pin identity so a future
+        refactor cannot silently re-split the domains back apart."""
+        assert la._LEDGER_LOCK is spine_ledger.LEDGER_WRITE_LOCK


### PR DESCRIPTION
## Problem / Motivation

The Auto-Improvement dedup ledger (`store.ledger_path()`) is written by **three** code paths, and they held **three different locks**:

- the loop's own filing — `spine.ledger.Ledger.record`, under the Ledger instance's own `self._lock`;
- the operator's manual draft / commit — `routes.ledger_admin_record` did a bare lock-free `open("a")`; `ledger_admin.record_committed` read+appended outside the lock;
- the operator's forget / purge — `ledger_admin.forget` / `purge`, under the module-level `_LEDGER_LOCK`.

Because the writers were in different lock domains, their read → decide → append sequences could interleave.

## Why it matters

`known()` resolves a fingerprint by its latest event (last-write-wins). The losing interleaving:

1. A finding sits `filed` with a `QUEUED:<fp>` placeholder (queued, no real PR yet).
2. A `forget` reads the placeholder and decides it is safe to clear (`is_real_pr_reference` is `False`) — about to append `purged`.
3. Concurrently, a real PR is filed — either the operator's manual draft **or the loop's own `spine.Ledger.record`** — appending `filed(<url>)`.
4. The tail lands `filed(QUEUED) → filed(real PR) → purged`; `purged` wins.

`known()` then reports the locus unknown, the findings list drops the row, and the next discovery cycle drafts a **second** PR for a change already up for review. All three paths run on gateway worker threads, so this is a real concurrent interleaving.

## What changed (motivation → approach → change)

- **Root cause:** writers to the one ledger file were spread across three lock domains, so no read→decide→append was atomic against the others.
- **Approach:** one process-wide lock shared by *every* writer, placed so both the spine engine and the backend can share the same object without the backend pulling the spine engine.
- **Change:**
  - New stdlib-only leaf `spine/ledger_lock.py` defines `LEDGER_WRITE_LOCK` (an `RLock`). It imports only `threading`, so `ledger_admin` can share the object without importing the driver / agent runner / PR pipeline; it lives in `spine` because the ledger is spine-owned durable state.
  - `spine.ledger.Ledger.record` now acquires `LEDGER_WRITE_LOCK` (outer) around its existing `self._lock` (which still guards the in-memory `_seen` map).
  - `ledger_admin` binds `_LEDGER_LOCK` to that same `LEDGER_WRITE_LOCK`, so `forget` / `purge` / `record_filed` / `record_committed` all serialize against the loop's `record()`.
  - New `ledger_admin.record_filed(fp, pr_ref)` performs the manual filed write under the shared lock; `routes.ledger_admin_record` delegates to it (was a bare lock-free append). `record_committed` is brought under the lock too, with a shared `_prior_kind_target` helper that reads `kind`/`target` from inside the critical section.
  - `forget` now either runs entirely before a filed write (which then supersedes its purge with the real PR) or entirely after it (and refuses with `has_pull_request`).
- **Lock ordering / deadlock:** unchanged and safe. The manual-draft route holds `commit.clone_lock` (outer) across materialize → commit → draft and only briefly takes this lock (inner) at the final ledger append; nothing acquires `clone_lock` while holding this lock (neither `spine.ledger` nor `ledger_admin` imports `commit`), so the two locks have one consistent order. `LEDGER_WRITE_LOCK` is an `RLock` acquired only for a bounded file append on worker threads, never on the asyncio event loop.

## Tests

In `test_ledger_admin.py` (deterministic, barrier-free — each pauses `forget` at its decision point via a `_purged_event` hook and releases the racing writer):

- `test_forget_and_manual_filed_write_do_not_interleave` — the operator's manual filed write cannot be hidden by a concurrent `forget`.
- `test_forget_cannot_hide_the_loops_own_in_run_filed_write` — the **loop's own** `spine.ledger.Ledger.record` filed write cannot be hidden either (the third-domain case). Verified to fail when `Ledger.record` is reverted to `self._lock` only.
- `test_manual_and_spine_writers_share_one_lock_object` — identity pin that `ledger_admin._LEDGER_LOCK is spine.ledger.LEDGER_WRITE_LOCK`, so a future refactor cannot silently re-split the domains.
- `test_record_filed_is_a_public_shared_helper` — the manual filed write is the shared `record_filed` helper and the row survives `spine.ledger.LedgerEntry(**row)`.

Each invariant asserts the current ledger state for the locus is the real filed PR (never a `purged` row hiding it) and the dedup index keeps the locus `known()`. Function-local imports were moved to the module import block.

## Manual verification

N/A — unit coverage sufficient. The change is a lock-domain unification exercised by the deterministic concurrency tests above; there is no user-visible surface.

## Related Issues

Fixes #6716

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (ledger locking); no rendered UI delta.
