### PR TITLE
fix(dev-fleet): stop flagging the whole fleet legacy on a duplicate upstream remote alias

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -741,6 +741,41 @@ async def _live_worktree_path(*, fresh: bool = False) -> str | None:
     return _LIVE_WORKTREE
 
 
+# owner/repo capture, shared by identity normalization and the fallback scan.
+_REPO_PATH_RE = re.compile(r"[:/]([^/]+/[^/]+?)(?:\.git)?$")
+
+
+def _normalize_repo_identity(url: str) -> tuple[str, str] | None:
+    """Return a ``(host, owner/repo)`` identity for a git remote URL, or None.
+
+    Normalizes across the spellings git accepts for the same repository so two
+    aliases of one repo compare equal:
+
+    - ``https://github.com/owner/Repo.git`` and ``git@github.com:owner/repo``
+      collapse to the same identity;
+    - a trailing ``.git`` is stripped and the whole identity is lowercased;
+    - the host is part of the identity, so ``owner/repo`` on two different
+      forges stays distinct.
+
+    Returns None when no ``owner/repo`` can be extracted.
+    """
+    url = url.strip()
+    m = _REPO_PATH_RE.search(url)
+    if not m:
+        return None
+    owner_repo = m.group(1).lower()
+    # Host: scp-style ``user@host:owner/repo`` or a URL with a scheme.
+    host = ""
+    scp = re.match(r"(?:[^@/]+@)?([^/:]+):", url)
+    if scp and "://" not in url:
+        host = scp.group(1).lower()
+    else:
+        scheme = re.match(r"[a-zA-Z][a-zA-Z0-9+.-]*://(?:[^@/]+@)?([^/:]+)", url)
+        if scheme:
+            host = scheme.group(1).lower()
+    return (host, owner_repo)
+
+
 async def _load_fallback_repos() -> None:
     global _FALLBACK_REPOS
     try:
@@ -749,7 +784,20 @@ async def _load_fallback_repos() -> None:
         # No checkout, no remotes to enumerate; the fallback list stays empty.
         return
     repos: list[str] = []
+    seen: set[tuple[str, str]] = set()
     upstream = await _upstream_remote()
+    # Resolve upstream's own repo identity so a duplicate alias that merely
+    # points at the SAME repository as upstream (e.g. an ``origin`` left in
+    # place after the tracking remote was renamed) is not mistaken for a
+    # pre-rename fork. Without this, ``merge-base --is-ancestor`` is trivially
+    # true for identical refs and upstream's own repo enters the fallback list,
+    # so the derived ``<reponame>-wt-`` prefix flags every worktree as legacy.
+    upstream_identity: tuple[str, str] | None = None
+    rc_up, up_url, _ = await _run_cmd(
+        ["git", "-C", repo, "remote", "get-url", upstream], timeout=5,
+    )
+    if rc_up == 0:
+        upstream_identity = _normalize_repo_identity(up_url)
     rc, out, _err = await _run_cmd(["git", "-C", repo, "remote"], timeout=5)
     if rc == 0:
         for remote in out.split():
@@ -765,10 +813,21 @@ async def _load_fallback_repos() -> None:
             rc3, url, _ = await _run_cmd(
                 ["git", "-C", repo, "remote", "get-url", remote], timeout=5,
             )
-            if rc3 == 0:
-                m = re.search(r"[:/]([^/]+/[^/]+?)(?:\.git)?$", url.strip())
-                if m:
-                    repos.append(m.group(1))
+            if rc3 != 0:
+                continue
+            identity = _normalize_repo_identity(url)
+            if identity is None:
+                continue
+            # Skip a remote that names the SAME repository as upstream — it is
+            # an alias, not a distinct fork. This keeps the genuine pre-rename
+            # case (a different repo whose main is an ancestor of upstream's)
+            # while removing upstream's own name from the fallback list.
+            if upstream_identity is not None and identity == upstream_identity:
+                continue
+            if identity in seen:
+                continue
+            seen.add(identity)
+            repos.append(identity[1])
     _FALLBACK_REPOS = repos
 
 

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -198,9 +198,15 @@ async def test_load_fallback_repos_collects_ancestor_remotes(monkeypatch):
         if "--is-ancestor" in cmd:
             return (0 if "fork/main" in cmd else 1), "", ""
         if "get-url" in cmd:
+            remote = cmd[-1]
+            # Upstream is a genuinely different repository from the fork, so the
+            # fork's ancestor main still qualifies as a pre-rename fallback repo.
+            if remote == "origin":
+                return 0, "git@github.com:kirodotdev/KiroCrew.git\n", ""
             return 0, "git@github.com:someone/kirocrew.git\n", ""
         return 1, "", "unexpected"
 
