### PR TITLE
fix(autonudge): report a stop lookup miss instead of a false success

### DIFF
--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -355,13 +355,42 @@ async def _monitor_update(session_key: str, args: dict[str, Any]) -> str:
     )
 
 
+def _no_loop_message(svc: Any, binding: str) -> str:
+    """The result for ``autonudge_stop`` when this session resolves no loop.
+
+    ``get_by_slot`` resolves only the loop bound to the CALLING session's
+    binding key, so its miss covers two states that a caller cannot otherwise
+    tell apart: no loop exists anywhere (an idempotent success — the goal
+    already holds), or a loop is running under a different slot key and is
+    simply unreachable from here (nothing was stopped). Counting the service's
+    active loops separates them.
+
+    Reports a COUNT and never a loop id or slot key. The stop tool exposes no
+    loop-id parameter precisely so a session cannot target another session's
+    loop; naming other sessions' loops here would hand the model the
+    identifiers that schema withholds. Cross-session enumeration stays on the
+    token-authed dashboard API. A count is all this branch needs, because the
+    caller's question is whether ITS OWN stop took effect.
+    """
+    active = [lp for lp in svc.list_all() if getattr(lp, "active", True)]
+    if not active:
+        return "No active auto-nudge loop on this session — nothing to stop."
+    return (
+        "NOTHING WAS STOPPED. No auto-nudge loop is bound to this session "
+        f"(binding: {binding}), but {len(active)} auto-nudge loop(s) are running on "
+        "other sessions. A loop can only be stopped from the session it is bound "
+        "to, so this call could not reach them."
+    )
+
+
 async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> str:
     from kiro_crew.autonudge import get_instance
 
     svc = get_instance()
     # "Nothing to stop" is an IDEMPOTENT success — the goal (no loop running on
     # this session) already holds — so the disabled-service and no-loop paths
-    # keep returning. The unsupported-session path is a refusal like its
+    # keep returning; a binding miss that is NOT that state is separated in
+    # ``_no_loop_message``. The unsupported-session path is a refusal like its
     # siblings: the caller asked for an effect this session can never carry.
     if svc is None:
         return "No auto-nudge loop to stop (auto-nudge is disabled on this host)."
@@ -370,7 +399,7 @@ async def _autonudge_stop(slot: Any, session_key: str, args: dict[str, Any]) -> 
         raise _DirectiveDenied("autonudge_stop is not supported from this session type.")
     loop = svc.get_by_slot(binding)
     if not loop:
-        return "No active auto-nudge loop on this session — nothing to stop."
+        return _no_loop_message(svc, binding)
     loop_id = loop.id
     reason = str(args.get("reason") or "").strip()
     # Research Lab consumes a persisted stop record to distinguish deliberate

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -733,7 +733,15 @@ def autonudge_stop(name: str, args: dict[str, Any]) -> str:
     return session_directive.encode(
         "autonudge_stop",
         {"reason": args.get("reason", "").strip()},
-        "Stopping the auto-nudge loop on this session (if one is active).",
+        # NOT a confirmation, and worded so a model cannot read it as one: this
+        # tool resolves no session, so it cannot know whether a loop is bound
+        # here. The consumer applies the stop and records the real outcome —
+        # including "nothing was stopped" when the binding resolves no loop —
+        # onto the transcript, so a caller that reads this as success would be
+        # acting on an unverified claim.
+        "Stop REQUESTED for this session's auto-nudge loop. This is not "
+        "confirmation that a loop was found or stopped; the applied outcome is "
+        "recorded separately and may report that nothing was stopped.",
     )
 
 

--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -230,7 +230,7 @@ def test_autonudge_stop_short_circuits_for_non_nudgeable_session(monkeypatch):
 class _FakeLoop:
     def __init__(
         self, loop_id, *, cycle_count=0, max_cycles=0, active=True, created_ts=0.0,
-        max_runtime_secs=0, stopped_reason="",
+        max_runtime_secs=0, stopped_reason="", slot_key="",
     ):
         self.id = loop_id
         self.cycle_count = cycle_count
