### PR TITLE
fix(auto-improvement): stand the app's workers down when it is disabled

### DIFF
--- a/docs/system-specs/modules/auto-improvement.md
+++ b/docs/system-specs/modules/auto-improvement.md
@@ -30,6 +30,17 @@ All routes live under `/api/apps/auto-improvement/` and are registered by
 in-process on the gateway's own aiohttp app. Every handler is wrapped in
 `_require_enabled` (403 when the app is disabled).
 
+`_require_enabled` closes the API, not the work. `register_routes` therefore stands
+both in-process workers down on both ways the app can be switched off: `on_cleanup`
+hooks for gateway shutdown (`_stop_watchers`, `_stop_run`), and an `apps.teardown`
+`register_app_disable_hook` for the operator disabling the app. Without the second,
+a disable leaves the routes answering 403 while a watcher keeps running agent turns
+in per-PR clones and an in-flight run keeps the clone lock and keeps spending
+budget. The disable hook fires inside the disable request, before the `enabled` flag
+is written, so both are signalled at the click rather than at the next sweep, and
+each is error-contained separately — the shutdown path gets that from holding two
+hooks, the disable path has to spell it out.
+
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/health` | liveness; echoes the app name |

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
@@ -23,6 +23,7 @@ from typing import Any, Awaitable, Callable
 
 from aiohttp import web
 
+from kiro_crew.apps import teardown
 from kiro_crew.apps.manager import is_app_enabled
 from kiro_crew.security import redact
 
@@ -474,7 +475,10 @@ async def _handle_pr_status(request: web.Request) -> web.StreamResponse:
     if status.get("ok"):
         return web.json_response(status, status=200)
     return web.json_response(
-        {"code": "pr_status_unavailable", "error": _redact_for_display(str(status.get("error") or ""))},
+        {
+            "code": "pr_status_unavailable",
+            "error": _redact_for_display(str(status.get("error") or "")),
+        },
         status=502,
     )
 
@@ -1506,6 +1510,38 @@ def register_routes(app: web.Application) -> None:
         except Exception:  # pragma: no cover - defensive
             logger.warning("%s: run shutdown failed", store.APP_NAME, exc_info=True)
 
+    async def _stop_on_disable(_app: str) -> None:
+        """Wind the same run down when the OPERATOR switches the app off.
+
+        ``on_cleanup`` fires at gateway shutdown and nowhere else. Disabling the app
+        takes a different path entirely: :func:`_require_enabled` starts refusing the
+        routes, while the supervisor thread keeps the clone lock and keeps spending
+        budget — the operator sees the app off and the work carries on.
+
+        :func:`~kiro_crew.apps.teardown.notify_app_disabled` fires INSIDE the disable
+        request and before the ``enabled`` flag is written, which is what makes this
+        an off-switch rather than a sweep: a run signalled on the next poll instead
+        would get a whole further candidate out of a permission that was already
+        withdrawn.
+
+        Both workers stand down, because both keep acting on the operator's
+        repositories: a watcher runs an agent turn inside a per-PR clone on a
+        timer, and the run holds the clone lock and spends budget. Each is
+        signalled the way its own shutdown hook signals it — ``stop_all``
+        only sets flags and joins nothing, ``stop`` is bounded and blocks, so it
+        goes off the loop — and each is contained separately. ``on_cleanup``
+        gets that independence free by holding two hooks; here one failing
+        signal must not swallow the other.
+        """
+        try:
+            pr_watchers.get_registry().stop_all()
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("%s: watcher stop on disable failed", store.APP_NAME, exc_info=True)
+        try:
+            await asyncio.to_thread(runner.get_supervisor().stop)
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("%s: run stop on disable failed", store.APP_NAME, exc_info=True)
+
     # Guarded: register_routes runs before the runner freezes its signal lists,
     # so appending is safe — but a failure here must never break gateway startup.
     try:
@@ -1514,5 +1550,16 @@ def register_routes(app: web.Application) -> None:
         app.on_cleanup.append(_stop_run)
     except Exception:  # pragma: no cover - defensive
         logger.warning("%s: could not register lifecycle hooks", store.APP_NAME)
+
+    # Same wind-down, different trigger. Feature-detected with ``getattr`` rather
+    # than called directly, so a core build whose teardown module predates this
+    # registry still loads — there the shutdown hook above is the only stop
+    # there is, which is the pre-registry behaviour rather than a regression.
+    try:
+        register_disable = getattr(teardown, "register_app_disable_hook", None)
+        if register_disable is not None:
+            register_disable(store.APP_NAME, _stop_on_disable)
+    except Exception:  # pragma: no cover - defensive
+        logger.warning("%s: could not register the app-disable hook", store.APP_NAME)
 
     logger.info("%s backend routes registered", store.APP_NAME)

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_disable_stops_run.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_disable_stops_run.py
@@ -1,0 +1,199 @@
+"""Disabling the app must stop an in-flight run, not just refuse its routes.
+
+Gateway shutdown is covered by ``test_shutdown_stops_run``. Disabling the app is a
+different path with the same exposure and none of the same wiring: ``on_cleanup``
+fires only when the gateway stops, so switching the app off leaves
+``_require_enabled`` answering 403 on every route while the supervisor thread keeps
+the clone lock and keeps spending budget. The operator sees the app off; the work
+carries on.
+
+``apps.teardown`` has a purpose-built seam for exactly this —
+``register_app_disable_hook`` / ``notify_app_disabled`` — fired INSIDE the disable
+request and before the ``enabled`` flag is written, which is what makes it an
+off-switch rather than a sweep. Its own docstring names the reason: a worker holding
+something time-bounded "can act once more in the gap between the operator's click and
+the next poll, which is a whole turn's worth of authority handed out after permission
+was withdrawn." This app registered nothing there.
+
+These tests drive the real ``register_routes``, start a run that parks in
+``driver.run`` so the supervisor genuinely owns a live thread, then fire
+``notify_app_disabled`` exactly as the disable request does.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+from kiro_crew.apps import teardown
+from kiro_crew.apps.builtins.auto_improvement.backend import pr_watchers
+from kiro_crew.apps.builtins.auto_improvement.backend import routes as R
+from kiro_crew.apps.builtins.auto_improvement.backend import runner, store
+
+
+class _BlockingDriver:
+    """Parks in ``run`` until stopped, so the supervisor has a genuinely live thread."""
+
+    def __init__(self) -> None:
+        self._release = threading.Event()
+
+    def run(self, **_kw: Any) -> Any:
+        self._release.wait(timeout=10.0)
+        return _FakeStats()
+
+    def request_stop(self) -> None:
+        self._release.set()
+
+
+class _FakeStats:
+    cycles = 0
+    discovered = 0
+    deduped = 0
+    gated_out = 0
+    not_kept = 0
+    kept = 0
+    filed = 0
+    errors = 0
+    cost_usd = 0.0
+
+
+@pytest.fixture
+def _fresh_singleton(monkeypatch: pytest.MonkeyPatch) -> runner.RunSupervisor:
+    """A fresh process-wide supervisor for the duration of the test.
+
+    The hook resolves the supervisor through ``runner.get_supervisor()``, so the test
+    must drive that same singleton — but a run leaked into the real module singleton
+    would make unrelated tests' "already active" refusal fire.
+    """
+    sup = runner.RunSupervisor()
+    monkeypatch.setattr(runner, "_SUPERVISOR", sup)
+    return sup
+
+
+@pytest.fixture(autouse=True)
+def _clean_disable_registry():
+    """The disable registry is process memory shared by every test in the worker, so
+    a hook registered here must not outlive the test that registered it."""
+    teardown.unregister_app_disable_hook(store.APP_NAME)
+    yield
+    teardown.unregister_app_disable_hook(store.APP_NAME)
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_app_stops_an_active_run(
+    _fresh_singleton: runner.RunSupervisor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    driver = _BlockingDriver()
+    monkeypatch.setattr(_fresh_singleton, "_build_driver", lambda _cfg: driver)
+
+    app = web.Application()
+    R.register_routes(app)
+
+    started = _fresh_singleton.start({"clone": "/does/not/matter"})
+    try:
+        assert started["status"] == runner.STATUS_RUNNING
+        assert _fresh_singleton.status()["status"] == runner.STATUS_RUNNING
+
+        # Exactly what the disable request does, at the point it does it.
+        await teardown.notify_app_disabled(store.APP_NAME)
+
+        # The load-bearing assertion: with no hook registered, `notify_app_disabled`
+        # returns immediately having found nothing, `request_stop` is never called,
+        # and the run keeps the clone lock and the budget.
+        assert (
+            driver._release.is_set()
+        ), "disabling the app did not ask the driver to stop — the run kept going"
+        # The released driver returns at once, so the join inside `stop` observes a
+        # finished thread and the terminal status is DONE. (STOPPING would be the
+        # honest answer only if a real measurement outran the join timeout.)
+        assert (
+            _fresh_singleton.status()["status"] == runner.STATUS_DONE
+        ), "the run supervisor was not stopped when the app was disabled"
+    finally:
+        driver.request_stop()
+        _fresh_singleton.stop()
+
+
+@pytest.mark.asyncio
+async def test_disabling_while_idle_is_a_no_op(
+    _fresh_singleton: runner.RunSupervisor,
+) -> None:
+    """``stop`` is idempotent, and the disable path must stay safe to fire at any
+    time — an operator may disable an app that is doing nothing, repeatedly."""
+    app = web.Application()
+    R.register_routes(app)
+
+    await teardown.notify_app_disabled(store.APP_NAME)
+    await teardown.notify_app_disabled(store.APP_NAME)
+
+    assert _fresh_singleton.status()["status"] != runner.STATUS_RUNNING
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_app_also_stops_the_pr_watchers(
+    _fresh_singleton: runner.RunSupervisor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The run is not the only worker a disable has to reach.
+
+    A watcher runs an agent turn inside a per-PR clone on a timer, so leaving it
+    going after the operator switches the app off keeps acting on their
+    repositories with a permission that was withdrawn — the same harm the run
+    poses, by a different worker. Gateway shutdown already signals both
+    (``_stop_watchers`` beside ``_stop_run``); disable must not stop only one.
+    """
+    stopped: list[bool] = []
+
+    def record_stop_all() -> int:
+        stopped.append(True)
+        return 0
+
+    monkeypatch.setattr(pr_watchers.get_registry(), "stop_all", record_stop_all)
+
+    app = web.Application()
+    R.register_routes(app)
+
+    await teardown.notify_app_disabled(store.APP_NAME)
+
+    assert stopped, "disabling the app left the PR watchers running"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_watcher_stop_still_stops_the_run(
+    _fresh_singleton: runner.RunSupervisor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The two signals are contained separately.
+
+    ``on_cleanup`` gets that for free by holding two hooks, so a raising watcher
+    stop cannot skip the run stop there. This hook is one function and has to
+    reproduce it deliberately.
+    """
+    driver = _BlockingDriver()
+    monkeypatch.setattr(_fresh_singleton, "_build_driver", lambda _cfg: driver)
+
+    def boom() -> int:
+        raise RuntimeError("registry exploded")
+
+    monkeypatch.setattr(pr_watchers.get_registry(), "stop_all", boom)
+
+    app = web.Application()
+    R.register_routes(app)
+
+    _fresh_singleton.start({"clone": "/does/not/matter"})
+    try:
+        await teardown.notify_app_disabled(store.APP_NAME)
+        assert driver._release.is_set(), "a failing watcher stop swallowed the run stop"
+    finally:
+        driver.request_stop()
+        _fresh_singleton.stop()
+
+
+def test_register_routes_wires_an_app_disable_hook() -> None:
+    """A structural guard, matching the one the shutdown hook carries: the disable
+    seam must be wired under this app's own name, so a future edit that drops it
+    fails here instead of silently letting a disabled app keep running."""
+    app = web.Application()
+    R.register_routes(app)
+    assert teardown._APP_DISABLE_HOOKS.get(store.APP_NAME) is not None


### PR DESCRIPTION
## Problem / Motivation

`_require_enabled` closes the API, not the work.

Every auto-improvement route is wrapped in it, so disabling the app makes them all
answer `403 app_disabled`. Both in-process workers are untouched:

* a **PR watcher** keeps running agent turns inside a per-PR clone on a timer
  (`DEFAULT_NUDGE_INTERVAL_S` apart), so it goes on acting on the operator's
  repositories;
* the **run supervisor**'s worker thread keeps going, holding the clone lock and
  spending budget, and the agent/measurer subprocess it spawned keeps running.

The operator sees the app switched off and the work carries on.

`register_routes` already stands both down on gateway shutdown (— `_stop_watchers`, and
`_stop_run` added by `#6701`). aiohttp fires `on_cleanup` when the gateway stops and at
no other time, so neither reaches a disable. `#6701`'s review said so:

