### PR TITLE
fix: warn when an agent-discovery scan parses zero of N candidate specs (#6727)

### DIFF
--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -198,6 +198,28 @@ def _read_agent_spec(path: Path) -> dict[str, Any] | None:
     return data
 
 
+def _warn_on_systematic_scan_failure(directory: Path, candidates: int, parsed: int) -> None:
+    """Emit ONE warning when a scan rejected every candidate spec it saw.
+
+    :func:`_read_agent_spec` deliberately degrades per file to ``None`` at debug
+    level — callers depend on that contract. The cost is that a SYSTEMATIC
+    failure (every spec in a scope unreadable for the same reason, e.g. the
+    trusted-root gate refusing an entire home layout) is indistinguishable at
+    default log levels from an empty agents directory: discovery lists nothing,
+    model resolution silently falls back, and nothing says why. This scan-level
+    check makes that case visible without touching the per-file contract: one
+    warning per scan invocation (the rate limit), none when the directory is
+    empty (N=0 is not failure) or when at least one spec parsed.
+    """
+    if candidates > 0 and parsed == 0:
+        logger.warning(
+            "agent discovery: read %d candidate spec file(s) under %s but parsed 0 — "
+            "all were unreadable or rejected; enable debug logging for per-file reasons",
+            candidates,
+            directory,
+        )
+
+
 def project_agent_files(
     project_dir: str | Path | None,
     include_legacy: bool = False,
@@ -327,14 +349,20 @@ def project_agent_names(project_dir: str | Path | None) -> frozenset[str]:
     cached = _PROJECT_NAMES_CACHE.get(key)
     if cached is not None and cached[0] == signature:
         return cached[1]
-    names = frozenset(
-        name
-        for f in project_agent_files(project_dir)
+    candidates = 0
+    declared: list[str] = []
+    for f in project_agent_files(project_dir):
+        # AppleDouble sidecars are rejected by design, not by failure — a
+        # directory holding only sidecars is empty of specs, not broken.
+        if not f.name.startswith("._"):
+            candidates += 1
         # Only a spec that parses contributes: a malformed or unreadable file can
         # never become a kiro-cli mode, and admitting its filename fallback here
         # would have dispatch accept a name whose session/set_mode then fails.
-        if (name := _declared_project_agent_name(f)) is not None
-    )
+        if (name := _declared_project_agent_name(f)) is not None:
+            declared.append(name)
+    _warn_on_systematic_scan_failure(project_agents_dir(project_dir), candidates, len(declared))
+    names = frozenset(declared)
     _PROJECT_NAMES_CACHE[key] = (signature, names)
     return names
 
@@ -768,15 +796,27 @@ def list_agents(
     agents: list[AgentInfo] = []
 
     if d.is_dir():
+        user_candidates = 0
+        user_parsed = 0
         for f in sorted(d.glob("*.json")):
+            # AppleDouble sidecars are rejected by design, not by failure — a
+            # directory holding only sidecars is empty of specs, not broken.
+            if not f.name.startswith("._"):
+                user_candidates += 1
             try:
                 data = _read_agent_spec(f)
                 if data is None:
                     continue
                 agents.append(_global_agent_info(f, data))
+                # Counted AFTER the append: a spec that parses but whose row
+                # construction raises into the handler below still ends in
+                # "discovery listed nothing", which is exactly what the
+                # systematic-failure warning exists to surface.
+                user_parsed += 1
             except Exception:
                 logger.debug("Skipping invalid agent config: %s", f)
                 continue
+        _warn_on_systematic_scan_failure(d, user_candidates, user_parsed)
 
     # Deduplicate by name — prefer package-installed (has package) over fallback
     seen: dict[str, AgentInfo] = {}
@@ -818,7 +858,11 @@ def list_agents(
     # dir as cwd, so the project entry is what would actually run. The warning
     # mirrors kiro-cli's own conflict notice — shadowing is correct here, silent
     # shadowing is not, because the two configs can differ in tools and permissions.
+    project_candidates = 0
+    project_parsed = 0
     for pf in project_files:
+        if not pf.name.startswith("._"):
+            project_candidates += 1
         try:
             data = _read_agent_spec(pf)
             if data is None:
@@ -833,9 +877,14 @@ def list_agents(
                     shadowed.filename,
                 )
             seen[info.name] = info
+            project_parsed += 1
         except Exception:
             logger.debug("Skipping invalid project agent config: %s", pf)
             continue
+    if project_dir:  # type narrowing only; without it candidates is 0 anyway
+        _warn_on_systematic_scan_failure(
+            project_agents_dir(project_dir), project_candidates, project_parsed
+        )
 
     result = list(seen.values())
     _LIST_AGENTS_CACHE[cache_key] = (signature, result)

--- a/test/test_agent_discovery.py
+++ b/test/test_agent_discovery.py
@@ -842,3 +842,129 @@ class TestListAgentsCache:
         # ... then force a clear: the next call must re-scan and see "v2".
         clear_list_agents_cache()
         assert [a.name for a in list_agents(agents_dir=d)] == ["v2"]
+
+
+def _discovery_warnings(caplog):
+    """WARNING+ records from the discovery logger about a systematic scan failure.
+
+    Filtered by logger name per the module-top note, and by message so the
+    pre-existing shadowing/duplicate warnings never contaminate the count.
+    """
+    return [
+        r
+        for r in caplog.records
+        if r.name == _DISCOVERY_LOGGER
+        and r.levelno >= logging.WARNING
+        and "parsed 0" in r.getMessage()
+    ]
+
+
+class TestSystematicScanFailureWarning:
+    """A scan that rejects EVERY candidate spec warns once; anything less stays quiet.
+
+    Regression: `_read_agent_spec` degrades per file to ``None`` at debug level, so
+    a systematic refusal (e.g. the trusted-root gate rejecting an entire home
+    layout, issue #6721) was indistinguishable at default log levels from an empty
+    agents directory — discovery listed nothing and nothing said why (#6727).
+    """
+
+    def test_all_unreadable_user_specs_emit_one_warning(self, fake_home, caplog):
+        d = _agents_dir(fake_home)
+        for i in range(3):
+            (d / f"broken-{i}.json").write_bytes(b"\xff\xfe\x00\x01\xa3")
+        clear_list_agents_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            assert list_agents(agents_dir=d) == []
+        warnings = _discovery_warnings(caplog)
+        assert len(warnings) == 1, "exactly one warning per scan, not per file"
+        # Count asserted via the record's args: a digit-in-string match is
+        # satisfiable by digits in the pytest tmp path.
+        assert warnings[0].args[0] == 3
+        assert str(d) in warnings[0].getMessage()
+
+    def test_mixed_directory_emits_no_warning(self, fake_home, caplog):
+        d = _agents_dir(fake_home)
+        (d / "good.json").write_text(json.dumps({"name": "good"}))
+        (d / "broken.json").write_bytes(b"\xff\xfe\x00\x01\xa3")
+        clear_list_agents_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            names = [a.name for a in list_agents(agents_dir=d)]
+        assert names == ["good"]
+        assert _discovery_warnings(caplog) == []
+
+    def test_empty_and_absent_directories_emit_no_warning(self, fake_home, caplog):
+        empty = _agents_dir(fake_home)
+        absent = fake_home / "nowhere" / "agents"
+        clear_list_agents_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            assert list_agents(agents_dir=empty) == []
+            clear_list_agents_cache()
+            assert list_agents(agents_dir=absent) == []
+        assert _discovery_warnings(caplog) == [], "N=0 is not systematic failure"
+
+    def test_all_unreadable_project_specs_emit_one_warning(self, fake_home, tmp_path, caplog):
+        d = _agents_dir(fake_home)
+        proj = tmp_path / "repo"
+        pd = _project_agents_dir(proj)
+        (pd / "bad-a.json").write_text("not json at all")
+        (pd / "bad-b.json").write_text(json.dumps(["top-level", "array"]))
+        clear_list_agents_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            assert list_agents(agents_dir=d, project_dir=str(proj)) == []
+        warnings = _discovery_warnings(caplog)
+        assert len(warnings) == 1
+        assert warnings[0].args[0] == 2
+        assert str(pd) in warnings[0].getMessage()
+
+    def test_project_agent_names_warns_on_systematic_failure(self, tmp_path, caplog):
+        """The per-turn resolver's scan warns too — this is the exact path whose
+        silence let model resolution fall back to auto in #6721."""
+        proj = tmp_path / "repo"
+        pd = _project_agents_dir(proj)
+        (pd / "bad.json").write_text("{broken")
+        clear_project_agent_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            assert project_agent_names(str(proj)) == frozenset()
+        warnings = _discovery_warnings(caplog)
+        assert len(warnings) == 1
+        assert str(pd) in warnings[0].getMessage()
+
+    def test_project_agent_names_mixed_directory_emits_no_warning(self, tmp_path, caplog):
+        proj = tmp_path / "repo"
+        pd = _project_agents_dir(proj)
+        (pd / "good.json").write_text(json.dumps({"name": "good"}))
+        (pd / "bad.json").write_text("{broken")
+        clear_project_agent_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            assert project_agent_names(str(proj)) == frozenset({"good"})
+        assert _discovery_warnings(caplog) == []
+
+    def test_sidecar_only_directory_emits_no_warning(self, fake_home, caplog):
+        """AppleDouble sidecars are rejected by design, not by failure — a
+        directory holding only ``._*.json`` is empty of specs, not broken."""
+        d = _agents_dir(fake_home)
+        (d / "._ghost.json").write_bytes(b"\x02\x00\x00\x00\xa3\x80\x81 not utf-8")
+        clear_list_agents_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            assert list_agents(agents_dir=d) == []
+        assert _discovery_warnings(caplog) == []
+
+    def test_row_construction_failure_counts_as_unparsed(self, fake_home, caplog, monkeypatch):
+        """A spec that parses but whose row construction raises still ends in
+        "discovery listed nothing" — the warning must cover that path too, so
+        the parsed counter means "produced a row", not "JSON loaded"."""
+        import kiro_crew.agent_discovery as mod
+
+        d = _agents_dir(fake_home)
+        (d / "parses.json").write_text(json.dumps({"name": "parses"}))
+
+        def _boom(f, data):
+            raise RuntimeError("row construction failed")
+
+        monkeypatch.setattr(mod, "_global_agent_info", _boom)
+        clear_list_agents_cache()
+        with caplog.at_level(logging.WARNING, logger=_DISCOVERY_LOGGER):
+            assert list_agents(agents_dir=d) == []
+        warnings = _discovery_warnings(caplog)
+        assert len(warnings) == 1
+        assert warnings[0].args[0] == 1


### PR DESCRIPTION
## Problem / Motivation

`_read_agent_spec` returns `None` for every unreadable spec with only a `logger.debug` line: the `safe_read_file_bytes` gate refusal, Unicode/JSON decode failures, and non-object payloads all degrade identically and silently at default log levels. Every consumer treats `None` as "no spec", so a SYSTEMATIC refusal (every spec in a scope unreadable for the same reason) is indistinguishable from an empty agents directory.

## Why it matters

Issue #6721 (Windows UNC roaming-profile home: the trusted-root gate refused every spec read) demonstrated the cost: user-scope discovery listed nothing, model resolution silently fell back to auto, and the boot-time spec migration never ran — with nothing in the log at default levels saying why. That gate bug is fixed; this is the observability follow-up deliberately kept out of that PR's scope.

## What changed (motivation → approach → change)

Symptom: a whole failure class hides behind per-file debug lines. Root cause: the per-file `None`-on-unreadable contract is load-bearing (callers depend on it), so no single file read can distinguish "this file is broken" from "everything is broken". The right layer is the scan: it alone sees N candidates in and 0 specs out.

- New `_warn_on_systematic_scan_failure(directory, candidates, parsed)`: emits ONE `logger.warning` per scan invocation when a scan saw N>0 candidate files and parsed 0, naming the directory and the count and pointing at debug logging for per-file reasons. One warning per scan, not per file, is the rate limit; result caching naturally suppresses repeats while the directory signature is unchanged.
- Wired into the three discovery scans that iterate candidates through `_read_agent_spec`: the user-scope and project scan loops in `list_agents`, and `project_agent_names` (the per-turn resolver path whose silence produced #6721's auto fallback).
- `parsed` counts rows actually produced (incremented after `append`/`seen[...] =`), so a spec that parses but whose row construction raises into the existing broad handler still counts toward systematic failure.
- AppleDouble `._*.json` sidecars are excluded from the candidate count: they are rejected by design, not by failure, so a directory holding only sidecars is "empty", not "broken".
- `_read_agent_spec` itself, its per-file debug lines, and the `is_sensitive_path` denial branch (owned by in-flight #6722) are byte-unchanged. Logging-observability only: no change to what discovery returns, no new config, no SEL changes.

## Tests

Extended `test/test_agent_discovery.py` (`TestSystematicScanFailureWarning`, 8 tests):
- N unreadable user-scope specs → exactly one warning carrying the count (asserted via record args, immune to digits in tmp paths) and the directory
- mixed directory (some parse) → no warning
- empty and absent directories → no warning (N=0 is not systematic failure)
- all-unreadable project scope via `list_agents` → one warning naming the project agents dir
- `project_agent_names` warns on systematic failure and stays quiet on mixed
- sidecar-only directory → no warning
- spec parses but row construction raises → still warns (parsed means "produced a row")

## Manual verification

N/A — unit coverage sufficient: the change is a pure logging addition on scan paths fully exercised by the test module; no UI, integration, or external-service surface.

Local gates: isort, flake8, mypy (1169 files clean), diff-scoped black gate, full backend pytest (74400 passed; 99 failed + 2 errors proven pre-existing host-env by running the identical failing set on an unmodified `main` worktree with identical results).

no linked issue screenshots: backend logging change, no UI surface.

Closes #6727
