### PR TITLE
fix: thread sendId through steer to resolve thinking boundaries (#6075)

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -696,7 +696,9 @@ rebuilds from server history).
 **Backend — segment cut at the steer boundary.** `_run_chat` publishes a sync
 closure on the slot (`slot._steer_segment_cut`, same lifecycle as
 `slot._acp_client`: set at turn start, cleared in the turn's `finally`). The
-steer handler calls it right BEFORE `slot.append("user", …, meta={"steer": True})`,
+steer handler calls it right BEFORE `slot.append("user", …, meta={"steer": True, …})`
+(the meta also carries the client's `sendId` when the POST supplied one — see
+the send-identity paragraph below),
 so the accumulated segment text is flushed as its own assistant message and the
 persisted order is `[assistant(pre-steer), user(steer), assistant(post-steer)]`
 — identical to the live view. The cut persists SILENTLY: `broadcast=False`
@@ -726,6 +728,34 @@ scene-interaction steered). The reconcile path deliberately does NOT freeze — 
 echo time a new post-steer streaming message may be live below the bubble and
 must keep streaming. Pinned by `test_chat_steer.py` (cut ordering, cut-failure
 resilience) and the `finalize-on-steer` describe in `chatSlice.test.ts`.
+
+**Send identity — `sendId` through the steer path (#6075).** The optimistic
+steer bubble is minted with a client `sendId` (the same one-shot convention the
+plain send path uses) and the steer POST carries it as `meta.sendId`. Both
+backend paths persist it: the accepted-steer row via
+`steer_into_running_turn` — which normalizes the raw client value at entry
+(`normalize_send_id`: the URL-safe id alphabet within `SEND_ID_MAX_LEN`, AND
+nothing the canonical credential scanner would redact, since the value reaches
+slot history and the `steer_push` broadcast without the outbound redaction the
+message text goes through; anything failing either gate is treated as absent,
+never truncated) and also echoes it on the `steer_push`
+broadcast — and the raced new-turn row via the generic client-meta persistence
+in `api_chat`. Resolution is id-first everywhere text used to be the key: the
+`steer_push` reconcile matches the bubble by id (an id-mismatched bubble is
+never consumed; a non-optimistic row already carrying the echo's id means the
+`chat_done` refresh installed it first and the echo is a redelivery that
+inserts nothing), and `mergePreservedThinking` resolves an optimistic STEER
+bubble's accepted-vs-new-turn ambiguity from the covered page's row with that
+id (steer flag = acceptance, scan continues; non-steer = new-turn boundary,
+recorded so the finished turn's chip drops with coverage). Text identity never
+resolves the bubble; an unmatched, duplicate, or absent id keeps the
+decline-to-guess default. `sendId` is additive optional meta everywhere it
+travels — no schema bump, and a send without one keeps the exact prior row,
+payload, and scan behavior. Pinned by the sendId tests in
+`test_chat_steer.py`, `chatThinkingSteerBoundary.test.ts`, and
+`ChatSliceCoverageSecondPass.test.tsx`. Known residual: the `STEER_REQUEUED`
+paths do not thread the id into the requeued queue entry, so a steer that
+requeues keeps today's behavior (over-keep — the bubble reconciles on reload).
 
 ### Wait countdown and early end (`/api/session-keepalive` as a control channel)
 

--- a/src/kiro_crew/dashboard/chat_delivery.py
+++ b/src/kiro_crew/dashboard/chat_delivery.py
@@ -16,6 +16,7 @@ format on top.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -39,6 +40,45 @@ logger = logging.getLogger(__name__)
 STEER_STEERED = "steered"
 STEER_REQUEUED = "requeued"
 STEER_UNAVAILABLE = "unavailable"
+
+# Upper bound on a client-minted ``meta.sendId`` accepted into the steer path.
+# Client mints are ~17 chars; the bound exists because the value is raw client
+# input that gets persisted into slot history and broadcast to every tab.
+SEND_ID_MAX_LEN = 128
+
+# The accepted send-id alphabet. Client mints are ``s-<base36>-<base36>``; the
+# allowlist is deliberately a little wider (URL-safe id charset) so a future
+# client id shape does not silently lose reconciliation, while still excluding
+# every separator a structured secret needs (``/ + = .`` — base64 padding, JWT
+# dots, path-shaped tokens).
+_SEND_ID_RE = re.compile(rf"^[A-Za-z0-9_-]{{1,{SEND_ID_MAX_LEN}}}$")
+
+
+def normalize_send_id(value: object) -> str | None:
+    """Return *value* when it is a usable client send-correlation id, else None.
+
+    Deny-by-default over raw client input, in two gates:
+
+    1. Shape: a non-empty string in the id alphabet within ``SEND_ID_MAX_LEN``.
+    2. Content: the canonical credential scan (``redact_credentials``) finds
+       nothing. The alphabet alone cannot exclude bare alphanumeric key shapes
+       (an AWS access-key id, a ``ghp_`` token), and this value is persisted
+       into slot history and broadcast on ``steer_push`` WITHOUT the outbound
+       redaction the message text goes through — so anything the scanner would
+       redact is refused outright here instead.
+
+    A failing value is treated as ABSENT (the old-client shape), never
+    truncated or redacted-in-place — a rewritten id would silently mismatch the
+    client's copy and defeat the reconciliation it exists for. Lives here, with
+    the sink that persists and broadcasts the value, so every caller inherits
+    both gates.
+    """
+    if not isinstance(value, str) or not _SEND_ID_RE.fullmatch(value):
+        return None
+    cleaned, _warnings = redact_credentials(value)
+    if cleaned != value:
+        return None
+    return value
 
 
 def sanitize_outbound(text: str) -> str:
@@ -107,13 +147,25 @@ async def steer_into_running_turn(
     state: "DashboardState",
     slot: "_ChatSlot",
     message: str,
+    *,
+    send_id: str | None = None,
 ) -> str:
     """Inject *message* into the slot's RUNNING turn; return a ``STEER_*`` outcome.
 
     Requires a live, steer-capable inner ACP client that the turn published on
     the slot. Fire-and-forget by design: the inline steer card materializes when
     kiro-cli echoes ``steering_consumed``.
+
+    ``send_id`` is the client-minted correlation id from the send's meta (the
+    same ``sendId`` convention the plain send path persists). When present it is
+    stamped onto the persisted steer row AND the ``steer_push`` broadcast, so the
+    client can reconcile its optimistic bubble — and resolve the bubble's
+    accepted-vs-new-turn ambiguity — by id identity instead of text. Optional
+    and additive: a send without one keeps the exact prior row/payload shape.
+    Normalized at entry (``normalize_send_id``) so the type/length bound holds
+    for every caller, not just the current one.
     """
+    send_id = normalize_send_id(send_id)
     client = getattr(slot, "_acp_client", None)
     if client is None or not getattr(client, "supports_steer", False):
         return STEER_UNAVAILABLE
@@ -296,17 +348,25 @@ async def steer_into_running_turn(
 
     sanitized = sanitize_outbound(message)
     meta: dict[str, Any] = {"steer": True}
+    if send_id:
+        # Persist the client correlation id alongside the steer flag: the
+        # transcript page is what mergePreservedThinking reads to resolve an
+        # optimistic bubble by id (accepted steer vs raced new turn, #6075).
+        meta["sendId"] = send_id
     # Store the sanitized form — raw content must never reach an external
     # surface — so the steer survives a page reload via the dirty-flush cycle.
     slot.append("user", sanitized, "msg msg-u", ts=ts, meta=meta)
-    state.broadcast_ws(
-        "steer_push",
-        {
-            "slot": slot.key,
-            "content": _redact_for_display(sanitized),
-            "ts": ts,
-        },
-    )
+    push_payload: dict[str, Any] = {
+        "slot": slot.key,
+        "content": _redact_for_display(sanitized),
+        "ts": ts,
+    }
+    if send_id:
+        # Echoed back so the initiating tab reconciles its optimistic bubble by
+        # id; omitted when absent so the payload shape is unchanged for sends
+        # that never minted one.
+        push_payload["sendId"] = send_id
+    state.broadcast_ws("steer_push", push_payload)
     return STEER_STEERED
 
 

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -522,7 +522,19 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         # path (steer is unavailable between stages, so it falls through to the
         # queue below and is held until the plan ends).
         if body.get("steer") and not request_app:
-            outcome = await steer_into_running_turn(state, slot, message)
+            # Client-minted send correlation id (the same `meta.sendId`
+            # convention the plain send path persists): thread it through the
+            # steer so the persisted row and the steer_push echo can be matched
+            # back to the optimistic bubble by id rather than by text (#6075).
+            # Raw client input — the sink (`normalize_send_id` at the top of
+            # `steer_into_running_turn`) type-checks and length-bounds it,
+            # treating anything unusable as absent (the old-client shape).
+            outcome = await steer_into_running_turn(
+                state,
+                slot,
+                message,
+                send_id=user_meta.get("sendId") if user_meta else None,
+            )
             if outcome == STEER_STEERED:
                 return web.json_response({"ok": True, "steered": True})
             if outcome == STEER_REQUEUED:

--- a/test/test_chat_steer.py
+++ b/test/test_chat_steer.py
@@ -206,6 +206,160 @@ class TestApiChatSteer:
         events = [c.args[0] for c in state.broadcast_ws.call_args_list]
         assert "steer_push" in events
 
+    @staticmethod
+    def _steer_capable_state(tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+        return state, slot
+
+    @staticmethod
+    def _steer_push_payload(state):
+        return next(
+            c.args[1] for c in state.broadcast_ws.call_args_list if c.args[0] == "steer_push"
+        )
+
+    @pytest.mark.asyncio
+    async def test_steer_send_id_persists_and_broadcasts(self, tmp_path, monkeypatch, _patch_sel):
+        """A client-minted meta.sendId rides the steer: the persisted steer row
+        and the steer_push broadcast both carry it, so the client can reconcile
+        its optimistic bubble by id instead of by text (#6075)."""
+        state, slot = self._steer_capable_state(tmp_path, monkeypatch)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "go left",
+                    "steer": True,
+                    "meta": {"sendId": "s-abc-123"},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("steered") is True
+
+        steer_row = next(m for m in slot.messages if m.get("meta", {}).get("steer"))
+        assert steer_row["meta"]["sendId"] == "s-abc-123"
+        assert self._steer_push_payload(state)["sendId"] == "s-abc-123"
+
+    @pytest.mark.asyncio
+    async def test_steer_without_send_id_keeps_prior_shape(self, tmp_path, monkeypatch, _patch_sel):
+        """No sendId in the request -> the persisted row's meta and the
+        steer_push payload keep exactly the pre-sendId shape (no key at all,
+        never a null): old clients see no new field."""
+        state, slot = self._steer_capable_state(tmp_path, monkeypatch)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"slot": "test", "message": "go left", "steer": True}
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("steered") is True
+
+        steer_row = next(m for m in slot.messages if m.get("meta", {}).get("steer"))
+        assert "sendId" not in steer_row["meta"]
+        assert "sendId" not in self._steer_push_payload(state)
+
+    @pytest.mark.asyncio
+    async def test_raced_steer_persists_send_id_on_new_turn_row(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        """A steer POST that lands on an IDLE slot (the POST raced chat_done)
+        falls onto the new-turn path, whose generic client-meta persistence must
+        carry the sendId onto the plain user row — with NO steer flag. That
+        non-steer row is exactly what the client reads as proof of the new-turn
+        path (#6075), so this pins the pass-through property the frontend half
+        of the fix rests on: an allowlist that later drops sendId from persisted
+        user meta would reopen the issue with every other test green.
+
+        ``?ws=1`` requests the JSON receipt instead of the SSE stream; the row
+        persistence under test happens before that response-shape fork.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")  # idle: no running task
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat?ws=1",
+                json={
+                    "slot": "test",
+                    "message": "raced text",
+                    "steer": True,
+                    "meta": {"sendId": "s-raced-1"},
+                },
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data.get("ok") is True
+            assert data.get("steered") is not True
+
+        user_row = next(m for m in slot.messages if m["role"] == "user")
+        assert user_row["meta"]["sendId"] == "s-raced-1"
+        assert not user_row["meta"].get("steer")
+        events = [c.args[0] for c in state.broadcast_ws.call_args_list]
+        assert "steer_push" not in events
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_send_id",
+        [
+            123,
+            "",
+            "x" * 129,
+            ["s-1"],
+            {"id": "s-1"},
+            "has spaces",
+            "a/b+c=",
+            "AKIAIOSFODNN7EXAMPLE",
+        ],
+        ids=[
+            "non-string",
+            "empty",
+            "oversized",
+            "list",
+            "dict",
+            "whitespace",
+            "base64-charset",
+            "credential-shaped",
+        ],
+    )
+    async def test_steer_send_id_invalid_treated_absent(
+        self, tmp_path, monkeypatch, _patch_sel, bad_send_id
+    ):
+        """sendId is raw client input that reaches slot history and the
+        steer_push broadcast WITHOUT the outbound redaction message text goes
+        through, so the sink refuses anything but the id alphabet — and, since
+        a bare alphanumeric key shape fits that alphabet, anything the
+        canonical credential scanner would redact (the AWS access-key-id case).
+        Every refused value is treated as absent (the old-client shape), never
+        persisted or echoed."""
+        state, slot = self._steer_capable_state(tmp_path, monkeypatch)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "go left",
+                    "steer": True,
+                    "meta": {"sendId": bad_send_id},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("steered") is True
+
+        steer_row = next(m for m in slot.messages if m.get("meta", {}).get("steer"))
+        assert "sendId" not in steer_row["meta"]
+        assert "sendId" not in self._steer_push_payload(state)
+
 
 class TestFlushSegmentQuietPersist:
     """Pin the steer-cut persistence contract: quiet_persist suppresses the

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -2846,8 +2846,13 @@ export const api = {
   // Mid-turn steer: inject into the RUNNING turn instead of queueing. Fire-and-forget
   // JSON response ({ok, steered}); the backend falls back to queue if steer is
   // unavailable so the text is never dropped.
-  steerChat: (message: string, slot?: string) =>
-    fetch('/api/chat', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, steer: true }) }).then(j),
+  // `sendId` is the client-minted correlation id stamped on the optimistic steer
+  // bubble (same convention as the plain send path). It rides in `meta`, which
+  // BOTH backend paths persist — the accepted-steer row and the new-turn row a
+  // steer that races chat_done falls onto — so the bubble is reconcilable, and
+  // its accepted-vs-new-turn ambiguity resolvable, by id identity (#6075).
+  steerChat: (message: string, slot?: string, sendId?: string) =>
+    fetch('/api/chat', { method: 'POST', headers: { 'Content-Type': 'application/json', ..._sk }, body: JSON.stringify({ message, slot, steer: true, ...(sendId ? { meta: { sendId } } : {}) }) }).then(j),
   sessionsHealth: () => fetch('/api/sessions/health').then(j),
   // Knowledge
   knowledgeSearch: (q: string) => get(`/api/knowledge/search-for-context?q=${encodeURIComponent(q)}`).then(j),

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1199,14 +1199,18 @@ export function useWebSocket() {
               bufferSlotActivity(data.slot, (data as { ts?: string }).ts || new Date().toISOString(), true)
             }
             break
-          case 'steer_push':
+          case 'steer_push': {
             // Mid-turn steer echo: show the user's steered text inline in the
             // target slot's transcript. Uses appendSlotMessage so the bubble
             // appears whether or not the slot is currently active (background
             // tabs). Persisted server-side — survives page reload.
+            // `sendId` (present when the initiating client minted one) rides
+            // into the meta so the reconcile in appendSlotMessage can match the
+            // optimistic bubble by id instead of by content (#6075).
+            const steerSid = (data as { sendId?: unknown }).sendId
             dispatch(appendSlotMessage({
               slot: (data as { slot?: string }).slot || store.getState().chat.activeSlot || '',
-              message: { role: 'user', content: (data as { content?: string }).content || '', cls: 'msg msg-u', meta: { steer: true }, ts: (data as { ts?: string }).ts },
+              message: { role: 'user', content: (data as { content?: string }).content || '', cls: 'msg msg-u', meta: { steer: true, ...(typeof steerSid === 'string' && steerSid ? { sendId: steerSid } : {}) }, ts: (data as { ts?: string }).ts },
             }))
             // Steering is the other way to type into a busy session, so it
             // settles the rank exactly like a queued send. The server appends a
@@ -1220,6 +1224,7 @@ export function useWebSocket() {
               )
             }
             break
+          }
           case 'queue_cancel':
             dispatch(cancelQueuedMessage(data))
             // A cancelled queued message is an answer that never lands. The

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -387,6 +387,15 @@ export function ChatHeaderMenu({ activeSlot, agent, onReveal, onRename, mode }: 
  *  suffix is as reload-stable as the key it disambiguates. Rows without a
  *  `mid` (locally-minted streaming/optimistic bubbles) fall back to `msgKey`
  *  alone, which is exactly the uniqueness they had before. */
+/** Client-generated one-shot correlation id for an optimistic user bubble.
+ *  The server preserves meta fields on the user row it appends, so an echo or
+ *  transcript page carries this id back and the bubble is matchable without
+ *  relying on content equality (#2845). Shared by the plain send path and the
+ *  mid-turn steer path (#6075) so the two cannot drift in id shape. */
+function mintSendId(): string {
+  return `s-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
 function msgIdentityKey(m: ChatMessage, msgKey: (m: ChatMessage) => string): string {
   const mid = m.meta?.mid
   return typeof mid === 'string' && mid ? `${msgKey(m)}~${mid}` : msgKey(m)
@@ -1222,7 +1231,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Mid-turn steer is a POST write, so it goes through useMutation for
   // consistent error/loading-state handling (fire-and-forget: no onSuccess).
   const steerMutation = useMutation({
-    mutationFn: (text: string) => api.steerChat(text, activeSlot!),
+    mutationFn: ({ text, sendId }: { text: string; sendId?: string }) => api.steerChat(text, activeSlot!, sendId),
     onError: (e) => { console.error('steer failed', e) },
   })
   const [reasoningEffortDropdown, setReasoningEffortDropdown] = useState(false)
@@ -4383,7 +4392,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // to this exact optimistic bubble without relying on content equality.
     // The server preserves meta fields on the user row it appends, so the
     // echo carries both this sendId AND the server-minted `mid` (#2845).
-    const sendId = `s-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const sendId = mintSendId()
     meta.sendId = sendId
     const metaPayload = meta
     // Skip optimistic user bubble when the slot is busy (shared rule:
@@ -5920,9 +5929,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // once the backend echoes it via the 'steer_push' WS event, making it look
     // like nothing happened until the response resumes.
     // Tagged meta.optimistic so the echo reconciles this bubble in place
-    // (appendSlotMessage) instead of rendering a duplicate.
-    dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true } }))
-    steerMutation.mutate(llmTxt)
+    // (appendSlotMessage) instead of rendering a duplicate. The sendId is the
+    // reconciliation key: it travels in the POST's meta, which both backend
+    // paths persist — the accepted-steer row and the new-turn row a steer that
+    // races chat_done falls onto — so the bubble is resolvable by id identity
+    // whichever path the server took (#6075).
+    const steerSendId = mintSendId()
+    dispatch(appendMessage({ role: 'user', content: llmTxt, cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true, sendId: steerSendId } }))
+    steerMutation.mutate({ text: llmTxt, sendId: steerSendId })
     // Staged session references are deliberately NOT part of steering: neither
     // carried into the payload nor cleared. `steerMutation`'s onError only logs,
     // so anything cleared here is gone for good — text, attachments and pastes

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1704,11 +1704,12 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
   }
   // Conservative row identity for the coverage cut: the STRONGEST available
   // class only — tool id, else server-minted `mid`, else role+ts, else
