### PR TITLE
test(windows): list seven symlink-creating tests as requiring real symlinks

### DIFF
--- a/test/requires-real-symlinks.txt
+++ b/test/requires-real-symlinks.txt
@@ -115,3 +115,14 @@ test/test_steering_api.py::TestUpdateDeleteEndpoints::test_delete_through_symlin
 test/test_steering_api.py::TestUpdateDeleteEndpoints::test_update_through_symlink_is_refused
 test/test_vendor_manifest.py::TestDivergenceDetection::test_a_symlink_is_refused_not_skipped
 test/test_vendor_manifest.py::TestDivergenceDetection::test_write_refuses_a_symlinked_tree_too
+
+# Create a real symlink in the test body (a linked home, staging dir, or vault
+# subdir the code under test must refuse). Without symlink privilege the setup
+# itself raises WinError 1314 before the refusal is ever exercised.
+test/test_aws_control_app.py::TestRound17Hardening::test_restore_refuses_a_symlinked_destination
+test/test_aws_control_app.py::TestRound18Hardening::test_restore_refuses_a_symlinked_staging_directory
+test/test_governance_distribution.py::TestTheCacheIsHiddenFromAgentSubprocesses::test_a_symlinked_home_costs_a_redundant_rule_never_a_missing_one
+test/test_kas_auth_store.py::test_linked_kas_dir_is_refused
+test/test_kas_auth_store.py::test_linked_vault_subdir_is_refused
+test/test_sel.py::TestCrossProcessSafety::test_symlinked_sidecar_is_refused
+test/test_snapshot_manifest_and_links.py::TestSymlinkedTreeRootsAreRefused::test_replace_restore_refuses_a_linked_destination_root


### PR DESCRIPTION
## Problem / Motivation

Seven backend tests fail on a Windows checkout that lacks symlink privilege
(no Developer Mode, not elevated) with:

```
OSError: [WinError 1314] A required privilege is not held by the client
```

- `test_aws_control_app.py::TestRound17Hardening::test_restore_refuses_a_symlinked_destination`
- `test_aws_control_app.py::TestRound18Hardening::test_restore_refuses_a_symlinked_staging_directory`
- `test_governance_distribution.py::TestTheCacheIsHiddenFromAgentSubprocesses::test_a_symlinked_home_costs_a_redundant_rule_never_a_missing_one`
- `test_kas_auth_store.py::test_linked_kas_dir_is_refused`
- `test_kas_auth_store.py::test_linked_vault_subdir_is_refused`
- `test_sel.py::TestCrossProcessSafety::test_symlinked_sidecar_is_refused`
- `test_snapshot_manifest_and_links.py::TestSymlinkedTreeRootsAreRefused::test_replace_restore_refuses_a_linked_destination_root`

Each creates a real symlink in its setup so the code under test can be shown
to *refuse* it. Without the privilege the setup raises before the refusal is
exercised, and the failure reads as a defect in the very code it protects.

## Why it matters

`test/requires-real-symlinks.txt` exists for exactly this class — `conftest`
skips every listed node on a Windows host that cannot symlink, with a reason
naming the capability — and these seven are not in it. The gap is invisible in
CI: the Windows job runs the cross-surface list from
`scripts/ci-surface-tests.py`, not the full suite, and `windows-latest` is
elevated anyway. It shows up only on a contributor's own Windows machine, as
seven reds that look like broken code.

## What changed (motivation → approach → change)

Symptom: seven `WinError 1314` failures on an unprivileged Windows host. Root
cause: the tests need real symlink creation and are absent from the list
that skips such tests where the host can't provide it. Change: add the seven
node ids to `test/requires-real-symlinks.txt`, grouped with a comment saying
what they have in common. No code changes; nothing changes on an elevated
runner, where the seven still run.

## Tests

With the list updated, the seven node ids run on an unprivileged Windows 10
host report `7 skipped` with the list's own reason ("test requires real
symlink creation; host lacks that capability"); before, each failed with
`WinError 1314`. Verified with `pytest -n 0` on the seven ids.

## Manual verification

N/A — the skip is applied by the existing `conftest` hook and its effect is
the test run above.

## Related Issues

None open for this. The mechanism was introduced with the list; this is a
coverage gap in it.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — N/A, list-only change
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
