### PR TITLE
fix(whatsapp): zero the JID proto's required fields so it serializes (#6756)

### DIFF
--- a/src/kiro_crew/whatsapp/client.py
+++ b/src/kiro_crew/whatsapp/client.py
@@ -799,4 +799,13 @@ class WhatsAppClient:
 
         norm = normalize_jid(jid_str)
         user, _, server = norm.partition("@")
-        return JID(User=user, Server=server or USER_SERVER)
+        # The JID proto marks RawAgent/Device/Integrator as required, so a
+        # two-field JID raises EncodeError at neonize's FFI boundary and every
+        # outbound call fails. Mirror neonize.utils.jid.build_jid: zero them.
+        return JID(
+            User=user,
+            RawAgent=0,
+            Device=0,
+            Integrator=0,
+            Server=server or USER_SERVER,
+        )

--- a/test/test_whatsapp_client.py
+++ b/test/test_whatsapp_client.py
@@ -462,9 +462,21 @@ def _install_fake_jid(monkeypatch):
     proto = ModuleType("neonize.proto.Neonize_pb2")
 
     class JID:
-        def __init__(self, User="", Server=""):
+        # Mirrors the real proto's contract: RawAgent/Device/Integrator are
+        # REQUIRED fields, so SerializeToString() on the real class raises
+        # EncodeError when they are unset. The fake records what was passed so
+        # tests can pin that _parse_jid supplies all five (issue #6756), and
+        # rejects unknown names because the real proto does too — a permissive
+        # fake would let a field typo pass while production regresses.
+        def __init__(self, User="", Server="", **required):
+            unknown = set(required) - {"RawAgent", "Device", "Integrator"}
+            if unknown:
+                raise ValueError(f"unknown JID field(s): {sorted(unknown)}")
             self.User = User
             self.Server = Server
+            self.RawAgent = required.get("RawAgent")
+            self.Device = required.get("Device")
+            self.Integrator = required.get("Integrator")
 
     proto.JID = JID
 
@@ -617,19 +629,34 @@ def test_list_groups_swallows_errors():
 
 
 # ── _parse_jid ──────────────────────────────────────────────────────────────
-def test_parse_jid_builds_proto(monkeypatch):
+@pytest.mark.parametrize(
+    ("jid_str", "expected_user", "expected_server"),
+    [
+        ("447700900000", "447700900000", "s.whatsapp.net"),  # bare number
+        ("447700900000@s.whatsapp.net", "447700900000", "s.whatsapp.net"),
+        ("120363021033254949@g.us", "120363021033254949", "g.us"),  # group
+        ("123456789@lid", "123456789", "lid"),  # linked-identity alias
+    ],
+)
+def test_parse_jid_sets_required_proto_fields(monkeypatch, jid_str, expected_user, expected_server):
+    """Regression for issue #6756: the neonize JID proto marks RawAgent,
+    Device and Integrator as REQUIRED, so a JID built without them raises
+    ``EncodeError`` from ``SerializeToString()`` at the FFI boundary and every
+    outbound WhatsApp operation fails. neonize is an optional dependency not
+    installed in CI, so this pins the constructor kwargs (all five fields
+    passed, the required trio zeroed — mirroring ``neonize.utils.jid.build_jid``)
+    rather than calling the real ``SerializeToString()``.
+    """
     _install_fake_jid(monkeypatch)
     c = WhatsAppClient("/tmp/none.db")
-    jid = c._parse_jid("447700900000@s.whatsapp.net")
-    assert jid.User == "447700900000"
-    assert jid.Server == "s.whatsapp.net"
-
-
-def test_parse_jid_defaults_server(monkeypatch):
-    _install_fake_jid(monkeypatch)
-    c = WhatsAppClient("/tmp/none.db")
-    jid = c._parse_jid("447700900000")
-    assert jid.Server == "s.whatsapp.net"
+    jid = c._parse_jid(jid_str)
+    assert jid.User == expected_user
+    assert jid.Server == expected_server
+    # Explicit zeros, not merely absent: None means the kwarg was NOT passed
+    # and the real proto would fail to serialize.
+    assert jid.RawAgent == 0
+    assert jid.Device == 0
+    assert jid.Integrator == 0
 
 
 def test_send_text_never_hands_neonize_a_bare_string(monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

Every outbound WhatsApp operation fails at protobuf encode time. `WhatsAppClient._parse_jid` constructs a neonize `JID` proto with only `User` and `Server` set, but the proto marks `RawAgent`, `Device`, and `Integrator` as **required** fields, so `SerializeToString()` raises:

```
google.protobuf.message.EncodeError: Message neonize.JID is missing required fields: RawAgent,Device,Integrator
```

neonize serializes the JID to cross its Go FFI boundary, so all 9 call sites that feed off `_parse_jid` break: `send_message`, message edit, reactions, mark-read, chat presence, and LID resolution (`get_pn_from_lid`).

## Why it matters

The WhatsApp channel can receive but not send — the agent reads every inbound message and answers none of them. Verified against neonize 0.4.3.post0 / protobuf: the failure reproduces deterministically on every send.

## What changed (motivation → approach → change)

Symptom: `EncodeError` on every outbound call → root cause: the two-field `JID(User=…, Server=…)` constructor leaves three required proto fields unset → change: mirror neonize's own reference constructor `neonize.utils.jid.build_jid`, which zeroes them:

```python
JID(User=user, RawAgent=0, Device=0, Integrator=0, Server=server or USER_SERVER)
```

`_parse_jid` is the only neonize `JID` construction site in `src/kiro_crew`, and all outbound/identity callers route through it, so this one change covers every reachable path. The 9 call sites are untouched — they are correct once `_parse_jid` emits a serializable JID.

## Tests

- `test_parse_jid_sets_required_proto_fields` (parametrized ×4: bare number, full user JID, `@g.us` group, `@lid` linked-identity alias) — pins that all five constructor kwargs are passed and the required trio is explicitly `0`, not merely absent. neonize is an optional dependency not installed in CI, so the test pins the constructor kwargs rather than calling the real `SerializeToString()`; the fake `JID` in `_install_fake_jid` now records the three required fields and **rejects unknown field names** (the real proto does too), so a field typo cannot pass the fake while regressing production.
- Two pre-existing `_parse_jid` tests subsumed by the parametrized rows were removed.

## Manual verification

Verified against the real `neonize==0.4.3.post0` proto in a local venv:
- Pre-fix two-field constructor reproduces the exact `EncodeError` (missing `RawAgent,Device,Integrator`).
- Post-fix, all three JID shapes serialize: plain user JID 36 bytes, full user JID 36 bytes, group JID 32 bytes — matching the reporter's findings.

no linked issue screenshots: backend-only change, no UI surface.

Closes #6756
