### PR TITLE
fix(dashboard): send an owner socket one slots frame, not two

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -148,6 +148,47 @@ def _safe_folder_tree(folders: object) -> list[dict[str, Any]]:
     return [f for f in folders if isinstance(f, dict) and isinstance(f.get("id"), str)]
 
 
+def _slots_ws_frame(
+    slots: object,
+    *,
+    yolo: bool,
+    channel_trusted: bool,
+    gitlab_hosts_gen: object,
+    folders: object,
+) -> str:
+    """Serialize the dashboard-user ``slots`` WS frame.
+
+    ONE builder for the two sites that send this frame — the generic fan-out in
+    :meth:`DashboardState._broadcast` and the owner frame in
+    :meth:`DashboardState._do_slots_broadcast` — because they must carry the SAME
+    keys and nothing else enforces that. ``_send_ws_all`` skips owner sockets for
+    ``slots``, so the generic frame no longer backstops an owner: a key present in
+    one envelope and not the other silently deprives every owner window, with no
+    error anywhere. Hand-building both is exactly how they drifted before (the
+    owner frame was a strict subset, missing ``folders`` and
+    ``gitlabHostsGeneration``), so the remedy is one builder rather than a second
+    careful copy — drift becomes impossible by construction instead of merely
+    detectable.
+
+    DELIBERATELY NOT used for the app-token frame in
+    :meth:`DashboardState._serialize_for_client`. That envelope diverges on
+    purpose: it omits ``folders`` (apps do not render the chat folder tree) and
+    gates ``yolo`` / ``channelTrusted`` behind the token's declared scope. Routing
+    it through here would widen an app's payload, so it is a third shape by
+    design, not a duplicate awaiting cleanup.
+    """
+    return json.dumps(
+        {
+            "type": "slots",
+            "data": slots,
+            "yolo": yolo,
+            "channelTrusted": channel_trusted,
+            "gitlabHostsGeneration": gitlab_hosts_gen,
+            "folders": folders,
+        }
+    )
+
+
 def _split_namespaced_channel_id(channel_id: str | None) -> tuple[str, str] | None:
     """Return ``(channel_type, target)`` for a ``<type>:<target>`` id."""
     if not channel_id:
@@ -8482,17 +8523,24 @@ class DashboardState:
                 "folders": _safe_folder_tree(getattr(self, "_folders", None)),
             }
         )
+        # The owner frame is the owner's ONLY slots frame — `_send_ws_all` skips
+        # owner sockets for `slots` (see there for why), so this envelope has to
+        # carry every key the generic one does. It previously carried a subset,
+        # which is why the owner had to receive both: `folders` seeds the
+        # first-paint folder tree and `gitlabHostsGeneration` drives the
+        # dashboard-config invalidation, and neither was here. Both frames are now
+        # built by `_slots_ws_frame`, so a key can no longer reach one and not the
+        # other.
         owner_ws_clients = getattr(self, "_owner_ws_clients", None)
         if owner_ws_clients:
             owner_slots = self.serialize_slots(include_check_status=True)
             self._send_ws_owners(
-                json.dumps(
-                    {
-                        "type": "slots",
-                        "data": owner_slots,
-                        "yolo": yolo_active,
-                        "channelTrusted": ch_trusted,
-                    }
+                _slots_ws_frame(
+                    owner_slots,
+                    yolo=yolo_active,
+                    channel_trusted=ch_trusted,
+                    gitlab_hosts_gen=gitlab_hosts_generation(),
+                    folders=_safe_folder_tree(getattr(self, "_folders", None)),
                 )
             )
 
@@ -8595,24 +8643,15 @@ class DashboardState:
                     "yolo": note.get("_yolo", False),
                     "channelTrusted": note.get("channelTrusted", False),
                 }
