### PR TITLE
fix(dashboard): show public-repo PR/MR chip status to any dashboard user

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -889,12 +889,15 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
 async def api_chat_slots(request: web.Request) -> web.Response:
     """GET /api/chat/slots — list all chat slots."""
     state: DashboardState = request.app["state"]
-    # Credential-backed check status is owner-only. Non-owner and app-token
-    # callers receive source links but neither cached status nor provider work.
+    # Credential-backed check status is owner-only for PRIVATE repos. For a
+    # PUBLIC repo the lifecycle is world-visible, so an authenticated
+    # dashboard-user (non-owner) may see it too. App-token callers receive
+    # source links but neither cached status nor provider work.
     from kiro_crew.dashboard.handlers.source_providers import (
         ensure_gitlab_hosts_loaded,
         is_owner_dashboard_request,
         schedule_check_refresh,
+        schedule_visibility_refresh,
     )
 
     # Same warm-up as the WebSocket connect path: slot source-link extraction is
@@ -906,10 +909,17 @@ async def api_chat_slots(request: web.Request) -> web.Response:
         logger.debug("GitLab allowlist warm-up failed; chips may lag one round", exc_info=True)
 
     include_check_status = is_owner_dashboard_request(request)
-    payloads = state.serialize_slots(include_check_status=include_check_status)
+    is_dashboard_user = bool(request.get("is_dashboard_user"))
+    payloads = state.serialize_slots(
+        include_check_status=include_check_status, dashboard_user=is_dashboard_user
+    )
     if include_check_status:
-        # Issue links carry no check status — skip them so the scheduler never
-        # hands an issue URL to the pull-request-only chip fetch.
+        # Only the OWNER's GET drives provider work. Both the visibility probe
+        # and the status refresh run the operator's `gh`/`glab` credentials, so
+        # a non-owner request must trigger NEITHER (GPT #6789) — it renders the
+        # owner-populated caches read-only via the fail-closed is_repo_public
+        # gate in _project_source_links. Issue links carry no check status, so
+        # skip them (the fetch is pull-request-only).
         urls = [
             link["url"]
             for payload in payloads
@@ -917,6 +927,7 @@ async def api_chat_slots(request: web.Request) -> web.Response:
             if link.get("kind", "change") == "change"
         ]
         if urls:
+            schedule_visibility_refresh(urls, state.push_slots_update)
             schedule_check_refresh(urls, state.push_slots_update)
     return web.json_response(payloads)
 
@@ -987,7 +998,8 @@ async def api_chat_slot_source_links(request: web.Request) -> web.Response:
             "GitLab allowlist warm-up failed; expanded chips may lag one round", exc_info=True
         )
 
-    # Cached status only, owner-gated exactly like the list endpoint. No
+    # Cached status only, gated exactly like the list endpoint: owner sees all,
+    # a dashboard-user sees public-repo status, app tokens see none. No
     # schedule_check_refresh here: that pushes a `slots` update, which by
     # definition cannot carry links outside the budget, so the provider work
     # would produce a result this response can never show.
@@ -999,7 +1011,10 @@ async def api_chat_slot_source_links(request: web.Request) -> web.Response:
     # the slot's messages -- these URLs are extracted FROM those messages, so
     # gating here would withhold nothing it does not already have.
     return web.json_response(
-        slot.source_links_payload(include_check_status=is_owner_dashboard_request(request))
+        slot.source_links_payload(
+            include_check_status=is_owner_dashboard_request(request),
+            dashboard_user=bool(request.get("is_dashboard_user")),
+        )
     )
 
 

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -5415,6 +5415,319 @@ def _clear_check_flap(url: str) -> None:
     _check_flap_damped.discard(url)
 
 
