### PR TITLE
docs(sidechat): record the followUpIsPlan exclusion with a pinning test (#6754)

### DIFF
--- a/website/src/pages/chat/SideChat.tsx
+++ b/website/src/pages/chat/SideChat.tsx
@@ -106,7 +106,27 @@ export default function SideChat({ slot }: { slot: string }) {
   )
 
   /** Derived from the same helper the main chat uses, so "options only after the answer
-   *  settles" and "a later user message clears them" behave identically. */
+   *  settles" and "a later user message clears them" behave identically.
+   *
+   *  `followUpIsPlan` is DELIBERATELY dropped here (#6754; sibling issue #6057 covers
+   *  the same drop in ChatEmbed): this side panel is not a plan-capable host, so a
+   *  plan-shaped chip stays on the composer-draft path instead of dispatching
+   *  POST /api/chat/slots/{slot}/plan-action. Why that is a recorded exclusion rather
+   *  than a live mis-dispatch:
+   *  - A side turn runs as an aside to the parent session, never as an orchestrator
+   *    turn, so a plan-shaped answer in the side buffer is conversational output, not
+   *    a plan awaiting dispatch; `useComposerDraft` owning the chip (pick → edits the
+   *    draft, amendable before send) is therefore the correct behaviour, not a
+   *    fallback.
+   *  - The dispatch path gates on the HOST slot's mode (ChatPage reads
+   *    `effectiveMode === 'orchestrator'` off the slot record before dispatching).
+   *    This panel does not read the host slot's mode today — its transcript is the
+   *    side buffer, a private mini-conversation beside the parent slot — and wiring
+   *    `usePlanActionMutation` in would first need that mode selector added, gating
+   *    on the PARENT's mode for a conversation that is not the parent's.
+   *  - An unconditional dispatch (no mode gate) would let any plan-shaped side
+   *    answer cancel or advance the parent's real plan.
+   *  Pinned by src/test/SideChat.planExclusion.test.tsx. */
   const { followUpOptions } = useMemo(
     () => deriveFollowUpOptions(transcript, isStreaming),
     [transcript, isStreaming]

--- a/website/src/test/SideChat.planExclusion.test.tsx
+++ b/website/src/test/SideChat.planExclusion.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import reducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import { renderWithProviders, createTestStore } from './helpers'
+
+vi.mock('../api/client', () => ({
+  api: {
+    sideOpen: vi.fn().mockResolvedValue({ ok: true, open: true, messages: 0, last_run_id: '', created_at: new Date().toISOString() }),
+    sideTurn: vi.fn().mockResolvedValue({ ok: true, run_id: 'r1', messages: 1 }),
+    sideClose: vi.fn().mockResolvedValue({ ok: true, was_open: true }),
+    sideQueueCancel: vi.fn().mockResolvedValue({ ok: true, content: '', depth: 0 }),
+    sideQueueEdit: vi.fn().mockResolvedValue({ ok: true, depth: 1 }),
+    // The plan-dispatch transport (usePlanActionMutation goes through this).
+    // Never wired into SideChat — that absence is exactly what this file pins.
+    planAction: vi.fn().mockResolvedValue({ ok: true }),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+
+import SideChat from '../pages/chat/SideChat'
+import { api } from '../api/client'
+import { deriveFollowUpOptions } from '../app-sdk/protocol'
+import type { ChatMessage } from '../types'
+
+const SLOT = 'side-plan-slot-1'
+const initial = reducer(undefined, { type: '@@INIT' })
+// The composer blocks sends while the gateway reads as offline, so the scene
+// runs against a connected dashboard.
+const dashInitial = { ...dashboardReducer(undefined, { type: '@@INIT' }), connected: true }
+
+// Header + stage line + protocol footer — the shape that makes parseOptions set
+// isPlan on an assistant turn (same fixture family as the ChatPane/ChatPage
+// dispatch tests).
+const PLAN_TEXT = '📋 Plan for: ship it\n\nStage 1: build the thing\n\n[OPTIONS: Go | Go All | Cancel]'
+
+// ONE source of truth for the side-buffer content: the store below renders it,
+// and the premise pin derives from it — so the two cannot diverge on content
+// or roles.
+const SIDE_MESSAGES = [
+  { role: 'user' as const, content: 'plan it', ts: '2026-05-20T00:00:00Z', run_id: 'r1' },
+  { role: 'assistant' as const, content: PLAN_TEXT, ts: '2026-05-20T00:00:01Z', run_id: 'r1' },
+]
+
+// The same role/cls mapping SideChat's transcript memo applies to the side
+// buffer (SideChat.tsx — is_error absent and streaming=false here, so a
+// non-user row maps to 'assistant').
+const asTranscript: ChatMessage[] = SIDE_MESSAGES.map(m => {
+  const role = m.role === 'user' ? 'user' : 'assistant'
+  return { role, content: m.content, cls: `msg msg-${role}`, ts: m.ts }
+})
+
+function planStore() {
+  return createTestStore({
+    dashboard: dashInitial,
+    chat: {
+      ...initial,
+      activeSlot: SLOT,
+      slotSide: {
+        [SLOT]: {
+          messages: SIDE_MESSAGES,
+          lastRunId: 'r1',
+          pending: false,
+          streaming: false,
+          openedAtTurnCount: 0,
+          createdAt: '2026-05-20T00:00:00Z',
+        },
+      },
+    },
+  })
+}
+
+// Pins the deliberate exclusion recorded at SideChat's deriveFollowUpOptions
+// destructure (#6754; sibling issue #6057 covers the same drop in ChatEmbed):
+// the side panel is NOT a plan-capable host. A side answer whose derivation yields
+// followUpIsPlan=true still keeps its chips on the composer-draft path, and no
+// plan action is ever dispatched from this surface.
+describe('SideChat plan exclusion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('a plan-shaped chip edits the draft and never dispatches a plan action', async () => {
+    // Premise pin: the rendered fixture MUST derive as a plan (user + settled
+    // assistant). `asTranscript` is mapped from the SAME `SIDE_MESSAGES` array
+    // the store renders, so this cannot silently degrade into a plain
+    // follow-up test if the fixture or the plan grammar drifts.
+    expect(deriveFollowUpOptions(asTranscript, false).followUpIsPlan).toBe(true)
+
+    renderWithProviders(<SideChat slot={SLOT} />, { store: planStore() })
+
+    const input = screen.getByLabelText('Ask a side question') as HTMLTextAreaElement
+    expect(screen.getByText('Go')).toBeInTheDocument()
+
+    // Single chip click. SideChat supplies onSend to FollowUpBar, so the click
+    // is debounced ~220ms before it lands on onSelect (toggleOption).
+    fireEvent.click(screen.getByText('Go'))
+
+    // Composer-draft path: the pick lands in the side composer's draft, staying
+    // amendable before send. This is the load-bearing assertion — a dispatch
+    // branch would return before the draft edit, so wiring plan dispatch into
+    // this handler reds this line.
+    await waitFor(() => expect(input.value).toBe('Go'))
+
+    // And no dispatch on the global client's plan-action transport.
+    expect(api.planAction).not.toHaveBeenCalled()
+    // Nor was a side turn sent — picking is an edit, not a submit.
+    expect(api.sideTurn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`deriveFollowUpOptions` (`website/src/app-sdk/protocol/options.ts`) returns `followUpOptions`, `followUpIsPlan`, and `followUpSourceKey`. `website/src/pages/chat/SideChat.tsx` destructures only `followUpOptions`, silently dropping `followUpIsPlan`. The drop is correct in effect — the side panel is not a plan-capable host — but nothing records that: no comment states the rationale, and no test pins the behaviour. A contributor auditing plan-chip coverage finds an undocumented drop and either re-derives the rationale from scratch or "fixes" it by wiring dispatch into a host that has no mode source to gate it.

## Why it matters

The undocumented exclusion is a trap for future contributors. Wiring plan dispatch into SideChat without a mode gate would let any plan-shaped side answer cancel or advance the parent slot's real orchestrator plan — a live cross-conversation mis-dispatch. The record (comment + pinning test) is what turns "silent drop" into "reviewed, deliberate exclusion" and makes any future wiring attempt fail a test instead of shipping.

## What changed (motivation → approach → change)

Applies the same-size record pattern as PR #6748 does for ChatEmbed (sibling issue #6057 covers the same drop there). Two deliverables, **zero runtime behaviour change**:

1. **A block comment at SideChat's `deriveFollowUpOptions` destructure** recording the load-bearing facts: a side turn runs as an aside to the parent session and is never an orchestrator turn, so `useComposerDraft` owning a plan-shaped chip (pick → edits the draft, amendable before send) is correct behaviour, not a fallback; the dispatch path gates on the host slot's mode (`ChatPage` reads `effectiveMode === 'orchestrator'` off the slot record), which this panel does not read today; and an unconditional dispatch would let a plan-shaped side answer cancel or advance the parent's real plan.
2. **A pinning test** (`website/src/test/SideChat.planExclusion.test.tsx`), mirroring the ChatEmbed plan-exclusion test shape, with a shared `SIDE_MESSAGES` fixture feeding both the rendered store and the premise derivation so they cannot drift apart.

Deliberately out of scope (same as #6748): wiring `usePlanActionMutation` into SideChat. Path B parity is a product decision, not this change.

## Tests

New file `website/src/test/SideChat.planExclusion.test.tsx`, three assertions in one scenario:

- **Premise pin**: `deriveFollowUpOptions(asTranscript, false).followUpIsPlan === true`, where `asTranscript` is mapped from the same `SIDE_MESSAGES` array the store renders, through the same role/cls expression SideChat's transcript memo applies (non-streaming, non-error case). Without this the test would pass vacuously the moment the fixture stops being plan-shaped.
- **Composer-draft path**: clicking the `Go` chip lands the label in the side composer's draft (`input.value === 'Go'`).
- **No dispatch**: `api.planAction` is never called (and `api.sideTurn` is not called either — picking is an edit, not a submit).

**Red-before proven**: a plan dispatch was temporarily wired into SideChat's chip handler (`if (followUpIsPlan) { void api.planAction(slot, o); return }`); the test then failed (`expected '' to be 'Go'` — the draft assertion reds because dispatch short-circuits the draft edit). The scaffolding was reverted; only the comment and the test remain in the diff.

Full frontend suite on the rebased branch: 1638 test files, 25,938 passed, 0 failures (`npx vitest run`). `npx tsc -b` clean.

## Manual verification

N/A — unit coverage sufficient: the change is a comment plus a test; the pinned interaction (chip click → draft edit, no dispatch) is exactly what the test drives through the real component.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the diff adds only a code comment and a test file; no rendered output changes anywhere.

N/A — this change adds a comment and a test and alters no rendered output. No pixel changes anywhere; explicitly not a skipped screenshot gate.

## Related Issues

Fixes #6754

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