-  // role+trimmed text. Never stacked: a strong-identity row must not also
-  // match on a weaker key, or a duplicate-content sibling (two `🔧 bash`
-  // calls with distinct tool ids) lets an OLDER incoming row text-match a
-  // NEWER existing row and falsely extend coverage past a post-snapshot
-  // anchor — which would drop live reasoning.
+  // role+trimmed text. Never stacked among those classes: a strong-identity
+  // row must not also match on a weaker key, or a duplicate-content sibling
+  // (two `🔧 bash` calls with distinct tool ids) lets an OLDER incoming row
+  // text-match a NEWER existing row and falsely extend coverage past a
+  // post-snapshot anchor — which would drop live reasoning. (`send:${sendId}`
+  // is the one deliberate exception; see below.)
   //
   // Coverage evidence comes ONLY from `coverageSource` — the PURE fetched
   // server page, before the reducer re-attaches any client-preserved rows
@@ -1725,16 +1726,70 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
   // contains — never to dedupe rows — so a residual text collision among
   // identity-less rows can only make coverage read longer, and only among
   // rows that carry no stronger key.
+  //
+  // `send:${sendId}` is the ONE key that rides ALONGSIDE the strongest class
+  // rather than being ranked in it. A UNIQUE send id is not a weak key — a
+  // client-minted one-shot id two rows can share only by being the same send
+  // (the same convention `rowIdentities` returns both halves of). It MUST
+  // stack, because the two copies of a pre-echo send have different strongest
+  // keys by construction: the local optimistic bubble carries only `sendId`
+  // while its persisted counterpart carries a server `mid` — ranked
+  // strongest-only they could never match, and the covered bubble would read
+  // as uncovered (#6075). A DUPLICATED id is excluded outright
+  // (`dupSendIds`): an id repeated within one list names two different sends,
+  // and letting it match would extend the coverage cut past a live
+  // post-snapshot anchor on the strength of the WRONG row — deleting live
+  // reasoning, the exact failure the never-stacked rule exists to prevent.
+  // The pre-echo pair is one occurrence in EACH list, so duplication is
+  // counted per list, never across the two. Only user rows emit the key:
+  // that is the only role a send id legitimately lives on, and honoring it
+  // elsewhere would let a mislabeled row vouch for a bubble.
+  const dupSendIds = new Set<string>()
+  const countDupSendIds = (list: M[]): void => {
+    const seen = new Set<string>()
+    for (const m of list) {
+      if (m.role !== 'user') continue
+      const sid = m.meta?.sendId
+      if (typeof sid !== 'string' || !sid) continue
+      if (seen.has(sid)) dupSendIds.add(sid)
+      else seen.add(sid)
+    }
+  }
+  countDupSendIds(coverageSource)
+  countDupSendIds(existing)
   const coverageIds = (m: M): string[] => {
+    const ids: string[] = []
     const tid = toolAnchorId(m)
-    if (tid) return [`tool:${tid}`]
     const mid = m.meta?.mid
-    if (typeof mid === 'string' && mid) return [`mid:${mid}`]
-    if (m.ts) return [`ts:${m.role}:${m.ts}`]
-    if (m.content) return [`txt:${m.role}:${m.content.trimEnd()}`]
-    return []
+    if (tid) ids.push(`tool:${tid}`)
+    else if (typeof mid === 'string' && mid) ids.push(`mid:${mid}`)
+    else if (m.ts) ids.push(`ts:${m.role}:${m.ts}`)
+    else if (m.content) ids.push(`txt:${m.role}:${m.content.trimEnd()}`)
+    if (m.role === 'user') {
+      const sid = m.meta?.sendId
+      if (typeof sid === 'string' && sid && !dupSendIds.has(sid)) ids.push(`send:${sid}`)
+    }
+    return ids
   }
   const preserved: Array<{ msg: M; anchor: ThinkingAnchor | null; anchorIdx: number; confirmed: boolean; boundaryIdx: number; skip: number }> = []
