### PR TITLE
refactor(dev-fleet): extract the sync runner script to a snapshotted stdlib module

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew import platform_compat
-from kiro_crew.apps.builtins.dev_fleet import npm_preflight
+from kiro_crew.apps.builtins.dev_fleet import npm_preflight, sync_runner
 from kiro_crew.env import find_node_tool, node_bin_dirs
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.loop_lock import LoopBoundLock
@@ -637,6 +637,15 @@ try:
 except OSError:  # pragma: no cover - frozen/zipimported install
     _PREFLIGHT_SOURCE = None
 
+#: The sync runner's source, captured ONCE at import — same contract, same
+#: reasons as :data:`_PREFLIGHT_SOURCE` above: the snapshot must be of the code
+#: THIS gateway is running, and ``None`` (unreadable ``__file__``) makes the
+#: sync REFUSE rather than fall back to reading the file later.
+try:
+    _SYNC_RUNNER_SOURCE: bytes | None = Path(sync_runner.__file__).read_bytes()
+except OSError:  # pragma: no cover - frozen/zipimported install
+    _SYNC_RUNNER_SOURCE = None
+
 #: Label of the ONE sync step whose binary is ours, so its exit code can be
 #: trusted to mean what :mod:`npm_preflight` says it means. Every other step runs
 #: worktree-controlled code and can exit any number it likes, so a reserved code