+# ── Repository visibility (public vs private) ────────────────────────────────
+# Chip status (state / CI rollup) is credential-backed provider data, so it is
+# sent only to the owner connection by default. But for a PUBLIC repository that
+# same lifecycle state is world-visible on the provider's website, so withholding
+# it from a legitimate authenticated dashboard user buys no confidentiality — it
+# only removes the chip's most useful signal (is this PR merged / closed / green).
+#
+# This cache lets the status gate admit a public-repo link for a dashboard-user
+# connection while keeping PRIVATE repos strictly owner-only. It is keyed by
+# ``provider|host|owner|repo`` (not by PR URL): visibility is a property of the
+# repository, and one repo backs many PR chips — so a per-repo entry, refreshed
+# on the SAME cadence as the chip status it gates, costs at most one extra
+# provider read per repo per TTL, shared across every chip on it.
+#
+# Fails CLOSED: until a repo is positively known public, ``is_repo_public``
+# returns None and the gate treats it as owner-only. A provider read that errors
+# or is unauthorized never flips a repo to public.
+#
+# TTL == the CHECK TTL, deliberately: the status a public flag authorizes is
+# refreshed every ``_CHECK_TTL_SECS`` and ``schedule_visibility_refresh`` runs
+# on the SAME calls, so visibility is never more than one refresh cycle staler
+# than the status it gates. A repo that flips public->private therefore stops
+# authorizing non-owner status within ~one check TTL (not an hour): the paired
+# status refresh re-reads visibility, the flip is observed, and a stale entry
+# fails closed the moment it crosses this TTL. This bounds the private-status
+# exposure to a single short refresh window rather than a long one.
+_VISIBILITY_TTL_SECS = _CHECK_TTL_SECS
+_VISIBILITY_CACHE_MAX = 512
+# provider|host|owner|repo -> (fetched_monotonic, is_public | None)
+_visibility_cache: dict[str, tuple[float, bool | None]] = {}
+_visibility_inflight: set[str] = set()
+# Per-key counter bumped every time a force=True refresh fails a cached-public
+# entry closed. ``_refresh_repo_visibility`` captures this at start and refuses
+# to write a positive (public) result if the generation changed while it was
+# fetching — i.e. a public->private force-invalidation landed mid-flight — so a
+# stale in-flight read can never RESTORE public across a flip (GPT #6789
+# round-14). The next refresh reconfirms from a fail-closed baseline.
+_visibility_force_gen: dict[str, int] = {}
+_VISIBILITY_TASKS: set[asyncio.Task] = set()
+# Jira has no public-repo concept and its status is credential-gated regardless,
+# so visibility is only meaningful for change providers.
+_VISIBILITY_PROVIDERS = frozenset({"github", "gitlab"})
+
+
+def _visibility_key(ref: SourceRef) -> str:
+    return f"{ref.provider}|{ref.host}|{ref.owner}|{ref.repo}"
+
+
+def _trim_visibility_cache() -> None:
+    while len(_visibility_cache) > _VISIBILITY_CACHE_MAX:
+        del _visibility_cache[min(_visibility_cache, key=lambda k: _visibility_cache[k][0])]
+
+
+def is_repo_public(url: str) -> bool | None:
+    """Whether the repo behind a source URL is known PUBLIC.
+
+    Returns True (known public), False (known private), or None (not yet
+    fetched / unknown / STALE / not a change provider). The status gate treats
+    anything other than True as owner-only, so an unfetched, errored, or stale
+    repo never leaks private status to a non-owner. Never blocks — reads the
+    cache only.
+
+    A cache entry older than ``_VISIBILITY_TTL_SECS`` is treated as STALE and
+    returns None: a repo that flipped public->private while its visibility
+    refresh kept failing must not keep authorizing status forever. The exposure
+    is bounded to one TTL from the last SUCCESSFUL read (``_refresh_repo_visibility``
+    never resets the timestamp on a failed read), after which this fails closed.
+    """
+    try:
+        ref = parse_source_url(url)
+    except Exception:
+        return None
+    if ref.provider not in _VISIBILITY_PROVIDERS:
+        return None
+    entry = _visibility_cache.get(_visibility_key(ref))
+    if not entry:
+        return None
+    fetched_at, value = entry
+    if time.monotonic() - fetched_at >= _VISIBILITY_TTL_SECS:
+        return None
+    return value
+
+
+async def _fetch_repo_visibility(ref: SourceRef) -> bool | None:
+    """Read a repo's public/private flag via the provider CLI. None on failure."""
+    try:
+        if ref.provider == "github":
+            # isPrivate is False for BOTH public AND internal (GitHub Enterprise)
+            # repos, but an internal repo is visible only to enterprise members —
+            # NOT anonymously — so classifying it public would leak credential-
+            # backed status to a non-owner (GPT #6789). Read `visibility` and
+            # require exactly "public" (mirrors the GitLab "public"-only gate);
+            # "internal"/"private" → owner-only. isPrivate is kept only as a
+            # belt-and-braces private check.
+            data = await _run_json(
+                "gh",
+                "repo",
+                "view",
+                f"{ref.owner}/{ref.repo}",
+                "--json",
+                "isPrivate,visibility",
+            )
+            if not isinstance(data, dict):
+                return None
+            if data.get("isPrivate") is True:
+                return False
+            vis = data.get("visibility")
+            if isinstance(vis, str):
+                return vis.lower() == "public"
+            return None
+        if ref.provider == "gitlab":
+            # GitLab exposes repository visibility as public/internal/private.
+            # Only "public" is world-readable without a credential; "internal"
+            # is visible to authenticated instance members, which is NOT the
+            # same as anonymous-public, so it stays owner-only.
+            #
+            # But a PUBLIC project can still restrict individual features:
+            # merge_requests_access_level / builds_access_level can be "private"
+            # (members only) or "disabled" even when the project is public, so a
+            # credentialed refresh would otherwise surface member-only MR/CI
+            # status to a non-owner (GPT #6789). Require the project to be public
+            # AND both feature levels to be "enabled" (available at the project's
+            # public visibility, i.e. anonymously readable) before treating the
+            # PR/MR lifecycle + CI status as public. GitHub has no such per-
+            # feature split — a public repo's PRs and checks are public.
+            #
+            # quote(ref.project, safe="") — NOT f"{owner}%2F{repo}": a subgroup
+            # project path (group/subgroup/repo) has interior slashes that must
+            # all be percent-encoded, and owner/repo drops the subgroup segment
+            # entirely. Mirrors every other glab-api call site.
+            project = quote(ref.project, safe="")
+            data = await _run_json("glab", "api", f"projects/{project}", host=ref.host)
+            if not isinstance(data, dict) or not isinstance(data.get("visibility"), str):
+                return None
+            if data["visibility"] != "public":
+                return False
+            # "enabled" = available at the project's (public) visibility level;
+            # "private"/"disabled" restrict the feature to members. Missing keys
+            # fail closed (owner-only) rather than assuming anonymous access.
+            mr_level = data.get("merge_requests_access_level")
+            ci_level = data.get("builds_access_level")
+            # public_jobs (a.k.a. "Public pipelines") is a SEPARATE gate: when
+            # False, a public project with builds_access_level "enabled" still
+            # hides pipeline/job status from non-members, so a credentialed
+            # refresh would leak private CI state to a non-owner (GPT #6789).
+            # Require it True (missing → fail closed) before treating CI status
+            # as anonymously public.
+            public_jobs = data.get("public_jobs")
+            return mr_level == "enabled" and ci_level == "enabled" and public_jobs is True
+    except Exception:
+        return None
+    return None
+
+
+async def _refresh_repo_visibility(
+    ref: SourceRef,
+    on_update: _CheckUpdateCallback | None = None,
+    *,
+    prev_public_override: bool | None = None,
+) -> None:
+    key = _visibility_key(ref)
+    prev_entry = _visibility_cache.get(key)
+    # Snapshot the force-invalidation generation at start. If a force=True
+    # refresh fails this key closed WHILE we are fetching (generation bumps), our
+    # read is stale w.r.t. that public->private flip, so we must NOT write back a
+    # positive result that would restore ``public`` — we leave the fail-closed
+    # unknown standing and let the next refresh reconfirm (GPT #6789 round-14).
+    start_gen = _visibility_force_gen.get(key, 0)
+    # The RENDERED gate value before this refresh: True only if a fresh public
+    # entry exists (mirrors ``is_repo_public``'s TTL check). A change in this
+    # boolean is exactly when a chip appears or disappears for a non-owner.
+    #
+    # ``prev_public_override`` carries the rendered-public value captured BEFORE
+    # a forced pre-invalidation clobbered the cache entry to unknown. Without it,
+    # the force path would read its own just-written (now, None) as prev_public
+    # =False, so a genuine public->private transition compares False==False and
+    # fires no update — leaving connected non-owners on the stale public chip
+    # indefinitely (GPT #6789). The override restores the true baseline so the
+    # hide-the-chip update is queued.
+    if prev_public_override is not None:
+        prev_public = prev_public_override
+    else:
+        prev_public = (
+            bool(prev_entry[1]) and (time.monotonic() - prev_entry[0]) < _VISIBILITY_TTL_SECS
+            if prev_entry
+            else False
+        )
+    try:
+        async with _check_semaphore:
+            public = await _fetch_repo_visibility(ref)
+    except Exception:
+        public = None
+    finally:
+        _visibility_inflight.discard(key)
+    prev = _visibility_cache.get(key)
+    if public is not None and _visibility_force_gen.get(key, 0) != start_gen:
+        # A force=True invalidation (public->private flip) landed while we were
+        # fetching. Our positive read predates the flip, so restoring ``public``
+        # here would re-open the leak the force path just closed. Discard the
+        # stale positive: leave the fail-closed entry as-is (or record unknown)
+        # so is_repo_public stays None until a post-flip refresh reconfirms.
+        if prev is None:
+            _visibility_cache[key] = (time.monotonic(), None)
+    elif public is not None:
+        # A positive read is authoritative: store the fresh value and reset the
+        # TTL clock. This is the ONLY path that may mark a repo public.
+        _visibility_cache[key] = (time.monotonic(), public)
+    elif prev is not None:
+        # Failed read. Keep the prior value but DO NOT reset the timestamp, so a
+        # persistently-failing refresh cannot extend a stale ``public`` past its
+        # TTL: it ages out from its last SUCCESSFUL read and ``is_repo_public``
+        # then returns None (fail closed). This is the public->private +
+        # visibility-read-fails hole — leaving the old timestamp bounds the
+        # exposure to one TTL rather than forever.
+        _visibility_cache[key] = (prev[0], prev[1])
+    else:
+        # Never successfully read: record an unknown so repeated cold failures
+        # do not re-spawn a fetch every slots push (still returns None).
+        _visibility_cache[key] = (time.monotonic(), None)
+    _trim_visibility_cache()
+    # Notify only when the RENDERED public flag flipped: a cold->public repo now
+    # shows its chip status, and a public->private (or aged-out) repo hides it.
+    # Without this a fresh visibility read never re-serialized the sidebar, so a
+    # chip could stay bare until an unrelated push (GPT #6789).
+    new_entry = _visibility_cache.get(key)
+    new_public = bool(new_entry and new_entry[1] is True)
+    if on_update is not None and new_public != prev_public:
+        _queue_check_update(on_update)
+
+
+def schedule_visibility_refresh(
+    urls: list[str], on_update: _CheckUpdateCallback | None = None, *, force: bool = False
+) -> None:
+    """Kick bounded background visibility reads for repos not freshly cached.
+
+    Fire-and-forget with inflight dedup, mirroring ``schedule_check_refresh``.
+    One entry per repo (deduped by visibility key), TTL-paced, so a large
+    workspace of PRs on a handful of repos costs a handful of reads per repo per
+    TTL.
+
+    ``on_update`` is invoked (debounced) whenever a repo's RENDERED public flag
+    flips, so the sidebar re-serializes when a chip should appear or disappear.
+    ``force`` bypasses the TTL freshness check for callers that know the repo's
+    status just moved (the turn-boundary refresh), so visibility is revalidated
+    in lockstep with the forced status read rather than lagging it.
+
+    On the ``force`` path the cached PUBLIC flag is invalidated SYNCHRONOUSLY
+    before the refresh task is spawned: the forced status read and the
+    visibility read run as concurrent tasks, and if status finished first it
+    could otherwise broadcast fresh (now-private) status against a still-cached-
+    public visibility entry (a non-owner private-status leak). Dropping the entry
+    to unknown up front makes ``is_repo_public`` fail closed for the whole
+    in-flight window; the refresh restores ``public`` only on a positive
+    reconfirmation, and its ``on_update`` re-serializes when it does.
+    """
+    now = time.monotonic()
+    seen: set[str] = set()
+    for url in dict.fromkeys(urls):
+        try:
+            ref = parse_source_url(url)
+        except Exception:
+            continue
+        if ref.provider not in _VISIBILITY_PROVIDERS:
+            continue
+        key = _visibility_key(ref)
+        if key in seen:
+            continue
+        seen.add(key)
+        entry = _visibility_cache.get(key)
+        if not force and entry and now - entry[0] < _VISIBILITY_TTL_SECS:
+            continue
+        prev_public_override: bool | None = None
+        if force:
+            # Bump the force generation on EVERY forced refresh, BEFORE the
+            # inflight-dedup return below and regardless of the current cache
+            # value. A forced refresh means "the status just moved, revalidate
+            # now"; any visibility read already in flight (which may have started
+            # before a public->private flip) must be treated as stale and
+            # refused write-back. Gating this bump on "currently public" was a
+            # hole: an entry already dropped to unknown (e.g. a first force
+            # landed, then a second arrives while the pre-privacy fetch is still
+            # in flight) would skip the bump, and that in-flight positive read
+            # could then restore ``public`` (GPT #6789 round-15).
+            _visibility_force_gen[key] = _visibility_force_gen.get(key, 0) + 1
+            if entry is not None and entry[1] is True:
+                # Capture the TRUE rendered-public baseline BEFORE clobbering, so
+                # the refresh's on_update comparison measures the flip against
+                # what non-owners currently see (public), not the unknown we are
+                # about to write. Otherwise a public->private transition compares
+                # False==False and never hides the chip (GPT #6789).
+                prev_public_override = (now - entry[0]) < _VISIBILITY_TTL_SECS
+                # Synchronously fail the entry closed so ``is_repo_public``
+                # returns None for the whole in-flight window; the refresh
+                # restores True only on a positive reconfirmation. Only clobber
+                # when currently public — an already-unknown entry is already
+                # fail-closed, and the generation bump above covers the stale
+                # in-flight read either way.
+                _visibility_cache[key] = (now, None)
+        if key in _visibility_inflight:
+            # A refresh is already running for this repo. We have already failed
+            # a cached-public entry closed above on the force path, so the
+            # in-flight result can only ever restore ``public`` via a positive
+            # reconfirmation (never leave a stale public flag standing); dedup
+            # the redundant spawn.
+            continue
+        _visibility_inflight.add(key)
+        task = asyncio.get_running_loop().create_task(
+            _refresh_repo_visibility(ref, on_update, prev_public_override=prev_public_override)
+        )
+        _VISIBILITY_TASKS.add(task)
+        task.add_done_callback(_VISIBILITY_TASKS.discard)
+
+
 def get_cached_check_status(url: str) -> dict[str, str] | None:
     """Cached status for a PR url: {"ci": ..., "state": ..., "mergeable": ...}.
 
@@ -5609,6 +5922,16 @@ def record_full_payload_status(url: str, payload: dict[str, Any]) -> None:
         # single repeating A→B loop and falsely damp legitimate CI churn (e.g.
         # three real re-runs of the same job).
         _clear_check_flap(url)
+        # Lockstep visibility revalidation (GPT #6789): the full-payload writer
+        # is a SECOND authoritative status writer alongside _refresh_check_status.
+        # A public->private change whose owner detail fetch refreshes status here
+        # would otherwise be served to a non-owner against a still-cached-public
+        # visibility flag. force=True bypasses the visibility TTL and synchronously
+        # fails a cached-public entry closed for the in-flight window (restoring
+        # public only on positive reconfirmation), closing the same window the
+        # chip-refresh path already guards. Bounded to real status transitions.
+        with contextlib.suppress(Exception):
+            schedule_visibility_refresh([url], force=True)
         _emit_status_delta(url, status, "detail")
 
 
@@ -5813,6 +6136,20 @@ async def _refresh_check_status(url: str, on_update: _CheckUpdateCallback | None
     if not changed:
         return
     assert status is not None  # narrowed by `changed`
+    # Lockstep visibility revalidation (GPT #6789) — FIRST, before flap handling
+    # and before the first ``await``. A status refresh can land a freshly-fetched
+    # (possibly now-private) status while this URL's visibility entry is still
+    # within its TTL, so ``is_repo_public`` would authorize the new status
+    # against a stale-fresh public flag. ``schedule_visibility_refresh(force=True)``
+    # SYNCHRONOUSLY fails a cached-public entry closed for the in-flight window
+    # (it pre-invalidates before spawning the refresh task), so it must run
+    # before any ``await`` yields the event loop and before the flap path's
+    # early return — otherwise a concurrent slots push (or the flap path, which
+    # returns without reaching the old call site) could observe the newly-cached
+    # private status against an un-invalidated public flag. Bounded to real
+    # status transitions only.
+    with contextlib.suppress(Exception):
+        schedule_visibility_refresh([url], on_update, force=True)
     # Structural loop-breaker: if this URL keeps repeating the identical chip
     # transition every refresh, the chip and full-payload projections disagree
     # on vocabulary and the mutual-invalidation protocol below would spin a

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2207,7 +2207,63 @@ def _source_links_by_kind(links: list[dict]) -> tuple[list[dict], list[dict]]:
     return changes, issues
 
 
-def _project_source_links(links: list[dict], include_check_status: bool) -> list[dict]:
+# Deduplicated SEL audit of the non-owner public-repo status grant. This runs on
+# the per-link serialization path (every push broadcast), so an un-deduplicated
+# write would be unbounded — collapse to one event per URL per window, mirroring
+# ws_event_scope._audit_decision. AUTOSDE (backend-security-controls) requires a
+# SEL event for every permission decision, grants included.
+_PUBLIC_STATUS_GRANT_AUDIT: dict[str, float] = {}
+_PUBLIC_STATUS_DENY_AUDIT: dict[str, float] = {}
+_PUBLIC_STATUS_GRANT_WINDOW_SECS = 300.0
+
+
+def _audit_public_status_grant(url: str) -> None:
+    now = time.monotonic()
+    last = _PUBLIC_STATUS_GRANT_AUDIT.get(url)
+    if last is not None and (now - last) < _PUBLIC_STATUS_GRANT_WINDOW_SECS:
+        return
+    _PUBLIC_STATUS_GRANT_AUDIT[url] = now
+    try:
+        sel().log_api_access(
+            caller="dashboard-user",
+            operation="source_link_public_status",
+            outcome="allowed",
+            source="source_links",
+            resources=url,
+        )
+    except Exception:
+        logger.debug("SEL audit for public-status grant failed", exc_info=True)
+
+
+def _audit_public_status_denied(url: str) -> None:
+    # Symmetric to the grant audit: AUTOSDE backend-security-controls requires a
+    # SEL event for every permission DECISION, denials included. A non-owner
+    # dashboard user requested status on a repo that is NOT confirmed public
+    # (private / unknown / stale) and was denied — record it, deduplicated per
+    # URL per window (same hot per-link broadcast path as the grant).
+    now = time.monotonic()
+    last = _PUBLIC_STATUS_DENY_AUDIT.get(url)
+    if last is not None and (now - last) < _PUBLIC_STATUS_GRANT_WINDOW_SECS:
+        return
+    _PUBLIC_STATUS_DENY_AUDIT[url] = now
+    try:
+        sel().log_api_access(
+            caller="dashboard-user",
+            operation="source_link_public_status",
+            outcome="denied",
+            source="source_links",
+            resources=url,
+        )
+    except Exception:
+        logger.debug("SEL audit for public-status denial failed", exc_info=True)
+
+
+def _project_source_links(
+    links: list[dict],
+    include_check_status: bool,
+    *,
+    dashboard_user: bool = False,
+) -> list[dict]:
     """Attach cached chip status to each link, gated on kind and on the caller.
 
     The chip-status cache is pull-request-only: it holds a {ci, state}
