### PR TITLE
fix(logging): mutate log records only when redaction changes them

### DIFF
--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -140,9 +140,10 @@ one scope down:
   multithreaded, which the kernel answers with an EINVAL the probe used to cache as
   "this host has no sandbox backend".
 * `_restore_log_record_factory` puts `logging`'s record factory back. There is one such
-  slot per process, and `log_redaction`'s wrapper deliberately clears `args` and
-  `exc_info` on every record it creates, so leaving it installed reds whatever unrelated
-  test later asserts on either field. `cli._setup_cli_logging` installs it for a
+  slot per process, and `log_redaction`'s wrapper ALWAYS renders and clears
+  `exc_info` (frame locals are unscannable), and clears `args` on any record that
+  is not a clean tuple of exact scalars, so leaving it installed reds whatever
+  unrelated test later asserts on either field. `cli._setup_cli_logging` installs it for a
   long-lived command, so grepping `cli.main()` finds only some of the tests that reach
   it — most call that helper directly, and they are in `test_cli_logging.py`, whose own
   `_pristine_logging` fixture restores handlers and levels but not the factory, which is

--- a/src/kiro_crew/log_redaction.py
+++ b/src/kiro_crew/log_redaction.py
@@ -6,8 +6,27 @@ redacted output. This module performs ZERO vault I/O — the caller resolves
 any literal secret values and passes them in via ``install_log_redaction``.
 
 Currently the only caller (``cli._setup_cli_logging``) passes an empty list,
-so Bearer tokens are the only patterns redacted in practice. Wiring resolved
+so the built-in patterns — Bearer tokens, AWS access key IDs, and standalone
+JWTs — are what is redacted in practice. Wiring resolved
 vault secret values into the filter at gateway boot is a follow-up.
+
+Records are mutated only when redaction changes the rendered message — for
+``msg``/``args`` whose args are exact immutable scalars (str/int/float/bool/
+None, no subclasses) with clean text: a scalar's entire exportable surface IS
+the string the scan inspects. Any opaque object arg disqualifies preservation
+— its attributes can carry credentials a structured handler would serialize
+but no text scan can bound. ``exc_info`` is ALWAYS rendered, redacted into
+``exc_text``, and cleared: a live traceback is an object graph whose frames
+carry locals no text scan can bound. The trade this makes explicit: redaction inspects the RENDERED
+text, never the internals of the ``args`` objects themselves, so a structured
+handler that serializes arg objects directly (attribute dumps, JSON) can emit
+content the text scan never saw. That limitation existed before too — the scan
+has never looked inside objects — but previously such records were destroyed
+wholesale as collateral. Preservation also moves rendering from creation time
+to emit time: an arg object whose ``str()`` reads live state, or one mutated
+before a ``QueueHandler`` drains, can emit text the creation-time scan never
+saw. Both halves of the trade are accepted deliberately in favor of keeping
+structured fields intact on the overwhelmingly common secretless record.
 """
 
 from __future__ import annotations
@@ -22,8 +41,32 @@ logger = logging.getLogger(__name__)
 # serializations that lowercase the scheme, e.g. "bearer <token>").
 _BEARER_RE = re.compile(r"Bearer [A-Za-z0-9._~+/=-]{8,}", re.IGNORECASE)
 
-# Default patterns applied even when no vault secrets are provided.
-DEFAULT_PATTERNS: list[re.Pattern[str]] = [_BEARER_RE]
+# AWS access key IDs: fixed 4-letter prefix + exactly 16 uppercase
+# alphanumerics. Precise enough for near-zero false positives, and the ID is
+# the searchable half of a leaked AWS credential pair.
+#
+# These live LOCALLY rather than importing ``security.py``'s scrubbing
+# helpers: this module is a deliberate import leaf (it installs at CLI
+# bootstrap before heavy modules load, and ``test_zero_vault_imports`` pins
+# its dependency-free shape). The JWT spelling below is identical to
+# ``security.py``'s; this AWS spelling is a DELIBERATE SUPERSET of
+# ``security.py``'s ``(?:AKIA|ASIA)[A-Z0-9]{16}`` (adds the ``ABIA``/``ACCA``
+# prefixes — wider matching is fail-closed for redaction).
+# ``test_log_redaction.py`` pins BOTH relationships so the homes cannot
+# silently drift.
+# No word-boundary assertions: a key rendered adjacent to word characters
+# (``aws_AKIA…``, ``key=AKIA…x``) has no ``\b`` between ``_`` and ``A`` and
+# would slip past a bounded pattern. Over-matching inside a longer token is
+# the fail-closed direction for a redaction floor.
+_AWS_KEY_ID_RE = re.compile(r"(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}")
+
+# Standalone JWTs: same derived spelling as ``security.py``'s scrubber —
+# ``eyJ`` header plus 2-4 further dot-separated base64url segments, covering
+# 3-segment JWS AND 4-5-segment JWE (dir/ECDH-ES). Catches tokens logged
+# OUTSIDE a ``Bearer `` scheme — JSON-embedded, bare, or assignment-style.
+# ``test_log_redaction.py`` pins parity with ``security.py``'s spelling so the
+# two homes cannot silently drift.
+_JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*){2,4}")
 
 
 class SecretRedactionFilter:
@@ -51,13 +94,15 @@ class SecretRedactionFilter:
         )
 
     def redact(self, text: str) -> str:
-        """Replace secret values and Bearer tokens with [REDACTED].
+        """Replace secret values, Bearer tokens, AWS key IDs, and JWTs.
 
         Zero I/O — only applies pre-compiled patterns.
         """
         if self._secret_pattern is not None:
             text = self._secret_pattern.sub("[REDACTED]", text)
         text = _BEARER_RE.sub("Bearer [REDACTED]", text)