-                ws_msg = json.dumps(
-                    {
-                        "type": "slots",
-                        "data": slots_list,
-                        "yolo": ws_data["yolo"],
-                        "channelTrusted": ws_data["channelTrusted"],
-                        # Forwarded explicitly: this envelope is rebuilt key-by-key,
-                        # so anything not named here is silently dropped. The client
-                        # invalidates its cached dashboard config when this changes.
-                        "gitlabHostsGeneration": note.get("gitlabHostsGeneration"),
-                        # Folder tree (no history_count) so the sidebar groups
-                        # sessions on first paint without waiting for the separate
-                        # GET /api/chat/folders. Only the dashboard-user frame
-                        # (default_msg) carries it; app-token frames are rebuilt in
-                        # the scope chokepoint and deliberately omit it (apps do not
-                        # render the chat folder tree).
-                        "folders": note.get("folders"),
-                    }
+                # Built by `_slots_ws_frame`, NOT inline: the owner frame in
+                # `_do_slots_broadcast` has to carry an identical key set, and it
+                # cannot if each site names its own keys. See that function.
+                ws_msg = _slots_ws_frame(
+                    slots_list,
+                    yolo=bool(ws_data["yolo"]),
+                    channel_trusted=bool(ws_data["channelTrusted"]),
+                    gitlab_hosts_gen=note.get("gitlabHostsGeneration"),
+                    folders=note.get("folders"),
                 )
             elif msg_type == "slot_title":
                 ws_data = {"key": note["key"], "title": note["title"]}
@@ -8883,9 +8922,22 @@ class DashboardState:
         :meth:`_serialize_for_client`.
         """
         dead: list[web.WebSocketResponse] = []
+        # An owner socket gets its own `slots` frame from `_do_slots_broadcast`,
+        # serialized WITH chip check status. Sending it this one too delivered the
+        # SAME list twice per push, the first copy missing `ci`/`state`/`mergeable`
+        # — and the client replaces `slots` wholesale per frame, so every decorated
+        # PR chip lost its status glyph on the first and regained it on the second.
+        # A glyph is a 14px flex child, so a session card's chip strip visibly
+        # re-wrapped on every push. Owners are excluded here rather than merged
+        # into one frame at the call site because the two payloads genuinely differ:
+        # the status fields are owner-gated and must stay off the generic frame.
+        skip_owners = msg_type == "slots"
+        owners = getattr(self, "_owner_ws_clients", None) or set()
         for ws in list(self._ws_clients):
             if ws.closed:
                 dead.append(ws)
+                continue
+            if skip_owners and ws in owners:
                 continue
             if not self._ws_client_allowed(ws, msg_type, data):
                 continue

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -826,10 +826,56 @@ class TestOwnerSourceStatusTransport:
         assert len(generic_messages) == 1
         assert "ci" not in str(generic_messages[0]["data"])
         assert "state" not in generic_messages[0]["data"][0]["source_links"][0]
-        assert len(owner_messages) == 2
-        assert "ci" not in str(owner_messages[0]["data"])
-        assert owner_messages[1]["data"][0]["source_links"][0]["ci"] == "passed"
-        assert owner_messages[1]["data"][0]["source_links"][0]["state"] == "OPEN"
+        # EXACTLY ONE frame for the owner, and it is the enriched one. Two frames
+        # delivered the same list twice, the first without `ci`/`state`, and the
+        # client replaces its slot list per frame — so every decorated PR chip lost
+        # its status glyph on frame one and regained it on frame two, re-wrapping
+        # the sidebar chip strip on every push.
+        assert len(owner_messages) == 1
+        assert owner_messages[0]["data"][0]["source_links"][0]["ci"] == "passed"
+        assert owner_messages[0]["data"][0]["source_links"][0]["state"] == "OPEN"
+        # The owner frame is now the owner's only one, so it must carry every key
+        # the generic frame does. Asserted as SET EQUALITY over the whole envelope,
+        # not as a list of the keys known today: `_send_ws_all` skips owner sockets
+        # for `slots`, so the generic frame no longer backstops an owner, and a key
+        # added to one site and not the other would silently deprive every owner
+        # window. Both frames come from `_slots_ws_frame`, which makes that
+        # impossible by construction; this pins the property so a future site that
+        # hand-builds the envelope again fails here instead of in production.
+        assert set(owner_messages[0]) == set(generic_messages[0])
+        assert owner_messages[0]["folders"] == generic_messages[0]["folders"]
+        assert (
+            owner_messages[0]["gitlabHostsGeneration"]
+            == generic_messages[0]["gitlabHostsGeneration"]
+        )
+
+    def test_owner_sockets_still_receive_non_slot_broadcasts(
+        self, state: DashboardState, monkeypatch
+    ) -> None:
+        """The `slots` exclusion must not silence an owner socket generally.
+
+        The generic fan-out skips owner sockets for `slots` alone, because that is
+        the one message type they receive twice. Every other type has no
+        owner-specific frame to fall back on, so a skip that keyed on the socket
+        rather than on the message type would drop it entirely — an owner window
+        that stops seeing refreshes, with nothing raised anywhere. This is the
+        control for that: it fails if the exclusion is ever widened.
+        """
+        sent: list[tuple[object, dict]] = []
+        monkeypatch.setattr(
+            state,
+            "_spawn_ws_send",
+            lambda client, message: sent.append((client, json.loads(message))),
+        )
+        owner_ws = MagicMock(closed=False)
+        state.register_ws(owner_ws, owner=True)
+
+        state._broadcast({"_type": "refresh", "kinds": "crons,agents"})
+
+        owner_messages = [message for client, message in sent if client is owner_ws]
+        assert len(owner_messages) == 1
+        assert owner_messages[0]["type"] == "refresh"
+        assert owner_messages[0]["data"]["kinds"] == ["crons", "agents"]
 
     @pytest.mark.parametrize(
         ("claims", "owner_request"),


### PR DESCRIPTION
## Problem / Motivation

A session card's pull-request chip strip visibly re-wraps whenever the sidebar
repaints — three chips sit on one row, then the third jumps to a second row and
back. It reads like sub-pixel flex-wrap jitter, but it is a payload problem: the
owner dashboard receives **two different `slots` frames per push**, and the first
one is missing the chip status fields.

`_do_slots_broadcast` sends the generic frame with `include_check_status` left at
its `False` default, then sends a second, enriched frame to owner sockets only.
`register_ws` puts every socket in `_ws_clients` **and** owner sockets in
`_owner_ws_clients`, so an owner window is in both sets and gets both. On the
first frame `_project_source_links` spreads no cached status, so `ci`, `state`,
`mergeable` and `mergeStateStatus` are all absent.

The client replaces its slot list wholesale per frame (`sseSlots`), and its dedup
guard cannot help — the two payloads differ by exactly those fields. So each push
renders the chips undecorated, then decorated. A status glyph is a `10px`
`.lucide-inline` box plus a `4px` flex gap, so a chip with one is **14px** wider.
Two decorated chips swing the strip by 28px, which straddles the wrap threshold
over a wide range of sidebar widths.

## Why it matters

It is a permanent, every-push visual defect on the busiest surface in the app,
and the wrong diagnosis is the cheap one: the card animates under a Framer
`layout="position"` spring and the strip is `flex flex-wrap`, so both invite a
long hunt through layout code that cannot produce the symptom (transforms do not
affect wrapping, and the columns are `flex-1 min-w-[220px]`, so their width is
stable). Nothing surfaces the real cause anywhere.

The two-frame delivery also makes the sidebar chip the one surface where a status
glyph is not a claim about the pull request but an artefact of frame ordering.

## What changed

Three edits in `src/kiro_crew/dashboard/state.py`, so an owner socket receives
exactly one `slots` frame and the two envelopes cannot drift apart:

- `_send_ws_all` skips owner sockets when `msg_type == "slots"`. The skip sits
  *after* the `ws.closed` check so closed owner sockets are still reaped, and it
  is keyed on the message type, not on the socket — every other type has no
  owner-specific frame to fall back on.
- The owner frame now carries `gitlabHostsGeneration` and `folders`. It was a
  strict subset of the generic envelope, which is *why* the owner needed both
  frames: `folders` seeds the first-paint folder tree and `gitlabHostsGeneration`
  drives the dashboard-config invalidation.
- **Both frames are now built by one function, `_slots_ws_frame`.** Removing the
  generic frame removes the redundancy that used to mask envelope drift: with the
  generic frame no longer backstopping an owner, a key added to one hand-built
  envelope and not the other would silently deprive every owner window. The two
  sites carried an identical key set, so a single builder makes that impossible by
  construction rather than merely detectable.

`_serialize_for_client`'s app-token frame deliberately does **not** use the
builder — it omits `folders` and gates `yolo` / `channelTrusted` behind the
token's declared scope, so routing it through here would widen an app's payload.
That divergence is documented on the builder so it is not "unified" later by
mistake.

Owners are excluded rather than the two frames merged at the call site, because
the payloads genuinely differ — the status fields are owner-gated and must stay
off the generic frame. That gate is unchanged: SSE and non-owner sockets still
receive no chip status.

`slots` reaches `_send_ws_all` only via `_broadcast`; there are no
`broadcast_ws("slots", ...)` callers, so the type gate covers every path.

## Tests

`test/test_dashboard_state_ws.py`

- `test_slot_updates_keep_status_out_of_sse_and_generic_websockets` updated: the
  owner now gets **one** frame and it is the enriched one. It asserts the owner
  and generic frames have **equal key sets** (`set(owner) == set(generic)`), not
  just the two keys known today — so any future key reaching one envelope and not
  the other fails here. Verified both directions: it fails on an unmodified
  baseline for the intended reason (`2 == len(...)`, first frame without `ci`),
  and injecting a key into the generic envelope alone fails with
  `Extra items in the right set: 'driftProbe'`.
- `test_owner_sockets_still_receive_non_slot_broadcasts` added as the control for
  the risk this change introduces: it fails if the exclusion is ever widened past
  `slots` and starts silencing owner sockets generally.

Suites run: `test_dashboard_state_ws.py`, `test_dashboard_source_links_expand.py`,
`test_dashboard_chat.py` — 777 passed. Full `pytest test/` — 69981 passed, 93
failed, 212 skipped. Every one of those 93 reproduces on an unmodified baseline:
the same run with both changed files reverted gives 93 failed / 69980 passed, and
the FAILED/ERROR test-id sets are **identical**, so there are no regressions.
They are environmental (subprocess-import and sandbox-dependent suites such as
`test_flock_compat`, `test_acp_backend_kas::TestNoImportCycle`,
`test_artifact_source`). `mypy` clean on the changed module; the black gate passes
on both files in scope.

No frontend change: the client is a correct consumer of a correct single frame.