@@ -2215,20 +2271,63 @@ def _project_source_links(links: list[dict], include_check_status: bool) -> list
     URL it never stores -- and if a PR and an issue ever normalized to the same
     key, the issue chip would inherit the PR's CI glyph. Gate on kind.
 
+    ``include_check_status`` is the OWNER gate: the owner sees status for every
+    link, public or private. ``dashboard_user`` is the weaker, PUBLIC-ONLY gate:
+    a non-owner but authenticated dashboard user sees status only for a link
+    whose repository is KNOWN public, because that lifecycle state is already
+    world-visible on the provider's website. Private and not-yet-known repos
+    fall through to owner-only (fail closed). App tokens pass neither flag and
+    keep bare chips.
+
     Shared by the budgeted slots payload and the unbudgeted overflow-expand
     read so the two cannot decorate the same link differently.
     """
-    return [
-        {
-            **link,
-            **(
-                (_cached_check_status(link["url"]) or {})
-                if include_check_status and link.get("kind", "change") == "change"
-                else {}
-            ),
-        }
-        for link in links
-    ]
+
+    def _attach(link: dict) -> bool:
+        if link.get("kind", "change") != "change":
+            return False
+        if include_check_status:
+            return True
+        granted = dashboard_user and _repo_is_public(link["url"]) is True
+        if granted:
+            # SEL-audit the AUTHORIZATION DECISION (AUTOSDE
+            # backend-security-controls: every permission decision, grants
+            # included). This grants a non-owner status on a repo whose public
+            # visibility we positively confirmed — a real access-control
+            # decision, so it must leave an allow event. Deduplicated per URL per
+            # window because this runs per-link on every push broadcast; an
+            # un-deduplicated write here would be unbounded on the hot path.
+            _audit_public_status_grant(link["url"])
+        elif dashboard_user:
+            # DENY decision: a non-owner dashboard user requested status on a
+            # change link but the repo is not confirmed public (private /
+            # unknown / stale), so status is withheld. AUTOSDE requires the
+            # denial to be audited too — deduplicated the same way (GPT #6789
+            # round-15). include_check_status (owner) paths never reach here, and
+            # app tokens set neither flag so they are not "denied dashboard-user"
+            # decisions.
+            _audit_public_status_denied(link["url"])
+        return granted
+
+    def _status(url: str) -> dict:
+        # Project ONLY the known chip-status keys, never the raw cache dict.
+        # Splatting ``**cache`` was fail-open: the cache payload already outgrew
+        # its docstring once (mergeStateStatus), so the next field would ride
+        # silently into every frame — including, via the general broadcast, an
+        # app-token frame (ws_event_scope strips the same names on the far end,
+        # but the two lists must not be the sole guarantee). Enumerating here
+        # fails closed at the source: an unlisted field is simply not emitted.
+        cached = _cached_check_status(url) or {}
+        return {k: cached[k] for k in _CHIP_STATUS_KEYS if k in cached}
+
+    return [{**link, **(_status(link["url"]) if _attach(link) else {})} for link in links]
+
+
+# The only fields the chip-status cache is allowed to project onto a source
+# link. Kept in step with ws_event_scope._SOURCE_LINK_STATUS_KEYS (the app-token
+# strip) and the frontend SidebarSourceLink type; a field absent here is never
+# emitted, so widening the cache cannot leak a new field into any frame.
+_CHIP_STATUS_KEYS = ("ci", "state", "mergeable", "mergeStateStatus")
 
 
 _NON_DURABLE_SOURCE_LINK_ROLES = frozenset({"chunk", "done", "streaming", "queued", "permission"})
@@ -4151,7 +4250,9 @@ class _ChatSlot:
             non_durable_roles=_NON_DURABLE_SOURCE_LINK_ROLES,
         )
 
-    def source_links_payload(self, *, include_check_status: bool = False) -> dict:
+    def source_links_payload(
+        self, *, include_check_status: bool = False, dashboard_user: bool = False
+    ) -> dict:
         """Every source link this slot carries — the unbudgeted read.
 
         ``to_dict`` serializes at most ``_SERIALIZED_SOURCE_LINKS_PER_SLOT`` per
@@ -4165,11 +4266,13 @@ class _ChatSlot:
         links = self._pr_source_links()
         changes, issues = _source_links_by_kind(links)
         return {
-            "links": _project_source_links(changes + issues, include_check_status),
+            "links": _project_source_links(
+                changes + issues, include_check_status, dashboard_user=dashboard_user
+            ),
             "total": len(links),
         }
 
-    def to_dict(self, *, include_check_status: bool = False) -> dict:
+    def to_dict(self, *, include_check_status: bool = False, dashboard_user: bool = False) -> dict:
         # Skip extraction itself when the chips are off, not just the two fields
         # the projection derives from it: `_pr_source_links()` scans the transcript
         # under a per-call parse budget, and paying for a payload nothing renders
@@ -4196,7 +4299,16 @@ class _ChatSlot:
             strip_markdown_preview=strip_markdown_preview,
             resolve_effective_agent=resolve_effective_agent,
             budget_source_links=_budgeted_source_links,
-            project_source_links=_project_source_links,
+            # Bind the PUBLIC-only gate through the projection's positional
+            # (links, include_check_status) callable so slot_projection.py needs
+            # no change: the owner gate rides include_check_status as before, and
+            # dashboard_user (a non-owner authenticated dashboard user) unlocks
+            # status ONLY for links whose repo is known public.
+            project_source_links=(
+                lambda links, incl: _project_source_links(
+                    links, incl, dashboard_user=dashboard_user
+                )
+            ),
         )
 
 
@@ -6584,10 +6696,20 @@ class DashboardState:
         review round is exactly when a PR's lifecycle moved, and nothing else in
         the system invalidates the status caches on that event: the chips would
         wait out the periodic rotation and the detail panel would not refetch at
-        all. Owner-gated (status is credential-backed, and with no owner window
-        open there is nobody to render it, so no provider subprocess is spawned)
-        and rate-floored inside ``request_check_refresh_now``.
+        all. Fires ONLY when an OWNER window is open: the read runs the
+        operator's credentials, so a non-owner window must not drive it (a
+        non-owner renders the owner-populated caches read-only). With no owner
+        window open there is nobody entitled to a credentialed read, so no
+        provider subprocess is spawned. Rate-floored inside
+        ``request_check_refresh_now``.
         """
+        # Both the status read and the visibility revalidation below run the
+        # operator's `gh`/`glab` credentials, so this turn-boundary refresh runs
+        # ONLY when an OWNER window is open. A non-owner dashboard window never
+        # drives it (GPT #6789): the owner's own connection keeps the caches warm
+        # and non-owner windows render the result read-only via the fail-closed
+        # is_repo_public gate. With no owner window open there is nobody entitled
+        # to drive a credentialed read, so this is a no-op.
         if not self._owner_ws_clients:
             return
         try:
@@ -6596,9 +6718,20 @@ class DashboardState:
                 return
             from kiro_crew.dashboard.handlers.source_providers import (
                 request_check_refresh_now,
+                schedule_visibility_refresh,
             )
 
             request_check_refresh_now(urls, self.push_slots_update)
+            # force=True: the status read above bypasses the TTL, so visibility
+            # MUST be revalidated in lockstep — otherwise fresh (now-private)
+            # status could be projected against a still-cached-public visibility
+            # entry, leaking private status to a non-owner (GPT #6789). Runs
+            # AFTER the status schedule: both are fire-and-forget schedulers, and
+            # ordering the status call first preserves the turn-boundary contract
+            # while the downstream render gate (`_project_source_links` ->
+            # is_repo_public) is what actually withholds status until visibility
+            # reconfirms.
+            schedule_visibility_refresh(urls, self.push_slots_update, force=True)
         except Exception:
             logger.debug("turn-boundary source status refresh failed", exc_info=True)
 
@@ -6794,10 +6927,16 @@ class DashboardState:
         return links, False, "", ""
 
     def serialize_slot(
-        self, slot: _ChatSlot, *, include_check_status: bool = False
+        self,
+        slot: _ChatSlot,
+        *,
+        include_check_status: bool = False,
+        dashboard_user: bool = False,
     ) -> dict[str, Any]:
         """Serialize one slot with state-backed channel-link metadata."""
-        payload = slot.to_dict(include_check_status=include_check_status)
+        payload = slot.to_dict(
+            include_check_status=include_check_status, dashboard_user=dashboard_user
+        )
         links, slack_linked, slack_channel, slack_thread_ts = self._slot_links(slot)
         payload.update(
             {
@@ -6809,17 +6948,26 @@ class DashboardState:
         )
         return payload
 
-    def serialize_slots(self, *, include_check_status: bool = False) -> list:
+    def serialize_slots(
+        self, *, include_check_status: bool = False, dashboard_user: bool = False
+    ) -> list:
         """Serialize slots, optionally including owner-only provider status.
 
         ``subagents_running`` remains available to every authenticated caller.
         Credential-backed ``ci`` and ``state`` fields are omitted unless an