> The problem statement says the run is orphaned "when the gateway shuts down **or the
> app is disabled**", but an `on_cleanup` hook fires only at gateway shutdown; disabling
> the app just 403s the routes (`_require_enabled`, routes.py:131) while the run keeps
> spending budget. The disable half has an existing, purpose-built mechanism this change
> doesn't use: `register_app_disable_hook` / `notify_app_disabled`
> (src/kiro_crew/apps/teardown.py:395,419; grep shows 1 registered consumer, issue_radar's
> crew_runtime.py:1045). One unfixed sibling path of the same root cause — either wire it
> or declare disable out of scope the way the join-window gap already is.

Verified on current `main` (`72e429791`): `grep register_app_disable_hook` across
`apps/builtins/auto_improvement/` returns nothing. The registry has exactly one consumer,
Issue Radar.

## Why it matters

The seam's own docstring states the harm this closes, and states it as a security
property rather than a tidiness one:

> This exists because a periodic sweep is not an off-switch. An app whose workers hold
> anything time-bounded — an auto-approval grant, a lease, a lock — can act once more in
> the gap between the operator's click and the next poll, which is a whole turn's worth of
> authority handed out after permission was withdrawn.

Auto-improvement's run is precisely such a worker: `#6701`'s own hook docstring names what
it holds — the clone lock, and budget. So the disable path today spends money and holds a
lock on behalf of an app the operator has already turned off, and reports nothing, because
the only surface that would say so is returning 403.