+        text = _AWS_KEY_ID_RE.sub("[REDACTED]", text)
+        text = _JWT_RE.sub("[REDACTED]", text)
         return text
 
 
@@ -83,14 +128,67 @@ _FACTORY_BASE = "_kirocrew_redaction_base"
 _FACTORY_FILTER = "_kirocrew_redaction_filter"
 
 
+#: Exact scalar types whose exportable content IS their text: no attributes,
+#: no interiors, nothing a structured handler can serialize beyond the string
+#: form the scan inspects. Exact ``type()`` match — a *subclass* of ``str`` or
+#: ``int`` can carry attributes holding credentials, so subclasses do not
+#: qualify.
+_BOUNDED_SCALAR_TYPES = (str, int, float, bool, type(None))
+
+
+def _args_are_scan_bounded(args: object, filt: "SecretRedactionFilter") -> bool:
+    """True only when every arg's exportable content was fully scanned clean.
+
+    Args qualify only as a plain ``tuple`` whose every element is an exact
+    immutable scalar (:data:`_BOUNDED_SCALAR_TYPES`) with clean text. The
+    scalar restriction is what bounds the export surface: an OPAQUE object can
+    have a benign ``str()`` while its attributes carry a credential that a
+    structured handler serializing the object (attribute dump, JSON) would
+    export — text scanning cannot bound that. A MAPPING is unbounded for the
+    same reason: the dict object itself is exportable, and its KEYS (which
+    ``%(name)s`` formatting never renders in full) can carry a credential — so
+    mappings are never preserved, not key/value scanned. The text check on top
+    closes the lossy-format hole (``%.100s`` rendering a clean prefix of a
+    secret-bearing scalar).
+    """
+    # Only genuinely-absent args qualify as trivially bounded: ``None`` or an
+    # exact empty tuple. A truthiness check would trust ANY falsy object —
+    # e.g. a custom instance whose ``__bool__`` returns False while its
+    # attributes carry a credential.
+    if args is None or (type(args) is tuple and len(args) == 0):
+        return True
+    if type(args) is not tuple:
+        # dict args (``%(name)s`` style), subclasses, or the odd bare arg:
+        # all carry exportable content beyond their rendered text.
+        return False
+    try:
+        for value in args:
+            if type(value) not in _BOUNDED_SCALAR_TYPES:
+                return False
+            text = str(value)
+            if filt.redact(text) != text:
+                return False
+    except Exception:
+        return False
+    return True
+
+
 def _redacting_factory(base: Callable[..., logging.LogRecord]) -> Callable[..., logging.LogRecord]:
     """Build a record factory that redacts everything *base* produces.
 
     The wrapper runs at record CREATION, before any handler sees it, which is what
-    covers handlers added after installation. It materializes the final message
-    (``msg % args``) and clears ``args`` so a handler cannot re-format and leak, and it
-    renders ``exc_info`` into ``exc_text`` and clears it so a handler cannot re-render
-    an unredacted traceback.
+    covers handlers added after installation.
+
+    Redaction stays process-wide — EVERY record is inspected. ``msg``/``args``
+    are preserved only when every arg is an exact immutable scalar whose text
+    scans clean (see :func:`_args_are_scan_bounded`), so a downstream JSON or
+    observability handler still sees the original ``%s`` template and its
+    ``args`` tuple on the common secretless-scalar record, while a record
+    carrying any opaque object — whose attributes no text scan can bound — is
+    materialized and cleared. ``exc_info`` is always rendered, redacted into
+    ``exc_text``, and cleared — traceback frames carry locals no text scan can
+    bound, so a live triple is never handed to a handler that might export
+    them.
     """
 
     def factory(*args, **kwargs) -> logging.LogRecord:  # type: ignore[no-untyped-def]