@@ -239,13 +239,15 @@ class _FakeLoop:
         self.created_ts = created_ts
         self.max_runtime_secs = max_runtime_secs
         self.stopped_reason = stopped_reason
+        self.slot_key = slot_key
 
 
 class _FakeSvc:
     """Minimal AutoNudge service double for session-directive mutations."""
 
-    def __init__(self, loop=None):
+    def __init__(self, loop=None, *, all_loops=None):
         self._loop = loop
+        self._all = list(all_loops) if all_loops is not None else ([loop] if loop else [])
         self.get_by_slot_keys: list[str] = []
         self.removed: list[str] = []
         self.updated: list[tuple[str, dict]] = []
@@ -253,6 +255,9 @@ class _FakeSvc:
     def get_by_slot(self, key):
         self.get_by_slot_keys.append(key)
         return self._loop
+
+    def list_all(self):
+        return list(self._all)
 
     async def remove(self, loop_id):
         self.removed.append(loop_id)
@@ -725,3 +730,91 @@ def test_applier_autonudge_stop_no_loop_is_a_clean_noop(monkeypatch):
     assert "nothing to stop" in result.lower()
     assert svc.removed == []
     assert svc.updated == []
+
+
+def test_applier_autonudge_stop_reports_a_binding_miss_instead_of_success(monkeypatch):
+    """A loop active on ANOTHER slot is a lookup miss, not an idempotent success.
+
+    ``get_by_slot`` resolves only the calling session's binding, so a loop armed
+    against a different slot key is unreachable here. The result must say
+    nothing was stopped and name this session's own binding — and it must not
+    remove or pause the loop it could not resolve.
+    """
+    elsewhere = _FakeLoop("loop-elsewhere", slot_key="chat-99-1700009999")
+    svc = _FakeSvc(None, all_loops=[elsewhere])
+    _install_svc(monkeypatch, svc)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(), _fake_slot(), _SESSION, "autonudge_stop", {"reason": "done"}
+        )
+    )
+    assert "nothing to stop" not in result.lower()
+    assert "NOTHING WAS STOPPED" in result
+    assert binding_key_for(_SESSION) in result
+    assert "1 auto-nudge loop(s) are running on other sessions" in result
+    assert svc.removed == []
+    assert svc.updated == []
+
+
+def test_applier_autonudge_stop_miss_names_no_other_session_identifier(monkeypatch):
+    """OWNERSHIP: the miss diagnostic reports a COUNT, never an id or slot key.
+
+    The stop tool exposes no loop-id parameter so a session cannot target
+    another session's loop; a message naming other sessions' loops would hand a
+    model the identifiers that schema withholds. Cross-session enumeration
+    belongs to the token-authed dashboard API, not to a tool result.
+    """
+    # Slot keys deliberately disjoint from the CALLER's own binding: the message
+    # prints that legitimately, so an overlapping fixture would fail on the
+    # caller's own identity rather than on a leak.
+    loops = [_FakeLoop(f"loop-{n}", slot_key=f"chat-9{n}-1700009999") for n in range(4)]
+    svc = _FakeSvc(None, all_loops=loops)
+    _install_svc(monkeypatch, svc)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(), _fake_slot(), _SESSION, "autonudge_stop", {"reason": "done"}
+        )
+    )
+    assert "4 auto-nudge loop(s) are running on other sessions" in result
+    for lp in loops:
+        assert lp.id not in result
+        assert lp.slot_key not in result
+    # No dead-end remedy: the message must not advertise a route whose path it
+    # does not print, and a loop's sentinel path can legitimately be empty.
+    assert "stop_sentinel_path" not in result
+    assert svc.removed == []
+
+
+def test_applier_autonudge_stop_ignores_inactive_loops_in_the_miss_diagnostic(monkeypatch):
+    """A deactivated loop fires no nudges, so it is not evidence of a miss.
+
+    Only active loops make the difference between "nothing exists" and "the
+    lookup failed"; a paused or tombstoned loop keeps the plain no-loop answer.
+    """
+    svc = _FakeSvc(None, all_loops=[_FakeLoop("loop-dead", active=False, slot_key="chat-99-1")])
+    _install_svc(monkeypatch, svc)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(), _fake_slot(), _SESSION, "autonudge_stop", {"reason": "done"}
+        )
+    )
+    assert "nothing to stop" in result.lower()
+    assert "loop-dead" not in result
+    assert svc.removed == []
+    assert svc.updated == []
+
+
+def test_autonudge_stop_directive_does_not_read_as_confirmation(default_install):
+    """The tool's OWN return is the only text the model receives in-turn.
+
+    The consumer applies the effect after the model already has this string, and
+    the applier's outcome lands on the transcript rather than rewriting the
+    model's tool result — so this wording must not let a caller conclude a loop
+    was found or stopped. The measured failure it guards is a loop that called
+    stop repeatedly, read a success-shaped reply each time, and never checked.
+    """
+    result = _call_tool_inner("autonudge_stop", {"reason": "done"})
+    assert session_directive.decode(result, "autonudge_stop") == {"reason": "done"}
+    assert "REQUESTED" in result
+    assert "not confirmation" in result.lower()
+    assert "nothing was stopped" in result.lower()


