### PR TITLE
docs: record ChatEmbed plan-action exclusion with a pinning test (#6057)

### DIFF
--- a/website/src/app-sdk/ChatEmbed.tsx
+++ b/website/src/app-sdk/ChatEmbed.tsx
@@ -91,7 +91,30 @@ function ChatEmbed({ slotKey, agent, placeholder, frameless, startAtBottom, onSe
   /** Derived from the same helper the main chat and side panel use, so "options only
    *  after the answer settles" and "a later user message clears them" behave identically
    *  here too — an agent's follow-up choices should never be silently dropped just
-   *  because the surface embedding them is thinner. */
+   *  because the surface embedding them is thinner.
+   *
+   *  `followUpIsPlan` is DELIBERATELY dropped here (#6057): this embed is not a
+   *  plan-capable host, so a plan-shaped chip stays on the composer-draft path
+   *  instead of dispatching POST /api/chat/slots/{slot}/plan-action. Why that is
+   *  a recorded exclusion rather than a live mis-dispatch:
+   *  - The slot-detail payload this embed polls carries no `mode` field, so the
+   *    embed structurally lacks the orchestrator-mode gate the dispatch path
+   *    requires (ChatPane/ChatPage read the slot record's mode before
+   *    dispatching; there is no equivalent source here).
+   *  - Exposure is narrow: `api_chat_slot_detail` runs
+   *    `_deny_cross_app_slot_access`, so an app-token embed 404s on any foreign
+   *    or unscoped slot. That proves "not another surface's slot", not "never a
+   *    plan-bearing slot" — an app could create and embed its own
+   *    orchestrator-mode slot, which is exactly why the missing mode field
+   *    above, not the ownership guard, carries the exclusion.
+   *  - On hosts that DO dispatch, the `isPlanAction` allowlist keeps
+   *    non-protocol plan-shaped labels on the composer path; this file never
+   *    consults it because it never dispatches.
+   *  SideChat makes the same exclusion, silently — it also destructures only
+   *  `followUpOptions`, with no record there. If dashboard-token embeds ever
+   *  need working plan chips, the parity option is wiring `usePlanActionMutation`
+   *  plus a mode source into this file — a product decision, not an oversight.
+   *  Pinned by the plan-exclusion test in src/test/ChatEmbed.test.tsx. */
   const { followUpOptions } = useMemo(
     () => deriveFollowUpOptions(messages, running),
     [messages, running]

--- a/website/src/test/ChatEmbed.test.tsx
+++ b/website/src/test/ChatEmbed.test.tsx
@@ -49,6 +49,9 @@ vi.mock('../app-sdk/ChatMessageList', () => ({
 }))
 
 import ChatEmbed from '../app-sdk/ChatEmbed'
+import { deriveFollowUpOptions } from '../app-sdk/protocol'
+import { api } from '../api/client'
+import type { ChatMessage } from '../types'
 
 let queryClient: QueryClient
 
@@ -573,6 +576,57 @@ describe('ChatEmbed follow-up options', () => {
       vi.advanceTimersByTime(250)
     })
     expect(input.value).toBe('')
+  })
+
+  // Pins the deliberate exclusion recorded at ChatEmbed's deriveFollowUpOptions
+  // destructure (#6057): this embed is NOT a plan-capable host. A message whose
+  // derivation yields followUpIsPlan=true still keeps its chips on the
+  // composer-draft path. Inverse of the ChatPane/ChatPage dispatch tests (same
+  // plan fixture: header + stage line + protocol footer, which is what makes
+  // parseOptions set isPlan).
+  it('a plan-shaped chip edits the draft and never dispatches a plan action', async () => {
+    const planMessages = [
+      { role: 'user', content: 'plan it' },
+      { role: 'assistant', content: '📋 Plan for: ship it\n\nStage 1: build the thing\n\n[OPTION: Go | Go All | Cancel]' },
+    ]
+    // Premise pin: the fixture MUST derive as a plan, or this test silently
+    // degrades into a duplicate of the plain follow-up test above while staying
+    // green (e.g. if the plan grammar tightens and only this copy drifts).
+    expect(deriveFollowUpOptions(planMessages as ChatMessage[], false).followUpIsPlan).toBe(true)
+    // Plan dispatch, wherever it is wired, goes through the global api client's
+    // planAction (usePlanActionMutation) -- NOT the useAppApi() object mocked as
+    // mockPost. Spy the real transport so a future wiring that dispatches AND
+    // fills the draft cannot sail through green. Stubbed (not call-through) so
+    // that failing case surfaces as this test's own assertion, not as an
+    // unhandled rejection from a real fetch under jsdom.
+    const planActionSpy = vi.spyOn(api, 'planAction').mockResolvedValue({ ok: true })
+
+    mockGet.mockResolvedValue({ messages: planMessages, running: false, title: '' })
+    await act(async () => {
+      renderWithProviders(<ChatEmbed slotKey="slot-plan-1" />)
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    const input = screen.getByLabelText('Chat message') as HTMLInputElement
+    expect(screen.getByText('Go')).toBeInTheDocument()
+
+    // Chip clicks are debounced 220ms (so a double-click can still fire the
+    // distinct "send now" gesture) whenever onSend is supplied, as it is here.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Go'))
+      vi.advanceTimersByTime(250)
+    })
+
+    // Composer-draft path: the label lands in the input, exactly like a plain
+    // follow-up chip. This is the load-bearing assertion -- a dispatch branch
+    // returns before the draft append (per ChatPane), so wiring dispatch into
+    // this path would red this line.
+    expect(input.value).toBe('Go')
+    // And no dispatch on either client: not the embed's own API surface, not
+    // the global client's plan-action transport.
+    expect(mockPost).not.toHaveBeenCalled()
+    expect(planActionSpy).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Problem / Motivation

`deriveFollowUpOptions` returns `followUpIsPlan` on every branch, but `ChatEmbed` destructures only `{ followUpOptions }`, silently dropping it. After #6040 wired plan-action dispatch into ChatPane and ChatPage, ChatEmbed was the one follow-up-rendering host left unsettled: is the drop a defect (same class as #5893) or a deliberate exclusion? Issue #6057 asks to settle and record it.

## Why it matters

An unrecorded drop is indistinguishable from an oversight. The next contributor auditing plan-chip coverage either wastes an investigation re-deriving why ChatEmbed is safe, or "fixes" it by wiring dispatch into a surface that structurally lacks the mode gate the dispatch path requires — reintroducing exactly the ambiguity #6040 closed elsewhere.

## What changed (motivation → approach → change)

Re-triage on main verified the defect is **latent, not live**, so this takes the issue's own "if not reachable, record it" branch (Path A) — a documentation-plus-pin change, deliberately NOT the full parity wiring (Path B):

- **Comment** at the `deriveFollowUpOptions` destructure in `website/src/app-sdk/ChatEmbed.tsx` recording the exclusion and why it holds: the slot-detail payload this embed polls carries no `mode` field (so the embed structurally lacks the orchestrator-mode gate ChatPane/ChatPage consult before dispatching), and `_deny_cross_app_slot_access` narrows exposure by 404ing app-token embeds on any foreign or unscoped slot. The comment is explicit that the ownership guard alone does not rule out a plan-bearing slot (an app could embed its own orchestrator-mode slot) — the missing mode source is what carries the exclusion. SideChat makes the same exclusion silently; that is stated truthfully rather than claimed as a recorded precedent.
- **Pinning test** in `website/src/test/ChatEmbed.test.tsx` asserting a plan-shaped chip stays on the composer-draft path. It pins its own premise (`deriveFollowUpOptions(fixture).followUpIsPlan === true`, so grammar/fixture drift fails loudly instead of degrading the test into a duplicate of the plain-chip case) and spies the global api client's `planAction` — the transport a future dispatch wiring would actually use — so a wiring that dispatches AND fills the draft cannot pass.

**Path B remains the future parity option**: if dashboard-token embeds ever need working plan chips, the wiring is `usePlanActionMutation` plus a mode source in ChatEmbed. That is a product decision nobody has asked for, and this PR deliberately does not make it (no mode field added to the endpoint, no `usePlanActionMutation` import, SideChat untouched).

### Pre-push adversarial review

Two rounds, two model-pinned blind lanes (GPT + Opus mirrors) per round. Round 1: BLOCK/BLOCK — 4 convergent actionable findings, all fixed (overbroad ownership-guard claim rescoped; false "SideChat records the same exclusion" corrected to "silently makes"; premise assertion added; dead same-mock URL-filter assertion replaced with a real-transport spy). Round 2: PASS/PASS, one Low advisory adopted (spy stubbed so the failing case surfaces as an assertion, not an unhandled rejection).

## Tests

- `a plan-shaped chip edits the draft and never dispatches a plan action` (`website/src/test/ChatEmbed.test.tsx`) — locks in: (1) the fixture genuinely derives `followUpIsPlan=true`; (2) clicking the chip lands the label in the composer draft; (3) no call on the embed's own API surface; (4) no call on `api.planAction`, the global-client transport plan dispatch uses.
- Full file re-run green: 35/35 (`npx vitest run src/test/ChatEmbed.test.tsx`), plus `ChatEmbed.frameless` and `ChatEmbed.approvalRollback` suites. `npx tsc -b` clean, eslint 0 errors, brand gate green.

## Manual verification

N/A — unit coverage sufficient: the change is a comment plus a test; no runtime behavior changes.

## Screenshots / video

No UI change, no screenshots — comment + test only, zero visual delta.

## Related Issues

Closes #6057

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the recorded exclusion IS the documentation
- [x] No secrets, credentials, or internal references in the diff