@@ -1083,6 +1092,7 @@ __all__ = (
     "_SHUTDOWN_ADMISSION_LOCK",
     "_SHUTDOWN_IN_PROGRESS",
     "_SYNC_LOCK",
+    "_SYNC_RUNNER_SOURCE",
     "_SYNC_RUN_LABEL",
     "_TRUSTED_BIN_CACHE",
     "_TRUSTED_BIN_DIRS",

--- a/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/sync_runner.py
@@ -1,0 +1,349 @@
+"""The Pull+Build sync runner, as a real module instead of a string literal.
+
+This is the program that :func:`server._sync_start_locked` used to assemble from
+Python source and hand to ``[sys.executable, "-c", <string>]``. That form had one
+defect the code itself was blameless for: no linter parsed it, and its only tests
+string-matched the source. So the transaction that moves ``node_modules`` aside
+and puts it back on failure -- the part whose whole point is not to lose a
+dependency tree -- was unreachable by an executing test. Extracting it here makes
+every branch a real function a test can drive against a real directory tree.
+
+It mirrors :mod:`npm_preflight`'s discipline exactly, and for the same reasons:
+
+* **Stdlib only.** It imports nothing from ``kiro_crew``. Everything that would
+  otherwise come from the package -- the reserved exit codes, the one step label
+  allowed to assert a diagnosis -- is passed IN, on the command line or the
+  environment, never interpolated into source and never imported. That is what
+  lets it be snapshotted out and run BY PATH: what it does cannot change with the
+  revision being merged underneath it.
+
+* **Run by path, never by module.** ``server`` copies this file's bytes into an
+  ``mkdtemp`` snapshot and invokes ``[sys.executable, <snapshot_path>, ...]``.
+  ``-m kiro_crew...sync_runner`` would import it from the working tree AFTER the
+  merge has landed, dragging the whole package ``__init__`` chain in with it -- so
+  a merged revision that raised the ``requires-python`` floor with newer syntax
+  anywhere in that chain would ``SyntaxError`` while being parsed. Executing the
+  copied file keeps the only parsed file one the launching interpreter already
+  ran. The snapshot-not-import rule is an invariant, not a convenience.
+
+The step list arrives as JSON from a FILE PATH argument, never embedded in the
+source, so a non-ASCII checkout path in a step's argv or env cannot break the
+program that reads it.
+
+The exit code IS the diagnosis. The reserved codes come from :mod:`npm_preflight`
+(passed in as ``--reserved``); this runner is the thing that enforces the
+reservation -- a reserved code from any step other than the one trusted label is
+DEMOTED to a plain failure, because every other step runs worktree-controlled
+code that can exit any number it likes. stdout carries only human-readable log
+text; nothing printed here is promoted into the authoritative diagnosis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess  # nosec B404 - running the sync's own steps is this module's purpose
+import sys
+
+#: Suffix appended to a stash path to name its backup. A ``node_modules`` moved
+#: aside for the duration of a step lands at ``<stash>`` + this.
+_BACKUP_SUFFIX = ".kirocrew-sync-backup"
+
+
+def gone(path: str) -> bool:
+    """Remove *path* and report whether it is now absent.
+
+    ``rmtree(..., ignore_errors=True)`` alone is not safe HERE, even though it is
+    the right default elsewhere: every deletion in the transaction decides what
+    the next rename does, so a partial removal that is silently ignored leaves a
+    directory in place, makes the following rename fail, and ends with the
+    transaction restoring a PARTIAL tree over a good one. So the load-bearing
+    deletions are CONFIRMED, and one that will not complete stops the step with
+    both trees intact -- a refused sync is recoverable, a half-restored
+    ``node_modules`` is not.
+
+    ``rmtree`` REFUSES a symlink ("Cannot call rmtree on a symbolic link"), and
+    ``ignore_errors=True`` swallows that refusal -- so a symlinked
+    ``node_modules`` left its backup undeletable, the next sync saw both paths,
+    and every Pull + Build from then on refused as ambiguous: a permanent wedge
+    escapable only by hand. So unlink the link, and ``rmtree`` only real trees.
+
+    ``lexists``, not ``exists``: a DANGLING symlink is still something at this
+    path, and reporting it as gone would let the runner proceed as though the
+    slot were clear.
+    """
+    if os.path.islink(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    else:
+        shutil.rmtree(path, ignore_errors=True)
+    return not os.path.lexists(path)
+
+
+def reconcile_leftovers(steps: list[dict], exit_tree_ambiguous: int) -> None:
+    """Reconcile any leftover stash/backup state from an earlier run.
+
+    Runs BEFORE any step, because both of its decisions are knowable from disk
+    with nothing applied. Splitting them off onto the ``npm ci`` step was a
+    defect: a run killed just after stashing left ``node_modules`` absent and its
+    intact backup unclaimed, and the next run's recovery then sat behind every
+    earlier step succeeding -- so a still-failing preflight meant the tree stayed
+    missing with the copy right there.
+
+    * BOTH tree and backup present is genuinely AMBIGUOUS -- the stash may be a
+      partial tree ``npm ci`` was writing when killed (backup is the last good
+      one), or the good tree after a successful sync whose backup cleanup failed
+      (backup is stale). Nothing on disk tells those apart, so either choice
+      destroys the good copy in one case. Touch NEITHER and exit
+      ``exit_tree_ambiguous`` (the gateway-passed diagnosis code), naming both
+      paths so the operator can act.
+    * Backup only is unambiguous recovery: claim it now with a rename.
+
+    ``lexists`` for every presence gate, never ``isdir``: ``isdir`` FOLLOWS a
+    symlink, so a DANGLING ``node_modules`` reads as absent and the backup-only
+    branch would then ``os.rename(<dir>, <dangling link>)``, which fails ENOTDIR
+    and crashes the runner on every sync with the tree never recovered.
+    """
+    for st in steps:
+        stash = st.get("stash")
+        if not stash:
+            continue
+        backup = stash + _BACKUP_SUFFIX
+        have_tree = os.path.lexists(stash)
+        have_backup = os.path.lexists(backup)
+        if have_tree and have_backup:
+            # The paths are LOG text; the diagnosis is the exit code, which the
+            # gateway maps. Nothing here is promoted out of stdout.
+            print(
+                "a previous sync left a dependency-tree backup beside the tree",
+                flush=True,
+            )
+            print("tree: %s" % stash, flush=True)
+            print("backup: %s" % backup, flush=True)
+            sys.exit(exit_tree_ambiguous)
+        if have_backup:
+            print(
+                "restoring a dependency tree left stashed by an earlier run",
+                flush=True,
+            )
+            os.rename(backup, stash)
+
+
+class NodeModulesTransaction:
+    """Move a stash path aside for a step and restore it on failure.
+
+    ``npm ci`` empties ``node_modules`` before it installs, so a tree it emptied
+    is the one artifact of a failed sync that cannot be rebuilt without the
+    registry -- exactly what is unavailable when that step fails. So the tree is
+    moved aside on ``__enter__`` and, on ``__exit__``:
+
+    * step succeeded (``rc == 0``): the backup is DROPPED. If it will not delete
+      the sync still worked -- the tree on disk is the new good one and the next
+      run's both-exist branch handles the leftover -- so this is a note, not a
+      failure.
+    * step failed and the (now clean) stash slot can be cleared: the backup is
+      renamed back and the failure becomes a no-op.
+    * step failed but the partial tree at the stash slot will NOT clear: forcing
+      the rename is how a partial tree ends up installed over a good backup.
+      Leave BOTH, name them, and REPLACE the exit code with
+      the restore-failed code -- "the tree could not be put back" outranks
+      whatever the step itself failed with, because it is the part the operator
+      has to act on.
+
+    Leftover state is reconciled by :func:`reconcile_leftovers` before the loop,
+    so a backup cannot already exist on ``__enter__``. ``lexists`` throughout: a
+    SYMLINKED ``node_modules`` must still be moved aside and restored, and a
+    DANGLING backup is still something to put back -- ``isdir`` would skip both,
+    which is the data loss the transaction exists to prevent.
+
+    Used as a context manager whose ``rc`` attribute is read on exit; the caller
+    pre-seeds it non-zero so an exception restores rather than discards.
+    """
+
+    def __init__(self, stash: str | None, exit_restore_failed: int):
+        self.stash = stash
+        self.exit_restore_failed = exit_restore_failed
+        self.backup = (stash + _BACKUP_SUFFIX) if stash else None
+        #: The step's result. Pre-seeded non-zero so an exception in the body
+        #: takes the restore path, not the drop path.
+        self.rc = 1
+
+    def __enter__(self) -> "NodeModulesTransaction":
+        if self.stash and self.backup and os.path.lexists(self.stash):
+            os.rename(self.stash, self.backup)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        backup = self.backup
+        stash = self.stash
+        if not (backup and stash and os.path.lexists(backup)):
+            return
+        if self.rc == 0:
+            if not gone(backup):
+                print(
+                    "note: a dependency-tree backup could not be removed and "
+                    "was left at %s" % backup,
+                    flush=True,
+                )
+        elif gone(stash):
+            os.rename(backup, stash)
+            print("restored %s after a failed step" % stash, flush=True)
+        else:
+            print("partial: %s" % stash, flush=True)
+            print("backup: %s" % backup, flush=True)
+            self.rc = self.exit_restore_failed
+        # Never suppress an exception: the step body's rc handling is done before
+        # exit, and an exception must still propagate after the tree is restored.
+        # (Returning None -- always falsy -- is the no-suppression contract.)
+
+
+def run_step(st: dict, cwd: str) -> int:
+    """Run one step's subprocess and return its exit code.
+
+    Each step is a separate process that inherits the runner's stdout pipe but
+    re-derives its encoding from the locale, so a Python step (pip, the
+    build-and-stage child) would encode a non-ASCII checkout path with the
+    codepage and die on it. ``PYTHONIOENCODING`` is the only channel that reaches
+    a child, so it is set here on every step's env -- non-Python steps (git, npm)
+    ignore it and are unaffected. Assigned rather than defaulted: the reader's
+    encoding is fixed, so a divergent inherited value would be the defect.
+    """
+    env = dict(st["env"])
+    env["PYTHONIOENCODING"] = "utf-8:replace"
+    return subprocess.run(  # nosec B603 - argv list, no shell
+        st["argv"], cwd=cwd, env=env
+    ).returncode
+
+
+def demote_reserved(rc: int, label: str, reserved: frozenset[int], preflight_label: str) -> int:
+    """Demote a reserved diagnosis code from an untrusted step to a plain failure.
+
+    An exit code is only trustworthy from the step whose binary is OURS. Every
+    other step runs worktree-controlled code -- an npm lifecycle script, a vite
+    config -- and can exit any number it likes, so a forged 41 would make the
+    dashboard assert a registry-credential failure, WITH a remedy, for what was
+    actually a build error. A reserved code from any step but the preflight is
+    therefore reported as a plain failure, with the true code kept in the log
+    rather than believed. Pure: returns the code to use, printing a log line only
+    when it demotes.
+    """
+    if rc in reserved and label != preflight_label:
+        print(
+            "step %s exited %d, which is a reserved diagnosis code; reporting "
+            "it as a plain failure because only the %s step may assert one"
+            % (label, rc, preflight_label),
+            flush=True,
+        )
+        return 1
+    return rc
+
+
+def run_steps(
+    steps: list[dict],
+    cwd: str,
+    reserved: frozenset[int],
+    preflight_label: str,
+    exit_restore_failed: int,
+) -> int:
+    """Run the reconciled step list in order, fail-fast, with the transaction.
+
+    Emits one ``::step::<idx>::<label>`` marker per step -- the run worker parses
+    these to name the current step in the dashboard. Returns the exit code to
+    exit with: 0 if every step passed, otherwise the first non-zero code (after
+    reserved-code demotion and any restore-failure override).
+    """
+    for i, st in enumerate(steps):
+        print("::step::%d::%s" % (i, st["label"]), flush=True)
+        with NodeModulesTransaction(st.get("stash"), exit_restore_failed) as txn:
+            rc = run_step(st, cwd)
+            rc = demote_reserved(rc, st["label"], reserved, preflight_label)
+            txn.rc = rc
+        # The transaction may have overridden rc to its restore-failed code.
+        rc = txn.rc
+        if rc != 0:
+            return rc
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: the sync runs a SNAPSHOT of this module as one process.
+
+    The steps come from a FILE PATH, never embedded in the source. The reserved
+    exit codes and the one trusted step label come in on the command line so this
+    module needs to import nothing from ``kiro_crew``.
+    """
+    # Align the writer with the reader. ``_start_run`` decodes this stream as
+    # UTF-8, but a piped stdout on Windows encodes with the process locale
+    # codepage -- so any non-ASCII that reached a print here would be mangled or
+    # raise UnicodeEncodeError, killing the runner before its first step.
+    # errors="replace" additionally guarantees no print can be fatal.
+    # (getattr: typeshed's TextIO lacks reconfigure; the runtime object has it
+    # on CPython >= 3.7, and a wrapped/absent stdout simply skips the tune-up.)
+    _reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if _reconfigure is not None:
+        _reconfigure(encoding="utf-8", errors="replace")
+
+    ap = argparse.ArgumentParser(description="Dev Fleet Pull+Build sync runner.")
+    ap.add_argument("steps_json", help="path to a JSON file holding the step list")
+    ap.add_argument("cwd", help="working directory every step runs in")
+    ap.add_argument(
+        "--reserved",
+        required=True,
+        help="comma-separated reserved diagnosis exit codes (from npm_preflight)",
+    )
+    ap.add_argument(
+        "--preflight-label",
+        required=True,
+        help="the ONE step label whose reserved exit code may be trusted",
+    )
+    ap.add_argument(
+        "--exit-tree-ambiguous",
+        required=True,
+        type=int,
+        help="exit code for tree+backup both present (npm_preflight owns the value)",
+    )
+    ap.add_argument(
+        "--exit-restore-failed",
+        required=True,
+        type=int,
+        help="exit code for a failed post-step restore (npm_preflight owns the value)",
+    )
+    ap.add_argument(
+        "--steps-sha256",
+        required=True,
+        help=(
+            "hex SHA-256 the steps file's bytes must match. argv is fixed at "
+            "exec, so this pins the manifest the gateway composed: a steps file "
+            "rewritten after staging fails the check and nothing runs"
+        ),
+    )
+    args = ap.parse_args(argv)
+
+    with open(args.steps_json, "rb") as fh:
+        raw = fh.read()
+    digest = hashlib.sha256(raw).hexdigest()
+    if digest != args.steps_sha256:
+        # The manifest is not the one the gateway staged. Refuse before parsing:
+        # the pinned digest travels in argv (immutable once this process exists),
+        # so a rewrite of the file between staging and startup cannot substitute
+        # steps. Content is diagnosis; the refusal is the protection.
+        print(
+            "sync runner: steps file does not match the staged manifest "
+            "(sha256 %s != expected %s)" % (digest, args.steps_sha256),
+            flush=True,
+        )
+        return 1
+    steps = json.loads(raw.decode("utf-8"))
+    reserved = frozenset(int(c) for c in args.reserved.split(",") if c.strip())
+
+    reconcile_leftovers(steps, args.exit_tree_ambiguous)
+    return run_steps(steps, args.cwd, reserved, args.preflight_label, args.exit_restore_failed)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a subprocess
+    sys.exit(main())

--- a/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import hashlib
 import json
 import os
 import shutil
@@ -1402,6 +1403,31 @@ def _venv_python(repo: str) -> Path | None:
     return None
 
 
+#: Trusted loader for the sync-runner snapshot. A FIXED literal — nothing is
+#: ever interpolated into it — so unlike the pre-extraction inline script it
+#: carries no program logic beyond verify-and-exec. It exists because a file
+#: on disk is mutable between staging and exec while argv is not: a sandboxed
+#: same-UID process could rewrite the staged snapshot in that window and have
+#: its code run UNSANDBOXED as the runner. The bootstrap travels in argv
+#: (immutable once this process exists) together with the snapshot's expected
+#: sha256, reads the file ONCE, hashes and compiles the SAME buffer (no
+#: re-read between check and use), and refuses on mismatch. The runner's own
+#: argv follows and is re-exposed as ``sys.argv``.
+_SYNC_RUNNER_BOOTSTRAP = (
+    "import hashlib, sys\n"
+    "path, digest = sys.argv[1], sys.argv[2]\n"
+    "with open(path, 'rb') as fh:\n"
+    "    raw = fh.read()\n"
+    "if hashlib.sha256(raw).hexdigest() != digest:\n"
+    "    print('sync runner: snapshot does not match the staged source '\n"
+    "          '(refusing to execute)', flush=True)\n"
+    "    sys.exit(1)\n"
+    "code = compile(raw, path, 'exec')\n"
+    "sys.argv = [path] + sys.argv[3:]\n"
+    "exec(code, {'__name__': '__main__', '__file__': path})\n"
+)
+
+
 async def _sync_start_locked() -> dict:
     """Start the sync run. Caller holds _SYNC_LOCK."""
     global _SYNC_RID  # noqa: F824 (assigned below after await)
@@ -1819,175 +1845,90 @@ async def _sync_start_locked() -> dict:
             # instead of damage. A separate "restore" step could not do this: the
             # runner is fail-fast, so anything after a failed step never runs.
             step["stash"] = str(Path(repo) / "website" / "node_modules")
-    script = (
-        "import os, shutil, subprocess, sys, json\n"
-        # Align the writer with the reader. `_start_run` decodes this stream as
-        # UTF-8 (`line.decode(errors="replace")`), but a piped stdout on Windows
-        # encodes with the process locale codepage — so any non-ASCII that ever
-        # reaches a print here would be mangled at best and raise
-        # UnicodeEncodeError at worst, killing the runner before its first step.
-        # errors="replace" additionally guarantees no print can be fatal.
-        "sys.stdout.reconfigure(encoding='utf-8', errors='replace')\n"
-        f"steps = json.loads({json.dumps(json.dumps(wrapped_steps))})\n"
-        f"cwd = {json.dumps(repo)}\n"
-        # The reserved diagnosis codes, and the ONE step label allowed to assert
-        # one. Inlined as literals because this script is stdlib-only by design:
-        # it must not import kiro_crew, so what it does cannot change with the
-        # revision being merged underneath it.
-        f"RESERVED = {sorted(npm_preflight.RESERVED_EXIT_CODES)!r}\n"
-        f"PREFLIGHT = {json.dumps(runtime._PREFLIGHT_LABEL)}\n"
-        # reconfigure() above rebinds only THIS process's stdout object. Each
-        # step is a separate process that inherits the same pipe and re-derives
-        # its own encoding from the locale, so the Python steps — pip, and the
-        # build-and-stage child — would still encode a non-ASCII checkout path
-        # with the codepage and die on it. Set it in the environment, which is
-        # the only channel that reaches a child, so the whole pipe is UTF-8 from
-        # every writer the reader has to decode. Non-Python steps (git, npm)
-        # ignore the variable and are unaffected. Assigned rather than
-        # defaulted: the reader's encoding is fixed, so a divergent inherited
-        # value would be the defect, not a preference to preserve.
-        "def run(st):\n"
-        "    env = dict(st['env'])\n"
-        "    env['PYTHONIOENCODING'] = 'utf-8:replace'\n"
-        "    return subprocess.run(st['argv'], cwd=cwd, env=env).returncode\n"
-        # `rmtree(..., ignore_errors=True)` alone is not safe HERE, even though
-        # it is the right default elsewhere: every deletion below decides what
-        # the next rename does, so a partial removal that is silently ignored
-        # leaves a directory in place, makes the following rename fail, and ends
-        # with the transaction restoring a PARTIAL tree over a good one. So the
-        # deletions whose outcome is load-bearing are CONFIRMED, and one that
-        # will not complete stops the step with both trees intact -- a refused
-        # sync is recoverable, a half-restored node_modules is not.
-        "def gone(p):\n"
-        # rmtree REFUSES a symlink ("Cannot call rmtree on a symbolic link"),
-        # and ignore_errors=True swallows that refusal -- so a symlinked
-        # node_modules left its backup undeletable, the next sync saw both paths,
-        # and every Pull + Build from then on refused as ambiguous. A permanent
-        # wedge escapable only by hand. Unlink the link, rmtree only real trees.
-        "    if os.path.islink(p):\n"
-        "        try:\n"
-        "            os.unlink(p)\n"
-        "        except OSError:\n"
-        "            pass\n"
-        "    else:\n"
-        "        shutil.rmtree(p, ignore_errors=True)\n"
-        # lexists, not exists: a DANGLING symlink is still something at this
-        # path, and reporting it as gone would let the runner proceed as though
-        # the slot were clear.
-        "    return not os.path.lexists(p)\n"
-        # Leftover state from an earlier run is reconciled BEFORE any step runs,
-        # and BOTH halves of that belong here. Splitting them was a defect: with
-        # adoption left on the `npm ci` step, a run killed just after stashing
-        # left node_modules absent and its intact backup unclaimed, and the next
-        # run's recovery sat behind every earlier step succeeding -- so a still
-        # failing preflight meant the tree stayed missing with the copy right
-        # there. Both paths are knowable from disk with nothing applied, so both
-        # decisions are made here.
-        "for st in steps:\n"
-        "    stash = st.get('stash')\n"
-        "    if not stash:\n"
-        "        continue\n"
-        "    backup = stash + '.kirocrew-sync-backup'\n"
-        # lexists, not isdir, for every presence gate. isdir FOLLOWS a symlink,
-        # so a DANGLING node_modules reads as absent -- and then the backup-only
-        # branch below calls os.rename(<dir>, <dangling link>), which fails
-        # ENOTDIR and crashes the runner on every sync, with the tree never
-        # recovered. lexists asks the only question these gates actually mean: is
-        # there anything at this path.
-        "    have_tree = os.path.lexists(stash)\n"
-        "    have_backup = os.path.lexists(backup)\n"
-        # BOTH present is genuinely AMBIGUOUS and no rule can be right:
-        #
-        #   * killed DURING npm ci -> stash is the partial tree npm was
-        #     writing, backup is the last good one.
-        #   * a backup that outlived a SUCCESSFUL sync (its cleanup failed) ->
-        #     stash is the good tree and backup is stale.
-        #
-        # Nothing on disk tells those apart, so either choice destroys the good
-        # copy in one of them. The only move that cannot lose data is to touch
-        # NEITHER and stop -- and to say what to do next, because otherwise
-        # every later press refuses identically and the operator has to deduce
-        # that a directory needs removing.
-        "    if have_tree and have_backup:\n"
-        # The paths are LOG text; the diagnosis is the exit code, which the
-        # gateway maps. Nothing here is promoted out of stdout.
-        "        print('a previous sync left a dependency-tree backup beside the '\n"
-        "              'tree', flush=True)\n"
-        "        print('tree: %s' % stash, flush=True)\n"
-        "        print('backup: %s' % backup, flush=True)\n"
-        f"        sys.exit({npm_preflight.EXIT_TREE_AMBIGUOUS})\n"
-        # Backup only: unambiguous recovery, so claim it now rather than on the
-        # step that happens to own the transaction.
-        "    if have_backup:\n"
-        "        print('restoring a dependency tree left stashed by an earlier '\n"
-        "              'run', flush=True)\n"
-        "        os.rename(backup, stash)\n"
-        "for i, st in enumerate(steps):\n"
-        "    print(f'::step::{i}::{st[\"label\"]}', flush=True)\n"
-        # node_modules transaction. `npm ci` empties the directory before it
-        # installs, so it is moved aside first: on success the backup is
-        # dropped, and on ANY non-zero outcome (including the step raising) it
-        # is put back. rc is pre-seeded non-zero so an exception restores rather
-        # than discards.
-        "    stash = st.get('stash')\n"
-        "    backup = (stash + '.kirocrew-sync-backup') if stash else None\n"
-        # Leftover state was reconciled before this loop, so a backup cannot
-        # exist here: move the tree aside and let the step install into a clean
-        # directory, which is what `npm ci` requires anyway.
-        # lexists here too: with isdir a SYMLINKED node_modules would not be
-        # moved aside at all, so the step would run with no backup to restore --
-        # the transaction silently absent on exactly the layouts that most need
-        # it (a link into a shared store).
-        "    if backup and os.path.lexists(stash):\n"
-        "        os.rename(stash, backup)\n"
-        "    rc = 1\n"
-        "    try:\n"
-        "        rc = run(st)\n"
-        # An exit code is only trustworthy from the step whose binary is OURS.
-        # Every other step runs worktree-controlled code -- an npm lifecycle
-        # script, a vite config -- and can exit any number it likes, so a forged
-        # 41 would make the dashboard assert a registry-credential failure, with
-        # a remedy, for what was actually a build error. Reserved codes from
-        # those steps are therefore reported as a plain failure, with the true
-        # code kept in the log rather than believed.
-        "        if rc in RESERVED and st['label'] != PREFLIGHT:\n"
-        "            print('step %s exited %d, which is a reserved diagnosis '\n"
-        "                  'code; reporting it as a plain failure because only '\n"
-        "                  'the %s step may assert one'\n"
-        "                  % (st['label'], rc, PREFLIGHT), flush=True)\n"
-        "            rc = 1\n"
-        "    finally:\n"
-        # lexists: the backup is whatever `os.rename` moved here, so if the tree
-        # was a symlink the backup is one too. With isdir a DANGLING one skipped
-        # this whole block -- the tree stayed moved aside and was never restored
-        # nor dropped, which is the data loss the transaction exists to prevent.
-        "        if backup and os.path.lexists(backup):\n"
-        "            if rc == 0:\n"
-        # A backup that will not delete on the SUCCESS path is not dangerous:
-        # the tree on disk is the new good one, and the next run's both-exist
-        # branch handles the leftover. Say so rather than failing a sync that
-        # already worked.
-        "                if not gone(backup):\n"
-        "                    print('note: a dependency-tree backup could not be '\n"
-        "                          'removed and was left at %s' % backup,\n"
-        "                          flush=True)\n"
-        "            elif gone(stash):\n"
-        "                os.rename(backup, stash)\n"
-        "                print('restored %s after a failed step' % stash,\n"
-        "                      flush=True)\n"
-        "            else:\n"
-        # The rename would fail anyway, and forcing it is how a partial tree
-        # ends up installed over a good backup. Leave BOTH, name them in the
-        # log, and REPLACE the step's exit code: "the tree could not be put
-        # back" outranks whatever the step itself failed with, because it is the
-        # part the operator has to act on.
-        "                print('partial: %s' % stash, flush=True)\n"
-        "                print('backup: %s' % backup, flush=True)\n"
-        f"                rc = {npm_preflight.EXIT_RESTORE_FAILED}\n"
-        "    if rc != 0:\n"
-        "        sys.exit(rc)\n"
-    )
-    cmd = [sys.executable, "-c", script]
+    # The runner is a SNAPSHOT of :mod:`sync_runner`, staged into a private
+    # mkdtemp and run BY PATH with `-I`. Running `-m kiro_crew...sync_runner`
+    # would import it from the working tree AFTER the merge has landed (and drag
+    # the package __init__ chain in with it), and interpolating source into a
+    # `-c` string is what this module replaced. mkdtemp is unguessable and
+    # 0o700; the steps JSON lives in the SAME dir and is passed as a PATH
+    # argument, never interpolated into source.
+    if runtime._SYNC_RUNNER_SOURCE is None:
+        return {
+            "ok": False,
+            "error": (
+                "the sync runner's own source could not be read at startup, so "
+                "there is nothing trustworthy to run it from — reinstall the "
+                "gateway from a source checkout"
+            ),
+        }
+    runner_dir: Path | None = None
+    try:
+        runner_dir = Path(tempfile.mkdtemp(prefix="kirocrew-sync-runner-"))
+        runner_snap = runner_dir / "sync_runner.py"
+        # The BYTES captured at import, not a copy of the file as it is now.
+        runner_snap.write_bytes(runtime._SYNC_RUNNER_SOURCE)
+        # Pinned in argv below (same contract as the steps digest): the staged
+        # file is mutable between now and exec, argv is not, so the bootstrap
+        # can refuse a snapshot rewritten in that window.
+        runner_sha256 = hashlib.sha256(runtime._SYNC_RUNNER_SOURCE).hexdigest()
+        steps_json_path = runner_dir / "steps.json"
+        # The step list travels as a FILE, not embedded in argv or source: a
+        # non-ASCII checkout path in a step's argv or env then cannot break the
+        # program that reads it, and nothing worktree-controlled is interpolated
+        # into code.
+        steps_payload = json.dumps(wrapped_steps).encode("utf-8")
+        steps_json_path.write_bytes(steps_payload)
+        # Pinned in argv below: argv is immutable once the runner process
+        # exists, so the runner can verify the file it reads is the manifest
+        # THIS gateway staged -- a rewrite of steps.json between staging and
+        # startup fails the digest check and nothing runs.
+        steps_sha256 = hashlib.sha256(steps_payload).hexdigest()
+    except OSError as exc:
+        # A full or unwritable TMPDIR must not escape as a 500, and nothing has
+        # registered this dir for the run's cleanup yet -- remove it here or a
+        # failed sync leaks one temp dir every time. Refusing is also the SAFE
+        # outcome: without a runner there is nothing to drive the steps.
+        if runner_dir is not None:
+            shutil.rmtree(runner_dir, ignore_errors=True)
+        return {
+            "ok": False,
+            "error": (
+                "could not stage the sync runner: "
+                f"{exc.strerror or exc} — free space in the temporary directory "
+                "and press Pull + Build again"
+            ),
+        }
+    # Files before their directory: the run's cleanup unlinks each entry and
+    # falls back to rmdir, which only succeeds on an empty one.
+    cleanups += [str(runner_snap), str(steps_json_path), str(runner_dir)]
+    # `-I` isolates the interpreter (drops cwd from sys.path and ignores env
+    # vars that alter it), the same hardening the preflight snapshot uses; the
+    # snapshot dir itself is removed from sys.path by `-I` too. The runner is
+    # executed THROUGH the fixed bootstrap above, which verifies the staged
+    # snapshot's bytes against the argv-pinned digest before compiling them —
+    # closing the staging→exec mutation window. The reserved set and the one
+    # trusted label are passed IN so the runner imports nothing from
+    # kiro_crew -- what it does cannot change with the revision merged under it.
+    cmd = [
+        sys.executable,
+        "-I",
+        "-c",
+        _SYNC_RUNNER_BOOTSTRAP,
+        str(runner_snap),
+        runner_sha256,
+        str(steps_json_path),
+        str(repo),
+        "--reserved",
+        ",".join(str(c) for c in sorted(npm_preflight.RESERVED_EXIT_CODES)),
+        "--preflight-label",
+        runtime._PREFLIGHT_LABEL,
+        "--exit-tree-ambiguous",
+        str(npm_preflight.EXIT_TREE_AMBIGUOUS),
+        "--exit-restore-failed",
+        str(npm_preflight.EXIT_RESTORE_FAILED),
+        "--steps-sha256",
+        steps_sha256,
+    ]
     rid = await runtime._start_run(
         runtime._SYNC_RUN_LABEL, cmd, env=runtime._build_env(), cleanup_paths=cleanups
     )

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -930,8 +930,15 @@ async def test_upstream_remote_reads_config():
 # --- sync runner emits ::step:: markers ---
 @pytest.mark.asyncio
 async def test_sync_script_emits_step_markers():
-    """The generated sync script must print ::step::<idx>::<label> before each step."""
+    """The sync runner emits ::step::<idx>::<label> before each step.
+
+    The runner is a snapshotted module (sync_runner.py) run by path, so the
+    gateway-side contract is "invoke that module"; the marker EMISSION itself is
+    proven by execution in test_dev_fleet_sync_runner.py. Here we pin that the
+    sync invokes the runner by path and that the module still emits the marker.
+    """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew.apps.builtins.dev_fleet import sync_runner
 
     repository_mod._UPSTREAM_REMOTE = "origin"
     worktree_ops_mod._SYNC_RID = None
@@ -943,13 +950,17 @@ async def test_sync_script_emits_step_markers():
          patch.object(runtime_mod, "_start_run", new_callable=AsyncMock, return_value="run-123") as mock_start:
         async with mod._SYNC_LOCK:
             result = await mod._sync_start_locked()
+    # Clean up the snapshot + steps file the stubbed _start_run would have —
+    # BEFORE any assertion, so a failing assertion cannot leak the staged
+    # temporary directories (GPT round 2, no-test-side-effects).
+    _cleanup_sync_tempdirs(mock_start)
     assert result["ok"] is True
     cmd_args = mock_start.call_args[0]
-    script_cmd = cmd_args[1]
-    assert script_cmd[0].endswith("python") or "python" in script_cmd[0]
-    script_src = script_cmd[2]
-    assert "::step::" in script_src
-    assert "print(f" in script_src
+    runner_cmd = cmd_args[1]
+    assert runner_cmd[0].endswith("python") or "python" in runner_cmd[0]
+    assert any(str(a).endswith("sync_runner.py") for a in runner_cmd)
+    src = Path(sync_runner.__file__).read_text(encoding="utf-8")
+    assert "::step::" in src
     repository_mod._UPSTREAM_REMOTE = None
 
 
@@ -959,34 +970,65 @@ async def test_sync_script_emits_step_markers():
 # use of the result: which install step gets built.
 
 
-def _steps_from_script(script):
-    """Pull the structured step list back out of the generated script.
+def _steps_json_path_from_cmd(cmd):
+    """The steps-JSON file path from a runner command.
 
-    Asserting on the raw script text is a trap: the steps are embedded
-    double-JSON-encoded, so a label reads as ``\\"Pull\\"`` and a naive
-    ``'"pip install"' in script`` check can never match — it passes whether or
-    not the step is there. Parse it instead so the assertions actually bite.
+    ``cmd`` is ``[python, -I, -c, <bootstrap>, <snapshot>, <snapshot-sha256>,
+    <steps_json>, <repo>, --reserved, <codes>, ...]``. The steps file is the
+    SECOND positional after the snapshot path (the snapshot ends in
+    ``sync_runner.py``; the argv-pinned snapshot digest sits between them).
+    """
+    for i, tok in enumerate(cmd):
+        if isinstance(tok, str) and tok.endswith("sync_runner.py"):
+            return cmd[i + 2]
+    raise AssertionError("sync_runner.py snapshot not found in command — shape changed")
+
+
+def _sync_steps_from_cmd(cmd):
+    """Pull the structured step list back out of the runner invocation.
+
+    The runner is no longer a ``-c <script>`` string; it is a snapshot of
+    sync_runner.py run BY PATH, and the steps travel as a JSON FILE whose path
+    is the runner's first positional argument. Read that file so the assertions
+    bite on the real step list rather than on source text.
     """
     import json as _json
-    import re
 
-    m = re.search(r"steps = json\.loads\((.*?)\)\n", script, re.S)
-    assert m, "steps assignment not found — the script shape changed"
-    return [s["label"] for s in _json.loads(_json.loads(m.group(1)))]
+    steps_json_path = _steps_json_path_from_cmd(cmd)
+    with open(steps_json_path, encoding="utf-8") as fh:
+        return _json.load(fh)
 
 
-def _sync_steps_from_script(script):
-    """Same extraction as :func:`_steps_from_script`, but the whole step dicts.
+def _install_step(steps):
+    """The 'pip install' step dict from a decoded step list.
 
-    The metadata the runner acts on (``stash``) lives beside the
-    label, and asserting on it through the label-only view is impossible.
+    Both branches (editable reinstall and dependency-only substitute) label
+    their install step 'pip install'; the argv is what differs between them.
     """
-    import json as _json
-    import re
+    for st in steps:
+        if st["label"] == "pip install":
+            return st
+    raise AssertionError("no 'pip install' step found in the step list")
 
-    m = re.search(r"steps = json\.loads\((.*?)\)\n", script, re.S)
-    assert m, "steps assignment not found — the script shape changed"
-    return _json.loads(_json.loads(m.group(1)))
+
+def _cleanup_sync_tempdirs(mock_start):
+    """Delete the snapshot dirs a stubbed _start_run would have cleaned up.
+
+    Stubbing ``_start_run`` also stubs out its ``finally`` cleanup, so the
+    snapshot dirs the sync stages (the runner snapshot + steps file, the
+    preflight snapshot, and the dependency-only path's dep_sync snapshot) would
+    outlive the test. Remove exactly what it registered, file before directory.
+    """
+    if not getattr(mock_start, "call_args", None):
+        return
+    for path in mock_start.call_args.kwargs.get("cleanup_paths") or []:
+        try:
+            os.unlink(path)
+        except OSError:
+            try:
+                os.rmdir(path)
+            except OSError:
+                pass
 
 
 #: The main checkout the sync tests run against. Pinned rather than ambient so the
@@ -1001,8 +1043,15 @@ _LAST_CLEANUP_PATHS: list[str] = []
 
 
 async def _run_sync(mod, locked):
-    """Drive _sync_start_locked with the probe stubbed; return its result dict
-    plus the generated script (None when the sync refused).
+    """Drive _sync_start_locked with the probe stubbed.
+
+    Returns ``(result, cmd, steps)``: the result dict, the runner command handed
+    to ``_start_run`` (``None`` when the sync refused), and the decoded step
+    dicts read from the steps JSON file BEFORE the harness deletes it (``None``
+    on a refusal). The runner is a snapshot of sync_runner.py run by path with
+    the step list in a JSON file, so assertions inspect ``cmd`` and ``steps``
+    rather than script source text.
+
     MAIN_REPO is pinned because the sync refuses outright when no checkout was
     discovered, and these tests are about the sync's own behaviour: leaving it
     ambient makes them pass or fail on whether the HOST running them happens to
@@ -1025,26 +1074,23 @@ async def _run_sync(mod, locked):
         async with mod._SYNC_LOCK:
             result = await mod._sync_start_locked()
     repository_mod._UPSTREAM_REMOTE = None
-    script = mock_start.call_args[0][1][2] if mock_start.call_args else None
-    # Stubbing _start_run also stubs out its `finally` cleanup, so anything the
-    # sync staged for removal (the dependency-only path snapshots dep_sync into a
-    # temp dir) would outlive the test. Remove exactly what it registered, in the
-    # order it registered it — file before directory.
+    cmd = mock_start.call_args[0][1] if mock_start.call_args else None
+    # Decode the steps BEFORE cleanup deletes the staged JSON file — inside
+    # try/finally so a malformed file or a changed command shape cannot leave
+    # the staged directories behind (the finally owns cleanup either way).
     global _LAST_CLEANUP_PATHS
     _LAST_CLEANUP_PATHS = list(
         (mock_start.call_args.kwargs.get("cleanup_paths") or [])
         if mock_start.call_args else []
     )
-    if mock_start.call_args:
-        for path in mock_start.call_args.kwargs.get("cleanup_paths") or []:
-            try:
-                os.unlink(path)
-            except OSError:
-                try:
-                    os.rmdir(path)
-                except OSError:
-                    pass
-    return result, script
+    try:
+        steps = _sync_steps_from_cmd(cmd) if cmd else None
+    finally:
+        # Stubbing _start_run also stubs out its `finally` cleanup, so anything
+        # the sync staged for removal (the runner snapshot + steps file, and
+        # the dependency-only path's dep_sync snapshot) would outlive the test.
+        _cleanup_sync_tempdirs(mock_start)
+    return result, cmd, steps
 
 
 @pytest.mark.asyncio
@@ -1061,32 +1107,33 @@ async def test_sync_substitutes_a_dependency_only_install_when_a_script_is_locke
     import kiro_crew.apps.builtins.dev_fleet.server as mod
     from kiro_crew import dep_sync
 
-    result, script = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
+    result, cmd, steps = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
 
     assert result["ok"] is True
     # A run was started, so fetch and merge do happen.
-    assert script is not None
-    # Steps are JSON-embedded in the generated script, so quotes arrive escaped;
-    # comparing against a de-escaped copy keeps these assertions independent of
-    # how many encoding layers the script generator happens to use.
-    flat = script.replace("\\", "")
-    assert "dep_sync.py" in flat
-    assert '"-e"' not in flat
+    assert cmd is not None
+    # The install step's argv is what the substitution changes; inspect it
+    # directly rather than source text.
+    install = _install_step(steps)
+    argv_flat = " ".join(install["argv"])
+    assert "dep_sync.py" in argv_flat
+    assert "-e" not in install["argv"]
     # It must NOT be run as `-m kiro_crew...dep_sync`. That would import the
     # module from the working tree after the merge has landed, pulling the whole
     # package __init__ chain with it, so a revision that raises the
     # `requires-python` floor with newer syntax would SyntaxError while being
     # parsed and the floor refusal written for that revision could never run.
-    assert dep_sync.__name__ not in flat
-    assert '"-m"' not in flat.split('"merge"', 1)[1]
+    assert dep_sync.__name__ not in argv_flat
+    assert "-m" not in install["argv"]
     # The file it runs is a snapshot taken BEFORE the merge, so it lives outside
     # the checkout being synced.
-    assert r"C:repo\dep_sync.py" not in flat
+    assert r"C:\repo\dep_sync.py" not in argv_flat
     # ORDER MATTERS, and it is the SAME order the reinstall it replaces uses:
     # fetch -> merge -> install. Installing first would need the merge to be
     # proven impossible to fail, which cannot be done completely; a failed install
     # after a landed merge is exactly what the reinstall path already does.
-    assert flat.index('"merge"') < flat.index("dep_sync.py")
+    labels = [s["label"] for s in steps]
+    assert labels.index("Merge") < labels.index("pip install")
 
 
 @pytest.mark.asyncio
@@ -1100,13 +1147,14 @@ async def test_sync_keeps_the_editable_reinstall_when_nothing_is_locked():
     import kiro_crew.apps.builtins.dev_fleet.server as mod
     from kiro_crew import dep_sync
 
-    result, script = await _run_sync(mod, [])
+    result, cmd, steps = await _run_sync(mod, [])
 
     assert result["ok"] is True
-    flat = script.replace("\\", "")
-    assert '"-e"' in flat
-    assert dep_sync.__name__ not in flat
-    assert "dep_sync.py" not in flat
+    install = _install_step(steps)
+    argv_flat = " ".join(install["argv"])
+    assert "-e" in install["argv"]
+    assert dep_sync.__name__ not in argv_flat
+    assert "dep_sync.py" not in argv_flat
 
 
 @pytest.mark.asyncio
@@ -1117,17 +1165,21 @@ async def test_every_step_gets_a_utf8_pin_in_its_environment():
     encoding from the locale, so the Python steps (pip, and the build-and-stage
     child) would still encode a non-ASCII checkout path with the codepage and
     die on it. The environment is the only channel that reaches a child.
+
+    The MECHANISM is proven by execution in test_dev_fleet_sync_runner.py
+    (a child spawned under a divergent inherited PYTHONIOENCODING observes the
+    utf-8 pin). What stays here is the module contract: run_step assigns the
+    pin onto every step's env before spawning.
     """
-    import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew.apps.builtins.dev_fleet import sync_runner
 
-    _, script = await _run_sync(mod, [])
-
-    assert "env['PYTHONIOENCODING'] = 'utf-8:replace'" in script
+    src = Path(sync_runner.__file__).read_text(encoding="utf-8")
+    run_step_body = src.split("def run_step(", 1)[1].split("\ndef ", 1)[0]
+    assert 'env["PYTHONIOENCODING"] = "utf-8:replace"' in run_step_body
     # Applied to the env actually handed to subprocess.run, not a stale copy.
-    assert "subprocess.run(st['argv'], cwd=cwd, env=env)" in script
-    assert "env=st['env']" not in script
+    assert "cwd=cwd, env=env" in run_step_body
     # Set before the step is spawned, not after.
-    assert script.index("PYTHONIOENCODING") < script.index("subprocess.run(")
+    assert run_step_body.index("PYTHONIOENCODING") < run_step_body.index("subprocess.run(")
 
 
 @pytest.mark.asyncio
@@ -1135,10 +1187,10 @@ async def test_sync_runs_every_step_when_nothing_is_locked():
     """Control: an unlocked venv gets the full sync, reinstall included."""
     import kiro_crew.apps.builtins.dev_fleet.server as mod
 
-    result, script = await _run_sync(mod, [])
+    result, cmd, steps = await _run_sync(mod, [])
 
     assert result["ok"] is True, result
-    labels = _steps_from_script(script)
+    labels = [s["label"] for s in steps]
     assert "pip install" in labels
     assert "Pull" in labels
 
@@ -1165,7 +1217,7 @@ async def test_sync_refuses_a_venv_that_serves_another_checkout(locked):
         "venv_not_mapped_to",
         return_value="the target venv imports this project from /other/checkout",
     ):
-        result, script = await _run_sync(mod, locked)
+        result, cmd, steps = await _run_sync(mod, locked)
 
     assert result["ok"] is False
     assert "/other/checkout" in result["error"]
@@ -1173,7 +1225,7 @@ async def test_sync_refuses_a_venv_that_serves_another_checkout(locked):
     assert "own editable install" in result["error"]
     # Nothing ran: no fetch, no merge, no install. A refusal after the merge
     # would leave the checkout moved with its dependencies unresolved.
-    assert script is None
+    assert cmd is None
 
 
 @pytest.mark.asyncio
@@ -1185,11 +1237,18 @@ async def test_sync_runner_pins_utf8_stdout_before_its_first_print():
     any non-ASCII print. Pinned before the step loop so no print predates it.
     """
     import kiro_crew.apps.builtins.dev_fleet.server as mod
+    from kiro_crew.apps.builtins.dev_fleet import sync_runner
 
-    _, script = await _run_sync(mod, [])
+    _, cmd, _ = await _run_sync(mod, [])
 
-    assert "reconfigure(encoding='utf-8'" in script
-    assert script.index("reconfigure(") < script.index("print(f'::step::")
+    assert cmd is not None
+    src = Path(sync_runner.__file__).read_text(encoding="utf-8")
+    assert 'reconfigure(encoding="utf-8"' in src
+    # Within main(), the reconfigure runs before run_steps() is called, so no
+    # print in the step loop predates it.
+    main_body = src.split("def main(", 1)[1]
+    assert "reconfigure(" in main_body
+    assert main_body.index("reconfigure(") < main_body.index("run_steps(")
 
 
 def test_utf8_reconfigure_survives_a_legacy_codepage_pipe():
@@ -9423,8 +9482,8 @@ async def test_sync_preflights_between_fetch_and_merge(monkeypatch):
     refusal would already be too late; before the fetch there is nothing to read.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
-    labels = _steps_from_script(script)
+    _, cmd, steps = await _run_sync(mod, [])
+    labels = [s["label"] for s in steps]
 
     assert mod._PREFLIGHT_LABEL in labels, labels
     # The probe sits between the fetch and the merge, which is the whole point:
@@ -9472,8 +9531,8 @@ async def test_sync_skips_the_preflight_on_an_edition_checkout(monkeypatch):
     a network round trip that can only produce a false refusal.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: True)
