### PR TITLE
fix(dev-fleet): sync prune-drain test double with _worktree_remove signature

### DIFF
--- a/test/test_devfleet_prune_shutdown_drain.py
+++ b/test/test_devfleet_prune_shutdown_drain.py
@@ -80,7 +80,7 @@ async def _start_prune(monkeypatch, *, remove_impl):
     async def fake_find(nm):
         return {"path": f"/wt/{nm}", "branch": "feat/x"}, None
 
-    async def fake_remove(nm, *, force, progress, _caller):
+    async def fake_remove(nm, *, force, progress, _caller, discard_untracked_paths=None):
         entered.set()
         return await remove_impl()
 
@@ -212,7 +212,7 @@ async def test_cleanup_stays_pending_and_holds_lock_until_mutation_releases(monk
     async def fake_find(nm):
         return {"path": "/wt/wt-x", "branch": "feat/x"}, None
 
-    async def fake_remove(nm, *, force, progress, _caller):
+    async def fake_remove(nm, *, force, progress, _caller, discard_untracked_paths=None):
         # Mirror the production shape: hold _GIT_MUTATION_LOCK across the
         # uninterruptible destructive mutation.
         async with mod._GIT_MUTATION_LOCK:


### PR DESCRIPTION
## Problem / Motivation
`test/test_devfleet_prune_shutdown_drain.py` (added by #6717) fails on `main` itself: 3 of its 5 tests hit their 5s `asyncio` timeout on every platform, so **every open PR inherits a red Backend Tests shard 2** (and a failed Coverage Gate) via rebase. Fixes #6743.

## Why it matters
Main's own CI is red and all in-flight PRs are blocked on failures their diffs cannot cause. Until this lands, contributors either misdiagnose their PRs or burn re-rolls against an inherited failure.

## What changed (motivation → approach → change)
Reproduced at pristine `origin/main`: the prune worker crashes with `TypeError: fake_remove() got an unexpected keyword argument 'discard_untracked_paths'` — the tests' `fake_remove` doubles predate the `discard_untracked_paths` keyword that `_prune_one` now passes to `_worktree_remove` (a cross-merge: both contributing PRs were green on their own bases). The crash means the shutdown drain never observes completion, so the tests wait out their timeouts. Production code is correct; the doubles are stale. Change: both `fake_remove` stubs now accept `discard_untracked_paths=None` (keyword-only), mirroring the production signature they stand in for.

## Tests
- Before: `pytest test/test_devfleet_prune_shutdown_drain.py` → 3 failed (5.01s timeout each), 2 passed — at pristine `origin/main`.
- After: 5 passed in 0.5s; full `test/test_devfleet*.py` set → 12 passed.
- flake8 / isort / black clean on the touched file.

## Manual verification
Ran the failing trio under the repo venv at the exact main tip (`afc8be653`) to confirm red, then on this branch to confirm green; the captured worker log shows the `TypeError` disappearing with the stub fix.

## Screenshots / video
<!-- no-visual-delta --> Test-only change; no user-visible surface.

## Related Issues
Fixes #6743. Context: #6717 (introduced the tests), and the cross-merged change that added `discard_untracked_paths` to `_worktree_remove`.

## Checklist
- [x] Tests pass locally (5/5 in the file; 12/12 devfleet set)
- [x] Lint/format gates clean
- [x] One commit, conventional-commits subject
- [x] Issue linked (Fixes #6743)

## Contribution License Agreement
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
