### PR TITLE
feat(connections): activate warm mints and absorb their approval URLs

### DIFF
--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -8,17 +8,16 @@ process, and every rule below answers an observed failure.
 adds only endpoint wiring and a function-local `expire_dead_mints` import on the status path,
 keeping the mint engine off the gateway's boot path.
 
-**Scope boundary: the TABLE and the SPECS have landed; the PROCESS LIFECYCLE has not.**
-Shipped now: the shared row shape (`shared`/`generation`/`activation`), the liveness registry
-those stamps are read against, `expire_dead_mints()` on the status path, and the spec side --
-the registry-derived universe, the plan and its servability test, the tool-alias key shape, the
-spec files the plan writes, and the filesystem-drift guard covering their synchronous helpers.
-Still deferred: everything that spawns, activates, parks or kills a process -- the spawn/respawn
-rules, the reaper, and `warm_mint_all`, which is the only thing that would give the spec planner
-a caller. The lifecycle slice lands those tests together with the code. Until it does, nothing
-calls the planner and no row is ever `shared`, so the shipped `expire_dead_mints()` call is a
-no-op scan whose predicate is nonetheless complete for the parked case, because a reader blind
-to a parked process withdraws a URL that process can still redeem.
+**Scope boundary: the TABLE, the SPECS and the PROCESS LIFECYCLE have landed; the ENDPOINT
+WIRING has not.** Shipped now: the shared row shape (`shared`/`generation`/`activation`), the
+liveness registry those stamps are read against, `expire_dead_mints()` on the status path, the
+spec side -- the registry-derived universe, the plan and its servability test, the tool-alias key
+shape, the spec files the plan writes, and the filesystem-drift guard covering their synchronous
+helpers -- and the lifecycle: spawn/respawn, activation, park-or-kill, the reaper, and
+`warm_mint_all`, which is what gives the spec planner a caller. Still deferred: the dashboard
+endpoint that premints a gallery, so `warm_mint_all` itself has NO CALLER yet and no request
+path reaches any of this. That is the last seam, and it is deliberately thin -- the endpoint adds
+a handler, not a rule.
 
 ## Measured facts
 
@@ -33,6 +32,22 @@ to a parked process withdraws a URL that process can still redeem.
   questions: `generation_is_live` (the process holds the verifier) **and** `activation_is_live`
   (the session still answers the redirect). Process liveness alone passed the
   terminated-session case.
+- **A frame becomes readable only when something DRAINS the session queue.**
+  `pop_pending_oauth_requests()` reads a list that only `drain_init` appends to, and
+  `create_session` runs exactly one drain before it hands the handle over. The settle loop
+  originally slept between pops, which consumes nothing — so a provider whose `oauth_request`
+  landed after that create-time drain's idle exit was unreachable however many rounds elapsed.
+  The 3s budget was never the binding constraint; the loop had no mechanism to absorb a late
+  frame at all, and in a multi-provider activation the later providers are exactly the ones at
+  risk. Each waiting round is now a bounded `drain_init(duration=0.5, idle_exit=0.5,
+  no_report_ceiling=0.0)`. The ceiling argument is load-bearing: it arms the idle shortcut at
+  entry so the call cannot hold waiting for a "first report" this session already produced
+  during `create_session`'s own drain — which is precisely the idle-window semantics that made
+  an *unbounded* drain the wrong tool here. Bounded per round it is the right one, the total
+  wall-clock budget is unchanged, and an activation whose frames are already staged still
+  short-circuits on the first pop without opening a window. Beyond the budget the claim is
+  released and the cold path serves that provider, which is the correct fallback rather than a
+  defect.
 
 ## Specs are read once at spawn
 
@@ -110,20 +125,176 @@ quietly drop the filesystem work the guard's coverage rests on without failing i
 
 ## Seams and residuals
 
-**Shared-mint expiry** is the lifecycle slice's, keyed on the fact that a minting process is
+**Shared-mint expiry** has landed with the lifecycle, keyed on the fact that a minting process is
 gone rather than on a cause, which is what covers a process that went away by a route no expiry
 path anticipated. PR #5899 is a different cause and a different table: it owns
 **Disconnect-driven grant revocation**, and the two meet only where a revoke should re-warm.
-**Proactive refresh** attaches to the reaper the lifecycle slice introduces; **a
-supervisor/watchdog** is absent, as are the accessors it would need. Two residuals:
+**Proactive refresh** attaches to `_warm_mint_reaper`, which now exists; **a
+supervisor/watchdog** is absent, as are the accessors it would need.
 