### PR DESCRIPTION
## Problem / Motivation

`autonudge_stop` can report success while stopping nothing.

`_autonudge_stop` in `src/kiro_crew/dashboard/session_directive_apply.py` resolves its
target with `svc.get_by_slot(binding)`, which matches only the **calling session's**
binding key. On a miss it returned:

```python
return "No active auto-nudge loop on this session — nothing to stop."
```

That one message covered two states the caller cannot otherwise tell apart:

1. **No loop exists anywhere** — an idempotent success, correctly reported.
2. **A loop is active but bound to a different slot key** — a lookup miss. Nothing was
   stopped, and the caller was told the goal already held.

The in-code comment asserted that "nothing to stop" is an idempotent success because
"the goal (no loop running on this session) already holds" — which is only true when the
lookup actually succeeded. The rest of the function was already correct: it does call
`await svc.remove(loop_id)` when it resolves a loop.

Separately, `autonudge_stop`'s own tool acknowledgement read `"Stopping the auto-nudge loop
on this session (if one is active)."` — present-progressive and success-shaped. That string
is the only text the model receives in-turn: the consumer applies the effect *after* the
model already has it, and gateway-off (the default) the applier's outcome does not rewrite
the model's tool result. So the one surface a caller reads synchronously implied completion.

**Measured symptom.** In an overnight autonomous run, `autonudge_stop` was called seven
consecutive times across cycles 105–112. Every call returned a success-shaped payload
and no nudge stopped; the loop ended only on reaching its armed `max_cycles` of 112,
burning seven no-op cycles after the work was already complete.

**Named limitation — the root cause is not proven.** The code path and the seven no-ops
are measured. *Why* the binding did not resolve — what the loop was armed against versus
what the calling session resolved to — is **not** established here, and this PR does not
claim to have root-caused it. The historical loop record no longer exists to inspect, so
no cheap proof was available. The change is correct regardless: it only makes a silent
miss speak, and a diagnostic is what turns that unproven question into an answerable one
the next time it happens.

## Why it matters

An agent that calls a stop tool and is told it succeeded has no reason to try anything
else, so it keeps burning turns against a loop that is still nudging. Every retry costs a
model turn and returns the same false reassurance — and because the acknowledgement it
reads in-turn also implied completion, nothing in the caller's own evidence contradicted
the false success.

## What changed (motivation → approach → change)

Symptom: seven no-op stops reported as success. Cause on the code path: a lookup miss and
a genuine absence share one return. Change: make the miss branch **discriminate** before
it concludes, and stop the in-turn acknowledgement from implying completion.

**1. `_no_loop_message(svc, binding)`** now consults `AutoNudgeService.list_all()` on the
miss branch:

