### PR TITLE
fix(sel): flush the audit tail before every gateway hard exit

### DIFF
--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -84,6 +84,16 @@ reached from the loop.
   `verify_integrity`, `prune`) and on exit. It waits on a pending-event counter
   (a `threading.Condition`, race-free vs a bare queue-empty check), bounded by
   `_FLUSH_TIMEOUT_SECS` so a wedged writer can't hang a read.
+- **Hard exits flush explicitly**: `os._exit` runs no `atexit` handler and does
+  not join a daemon thread, so "on exit" above covers only an ordinary
+  interpreter shutdown. Every hard exit in the gateway process therefore drains
+  the queue for itself — `flush_audit_queue(timeout=...)` from a synchronous
+  signal handler, `await flush_audit_queue_before_hard_exit()` from a coroutine
+  (it offloads the blocking drain so the loop is not parked). Both are bounded by
+  `_HARD_EXIT_FLUSH_TIMEOUT_SECS` and neither raises: a hard exit must not be
+  blocked, or replaced, by auditing. `flush_audit_queue` is a no-op when no
+  singleton exists, so it never creates the trust directory as a side effect of
+  leaving. Pinned by the AST ratchet in `test/test_sel_hard_exit_flush.py`.
 - **Fallback**: if the writer can't be started, `log()` writes synchronously so
   an event is never silently dropped.
 - **`sync=True`**: `SecurityEventLog(base_dir=..., sync=True)` writes each event

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -55,6 +55,7 @@ from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.credential_patterns import AWS_KEY_ID_PREFIXES
+from kiro_crew.executors import subprocess_executor
 
 logger = logging.getLogger(__name__)
 
@@ -370,6 +371,10 @@ _MAX_ARG_LEN = 500
 # read so read-after-write stays consistent.
 _QUEUE_DRAIN_BATCH = 256  # max events appended per open() in the writer loop
 _FLUSH_TIMEOUT_SECS = 5.0  # bound on flush() so a stuck writer can't hang reads
+# Tighter bound for the hard-exit paths. os._exit() is imminent there, so a
+# wedged writer must not be given the whole read-path budget before the process
+# is allowed to leave.
+_HARD_EXIT_FLUSH_TIMEOUT_SECS = 3.0
 
 
 def _redact_deep(obj: object, redactor: Callable[[str], str]) -> object:
@@ -3415,6 +3420,54 @@ def _trust_root_key_loads(path: Path) -> bool:
     except OSError:
         return False
     return stat.S_ISREG(st.st_mode) and st.st_size >= _HMAC_KEY_MIN_BYTES
+
+
+def flush_audit_queue(timeout: float = _HARD_EXIT_FLUSH_TIMEOUT_SECS) -> None:
+    """Drain the queued audit tail, bounded by *timeout*. Never raises.
+
+    The writer is a *daemon* thread fed by an unbounded queue, and its drain is
+    registered with :mod:`atexit`. ``os._exit`` runs no ``atexit`` handler and
+    does not join daemon threads, so every event still queued at a hard exit
+    dies with the process -- including the ones recorded during the shutdown
+    that is exiting, which are exactly the records an investigator reaches for.
+
+    Flushes only an ALREADY-INITIALIZED singleton: with no live instance there
+    is nothing queued, and constructing one here would create the trust
+    directory and HMAC key as a side effect of leaving.
+    """
+    inst = SecurityEventLog._instance
+    if inst is None:
+        return
+    try:
+        inst.flush(timeout=timeout)
+    except Exception:
+        logger.debug("SEL flush before hard exit failed", exc_info=True)
+
+
+async def flush_audit_queue_before_hard_exit(
+    timeout: float = _HARD_EXIT_FLUSH_TIMEOUT_SECS,
+) -> None:
+    """:func:`flush_audit_queue` for an ``async`` hard-exit path.
+
+    :meth:`SecurityEventLog.flush` is a *synchronous* blocking drain, so calling
+    it inline from a coroutine would park the event loop for up to *timeout*.
+    Offload it to :func:`~kiro_crew.executors.subprocess_executor` -- the pool
+    reserved for teardown work that can block on a wedged resource -- under an
+    outer deadline just past the inner one, so a writer wedged on a full disk or
+    an unreachable sink delays neither the loop nor the exit, and leaves no pool
+    thread blocked past the deadline that already gave up on it.
+
+    Never raises: a hard exit must not be blocked, or replaced, by auditing.
+    """
+    try:
+        await asyncio.wait_for(
+            asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), flush_audit_queue, timeout
+            ),
+            timeout=timeout + 1.0,
+        )
+    except Exception:
+        logger.debug("SEL flush before hard exit failed", exc_info=True)
 
 
 def sel_hmac_key_path() -> Path:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -285,7 +285,7 @@ from kiro_crew.security import (
     redact_credentials,
     redact_exfiltration_urls,
 )
