### PR TITLE
docs: stop calling the audit-only computer-use gate fail-closed

### DIFF
--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -2317,14 +2317,14 @@ window list.
 ### `call` is a harness, not an eleventh tool
 
 `call` runs the existing tools through `tools.dispatch_tool` — **the same ordered
-chokepoint an agent call traverses**. The primary enable, the fail-closed
-`gate.require_computer_use`, the app denylist, index freshness, the secure-target
-refusals and the observation ceiling all apply, so `call` cannot see or do anything
-the agent could not. That is precisely what makes it a faithful reproduction tool
-rather than a debug backdoor, and it is why the implementation goes through
-`tools` rather than reaching into `service` (a test asserts that over the AST — a
-future "skip the overhead" edit would otherwise stay green while dropping
-governance on the floor).
+chokepoint an agent call traverses**. The fail-closed primary enable, the
+audit-only `gate.require_computer_use`, the app denylist, index freshness, the
+secure-target refusals and the observation ceiling all apply, so `call` cannot see
+or do anything the agent could not. That is precisely what makes it a faithful
+reproduction tool rather than a debug backdoor, and it is why the implementation
+goes through `tools` rather than reaching into `service` (a test asserts that over
+the AST — a future "skip the overhead" edit would otherwise stay green while
+dropping governance on the floor).
 
 One consequence, stated rather than left to be discovered: the session key is
 always the attended `cli_chat` surface (`sel._infer_source` → `cli`), used for the

--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -2508,7 +2508,7 @@ carve-out stay as code. It expects `CONTRACT_VERSION == 1` (pinned pre-launch).
 - `dashboard/handlers/security.py` — `GET /api/governance/policy` (posture-only
   serialization).
 - chokepoints: `sandbox.py`, `mcp_cron.py`, `subagent.py`, `mcp_core.py`,
-  `computer_use/gate.py` (`require_computer_use` fail-closed +
+  `computer_use/gate.py` (`require_computer_use` audit-only +
   `apply_observation_ceiling`).
 - `cli.py` / `cli_commands.py` — the `policy` command.
 

--- a/src/kiro_crew/computer_use/cli.py
+++ b/src/kiro_crew/computer_use/cli.py
@@ -30,12 +30,12 @@ approved invocation.
 
 **``call`` is fully gated, and that is the point of routing it through
 ``tools.dispatch_tool`` rather than reaching into ``service``.** Every call goes
-through the same ordered chokepoint as an agent call: the keystone primary enable,
-the fail-closed ``gate.require_computer_use``, the built-in app denylist, index
-freshness, the secure-target refusals, and the observation ceiling. So this
-command cannot be used to see or do anything the agent could not, which is
-exactly what makes it a faithful reproduction tool. Two consequences worth
-stating rather than discovering:
+through the same ordered chokepoint as an agent call: the fail-closed keystone
+primary enable, the audit-only ``gate.require_computer_use``, the built-in app
+denylist, index freshness, the secure-target refusals, and the observation
+ceiling. So this command cannot be used to see or do anything the agent could
+not, which is exactly what makes it a faithful reproduction tool. Two
+consequences worth stating rather than discovering:
 
 * the session key is the attended CLI surface (:data:`_CLI_SESSION_KEY`) — a real
   surface the gate accepts, not a bypass sentinel;

--- a/src/kiro_crew/computer_use/tools.py
+++ b/src/kiro_crew/computer_use/tools.py
@@ -471,7 +471,9 @@ def _dispatch(
             )
         request = built_drag
 
-    # (4) AUTHORIZATION — fail-closed, before any accessibility or capture call.
+    # (4) AUDIT — recorded before any accessibility or capture call, so the record
+    # exists even when the driver then fails. This step returns no decision: the
+    # fail-closed authorization is the keystone primary enable at step (1).
     denial = gate.require_computer_use(
         tool_name,
         session_key=session_key,

--- a/test/test_computer_use_gate.py
+++ b/test/test_computer_use_gate.py
@@ -21,6 +21,8 @@ a future edit could quietly reintroduce a refusal (or lose the audit):
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -227,3 +229,62 @@ class TestTheOneRetainedRefusalIsNotHere:
 
         term = AppRef(name="Terminal", pid=1, bundle_id="com.apple.Terminal")
         assert policy.check_app(term, PolicyConfig()) is None
+
+
+class TestNothingInTreeStillCallsThisGateFailClosed:
+    """Ratchet: the tests above prove the gate PERMITS unconditionally, so prose
+    that calls it the fail-closed authorization point is not a stale phrasing --
+    it is a false statement about a security boundary, and it is the statement a
+    reader reasons from when wiring a new surface.
+
+    The fail-closed step is the keystone primary enable at the top of
+    ``tools._dispatch``; ``require_computer_use`` audits and returns no decision.
+    A source comment or spec paragraph that swaps those two sends the reader to
+    the wrong layer, and nothing else in the suite notices.
+
+    A mention is a violation when a fail-closed claim sits within
+    ``_WINDOW`` characters of it AND no audit-only correction sits in the same
+    window -- which is how a human reads the paragraph, and what keeps the
+    passages that name the enable's fail-closed posture *while* calling this gate
+    audit-only from being flagged.
+    """
+
+    _WINDOW = 200
+    _MENTION = re.compile(r"require_computer_use")
+    _CLAIMS_FAIL_CLOSED = re.compile(r"fail-?\s*clos|fails\s+CLOSED|authoritative gate", re.I)
+    _CORRECTS_IT = re.compile(r"audit-only|only audits|no decision|unconditionally permits", re.I)
+
+    @property
+    def _files(self):
+        root = Path(__file__).resolve().parents[1]
+        return [
+            p
+            for p in [*root.glob("src/kiro_crew/**/*.py"), *root.glob("docs/**/*.md")]
+            # gate.py is the definition; its own docstring states the contract.
+            if p.name != "gate.py"
+        ]
+
+    def _violations(self):
+        found = []
+        for path in self._files:
+            text = path.read_text(encoding="utf-8")
+            for match in self._MENTION.finditer(text):
+                window = text[max(0, match.start() - self._WINDOW) : match.end() + self._WINDOW]
+                window = " ".join(window.split())
+                if self._CLAIMS_FAIL_CLOSED.search(window) and not self._CORRECTS_IT.search(window):
+                    found.append(f"{path.name}:{text[: match.start()].count(chr(10)) + 1}")
+        return sorted(set(found))
+
+    def test_the_ratchet_actually_reads_the_mentions(self):
+        """A scan that matched nothing would pass vacuously."""
+        total = sum(len(self._MENTION.findall(p.read_text(encoding="utf-8"))) for p in self._files)
+        assert total >= 5, f"expected the known mentions of the gate, found {total}"
+
+    def test_no_source_or_spec_describes_this_gate_as_fail_closed(self):
+        violations = self._violations()
+        assert not violations, (
+            "require_computer_use permits unconditionally (see TestTheGatePermits); "
+            "the fail-closed step is the keystone primary enable at the top of "
+            "tools._dispatch. These describe it as the fail-closed authorization "
+            "point: " + ", ".join(violations)
+        )


### PR DESCRIPTION
## Problem / Motivation

`computer_use/gate.py::require_computer_use` does not authorize anything. Its own
docstring is unambiguous:

```python
def require_computer_use(...) -> "str | None":
    """Always returns ``None`` (proceed). Audits the call.
    ...
    The keystone primary enable, checked upstream in :mod:`tools`, is the whole gate.
    """
    _audit_allowed(session_key, agent, action, app_bundle_id or app_display_name)
    return None
```

`test_computer_use_gate.py` already pins that across every tool, every
formerly-refused surface, an unresolvable app identity, and a mutator with no recorded
approval. `tools.py`'s module docstring agrees — step 4 is *"now audit-only, and
unconditionally permits."*

Four places in the tree still say the opposite, naming it as the fail-closed
authorization point:

| Site | Text |
|---|---|
| `computer_use/tools.py:475` | `# (4) AUTHORIZATION — fail-closed, before any accessibility or capture call.` — the inline comment **directly above the call** |
| `computer_use/cli.py:34` | "the keystone primary enable, **the fail-closed** `gate.require_computer_use`, the built-in app denylist…" |
| `docs/system-specs/modules/computer-use.md:2321` | "The primary enable, **the fail-closed** `gate.require_computer_use`, the app denylist…" |
| `docs/system-specs/modules/governance.md:2511` | "`computer_use/gate.py` (`require_computer_use` **fail-closed** + `apply_observation_ceiling`)" |

`tools.py` is the sharp one: the file's own docstring says step 4 is audit-only, and 440
lines later the comment introducing step 4 calls it fail-closed authorization. A reader
who scrolls to the call site — which is what you do when you are following the chokepoint
— gets the wrong one.

This is the counted remainder from the review on #6627, which corrected the same claim in
`mcp_computer.py` and named what it left: *"Grepped `require_computer_use` against
fail-closed wording: 3 stale sites carry the exact claim this PR corrects… fix them in
this sweep or declare them deferred like the third."* The ratchet added here finds a
fourth the grep missed — `tools.py:475`, whose comment does not contain the identifier on
the same line.

## Why it matters

This is not stale phrasing; it is a false statement about where a security boundary lives,
sitting in the two documents someone reads before touching this subsystem.

The failure mode is concrete and quiet. `require_computer_use` accepts `session_key`,
`app_bundle_id`, `target_roles`, `approval_recorded` — everything that *looks* like an
authorization decision — and ignores all of it, by design, because the parameters are
there for the SEL audit line. Someone adding a computer-use surface, or reviewing one,
reads "the fail-closed `gate.require_computer_use`", routes through it, sees the identity
arguments accepted, and concludes the surface is gated. It is not: the only refusal on
that path is the keystone primary enable at step 1, plus the target policy at step 5. A
surface wired past the enable would be authorized by nothing, and the resulting review
would read as correct against the documentation.

`AGENTS.md` states that computer use is deliberately not governed and that its refusals
run in band on the `tools._dispatch` path. These four lines contradict the one paragraph a
contributor is told to trust, on the one subsystem that can read a password field's
`AXValue`.

## What changed (motivation → approach → change)

Symptom: four sites call an unconditionally-permitting function the fail-closed
authorization point. Root cause: the governance removal turned the gate into an audit
step, and the prose describing the chokepoint was corrected on some surfaces
(`mcp_computer.py`, `tools.py`'s docstring, `computer-use.md`'s step table) and not
others. Fix: say the true thing at the remaining four, in the wording the corrected
surfaces already use, and add a ratchet so the two halves cannot drift apart again.

- `tools.py:475` — the comment now reads **AUDIT**, states that the record is written
  before any accessibility or capture call so it survives a driver failure, and points at
  step (1) as the fail-closed authorization. The step number and ordering are unchanged.
- `cli.py:34`, `computer-use.md:2321` — both enumerate the chokepoint and both already
  name the primary enable first, so the adjective simply moves to the step that owns it:
  "the fail-closed keystone primary enable, the audit-only `gate.require_computer_use`,
  …". The paragraphs' claim — that `call` is as gated as an agent call — is unchanged and
  still true.
- `governance.md:2511` — one word in a chokepoint inventory: `fail-closed` → `audit-only`.

No behaviour changes; `gate.py` itself is untouched. The wording is lifted from
`mcp_computer.py`, corrected and merged in #6627, rather than newly invented.

`governance.md` currently has 6 open PRs against it. Its hunk here is one word in a
bullet list, and none of those 6 touch `require_computer_use` anywhere in their diffs
(checked per-PR), so the change is disjoint. The other three files have no open-PR
contention at all.

## Tests

`TestNothingInTreeStillCallsThisGateFailClosed`, added to `test/test_computer_use_gate.py`
so it sits beside `TestTheGatePermits` — the class that proves the claim false is the
class this ratchet cites.

It scans `src/kiro_crew/**/*.py` and `docs/**/*.md` (excluding `gate.py`, which is the
definition), and flags a mention of `require_computer_use` when a fail-closed claim
(`fail-clos…`, `fails CLOSED`, `authoritative gate`) appears within 200 characters **and**
no audit-only correction (`audit-only`, `only audits`, `no decision`, `unconditionally
permits`) appears in the same window.

That second condition is what makes it usable rather than noisy, and it is how a human
reads the paragraph. `mcp_computer.py` legitimately discusses fail-closed posture at
length two sentences away from this mention — it is the passage #6627 fixed — and
`computer-use.md:61` / `:1483` describe the gate as auditing beside prose about the
enable. All three are correct today and none is flagged. The window was checked at 120,
200 and 300 characters: the four true sites are found at every width, and only at 300 does
`mcp_computer.py` start to trip on distant text, which is why 200 is the setting.

A `test_the_ratchet_actually_reads_the_mentions` self-check asserts the scan finds at
least 5 mentions, so a glob that silently matched nothing could not pass vacuously.

**Red-before**, with the four source and doc files reverted to `origin/main`:

```
AssertionError: require_computer_use permits unconditionally (see TestTheGatePermits);
the fail-closed step is the keystone primary enable at the top of tools._dispatch.
These describe it as the fail-closed authorization point:
cli.py:34, computer-use.md:2321, governance.md:2511, tools.py:475
```

Green on the branch. `test_computer_use_gate.py`: 34 passed. With
`test_mcp_computer.py`: **198 passed**. Gates: `check_black_formatting.py` pass, `flake8`
clean, `isort --check-only` clean, `mypy src/kiro_crew` — "Success: no issues found in
1166 source files".

`scripts/docs-lint.sh` was not run: its wrapper is `exec python3 …` and `python3` on this
box resolves to a stub. Its two properties are that every doc is indexed and every link
resolves; this change edits prose inside existing sections of two already-indexed
documents, adds no file, and adds or removes no link, so neither property is reachable
from the diff. CI runs it.

## Manual verification

N/A — unit coverage sufficient: the change is source comments and spec prose, and the
assertion that matters (no such claim survives anywhere in `src/` or `docs/`) is exactly
what the ratchet checks mechanically over the whole tree.

## Related Issues

Completes the remainder named in the review on #6627, plus one site that grep missed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