+    monkeypatch.setattr(mod, "_repo", lambda: "/fake/repo")
     monkeypatch.setattr(mod, "_run_cmd", fake_run)
     await mod._load_fallback_repos()
     assert mod._FALLBACK_REPOS == ["someone/kirocrew"]
@@ -211,6 +217,97 @@ async def test_load_fallback_repos_empty_when_remote_listing_fails(monkeypatch):
     monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(1, "", "boom")))
     await mod._load_fallback_repos()
     assert mod._FALLBACK_REPOS == []
+
+
+@pytest.mark.asyncio
+async def test_load_fallback_repos_skips_duplicate_upstream_alias(monkeypatch):
+    """A remote that merely aliases the upstream repo is NOT a fallback repo.
+
+    This is the fleet-misflag defect: an ``origin`` left in place after the
+    tracking remote was renamed points at the SAME repo as upstream, so
+    ``merge-base --is-ancestor`` is trivially true. Upstream's own name must
+    not enter the fallback list (which would flag every worktree as legacy).
+    """
+    async def fake_run(cmd, **kw):
+        if cmd[-1] == "remote":
+            return 0, "kirocrew\norigin\n", ""
+        if "--is-ancestor" in cmd:
+            return 0, "", ""  # identical refs -> trivially an ancestor
+        if "get-url" in cmd:
+            # Both remotes point at the SAME upstream repository.
+            return 0, "https://github.com/kirodotdev/KiroCrew.git\n", ""
+        return 1, "", "unexpected"
+
+    monkeypatch.setattr(mod, "_repo", lambda: "/fake/repo")
+    monkeypatch.setattr(mod, "_UPSTREAM_REMOTE", "kirocrew")
+    monkeypatch.setattr(mod, "_run_cmd", fake_run)
+    await mod._load_fallback_repos()
+    assert mod._FALLBACK_REPOS == []
+
+
+@pytest.mark.asyncio
+async def test_load_fallback_repos_recognizes_scp_and_git_suffix_as_same(monkeypatch):
+    """scp-style and .git-suffixed spellings of the upstream URL are one repo.
+
+    The alias uses ``git@github.com:...`` while upstream uses the https,
+    ``.git``-suffixed spelling; both normalize to the same identity, so the
+    alias is skipped rather than treated as a distinct fork.
+    """
+    async def fake_run(cmd, **kw):
+        if cmd[-1] == "remote":
+            return 0, "kirocrew\norigin\n", ""
+        if "--is-ancestor" in cmd:
+            return 0, "", ""
+        if "get-url" in cmd:
+            remote = cmd[-1]
+            if remote == "kirocrew":
+                return 0, "https://github.com/kirodotdev/KiroCrew.git\n", ""
+            return 0, "git@github.com:KiroDotDev/kirocrew\n", ""
+        return 1, "", "unexpected"
+
+    monkeypatch.setattr(mod, "_repo", lambda: "/fake/repo")
+    monkeypatch.setattr(mod, "_UPSTREAM_REMOTE", "kirocrew")
+    monkeypatch.setattr(mod, "_run_cmd", fake_run)
+    await mod._load_fallback_repos()
+    assert mod._FALLBACK_REPOS == []
+
+
+@pytest.mark.asyncio
+async def test_load_fallback_repos_dedupes_multiple_aliases_of_one_repo(monkeypatch):
+    """Two aliases of one genuine fork collapse to a single fallback entry."""
+    async def fake_run(cmd, **kw):
+        if cmd[-1] == "remote":
+            return 0, "kirocrew\nfork-a\nfork-b\n", ""
+        if "--is-ancestor" in cmd:
+            # Both forks' mains are ancestors of upstream's.
+            return 0, "", ""
+        if "get-url" in cmd:
+            remote = cmd[-1]
+            if remote == "kirocrew":
+                return 0, "https://github.com/kirodotdev/KiroCrew.git\n", ""
+            if remote == "fork-a":
+                return 0, "git@github.com:someone/kirocrew.git\n", ""
+            return 0, "https://github.com/someone/KiroCrew\n", ""  # same repo, other spelling
+        return 1, "", "unexpected"
+
+    monkeypatch.setattr(mod, "_repo", lambda: "/fake/repo")
+    monkeypatch.setattr(mod, "_UPSTREAM_REMOTE", "kirocrew")
+    monkeypatch.setattr(mod, "_run_cmd", fake_run)
+    await mod._load_fallback_repos()
+    assert mod._FALLBACK_REPOS == ["someone/kirocrew"]
+
+
+def test_normalize_repo_identity_spellings_and_host():
+    """Same repo across https/scp/.git spellings is one identity; host matters."""
+    https = mod._normalize_repo_identity("https://github.com/kirodotdev/KiroCrew.git")
+    scp = mod._normalize_repo_identity("git@github.com:KiroDotDev/kirocrew")
+    assert https == scp == ("github.com", "kirodotdev/kirocrew")
+    # Same owner/repo on a different forge is a DISTINCT identity.
+    other = mod._normalize_repo_identity("https://gitlab.com/kirodotdev/kirocrew.git")
+    assert other == ("gitlab.com", "kirodotdev/kirocrew")
+    assert other != https
+    # Unparseable URL yields None.
+    assert mod._normalize_repo_identity("not-a-url") is None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What is the problem?