`teardown.py` also orders `notify_app_disabled` **first**, ahead of the app's own
`onDisable` script and backend teardown, for exactly this reason — "so a worker holding
something time-bounded would [not] keep that authority for the duration". An app that
registers nothing there silently opts out of that ordering guarantee.

## What changed (motivation → approach → change)

Symptom: disabling the app leaves both workers going. Root cause: their stops are wired to
one of the two ways the app can be switched off. Fix: wire them to the other one too,
through the mechanism that already exists for it, with the same bodies.

`register_routes` now also registers an app-disable hook:

```python
async def _stop_on_disable(_app: str) -> None:
    try:
        pr_watchers.get_registry().stop_all()
    except Exception:
        logger.warning(...)
    try:
        await asyncio.to_thread(runner.get_supervisor().stop)
    except Exception:
        logger.warning(...)
```

Each worker is signalled the way its own `on_cleanup` hook signals it, and for that hook's
reasons. `stop_all` only sets flags and joins nothing (— "Nothing is joined — a route must
not block for a turn to finish"), so it runs inline; `stop` is idempotent (a no-op when
idle) and bounded (it signals the run and joins for at most `STOP_JOIN_TIMEOUT_S`), so it
goes off the loop because that join blocks.

The two are contained **separately**, which is the one thing this hook has to do
deliberately that the shutdown path gets for free: `on_cleanup` holds two independent
hooks, so a raising watcher stop cannot skip the run stop there. Collapsed into one
function, a single `try` would have made exactly that regression, and a test pins it.

