### PR TITLE
fix: migrate seven agent-spec reads onto the hardened reader (#6695)

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2653,11 +2653,12 @@ def migrate_agent_specs() -> int:
         return 0
     cleaned = 0
     for spec_path in sorted(kiro_agents_dir_path().glob("*.json")):
-        try:
-            data = json.loads(spec_path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
-        if not isinstance(data, dict):
+        # The hardened reader (size cap, AppleDouble/sensitive-symlink and
+        # non-object refusal). This site also WRITES below: a spec the reader
+        # refuses is now never rewritten at all, whereas the old read_text
+        # path read -- and then rewrote -- whatever the file or link named.
+        data = _read_agent_spec(spec_path)
+        if data is None:
             continue
         if "model_managed" not in data and "cc_model" not in data:
             continue

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -17,6 +17,7 @@ from itertools import islice
 
 from kiro_crew import model_registry
 from kiro_crew.agent import kiro_agents_dir_path
+from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.dashboard.channel_slots import slot_closed_since
@@ -251,14 +252,16 @@ def _build_kiro_model_map() -> dict[str, str]:
     out: dict[str, str] = {}
     try:
         for f in kiro_agents_dir_path().glob("*.json"):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                model = data.get("model", "")
-                if data.get("name"):
-                    out[data["name"]] = model
-                out[f.stem] = model
-            except (json.JSONDecodeError, OSError):
+            # Hardened reader: a refused spec (oversized, sensitive symlink,
+            # non-object JSON, ...) is skipped like an absent one instead of
+            # aborting the whole scan through the outer except.
+            data = _read_agent_spec(f)
+            if data is None:
                 continue
+            model = data.get("model", "")
+            if data.get("name"):
+                out[data["name"]] = model
+            out[f.stem] = model
     except Exception:
         logger.debug("Failed to build kiro model map", exc_info=True)
     return out

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -26,6 +26,7 @@ from kiro_crew.agent import (
     kiro_agents_dir_path,
 )
 from kiro_crew.agent_discovery import (
+    _read_agent_spec,
     clear_list_agents_cache,
     list_agents,
     project_agent_names,
@@ -95,11 +96,10 @@ def _namespaced_agent_file_exists(agent_name: str) -> bool:
     # glob the real ~/.kiro from an isolated run.
     try:
         for path in kiro_agents_dir_path().glob(f"*--{agent_name}.json"):
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, ValueError):
+            data = _read_agent_spec(path)
+            if data is None:
                 continue
-            if isinstance(data, dict) and data.get("name") == agent_name:
+            if data.get("name") == agent_name:
                 return True
     except OSError:
         return False
@@ -1565,8 +1565,17 @@ async def api_agent_detail(request: web.Request) -> web.Response:
 
     state: DashboardState = request.app["state"]
     for f in kiro_agents_dir_path().glob("*.json"):
+        spec = _read_agent_spec(f)
+        if spec is None:
+            continue
+        # Two-step so ``data`` stays typed ``dict`` for the PATCH branch's
+        # re-read below, which reassigns it from a raw ``json.loads``.
+        data = spec
+        # The try stays even though the parse moved out: the DELETE/PATCH
+        # bodies still raise the caught pair mid-flight (the PATCH re-read
+        # under the config lock, unlink), and those were -- and remain --
+        # skip-to-next-file.
         try:
-            data = json.loads(f.read_text(encoding="utf-8"))
             if data.get("name") == name or f.stem == name:
                 if request.method == "DELETE":
                     if f.name in (

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -21,6 +21,7 @@ from kiro_crew.agent import (
     kiro_agents_dir_path,
     rebuild_agent_config,
 )
+from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import (
     FORWARD_DECLARED_ENV_DEFAULT,
@@ -779,15 +780,14 @@ async def api_mcp_active(request: web.Request) -> web.Response:
     # Non-kirocrew agent: read from agent config
     if agent and agent != "kirocrew":
         for f in kiro_agents_dir_path().glob("*.json"):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                if data.get("name") == agent:
-                    agent_mcps = data.get("mcpServers", {})
-                    return web.json_response(
-                        [{"name": n, "enabled": True} for n in sorted(agent_mcps)]
-                    )
-            except (json.JSONDecodeError, OSError):
+            spec = _read_agent_spec(f)
+            if spec is None:
                 continue
+            if spec.get("name") == agent:
+                agent_mcps = spec.get("mcpServers", {})
+                return web.json_response(
+                    [{"name": n, "enabled": True} for n in sorted(agent_mcps)]
+                )
         return web.json_response([])
 
     # Kirocrew / default: read from global mcp.json
@@ -2690,11 +2690,8 @@ def _collect_server_rows() -> dict[str, dict[str, Any]]:
     if not agents_dir.is_dir():
         return rows
     for path in sorted(agents_dir.glob("*.json")):
-        try:
-            spec = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(spec, dict):
+        spec = _read_agent_spec(path)
+        if spec is None:
             continue
         agent_name = spec.get("name") or path.stem
         mcp_servers = spec.get("mcpServers")
@@ -2756,11 +2753,8 @@ def _launch_specs_for(names: set[str]) -> dict[str, list[SimpleNamespace]]:
     if not agents_dir.is_dir():
         return specs
     for path in sorted(agents_dir.glob("*.json")):
-        try:
-            spec = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(spec, dict):
+        spec = _read_agent_spec(path)
+        if spec is None:
             continue
         mcp_servers = spec.get("mcpServers")
         if not isinstance(mcp_servers, dict):

--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -1,0 +1,293 @@
+"""Every remaining agent-spec scan reads through the hardened reader (#6695).
+
+Seven call sites read ``~/.kiro/agents/*.json`` with a hand-rolled
+``json.loads(read_text())`` until this migration; each now goes through
+``agent_discovery._read_agent_spec`` -- the size-capped, sensitive-symlink- and
+non-object-refusing reader #5423 adopted for ``_resolve_agent_model``. Per
+surface this pins the two properties the migration promises: a refused spec is
+SKIPPED (it degrades exactly like an absent one, and the surface still
+answers), and a valid spec is unaffected under the same cap.
+
+Refusal is exercised with a LOWERED ``hooks.MAX_FILE_BYTES`` (the property is
+that the cap is consulted, not its value) and with non-object JSON -- both
+observable without planting symlinks, mirroring #5423's tests. One
+representative symlink test proves the sensitive-target guard applies through
+a migrated caller; the guard itself lives in ``_read_agent_spec`` and has its
+own coverage.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+
+from kiro_crew.agent import migrate_agent_specs
+from kiro_crew.dashboard.chat_persistence import _build_kiro_model_map
+from kiro_crew.dashboard.handlers.agents import (
+    _namespaced_agent_file_exists,
+    api_agent_detail,
+)
+from kiro_crew.dashboard.handlers.mcp import (
+    _collect_server_rows,
+    _launch_specs_for,
+    api_mcp_active,
+)
+
+# The two refusal shapes cheap enough to plant per surface. "oversized" is the
+# differential case (the old read_text path had no cap, so it PARSED these);
+# "non_object" pins that valid-JSON-wrong-shape degrades as absent everywhere,
+# including the surfaces whose old parse crashed on it (AttributeError past an
+# ``except (JSONDecodeError, OSError)``).
+REFUSALS = ("oversized", "non_object")
+
+
+@pytest.fixture
+def agents_dir(tmp_path, monkeypatch):
+    """Isolated agents dir behind a lowered read cap.
+
+    ``KIRO_AGENTS_DIR`` is the documented override hook every migrated site
+    resolves through ``kiro_agents_dir_path()``; the cap is lowered rather than
+    writing a real 50 MB fixture (same trade #5423's tests made).
+    """
+    from kiro_crew import hooks
+
+    monkeypatch.setattr(hooks, "MAX_FILE_BYTES", 256)
+    monkeypatch.setattr("kiro_crew.agent.KIRO_AGENTS_DIR", tmp_path)
+    return tmp_path
+
+
+def _plant(agents_dir: Path, filename: str, spec: dict) -> Path:
+    p = agents_dir / filename
+    p.write_text(json.dumps(spec), encoding="utf-8")
+    return p
+
+
+def _plant_refused(agents_dir: Path, filename: str, spec: dict, kind: str) -> Path:
+    p = agents_dir / filename
+    if kind == "oversized":
+        body = dict(spec)
+        body["pad"] = "x" * 1024  # far past the lowered 256-byte cap
+        p.write_text(json.dumps(body), encoding="utf-8")
+    else:  # non_object: valid JSON, wrong shape
+        p.write_text(json.dumps([spec]), encoding="utf-8")
+    return p
+
+
+class TestMigrateAgentSpecs:
+    """agent.migrate_agent_specs -- the one site that also WRITES."""
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_spec_is_never_rewritten(self, agents_dir, kind):
+        """A spec the reader refuses is not cleaned AND not written back.
+
+        Strictly safer than the old path, which read (and rewrote) whatever
+        the file held: refusal now keeps the write from happening at all.
+        """
+        p = _plant_refused(agents_dir, "dirty.json", {"name": "dirty", "model_managed": True}, kind)
+        before = p.read_text(encoding="utf-8")
+
+        assert migrate_agent_specs() == 0
+        assert p.read_text(encoding="utf-8") == before
+
+    def test_valid_spec_still_cleaned_under_the_same_cap(self, agents_dir):
+        p = _plant(agents_dir, "dirty.json", {"name": "dirty", "model_managed": True})
+
+        assert migrate_agent_specs() == 1
+        assert "model_managed" not in json.loads(p.read_text(encoding="utf-8"))
+
+
+class TestBuildKiroModelMap:
+    """chat_persistence._build_kiro_model_map -- feeds legacy session restore."""
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_spec_is_skipped_not_fatal(self, agents_dir, kind):
+        """The refused file contributes nothing and the scan keeps going.
+
+        Under the old parse a non-object spec raised past the inner except and
+        aborted the whole scan through the outer one; now it is a per-file skip.
+        """
+        _plant_refused(agents_dir, "bad.json", {"name": "bad", "model": "pinned-by-bad"}, kind)
+        _plant(agents_dir, "good.json", {"name": "good", "model": "pinned-by-good"})
+
+        out = _build_kiro_model_map()
+
+        assert out.get("good") == "pinned-by-good"
+        assert "bad" not in out
+
+    def test_valid_spec_still_maps_under_the_same_cap(self, agents_dir):
+        _plant(agents_dir, "good.json", {"name": "good", "model": "pinned-by-good"})
+
+        out = _build_kiro_model_map()
+
+        # Keyed by both the declared name and the file stem (here identical).
+        assert out == {"good": "pinned-by-good"}
+
+
+class TestNamespacedAgentFileExists:
+    """handlers.agents._namespaced_agent_file_exists -- the app-agent probe."""
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_spec_does_not_back_the_agent(self, agents_dir, kind):
+        _plant_refused(agents_dir, "app--probe.json", {"name": "probe"}, kind)
+
+        assert _namespaced_agent_file_exists("probe") is False
+
+    def test_valid_spec_still_backs_the_agent(self, agents_dir):
+        _plant(agents_dir, "app--probe.json", {"name": "probe"})
+
+        assert _namespaced_agent_file_exists("probe") is True
+
+
+def _detail_request(name: str) -> MagicMock:
+    request = MagicMock(spec=web.Request)
+    request.method = "GET"
+    request.match_info = {"name": name}
+    request.app = {"state": MagicMock()}
+    return request
+
+
+class TestApiAgentDetail:
+    """handlers.agents.api_agent_detail -- GET by-name lookup."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", REFUSALS)
+    async def test_refused_spec_reads_as_absent(self, agents_dir, kind):
+        """A refused spec is a 404, not a 500: the old parse let a non-object
+        file escape as AttributeError past ``except (JSONDecodeError, OSError)``."""
+        _plant_refused(agents_dir, "ghost.json", {"name": "ghost"}, kind)
+
+        resp = await api_agent_detail(_detail_request("ghost"))
+
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_valid_spec_still_served_under_the_same_cap(self, agents_dir):
+        _plant(agents_dir, "real.json", {"name": "real", "model": "pinned-by-real"})
+
+        resp = await api_agent_detail(_detail_request("real"))
+
+        assert resp.status == 200
+        assert json.loads(resp.text)["name"] == "real"
+
+
+def _mcp_request(agent: str) -> MagicMock:
+    request = MagicMock(spec=web.Request)
+    request.query = {"agent": agent}
+    return request
+
+
+@pytest.fixture
+def identity_bindings(monkeypatch):
+    """Bind every Kiro Crew agent name to a same-named kiro agent.
+
+    Without this the real resolver maps an unknown name onto the ``kirocrew``
+    default, so ``/api/mcp/active`` would always take the global-scope branch
+    and the per-agent branch under test would be unreachable (same fixture
+    shape as test_handlers_mcp_coverage.py).
+    """
+    from types import SimpleNamespace
+
+    import kiro_crew.config.loader as loader
+
+    monkeypatch.setattr(
+        loader,
+        "resolve_agent_bindings",
+        lambda cfg, name: SimpleNamespace(kiro_agent=name),
+    )
+
+
+class TestApiMcpActive:
+    """handlers.mcp.api_mcp_active -- per-agent mcpServers list."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", REFUSALS)
+    async def test_refused_spec_reads_as_absent(self, agents_dir, identity_bindings, kind):
+        _plant_refused(
+            agents_dir, "probe.json", {"name": "probe-6695", "mcpServers": {"srv": {}}}, kind
+        )
+
+        resp = await api_mcp_active(_mcp_request("probe-6695"))
+
+        assert resp.status == 200
+        assert json.loads(resp.text) == []
+
+    @pytest.mark.asyncio
+    async def test_valid_spec_still_lists_servers(self, agents_dir, identity_bindings):
+        _plant(agents_dir, "probe.json", {"name": "probe-6695", "mcpServers": {"b": {}, "a": {}}})
+
+        resp = await api_mcp_active(_mcp_request("probe-6695"))
+
+        assert json.loads(resp.text) == [
+            {"name": "a", "enabled": True},
+            {"name": "b", "enabled": True},
+        ]
+
+
+class TestCollectServerRows:
+    """handlers.mcp._collect_server_rows -- the fleet row scan."""
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_spec_contributes_no_rows(self, agents_dir, kind):
+        _plant_refused(
+            agents_dir,
+            "bad.json",
+            {"name": "bad", "mcpServers": {"phantom": {"command": "x"}}},
+            kind,
+        )
+
+        assert "phantom" not in _collect_server_rows()
+
+    def test_valid_spec_rows_survive_the_same_cap(self, agents_dir):
+        _plant(agents_dir, "good.json", {"name": "good", "mcpServers": {"real": {"command": "x"}}})
+
+        assert "real" in _collect_server_rows()
+
+
+class TestLaunchSpecsFor:
+    """handlers.mcp._launch_specs_for -- the batch-stub spec collection."""
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_spec_contributes_no_launch_specs(self, agents_dir, kind):
+        _plant_refused(
+            agents_dir,
+            "bad.json",
+            {"name": "bad", "mcpServers": {"srv": {"command": "x"}}},
+            kind,
+        )
+
+        assert _launch_specs_for({"srv"}) == {}
+
+    def test_valid_spec_still_yields_a_launch_spec(self, agents_dir):
+        _plant(agents_dir, "good.json", {"name": "good", "mcpServers": {"srv": {"command": "x"}}})
+
+        specs = _launch_specs_for({"srv"})
+
+        assert "srv" in specs
+        assert specs["srv"][0].command == "x"
+
+
+class TestSensitiveSymlinkGuard:
+    """One representative surface proves the symlink guard flows through.
+
+    The guard's own matrix lives with ``_read_agent_spec``; this pins that a
+    migrated caller actually consults it (same shape as #5423's test).
+    """
+
+    def test_link_to_a_sensitive_target_is_refused(self, tmp_path, monkeypatch):
+        from kiro_crew import agent_discovery
+
+        target = tmp_path / "protected.json"
+        target.write_text(json.dumps({"name": "linked", "model": "leaked-value"}))
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "linked.json").symlink_to(target)
+        monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda p: str(target) in str(p))
+        monkeypatch.setattr("kiro_crew.agent.KIRO_AGENTS_DIR", agents)
+
+        out = _build_kiro_model_map()
+
+        assert "linked" not in out


### PR DESCRIPTION
## Problem / Motivation

Seven call sites still read the user-writable agents directory's `*.json` specs with a hand-rolled `json.loads(path.read_text(encoding="utf-8"))` instead of `agent_discovery._read_agent_spec`, the module's documented single hardened reader. Each hand-rolled read skips that reader's guards: the AppleDouble (`._*`) screen, refusal of a symlink whose RESOLVED target is a sensitive path, the `safe_read_file_bytes` 50 MB size cap, non-UTF-8 rejection, and non-object-JSON rejection.

#5423 migrated one such site (`SessionManager._resolve_agent_model`) and its First Principles review lane enumerated the seven siblings left behind; #6695 is that enumeration, filed as an accepted-and-deferred follow-up.

## Why it matters

The agents directory is user-writable and shared with kiro-cli, so none of the guards are hypothetical there. Before this change: a multi-gigabyte "agent config" was slurped whole into memory by `migrate_agent_specs` on every gateway start (and by four dashboard surfaces on demand); a planted symlink was read out of whatever it named — and at the migrate site, **rewritten**; and a non-object JSON file escaped as `AttributeError` (HTTP 500 on two handlers, whole-scan abort in the legacy model map).

## What changed (motivation → approach → change)

Approach: a mechanical, behaviour-preserving substitution, per site. `_read_agent_spec` returns `None` — never raises — for every rejection case, and every one of the seven callers already did skip-and-continue via `except (OSError, ValueError)` plus an `isinstance(data, dict)` guard. So:

```python
# before                                           # after
try:                                               data = _read_agent_spec(p)
    data = json.loads(p.read_text(encoding=...))   if data is None:
except (OSError, ValueError):                          continue
    continue
if not isinstance(data, dict):
    continue
```

A refused spec degrades exactly like an absent one — the property #5423 established and the issue explicitly requires. The `isinstance` guard becomes dead (the reader rejects non-objects) and is removed as part of the substitution.

The seven sites:

| Site | Surface |
|---|---|
| `agent.py` `migrate_agent_specs` | boot-time spec repair (**also writes** — see below) |
| `dashboard/chat_persistence.py` `_build_kiro_model_map` | legacy session restore |
| `dashboard/handlers/agents.py` `_namespaced_agent_file_exists` | app-agent probe |
| `dashboard/handlers/agents.py` `api_agent_detail` | GET/PATCH/DELETE by-name lookup |
| `dashboard/handlers/mcp.py` `api_mcp_active` | per-agent mcpServers list |
| `dashboard/handlers/mcp.py` `_collect_server_rows` | fleet row scan |
| `dashboard/handlers/mcp.py` `_launch_specs_for` | batch-stub spec collection |

Where a site's `try` wrapped more than the parse, it was narrowed rather than left dead: `api_mcp_active`'s try is removed entirely (the remaining body cannot raise the caught pair), while `api_agent_detail`'s try **stays** — its DELETE/PATCH bodies still raise the caught pair mid-flight (the PATCH re-read under the config lock, `unlink`), and those were and remain skip-to-next-file.

New imports in `chat_persistence.py` and `handlers/mcp.py` only; `agent_discovery` imports nothing from `kiro_crew.dashboard` (verified by importing all four modules), so no cycle.

### The copy-out case: `migrate_agent_specs` also writes

This is the one site that also WRITES, via `_atomic_json_write(spec_path, data)`. Reading through `_read_agent_spec` resolves a symlink and reads the RESOLVED target, while the write still targets `spec_path` itself. That read/write path asymmetry existed with `read_text` too (it follows symlinks), so the migration does not introduce it — but it does make it explicit. The strictly-safer delta: a spec the reader refuses is now **never rewritten at all**, where previously a sensitive-symlink spec got read AND rewritten. Evaluated deliberately per the triage scope decision posted on the issue; the write path itself is intentionally untouched here.

### Behavior deltas (all in the degrade-as-absent direction)

- Non-object JSON: previously `AttributeError` escaping `except (JSONDecodeError, OSError)` — HTTP 500 on `api_agent_detail` and `api_mcp_active`, whole-scan abort (partial map) in `_build_kiro_model_map`. Now: per-file skip.
- Non-UTF-8 bytes: previously `UnicodeDecodeError` escaped the same sites the same way (it is a `ValueError`, not a `JSONDecodeError`). Now: per-file skip.
- Oversized (>50 MB) specs: previously slurped and honoured; now refused. At the migrate site this means such a spec is no longer repaired — see the pre-push review dispositions below.

### Scope decisions honoured (posted on the issue at triage)

1. The shared name→model helper the issue floats is OUT of scope — landing the security migration first, the convergence is its own issue against the then-uniform baseline.
2. The copy-out case is called out above, not smoothed over.

Adjacent read deliberately left as-is: `api_agent_detail`'s PATCH branch re-reads the matched file under the config lock (`handlers/agents.py:1674`). It is not one of the issue's seven glob-loop sites; migrating it changes which exceptions the surrounding `except` sees and belongs to its own change if wanted.

### Pre-push review dispositions

Two model-pinned pre-push review lanes ran on this head (mirroring the CI contracts):

- **GPT 5.6 Sol — BLOCKING, rebutted.** Finding: an oversized (>50 MB) legacy spec carrying `model_managed`/`cc_model` is no longer repaired by `migrate_agent_specs`, so kiro-cli keeps rejecting it. The mechanism is accurate and stated under the deltas above. Rebuttal: a >50 MB agent spec is precisely the pathological artifact the cap exists to refuse — the repo's design position since #5423 is that a refused spec is not a usable spec for ANY consumer, and the issue explicitly enumerates this site with the write called out. The demanded fix (revert this one site to a raw read) would leave the only write-capable site as the only unhardened reader, restoring the 50 MB startup slurp and the planted-symlink read-and-rewrite this PR exists to close. The spec file is left byte-identical (no data loss) and the refusal is logged by the reader.
- **Opus 5 — PASS**, two advisory findings, both accepted-and-deferred with follow-up issues since their fixes land in files this migration must not edit: #6721 (Windows UNC-home: `unc_probe_allowed` excludes the agents dir, a pre-existing property of the shared reader that already governs `list_agents`/#5423/#5613 on main) and #6722 (`_read_agent_spec` hardcodes `list_agents` on its SEL sensitive-path denial, mislabeling other surfaces' denials).

## Tests

`test/test_agent_spec_hardened_reads.py` (22 tests), mirroring #5423's shape: lowered `hooks.MAX_FILE_BYTES` (the property is that the cap is consulted, not its value) and the `KIRO_AGENTS_DIR` override hook. Per surface: a refused spec (parametrized: oversized, non-object) is SKIPPED and the surface still answers, and a valid spec is unaffected under the same cap. Plus one representative sensitive-symlink test through `_build_kiro_model_map`.

Differential proof: with the production hunks reverted (test file kept), 11 of the 22 fail — every oversized case (the old path had no cap) and the non-object cases on the surfaces that previously crashed; the rest pin behavior that was already correct.

Regression discipline: full suite on this branch vs a clean-main control in the same environment — failure sets are byte-identical (86 failed + 2 errors on both sides, all pre-existing host-environment reds; zero delta in either direction). `isort`, `flake8`, `mypy` (1166 files), and the black ratchet all green.

## Manual verification

N/A — the surfaces are exercised directly at the function/handler level by the new tests, and the migration is behaviour-preserving by construction; no UI or external-service path is touched.

## Related Issues

Closes #6695. Follow-ups filed from review: #6721, #6722.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no doc documents the per-site read mechanics; the reader's own docs already describe the guards
- [x] No secrets, credentials, or internal references in the diff
