### PR TITLE
perf(chat): structurally share turn grouping and index tool-row lookups

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -179,6 +179,7 @@ import { useVoiceInput, voiceInputSupported, type TranscriptOrigin } from '../ho
 import { usePushToTalk } from '../hooks/usePushToTalk'
 import VoiceDisabledModal from '../components/VoiceDisabledModal'
 import { ChatFooter, AssistantMessage, UserMessage, PinnedPrompt } from './chat'
+import { useStreamIdle } from './chat/ChatFooter'
 import type { TurnStats } from './chat/AssistantMessage'
 import { turnHadPolicyBlock } from '../app-sdk/turnPolicyBlock'
 import MarkdownRenderer from '../components/MarkdownRenderer'
@@ -191,7 +192,7 @@ import SubagentProgressBar from './chat/SubagentProgressBar'
 import TaskProgressBar from './chat/TaskProgressBar'
 import SidePanel, { CHAT_PANE_MIN_W, sidePanelFillWidth } from './chat/SidePanel'
 import { useSidePanelDock } from '../hooks/useSidePanelDock'
-import { groupDisplayItems, applyRunningState, hasReasoningContent, isReasoningRole } from './chat/groupDisplayItems'
+import { createTurnGrouper, applyRunningState, hasReasoningContent, isReasoningRole } from './chat/groupDisplayItems'
 import { setSessionPreviewPending, normalizeUrl, PREVIEW_EXPAND_EVENT, PREVIEW_SNIP_EVENT } from '../components/WebPreviewPanel'
 import { detectPreviewUrl, previewFeedDecision } from '../utils/detectPreviewUrl'
 import { fileLandingSlot } from '../utils/uploadRouting'
@@ -4627,8 +4628,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Any UI feeding this path must offer only those decisions — a Trust
   // affordance here would claim a standing grant the backend never records
   // (#5400 on the spawn-approval card, #5434 on the collapsed tool row).