The Dev Fleet dashboard hides an operator's entire worktree fleet behind the
"N legacy worktrees hidden" toggle whenever the local checkout has a duplicate
remote alias that points at the same repository as the upstream remote. This is
a very common configuration: an `origin` remote left in place after the tracking
remote was renamed (for example to `kirocrew`) both point at the upstream repo.
In that state, every worktree of the current repo is misclassified as `legacy`
and collapsed out of view.

## Why this issue matters to the user

The fleet view is the operator's map of their own active work. When a stock
duplicate-remote setup silently flags all of it legacy, the dashboard appears
empty or nearly so, and the operator has to know to expand a "legacy" toggle to
see worktrees that are not legacy at all. It turns a routine remote layout into
a confusing loss of the primary view.

There is a second, smaller cost: `_fetch_pr_status()` iterates the fallback repo
list as a secondary `gh` lookup when the upstream query misses. With upstream's
own repository in that list, every miss pays for a duplicate identical `gh`
query against the same repo.

## How our fix solves it (symptom to root cause)

Symptom: all worktrees show as legacy.

`_build_fleet()` derives the legacy prefixes from the module's fallback repo
list: `f"{r.split('/')[-1].lower()}-wt-"` for each entry. A worktree whose name
starts with one of those prefixes is flagged legacy.

That list is populated by `_load_fallback_repos()`, whose intent is to keep PRs
from a genuine pre-rename repository visible and prunable: it collects every
non-upstream remote whose `<remote>/main` is an ancestor of `<upstream>/main`.

Root cause: when a remote is merely a duplicate alias of upstream, its
`<remote>/main` and `<upstream>/main` are the identical ref, so
`merge-base --is-ancestor` is trivially true. Upstream's own `owner/repo` then
enters the fallback list, and the derived `<reponame>-wt-` prefix matches every
worktree of the current repository.

The fix resolves upstream's own repository identity and skips any remote that
resolves to the same identity, so an alias of upstream never enters the list:

- Identity is normalized, not compared by remote name or raw URL: a trailing
  `.git` is stripped, the value is lowercased, and both `https://host/owner/repo`
  and scp-style `git@host:owner/repo` spellings collapse to one identity.
- The host is part of the identity, so the same `owner/repo` on two different
  forges stays distinct.
- The resulting list is de-duplicated, since several aliases can name one repo.

The genuine case the feature exists for is preserved: a truly different
repository whose `main` is an ancestor of upstream's (a real pre-rename fork)
still lands in the list and its worktrees still classify correctly. The URL
parsing reuses the existing `owner/repo` regex, extracted into a shared
`_normalize_repo_identity()` helper rather than adding a second parser. Because
upstream's own repo no longer appears in the list, the duplicated fallback `gh`
query in `_fetch_pr_status()` is eliminated too.

## What tests we did

Added unit tests to `test/test_dev_fleet_server_coverage.py`, alongside the
existing `_load_fallback_repos` coverage:

1. A duplicate-URL alias of upstream yields an EMPTY fallback list (the fleet is
   not flagged legacy).
2. A genuinely different ancestor repository is still kept (updated the existing
   ancestor test so upstream and the fork resolve to distinct URLs, which the
   new identity check requires).
3. scp-style and `.git`-suffixed spellings of the upstream URL are recognized as
   the same repository and skipped.
4. Two aliases of one genuine fork de-duplicate to a single entry.
5. A direct test of `_normalize_repo_identity` covering https/scp spelling
   equality, host-based forge distinction, and the unparseable-URL case.

Each new assertion was mutation-verified: the corresponding branch of the fix
was disabled, the test was confirmed to go red, then the fix was restored.
Scoped gates run clean on the changed files: the dev_fleet server test module
(234 passed), isort, flake8, mypy, and the repository's diff-scoped black gate.

## Any other suggestions on the work

The classification depends on `_upstream_remote()` resolving correctly via
`branch.main.remote`; when it degrades to `origin` on a checkout that has since
renamed its tracking remote, upstream identity resolution still holds because it
is derived from the resolved remote's own URL. No change is proposed here, but it
is worth keeping the two resolution paths (upstream remote name and upstream
repo identity) in mind together if the fleet classification is revisited.