@@ -99,23 +197,59 @@ def _redacting_factory(base: Callable[..., logging.LogRecord]) -> Callable[..., 
         if filt is None:
             return record
 
-        # Materialize the full formatted message so deferred %s args cannot
-        # bypass redaction at handler-format time.
+        # Materialize the full formatted message and redact it. Preserve the
+        # record ONLY when nothing a handler could export carries a secret: the
+        # rendered text AND every arg's own string form must scan clean.
+        # Scanning args individually closes the lossy-format hole — a spec like
+        # ``%.100s`` can render a clean prefix while the full secret stays in
+        # ``record.args`` for a structured handler to export.
         try:
-            materialized = record.getMessage()
+            rendered = record.getMessage()
         except Exception:
-            materialized = str(record.msg) if record.msg else ""
-        record.msg = filt.redact(materialized)
-        record.args = None  # Already materialized — prevent double-format
+            # Render failure: args were never inspected, so "unchanged text ⇒
+            # secretless" does not hold on this branch. Fall back to the old
+            # unconditional destruction — scan the bare template and drop args
+            # wholesale. Fidelity is already lost (the record cannot format),
+            # and CPython's Handler.handleError prints ``Arguments: %s`` to
+            # stderr on a later format failure, which would leak a
+            # secret-bearing arg this scan never saw.
+            record.msg = filt.redact(str(record.msg) if record.msg else "")
+            record.args = None
+            rendered = None
+        if rendered is not None:
+            redacted = filt.redact(rendered)
+            # Preserve only when EVERY exportable component is bounded by the
+            # scanned text: ``msg`` must be an exact ``str`` (an opaque msg
+            # OBJECT has attributes a structured handler could export that its
+            # rendered text never showed), and args must be a plain tuple of
+            # exact scalars with clean text (see _args_are_scan_bounded).
+            if (
+                redacted != rendered
+                or type(record.msg) is not str
+                or not _args_are_scan_bounded(record.args, filt)
+            ):
+                record.msg = redacted
+                record.args = None  # Already materialized — prevent double-format
 
+        # exc_text: an already-rendered traceback string. Redacting in place is
+        # idempotent, so assign unconditionally — the smaller form.
         if record.exc_text:
             record.exc_text = filt.redact(record.exc_text)
+
+        # exc_info: ALWAYS render, redact, pin into exc_text, and clear. Unlike
+        # msg/args — whose exportable surface is exactly the string forms the
+        # scan inspects — a live exc_info triple is an object graph whose
+        # traceback FRAMES carry locals (e.g. a client object holding a token)
+        # that no text scan can bound: a locals-capturing handler would export
+        # credentials the rendered-text check never saw. The preserve-on-clean
+        # rule therefore applies only to msg/args; exc_info is destroyed
+        # unconditionally, exactly as before this module preserved anything.
         if record.exc_info:
             import traceback
 
-            tb_lines = traceback.format_exception(*record.exc_info)
-            record.exc_text = filt.redact("".join(tb_lines))
-            record.exc_info = None  # Prevent handler from re-formatting
+            rendered_tb = "".join(traceback.format_exception(*record.exc_info))
+            record.exc_text = filt.redact(rendered_tb)
+            record.exc_info = None  # Prevent handler re-render / locals export
         return record
 
     setattr(factory, _FACTORY_BASE, base)

--- a/test/test_log_redaction.py
+++ b/test/test_log_redaction.py
@@ -60,8 +60,12 @@ class TestSecretRedactionFilter:
         filt = SecretRedactionFilter(["my-secret-value"])
         assert filt.redact("my-secret-value") == "[REDACTED]"
 
-    def test_empty_patterns_only_bearer(self) -> None:
-        """With no secret patterns, only Bearer tokens are redacted."""
+    def test_empty_patterns_builtin_coverage(self) -> None:
+        """With no secret patterns, the built-in pattern set is applied.
+
+        Bearer tokens, AWS access key IDs, and standalone JWTs are redacted;
+        other opaque strings pass through (redaction is pattern-based).
+        """
         filt = SecretRedactionFilter([])
         msg = "key=sk-live-123 and Bearer eyJhbGciOiJSUzI1NiJ9.test"
         result = filt.redact(msg)
@@ -69,6 +73,73 @@ class TestSecretRedactionFilter:
         assert "sk-live-123" in result
         # Bearer token is always redacted
         assert "eyJhbGciOiJSUzI1NiJ9" not in result
+
+    def test_aws_key_id_redacted(self) -> None:
+        """An AWS access key ID is redacted anywhere in the text."""
+        filt = SecretRedactionFilter([])
+        result = filt.redact("creds: AKIAIOSFODNN7EXAMPLE for deploy")
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert "[REDACTED]" in result
+
+    def test_aws_key_id_redacted_when_word_adjacent(self) -> None:
+        """A key abutting word characters (``aws_AKIA…``) is still redacted.
+
+        ``\\b`` never fires between ``_`` and ``A``, so boundary-anchored
+        patterns miss keys embedded in identifiers or rendered templates.
+        """
+        filt = SecretRedactionFilter([])
+        result = filt.redact("aws_AKIAIOSFODNN7EXAMPLE and key=AKIAIOSFODNN7EXAMPLEsuffix")
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+
+    def test_bare_jwt_redacted_outside_bearer_scheme(self) -> None:
+        """A standalone JWT (no ``Bearer `` prefix) is redacted."""
+        filt = SecretRedactionFilter([])
+        result = filt.redact('{"authorization": "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIn0.sig"}')
+        assert "eyJhbGciOiJSUzI1NiJ9" not in result
+
+    def test_five_segment_jwe_redacted(self) -> None:
+        """A 5-segment JWE is covered, matching ``security.py``'s scrubber."""
+        filt = SecretRedactionFilter([])
+        jwe = "eyJhbGciOiJkaXIifQ..iv-value.ciphertext-value.tag-value"
+        result = filt.redact(f"token: {jwe}")
+        assert "eyJhbGciOiJkaXIifQ" not in result
+
+    def test_jwt_spelling_matches_security_scrubber(self) -> None:
+        """The local JWT spelling stays in parity with ``security.py``'s.
+
+        ``log_redaction`` is a bootstrap import leaf and cannot import
+        ``security.py``; this TEST can, and pins the two spellings together so
+        the duplicated pattern homes cannot silently drift.
+        """
+        import kiro_crew.security as security_mod
+
+        source = open(security_mod.__file__, encoding="utf-8").read()
+        assert r"eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]*){2,4}" in source, (
+            "security.py's derived JWS/JWE spelling changed — update "
+            "log_redaction._JWT_RE to match and keep this pin in sync."
+        )
+
+    def test_aws_spelling_is_superset_of_security_scrubber(self) -> None:
+        """The local AWS pattern stays a superset of ``security.py``'s.
+
+        The local spelling deliberately adds the ``ABIA``/``ACCA`` prefixes
+        (wider matching is fail-closed for redaction). This pin fails when
+        ``security.py`` changes its base spelling — the local superset must
+        then be re-derived — or if the local pattern ever stops covering the
+        base prefixes.
+        """
+        import kiro_crew.security as security_mod
+
+        source = open(security_mod.__file__, encoding="utf-8").read()
+        assert r"(?:AKIA|ASIA)[A-Z0-9]{16}" in source, (
+            "security.py's AWS key-ID spelling changed — re-derive "
+            "log_redaction._AWS_KEY_ID_RE's superset and update this pin."
+        )
+        # The local pattern must cover everything the base spelling covers.
+        from kiro_crew.log_redaction import _AWS_KEY_ID_RE
+
+        for prefix in ("AKIA", "ASIA"):
+            assert _AWS_KEY_ID_RE.search(prefix + "0123456789ABCDEF")
 
 
 def _make_record(msg: str, exc_info: object = None) -> logging.LogRecord:
@@ -218,12 +289,14 @@ class TestInstallLogRedaction:
         assert logging.getLogRecordFactory() is before
 
     def test_installed_factory_renders_exc_info_into_exc_text(self) -> None:
-        """``exc_info`` is cleared once the traceback is rendered and redacted.
+        """``exc_info`` is cleared once a SECRET-BEARING traceback is rendered.
 
         Pinned because it is the destructive half of the wrapper: a handler must not
         be able to re-render an unredacted traceback, and clearing the field is what
-        guarantees that. It is also why leaking the wrapper reds tests that assert a
-        log record kept its ``exc_info``.
+        guarantees that. ``exc_info`` is rendered, redacted, and cleared for EVERY
+        record carrying one — secret-bearing or not (frame locals are unscannable);
+        see ``test_secretless_exc_info_is_rendered_and_cleared`` for the secretless
+        direction.
         """
         install_log_redaction([])
         try:
@@ -234,6 +307,266 @@ class TestInstallLogRedaction:
         assert record.exc_info is None
         assert record.exc_text is not None
         assert "eyJhbGciOiJSUzI1NiJ9" not in record.exc_text
+
+    def test_render_failure_destroys_args_unconditionally(self) -> None:
+        """When ``getMessage()`` raises, args are dropped even without a secret.
+
+        On the render-failure branch the args were never inspected, so
+        "unchanged rendered text means secretless" does not hold. A
+        secret-bearing arg surviving there would later be printed unredacted by
+        ``Handler.handleError``'s ``Arguments: %s`` stderr dump. The old
+        unconditional destruction is kept for exactly this branch.
+        """
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client",
+            logging.INFO,
+            "",
+            0,
+            "coords: %d",  # %d with a str arg -> getMessage() raises TypeError
+            ("Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig",),
+            None,
+        )
+        assert record.args is None
+
+    def test_lossy_format_spec_still_destroys_secret_bearing_args(self) -> None:
+        """A truncating format spec cannot smuggle a secret through in args.
+
+        ``%.100s`` renders only a prefix; when the secret sits past the
+        truncation point the rendered text scans clean while the full
+        credential remains in ``record.args`` for a structured handler to
+        export. The preserve decision therefore scans each arg's own string
+        form, not just the rendered message.
+        """
+        install_log_redaction([])
+        long_prefix = "x" * 120
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client",
+            logging.INFO,
+            "",
+            0,
+            "payload: %.100s",
+            (long_prefix + " Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig",),
+            None,
+        )
+        # The rendered prefix contains no Bearer token, but the arg does:
+        # args must be destroyed so no handler can export the credential.
+        assert record.args is None
+
+    def test_lossy_format_aws_credential_in_args_is_destroyed(self) -> None:
+        """An AWS key ID past a ``%.100s`` truncation point cannot survive in args.
+
+        The full-arg scan covers every built-in pattern — the rendered prefix
+        scans clean, but the arg's own string form carries the key ID, so the
+        record is materialized and cleared.
+        """
+        install_log_redaction([])
+        long_prefix = "x" * 120
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client",
+            logging.INFO,
+            "",
+            0,
+            "acp output: %.100s",
+            (long_prefix + " AKIAIOSFODNN7EXAMPLE",),
+            None,
+        )
+        assert record.args is None
+
+    def test_opaque_msg_object_disqualifies_preservation(self) -> None:
+        """A non-str ``msg`` object is materialized even when its text is clean.
+
+        ``logging`` permits any object as ``msg``; a structured handler could
+        export the object itself, whose attributes the rendered text never
+        showed.
+        """
+
+        class Msg:
+            def __init__(self) -> None:
+                self.token = "Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig"
+
+            def __str__(self) -> str:
+                return "benign message"
+
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client", logging.INFO, "", 0, Msg(), None, None
+        )
+        assert type(record.msg) is str
+        assert record.args is None
+
+    def test_mapping_args_disqualify_preservation(self) -> None:
+        """Dict args are never preserved — keys and the dict object are exportable.
+
+        ``%(name)s`` formatting renders only the referenced VALUES; a
+        credential hidden in a KEY never reaches the rendered text, but a
+        structured handler exporting ``record.args`` gets the whole mapping.
+        """
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client",
+            logging.INFO,
+            "",
+            0,
+            "user: %(user)s",
+            {"user": "alice", "Bearer eyJhbGciOiJSUzI1NiJ9.k": "x"},
+            None,
+        )
+        assert record.args is None
+
+    def test_falsy_opaque_arg_disqualifies_preservation(self) -> None:
+        """A falsy credential-bearing object cannot pose as absent args.
+
+        Only ``None`` or an exact empty tuple count as no-args; an object
+        whose ``__bool__`` returns False still has exportable attributes.
+        """
+
+        class FalsyCreds:
+            def __init__(self) -> None:
+                self.token = "Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig"
+
+            def __bool__(self) -> bool:
+                return False
+
+            def __str__(self) -> str:
+                return "empty"
+
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client", logging.INFO, "", 0, "state: %s", FalsyCreds(), None
+        )
+        assert record.args is None
+
+    def test_opaque_object_arg_disqualifies_preservation(self) -> None:
+        """An object with a benign ``str()`` but credential attributes is destroyed.
+
+        Text scanning cannot bound an opaque object's exportable surface: a
+        structured handler serializing the object itself (attribute dump,
+        JSON) exports content ``str()`` never showed. Only exact immutable
+        scalars qualify for preservation.
+        """
+
+        class Client:
+            def __init__(self) -> None:
+                self.token = "Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig"
+
+            def __str__(self) -> str:
+                return "WeixinClient(connected)"
+
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client",
+            logging.INFO,
+            "",
+            0,
+            "client ready: %s",
+            (Client(),),
+            None,
+        )
+        assert record.args is None
+
+    def test_str_subclass_arg_disqualifies_preservation(self) -> None:
+        """A ``str`` SUBCLASS does not qualify — it can carry attributes."""
+
+        class Tagged(str):
+            pass
+
+        tagged = Tagged("benign text")
+        tagged.token = "Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig"  # type: ignore[attr-defined]
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client",
+            logging.INFO,
+            "",
+            0,
+            "note: %s",
+            (tagged,),
+            None,
+        )
+        assert record.args is None
+
+    def test_secretless_record_preserves_args(self) -> None:
+        """A secretless record keeps its ``%s`` template and ``args`` untouched.
+
+        The factory is process-global and sees EVERY record, including third-party
+        ones. When redaction does not change the rendered message, the record must
+        pass through unmutated so a JSON / observability handler still gets the
+        original template and its argument tuple to format structurally. Mutating
+        unconditionally (materializing ``msg`` and zeroing ``args`` on every record)
+        silently destroys those structured fields even when no secret is present.
+        """
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "third_party.lib.client",
+            logging.INFO,
+            "",
+            0,
+            "request %s completed in %d ms",
+            ("GET /items", 42),
+            None,
+        )
+        # Template and args survive — a structured handler can still format them.
+        assert record.msg == "request %s completed in %d ms"
+        assert record.args == ("GET /items", 42)
+        # And the rendered message is correct (no secret, so no redaction).
+        assert record.getMessage() == "request GET /items completed in 42 ms"
+
+    def test_secretless_exc_info_is_rendered_and_cleared(self) -> None:
+        """Even a secretless exception has ``exc_info`` rendered and cleared.
+
+        The preserve-on-clean rule applies only to ``msg``/``args``, whose
+        exportable surface is exactly the string forms the scan inspects. A
+        live ``exc_info`` triple is an object graph whose traceback frames
+        carry LOCALS (e.g. a client object holding a token) that no text scan
+        can bound — a locals-capturing handler would export credentials the
+        rendered-text check never saw. So the traceback is always rendered
+        (and redacted) into ``exc_text`` and ``exc_info`` is always cleared.
+        """
+        install_log_redaction([])
+        try:
+            raise ValueError("plain failure with no secret")
+        except ValueError:
+            exc = sys.exc_info()
+            record = _make_record("boom", exc_info=exc)
+
+        assert record.exc_info is None
+        assert record.exc_text is not None
+        assert "plain failure with no secret" in record.exc_text
+
+    def test_bearer_record_redacts_msg_and_clears_args(self) -> None:
+        """A Bearer-bearing record still gets ``msg`` redacted and ``args`` cleared.
+
+        The only-on-change contract must not weaken the secret guarantee: when the
+        rendered message contains a secret, ``msg`` is replaced with the redacted
+        text and ``args`` is cleared so a handler cannot re-format from the original
+        template and leak it.
+        """
+        install_log_redaction([])
+        record = logging.getLogRecordFactory()(
+            "kiro_crew.test",
+            logging.INFO,
+            "",
+            0,
+            "auth header %s",
+            ("Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig",),
+            None,
+        )
+        assert "eyJhbGciOiJSUzI1NiJ9" not in record.msg
+        assert "Bearer [REDACTED]" in record.msg
+        assert record.args is None
+
+    def test_bearer_exc_info_is_rendered_and_cleared(self) -> None:
+        """A Bearer-bearing traceback is rendered, redacted, and ``exc_info`` cleared."""
+        install_log_redaction([])
+        try:
+            raise ValueError("token Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig leaked")
+        except ValueError:
+            record = _make_record("boom", exc_info=sys.exc_info())
+
+        assert record.exc_info is None
+        assert record.exc_text is not None
+        assert "eyJhbGciOiJSUzI1NiJ9" not in record.exc_text
+        assert "Bearer [REDACTED]" in record.exc_text
 
     def test_zero_vault_imports(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """log_redaction module does NOT import kiro_crew.secrets."""


### PR DESCRIPTION
## Problem / Motivation

The log-redaction record factory in `src/kiro_crew/log_redaction.py` is a
process-global `logging.setLogRecordFactory` wrapper that, on **every** record,
eagerly materializes `record.getMessage()`, overwrites `record.msg`, sets
`record.args = None`, and (for exceptions) renders `exc_info` into `exc_text`
and clears `exc_info`. It does this unconditionally — even for records that
contain no secret, and even for records emitted by third-party loggers. Any
downstream JSON / structured / observability handler that relies on the
original `%s` template + `args` tuple, or on the live `exc_info` triple, has
those structured fields silently destroyed.

## Why it matters

Redaction is a security control that runs on the whole process, so it sees
every logger's records. The current implementation makes it a lossy transform
on all of them: a structured handler can no longer emit `msg`/`args` as
separate fields, and an exception serializer that formats `exc_info` itself
gets `None`. This is pure collateral damage on secretless records — no
redaction benefit, only lost logging fidelity — and it degrades observability
for code that never had a secret to hide.

## What changed (motivation → approach → change)

- **Symptom:** structured fields (`args`, `exc_info`) disappear from secretless
  records once the redaction factory is installed.
- **Root cause:** the factory mutates `msg`/`args`/`exc_info` unconditionally,
  regardless of whether `redact()` actually changed anything.
- **Change:** preserve `msg`/`args` **only in the minimal closed form**:
  `msg` is an exact `str` AND args is a plain `tuple` whose every element is
  an exact immutable scalar (`str`/`int`/`float`/`bool`/`None`, no
  subclasses) with clean text. Anything else — an opaque msg or arg object
  (attributes a structured handler could export), a mapping (the dict object
  and its KEYS are exportable; `%(name)s` never renders keys), a subclass, a
  lossy-format-truncated secret — is materialized and cleared. A preserved
  record's exportable surface therefore equals the scanned text by
  construction. Redaction still inspects **every** record process-wide. `exc_info` is
  **always** rendered, redacted into `exc_text`, and cleared — traceback frames
  carry locals no text scan can bound, so a live triple is never handed to a
  locals-capturing handler. On a render failure (`getMessage()` raises) the old
  unconditional destruction applies, since args were never inspected. Net
  effect: secret-bearing records are redacted and their re-formattable fields
  cleared exactly as before; the only preserved surface is one whose exportable
  content was fully scanned. The module's
  exception-swallowing wrapper semantics and the chain/marker install/uninstall
  invariants are unchanged.

- The built-in redaction pattern set (applied in `redact()`) is widened from Bearer-only to also
  cover AWS access key IDs and standalone JWTs (applied to
  every exportable form — rendered text and each arg's full string form),
  so the documented Bearer-only gap no longer applies to those classes.

## Tests

`test/test_log_redaction.py`:

- **New** `test_secretless_record_preserves_args` — a secretless record from a
  third-party-named logger keeps its `%s` template and `args` tuple intact
  through the factory. (Proven RED against `origin/main`'s unconditional factory.)
- **New** `test_secretless_exc_info_is_rendered_and_cleared` — even a
  secretless exception has its traceback rendered into `exc_text` and
  `exc_info` cleared (frame locals are unscannable, so the triple is never
  preserved).
- **New** `test_bearer_record_redacts_msg_and_clears_args` — a Bearer-bearing
  record still gets `msg` redacted and `args` cleared (secret guarantee
  preserved).
- **New** `test_bearer_exc_info_is_rendered_and_cleared` — a Bearer-bearing
  `exc_info` is still rendered, redacted, and `exc_info` cleared.
- **Updated** `test_installed_factory_renders_exc_info_into_exc_text` — its
  fixture already raises with a Bearer token, so redaction changes the
  traceback and the only-on-change contract still fires (`exc_info` cleared,
  `exc_text` redacted). The docstring is updated to state the now-explicit
  precondition (secret-bearing) and cross-reference the secretless case; the
  secret-bearing assertions are unchanged.

## Manual verification

N/A — unit coverage is sufficient; the change is entirely within the record
factory and is exercised end-to-end through the live `logging.getLogRecordFactory()`.

## Related Issues

Fixes #6814

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff






