### PR TITLE
fix(artifacts): warn when a colliding name lands at a suffixed slug

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -2337,7 +2337,23 @@ def _artifact(args: argparse.Namespace) -> None:
         if d.get("error"):
             print(f"Error: {d['error']}", file=sys.stderr)
             sys.exit(1)
-        print(f"Saved: slug={d.get('slug', '?')} version={d.get('version', 1)}")
+        slug = d.get("slug", "?")
+        print(f"Saved: slug={slug} version={d.get('version', 1)}")
+        # `save` has no --slug, so the slug is always derived from --name and a
+        # name collision can only ever be resolved by suffixing. That reads as
+        # success (exit 0, "version=1"), which is how a re-save of corrected
+        # content ends up published at a slug nobody looks at while the
+        # original keeps serving the old text. Name the slug that was taken and
+        # the verb that versions in place.
+        taken = d.get("slug_collided_with")
+        if taken:
+            print(
+                f"Warning: slug '{taken}' is already taken, so this created a NEW "
+                f"artifact at '{slug}' rather than a new version of '{taken}'. "
+                f"To version the existing artifact in place, use: "
+                f"kirocrew artifact update {taken}",
+                file=sys.stderr,
+            )
         return
 
     if action == "update":

--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -54,6 +54,7 @@ from kiro_crew.artifacts import (
     get_default_folder_store,
     get_default_store,
     is_document_path,
+    slugify,
     webapp_metadata_from_dict,
 )
 from kiro_crew.dashboard.chat_folders import generate_emoji_for_name
@@ -1472,7 +1473,23 @@ async def api_artifacts_create(request: web.Request) -> web.Response:
     )
     # New library entries appear live in every open window.
     _notify_artifact_update(state, art.slug, art.version)
-    return _json_response(_serialize(art, include_content=True), status=201)
+    # Report a de-duplicated slug to the CLI and the MCP tool, both of which are
+    # HTTP clients and so cannot see the store's log line. Create-only: the value
+    # describes this call, and a GET or LIST would carry it empty forever.
+    #
+    # Derived from ``art.name`` (post-validation) rather than the raw body, so the
+    # comparison uses the exact string the store slugified. Guarded on an absent
+    # ``slug``: an explicit one legitimately differs from the name, and the store
+    # refuses it on collision rather than renaming, so comparing there would warn
+    # about a collision that never happened.
+    payload = _serialize(art, include_content=True)
+    collided_with = ""
+    if not body.get("slug"):
+        requested = slugify(art.name)
+        if art.slug != requested:
+            collided_with = requested
+    payload["slug_collided_with"] = collided_with
+    return _json_response(payload, status=201)
 
 
 # ── Item: read / update / delete ──────────────────────────────────────────────

--- a/src/kiro_crew/mcp_tools/artifacts.py
+++ b/src/kiro_crew/mcp_tools/artifacts.py
@@ -700,12 +700,28 @@ def artifact_save(name: str, args: dict[str, Any]) -> str:
             )
     # Widgets re-surface via the re-emit tag; only non-widgets need the link.
     ref_link = "" if kind == "widget" else f"{mcp_core._artifact_ref_link(slug, name)}\n\n"
+    # The store had to suffix the derived slug, so this is a new artifact rather
+    # than a new version of the one already at that slug. Reported by the store,
+    # so it holds for every kind — the dedup probe above is a name-based
+    # pre-check scoped to chat widgets, and stays silent for a markdown or text
+    # deliverable saved under a name that is already in use. Suppressed when
+    # that probe already fired, so a colliding widget gets one warning.
+    collision_hint = ""
+    taken = d.get("slug_collided_with")
+    if taken and not dedup_hint:
+        collision_hint = (
+            f"\n\n⚠️  slug {taken!r} is already taken, so this is a NEW artifact "
+            f"at slug={slug!r} — not a new version of {taken!r}. If you meant to "
+            f"revise that artifact, delete this one and call `artifact_update` on "
+            f"{taken!r}. If both are genuinely needed, rename one to disambiguate."
+        )
     return (
         f"Saved artifact: slug={slug} version={version}\n\n"
         f"{ref_link}"
         f"{mcp_core._artifact_reemit_hint(slug, name, kind)}"
         f"{dedup_hint}"
         f"{cost_hint}"
+        f"{collision_hint}"
     )
 
 

--- a/test/test_artifacts_handlers.py
+++ b/test/test_artifacts_handlers.py
@@ -457,6 +457,47 @@ class TestCreate:
         assert resp.status == 409
 
     @pytest.mark.asyncio