-  const toApiDecision = (action: string): 'approve' | 'reject' =>
-    action === 'approved' ? 'approve' : 'reject'
+  const toApiDecision = useCallback((action: string): 'approve' | 'reject' =>
+    action === 'approved' ? 'approve' : 'reject', [])
   const dismissApproval = useCallback((aid: string, decision?: string) => {
     dispatch(resolveByApprovalId({ id: aid, decision }))
     const n = store.getState().notifications.items.find(x => x.approval_id === aid)
@@ -5559,6 +5560,21 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // or a tool group holding the trailing 'streaming' message open). 0 whenever no
   // streaming message is in flight.
   const streamTick = lastRole === 'streaming' ? (messages[messages.length - 1]?.content.length ?? 0) : 0
+  // Transcript heat: advances on ANY transcript mutation (streamed chunk, tool
+  // row, thinking burst), so useStreamIdle can tell a high-frequency burst from
+  // a quiet running turn. Render-phase ref bump, guarded on the identity change
+  // — the same pattern as a lazy initializer, so it is StrictMode-safe.
+  const heatMessagesRef = useRef<ChatMessage[] | null>(null)
+  const heatTickRef = useRef(0)
+  if (heatMessagesRef.current !== messages) { heatMessagesRef.current = messages; heatTickRef.current++ }
+  // Hot while the slot runs and mutations landed within the idle window. The
+  // state update inside useStreamIdle commits AFTER the render that delivered a
+  // mutation, so a row mounting on the first mutation after a quiet spell still
+  // reads idle=true (hot=false) and keeps its entrance ease; only rows mounting
+  // inside a burst (a second mutation within 700ms) snap. Passed down to
+  // ToolCallLine to gate its height animations — see `transcriptHot` there.
+  const transcriptIdle = useStreamIdle(heatTickRef.current, slotRunning)
+  const transcriptHot = slotRunning && !transcriptIdle
   // Precompute: index of last finalized assistant message (tools after this are "trailing")
   // The activity panel has exactly two modes, and the question that picks one
   // is NOT "how wide is the window" — it is "how much width is left for the
@@ -5643,7 +5659,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // every turn start/stop just to flip that flag, and the new identity cascaded into
   // messageToDisplayIdx / visibleIndexMap / the virtualizer. Split: group once, then
   // apply the flag in O(1).
-  const groupedTurns = useMemo(() => groupDisplayItems(messages), [messages])
+  //
+  // The grouper is the per-page identity cache (see createTurnGrouper): each
+  // streaming flush replaces `messages`, so this memo re-runs per flush — the
+  // grouper reconciles against the previous result so settled turns keep their
+  // object identity and memo(TurnBlock) / mergeTurnThinking bail out.
+  const groupTurns = useMemo(() => createTurnGrouper(), [])
+  const groupedTurns = useMemo(() => groupTurns(messages), [groupTurns, messages])
 
   const displayItems = useMemo<DisplayItem[]>(
     () => applyRunningState(groupedTurns, slotRunning),
@@ -6319,6 +6341,19 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     [sessionDocs],
   )
 
+  // Flush-volatile positional state is read through refs so a streaming flush
+  // (which replaces `messages` and rebuilds the derived index/tail values)
+  // does not mint a new renderMessage -> renderTurnItem identity and defeat
+  // memo(TurnBlock) for every settled turn. The refs are synced per render, so
+  // a callback invoked during THIS render's children sees current values.
+  // UI-state deps (chatConfig, linkPreviewsOn, disclosure, pin state, ...)
+  // deliberately STAY in the dep array: when they change, settled turns must
+  // re-render with the new behavior, and the changed identity is what breaks
+  // through the memo.
+  const visibleIndexMapRef = useRef(visibleIndexMap); visibleIndexMapRef.current = visibleIndexMap
+  const lastTextIdxRef = useRef(lastTextIdx); lastTextIdxRef.current = lastTextIdx
+  const slotStateRef2 = useRef(slotState); slotStateRef2.current = slotState
+
   const renderMessage = useCallback((i: number, m: ChatMessage) => {
     // Key identity rules (clientTs preference + streaming→assistant role
     // normalization) live in messageRowKey — see its doc comment.
@@ -6341,8 +6376,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       const spawnLaunch = extractSpawnRunLaunch(m)
       if (spawnLaunch) return <SubagentRunCard key={key} launch={spawnLaunch} slot={activeSlot || ''} />
       // Animate tools in the trailing group (after last assistant/streaming text)
-      const isInTrailingGroup = slotState === 'tool_running' && i > lastTextIdx
-      return <ToolCallLine key={key} message={m} running={isInTrailingGroup} onFileOpen={handleFileOpen} disclosure={toolDisclosure[key]} disclosureKey={key} onDisclosureChange={setToolDisclosureFor} appInPanel={mcpAppPanel} onOpenApp={revealAppInPanel} />
+      const isInTrailingGroup = slotStateRef2.current === 'tool_running' && i > lastTextIdxRef.current
+      return <ToolCallLine key={key} message={m} running={isInTrailingGroup} onFileOpen={handleFileOpen} disclosure={toolDisclosure[key]} disclosureKey={key} onDisclosureChange={setToolDisclosureFor} appInPanel={mcpAppPanel} onOpenApp={revealAppInPanel} transcriptHot={transcriptHot} />
     }
     if (m.role === 'file') {
       try {
@@ -6404,7 +6439,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // on AssistantMessage can short-circuit when only unrelated state changes.
     // visibleIndexMap is O(1) per row.
     const canFork = canForkAtWindow({ isStreaming, isInject, slotHasMore, cursorIsForActiveSlot })
-    const forkIndex = canFork ? visibleIndexMap.get(i) : undefined
+    const forkIndex = canFork ? visibleIndexMapRef.current.get(i) : undefined
     const msgTime = fmtMessageTime(m.ts)
     const msgTimeFull = fmtMessageTimeFull(m.ts)
     return (
@@ -6453,17 +6488,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
             })()
           ) : (
             <div className="flex flex-col gap-0">
-              <AssistantMessage suppressSteerAck={turnHadPolicyBlock(messages, i)} linkPreviews={linkPreviewsOn} content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdx} onFileOpen={handleFileOpen} onFolderOpen={handleFolderOpen} onArtifactOpen={handleArtifactOpen} onQuote={handleQuote} onAsk={handleAsk} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} timestampTitle={msgTimeFull} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} turnStats={chatConfig.showTurnStats ? (m.meta as Record<string, unknown> | undefined)?.turn_stats as TurnStats | undefined : undefined} onOpenDiff={handleOpenDiff} fileChipStyle={chatConfig.fileChipStyle} artifactPaths={artifactPaths} pinned={m.ts && (m.meta as Record<string, unknown> | undefined)?.mid ? isPinned((m.meta as Record<string, unknown>).mid as string) : false} onTogglePin={m.ts && (m.meta as Record<string, unknown> | undefined)?.mid ? () => handleTogglePinForMessage((m.meta as Record<string, unknown>).mid as string, m.ts!, 'assistant', m.content) : undefined} showFooter={(() => {
+              <AssistantMessage suppressSteerAck={turnHadPolicyBlock(messagesRef.current, i)} linkPreviews={linkPreviewsOn} content={m.content} isStreaming={isStreaming} isRegenerating={regenerating && i === lastTextIdxRef.current} onFileOpen={handleFileOpen} onFolderOpen={handleFolderOpen} onArtifactOpen={handleArtifactOpen} onQuote={handleQuote} onAsk={handleAsk} slotRunning={slotRunning} planTaskId={planTaskId} timestamp={chatConfig.showTimestamps ? msgTime : undefined} timestampTitle={msgTimeFull} messageTs={m.ts} slotKey={activeSlot || undefined} slotTitle={activeSlotTitle} mode={mode} fileChanges={(m.meta as Record<string, unknown> | undefined)?.file_changes as FileChangeEntry[] | undefined} turnStats={chatConfig.showTurnStats ? (m.meta as Record<string, unknown> | undefined)?.turn_stats as TurnStats | undefined : undefined} onOpenDiff={handleOpenDiff} fileChipStyle={chatConfig.fileChipStyle} artifactPaths={artifactPaths} pinned={m.ts && (m.meta as Record<string, unknown> | undefined)?.mid ? isPinned((m.meta as Record<string, unknown>).mid as string) : false} onTogglePin={m.ts && (m.meta as Record<string, unknown> | undefined)?.mid ? () => handleTogglePinForMessage((m.meta as Record<string, unknown>).mid as string, m.ts!, 'assistant', m.content) : undefined} showFooter={(() => {
                 // Show footer on the last assistant message of each completed turn
                 if (isStreaming) return false
                 // Find next message after this one that's assistant, user, or streaming
-                for (let j = i + 1; j < messages.length; j++) {
-                  if (messages[j].role === 'user') return true // end of turn — show footer
-                  if (messages[j].role === 'assistant' || messages[j].role === 'streaming') return false // not last assistant in turn
+                for (let j = i + 1; j < messagesRef.current.length; j++) {
+                  if (messagesRef.current[j].role === 'user') return true // end of turn — show footer
+                  if (messagesRef.current[j].role === 'assistant' || messagesRef.current[j].role === 'streaming') return false // not last assistant in turn
                 }
                 // End of messages — show footer only if agent is done
                 return !slotRunning
-              })()} onSpeak={handleSpeak} onRegenerate={i === lastTextIdx && !slotRunning && !regenerating && activeSlot ? handleRegenerate : undefined} variants={m.variants} variantIdx={m.variant_idx} onSwitchVariant={i === lastTextIdx && m.variants && m.variants.length > 1 && activeSlot ? (idx: number) => { api.switchVariant(activeSlot, idx).catch((e: unknown) => {
+              })()} onSpeak={handleSpeak} onRegenerate={i === lastTextIdxRef.current && !slotRunning && !regenerating && activeSlot ? handleRegenerate : undefined} variants={m.variants} variantIdx={m.variant_idx} onSwitchVariant={i === lastTextIdxRef.current && m.variants && m.variants.length > 1 && activeSlot ? (idx: number) => { api.switchVariant(activeSlot, idx).catch((e: unknown) => {
                 showRefusedPress('switch_variant', e)
               }) } : undefined} onFork={handleFork} onPlanFromHere={handlePlanFromHere} forkIndex={forkIndex} onLoadEarlier={cursorIsForActiveSlot ? handleLoadEarlier : undefined} loadingOlder={loadingOlder} earlierRemaining={slotOldestIndex} onApplyPlan={handleApplyPlan} />
             </div>
@@ -6479,7 +6514,39 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // through renderUserContentCb), so they are omitted to keep it stable.
     // cursorIsForActiveSlot/slotOldestIndex/handleLoadEarlier belong here: a switch
     // back restores the cursor while changing no other dep, stranding Fork shut.
-  }, [messages, visibleIndexMap, slotRunning, slotState, lastTextIdx, handleFileOpen, handleArtifactOpen, handleFork, handleQuote, handleAsk, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, loadingOlder, cursorIsForActiveSlot, slotOldestIndex, handleLoadEarlier, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId, artifactPaths, autoNudgeLoop, toolDisclosure, setToolDisclosureFor, linkPreviewsOn, handleSubagentPanelOpen, isPinned, handleTogglePinForMessage, connectionsUiOn, showRefusedPress])
+  }, [slotRunning, handleFileOpen, handleArtifactOpen, handleFork, handleQuote, handleAsk, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, loadingOlder, cursorIsForActiveSlot, slotOldestIndex, handleLoadEarlier, renderUserContentCb, highlightTs, activeSlotTitle, mode, dispatch, handleOpenDiff, handlePlanFromHere, navigate, planTaskId, artifactPaths, autoNudgeLoop, toolDisclosure, setToolDisclosureFor, linkPreviewsOn, handleSubagentPanelOpen, isPinned, handleTogglePinForMessage, connectionsUiOn, showRefusedPress, transcriptHot])
+
+  // Hoisted out of the row map so every TurnBlock receives the SAME function
+  // identity per render — an inline closure there re-created it per row per
+  // render and defeated memo(TurnBlock) even when the turn identity was stable
+  // (see createTurnGrouper). It depends on nothing row-specific.
+  const renderTurnItem = useCallback((it: TurnItem, _j: number) => {
+    // Skip hidden tool messages (✅/🚫 completions) to avoid empty py-1 wrappers
+    if (it.kind === 'single' && it.msg.role === 'tool' && !it.msg.content.startsWith('🔧')) return null
+    return <div key={turnLeadKey(it, stableMsgKey)} className={`px-4 mx-auto w-full py-1`} style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
+      {it.kind === 'group' ? (() => {
+        const unresolvedPerms = it.msgs.filter(m => m.role === 'permission' && !m.meta?.resolved)
+        // Skip group entirely if it only contains unresolved permissions (handled by ApprovalBar)
+        if (it.msgs.every(m => m.role === 'permission')) return null
+        return (
+        <CollapsibleToolGroup
+          count={it.msgs.filter(m => m.role !== 'permission').length}
+          disclosureKey={`ctg-${turnLeadKey(it, stableMsgKey)}`}
+          hasPermission={false}
+          isRunning={false}
+          permissionMeta={unresolvedPerms.at(-1)?.meta as Record<string, unknown> | undefined}
+          pendingPermCount={unresolvedPerms.length}
+          onApprove={(() => {
+            const aid = unresolvedPerms.at(-1)?.meta?.approval_id as string | undefined
+            if (!aid) return approve
+            return async (action: string) => { await api.resolveApproval(aid, toApiDecision(action)); dismissApproval(aid) }
+          })()}
+          onViewActivity={toggleAct}
+          activityOpen={activityOpen}
+        >{it.msgs.map((m, j) => <div key={msgIdentityKey(m, stableMsgKey)}>{renderMessage(it.startIdx + j, m)}</div>)}</CollapsibleToolGroup>)
+      })() : renderMessage(it.idx, it.msg)}
+    </div>
+  }, [stableMsgKey, renderMessage, approve, toApiDecision, dismissApproval, toggleAct, activityOpen])
 
   /**
    * Mobile sessions drawer, as ONE value rather than an open flag plus a
@@ -7308,34 +7375,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 const item = vi.data
                 const displayIdx = vi.index
                 if (item.kind === 'turn') {
-                  const renderTurnItem = (it: TurnItem, _j: number) => {
-                    // Skip hidden tool messages (✅/🚫 completions) to avoid empty py-1 wrappers
-                    if (it.kind === 'single' && it.msg.role === 'tool' && !it.msg.content.startsWith('🔧')) return null
-                    return <div key={turnLeadKey(it, stableMsgKey)} className={`px-4 mx-auto w-full py-1`} style={{ maxWidth: 'var(--mc-content-width, 900px)' }}>
-                      {it.kind === 'group' ? (() => {
-                        const unresolvedPerms = it.msgs.filter(m => m.role === 'permission' && !m.meta?.resolved)
-                        // Skip group entirely if it only contains unresolved permissions (handled by ApprovalBar)
-                        if (it.msgs.every(m => m.role === 'permission')) return null
-                        return (
-                        <CollapsibleToolGroup
-                          count={it.msgs.filter(m => m.role !== 'permission').length}
-                          disclosureKey={`ctg-${turnLeadKey(it, stableMsgKey)}`}
-                          hasPermission={false}
-                          isRunning={false}
-                          permissionMeta={unresolvedPerms.at(-1)?.meta as Record<string, unknown> | undefined}
-                          pendingPermCount={unresolvedPerms.length}
-                          onApprove={(() => {
-                            const aid = unresolvedPerms.at(-1)?.meta?.approval_id as string | undefined
-                            if (!aid) return approve
-                            return async (action: string) => { await api.resolveApproval(aid, toApiDecision(action)); dismissApproval(aid) }
-                          })()}
-                          onViewActivity={toggleAct}
-                          activityOpen={activityOpen}
-                        >{it.msgs.map((m, j) => <div key={msgIdentityKey(m, stableMsgKey)}>{renderMessage(it.startIdx + j, m)}</div>)}</CollapsibleToolGroup>)
-                      })() : renderMessage(it.idx, it.msg)}
-                    </div>
-                  }
-                  return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx}><TurnBlock turn={item} renderItem={renderTurnItem} collapseAll={chatConfig.collapseAllSteps} appToolCallIds={appToolCallIds} disclosure={turnDisclosure[vi.key]} onDisclosureChange={(next: boolean) => setTurnDisclosureFor(vi.key, next)} /></div>
+                  return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx}><TurnBlock turn={item} renderItem={renderTurnItem} collapseAll={chatConfig.collapseAllSteps} appToolCallIds={appToolCallIds} disclosure={turnDisclosure[vi.key]} disclosureKey={vi.key} onDisclosureChange={setTurnDisclosureFor} /></div>
                 }
                 return <div key={vi.key} ref={virt.measureRef(vi.index)} data-display-index={displayIdx} className={`px-4 mx-auto w-full py-1`} style={{
                   maxWidth: 'var(--mc-content-width, 900px)',

--- a/website/src/pages/chat/ToolCallLine.tsx
+++ b/website/src/pages/chat/ToolCallLine.tsx
@@ -28,6 +28,14 @@ import { fmtDateFields, fmtDuration as fmtDurationParts, fmtUnit } from '../../i
 import { api } from '../../api/client'
 import { useLanguageGeneration } from '../../i18n/useLanguageGeneration'
 import { isRejectedDecision } from '../../utils/approvalDecision'
+import { selectToolRowIndex, lookupLogEntry, denySiblingContent } from './toolRowIndex'
+import type { ToolActivity } from '../../types'
+
+// Stable empties for slots with no per-slot state yet. A fresh `[]` per
+// selector run would change identity every dispatch and defeat the
+// per-(messages, toolLog) memoization of selectToolRowIndex.
+const EMPTY_MESSAGES: ChatMessage[] = []
+const EMPTY_TOOL_LOG: ToolActivity[] = []
 
 // Tool-call ids that have already played their one-shot `.ft-block-reveal`
 // entrance fade. A CSS animation re-fires on every DOM *mount*, and a pill
@@ -94,8 +102,13 @@ const LABEL_EXPANDED_CLASS = 'break-words'
  * `children` are constructed by the caller even while hidden (ordinary JSX
  * evaluation) — they must therefore stay cheap and side-effect free, which the
  * two status lines are.
+ *
+ * `snap` disables the ease while the transcript is streaming at high
+ * frequency (see the `transcriptHot` prop): each animated frame costs a
+ * scrollTop re-pin, and during a hot stream those stack across rows. The ease
+ * stays for quiet-transcript transitions.
  */
-function StatusRow({ show, children }: { show: boolean; children: ReactNode }) {
+function StatusRow({ show, snap = false, children }: { show: boolean; snap?: boolean; children: ReactNode }) {
   const reduce = useReducedMotion()
   return (
     <AnimatePresence initial={false}>
@@ -104,7 +117,7 @@ function StatusRow({ show, children }: { show: boolean; children: ReactNode }) {
           initial={{ height: 0, opacity: 0 }}
           animate={{ height: 'auto', opacity: 1 }}
           exit={{ height: 0, opacity: 0 }}
-          transition={reduce
+          transition={reduce || snap
             ? { duration: 0 }
             : { height: { duration: SLIDE_DURATION, ease: SLIDE_EASE }, opacity: { duration: 0.15 } }}
           style={{ overflow: 'hidden' }}
@@ -118,7 +131,13 @@ function StatusRow({ show, children }: { show: boolean; children: ReactNode }) {
 
 /** Inline tool call pill. Click toggles an expanded panel below the pill that
  *  shows purpose / input / output. */
-export default memo(function ToolCallLine({ message, running: _running, slot, onFileOpen, disclosure, disclosureKey, onDisclosureChange, appInPanel, onOpenApp }: { message: ChatMessage; running: boolean; slot?: string; onFileOpen?: (path: string) => void; disclosure?: boolean; disclosureKey?: string; onDisclosureChange?: (key: string, expanded: boolean) => void; appInPanel?: boolean; onOpenApp?: (toolCallId: string) => void }) {
+export default memo(function ToolCallLine({ message, running: _running, slot, onFileOpen, disclosure, disclosureKey, onDisclosureChange, appInPanel, onOpenApp, transcriptHot = false }: { message: ChatMessage; running: boolean; slot?: string; onFileOpen?: (path: string) => void; disclosure?: boolean; disclosureKey?: string; onDisclosureChange?: (key: string, expanded: boolean) => void; appInPanel?: boolean; onOpenApp?: (toolCallId: string) => void;
+  /** True while the transcript is streaming at high frequency (host-derived
+   *  from useStreamIdle). Gates the entrance/status height eases: a hot-stream
+   *  mount lands at full height in one frame, a quiet-transcript mount keeps
+   *  the ease. Defaults to false so hosts without a heat signal keep the
+   *  animations unconditionally. */
+  transcriptHot?: boolean }) {
   useLanguageGeneration() // memo() bails out of the provider-level repaint; subscribe directly
   const dispatch = useAppDispatch()
   const label = message.content.replace(/^🔧\s*/, '')
@@ -136,27 +155,25 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   })
 
   // Pull the matching toolLog entry. Returns purpose/input/output for the inline
-  // expansion as well as completion status for the icon.
+  // expansion as well as completion status for the icon. All transcript scans go
+  // through the shared per-slot index (see toolRowIndex.ts): built once per
+  // (messages, toolLog) identity change, O(1) per row per dispatch.
   const { effectiveId, isDone: logIsDone, isRejected, isAutoDenied, autoDenyReason, purpose, input, output, auto, ts, executionStartedAt, hasEntry, isShell, toolKind, toolName, fromLog } = useAppSelector(s => {
     // Slot-aware: for a non-active slot (split-view pane) read that slot's
     // per-slot tool log / messages / running state; `slot` undefined or equal to
     // the active slot → active-slot globals.
     const bg = slot && slot !== s.chat.activeSlot ? slot : null
-    const log = bg ? (s.chat.slotActivity[bg]?.toolLog ?? []) : s.chat.toolLog
+    const log = bg ? (s.chat.slotActivity[bg]?.toolLog ?? EMPTY_TOOL_LOG) : s.chat.toolLog
     const slotRunning = bg ? ((s.chat.slotRun[bg]?.state ?? 'idle') !== 'idle') : s.chat.slotRunning
-    const msgs = bg ? (s.chat.slotMessages[bg] ?? []) : s.chat.messages
+    const msgs = bg ? (s.chat.slotMessages[bg] ?? EMPTY_MESSAGES) : s.chat.messages
+    const index = selectToolRowIndex(msgs, log)
 
-    // Helper: check if this tool's permission was resolved as rejected
+    // Was this tool's permission resolved as rejected? Only the NEWEST
+    // permission message for the id carries the decision.
     const wasRejectedByPerm = () => {
       if (!toolCallId) return false
-      for (let j = msgs.length - 1; j >= 0; j--) {
-        const m = msgs[j]
-        if (m.role !== 'permission' || !m.meta?.tool_call_id) continue
-        if (m.meta.tool_call_id === toolCallId) {
-          return isRejectedDecision(m.meta?.resolved)
-        }
-      }
-      return false
+      const perm = index.lastPermById.get(toolCallId)
+      return perm ? isRejectedDecision(perm.meta?.resolved) : false
     }
 
     // Auto-denied detection. When a security-policy deny rule or hook blocks a
@@ -173,52 +190,37 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
     // that flow ALSO resolves a permission message as rejected —
     // wasRejectedByPerm() takes precedence below, so a user rejection still
     // shows red, not amber.
-    const autoDenySiblingContent = (): string => {
-      if (!toolCallId) return ''
-      for (let j = msgs.length - 1; j >= 0; j--) {
-        const m = msgs[j]
-        if (m.role !== 'tool' || m.meta?.tool_call_id !== toolCallId) continue
-        if (m.content.startsWith('🚫')) return m.content
-        // The pill's own 🔧 message reached without a 🚫 sibling above it —
-        // any earlier match would predate this call; stop scanning.
-        if (m === message) break
-      }
-      return ''
-    }
-    const denySibling = autoDenySiblingContent()
+    const denySibling = denySiblingContent(index, toolCallId, message)
     const autoDenied = !!denySibling
     const autoDenyReason = extractDenyDetail(denySibling)
 
-    for (let i = log.length - 1; i >= 0; i--) {
-      const e = log[i]
-      if (e.type !== 'tool') continue
-      if ((toolCallId && e.tool_call_id === toolCallId) || (!toolCallId && e.tool_call_id && label.includes(e.text))) {
-        const rejected = !!e.rejected || wasRejectedByPerm()
-        const isDone = e.output != null || rejected || autoDenied || !slotRunning
-        return {
-          effectiveId: e.tool_call_id || null,
-          isDone, isRejected: rejected,
-          isAutoDenied: !rejected && autoDenied,
-          autoDenyReason,
-          purpose: e.purpose || '',
-          input: e.input || '',
-          output: e.output || '',
-          auto: !!e.auto,
-          ts: e.ts || 0,
-          executionStartedAt: e.execution_started_at || 0,
-          hasEntry: true,
-          // Older ACP update frames may omit is_shell; execute is the stable
-          // tool-kind value used by the transport and keeps those frames live.
-          isShell: e.is_shell === true || e.kind === 'execute' || e.text.startsWith('Running:'),
-          // Raw ACP tool kind — gates the inline diff-card promotion below
-          // (only kind === 'edit' rows promote).
-          toolKind: e.kind || '',
-          // Raw transport tool name, kept separate from the display `label`:
-          // the label is simplified/localized for humans, so gating behaviour on
-          // it would break under `useSimplifiedToolNames` or a translated UI.
-          toolName: e.text || '',
-          fromLog: true,
-        }
+    const e = lookupLogEntry(index, toolCallId, label)
+    if (e) {
+      const rejected = !!e.rejected || wasRejectedByPerm()
+      const isDone = e.output != null || rejected || autoDenied || !slotRunning
+      return {
+        effectiveId: e.tool_call_id || null,
+        isDone, isRejected: rejected,
+        isAutoDenied: !rejected && autoDenied,
+        autoDenyReason,
+        purpose: e.purpose || '',
+        input: e.input || '',
+        output: e.output || '',
+        auto: !!e.auto,
+        ts: e.ts || 0,
+        executionStartedAt: e.execution_started_at || 0,
+        hasEntry: true,
+        // Older ACP update frames may omit is_shell; execute is the stable
+        // tool-kind value used by the transport and keeps those frames live.
+        isShell: e.is_shell === true || e.kind === 'execute' || e.text.startsWith('Running:'),
+        // Raw ACP tool kind — gates the inline diff-card promotion below
+        // (only kind === 'edit' rows promote).
+        toolKind: e.kind || '',
+        // Raw transport tool name, kept separate from the display `label`:
+        // the label is simplified/localized for humans, so gating behaviour on
+        // it would break under `useSimplifiedToolNames` or a translated UI.
+        toolName: e.text || '',
+        fromLog: true,
       }
     }
     // No toolLog entry — historical message. Check permission state for rejection.
@@ -271,13 +273,9 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   const hasPendingPerm = useAppSelector(s => {
     if (isDone || !toolCallId) return false
     const bg = slot && slot !== s.chat.activeSlot ? slot : null
-    const msgs = bg ? (s.chat.slotMessages[bg] ?? []) : s.chat.messages
-    for (let j = msgs.length - 1; j >= 0; j--) {
-      const m = msgs[j]
-      if (m.role !== 'permission' || m.meta?.resolved || !m.meta?.tool_call_id) continue
-      if (m.meta.tool_call_id === toolCallId) return true
-    }
-    return false
+    const msgs = bg ? (s.chat.slotMessages[bg] ?? EMPTY_MESSAGES) : s.chat.messages
+    const log = bg ? (s.chat.slotActivity[bg]?.toolLog ?? EMPTY_TOOL_LOG) : s.chat.toolLog
+    return selectToolRowIndex(msgs, log).pendingPermIds.has(toolCallId)
   })
 
   // Shell commands do not expose a reliable total, so their live indicator is
@@ -325,19 +323,16 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
     // belonging to some other sleep the backend is tracking.
     if (!found?.running) return null
     const bg = slot && slot !== s.chat.activeSlot ? slot : null
-    const msgs = bg ? (s.chat.slotMessages[bg] ?? []) : s.chat.messages
+    const msgs = bg ? (s.chat.slotMessages[bg] ?? EMPTY_MESSAGES) : s.chat.messages
+    const log = bg ? (s.chat.slotActivity[bg]?.toolLog ?? EMPTY_TOOL_LOG) : s.chat.toolLog
     // Exactly one pill owns the countdown, and it must be the transcript's
     // newest TOOL call of any kind -- not merely its newest wait. Scanning only
     // for waits would let a completed wait from earlier in the turn light up
     // while the agent is busy in some later tool, which is the shape a sleep
     // belonging to a different ACP session on this same slot would take.
-    for (let j = msgs.length - 1; j >= 0; j--) {
-      const m = msgs[j]
-      if (m.role !== 'tool') continue
-      if (m.meta?.tool_call_id !== toolCallId) return null
-      return isWaitToolTitle(m.content.replace(/^🔧\s*/, '')) ? ws : null
-    }
-    return null
+    const last = selectToolRowIndex(msgs, log).lastToolMsg
+    if (!last || last.meta?.tool_call_id !== toolCallId) return null
+    return isWaitToolTitle(last.content.replace(/^🔧\s*/, '')) ? ws : null
   }, shallowEqual)
   const showWaitCountdown = !!waitState && waitState.deadline_ts > 0
   const [activityNow, setActivityNow] = useState(() => Date.now())
@@ -765,7 +760,14 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
   // does, so the slide takes stable identity or nothing.
   const reduceMotion = useReducedMotion()
   const [slidePlayed, setSlidePlayed] = useState(false)
-  const sliding = !!revealId && animateEntrance && !slidePlayed && !reduceMotion
+  // Heat is sampled ONCE at mount: a row that mounts during a hot stream snaps
+  // to full height (each animated frame costs a scrollTop re-pin, and bursts
+  // of tool calls stack those), while a quiet-transcript mount keeps the ease.
+  // Captured in a state initializer so a heat flip mid-animation can neither
+  // cut a playing slide short nor start one retroactively — the one-shot
+  // revealedToolIds/slidePlayed machinery still prevents replays either way.
+  const [snapOnMount] = useState(() => transcriptHot)
+  const sliding = !!revealId && animateEntrance && !slidePlayed && !reduceMotion && !snapOnMount
   // Release from the effect rather than from the completion callback alone, so
   // the inline values are cleared however `sliding` ends — the animation
   // finishing, or the OS reduced-motion preference flipping mid-flight, which
@@ -924,7 +926,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
         </div>
       )}
 
-      <StatusRow show={showShellActivity}>
+      <StatusRow show={showShellActivity} snap={transcriptHot}>
         {/* ml-5 = the pill's icon (12px) + the pill BUTTON's gap-2 (8px), so
             this secondary line starts exactly where the pill's label text
             does. (The outer wrapper's gap-1 is between pill and file chip —
@@ -936,7 +938,7 @@ export default memo(function ToolCallLine({ message, running: _running, slot, on
           </span>
         </div>
       </StatusRow>
-      <StatusRow show={showWaitCountdown}>
+      <StatusRow show={showWaitCountdown} snap={transcriptHot}>
         {/* Same ml-5 anchor as the shell-activity line above: the countdown is
             a continuation of the pill's label text, not of its icon column. */}
         <div className="ml-5 mt-1 flex items-center gap-2 text-[12px] leading-5 text-muted" data-testid="wait-countdown">

--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect, useMemo, useCallback, type ReactNode } from 'react'
+import { memo, useState, useRef, useEffect, useMemo, useCallback, type ReactNode } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
 import type { DisplayItem, TurnItem } from './types'
+import { useLanguageGeneration } from '../../i18n/useLanguageGeneration'
 import { useSearchHighlight } from '../../hooks/SearchHighlightContext'
 import { isWorkflowRunTool } from './WorkflowRunCard'
 import { isSpawnRunTool } from './SubagentRunCard'
@@ -236,7 +237,11 @@ function mergeTurnThinking(items: TurnItem[]): TurnItem[] {
  *  renders it for ChatEmbed with no Provider mounted, and a pane must scope the
  *  set to its OWN session key, not the globally-active slot.
  */
-export default function TurnBlock({ turn, renderItem, collapseAll = false, appToolCallIds = EMPTY_ID_SET, disclosure, onDisclosureChange }: { turn: Extract<DisplayItem, {kind:'turn'}>; renderItem: (item: TurnItem, i: number) => ReactNode; collapseAll?: boolean; appToolCallIds?: ReadonlySet<string>; disclosure?: boolean; onDisclosureChange?: (expanded: boolean) => void }) {
+function TurnBlock({ turn, renderItem, collapseAll = false, appToolCallIds = EMPTY_ID_SET, disclosure, disclosureKey, onDisclosureChange }: { turn: Extract<DisplayItem, {kind:'turn'}>; renderItem: (item: TurnItem, i: number) => ReactNode; collapseAll?: boolean; appToolCallIds?: ReadonlySet<string>; disclosure?: boolean; disclosureKey?: string; onDisclosureChange?: (key: string, expanded: boolean) => void }) {
+  // memo() bails out of the provider-level language repaint, so this component
+  // subscribes to language generation itself: its i18nT() strings must
+  // re-translate even when no prop moves.
+  useLanguageGeneration()
   const [localExpanded, setLocalExpanded] = useState(!turn.complete)
   // Disclosure is HOST-OWNED when `disclosure` is supplied, and that is what
   // makes an explicit choice durable: the transcript is virtualised, so this
@@ -255,9 +260,9 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false, appTo
   const toggle = useCallback(() => {
     userToggled.current = true
     const next = !expanded
-    if (onDisclosureChange) onDisclosureChange(next)
+    if (onDisclosureChange && disclosureKey !== undefined) onDisclosureChange(disclosureKey, next)
     else setLocalExpanded(next)
-  }, [expanded, onDisclosureChange])
+  }, [expanded, onDisclosureChange, disclosureKey])
   const wasComplete = useRef(turn.complete)
   useEffect(() => {
     if (turn.complete && !wasComplete.current && !userToggled.current) setLocalExpanded(false)
@@ -299,10 +304,12 @@ export default function TurnBlock({ turn, renderItem, collapseAll = false, appTo
   // callback cannot re-fire this effect on every render.
   const onDisclosureChangeRef = useRef(onDisclosureChange)
   onDisclosureChangeRef.current = onDisclosureChange
+  const disclosureKeyRef = useRef(disclosureKey)
+  disclosureKeyRef.current = disclosureKey
   useEffect(() => {
     if (!matchInCollapsedSegment) return
     const notify = onDisclosureChangeRef.current
-    if (notify) notify(true)
+    if (notify && disclosureKeyRef.current !== undefined) notify(disclosureKeyRef.current, true)
     else setLocalExpanded(true)
   }, [matchInCollapsedSegment])
 
@@ -421,3 +428,9 @@ function CollapsibleSection({ expanded, children }: { expanded: boolean; childre
     </motion.div>
   )
 }
+
+// Memoized so settled turns bail out entirely when the grouping's structural
+// sharing (createTurnGrouper) hands back identical `turn` references across
+// streaming flushes. The bail-out only holds when the host also passes stable
+// renderItem/onDisclosureChange props — ChatPage hoists both for exactly this.
+export default memo(TurnBlock)

--- a/website/src/pages/chat/groupDisplayItems.ts
+++ b/website/src/pages/chat/groupDisplayItems.ts
@@ -189,6 +189,86 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
   return { turns, trailingTurnIdx }
 }
 
+/** Two turn items describe the same rows: same kind, same underlying message
+ *  REFERENCES, same transcript indices. Reference equality on `msg` is the
+ *  load-bearing check — the store replaces a message object whenever its
+ *  content changes, so an unchanged reference means the row's input is
+ *  byte-identical. */
+// PURITY INVARIANT for the reconcile below: every field of a DisplayItem/
+// TurnItem must be a pure function of (its message references, their indices,
+// and `complete`). The equality helpers compare exactly those inputs, so a
+// future field derived from anything else will be silently frozen by the
+// substitution — such a field must be added to these comparisons.
+const sameTurnItem = (a: TurnItem, b: TurnItem): boolean => {
+  if (a.kind === 'single') return b.kind === 'single' && a.msg === b.msg && a.idx === b.idx
+  if (b.kind !== 'group') return false
+  if (a.startIdx !== b.startIdx || a.msgs.length !== b.msgs.length) return false
+  for (let i = 0; i < a.msgs.length; i++) if (a.msgs[i] !== b.msgs[i]) return false
+  return true
+}
+
+const sameDisplayItem = (a: DisplayItem, b: DisplayItem): boolean => {
+  if (a.kind === 'turn') {
+    if (b.kind !== 'turn') return false
+    if (a.complete !== b.complete || a.items.length !== b.items.length) return false
+    for (let i = 0; i < a.items.length; i++) if (!sameTurnItem(a.items[i], b.items[i])) return false
+    return true
+  }
+  if (b.kind === 'turn') return false
+  return sameTurnItem(a, b)
+}
+
+/**
+ * Identity-preserving wrapper around {@link groupDisplayItems}.
+ *
+ * The grouping is memoized on `messages` alone, but every streaming rAF flush
+ * replaces the messages array, so the memo re-runs and mints FRESH turn objects
+ * for every turn in the transcript — handing each mounted TurnBlock a new
+ * `turn` prop per flush and defeating all downstream memoization
+ * (memo(TurnBlock), mergeTurnThinking's [turn.items] memo, the disclosure
+ * machinery). This factory reconciles each fresh result against the previous
+ * one and substitutes the PRIOR object wherever the new element describes the
+ * same underlying message references — so a flush that only grew the trailing
+ * message returns the identical settled-turn objects and only the trailing
+ * turn carries a new identity.
+ *
+ * Cache shape and why it cannot leak: the closure holds exactly ONE
+ * (messages, result) pair — the last call's — and both slots are overwritten
+ * on every call, so the previous messages array is released as soon as the
+ * next one arrives. Each caller creates its own grouper (one per mounted
+ * ChatPage via useMemo), so two transcripts never thrash a shared slot and the
+ * whole cache dies with the component. `applyRunningState` stays downstream
+ * and untouched: it already applies the running flag in O(1) on top of
+ * whatever this returns.
+ */
+export function createTurnGrouper(): (messages: ChatMessage[]) => GroupedTurns {
+  let prevMessages: ChatMessage[] | null = null
+  let prevResult: GroupedTurns | null = null
+  return (messages: ChatMessage[]): GroupedTurns => {
+    if (prevMessages === messages && prevResult) return prevResult
+    const next = groupDisplayItems(messages)
+    if (prevResult) {
+      const prevTurns = prevResult.turns
+      let allReused = next.turns.length === prevTurns.length &&
+        next.trailingTurnIdx === prevResult.trailingTurnIdx
+      for (let i = 0; i < next.turns.length; i++) {
+        const p = prevTurns[i]
+        if (p && sameDisplayItem(next.turns[i], p)) next.turns[i] = p
+        else allReused = false
+      }
+      // Every element (and the trailing index) survived: keep the previous
+      // top-level object too, so the [groupedTurns] memos downstream also hit.
+      if (allReused) {
+        prevMessages = messages
+        return prevResult
+      }
+    }
+    prevMessages = messages
+    prevResult = next
+    return next
+  }
+}
+
 /**
  * Apply the slot's running state to the grouped output. O(1): when the slot is
  * still running the trailing turn is not complete yet, so exactly one element is

--- a/website/src/pages/chat/toolRowIndex.ts
+++ b/website/src/pages/chat/toolRowIndex.ts
@@ -1,0 +1,126 @@
+import { createSelector } from '@reduxjs/toolkit'
+import type { ChatMessage, ToolActivity } from '../../types'
+
+/**
+ * Per-slot index over a transcript's messages + tool log, built ONCE per
+ * (messages, toolLog) array-identity pair and shared by every mounted
+ * ToolCallLine row in that slot.
+ *
+ * Why this exists: each ToolCallLine used to run O(messages + toolLog)
+ * reverse scans INSIDE its useAppSelector bodies — a full permission walk, a
+ * 🚫-sibling walk, and a toolLog reverse scan — and useAppSelector re-runs on
+ * every store dispatch, per mounted row. With N rows mounted that is N full
+ * walks per dispatch. The index converts every one of those scans into an
+ * O(1) map lookup; the single O(messages + toolLog) build runs only when one
+ * of the two arrays actually changes identity.
+ *
+ * Memoization: reselect 5's default weakMapMemoize keys the cache on the
+ * input array identities via WeakMaps, so results for different slots coexist
+ * (no LRU thrash between the active slot and split-view panes) and an index
+ * is released as soon as the store releases its source arrays — nothing here
+ * pins old messages arrays alive.
+ */
+export interface ToolRowIndex {
+  /** Latest tool-log entry per tool_call_id (last write wins — mirrors the
+   *  reverse scan's "first match from the end"). */
+  logById: Map<string, ToolActivity>
+  /** Id-bearing tool-log entries, newest first, for id-less historical rows
+   *  whose only join key is a label-substring match on entry text. */
+  idBearingLogDesc: ToolActivity[]
+  /** Latest permission message per tool_call_id — the reverse permission scan
+   *  only ever consulted the newest one. */
+  lastPermById: Map<string, ChatMessage>
+  /** tool_call_ids that have at least one UNRESOLVED permission message. */
+  pendingPermIds: Set<string>
+  /** All tool-role messages per tool_call_id, in transcript order — the
+   *  🚫-deny-sibling scan walks only this row's own id group. */
+  toolMsgsById: Map<string, ChatMessage[]>
+  /** The transcript's newest tool-role message (owns the wait countdown). */
+  lastToolMsg: ChatMessage | undefined
+}
+
+/** Build-count probe: lets tests assert the index is built once per
+ *  (messages, toolLog) identity change, not once per mounted row. */
+function buildToolRowIndex(messages: ChatMessage[], toolLog: ToolActivity[]): ToolRowIndex {
+  const logById = new Map<string, ToolActivity>()
+  const idBearingLogDesc: ToolActivity[] = []
+  for (const e of toolLog) {
+    if (e.type !== 'tool' || !e.tool_call_id) continue
+    logById.set(e.tool_call_id, e)
+    idBearingLogDesc.push(e)
+  }
+  idBearingLogDesc.reverse()
+  const lastPermById = new Map<string, ChatMessage>()
+  const pendingPermIds = new Set<string>()
+  const toolMsgsById = new Map<string, ChatMessage[]>()
+  let lastToolMsg: ChatMessage | undefined
+  for (const m of messages) {
+    const id = m.meta?.tool_call_id as string | undefined
+    if (m.role === 'permission') {
+      if (!id) continue
+      lastPermById.set(id, m)
+      if (!m.meta?.resolved) pendingPermIds.add(id)
+    } else if (m.role === 'tool') {
+      lastToolMsg = m
+      if (!id) continue
+      const arr = toolMsgsById.get(id)
+      if (arr) arr.push(m)
+      else toolMsgsById.set(id, [m])
+    }
+  }
+  return { logById, idBearingLogDesc, lastPermById, pendingPermIds, toolMsgsById, lastToolMsg }
+}
+
+/** Memoized on the two array identities (weakMapMemoize — see module doc). */
+export const selectToolRowIndex = createSelector(
+  [(messages: ChatMessage[]) => messages, (_messages: ChatMessage[], toolLog: ToolActivity[]) => toolLog],
+  buildToolRowIndex,
+)
+
+// Per-index cache of id-less label lookups. The historical fallback matches a
+// row to the newest id-bearing log entry whose text is a SUBSTRING of the
+// row's label — substring matching cannot be a map lookup, so the linear scan
+// survives here, but it runs once per (index, label) pair instead of once per
+// dispatch per row. WeakMap-keyed on the index so it dies with it.
+const idLessLookups = new WeakMap<ToolRowIndex, Map<string, ToolActivity | null>>()
+
+/**
+ * Resolve the tool-log entry backing a row: by tool_call_id when the row has
+ * one, else by the label-substring fallback for id-less historical rows.
+ * Returns undefined when no entry matches (the caller falls to the
+ * historical-message branch). Semantics match the old reverse scan exactly:
+ * newest entry wins, and the id-less path only considers id-bearing entries.
+ */
+export function lookupLogEntry(index: ToolRowIndex, toolCallId: string | undefined, label: string): ToolActivity | undefined {
+  if (toolCallId) return index.logById.get(toolCallId)
+  let cache = idLessLookups.get(index)
+  if (!cache) { cache = new Map(); idLessLookups.set(index, cache) }
+  const hit = cache.get(label)
+  if (hit !== undefined) return hit ?? undefined
+  let found: ToolActivity | null = null
+  for (const e of index.idBearingLogDesc) {
+    if (label.includes(e.text)) { found = e; break }
+  }
+  cache.set(label, found)
+  return found ?? undefined
+}
+
+/**
+ * The 🚫 deny-sibling for a pill: the newest tool message sharing the pill's
+ * tool_call_id whose content starts with 🚫, looking only ABOVE the pill's own
+ * message (the old scan walked from the end and stopped at the pill itself).
+ * O(k) over the id's own sibling group — in practice 2 messages.
+ */
+export function denySiblingContent(index: ToolRowIndex, toolCallId: string | undefined, ownMessage: ChatMessage): string {
+  if (!toolCallId) return ''
+  const siblings = index.toolMsgsById.get(toolCallId)
+  if (!siblings) return ''
+  for (let j = siblings.length - 1; j >= 0; j--) {
+    const m = siblings[j]
+    if (m.content.startsWith('🚫')) return m.content
+    // The pill's own 🔧 message reached without a 🚫 sibling above it — any
+    // earlier match would predate this call; stop scanning.
+    if (m === ownMessage) break
+  }
+  return ''
+}

--- a/website/src/test/TurnBlock.disclosureDurable.test.tsx
+++ b/website/src/test/TurnBlock.disclosureDurable.test.tsx
@@ -44,7 +44,7 @@ function Transcript({ messages, running, mounted }: { messages: ChatMessage[]; r
                 turn={item}
                 renderItem={renderTurnItem}
                 disclosure={disclosure[k]}
-                onDisclosureChange={(next: boolean) => setFor(k, next)}
+                disclosureKey={k} onDisclosureChange={setFor}
               />
             </div>
           )

--- a/website/src/test/TurnBlock.rowMemo.test.tsx
+++ b/website/src/test/TurnBlock.rowMemo.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { readFileSync } from 'fs'
+import path from 'path'
+import { useState } from 'react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import TurnBlock from '../pages/chat/TurnBlock'
+import type { DisplayItem, TurnItem } from '../pages/chat/types'
+
+// memo(TurnBlock) contract: when a host re-renders but hands TurnBlock the
+// IDENTICAL turn/renderItem/disclosure props (which createTurnGrouper's
+// structural sharing guarantees for settled turns across streaming flushes),
+// the TurnBlock body must not re-execute. renderItem runs inside the body, so
+// its invocation count is the render probe.
+
+const makeTurn = (items: TurnItem[], complete = true): Extract<DisplayItem, { kind: 'turn' }> =>
+  ({ kind: 'turn', items, complete })
+
+const items: TurnItem[] = [
+  { kind: 'single', msg: { role: 'assistant', content: 'working on it', ts: '1' }, idx: 0 },
+  { kind: 'single', msg: { role: 'tool', content: '🔧 Running: ls', ts: '2' }, idx: 1 },
+  { kind: 'single', msg: { role: 'assistant', content: 'the answer', ts: '3' }, idx: 2 },
+]
+
+// Module-level so its identity is stable across host re-renders — the same
+// guarantee ChatPage provides by hoisting renderTurnItem into a useCallback.
+const probe = { calls: 0 }
+const renderItem = (it: TurnItem) => {
+  probe.calls++
+  return <div>{it.kind === 'single' ? it.msg.content : 'group'}</div>
+}
+
+function Host({ turn }: { turn: Extract<DisplayItem, { kind: 'turn' }> }) {
+  const [, setTick] = useState(0)
+  return (
+    <div>
+      <button onClick={() => setTick(t => t + 1)}>rerender</button>
+      <TurnBlock turn={turn} renderItem={renderItem} />
+    </div>
+  )
+}
+
+describe('TurnBlock — memo bail-out', () => {
+  it('a host re-render with an identical turn reference re-executes zero TurnBlock bodies', () => {
+    const turn = makeTurn(items)
+    probe.calls = 0
+    render(<Host turn={turn} />)
+    const afterMount = probe.calls
+    expect(afterMount).toBeGreaterThan(0)
+    fireEvent.click(screen.getByText('rerender'))
+    fireEvent.click(screen.getByText('rerender'))
+    expect(probe.calls).toBe(afterMount) // bailed out both times
+  })
+
+  it('a NEW turn object (the trailing turn during streaming) does re-render', () => {
+    const turn = makeTurn(items)
+    probe.calls = 0
+    const { rerender } = render(<Host turn={turn} />)
+    const afterMount = probe.calls
+    rerender(<Host turn={makeTurn(items.slice())} />)
+    expect(probe.calls).toBeGreaterThan(afterMount) // probe has teeth
+  })
+})
+
+// The production-shaped guarantee the module-level renderItem above cannot
+// pin: ChatPage builds renderTurnItem via useCallback whose transitive deps
+// must NOT include the messages array (flush-volatile reads go through refs).
+// This host mirrors that construction — a state-held messages array feeds a
+// ref, renderItem's useCallback has no messages dep — and a flush-shaped
+// re-render (replacing the array) must re-execute zero settled TurnBlock
+// bodies. If someone re-adds messages to the dep chain, the identity churns
+// and this fails.
+describe('TurnBlock — memo survives a flush-shaped host re-render', () => {
+  it('replacing the messages array re-executes zero settled turn bodies', () => {
+    const { useRef, useCallback, useState: useStateReact } = React
+    const flushProbe = { calls: 0 }
+    const turn = makeTurn(items)
+    function FlushHost() {
+      const [messages, setMessages] = useStateReact<unknown[]>([{ role: 'user' }])
+      const messagesRef = useRef(messages); messagesRef.current = messages
+      // Mirrors ChatPage: volatile reads via ref, dep array without messages.
+      const renderItemCb = useCallback((it: TurnItem) => {
+        void messagesRef.current.length
+        flushProbe.calls++
+        return <div>{it.kind === 'single' ? it.msg.content : 'group'}</div>
+      }, [])
+      return (
+        <div>
+          <button onClick={() => setMessages(prev => [...prev, { role: 'chunk' }])}>flush</button>
+          <TurnBlock turn={turn} renderItem={renderItemCb} />
+        </div>
+      )
+    }
+    flushProbe.calls = 0
+    render(<FlushHost />)
+    const afterMount = flushProbe.calls
+    expect(afterMount).toBeGreaterThan(0)
+    fireEvent.click(screen.getByText('flush'))
+    fireEvent.click(screen.getByText('flush'))
+    expect(flushProbe.calls).toBe(afterMount)
+  })
+})
+
+// Source ratchet: the flush-volatile values must never return to
+// renderMessage's dependency array — that chain (renderMessage ->
+// renderTurnItem -> TurnBlock's renderItem prop) is what would defeat
+// memo(TurnBlock) on every streaming flush.
+describe('ChatPage renderMessage dep hygiene', () => {
+  it('renderMessage does not depend on flush-volatile positional state', () => {
+    const src = readFileSync(
+      path.join(__dirname, '../pages/ChatPage.tsx'), 'utf8')
+    const depMatch = src.match(/\}, (\[[^\]]*handleFileOpen[^\]]*\])\)\n\n  \/\/ Hoisted out of the row map/)
+    expect(depMatch, 'renderMessage dep array not found — update this ratchet if the anchor moved').toBeTruthy()
+    const deps = depMatch![1]
+    for (const banned of ['messages', 'visibleIndexMap', 'lastTextIdx', 'slotState']) {
+      expect(deps.includes(banned), `"${banned}" is back in renderMessage's deps — read it through its ref instead`).toBe(false)
+    }
+  })
+})

--- a/website/src/test/groupDisplayItems.structuralSharing.test.ts
+++ b/website/src/test/groupDisplayItems.structuralSharing.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import { createTurnGrouper, groupDisplayItems } from '../pages/chat/groupDisplayItems'
+import type { ChatMessage } from '../types'
+
+// Structural-sharing contract for createTurnGrouper: a streaming flush that
+// only changes the TAIL message must hand back the previous objects — by
+// reference — for every settled turn, so memo(TurnBlock) and the
+// mergeTurnThinking [turn.items] memo bail out. Only the trailing turn may
+// carry a new identity.
+
+const msg = (role: string, content: string, i: number): ChatMessage =>
+  ({ role, content, ts: String(i) })
+
+/** Two settled turns + a trailing turn ending in a streaming row. Each turn
+ *  has >2 non-opener items with working steps, so flushTurn wraps it. */
+function buildMessages(): ChatMessage[] {
+  return [
+    msg('user', 'first question', 0),
+    msg('assistant', 'thinking about it', 1),
+    msg('tool', '🔧 Running: ls', 2),
+    msg('assistant', 'first answer', 3),
+    msg('user', 'second question', 4),
+    msg('assistant', 'working', 5),
+    msg('tool', '🔧 Running: cat', 6),
+    msg('assistant', 'second answer', 7),
+    msg('user', 'third question', 8),
+    msg('assistant', 'partial', 9),
+    msg('tool', '🔧 Running: grep', 10),
+    msg('streaming', 'streaming tail', 11),
+  ]
+}
+
+describe('createTurnGrouper — structural sharing', () => {
+  it('groups identically to the pure groupDisplayItems', () => {
+    const messages = buildMessages()
+    expect(createTurnGrouper()(messages)).toEqual(groupDisplayItems(messages))
+  })
+
+  it('returns the same result object for the same messages array', () => {
+    const grouper = createTurnGrouper()
+    const messages = buildMessages()
+    const r1 = grouper(messages)
+    expect(grouper(messages)).toBe(r1)
+  })
+
+  it('appending a chunk to the trailing turn keeps every settled turn BY REFERENCE and rebuilds only the trailing turn', () => {
+    const grouper = createTurnGrouper()
+    const messages1 = buildMessages()
+    const r1 = grouper(messages1)
+    // Shape check: 3 turn openers + 3 wrapped turns, trailing turn last.
+    expect(r1.turns.length).toBe(6)
+    expect(r1.trailingTurnIdx).toBe(5)
+
+    // Streaming flush: same array shape, only the tail message object replaced.
+    const messages2 = messages1.slice()
+    messages2[messages2.length - 1] = { ...messages2[messages2.length - 1], content: 'streaming tail grew' }
+    const r2 = grouper(messages2)
+
+    expect(r2.turns.length).toBe(r1.turns.length)
+    for (let i = 0; i < r2.turns.length - 1; i++) {
+      expect(r2.turns[i]).toBe(r1.turns[i]) // identity, not equality
+    }
+    const trailing1 = r1.turns[5]
+    const trailing2 = r2.turns[5]
+    expect(trailing2).not.toBe(trailing1)
+    if (trailing2.kind !== 'turn' || trailing1.kind !== 'turn') throw new Error('trailing element must be a turn')
+    expect(trailing2.items[trailing2.items.length - 1]).toMatchObject({ kind: 'single', msg: { content: 'streaming tail grew' } })
+  })
+
+  it('a new messages array with unchanged element references returns the previous result object', () => {
+    const grouper = createTurnGrouper()
+    const messages1 = buildMessages()
+    const r1 = grouper(messages1)
+    const r2 = grouper(messages1.slice())
+    expect(r2).toBe(r1)
+  })
+
+  it('appending a NEW message to the trailing turn still shares all settled turns', () => {
+    const grouper = createTurnGrouper()
+    const messages1 = buildMessages()
+    const r1 = grouper(messages1)
+    const messages2 = [...messages1, msg('tool', '🔧 Running: tail', 12)]
+    const r2 = grouper(messages2)
+    for (let i = 0; i < r2.turns.length - 1; i++) {
+      expect(r2.turns[i]).toBe(r1.turns[i])
+    }
+    expect(r2.turns[5]).not.toBe(r1.turns[5])
+  })
+
+  it('two groupers do not share cache state', () => {
+    const a = createTurnGrouper()
+    const b = createTurnGrouper()
+    const messages = buildMessages()
+    const ra = a(messages)
+    const rb = b(messages)
+    expect(ra).toEqual(rb)
+    expect(ra).not.toBe(rb) // independent closures build independent results
+  })
+})
+
+// Field-exhaustiveness gate for the purity invariant: the reconcile's equality
+// helpers compare a FIXED set of fields per variant, so a field added to the
+// grouper's output without extending the comparison would be silently frozen
+// on settled turns. Pin the runtime key sets of produced objects to exactly
+// what sameTurnItem/sameDisplayItem read — an added field fails here by name
+// instead of shipping stale UI.
+describe('reconcile field exhaustiveness', () => {
+  it('produced TurnItem/DisplayItem variants carry only fields the reconcile compares', () => {
+    const msgs: ChatMessage[] = [
+      { role: 'user', content: 'q', ts: '1' },
+      { role: 'assistant', content: 'a', ts: '2' },
+      { role: 'tool', content: '🔧 Running: ls', ts: '3' },
+      { role: 'tool', content: '🔧 Running: cat', ts: '4' },
+      { role: 'assistant', content: 'done', ts: '5' },
+      { role: 'user', content: 'next', ts: '6' },
+    ]
+    const { turns } = groupDisplayItems(msgs)
+    const expectedKeys: Record<string, string[]> = {
+      // sameDisplayItem: kind + complete + items (recursing per item);
+      // sameTurnItem singles: kind + msg + idx; groups: kind + msgs + startIdx.
+      'display:turn': ['kind', 'items', 'complete'],
+      'display:single': ['kind', 'msg', 'idx'],
+      'display:group': ['kind', 'msgs', 'startIdx'],
+      'turn:single': ['kind', 'msg', 'idx'],
+      'turn:group': ['kind', 'msgs', 'startIdx'],
+    }
+    const seen = new Set<string>()
+    for (const it of turns) {
+      const tag = `display:${it.kind}`
+      expect(Object.keys(it).sort(), `${tag} keys drifted — extend sameDisplayItem`).toEqual([...expectedKeys[tag]].sort())
+      seen.add(tag)
+      if (it.kind === 'turn') {
+        for (const ti of it.items) {
+          const ttag = `turn:${ti.kind}`
+          expect(Object.keys(ti).sort(), `${ttag} keys drifted — extend sameTurnItem`).toEqual([...expectedKeys[ttag]].sort())
+          seen.add(ttag)
+        }
+      }
+    }
+    // The fixture must exercise the variants it gates, or the pin is hollow.
+    // group variants are absent: the raw pass skips permission messages (the
+    // pinned ApprovalBar owns them), so the grouper currently never emits
+    // kind:'group' — the comparators' group branches are defensive. If a
+    // GROUPABLE role becomes reachable, add it here and to expectedKeys.
+    for (const required of ['display:turn', 'display:single', 'turn:single']) {
+      expect(seen.has(required), `fixture no longer produces ${required}`).toBe(true)
+    }
+  })
+})

--- a/website/src/test/toolRowIndex.test.ts
+++ b/website/src/test/toolRowIndex.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { selectToolRowIndex, lookupLogEntry, denySiblingContent } from '../pages/chat/toolRowIndex'
+import type { ChatMessage, ToolActivity } from '../types'
+
+// Per-slot tool-row index contract: ONE build per (messages, toolLog)
+// identity pair, no matter how many mounted rows consult it per dispatch —
+// this is what converts ToolCallLine's per-row O(messages + toolLog) selector
+// scans into O(1) lookups.
+
+const toolMsg = (id: string | undefined, content: string, i: number): ChatMessage =>
+  ({ role: 'tool', content, ts: String(i), meta: id ? { tool_call_id: id } : {} })
+
+const permMsg = (id: string, resolved: string | undefined, i: number): ChatMessage =>
+  ({ role: 'permission', content: 'perm', ts: String(i), meta: { tool_call_id: id, ...(resolved ? { resolved } : {}) } })
+
+const logEntry = (id: string | undefined, text: string, ts: number): ToolActivity =>
+  ({ type: 'tool', text, ts, tool_call_id: id })
+
+describe('toolRowIndex — build count', () => {
+  it('builds once per (messages, toolLog) identity pair, not per row', () => {
+    const msgs = [toolMsg('a', '🔧 one', 0), toolMsg('b', '🔧 two', 1)]
+    const log = [logEntry('a', 'one', 0), logEntry('b', 'two', 1)]
+    const before = selectToolRowIndex.recomputations()
+    // Three mounted rows each running their selector on the same dispatch:
+    const i1 = selectToolRowIndex(msgs, log)
+    const i2 = selectToolRowIndex(msgs, log)
+    const i3 = selectToolRowIndex(msgs, log)
+    expect(selectToolRowIndex.recomputations()).toBe(before + 1)
+    expect(i2).toBe(i1)
+    expect(i3).toBe(i1)
+    // A toolLog identity change rebuilds exactly once:
+    const log2 = log.slice()
+    selectToolRowIndex(msgs, log2)
+    selectToolRowIndex(msgs, log2)
+    expect(selectToolRowIndex.recomputations()).toBe(before + 2)
+    // A messages identity change rebuilds exactly once:
+    const msgs2 = msgs.slice()
+    selectToolRowIndex(msgs2, log2)
+    selectToolRowIndex(msgs2, log2)
+    expect(selectToolRowIndex.recomputations()).toBe(before + 3)
+  })
+})
+
+describe('toolRowIndex — lookup semantics', () => {
+  it('logById resolves the NEWEST entry per tool_call_id', () => {
+    const older = logEntry('a', 'first frame', 0)
+    const newer = logEntry('a', 'second frame', 1)
+    const index = selectToolRowIndex([], [older, newer])
+    expect(lookupLogEntry(index, 'a', 'irrelevant')).toBe(newer)
+    expect(lookupLogEntry(index, 'missing', 'irrelevant')).toBeUndefined()
+  })
+
+  it('id-less rows fall back to the newest id-bearing entry whose text is a label substring', () => {
+    const e1 = logEntry('x', 'Running: ls', 0)
+    const e2 = logEntry('y', 'Running: cat', 1)
+    const index = selectToolRowIndex([], [e1, e2])
+    expect(lookupLogEntry(index, undefined, '🔧 Running: ls -la')).toBe(e1)
+    expect(lookupLogEntry(index, undefined, 'no match here')).toBeUndefined()
+    // Cached second lookup returns the same entry.
+    expect(lookupLogEntry(index, undefined, '🔧 Running: ls -la')).toBe(e1)
+  })
+
+  it('pendingPermIds tracks unresolved permissions; lastPermById the newest decision', () => {
+    const msgs = [
+      permMsg('a', undefined, 0),          // unresolved → pending
+      permMsg('b', 'rejected', 1),         // resolved
+      permMsg('b', 'approved', 2),         // NEWEST decision for b
+    ]
+    const index = selectToolRowIndex(msgs, [])
+    expect(index.pendingPermIds.has('a')).toBe(true)
+    expect(index.pendingPermIds.has('b')).toBe(false)
+    expect(index.lastPermById.get('b')?.meta?.resolved).toBe('approved')
+  })
+
+  it('denySiblingContent finds a 🚫 sibling above the pill and stops at the pill itself', () => {
+    const own = toolMsg('a', '🔧 Running: rm', 0)
+    const deny = toolMsg('a', '🚫 Running: rm — Blocked by security policy: no', 1)
+    const withDeny = selectToolRowIndex([own, deny], [])
+    expect(denySiblingContent(withDeny, 'a', own)).toContain('🚫')
+    // A 🚫 row BELOW the pill (earlier in the transcript) belongs to an
+    // earlier call and must not mark this pill blocked.
+    const laterOwn = toolMsg('a', '🔧 Running: rm', 2)
+    const denyBelow = selectToolRowIndex([deny, laterOwn], [])
+    expect(denySiblingContent(denyBelow, 'a', laterOwn)).toBe('')
+    expect(denySiblingContent(withDeny, undefined, own)).toBe('')
+  })
+
+  it('lastToolMsg is the transcript-newest tool message', () => {
+    const a = toolMsg('a', '🔧 one', 0)
+    const b = toolMsg('b', '🔧 two', 1)
+    const index = selectToolRowIndex([a, { role: 'assistant', content: 'x', ts: '2' }, b], [])
+    expect(index.lastToolMsg).toBe(b)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

During a long streaming turn the entire mounted transcript window re-renders on every rAF-coalesced flush: each flush replaces the messages array, `groupDisplayItems` rebuilds every turn object with a fresh identity, and un-memoized `TurnBlock`s re-render settled turns far above the viewport. On top of that, every mounted `ToolCallLine`'s Redux selectors run O(messages + toolLog) scans per store dispatch, and each tool row's entrance plays a height animation that forces a layout + scrollTop re-pin per frame — exactly while frames are scarcest.

## Why it matters

These are the transcript's dominant frame-budget consumers in the render audit (items #2, #6, #9): in a multi-thousand-message session, streaming text costs a full-window reconcile up to ~60×/s plus per-dispatch linear scans multiplied by mounted tool rows. Users see dropped frames and sluggish scrolling for the duration of every long agent turn.

## What changed (motivation → approach → change)

1. **Structural sharing** — `createTurnGrouper()` wraps the grouping walk with a one-pair cache (previous messages array → previous result): a call with unchanged element references returns prior turn objects BY REFERENCE, and only the trailing turn rebuilds when just the tail message changed. The reconcile is guarded by reference-and-index equality (`a.msg === b.msg && a.idx === b.idx`, plus `complete`/`trailingTurnIdx`), so an out-of-band insert, steer, or truncation shifts indices and gets fresh objects — a settled turn can never be wrongly reused. `applyRunningState` is untouched.
2. **`memo(TurnBlock)`** — with identities stable, settled turns bail out entirely. ChatPage hoists `renderTurnItem` into a `useCallback` and hands every TurnBlock the same keyed setter (`disclosureKey` + a stable `(key, expanded)` callback) so the memo actually holds. Because `memo()` skips the provider-level language repaint, TurnBlock subscribes to `useLanguageGeneration()` itself (the repo's ratchet test enforces this pairing).
3. **Per-slot tool-row index** — `toolRowIndex` builds `{logById, idBearingLogDesc, lastPermById, pendingPermIds, denySiblingContent, lastToolMsg}` once per messages/toolLog identity change via `createSelector`; each `ToolCallLine`'s read becomes O(1), with every replaced scan's early-exit semantics preserved (newest-first log resolution, substring fallback only for id-less rows, deny-scan stopping at the row's own message).
4. **Stream-idle animation gating** — the tool-row entrance slide and StatusRow height ease snap to full height during high-frequency streaming (no per-frame reflow + scrollTop write) and keep their eases on quiet-transcript mounts. The gate only zeroes the transition duration with `animate: height 'auto'`, so a row can never strand at height 0.

## Tests

- 14 new mutation-verified pinning tests: structural sharing (settled turns keep `toBe` identity across a tail-only change; inserts/truncations get fresh objects — disabling the reconcile fails 3), memo boundary (a re-render with an identical turn reference re-executes zero settled bodies — unwrapping memo fails the pin), and the index (built once per identity change, not per row — bypassing memoization fails the build-count pin).
- The full behavior-contract set (59 files matching TurnBlock/ToolCallLine/groupDisplayItems/ChatPage + new files): 590 passed.
- Full suite: 1638 files / 25902 tests green; electron 1422. The memo+i18n subscription ratchet caught the missing `useLanguageGeneration()` during verification — fixed and covered above.

## Manual verification

N/A — the behavior-contract suite exercises the transcript's interactive paths against the refactor, and rendering output is identical by construction (settled turns render the same element trees, just not repeatedly).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** render-frequency refactor — pixel output is unchanged; the animation gate only affects mounts during high-frequency streaming, where the pre-change ease was itself the jank being removed, and the quiet-path eases are untouched.

## Related Issues

no linked issue: part of the dashboard performance push (sibling PRs #6666, #6684, #6703). Pre-push blind review: GPT PASS (0 findings), Opus PASS (0 findings; grouper retention, reconcile safety, index parity, and gate stranding each explicitly falsified).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no contract change
- [x] No secrets, credentials, or internal references in the diff

