### PR TITLE
fix(agents): route remaining kirocrew.json reads through the hardened spec reader (#6736)

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4891,9 +4891,17 @@ def _install_heartbeat_agent() -> None:
     # agent's ``--include-tools``/``--include-tool-tags``/``--exclude-tools``
     # filters so all read tools surface to the heartbeat agent — security is
     # enforced gateway-side against ``HEARTBEAT_SAFE_TOOLS`` via
-    # ``_heartbeat_approval``, not by per-agent MCP filtering.
-    main_config = _load_json(kiro_agents_dir_path() / AGENT_FILENAME)
-    main_mcp = main_config.get("mcpServers", {}) or {}
+    # ``_heartbeat_approval``, not by per-agent MCP filtering. Read through the
+    # capped reader (#6736): a refused main spec degrades as absent, but with an
+    # operator-visible signal, because the result is a heartbeat agent with no
+    # MCP servers -- a worker that fails every task.
+    main_path = kiro_agents_dir_path() / AGENT_FILENAME
+    main_config = _read_spec_capped(main_path)
+    if main_config is None and main_path.exists():
+        logger.warning(
+            "Main agent spec %s unusable; heartbeat agent installs with no MCP servers", main_path
+        )
+    main_mcp = (main_config or {}).get("mcpServers", {}) or {}
 
     _strip_flags = ("--include-tools", "--include-tool-tags", "--exclude-tools")
     mcp: dict[str, dict] = {}

--- a/src/kiro_crew/connections/mint.py
+++ b/src/kiro_crew/connections/mint.py
@@ -59,6 +59,7 @@ from uuid import uuid4
 # binding.
 from kiro_crew import agent as _agent
 from kiro_crew.acp.client import AcpClient
+from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.agent_files import AGENT_FILENAME, OWNED_KIRO_AGENT_FILES
 from kiro_crew.config.loader import data_home
 from kiro_crew.loop_lock import LoopBoundLock
@@ -359,11 +360,26 @@ def _write_mint_agent_spec(slug: str) -> tuple[str, str]:
     this provider's challenge, all of it on the path the card waits on.
 
     Falls back to the main agent name when ``slug`` has no entry in the main spec
-    yet, so a mint never ends up with FEWER servers than it needs.
+    yet, so a mint never ends up with FEWER servers than it needs. A main spec
+    that exists but is REFUSED by the hardened reader raises ``OSError`` instead:
+    the fallback would hand the refused file to the spawned child to reload.
     """
     agents_dir = _agent.kiro_agents_dir_path()
     alias = mcp_server_alias(slug)
-    entry = (_agent._load_json(agents_dir / AGENT_FILENAME).get("mcpServers") or {}).get(alias)
+    # Hardened reader (#6736). A REFUSED main spec (oversize, sensitive symlink,
+    # non-object) must NOT reach the main-agent fallback: that fallback spawns
+    # ``kiro-cli --agent kirocrew``, and the child would reload the very file the
+    # gateway just refused to read -- uncapped and unguarded. Raising instead
+    # lands in the mint flow's failure path (retryable ``failed`` row, holdings
+    # disposed, no child spawned). The fallback below stays reserved for what it
+    # always meant: the file or the alias entry being genuinely absent.
+    spec = _read_agent_spec(agents_dir / AGENT_FILENAME)
+    if spec is None:
+        if (agents_dir / AGENT_FILENAME).exists():
+            logger.warning("Main agent spec unusable; refusing to mint for %r", alias)
+            raise OSError("main agent spec unusable")
+        spec = {}
+    entry = (spec.get("mcpServers") or {}).get(alias)
     if not isinstance(entry, dict):
         logger.debug("No %r entry in the main agent spec; minting with %r", alias, _MAIN_AGENT_NAME)
         return _MAIN_AGENT_NAME, ""
@@ -808,7 +824,10 @@ def _agent_spec_entry_missing(slug: str) -> bool:
     through ``asyncio.to_thread``.
     """
     agents_dir = _agent.kiro_agents_dir_path()
-    servers = _agent._load_json(agents_dir / AGENT_FILENAME).get("mcpServers") or {}
+    # Hardened reader (#6736): a refused main spec reads as absent, so the entry
+    # counts as missing -- the same degrade-as-absent direction as before.
+    spec = _read_agent_spec(agents_dir / AGENT_FILENAME) or {}
+    servers = spec.get("mcpServers") or {}
     return mcp_server_alias(slug) not in servers
 
 

--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -14,6 +14,14 @@ observable without planting symlinks, mirroring #5423's tests. One
 representative symlink test proves the sensitive-target guard applies through
 a migrated caller; the guard itself lives in ``_read_agent_spec`` and has its
 own coverage.
+
+#6736 extends the migration to three more raw ``_load_json`` reads of
+``kirocrew.json`` (``mint._write_mint_agent_spec``,
+``mint._agent_spec_entry_missing``, ``agent._install_heartbeat_agent``); their
+classes below pin the same two properties per site. For those three sites only
+the ``oversized`` and symlink cases are differential against the old path
+(``_load_json`` already normalized a non-object root to ``{}``); the
+``non_object`` cases are kept as non-differential regression pins.
 """
 
 from __future__ import annotations
@@ -25,7 +33,9 @@ from unittest.mock import MagicMock
 import pytest
 from aiohttp import web
 
-from kiro_crew.agent import migrate_agent_specs
+from kiro_crew.agent import _install_heartbeat_agent, migrate_agent_specs
+from kiro_crew.agent_files import AGENT_FILENAME, HEARTBEAT_AGENT_FILENAME
+from kiro_crew.connections import mint
 from kiro_crew.dashboard.chat_persistence import _build_kiro_model_map
 from kiro_crew.dashboard.handlers.agents import (
     _namespaced_agent_file_exists,
@@ -291,3 +301,121 @@ class TestSensitiveSymlinkGuard:
         out = _build_kiro_model_map()
 
         assert "linked" not in out
+
+
+class TestWriteMintAgentSpec:
+    """connections.mint._write_mint_agent_spec -- the one-server mint spec (#6736).
+
+    A refused main spec must FAIL the mint (raise): the main-agent fallback
+    spawns ``kiro-cli --agent kirocrew``, and the child would reload the very
+    file the gateway just refused. The fallback stays reserved for a genuinely
+    absent file or alias entry. Under the old ``_load_json`` path an oversized
+    main spec was parsed and minted from.
+    """
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_main_spec_fails_the_mint(self, agents_dir, monkeypatch, kind):
+        # Stubbed for hermeticity: the refusal path never records a mint spec,
+        # but a regression that DID mint must not write a real manifest.
+        monkeypatch.setattr(mint, "_record_mint_spec", lambda spec_path: True)
+        alias = mint.mcp_server_alias("probe")
+        _plant_refused(agents_dir, AGENT_FILENAME, {"mcpServers": {alias: {"command": "x"}}}, kind)
+
+        with pytest.raises(OSError, match="main agent spec unusable"):
+            mint._write_mint_agent_spec("probe")
+
+    def test_absent_main_spec_still_falls_back_to_the_main_agent(self, agents_dir):
+        assert mint._write_mint_agent_spec("probe") == (mint._MAIN_AGENT_NAME, "")
+
+    def test_valid_main_spec_still_mints_under_the_same_cap(self, agents_dir, monkeypatch):
+        monkeypatch.setattr(mint, "_record_mint_spec", lambda spec_path: True)
+        alias = mint.mcp_server_alias("probe")
+        _plant(agents_dir, AGENT_FILENAME, {"mcpServers": {alias: {"command": "x"}}})
+
+        name, path = mint._write_mint_agent_spec("probe")
+
+        # Names carry a per-mint random suffix; pin the stable properties:
+        # a real (non-fallback) mint whose file matches the returned name.
+        assert name != mint._MAIN_AGENT_NAME
+        assert path == str(agents_dir / f"{name}.json")
+        written = json.loads(Path(path).read_text(encoding="utf-8"))
+        assert written["mcpServers"] == {alias: {"command": "x"}}
+
+
+class TestAgentSpecEntryMissing:
+    """connections.mint._agent_spec_entry_missing -- the concurrent-uninstall probe (#6736).
+
+    A refused main spec reads as absent, so the entry counts as missing; the old
+    path PARSED an oversized spec and reported the entry present.
+    """
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_main_spec_reads_as_entry_missing(self, agents_dir, kind):
+        alias = mint.mcp_server_alias("probe")
+        _plant_refused(agents_dir, AGENT_FILENAME, {"mcpServers": {alias: {"command": "x"}}}, kind)
+
+        assert mint._agent_spec_entry_missing("probe") is True
+
+    def test_valid_main_spec_entry_still_found_under_the_same_cap(self, agents_dir):
+        alias = mint.mcp_server_alias("probe")
+        _plant(agents_dir, AGENT_FILENAME, {"mcpServers": {alias: {"command": "x"}}})
+
+        assert mint._agent_spec_entry_missing("probe") is False
+
+    def test_link_to_a_sensitive_target_reads_as_entry_missing(self, tmp_path, monkeypatch):
+        """The sensitive-symlink guard flows through a migrated mint caller."""
+        from kiro_crew import agent_discovery
+
+        alias = mint.mcp_server_alias("probe")
+        target = tmp_path / "protected.json"
+        target.write_text(json.dumps({"mcpServers": {alias: {"command": "x"}}}), encoding="utf-8")
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / AGENT_FILENAME).symlink_to(target)
+        monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda p: str(target) in str(p))
+        monkeypatch.setattr("kiro_crew.agent.KIRO_AGENTS_DIR", agents)
+
+        assert mint._agent_spec_entry_missing("probe") is True
+
+
+class TestInstallHeartbeatAgent:
+    """agent._install_heartbeat_agent -- the main-config mcpServers pull (#6736).
+
+    A refused main spec contributes no MCP entries (the heartbeat agent installs
+    with an empty toolset, same as when the main entry does not exist yet); the
+    old path parsed an oversized main spec and copied its entry through.
+    """
+
+    @pytest.fixture
+    def heartbeat_env(self, monkeypatch):
+        """Keep the install local: no config load, no cc-model sidecar write."""
+        monkeypatch.setattr("kiro_crew.agent._background_agent_model", lambda: "auto")
+        monkeypatch.setattr("kiro_crew.agent.agent_state.set_cc_model", lambda *a, **k: None)
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_main_spec_yields_no_mcp_servers(self, agents_dir, heartbeat_env, kind):
+        _plant_refused(
+            agents_dir,
+            AGENT_FILENAME,
+            {"mcpServers": {"kirocrew-core": {"command": "x"}}},
+            kind,
+        )
+
+        _install_heartbeat_agent()
+
+        written = json.loads((agents_dir / HEARTBEAT_AGENT_FILENAME).read_text(encoding="utf-8"))
+        assert written["mcpServers"] == {}
+        assert written["tools"] == []
+
+    def test_valid_main_spec_still_feeds_the_heartbeat_agent(self, agents_dir, heartbeat_env):
+        _plant(
+            agents_dir,
+            AGENT_FILENAME,
+            {"mcpServers": {"kirocrew-core": {"command": "x", "args": ["--include-tools", "a"]}}},
+        )
+
+        _install_heartbeat_agent()
+
+        written = json.loads((agents_dir / HEARTBEAT_AGENT_FILENAME).read_text(encoding="utf-8"))
+        assert written["mcpServers"]["kirocrew-core"]["args"] == []
+        assert written["tools"] == ["@kirocrew-core"]


### PR DESCRIPTION
## What is the problem?

Three reads of the user-writable, tool-shared `kirocrew.json` (`agents_dir / AGENT_FILENAME`) still went through `_agent._load_json` instead of the hardened `agent_discovery._read_agent_spec` reader the project converged on across #5423 / #6695 / #6726 / #6723:

- `src/kiro_crew/connections/mint.py` `_write_mint_agent_spec` -- picks the one server a mint spec carries
- `src/kiro_crew/connections/mint.py` `_agent_spec_entry_missing` -- the concurrent-uninstall probe
- `src/kiro_crew/agent.py` `_install_heartbeat_agent` -- pulls the `kirocrew-core` entry for the heartbeat agent

`_load_json` never raises and normalizes to `{}`, but it has no size cap, no sensitive-symlink screen, and emits no SEL denied event -- the exact gap class #6695/#6726 closed elsewhere. The `agent.py` site was previously blocked inside PR #6723's file span; #6723 is merged, unblocking it.

## Why it matters to the user

The agents directory is user-writable and shared with other tools. Through these three paths, a multi-gigabyte "agent config" was slurped into memory during a mint or a heartbeat-agent install, and a symlink whose resolved target is sensitive (`kirocrew.json -> ~/.aws/credentials`) was followed and parsed with no audit signal. `_read_agent_spec` refuses both (plus non-UTF-8, AppleDouble sidecars, and non-object JSON) and logs a SEL `denied` event for the sensitive-symlink case.

## How the fix solves it

Each site now reads through the hardened reader. The two pure-read probes preserve the existing degrade-as-absent contract (`_read_agent_spec(path) or {}` where `_load_json` returned `{}`); the mint spec-writer deliberately does NOT:

- `_write_mint_agent_spec`: **fails closed**. A main spec that exists but is refused raises `OSError` -- the pre-push GPT lane showed the draft fallback ("mint with the main agent") would hand the refused file to the spawned `kiro-cli --agent kirocrew` child, which reloads it uncapped and unguarded. The raise lands in the mint flow's existing `except Exception` failure path (retryable `failed` row, holdings disposed, no child spawned), with an operator-visible `warning`. The main-agent fallback stays reserved for what it always meant: a genuinely absent file or alias entry.
- `_agent_spec_entry_missing`: a refused spec reads as entry-missing, same fail direction as before.
- `_install_heartbeat_agent`: reads via the in-file `_read_spec_capped` wrapper (same as the other two `agent.py` sites), with a `warning` when the file exists but was refused -- the result is a heartbeat agent with no MCP servers, which an operator should be able to see above debug level.

## What tests we did

- Extended `test/test_agent_spec_hardened_reads.py` with three classes (one per migrated site) mirroring #6695/#6723's pattern: each pins that a refused spec degrades as absent and that a valid spec is unaffected under the same cap, plus one sensitive-symlink test flowing through a migrated mint caller. 32/32 pass on the branch.
- A/B differential: with the branch's tests against **main's** `src`, the 4 differential cases (oversized x3 + sensitive symlink) FAIL -- proving the old path parsed/followed what the new path refuses. The `non_object` cases are non-differential (old `_load_json` also normalized a non-dict root) and are kept as regression pins; the test module docstring says so explicitly.
- The Opus pre-push lane additionally mutation-verified: reverting each site to `_load_json` reddens one test per site plus the symlink case.
- Gates: `isort` clean, `flake8` clean, `mypy` clean (1169 files), full `pytest` run -- all failures (91) reproduce byte-identically on pristine main `src` in the same environment (AF_UNIX path-length and app-fixture env issues in `test_file_explorer_app` / `test_design_tweak_backend` / `test_host_isolation_floor` etc.), zero branch-owned.

## Any other suggestions

Four more raw reads of the same file remain, deliberately NOT in this diff:

- `agent.py` `_sanitize_agent_hooks` is a read-modify-write path, explicitly out of scope per the issue (fail-direction inversion risk).
- `dashboard/handlers/mcp.py` `_find_server_spec_anywhere` reads via `_load_json_or_empty` (no cap, no symlink guard, hardcoded filename literal).
- `cron_script.py` `_resolve_mcp_server` and `dashboard/handlers/hooks.py` `api_kiro_hooks` read via raw `json.loads(read_text())` (no cap, no symlink guard) -- identified by the First Principles lane on this PR.

All except the first (which the issue itself scopes out) are recorded in the local backlog to be filed/fixed separately rather than growing this PR past its spec'd three sites.

Closes #6736