-- **A cancel between the claim and the activation leaks the claim.** The lifecycle entry point
-  takes its claim outside any `try`/`finally` and the activation catches `Exception`, not
-  `BaseException`, so a `CancelledError` in that window leaves rows `minting` with no watcher:
-  nothing expires them, the pending check stays true, and the process is never retired.
-  Unreachable while that entry point does not exist, and **must be closed before the lifecycle
-  slice wires it up** -- along with replacing a shared row's state-string fence with a unique row
-  token (issue #6110), and screening an approval URL for a credential *before* it is stored.
+Three residuals the lifecycle slice was required to close, and did:
+
+- **A cancel between the claim and the activation leaked the claim.** The entry point took its
+  claim outside any `try`/`finally` and the activation catches `Exception`, not `BaseException`,
+  so a `CancelledError` in that window left rows `minting` with no watcher: nothing expires them
+  (`expire_dead_mints` judges `waiting` rows only), the pending check stays true, and the process
+  is never retired. `warm_mint_all` now holds every claim inside a `try` whose `except
+  BaseException` releases them and re-raises, so cancellation still propagates -- the activation
+  deliberately does NOT swallow it, because reporting a clean stand-down to a caller being torn
+  down is the worse failure. The window after the activation returns is covered by the same
+  block. **The claim loop itself was a second copy of this window**, since the claim is taken
+  *before* that `try`: it awaited `_dispose_mint` on each row it replaced, which suspends on a
+  client teardown and again on the shielded spec removal in that function's `finally`. The claim
+  loop is now await-free and atomic by construction -- it returns the displaced rows for the
+  caller to dispose *inside* the protected region, which also moves the dispose outside the
+  table lock, where the mint engine's own rule wants it. Pinned by an AST guard, not just by a
+  behavioural test.
+- **A shared row's fence was a batch clock reading, not a row identity** (issue #6110). Rows were
+  separated by `entry["started"] == started`, one `time.monotonic()` value per `warm_mint_all`
+  call. The clock has ~15.6ms granularity on Windows -- the reason `_new_mint_token` exists for
+  the cold engine -- so two Connects for one provider inside a tick read as the same row and a
+  late absorb wrote its URL over the newer claim. Claiming now returns `{slug: token}` and
+  absorb and release both verify that opaque per-row token; `started` is kept as information and
+  is never a fence.
+- **An approval URL was stored without being screened for a credential.** `_absorb_warm_requests`
+  wrote the popped `oauth_request` URL straight onto the row. It now passes every popped URL
+  through `security.oauth_url_contains_credential` -- the same gate the cold mint and the chat
+  consent banner apply, called, not re-implemented -- *before* the table lock, since the verdict
+  is a pure function of the URL and the gate can read the operator's on-disk endpoint extension.
+  A refused URL never reaches the store: the claim is released so the card asks for a fresh mint,
+  and the refusal is audited without the value.
+
+Two more the same slice closed, both about **withdrawal and retirement following the
+generation** rather than anything else:
+
+- **The retry's expiry pass was unscoped.** `_WarmMintDied` is raised only after the stand-down
+  inside `mint_for` has already run `_expire_shared_mints(generation=<the dead one>)` through
+  `_kill_generation`, so the rows whose verifier died are withdrawn before the retry ever sees
+  the exception. A second pass in `_warm_activate`, narrowed only by the caller's own row
+  tokens, therefore expired every *other* live shared row: a parked generation's URL is still
+  redeemable (its process holds the verifier and its session still answers the redirect), and a
+  concurrent batch's claims are another activation's to fill. The pass is gone, and
+  `_expire_shared_mints` now takes `generation` as its only narrowing, because withdrawal
+  follows the verifier.
+- **A parked generation was stranded when the current process died.** `sweep_retiring` is the
+  only thing that retires a parked process, and every route to it runs off a NEW mint -- which
+  is exactly what the leak does not have. The reaper used to `return` as soon as the current
+  process was gone, and the stand-down before a *failed* respawn cancelled the reaper without
+  creating one, so in both cases the parked process, its sessions and their loopback servers
+  stayed resident forever once its last card completed. `_drain_parked_generations` now keeps
+  sweeping until nothing is parked, and both routes run it.
+
+And one the second review round found, which is not a cancellation bug at all:
+
+- **A refused spec was still activated by name.** The writer declines to overwrite a file at
+  a planned spec path whose contents this module did not write — which protects the file and
+  nothing else, because the spawn is handed `agent=<fixed name>` and kiro-cli resolves that
+  name off the same agents directory. A hand-written agent parked at
+  `kirocrew-mint-warm-base.json` would therefore have been executed, with its own
+  `mcpServers` commands initialized, by the very code that had just refused to own it.
+  `_unowned_plan_specs` now re-verifies, off the loop, that every planned spec exists *and*
+  is sentinel-owned before the runtime is constructed; any refusal aborts warming entirely
+  and is audited. Aborting is safe because the cold path still serves every Connect — it
+  just spawns per provider.
+
+One residual remains:
+
+## Session-handle ownership, made explicit
+
+Three review rounds kept producing findings in this area because the ownership transfers were
+*implicit* — a handle moved between "the backend has it", "we have it", and "the registry has
+it" with no stated rule about who is responsible if an await in between is interrupted. The
+rule is now one sentence: **a handle is registered before anything can interrupt, and
+forgotten only once its destroy has completed.** Every touchpoint:
+
+| # | Point | Transfer | How it is cancellation-safe |
+|---|---|---|---|
+| 1 | `runtime.create_session` in `_activate_locked` | backend → us | Run as a SHIELDED task we keep a reference to, so the handle stays reachable when the wait is abandoned. `except BaseException` → `_abandon_session_creation_locked` → re-raise. |
+| 2 | `_sessions[activation] = _WarmSession(...)` | us → registry | No await between the handle arriving and the registration (counter bump + dataclass are sync). Atomic by construction. |
+| 3 | abandoned create, handle recovered | backend → registry | Registered settled-and-expired *before* the destroy, so it enters rule 6 rather than being a special case. |
+| 4 | abandoned create, no handle recovered | — | `create.cancel()`, then the generation is **quarantined** (`_plan`/`_digest` cleared) so the next activation stands it down and the orphan dies with the process. See the bound below. |
+| 5 | oauth-poll failure in `_activate_locked` | registry → destroyed | Record marked settled + `expires_at = 0` BEFORE the destroy, popped after. An interrupted destroy leaves a sweepable record. |
+| 6 | `_sweep_sessions_locked` | registry → destroyed | `try/finally` popping only when `destroyed` is true. Held across the await on purpose: a lock-free reader then over-reports liveness briefly, which keeps a row waiting rather than withdrawing a URL. |
+| 7 | `_drop_generation_sessions` | registry → dropped, no destroy | Sync, and correct: the process is dead, so its sessions died with it. |
+| 8 | `_retire_locked`'s `_sessions.clear()` | registry → dropped, no destroy | Sync. Every runtime is being killed, so every session dies with its process; on this path withdrawing the rows is the intent. |
+| 9 | `_destroy_session_quietly` | — | Swallows `Exception`, propagates `CancelledError` **by design** — that is what lets callers 5, 6 and 3 retain the record and retry. |
+
+Two awaits in `_activate_locked`'s own `except BaseException` handler are the cleanup rather
+than a window, and their safety is state ordering (rule 5) rather than a nested handler, so
+they are pinned by behavioural tests instead of the AST guard.
+
+That guard is now bound to **specific (function, await-target) pairs**, not to "this function
+contains some protected try" — the coarse form is what let a bare sibling await in
+`_activate_locked` pass by association, and it omitted `_sweep_sessions_locked` entirely.
+
+**The residual, and its bound.** A `session/new` the backend accepts *after* we cancel the
+create carries no id we hold, so nothing can address it directly. The first version of this
+note claimed that was fine because "it is reaped when the runtime is retired" — and a review
+round falsified exactly that argument: retirement is not guaranteed to arrive. Any card
+holding a URL keeps `_shared_mints_pending` true, which resets the reaper's idle clock on
+every cycle, while `_ensure_locked`'s digest-equality fast path keeps the same generation
+reusable — so each repetition parked another orphan session and its callback children on ONE
+live process, unbounded until listener or memory exhaustion.
+
+So the generation is now **quarantined** instead: row 4 clears `_plan` and `_digest`, which
+makes the next activation find the resident plan unservable and stand the generation down
+through the ordinary path — parked for the drain when a card still needs it, killed outright
+otherwise. Either way the process dies and takes the orphan with it. **The bound is therefore
+at most one generation's sessions, released on the next activation or on idle retirement,
+whichever comes first.** The cost is a respawn (~5s) on the next warm call after a transient
+session timeout, which is the right trade: correctness over a warm-cache hit. Closing the
+residual entirely would need the backend to expose a session id at request time rather than at
+response time.
+
 - **A hard gateway kill strands warm spec files.** They carry no manifest row, so the cold
   engine's aged-row sweep cannot see them. The next spawn's write-time sweep removes them, so
   the exposure is bounded, but it is not a clean teardown.
+
+## The one bug class, and the uniform shape that closes it
+
+Two independent review rounds on the lifecycle slice produced seven findings between them,
+and **six were the same defect wearing different clothes**: an `await` sitting between a
+state mutation and that mutation's settlement or cleanup, guarded only by an
+`except Exception` — which a `CancelledError` walks straight past, because it inherits from
+`BaseException`. Each instance leaks something different, which is why they read as
+unrelated:
+
+| Mutation | The await in the window | What leaked |
+|---|---|---|
+| rows installed as `minting` | `_dispose_mint` on a replaced row, inside the claim loop | rows nothing withdraws, process never retired |
+| rows installed as `minting` | the activation and the absorb | same |
+| a generation parked, its reaper cancelled | the spec write and `runtime.spawn()` | parked process with no sweeper, forked child, orphan specs |
+| a session registered | the credential screen's thread hop | session + its loopback callback servers, for the process's life |
+| generations moved out of `_retiring` | `_kill_generation` per generation | processes with no reference left anywhere |
+| `_runtime` cleared, reaper cancelled | `_kill_generation` in the stand-down | the same |
+| `_retiring` emptied, `_runtime` cleared | the hard teardown's kill loop | the same |
+
+One further finding was NOT a cancellation window but the same *implicitness* — a state that
+had always been reachable and became routine. `generation_is_live` denied liveness on the
+equality branch: `generation == self._generation` answered `is_alive()`, which reads
+`self._runtime`. But only a successful spawn bumps the counter, so a stood-down process sits
+in `_retiring` under the number that is still `self._generation` with `self._runtime` already
+cleared. A lock-free status scan in that window read a live parked process as dead, withdrew
+its redeemable URLs, and the withdrawal then made `_generation_holds_live_rows` false so the
+next sweep killed it. The ordinary incompatible-plan respawn always had this window; the
+re-park fixes above *widened* it by adding a second route (an interrupted kill re-parks under
+the current number). The equality test now confirms liveness and never denies it, falling
+through to the parked list.
+
+Fixing them one at a time is what produced two rounds, so the module now states the
+invariant instead: **a mutation is either atomic by construction, or its cleanup runs in a
+`finally` / `except BaseException` that re-raises.** In practice that is three shapes —
+make the loop await-free so there is no window (the claim), settle in a `finally` that
+takes its own fresh snapshot (the session), or re-park what a teardown did not finish and
+arm the drain synchronously before any further await (every process path). An AST guard
+asserts the functions owning these windows carry a bare-`finally` or `BaseException`
+handler rather than only `except Exception`, so the class cannot silently return; the
+remaining awaits are covered by a written audit rather than a test, because "this await has
+no mutation behind it" is not mechanically checkable.
+
+Three awaits are deliberately left unprotected, and each is a judgement rather than an
+oversight: `_dispose_displaced_rows` can be interrupted partway, but the rows are already
+evicted and their watchers are token-fenced, so a survivor writes nothing;
+`_expire_shared_mints` and `expire_dead_mints` flip a row to `expired` before awaiting its
+dispose, which the reaper's next pass re-scans and completes; and the reaper and drain
+treat their own cancellation as the signal that a replacement is taking over.

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -6,14 +6,15 @@ mode activation costs a FIXED ~5.18s whether the spec carries one remote server 
 a spec holding every mintable provider yields every ``oauth_request`` in a SINGLE
 activation.
 
-Two halves have landed. The TABLE: the row shape a shared mint uses (``shared`` /
-``generation`` / ``activation`` on :class:`~kiro_crew.connections.mint.MintState`), the
-liveness registry those stamps are read against (:class:`_WarmMintRuntime`), and the
+Three halves have landed. The TABLE: the row shape a shared mint uses (``shared`` /
+``generation`` / ``activation`` on :class:`~kiro_crew.connections.mint.MintState`) and the
 withdrawal chokepoint the dashboard's status path calls (:func:`expire_dead_mints`). The
 SPECS: the registry scan deciding which providers a warm process could serve
 (:func:`warm_spec_providers`), the plan it would spawn on (:func:`_warm_spec_plan`), and
-the spec files that plan writes (:func:`_write_warm_mint_specs`). Nothing here spawns,
-activates, parks or kills a process.
+the spec files that plan writes (:func:`_write_warm_mint_specs`). The RUNTIME: the one
+process every card shares (:class:`_WarmMintRuntime`) -- spawned, activated, parked, killed
+and reaped (:func:`_warm_mint_reaper`) -- and the flow that turns one activation into a
+whole table of URLs (:func:`warm_mint_all`).
 
 Redeemability takes TWO questions and they die independently: the PKCE verifier lives in
 the PROCESS (``generation_is_live``) while the loopback listener answering the redirect
@@ -21,11 +22,66 @@ belongs to the SESSION (``activation_is_live``). Process liveness alone passed a
 terminated-session row, which is how a card kept serving an unredeemable URL. Both
 failures are recorded in ``docs/architecture/design-notes/connections-warm-table.md``.
 
-Two rules on the spec side are load-bearing and recorded in that same note: specs are
-enumerated ONCE at spawn, so a plan that merely SHRANK must not force a respawn
-(:func:`_plan_is_servable`), and the spec universe is registry-derived and BLIND to grant
-and cancel state, because a plan tracking who needs a URL now retires a process holding
-other cards' listeners.
+Four rules are load-bearing and recorded in that same note: the SESSION is HELD (see
+:func:`_warm_row_alive`), specs are enumerated ONCE at spawn so a plan that merely SHRANK
+must not force a respawn and a process still holding a consent is PARKED rather than killed
+(:func:`_plan_is_servable`, :meth:`_WarmMintRuntime._park_or_kill_locked`), the spec
+universe is registry-derived and BLIND to grant and cancel state because a plan tracking
+who needs a URL now retires a process holding other cards' listeners, and a warm session
+injects an EMPTY ``mcp_servers`` list because remote servers passed through ``session/new``
+kill the process with every pending verifier in it
+(:func:`_warm_session_mcp_servers`).
+
+IDENTITY: a row is fenced by its own opaque ``token``, never by the batch clock reading in
+``started``. ``time.monotonic()`` has ~15.6ms granularity on Windows, so two Connects for
+one provider inside a tick read as one row and a late absorb overwrites the newer claim --
+the same reasoning
+:func:`~kiro_crew.connections.mint._new_mint_token` records for the cold engine. WITHDRAWAL
+is the other axis and does NOT use the token: a row is expired because the process that
+holds its verifier is gone, so :func:`_expire_shared_mints` narrows by ``generation`` only.
+
+ATOMICITY: :func:`_claim_shared_mints` contains no await, so a caller either holds every
+claim it asked for or none -- the claim is taken before :func:`warm_mint_all` enters the
+``try`` that rolls it back, which makes any await in that loop an unprotected cancel window.
+The rows a claim displaced come back to the caller and are disposed inside that ``try``.
+
+CANCELLATION SAFETY is the invariant this module is written around, because two review
+rounds found the same bug class: an await sitting between a state mutation and that
+mutation's settlement or cleanup, guarded only by an ``except Exception`` that a
+``CancelledError`` walks straight past. Every such window is closed the same way -- the
+mutation is either atomic by construction (no await in it) or its cleanup is a ``finally``
+/ ``except BaseException`` that re-raises. Concretely: a claim rolls back
+(:func:`warm_mint_all`), an activation's session is ALWAYS settled so the sweep can collect
+it (:func:`_absorb_warm_requests`), and a process whose teardown did not finish stays
+PARKED with a drain armed rather than losing its only reference
+(:meth:`_WarmMintRuntime._park_or_kill_locked`, ``_sweep_retiring_locked``,
+``_retire_locked``, ``_abandon_spawn_locked``). Pinned by an AST guard in
+``test/test_connections_warm.py``, not merely described here.
+
+SESSION OWNERSHIP is explicit at every transfer, because the handle is the ONLY way to
+terminate a backend session and the loopback callback children it owns. One rule covers
+every point: a handle is REGISTERED in ``_sessions`` before anything can be interrupted, and
+FORGOTTEN only once its destroy has completed -- so an interrupted teardown leaves a record
+the ordinary sweep retries. The create is run as a shielded task so its handle stays
+reachable even when the wait for it is abandoned
+(:meth:`_WarmMintRuntime._abandon_session_creation_locked`). When no handle can be recovered
+at all the generation is QUARANTINED rather than trusted to retire on its own, which bounds
+the unaddressable residual to one generation's sessions -- retirement is not guaranteed to
+arrive, because a card holding a URL keeps the reaper's idle clock reset while the digest fast
+path keeps the same process reusable.
+
+LIVENESS is asked of the parked list too. A generation keeps its NUMBER while parked -- only
+a successful spawn bumps the counter -- so ``generation_is_live`` uses the equality test to
+CONFIRM liveness and never to deny it, then falls through to ``_retiring``. Denying on
+equality reported a stood-down-but-alive process dead, which withdrew redeemable URLs and
+then let the next sweep kill the process the park existed to preserve.
+
+OWNERSHIP is checked twice, because a spec is activated BY NAME. The writer refuses a path
+whose contents this module did not write, which protects the FILE; :func:`_unowned_plan_specs`
+then re-verifies every planned spec exists and is ours BEFORE the runtime is constructed,
+which protects the SPAWN. Without the second check the refusal would hand kiro-cli a
+stranger's spec at our fixed name and initialize its ``mcpServers``. A refusal aborts
+warming entirely, audited: the cold path still serves every Connect.
 
 OWNERSHIP: these specs carry FIXED, predictable names in the user's own agents directory,
 so a name is where a spec of ours would GO and never proof that the file there is one.
@@ -36,41 +92,45 @@ so the sentinel is what actually discriminates. Neither :func:`_write_warm_mint_
 not write -- see :func:`_warm_spec_is_foreign`.
 
 INVARIANT: no coroutine here touches the filesystem directly. The spec helpers read the
-user's config, the shared agents dir, or kiro-cli's OAuth cache -- any of which can sit on
-a network mount where a stat is unbounded -- so they are synchronous, and a coroutine
-reaches them through ``asyncio.to_thread``. Enforced by a fixed-point drift guard in
+user's config, the shared agents dir, or kiro-cli's OAuth cache, and the credential gate
+reads the operator's OAuth-endpoint extension -- any of which can sit on a network mount
+where a stat is unbounded -- so they are synchronous, and a coroutine reaches them through
+``asyncio.to_thread``. Enforced by a fixed-point drift guard in
 ``test/test_connections_warm.py``, not merely described here.
 
-DEFERRED to the lifecycle slice: everything that spawns, activates, parks or reaps a
-process, and the ``warm_mint_all`` entry point that drives them. Until it lands nothing
-sets ``shared`` on a row and nothing calls the spec planner, so :func:`expire_dead_mints`
-is a no-op scan and the registry below stays empty. Both are written to answer correctly
-the moment that slice starts filling them, parked generations included: a reader blind to
-a parked process withdraws a code that process can still redeem, so completing the
-predicate later would mean revisiting this decision under a live bug.
+SEAM left open: :func:`warm_mint_all` has NO CALLER yet. The dashboard endpoint that
+premints a whole gallery is its own slice, so nothing here is reachable from a request
+today. Proactive refresh attaches in :func:`_warm_mint_reaper` when slice N3 lands.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
 import re
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from kiro_crew import agent as _agent
+from kiro_crew.acp.runtime import AcpRuntime
 from kiro_crew.agent_files import AGENT_FILENAME
 from kiro_crew.config.loader import data_home
 from kiro_crew.connections.mint import (
     _MINT_AGENT_PREFIX,
+    _MINT_GRANT_POLL_SECONDS,
     _MINT_NAME_RE,
+    _MINT_TTL_SECONDS,
     MintState,
     _dispose_mint,
     _mint_spec_body,
+    _mint_watcher,
     _mints,
     _mints_lock,
+    _new_mint_token,
 )
 from kiro_crew.connections.registry import Provider, get_visible_providers
 from kiro_crew.connections.tool_aliases import declared_tool_aliases, resolve_tool_aliases
@@ -82,6 +142,7 @@ from kiro_crew.mcp_utils import (
     kiro_oauth_wire_entry,
     mcp_server_alias,
 )
+from kiro_crew.security import oauth_url_contains_credential
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -102,6 +163,53 @@ _WARM_ALL_AGENT = f"{_WARM_AGENT_PREFIX}all"
 #: ``description`` is the only schema-legal field free enough to carry a marker: kiro-cli
 #: rejects an unknown spec key, and the agent-spec migration sweep strips bookkeeping keys.
 _WARM_SPEC_SENTINEL = "Kiro Crew warm mint spec (machine-written; safe to delete)"
+_WARM_SPAWN_TIMEOUT_SECONDS = 90.0
+_WARM_SESSION_TIMEOUT_SECONDS = 90.0
+_WARM_SESSION_DESTROY_TIMEOUT_SECONDS = 10.0
+#: How long to keep waiting for a handle whose create we already gave up on. Short, because
+#: this only buys back a session already on its way; see ``_abandon_session_creation``.
+_WARM_SESSION_REAP_TIMEOUT_SECONDS = 10.0
+_WARM_KILL_TIMEOUT_SECONDS = 20.0
+#: The oauth_request frame lands a beat AFTER set_mode returns (~0.35s measured),
+#: beyond drain_init's idle window for a slow provider. Poll rather than race it.
+_WARM_OAUTH_SETTLE_SECONDS = 0.5
+_WARM_OAUTH_SETTLE_ROUNDS = 6
+#: A tenth of the mint TTL: long enough that reopening the gallery reuses the
+#: process, short enough that an abandoned visit leaves no kiro-cli resident.
+_WARM_IDLE_GRACE_SECONDS = _MINT_TTL_SECONDS / 10
+#: One respawn, then the cold path -- a second death means the process cannot stay
+#: up, and a Connect is better served by its own dedicated spawn.
+_WARM_ACTIVATION_ATTEMPTS = 2
+
+#: The row states a shared mint is still working on. ``minting`` counts: a claim with no
+#: URL yet is exactly what a cancelled activation must not leave behind.
+_LIVE_STATES = ("minting", "waiting")
+
+
+class _WarmMintUnsafe(RuntimeError):
+    """A warm mint was about to be issued in a way that kills the shared process."""
+
+
+class _WarmMintDied(RuntimeError):
+    """The shared process was gone by the end of an activation."""
+
+    def __init__(self, cause: str) -> None:
+        super().__init__(cause)
+        self.cause = cause
+
+
+def _acp_runtime_factory() -> Any:
+    """Indirection so tests can substitute a fake runtime class."""
+    return AcpRuntime
+
+
+def _warm_session_mcp_servers() -> list[dict[str, Any]]:
+    """The session-injected MCP servers for a warm mint: ALWAYS empty.
+
+    A remote server passed through ``session/new`` kills the process together with every
+    pending verifier in it, so the spec -- never the session -- is what mounts servers.
+    """
+    return []
 
 
 def _log_warm_event(operation: str, resources: str, outcome: str = "ok") -> None:
@@ -220,6 +328,11 @@ def _warm_candidate_scan() -> tuple[list[Provider], list[Provider]]:
 def mintable_providers() -> list[Provider]:
     """Providers an activation should warm right now, registry order."""
     return _warm_candidate_scan()[1]
+
+
+def _wanted_aliases(providers: list[Provider]) -> frozenset[str]:
+    """The server aliases an activation must produce a challenge for."""
+    return frozenset(mcp_server_alias(provider["slug"]) for provider in providers)
 
 
 def _auth_shape(entry: dict[str, Any]) -> tuple[str, tuple[str, ...], str]:
@@ -419,6 +532,27 @@ def _write_warm_mint_specs(plan: _WarmSpecPlan) -> None:
         _agent._atomic_json_write(path, spec)
 
 
+def _unowned_plan_specs(plan: _WarmSpecPlan) -> list[str]:
+    """The planned spec names whose file is missing, or is not one this module wrote.
+
+    Activation happens BY NAME: the runtime is handed ``agent=<fixed name>`` and kiro-cli
+    resolves that name off this same agents directory. So the write's refusal protects the
+    FILE and nothing else -- a hand-written agent sitting at a name we declined to
+    overwrite would be spawned, and its ``mcpServers`` commands would initialize. This is
+    what protects the SPAWN.
+
+    Existence is tested as well as ownership, because :func:`_warm_spec_is_foreign` answers
+    False for an absent path: a spec that is not there is equally not ours to activate.
+    """
+    agents_dir = _agent.kiro_agents_dir_path()
+    unowned: list[str] = []
+    for name in plan.specs:
+        path = agents_dir / f"{name}.json"
+        if not path.is_file() or _warm_spec_is_foreign(path):
+            unowned.append(name)
+    return unowned
+
+
 def _remove_warm_mint_specs() -> None:
     """Unlink every warm spec THIS module wrote. Called when the process is retired."""
     try:
@@ -449,35 +583,104 @@ def _runtime_alive(runtime: Any) -> bool:
         return False
 
 
-class _WarmMintRuntime:
-    """The liveness registry a shared row's ``generation``/``activation`` are read against.
+def _live_row_count(generation: int) -> int:
+    """How many cards are still mid-consent on ``generation``."""
+    return sum(
+        1
+        for entry in _mints.values()
+        if entry.get("shared")
+        and entry.get("generation") == generation
+        and entry.get("state") in _LIVE_STATES
+    )
 
-    Both containers are filled by the deferred lifecycle (slice N2b) and are empty until it
-    lands. They are READ here rather than in N2b because the reader is what decides whether
-    a card's URL is withdrawn, and the parked case is exactly the one where a wrong answer
-    destroys a code the user could still redeem.
+
+def _generation_holds_live_rows(generation: int) -> bool:
+    """True while killing ``generation`` would strand a redeemable code."""
+    return _live_row_count(generation) > 0
+
+
+def _activations_in_use() -> set[int]:
+    """Activation ids a live shared row still points at -- the sweep's keep-set."""
+    return {
+        int(entry["activation"])
+        for entry in _mints.values()
+        if entry.get("shared") and entry.get("activation") and entry.get("state") in _LIVE_STATES
+    }
+
+
+@dataclass
+class _WarmSession:
+    """One live ACP session on the shared process, and what it owns.
+
+    Held because the session owns the loopback callback servers for its challenges.
+    ``settled`` flips once the URLs are absorbed into the mint table, which is what makes
+    the sweep safe -- an activation still in flight is referenced by no row. ``expires_at``
+    is why a session outlives the rows that pointed at it: a replaced URL may still be open
+    on the provider's consent page, and one mint TTL is exactly the window in which that
+    code is still redeemable.
+    """
+
+    generation: int
+    handle: Any
+    expires_at: float
+    settled: bool = False
+
+
+@dataclass(frozen=True)
+class _WarmMintResult:
+    """One activation's product, plus the snapshot and process it ran on."""
+
+    generation: int
+    activation: int
+    providers: list[Provider]
+    requests: list[dict[str, str]]
+
+
+class _WarmMintRuntime:
+    """One kiro-cli process shared by every card's approval-URL mint.
+
+    Also the liveness registry a shared row's ``generation``/``activation`` are read
+    against: the reader is what decides whether a card's URL is withdrawn, and the parked
+    case is exactly the one where a wrong answer destroys a code the user could still
+    redeem.
     """
 
     def __init__(self) -> None:
         self._runtime: Any = None
+        self._plan: _WarmSpecPlan | None = None
+        self._digest = ""
         #: Bumped on every spawn. Rows record the generation that minted them, letting a
         #: stand-down tell "nothing needs this" from "killing it strands a user mid-consent".
         self._generation = 0
         #: Generations kept alive ONLY because a card still holds one of their URLs.
+        #: New mints never route here; the reaper kills each once its rows are gone.
         self._retiring: list[tuple[int, Any]] = []
         #: Live sessions by activation id -- each owns the loopback servers for its
         #: challenges, so one is held while a card points at one of its URLs.
-        self._sessions: dict[int, Any] = {}
+        self._sessions: dict[int, _WarmSession] = {}
+        self._activation_seq = 0
+        self._lock = asyncio.Lock()
+        self._reaper: Any = None
 
     def is_alive(self) -> bool:
         return _runtime_alive(self._runtime)
 
     def generation_is_live(self, generation: int) -> bool:
-        """True while the process that minted ``generation`` can still redeem."""
+        """True while the process that minted ``generation`` can still redeem.
+
+        A generation keeps its NUMBER while it is parked: only a successful spawn bumps the
+        counter, so between a stand-down and its replacement the CURRENT number names a
+        process that lives in ``_retiring`` with ``self._runtime`` already cleared. The
+        equality test therefore CONFIRMS liveness but never denies it -- a miss falls
+        through to the parked list. Answering False there withdrew redeemable URLs, and the
+        withdrawal then made ``_generation_holds_live_rows`` false, so the next sweep killed
+        the very process the park existed to preserve. Readers reach this without the
+        runtime lock (the dashboard status path does), so the window is observable.
+        """
         if generation <= 0:
             return False
-        if generation == self._generation:
-            return self.is_alive()
+        if generation == self._generation and self.is_alive():
+            return True
         return any(
             parked == generation and _runtime_alive(runtime) for parked, runtime in self._retiring
         )
@@ -487,6 +690,456 @@ class _WarmMintRuntime:
         if activation <= 0:
             return False
         return activation in self._sessions
+
+    def parked_count(self) -> int:
+        """How many generations are parked -- alive only for a card still mid-consent.
+
+        Read by :func:`_drain_parked_generations`, which is what retires them once the
+        current process is gone and no new mint will sweep them.
+        """
+        return len(self._retiring)
+
+    async def settle_activation(self, activation: int, in_use: set[int]) -> None:
+        """Mark ``activation`` absorbed, then collect the sessions nothing needs."""
+        async with self._lock:
+            record = self._sessions.get(activation)
+            if record is not None:
+                record.settled = True
+            await self._sweep_sessions_locked(in_use)
+
+    async def sweep_sessions(self, in_use: set[int]) -> None:
+        """Collect settled sessions no live row points at."""
+        async with self._lock:
+            await self._sweep_sessions_locked(in_use)
+
+    async def _sweep_sessions_locked(self, in_use: set[int]) -> None:
+        """Collect settled sessions no row needs AND whose TTL has run out."""
+        now = time.monotonic()
+        doomed = [
+            activation
+            for activation, record in self._sessions.items()
+            if record.settled and activation not in in_use and record.expires_at <= now
+        ]
+        for activation in doomed:
+            record = self._sessions.get(activation)
+            if record is None:
+                continue
+            destroyed = False
+            try:
+                await _destroy_session_quietly(record.handle)
+                destroyed = True
+            finally:
+                # Forgotten only once the destroy completed. The record is the only reference
+                # left to the handle, so losing it mid-destroy leaves a session -- and the
+                # loopback servers it owns -- with nothing that could ever retry. Held across
+                # the await deliberately: a reader without the lock then over-reports the
+                # session as live for a moment, which keeps a row waiting a beat longer
+                # rather than withdrawing a URL, the safe direction.
+                if destroyed:
+                    self._sessions.pop(activation, None)
+
+    def _drop_generation_sessions(self, generation: int) -> None:
+        """Forget one generation's sessions. Its process death already reaped them."""
+        for activation in [
+            activation
+            for activation, record in self._sessions.items()
+            if record.generation == generation
+        ]:
+            self._sessions.pop(activation, None)
+
+    async def mint_for(self, *, slug: str = "") -> _WarmMintResult | None:
+        """Ensure a live process, activate it, return its challenges."""
+        async with self._lock:
+            await self._sweep_retiring_locked()
+            universe, candidates = await asyncio.to_thread(_warm_candidate_scan)
+            if slug and not any(provider["slug"] == slug for provider in candidates):
+                return None
+            # The UNIVERSE decides what the process must have enumerated; the CANDIDATES
+            # decide what this activation asks for. Apart, a grant moves the second only.
+            if not await self._ensure_locked(universe):
+                return None
+            plan = self._plan
+            if plan is None:
+                return None
+            agent = plan.per_provider.get(slug, "") if slug else plan.all_agent
+            if not agent:
+                return None
+            wanted = [
+                provider
+                for provider in candidates
+                if provider["slug"] in plan.per_provider and (not slug or provider["slug"] == slug)
+            ]
+            if not wanted:
+                return None
+            generation = self._generation
+            try:
+                activation, requests = await self._activate_locked(agent, _wanted_aliases(wanted))
+            except Exception as exc:
+                if self.is_alive():
+                    # One activation failed but the process still serves: its other verifiers
+                    # are intact, so killing it here destroys still-completable consent flows.
+                    raise
+                await self._park_or_kill_locked()
+                raise _WarmMintDied(type(exc).__name__) from exc
+            return _WarmMintResult(
+                generation=generation,
+                activation=activation,
+                providers=wanted,
+                requests=requests,
+            )
+
+    async def _ensure_locked(self, providers: list[Provider]) -> bool:
+        """Guarantee a process whose specs can serve ``providers``."""
+        try:
+            plan = await asyncio.to_thread(_warm_spec_plan, providers)
+        except Exception:  # noqa: BLE001 — reads user-editable JSON; never fail a mint
+            logger.debug("warm mint spec plan failed", exc_info=True)
+            return False
+        if not plan.all_agent:
+            return False
+
+        if self.is_alive() and self._digest == plan.digest:
+            return True
+        resident = self._plan
+        if self.is_alive() and resident is not None and _plan_is_servable(resident, plan):
+            logger.info(
+                "Shared mint generation %d already serves the new candidate set; "
+                "re-activating instead of respawning",
+                self._generation,
+            )
+            return True
+        if self._runtime is not None:
+            logger.info(
+                "Starting a new shared mint generation (%s)",
+                "specs are incompatible" if self.is_alive() else "process is gone",
+            )
+        await self._park_or_kill_locked()
+
+        runtime: Any = None
+        handed_over = False
+        try:
+            await asyncio.to_thread(_write_warm_mint_specs, plan)
+            # The write REFUSES a path it does not own rather than clobbering it, and the
+            # spawn below activates by NAME -- so without this the refusal would hand
+            # kiro-cli a stranger's spec to execute. Aborting is safe and honest: the cold
+            # path still serves every Connect, it just spawns per provider.
+            unowned = await asyncio.to_thread(_unowned_plan_specs, plan)
+            if unowned:
+                logger.warning(
+                    "Not warming: %d planned mint spec(s) are not ours to activate", len(unowned)
+                )
+                await asyncio.to_thread(
+                    _log_warm_event,
+                    "connections_warm_mint_spawn",
+                    f"unowned_specs:{len(unowned)}",
+                    "refused",
+                )
+                return False
+            runtime = _acp_runtime_factory()(
+                work_dir=await asyncio.to_thread(_warm_work_dir),
+                agent=_WARM_BASE_AGENT,
+                sandbox_mode="auto",
+            )
+            await asyncio.wait_for(runtime.spawn(), timeout=_WARM_SPAWN_TIMEOUT_SECONDS)
+            # No await between the spawn returning and the flag: the handover is a run of
+            # plain assignments plus a synchronous ``create_task``, so there is no window
+            # in which the process is ours but the ``finally`` would still tear it down.
+            self._runtime, self._plan, self._digest = runtime, plan, plan.digest
+            self._generation += 1
+            self._reaper = asyncio.get_running_loop().create_task(
+                _warm_mint_reaper(self._generation)
+            )
+            handed_over = True
+        except Exception as exc:  # noqa: BLE001 — degrade to the cold path
+            logger.warning("Shared mint process spawn failed: %s", type(exc).__name__)
+            return False
+        finally:
+            # A ``finally``, not an ``except Exception``: the stand-down above has already
+            # parked the old generation AND cancelled its reaper, so a CancelledError in the
+            # spec write or the spawn would otherwise leave that process with nothing that
+            # will ever sweep it -- the parked-generation leak by a third route -- plus a
+            # forked child and a set of specs nobody owns.
+            if not handed_over:
+                await self._abandon_spawn_locked(runtime)
+        await asyncio.to_thread(
+            _log_warm_event,
+            "connections_warm_mint_spawn",
+            f"providers:{len(plan.per_provider)} generation:{self._generation}",
+        )
+        return True
+
+    async def _abandon_spawn_locked(self, runtime: Any) -> None:
+        """Undo a spawn attempt that never became this object's process.
+
+        Reached from a ``finally``, so it covers cancellation as well as failure.
+        """
+        if self._retiring:
+            # Armed BEFORE any await, because ``create_task`` is synchronous: the parked
+            # generation then has its sweeper even if the teardown below is interrupted.
+            # Stored as the reaper so a later spawn's own reaper replaces it.
+            self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
+        if runtime is not None:
+            await _kill_quietly(runtime)
+        if not self._retiring:
+            await asyncio.to_thread(_remove_warm_mint_specs)
+
+    async def _abandon_session_creation_locked(self, create: Any) -> None:
+        """Reap a session the backend may have created after we stopped waiting for it.
+
+        ``create`` was shielded from our own cancellation precisely so its result stays
+        reachable here: the handle is the ONLY way to terminate the session and the loopback
+        callback children it owns. A handle that does arrive is REGISTERED before it is
+        destroyed -- settled and already expired -- so it enters the same ownership rule the
+        rest of this class uses, and an interrupted destroy is retried by the ordinary sweep
+        instead of being lost.
+        """
+        handle: Any = None
+        try:
+            # Bounded: this only buys back a session already on its way.
+            handle = await asyncio.wait_for(
+                asyncio.shield(create), timeout=_WARM_SESSION_REAP_TIMEOUT_SECONDS
+            )
+        except BaseException:  # noqa: BLE001 — best-effort reap; the caller re-raises its own
+            handle = None
+        if handle is None:
+            # Nothing addressable exists to destroy: the backend may still accept a session
+            # carrying an id we never received. QUARANTINE the generation rather than trust
+            # retirement to arrive on its own -- it is not guaranteed to. Any card holding a
+            # URL keeps ``_shared_mints_pending`` true, which resets the reaper's idle clock
+            # every cycle, while ``_ensure_locked``'s digest fast path keeps this same
+            # process reusable; so without this, every repetition of this path parked another
+            # unaddressable session and its callback children on ONE live runtime, without
+            # bound. Clearing the resident plan makes the next activation find it unservable,
+            # which stands this generation down through the ordinary path (parked for the
+            # drain when a card still needs it, killed outright otherwise) and takes the
+            # orphan with it. The residual is therefore at most ONE generation's sessions.
+            #
+            # Scoped deliberately to this branch: the recovered-handle path below repairs
+            # itself completely, so quarantining there would cost a respawn on every
+            # transient timeout for nothing.
+            self._plan, self._digest = None, ""
+            logger.warning(
+                "Quarantining shared mint generation %d: a session was created that we "
+                "cannot address, so the process is stood down at the next activation",
+                self._generation,
+            )
+            create.cancel()
+            return
+        self._activation_seq += 1
+        activation = self._activation_seq
+        self._sessions[activation] = _WarmSession(
+            generation=self._generation, handle=handle, expires_at=0.0, settled=True
+        )
+        destroyed = False
+        try:
+            await _destroy_session_quietly(handle)
+            destroyed = True
+        finally:
+            if destroyed:
+                self._sessions.pop(activation, None)
+
+    async def _activate_locked(
+        self, agent: str, wanted: frozenset[str]
+    ) -> tuple[int, list[dict[str, str]]]:
+        """Activate ``agent`` on the shared process and return its challenges."""
+        runtime = self._runtime
+        if runtime is None or not self.is_alive():
+            raise _WarmMintUnsafe("the shared mint process is not alive")
+        servers = _warm_session_mcp_servers()
+        if servers:
+            # Never reachable from our own code -- the guard exists because the failure is
+            # silent and total: session/new-injected servers kill the process and its verifiers.
+            raise _WarmMintUnsafe("session-injected MCP servers would kill the shared process")
+
+        # OWNERSHIP TRANSFER, and the one that has no second chance: the returned handle is
+        # the ONLY way to terminate a session and the loopback callback children it owns, so
+        # a wait we abandon after the backend already accepted `session/new` would leak them
+        # until the whole runtime is retired. The create runs as a task we keep a reference
+        # to and shield, so the handle stays REACHABLE even when we stop waiting for it.
+        create = asyncio.get_running_loop().create_task(
+            runtime.create_session(agent=agent, mcp_servers=servers)
+        )
+        try:
+            handle = await asyncio.wait_for(
+                asyncio.shield(create), timeout=_WARM_SESSION_TIMEOUT_SECONDS
+            )
+        except BaseException:
+            await self._abandon_session_creation_locked(create)
+            raise
+        # No await between the handle arriving and its registration, so there is no window
+        # in which the session exists and nothing in this object knows about it.
+        self._activation_seq += 1
+        activation = self._activation_seq
+        self._sessions[activation] = _WarmSession(
+            generation=self._generation,
+            handle=handle,
+            expires_at=time.monotonic() + _MINT_TTL_SECONDS,
+        )
+        collected: dict[str, dict[str, str]] = {}
+        try:
+            for round_index in range(_WARM_OAUTH_SETTLE_ROUNDS):
+                for request in handle.pop_pending_oauth_requests():
+                    name = str(request.get("serverName") or "")
+                    if name and request.get("oauthUrl"):
+                        collected[name] = request
+                if wanted and wanted <= collected.keys():
+                    break
+                if round_index + 1 < _WARM_OAUTH_SETTLE_ROUNDS:
+                    # CONSUME the queue rather than sleep past it. This is the whole
+                    # mechanism: ``pop_pending_oauth_requests`` reads a list that only
+                    # ``drain_init`` appends to, and ``create_session`` runs exactly one
+                    # drain before handing the handle over -- so a bare sleep here moved
+                    # nothing, and a frame arriving after that drain's idle exit was
+                    # unreachable however many rounds elapsed. The budget was never the
+                    # binding constraint; the loop had no way to absorb a late frame at all.
+                    #
+                    # ``no_report_ceiling=0.0`` is load-bearing: it arms the idle shortcut at
+                    # entry, so this call cannot hold waiting for a "first report" that this
+                    # session already produced during ``create_session``'s own drain. That is
+                    # precisely the idle-window semantics that made an unbounded drain the
+                    # wrong tool here -- bounded per round, it is the right one. Each round is
+                    # therefore a window of at most ``_WARM_OAUTH_SETTLE_SECONDS`` that
+                    # returns as soon as the queue goes quiet, so the total budget is
+                    # unchanged and a satisfied activation still short-circuits on the pop
+                    # above without opening a window at all.
+                    await handle.drain_init(
+                        duration=_WARM_OAUTH_SETTLE_SECONDS,
+                        idle_exit=_WARM_OAUTH_SETTLE_SECONDS,
+                        no_report_ceiling=0.0,
+                    )
+        except BaseException:
+            # Nothing will ever be stamped with this activation, so the session it
+            # registered would leak past the sweep's settled-only rule. Marked settled and
+            # already expired FIRST, so that if the destroy below is interrupted the sweep
+            # is a real retry; and popped only once the destroy actually completed, because
+            # the record is the only reference left to the handle.
+            record = self._sessions.get(activation)
+            if record is not None:
+                record.settled = True
+                record.expires_at = 0.0
+            await _destroy_session_quietly(handle)
+            self._sessions.pop(activation, None)
+            raise
+        return activation, list(collected.values())
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            await self._retire_locked()
+
+    async def sweep_retiring(self) -> None:
+        """Kill parked generations nothing is waiting on any more."""
+        async with self._lock:
+            await self._sweep_retiring_locked()
+
+    async def _sweep_retiring_locked(self) -> None:
+        keep: list[tuple[int, Any]] = []
+        drop: list[tuple[int, Any]] = []
+        for pair in self._retiring:
+            generation, runtime = pair
+            needed = _runtime_alive(runtime) and _generation_holds_live_rows(generation)
+            (keep if needed else drop).append(pair)
+        self._retiring = keep
+        try:
+            while drop:
+                generation, runtime = drop[0]
+                logger.info("Retiring parked shared mint generation %d", generation)
+                await self._kill_generation(generation, runtime)
+                # Popped only once its kill has actually completed.
+                drop.pop(0)
+        finally:
+            if drop:
+                # Whatever this sweep did not finish stays PARKED. Removing it from the list
+                # without killing it would make ``parked_count()`` read zero, so the drain
+                # would exit and no later sweep would retry -- the process, its sessions and
+                # their loopback servers would simply leak.
+                self._retiring = drop + self._retiring
+
+    async def _park_or_kill_locked(self) -> None:
+        """Stand the current process down: PARKED when a card still needs it."""
+        runtime, generation = self._runtime, self._generation
+        reaper, self._reaper = self._reaper, None
+        self._runtime, self._plan, self._digest = None, None, ""
+        # The reaper is the caller on the idle path; cancelling the current task
+        # would abandon the kill it is in the middle of awaiting.
+        if reaper is not None and reaper is not asyncio.current_task():
+            reaper.cancel()
+        if runtime is None:
+            return
+        if _runtime_alive(runtime) and _generation_holds_live_rows(generation):
+            self._retiring.append((generation, runtime))
+            logger.info(
+                "Parking shared mint generation %d: %d card(s) still mid-consent on it",
+                generation,
+                _live_row_count(generation),
+            )
+            return
+        try:
+            await self._kill_generation(generation, runtime)
+        except BaseException:
+            # ``_runtime`` and the reaper were cleared synchronously above, so this list is
+            # now the ONLY reference to a process the kill did not finish with. Park it and
+            # arm the drain rather than dropping it: an untracked child never gets retired.
+            self._retiring.append((generation, runtime))
+            if self._reaper is None:
+                self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
+            raise
+
+    async def _kill_generation(self, generation: int, runtime: Any) -> None:
+        """Kill one process and expire the links only it could have redeemed."""
+        await _kill_quietly(runtime)
+        self._drop_generation_sessions(generation)
+        await _expire_shared_mints("mint_process_gone", generation=generation)
+        if self._runtime is None and not self._retiring:
+            await asyncio.to_thread(_remove_warm_mint_specs)
+
+    async def _retire_locked(self) -> None:
+        """Hard teardown: every generation, parked ones included."""
+        reaper, runtime, generation = self._reaper, self._runtime, self._generation
+        # Parked generations first, then the current one -- a parked process is the one a
+        # card may still be mid-consent on, so it is retired before the live one.
+        pending = list(self._retiring)
+        if runtime is not None:
+            pending.append((generation, runtime))
+        had_work = bool(pending)
+        self._retiring = []
+        self._reaper = self._runtime = None
+        self._plan, self._digest = None, ""
+        self._sessions.clear()
+        if reaper is not None and reaper is not asyncio.current_task():
+            reaper.cancel()
+        try:
+            while pending:
+                doomed_generation, doomed_runtime = pending[0]
+                await _kill_quietly(doomed_runtime)
+                await _expire_shared_mints("mint_process_gone", generation=doomed_generation)
+                # Popped only once this generation is fully retired.
+                pending.pop(0)
+        finally:
+            if pending:
+                # Same rule as everywhere else in this class: a process whose teardown did
+                # not complete stays tracked, with something scheduled to retire it. The
+                # lists above were emptied synchronously, so this is the only reference left.
+                self._retiring = pending
+                self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
+        if had_work and not self._retiring:
+            # Only once nothing is left: a spec removed under a still-running parked process
+            # strands it without the file it was spawned on.
+            await asyncio.to_thread(_remove_warm_mint_specs)
+
+
+async def _destroy_session_quietly(handle: Any) -> None:
+    """Terminate one warm session. Only ever called once nothing points at it."""
+    try:
+        await asyncio.wait_for(handle.destroy(), timeout=_WARM_SESSION_DESTROY_TIMEOUT_SECONDS)
+    except Exception:  # noqa: BLE001 — best-effort teardown of our own session
+        logger.debug("warm mint session destroy failed", exc_info=True)
+
+
+async def _kill_quietly(runtime: Any) -> None:
+    try:
+        await asyncio.wait_for(runtime.kill(), timeout=_WARM_KILL_TIMEOUT_SECONDS)
+    except Exception:  # noqa: BLE001 — best-effort teardown of our own child
+        logger.debug("warm mint runtime kill failed", exc_info=True)
 
 
 _warm_mint = _WarmMintRuntime()
@@ -506,6 +1159,38 @@ def _warm_row_alive(entry: MintState) -> bool:
     return _warm_mint.activation_is_live(int(entry.get("activation") or 0))
 
 
+def _shared_mints_pending() -> bool:
+    """True while any card still needs the shared process alive."""
+    return any(
+        entry.get("shared") and entry.get("state") in _LIVE_STATES for entry in _mints.values()
+    )
+
+
+async def _expire_shared_mints(reason: str, *, generation: int | None = None) -> list[str]:
+    """Flip live shared mints stale. Called when a process is gone.
+
+    ``generation`` is the only narrowing there is, and every caller passes it: the rows a
+    dead process can no longer redeem are exactly the ones it minted. A pass narrowed by
+    the CALLER's own row tokens instead used to exist here; it read as "spare my retry" but
+    meant "expire every other generation", which withdrew a parked generation's redeemable
+    URL. Withdrawal follows the verifier, so it follows the generation.
+    """
+    flipped: list[str] = []
+    async with _mints_lock:
+        for slug, entry in _mints.items():
+            if not entry.get("shared") or entry.get("state") not in _LIVE_STATES:
+                continue
+            if generation is not None and entry.get("generation") != generation:
+                continue
+            entry["state"] = "expired"
+            entry["reason"] = reason
+            await _dispose_mint(entry)
+            flipped.append(slug)
+    if flipped:
+        logger.info("Shared mint process gone; %d pending mint(s) flipped stale", len(flipped))
+    return flipped
+
+
 async def expire_dead_mints() -> list[str]:
     """Withdraw every shared row whose holding process is gone. THE chokepoint."""
     doomed: list[str] = []
@@ -522,3 +1207,318 @@ async def expire_dead_mints() -> list[str]:
     if doomed:
         logger.info("Withdrew %d approval URL(s) whose minting process is gone", len(doomed))
     return doomed
+
+
+async def _warm_activate(*, slug: str = "") -> _WarmMintResult | None:
+    """Activate the shared process, surviving one death of it.
+
+    The death path does NOT expire anything itself. The stand-down inside ``mint_for`` --
+    reached only when the process is already gone -- has just run
+    ``_expire_shared_mints(generation=<the dead one>)`` through ``_kill_generation``, so the
+    rows whose verifier died are already withdrawn, scoped to that generation. A second,
+    unscoped pass here withdrew every other live shared row instead: a PARKED generation's
+    URL is still redeemable (its process holds the verifier and its session still answers
+    the redirect) and a concurrent batch's claims are another activation's to fill.
+
+    ``CancelledError`` is deliberately NOT caught: swallowing it would report a successful
+    stand-down to a caller that is being torn down. The caller releases its claims and
+    re-raises (see ``warm_mint_all``).
+    """
+    for attempt in range(_WARM_ACTIVATION_ATTEMPTS):
+        try:
+            return await _warm_mint.mint_for(slug=slug)
+        except _WarmMintDied as died:
+            last = attempt + 1 >= _WARM_ACTIVATION_ATTEMPTS
+            logger.warning(
+                "Shared mint process died mid-activation (%s); %s",
+                died.cause,
+                "falling back to the cold path" if last else "respawning it",
+            )
+        except Exception as exc:  # noqa: BLE001 — the process lives; degrade to cold
+            logger.warning(
+                "Shared mint activation failed on a live process (%s); "
+                "falling back to the cold path",
+                type(exc).__name__,
+            )
+            return None
+    return None
+
+
+async def _drain_parked_generations() -> None:
+    """Keep sweeping until no parked generation is left, then return.
+
+    A parked generation is a process kept alive ONLY because a card still holds one of its
+    URLs, so it can be retired the moment that card grants, cancels or times out -- and
+    ``sweep_retiring`` is the only thing that retires it. Every other route to that sweep
+    runs off a NEW mint (``mint_for``, or the reaper a fresh spawn creates), which is
+    precisely what the leak does not have: once the current process is gone and no further
+    Connect arrives, nothing calls it again and the parked process, its sessions and their
+    loopback servers stay resident indefinitely.
+
+    Returns immediately when nothing is parked, so the callers can invoke it unconditionally.
+    """
+    while _warm_mint.parked_count():
+        await asyncio.sleep(_MINT_GRANT_POLL_SECONDS)
+        await _warm_mint.sweep_retiring()
+        # A parked process can also die while parked, which withdraws its cards' URLs.
+        await expire_dead_mints()
+        async with _mints_lock:
+            in_use = _activations_in_use()
+        await _warm_mint.sweep_sessions(in_use)
+
+
+async def _warm_mint_reaper(generation: int) -> None:
+    """Retire the shared process once no card is waiting on it.
+
+    Outlives its own generation on the death path: standing the current process down does
+    not release the generations parked behind it, so the reaper drains those before it
+    returns (see :func:`_drain_parked_generations`).
+    """
+    idle_since = 0.0
+    try:
+        while True:
+            await asyncio.sleep(_MINT_GRANT_POLL_SECONDS)
+            await _warm_mint.sweep_retiring()
+            # Every generation, parked ones included: a card pointing at a process that is
+            # gone must not keep its URL until this reaper's own generation is the dead one.
+            await expire_dead_mints()
+            # Sessions outlive the rows that needed them on every path ending a mint without
+            # a new activation (grant, cancel, TTL). Collected here, not for the process life.
+            async with _mints_lock:
+                in_use = _activations_in_use()
+            await _warm_mint.sweep_sessions(in_use)
+            if not _warm_mint.is_alive():
+                await _expire_shared_mints("mint_process_gone", generation=generation)
+                await _drain_parked_generations()
+                return
+            if _shared_mints_pending():
+                idle_since = 0.0
+                continue
+            now = time.monotonic()
+            if idle_since == 0.0:
+                idle_since = now
+            elif now - idle_since >= _WARM_IDLE_GRACE_SECONDS:
+                logger.info("Retiring the idle shared mint process")
+                # Hard teardown, parked generations included -- so no drain is needed after.
+                await _warm_mint.shutdown()
+                return
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 — the reaper must never take the gateway down
+        logger.debug("warm mint reaper failed", exc_info=True)
+
+
+def _mint_is_cold_held(entry: MintState | None) -> bool:
+    """True when a dedicated client -- not the shared process -- holds this URL."""
+    return entry is not None and entry.get("state") == "waiting" and entry.get("client") is not None
+
+
+async def _claim_shared_mints(slugs: list[str]) -> tuple[dict[str, str], list[MintState]]:
+    """Claim ``slugs`` for the shared process. Returns ``({slug: row token}, displaced rows)``.
+
+    The token is the row's OWN identity and it is what every later step fences on. A batch
+    ``time.monotonic()`` reading cannot do that job: it has ~15.6ms granularity on Windows,
+    so two Connects for one provider inside a single tick read as the same row and a late
+    absorb writes its URL over the newer claim (see ``_new_mint_token``, which records the
+    same reasoning for the cold engine).
+
+    ATOMIC BY CONSTRUCTION: the loop contains NO await, so the caller either gets every
+    claim or none. It used to await ``_dispose_mint`` on each replaced row, which suspends
+    on a client teardown and again on the shielded spec removal in that function's
+    ``finally`` -- and the claim is taken BEFORE ``warm_mint_all`` enters the try that rolls
+    it back, so a cancellation there left earlier slugs installed as ``minting`` with no
+    caller holding their tokens. Nothing withdraws such a row (``expire_dead_mints`` judges
+    ``waiting`` only) and it keeps ``_shared_mints_pending`` true, so the process is never
+    retired either. The replaced rows come back for the caller to dispose INSIDE that try
+    instead -- which also puts the dispose outside the table lock, where the mint engine's
+    own rule wants it.
+    """
+    claimed: dict[str, str] = {}
+    displaced: list[MintState] = []
+    started = time.monotonic()
+    async with _mints_lock:
+        for slug in slugs:
+            prior = _mints.get(slug)
+            if _mint_is_cold_held(prior):
+                # A dedicated client owns this provider's verifier. Leave its URL on
+                # the card rather than replace a working link.
+                continue
+            if prior is not None:
+                # Hand it back, don't just drop it: the replaced row may own a watcher, and
+                # a watcher outliving its row expires the NEW mint on the OLD mint's
+                # deadline. Recorded only alongside the claim that displaced it, so a
+                # non-empty list always implies a non-empty claim set.
+                displaced.append(prior)
+            token = _new_mint_token()
+            _mints[slug] = {
+                "state": "minting",
+                # Informational only -- when the claim was taken. Never a fence.
+                "started": started,
+                "shared": True,
+                "token": token,
+            }
+            claimed[slug] = token
+    return claimed, displaced
+
+
+async def _dispose_displaced_rows(rows: list[MintState]) -> None:
+    """Release the holdings of the rows a claim replaced -- watcher, client, PID, spec.
+
+    Split out of the claim itself because it awaits: see ``_claim_shared_mints``. Called
+    from inside the caller's protected region, so a cancellation here rolls the claims back
+    rather than stranding them.
+    """
+    for row in rows:
+        await _dispose_mint(row)
+
+
+async def _release_shared_claims(claims: dict[str, str]) -> None:
+    """Drop unfulfilled claims so the card asks for a fresh mint.
+
+    Keyed on the row token, so a claim already superseded by a newer one at the same slug
+    is left alone rather than dropped out from under the activation now filling it.
+    """
+    async with _mints_lock:
+        for slug, token in claims.items():
+            entry = _mints.get(slug)
+            if entry is not None and entry.get("token") == token and entry.get("shared"):
+                await _dispose_mint(entry)
+                _mints.pop(slug, None)
+
+
+def _credential_bearing_slugs(urls: dict[str, str]) -> set[str]:
+    """The slugs in ``{slug: url}`` whose approval URL carries a credential.
+
+    The gate is :func:`~kiro_crew.security.oauth_url_contains_credential` -- the same
+    predicate the cold mint and the chat consent banner apply -- and it is synchronous
+    because it can consult the operator's on-disk OAuth-endpoint extension, an unbounded
+    stat on a network mount. Never returns or logs the value it judged.
+    """
+    return {slug for slug, url in urls.items() if url and oauth_url_contains_credential(url)}
+
+
+async def _absorb_warm_requests(result: _WarmMintResult, claims: dict[str, str]) -> list[str]:
+    """Move popped challenges into the mint table. Returns the slugs now waiting."""
+    popped = {
+        str(request.get("serverName") or ""): str(request.get("oauthUrl") or "")
+        for request in result.requests
+    }
+    # An activation names its challenges by the alias the SPEC mounted; the table is keyed by
+    # registry slug. Resolved once, here, so the screen and the store judge the same string.
+    resolved = {
+        slug: popped.get(mcp_server_alias(slug)) or popped.get(slug) or ""
+        for slug in (provider["slug"] for provider in result.providers)
+    }
+    minted: list[str] = []
+    unfulfilled: dict[str, str] = {}
+    tainted: set[str] = set()
+    try:
+        # Screened BEFORE the table lock: the verdict is a pure function of the URL, and the
+        # gate can read the operator's endpoint extension off disk. A refused URL never
+        # reaches the store, so no card can be handed one.
+        tainted = await asyncio.to_thread(_credential_bearing_slugs, resolved)
+        loop = asyncio.get_running_loop()
+        async with _mints_lock:
+            for provider in result.providers:
+                slug = provider["slug"]
+                token = claims.get(slug, "")
+                entry = _mints.get(slug)
+                if entry is None or not token or entry.get("token") != token:
+                    # Superseded while the activation ran. Its challenge stays alive in the
+                    # session that produced it and nothing points at it; the sweep collects
+                    # that session.
+                    continue
+                url = resolved.get(slug, "")
+                if not url or slug in tainted:
+                    # Released either way, not failed: the card asks for a fresh mint rather
+                    # than sitting on a claim nothing will ever fill.
+                    unfulfilled[slug] = token
+                    continue
+                entry.update(
+                    {
+                        "state": "waiting",
+                        "oauth_url": url,
+                        "generation": result.generation,
+                        "activation": result.activation,
+                        "watcher": loop.create_task(
+                            _mint_watcher(slug, provider["mcp_url"], token)
+                        ),
+                    }
+                )
+                minted.append(slug)
+    finally:
+        # Settlement on EVERY post-activation exit, which is why it is a ``finally``. The
+        # session was registered by ``_activate_locked`` before this function ran, and the
+        # sweep only ever collects a SETTLED session -- so a raise anywhere above (the
+        # screen's thread hop is a cancellation point, and the gate itself can fail on an
+        # unreadable file) would leave the session, and the loopback callback servers it
+        # owns, resident for the life of the process. The in-use snapshot is taken HERE,
+        # under the lock, so it reflects whatever the loop above actually installed rather
+        # than what it intended to.
+        async with _mints_lock:
+            in_use = _activations_in_use()
+        await _warm_mint.settle_activation(result.activation, in_use)
+    for slug in tainted:
+        logger.warning("Shared mint for %r produced a URL with a credential pattern", slug)
+        await asyncio.to_thread(
+            _log_warm_event, "connections_warm_mint_url", f"provider:{slug}", "refused"
+        )
+    if unfulfilled:
+        await _release_shared_claims(unfulfilled)
+    return minted
+
+
+async def warm_mint_all(providers: list[Provider] | None = None) -> list[str]:
+    """Warm every mintable provider's approval URL in ONE activation.
+
+    Returns the slugs now holding a URL. Never raises for a mint failure -- that leaves the
+    cards exactly as they were, asking for a mint. CANCELLATION does propagate, after the
+    claims are released.
+
+    The claim is taken BEFORE the process is ensured, because ensuring and activating are
+    one locked step (see ``mint_for``) and nothing may run between them. ``providers``
+    therefore only decides which rows are CLAIMED; what gets activated is the snapshot the
+    lock holder computes, so a claim the activation did not cover is released rather than
+    left minting forever.
+
+    NO CALLER YET: the premint endpoint that drives this lands in its own slice.
+    """
+    candidates = (
+        await asyncio.to_thread(mintable_providers) if providers is None else list(providers)
+    )
+    if not candidates:
+        return []
+
+    claims, displaced = await _claim_shared_mints([provider["slug"] for provider in candidates])
+    if not claims:
+        # A displaced row is only ever recorded alongside the claim that displaced it, so an
+        # empty claim set means there is nothing to dispose either.
+        return []
+    try:
+        # Inside the protected region on purpose: this is the awaiting half of the claim, so
+        # a cancellation here must roll the whole claim set back rather than strand it.
+        await _dispose_displaced_rows(displaced)
+        result = await _warm_activate()
+        if result is None:
+            await _release_shared_claims(claims)
+            return []
+
+        minted = await _absorb_warm_requests(result, claims)
+        activated = {provider["slug"] for provider in result.providers}
+        stranded = {slug: token for slug, token in claims.items() if slug not in activated}
+        if stranded:
+            await _release_shared_claims(stranded)
+    except BaseException:
+        # BaseException, not Exception: a CancelledError landing between the claim and the
+        # activation would otherwise leave every row ``minting`` with no watcher and no
+        # activation. ``expire_dead_mints`` judges ``waiting`` rows only, so nothing would
+        # ever withdraw them -- and they keep ``_shared_mints_pending`` true, so the reaper
+        # never retires the process either. The release awaits to completion: a task is
+        # handed its cancellation once, so this cleanup runs before the raise resumes it.
+        await _release_shared_claims(claims)
+        raise
+    await asyncio.to_thread(
+        _log_warm_event, "connections_warm_mint", f"activated:{len(claims)} minted:{len(minted)}"
+    )
+    logger.info("Shared mint activation warmed %d of %d card(s)", len(minted), len(claims))
+    return minted

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 import inspect
 import json
+import textwrap
+import time
 from pathlib import Path
 from typing import Any
 
 import pytest
 from test_connections_mint import _FS_ATTRS, _FS_NAMES, _called_names
 
+from kiro_crew import security
 from kiro_crew.connections import tool_aliases, warm
 from kiro_crew.connections.mint import _mints
 from kiro_crew.connections.registry import Provider
@@ -149,8 +153,10 @@ def _provider(slug: str, url: str = "") -> Provider:
 # ── the loop/filesystem invariant (mirrors the mint engine's own guard) ──
 #
 # Reuses the mint guard's primitive sets so the two cannot drift apart, plus the names that
-# reach the filesystem only from THIS module: the MCP inventory read and the grant stat.
-_WARM_FS_NAMES = _FS_NAMES | {"list_servers", "grant_present"}
+# reach the filesystem only from THIS module: the MCP inventory read, the grant stat, and the
+# credential gate -- which consults the operator's on-disk OAuth-endpoint extension for any
+# host outside the builtin set, so it is an unbounded stat like the rest.
+_WARM_FS_NAMES = _FS_NAMES | {"list_servers", "grant_present", "oauth_url_contains_credential"}
 
 
 def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
@@ -188,9 +194,11 @@ def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
         "mintable_providers",
         "_warm_spec_plan",
         "_warm_spec_is_foreign",
+        "_unowned_plan_specs",
         "_write_warm_mint_specs",
         "_remove_warm_mint_specs",
         "_warm_work_dir",
+        "_credential_bearing_slugs",
     }
 
     offenders = {
@@ -567,3 +575,1365 @@ def test_an_unreadable_inventory_warms_nothing_rather_than_raising(
         warm, "warm_spec_providers", lambda: (_ for _ in ()).throw(OSError("config unreadable"))
     )
     assert warm._warm_candidate_scan() == ([], [])
+
+
+def test_a_warm_session_never_injects_mcp_servers():
+    """A remote server through ``session/new`` kills the process and every verifier."""
+    assert warm._warm_session_mcp_servers() == []
+
+
+# ── one activation fills the whole table ──
+
+
+@pytest.fixture
+def _stub_activation(monkeypatch: pytest.MonkeyPatch):
+    """Neutralize the process, the audit log and the grant watcher."""
+
+    async def _no_watcher(slug: str, mcp_url: str, token: str) -> None:
+        return None
+
+    async def _no_settle(activation: int, in_use: set[int]) -> None:
+        return None
+
+    monkeypatch.setattr(warm, "_mint_watcher", _no_watcher)
+    monkeypatch.setattr(warm, "_log_warm_event", lambda *a, **k: None)
+    monkeypatch.setattr(warm._warm_mint, "settle_activation", _no_settle)
+
+
+def _result(
+    providers: list[Provider],
+    requests: list[dict[str, str]],
+    *,
+    generation: int = 7,
+    activation: int = 3,
+) -> warm._WarmMintResult:
+    return warm._WarmMintResult(
+        generation=generation, activation=activation, providers=providers, requests=requests
+    )
+
+
+def _returns(result: warm._WarmMintResult | None):
+    async def _activate(*, slug: str = ""):
+        return result
+
+    return _activate
+
+
+async def _claim(*slugs: str) -> dict[str, str]:
+    """Claim helper for the tests that do not exercise the displaced-row half."""
+    claims, displaced = await warm._claim_shared_mints(list(slugs))
+    assert not displaced, "these tests claim into empty slots"
+    return claims
+
+
+@pytest.mark.asyncio
+async def test_one_activation_stamps_every_row_with_its_generation_and_activation(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    providers = [_provider("linear"), _provider("vercel")]
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result(
+                providers,
+                [
+                    {"serverName": "linear", "oauthUrl": "https://l/consent"},
+                    {"serverName": "vercel", "oauthUrl": "https://v/consent"},
+                ],
+            )
+        ),
+    )
+
+    minted = await warm.warm_mint_all(providers)
+
+    assert sorted(minted) == ["linear", "vercel"]
+    for slug in ("linear", "vercel"):
+        row = _mints[slug]
+        assert row["state"] == "waiting"
+        assert row["generation"] == 7 and row["activation"] == 3
+        assert row["shared"] is True
+        # Every row carries the cold engine's row identity, which is what the grant
+        # watcher re-checks before it writes a verdict.
+        assert row["token"]
+    assert len({_mints["linear"]["token"], _mints["vercel"]["token"]}) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_claim_the_activation_did_not_cover_is_released_not_left_minting(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    claimed = [_provider("linear"), _provider("stranded")]
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result([claimed[0]], [{"serverName": "linear", "oauthUrl": "https://l/consent"}])
+        ),
+    )
+
+    assert await warm.warm_mint_all(claimed) == ["linear"]
+    assert "stranded" not in _mints, "an uncovered claim must not sit in the table forever"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_activation_releases_every_claim(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    monkeypatch.setattr(warm, "_warm_activate", _returns(None))
+    assert await warm.warm_mint_all([_provider("linear")]) == []
+    assert _mints == {}
+
+
+@pytest.mark.asyncio
+async def test_a_cold_held_row_is_never_replaced_by_a_warm_claim():
+    _mints["linear"] = {"state": "waiting", "client": object(), "oauth_url": "https://cold"}
+    assert await warm._claim_shared_mints(["linear"]) == ({}, [])
+    assert _mints["linear"]["oauth_url"] == "https://cold"
+
+
+@pytest.mark.asyncio
+async def test_expiry_is_narrowed_to_the_one_generation_whose_verifier_died():
+    """Withdrawal follows the verifier, so it follows the generation. A row on any OTHER
+    generation is redeemable on a process this expiry is not about."""
+    _mints["a"] = {"state": "waiting", "shared": True, "generation": 1, "token": "tok-a"}
+    _mints["b"] = {"state": "waiting", "shared": True, "generation": 2, "token": "tok-b"}
+    # A claim not yet stamped with a generation belongs to an activation still in flight.
+    _mints["c"] = {"state": "minting", "shared": True, "token": "tok-c"}
+    assert await warm._expire_shared_mints("mint_process_gone", generation=1) == ["a"]
+    assert _mints["b"]["state"] == "waiting"
+    assert _mints["c"]["state"] == "minting"
+
+
+# ── defect #6110: a batch timestamp is not a row identity ──
+#
+# The fence separating one activation's rows from the next at the SAME slug was
+# ``entry["started"] == started``, a ``time.monotonic()`` reading taken once per
+# ``warm_mint_all`` call. ``_new_mint_token``'s own docstring records why that is not a row
+# identity: the clock has ~15.6ms granularity on Windows, so two Connects for one provider
+# inside a single tick read as the same row and every guard built on it fails OPEN.
+
+
+@pytest.mark.asyncio
+async def test_a_late_absorb_does_not_write_its_url_over_a_newer_claim(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """Two overlapping activations at one slug. The first one's absorb lands last, and it
+    must not replace the second's claim -- the URL it carries belongs to a session the
+    second Connect is not waiting on."""
+    # A coarse clock, as Windows has: both claims are taken inside one tick, so a fence
+    # reading ``started`` cannot tell the two rows apart.
+    monkeypatch.setattr(warm.time, "monotonic", lambda: 100.0)
+    provider = _provider("linear")
+
+    first = await _claim("linear")
+    second, displaced = await warm._claim_shared_mints(["linear"])
+    assert first and second
+    assert first["linear"] != second["linear"], "each claim needs its own row identity"
+    assert [row["token"] for row in displaced] == [
+        first["linear"]
+    ], "the row the second claim replaced comes back for the caller to dispose"
+
+    stale = _result(
+        [provider], [{"serverName": "linear", "oauthUrl": "https://stale/consent"}], activation=1
+    )
+    assert await warm._absorb_warm_requests(stale, first) == []
+    row = _mints["linear"]
+    assert row.get("oauth_url") != "https://stale/consent"
+    assert row["state"] == "minting", "the newer claim is still the activation's to fill"
+    assert row["token"] == second["linear"]
+
+
+@pytest.mark.asyncio
+async def test_a_release_leaves_a_newer_claim_at_the_same_slug_alone(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The release path needs the same identity: dropping the row a newer activation is
+    filling would strand that Connect on a card with no claim and no URL."""
+    monkeypatch.setattr(warm.time, "monotonic", lambda: 100.0)
+    first = await _claim("linear")
+    second, _ = await warm._claim_shared_mints(["linear"])
+
+    await warm._release_shared_claims(first)
+
+    assert _mints["linear"]["token"] == second["linear"]
+
+
+# ── defect: a credential-bearing URL must be refused before it is stored ──
+
+
+@pytest.mark.asyncio
+async def test_a_url_carrying_a_credential_is_refused_rather_than_stored(_stub_activation):
+    """The same gate the cold mint and the chat consent banner apply. A refused URL is
+    never written to the row, so nothing can serve it to a card."""
+    provider = _provider("linear")
+    claims = await _claim("linear")
+    assert claims
+
+    bearing = _result(
+        [provider],
+        [
+            {
+                "serverName": "linear",
+                "oauthUrl": "https://linear.example/authorize?state=AKIA" + "IOSFODNN7EXAMPLE1",
+            }
+        ],
+    )
+    assert await warm._absorb_warm_requests(bearing, claims) == []
+    assert "linear" not in _mints, "the claim is released so the card asks for a fresh mint"
+
+
+@pytest.mark.asyncio
+async def test_the_screen_is_the_shared_security_gate_not_a_local_copy(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """A second implementation of the predicate would drift from the one the rest of the
+    product enforces, so the module must call through to security's."""
+    assert warm.oauth_url_contains_credential is security.oauth_url_contains_credential
+
+    monkeypatch.setattr(warm, "oauth_url_contains_credential", lambda url: True)
+    claims = await _claim("linear")
+    plain = _result(
+        [_provider("linear")], [{"serverName": "linear", "oauthUrl": "https://l/consent"}]
+    )
+    assert await warm._absorb_warm_requests(plain, claims) == []
+
+
+@pytest.mark.asyncio
+async def test_a_clean_url_still_lands_on_the_row(_stub_activation):
+    """The screen must not refuse the ordinary case it exists to let through."""
+    claims = await _claim("linear")
+    clean = _result(
+        [_provider("linear")],
+        [{"serverName": "linear", "oauthUrl": "https://linear.example/oauth/authorize?state=xyz"}],
+    )
+    assert await warm._absorb_warm_requests(clean, claims) == ["linear"]
+    assert _mints["linear"]["state"] == "waiting"
+
+
+# ── defect: a cancel between claim and activation strands every claimed row ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_between_claim_and_activation_releases_every_row(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """``minting`` rows are invisible to ``expire_dead_mints`` (it judges ``waiting`` only)
+    and they keep ``_shared_mints_pending`` true, so a row left behind here is never
+    withdrawn AND the process is never retired."""
+
+    async def _cancelled(*, slug: str = ""):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_warm_activate", _cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm.warm_mint_all([_provider("linear"), _provider("vercel")])
+
+    assert _mints == {}, "a cancelled activation must not leave a claim minting with no watcher"
+    assert warm._shared_mints_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_a_real_task_cancel_mid_activation_still_completes_the_release(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """The stronger form: not a raised ``CancelledError`` but a real ``Task.cancel()`` while
+    the coroutine is suspended. The cleanup awaits a lock and a dispose, so this is what
+    proves those awaits run rather than being interrupted a second time."""
+    entered = asyncio.Event()
+
+    async def _hangs(*, slug: str = ""):
+        entered.set()
+        await asyncio.Event().wait()  # never completes; the cancel lands here
+
+    monkeypatch.setattr(warm, "_warm_activate", _hangs)
+
+    task = asyncio.get_running_loop().create_task(warm.warm_mint_all([_provider("linear")]))
+    await entered.wait()
+    assert _mints["linear"]["state"] == "minting", "the claim is taken before the activation"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert _mints == {}
+    assert warm._shared_mints_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_after_the_activation_lands_releases_the_rows_too(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """The window does not close when the activation returns: an absorb interrupted
+    mid-flight leaves the same orphaned claims."""
+
+    async def _cancelling_absorb(result, claims):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result(
+                [_provider("linear")], [{"serverName": "linear", "oauthUrl": "https://l/consent"}]
+            )
+        ),
+    )
+    monkeypatch.setattr(warm, "_absorb_warm_requests", _cancelling_absorb)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm.warm_mint_all([_provider("linear")])
+
+    assert _mints == {}
+
+
+# ── defect: the claim loop's own await is a cancel window OUTSIDE the protected region ──
+#
+# ``warm_mint_all`` takes its claims BEFORE entering the try whose ``except BaseException``
+# rolls them back, so any await inside the claim loop is unprotected. Replacing an existing
+# row awaits ``_dispose_mint``, which suspends on a client teardown and again on the
+# shielded spec removal in its ``finally`` -- so a cancellation there unwinds with earlier
+# slugs already installed as ``minting`` and no caller holding their tokens.
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_while_replacing_a_row_does_not_strand_the_earlier_claims(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """``vercel`` is claimed first and needs no dispose; ``linear`` already holds a row, so
+    replacing it is the await the cancellation lands in. ``vercel`` must not survive it."""
+    real_dispose = warm._dispose_mint
+
+    async def _cancel_on_the_displaced_row(entry):
+        # Only the row being REPLACED carries a URL; our own fresh claims do not, so the
+        # rollback's own disposes still run for real.
+        if entry.get("oauth_url"):
+            raise asyncio.CancelledError()
+        await real_dispose(entry)
+
+    monkeypatch.setattr(warm, "_dispose_mint", _cancel_on_the_displaced_row)
+    _mints["linear"] = {
+        "state": "waiting",
+        "shared": True,
+        "oauth_url": "https://l/consent",
+        "generation": 5,
+        "activation": 1,
+        "token": "older-linear-row",
+    }
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm.warm_mint_all([_provider("vercel"), _provider("linear")])
+
+    assert _mints == {}, "an interrupted claim must not leave a row minting with no owner"
+    # `minting` rows are invisible to expire_dead_mints and keep the pending check true, so
+    # a survivor here is never withdrawn AND stops the process from ever being retired.
+    assert warm._shared_mints_pending() is False
+
+
+@pytest.mark.asyncio
+async def test_the_claim_loop_itself_contains_no_await():
+    """The structural invariant behind the test above: with no await between the first row
+    being installed and the loop ending, there is no window to be cancelled in."""
+    body = ast.parse(inspect.getsource(warm._claim_shared_mints)).body[0]
+    loops = [node for node in ast.walk(body) if isinstance(node, ast.For)]
+    assert loops, "guard is reading the wrong tree"
+    offenders = [
+        type(node).__name__
+        for loop in loops
+        for node in ast.walk(loop)
+        if isinstance(node, ast.Await)
+    ]
+    assert not offenders, f"awaits inside the claim loop: {offenders} -- move them out"
+
+
+# ── defect: the retry's expiry pass is unscoped ──
+
+
+@pytest.mark.asyncio
+async def test_a_retry_does_not_withdraw_a_parked_generations_live_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A parked generation's process still holds its verifier and its session still answers
+    the redirect, so its URL is redeemable. An expiry pass not scoped to the DEAD generation
+    withdraws a working link."""
+    _mints["parked"] = {
+        "state": "waiting",
+        "shared": True,
+        "oauth_url": "https://p/consent",
+        "generation": 3,
+        "activation": 1,
+        "token": "tok-parked",
+    }
+
+    attempts: list[str] = []
+
+    async def _dies_then_declines(*, slug: str = ""):
+        attempts.append(slug)
+        if len(attempts) == 1:
+            raise warm._WarmMintDied("ProcessGone")
+        return None
+
+    monkeypatch.setattr(warm._warm_mint, "mint_for", _dies_then_declines)
+
+    assert await warm._warm_activate() is None
+    assert len(attempts) == 2, "the death is retried once"
+    assert _mints["parked"]["state"] == "waiting"
+    assert _mints["parked"]["oauth_url"] == "https://p/consent"
+
+
+@pytest.mark.asyncio
+async def test_a_dead_generations_rows_are_expired_by_the_kill_itself(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Why the retry needs no expiry pass of its own: the stand-down that precedes
+    ``_WarmMintDied`` already withdrew exactly the rows whose verifier died, scoped to that
+    generation and leaving every other generation alone."""
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    _mints["dead"] = {"state": "waiting", "shared": True, "generation": 4, "token": "t4"}
+    _mints["parked"] = {"state": "waiting", "shared": True, "generation": 3, "token": "t3"}
+
+    await warm._warm_mint._park_or_kill_locked()
+
+    assert _mints["dead"]["state"] == "expired"
+    assert _mints["dead"]["reason"] == "mint_process_gone"
+    assert _mints["parked"]["state"] == "waiting"
+
+
+# ── defect: a parked generation is stranded when the current process dies ──
+
+
+def _parked_session(generation: int) -> warm._WarmSession:
+    """An unsettled session, so the sweep holds it exactly as a live activation's would be."""
+    return warm._WarmSession(
+        generation=generation, handle=object(), expires_at=time.monotonic() + 600
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_reaper_drains_parked_generations_after_the_current_process_dies(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Nothing else on any path reaches a parked generation once the current process is gone:
+    a new mint would sweep it, and the leak is exactly the case where none arrives. So the
+    process and its sessions stay resident forever after its last card completes."""
+    parked_runtime = _Runtime(True)
+    killed: list[Any] = []
+
+    async def _record_kill(runtime):
+        killed.append(runtime)
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 6)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, parked_runtime)])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {9: _parked_session(5)})
+    # Generation 5 is parked because this card still points at it.
+    _mints["parked"] = {
+        "state": "waiting",
+        "shared": True,
+        "generation": 5,
+        "activation": 9,
+        "token": "t5",
+    }
+
+    sweeps = 0
+    real_sweep = warm._warm_mint.sweep_retiring
+
+    async def _counting_sweep():
+        nonlocal sweeps
+        sweeps += 1
+        if sweeps == 2:
+            # The card completes, so nothing needs generation 5 any more.
+            _mints.pop("parked", None)
+        await real_sweep()
+
+    monkeypatch.setattr(warm._warm_mint, "sweep_retiring", _counting_sweep)
+
+    await asyncio.wait_for(warm._warm_mint_reaper(6), timeout=5)
+
+    assert killed == [parked_runtime], "the parked generation's process was never retired"
+    assert warm._warm_mint._retiring == []
+    assert warm._warm_mint._sessions == {}, "its sessions own the loopback servers"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_respawn_still_drains_the_generation_it_parked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The same leak by the other route: the stand-down cancels the old reaper, so a spawn
+    that then fails leaves a parked generation with no reaper at all."""
+    parked_runtime = _Runtime(True)
+    killed: list[Any] = []
+
+    async def _record_kill(runtime):
+        killed.append(runtime)
+
+    def _explode(*a, **k):
+        raise OSError("kiro-cli is not installed")
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _explode)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, parked_runtime)])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is False
+
+    drain = warm._warm_mint._reaper
+    assert drain is not None, "a parked generation with no process needs a drain task"
+    await asyncio.wait_for(drain, timeout=5)
+    assert killed == [parked_runtime]
+    assert warm._warm_mint._retiring == []
+
+
+# ── defect: a refused spec is still activated BY NAME ──
+#
+# The writer audits and SKIPS a foreign file at a planned spec path, which protects the
+# file. It does not protect the ACTIVATION: the runtime is handed `agent=<fixed name>` and
+# kiro-cli resolves that name off the same directory, so a hand-written agent sitting at
+# the name we declined to own gets executed and its `mcpServers` commands initialize.
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_spec_at_a_planned_path_aborts_warming_instead_of_being_activated(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """The refusal has to reach the SPAWN, not just the write."""
+    _foreign_spec(_agents_dir, warm._WARM_BASE_AGENT)
+    constructed: list[str] = []
+
+    def _factory():
+        def _build(**kwargs):
+            constructed.append(str(kwargs.get("agent")))
+            raise AssertionError("a refused spec must never be activated")
+
+        return _build
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", _factory)
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is False
+    assert constructed == [], "the runtime was constructed on a spec we refused to own"
+
+
+@pytest.mark.asyncio
+async def test_a_missing_planned_spec_also_aborts_warming(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """Absence and foreignness are the same answer here: an unreadable spec path is not a
+    spec of ours, and `_warm_spec_is_foreign` answers False for an absent file, so the
+    verification has to test existence as well as ownership."""
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)  # writes nothing
+    constructed: list[str] = []
+
+    def _factory():
+        def _build(**kwargs):
+            constructed.append(str(kwargs.get("agent")))
+            raise AssertionError("a missing spec must never be activated")
+
+        return _build
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", _factory)
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is False
+    assert constructed == []
+
+
+@pytest.mark.asyncio
+async def test_a_spec_set_this_module_owns_is_activated_normally(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """The verification must not refuse the ordinary case it exists to let through."""
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
+    built: list[str] = []
+
+    class _Spawnable:
+        def __init__(self, **kwargs):
+            built.append(str(kwargs.get("agent")))
+
+        async def spawn(self):
+            return None
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _Spawnable)
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is True
+    assert built == [warm._WARM_BASE_AGENT]
+    reaper = warm._warm_mint._reaper
+    assert reaper is not None
+    reaper.cancel()
+
+
+# ── defect: the stand-down -> spawn transition is not BaseException-safe ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_spec_write_still_arms_the_drain(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """Third route into the parked-generation leak. The park has already cancelled the old
+    reaper, so a cancellation before a replacement exists leaves the parked process with
+    nothing that will ever sweep it."""
+    parked_runtime = _Runtime(True)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, parked_runtime)])
+
+    def _cancel(plan):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", _cancel)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._ensure_locked([_provider("linear")])
+
+    drain = warm._warm_mint._reaper
+    assert drain is not None, "a park with no replacement reaper needs a drain armed"
+    drain.cancel()
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_spawn_kills_the_partial_runtime(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """A runtime that was constructed and may have forked a child must not be dropped on
+    the floor when the spawn await is cancelled."""
+    killed: list[Any] = []
+
+    async def _record_kill(runtime):
+        killed.append(runtime)
+
+    class _CancelsOnSpawn:
+        def __init__(self, **kwargs):
+            pass
+
+        async def spawn(self):
+            raise asyncio.CancelledError()
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _CancelsOnSpawn)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._ensure_locked([_provider("linear")])
+
+    assert len(killed) == 1, "the constructed runtime was leaked"
+
+
+# ── defect: settlement is not reached on every post-activation exit ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_credential_screen_still_settles_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The screen's `to_thread` await sits between the session's creation and its
+    settlement. A session left `settled=False` is permanently ineligible for the sweep, so
+    it and its loopback callback servers accumulate for the life of the process."""
+    settled: list[int] = []
+
+    async def _record_settle(activation: int, in_use: set[int]) -> None:
+        settled.append(activation)
+
+    def _cancel(urls):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm._warm_mint, "settle_activation", _record_settle)
+    monkeypatch.setattr(warm, "_credential_bearing_slugs", _cancel)
+
+    claims = await _claim("linear")
+    result = _result(
+        [_provider("linear")],
+        [{"serverName": "linear", "oauthUrl": "https://l/consent"}],
+        activation=11,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._absorb_warm_requests(result, claims)
+
+    assert settled == [11], "an unsettled session can never be collected"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_absorb_still_settles_the_session(monkeypatch: pytest.MonkeyPatch):
+    """Not only cancellation: any raise after the activation exists has the same
+    consequence, so the settlement belongs in a finally rather than on one branch."""
+    settled: list[int] = []
+
+    async def _record_settle(activation: int, in_use: set[int]) -> None:
+        settled.append(activation)
+
+    def _explode(urls):
+        raise OSError("the operator endpoint file is unreadable")
+
+    monkeypatch.setattr(warm._warm_mint, "settle_activation", _record_settle)
+    monkeypatch.setattr(warm, "_credential_bearing_slugs", _explode)
+
+    claims = await _claim("linear")
+    result = _result(
+        [_provider("linear")], [{"serverName": "linear", "oauthUrl": "https://l/consent"}]
+    )
+
+    with pytest.raises(OSError):
+        await warm._absorb_warm_requests(result, claims)
+
+    assert settled == [3]
+
+
+# ── defect (found by the systematic audit, not the lane): the retiring sweep drops
+# generations from its own list before killing them ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_mid_sweep_leaves_the_unkilled_generations_parked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`_sweep_retiring_locked` assigns the keep-list before it kills the drop-list, so a
+    cancellation partway through used to remove BOTH generations from `_retiring` while only
+    one was actually killed -- `parked_count()` then reads zero and the drain exits, so
+    nothing ever retries. A generation whose kill completed is gone; one whose kill was
+    interrupted stays parked for a later sweep."""
+    first, second = _Runtime(False), _Runtime(False)
+    killed: list[Any] = []
+
+    async def _kill_then_cancel(runtime):
+        killed.append(runtime)
+        if len(killed) == 2:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_kill_quietly", _kill_then_cancel)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(1, first), (2, second)])
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint.sweep_retiring()
+
+    assert killed == [first, second]
+    assert warm._warm_mint.parked_count() == 1, "the ungathered generation must stay parked"
+    assert warm._warm_mint._retiring == [(2, second)]
+
+
+# ── the invariant itself, pinned where it is mechanically checkable ──
+
+
+def _await_protections(func: Any) -> list[tuple[str, list[str]]]:
+    """Every await in ``func`` as ``(source text, enclosing try protections)``.
+
+    A protection reads ``finally`` or ``except BaseException`` -- the only two shapes a
+    ``CancelledError`` cannot walk past. An ``except Exception`` is recorded so the guard can
+    say what WAS there rather than only that nothing qualified.
+    """
+    source = textwrap.dedent(inspect.getsource(func))
+    tree = ast.parse(source)
+    found: list[tuple[str, list[str]]] = []
+
+    def label(node: ast.Try) -> str:
+        kinds = ["finally"] if node.finalbody else []
+        for handler in node.handlers:
+            if handler.type is None:
+                kinds.append("except BaseException")
+            elif isinstance(handler.type, ast.Name):
+                kinds.append(f"except {handler.type.id}")
+            else:
+                kinds.append("except <expr>")
+        return "+".join(kinds)
+
+    def walk(node: ast.AST, stack: list[str]) -> None:
+        if isinstance(node, ast.Try):
+            here = label(node)
+            for child in node.body:
+                walk(child, stack + [here])
+            for handler in node.handlers:
+                for child in handler.body:
+                    walk(child, stack)
+            for child in node.finalbody + node.orelse:
+                walk(child, stack)
+            return
+        if isinstance(node, ast.Await):
+            found.append((ast.get_source_segment(source, node) or "", list(stack)))
+        for child in ast.iter_child_nodes(node):
+            walk(child, stack)
+
+    for child in ast.iter_child_nodes(tree):
+        walk(child, [])
+    return found
+
+
+#: The awaits that sit between a state mutation and that mutation's settlement or cleanup.
+#: Named individually rather than "this function has SOME protected try", because the coarse
+#: form passed while a sibling await in the same function was still bare.
+_MUST_BE_PROTECTED = [
+    ("warm_mint_all", "_warm_activate", warm.warm_mint_all),
+    ("warm_mint_all", "_absorb_warm_requests", warm.warm_mint_all),
+    ("warm_mint_all", "_dispose_displaced_rows", warm.warm_mint_all),
+    ("_absorb_warm_requests", "_credential_bearing_slugs", warm._absorb_warm_requests),
+    (
+        "_activate_locked",
+        "asyncio.shield(create)",
+        warm._WarmMintRuntime._activate_locked,
+    ),
+    ("_activate_locked", "handle.drain_init", warm._WarmMintRuntime._activate_locked),
+    (
+        "_abandon_session_creation_locked",
+        "_destroy_session_quietly",
+        warm._WarmMintRuntime._abandon_session_creation_locked,
+    ),
+    (
+        "_sweep_sessions_locked",
+        "_destroy_session_quietly",
+        warm._WarmMintRuntime._sweep_sessions_locked,
+    ),
+    ("_ensure_locked", "_write_warm_mint_specs", warm._WarmMintRuntime._ensure_locked),
+    ("_ensure_locked", "runtime.spawn()", warm._WarmMintRuntime._ensure_locked),
+    ("_sweep_retiring_locked", "_kill_generation", warm._WarmMintRuntime._sweep_retiring_locked),
+    ("_park_or_kill_locked", "_kill_generation", warm._WarmMintRuntime._park_or_kill_locked),
+    ("_retire_locked", "_kill_quietly", warm._WarmMintRuntime._retire_locked),
+]
+
+_PROTECTING = ("finally", "except BaseException")
+
+
+def test_every_post_mutation_await_is_individually_protected():
+    """Both review rounds found the same class: an await between a state mutation and its
+    settlement or cleanup, guarded only by an `except Exception` that a CancelledError walks
+    straight past. Bound to the SPECIFIC await rather than the function, so a newly-added
+    sibling await in an already-protected function cannot pass by association."""
+    for name, target, func in _MUST_BE_PROTECTED:
+        awaits = _await_protections(func)
+        matching = [(text, stack) for text, stack in awaits if target in text]
+        assert matching, (
+            f"{name}: no await matching {target!r} -- the guard is reading the wrong code, "
+            "so update this table rather than deleting the entry"
+        )
+        for text, stack in matching:
+            assert any(any(kind in entry for kind in _PROTECTING) for entry in stack), (
+                f"{name}: `{text}` is guarded only by {stack or ['nothing']} -- a "
+                "CancelledError walks past every `except Exception`, which is exactly the "
+                "bug class three review rounds found"
+            )
+
+
+# ── two more of the same class, found by the systematic audit ──
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_stand_down_kill_re_parks_the_process(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`_park_or_kill_locked` clears `_runtime` and cancels the reaper BEFORE it awaits the
+    kill, so a cancellation inside that kill used to drop the only reference to a process
+    that is still running -- neither registered, nor parked, nor dead."""
+    doomed = _Runtime(False)
+
+    async def _cancel(runtime):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_kill_quietly", _cancel)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", doomed)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 7)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    monkeypatch.setattr(warm._warm_mint, "_reaper", None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._park_or_kill_locked()
+
+    assert warm._warm_mint._retiring == [(7, doomed)], "an unkilled process must stay tracked"
+    drain = warm._warm_mint._reaper
+    assert drain is not None, "and something must be scheduled to retire it"
+    drain.cancel()
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_during_the_hard_teardown_re_parks_what_is_left(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`_retire_locked` empties `_retiring` and clears `_runtime` up front, so a
+    cancellation partway through its kill loop used to leak every remaining process with no
+    reference left anywhere."""
+    parked, current = _Runtime(False), _Runtime(False)
+    killed: list[Any] = []
+
+    async def _kill_then_cancel(runtime):
+        killed.append(runtime)
+        if len(killed) == 2:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_kill_quietly", _kill_then_cancel)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", current)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 9)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(8, parked)])
+    monkeypatch.setattr(warm._warm_mint, "_reaper", None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._retire_locked()
+
+    # The parked one was killed first and is gone; the current one was interrupted.
+    assert killed == [parked, current]
+    assert warm._warm_mint._retiring == [(9, current)]
+    drain = warm._warm_mint._reaper
+    assert drain is not None
+    drain.cancel()
+
+
+# ── defect: the CURRENT generation number can name a PARKED process ──
+#
+# Only a successful spawn bumps `_generation`, so a stand-down leaves the live process in
+# `_retiring` under the number that is still `self._generation`, with `self._runtime`
+# cleared. The equality branch answered `is_alive()` for that number and so reported the
+# parked process dead -- withdrawing redeemable URLs, and then letting the next sweep kill
+# the very process the park existed to preserve.
+
+
+@pytest.mark.asyncio
+async def test_a_generation_parked_mid_respawn_keeps_its_rows(monkeypatch: pytest.MonkeyPatch):
+    """A status scan runs without the runtime lock, so it sees the window between the
+    stand-down and its replacement spawn."""
+    live = _Runtime(True)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    # Exactly the mid-respawn state: stood down, replacement not yet spawned, so the
+    # parked entry still carries the CURRENT number.
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(4, live)])
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {2: _parked_session(4)})
+    _mints["linear"] = {
+        "state": "waiting",
+        "shared": True,
+        "oauth_url": "https://l/consent",
+        "generation": 4,
+        "activation": 2,
+        "token": "t4",
+    }
+
+    assert warm._warm_mint.generation_is_live(4) is True
+    assert await warm.expire_dead_mints() == []
+    assert _mints["linear"]["state"] == "waiting"
+
+
+def test_a_dead_current_runtime_is_still_dead_when_nothing_is_parked(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The fall-through must not turn a genuinely dead generation live."""
+    monkeypatch.setattr(warm._warm_mint, "_generation", 4)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+    assert warm._warm_mint.generation_is_live(4) is False
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [(4, _Runtime(False))])
+    assert warm._warm_mint.generation_is_live(4) is False
+
+
+# ── defect: session-handle ownership transfers are not cancellation-safe ──
+
+
+class _SessionHandle:
+    """A backend session. Records that it exists, and whether it was terminated."""
+
+    def __init__(self, created: list[Any]) -> None:
+        self.destroyed = False
+        created.append(self)
+
+    async def destroy(self) -> None:
+        self.destroyed = True
+
+    def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_create_still_destroys_the_session_the_backend_made(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The backend's session/new has already succeeded when our wait is abandoned. The
+    handle is the ONLY way to terminate that session and its loopback callback children, so
+    dropping it leaks them until the whole runtime is retired."""
+    created: list[Any] = []
+    exists = asyncio.Event()
+
+    class _SlowToReturn:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            handle = _SessionHandle(created)  # the backend session now EXISTS
+            exists.set()
+            await asyncio.sleep(0.2)  # ...and our wait is abandoned during this
+            return handle
+
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _SlowToReturn())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    task = asyncio.get_running_loop().create_task(
+        warm._warm_mint._activate_locked("agent", frozenset())
+    )
+    await exists.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert len(created) == 1
+    assert created[0].destroyed is True, "an abandoned session must still be terminated"
+    assert warm._warm_mint._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_mid_session_destroy_keeps_the_record_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The sweep popped the record before awaiting the destroy, so a cancellation there lost
+    the only reference to a session that is still listening."""
+
+    async def _cancels(handle: Any) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_destroy_session_quietly", _cancels)
+    record = warm._WarmSession(generation=1, handle=object(), expires_at=0.0, settled=True)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {5: record})
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint.sweep_sessions(set())
+
+    assert warm._warm_mint._sessions == {5: record}, "the only retry record must survive"
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_destroying_an_unstamped_session_leaves_it_sweepable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The activation's own failure path has the same shape: it popped the record, so a
+    cancellation mid-destroy lost it. Retained instead -- and marked settled and expired, so
+    the next sweep is the retry rather than nothing being."""
+    created: list[Any] = []
+
+    class _PollExplodes:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            return _SessionHandle(created)
+
+    async def _cancels(handle: Any) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_destroy_session_quietly", _cancels)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _PollExplodes())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    monkeypatch.setattr(warm, "_WARM_OAUTH_SETTLE_ROUNDS", 1)
+    # The oauth poll raises, which is what sends the activation down its teardown path.
+    monkeypatch.setattr(
+        _SessionHandle,
+        "pop_pending_oauth_requests",
+        lambda self: (_ for _ in ()).throw(RuntimeError("frame decode failed")),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    sessions = warm._warm_mint._sessions
+    assert len(sessions) == 1, "an undestroyed session must stay tracked"
+    record = next(iter(sessions.values()))
+    assert (
+        record.settled is True and record.expires_at <= time.monotonic()
+    ), "and must be eligible for the sweep, or retaining it just moves the leak"
+
+
+@pytest.mark.asyncio
+async def test_a_cancel_destroying_an_abandoned_session_leaves_it_sweepable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The reaped handle enters the SAME ownership rule as every other session: registered
+    settled-and-expired before the destroy, so an interrupted destroy is retried by the
+    ordinary sweep rather than losing the only reference."""
+    created: list[Any] = []
+    exists = asyncio.Event()
+
+    class _SlowToReturn:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            handle = _SessionHandle(created)
+            exists.set()
+            await asyncio.sleep(0.2)
+            return handle
+
+    async def _cancels(handle: Any) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(warm, "_destroy_session_quietly", _cancels)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _SlowToReturn())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    task = asyncio.get_running_loop().create_task(
+        warm._warm_mint._activate_locked("agent", frozenset())
+    )
+    await exists.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    sessions = warm._warm_mint._sessions
+    assert len(sessions) == 1, "an undestroyed reaped session must stay tracked"
+    record = next(iter(sessions.values()))
+    assert record.settled is True and record.expires_at <= time.monotonic()
+
+
+# ── defect: an unaddressable abandoned session accumulated without bound ──
+#
+# The no-handle abandon path's acceptance was "reaped when the runtime is retired". But
+# retirement is not guaranteed to arrive: any card holding a URL keeps `_shared_mints_pending`
+# true, which resets the reaper's idle clock every cycle, while `_ensure_locked`'s
+# digest-equality fast path keeps the SAME generation reusable -- so every repetition parked
+# another orphan session and its callback children on one live process.
+
+
+@pytest.mark.asyncio
+async def test_an_unaddressable_abandoned_session_quarantines_its_generation(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """Quarantining bounds the residual to ONE generation's worth: the next activation finds
+    the resident plan unservable, stands the generation down, and the orphan dies with the
+    process."""
+    monkeypatch.setattr(warm, "_WARM_SESSION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(warm, "_WARM_SESSION_REAP_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)
+    monkeypatch.setattr(warm, "_unowned_plan_specs", lambda plan: [])
+
+    class _NeverReturnsAHandle:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            # No handle ever becomes reachable to us, so nothing is addressable to destroy.
+            await asyncio.Event().wait()
+
+    stale = _NeverReturnsAHandle()
+    # The REAL resident plan, so the digest fast path is genuinely reachable -- otherwise the
+    # test would respawn for an unrelated reason and prove nothing.
+    resident = warm._warm_spec_plan([_provider("linear")])
+    monkeypatch.setattr(warm._warm_mint, "_runtime", stale)
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_plan", resident)
+    monkeypatch.setattr(warm._warm_mint, "_digest", resident.digest)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+
+    with pytest.raises(BaseException):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    assert warm._warm_mint._plan is None, "the generation must be quarantined"
+    assert warm._warm_mint._digest == ""
+
+    # A subsequent activation must stand the quarantined generation DOWN, not reuse it.
+    killed: list[Any] = []
+
+    async def _record_kill(runtime: Any) -> None:
+        killed.append(runtime)
+
+    class _Spawnable:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        async def spawn(self) -> None:
+            return None
+
+        def is_alive(self) -> bool:
+            return True
+
+    monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _Spawnable)
+
+    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is True
+    assert killed == [stale], "the process holding the orphan session was reused instead"
+    reaper = warm._warm_mint._reaper
+    if reaper is not None:
+        reaper.cancel()
+
+
+@pytest.mark.asyncio
+async def test_a_recovered_handle_does_not_quarantine_the_generation(
+    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+):
+    """The opposite failure mode: the RECOVERED-handle path registers and destroys cleanly,
+    so it needs no stand-down. Quarantining there would cost a respawn on every transient
+    timeout that the reap already fully repaired."""
+    monkeypatch.setattr(warm, "_WARM_SESSION_TIMEOUT_SECONDS", 0.01)
+    created: list[Any] = []
+
+    class _SlowToReturn:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            handle = _SessionHandle(created)
+            await asyncio.sleep(0.05)
+            return handle
+
+    resident = warm._warm_spec_plan([_provider("linear")])
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _SlowToReturn())
+    monkeypatch.setattr(warm._warm_mint, "_generation", 5)
+    monkeypatch.setattr(warm._warm_mint, "_plan", resident)
+    monkeypatch.setattr(warm._warm_mint, "_digest", resident.digest)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    with pytest.raises(BaseException):
+        await warm._warm_mint._activate_locked("agent", frozenset())
+
+    assert created and created[0].destroyed is True, "the reap must still have worked"
+    assert warm._warm_mint._plan is resident, "a fully repaired reap must not force a respawn"
+    assert warm._warm_mint._digest == resident.digest
+
+
+# ── defect: the settle loop never CONSUMED the session queue ──
+#
+# `pop_pending_oauth_requests()` reads a list that only `drain_init` appends to, and
+# `create_session` runs exactly one drain before returning the handle. So `asyncio.sleep`
+# between pops moved nothing: a frame arriving after that create-time drain's idle exit was
+# unreachable no matter how many rounds elapsed. The budget was never the binding
+# constraint -- the loop had no mechanism to absorb a late frame at all.
+
+
+class _QueuedOauthHandle:
+    """A session handle with the real contract: a frame is poppable only after a DRAIN.
+
+    ``available_after_drains`` is how many ``drain_init`` calls must have happened before
+    that provider's frame moves onto the poppable list -- 0 models a frame staged during
+    ``session/new`` and already drained by ``create_session``.
+    """
+
+    def __init__(self, schedule: dict[str, int]) -> None:
+        self._schedule = dict(schedule)
+        self._poppable: list[dict[str, str]] = []
+        self.drains = 0
+        self.destroyed = False
+        self._promote()
+
+    def _promote(self) -> None:
+        for name, due in sorted(self._schedule.items()):
+            if due <= self.drains:
+                self._poppable.append({"serverName": name, "oauthUrl": f"https://{name}/consent"})
+                del self._schedule[name]
+
+    def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+        out, self._poppable = list(self._poppable), []
+        return out
+
+    async def drain_init(self, **kwargs) -> None:
+        self.drains += 1
+        self._promote()
+
+    async def destroy(self) -> None:
+        self.destroyed = True
+
+
+def _queued_runtime(handle: Any) -> Any:
+    class _Runtime:
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs):
+            return handle
+
+    return _Runtime()
+
+
+@pytest.mark.asyncio
+async def test_a_frame_arriving_after_the_create_drain_is_still_absorbed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`linear`'s frame was staged during session/new; `vercel`'s lands three windows later.
+    Sleeping past it consumed nothing, so it was never poppable."""
+    handle = _QueuedOauthHandle({"linear": 0, "vercel": 3})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    activation, requests = await warm._warm_mint._activate_locked(
+        "agent", frozenset({"linear", "vercel"})
+    )
+
+    names = sorted(str(request["serverName"]) for request in requests)
+    assert names == ["linear", "vercel"], "a late frame must be consumed, not slept past"
+    assert activation in warm._warm_mint._sessions
+    assert handle.destroyed is False
+
+
+@pytest.mark.asyncio
+async def test_the_settle_loop_stops_as_soon_as_every_wanted_frame_is_in(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Consuming must not cost latency when the frames are already staged: the loop still
+    short-circuits on the first pop and opens no drain window at all."""
+    handle = _QueuedOauthHandle({"linear": 0})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    _, requests = await warm._warm_mint._activate_locked("agent", frozenset({"linear"}))
+
+    assert [str(r["serverName"]) for r in requests] == ["linear"]
+    assert handle.drains == 0, "an already-satisfied activation must open no drain window"
+
+
+@pytest.mark.asyncio
+async def test_the_settle_loop_consumes_on_every_round_it_waits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The budget is only meaningful if every waiting round is a CONSUMING round -- one
+    bare sleep anywhere in the loop is a window a frame can land in unseen."""
+    handle = _QueuedOauthHandle({"linear": 0, "never": 99})
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _queued_runtime(handle))
+    monkeypatch.setattr(warm._warm_mint, "_generation", 3)
+    monkeypatch.setattr(warm._warm_mint, "_sessions", {})
+
+    await warm._warm_mint._activate_locked("agent", frozenset({"linear", "never"}))
+
+    assert (
+        handle.drains == warm._WARM_OAUTH_SETTLE_ROUNDS - 1
+    ), "every round that waits must consume; the last round pops and does not wait"
+
+
+@pytest.mark.asyncio
+async def test_a_frame_past_the_whole_budget_releases_its_claim_cleanly(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation
+):
+    """Beyond the budget the cold path is the correct answer, so the claim must be RELEASED
+    -- no row left minting, and the token fence still refuses a late absorb."""
+    provider = _provider("slowpoke")
+    claims = await _claim("slowpoke")
+    token = claims["slowpoke"]
+
+    # The activation produced no frame for it at all.
+    empty = _result([provider], [])
+    assert await warm._absorb_warm_requests(empty, claims) == []
+    assert "slowpoke" not in _mints, "an unfulfilled claim must not sit in the table"
+
+    # A later activation re-claims the slug; the first claim's token must not resurrect it.
+    fresh = await _claim("slowpoke")
+    assert fresh["slowpoke"] != token
+    late = _result([provider], [{"serverName": "slowpoke", "oauthUrl": "https://s/consent"}])
+    assert await warm._absorb_warm_requests(late, claims) == []
+    assert _mints["slowpoke"]["state"] == "minting"
+    assert _mints["slowpoke"]["token"] == fresh["slowpoke"]


### PR DESCRIPTION
## Problem / Motivation

[#6697](https://github.com/kirodotdev/KiroCrew/pull/6697) plans which providers a shared warm process should serve and writes its agent specs — but nothing spawns, activates, parks, or retires that process, and nothing absorbs the approval URLs it yields. The warm table (#6045) still sits empty and every Connect pays the ~7.5s cold spawn. Issue #6110 additionally names three lifecycle findings that had to close before the entry point could ever be wired.

## Why it matters

This is the half that makes warm minting real: one shared process activation yields every card's approval URL. Without it, the plan half and the table are inert scaffolding.

## What changed (motivation → approach → change)

Goal: land the warm-mint RUNTIME as the second slice of W1 (stacked on #6697; retarget to main after it merges), with the process lifecycle correct under cancellation — the failure mode that dominates this path, since every caller is a request task that can be torn down at any await.

What was built, extending `src/kiro_crew/connections/warm.py`:

- **Process lifecycle** on `_WarmMintRuntime`: spawn, activation settlement, session sweep, park-or-kill on plan changes, generation retirement, and a reaper; a parked-generation **drain** keeps sweeping until every parked generation is gone, covering reaper-death, spawn-failure, and cancellation routes.
- **Claim/absorb/expire** for shared rows: `_claim_shared_mints` (await-free and atomic by construction — pinned by an AST guard), `_absorb_warm_requests`, `_release_shared_claims`, `_expire_shared_mints` (generation-scoped only), and the callerless entry point `warm_mint_all` — the dashboard wiring deliberately lands in a later slice, so callerless is declared, not accidental.
- **The three #6110 gating fixes, each red-first and mutation-checked**:
  1. Claims are fenced by the row's existing uuid4 `token` instead of a wall-clock `started` value (whose ~15.6ms Windows granularity made the donor's fence fail open) — a late absorb can no longer overwrite a newer claim.
  2. Every URL is screened by `oauth_url_contains_credential` (off-loop) **before** it is stored on a row; a credential-bearing URL is refused and audited, never stored.
  3. A cancellation between claim and activation releases every installed token (`BaseException`-safe with re-raise) — no more orphaned `minting` rows with no watcher.
- **A cancellation-safety campaign** driven by four local review rounds (3→3→2→1 findings, all validated and fixed red-first): activation only ever runs on specs re-verified as sentinel-owned (a refused foreign spec is never executed — warming aborts to the cold path); the stand-down→spawn transition, session settlement, retiring sweep, and hard teardown are all `BaseException`-safe under one uniform pattern; a liveness query now consults `_retiring` so a parked-mid-respawn generation is not misread as dead; and the abandoned-session residual is **bounded** — a no-handle abandon quarantines its generation, so orphans die on the next activation instead of accumulating. The invariant ("registered before anything can interrupt, forgotten only once its destroy completed") is documented as a 9-row ownership table in the design note and enforced by an AST test bound to the specific awaits, plus 18 compile-verified mutation checks proving every guard is load-bearing.

## Tests

`test/test_connections_warm.py` grows 34 → 73: the seven donor async lifecycle tests; red-first regressions for all three #6110 fixes; red-first regressions for every review-round fix (claim-window cancel, scoped expiry, parked drain both routes, refused-spec activation gate, spawn-transition abandon, settlement-on-every-exit, sweep retain-until-destroyed, liveness fall-through, abandoned-create reap, generation quarantine); the AST invariant guards (await-free claim loop; protected post-mutation awaits per function); and the session-never-injects-mcp-servers pin. Full `test_connections_*.py` surface: 775 passing.

## Manual verification

N/A — unit coverage sufficient: backend-only, the entry point is deliberately callerless in this slice and is exercised directly by the suite, including under injected cancellation at every audited window.

## Screenshots / video

N/A — backend + docs only; no user-visible UI change.

## Related Issues

Stacked on [#6697](https://github.com/kirodotdev/KiroCrew/pull/6697) (base `feat/connections-warm-mints`; will retarget to `main` when it merges). The dashboard endpoint wiring lands in a follow-up slice.

Fixes #6110

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