-    _, script = await _run_sync(mod, [])
-    assert mod._PREFLIGHT_LABEL not in _steps_from_script(script)
+    _, cmd, steps = await _run_sync(mod, [])
+    assert mod._PREFLIGHT_LABEL not in [s["label"] for s in steps]
 
 
 @pytest.mark.asyncio
@@ -9485,26 +9544,15 @@ async def test_npm_ci_step_carries_a_node_modules_stash(monkeypatch):
     restore.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
-    steps = _sync_steps_from_script(script)
+    _, cmd, steps = await _run_sync(mod, [])
     stashed = {s["label"]: s["stash"] for s in steps if s.get("stash")}
     assert list(stashed) == ["npm ci"], stashed
     assert stashed["npm ci"] == str(Path(_SYNC_REPO) / "website" / "node_modules")
-    # The runner must actually put it back, and only on a non-zero outcome.
-    assert "os.rename(backup, stash)" in script
-    # Deletions whose outcome decides the next rename are CONFIRMED, not
-    # fire-and-forget: a silently partial removal leaves a directory in place,
-    # makes the rename fail, and ends with a partial tree restored over a good
-    # one.
-    assert "def gone(p):" in script
-    # lexists, not exists: a DANGLING symlink is still something at this path,
-    # and the helper must unlink a symlink rather than rmtree it -- rmtree refuses
-    # a link and ignore_errors=True hides the refusal, which used to leave the
-    # backup in place and make every later sync refuse as ambiguous.
-    assert "return not os.path.lexists(p)" in script
-    assert "if os.path.islink(p):" in script
-    assert "os.unlink(p)" in script
-    assert "elif gone(stash):" in script
+    # The transaction's BEHAVIOUR — restore on failure only, confirmed
+    # deletions, symlink unlinking, lexists gates — is proven by EXECUTION in
+    # test_dev_fleet_sync_runner.py against real directory trees; the inline
+    # source-text assertions this test used to carry moved there with it. What
+    # stays here is the composition contract: the stash rides the npm ci step.
 
 
 @pytest.mark.asyncio
