### PR TITLE
fix(agent-discovery): attribute sensitive-path denials to the calling surface

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2722,7 +2722,7 @@ def _read_spec_capped(path: Path) -> dict | None:
     A thin wrapper rather than a direct call at each site, so the reason the
     capped reader is used lives in one place.
     """
-    return _read_agent_spec(path)
+    return _read_agent_spec(path, operation="agent_spec_lookup", source="unknown")
 
 
 def _spec_path_is_safe(path: Path, agents_dir: Path) -> bool:

--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -161,6 +161,20 @@ def _read_agent_spec(
     the size cap instead of being slurped into memory during a cache warm. The
     agents directories are user-writable and shared with other tools, so none of
     these are hypothetical.
+
+    *operation*/*source* label the SEL denial event emitted on a sensitive
+    resolved target. Precisely BECAUSE this is the one reader for every surface,
+    a fixed label would record a denial served for an unrelated request as an
+    agent-listing cache warm (#6722): the calling surface names itself here so
+    the security trail attributes the refusal to the request that triggered it.
+    ``source`` is the interface channel (``SecurityEvent.source`` vocabulary:
+    dashboard, cli, slack, cron, ...; ``"unknown"`` when the caller serves
+    multiple channels) — every call site passes it explicitly, enforced by the
+    call-site ratchet test. Both defaults exist ONLY so a bare call reproduces
+    the historical event byte-for-byte (a forgotten future call site degrades
+    to exactly today's trail); they are not for new call sites.
+    ``caller`` stays fixed at ``"agent_discovery"``: the reader genuinely is the
+    caller into SEL, and a fixed value keeps the trail greppable by module.
     """
     if path.name.startswith("._"):
         return None
@@ -286,7 +300,7 @@ def _declared_project_agent_name(spec: Path) -> str | None:
     allowlist: offering the filename of a broken spec has the session accept the
     agent and then fail at ``session/set_mode``.
     """
-    data = _read_agent_spec(spec)
+    data = _read_agent_spec(spec, operation="resolve_project_agent_name", source="unknown")
     if data is None:
         return None
     return spec_str(data, "name", _project_agent_fallback_name(spec))
@@ -644,7 +658,7 @@ def agent_skill_globs(agent: str, agents_dir: Path | None = None) -> list[str]:
         # Pass ``f``, not the resolved target: ``f.stem`` and
         # ``expand_skill_uri`` below must see the ORIGINAL path so a symlinked
         # spec's relative globs stay anchored where the symlink lives.
-        data = _read_agent_spec(f)
+        data = _read_agent_spec(f, operation="agent_skill_globs", source="unknown")
         if data is None:
             continue
         if data.get("name") != agent and f.stem != agent:
@@ -857,7 +871,7 @@ def list_agents(
             if not f.name.startswith("._"):
                 user_candidates += 1
             try:
-                data = _read_agent_spec(f)
+                data = _read_agent_spec(f, operation="list_agents", source="unknown")
                 if data is None:
                     continue
                 agents.append(_global_agent_info(f, data))
@@ -917,7 +931,7 @@ def list_agents(
         if not pf.name.startswith("._"):
             project_candidates += 1
         try:
-            data = _read_agent_spec(pf)
+            data = _read_agent_spec(pf, operation="list_agents", source="unknown")
             if data is None:
                 continue
             info = _project_agent_info(pf, data)

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -169,7 +169,7 @@ def _doctor_effective_model(cfg: KiroCrewConfig, project_dir: str, issues: list[
         checks here would be a second, weaker copy of a reader that already
         exists.
         """
-        data = _read_agent_spec(path)
+        data = _read_agent_spec(path, operation="doctor", source="cli")
         if data is None:
             # An ABSENT spec is not a fault -- a clean install has none, and the
             # resolver simply falls through to the bundled default. Only a file
@@ -444,7 +444,7 @@ def _agent_spec_model_problems(
             *((path, False) for path in global_specs),
             *((path, True) for path in project_specs),
         ):
