### PR TITLE
fix(secrets): batch vault reads at spawn and fail closed on malformed URIs and corrupt stores

### DIFF
--- a/src/kiro_crew/mcp_gateway/secret_uri.py
+++ b/src/kiro_crew/mcp_gateway/secret_uri.py
@@ -8,12 +8,38 @@ the secret is never persisted in plaintext outside the vault.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 from kiro_crew.secrets import SecretVault
 
-_SECRET_URI_RE = re.compile(r"^secret://(.+)$")
+#: Scheme prefix for a vault secret reference.
+_SECRET_URI_PREFIX = "secret://"
+
+#: Validation accepts EVERY name the vault write path can store, rejecting
+#: only what can never round-trip: the empty name and names with
+#: leading/trailing whitespace (``api_secrets_set`` ``.strip()``s the name
+#: before storing, so such a reference can never match a stored entry — see
+#: ``kiro_crew.dashboard.handlers.secrets``). No character-class policy is
+#: applied here: an interior space, control, format, or private-use character
+#: is storable, so refusing it would strand a real vault entry and abort MCP
+#: spawn for a name the product's own write path accepted. The log-injection
+#: concern that motivates charset filtering is closed at the SINK instead:
+#: no error or log line raised by this module ever echoes the secret name —
+#: every message names only the operator-declared env-var KEY. With nothing
+#: echoed, a hostile name (bidi override, newline, zero-width) has no text to
+#: forge.
+
+
+def _is_valid_secret_name(name: str) -> bool:
+    """True if *name* could round-trip through the vault's storage boundary.
+
+    Rejects only the empty name and leading/trailing whitespace (the store
+    ``.strip()``s names, so such a reference can never match a stored entry).
+    Every storable name — including interior spaces and unusual Unicode — is
+    accepted; hostile characters are neutralized by never echoing names in
+    errors, not by refusing to resolve them.
+    """
+    return bool(name) and name == name.strip()
 
 
 def resolve_secret_uris(env: dict[str, str], config_dir: Path) -> tuple[dict[str, str], set[str]]:
@@ -25,32 +51,67 @@ def resolve_secret_uris(env: dict[str, str], config_dir: Path) -> tuple[dict[str
     process has been spawned (``exec`` copies them into the child's address
     space) so that plaintext secrets do not linger in parent-process memory.
 
-    Non-matching values pass through unchanged. Raises :exc:`ValueError`
-    when a referenced secret does not exist in the vault — failing closed
-    prevents an MCP server from starting with a missing credential.
+    Non-matching values pass through unchanged. Any value beginning with the
+    ``secret://`` scheme is treated as a secret reference — including
+    ``secret://`` with an empty or malformed name, which fails closed with a
+    :exc:`ValueError` rather than passing the literal template through into the
+    child's environment. Raises :exc:`ValueError` when a referenced secret does
+    not exist in the vault — failing closed prevents an MCP server from
+    starting with a missing credential.
+
+    All referenced secrets are read from the vault in a single batch
+    (:meth:`SecretVault.get_many`), so K references cost one store load and one
+    key read rather than K of each.
 
     This function is intentionally synchronous: vault reads are local
     filesystem I/O and the caller (gatewayd spawn path) is already in an
     async context that would need ``await asyncio.to_thread(...)`` for a
     blocking call — keeping this sync lets the caller wrap it once.
     """
-    vault = SecretVault(config_dir)
     resolved: dict[str, str] = {}
     secret_keys: set[str] = set()
 
+    # First pass: classify each env value. Validate every secret reference's
+    # name BEFORE touching the vault so a malformed URI fails closed without a
+    # store read. ``pending`` maps env-var key -> secret name to resolve.
+    pending: dict[str, str] = {}
     for key, value in env.items():
-        m = _SECRET_URI_RE.match(value)
-        if m is None:
+        if not value.startswith(_SECRET_URI_PREFIX):
             resolved[key] = value
             continue
 
-        secret_name = m.group(1)
-        secret_value = vault.get(secret_name)
+        secret_name = value[len(_SECRET_URI_PREFIX) :]
+        if not _is_valid_secret_name(secret_name):
+            # Do NOT echo the raw reference: a malformed name can carry
+            # control characters (CWE-117 log injection) and this ValueError
+            # propagates to the spawn path's logs unsanitised. Name only the
+            # env-var key, which is operator-declared config.
+            raise ValueError(
+                f"MCP server env var {key!r} has a malformed secret:// "
+                f"reference: the name after 'secret://' must be non-empty with "
+                f"no leading or trailing whitespace (stored names are "
+                f"stripped, so such a reference can never match). "
+                f"Fix the reference, then store the secret under "
+                f"Settings > Secrets in the dashboard (or migrate it with "
+                f"`kirocrew secrets import`)."
+            )
+        pending[key] = secret_name
+
+    if not pending:
+        return resolved, secret_keys
+
+    vault = SecretVault(config_dir)
+    fetched = vault.get_many(list(pending.values()))
+
+    for key, secret_name in pending.items():
+        secret_value = fetched.get(secret_name)
         if secret_value is None:
             raise ValueError(
-                f"MCP server env var {key!r} references secret://{secret_name} "
-                f"but no secret named {secret_name!r} exists in the vault. "
-                f"Run `kirocrew secrets set {secret_name}` to store it."
+                f"MCP server env var {key!r} references a secret that does not "
+                f"exist in the vault (read the referenced name from the "
+                f"server's env config under {key!r}). "
+                f"Store it under Settings > Secrets in the dashboard (or "
+                f"migrate it with `kirocrew secrets import`)."
             )
         resolved[key] = secret_value.reveal()
         secret_keys.add(key)

--- a/src/kiro_crew/secrets/vault.py
+++ b/src/kiro_crew/secrets/vault.py
@@ -99,8 +99,49 @@ class SecretVault:
         entries = self._load_entries()
         if name not in entries:
             return None
-        plaintext = self._decrypt_entry(name, entries[name])
+        key = self._get_or_create_key()
+        plaintext = self._decrypt_entry(name, entries[name], key)
         return SecretValue(plaintext.decode("utf-8"))
+
+    def get_many(self, names: list[str]) -> dict[str, Optional[SecretValue]]:
+        """Batch-retrieve secrets, loading the store and key exactly once.
+
+        Returns a mapping from each requested name to its :class:`SecretValue`,
+        or ``None`` for names not present in the store — the same
+        per-name found/missing semantics as :meth:`get`, but without re-reading
+        ``secrets.enc`` (``_load_entries``) and the key file
+        (``_get_or_create_key``) once per name. On the spawn path K secret
+        references would otherwise cost K full store loads plus K key reads.
+
+        Like :meth:`get`, this is lock-free by design: ``_load_entries`` reads
+        the store atomically (writers commit via ``os.replace``, so a torn read
+        is impossible), and the key file is immutable once created. All names
+        resolve against the SAME on-disk snapshot, which is the intended
+        behaviour for a single spawn.
+
+        The vault key is only loaded when at least one requested name is
+        present, so a call for names none of which exist on a fresh vault does
+        not create a key file (matching :meth:`get`, which returns before
+        ``_get_or_create_key`` for a missing name).
+        """
+        entries = self._load_entries()
+        result: dict[str, Optional[SecretValue]] = {}
+        key: Optional[bytes] = None
+        for name in names:
+            # Membership, then index: a corrupt store can hold a JSON ``null``
+            # entry, and ``entries.get(name)`` would misclassify it as MISSING
+            # (wrong remediation: "store the secret") instead of MALFORMED
+            # (the store is corrupt) — ``_decrypt_entry`` raises the
+            # descriptive fail-closed ValueError for it.
+            if name not in entries:
+                result[name] = None
+                continue
+            entry = entries[name]
+            if key is None:
+                key = self._get_or_create_key()
+            plaintext = self._decrypt_entry(name, entry, key)
+            result[name] = SecretValue(plaintext.decode("utf-8"))
+        return result
 
     async def set(self, name: str, value: str) -> None:
         """Store or overwrite a secret."""
@@ -297,11 +338,24 @@ class SecretVault:
         ct = aesgcm.encrypt(nonce, plaintext, self._aad_for(name))
         return {"nonce": nonce.hex(), "ct": ct.hex()}
 
-    def _decrypt_entry(self, name: str, entry: dict[str, str]) -> bytes:
-        key = self._get_or_create_key()
+    def _decrypt_entry(self, name: str, entry: dict[str, str], key: bytes) -> bytes:
         aesgcm = AESGCM(key)
-        nonce = bytes.fromhex(entry["nonce"])
-        ct = bytes.fromhex(entry["ct"])
+        # A corrupt / hand-edited store can make ``entry`` any shape (a string,
+        # a list, a dict missing ``nonce``/``ct``, or one whose values are not
+        # valid hex). Guard the extraction so callers see the module's
+        # fail-closed descriptive ValueError instead of a raw TypeError /
+        # KeyError / non-hex ValueError. The message names the entry but NEVER
+        # includes ciphertext or plaintext material.
+        try:
+            nonce = bytes.fromhex(entry["nonce"])
+            ct = bytes.fromhex(entry["ct"])
+        except (TypeError, KeyError, ValueError, AttributeError) as exc:
+            # No entry name in the message: names are caller-supplied strings
+            # that may contain anything, and this error propagates into spawn
+            # logs. The resolution caller already names the env-var key.
+            raise ValueError(
+                f"Vault store corrupt: an entry is malformed ({type(exc).__name__})."
+            ) from None
         return aesgcm.decrypt(nonce, ct, self._aad_for(name))
 
     # ── Store I/O ──
@@ -320,7 +374,17 @@ class SecretVault:
                 f"got {envelope.get('backend')!r}"
             )
 
-        return dict(envelope.get("entries", {}))
+        entries = envelope.get("entries", {})
+        # A corrupt / hand-edited store can carry a non-mapping ``entries``
+        # (a list, a string, null). Fail closed with a descriptive ValueError
+        # rather than letting ``dict(entries)`` raise a raw ValueError/TypeError
+        # deep in an unrelated caller. No store content is echoed.
+        if not isinstance(entries, dict):
+            raise ValueError(
+                f"Vault store corrupt: 'entries' must be an object, "
+                f"got {type(entries).__name__}."
+            )
+        return dict(entries)
 
     @contextmanager
     def hold_cross_process_lock(self) -> Iterator[None]:

--- a/test/test_secret_uri_resolution.py
+++ b/test/test_secret_uri_resolution.py
@@ -60,7 +60,7 @@ class TestResolveSecretUris:
 
     def test_missing_secret_raises_valueerror(self, vault_dir: Path) -> None:
         env = {"KEY": "secret://NONEXISTENT_SECRET"}
-        with pytest.raises(ValueError, match="NONEXISTENT_SECRET"):
+        with pytest.raises(ValueError, match="does not .{0,10}exist in the vault"):
             resolve_secret_uris(env, vault_dir)
 
     def test_error_message_includes_env_var_name(self, vault_dir: Path) -> None:
@@ -68,23 +68,218 @@ class TestResolveSecretUris:
         with pytest.raises(ValueError, match="MY_VAR"):
             resolve_secret_uris(env, vault_dir)
 
-    def test_error_message_includes_secret_name(self, vault_dir: Path) -> None:
+    def test_error_message_names_the_env_key_not_the_secret_name(self, vault_dir: Path) -> None:
+        """The missing-secret error names the env var, never the secret name.
+
+        Storable names may contain injection-capable characters, so the sink
+        rule is: no resolution error echoes the referenced name.
+        """
         env = {"KEY": "secret://MISSING"}
-        with pytest.raises(ValueError, match="MISSING"):
+        with pytest.raises(ValueError) as exc:
             resolve_secret_uris(env, vault_dir)
+        msg = str(exc.value)
+        assert "'KEY'" in msg
+        assert "MISSING" not in msg
 
     def test_empty_env(self, vault_dir: Path) -> None:
         result, keys = resolve_secret_uris({}, vault_dir)
         assert result == {}
         assert keys == set()
 
-    def test_secret_uri_prefix_only_no_name(self, empty_vault_dir: Path) -> None:
-        """secret:// with empty name still tries to resolve (and fails)."""
-        # The regex requires at least one char after secret://
+    def test_secret_uri_prefix_only_no_name_raises(self, empty_vault_dir: Path) -> None:
+        """secret:// with an empty name now fails closed (was: passed through).
+
+        The literal ``secret://`` template must never reach the child server
+        env — an empty name is a malformed reference, so it raises before any
+        vault read.
+        """
         env = {"KEY": "secret://"}
-        # Should pass through since regex requires .+ after secret://
+        with pytest.raises(ValueError, match="malformed secret:// reference"):
+            resolve_secret_uris(env, empty_vault_dir)
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            " ",  # whitespace only — strips to empty at the store, can never exist
+            " MY_KEY",  # leading space — the store strips it, cannot round-trip
+            "MY_KEY\n",  # trailing newline — stripped at the store
+            "MY_KEY ",  # trailing space — stripped at the store
+        ],
+    )
+    def test_invalid_secret_name_raises(self, empty_vault_dir: Path, bad_name: str) -> None:
+        """A name that cannot round-trip through the store fails closed.
+
+        The store ``.strip()``s names before writing, so an empty name or one
+        with leading/trailing whitespace can never match a stored entry — the
+        reference is malformed by construction and must not pass the literal
+        template into the child env.
+        """
+        env = {"KEY": f"secret://{bad_name}"}
+        with pytest.raises(ValueError, match="malformed secret:// reference"):
+            resolve_secret_uris(env, empty_vault_dir)
+
+    def test_missing_secret_error_never_echoes_the_name(self, empty_vault_dir: Path) -> None:
+        """No resolution error ever echoes the secret name (CWE-117 sink guard).
+
+        Storable names may legally contain newlines, bidi overrides, or
+        zero-width characters; charset filtering here would strand stored
+        entries, so injection is closed at the SINK instead — the error names
+        only the operator-declared env-var key, never the referenced name.
+        """
+        env = {"API_KEY": "secret://MY\nEVIL\u202eKEY"}
+        with pytest.raises(ValueError) as exc:
+            resolve_secret_uris(env, empty_vault_dir)
+        msg = str(exc.value)
+        assert "API_KEY" in msg
+        assert "EVIL" not in msg
+        assert "\n" not in msg.replace("\\n", "")
+        assert "\u202e" not in msg
+
+    def test_punctuation_names_the_vault_accepts_resolve(self, tmp_path: Path) -> None:
+        """Names the vault legitimately stores (hyphen/dot) are NOT rejected.
+
+        The dashboard set path (`/api/secrets`) accepts any non-empty stripped
+        name, so validation must not be stricter than what the vault can hold —
+        only control/format/line-break chars and unstorable shapes are rejected.
+        """
+        from kiro_crew.secrets import SecretVault
+
+        vault = SecretVault(tmp_path)
+        vault._set_sync("my-api-key", "v-hyphen")
+        vault._set_sync("my.token", "v-dot")
+        env = {
+            "A": "secret://my-api-key",
+            "B": "secret://my.token",
+        }
+        result, keys = resolve_secret_uris(env, tmp_path)
+        assert result["A"] == "v-hyphen"
+        assert result["B"] == "v-dot"
+        assert keys == {"A", "B"}
+
+    def test_valid_name_with_interior_space_resolves(self, tmp_path: Path) -> None:
+        """A stored name containing an ordinary space stays resolvable.
+
+        The dashboard stores ``MY KEY`` (any non-empty stripped string), so a
+        ``secret://MY KEY`` reference must resolve — rejecting it would make
+        the stored entry unreachable and block MCP spawn for a name the
+        product's own write path accepted.
+        """
+        from kiro_crew.secrets import SecretVault
+
+        vault = SecretVault(tmp_path)
+        vault._set_sync("MY KEY", "v-space")
+        env = {"A": "secret://MY KEY"}
+        result, keys = resolve_secret_uris(env, tmp_path)
+        assert result["A"] == "v-space"
+        assert keys == {"A"}
+
+    def test_stored_unicode_and_control_names_resolve(self, tmp_path: Path) -> None:
+        """Every storable name resolves — including unusual Unicode.
+
+        The write path (`/api/secrets`) accepts any non-empty stripped string,
+        so names with a ZWJ, private-use character, or interior newline are
+        real vault entries. Rejecting them at resolution would abort MCP spawn
+        for a name the product accepted; injection safety comes from never
+        echoing names in errors, not from refusing to resolve.
+        """
+        from kiro_crew.secrets import SecretVault
+
+        vault = SecretVault(tmp_path)
+        vault._set_sync("MY\u200dKEY", "v-zwj")  # zero-width joiner (Cf)
+        vault._set_sync("MY\ue000KEY", "v-pua")  # private use (Co)
+        vault._set_sync("MY\nKEY", "v-nl")  # interior newline (Cc)
+        env = {
+            "A": "secret://MY\u200dKEY",
+            "B": "secret://MY\ue000KEY",
+            "C": "secret://MY\nKEY",
+        }
+        result, keys = resolve_secret_uris(env, tmp_path)
+        assert result["A"] == "v-zwj"
+        assert result["B"] == "v-pua"
+        assert result["C"] == "v-nl"
+        assert keys == {"A", "B", "C"}
+
+    def test_valid_underscore_and_digits_name_resolves(self, tmp_path: Path) -> None:
+        """A name matching the env-var-key grammar resolves normally."""
+        from kiro_crew.secrets import SecretVault
+
+        vault = SecretVault(tmp_path)
+        vault._set_sync("JIRA_TOKEN_9f8e", "tok-123")
+        vault._set_sync("_LEADING_UNDERSCORE", "u-1")
+        env = {
+            "A": "secret://JIRA_TOKEN_9f8e",
+            "B": "secret://_LEADING_UNDERSCORE",
+        }
+        result, keys = resolve_secret_uris(env, tmp_path)
+        assert result["A"] == "tok-123"
+        assert result["B"] == "u-1"
+        assert keys == {"A", "B"}
+
+    def test_batch_reads_store_once_for_multiple_refs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """K secret refs trigger exactly one store load and one key read.
+
+        Counts calls on the SecretVault class methods (reader-agnostic: patched
+        on the class, so it holds regardless of how get_many is wired
+        internally) to prove the spawn path no longer re-reads the store and
+        key file per reference.
+        """
+        from kiro_crew.secrets import SecretVault
+        from kiro_crew.secrets.vault import SecretVault as VaultClass
+
+        vault = SecretVault(tmp_path)
+        vault._set_sync("S1", "v1")
+        vault._set_sync("S2", "v2")
+        vault._set_sync("S3", "v3")
+
+        load_calls = 0
+        key_calls = 0
+        orig_load = VaultClass._load_entries
+        orig_key = VaultClass._get_or_create_key
+
+        def counting_load(self):  # type: ignore[no-untyped-def]
+            nonlocal load_calls
+            load_calls += 1
+            return orig_load(self)
+
+        def counting_key(self):  # type: ignore[no-untyped-def]
+            nonlocal key_calls
+            key_calls += 1
+            return orig_key(self)
+
+        monkeypatch.setattr(VaultClass, "_load_entries", counting_load)
+        monkeypatch.setattr(VaultClass, "_get_or_create_key", counting_key)
+
+        env = {
+            "A": "secret://S1",
+            "B": "secret://S2",
+            "C": "secret://S3",
+            "D": "plain",
+        }
+        result, keys = resolve_secret_uris(env, tmp_path)
+        assert result["A"] == "v1"
+        assert result["B"] == "v2"
+        assert result["C"] == "v3"
+        assert result["D"] == "plain"
+        assert keys == {"A", "B", "C"}
+        # Exactly one store load and one key read for 3 references.
+        assert load_calls == 1
+        assert key_calls == 1
+
+    def test_no_vault_touch_when_no_refs(
+        self, empty_vault_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pass-through-only env never constructs a vault read."""
+        from kiro_crew.secrets.vault import SecretVault as VaultClass
+
+        def boom(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("vault must not be read when there are no refs")
+
+        monkeypatch.setattr(VaultClass, "_load_entries", boom)
+        env = {"HOST": "localhost", "PORT": "5432"}
         result, keys = resolve_secret_uris(env, empty_vault_dir)
-        assert result["KEY"] == "secret://"
+        assert result == env
         assert keys == set()
 
     def test_partial_secret_prefix_not_resolved(self, vault_dir: Path) -> None:

--- a/test/test_secrets_vault.py
+++ b/test/test_secrets_vault.py
@@ -294,3 +294,165 @@ def test_vault_dir_is_hidden_by_the_os_sandbox() -> None:
             ".kiro/crew/.vault" in mode_list
         ), "the vault dir must be OS-sandbox-hidden in every mode"
         assert ".kirocrew/.vault" in mode_list, "the legacy vault dir path must also be hidden"
+
+
+# ── get_many: single-load batch read ──
+
+
+@pytest.mark.asyncio
+async def test_get_many_roundtrip(vault: SecretVault) -> None:
+    """get_many returns SecretValues for present names and None for absent."""
+    await vault.set("A", "va")
+    await vault.set("B", "vb")
+
+    result = vault.get_many(["A", "B", "MISSING"])
+    assert result["A"] is not None and result["A"].reveal() == "va"
+    assert result["B"] is not None and result["B"].reveal() == "vb"
+    assert result["MISSING"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_many_empty_list(vault: SecretVault) -> None:
+    """get_many([]) returns an empty mapping and reads nothing."""
+    await vault.set("A", "va")
+    assert vault.get_many([]) == {}
+
+
+def test_get_many_loads_store_and_key_once(tmp_path, monkeypatch) -> None:
+    """get_many reads secrets.enc once and the key file once for K names."""
+    vault = SecretVault(tmp_path)
+    vault._set_sync("A", "va")
+    vault._set_sync("B", "vb")
+    vault._set_sync("C", "vc")
+
+    load_calls = 0
+    key_calls = 0
+    orig_load = SecretVault._load_entries
+    orig_key = SecretVault._get_or_create_key
+
+    def counting_load(self):
+        nonlocal load_calls
+        load_calls += 1
+        return orig_load(self)
+
+    def counting_key(self):
+        nonlocal key_calls
+        key_calls += 1
+        return orig_key(self)
+
+    monkeypatch.setattr(SecretVault, "_load_entries", counting_load)
+    monkeypatch.setattr(SecretVault, "_get_or_create_key", counting_key)
+
+    result = vault.get_many(["A", "B", "C"])
+    assert {k: v.reveal() for k, v in result.items() if v} == {
+        "A": "va",
+        "B": "vb",
+        "C": "vc",
+    }
+    assert load_calls == 1
+    assert key_calls == 1
+
+
+def test_get_many_all_missing_does_not_create_key(tmp_path) -> None:
+    """get_many for names none of which exist does not create a key file.
+
+    Matches get()'s behaviour (returns before _get_or_create_key for a missing
+    name), so a spawn that references only absent secrets on a fresh vault does
+    not materialise vault key state.
+    """
+    vault = SecretVault(tmp_path)
+    result = vault.get_many(["NOPE", "ALSO_NOPE"])
+    assert result == {"NOPE": None, "ALSO_NOPE": None}
+    assert not (tmp_path / ".vault" / ".vault_key").exists()
+
+
+# ── Corrupt-store error contract ──
+
+
+def _seed_key(tmp_path: Path) -> None:
+    (tmp_path / ".vault").mkdir(exist_ok=True)
+    (tmp_path / ".vault" / ".vault_key").write_bytes(os.urandom(32))
+    os.chmod(str(tmp_path / ".vault" / ".vault_key"), 0o600)
+
+
+def _write_store(tmp_path: Path, entries) -> None:
+    store = {"version": 1, "backend": "file", "entries": entries}
+    (tmp_path / ".vault" / "secrets.enc").write_text(json.dumps(store))
+
+
+def test_corrupt_entries_not_a_dict_raises(tmp_path) -> None:
+    """A non-mapping 'entries' fails closed with a descriptive ValueError."""
+    _seed_key(tmp_path)
+    _write_store(tmp_path, ["not", "a", "dict"])
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="Vault store corrupt: 'entries' must be an object"):
+        vault._load_entries()
+
+
+def test_corrupt_string_entry_raises_from_get(tmp_path) -> None:
+    """A string entry (not a dict) raises a descriptive ValueError from get()."""
+    _seed_key(tmp_path)
+    _write_store(tmp_path, {"A": "i-am-not-an-entry-dict"})
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="Vault store corrupt: an entry is malformed"):
+        vault.get("A")
+
+
+def test_corrupt_null_entry_is_malformed_not_missing_in_get_many(tmp_path) -> None:
+    """A JSON ``null`` entry raises corrupt-store, not a missing-name ``None``.
+
+    ``entries.get(name)`` would fold a corrupt ``null`` value into the
+    missing-name branch, telling the operator to store a secret that IS in the
+    (corrupt) store. Membership is checked first so the null reaches
+    ``_decrypt_entry`` and fails closed with the corrupt-store message.
+    """
+    _seed_key(tmp_path)
+    _write_store(tmp_path, {"A\u202eEVIL": None})
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError) as exc:
+        vault.get_many(["A\u202eEVIL"])
+    msg = str(exc.value)
+    assert "Vault store corrupt: an entry is malformed" in msg
+    # The sink rule holds one layer down too: the caller-supplied entry name
+    # (which may carry injection-capable characters) never appears in the
+    # error text.
+    assert "EVIL" not in msg
+    assert "\u202e" not in msg
+
+
+def test_corrupt_missing_nonce_raises_from_get(tmp_path) -> None:
+    """An entry missing 'nonce' raises a descriptive ValueError."""
+    _seed_key(tmp_path)
+    _write_store(tmp_path, {"A": {"ct": "abcd"}})
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="Vault store corrupt: an entry is malformed"):
+        vault.get("A")
+
+
+def test_corrupt_bad_hex_raises_from_get(tmp_path) -> None:
+    """An entry with non-hex nonce/ct raises a descriptive ValueError."""
+    _seed_key(tmp_path)
+    _write_store(tmp_path, {"A": {"nonce": "zzzz", "ct": "zzzz"}})
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="Vault store corrupt: an entry is malformed"):
+        vault.get("A")
+
+
+def test_corrupt_error_does_not_leak_material(tmp_path) -> None:
+    """The corrupt-entry error carries no ciphertext/plaintext material."""
+    _seed_key(tmp_path)
+    secret_ct = "deadbeefdeadbeefdeadbeef"
+    _write_store(tmp_path, {"A": {"nonce": "zz", "ct": secret_ct}})
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError) as exc:
+        vault.get("A")
+    assert secret_ct not in str(exc.value)
+
+
+def test_corrupt_entry_raises_from_get_many(tmp_path) -> None:
+    """get_many surfaces the same descriptive ValueError on a corrupt entry."""
+    _seed_key(tmp_path)
+    _write_store(tmp_path, {"A": {"nonce": "zzzz", "ct": "zzzz"}})
+    vault = SecretVault(tmp_path)
+    with pytest.raises(ValueError, match="Vault store corrupt: an entry is malformed"):
+        vault.get_many(["A"])


### PR DESCRIPTION
## Problem / Motivation

`secret://NAME` env values are resolved at MCP-server spawn time by `resolve_secret_uris` (`src/kiro_crew/mcp_gateway/secret_uri.py`), backed by `SecretVault` (`src/kiro_crew/secrets/vault.py`). Three defects live on that path:

1. **Perf:** each `secret://` reference calls `vault.get(name)`, and every `get()` re-reads and `json.loads` the entire `secrets.enc` (`_load_entries`) *and* re-reads the key file + runs `restrict_to_owner` (`_get_or_create_key`). K references = K full store loads + K key reads.
2. **Validation:** the matcher `^secret://(.+)$` requires ≥1 char after the scheme, so a value of exactly `secret://` fails the match and the literal template is forwarded into the child server's environment instead of failing closed. Un-storable names (leading/trailing whitespace) are likewise accepted and can never resolve.
3. **Error contract:** `_load_entries` returns `entries` unvalidated and `_decrypt_entry` reads `entry["nonce"]`/`entry["ct"]` + `bytes.fromhex` with no guard, so a corrupt/hand-edited store raises a raw `TypeError`/`KeyError`/bare `ValueError` instead of the module's fail-closed descriptive `ValueError`.

## Why it matters

The spawn path is security-sensitive and latency-sensitive: an operator with several `secret://` refs pays a multiplied filesystem + crypto-setup cost on every cold spawn, a malformed reference silently hands an MCP server a useless `secret://` literal instead of refusing to start, and a corrupt store produces an opaque stack trace rather than a descriptive, non-leaking error. All three weaken a boundary that should fail closed and stay quiet about secret material.

## What changed (motivation → approach → change)

- **Perf (batch read):** added `SecretVault.get_many(names)` which loads `secrets.enc` once and the key once, then decrypts each requested name (preserving per-name found/`None` semantics). It loads the key only when at least one requested name is present, matching `get()`'s "no key materialised for a purely-missing lookup" behaviour. `resolve_secret_uris` now validates all references, then resolves them in a single `get_many` call. Reads stay lock-free by design (atomic `os.replace` makes torn reads impossible) — no locking semantics changed. `get()` is unchanged in contract (it now passes its already-loaded key into `_decrypt_entry`).
- **Validation (fail closed) + non-echoing errors:** any value beginning with `secret://` is now treated as a reference. Validation accepts EVERY name the vault write path can store and rejects only what can never round-trip: the empty name and names with leading/trailing whitespace (`api_secrets_set` strips names before storing, so such a reference can never match a stored entry). No character-class policy is applied — an interior space, control, format, or private-use character is storable, and refusing it would strand a real vault entry and abort MCP spawn for a name the product's own write path accepted. The log-injection concern that would motivate charset filtering is closed at the SINK instead: **no resolution error ever echoes the referenced name** — every message names only the operator-declared env-var key, so a hostile name (bidi override, newline, zero-width) has no text to forge. `ValueError` propagates through the `asyncio.to_thread(resolve_secret_uris, ...)` call in `gatewayd.py` (~L3126) and fails the backend spawn — a useful, fail-closed surface.
- **Error contract:** `_load_entries` now validates `entries` is a dict; `_decrypt_entry` wraps nonce/ct extraction + `fromhex` in a guard that raises `ValueError("Vault store corrupt: ...")` naming the entry but never including ciphertext/plaintext material.

The diff is intentionally minimal and fail-closed throughout.

## Tests

Extended `test/test_secret_uri_resolution.py` and `test/test_secrets_vault.py` (all proven red against `origin/main` where applicable):

- `get_many`: roundtrip, empty list, all-missing does not create a key file, and a call-counting test proving **one** `_load_entries` + **one** `_get_or_create_key` for K names (counts patched on the class → reader-agnostic).
- `resolve_secret_uris`: still resolves / passes through / raises on missing name; batch path reads the store once for multiple refs; no vault read at all when there are no refs.
- Validation: `secret://` (empty) and leading/trailing-whitespace names now raise (was: passed through / unreachable); EVERY storable name resolves — regressions cover interior spaces, ZWJ (Cf), private-use (Co), and interior-newline (Cc) names; no resolution error echoes the referenced name (asserted for newline and bidi-override payloads); punctuation (`my-api-key`, `my.token`) and underscore/digit names still resolve.
- Corrupt store: non-dict `entries`, string entry, missing `nonce`, and bad hex all raise the descriptive `ValueError` from both `get()` and `get_many()`; the error carries no ciphertext material.

## Manual verification

N/A — unit coverage sufficient; this is a backend-only change to a pure-Python resolution/decryption path fully exercised by the added tests. Local gates green: `pytest` (the four affected suites + `test_secrets_migrate`, `test_secrets_handler`, `test_mcp_gateway_shutdown_and_env` — 118+ passing), `black`, `isort`, `flake8`, `mypy` all clean.

## Related Issues

Fixes #6817

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff

## Coexistence with open PR #6041

Open PR #6041 (`feat/security-enforce-secret-cleanup`) also edits `src/kiro_crew/mcp_gateway/secret_uri.py` (adds a `clear_resolved_secrets` helper, a SEL audit event, and `caller_identity`/`source` kwargs on `resolve_secret_uris`) plus `gatewayd.py`. The concerns are complementary — that PR is about post-resolution cleanup/audit, this one about batch reads + input validation + corrupt-store errors — but both edit the body of `resolve_secret_uris`, so whichever lands second will need a small textual merge in that function. This PR does **not** touch `gatewayd.py`, and #6041 does **not** touch `vault.py`, so the vault changes here are conflict-free. (The now-closed PR #4680 does not overlap.)