+  // Which backend path each covered send took, keyed by its client-minted
+  // `sendId` (#6075). Read where the anchor scan below breaks at an optimistic
+  // STEER bubble: a persisted NON-steer row carrying the bubble's id proves the
+  // steer POST raced `chat_done` onto the new-turn path (the bubble IS a turn
+  // boundary), a persisted STEER row proves acceptance into the running turn
+  // (not a boundary at all). Built from `coverageSource` only — the same
+  // provenance rule the coverage cut follows — so a re-attached client row can
+  // never vouch for itself. A `null` entry is a tombstone: the page holds MORE
+  // THAN ONE row with that id, so the id names no single path and resolves
+  // nothing (decline, not guess — ids are minted unique, so a duplicate is
+  // either a client defect or an adversarial echo, and both must fail safe).
+  const steerBySendId = new Map<string, boolean | null>()
+  for (const m of coverageSource) {
+    if (m.role !== 'user') continue
+    const sid = m.meta?.sendId
+    if (typeof sid !== 'string' || !sid) continue
+    steerBySendId.set(sid, steerBySendId.has(sid) ? null : !!m.meta?.steer)
+  }
   // How many rows already repeated this text, so a duplicated anchor resolves to the
   // block's OWN turn rather than to the first match.
   const priorText = new Map<string, number>()