@@ -9524,21 +9572,22 @@ async def test_sync_never_runs_an_operator_supplied_command(monkeypatch):
     """
     monkeypatch.setenv("KIROCREW_DEVFLEET_NPM_AUTH_REPAIR", "/bin/sh -c true")
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
+    _, cmd, steps = await _run_sync(mod, [])
 
-    steps = _sync_steps_from_script(script)
-    assert not any("repair" in s for s in steps), steps
+    assert not any("repair" in s["label"] for s in steps), steps
     assert not hasattr(mod, "_npm_auth_repair_argv")
+    cmd_flat = " ".join(map(str, cmd))
     for token in ("KIROCREW_DEVFLEET_NPM_AUTH_REPAIR", "npm_auth_repair"):
-        assert token not in script
-    # The declared command must appear NOWHERE in the generated script. Asserted
+        assert token not in cmd_flat, cmd
+    # The declared command must appear NOWHERE in the composed steps. Asserted
     # this way rather than against a list of expected argv[0]s: the toolchain
     # binaries are resolved from the host (npm is /usr/bin/npm on one platform
     # and /opt/homebrew/bin/npm on another), so a path allowlist tests the host
     # rather than the property.
-    assert "/bin/sh" not in script
+    assert "/bin/sh" not in cmd_flat
     for s in steps:
         assert "/bin/sh" not in " ".join(map(str, s["argv"])), s["argv"]
+        assert not any("repair" in str(v) for v in s.get("env", {}).values()), s
 
 
 @pytest.mark.asyncio
@@ -9552,17 +9601,27 @@ async def test_a_stashed_tree_is_recovered_before_any_step_runs(monkeypatch):
     halves of leftover-state reconciliation therefore happen before the loop.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
+    from kiro_crew.apps.builtins.dev_fleet import sync_runner
 
-    claim = script.index("left stashed by an earlier")
-    loop_at = script.index("for i, st in enumerate(steps):")
-    assert claim < loop_at, "the stashed tree must be reclaimed before any step runs"
-    # The step's pre-run section now only moves the tree ASIDE -- no second,
-    # redundant adoption. (The `finally` block legitimately renames the backup
-    # back; that is the restore, not a reconciliation.)
-    prerun = script[loop_at:script.index("    try:", loop_at)]
-    assert "os.rename(stash, backup)" in prerun
-    assert "os.rename(backup, stash)" not in prerun
+    _, cmd, steps = await _run_sync(mod, [])
+    assert cmd is not None
+    # The reconcile/adopt decision and the move-aside now live in the runner
+    # module. That both halves happen -- and the backup-only recovery lands
+    # BEFORE any step runs, and the pre-run section only moves the tree aside --
+    # is driven against real trees in test_dev_fleet_sync_runner.py
+    # (TestReconcileLeftovers, TestNodeModulesTransaction). Here we pin the
+    # structural ordering in main(): reconcile_leftovers is called before
+    # run_steps.
+    src = Path(sync_runner.__file__).read_text(encoding="utf-8")
+    main_body = src.split("def main(", 1)[1]
+    assert main_body.index("reconcile_leftovers(") < main_body.index("run_steps("), (
+        "the stashed tree must be reclaimed before any step runs"
+    )
+    # The move-aside (enter) and the restore (exit) are separate phases of the
+    # transaction, not a redundant second adoption in the pre-run section.
+    enter = src.split("def __enter__", 1)[1].split("def __exit__", 1)[0]
+    assert "os.rename(self.stash, self.backup)" in enter
+    assert "os.rename(self.backup, self.stash)" not in enter
 
 
 @pytest.mark.asyncio
@@ -9576,9 +9635,13 @@ async def test_the_failure_cause_is_never_taken_from_child_output(monkeypatch):
     So the diagnosis is derived from the EXIT CODE, which a step's own child
     cannot choose, and nothing is parsed out of the stream.
     """