+    async def test_suffixed_slug_is_reported_in_the_response(
+        self, isolated_store, patch_restricted
+    ) -> None:
+        # The CLI and the MCP tool are both HTTP clients, so the collision only
+        # reaches them if the create response carries it.
+        body = {"name": "Run Summary", "content": "first"}
+        first = _json_body(await api_artifacts_create(_request(body=body)))
+        assert first["slug"] == "run-summary"
+        assert first["slug_collided_with"] == ""
+
+        second = _json_body(await api_artifacts_create(_request(body=body)))
+        assert second["slug"] == "run-summary-2"
+        assert second["slug_collided_with"] == "run-summary"
+
+    @pytest.mark.asyncio
+    async def test_an_explicit_slug_reports_no_collision(
+        self, isolated_store, patch_restricted
+    ) -> None:
+        # An explicit slug differs from the name-derived one by intent; the store
+        # refuses a taken one outright, so comparing the two here would invent a
+        # collision that never happened.
+        body = {"name": "Run Summary", "content": "a", "slug": "chosen-by-hand"}
+        created = _json_body(await api_artifacts_create(_request(body=body)))
+        assert created["slug"] == "chosen-by-hand"
+        assert created["slug_collided_with"] == ""
+
+    @pytest.mark.asyncio
+    async def test_the_collision_report_is_create_only(
+        self, isolated_store, patch_restricted
+    ) -> None:
+        # It describes one create call, so a later read must not carry it —
+        # otherwise every GET and LIST ships a permanently empty field.
+        body = {"name": "Run Summary", "content": "a"}
+        await api_artifacts_create(_request(body=body))
+        fetched = _json_body(await api_artifact_detail(_request(match={"slug": "run-summary"})))
+        # Positive control: this is a real artifact payload, so the absence below
+        # is a fact about the field and not about a failed read.
+        assert fetched["slug"] == "run-summary"
+        assert "slug_collided_with" not in fetched
+
+    @pytest.mark.asyncio
     async def test_restricted_session_denied(self, isolated_store, patch_restricted) -> None:
         body = {"name": "x", "content": "a"}
         resp = await api_artifacts_create(_request(body=body, restricted=True))

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -1810,6 +1810,59 @@ class TestArtifactCli:
             )
         assert "Saved: slug=new version=1" in capsys.readouterr().out
 