-        authenticated owner boundary explicitly opts in.
+        authenticated owner boundary explicitly opts in — EXCEPT a link whose
+        repository is known public, which any authenticated dashboard user
+        (``dashboard_user=True``) may see because that lifecycle is already
+        world-visible. Private/unknown repos and app tokens stay owner-only.
         """
         out = []
         subs = getattr(self, "subagents", None)
         for s in self._slots.values():
-            d = self.serialize_slot(s, include_check_status=include_check_status)
+            d = self.serialize_slot(
+                s,
+                include_check_status=include_check_status,
+                dashboard_user=dashboard_user,
+            )
             d["subagents_running"] = bool(subs and subs.running_agents_for(f"dashboard:{s.key}"))
             out.append(d)
         return out
@@ -6970,7 +7118,22 @@ class DashboardState:
         )
 
         yolo_active = self.is_yolo_active()  # expire first if needed
+        # PUBLIC-repo chip status rides the general frame so any authenticated
+        # dashboard user (SSE and WS both run on dashboard-user tokens) sees the
+        # merged/closed/CI glyph for a repo whose lifecycle is already
+        # world-visible. Private/unknown repos fall through to owner-only inside
+        # serialize_slots, and app tokens are stripped of this status in
+        # ``_serialize_for_client`` -> ``filter_slots_for_app`` before delivery,
+        # so widening the general list here never leaks status to an app scope.
+        # SSE carries the BARE list (see below); the WS dashboard-user frame
+        # carries the enriched one. GPT #6789: the general ``_slots_list`` feeds
+        # BOTH the SSE queue (which has NO per-app filtering) and the WS frame,
+        # so enriching it here leaked public-repo status onto ``/api/stream`` for
+        # any app token allowed that route. Keep the broadcast list bare and put
+        # the public-repo enrichment only on the WS path, where
+        # ``_serialize_for_client`` re-filters app tokens.
         slots_data = self.serialize_slots()
+        slots_data_ws = self.serialize_slots(dashboard_user=True)
         mgr = getattr(self, "channel_manager", None)
         ch_trusted = bool(mgr and any(ch.trusted for ch in mgr._channels.values()))
         # Piggyback the allowlist generation so clients invalidate the cached
@@ -6991,7 +7154,13 @@ class DashboardState:
         self._broadcast(
             {
                 "_type": "slots",
+                # BARE list for SSE and the generic-envelope fields below.
                 "_slots_list": slots_data,
+                # Enriched (public-repo status) list for the WS dashboard-user
+                # frame ONLY. ``_broadcast`` builds the WS frame from this when
+                # present; SSE never reads it, so status cannot reach the
+                # unfiltered stream.
+                "_slots_list_ws": slots_data_ws,
                 "_yolo": yolo_active,
                 "slots": json.dumps(slots_data),
                 "channelTrusted": ch_trusted,
@@ -7127,7 +7296,17 @@ class DashboardState:
             # branch so the chokepoint can filter correctly.
             ws_data: object
             if msg_type == "slots":
-                slots_list = note.get("_slots_list") or json.loads(note["slots"])
+                # SSE (above) consumed the BARE ``_slots_list``. The WS frame is
+                # built from the ENRICHED ``_slots_list_ws`` (public-repo status
+                # for dashboard users) when present — app tokens are re-filtered
+                # in ``_serialize_for_client`` so they never receive it, and SSE
+                # never reads this key. Falls back to the bare list for callers
+                # (targeted title pushes, tests) that send only ``_slots_list``.
+                slots_list = (
+                    note.get("_slots_list_ws")
+                    or note.get("_slots_list")
+                    or json.loads(note["slots"])
+                )
                 # ``data`` for slots carries the whole envelope so the
                 # chokepoint can per-app filter and re-serialize it.
                 ws_data = {
@@ -7524,3 +7703,16 @@ def _cached_check_status(url: str) -> dict | None:
     from kiro_crew.dashboard.handlers.source_providers import get_cached_check_status
 
     return get_cached_check_status(url)
+
+
+def _repo_is_public(url: str) -> bool | None:
+    """Lazy wrapper for the repo-visibility reader (public/private/unknown).
+
+    Function-local import (top-level-imports exception): ``source_providers``
+    imports chat-state helpers from this module, so a module-scope import here
+    would create a bootstrap import cycle. Same rationale as
+    ``_cached_check_status`` directly above.
+    """
+    from kiro_crew.dashboard.handlers.source_providers import is_repo_public
+
+    return is_repo_public(url)

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -330,6 +330,7 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
         gitlab_hosts_generation,
         is_owner_dashboard_request,
         schedule_check_refresh,
+        schedule_visibility_refresh,
     )
 
     owner_request = is_owner_dashboard_request(request)
@@ -402,8 +403,11 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
     # Push current slots immediately so sidebar populates without waiting.
     # App tokens get only the slots their manifest scope allows.
     try:
-        all_slots = state.serialize_slots(include_check_status=owner_request)
-        if ws.get("_is_dashboard_user", False):
+        is_dashboard_user = ws.get("_is_dashboard_user", False)
+        all_slots = state.serialize_slots(
+            include_check_status=owner_request, dashboard_user=is_dashboard_user
+        )
+        if is_dashboard_user:
             slots_data = all_slots
         elif ws_app:
             slots_data = filter_slots_for_app(all_slots, ws_app, allowed_events, state)
@@ -456,7 +460,7 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                 "gitlabHostsGeneration": gitlab_hosts_generation(),
             }
         )
-        if owner_request:
+        if owner_request or is_dashboard_user:
             # Issue links carry no check status — skip them so the scheduler
             # never hands an issue URL to the pull-request-only chip fetch.
             urls = [
@@ -466,7 +470,23 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                 if link.get("kind", "change") == "change"
             ]
             if urls:
-                schedule_check_refresh(urls, state.push_slots_update)
+                # Both the status refresh AND the visibility probe run the
+                # operator's `gh`/`glab` credentials, so a NON-owner connection
+                # must trigger NEITHER — otherwise a non-owner would cause
+                # authenticated provider reads (status content AND repo
+                # visibility metadata) on repos it has no right to drive traffic
+                # for (GPT #6789). Only the OWNER's connection refreshes the
+                # caches; a non-owner is READ-ONLY against them. The owner is the
+                # dashboard operator and is effectively always connected, so its
+                # driver classifies each repo's visibility and fetches public
+                # status once, and every authenticated non-owner viewer then
+                # renders that cached public-repo status via the fail-closed
+                # `is_repo_public` gate in `_project_source_links`. A repo the
+                # owner has never classified stays owner-only for non-owners
+                # (fail closed) — no non-owner-driven credentialed probe.
+                if owner_request:
+                    schedule_visibility_refresh(urls, state.push_slots_update)
+                    schedule_check_refresh(urls, state.push_slots_update)
     except Exception:
         pass
 
@@ -559,6 +579,14 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                 if urls:
                     offset = (refresh_round * CHECK_STATUS_PENDING_MAX) % len(urls)
                     urls = urls[offset:] + urls[:offset]
+                    # Owner-only driver (see _run_status_driver): both refreshes
+                    # run operator credentials, so only the owner's connection
+                    # drives them. This keeps the check + visibility caches warm
+                    # for every repo the owner's slots reference; non-owner
+                    # viewers render the resulting cached public-repo status
+                    # read-only via is_repo_public. No non-owner-driven
+                    # credentialed provider read (GPT #6789).
+                    schedule_visibility_refresh(urls, state.push_slots_update)
                     schedule_check_refresh(urls, state.push_slots_update)
                 refresh_round += 1
             except asyncio.CancelledError:
@@ -566,7 +594,16 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
             except Exception:
                 logger.warning("check-status refresh round failed; continuing", exc_info=True)
 
-    check_task = asyncio.create_task(_refresh_check_loop()) if owner_request else None
+    # Run the refresh driver ONLY for the owner connection: both the status and
+    # the visibility refresh call the operator's `gh`/`glab` credentials, so a
+    # non-owner must never drive them (GPT #6789). The owner is the dashboard
+    # operator and is effectively always connected, so its driver keeps the
+    # check + visibility caches warm for every repo its slots reference; a
+    # non-owner dashboard connection renders the resulting cached PUBLIC-repo
+    # status read-only (via the fail-closed is_repo_public gate) and spawns no
+    # provider subprocess. App tokens never render status either way.
+    _run_status_driver = owner_request
+    check_task = asyncio.create_task(_refresh_check_loop()) if _run_status_driver else None
     # The resume prefetch this socket's most recent slot_focused frame armed.
     # Tracked per connection so a focus change (or blur/disconnect) cancels
     # only this socket's speculation, never another window's.

--- a/src/kiro_crew/dashboard/ws_event_scope.py
+++ b/src/kiro_crew/dashboard/ws_event_scope.py
@@ -1105,8 +1105,35 @@ def filter_slots_for_app(
         if slot is None:
             continue
         if _slot_visible(slot, app, allowed_events, state):
-            result.append(slot_dict)
+            result.append(_strip_source_link_status(slot_dict))
             _audit_allow(app, "slots_item")
         else:
             _audit_deny(app, "slots_item", "slot_scope_denied")
     return result
+
+
+# Credential-backed chip fields attached by ``state._project_source_links``.
+# The general broadcast carries them for a dashboard user (public repos), but
+# an app token must never receive provider status — its scope is slot metadata,
+# not the operator's credential-backed view of a repository. Stripped here so
+# widening the general list for dashboard users cannot leak into an app frame.
+_SOURCE_LINK_STATUS_KEYS = ("ci", "state", "mergeable", "mergeStateStatus")
+
+
+def _strip_source_link_status(slot_dict: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *slot_dict* with chip status removed from source links.
+
+    Only touches slots that carry source links with status; otherwise returns
+    the input unchanged (no needless copy on the hot path).
+    """
+    links = slot_dict.get("source_links")
+    if not links or not any(
+        any(k in link for k in _SOURCE_LINK_STATUS_KEYS) for link in links
+    ):
+        return slot_dict
+    cleaned = dict(slot_dict)
+    cleaned["source_links"] = [
+        {k: v for k, v in link.items() if k not in _SOURCE_LINK_STATUS_KEYS}
+        for link in links
+    ]
+    return cleaned

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -884,14 +884,19 @@ def test_folder_breadcrumb_cycle_safe(state):
 
 
 class TestOwnerSourceStatusTransport:
-    def test_slot_updates_keep_status_out_of_sse_and_generic_websockets(
+    def test_public_repo_status_rides_general_frame_owner_gets_full(
         self, state: DashboardState, monkeypatch
     ) -> None:
         source_url = "https://github.com/acme/repo/pull/12"
 
-        def serialize_slots(*, include_check_status: bool = False) -> list[dict]:
+        def serialize_slots(
+            *, include_check_status: bool = False, dashboard_user: bool = False
+        ) -> list[dict]:
             link = {"url": source_url, "provider": "github", "number": 12}
-            if include_check_status:
+            # Owner (include_check_status) sees status for any repo. A
+            # dashboard-user sees it for a KNOWN-public repo; this fixture treats
+            # dashboard_user=True as "public repo, show status".
+            if include_check_status or dashboard_user:
                 link.update({"ci": "passed", "state": "OPEN"})
             return [{"key": "chat-1", "source_links": [link]}]
 
@@ -903,44 +908,58 @@ class TestOwnerSourceStatusTransport:
             "_spawn_ws_send",
             lambda client, message: sent.append((client, json.loads(message))),
         )
-        generic_ws = MagicMock(closed=False)
-        owner_ws = MagicMock(closed=False)
-        state.register_ws(generic_ws)
+
+        class _FakeWs:
+            def __init__(self, *, dashboard_user: bool) -> None:
+                self.closed = False
+                self._flags = {"_is_dashboard_user": dashboard_user}
+
+            def get(self, key, default=None):
+                return self._flags.get(key, default)
+
+        dash_ws = _FakeWs(dashboard_user=True)
+        owner_ws = _FakeWs(dashboard_user=True)
+        state.register_ws(dash_ws)
         state.register_ws(owner_ws, owner=True)
         sse_queue = state.register_sse()
 
         state.push_slots_update()
 
+        # SSE carries the BARE list: the SSE queue has NO per-app filtering, so
+        # status must never ride it (GPT #6789 — an app token on /api/stream
+        # would otherwise receive credential-backed chip status). The enriched
+        # list is carried separately in `_slots_list_ws` for the WS path only.
         sse_note = sse_queue.get_nowait()
         assert "ci" not in str(sse_note["_slots_list"])
         assert "state" not in sse_note["_slots_list"][0]["source_links"][0]
+        # The enriched WS-only list DOES carry status (delivered to WS
+        # dashboard-user sockets, re-filtered for app tokens in
+        # `_serialize_for_client`).
+        assert sse_note["_slots_list_ws"][0]["source_links"][0]["ci"] == "passed"
+        assert sse_note["_slots_list_ws"][0]["source_links"][0]["state"] == "OPEN"
 
-        generic_messages = [message for client, message in sent if client is generic_ws]
+        dash_messages = [message for client, message in sent if client is dash_ws]
         owner_messages = [message for client, message in sent if client is owner_ws]
-        assert len(generic_messages) == 1
-        assert "ci" not in str(generic_messages[0]["data"])
-        assert "state" not in generic_messages[0]["data"][0]["source_links"][0]
-        # EXACTLY ONE frame for the owner, and it is the enriched one. Two frames
-        # delivered the same list twice, the first without `ci`/`state`, and the
-        # client replaces its slot list per frame — so every decorated PR chip lost
-        # its status glyph on frame one and regained it on frame two, re-wrapping
-        # the sidebar chip strip on every push.
+        # Dashboard user (non-owner): the single general frame carries public-repo
+        # status. `_send_ws_all` delivers exactly one `slots` frame to it.
+        assert len(dash_messages) == 1
+        assert dash_messages[0]["data"][0]["source_links"][0]["ci"] == "passed"
+        assert dash_messages[0]["data"][0]["source_links"][0]["state"] == "OPEN"
+        # Owner: EXACTLY ONE frame (the enriched owner frame). `_send_ws_all`
+        # skips owner sockets for `slots` (PR #6795), so the generic frame no
+        # longer backstops an owner; the owner frame is its only one and carries
+        # full status.
         assert len(owner_messages) == 1
         assert owner_messages[0]["data"][0]["source_links"][0]["ci"] == "passed"
         assert owner_messages[0]["data"][0]["source_links"][0]["state"] == "OPEN"