-            data = _read_agent_spec(path)
+            data = _read_agent_spec(path, operation="doctor", source="cli")
             if data is None:
                 return None
             model = normalize_agent_model(data.get("model"))

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -9313,7 +9313,7 @@ def _read_hardened_agent_spec(path: Path) -> dict | None:
     try:
         from kiro_crew.agent_discovery import _read_agent_spec
 
-        return _read_agent_spec(path)
+        return _read_agent_spec(path, operation="load_config", source="unknown")
     except Exception:
         return None
 

--- a/src/kiro_crew/connections/mint.py
+++ b/src/kiro_crew/connections/mint.py
@@ -373,7 +373,11 @@ def _write_mint_agent_spec(slug: str) -> tuple[str, str]:
     # lands in the mint flow's failure path (retryable ``failed`` row, holdings
     # disposed, no child spawned). The fallback below stays reserved for what it
     # always meant: the file or the alias entry being genuinely absent.
-    spec = _read_agent_spec(agents_dir / AGENT_FILENAME)
+    spec = _read_agent_spec(
+        agents_dir / AGENT_FILENAME,
+        operation="connections_mint",
+        source="dashboard",
+    )
     if spec is None:
         if (agents_dir / AGENT_FILENAME).exists():
             logger.warning("Main agent spec unusable; refusing to mint for %r", alias)
@@ -826,7 +830,14 @@ def _agent_spec_entry_missing(slug: str) -> bool:
     agents_dir = _agent.kiro_agents_dir_path()
     # Hardened reader (#6736): a refused main spec reads as absent, so the entry
     # counts as missing -- the same degrade-as-absent direction as before.
-    spec = _read_agent_spec(agents_dir / AGENT_FILENAME) or {}
+    spec = (
+        _read_agent_spec(
+            agents_dir / AGENT_FILENAME,
+            operation="connections_mint",
+            source="dashboard",
+        )
+        or {}
+    )
     servers = spec.get("mcpServers") or {}
     return mcp_server_alias(slug) not in servers
 

--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -26,6 +26,7 @@ the ``oversized`` and symlink cases are differential against the old path
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -33,6 +34,7 @@ from unittest.mock import MagicMock
 import pytest
 from aiohttp import web
 
+from conftest import requires_symlinks
 from kiro_crew.agent import _install_heartbeat_agent, migrate_agent_specs
 from kiro_crew.agent_files import AGENT_FILENAME, HEARTBEAT_AGENT_FILENAME
 from kiro_crew.connections import mint