+    def test_save_warns_when_the_slug_was_suffixed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # `save` has no --slug, so a colliding name silently lands a NEW
+        # artifact at a suffixed slug while the canonical one keeps its old
+        # content. The warning has to name both the taken slug and the verb
+        # that versions in place.
+        with _ArtifactHarness(
+            [
+                _FakeResponse(
+                    {
+                        "slug": "run-summary-2",
+                        "version": 1,
+                        "slug_collided_with": "run-summary",
+                    }
+                )
+            ]
+        ):
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Run Summary",
+                    content="corrected",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        captured = capsys.readouterr()
+        assert "Saved: slug=run-summary-2 version=1" in captured.out
+        assert "run-summary" in captured.err
+        assert "kirocrew artifact update run-summary" in captured.err
+
+    def test_save_is_silent_when_the_slug_was_free(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with _ArtifactHarness([_FakeResponse({"slug": "fresh", "version": 1})]):
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Fresh",
+                    content="body",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        captured = capsys.readouterr()
+        assert "Saved: slug=fresh version=1" in captured.out
+        assert captured.err == ""
+
     def test_save_reads_content_file(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/test/test_mcp_artifacts.py
+++ b/test/test_mcp_artifacts.py
@@ -108,6 +108,45 @@ class TestArtifactReferenceLink:
         assert ARTIFACT_ROUTE_PREFIX not in result
         assert "<mcwidget" in result
 
+    def test_save_hints_when_the_slug_was_suffixed(self) -> None:
+        # given a markdown save whose derived slug was already taken. The
+        # name-based dedup probe is scoped to chat widgets and stays silent
+        # here, so the store's report is the only signal.
+        with patch(
+            "kiro_crew.mcp_core._post",
+            return_value={
+                "slug": "run-summary-2",
+                "version": 1,
+                "name": "Run Summary",
+                "kind": "markdown",
+                "slug_collided_with": "run-summary",
+            },
+        ):
+            # when the save tool result is rendered
+            result = _call_tool_inner(
+                "artifact_save",
+                {"name": "Run Summary", "content": "# corrected", "kind": "markdown"},
+            )
+        # then it names the taken slug and the verb that versions in place
+        assert "'run-summary'" in result
+        assert "artifact_update" in result
+
+    def test_save_omits_the_hint_when_the_slug_was_free(self) -> None:
+        with patch(
+            "kiro_crew.mcp_core._post",
+            return_value={
+                "slug": "run-summary",
+                "version": 1,
+                "name": "Run Summary",
+                "kind": "markdown",
+            },
+        ):
+            result = _call_tool_inner(
+                "artifact_save",
+                {"name": "Run Summary", "content": "# notes", "kind": "markdown"},
+            )
+        assert "already taken" not in result
+
     def test_get_non_widget_emits_markdown_link(self) -> None:
         # given a fetched markdown artifact
         with patch(


### PR DESCRIPTION
## Problem / Motivation

`ArtifactStore.create()` handles one condition — *the target slug is taken* — two opposite ways,
about ten lines apart:

```python
if slug is None:
    slug = self._unique_slug(slugify(name))    # silently suffixes: -2, -3, ...
else:
    slug = _validate_slug(slug)
    if self._artifact_dir(slug).exists():
        raise ArtifactAlreadyExistsError(...)  # loud
```

That is not a design preference between two defensible policies — it is one code path refusing
and the adjacent one quietly renaming. And a CLI caller can only ever reach the silent one:
`kirocrew artifact save` has no `--slug` flag, so the slug is always derived from `--name`.

## Why it matters

A finalized run summary was corrected and re-saved:

```
kirocrew artifact save --name "After-Hours Run 2026-08-28" --content-file <path>
```

That created a **second artifact** at `after-hours-run-2026-08-28-2`, version 1, while the
canonical `after-hours-run-2026-08-28` stayed at its stale version 1. Exit code 0, no warning,
and the success line `Saved: slug=... version=1` read as though it had worked. The corrections
were published to a slug nobody would look at while the original kept serving text known to be
wrong. The verb that would have worked is `kirocrew artifact update <slug>`, which versions in
place.

## What changed — and what it deliberately does not

The suffix behaviour is **unchanged**. Silently overwriting would be strictly worse, and raising
from the derived path would break callers that legitimately want a fresh artifact
(`publish_sync`'s import and fork paths, the auto-research report handler). The defect is the
silence, so only the silence is fixed.

The change surfaces the collision at each layer the caller can actually see it:

- **CLI** (`artifact save`) prints a stderr warning naming the taken slug and
  `kirocrew artifact update <slug>`. Here the advice IS right: `save` has no `--slug`, so a
  colliding name is nearly always a caller who meant to version in place. stdout is untouched, so
  nothing that parses the success line breaks.
- **MCP `artifact_save`** appends a hint. This matters because the existing duplicate probe in
  that tool is gated on `kind == "widget" and source == "chat"`, so it stays silent for exactly
  the markdown/text deliverables the incident above involved. The new hint is suppressed when that
  probe already fired, so a colliding widget still gets one warning rather than two.

The CLI and the MCP tool are both HTTP clients of `POST /api/artifacts`, so `api_artifacts_create`
computes the collision and adds `slug_collided_with` to the **201 payload only**. Two details make
that computation exact rather than a guess:

1. It is derived from `art.name` — the post-validation name the store actually slugified — not the
   raw request body, so the comparison uses the same string `_unique_slug` was given.
2. It is guarded on an absent `slug` in the request. An explicit slug legitimately differs from
   the name, and the store refuses a taken one outright rather than renaming, so comparing there
   would invent a collision that never happened.

Create-only is deliberate: the value describes one call. Carrying it on the artifact record would
put a permanently empty field on every GET and LIST response, and would keep reporting a collision
long after the artifact it collided with is deleted and the name is free again. There is a test
pinning that a later read does not carry it.

`create_image` is deliberately **not** touched. Its only production caller
(`image_artifacts.py:219`) passes an explicit `slug=`, so it cannot reach the silent-suffix branch
and a report there would be dead code.

## Tests

- handler: the collision reaches the 201 payload; an explicit slug reports `""`; and a later GET
  does **not** carry the key, with a positive control on the same payload so the absence is a fact
  about the field rather than about a failed read.
- CLI: a suffixed save warns on stderr naming the taken slug and the `update` verb; a free slug
  leaves stderr empty.
- MCP: a non-widget save whose slug was suffixed names the taken slug and `artifact_update`; a
  free slug emits no hint.

Negative control run explicitly against the pre-change source: the create-only test fails there,
because the earlier design carried the value on the artifact record and so leaked it into the GET.
The regression guards pass on both sides, as they must.

## Gates

`pytest` (full backend), `isort`, `flake8`, `mypy`, `tsc -b`, `vitest` — plus the
testpaths-coverage, harness-parity and de-Amazon scrub gates. Frontend is green at
1638 files / 25954 tests, and this change touches no frontend file.

The backend suite carries pre-existing failures in this environment (a checkout outside `$HOME`,
which trips the source-root classification and host-isolation tests). Verified rather than assumed:
the failing-file set was run against a clean `upstream/main` and the failure sets diffed —
**identical, 126 entries each, zero new failures**.
## Follow-up, deliberately not in this PR

Exposing `--slug` on `kirocrew artifact save` would give CLI callers access to the loud branch at
all. It is a small addition, but it is a new capability rather than a fix to this asymmetry, and
it brings its own surface (a 409 path the CLI would need to report well). Worth doing separately.