-        # The owner frame is now the owner's only one, so it must carry every key
-        # the generic frame does. Asserted as SET EQUALITY over the whole envelope,
-        # not as a list of the keys known today: `_send_ws_all` skips owner sockets
-        # for `slots`, so the generic frame no longer backstops an owner, and a key
-        # added to one site and not the other would silently deprive every owner
-        # window. Both frames come from `_slots_ws_frame`, which makes that
-        # impossible by construction; this pins the property so a future site that
-        # hand-builds the envelope again fails here instead of in production.
-        assert set(owner_messages[0]) == set(generic_messages[0])
-        assert owner_messages[0]["folders"] == generic_messages[0]["folders"]
+        # Both frames come from `_slots_ws_frame`, so they must carry the SAME
+        # envelope keys — asserted as set equality so a key added to one site and
+        # not the other fails here instead of silently depriving an owner window.
+        assert set(owner_messages[0]) == set(dash_messages[0])
+        assert owner_messages[0]["folders"] == dash_messages[0]["folders"]
         assert (
             owner_messages[0]["gitlabHostsGeneration"]
-            == generic_messages[0]["gitlabHostsGeneration"]
+            == dash_messages[0]["gitlabHostsGeneration"]
         )
 
     def test_owner_sockets_still_receive_non_slot_broadcasts(
@@ -970,6 +989,36 @@ class TestOwnerSourceStatusTransport:
         assert len(owner_messages) == 1
         assert owner_messages[0]["type"] == "refresh"
         assert owner_messages[0]["data"]["kinds"] == ["crons", "agents"]
+
+    def test_app_token_frame_is_stripped_of_chip_status(self) -> None:
+        # The per-app filter must remove credential-backed chip status even when
+        # the general list carries it (widened for dashboard users). Slot
+        # metadata stays; ci/state/mergeable go.
+        from kiro_crew.dashboard.ws_event_scope import _strip_source_link_status
+
+        slot = {
+            "key": "chat-1",
+            "source_links": [
+                {
+                    "url": "https://github.com/acme/repo/pull/12",
+                    "provider": "github",
+                    "number": 12,
+                    "ci": "passed",
+                    "state": "merged",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                }
+            ],
+        }
+        cleaned = _strip_source_link_status(slot)
+        link = cleaned["source_links"][0]
+        assert link["url"].endswith("/pull/12")
+        assert link["number"] == 12
+        for k in ("ci", "state", "mergeable", "mergeStateStatus"):
+            assert k not in link
+        # A slot with no status is returned unchanged (identity, no copy).
+        bare = {"key": "c", "source_links": [{"url": "u", "number": 1}]}
+        assert _strip_source_link_status(bare) is bare
 
     @pytest.mark.parametrize(
         ("claims", "owner_request"),
@@ -1001,8 +1050,12 @@ class TestOwnerSourceStatusTransport:
 
         source_url = "https://github.com/acme/repo/pull/12"
 
-        def serialize_slots(*, include_check_status: bool = False) -> list[dict]:
+        def serialize_slots(
+            *, include_check_status: bool = False, dashboard_user: bool = False
+        ) -> list[dict]:
             link = {"url": source_url, "provider": "github", "number": 12}
+            # This connect test seeds no repo visibility, so a dashboard user
+            # fails closed to a bare chip (only the owner opt-in carries status).
             if include_check_status:
                 link.update({"ci": "passed", "state": "OPEN"})
             return [{"key": "chat-1", "source_links": [link]}]
@@ -1056,9 +1109,11 @@ class TestOwnerSourceStatusTransport:
 
         fake_ws = FakeWebSocket()
         refresh = MagicMock()
+        vis_refresh = MagicMock()
         monkeypatch.setattr(dashboard_ws, "_check_ws_origin", lambda request: None)
         monkeypatch.setattr(dashboard_ws.web, "WebSocketResponse", lambda **kwargs: fake_ws)
         monkeypatch.setattr(source_providers, "schedule_check_refresh", refresh)
+        monkeypatch.setattr(source_providers, "schedule_visibility_refresh", vis_refresh)
 
         result = await dashboard_ws.api_ws(Request())  # type: ignore[arg-type]
         await asyncio.sleep(0)
@@ -1070,23 +1125,124 @@ class TestOwnerSourceStatusTransport:
         if owner_request:
             assert initial_slots[0]["source_links"][0]["ci"] == "passed"
             refresh.assert_called_once_with([source_url], state.push_slots_update)
+            vis_refresh.assert_called_once_with([source_url], state.push_slots_update)
         elif claims.get("app"):
             # App token: the per-app WS scope gate filters the initial push, so
             # an app that declared no slots:* scope sees no slots at all — a
-            # stronger guarantee than merely withholding check status.
+            # stronger guarantee than merely withholding check status. No
+            # provider work is scheduled for it.
             assert initial_slots == []
             refresh.assert_not_called()
+            vis_refresh.assert_not_called()
             # Folders never ride an app-token frame (apps don't render the tree).
             assert "folders" not in initial_frame
         else:
+            # Non-owner dashboard user: connect frame carries NO status (this
+            # test seeds no visibility, so the public gate fails closed), and the
+            # connection MUST drive NEITHER refresh — both the status read and
+            # the visibility probe run the operator's credentials, so only the
+            # owner's connection may trigger them (GPT round-13). A non-owner
+            # renders the owner-populated caches read-only; it spawns no provider
+            # work of its own.
             assert "ci" not in str(initial_slots)
             assert "state" not in initial_slots[0]["source_links"][0]
             refresh.assert_not_called()
+            vis_refresh.assert_not_called()
             # The connect-time frame is what populates the sidebar on a cold
             # load, so a dashboard user MUST receive the folder tree here — this
             # is the frame that fixes the #4127 flicker.
             assert initial_frame["folders"] == [{"id": "f1", "name": "Work", "order": 0}]
         state.unregister_ws.assert_called_once_with(fake_ws)
+
+    @pytest.mark.asyncio
+    async def test_non_owner_status_refresh_only_for_confirmed_public(
+        self, monkeypatch
+    ) -> None:
+        """A non-owner dashboard connection drives NEITHER a status refresh NOR
+        a visibility probe, even when a confirmed-public repo is present — both
+        run the operator's credentials, so only the owner's connection may
+        trigger them (GPT round-13). The non-owner renders the owner-populated
+        caches read-only."""
+        from kiro_crew.dashboard import ws as dashboard_ws
+        from kiro_crew.dashboard import ws_event_scope
+        from kiro_crew.dashboard.handlers import source_providers
+
+        monkeypatch.setattr(ws_event_scope, "is_app_enabled", lambda _name: True)
+        monkeypatch.setattr(ws_event_scope, "get_app_manifest", lambda _name: None)
+        monkeypatch.setattr(ws_event_scope, "_declared_cache", {})
+
+        public_url = "https://github.com/acme/public/pull/1"
+        private_url = "https://github.com/acme/private/pull/2"
+
+        def serialize_slots(
+            *, include_check_status: bool = False, dashboard_user: bool = False
+        ) -> list[dict]:
+            return [
+                {
+                    "key": "chat-1",
+                    "source_links": [
+                        {"url": public_url, "provider": "github", "number": 1},
+                        {"url": private_url, "provider": "github", "number": 2},
+                    ],
+                }
+            ]
+
+        state = MagicMock()
+        state.owner_id = "U_OWNER"
+        state.serialize_slots.side_effect = serialize_slots
+        state._yolo = False
+        state._folders = []
+
+        class Request(dict):
+            def __init__(self) -> None:
+                super().__init__({"user": "U_OTHER", "app": ""})
+                self.setdefault("is_dashboard_user", True)
+                self.app = {"state": state}
+
+        class FakeWebSocket:
+            def __init__(self) -> None:
+                self.closed = True
+                self.sent: list[dict] = []
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
+
+            async def prepare(self, request) -> None:
+                return None
+
+            async def send_json(self, payload: dict) -> None:
+                self.sent.append(payload)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        fake_ws = FakeWebSocket()
+        refresh = MagicMock()
+        vis_refresh = MagicMock()
+        monkeypatch.setattr(dashboard_ws, "_check_ws_origin", lambda request: None)
+        monkeypatch.setattr(dashboard_ws.web, "WebSocketResponse", lambda **kwargs: fake_ws)
+        monkeypatch.setattr(source_providers, "schedule_check_refresh", refresh)
+        monkeypatch.setattr(source_providers, "schedule_visibility_refresh", vis_refresh)
+
+        result = await dashboard_ws.api_ws(Request())  # type: ignore[arg-type]
+        await asyncio.sleep(0)
+
+        assert result is fake_ws
+        # Owner-only model: a non-owner triggers NO provider work at all — not a
+        # status refresh and not a visibility probe — regardless of whether a
+        # repo would read public. The owner's connection populates the caches.
+        vis_refresh.assert_not_called()
+        refresh.assert_not_called()
 
 
 class TestPeriodicCheckStatusRefresh:
@@ -1385,8 +1541,12 @@ class TestPeriodicCheckStatusRefresh:
         assert order[:2] == ["ensure", "serialize"]
 
     @pytest.mark.asyncio
-    async def test_non_owner_ws_never_starts_refresh_loop(self, monkeypatch) -> None:
+    async def test_app_token_ws_never_starts_refresh_loop(self, monkeypatch) -> None:
+        """An app token renders no chip status (public or private), so it must
+        not spawn the periodic provider driver. Only owner or dashboard-user
+        connections do."""
         from kiro_crew.dashboard import ws as dashboard_ws
+        from kiro_crew.dashboard import ws_event_scope
         from kiro_crew.dashboard.handlers import source_providers
 
         state = MagicMock()
@@ -1396,9 +1556,8 @@ class TestPeriodicCheckStatusRefresh:
 
         class Request(dict):
             def __init__(self) -> None:
-                super().__init__({"user": "U_OTHER", "app": ""})
-                # Mirror the auth middleware: it sets this POSITIVE flag so the
-                # WS layer never infers trust from a falsy app claim.
+                # An app token: non-empty app claim, NOT a dashboard user.
+                super().__init__({"user": "U_OWNER", "app": "source-app"})
                 self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
@@ -1408,8 +1567,74 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
-                # api_ws stores scope state on the socket via item assignment;
-                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": False}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
+
+            async def prepare(self, request) -> None:
+                return None
+
+            async def send_json(self, payload: dict) -> None:
+                self.sent.append(payload)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                await asyncio.sleep(0.05)
+                raise StopAsyncIteration
+
+        fake_ws = FakeWebSocket()
+        monkeypatch.setattr(ws_event_scope, "is_app_enabled", lambda _name: True)
+        monkeypatch.setattr(ws_event_scope, "get_app_manifest", lambda _name: None)
+        monkeypatch.setattr(ws_event_scope, "_declared_cache", {})
+        monkeypatch.setattr(dashboard_ws, "_check_ws_origin", lambda request: None)
+        monkeypatch.setattr(dashboard_ws.web, "WebSocketResponse", lambda **kwargs: fake_ws)
+        monkeypatch.setattr(source_providers, "CHECK_STATUS_TTL_SECS", 0.01)
+        monkeypatch.setattr(source_providers, "schedule_check_refresh", refresh)
+        monkeypatch.setattr(source_providers, "schedule_visibility_refresh", MagicMock())
+
+        await asyncio.wait_for(dashboard_ws.api_ws(Request()), timeout=5)  # type: ignore[arg-type]
+
+        refresh.assert_not_called()
+        state.source_link_urls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_owner_dashboard_user_does_not_start_refresh_loop(self, monkeypatch) -> None:
+        """A signed-in dashboard user who is NOT the owner renders PUBLIC-repo
+        chip status READ-ONLY from the owner-populated caches, so it must NOT
+        start the periodic driver — both the status and visibility refreshes run
+        the operator's credentials and are owner-only (GPT round-13)."""
+        from kiro_crew.dashboard import ws as dashboard_ws
+        from kiro_crew.dashboard.handlers import source_providers
+
+        state = MagicMock()
+        state.owner_id = "U_OWNER"
+        state.serialize_slots.return_value = []
+        state._yolo = False
+        # A real list so the loop's modulo has a real length (no MagicMock len).
+        state.source_link_urls.return_value = ["https://github.com/acme/repo/pull/1"]
+
+        class Request(dict):
+            def __init__(self) -> None:
+                super().__init__({"user": "U_OTHER", "app": ""})
+                self.setdefault("is_dashboard_user", not self.get("app"))
+                self.app = {"state": state}
+
+        check_refresh = MagicMock()
+        vis_refresh = MagicMock()
+
+        class FakeWebSocket:
+            def __init__(self) -> None:
+                self.closed = False
+                self.sent: list[dict] = []
                 self._flags: dict = {"_is_dashboard_user": True}
 
             def __setitem__(self, key: str, value) -> None:
@@ -1431,7 +1656,6 @@ class TestPeriodicCheckStatusRefresh:
                 return self
 
             async def __anext__(self):
-                # Stay open long enough for several 0.01s TTL ticks to elapse.
                 await asyncio.sleep(0.05)
                 raise StopAsyncIteration
 
@@ -1439,12 +1663,14 @@ class TestPeriodicCheckStatusRefresh:
         monkeypatch.setattr(dashboard_ws, "_check_ws_origin", lambda request: None)
         monkeypatch.setattr(dashboard_ws.web, "WebSocketResponse", lambda **kwargs: fake_ws)
         monkeypatch.setattr(source_providers, "CHECK_STATUS_TTL_SECS", 0.01)
-        monkeypatch.setattr(source_providers, "schedule_check_refresh", refresh)
+        monkeypatch.setattr(source_providers, "schedule_check_refresh", check_refresh)
+        monkeypatch.setattr(source_providers, "schedule_visibility_refresh", vis_refresh)
 
         await asyncio.wait_for(dashboard_ws.api_ws(Request()), timeout=5)  # type: ignore[arg-type]
-
-        refresh.assert_not_called()
-        state.source_link_urls.assert_not_called()
+        # Non-owner: the driver never starts, so neither refresh is ever called
+        # and source_link_urls is never polled by a refresh round.
+        assert not check_refresh.called
+        assert not vis_refresh.called
 
     @pytest.mark.asyncio
     async def test_refresh_loop_rotates_offset_across_rounds(self, monkeypatch) -> None:
@@ -1661,6 +1887,47 @@ class TestTurnBoundarySourceStatus:
         state.refresh_slot_source_status("chat-a")
 
         refresh.assert_not_called()
+
+    def test_turn_boundary_non_owner_drives_no_refresh(
+        self, state: DashboardState, monkeypatch
+    ) -> None:
+        """GPT #6789 round-13: at a turn boundary with ONLY a non-owner
+        dashboard-user window open (no owner window), NEITHER the credentialed
+        status read NOR the visibility probe fires — both run the operator's
+        credentials and are owner-only. A non-owner audience triggers nothing."""
+        from kiro_crew.dashboard import state as state_mod  # noqa: F401
+        from kiro_crew.dashboard.handlers import source_providers
+
+        slot = state.get_or_create_slot("chat-a")
+        slot.append(
+            "assistant",
+            "pub https://github.com/acme/pub/pull/1 priv https://github.com/acme/priv/pull/2",
+            broadcast=False,
+        )
+        # No owner window; one non-owner dashboard-user window.
+        state._owner_ws_clients.clear()
+        _du_ws = MagicMock(closed=False)
+        _du_ws.get.side_effect = lambda k, d=None: True if k == "_is_dashboard_user" else d
+        state._ws_clients = [_du_ws]
+        status_calls: list[tuple] = []
+        vis_calls: list[tuple] = []
+        monkeypatch.setattr(
+            source_providers,
+            "request_check_refresh_now",
+            lambda urls, on_update=None: status_calls.append((list(urls), on_update)),
+        )
+        monkeypatch.setattr(
+            source_providers,
+            "schedule_visibility_refresh",
+            lambda urls, on_update=None, *, force=False: vis_calls.append((list(urls), force)),
+        )
+
+        state.refresh_slot_source_status("chat-a")
+
+        # No owner window → the turn-boundary refresh is a no-op: neither the
+        # status read nor the visibility probe runs.
+        assert status_calls == []
+        assert vis_calls == []
 
     def test_turn_boundary_swallows_refresh_failures(
         self, state: DashboardState, monkeypatch

--- a/test/test_public_repo_chip_status.py
+++ b/test/test_public_repo_chip_status.py
@@ -1,0 +1,652 @@
+"""Public-repo chip-status gate: a non-owner dashboard user sees PR/MR status
+for PUBLIC repos, while private/unknown repos stay owner-only and app tokens
+see nothing (issue #6786).
+
+Covers the three cooperating pieces:
+  * ``source_providers`` repo-visibility cache + fetch + scheduler,
+  * ``state._project_source_links`` per-link gate matrix,
+  * the ``serialize_slots(dashboard_user=...)`` plumbing.
+"""
+
+import asyncio
+import contextlib
+import time
+
+import pytest
+
+import kiro_crew.dashboard.handlers.source_providers as source
+from kiro_crew.dashboard.state import _project_source_links
+
+PR_URL = "https://github.com/acme/repo/pull/7"
+PR_URL_2 = "https://github.com/other/proj/pull/3"
+ISSUE_URL = "https://github.com/acme/repo/issues/9"
+GLAB_URL = "https://gitlab.com/grp/sub/-/merge_requests/4"
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    source._visibility_cache.clear()
+    source._visibility_inflight.clear()
+    source._visibility_force_gen.clear()
+    source._check_cache.clear()
+    yield
+    source._visibility_cache.clear()
+    source._visibility_inflight.clear()
+    source._visibility_force_gen.clear()
+    source._check_cache.clear()
+    # A test that armed the debounced update (force visibility refresh /
+    # status-change path) can leave a pending global TimerHandle bound to this
+    # test's now-closing event loop; if it survives, a later test's callback
+    # cannot arm (the handle looks live) and the stale callback set leaks across
+    # tests. Cancel + reset it and clear the callback set after each test
+    # (no-test-side-effects).
+    handle = getattr(source, "_check_update_handle", None)
+    if handle is not None:
+        with contextlib.suppress(Exception):
+            handle.cancel()
+    source._check_update_handle = None
+    source._check_update_callbacks.clear()
+    # Reset the public-status-grant SEL dedup so one test's grant does not
+    # suppress another's audit assertion.
+    import kiro_crew.dashboard.state as _state_mod
+
+    _state_mod._PUBLIC_STATUS_GRANT_AUDIT.clear()
+    _state_mod._PUBLIC_STATUS_DENY_AUDIT.clear()
+
+
+def _seed_visibility(url: str, public: bool | None) -> None:
+    ref = source.parse_source_url(url)
+    source._visibility_cache[source._visibility_key(ref)] = (time.monotonic(), public)
+
+
+def _seed_status(url: str, status: dict) -> None:
+    source._check_cache[url] = (time.monotonic(), status)
+
+
+# ── is_repo_public reader ────────────────────────────────────────────────────
+
+
+def test_is_repo_public_unknown_until_fetched():
+    assert source.is_repo_public(PR_URL) is None
+
+
+def test_is_repo_public_reads_cached_public_and_private():
+    _seed_visibility(PR_URL, True)
+    _seed_visibility(PR_URL_2, False)
+    assert source.is_repo_public(PR_URL) is True
+    assert source.is_repo_public(PR_URL_2) is False
+
+
+def test_is_repo_public_none_for_unparseable_and_jira():
+    assert source.is_repo_public("not a url") is None
+    # Jira has no public-repo concept; visibility is never meaningful for it.
+    assert source.is_repo_public("https://org.atlassian.net/browse/PROJ-1") is None
+
+
+# ── _fetch_repo_visibility ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_visibility_maps_isprivate(monkeypatch):
+    async def fake_run(*argv, **kw):
+        assert argv[:3] == ("gh", "repo", "view")
+        return {"isPrivate": False, "visibility": "public"}
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(PR_URL)
+    assert await source._fetch_repo_visibility(ref) is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_internal_is_not_public(monkeypatch):
+    # GPT #6789 round-9: isPrivate is False for internal (Enterprise) repos too,
+    # but internal is NOT anonymously readable — must not classify as public.
+    async def fake_run(*argv, **kw):
+        return {"isPrivate": False, "visibility": "internal"}
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(PR_URL)
+    assert await source._fetch_repo_visibility(ref) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_private_is_false(monkeypatch):
+    async def fake_run(*argv, **kw):
+        return {"isPrivate": True, "visibility": "private"}
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(PR_URL)
+    assert await source._fetch_repo_visibility(ref) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_only_public_is_public(monkeypatch):
+    seen = {}
+
+    async def fake_run(*argv, **kw):
+        seen["host"] = kw.get("host")
+        return {"visibility": "internal"}  # NOT anonymous-public
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(GLAB_URL)
+    assert await source._fetch_repo_visibility(ref) is False
+    assert seen["host"] == "gitlab.com"
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_public_with_public_features_is_public(monkeypatch):
+    async def fake_run(*argv, **kw):
+        return {
+            "visibility": "public",
+            "merge_requests_access_level": "enabled",
+            "builds_access_level": "enabled",
+            "public_jobs": True,
+        }
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(GLAB_URL)
+    assert await source._fetch_repo_visibility(ref) is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_public_but_private_pipelines_is_not_public(monkeypatch):
+    # GPT #6789 round-6: public_jobs=false hides pipeline/CI status from
+    # non-members even when builds_access_level is "enabled".
+    async def fake_run(*argv, **kw):
+        return {
+            "visibility": "public",
+            "merge_requests_access_level": "enabled",
+            "builds_access_level": "enabled",
+            "public_jobs": False,  # private pipelines
+        }
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(GLAB_URL)
+    assert await source._fetch_repo_visibility(ref) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_public_but_member_only_mr_is_not_public(monkeypatch):
+    # GPT #6789 round-5: a public project can restrict MR/CI to members, so
+    # visibility=="public" alone must NOT authorize non-owner status.
+    async def fake_run(*argv, **kw):
+        return {
+            "visibility": "public",
+            "merge_requests_access_level": "private",  # members only
+            "builds_access_level": "enabled",
+        }
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(GLAB_URL)
+    assert await source._fetch_repo_visibility(ref) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_public_missing_feature_levels_fails_closed(monkeypatch):
+    async def fake_run(*argv, **kw):
+        return {"visibility": "public"}  # no feature-access-level keys
+
+    monkeypatch.setattr(source, "_run_json", fake_run)
+    ref = source.parse_source_url(GLAB_URL)
+    assert await source._fetch_repo_visibility(ref) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_visibility_fails_closed_on_error(monkeypatch):
+    async def boom(*argv, **kw):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(source, "_run_json", boom)
+    ref = source.parse_source_url(PR_URL)
+    assert await source._fetch_repo_visibility(ref) is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_keeps_prior_known_value_on_failure(monkeypatch):
+    _seed_visibility(PR_URL, True)
+    ref = source.parse_source_url(PR_URL)
+
+    async def boom(*argv, **kw):
+        raise RuntimeError("transient")
+
+    monkeypatch.setattr(source, "_run_json", boom)
+    source._visibility_inflight.add(source._visibility_key(ref))
+    await source._refresh_repo_visibility(ref)
+    # A failed read must not erase a previously-known public flag (within TTL).
+    assert source.is_repo_public(PR_URL) is True
+
+
+def test_stale_public_entry_reads_as_unknown(monkeypatch):
+    # GPT-blocked hole: a repo cached public must NOT authorize status forever.
+    # An entry older than the TTL reads as None (fail closed) even if its stored
+    # value is True.
+    ref = source.parse_source_url(PR_URL)
+    stale_at = time.monotonic() - source._VISIBILITY_TTL_SECS - 1
+    source._visibility_cache[source._visibility_key(ref)] = (stale_at, True)
+    assert source.is_repo_public(PR_URL) is None
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_does_not_extend_stale_public(monkeypatch):
+    # public -> private transition where the visibility read keeps failing: the
+    # failed refresh must NOT reset the timestamp, so the stale public ages out
+    # from its last SUCCESSFUL read and is_repo_public fails closed within one TTL.
+    ref = source.parse_source_url(PR_URL)
+    key = source._visibility_key(ref)
+    original_at = time.monotonic() - source._VISIBILITY_TTL_SECS + 5  # nearly stale
+    source._visibility_cache[key] = (original_at, True)
+
+    async def boom(*argv, **kw):
+        raise RuntimeError("visibility read fails while repo went private")
+
+    monkeypatch.setattr(source, "_run_json", boom)
+    source._visibility_inflight.add(key)
+    await source._refresh_repo_visibility(ref)
+    # Value kept but timestamp NOT reset — so the entry is still anchored to the
+    # original (nearly-stale) fetch time, not refreshed to now.
+    assert source._visibility_cache[key][0] == original_at
+    # And once that original time crosses the TTL, it reads unknown (fail closed).
+    source._visibility_cache[key] = (
+        time.monotonic() - source._VISIBILITY_TTL_SECS - 1,
+        True,
+    )
+    assert source.is_repo_public(PR_URL) is None
+
+
+@pytest.mark.asyncio
+async def test_cold_failed_refresh_records_unknown(monkeypatch):
+    ref = source.parse_source_url(PR_URL)
+    key = source._visibility_key(ref)
+
+    async def boom(*argv, **kw):
+        raise RuntimeError("cold miss, provider down")
+
+    monkeypatch.setattr(source, "_run_json", boom)
+    source._visibility_inflight.add(key)
+    await source._refresh_repo_visibility(ref)
+    # A never-known repo whose first read failed records an unknown (None), so
+    # the scheduler does not respawn a fetch on every slots push.
+    assert key in source._visibility_cache
+    assert source._visibility_cache[key][1] is None
+    assert source.is_repo_public(PR_URL) is None
+
+
+# ── schedule_visibility_refresh ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_schedule_dedups_by_repo_and_skips_issue_and_jira(monkeypatch):
+    calls: list[str] = []
+
+    async def fake_refresh(ref, on_update=None, *, prev_public_override=None):
+        calls.append(source._visibility_key(ref))
+        source._visibility_inflight.discard(source._visibility_key(ref))
+
+    monkeypatch.setattr(source, "_refresh_repo_visibility", fake_refresh)
+    # Two PRs on the SAME repo + an issue on it + a jira: one repo key scheduled.
+    source.schedule_visibility_refresh(
+        [PR_URL, ISSUE_URL, "https://github.com/acme/repo/pull/99", "not-a-url"]
+    )
+    # Let the created tasks run.
+    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    assert calls == [source._visibility_key(source.parse_source_url(PR_URL))]
+
+
+@pytest.mark.asyncio
+async def test_schedule_respects_fresh_ttl(monkeypatch):
+    _seed_visibility(PR_URL, True)  # fresh entry
+    called = False
+
+    async def fake_refresh(ref, on_update=None, *, prev_public_override=None):
+        nonlocal called
+        called = True
+        source._visibility_inflight.discard(source._visibility_key(ref))
+
+    monkeypatch.setattr(source, "_refresh_repo_visibility", fake_refresh)
+    source.schedule_visibility_refresh([PR_URL])
+    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_force_synchronously_invalidates_public_before_refresh(monkeypatch):
+    # GPT #6789 round-4 race: a forced refresh runs concurrently with the forced
+    # status read; if status finishes first it must NOT see a still-cached-public
+    # visibility. force=True drops a public entry to unknown SYNCHRONOUSLY (before
+    # the task is spawned), so is_repo_public fails closed for the in-flight window.
+    _seed_visibility(PR_URL, True)
+    assert source.is_repo_public(PR_URL) is True
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_refresh(ref, on_update=None, *, prev_public_override=None):
+        started.set()
+        await release.wait()  # hold the refresh open to model the in-flight window
+        source._visibility_inflight.discard(source._visibility_key(ref))
+
+    monkeypatch.setattr(source, "_refresh_repo_visibility", slow_refresh)
+    source.schedule_visibility_refresh([PR_URL], force=True)
+    # BEFORE the refresh completes, the public flag is already gone (fail closed).
+    assert source.is_repo_public(PR_URL) is None
+    await started.wait()
+    assert source.is_repo_public(PR_URL) is None
+    release.set()
+    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_force_invalidates_public_even_when_refresh_already_inflight(monkeypatch):
+    # GPT #6789 round-14: the force path must fail a cached-public entry closed
+    # BEFORE the inflight-dedup return — otherwise a force=True call that arrives
+    # while a (pre-flip) refresh is already running would `continue` without
+    # invalidating, and the in-flight positive read could restore public after a
+    # public->private flip.
+    source._visibility_cache.clear()
+    source._visibility_inflight.clear()
+    source._visibility_force_gen.clear()
+    key = source._visibility_key(source.parse_source_url(PR_URL))
+    _seed_visibility(PR_URL, True)
+    # Model a refresh already in flight for this key (spawned before the flip).
+    source._visibility_inflight.add(key)
+
+    # A forced refresh now arrives (status just detected the repo went private).
+    # It must synchronously invalidate the cached-public entry despite the
+    # in-flight dedup, so is_repo_public fails closed immediately.
+    source.schedule_visibility_refresh([PR_URL], force=True)
+    assert source.is_repo_public(PR_URL) is None
+    # The force generation bumped, so a stale in-flight positive read is refused.
+    assert source._visibility_force_gen.get(key, 0) >= 1
+    source._visibility_inflight.discard(key)
+
+
+@pytest.mark.asyncio
+async def test_stale_inflight_positive_cannot_restore_public_across_force(monkeypatch):
+    # GPT #6789 round-14: a visibility refresh whose positive read predates a
+    # force-invalidation (public->private flip) must NOT write ``public`` back —
+    # doing so would re-open the leak the force path just closed. The generation
+    # guard makes it record unknown instead, so is_repo_public stays None.
+    source._visibility_cache.clear()
+    source._visibility_inflight.clear()
+    source._visibility_force_gen.clear()
+    key = source._visibility_key(source.parse_source_url(PR_URL))
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_public_fetch(ref):
+        entered.set()
+        await release.wait()  # hold open so a force-invalidation can land mid-flight
+        return True  # positive read — but it predates the flip below
+
+    monkeypatch.setattr(source, "_fetch_repo_visibility", slow_public_fetch)
+
+    # Start a refresh that will positively read "public" (pre-flip).
+    source._visibility_inflight.add(key)
+    ref = source.parse_source_url(PR_URL)
+    task = asyncio.get_running_loop().create_task(source._refresh_repo_visibility(ref))
+    await entered.wait()
+    # Mid-flight, the repo flips private: a force-invalidation bumps the gen.
+    _seed_visibility(PR_URL, True)  # simulate the cached-public the force sees
+    source.schedule_visibility_refresh([PR_URL], force=True)
+    # Let the stale positive read complete.
+    release.set()
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    # The stale positive did NOT restore public — is_repo_public stays fail-closed.
+    assert source.is_repo_public(PR_URL) is None
+
+
+@pytest.mark.asyncio
+async def test_force_bumps_generation_even_when_entry_already_unknown(monkeypatch):
+    # GPT #6789 round-15: the generation bump must fire on EVERY forced refresh
+    # (before inflight dedup), not only when the cached entry is currently
+    # public. Otherwise a second force arriving while the entry is already
+    # unknown (first force landed, pre-privacy fetch still in flight) would skip
+    # the bump and let that stale in-flight positive read restore public.
+    source._visibility_cache.clear()
+    source._visibility_inflight.clear()
+    source._visibility_force_gen.clear()
+    key = source._visibility_key(source.parse_source_url(PR_URL))
+    # Entry is already UNKNOWN (not public) and a refresh is in flight.
+    source._visibility_cache[key] = (0.0, None)
+    source._visibility_inflight.add(key)
+    gen_before = source._visibility_force_gen.get(key, 0)
+
+    source.schedule_visibility_refresh([PR_URL], force=True)
+
+    assert source._visibility_force_gen.get(key, 0) == gen_before + 1
+    source._visibility_inflight.discard(key)
+
+
+@pytest.mark.asyncio
+async def test_force_public_to_private_transition_queues_hide_update(monkeypatch):
+    # GPT #6789 round-7: a forced refresh pre-invalidates a cached-public entry
+    # to unknown before spawning the refresh. If the repo genuinely went private,
+    # the refresh must STILL queue an on_update so connected non-owners hide the
+    # now-stale public chip — the comparison must measure the flip against the
+    # TRUE prior rendered value (public), not the pre-invalidated unknown.
+    source._check_update_callbacks.clear()
+    _seed_visibility(PR_URL, True)  # was rendered public
+
+    async def fetch_private(ref):
+        return False  # repo is now private
+
+    monkeypatch.setattr(source, "_fetch_repo_visibility", fetch_private)
+
+    fired = {"n": 0}
+
+    def on_update():
+        fired["n"] += 1
+
+    source.schedule_visibility_refresh([PR_URL], on_update=on_update, force=True)
+    await asyncio.gather(*list(source._VISIBILITY_TASKS), return_exceptions=True)
+    # The hide-the-chip update was queued (public -> private is a rendered flip).
+    assert on_update in source._check_update_callbacks or fired["n"] >= 1
+    assert source.is_repo_public(PR_URL) is False
+
+
+@pytest.mark.asyncio
+async def test_status_change_forces_visibility_revalidation(monkeypatch):
+    # GPT #6789 round-8: a status refresh can land a freshly-fetched status while
+    # this URL's visibility entry is still within its TTL, so a plain (non-force)
+    # visibility schedule would SKIP the read and is_repo_public would authorize
+    # the new status against a stale-fresh public flag. A confirmed status change
+    # must force-revalidate visibility for that URL in lockstep.
+    source._check_cache.clear()
+    _seed_status(PR_URL, {"state": "open"})  # prior status
+
+    async def fetch_changed(url):
+        return {"state": "merged"}  # status changed
+
+    monkeypatch.setattr(source, "_fetch_check_status", fetch_changed)
+
+    forced: list[tuple[list[str], bool]] = []
+    real_schedule = source.schedule_visibility_refresh
+
+    def spy_schedule(urls, on_update=None, *, force=False):
+        forced.append((list(urls), force))
+        # Do not spawn real tasks in this unit test.
+
+    monkeypatch.setattr(source, "schedule_visibility_refresh", spy_schedule)
+    monkeypatch.setattr(source, "_emit_status_delta", lambda *a, **k: None)
+
+    source._check_inflight.add(PR_URL)  # _refresh_check_status discards it
+    await source._refresh_check_status(PR_URL, on_update=None)
+
+    # Visibility was force-revalidated for exactly this URL in lockstep.
+    assert ([PR_URL], True) in forced
+    assert real_schedule is not None
+
+
+def test_full_payload_status_change_forces_visibility_revalidation(monkeypatch):
+    # GPT #6789 round-9: record_full_payload_status is a SECOND authoritative
+    # status writer (the detail panel). A public->private change refreshed here
+    # must also force-revalidate visibility, or a non-owner is served the new
+    # status against a stale-fresh public flag. Fix the writer, do NOT drop the
+    # non-owner feature.
+    source._check_cache.clear()
+    _seed_status(PR_URL, {"state": "open"})  # prior status
+
+    monkeypatch.setattr(source, "status_from_full_payload", lambda payload: {"state": "merged"})
+    monkeypatch.setattr(source, "_emit_status_delta", lambda *a, **k: None)
+
+    forced: list[tuple[list[str], bool]] = []
+
+    def spy_schedule(urls, on_update=None, *, force=False):
+        forced.append((list(urls), force))
+
+    monkeypatch.setattr(source, "schedule_visibility_refresh", spy_schedule)
+
+    source.record_full_payload_status(PR_URL, {"state": "merged"})
+
+    assert ([PR_URL], True) in forced
+
+
+@pytest.mark.asyncio
+async def test_status_change_forces_visibility_before_flap_and_await(monkeypatch):
+    # GPT #6789 round-11 finding 2: the force visibility invalidation must run
+    # IMMEDIATELY after 'changed' is detected — before flap handling (which can
+    # early-return) and before the first await (_invalidate_full_payload_cache).
+    # Otherwise a public->private repo whose transition is flapping would return
+    # without ever invalidating visibility, or a concurrent slots push during the
+    # await could observe the newly-cached private status against a stale-fresh
+    # public flag.
+    source._check_cache.clear()
+    _seed_status(PR_URL, {"state": "open"})
+
+    async def fetch_changed(url):
+        return {"state": "merged"}
+
+    monkeypatch.setattr(source, "_fetch_check_status", fetch_changed)
+
+    order: list[str] = []
+
+    def spy_schedule(urls, on_update=None, *, force=False):
+        order.append(f"visibility_force={force}")
+
+    async def spy_invalidate_full(url):
+        order.append("full_payload_await")
+
+    monkeypatch.setattr(source, "schedule_visibility_refresh", spy_schedule)
+    monkeypatch.setattr(source, "_invalidate_full_payload_cache", spy_invalidate_full)
+    monkeypatch.setattr(source, "_emit_status_delta", lambda *a, **k: None)
+
+    # Case A: force the flap path (early return). Visibility must STILL have been
+    # invalidated first.
+    monkeypatch.setattr(source, "_note_check_flap", lambda *a, **k: True)
+    source._check_inflight.add(PR_URL)
+    await source._refresh_check_status(PR_URL, on_update=None)
+    assert order and order[0] == "visibility_force=True"
+    assert "full_payload_await" not in order  # flap path returned before the await
+
+    # Case B: normal path — visibility force precedes the full-payload await.
+    order.clear()
+    source._check_cache.clear()
+    _seed_status(PR_URL, {"state": "open"})
+    monkeypatch.setattr(source, "_note_check_flap", lambda *a, **k: False)
+    source._check_inflight.add(PR_URL)
+    await source._refresh_check_status(PR_URL, on_update=None)
+    assert order == ["visibility_force=True", "full_payload_await"]
+
+
+# ── _project_source_links gate matrix ────────────────────────────────────────
+
+
+def _link(url: str, kind: str = "change") -> dict:
+    return {"provider": "github", "number": 7, "url": url, "kind": kind}
+
+
+def _has_status(projected: dict) -> bool:
+    return "state" in projected or "ci" in projected
+
+
+def test_owner_sees_status_for_private_repo():
+    _seed_status(PR_URL, {"state": "merged", "ci": "passed"})
+    _seed_visibility(PR_URL, False)  # private
+    out = _project_source_links([_link(PR_URL)], True, dashboard_user=False)
+    assert _has_status(out[0])  # owner gate wins regardless of visibility
+
+
+def test_dashboard_user_sees_status_for_public_repo():
+    _seed_status(PR_URL, {"state": "merged", "ci": "passed"})
+    _seed_visibility(PR_URL, True)
+    out = _project_source_links([_link(PR_URL)], False, dashboard_user=True)
+    assert out[0].get("state") == "merged"
+    assert out[0].get("ci") == "passed"
+
+
+def test_dashboard_user_gets_bare_chip_for_private_repo():
+    _seed_status(PR_URL, {"state": "merged", "ci": "passed"})
+    _seed_visibility(PR_URL, False)
+    out = _project_source_links([_link(PR_URL)], False, dashboard_user=True)
+    assert not _has_status(out[0])
+
+
+def test_dashboard_user_fails_closed_when_visibility_unknown():
+    _seed_status(PR_URL, {"state": "merged", "ci": "passed"})
+    # No visibility seeded -> unknown -> owner-only.
+    out = _project_source_links([_link(PR_URL)], False, dashboard_user=True)
+    assert not _has_status(out[0])
+
+
+def test_app_token_gets_bare_chip_even_on_public_repo():
+    _seed_status(PR_URL, {"state": "merged", "ci": "passed"})
+    _seed_visibility(PR_URL, True)
+    # Neither owner nor dashboard-user -> app token -> no status.
+    out = _project_source_links([_link(PR_URL)], False, dashboard_user=False)
+    assert not _has_status(out[0])
+
+
+def test_issue_link_never_gets_status_even_for_owner():
+    _seed_status(ISSUE_URL, {"state": "closed"})
+    _seed_visibility(ISSUE_URL, True)
+    out = _project_source_links([_link(ISSUE_URL, kind="issue")], True, dashboard_user=True)
+    assert not _has_status(out[0])
+
+
+def test_non_owner_public_status_grant_is_sel_audited(monkeypatch):
+    # GPT #6789 round-12: granting a non-owner status on a confirmed-public repo
+    # is an access-control decision and MUST leave an SEL allow event
+    # (AUTOSDE backend-security-controls: grants, not only denials). Owner and
+    # app-token paths do NOT go through this grant, so they emit nothing here.
+    import kiro_crew.dashboard.state as state_mod
+
+    state_mod._PUBLIC_STATUS_GRANT_AUDIT.clear()
+    state_mod._PUBLIC_STATUS_DENY_AUDIT.clear()
+    events: list[tuple] = []
+
+    class _FakeSel:
+        def log_api_access(self, **kw):
+            events.append((kw.get("operation"), kw.get("outcome"), kw.get("resources")))
+
+    monkeypatch.setattr(state_mod, "sel", lambda: _FakeSel())
+
+    _seed_status(PR_URL, {"state": "merged", "ci": "passed"})
+    _seed_visibility(PR_URL, True)
+
+    # Non-owner + public -> grant -> one allow event.
+    _project_source_links([_link(PR_URL)], False, dashboard_user=True)
+    assert events == [("source_link_public_status", "allowed", PR_URL)]
+
+    # Deduplicated within the window: a second projection emits nothing new.
+    _project_source_links([_link(PR_URL)], False, dashboard_user=True)
+    assert len(events) == 1
+
+    # Owner path does not go through the non-owner grant -> no new event.
+    events.clear()
+    _seed_visibility(PR_URL_2, False)
+    _seed_status(PR_URL_2, {"state": "open"})
+    _project_source_links([_link(PR_URL_2)], True, dashboard_user=False)
+    assert events == []
+
+    # DENY decision (GPT #6789 round-15): a non-owner on a NON-public repo is
+    # denied status and that denial must ALSO be SEL-audited (deduped per url).
+    events.clear()
+    _seed_status(PR_URL_2, {"state": "open", "ci": "passed"})
+    _seed_visibility(PR_URL_2, False)  # private -> denied for a non-owner
+    _project_source_links([_link(PR_URL_2)], False, dashboard_user=True)
+    assert events == [("source_link_public_status", "denied", PR_URL_2)]
+    # Deduped within the window.
+    _project_source_links([_link(PR_URL_2)], False, dashboard_user=True)
+    assert len(events) == 1


### PR DESCRIPTION
## Problem / Motivation

Sidebar session rows render PR / MR / issue chips, but the **lifecycle status** (merged / closed / open / draft) and the **CI rollup** glyph are stripped for any dashboard connection not classified as the configured owner — even when the repository is **public**, where that same status is world-visible on the provider's website.

The status pipeline was double-gated on `is_owner_dashboard_request`:

- `dashboard/ws.py` — the periodic chip refresh loop and connect-time refresh ran only for an owner connection, so a non-owner never populated the chip-status cache.
- `dashboard/state.py` — the status-bearing slots frame was sent only to owner WS clients.

`is_owner_dashboard_request` returns true only when the token subject equals `owner_id`. A dashboard session minted **before** `KIROCREW_OWNER_ID` was configured carries a `local-app` / `local-startup` subject for its whole life (the token re-mints from the incoming subject on refresh), so once an owner exists that session is denied owner status and every chip renders as a bare number — uniformly across GitHub, GitLab, and Jira.

## Why it matters

For a public repo the PR's merge/close/CI state is not sensitive — it is visible to anyone on the provider website. Withholding it from a legitimate authenticated dashboard user provides no confidentiality benefit while removing the single most useful signal the chip carries (is this PR merged / closed / green). The symptom reads as a regression even though the chip code never changed — what changed was the session's relationship to `owner_id`.

## What changed (motivation → approach → change)

Symptom: public-repo PR/MR chips lose their status for a non-owner dashboard session. Root cause: status is gated purely on connection-owner identity, never on whether the underlying repo is public. Change: gate chip status on **repository visibility** in addition to owner identity.

- **Owner** → status for every repo (public and private), unchanged.
- **Authenticated dashboard user (non-owner)** → status only for a **known-public** repo.
- **Private / not-yet-known** repos → owner-only (fail closed).
- **App tokens** → no status at all (scope unchanged).

Implementation:
- New per-repo **visibility cache** (`public` / `private` / `unknown`) in `handlers/source_providers.py`, keyed `provider|host|owner|repo`, with a long TTL, a bounded fire-and-forget fetch (`gh repo view --json isPrivate` / `glab api projects/...` — GitLab `internal` is treated as non-public), inflight dedup, and a fail-closed reader `is_repo_public`.
- A `dashboard_user` gate threaded through `_project_source_links` and the `serialize_slots` / `to_dict` / `source_links_payload` chain.
- The general slots broadcast is enriched with public-repo status (SSE and WS both run on dashboard-user tokens); app-token frames are stripped of the credential-backed status keys in `filter_slots_for_app` so no app scope can receive it.
- The periodic check-status + visibility refresh driver now runs for any authenticated dashboard connection, not only the owner (TTL + inflight dedup keep it to one provider fetch per URL/repo per TTL).

## Tests

- New `test/test_public_repo_chip_status.py` (16 tests): `is_repo_public` reader; GitHub/GitLab visibility fetch + fail-closed on error; refresh keeps prior known value on failure; scheduler repo-dedup + TTL + issue/Jira skip; and the full `_project_source_links` gate matrix — owner/private, dashboard-user/public, dashboard-user/private, dashboard-user/unknown (fail-closed), app-token, and issue link.
- Updated `test/test_dashboard_state_ws.py`: public-repo status now rides the general/SSE frame; owner still gets the dedicated full-status frame; a new test proves app-token frames are stripped of status; the refresh-loop tests now assert app tokens never start the driver while a non-owner dashboard user does (with visibility refresh scheduled).

## Manual verification

N/A — unit coverage is sufficient. The change is a backend gate with no new UI; the gate matrix, the broadcast routing (owner / dashboard-user / app-token), and the visibility cache are all exercised by the automated tests above. Local gates all green: `pytest` (touched suites), `isort`, `flake8`, `mypy src/kiro_crew/`, and the baselined `black` gate.

## Related Issues

Fixes #6786

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff

## Pattern harvest

Rule candidate: semgrep
Pattern: when a permission gate is widened from owner-only to a broader audience (here a non-owner dashboard user, gated on repo visibility), EVERY code path that acts on the gated resource must apply the same gate — not only the data-*serving* path but every *scheduling-time credentialed side-read* it triggers. In this PR the identical non-owner-drives-credentialed-read-on-private-repo leak reappeared at four distinct sites (`ws.py` connect scheduler, `ws.py` periodic refresh loop, `chat_handlers.py` `GET /api/chat/slots`, `state.py` turn-completion refresh) because the visibility gate was added to the render/serialize path but each independent `schedule_check_refresh` / `request_check_refresh_now` call site had to be gated separately. Generalized rule: flag a call that fans a user-reachable request out to an operator-credentialed subprocess/API read (`schedule_check_refresh`, `request_check_refresh_now`, `gh`/`glab` invocations) when it is reachable by a non-owner principal but not guarded by the same positive authorization predicate (`is_repo_public(url) is True` / owner check) that gates the corresponding response projection. Companion rule: a positive authorization GRANT (not only a denial) must emit an SEL audit event.