@@ -287,6 +289,7 @@ class TestSensitiveSymlinkGuard:
     migrated caller actually consults it (same shape as #5423's test).
     """
 
+    @requires_symlinks
     def test_link_to_a_sensitive_target_is_refused(self, tmp_path, monkeypatch):
         from kiro_crew import agent_discovery
 
@@ -362,6 +365,7 @@ class TestAgentSpecEntryMissing:
 
         assert mint._agent_spec_entry_missing("probe") is False
 
+    @requires_symlinks
     def test_link_to_a_sensitive_target_reads_as_entry_missing(self, tmp_path, monkeypatch):
         """The sensitive-symlink guard flows through a migrated mint caller."""
         from kiro_crew import agent_discovery
@@ -419,3 +423,157 @@ class TestInstallHeartbeatAgent:
         written = json.loads((agents_dir / HEARTBEAT_AGENT_FILENAME).read_text(encoding="utf-8"))
         assert written["mcpServers"]["kirocrew-core"]["args"] == []
         assert written["tools"] == ["@kirocrew-core"]
+
+
+class TestDenialAttribution:
+    """Sensitive-path denials name the surface that triggered the read."""
+
+    @staticmethod
+    def _denial_events(tmp_path, monkeypatch):
+        """Return a sensitive spec and a spy collecting SEL denial fields.
+
+        Symlink resolution itself is covered separately. This attribution test
+        uses a regular file so it exercises the SEL event on hosts that cannot
+        create symlinks (notably unelevated Windows shells).
+        """
+        from types import SimpleNamespace
+
+        from kiro_crew import agent_discovery
+
+        path = tmp_path / "protected.json"
+        path.write_text(json.dumps({"name": "linked"}), encoding="utf-8")
+        monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda p: str(path) in str(p))
+        events: list[dict] = []
+        monkeypatch.setattr(
+            agent_discovery,
+            "_sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        return path, events
+
+    def test_default_call_shape_emits_exactly_the_historical_event(self, tmp_path, monkeypatch):
+        """The compatibility defaults preserve the pre-attribution event."""
+        from kiro_crew.agent_discovery import _read_agent_spec
+
+        link, events = self._denial_events(tmp_path, monkeypatch)
+
+        assert _read_agent_spec(link) is None
+        assert events == [
+            {
+                "caller": "agent_discovery",
+                "operation": "list_agents",
+                "outcome": "denied",
+                "source": "list_agents",
+                "resources": str(link.resolve()),
+                "error": "sensitive path rejected",
+            }
+        ]
+
+    def test_labelled_call_attributes_the_denial_to_that_surface(self, tmp_path, monkeypatch):
+        from kiro_crew.agent_discovery import _read_agent_spec
+
+        link, events = self._denial_events(tmp_path, monkeypatch)
+
+        assert _read_agent_spec(link, operation="doctor", source="cli") is None
+        assert len(events) == 1
+        assert events[0]["operation"] == "doctor"
+        assert events[0]["source"] == "cli"
+        assert events[0]["caller"] == "agent_discovery"
+        assert events[0]["outcome"] == "denied"
+
+    def test_source_defaults_independently_of_operation(self, tmp_path, monkeypatch):
+        """Supplying an operation must not corrupt the source vocabulary."""
+        from kiro_crew.agent_discovery import _read_agent_spec
+
+        link, events = self._denial_events(tmp_path, monkeypatch)
+
+        assert _read_agent_spec(link, operation="doctor") is None
+        assert events[0]["operation"] == "doctor"
+        assert events[0]["source"] == "list_agents"
+
+
+# Exact direct-call inventory. A new caller must name its user-facing operation
+# and interface channel (or ``unknown`` for a helper shared across interfaces).
+# Forwarding helpers are pinned as forwarding rather than forced to use a fixed
+# literal that would erase the caller's attribution.
+_EXPECTED_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
+    "kiro_crew/agent.py": [
+        ("agent_spec_lookup", "unknown"),
+        ("migrate_agent_specs", "unknown"),
+    ],
+    "kiro_crew/agent_discovery.py": [
+        ("agent_skill_globs", "unknown"),
+        ("forward:operation", "forward:source"),
+        ("list_agents", "unknown"),
+        ("list_agents", "unknown"),
+        ("resolve_project_agent_name", "unknown"),
+    ],
+    "kiro_crew/cli_doctor.py": [("doctor", "cli"), ("doctor", "cli")],
+    "kiro_crew/config/loader.py": [("load_config", "unknown")],
+    "kiro_crew/connections/mint.py": [
+        ("connections_mint", "dashboard"),
+        ("connections_mint", "dashboard"),
+    ],
+    "kiro_crew/dashboard/handlers/agents.py": [
+        ("api_agent_detail", "dashboard"),
+        ("api_agent_detail", "dashboard"),
+        ("api_agents_sync", "dashboard"),
+    ],
+    "kiro_crew/dashboard/handlers/mcp.py": [
+        ("api_mcp_active", "dashboard"),
+        ("mcp_server_rows", "dashboard"),
+        ("mcp_stub_eligibility", "dashboard"),
+    ],
+    "kiro_crew/session.py": [("resolve_agent_model", "unknown")],
+}
+
+
+def _read_agent_spec_call_sites() -> dict[str, list[tuple[str | None, str | None]]]:
+    """Return every direct ``_read_agent_spec`` call and its label pair."""
+    src = Path(__file__).resolve().parent.parent / "src"
+    sites: dict[str, list[tuple[str | None, str | None]]] = {}
+    for path in sorted(src.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute) else ""
+            )
+            if name != "_read_agent_spec":
+                continue
+            labels: dict[str, str | None] = {"operation": None, "source": None}
+            for kw in node.keywords:
+                if kw.arg not in labels:
+                    continue
+                if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    labels[kw.arg] = kw.value.value
+                elif isinstance(kw.value, ast.Name) and kw.value.id == kw.arg:
+                    labels[kw.arg] = f"forward:{kw.value.id}"
+            sites.setdefault(path.relative_to(src).as_posix(), []).append(
+                (labels["operation"], labels["source"])
+            )
+    return {
+        path: sorted(pairs, key=lambda pair: tuple((item is not None, item or "") for item in pair))
+        for path, pairs in sites.items()
+    }
+
+
+class TestCallSiteLabelRatchet:
+    """Every direct reader call is enumerated and explicitly attributed."""
+
+    def test_every_call_site_carries_the_expected_label(self):
+        assert _read_agent_spec_call_sites() == _EXPECTED_CALL_SITE_LABELS
+
+    def test_no_call_site_is_silently_unlabelled(self):
+        for path, pairs in _read_agent_spec_call_sites().items():
+            for operation, source in pairs:
+                assert (
+                    operation is not None
+                ), f"{path} calls _read_agent_spec without an explicit operation label"
+                assert (
+                    source is not None
+                ), f"{path} calls _read_agent_spec without an explicit source label"

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -1500,11 +1500,13 @@ class TestEffectiveModelSection:
         monkeypatch.setattr(cli_doctor, "project_agent_files", lambda d: [hostile])
         monkeypatch.setattr(cli_doctor, "project_agent_name", lambda p: "kirocrew")
         # Only the injected path is faked; the user-level spec still goes through
-        # the real reader so the report's own self-check is not disturbed.
+        # the real reader so the report's own self-check is not disturbed. The
+        # stub forwards **kw because the reader takes keyword-only SEL
+        # attribution labels (#6722) that this test does not care about.
         monkeypatch.setattr(
             cli_doctor,
             "_read_agent_spec",
-            lambda p: {"model": "m"} if p == hostile else real_reader(p),
+            lambda p, **kw: {"model": "m"} if p == hostile else real_reader(p, **kw),
         )
         issues: list[str] = []
 


### PR DESCRIPTION
## Problem / Motivation

The shared hardened agent-spec reader recorded every sensitive-path denial as list_agents, even when the request came from chat persistence, doctor, MCP, configuration loading, agent skills, or Connections minting. The denial was correct, but its audit attribution was misleading.

## Why it matters

Incorrect operation and source labels make security investigations unable to identify which surface actually attempted the denied read. The current main branch also added callers after this PR was opened, so resolving only the textual conflict would have left new surfaces misattributed.

## What changed (motivation → approach → change)

The reader now accepts explicit keyword-only operation and source attribution while retaining the historical list_agents defaults for compatibility. Every direct caller on current main is migrated, including agent-skill globs and both Connections mint paths. Dynamic helpers continue forwarding their caller-supplied operation and source.

The tests include an AST inventory of all 19 direct call sites and pin their expected labels, so a future unlabeled caller fails deterministically. Windows symlink coverage uses the repository capability probe; where symlinks are unavailable, a regular sensitive-file case verifies attribution without timing, retries, sleeps, or timeout-based synchronization.

The branch was rebuilt on current main as one commit. Main's conflict-side behavior was preserved first, then only the still-missing attribution behavior was reapplied. A merge-tree verification against current main completed without conflicts.

## Tests

- Focused hardened-reader and attribution suite: 56 passed, 3 skipped.
- Broader agent-related suites: 193 passed, 7 skipped; 261 passed, 9 skipped; final focused regression set 13 passed, 2 skipped.
- Repository Black gate, isort, flake8, mypy, compile checks, and git diff validation passed.
- No flaky-test masking was added: no retries, sleeps, relaxed assertions, warning filters, or extended timeouts.

## Manual verification

N/A — the change is backend audit attribution with deterministic unit and structural coverage; no user interface or external service path changed.

## Related Issues

Fixes #6722

Related follow-up: #6764 covers the separate project_agent_names denial path.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing relevant tests pass and new tests cover the behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated if applicable (no system-spec document pins these labels)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder only; no OSPO CLA text has been supplied.