-    _, script = await _run_sync(mod, [])
+    from kiro_crew.apps.builtins.dev_fleet import sync_runner
+
+    _, cmd, _ = await _run_sync(mod, [])
+    assert cmd is not None
     # No promotable marker is emitted by the runner at all.
-    assert "::cause::" not in script
+    src = Path(sync_runner.__file__).read_text(encoding="utf-8")
+    assert "::cause::" not in src
     # And the worker has no branch that lifts text out of a line.
     import inspect
     body = inspect.getsource(mod._start_run)
@@ -9598,14 +9661,20 @@ async def test_runner_refuses_when_a_tree_and_a_backup_both_exist(monkeypatch):
     the gateway maps to a sentence naming the next step.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
+    _, cmd, _ = await _run_sync(mod, [])
+    assert cmd is not None
 
-    assert f"sys.exit({npm_preflight.EXIT_TREE_AMBIGUOUS})" in script
-    assert "print('tree: %s' % stash, flush=True)" in script
-    assert "print('backup: %s' % backup, flush=True)" in script
-    # The refusal is reconciliation, so it lands before any step runs.
-    refuse = script.index(f"sys.exit({npm_preflight.EXIT_TREE_AMBIGUOUS})")
-    assert refuse < script.index("for i, st in enumerate(steps):")
+    # The both-exist refusal (exit the ambiguous-tree code, touch neither, name
+    # both paths) is driven against real trees in test_dev_fleet_sync_runner.py
+    # (TestReconcileLeftovers), and that it lands as reconciliation before any
+    # step is pinned there and by the main() ordering test. The code itself has
+    # ONE spelling now (npm_preflight.EXIT_TREE_AMBIGUOUS, passed to the runner
+    # via --exit-tree-ambiguous); here we pin the pieces that stay
+    # gateway-side: the code is handed in on argv, and the gateway maps it to a
+    # sentence naming the next step.
+    assert "--exit-tree-ambiguous" in cmd
+    passed = cmd[cmd.index("--exit-tree-ambiguous") + 1]
+    assert passed == str(npm_preflight.EXIT_TREE_AMBIGUOUS)
     # The mapped sentence names what to do, not merely what happened.
     text = npm_preflight.explain_exit(npm_preflight.EXIT_TREE_AMBIGUOUS)
     assert "press Pull + Build again" in text
