### PR TITLE
refactor(agent): route migrate_agent_specs through _read_spec_capped wrapper (#6726)

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2653,11 +2653,11 @@ def migrate_agent_specs() -> int:
         return 0
     cleaned = 0
     for spec_path in sorted(kiro_agents_dir_path().glob("*.json")):
-        # The hardened reader (size cap, AppleDouble/sensitive-symlink and
-        # non-object refusal). This site also WRITES below: a spec the reader
-        # refuses is now never rewritten at all, whereas the old read_text
-        # path read -- and then rewrote -- whatever the file or link named.
-        data = _read_agent_spec(spec_path)
+        # This site also WRITES below: a spec the reader refuses is now never
+        # rewritten at all, whereas the old read_text path read -- and then
+        # rewrote -- whatever the file or link named. The capped-reader rationale
+        # lives on _read_spec_capped.
+        data = _read_spec_capped(spec_path)
         if data is None:
             continue
         if "model_managed" not in data and "cc_model" not in data:


### PR DESCRIPTION
## Summary

Closes the remaining **rider** from issue #6726, which the primary fix PR #6734 did not cover.

`migrate_agent_specs()` in `src/kiro_crew/agent.py` called `_read_agent_spec` directly with a local rationale comment. The module's own `_read_spec_capped` wrapper (agent.py, two existing consumers) exists precisely so the capped-reader rationale lives in one place. This routes `migrate_agent_specs` through that wrapper for in-module consistency.

### What changed
- Swapped the direct `_read_agent_spec(spec_path)` call for `_read_spec_capped(spec_path)` in `migrate_agent_specs`.
- Reconciled the now-redundant local comment: removed the duplicated capped-reader description (it now lives on the wrapper's docstring) while preserving the note unique to this site (it also WRITES below, so a refused spec is never rewritten).
- Left the `_read_agent_spec` import intact — `_read_spec_capped` still uses it, so it is not unused.

### Scope
This PR does NOT touch the two primary sites from #6726 (`agent_skill_globs`, `api_kiro_hooks`); those are handled in #6734. This is the deferred cosmetic rider only.

### Behavior
Behavior-preserving: `_read_spec_capped` is a thin pass-through (`return _read_agent_spec(path)`), so this is a no-op at runtime. No test changes needed.

### Testing
- `python -m py_compile src/kiro_crew/agent.py` passes.
- AST check confirms `migrate_agent_specs` now calls `_read_spec_capped` and no longer calls `_read_agent_spec` directly.
- `ruff check src/kiro_crew/agent.py`: lint parity with base (pre-existing errors unchanged, zero new issues in the touched range).

### Note on environment
Full test suite (`pytest`) could not be executed in the sandbox: the network mode is 'Repository access only' (INTEGRATIONS_ONLY), which prevents installing the third-party test dependencies (pytest, hypothesis, etc.) that the project's `conftest.py` imports. The change is a behavior-preserving pass-through swap verified by compile + AST + lint parity.