### PR TITLE
fix(schedule): show WHICH day a cron fires, not just the hour

### DIFF
--- a/website/src/pages/SchedulePage.tsx
+++ b/website/src/pages/SchedulePage.tsx
@@ -21,7 +21,7 @@ import { useAgents } from '../hooks/useAgents'
 import { useCronActions } from '../hooks/useCronActions'
 import { useScrollEdges } from '../hooks/useScrollEdges'
 import { useAppSelector } from '../store'
-import { SaveCreateLabel } from '../utils/cronUtils'
+import { SaveCreateLabel, scheduleLabel, scheduleMinutes } from '../utils/cronUtils'
 import { useSortableTable } from '../hooks/useSortableTable'
 import { SortableTableHead } from '../components/SortableHeader'
 import ExecutionsView from '../components/ExecutionsView'
@@ -47,7 +47,7 @@ import ScheduleTemplateGallery from '../components/ScheduleTemplateGallery'
 import { i18nT } from '../i18n/t'
 import { defaultAgentQuery } from '../api/defaultAgentQuery'
 import { agentOrDefaultLabel } from '../utils/agentLabel'
-import { fmtDateTimeNumeric } from '../i18n/format'
+import { compareText, fmtDateTimeNumeric } from '../i18n/format'
 import { formatCadence } from '../utils/scheduleCadence'
 const RENDER_TZ_STORAGE_KEY = 'kirocrew.schedule.renderTz'
 