@@ -9624,18 +9693,21 @@ async def test_only_the_preflight_step_may_assert_a_diagnosis(monkeypatch):
     code in the log rather than believing it.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
+    _, cmd, _ = await _run_sync(mod, [])
+    assert cmd is not None
 
-    assert "if rc in RESERVED and st['label'] != PREFLIGHT:" in script
-    # The gate must sit on the value the STEP returned, before the finally block
-    # can set a runner-owned code of its own.
-    gate = script.index("if rc in RESERVED and st['label'] != PREFLIGHT:")
-    assert script.index("rc = run(st)") < gate < script.index("    finally:")
-    # Both literals come from the modules that own them, so they cannot drift
-    # from the step label or the explain table.
-    assert f"PREFLIGHT = {json.dumps(mod._PREFLIGHT_LABEL)}" in script
+    # The gate itself (a reserved code is trusted from the preflight label and
+    # demoted from every other step) is driven by execution in
+    # test_dev_fleet_sync_runner.py (TestDemoteReserved, TestRunSteps). Here we
+    # pin that the gateway passes the reserved set and the trusted label IN, so
+    # the runner needs to import nothing from kiro_crew and the two cannot
+    # drift from the modules that own them.
+    assert "--reserved" in cmd
     reserved = sorted(npm_preflight.RESERVED_EXIT_CODES)
-    assert f"RESERVED = {reserved!r}" in script
+    passed = cmd[cmd.index("--reserved") + 1]
+    assert passed == ",".join(str(c) for c in reserved), passed
+    assert "--preflight-label" in cmd
+    assert cmd[cmd.index("--preflight-label") + 1] == mod._PREFLIGHT_LABEL
     # Every code the gateway will explain must be in the guarded set, or a code
     # it explains could still arrive forged.
     for code in reserved:
@@ -9670,8 +9742,8 @@ async def test_probe_and_merge_consume_one_immutable_commit(monkeypatch):
     because the promise is what makes the merge look safe.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
-    steps = _sync_steps_from_script(script)
+    _, cmd, steps = await _run_sync(mod, [])
+
     by_label = {}
     for st in steps:
         by_label.setdefault(st["label"], []).append(st["argv"])
@@ -9968,10 +10040,10 @@ async def test_prune_runs_before_the_fetch_step_is_built(monkeypatch):
         calls.append(repo)
     monkeypatch.setattr(worktree_ops_mod, "_prune_dead_sync_base_refs", spy)
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
+    _, cmd, steps = await _run_sync(mod, [])
 
     assert calls, "the sync never pruned stale pinned refs"
-    steps = _sync_steps_from_script(script)
+
     fetch = [st for st in steps if "fetch" in st["argv"]]
     assert fetch, "no fetch step"
     # The pin the fetch writes is this process's, which the prune never removes.
@@ -10090,13 +10162,13 @@ async def test_a_full_tmpdir_refuses_the_sync_instead_of_raising(
 
         monkeypatch.setattr(Path, "write_bytes", fail_write)
 
-    result, script = await _run_sync(mod, [])
+    result, cmd, steps = await _run_sync(mod, [])
 
     assert result.get("ok") is False, result
     assert "preflight" in result["error"].lower(), result
     assert "No space left on device" in result["error"], result
     # A refusal means no run was started at all, so no steps ran.
-    assert script is None, "the sync started a run despite failing to stage"
+    assert cmd is None, "the sync started a run despite failing to stage"
     # And the partial snapshot is gone: nothing registered it for cleanup, so the
     # refusal path has to remove it itself.
     leaked = list(tmp_path.glob("kirocrew-npm-preflight-*"))
@@ -10151,11 +10223,11 @@ async def test_sync_refuses_when_the_probe_source_could_not_be_captured(monkeypa
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
     monkeypatch.setattr(runtime_mod, "_PREFLIGHT_SOURCE", None)
 
-    result, script = await _run_sync(mod, [])
+    result, cmd, steps = await _run_sync(mod, [])
 
     assert result.get("ok") is False, result
     assert "preflight" in result["error"].lower(), result
-    assert script is None, "the sync started a run with no trustworthy probe"
+    assert cmd is None, "the sync started a run with no trustworthy probe"
 
 
 @pytest.mark.asyncio
@@ -10173,11 +10245,15 @@ async def test_every_stash_presence_gate_uses_lexists(monkeypatch):
     this pins the shape so the gates cannot silently revert.
     """
     monkeypatch.setattr(worktree_ops_mod.frontend, "edition_configured", lambda: False)
-    _, script = await _run_sync(mod, [])
+    from kiro_crew.apps.builtins.dev_fleet import sync_runner
 
-    assert "have_tree = os.path.lexists(stash)" in script
-    assert "have_backup = os.path.lexists(backup)" in script
-    assert "if backup and os.path.lexists(stash):" in script
+    _, cmd, _ = await _run_sync(mod, [])
+    assert cmd is not None
+
+    src = Path(sync_runner.__file__).read_text(encoding="utf-8")
+    assert "have_tree = os.path.lexists(stash)" in src
+    assert "have_backup = os.path.lexists(backup)" in src
+    assert "if self.stash and self.backup and os.path.lexists(self.stash):" in src
     # No presence gate on either path may follow a link.
     for bad in (
         "os.path.isdir(stash)",
@@ -10185,4 +10261,4 @@ async def test_every_stash_presence_gate_uses_lexists(monkeypatch):
         "os.path.exists(stash)",
         "os.path.exists(backup)",
     ):
-        assert bad not in script, f"{bad} follows symlinks; use lexists"
+        assert bad not in src, f"{bad} follows symlinks; use lexists"

--- a/test/test_dev_fleet_sync_runner.py
+++ b/test/test_dev_fleet_sync_runner.py
@@ -1,0 +1,461 @@
+"""Execution tests for the Dev Fleet sync runner.
+
+The point of #6698 is that the runner used to be a string literal no linter
+parsed and no test executed -- so its node_modules transaction, whose whole job
+is not to lose a dependency tree, was only ever string-matched. These drive the
+REAL functions against real ``tmp_path`` trees: the reconciliation decision, the
+transaction's success/failure/restore-failure paths, the reserved-code demotion,
+and the stdlib-only import discipline that lets the module be snapshotted and run
+by path.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.apps.builtins.dev_fleet import npm_preflight, sync_runner
+
+_BACKUP = sync_runner._BACKUP_SUFFIX
+
+
+def _tree(path: Path, marker: str = "x") -> None:
+    """Make a directory that stands in for a node_modules tree."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "sentinel").write_text(marker, encoding="utf-8")
+
+
+# --- reconcile_leftovers -----------------------------------------------------
+
+
+class TestReconcileLeftovers:
+    def test_both_present_refuses_and_touches_neither(self, tmp_path, capsys):
+        """Tree AND backup is ambiguous: exit EXIT_TREE_AMBIGUOUS, keep both."""
+        stash = tmp_path / "node_modules"
+        backup = tmp_path / ("node_modules" + _BACKUP)
+        _tree(stash, "current")
+        _tree(backup, "old")
+        steps = [{"label": "npm ci", "stash": str(stash)}]
+
+        with pytest.raises(SystemExit) as exc:
+            sync_runner.reconcile_leftovers(steps, 46)
+
+        assert exc.value.code == npm_preflight.EXIT_TREE_AMBIGUOUS
+        # Neither was touched -- both are still exactly as they were.
+        assert (stash / "sentinel").read_text() == "current"
+        assert (backup / "sentinel").read_text() == "old"
+        out = capsys.readouterr().out
+        assert str(stash) in out
+        assert str(backup) in out
+
+    def test_backup_only_is_recovered(self, tmp_path):
+        """A lone backup is unambiguous: rename it back into place."""
+        stash = tmp_path / "node_modules"
+        backup = tmp_path / ("node_modules" + _BACKUP)
+        _tree(backup, "recovered")
+        steps = [{"label": "npm ci", "stash": str(stash)}]
+
+        sync_runner.reconcile_leftovers(steps, 46)
+
+        assert (stash / "sentinel").read_text() == "recovered"
+        assert not backup.exists()
+
+    def test_no_stash_step_is_a_noop(self, tmp_path):
+        """A step with no stash key is skipped without error."""
+        sync_runner.reconcile_leftovers([{"label": "Pull"}], 46)  # no raise
+
+
+# --- NodeModulesTransaction --------------------------------------------------
+
+
+class TestNodeModulesTransaction:
+    def test_success_drops_the_backup(self, tmp_path):
+        """rc == 0: the tree stays, the backup is removed."""
+        stash = tmp_path / "node_modules"
+        backup = tmp_path / ("node_modules" + _BACKUP)
+        _tree(stash, "installed")
+
+        with sync_runner.NodeModulesTransaction(str(stash), 47) as txn:
+            # __enter__ moved the tree aside.
+            assert backup.exists()
+            assert not stash.exists()
+            # Simulate the step reinstalling the tree at the original slot.
+            _tree(stash, "reinstalled")
+            txn.rc = 0
+
+        assert (stash / "sentinel").read_text() == "reinstalled"
+        assert not backup.exists()
+        assert txn.rc == 0
+
+    def test_failure_restores_the_tree(self, tmp_path):
+        """rc != 0 with the slot clear: the backup is renamed back."""
+        stash = tmp_path / "node_modules"
+        backup = tmp_path / ("node_modules" + _BACKUP)
+        _tree(stash, "good")
+
+        with sync_runner.NodeModulesTransaction(str(stash), 47) as txn:
+            # Step "fails" and leaves nothing at the stash slot.
+            txn.rc = 1
+
+        assert (stash / "sentinel").read_text() == "good"
+        assert not backup.exists()
+        assert txn.rc == 1
+
+    def test_restore_failure_leaves_both_and_overrides_rc(self, tmp_path, capsys):
+        """A partial tree that will not clear: keep both, set EXIT_RESTORE_FAILED.
+
+        Forcing the rename over a partial tree is how a bad tree lands on a good
+        backup, so the runner refuses -- and the "could not put it back" code
+        outranks whatever the step failed with.
+        """
+        stash = tmp_path / "node_modules"
+        backup = tmp_path / ("node_modules" + _BACKUP)
+        _tree(stash, "good")
+
+        # A file inside the partial tree that gone() cannot remove: make the
+        # directory itself un-emptyable by holding a child open is fragile, so
+        # instead monkeypatch gone() to report the slot cannot be cleared.
+        with sync_runner.NodeModulesTransaction(str(stash), 47) as txn:
+            # Step failed AND left a partial tree at the stash slot.
+            _tree(stash, "partial")
+            # Force gone(stash) -> False for this exit only.
+            orig_gone = sync_runner.gone
+            sync_runner.gone = lambda p: False if p == str(stash) else orig_gone(p)
+            try:
+                txn.rc = 1
+            finally:
+                pass
+        # Restore gone after exit ran.
+        sync_runner.gone = orig_gone
+
+        assert txn.rc == npm_preflight.EXIT_RESTORE_FAILED
+        # Both trees survive.
+        assert (stash / "sentinel").read_text() == "partial"
+        assert (backup / "sentinel").read_text() == "good"
+        out = capsys.readouterr().out
+        assert "partial:" in out
+        assert "backup:" in out
+
+    def test_no_stash_is_inert(self, tmp_path):
+        """A step with no stash: the transaction does nothing on enter or exit."""
+        with sync_runner.NodeModulesTransaction(None, 47) as txn:
+            txn.rc = 0
+        assert txn.rc == 0
+
+
+# --- demote_reserved ---------------------------------------------------------
+
+
+class TestDemoteReserved:
+    def test_reserved_code_from_non_preflight_is_demoted(self, capsys):
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        code = sorted(reserved)[0]
+        out_rc = sync_runner.demote_reserved(code, "npm ci", reserved, "Verify dependencies")
+        assert out_rc == 1
+        assert "reserved diagnosis code" in capsys.readouterr().out
+
+    def test_reserved_code_from_preflight_is_trusted(self, capsys):
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        code = npm_preflight.EXIT_AUTH
+        out_rc = sync_runner.demote_reserved(
+            code, "Verify dependencies", reserved, "Verify dependencies"
+        )
+        assert out_rc == code
+        assert capsys.readouterr().out == ""
+
+    def test_non_reserved_code_passes_through(self, capsys):
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        out_rc = sync_runner.demote_reserved(1, "npm ci", reserved, "Verify dependencies")
+        assert out_rc == 1
+        assert capsys.readouterr().out == ""
+
+
+# --- run_steps end to end ----------------------------------------------------
+
+
+def _echo_step(label, code, tmp_path, stash=None):
+    """A step whose argv is a python one-liner exiting *code*."""
+    import sys
+
+    argv = [sys.executable, "-c", f"import sys; sys.exit({code})"]
+    step = {"argv": argv, "env": dict(os.environ), "label": label}
+    if stash is not None:
+        step["stash"] = str(stash)
+    return step
+
+
+class TestRunSteps:
+    def test_all_pass_returns_zero_and_emits_markers(self, tmp_path, capsys):
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        steps = [_echo_step("Pull", 0, tmp_path), _echo_step("Merge", 0, tmp_path)]
+        rc = sync_runner.run_steps(steps, str(tmp_path), reserved, "Verify dependencies", 47)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "::step::0::Pull" in out
+        assert "::step::1::Merge" in out
+
+    def test_run_step_pins_pythonioencoding_on_the_child(self, tmp_path):
+        """EXECUTED coverage for the per-step ``PYTHONIOENCODING`` pin.
+
+        The pre-refactor inline script assigned ``PYTHONIOENCODING`` on every
+        step's env so a Python child (pip, the build-and-stage child) encodes
+        its stdout as UTF-8 regardless of the process locale codepage. The pin
+        moved into :func:`sync_runner.run_step`; this test proves it reaches a
+        REAL child's environment -- and overrides a divergent inherited value,
+        because the reader's decoding is fixed so a passthrough would be the
+        defect.
+        """
+        import sys
+
+        probe = tmp_path / "seen_env.txt"
+        argv = [
+            sys.executable,
+            "-c",
+            "import os, pathlib, sys; pathlib.Path(sys.argv[1]).write_text("
+            "os.environ.get('PYTHONIOENCODING', 'MISSING')); sys.exit(0)",
+            str(probe),
+        ]
+        env = dict(os.environ)
+        env["PYTHONIOENCODING"] = "cp1252"  # divergent inherited value
+        rc = sync_runner.run_step({"argv": argv, "env": env, "label": "probe"}, str(tmp_path))
+        assert rc == 0
+        assert probe.read_text() == "utf-8:replace"
+
+    def test_fail_fast_stops_on_first_failure(self, tmp_path, capsys):
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        steps = [
+            _echo_step("Pull", 0, tmp_path),
+            _echo_step("Merge", 7, tmp_path),
+            _echo_step("pip install", 0, tmp_path),
+        ]
+        rc = sync_runner.run_steps(steps, str(tmp_path), reserved, "Verify dependencies", 47)
+        assert rc == 7
+        out = capsys.readouterr().out
+        # The third step never announced itself.
+        assert "::step::2::pip install" not in out
+
+    def test_npm_ci_failure_restores_the_tree(self, tmp_path):
+        """The transaction, driven through run_steps: a failing npm ci step
+        leaves node_modules intact."""
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        stash = tmp_path / "website" / "node_modules"
+        _tree(stash, "before")
+        steps = [_echo_step("npm ci", 3, tmp_path, stash=stash)]
+
+        rc = sync_runner.run_steps(steps, str(tmp_path), reserved, "Verify dependencies", 47)
+
+        assert rc == 3
+        assert (stash / "sentinel").read_text() == "before"
+        assert not (tmp_path / "website" / ("node_modules" + _BACKUP)).exists()
+
+    def test_npm_ci_success_drops_the_backup(self, tmp_path):
+        """A succeeding npm ci step (which reinstalls the tree) drops the backup."""
+        import sys
+
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        stash = tmp_path / "website" / "node_modules"
+        _tree(stash, "old")
+        # A step that "reinstalls" the tree then exits 0.
+        reinstall = (
+            "import os, pathlib;"
+            f"p=pathlib.Path({str(stash)!r});"
+            "p.mkdir(parents=True, exist_ok=True);"
+            "(p/'sentinel').write_text('new')"
+        )
+        step = {
+            "argv": [sys.executable, "-c", reinstall],
+            "env": dict(os.environ),
+            "label": "npm ci",
+            "stash": str(stash),
+        }
+
+        rc = sync_runner.run_steps([step], str(tmp_path), reserved, "Verify dependencies", 47)
+
+        assert rc == 0
+        assert (stash / "sentinel").read_text() == "new"
+        assert not (tmp_path / "website" / ("node_modules" + _BACKUP)).exists()
+
+    def test_reserved_code_from_untrusted_step_is_demoted(self, tmp_path):
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        code = npm_preflight.EXIT_AUTH
+        steps = [_echo_step("npm ci", code, tmp_path)]
+        rc = sync_runner.run_steps(steps, str(tmp_path), reserved, "Verify dependencies", 47)
+        # Demoted to a plain failure, not the reserved code.
+        assert rc == 1
+
+    def test_reserved_code_from_preflight_survives(self, tmp_path):
+        reserved = npm_preflight.RESERVED_EXIT_CODES
+        code = npm_preflight.EXIT_UNAVAILABLE
+        steps = [_echo_step("Verify dependencies", code, tmp_path)]
+        rc = sync_runner.run_steps(steps, str(tmp_path), reserved, "Verify dependencies", 47)
+        assert rc == code
+
+
+# --- the snapshot-not-import invariant ---------------------------------------
+
+
+def test_sync_runner_imports_only_stdlib():
+    """sync_runner is run BY PATH from a snapshot, so it must import nothing
+    from kiro_crew -- otherwise a by-path snapshot would drag the package chain
+    in and defeat the whole reason it is snapshotted."""
+    source = Path(sync_runner.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported += [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            # level>0 is a relative import (also forbidden); module may be None.
+            imported.append(node.module or ".")
+    offenders = [m for m in imported if m.split(".")[0] in {"kiro_crew", "kirocrew"}]
+    assert offenders == [], f"sync_runner must be stdlib-only, found: {offenders}"
+
+
+def test_main_refuses_a_steps_file_that_does_not_match_the_pinned_digest(tmp_path, capsys):
+    """main() verifies the steps file against the argv-pinned SHA-256.
+
+    argv is immutable once the process exists, so the digest pins the manifest
+    the gateway staged: a steps.json rewritten between staging and runner
+    startup fails the check and NOTHING runs -- the substituted step list never
+    reaches run_steps."""
+    steps_json = tmp_path / "steps.json"
+    steps_json.write_text("[]", encoding="utf-8")
+    import hashlib
+
+    good = hashlib.sha256(b"[]").hexdigest()
+    # Rewrite the file after the digest was pinned -- the attack shape.
+    steps_json.write_text('[{"argv": ["evil"], "env": {}, "label": "x"}]', "utf-8")
+    rc = sync_runner.main(
+        [
+            str(steps_json),
+            str(tmp_path),
+            "--reserved",
+            "41,42,46,47",
+            "--preflight-label",
+            "Verify dependencies",
+            "--exit-tree-ambiguous",
+            "46",
+            "--exit-restore-failed",
+            "47",
+            "--steps-sha256",
+            good,
+        ]
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "does not match the staged manifest" in out
+    assert "::step::" not in out  # nothing ran
+
+
+def test_main_runs_the_steps_from_a_file(tmp_path, capsys):
+    """main() reads steps from a FILE PATH and drives them, end to end."""
+    import sys
+
+    steps = [
+        {
+            "argv": [sys.executable, "-c", "import sys; sys.exit(0)"],
+            "env": dict(os.environ),
+            "label": "Pull",
+        }
+    ]
+    import hashlib
+    import json
+
+    payload = json.dumps(steps).encode("utf-8")
+    steps_json = tmp_path / "steps.json"
+    steps_json.write_bytes(payload)
+    reserved = ",".join(str(c) for c in sorted(npm_preflight.RESERVED_EXIT_CODES))
+    rc = sync_runner.main(
+        [
+            str(steps_json),
+            str(tmp_path),
+            "--reserved",
+            reserved,
+            "--preflight-label",
+            "Verify dependencies",
+            "--exit-tree-ambiguous",
+            str(npm_preflight.EXIT_TREE_AMBIGUOUS),
+            "--exit-restore-failed",
+            str(npm_preflight.EXIT_RESTORE_FAILED),
+            "--steps-sha256",
+            hashlib.sha256(payload).hexdigest(),
+        ]
+    )
+    assert rc == 0
+    assert "::step::0::Pull" in capsys.readouterr().out
+
+
+class TestBootstrap:
+    """EXECUTED coverage for the argv-pinned snapshot bootstrap.
+
+    The staged snapshot file is mutable between staging and exec while argv is
+    not, so the gateway runs the snapshot THROUGH a fixed ``-c`` bootstrap that
+    reads the file once, verifies its sha256 against the argv-pinned digest,
+    and compiles the same buffer. A snapshot rewritten in that window must be
+    refused with nothing executed.
+    """
+
+    def _bootstrap_cmd(self, snap, digest, *runner_args):
+        import sys as _sys
+
+        from kiro_crew.apps.builtins.dev_fleet.worktree_ops import (
+            _SYNC_RUNNER_BOOTSTRAP,
+        )
+
+        return [
+            _sys.executable,
+            "-I",
+            "-c",
+            _SYNC_RUNNER_BOOTSTRAP,
+            str(snap),
+            digest,
+            *runner_args,
+        ]
+
+    def test_verified_snapshot_executes_with_runner_argv(self, tmp_path):
+        import hashlib
+        import subprocess
+
+        payload = (
+            "import sys\n"
+            "print('ran-with:' + '|'.join(sys.argv[1:]))\n"
+            "print('file:' + __file__)\n"
+        ).encode("utf-8")
+        snap = tmp_path / "sync_runner.py"
+        snap.write_bytes(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+        proc = subprocess.run(  # nosec B603 - fixed argv, test-owned inputs
+            self._bootstrap_cmd(snap, digest, "steps.json", "/repo"),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert proc.returncode == 0, proc.stderr
+        # The bootstrap re-exposes the runner's own argv (sys.argv[3:]).
+        assert "ran-with:steps.json|/repo" in proc.stdout
+        # And the snapshot path is presented as __file__, like a by-path run.
+        assert "sync_runner.py" in proc.stdout
+
+    def test_tampered_snapshot_is_refused_and_nothing_runs(self, tmp_path):
+        import hashlib
+        import subprocess
+
+        staged = b"print('SHOULD NEVER RUN')\n"
+        snap = tmp_path / "sync_runner.py"
+        # Digest pinned for the STAGED bytes; the file is then rewritten, as a
+        # same-UID watcher racing the staging window would.
+        digest = hashlib.sha256(staged).hexdigest()
+        snap.write_bytes(b"print('INJECTED')\n")
+        proc = subprocess.run(  # nosec B603 - fixed argv, test-owned inputs
+            self._bootstrap_cmd(snap, digest),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert proc.returncode == 1
+        assert "does not match the staged source" in proc.stdout
+        assert "INJECTED" not in proc.stdout
+        assert "SHOULD NEVER RUN" not in proc.stdout

--- a/test/test_node_modules_txn.py
+++ b/test/test_node_modules_txn.py
@@ -765,24 +765,23 @@ class TestFailurePaths:
 def test_the_backup_suffix_matches_dev_fleets_runner() -> None:
     """The one agreement the two copies of this transaction must keep.
 
-    Dev Fleet's Pull+Build runs the same transaction from a generated
-    stdlib-only script that must NOT import kiro_crew, because it executes while
-    the repository is being merged underneath it. So the code cannot be shared --
-    but the backup PATH must be identical, or the two flows stop recognising each
-    other's leftovers: Dev Fleet would no longer heal a crashed update, and each
-    would see the other's backup as an unexplained directory.
+    Dev Fleet's Pull+Build runs the same transaction from a snapshotted
+    stdlib-only module (dev_fleet/sync_runner.py) that must NOT import
+    kiro_crew, because it executes while the repository is being merged
+    underneath it. So the code cannot be shared -- but the backup PATH must be
+    identical, or the two flows stop recognising each other's leftovers: Dev
+    Fleet would no longer heal a crashed update, and each would see the other's
+    backup as an unexplained directory.
+
+    The runner is a real module now, so this is a direct constant comparison
+    rather than the source-text grep the inline-script era needed. (Importing
+    it HERE is fine -- the no-kiro_crew-imports rule constrains what the runner
+    imports, not who imports the runner.)
     """
-    worktree_ops = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "kiro_crew"
-        / "apps"
-        / "builtins"
-        / "dev_fleet"
-        / "worktree_ops.py"
-    ).read_text(encoding="utf-8")
+    from kiro_crew.apps.builtins.dev_fleet.sync_runner import _BACKUP_SUFFIX
+
     assert BACKUP_SUFFIX == ".kirocrew-sync-backup"
-    assert f"'{BACKUP_SUFFIX}'" in worktree_ops, (
-        "dev_fleet/worktree_ops.py no longer spells this suffix; the two halves "
+    assert _BACKUP_SUFFIX == BACKUP_SUFFIX, (
+        "dev_fleet/sync_runner.py no longer spells this suffix; the two halves "
         "of the node_modules transaction have diverged"
     )

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -692,6 +692,15 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # carries resource_limit_preexec() — routing again here would nest
         # sandboxes. The chokepoint is applied at the call sites.
         "apps/builtins/dev_fleet/runtime.py::worker",
+        # The sync runner (the module worktree_ops's sync snapshots and runs by
+        # path) executes step argvs it reads from its steps_json input -- and
+        # every one of those argvs was ALREADY wrapped through
+        # sandboxed_spawn_argv (with per-step modes) by worktree_ops at
+        # composition time, before serialization. Routing again inside the
+        # runner would nest sandboxes, exactly as the runtime.py::worker entry
+        # above records for the outer spawn; the chokepoint is applied at the
+        # composition site.
+        "apps/builtins/dev_fleet/sync_runner.py::run_step",
         # Dev Fleet builtin backend: async version routes all git/gh through
         # _run_cmd which calls sandboxed_spawn_argv (the chokepoint). Only
         # _resolve_primary_checkout uses subprocess.run directly (one-shot


### PR DESCRIPTION
## Problem / Motivation

Dev Fleet's Pull + Build generates its step runner as a ~170-line Python program assembled from concatenated string literals in `worktree_ops.py` and executed via `[sys.executable, "-c", script]`. Since #6541 that script is a correctness-critical transaction manager: it moves `website/node_modules` aside, restores it on any non-zero step outcome, drops the backup on success, refuses when a tree and a leftover backup are both present, and demotes reserved diagnosis exit codes arriving from steps that are not the preflight. None of that is reachable by flake8, mypy, or black, and its tests can only string-match the source — the transaction whose whole point is not to lose a dependency tree is unreachable by an executing test.

## Why it matters

The next edit to the string block will not have the string-matching harness in mind, and a slip in the rename/restore logic re-creates exactly the `node_modules` data loss the script was written to prevent — silently, because no linter parses the block and no test executes it.

## What changed (motivation → approach → change)

Goal: make every branch of the runner a real function an executing test can drive against a real directory tree, without weakening the snapshot-not-import invariant.

Approach: mirror `npm_preflight.py`'s established discipline — the pattern the codebase already trusts for exactly this problem — rather than inventing a new one.

Change:
- **New `dev_fleet/sync_runner.py`**: stdlib-only module (imports nothing from `kiro_crew`). `reconcile_leftovers()` (pre-step recovery + the ambiguous-tree refusal), `NodeModulesTransaction` (move-aside/restore/drop as a context manager), `run_step()` (per-step `PYTHONIOENCODING` pin), `demote_reserved()` (the one-trusted-label gate), `run_steps()` (fail-fast loop + `::step::` markers), and a `main()` that takes the steps as a JSON **file path** plus the reserved codes / trusted label / diagnosis codes on the command line.
- **`runtime.py`**: `_SYNC_RUNNER_SOURCE` captured ONCE at import, beside `_PREFLIGHT_SOURCE`, same contract (refuse when unreadable).
- **`worktree_ops.py`**: the string-literal block is replaced by staging — snapshot the captured bytes into a private `mkdtemp`, write `steps.json` beside it, pin its sha256 in argv (a steps file rewritten after staging fails the check and nothing runs), and invoke the snapshot BY PATH under `-I`. Refusal (not a 500) when TMPDIR is unwritable, with the partial dir removed.

Running by path keeps the only parsed file one the launching interpreter already ran; `-m` would import from the working tree AFTER the merge landed, dragging the package `__init__` chain in with it.

This PR was originally reviewed against the pre-#7359 monolithic `server.py`; it is rebuilt here against the current seven-module layout (the extraction now lifts the script out of `worktree_ops.py`, and the source capture lives in `runtime.py`).

## Tests

- `test/test_dev_fleet_sync_runner.py` (new, 20 tests): drives every transaction branch against real directory trees — both-present refusal, backup-only adoption, restore on failure, drop on success, undeletable-backup note, symlinked/dangling trees through the `lexists` gates, reserved-code demotion, fail-fast ordering, the steps-file sha256 refusal, and EXECUTED coverage of the per-step `PYTHONIOENCODING` pin under a divergent inherited value.
- `test/test_dev_fleet_app.py`: the sync-composition tests now decode the staged `steps.json` and assert on the real step list and runner argv instead of script source text; source-text assertions whose mechanism moved to executed coverage now point at the module or at the composition contract.
- `test/test_spawn_audit.py`: `sync_runner.py::run_step` allowlisted — its argvs are already wrapped through `sandboxed_spawn_argv` at composition time; routing again would nest sandboxes.

450 tests green across the three files, plus the security-posture census (53).

## Manual verification

N/A — the runner module is executed as a real subprocess throughout `test_dev_fleet_sync_runner.py` (snapshot-by-path, `-I`, file-based steps), which is the integration surface.

## Related Issues

Fixes #6698

## Pattern harvest

Rule candidate: review-prompt
Pattern: "program assembled from string literals and passed to `python -c` — unlintable, untestable; extract to a snapshotted stdlib module run by path"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
