### PR TITLE
fix(agents): harden the two remaining raw agent-spec reads (#6726)

### DIFF
--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -552,19 +552,16 @@ def agent_skill_globs(agent: str, agents_dir: Path | None = None) -> list[str]:
     except OSError:
         return []
     for f in candidates:
-        if f.name.startswith("._"):
-            continue
-        try:
-            real = f.resolve(strict=True)
-        except OSError:
-            continue
-        if is_sensitive_path(str(real)):
-            continue
-        try:
-            data = json.loads(real.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
-        if not isinstance(data, dict):
+        # The one hardened reader for the user-writable agents dir: AppleDouble
+        # sidecars, symlink loops (``RuntimeError`` on resolve), sensitive
+        # resolved targets (with the SEL ``denied`` event), the size cap, and
+        # non-UTF-8 / non-object JSON all collapse to ``None`` — skipped like an
+        # absent file, preserving this function's never-raises / ``[]`` contract.
+        # Pass ``f``, not the resolved target: ``f.stem`` and
+        # ``expand_skill_uri`` below must see the ORIGINAL path so a symlinked
+        # spec's relative globs stay anchored where the symlink lives.
+        data = _read_agent_spec(f)
+        if data is None:
             continue
         if data.get("name") != agent and f.stem != agent:
             continue

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -15,7 +15,7 @@ from aiohttp import web
 
 from kiro_crew import webhooks
 from kiro_crew.agent import _VALID_HOOK_EVENTS, _shipped_defaults, kiro_agents_dir_path
-from kiro_crew.agent_discovery import list_agents
+from kiro_crew.agent_discovery import _read_agent_spec, list_agents
 from kiro_crew.config.loader import KiroCrewConfig, data_home
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.executors import run_in_embed_pool
@@ -100,10 +100,20 @@ async def api_kiro_hooks(request: web.Request) -> web.Response:
     from kiro_crew.platform import redact_via_context as redact
 
     agent_cfg = kiro_agents_dir_path() / "kirocrew.json"
-    try:
-        raw = json.loads(agent_cfg.read_text())
-        hooks = raw.get("hooks", {}) if isinstance(raw, dict) else {}
-    except (OSError, json.JSONDecodeError):
+    # ``kirocrew.json`` lives in the user-writable, tool-shared agents dir, so
+    # the read goes through the hardened agents-dir reader (size cap, symlink
+    # and sensitive-target screens, explicit UTF-8, non-object rejection).
+    # ``None`` covers every case the old ``except (OSError, JSONDecodeError)``
+    # caught — plus the ones it missed, e.g. non-UTF-8 bytes, which previously
+    # escaped as an unhandled 500 — and degrades the same way: no user hooks.
+    # Off-loop: the reader stats + reads up to the size cap, and this handler
+    # runs on the gateway event loop (review-adopted, no-blocking-call rule).
+    raw = await asyncio.to_thread(_read_agent_spec, agent_cfg)
+    # The reader guarantees the TOP level is an object, not the "hooks" value:
+    # a user-writable {"hooks": []} would reach hooks.items() below and escape
+    # as a 500. Same degrade-as-absent rule as every other unusable shape.
+    hooks = raw.get("hooks") if raw is not None else None
+    if not isinstance(hooks, dict):
         hooks = {}
     # Load bundled defaults to tag source
     try:

--- a/test/test_agent_spec_reads_globs_hooks.py
+++ b/test/test_agent_spec_reads_globs_hooks.py
@@ -1,0 +1,273 @@
+"""Hardened-reader migration for the two remaining raw agent-spec reads (#6726).
+
+``agent_discovery.agent_skill_globs`` and ``dashboard.handlers.hooks.api_kiro_hooks``
+both read files from the user-writable, tool-shared kiro agents directory. Both
+now route through ``agent_discovery._read_agent_spec`` — the single hardened
+reader (#5423) — instead of hand-rolling a subset of its screens.
+
+Differentially RED against the pre-change code:
+
+- ``test_oversized_spec_widens_to_no_mapping`` — old code had no size cap and
+  returned the oversized spec's globs.
+- ``test_symlink_loop_is_skipped_not_raised`` — old code caught only ``OSError``
+  on resolve; pathlib signals a symlink loop with ``RuntimeError`` (< 3.13),
+  which escaped and violated the function's own never-raises docstring.
+- ``test_sensitive_symlink_target_skipped_and_sel_denied`` — old code skipped
+  the file but emitted no SEL ``denied`` event.
+- ``test_oversized_kirocrew_json_degrades_to_empty`` — old handler had no size
+  cap and served the oversized file's hooks.
+- ``test_non_utf8_kirocrew_json_degrades_to_empty`` — old handler decoded with
+  the platform default and caught only ``(OSError, JSONDecodeError)``, so a
+  ``UnicodeDecodeError`` escaped as an unhandled 500 where the default codec is
+  strict (UTF-8 platforms).
+- ``test_non_dict_hooks_value_degrades_to_empty`` — old handler passed a
+  non-dict ``hooks`` value straight to ``hooks.items()``, an ``AttributeError``
+  500.
+
+The rest are regression guards pinning behavior that must NOT change: the
+AppleDouble skip, normal specs' globs, the symlinked-spec glob anchor (the
+reader resolves internally but expansion must keep seeing the ORIGINAL path),
+normal hooks serving, and bundled-source tagging.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import kiro_crew.agent_discovery as ad
+import kiro_crew.hooks as kc_hooks
+from kiro_crew.agent_discovery import agent_skill_globs
+from kiro_crew.dashboard.handlers.hooks import api_kiro_hooks
+
+# Same patch targets as test_api_kiro_hooks.py: ``kiro_agents_dir_path()`` reads
+# ``KIRO_AGENTS_DIR`` from ``agent``'s globals at call time, and the handler
+# imports ``_shipped_defaults`` at module scope, so it is patched in the
+# handler's namespace.
+_P_AGENTS_DIR = "kiro_crew.agent.KIRO_AGENTS_DIR"
+_P_DEFAULTS = "kiro_crew.dashboard.handlers.hooks._shipped_defaults"
+
+
+def _agents_dir(tmp_path: Path) -> Path:
+    """An agents dir nested like the real one (``<root>/.kiro/agents``).
+
+    The two extra levels matter for the glob-anchor tests: a relative
+    ``skill://`` URI expands against ``agent_path.parent.parent.parent``.
+    """
+    d = tmp_path / "root" / ".kiro" / "agents"
+    d.mkdir(parents=True)
+    return d
+
+
+def _spec(name: str, *uris: str) -> str:
+    return json.dumps({"name": name, "resources": list(uris)})
+
+
+def _symlink_or_skip(target: Path | str, link: Path) -> None:
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform")
+
+
+class TestAgentSkillGlobsHardenedRead:
+    def test_normal_spec_globs_unchanged(self, tmp_path: Path) -> None:
+        """A plain readable spec keeps returning its expanded globs."""
+        d = _agents_dir(tmp_path)
+        (d / "mapped.json").write_text(
+            _spec("mapped", "skill://skills/foo/SKILL.md", "file://.kiro/steering/**/*.md"),
+            encoding="utf-8",
+        )
+        assert agent_skill_globs("mapped", agents_dir=d) == [
+            str(tmp_path / "root" / "skills" / "foo" / "SKILL.md")
+        ]
+
+    def test_oversized_spec_widens_to_no_mapping(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An over-cap spec is refused, so the agent falls back to ``[]``.
+
+        Documented consequence of the migration (#6726): the old code had no
+        size cap and would have parsed this spec and returned its globs; the
+        hardened reader refuses it and ``[]`` means "no explicit mapping", so
+        the effect depends on the caller. The skills LISTING
+        (``prompts.py``) drops its agent filter — scope WIDENS to the legacy
+        all-or-nothing default, the same direction any malformed spec already
+        took. The INJECTION plan (``context._skills_injection_plan``) returns
+        ``not is_custom`` for empty globs, so a CUSTOM agent's refused spec
+        drops skill injection to none — fail-closed on that axis.
+        """
+        monkeypatch.setattr(kc_hooks, "MAX_FILE_BYTES", 256)
+        d = _agents_dir(tmp_path)
+        body = json.dumps(
+            {
+                "name": "big",
+                "resources": ["skill://skills/foo/SKILL.md"],
+                "pad": "x" * 512,
+            }
+        )
+        assert len(body.encode("utf-8")) > 256
+        (d / "big.json").write_text(body, encoding="utf-8")
+        assert agent_skill_globs("big", agents_dir=d) == []
+
+    def test_appledouble_sidecar_is_skipped(self, tmp_path: Path) -> None:
+        """A ``._`` sidecar never contributes a mapping, even with a matching name."""
+        d = _agents_dir(tmp_path)
+        (d / "._mapped.json").write_text(
+            _spec("mapped", "skill://skills/foo/SKILL.md"), encoding="utf-8"
+        )
+        assert agent_skill_globs("mapped", agents_dir=d) == []
+
+    def test_symlink_loop_is_skipped_not_raised(self, tmp_path: Path) -> None:
+        """A self-referential symlink is skipped, honoring the never-raises contract.
+
+        Pre-migration this RAISED on Python < 3.13: ``resolve(strict=True)``
+        signals a symlink loop with ``RuntimeError``, and the inline screen
+        caught only ``OSError``.
+        """
+        d = _agents_dir(tmp_path)
+        _symlink_or_skip("loop.json", d / "loop.json")
+        assert agent_skill_globs("loop", agents_dir=d) == []
+
+    def test_sensitive_symlink_target_skipped_and_sel_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A spec resolving into a sensitive target is skipped AND SEL-audited."""
+        d = _agents_dir(tmp_path)
+        secret = tmp_path / "creds"
+        secret.write_text(_spec("evil", "skill://skills/foo/SKILL.md"), encoding="utf-8")
+        _symlink_or_skip(secret, d / "evil.json")
+        resolved = str(secret.resolve())
+        monkeypatch.setattr(
+            "kiro_crew.agent_discovery.is_sensitive_path", lambda p: str(p) == resolved
+        )
+        sel_events: list[dict] = []
+        monkeypatch.setattr(
+            ad, "_sel", lambda: SimpleNamespace(log_api_access=lambda **kw: sel_events.append(kw))
+        )
+        assert agent_skill_globs("evil", agents_dir=d) == []
+        assert (
+            sel_events and sel_events[0]["outcome"] == "denied"
+        ), f"sensitive-target rejection must emit a SEL denial: {sel_events}"
+
+    def test_symlinked_spec_globs_anchor_at_symlink(self, tmp_path: Path) -> None:
+        """Glob expansion sees the ORIGINAL path, not the resolved target.
+
+        The reader resolves internally, but ``f.stem`` (name fallback) and
+        ``expand_skill_uri(uri, f)`` must keep operating on the symlink's own
+        location: anchoring at the resolved target would silently relocate a
+        symlinked spec's relative skill globs.
+        """
+        d = _agents_dir(tmp_path)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        real = elsewhere / "real.json"
+        real.write_text(_spec("other-name", "skill://skills/foo/SKILL.md"), encoding="utf-8")
+        _symlink_or_skip(real, d / "linked.json")
+        # Matched via ``f.stem`` ("linked"), and anchored three levels above the
+        # SYMLINK (<root>), not above the real file (<elsewhere>).
+        assert agent_skill_globs("linked", agents_dir=d) == [
+            str(tmp_path / "root" / "skills" / "foo" / "SKILL.md")
+        ]
+
+
+def _make_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/kiro-hooks", api_kiro_hooks)
+    return app
+
+
+async def _get_hooks(kiro_dir: Path, defaults: Path) -> tuple[int, dict]:
+    with patch(_P_AGENTS_DIR, kiro_dir), patch(_P_DEFAULTS, return_value=defaults):
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get("/api/kiro-hooks")
+            return resp.status, await resp.json()
+
+
+class TestApiKiroHooksHardenedRead:
+    @pytest.fixture
+    def kiro_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "agents"
+        d.mkdir(parents=True)
+        return d
+
+    @pytest.fixture
+    def defaults(self, tmp_path: Path) -> Path:
+        p = tmp_path / "defaults.json"
+        p.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+        return p
+
+    @pytest.mark.asyncio
+    async def test_oversized_kirocrew_json_degrades_to_empty(
+        self, kiro_dir: Path, defaults: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An over-cap ``kirocrew.json`` yields no user hooks — 200, not 500."""
+        monkeypatch.setattr(kc_hooks, "MAX_FILE_BYTES", 256)
+        body = json.dumps(
+            {
+                "hooks": {"preToolUse": [{"command": "echo hi", "matcher": ""}]},
+                "pad": "x" * 512,
+            }
+        )
+        assert len(body.encode("utf-8")) > 256
+        (kiro_dir / "kirocrew.json").write_text(body, encoding="utf-8")
+        status, payload = await _get_hooks(kiro_dir, defaults)
+        assert status == 200
+        assert payload == {"hooks": {}}
+
+    @pytest.mark.asyncio
+    async def test_non_utf8_kirocrew_json_degrades_to_empty(
+        self, kiro_dir: Path, defaults: Path
+    ) -> None:
+        """Non-UTF-8 bytes are refused deterministically instead of decoded with
+        the platform default (previously an unhandled 500 on UTF-8 platforms)."""
+        (kiro_dir / "kirocrew.json").write_bytes(b'\xff\xfe{"hooks": {}}')
+        status, payload = await _get_hooks(kiro_dir, defaults)
+        assert status == 200
+        assert payload == {"hooks": {}}
+
+    @pytest.mark.asyncio
+    async def test_non_dict_hooks_value_degrades_to_empty(
+        self, kiro_dir: Path, defaults: Path
+    ) -> None:
+        """A top-level object whose ``hooks`` value is not a dict yields no user
+        hooks — 200, not an ``AttributeError`` 500 from ``hooks.items()``."""
+        (kiro_dir / "kirocrew.json").write_text(json.dumps({"hooks": []}), encoding="utf-8")
+        status, payload = await _get_hooks(kiro_dir, defaults)
+        assert status == 200
+        assert payload == {"hooks": {}}
+
+    @pytest.mark.asyncio
+    async def test_normal_kirocrew_json_still_serves_hooks(
+        self, kiro_dir: Path, defaults: Path
+    ) -> None:
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps({"hooks": {"preToolUse": [{"command": "echo hi", "matcher": ""}]}}),
+            encoding="utf-8",
+        )
+        status, payload = await _get_hooks(kiro_dir, defaults)
+        assert status == 200
+        assert payload["hooks"]["preToolUse"][0]["command"] == "echo hi"
+        assert payload["hooks"]["preToolUse"][0]["source"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_bundled_source_tagging_unaffected(self, kiro_dir: Path, tmp_path: Path) -> None:
+        """The `_shipped_defaults()` read is deliberately NOT migrated (it reads
+        a file shipped inside the package, not the user-writable agents dir), so
+        source tagging keeps working exactly as before."""
+        entry = {"command": "echo bundled", "matcher": ""}
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps({"hooks": {"preToolUse": [entry]}}), encoding="utf-8"
+        )
+        defaults = tmp_path / "defaults.json"
+        defaults.write_text(json.dumps({"hooks": {"preToolUse": [entry]}}), encoding="utf-8")
+        status, payload = await _get_hooks(kiro_dir, defaults)
+        assert status == 200
+        assert payload["hooks"]["preToolUse"][0]["source"] == "bundled"


### PR DESCRIPTION
## Problem / Motivation

Two reads of files in the user-writable, tool-shared kiro agents directory still bypass `agent_discovery._read_agent_spec`, the single hardened reader the project converged on (#5423, #5613, #6695):

- `agent_discovery.py::agent_skill_globs` — a `*.json` scan that hand-rolls two of the reader's screens inline and then reads raw: no size cap, no `RuntimeError` symlink-loop guard (a self-referential symlink RAISES out of a function documented to never raise, on Python < 3.13), and no SEL `denied` event on the sensitive-path skip.
- `dashboard/handlers/hooks.py::api_kiro_hooks` — reads `kirocrew.json` via `json.loads(agent_cfg.read_text())`: no size cap, no symlink screen, and platform-default decoding, so non-UTF-8 bytes escape the `except (OSError, JSONDecodeError)` as an unhandled 500 on UTF-8 platforms.

Both sites were outside #6695's enumeration and outside PR #6723's permitted file set, so the class had not fully closed.

## Why it matters

The agents directory is user-writable and shared with other tools, so none of the missing guards are hypothetical: a symlink loop crashes skill-scope resolution, an unbounded read slurps an arbitrarily large "agent config" into memory on a dashboard GET, and a sensitive-target symlink is skipped silently with no audit trail.

## What changed (motivation → approach → change)

Two mechanical substitutions onto the existing hardened reader — no new mechanism, no new contract:

- **`agent_skill_globs`**: the four inline `continue` screens (AppleDouble prefix, resolve `OSError`, `is_sensitive_path`, read/parse failure/non-dict) collapse into `data = _read_agent_spec(f); if data is None: continue`. The ORIGINAL path `f` (not the resolved target) still drives `f.stem` matching and `expand_skill_uri` anchoring, so a symlinked spec's relative globs stay anchored where the symlink lives — pinned by test.
- **`api_kiro_hooks`**: `raw = await asyncio.to_thread(_read_agent_spec, agent_cfg)` with the existing degrade-as-absent behavior preserved (off-loop per review: the reader stats and reads up to the size cap on a dashboard GET). Additionally guards a non-dict `"hooks"` value (`{"hooks": []}` previously reached `hooks.items()` → `AttributeError` 500) — adopted from review.

**Fail-direction checked** (both sites): each is a pure READ path that degrades safely on `None`; neither is a read-modify-write repair path, where routing through a None-returning reader would invert the safe-fail direction.

**Deliberately NOT migrated** (do not read the asymmetry as an oversight):

- The `_shipped_defaults()` read in the same handler reads a file shipped inside the installed package, not the user-writable agents dir; the agents-dir threat model and the reader's spec semantics would be the wrong contract for it.
- `agent.py::migrate_agent_specs`, `dashboard/handlers/agents.py`'s PATCH re-read: inside open PR #6723's file set; this PR stays disjoint from its five files so the two cannot conflict.
- `doctor_deadpath.py::_walk_spec`: needs per-file refusal REASONS for its report, which the reader's None-collapsing contract cannot supply.
- Three `_agent._load_json` reads of the same `kirocrew.json` survive outside this PR's scope (raised by First Principles review, verified): `connections/mint.py:366`, `connections/mint.py:811`, and `agent.py:4895`. `agent.py` is inside open PR #6723's file set (kept disjoint here for the same no-conflict reason as the deferred rider); the two `mint.py` sites are a same-shaped follow-up, tracked in a dedicated issue. So: this PR closes the two sites #6726 enumerates, not the whole class.

**Behavior consequence (documented, pinned by test):** a spec above the reader's size cap (or behind a symlink loop) now yields `[]`, and the effect depends on the caller. The skills listing (`prompts.py`) drops its agent filter — scope **widens** to the legacy all-or-nothing default, the same direction any malformed spec already took. The injection plan (`context._skills_injection_plan`) returns `not is_custom` for empty globs, so a custom agent's refused spec drops skill injection to none — **fail-closed** on that axis.

**Known pre-existing boundary (out of scope):** on a Windows install whose home is a UNC path, `unc_probe_allowed` allowlists the data home + temp but not the sibling `~/.kiro/agents`, so hardened reads there are refused. That property is shared by all 8 pre-existing `_read_agent_spec` call sites on main (including the `list_agents` scan itself since #5423) — on such a host, agents are already invisible to the picker and unresolvable per-turn, so these two sites converging onto the same behavior adds no new user-visible breakage. Widening that allowlist is a security-chokepoint change belonging to its own reviewed follow-up, not a rider on a mechanical migration.

## Tests

New module `test/test_agent_spec_reads_globs_hooks.py` (11 tests), each verified against the pre-change code — six differentially RED:

- oversized spec → `[]` (old code parsed and returned its globs)
- symlink loop → skipped (old code raised `RuntimeError` on Python < 3.13)
- sensitive symlink target → skipped **and** SEL `denied` emitted (old code emitted nothing)
- oversized `kirocrew.json` → `hooks == {}`, 200 (old code served its hooks)
- non-UTF-8 `kirocrew.json` → `{}`, 200 (old code: unhandled 500)
- `{"hooks": []}` → `{}`, 200 (old code: `AttributeError` 500)

and five regression guards: AppleDouble skip, normal spec globs unchanged, symlinked-spec glob anchoring at the symlink (proves `f`, not the resolved target, feeds expansion), normal hooks serving, bundled-source tagging.

Full suite vs a clean-main control at the same base (`293544d43`): failure sets byte-identical (88 = 86 failed + 2 errors, all pre-existing host-env), zero failures from the changed files.

## Manual verification

N/A — unit coverage sufficient: both sites are pure functions/handlers fully exercised through their public surfaces by the new tests.

## Related Issues

Closes #6726

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented contract changed
- [x] No secrets, credentials, or internal references in the diff