- **No active loop** → the original message, byte-for-byte unchanged.
- **Active loop(s) elsewhere** → a result that says `NOTHING WAS STOPPED`, names this
  session's own resolved binding, and reports **only the COUNT** of loops running on other
  sessions. It deliberately does **not** name their loop ids or slot keys, and does not
  advertise a `stop_sentinel_path` remedy.

  *Why count-only.* The stop tool exposes no loop-id parameter precisely so a session
  cannot target another session's loop (pinned by
  `test_monitor_update_exposes_no_loop_id_parameter`). Naming other sessions' loops in a
  tool result would hand the model exactly the identifiers that schema withholds;
  cross-session enumeration stays on the token-authed dashboard API
  (`handlers/autonudge.py` `api_autonudge_list`). A count is sufficient, because the
  caller's question is only whether ITS OWN stop took effect. The sentinel sentence is
  omitted for a second reason: a loop's `stop_sentinel_path` defaults to `""` and
  `repair_sentinel_path` can drop it, so advertising that route without printing a path
  can dead-end.

**2. `src/kiro_crew/mcp_tools/control.py`** — `autonudge_stop`'s acknowledgement is reworded
to `"Stop REQUESTED for this session's auto-nudge loop. This is not confirmation that a loop
was found or stopped; the applied outcome is recorded separately and may report that nothing
was stopped."` This is a **model-visible behaviour change** and is the point of the fix that
lands in-turn. It also makes the file internally consistent: of the six
`session_directive.encode` sites, the other five already hedge — `ask_question` ("Question
card requested…"), `monitor_start` ("Monitor loop requested on this session…"),
`monitor_update` ("…so do not assume the change landed"), `set_project` ("…if the path is
valid and permitted"), `suggest_followup` ("Follow-up card requested…") — and
`autonudge_stop` was the last one whose ack asserted the effect.

Deliberate scoping:

- **Additive on the applier side.** No control flow changes on any path that currently
  succeeds. The success path and the Research-Lab tombstone branch are untouched, and the
  diagnostic never removes or pauses a loop it could not resolve.
- **Diagnostic, not a wider lookup.** `_find_by_slot` already tries two spellings
  (binding key, then the channel-key fold). A third resolution attempt was considered and
  rejected: a better error beats a wider guess, and a guess that stops the *wrong* loop is
  worse than a miss.
- **Only `active` loops count.** A paused or tombstoned loop fires no nudges, so it is not
  evidence of a miss and keeps the plain no-loop answer.
- **Bounded output by construction.** Because the message reports a count and no per-loop
  detail, its length does not scale with how many loops the host carries.
- Reporting a miss still *returns* rather than raising `_DirectiveDenied`, so SEL continues
  to derive `success` for it. Converting it to a refusal would be a control-flow change on
  a currently-succeeding path and is left out of this PR on purpose — flagged here rather
  than done silently.

## Tests

Extended `test/test_autonudge_stop_auth.py` (the existing home of the `_autonudge_stop`
applier contract) rather than adding a file. `_FakeLoop` gains `slot_key`; `_FakeSvc`
gains `list_all`.

| Test | Locks in |
| --- | --- |
| `test_applier_autonudge_stop_removes_ordinary_monitor_loop` (existing) | Regression guard: a loop bound to this session still stops and still removes. |
| `test_applier_autonudge_stop_no_loop_is_a_clean_noop` (existing) | Genuinely no loops → the original message, unchanged. |
| `test_applier_autonudge_stop_reports_a_binding_miss_instead_of_success` (new) | A loop active on a **different** slot → `NOTHING WAS STOPPED`, the caller's own binding, the count of loops elsewhere, and `remove`/`update` NOT called. |
| `test_applier_autonudge_stop_miss_names_no_other_session_identifier` (new) | OWNERSHIP: with 4 loops active elsewhere the message carries the count but **no** loop id, **no** slot key, and no `stop_sentinel_path` — `assert lp.slot_key not in result`, `assert "stop_sentinel_path" not in result`. |
| `test_applier_autonudge_stop_ignores_inactive_loops_in_the_miss_diagnostic` (new) | An inactive loop is not evidence of a miss; the plain message survives. |
| `test_autonudge_stop_directive_does_not_read_as_confirmation` (new) | The tool's own in-turn ack decodes to the directive and cannot be read as success: it contains `REQUESTED`, `not confirmation`, and `nothing was stopped`. |

**Negative control re-run against this head, output pasted verbatim.** With only the two
source files reverted to this commit's parent (`954736180`) and the tests left at HEAD,
the three tests that depend on the change fail and the rest pass:

```
>       assert "nothing to stop" not in result.lower()
E       AssertionError: assert 'nothing to stop' not in 'no active a...ing to stop.'
>       assert "4 auto-nudge loop(s) are running on other sessions" in result
E       AssertionError: assert '4 auto-nudge loop(s) are running on other sessions' in 'No active auto-nudge loop on this session — nothing to stop.'
>       assert "REQUESTED" in result
E       assert 'REQUESTED' in 'Stopping the auto-nudge loop on this session (if one is active).\n[[KIROCREW_SESSION_DIRECTIVE]]{"kind":"autonudge_stop","args":{"reason":"done"}}'
FAILED test_applier_autonudge_stop_reports_a_binding_miss_instead_of_success
FAILED test_applier_autonudge_stop_miss_names_no_other_session_identifier
FAILED test_autonudge_stop_directive_does_not_read_as_confirmation
=================== 3 failed, 38 passed, 2 warnings in 1.07s ===================
```

`test_applier_autonudge_stop_ignores_inactive_loops_in_the_miss_diagnostic` and the two
pre-existing guards pass both before and after, confirming no currently-succeeding path
moved. With the change restored: 41 passed.

The ownership guard also earned its place: it failed on first run because a fixture loop's
slot key collided with the *caller's own* binding, which the message prints legitimately.
The fixture was disjointed rather than the assertion weakened — so the guard is known to be
able to fail.

## Manual verification

N/A — unit coverage is sufficient. Both changes are string construction: one message branch
in a pure function over the service's own listing API, and one tool acknowledgement. No UI
surface and no I/O to exercise.

## Related Issues

Refs #6838 — `autonudge_stop`: binding-resolution miss has an unproven root cause.
The seven no-op stops and the code path are measured in this PR; *why* the binding failed
to resolve is not, so the question the diagnostic exists to answer is tracked there rather
than left unowned. Raised by the Design Review and First Principles Review lanes.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc surface
- [x] No secrets, credentials, or internal references in the diff

### Gate results

Full blocking floor, re-run locally on this head after rebasing onto `954736180`:

| Gate | Result |
| --- | --- |
| `pytest` (full, `-n auto --dist loadgroup`) | 74,632 passed |
| `isort --check-only` | clean |
| `flake8` | clean |
| `mypy src/kiro_crew/` (CI-parity venv, 1.14.1, no faiss) | no issues, 1167 files |
| `npx tsc -b` | clean |
| `npx vitest run` | 1638 files, 25,954 passed |

Rebase was verified rather than assumed: `git patch-id --stable` is identical before and
after (`8d7f7b78…`), `954736180` is an ancestor of HEAD, and the branch is one commit with a
single parent.

This host carries a set of pre-existing environment failures (temp-repo `git commit`
without an author identity, `AF_UNIX path too long`, real-`HOME` pinning). Confirmed
pre-existing by running the full suite on a clean tree: both runs produced **127 unique
failing node ids**, differing by one test each in opposite directions
(`test_mcp_preflight.py::…do_not_discard_the_other_verdicts` on the branch,
`test_playwright_cli_installer.py::…mktemp_stays_inside_the_test_tmp_dir` on clean) — both
pass in isolation. Nothing touching `session_directive_apply`, `mcp_tools/control` or the
autonudge tests failed.

