### PR TITLE
test(dev-fleet): match the prune-shutdown fakes to the current remove signature

### DIFF
--- a/test/test_devfleet_prune_shutdown_drain.py
+++ b/test/test_devfleet_prune_shutdown_drain.py
@@ -80,7 +80,11 @@ async def _start_prune(monkeypatch, *, remove_impl):
     async def fake_find(nm):
         return {"path": f"/wt/{nm}", "branch": "feat/x"}, None
 
-    async def fake_remove(nm, *, force, progress, _caller):
+    async def fake_remove(nm, *, force, progress, _caller, **_kw):
+        # ``**_kw`` absorbs any keyword the production ``_worktree_remove`` gains
+        # (e.g. ``discard_untracked_paths``) so a call-site signature change can
+        # never silently make the item fail before ``entered`` is set and hang
+        # the test on ``entered.wait()``.
         entered.set()
         return await remove_impl()
 
@@ -212,7 +216,9 @@ async def test_cleanup_stays_pending_and_holds_lock_until_mutation_releases(monk
     async def fake_find(nm):
         return {"path": "/wt/wt-x", "branch": "feat/x"}, None
 
-    async def fake_remove(nm, *, force, progress, _caller):
+    async def fake_remove(nm, *, force, progress, _caller, **_kw):
+        # ``**_kw`` future-proofs against production signature drift (see the
+        # note on the fake in _start_prune).
         # Mirror the production shape: hold _GIT_MUTATION_LOCK across the
         # uninterruptible destructive mutation.
         async with mod._GIT_MUTATION_LOCK:


### PR DESCRIPTION
## Problem / Motivation

`test/test_devfleet_prune_shutdown_drain.py` has three tests that fail deterministically on pristine `main`, so the breakage is inherited by every branch:

- `test_worker_is_retained`
- `test_cleanup_drains_prune_worker_and_clears_handle`
- `test_cleanup_stays_pending_and_holds_lock_until_mutation_releases`

Each fails with `asyncio.TimeoutError` after the 5s test timeout, on both `ubuntu-3.10` and `Windows` shard 2 (and single-process locally).

## Why it matters

The `TimeoutError` is a symptom. `_prune_one` now calls `_worktree_remove(..., discard_untracked_paths=...)`, but the tests stub `_worktree_remove` with fakes whose signature is `(nm, *, force, progress, _caller)`. Every stubbed call raises `TypeError: unexpected keyword argument 'discard_untracked_paths'`; `_prune_one` catches it in its `except Exception`, finalizes the item as failed, and never reaches the fake's `entered.set()`. The three tests that drive a prune through `_prune_run` then hang on `await asyncio.wait_for(entered.wait(), timeout=5.0)`. Because it fails on `main`, it reds CI for the whole repo.

## What changed (motivation → approach → change)

- **Symptom:** three drain tests time out at 5s on `main`.
- **Root cause:** the test fakes for `_worktree_remove` are missing the `discard_untracked_paths` keyword the production call site now passes, so each stubbed call raises before the fake signals readiness.
- **Change:** widen both `fake_remove` stubs from `(nm, *, force, progress, _caller)` to `(nm, *, force, progress, _caller, **_kw)`. The `**_kw` accepts the current keyword and absorbs any future one, so a call-site signature change can no longer silently make the item fail before the fake signals and wedge the wait. Timeouts are left untouched (raising them would only mask the crash); no arbitrary sleeps are added.

No production code changes — the cancellation-drain invariant and its assertions are untouched.

## Tests

`test/test_devfleet_prune_shutdown_drain.py` now passes in full (5 tests), single-process and under `pytest -n2/-n4 --dist loadgroup`, completing in ~0.5s instead of timing out at 5s. Combined Dev Fleet shutdown/remove/prune suites (342 tests) pass under `-n4`.

## Manual verification

N/A — unit coverage is sufficient; the fix is a test-stub signature change fully exercised by the affected async tests.

## Related Issues

Fixes #6743

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