@@ -406,7 +406,16 @@ export default function SchedulePage() {
   const filteredJobs = useMemo(() => sanitizedJobs.filter(j => !cronFilter || (j.name+' '+j.safeMessage+' '+(j.agent||'')+' '+(j.model||'')+' '+(j.session_key||'')).toLowerCase().includes(cronFilter.toLowerCase())), [sanitizedJobs, cronFilter])
   const scheduleComparators = useMemo(() => ({
     name: (a: CronJob, b: CronJob) => a.name.localeCompare(b.name),
-    schedule: (a: CronJob, b: CronJob) => (a.schedule || '').localeCompare(b.schedule || ''),
+    // Clock time first, so `9:00 AM` precedes `1:00 PM` -- the label sorts wrongly
+    // as text. Rows with no clock (raw fallback, intervals) go last, then by label.
+    schedule: (a: CronJob, b: CronJob) => {
+      const ka = scheduleMinutes(a), kb = scheduleMinutes(b)
+      if (ka === null || kb === null) {
+        if (ka !== kb) return ka === null ? 1 : -1
+        return compareText(scheduleLabel(a), scheduleLabel(b))
+      }
+      return ka - kb || compareText(scheduleLabel(a), scheduleLabel(b))
+    },
     status: (a: CronJob, b: CronJob) => {
       const rank = (j: CronJob) =>
         j.is_running ? 4 : !j.enabled ? 0 : j.last_status === 'error' ? 1 : j.last_status === 'ok' ? 2 : 3;
@@ -691,11 +700,13 @@ export default function SchedulePage() {
                   it overlaps the next cell. That is what put the Message chevron
                   and preview on top of the Status badge at phone widths, and on a
                   1280px desktop with the nav rail open (measured 0px there too).
-                - `min-w` covers the nine px columns (940px, border-box, so the
+                - `min-w` covers the nine px columns (996px, border-box, so the
                   `p-2`/`px-2` is inside each) PLUS a 180px floor for Message —
                   enough for the 14px chevron and a one-line preview. A narrower
                   container scrolls the table, which is honest; voiding a column
-                  silently is not. */}
+                  silently is not. Widening any px column means moving `min-w` by
+                  the same amount: the two numbers are one statement, and editing
+                  only the column takes the difference out of Message. */}
             <div className="relative">
             {/* The scroller is the shadcn Table's own wrapper (the table's
                 parentElement — `relative w-full overflow-x-auto` in
@@ -703,7 +714,7 @@ export default function SchedulePage() {
                 against it, so the overflow measurement must read the same box.
                 `className` stays the FIRST attribute: the columnContract test
                 anchors on the literal `<Table className="table-fixed` opener. */}
-            <Table className="table-fixed min-w-[1120px]" ref={attachJobsTable}>
+            <Table className="table-fixed min-w-[1176px]" ref={attachJobsTable}>
               <TableHeader>
                 <TableRow className="hover:bg-transparent">
                   <TableHead className="w-[36px] px-2 text-center">
@@ -720,7 +731,13 @@ export default function SchedulePage() {
                   <TableHead className="w-[68px]">{i18nT('pages.schedulePage.id')}</TableHead>
                   <SortableTableHead label={i18nT('pages.schedulePage.name')} sortKey="name" sort={schedSort} onToggle={toggleSchedSort} className="w-[160px]" />
                   <TableHead className="w-[116px]">{i18nT('pages.schedulePage.type')}</TableHead>
-                  <SortableTableHead label={i18nT('pages.schedulePage.schedule')} sortKey="schedule" sort={schedSort} onToggle={toggleSchedSort} className="w-[124px]" />
+                  {/* 180px, not the original 124: the value here is a clock time
+                      plus a qualifier (`12:00 AM · Mon,Wed`), and 124px fitted
+                      the time alone -- so every midnight job rendered the same
+                      truncated string and the column stopped distinguishing
+                      rows. Widening is paid for in the table's min-width below,
+                      NOT out of Message, which keeps its floor. */}
+                  <SortableTableHead label={i18nT('pages.schedulePage.schedule')} sortKey="schedule" sort={schedSort} onToggle={toggleSchedSort} className="w-[180px]" />
                   <TableHead>{i18nT('pages.schedulePage.message')}</TableHead>
                   <SortableTableHead label={i18nT('pages.schedulePage.status')} sortKey="status" sort={schedSort} onToggle={toggleSchedSort} className="w-[86px]" />
                   <SortableTableHead label={i18nT('pages.schedulePage.last_run')} sortKey="lastRun" sort={schedSort} onToggle={toggleSchedSort} className="w-[82px]" />
@@ -832,7 +849,26 @@ export default function SchedulePage() {
                         <span className="block truncate text-[11px] text-muted">{agentOrDefaultLabel(j.agent, defaultAgent)}</span>
                       </>}
                 </TableCell>
-                <TableCell className="truncate" title={j.schedule}><code>{j.schedule}</code>{j.timezone && <span className="block truncate text-[11px] text-muted">{j.timezone.replace(/_/g, ' ')}</span>}</TableCell>
+                {/* The compact label in the cell, the verbose one in the
+                    tooltip. `schedule` is cron_descriptor prose -- 53 chars for
+                    `0 0 30 2 *` -- so at any width this column can afford, it
+                    renders as "At 12:00 AM ...", which is the SAME string for
+                    every midnight job: the part identifying the schedule is
+                    exactly the part that gets clipped.
+
+                    Derived HERE from the already-shipped `cron_expr` rather than
+                    minted server-side, so the day and month names translate with
+                    the dashboard through `fmtWeekday` / `Intl` instead of pinning
+                    English into the API. A non-cron schedule (interval, one-shot)
+                    has no `cron_expr` and already reads compactly, so it keeps
+                    the backend string.
+
+                    No `<code>`: the short form is prose, and monospace is the
+                    WIDEST rendering available for the least code-like value on
+                    the page -- it was spending the column's pixels to fit fewer
+                    characters. `fmtCron`'s raw-expression fallback stays legible
+                    without it. */}
+                <TableCell className="truncate" title={j.schedule}>{scheduleLabel(j)}{j.timezone && <span className="block truncate text-[11px] text-muted">{j.timezone.replace(/_/g, ' ')}</span>}</TableCell>
                 <TableCell className="align-top"><CollapsibleMessage message={j.script ? j.script : j.command ? j.command : j.safeMessage} /></TableCell>
                 <TableCell title={j.last_error || j.last_result || ''}>{j.is_running ? <Badge variant="ok"><span className="inline-block w-1.5 h-1.5 rounded-full bg-ok animate-pulse mr-1 align-middle" />{i18nT('pages.schedulePage.running')}</Badge> : j.enabled ? (j.last_status === 'ok' ? <Badge variant="ok">{i18nT('pages.schedulePage.ok')}</Badge> : j.last_status === 'error' ? <Badge variant="err">{i18nT('pages.schedulePage.error')}</Badge> : <Badge variant="ok">{i18nT('pages.schedulePage.ready')}</Badge>) : <Badge variant="warn">{i18nT('pages.schedulePage.paused')}</Badge>}</TableCell>
                 <TableCell className="text-muted">{fmtAgo(j.last_run_ts)}</TableCell>

--- a/website/src/test/SchedulePage.scheduleCell.test.tsx
+++ b/website/src/test/SchedulePage.scheduleCell.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import SchedulePage from '../pages/SchedulePage'
+import type { CronJob } from '../types'
+
+/**
+ * The Schedule cell shows a COMPACT label derived from `cron_expr` and keeps the
+ * verbose backend `schedule` in its tooltip. Three things are load-bearing:
+ *
+ * 1. The cell renders the compact label; the verbose prose reaches `title` only.
+ * 2. A non-cron job (interval, one-shot) has no `cron_expr` and keeps its
+ *    backend string, so those rows never render blank.
+ * 3. The timezone keeps its own line — the compact label carries no zone
+ *    abbreviation, so this is the only place the zone appears in the row.
+ */
+
+const mkJob = (overrides: Partial<CronJob> = {}): CronJob => ({
+  id: 'job-1',
+  name: 'Nightly report',
+  schedule: 'every 1d',
+  message: 'send report',
+  enabled: true,
+  ...overrides,
+} as CronJob)
+
+vi.mock('../api/client', () => ({
+  api: {
+    crons: vi.fn(),
+    cronFolders: vi.fn().mockResolvedValue([]),
+    deleteCron: vi.fn(),
+    batchDeleteCron: vi.fn(),
+    createCron: vi.fn().mockResolvedValue({}),
+    models: vi.fn().mockResolvedValue([]),
+    updateCron: vi.fn().mockResolvedValue({}),
+    toggleCron: vi.fn().mockResolvedValue({}),
+    runCron: vi.fn().mockResolvedValue({}),
+    cronToChat: vi.fn().mockResolvedValue({}),
+    cronHistoryAll: vi.fn().mockResolvedValue({ runs: [] }),
+    kirocrewAgents: vi.fn().mockResolvedValue({ agents: [], default_agent: '' }),
+    syncKirocrewAgents: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+const VERBOSE = 'At 12:00 AM, on day 30 of the month, only in February'
+
+describe('SchedulePage schedule cell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the compact label and keeps the verbose form in the tooltip', async () => {
+    const { api } = await import('../api/client')
+    vi.mocked(api).crons.mockResolvedValue({
+      jobs: [mkJob({ name: 'Feb job', schedule: VERBOSE, cron_expr: '0 0 30 2 *' })],
+    })
+
+    renderWithProviders(<SchedulePage />)
+    await waitFor(() => expect(screen.getByText('Feb job')).toBeInTheDocument())
+
+    const cell = screen.getByTitle(VERBOSE)
+    expect(cell.tagName).toBe('TD')
+    expect(cell.textContent).toContain('12:00 AM')
+    expect(cell.textContent).toContain('Feb 30')
+    // The qualifier the verbose form buries past the truncation point must NOT
+    // be what the cell paints -- otherwise the tooltip is still the only copy.
+    expect(cell.textContent).not.toContain('only in February')
+  })
+
+  it('keeps the backend string for a job with no cron expression', async () => {
+    const { api } = await import('../api/client')
+    vi.mocked(api).crons.mockResolvedValue({
+      jobs: [mkJob({ name: 'Interval job', schedule: 'every 600s' })],
+    })
+
+    renderWithProviders(<SchedulePage />)
+    await waitFor(() => expect(screen.getByText('Interval job')).toBeInTheDocument())
+
+    // Never a blank Schedule column for an interval or one-shot job.
+    expect(screen.getByTitle('every 600s').textContent).toContain('every 600s')
+  })
+
+  it('keeps the timezone on its own line beneath the label', async () => {
+    const { api } = await import('../api/client')
+    vi.mocked(api).crons.mockResolvedValue({
+      jobs: [mkJob({
+        name: 'Tz job',
+        schedule: VERBOSE,
+        cron_expr: '0 0 30 2 *',
+        timezone: 'America/New_York',
+      })],
+    })
+
+    renderWithProviders(<SchedulePage />)
+    await waitFor(() => expect(screen.getByText('Tz job')).toBeInTheDocument())
+
+    // Underscores are spaced for reading; the zone is the label's only home in
+    // the row, since the compact form drops the abbreviation.
+    const zone = screen.getByText('America/New York')
+    expect(zone.className).toContain('block')
+    expect(zone.closest('td')).toBe(screen.getByTitle(VERBOSE))
+  })
+})

--- a/website/src/test/cronUtils.test.ts
+++ b/website/src/test/cronUtils.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { expandDow, fmtCron } from '../utils/cronUtils'
+import { describe, it, expect, afterEach } from 'vitest'
+// The INITIALIZED instance: the bare `i18next` package has no catalogs, so
+// `changeLanguage` resolves nothing and every assertion below passes vacuously.
+import { i18next } from '../i18n/all'
+import { expandDow, fmtCron, scheduleLabel, scheduleMinutes } from '../utils/cronUtils'
+import { __resetFormatterCache } from '../i18n/format'
+import type { CronJob } from '../types'
 
 describe('expandDow', () => {
   it('expands a range', () => {
@@ -63,31 +68,240 @@ describe('expandDow', () => {
 })
 
 describe('fmtCron', () => {
-  it('includes day-of-month when not wildcard', () => {
-    expect(fmtCron('0 9 1-3 * 1-5')).toBe('Mon,Tue,Wed,Thu,Fri 09:00 (days 1-3)')
+  it('names a THREE-day gappy list, the picker toggles Mon/Wed/Fri produce', () => {
+    // The toggle buttons emit a gappy list, so a 2-name cap showed raw cron for
+    // one of the commonest weekly schedules. Measured 147px in a 164px box.
+    expect(fmtCron('0 9 * * 1,3,5')).toBe('9:00 AM · Mon,Wed,Fri')
+    expect(fmtCron('0 0 * * 0,3,6')).toBe('12:00 AM · Sun,Wed,Sat')
   })
-  it('formats Mon-Fri range correctly', () => {
-    expect(fmtCron('0 9 * * 1-5')).toBe('Mon,Tue,Wed,Thu,Fri 09:00')
+
+  it('reads an all-seven-day set as the bare clock, exactly like `*`', () => {
+    // Every day ticked IS daily; `Sun-Sat` would be a second spelling of it in
+    // one column. Held for every syntax that covers the week.
+    const daily = fmtCron('0 9 * * *')
+    expect(daily).toBe('9:00 AM')
+    expect(fmtCron('0 9 * * 0,1,2,3,4,5,6')).toBe(daily)
+    expect(fmtCron('0 9 * * 0-6')).toBe(daily)
+    expect(fmtCron('0 9 * * 1-7')).toBe(daily)
   })
-  it('formats comma-separated days', () => {
-    expect(fmtCron('30 15 * * 2,4')).toBe('Tue,Thu 15:30')
+
+  it('still declines a gappy list past three names', () => {
+    // Four gappy names outgrow the column, and the raw expression is shorter.
+    expect(fmtCron('0 0 * * 1,2,4,6')).toBe('0 0 * * 1,2,4,6')
   })
-  it('formats daily', () => {
-    expect(fmtCron('0 8 * * *')).toBe('daily 08:00')
+
+  it('collapses a CONTIGUOUS comma list to endpoints, as the picker emits it', () => {
+    // `JobForm`'s weekly mode joins checked days with commas, so five ticked
+    // weekdays arrive as a LIST, not a range, and used to show raw cron.
+    expect(fmtCron('0 9 * * 1,2,3,4,5')).toBe('9:00 AM · Mon-Fri')
+    expect(fmtCron('0 9 * * 1,2,3')).toBe('9:00 AM · Mon-Wed')
   })
-  it('formats weekend', () => {
-    expect(fmtCron('0 10 * * 0,6')).toBe('Sun,Sat 10:00')
+
+  it('does NOT collapse a gappy list into a range it never asked for', () => {
+    // `Mon-Fri` would assert Tue/Thu, which `1,3,5` excludes. Up to three names it
+    // lists them out instead; past that the raw expression stands.
+    expect(fmtCron('0 0 * * 1,3,5')).toBe('12:00 AM · Mon,Wed,Fri')
+    expect(fmtCron('0 0 * * 1,2,4,6')).toBe('0 0 * * 1,2,4,6')
+    // Two names still render as a list.
+    expect(fmtCron('30 15 * * 2,4')).toBe('3:30 PM · Tue,Thu')
   })
-  it('formats reversed range (wrap-around)', () => {
-    expect(fmtCron('0 9 * * 5-1')).toBe('Fri,Sat,Sun,Mon 09:00')
+
+  it('keeps a literal range on its authored endpoints, not the sorted ones', () => {
+    // `5-1` is Fri..Mon; sorting would read Sun-Sat and silently widen it.
+    expect(fmtCron('0 9 * * 5-1')).toBe('9:00 AM · Fri-Mon')
   })
-  it('falls back to raw dow for step expressions', () => {
-    expect(fmtCron('0 9 * * */2')).toBe('*/2 09:00')
+
+  it('renders a weekday range by its ENDPOINTS, not five names', () => {
+    // The label lives in a narrow column, so a range shows Mon-Fri rather than
+    // expanding to every day it covers.
+    expect(fmtCron('0 9 * * 1-5')).toBe('9:00 AM · Mon-Fri')
   })
-  it('formats named DOW range (MON-FRI)', () => {
-    expect(fmtCron('0 13 * * MON-FRI')).toBe('Mon,Tue,Wed,Thu,Fri 13:00')
+  it('renders a two-day list', () => {
+    expect(fmtCron('30 15 * * 2,4')).toBe('3:30 PM · Tue,Thu')
   })
-  it('formats named DOW comma list', () => {
-    expect(fmtCron('30 9 * * MON,WED,FRI')).toBe('Mon,Wed,Fri 09:30')
+  it('renders a single weekday', () => {
+    expect(fmtCron('5 6 * * 1')).toBe('6:05 AM · Mon')
+  })
+  it('renders an unrestricted expression as the clock alone', () => {
+    expect(fmtCron('0 8 * * *')).toBe('8:00 AM')
+  })
+  it('renders a month and day-of-month pair', () => {
+    // February 30 does not exist as a Date; the pair must still render.
+    expect(fmtCron('0 0 30 2 *')).toBe('12:00 AM · Feb 30')
+  })
+  it('renders a month alone', () => {
+    expect(fmtCron('15 6 * 7 *')).toBe('6:15 AM · Jul')
+  })
+  it('handles the 12-hour clock at noon and midnight', () => {
+    expect(fmtCron('0 0 * * *')).toBe('12:00 AM')
+    expect(fmtCron('0 12 * * *')).toBe('12:00 PM')
+  })
+  it('names Sunday whether it is spelled 0 or 7', () => {
+    expect(fmtCron('0 12 * * 0')).toBe('12:00 PM · Sun')
+    expect(fmtCron('0 12 * * 7')).toBe('12:00 PM · Sun')
+  })
+  it('resolves a wrap-around range to its endpoints', () => {
+    expect(fmtCron('0 9 * * 5-1')).toBe('9:00 AM · Fri-Mon')
+  })
+  it('resolves named day tokens', () => {
+    expect(fmtCron('0 13 * * MON-FRI')).toBe('1:00 PM · Mon-Fri')
+    expect(fmtCron('30 9 * * MON,WED')).toBe('9:30 AM · Mon,Wed')
+  })
+
+  describe('falls back to the raw expression rather than to prose', () => {
+    it('does NOT combine a restricted day-of-month with a day-of-week', () => {
+      // Cron ORs the two fields: this fires on the 1st AND every Monday. The old
+      // spelling rendered `Mon 00:00 (days 1)`, asserting an AND that is not there.
+      expect(fmtCron('0 0 1 * 1')).toBe('0 0 1 * 1')
+      expect(fmtCron('0 9 1-3 * 1-5')).toBe('0 9 1-3 * 1-5')
+    })
+    it('declines a bare day-of-month, which has no Intl rendering', () => {
+      expect(fmtCron('0 0 1 * *')).toBe('0 0 1 * *')
+    })
+    it('declines a FOUR-item gappy day list as too wide', () => {
+      expect(fmtCron('0 0 * * 1,2,4,6')).toBe('0 0 * * 1,2,4,6')
+    })
+    it('declines step and range forms in minute, hour or day-of-week', () => {
+      expect(fmtCron('0 9 * * */2')).toBe('0 9 * * */2')
+      expect(fmtCron('0,30 * * * *')).toBe('0,30 * * * *')
+      expect(fmtCron('*/5 9-16 * * 1-5')).toBe('*/5 9-16 * * 1-5')
+    })
+    it('declines out-of-range clock and calendar fields', () => {
+      expect(fmtCron('0 99 * * *')).toBe('0 99 * * *')
+      expect(fmtCron('0 0 32 1 *')).toBe('0 0 32 1 *')
+      expect(fmtCron('0 0 * 13 *')).toBe('0 0 * 13 *')
+    })
+    it('returns anything that is not five fields untouched', () => {
+      expect(fmtCron('bogus')).toBe('bogus')
+      expect(fmtCron('0 0 * *')).toBe('0 0 * *')
+      expect(fmtCron('0 0 * * * *')).toBe('0 0 * * * *')
+    })
+  })
+
+  it('is shorter than the verbose backend prose it replaces', () => {
+    // The whole point: it has to fit where cron_descriptor's 53 characters
+    // could not.
+    expect(fmtCron('0 0 30 2 *').length).toBeLessThanOrEqual(20)
+  })
+})
+
+describe('fmtCron localization', () => {
+  /**
+   * The reason this label is built here instead of on the server: every word in
+   * it comes from `Intl`, so it follows the dashboard's language. A backend-minted
+   * string could not, having no catalog path. These assert the label genuinely
+   * CHANGES with the language rather than being English that merely passed
+   * through `Intl` — so they compare against the `en` rendering, not just against
+   * a fixed foreign string.
+   */
+  afterEach(async () => {
+    await i18next.changeLanguage('en')
+    __resetFormatterCache()
+  })
+
+  async function inLanguage(code: string, expr: string): Promise<string> {
+    await i18next.changeLanguage(code)
+    __resetFormatterCache()
+    return fmtCron(expr)
+  }
+
+  it('translates the weekday name', async () => {
+    const en = await inLanguage('en', '0 9 * * 1-5')
+    const de = await inLanguage('de', '0 9 * * 1-5')
+    const ja = await inLanguage('ja', '0 9 * * 1-5')
+    expect(en).toBe('9:00 AM · Mon-Fri')
+    expect(de).not.toBe(en)
+    expect(ja).not.toBe(en)
+    // Not merely different — actually the target language's weekday.
+    expect(ja).toContain('月')
+  })
+
+  it('translates the month name and respects the locale field order', async () => {
+    expect(await inLanguage('en', '0 0 30 2 *')).toBe('12:00 AM · Feb 30')
+    // de and fr put the day first, with their own separators and abbreviation
+    // periods — supplied by the formatter, not hand-assembled.
+    expect(await inLanguage('de', '0 0 30 2 *')).toBe('0:00 · 30. Feb.')
+    expect(await inLanguage('fr', '0 0 30 2 *')).toBe('0:00 · 30 févr.')
+  })
+
+  it('does not double the CJK month affix', async () => {
+    // A CJK locale returns the month as a BARE NUMBER with `月` a separate literal,
+    // so injecting a pre-formatted `2月` produced `2月月30日`. Only the DAY is replaced.
+    expect(await inLanguage('ja', '0 0 30 2 *')).toBe('0:00 · 2月30日')
+    expect(await inLanguage('zh-CN', '0 0 30 2 *')).toBe('0:00 · 2月30日')
+  })
+
+  it('renders February 30 rather than rolling it over to March', async () => {
+    // `Date.UTC(2024, 1, 30)` is March 1, so a naive format names the WRONG month.
+    // Asserted on the month NAME, since the day "30" contains a 3 of its own.
+    expect(await inLanguage('en', '0 0 30 2 *')).not.toContain('Mar')
+    expect(await inLanguage('ja', '0 0 30 2 *')).not.toContain('3月')
+    expect(await inLanguage('de', '0 0 30 2 *')).not.toContain('Mär')
+  })
+
+  it('uses the locale 24-hour clock where that is the convention', async () => {
+    // de is a 24-hour locale, so the AM/PM the en label carries must be absent.
+    const de = await inLanguage('de', '0 13 * * *')
+    expect(de).not.toContain('AM')
+    expect(de).not.toContain('PM')
+    expect(de).toContain('13')
+  })
+
+  it('leaves the raw-expression fallback untranslated, since it is not prose', async () => {
+    // A cron expression is the user's own input and must round-trip verbatim in
+    // every language.
+    for (const code of ['en', 'de', 'ja', 'zh-CN']) {
+      expect(await inLanguage(code, '*/5 9-16 * * 1-5')).toBe('*/5 9-16 * * 1-5')
+    }
+  })
+
+  it('renders the day in the locale numbering system', async () => {
+    // bn uses Bengali digits; substituting ASCII gave `30 ফেব` for `৩০ ফেব`.
+    const bn = await inLanguage('bn', '0 0 30 2 *')
+    expect(bn).toContain('৩০')
+    expect(bn).not.toContain('30')
+  })
+})
+
+describe('scheduleMinutes', () => {
+  const job = (o: Partial<CronJob>) => ({ id: 'j', name: 'n', message: 'm', enabled: true, schedule: '', ...o }) as CronJob
+
+  it('returns minutes since midnight so the sort is chronological', () => {
+    // The label sorts wrongly as text: `1:00 PM` collates before `9:00 AM`.
+    expect(scheduleMinutes(job({ cron_expr: '0 9 * * *' }))).toBe(540)
+    expect(scheduleMinutes(job({ cron_expr: '0 13 * * *' }))).toBe(780)
+    expect(scheduleMinutes(job({ cron_expr: '30 0 * * *' }))).toBe(30)
+  })
+
+  it('is null for a row with no clock to compare', () => {
+    // A declined shape's minute/hour still parse, which is why the check asks
+    // whether `fmtCron` produced a label, not whether the digits look like a time.
+    expect(scheduleMinutes(job({ schedule: 'every 600s' }))).toBeNull()
+    expect(scheduleMinutes(job({ cron_expr: '0 0 1 * 1' }))).toBeNull()
+    expect(scheduleMinutes(job({ cron_expr: '*/5 9-16 * * 1-5' }))).toBeNull()
+    expect(scheduleMinutes(job({ cron_expr: 'bogus' }))).toBeNull()
+  })
+
+  it('orders 9 AM before 1 PM, which the label alone does not', () => {
+    const nine = job({ cron_expr: '0 9 * * *' })
+    const onePm = job({ cron_expr: '0 13 * * *' })
+    expect(scheduleMinutes(nine)!).toBeLessThan(scheduleMinutes(onePm)!)
+    // The defect this replaces: as text, the 1 PM label sorts first.
+    expect(scheduleLabel(onePm).localeCompare(scheduleLabel(nine))).toBeLessThan(0)
+  })
+})
+
+describe('scheduleLabel', () => {
+  const job = (o: Partial<CronJob>) => ({ id: 'j', name: 'n', message: 'm', enabled: true, schedule: '', ...o }) as CronJob
+
+  it('renders a cron job through fmtCron', () => {
+    expect(scheduleLabel(job({ cron_expr: '0 0 30 2 *', schedule: 'At 12:00 AM, on day 30…' })))
+      .toBe('12:00 AM · Feb 30')
+  })
+  it('keeps the backend string when there is no cron expression', () => {
+    expect(scheduleLabel(job({ schedule: 'every 600s' }))).toBe('every 600s')
+  })
+  it('never returns undefined for a job with neither', () => {
+    expect(scheduleLabel(job({}))).toBe('')
   })
 })

--- a/website/src/test/cronUtilsCov80.test.tsx
+++ b/website/src/test/cronUtilsCov80.test.tsx
@@ -2,65 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 import {
-  TH_CLS, TD_CLS, renderThCells, fmtSchedule, SaveCreateLabel, expandDow, fmtCron,
+  TH_CLS, TD_CLS, renderThCells, SaveCreateLabel, expandDow, fmtCron,
 } from '../utils/cronUtils'
-import type { CronJob } from '../types'
 
 /**
- * Coverage for the parts of cronUtils the existing suite skips: the schedule
- * formatter's unit ladder (the wire shape `parseEveryFromSchedule` reads back),
- * the shared table-header renderer, and the Save/Create button label.
+ * Coverage for the parts of cronUtils the existing suite skips: the shared
+ * table-header renderer, and the Save/Create button label.
  */
-function job(overrides: Partial<CronJob> = {}): CronJob {
-  return {
-    id: 'zz-1',
-    name: 'zzz-job',
-    message: 'zzz',
-    enabled: true,
-    schedule: '',
-    last_status: 'ok',
-    ...overrides,
-  }
-}
-
-describe('fmtSchedule', () => {
-  it('prefers a raw cron expression verbatim', () => {
-    expect(fmtSchedule(job({ cron_expr: '0 9 * * 1-5', every: 60 }))).toBe('0 9 * * 1-5')
-  })
-
-  it('renders sub-minute intervals in seconds', () => {
-    expect(fmtSchedule(job({ every: 45 }))).toBe('45s')
-    expect(fmtSchedule(job({ every: 59 }))).toBe('59s')
-  })
-
-  it('floors to whole minutes below an hour', () => {
-    expect(fmtSchedule(job({ every: 60 }))).toBe('1m')
-    expect(fmtSchedule(job({ every: 3599 }))).toBe('59m')
-  })
-
-  it('floors to whole hours below a day', () => {
-    expect(fmtSchedule(job({ every: 3600 }))).toBe('1h')
-    expect(fmtSchedule(job({ every: 7200 }))).toBe('2h')
-  })
-
-  it('floors to whole days at and beyond 86400s', () => {
-    expect(fmtSchedule(job({ every: 86_400 }))).toBe('1d')
-    expect(fmtSchedule(job({ every: 200_000 }))).toBe('2d')
-  })
-
-  it('formats a one-shot `at` timestamp as a date-time', () => {
-    // 2026-08-14T00:00:00Z — TZ is pinned to UTC by the vitest config.
-    const out = fmtSchedule(job({ at: 1_786_060_800 }))
-    expect(out).not.toBe('—')
-    expect(out).toMatch(/2026/)
-  })
-
-  it('falls back to an em dash when no schedule field is set', () => {
-    expect(fmtSchedule(job())).toBe('—')
-    // A zero `every` is not a schedule either (falsy) — it must not read as "0s".
-    expect(fmtSchedule(job({ every: 0 }))).toBe('—')
-  })
-})
 
 describe('renderThCells', () => {
   it('renders one <th> per column, keyed by header, with the shared + per-column class', () => {
@@ -110,7 +58,7 @@ describe('cronUtils table classes', () => {
 describe('cronUtils dow/cron formatting (smoke)', () => {
   it('expands a named range and formats a weekday expression', () => {
     expect(expandDow('MON-WED')).toEqual([1, 2, 3])
-    expect(fmtCron('5 6 * * 1')).toBe('Mon 06:05')
+    expect(fmtCron('5 6 * * 1')).toBe('6:05 AM · Mon')
     // Not five fields — returned untouched.
     expect(fmtCron('bogus')).toBe('bogus')
   })

--- a/website/src/utils/cronUtils.tsx
+++ b/website/src/utils/cronUtils.tsx
@@ -1,6 +1,6 @@
 /** Shared cron formatting utilities used by SchedulePage and JobForm */
 import { Save, Plus } from 'lucide-react'
-import { fmtDateTime, fmtWeekday } from '../i18n/format'
+import { activeLocale, fmtDateFields, fmtNumber, fmtWeekday } from '../i18n/format'
 import type { CronJob } from '../types'
 import { i18nT } from '../i18n/t'
 
@@ -10,25 +10,6 @@ export const TD_CLS = 'px-2.5 py-2 border-b border-border text-sm'
 /** Render table header cells from column definitions */
 export function renderThCells(cols: { h: string; w: string }[]) {
   return cols.map(c => <th key={c.h} className={`${TH_CLS} ${c.w}`}>{c.h}</th>)
-}
-
-export function fmtSchedule(j: CronJob): string {
-  if (j.cron_expr) return j.cron_expr
-  if (j.every) {
-    // Bare unit letters, deliberately NOT localized: this shape ("every 3600s",
-    // "1h") is the wire format the backend emits and `parseEveryFromSchedule`
-    // in WeekGrid.tsx parses back with /^every\s+(\d+)\s*([sh])/. A localized
-    // unit (de "3600 Sek.", bn Bengali digits) would silently fail that parse
-    // and empty the schedule grid. Rendering these as a translated duration
-    // requires separating the display string from the parsed one first.
-    const s = j.every
-    if (s < 60) return `${s}s`
-    if (s < 3600) return `${Math.floor(s / 60)}m`
-    if (s < 86400) return `${Math.floor(s / 3600)}h`
-    return `${Math.floor(s / 86400)}d`
-  }
-  if (j.at) return fmtDateTime(j.at)
-  return '—'
 }
 
 const DOW_NAMES: Record<string, number> = { SUN: 0, MON: 1, TUE: 2, WED: 3, THU: 4, FRI: 5, SAT: 6 }
@@ -60,22 +41,177 @@ export function expandDow(dow: string): number[] {
   }))]
 }
 
+/** A cron minute/hour pair as a locale-formatted clock time, or null if either
+ *  field is not a plain in-range number.
+ *
+ *  The fields are rendered as a WALL CLOCK, with no timezone conversion: the
+ *  scheduler evaluates a cron expression in the job's own timezone, so the
+ *  stored hour already IS the local hour. A fixed UTC reference date pinned with
+ *  `timeZone: 'UTC'` keeps the host zone from shifting the digits, exactly as
+ *  `fmtWeekday` does for weekday names. 12- vs 24-hour is the locale's choice. */
+function cronClock(minute: string, hour: string): string | null {
+  if (!/^\d{1,2}$/.test(minute) || !/^\d{1,2}$/.test(hour)) return null
+  const m = +minute, h = +hour
+  if (m > 59 || h > 23) return null
+  return fmtDateFields(new Date(Date.UTC(2024, 0, 1, h, m)), {
+    hour: 'numeric', minute: '2-digit', timeZone: 'UTC',
+  })
+}
+
+/** A cron month number as a locale-formatted short month name, or null. */
+function cronMonth(month: string): string | null {
+  if (!/^\d{1,2}$/.test(month) || +month < 1 || +month > 12) return null
+  return fmtDateFields(new Date(Date.UTC(2024, +month - 1, 1)), {
+    month: 'short', timeZone: 'UTC',
+  })
+}
+
+/** A cron month + day-of-month pair in the LOCALE's own field order — `Feb 30`
+ *  in en, `2月30日` in ja, `30. Feb` in de.
+ *
+ *  Composed from `formatToParts` on a date carrying the RIGHT MONTH but a SAFE
+ *  DAY (the 15th, which every month has), substituting only the day. Two traps
+ *  make the obvious spellings wrong:
+ *
+ *  - Formatting the real date cannot work, because cron can name a day that does
+ *    not exist: `0 0 30 2 *` asks for February 30, and `Date.UTC(2024, 1, 30)`
+ *    rolls over to March 1 — a confidently WRONG month.
+ *  - Substituting a pre-formatted month NAME cannot work either. Under
+ *    `{month: 'short'}` a CJK locale returns the month as a bare number with its
+ *    `月` as a separate LITERAL part, so injecting the full `2月` yields `2月月30日`.
+ *    Letting the formatter render the month and replacing only the day keeps
+ *    whatever shape the locale uses. */
+function cronMonthDay(month: number, day: number): string {
+  // `fmtNumber`, not `String(day)`: substituting ASCII gave bn `30 ফেব` for
+  // `৩০ ফেব`. `useGrouping: false` keeps a bare day out of thousands form.
+  const localizedDay = fmtNumber(day, { useGrouping: false })
+  const parts = new Intl.DateTimeFormat(activeLocale(), {
+    month: 'short', day: 'numeric', timeZone: 'UTC',
+  }).formatToParts(new Date(Date.UTC(2024, month - 1, 15)))
+  // A locale whose short-date pattern omits the day would silently drop it; fall
+  // back to a space-joined pair rather than render a half label.
+  if (!parts.some(p => p.type === 'day')) {
+    return `${cronMonth(String(month)) ?? localizedDay} ${localizedDay}`
+  }
+  return parts.map(p => (p.type === 'day' ? localizedDay : p.value)).join('')
+}
+
+/** A cron day-of-week field as locale-formatted names; `''` when it restricts
+ *  nothing, or null when no honest short form exists.
+ *
+ *  Built on `expandDow`, so named tokens (`MON-FRI`) and wrap-around ranges
+ *  (`5-1`) resolve for free, and Sunday works spelled 0 or 7.
+ *
+ *  Three outcomes, because `JobForm`'s weekly picker emits a comma LIST from its
+ *  toggle buttons and every shape below is something a user can produce without
+ *  typing cron:
+ *
+ *  - A set covering all seven days restricts nothing, so it yields `''` and the
+ *    caller renders the bare clock. `Sun-Sat` would be a second spelling of
+ *    "daily" sitting in the same column as a `*` job's.
+ *  - A CONTIGUOUS set collapses to its endpoints (`Mon-Fri`) however it was
+ *    spelled -- five ticked weekdays arrive as `1,2,3,4,5`.
+ *  - Up to three names list out (`Mon,Wed,Fri`), which covers the gappy sets the
+ *    toggles produce. Past that, null: the raw expression is shorter than the
+ *    names AND exact, where a fabricated range would assert days the set omits. */
+function cronDows(field: string): string | null {
+  const name = (d: number) => fmtWeekday(d === 0 ? 7 : d)
+  const expanded = expandDow(field)
+  if (expanded.length === 0 || field.includes('/')) return null
+  if (expanded.length >= 7) return ''
+  // A literal range keeps its own endpoints, which carry the author's wrap-around
+  // direction (`5-1` is Fri..Mon, whose ascending sort would read Sun-Sat).
+  if (field.includes('-')) {
+    return field.includes(',')
+      ? null // mixed range + list: no single pair of endpoints describes it
+      : `${name(expanded[0])}-${name(expanded[expanded.length - 1])}`
+  }
+  const sorted = [...expanded].sort((a, b) => a - b)
+  const contiguous = sorted.length >= 3
+    && sorted.every((d, i) => i === 0 || d === sorted[i - 1] + 1)
+  if (contiguous) return `${name(sorted[0])}-${name(sorted[sorted.length - 1])}`
+  return expanded.length <= 3 ? expanded.map(name).join(',') : null
+}
+
+/**
+ * A cron expression as a COMPACT label for a narrow column: `12:00 AM · Feb 30`,
+ * `9:00 AM · Mon-Fri`, `12:00 AM`.
+ *
+ * Every word comes from `Intl` via `fmtWeekday` / `fmtDateFields`, so the label
+ * translates with the dashboard instead of pinning English into it. That is also
+ * why an unhandled shape returns the RAW EXPRESSION rather than prose: the raw
+ * form needs no catalog entry, is shorter than the sentence it replaces, and is
+ * exactly what the user typed.
+ *
+ * A restricted day-of-month AND day-of-week is deliberately NOT combined. Cron
+ * ORs those two fields, so `0 0 1 * 1` fires on the 1st *and* every Monday — the
+ * previous spelling of this function rendered that as `Mon 00:00 (days 1)`,
+ * asserting an AND that is not there. It now takes the raw-expression path.
+ */
 export function fmtCron(expr: string): string {
   try {
-    const p = expr.trim().split(/\s+/)
+    const raw = expr.trim()
+    const p = raw.split(/\s+/)
     if (p.length !== 5) return expr
-    const [min, hr, dom, , dow] = p
-    // Cron day numbers are Sunday-first (0=Sun, and 7 is also Sunday), so the
-    // index is converted to ISO (1=Mon…7=Sun) before asking for a name. The
-    // number stays the contract; only the name is localized. English output is
-    // unchanged. Anything outside 0-7 is not a weekday and falls back to the raw
-    // value, exactly as the hardcoded array's sparse lookup did.
-    const cronDowName = (d: number) => (d >= 0 && d <= 7 ? fmtWeekday(d === 0 ? 7 : d) : String(d))
-    const expanded = expandDow(dow)
-    const days = dow === '*' ? 'daily' : expanded.length > 0 ? expanded.map(cronDowName).join(',') : dow
-    const domPart = dom !== '*' ? ` (days ${dom})` : ''
-    return `${days} ${hr.padStart(2,'0')}:${min.padStart(2,'0')}${domPart}`
+    const [min, hr, dom, month, dow] = p
+    const clock = cronClock(min, hr)
+    if (clock === null) return raw
+    // null = no honest short form, fall back to the expression. '' = the field
+    // restricts nothing, so the clock alone already says it.
+    const withQualifier = (q: string | null) =>
+      q === null ? raw : q === '' ? clock : `${clock} · ${q}`
+    if (dow !== '*') {
+      // OR-semantics: only a day-of-week alone can be joined to the clock.
+      return dom === '*' && month === '*' ? withQualifier(cronDows(dow)) : raw
+    }
+    if (month !== '*') {
+      const monthName = cronMonth(month)
+      if (monthName === null) return raw
+      if (dom === '*') return withQualifier(monthName)
+      return /^\d{1,2}$/.test(dom) && +dom >= 1 && +dom <= 31
+        ? withQualifier(cronMonthDay(+month, +dom))
+        : raw
+    }
+    // A bare day-of-month has no Intl rendering and would need an untranslatable
+    // "day N", so it takes the raw expression too.
+    return dom === '*' ? clock : raw
   } catch { return expr }
+}
+
+/**
+ * The Schedule column's value for a job — ONE definition, because the cell and
+ * the column's sort comparator must agree. They did not before: the cell showed
+ * a compact label while the comparator keyed on the verbose backend string, so
+ * sorting ordered rows by text the user could not see.
+ *
+ * A cron job renders through `fmtCron` over the payload's `cron_expr`. An
+ * interval or one-shot has no `cron_expr` and its backend string ("every 600s")
+ * is already compact, so that is kept as-is.
+ */
+export function scheduleLabel(j: CronJob): string {
+  return j.cron_expr ? fmtCron(j.cron_expr) : (j.schedule || '')
+}
+
+/**
+ * Minutes-since-midnight of a job's rendered clock, or null when it has none.
+ *
+ * The Schedule column's sort needs this because the LABEL sorts wrongly as text:
+ * `1:00 PM` collates before `9:00 AM`, so ordering by the visible string — which
+ * is what this PR set out to do — still produced an order no reader expects.
+ *
+ * Null covers both rows with no clock to compare: a non-cron job, and a cron
+ * shape `fmtCron` declines, which renders as its raw expression. The fields of a
+ * declined shape may still parse, so the check is whether `fmtCron` actually
+ * produced a label rather than whether the digits look like a time.
+ */
+export function scheduleMinutes(j: CronJob): number | null {
+  if (!j.cron_expr) return null
+  const expr = j.cron_expr.trim()
+  const [min, hr, ...rest] = expr.split(/\s+/)
+  if (rest.length !== 3) return null
+  if (!/^\d{1,2}$/.test(min) || !/^\d{1,2}$/.test(hr)) return null
+  if (+min > 59 || +hr > 23) return null
+  return fmtCron(expr) === expr ? null : +hr * 60 + +min
 }
 
 /** Save/Create button label with icon — shared by JobForm and SchedulePage */


### PR DESCRIPTION
## Problem / Motivation

The Schedule column renders `format_schedule`, which is `cron_descriptor` prose. For `0 0 30 2 *` that is 53 characters — `At 12:00 AM, on day 30 of the month, only in February` — in a 124px column that holds about 13 monospace ones.

So the cell reads `At 12:00 AM ...`, and that is the **same string for every midnight job in the table**. The part that identifies a schedule is exactly the part being clipped, and telling two rows apart means hovering each one for its tooltip.

Measured in Chromium at the real geometry (`table-fixed`, the cell's `p-2` under border-box, `text-sm`, and the dashboard's own `--font-body` / `--mono` stacks):

| expression | rendered | content box | text needs | result |
| ------------- | ------------------------------------------------------ | ----------- | ---------- | ----------------- |
| `0 0 30 2 *`  | `At 12:00 AM, on day 30 of the month, only in February` | 108px       | 447px      | **clipped 339px** |
| `0 9 * * 1-5` | `At 09:00 AM, Monday through Friday`                    | 108px       | 287px      | **clipped 179px** |
| `0 0 * * *`   | `At 12:00 AM`                                           | 108px       | 93px       | fits, +15px       |

Only a bare daily expression fits. The February job loses 76% of its label.

This is not a regression against the fixed-width contract — that contract is right, and `8e2e428e1` was explicit that over-long values truncate with a tooltip. What was never checked is whether *this* column's own worst-case value was 4x its width.

## Why it matters

Every cron whose schedule needs a qualifier — a specific day, a specific month, a weekday range — renders the same `At 12:00 AM ...` in the Schedule column today, so the table cannot tell those jobs apart and the only way to read a schedule is to hover each row for its tooltip. After this the qualifier is in the cell itself: `12:00 AM · Feb 30` instead of a truncated sentence. That restores the column to the job it exists for — distinguishing one scheduled job from another at a glance, while scanning rather than probing.

## What changed

**Frontend only.** `fmtCron` is rewritten to build the label from the `cron_expr` the payload already carried. Recognised shapes collapse to `<clock> · <qualifier>`; anything else returns the **raw expression**, which is both shorter than the prose and exact where a truncated sentence is neither.

| expression         | before (clipped)               | after               |
| ------------------ | ------------------------------ | ------------------- |
| `0 0 30 2 *`       | `At 12:00 AM ...`              | `12:00 AM · Feb 30` |
| `0 9 * * 1-5`      | `At 09:00 AM, Mon ...`         | `9:00 AM · Mon-Fri` |
| `0 9 * * 1,2,3,4,5`| `At 09:00 AM, Mon ...`         | `9:00 AM · Mon-Fri` |
| `0 0 * * *`        | `At 12:00 AM`                  | `12:00 AM`          |
| `0 0 * * 1,3,5`    | `At 12:00 AM, only on Mon ...` | `12:00 AM · Mon,Wed,Fri` |
| `0 0 * * 1,2,4,6`  | `At 12:00 AM, only on Mon ...` | `0 0 * * 1,2,4,6`   |
| `*/5 9-16 * * 1-5` | `Every 5 minutes, betwee ...`  | `*/5 9-16 * * 1-5`  |

Same measurement after: 116px in a 164px box, **+48px headroom**; the widest short form leaves **+38px**.

### It localizes

Every word comes from `Intl` via `fmtWeekday` / `fmtDateFields` / `fmtNumber`, so the label follows the dashboard's language — including its numbering system — instead of pinning English into a 12-locale UI:

| locale | `0 9 * * 1,2,3,4,5`    | `0 0 30 2 *`         | `0 13 * * *` |
| ------ | ---------------------- | -------------------- | ------------ |
| `en`   | `9:00 AM · Mon-Fri`    | `12:00 AM · Feb 30`  | `1:00 PM`    |
| `de`   | `9:00 · Mo-Fr`         | `0:00 · 30. Feb.`    | `13:00`      |
| `ja`   | `9:00 · 月-金`          | `0:00 · 2月30日`      | `13:00`      |
| `bn`   | `৯:০০ AM · সোম-শুক্র`     | `১২:০০ AM · ৩০ ফেব`  | `১৩:০০`      |
| `hi`   | `9:00 am · सोम-शुक्र`    | `12:00 am · 30 फ़र॰` | `1:00 pm`    |

That is why an unhandled shape falls back to the raw expression rather than to prose: the raw form needs no catalog entry. `catalogParity.test.ts` requires every key in all 13 locales, so a new prose string would mean 12 unverifiable translations — which also keeps a bare day-of-month (`0 0 1 * *`) out of the shortener rather than inventing an untranslatable "day 1".

### A contiguous day list collapses, a gappy one does not

`JobForm`'s weekly mode joins checked days with commas, so five ticked weekdays arrive as `1,2,3,4,5` — a list, not a range. An earlier revision capped lists at two names, so **the picker's own archetypal output rendered as raw cron** and the headline `9:00 AM · Mon-Fri` only appeared for hand-typed `1-5`. A contiguous set now collapses to its endpoints however it was spelled.

A gappy set is never collapsed into a range, because naming `1,3,5` `Mon-Fri` would assert Tuesday and Thursday. Up to three names it lists them out instead — `0 9 * * 1,3,5` reads `9:00 AM · Mon,Wed,Fri`, which the toggle buttons make one of the commonest weekly schedules. Past three it takes the raw expression, which is shorter than the names and exact.

A note on that three-name cap: measured in Chromium at the real geometry, `9:00 AM · Mon,Wed,Fri` is 147px in the 164px content box (+17px), and the widest case — a two-digit hour, `12:00 AM · Mon,Wed,Fri` — is 155px (**+9px**). So three names fit, but with a thin margin; a fourth does not, which is where the cap is. The same caveat as the other pixel figures below applies, and overflow degrades to the existing truncate-plus-tooltip rather than to a broken row.

A set covering all seven days restricts nothing, so it renders the bare clock and reads identically to a `*` job — otherwise an all-ticked picker job and a daily one would be two spellings of the same schedule in one column. A literal range keeps its **authored** endpoints rather than sorted ones, so `5-1` stays `Fri-Mon` instead of silently widening to `Sun-Sat`.

### It removes wire surface rather than adding it

An earlier revision minted the label server-side. Building it in the frontend deletes that surface entirely — `format_schedule_short` and its three helpers, the `schedule_short` payload field, `CronJob.schedule_short`, and the old-gateway compat branch — because `cron_expr` predates this PR. `format_schedule` is untouched, so Slack, `kirocrew cron list` and the MCP tools keep the verbose text they have room for, and the cell keeps it as its `title`.

`fmtSchedule` is deleted too. It was a second `CronJob → schedule string` mapping in the same file with **zero non-test consumers**, and its `every` / `at` branches key on fields the GET payload does not send (it sends `every_secs`, and no `at`), so they could not fire on live data. One definition of the column's value was this PR's own goal.

### It fixes two defects in `fmtCron` rather than adding a second shortener

`fmtCron` had no non-test consumers; folding the short form into it gives it one and repairs what it got wrong:

- **A restricted day-of-month AND day-of-week is no longer combined.** Cron ORs those two fields, so `0 0 1 * 1` fires on the 1st *and* every Monday — the old spelling rendered `Mon 00:00 (days 1)`, asserting an AND that is not there. It now takes the raw-expression path.
- **`daily` and `days N` were hardcoded English** in an otherwise localized module.

A month + day pair is composed from `formatToParts` on a date carrying the right month but a **safe day**, substituting only the day. Formatting the real date cannot work — cron accepts February 30, and `Date.UTC(2024, 1, 30)` rolls over to March 1, naming a confidently wrong month. Substituting a pre-formatted month *name* cannot work either: under `{month:'short'}` a CJK locale returns the month as a bare number with its `月` as a separate literal, so injecting `2月` produced `2月月30日`. Both are pinned by tests.

### Sorting matches what is displayed, and is chronological

The column sorted on the verbose `schedule` while displaying the compact label, so clicking sort ordered rows by text the user could not see. It now keys on `scheduleMinutes` — minutes since midnight — because the label itself sorts wrongly as text: `1:00 PM` collates before `9:00 AM`. Rows with no clock (raw fallback, intervals) sort last, then by `compareText` on the shared `scheduleLabel`, which the localized names require.

## Column width

124px → 180px, and the table min-width 1120px → 1176px **in lockstep**: under `table-fixed` those two numbers are one statement, and moving only the column would take the 56px out of Message, whose 176px floor `SchedulePage.columnContract.test.ts` exists to defend.

Confirmed that test discriminates, by reverting the min-width alone:

```
AssertionError: Message gets 124px at the table's own min-width:
  expected 124 to be greater than or equal to 176
```

The cell also drops its `<code>` wrapper. The short form is prose, and monospace is the widest rendering available for the least code-like value on the page — it was spending the column's pixels to fit fewer characters.

## Tests

- `website/src/test/cronUtils.test.ts` — the shortened shapes; both Sunday spellings (cron numbers it 0 *and* 7); noon/midnight on the 12-hour clock; named tokens and wrap-around ranges; the contiguous-list collapse (`1,2,3,4,5`), the three-name gappy list (`1,3,5` → `Mon,Wed,Fri`), the four-name decline (`1,2,4,6`) proving no range is fabricated, and the all-seven-day set rendering byte-identically to `*`; 12 fallback shapes asserting the raw expression rather than clipped prose; the dom+dow OR-semantics fix; `scheduleMinutes` including its nulls and the 9 AM / 1 PM ordering the label alone gets wrong; and a localization block asserting `de`/`ja`/`fr` differ from `en` (not merely that they render), the exact CJK pair, Bengali digits, and the raw fallback round-tripping verbatim in every language.
- `website/src/test/SchedulePage.scheduleCell.test.tsx` — the cell renders the compact label while the verbose prose reaches `title` only, a non-cron job keeps its backend string, and the timezone keeps its own line.

Green: 847 frontend vitest across 56 files (i18n, Schedule, cronUtils, JobForm, WeekGrid), 213 backend pytest, `tsc --noEmit`, `eslint` (0 errors, 0 warnings on the touched files), `flake8`, `isort`, `mypy`.

## Caveat on the measurement

`Space Grotesk` and `JetBrains Mono` are webfonts and are not installed on the box that measured the pixel figures, so it fell back to generic `sans-serif` / `monospace` and the per-character metrics are approximate. The conclusion tolerates that: 447px against a 108px box is not a borderline case, and the worst-case +38px headroom absorbs plausible metric variation.