Nothing new is introduced: no state, no config key, no constant, no route, no change to
`RunSupervisor` or `PRWatcherRegistry`.

Registration is feature-detected with `getattr(teardown, "register_app_disable_hook",
None)`, copying Issue Radar's pattern verbatim and for its stated reason: a core build
whose `teardown` module predates the registry keeps loading, and there the shutdown hook
is the only stop there is — the pre-registry behaviour, not a regression. It is wrapped in
its own `try`, matching the existing lifecycle-hook registration, because a failure here
must never break gateway startup.

Registering in `register_routes` rather than per-cycle is deliberate. Issue Radar
re-registers from its watchdog because the registry is process memory and a restart empties
it; `register_routes` runs once per gateway process, which is the same guarantee arrived at
more cheaply.

`docs/system-specs/modules/auto-improvement.md` gains a paragraph beside the
`_require_enabled` line it corrects — that sentence, on its own, reads as though 403 is what
disabling does.

One line is pruned from `.github/black-baseline.txt`. `routes.py` is listed there but is
already black-clean, and the gate scopes to changed files, so touching the file surfaces the
stale entry as `1 graduated entry to prune` and fails until it is removed. No reformatting
rides along: the whole `routes.py` diff is the 36 added lines.

## Tests

New `src/kiro_crew/apps/builtins/auto_improvement/tests/test_disable_stops_run.py`,
3 tests, mirroring `test_shutdown_stops_run.py`'s harness so the two paths are pinned the
same way. Each drives the real `register_routes` on a bare aiohttp application and starts a
run that parks in `driver.run`, so the supervisor genuinely owns a live thread rather than
a mock.