@@ -1785,27 +1840,49 @@ function mergePreservedThinking<M extends { role: string; content: string; cls?:
       //
       // An OPTIMISTIC bubble of ANY kind breaks the scan (it may be a new turn,
       // and reading past it could splice that turn's reasoning onto this block)
-      // but NEVER records a boundary and never authorizes a drop. The predicate
-      // is `optimistic` alone, NOT `steer && optimistic`: a plain send is
-      // stamped optimistic too (keyed on its `sendId`, see `appendMessage`), and
-      // it is just as ambiguous. If the client's idle state was stale the server
-      // takes its QUEUE path — persisting no `user` row for that text at all —
-      // while the turn keeps emitting rows; a refresh covering one of those
-      // later rows would then put this unpersisted bubble INSIDE the covered
-      // region and drop the live turn's reasoning above it. A steer bubble is
-      // ambiguous for its own reason: accepted into the running turn (its
-      // `steer_push` echo pending, real anchor one reconciliation away) or raced
-      // `chat_done` onto the new-turn path. Every attempt to resolve either
-      // ambiguity from text identity proved unsound in review (duplicate-text
-      // turns, missed echoes, pages reaching past the bounded cache window), so
-      // this code declines to guess: only a bubble the server has CONFIRMED
-      // (echo reconciled, the flag deleted) is trustworthy as a boundary. The
-      // cost is a narrow residual — a new-turn-path steer's pre-steer chip can
-      // strand at the tail until reload — tracked as #6075, whose sound fix is a
-      // client-minted id persisted through both backend paths, rather than
-      // resolved with weak evidence here.
+      // and by default records no boundary and authorizes no drop. The
+      // predicate is `optimistic` alone, NOT `steer && optimistic`: a plain
+      // send is stamped optimistic too (keyed on its `sendId`, see
+      // `appendMessage`), and it is just as ambiguous. If the client's idle
+      // state was stale the server takes its QUEUE path — persisting no `user`
+      // row for that text at all — while the turn keeps emitting rows; a
+      // refresh covering one of those later rows would then put this
+      // unpersisted bubble INSIDE the covered region and drop the live turn's
+      // reasoning above it. A steer bubble is ambiguous for its own reason:
+      // accepted into the running turn (its `steer_push` echo pending, real
+      // anchor one reconciliation away) or raced `chat_done` onto the new-turn
+      // path. Every attempt to resolve either ambiguity from TEXT identity
+      // proved unsound in review (duplicate-text turns, missed echoes, pages
+      // reaching past the bounded cache window), so text never resolves it.
+      //
+      // ID identity does (#6075) — for STEER bubbles only. A steer bubble
+      // minted with a `sendId` names its persisted counterpart outright: the
+      // covered page holding a NON-steer row with that id proves the new-turn
+      // path — the bubble is a real turn boundary, recorded so the finished
+      // turn's chip drops instead of stranding at the tail — while a STEER row
+      // with that id proves acceptance, so the scan continues past it exactly
+      // as it would past a confirmed steer (the block's real anchor lies
+      // further down). A bubble whose id the page does not contain — or
+      // contains MORE THAN ONCE (the `null` tombstone) — keeps the
+      // decline-to-guess default: break, no boundary, no drop.
+      //
+      // A PLAIN optimistic send is deliberately NOT resolved this way, even
+      // though it carries a `sendId` too: for a non-steer send, "a persisted
+      // row with this id exists" does not prove "the turn above this bubble is
+      // over" — crew mode persists the user row as a durable queue entry and
+      // starts no turn at all — so recording a boundary there re-opens the
+      // over-drop class the text heuristics were retired for. For a steer
+      // bubble the inference is sound precisely because the row's own `steer`
+      // flag names which backend path consumed the send.
       if (isTurnBoundaryUser(cand)) {
-        if (!cand.meta?.optimistic) boundaryIdx = j
+        if (!cand.meta?.optimistic) { boundaryIdx = j; break }
+        if (cand.meta?.steer) {
+          const sid = cand.meta?.sendId
+          const steered =
+            typeof sid === 'string' && sid && !dupSendIds.has(sid) ? steerBySendId.get(sid) : undefined
+          if (steered === true) continue
+          if (steered === false) boundaryIdx = j
+        }
         break
       }
     }