-from kiro_crew.sel import sel
+from kiro_crew.sel import flush_audit_queue, flush_audit_queue_before_hard_exit, sel
 from kiro_crew.service.common import restart_command_hint
 from kiro_crew.session import (
     HEARTBEAT_KEY,
@@ -11486,6 +11486,13 @@ class GatewayOrchestrator:
                     _stop_log_queue_listener(timeout=2.0)
                 except Exception:
                     pass  # force exit must never be blocked by logging
+                # The SEL audit queue has the identical shape and the identical
+                # exposure: a daemon writer thread whose drain is an atexit hook
+                # this exit skips, so the events recorded while shutting down --
+                # the ones a security review reads first -- die here. Bounded
+                # the same way. This handler runs on the loop thread, but the
+                # process leaves on the next line, so blocking it costs nothing.
+                flush_audit_queue(timeout=2.0)
                 os._exit(0)
             _shutting_down = True
             shutdown_event.set()
@@ -11718,6 +11725,10 @@ class GatewayOrchestrator:
         from kiro_crew.cli import drain_log_queue_before_hard_exit
 
         await drain_log_queue_before_hard_exit()
+        # And the SEL audit queue, for the same reason at the same layer: the
+        # restart path already flushes it before its own os._exit, so a normal
+        # shutdown dropping the audit tail is the inconsistency, not the fix.
+        await flush_audit_queue_before_hard_exit()
         os._exit(exit_code)
 
     async def _start_channel_transports(

--- a/test/test_sel_hard_exit_flush.py
+++ b/test/test_sel_hard_exit_flush.py
@@ -1,0 +1,309 @@
+"""The SEL audit tail must survive every gateway hard exit.
+
+SEL logging is asynchronous: :meth:`SecurityEventLog.log` enqueues onto an
+unbounded queue drained by a **daemon** writer thread, and the only thing that
+guarantees the queue reaches disk is a drain registered with :mod:`atexit`.
+
+``os._exit`` runs no ``atexit`` handler and does not join daemon threads. So on
+any hard-exit path that does not flush for itself, the events recorded while the
+gateway was shutting down -- the last audit records before the process is gone,
+and the ones an investigator reads first -- are dropped with no error and no gap
+marker. The restart path has flushed for exactly this reason for a while; these
+tests hold the other two hard exits to the same contract, and the ratchet at the
+bottom keeps a fourth from being added without one.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.sel import (
+    SecurityEvent,
+    SecurityEventLog,
+    flush_audit_queue,
+    flush_audit_queue_before_hard_exit,
+)
+
+
+def _retire_writer(log: SecurityEventLog) -> None:
+    """Stop the daemon writer this test started, before dropping the singleton.
+
+    Clearing ``_instance`` on its own abandons a live thread: it keeps holding
+    the queue, and the test's ``tmp_path``, for the rest of the worker. That is
+    the leak the repo's testing guidance names -- a singleton with a daemon
+    thread beats every filesystem cleanup -- and these tests start a real writer
+    precisely because a mock would not prove the drain.
+
+    Flush first so nothing queued is lost, then the ``None`` sentinel makes
+    ``_writer_loop`` return, then join. The flush is best-effort: several tests
+    here deliberately replace ``flush`` with a raising or wedged stub, and
+    teardown must retire the thread regardless.
+    """
+    writer = log._writer
+    if writer is None or not writer.is_alive():
+        return
+    try:
+        log.flush(timeout=5.0)
+    except Exception:
+        pass
+    log._queue.put(None)
+    writer.join(timeout=5.0)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset the SEL singleton between tests, retiring any writer it started."""
+    SecurityEventLog._instance = None
+    SecurityEventLog._initialized = False
+    yield
+    live = SecurityEventLog._instance
+    if live is not None:
+        _retire_writer(live)
+    SecurityEventLog._instance = None
+    SecurityEventLog._initialized = False
+
+
+def _event(event_id: str) -> SecurityEvent:
+    return SecurityEvent(
+        event_id=event_id,
+        timestamp="2026-05-13T00:00:00+00:00",
+        event_type="tool_invocation",
+        caller_identity="dashboard:abc",
+        agent="kirocrew",
+        source="dashboard",
+        operation="execute_bash",
+        outcome="approved",
+    )
+
+
+class TestFlushAuditQueue:
+    """The synchronous drain, used by the sync signal handler."""
+
+    def test_queued_tail_reaches_disk(self, tmp_path: Path) -> None:
+        """The records enqueued immediately before a hard exit are on disk when
+        the drain returns -- the whole reason for calling it."""
+        log = SecurityEventLog(base_dir=tmp_path)  # async writer, as in prod
+        log.log(_event("shutdown-tail"))
+        flush_audit_queue()
+        written = (tmp_path / "security_events.jsonl").read_text(encoding="utf-8")
+        assert "shutdown-tail" in written
+
+    def test_no_singleton_is_a_no_op_and_creates_nothing(self, tmp_path, monkeypatch):
+        """With no live SEL there is nothing queued, and constructing one to
+        find that out would create the trust directory and HMAC key as a side
+        effect of leaving. The drain must not reach for the filesystem at all."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        before = sorted(p.name for p in tmp_path.iterdir())
+        flush_audit_queue()
+        assert SecurityEventLog._instance is None
+        assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+    def test_a_wedged_writer_cannot_hang_the_exit(self, tmp_path: Path) -> None:
+        """A writer stuck on a full disk or an unreachable sink must not hold
+        the process on its way out. Credit a pending event no writer will ever
+        clear, so the REAL flush waits on its condition variable and only its
+        own deadline can end the wait."""
+        log = SecurityEventLog(base_dir=tmp_path)
+        with log._pending_cond:
+            log._pending = 1
+        started = time.monotonic()
+        try:
+            flush_audit_queue(timeout=0.2)
+        finally:
+            with log._pending_cond:
+                log._pending = 0
+        assert time.monotonic() - started < 5.0
+
+    def test_a_raising_flush_never_escapes(self, tmp_path: Path) -> None:
+        """A hard exit must not be blocked, or replaced, by auditing."""
+        log = SecurityEventLog(base_dir=tmp_path)
+
+        def boom(**_kwargs):
+            raise RuntimeError("writer exploded")
+
+        log.flush = boom  # type: ignore[method-assign]
+        flush_audit_queue()  # does not raise
+
+
+class TestFlushAuditQueueBeforeHardExit:
+    """The async wrapper, used by the two coroutine hard-exit paths."""
+
+    @pytest.mark.asyncio
+    async def test_queued_tail_reaches_disk(self, tmp_path: Path) -> None:
+        log = SecurityEventLog(base_dir=tmp_path)
+        log.log(_event("async-shutdown-tail"))
+        await flush_audit_queue_before_hard_exit()
+        written = (tmp_path / "security_events.jsonl").read_text(encoding="utf-8")
+        assert "async-shutdown-tail" in written
+
+    @pytest.mark.asyncio
+    async def test_the_blocking_drain_runs_off_the_event_loop(self, tmp_path) -> None:
+        """flush() blocks on a condition variable. Doing that inline would park
+        the loop for the whole deadline, which is what the executor hop buys."""
+        log = SecurityEventLog(base_dir=tmp_path)
+        flush_threads: list[int] = []
+        real_flush = log.flush
+
+        def recording_flush(**kwargs):
+            flush_threads.append(threading.get_ident())
+            return real_flush(**kwargs)
+
+        log.flush = recording_flush  # type: ignore[method-assign]
+        log.log(_event("off-loop"))
+        await flush_audit_queue_before_hard_exit()
+        assert flush_threads, "the drain never ran"
+        assert threading.get_ident() not in flush_threads
+
+    @pytest.mark.asyncio
+    async def test_a_wedged_writer_delays_neither_the_loop_nor_the_exit(self, tmp_path):
+        """The outer deadline holds even when the offloaded drain does not."""
+        log = SecurityEventLog(base_dir=tmp_path)
+        released = threading.Event()
+
+        def wedged(**_kwargs):
+            released.wait(30.0)
+
+        log.flush = wedged  # type: ignore[method-assign]
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        try:
+            await flush_audit_queue_before_hard_exit(timeout=0.2)
+        finally:
+            released.set()
+        assert loop.time() - started < 20.0
+
+
+class TestEveryGatewayHardExitFlushesTheAuditQueue:
+    """Ratchet: the audit log only survives if EVERY hard exit in the gateway
+    process drains it. ``slack/gateway.py`` and ``slack/events.py`` are the two
+    modules that call ``os._exit`` from inside the long-lived gateway process --
+    the other ``os._exit`` sites in the tree (``sandbox.py``,
+    ``_process_group_supervisor.py``) run in forked/pre-exec children that never
+    initialize a SEL singleton.
+
+    The check is per-function and does NOT look inside nested functions, so a
+    flush in a sibling closure cannot vouch for its parent. It mirrors the
+    gateway.log ratchet in ``test_cli_logging.py``: the two sinks fail by one
+    mechanism, so they are held to one contract.
+
+    What it requires is that the queue is drained, not that a particular
+    function is called: the restart path's own inline drain satisfies it.
+    """
+
+    _MODULES = (
+        Path(__file__).resolve().parents[1] / "src/kiro_crew/slack/gateway.py",
+        Path(__file__).resolve().parents[1] / "src/kiro_crew/slack/events.py",
+    )
+    _HELPERS = {"flush_audit_queue", "flush_audit_queue_before_hard_exit"}
+
+    @staticmethod
+    def _has_inline_drain(fn):
+        """True when ``fn``'s own body contains the ``sel().flush`` expression.
+
+        The restart path drains the queue that way instead of through the
+        helper. It is a different spelling of the same contract, not a
+        violation, so the ratchet accepts it -- but it is matched
+        STRUCTURALLY, not as a co-occurrence of the names ``sel`` and
+        ``flush``. ``_dispatch``-sized functions mention both incidentally, and
+        a name-pair rule would hand them a pass they have not earned.
+        """
+        found = False
+
+        class _Walk(ast.NodeVisitor):
+            def visit_FunctionDef(self, node):  # nested def: not fn's own body
+                if node is fn:
+                    self.generic_visit(node)
+
+            visit_AsyncFunctionDef = visit_FunctionDef
+
+            def visit_Attribute(self, node):
+                nonlocal found
+                value = node.value
+                if (
+                    node.attr == "flush"
+                    and isinstance(value, ast.Call)
+                    and isinstance(value.func, ast.Name)
+                    and value.func.id == "sel"
+                ):
+                    found = True
+                self.generic_visit(node)
+
+        _Walk().visit(fn)
+        return found
+
+    def _drains(self, fn):
+        return bool(self._own_body_names(fn) & self._HELPERS) or self._has_inline_drain(fn)
+
+    @staticmethod
+    def _own_body_names(fn):
+        """Every Name/Attribute identifier in ``fn``'s own body, skipping the
+        bodies of functions nested inside it."""
+        names: set[str] = set()
+
+        class _Walk(ast.NodeVisitor):
+            def visit_FunctionDef(self, node):  # nested def: not fn's own body
+                if node is fn:
+                    self.generic_visit(node)
+
+            visit_AsyncFunctionDef = visit_FunctionDef
+
+            def visit_Name(self, node):
+                names.add(node.id)
+
+            def visit_Attribute(self, node):
+                names.add(node.attr)
+                self.generic_visit(node)
+
+        _Walk().visit(fn)
+        return names
+
+    def _hard_exit_functions(self, tree):
+        """(function node, line) for each ``os._exit(...)`` call, attributed to
+        the nearest enclosing function."""
+        parents: "dict[ast.AST, ast.AST]" = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                parents[child] = node
+        found = []
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "_exit"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "os"
+            ):
+                continue
+            cur = parents.get(node)
+            while cur is not None and not isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                cur = parents.get(cur)
+            if cur is not None:
+                found.append((cur, node.lineno))
+        return found
+
+    def test_the_ratchet_actually_finds_the_hard_exits(self):
+        """A scan that matches nothing would pass vacuously."""
+        total = 0
+        for path in self._MODULES:
+            total += len(self._hard_exit_functions(ast.parse(path.read_text(encoding="utf-8"))))
+        assert total >= 3, f"expected the known os._exit sites, found {total}"
+
+    def test_no_hard_exit_strands_the_queued_audit_tail(self):
+        violations = []
+        for path in self._MODULES:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for fn, lineno in self._hard_exit_functions(tree):
+                if not self._drains(fn):
+                    violations.append(f"{path.name}:{lineno} in {fn.name}()")
+        assert not violations, (
+            "os._exit runs no atexit handler and does not join the SEL daemon "
+            "writer, so these hard exits drop the queued audit tail; await "
+            "flush_audit_queue_before_hard_exit() (or call flush_audit_queue("
+            "timeout=...) from a sync handler) first: " + ", ".join(violations)
+        )


### PR DESCRIPTION
## Problem / Motivation

SEL logging is asynchronous. `SecurityEventLog.log()` enqueues onto an unbounded
`queue.Queue` and a **daemon** writer thread drains it; the only thing that guarantees the
queue reaches disk on the way out is a drain registered with `atexit`, installed lazily in
`_ensure_writer`:

```python
self._writer = threading.Thread(target=self._writer_loop, name="sel-writer", daemon=True)
self._writer.start()
atexit.register(self.flush)
```

`os._exit` runs no `atexit` handler and does not join daemon threads. On any hard-exit path
that does not flush for itself, everything still queued is gone — including the events
recorded *during the shutdown that is exiting*, which are the last records the log will
ever hold and the first ones an investigator reads.

The gateway process has three hard exits, and only one of them flushes:

| Path | Site | SEL flush before this change |
|---|---|---|
| `/restart` slash command | `slack/events.py` `_handle_restart` | **yes** — inline, and its comment names this exact reason |
| Normal shutdown (`Ctrl-C` once, SIGTERM) | `slack/gateway.py` `run` | no |
| Force exit (`Ctrl-C` twice) | `slack/gateway.py` `_on_signal` | no |

So the one path a developer takes deliberately preserves its audit tail, and the two paths
every real operator takes — an ordinary stop, and an impatient double-`Ctrl-C` — drop
theirs. `sel().flush` has exactly one call site in the whole gateway, at `events.py:776`.

This is the counted remainder from the review on #6692, which fixed the identical
mechanism for `gateway.log`: *"SEL's flush is also atexit-registered (`sel.py:588`) and
hand-called at exactly 1 of 3 gateway hard exits (grep `sel().flush` → `events.py:776`
only). The normal-shutdown exit (`gateway.py:10385`) and force-exit (`gateway.py:10173`)
strand SEL's in-flight audit tail by the identical mechanism this PR fixes for
gateway.log — 2 sibling sites, same idiom would fix them."*

Both of those exits already drain the **log** queue, as of #6692. They sit one line above
an `os._exit` and flush one of the two async sinks.

## Why it matters

The SEL audit log is one of the security controls this fork is required to keep. It is
append-only and HMAC-chained precisely so that what it says can be relied on after the
fact — and the events most likely to be lost here are the ones most worth having: whatever
was audited in the seconds before the process went away, which is the window that matters
when the question is why it went away.

The loss is also silent by construction. There is no error, no partial write, and no gap
marker; the chain that survives verifies cleanly, because the missing entries were never
written and so were never chained. Nothing downstream can tell a quiet shutdown from one
that dropped its tail. The spec's own durability line — `flush()` "runs before every read
path … **and on exit**" — reads as true while being false on two of the three ways this
process actually exits.

This is bounded, not unbounded: the queue holds what has not yet been batched to disk, so
the exposure is the in-flight tail rather than the log. That is exactly the part a
post-mortem wants.

## What changed (motivation → approach → change)

Symptom: audit events recorded during shutdown never reach disk. Root cause: the drain is
an `atexit` hook and these paths leave through `os._exit`, which skips it. Fix: flush at
the exits — reusing the shape #6692 established for the other sink rather than inventing a
second one, and carrying the reason in one place rather than as a third hand-copy.

Two helpers in `sel.py`, beside `flush()` and mirroring `cli.py`'s
`_stop_log_queue_listener` / `drain_log_queue_before_hard_exit` pairing:

- **`flush_audit_queue(timeout)`** — the synchronous drain, for the signal handler. It
  flushes only an **already-initialized** singleton: with no live instance there is nothing
  queued, and constructing one to discover that would create the trust directory and HMAC
  key as a side effect of exiting. It never raises.
- **`flush_audit_queue_before_hard_exit(timeout)`** — the coroutine form. `flush()` blocks
  on a condition variable, so calling it inline from a coroutine would park the loop for
  the whole deadline; it is offloaded to `subprocess_executor` (the pool reserved for
  teardown work that can block on a wedged resource) under an outer deadline just past the
  inner one, so a writer wedged on a full disk delays neither the loop nor the exit and
  leaves no pool thread blocked past the deadline that already gave up on it.

Both are bounded by a new `_HARD_EXIT_FLUSH_TIMEOUT_SECS = 3.0` — tighter than the
read-path `_FLUSH_TIMEOUT_SECS = 5.0`, because `os._exit` is imminent and a wedged writer
must not be given the whole read budget before the process is allowed to leave.

At the three sites:

- **Normal shutdown** awaits the async helper, right beside the `gateway.log` drain
  #6692 added.
- **Force exit** calls the synchronous one with the same `timeout=2.0` its
  `_stop_log_queue_listener` neighbour already uses. This handler runs on the loop thread,
  but the process leaves on the next line, so blocking it costs nothing — and that is the
  precedent the line above it already set.
- **Restart** is not touched. Collapsing its inline drain onto the shared helper was in an
  earlier revision of this branch and has been removed: four tests in
  `test_restart_command.py` patch `kiro_crew.slack.events.sel` and assert `sel().flush`
  ran, so routing that call through a helper in `sel.py` moved it past their patch point
  and turned a real, valuable invariant into a red suite. De-duplicating that third copy
  is a separate change that has to rewrite those tests, and it is not part of the residual
  this PR closes.

`docs/system-specs/modules/sel.md` gains a bullet next to the durability contract stating
that "on exit" covers only an ordinary interpreter shutdown and that hard exits flush
explicitly.

## Tests

New `test/test_sel_hard_exit_flush.py`, 9 tests.

**Behavioural — the synchronous drain**

- A record enqueued through the real async writer is on disk when `flush_audit_queue()`
  returns.
- With no live singleton it is a no-op **and touches nothing**: the test snapshots the data
  home before and after and asserts the directory listing is unchanged, so the "don't build
  a trust root on the way out" property is pinned rather than asserted in a comment.
- A wedged writer cannot hang the exit: a pending event no writer will ever credit is
  posted so the **real** `flush()` waits on its own condition variable, and only its
  deadline can end the wait. (Stubbing `flush` here would have proved nothing about the
  bound — the stub would just be ignoring the argument.)
- A raising `flush` never escapes.

**Behavioural — the async wrapper**

- The queued tail reaches disk through it too.
- The blocking drain runs **off the event-loop thread**: `flush` is spied on and records
  `threading.get_ident()`, and the test asserts that ident is not the coroutine's. This is
  the property the executor hop exists for, and a ratchet alone would not catch its loss.
- A wedged inner drain does not outlive the outer deadline.

**Ratchet — every gateway hard exit flushes**

An AST scan of `slack/gateway.py` and `slack/events.py` attributing each `os._exit(...)`
to its nearest enclosing function and requiring that function's **own** body to drain the
queue — nested closures do not vouch for their parent. It requires a drain, not a particular
function: either helper counts, and so does the restart path's inline `sel().flush`, which
is matched **structurally** (an `Attribute(attr='flush')` on a `Call` to `Name('sel')`)
rather than as a co-occurrence of the names `sel` and `flush`. That distinction is
load-bearing: `run()` is thousands of lines and mentions both incidentally, so a name-pair
rule would hand it a pass it has not earned — which the red-before below is what proves.
It is otherwise deliberately the same
scanner #6692 added for `gateway.log` in `test_cli_logging.py`: the two sinks fail by one
mechanism, so they are held to one contract, and a fourth hard exit added later fails on
both. It carries the same `test_the_ratchet_actually_finds_the_hard_exits` self-check, so a
scan that silently matched nothing could not pass vacuously.

**Red-before**, with `gateway.py` restored to current `origin/main` (`72e429791`) and
nothing else changed — so the control is main as it stands today, not this branch's base:

```
AssertionError: os._exit runs no atexit handler and does not join the SEL daemon writer,
so these hard exits drop the queued audit tail; await flush_audit_queue_before_hard_exit()
(or call flush_audit_queue(timeout=...) from a sync handler) first:
gateway.py:10394 in run(), gateway.py:10173 in _on_signal()
```

Exactly the two sites the #6692 review counted, still present on current main.
`events.py` does not appear: it drains already, and the ratchet recognises its spelling.

Green on the branch: 9 passed. Siblings, including the four `test_restart_command.py`
tests that pin the flush-before-restart invariant: that file + `test_slack_events_coverage.py`
+ `test_cli_logging.py` + `test_sel_hard_exit_flush.py` → **236 passed, 1 skipped**.

**Gates, re-measured on the current head `50dd8b9c4` after the isort fix**, and scoped
to what was actually verified rather than asserted tree-wide:

* `isort --check-only src/kiro_crew test conftest.py xdist_budget.py` — **clean**. This
  is the gate that was red: `a7b4a8df0` moved `subprocess_executor` to module scope in
response to the `top-level-imports` finding and inserted it above
  `kiro_crew.config.paths`, which sorts first. Fixed by running `isort` on the file, so
  the import block is ordered rather than hand-placed.
* `check_black_formatting.py` — **passes**. `sel.py` is in `.github/black-baseline.txt`
  and its findings are pre-existing regex/signature wrapping outside this diff; no added
  line is reformatted, so the baseline count is unchanged.
* `flake8` — **clean on the three touched Python files**. The previous wording claimed
  `flake8 src/kiro_crew test` clean tree-wide; that is not reproducible here and should
  not have been stated so broadly. A whole-tree run reports 7 `F824` findings, all in
  files this PR does not touch (`dashboard/handlers/sessions.py`,
  `dashboard/handlers/source_providers.py`, two test files).
* `mypy` — **0 findings in the touched modules**. The previous wording quoted
  "Success: no issues found in 1166 source files"; a whole-tree run on this head now
  reports 20 errors across 9 files, none of them touched by this PR, and checks 1262
  files rather than 1166. Both numbers moved with `main`, so the old line described an
  earlier revision, not this head.

The two broad claims above were measured against an older base and were carried forward
unchanged; they are corrected here rather than re-asserted.

## Manual verification

N/A — unit coverage sufficient: both helpers are exercised against a real
`SecurityEventLog` with its real async writer, and the assertion is the bytes on disk. The
part that cannot be unit-tested — that the process really does reach `os._exit` next — is
what the AST ratchet pins instead.

## Related Issues

Closes the 2 unfixed siblings counted in the review on #6692, and follows the idiom it
established.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a queue whose only drain is registered with `atexit` is silently discarded
at every `os._exit` site, because `os._exit` runs no `atexit` handler and joins no
daemon thread.

This is the second instance in this codebase, not the first: #6692 found and fixed it
for the gateway log queue (`drain_log_queue_before_hard_exit`), and this PR closes the
counted remainder for the SEL audit queue. Both are the same shape -- a producer that
looks durable because a handler exists, and a hard-exit path that never reaches it --
and the records lost are exactly the ones written during the shutdown that is exiting,
which is when an investigator wants them most.

The mechanical check is cheap and would have found both at once: at each `os._exit`
call site, every queue-backed sink registered via `atexit.register` must have an
explicit drain before it. The ratchet here mirrors the one #6692 added, so the two
sinks now share one contract; a third sink is what would justify promoting this from a
review prompt to a lint rule rather than a third hand-written ratchet.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->