- **Disabling stops an active run** — fires `teardown.notify_app_disabled(APP_NAME)`,
  exactly what the disable request does and at the point it does it, then asserts the
  driver was asked to stop and the supervisor reached `STATUS_DONE`.
- **Disabling also stops the PR watchers** — the second worker, and the one that acts on
  the operator's repositories rather than just spending budget.
- **A failing watcher stop still stops the run** — `stop_all` is made to raise, and the
  run must still be signalled. This is the containment guard: it fails if the two calls
  are ever collapsed under one `try`.
- **Disabling while idle is a no-op** — fired twice, because an operator may disable an app
  that is doing nothing, repeatedly. This is the over-fix guard, and it is the one test
  that passes on `main` as well: the fix must not turn a harmless disable into an error.
- **`register_routes` wires a disable hook** — a structural guard matching the one
  `test_shutdown_stops_run.py` carries for `on_cleanup`, so an edit that drops the
  registration fails here instead of silently letting a disabled app keep running.

An autouse fixture unregisters the hook before and after each test: the registry is process
memory shared by every test in the worker, so a hook left behind would leak into unrelated
tests.

**Red-before**, with `routes.py` restored to current `origin/main` (`72e429791`) and
nothing else changed:

```
FAILED test_disabling_the_app_stops_an_active_run
  AssertionError: disabling the app did not ask the driver to stop — the run kept going
FAILED test_disabling_the_app_also_stops_the_pr_watchers
  AssertionError: disabling the app left the PR watchers running
FAILED test_a_failing_watcher_stop_still_stops_the_run
  AssertionError: a failing watcher stop swallowed the run stop
FAILED test_register_routes_wires_an_app_disable_hook
  AssertionError: assert None is not None
4 failed, 1 passed
```

The one that passes on `main` is the idle no-op guard, which is the point of it.

Green on the branch: 5 passed. Whole app suite: **972 passed, 63 skipped**. Gates:
`check_black_formatting.py` pass, `flake8 src/kiro_crew/apps/builtins/auto_improvement/`
clean, `isort --check-only src/kiro_crew test` clean, `mypy src/kiro_crew` — "Success: no
issues found in 1170 source files".

## Manual verification

N/A — unit coverage sufficient: the tests exercise the real registration and the real
supervisor over a genuinely running worker thread, and fire the disable notification
through the same function the disable request calls, so the whole path this change adds is
covered mechanically.

## Related Issues

Closes the unfixed sibling path named in the review on #6701.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