@@ -3006,19 +3083,45 @@ const chatSlice = createSlice({
       // by definition sent mid-turn, so streaming/thinking/tool messages keep
       // landing between the optimistic append and the WS echo. A tail-only
       // check loses that race and renders a duplicate "Steered into the
-      // running turn" card. Scan backwards (bounded) over optimistic STEER
-      // bubbles only (a plain optimistic user message with coincidentally
-      // identical text must never be consumed): prefer exactly matching
-      // content (handles rapid back-to-back steers in order), else fall back
-      // to the most recent one (server-side redaction can alter the echoed
-      // content, so an exact match isn't guaranteed).
+      // running turn" card. Resolution (#6075) pairs strictly by id CLASS:
+      // an echo carrying a `sendId` matches by id ONLY, and an ID-LESS echo
+      // pairs only with ID-LESS bubbles. The gateway serves this SPA bundle,
+      // so client and gateway do not skew: an id-less echo does not mean "an
+      // old gateway stripped the id" — it means the POST carried none (a
+      // scene-interaction steer, a non-minting caller), i.e. a DIFFERENT send
+      // whose echo can never name this tab's id-bearing bubble. Consuming
+      // across classes shows the wrong message twice over: the id-bearing
+      // bubble adopts the foreign echo's text, and its own later exact-id
+      // echo is then suppressed by the redelivery guard. An unmatched echo
+      // inserts instead — over-insert is the recoverable direction. A
+      // NON-optimistic user row already carrying an id-bearing echo's id
+      // means the row was ALREADY installed (the chat_done refresh can
+      // replace the bubble with the persisted row before a delayed echo is
+      // processed) — that echo is a redelivery and inserts nothing. Within
+      // the id-less pairing, prefer exactly matching content, else the most
+      // recent id-less optimistic STEER bubble (a plain optimistic user
+      // message with coincidentally identical text must never be consumed;
+      // server-side redaction can alter the echoed content, so an exact match
+      // isn't guaranteed).
       if (message.role === 'user' && message.meta?.steer && !message.meta?.optimistic) {
+        const echoSid = typeof message.meta?.sendId === 'string' && message.meta.sendId ? message.meta.sendId : ''
         const floor = Math.max(0, msgs.length - 50)
         let target: ChatMessage | undefined
         let fallback: ChatMessage | undefined
         for (let i = msgs.length - 1; i >= floor; i--) {
           const m = msgs[i]
-          if (m.role !== 'user' || !m.meta?.optimistic || !m.meta?.steer) continue
+          if (m.role !== 'user') continue
+          const rowSid = typeof m.meta?.sendId === 'string' && m.meta.sendId ? m.meta.sendId : ''
+          if (echoSid && rowSid === echoSid && !m.meta?.optimistic) return
+          if (!m.meta?.optimistic || !m.meta?.steer) continue
+          if (echoSid) {
+            // Id-bearing echo: the match is exact or there is no match.
+            if (rowSid === echoSid) { target = m; break }
+            continue
+          }
+          // Id-less echo: an id-bearing bubble belongs to a send whose own
+          // exact-id echo is still coming — never consume it here.
+          if (rowSid) continue
           if (message.content && m.content === message.content) { target = m; break }
           if (!fallback) fallback = m
         }

--- a/website/src/test/ChatSliceCoverageSecondPass.test.tsx
+++ b/website/src/test/ChatSliceCoverageSecondPass.test.tsx
@@ -538,9 +538,10 @@ describe('chatSlice slot-detail refresh merges', () => {
     // Resolving that ambiguity from text identity was attempted and retired:
     // every variant carried a real over-drop hole (duplicate-text turns,
     // missed echoes, pages reaching past the bounded cache window). The
-    // contract is now: the bubble breaks the scan but NEVER authorizes a
-    // drop — over-keep, not over-drop. The new-turn residual (this chip can
-    // strand until reload) is tracked as issue #6075.
+    // contract: TEXT never resolves the bubble — only a persisted row carrying
+    // the bubble's own client-minted sendId does (#6075) — so an id-less
+    // bubble breaks the scan and NEVER authorizes a drop, whatever text the
+    // page holds. Over-keep, not over-drop.
     let s = chatReducer(initial, setActiveSlot('A'))
     s = chatReducer(s, replaceMessages([
       msg({ role: 'user', content: 'question', ts: '1' }),
@@ -596,6 +597,131 @@ describe('chatSlice slot-detail refresh merges', () => {
       msg({ role: 'user', content: 'check the logs', ts: '5' }),
     ], { running: true })))
     expect(s.messages.some(m => m.role === 'thinking' && m.content === 'pre-steer reasoning')).toBe(true)
+  })
+
+  it('resolves a raced steer bubble by send-id and drops the finished turn\'s chip (#6075)', () => {
+    // The steer POST landed after chat_done: the server persisted the text as
+    // a PLAIN user row on the new-turn path, carrying the client-minted
+    // sendId the bubble was stamped with. That id-proven boundary sits inside
+    // the covered page (the row itself vouches for the bubble via the shared
+    // send-id identity), so the pre-steer chip of the FINISHED turn drops —
+    // matching a reload — instead of stranding at the tail on every refresh.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'finished-turn reasoning' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true, sendId: 'sid-raced' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '5', meta: { sendId: 'sid-raced', mid: 'm-raced' } }),
+      msg({ role: 'assistant', content: 'new turn answer', ts: '6' }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking')).toBe(false)
+  })
+
+  it('a page row with a DIFFERENT send-id never vouches for the bubble (#6075)', () => {
+    // Id identity is exact: a persisted row carrying some OTHER send's id —
+    // plus a plain-text copy of the bubble's content — is not evidence about
+    // THIS bubble. The unmatched bubble keeps the decline-to-guess default
+    // and the pre-steer reasoning survives.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'pre-steer reasoning' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true, sendId: 'sid-mine' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '5', meta: { sendId: 'sid-someone-else', mid: 'm-x' } }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'pre-steer reasoning')).toBe(true)
+  })
+
+  it('an id-proven ACCEPTED steer lets the scan reach the real anchor below (#6075)', () => {
+    // The covered page holds a STEER row carrying the bubble's sendId:
+    // acceptance is proven, so the bubble does not end the block's turn and
+    // the forward scan continues to the post-steer answer — the block anchors
+    // above it instead of stranding at the tail.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'pre-steer reasoning' }),
+      msg({ role: 'user', content: 'also check X', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true, sendId: 'sid-accepted' } }),
+      msg({ role: 'assistant', content: 'steered answer', ts: '4' }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'also check X', ts: '3', meta: { steer: true, sendId: 'sid-accepted', mid: 'm-acc' } }),
+      msg({ role: 'assistant', content: 'steered answer', ts: '4' }),
+    ], { running: true })))
+    const roles = s.messages.map(m => m.role)
+    const thinkingIdx = roles.indexOf('thinking')
+    expect(thinkingIdx).toBeGreaterThanOrEqual(0)
+    expect(thinkingIdx).toBeLessThan(roles.indexOf('assistant'))
+  })
+
+  it('a PLAIN optimistic send is never id-resolved into a boundary (#6075)', () => {
+    // For a NON-steer send, "a persisted row with this id exists" does not
+    // prove "the turn above this bubble is over": crew mode persists the user
+    // row as a durable queue entry and starts no turn at all. Recording a
+    // boundary there would re-open the over-drop class the retired text
+    // heuristics were rejected for — id resolution is licensed for STEER
+    // bubbles only, where the row's own steer flag names the consuming path.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'live reasoning' }),
+      msg({ role: 'user', content: 'queued for later', ts: '2026-08-26T06:00:00.000Z', meta: { optimistic: true, sendId: 'sid-plain' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'queued for later', ts: '5', meta: { sendId: 'sid-plain', mid: 'm-plain' } }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'live reasoning')).toBe(true)
+  })
+
+  it('a send-id the page holds MORE THAN ONCE resolves nothing (#6075)', () => {
+    // Ids are minted unique, so a duplicate in one page is a client defect or
+    // an adversarial echo — either way the id names no single path and the
+    // tombstone keeps the decline-to-guess default instead of letting the
+    // first-seen row classify the bubble.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'pre-steer reasoning' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true, sendId: 'sid-dupe' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'do the next thing', ts: '5', meta: { sendId: 'sid-dupe', mid: 'm-a' } }),
+      msg({ role: 'user', content: 'do the next thing again', ts: '6', meta: { sendId: 'sid-dupe', mid: 'm-b' } }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'pre-steer reasoning')).toBe(true)
+  })
+
+  it('a duplicated send-id never extends the coverage cut past a live anchor (#6075)', () => {
+    // The coverage-cut half of the same fail-safe: a client reusing one id on
+    // two different sends must not let a stale page's copy of the OLDER send
+    // match the NEWER bubble and advance coveredIdx past a post-snapshot tool
+    // anchor — that would drop the live turn's reasoning, the exact over-drop
+    // the never-stacked identity rule exists to prevent. With the id
+    // duplicated (one copy in the page, two claimants in the cache), send-id
+    // identity is withheld from coverage entirely and the block survives.
+    let s = chatReducer(initial, setActiveSlot('A'))
+    s = chatReducer(s, replaceMessages([
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'thinking', content: 'live reasoning' }),
+      // Post-snapshot anchor: landed after the page below was fetched.
+      msg({ role: 'tool', content: '🔧 grep', ts: '9', meta: { tool_call_id: 'tc-live' } }),
+      msg({ role: 'user', content: 'first send', ts: '2026-08-26T06:00:00.000Z', meta: { steer: true, optimistic: true, sendId: 'sid-reused' } }),
+      msg({ role: 'user', content: 'second send', ts: '2026-08-26T06:00:01.000Z', meta: { steer: true, optimistic: true, sendId: 'sid-reused' } }),
+    ]))
+    s = chatReducer(s, lifecycle('chat/refreshSlot/fulfilled', 'A', detail('A', [
+      msg({ role: 'user', content: 'question', ts: '1' }),
+      msg({ role: 'user', content: 'first send', ts: '5', meta: { sendId: 'sid-reused', mid: 'm-first' } }),
+    ], { running: true })))
+    expect(s.messages.some(m => m.role === 'thinking' && m.content === 'live reasoning')).toBe(true)
   })
 
   it('keeps a block anchored to unconfirmed text through a racing mid-turn refresh', () => {

--- a/website/src/test/SideSlashCommand.steer.test.tsx
+++ b/website/src/test/SideSlashCommand.steer.test.tsx
@@ -165,7 +165,10 @@ describe('/side while a turn is running', () => {
     fireEvent.change(input, { target: { value: 'plain steer text' } })
     await armRunning(store)
     fireEvent.keyDown(input, { key: 'Enter' })
-    await waitFor(() => expect(mockSteerChat).toHaveBeenCalledWith('plain steer text', SLOT))
+    // The third argument is the client-minted send-correlation id the steer
+    // path stamps on its optimistic bubble (#6075) — pin its shape, not its
+    // random value.
+    await waitFor(() => expect(mockSteerChat).toHaveBeenCalledWith('plain steer text', SLOT, expect.stringMatching(/^s-/)))
     expect(mockSendChat).not.toHaveBeenCalled()
   })
 

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -669,6 +669,80 @@ describe('appendSlotMessage steer reconcile', () => {
     expect(state.messages.filter(m => m.role === 'user')[1].meta?.optimistic).toBeUndefined()
   })
 
+  it('reconciles by sendId when both echo and bubble carry one, over any content drift (#6075)', () => {
+    let state = { ...initial, activeSlot: 'A', messages: [] as ChatMessage[] }
+    state = reducer(state, appendMessage({ role: 'user', content: 'raw with secret AKIA123', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true, sendId: 'sid-1' } }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'raw with secret [REDACTED]', cls: 'msg msg-u', ts: 't2', meta: { steer: true, sendId: 'sid-1' } } }))
+    const users = state.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(1)
+    expect(users[0].meta?.optimistic).toBeUndefined()
+    expect(users[0].content).toBe('raw with secret [REDACTED]')
+  })
+
+  it('an id-carrying echo never consumes a bubble with a DIFFERENT sendId (#6075)', () => {
+    // Another tab steered too: its echo must not eat this tab's pending
+    // bubble, even when the texts coincide. The foreign echo inserts its own
+    // row; this tab's bubble stays optimistic until ITS echo arrives.
+    let state = { ...initial, activeSlot: 'A', messages: [] as ChatMessage[] }
+    state = reducer(state, appendMessage({ role: 'user', content: 'same text', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true, sendId: 'sid-mine' } }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'same text', cls: 'msg msg-u', ts: 't2', meta: { steer: true, sendId: 'sid-theirs' } } }))
+    const users = state.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(2)
+    expect(users[0].meta?.optimistic).toBe(true)
+    expect(users[0].meta?.sendId).toBe('sid-mine')
+  })
+
+  it('an id-carrying echo never content-consumes an ID-LESS bubble (#6075)', () => {
+    // A pre-upgrade tab left an id-less optimistic steer bubble; a NEW tab
+    // then steers byte-identical text with a sendId. The id-bearing echo
+    // belongs to the new send: consuming the old bubble on the text
+    // coincidence would overwrite it AND omit the new steer's card. Id-bearing
+    // echoes match by id only — no match means insert (over-insert is the
+    // recoverable direction; the old bubble keeps waiting for its own echo).
+    let state = { ...initial, activeSlot: 'A', messages: [] as ChatMessage[] }
+    state = reducer(state, appendMessage({ role: 'user', content: 'same text', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true } }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'same text', cls: 'msg msg-u', ts: 't2', meta: { steer: true, sendId: 'sid-new-tab' } } }))
+    const users = state.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(2)
+    expect(users[0].meta?.optimistic).toBe(true)
+    expect(users[0].meta?.sendId).toBeUndefined()
+    expect(users[1].meta?.sendId).toBe('sid-new-tab')
+  })
+
+  it('a delayed echo after the refresh already installed the persisted row inserts nothing (#6075)', () => {
+    // chat_done fires a transcript refresh that can replace the optimistic
+    // bubble with the persisted steer row BEFORE the steer_push echo is
+    // processed. The id-matched non-optimistic row proves the echo is a
+    // redelivery: inserting would render a duplicate steer card (and
+    // finalize-on-steer could freeze an unrelated live stream below it).
+    let state = { ...initial, activeSlot: 'A', messages: [] as ChatMessage[] }
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'check X', cls: 'msg msg-u', ts: 't3', meta: { steer: true, sendId: 'sid-dup', mid: 'm-1' } } }))
+    state = reducer(state, updateStreamingMessage('post-steer stream'))
+    const before = state.messages.length
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'check X', cls: 'msg msg-u', ts: 't3', meta: { steer: true, sendId: 'sid-dup' } } }))
+    expect(state.messages).toHaveLength(before)
+    expect(state.messages.filter(m => m.role === 'user')).toHaveLength(1)
+    // The live post-steer stream was not frozen by the redelivered echo.
+    expect(state.messages.some(m => m.role === 'streaming')).toBe(true)
+  })
+
+  it('an ID-LESS echo never consumes an id-bearing bubble (#6075)', () => {
+    // The gateway serves this SPA bundle, so an id-less echo is not version
+    // skew — it is a DIFFERENT send that carried no id (a scene-interaction
+    // steer). Consuming this tab's id-bearing bubble on the text coincidence
+    // would adopt the foreign echo's identity AND suppress the bubble's own
+    // later exact-id echo via the redelivery guard. The id-less echo inserts
+    // its own row; the id-bearing bubble keeps waiting for its echo.
+    let state = { ...initial, activeSlot: 'A', messages: [] as ChatMessage[] }
+    state = reducer(state, appendMessage({ role: 'user', content: 'steered text', cls: 'msg msg-u', ts: 't1', meta: { steer: true, optimistic: true, sendId: 'sid-this-tab' } }))
+    state = reducer(state, appendSlotMessage({ slot: 'A', message: { role: 'user', content: 'steered text', cls: 'msg msg-u', ts: 't2', meta: { steer: true } } }))
+    const users = state.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(2)
+    expect(users[0].meta?.optimistic).toBe(true)
+    expect(users[0].meta?.sendId).toBe('sid-this-tab')
+    expect(users[1].meta?.sendId).toBeUndefined()
+  })
+
   it('does not reconcile into an unrelated non-steer optimistic user message', () => {
     // A plain queued/optimistic user message (no meta.steer) with different
     // content must NOT swallow a steer echo — the echo appends instead.

--- a/website/src/test/chatThinkingSteerBoundary.test.ts
+++ b/website/src/test/chatThinkingSteerBoundary.test.ts
@@ -18,7 +18,7 @@
  * by a test double that skips the scan.
  */
 import { describe, it, expect } from 'vitest'
-import reducer, { sseThinkingChunk, sseChatMessage, refreshSlot } from '../store/chatSlice'
+import reducer, { sseThinkingChunk, sseChatMessage, refreshSlot, appendMessage } from '../store/chatSlice'
 
 type State = ReturnType<typeof reducer>
 
@@ -147,5 +147,66 @@ describe('mergePreservedThinking anchoring across a steer', () => {
     const roles = s.messages.map(m => m.role)
     expect(roles.indexOf('thinking')).toBeLessThan(roles.indexOf('assistant'))
     expect(s.messages[s.messages.length - 1].role).not.toBe('thinking')
+  })
+
+  it('drops the pre-steer chip when the covered page proves the steer raced onto the new-turn path (#6075)', () => {
+    // The steer POST lands after chat_done: the bubble was appended
+    // optimistically with a client-minted sendId, but slot.running was already
+    // false server-side, so the text was persisted as a PLAIN user row (new
+    // turn) carrying that same sendId — no steer_push echo ever arrives. The
+    // pre-steer reasoning belongs to the FINISHED turn; the page covering its
+    // id-proven boundary must drop the chip (a reload shows no reasoning)
+    // instead of stranding it at the tail forever.
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'stranded reasoning' }))
+    s = reducer(s, appendMessage({ role: 'user', content: 'next thing', cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true, sendId: 'sid-race' } }))
+
+    s = refreshWith(s, [
+      { role: 'user', content: 'do the thing', ts: '100' },
+      { role: 'user', content: 'next thing', ts: '200', meta: { sendId: 'sid-race', mid: 'm-race' } },
+      { role: 'assistant', content: 'new turn answer', ts: '201' },
+    ])
+
+    expect(thinkingRows(s)).toHaveLength(0)
+    expect(s.messages[s.messages.length - 1].role).not.toBe('thinking')
+  })
+
+  it('scans past an id-proven ACCEPTED steer and anchors above the post-steer answer (#6075)', () => {
+    // The page holds a STEER row carrying the bubble's sendId: acceptance is
+    // proven, the steer does not end the block's turn, and the scan continues
+    // to the real anchor below — the block lands above the answer, never at
+    // the tail and never dropped.
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'pre-steer reasoning' }))
+    s = reducer(s, appendMessage({ role: 'user', content: 'also check X', cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true, sendId: 'sid-acc' } }))
+    s = reducer(s, sseChatMessage({ slot: SLOT, role: 'assistant', content: 'the answer', ts: '102' }))
+
+    s = refreshWith(s, [
+      { role: 'user', content: 'do the thing', ts: '100' },
+      { role: 'user', content: 'also check X', ts: '101', meta: { steer: true, sendId: 'sid-acc', mid: 'm-acc' } },
+      { role: 'assistant', content: 'the answer', ts: '102' },
+    ])
+
+    const roles = s.messages.map(m => m.role)
+    const thinkingIdx = roles.indexOf('thinking')
+    expect(thinkingIdx).toBeGreaterThanOrEqual(0)
+    expect(thinkingIdx).toBeLessThan(roles.indexOf('assistant'))
+    expect(thinkingRows(s)).toHaveLength(1)
+  })
+
+  it('declines to guess when the page holds no row for the bubble id (#6075)', () => {
+    // The steer is still in flight: the bubble carries a sendId but the page
+    // has no persisted row with it (neither path has landed). Id identity is
+    // the ONLY licensed resolution, so an unmatched id keeps the default:
+    // break, no boundary, no drop — over-keep, never over-drop.
+    let s = withOpenTurn()
+    s = reducer(s, sseThinkingChunk({ slot: SLOT, content: 'live reasoning' }))
+    s = reducer(s, appendMessage({ role: 'user', content: 'pending steer', cls: 'msg msg-u', ts: new Date().toISOString(), meta: { steer: true, optimistic: true, sendId: 'sid-pending' } }))
+
+    s = refreshWith(s, [
+      { role: 'user', content: 'do the thing', ts: '100' },
+    ])
+
+    expect(thinkingRows(s).map(m => m.content)).toEqual(['live reasoning'])
   })
 })


### PR DESCRIPTION
## Problem / Motivation

When a mid-turn steer POST races `chat_done`, `slot.running` is already false server-side, so the request falls past the busy branch onto the new-turn path: the text is persisted as a plain user row, no `steer_push` echo ever arrives, the optimistic steer bubble stays optimistic forever, and the anchor scan in `mergePreservedThinking` breaks at that bubble without recording a boundary. The user observes the pre-steer thinking chip stranded at the transcript tail, re-appended on every refresh — the residual that PR #6019's own code comment names as issue #6075.

## Why it matters

Anyone who presses the steer button near the end of a turn hits the race, and the stranded chip is a permanent visual corruption of the transcript (a reasoning block sitting below unrelated turns) that only a full page reload clears. It is the last open shape in the #5815/#5798/#6019 family of thinking-chip placement bugs.

## What changed (motivation → approach → change)

The root cause is that the steer transport carried no client identity, so the client could not tell which backend path consumed a steer — and three GPT review rounds on #6019 established that text identity cannot resolve it (duplicate-text turns, missed echoes, bounded cache windows). The settled design is the existing `sendId` convention the plain send path already uses:

- **`website/src/pages/ChatPage.tsx`** mints a `sendId` on the optimistic steer bubble (shared `mintSendId()` helper, extracted from the plain send path so the two cannot drift) and passes it to the steer mutation.
- **`website/src/api/client.ts`** carries it as `meta.sendId` on the steer POST — the new-turn path already persists client meta, so raced-path persistence is free.
- **`src/kiro_crew/dashboard/chat_handlers.py`** threads the raw value into `steer_into_running_turn`.
- **`src/kiro_crew/dashboard/chat_delivery.py`** normalizes it at the sink (`normalize_send_id`: non-empty string ≤ 128 chars, anything else treated as absent — never truncated, so the bound travels with every caller), stamps it on the persisted steer row, and echoes it on the `steer_push` broadcast.
- **`website/src/hooks/useWebSocket.ts`** passes the echoed id into the appended message meta.
- **`website/src/store/chatSlice.ts`** resolves by id identity in three places:
  - `mergePreservedThinking` builds a `sendId → steer?` map from the pure server page (with a tombstone for a duplicated id): at the optimistic-STEER-bubble break, a matching non-steer row proves the new-turn path (boundary recorded — the finished turn's chip drops with coverage, matching a reload), a matching steer row proves acceptance (scan continues to the real anchor). Plain optimistic sends are deliberately NOT resolved this way — crew mode persists a user row without starting a turn, so the inference is only sound where the row's own `steer` flag names the consuming path.
  - The coverage cut gains `send:${sendId}` as a deliberate stacked identity: the two copies of a pre-echo send have different strongest keys by construction (bubble: `sendId` only; persisted row: `mid`), so ranked strongest-only they could never match.
  - The `steer_push` reconcile matches by id first (an id-mismatched bubble is never consumed; a non-optimistic row already carrying the echo's id means the `chat_done` refresh installed it first, so the redelivered echo inserts nothing instead of rendering a duplicate steer card). Content/recency matching survives only for mixed-version id-less pairings.

Scope guard: `sendId` is additive optional meta everywhere it travels — no schema/version bump, and old clients/servers keep exactly today's behavior. An unmatched, duplicate, or absent id keeps the decline-to-guess default (over-keep, never over-drop). Known residual: the `STEER_REQUEUED` paths do not thread the id into the requeued queue entry (today's over-keep behavior, reconciles on reload) — accepted-and-deferred to #6751, and documented in the spec.

`docs/system-specs/modules/learn-cron-dashboard.md` gains a send-identity paragraph in the steer section (same commit, per AGENTS.md spec-management rule).

## Tests

- `test/test_chat_steer.py`: persisted steer row + `steer_push` payload carry the client `sendId`; absent id keeps the exact prior row/payload shape (no key, never null); invalid ids (non-string, empty, oversized, list, dict) treated as absent; a steer POST landing on an idle slot persists the id on the plain new-turn user row with no steer flag (pins the pass-through property the frontend resolution rests on).
- `website/src/test/chatThinkingSteerBoundary.test.ts`: the raced steer drops the finished turn's chip; an id-proven accepted steer lets the scan anchor above the post-steer answer; an unmatched id keeps live reasoning.
- `website/src/test/ChatSliceCoverageSecondPass.test.tsx`: raced-steer drop by id; a different id never vouches for the bubble; accepted-steer anchoring; a PLAIN optimistic send is never id-resolved into a boundary; a duplicated page id resolves nothing (tombstone).
- `website/src/test/chatSlice.test.ts`: id-first echo reconcile over content drift; an id-carrying echo never consumes a foreign bubble; a delayed echo after the refresh installed the row inserts nothing; an id-less echo still reconciles an id-carrying bubble (older gateway).

Mutation-verified: reverting the boundary-resolution branch fails 4 new tests; reverting the coverage stacking fails 2; removing the redelivery guard fails its test; relaxing the steer-only gate fails the plain-send test.

## Manual verification

N/A — unit coverage sufficient: both reducers are exercised through the real store with server-shaped payloads, and the backend paths through the real aiohttp handler; the race is a pure event-ordering condition fully reproducible in tests.

## Related Issues

Closes #6075. Follow-up residual tracked in #6751.

No UI change, no screenshots: the fix changes transcript state resolution, not any rendered surface.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
