### PR TITLE
feat(tips): add curated tip surfacing the secrets vault

### DIFF
--- a/src/kiro_crew/data/tips_curated.json
+++ b/src/kiro_crew/data/tips_curated.json
@@ -211,6 +211,16 @@
       "doc": "",
       "cta_prompt": "",
       "action": { "kind": "route", "label": "Open Remote Crew settings", "route": "/settings/instances" }
+    },
+    {
+      "id": "secrets-vault",
+      "feature": "Secrets Vault",
+      "title": "Store credentials in the encrypted vault",
+      "body": "Keep API keys and tokens out of your config and chat: save them in the encrypted vault under **Settings › Secrets**, then reference one as `secret://KEY` wherever an MCP server takes an env value — it is resolved at launch and never written to disk in the clear.",
+      "why": "",
+      "doc": "",
+      "cta_prompt": "",
+      "action": { "kind": "route", "label": "Open Secrets settings", "route": "/settings/secrets" }
     }
   ]
 }

--- a/test/test_tips.py
+++ b/test/test_tips.py
@@ -1506,8 +1506,15 @@ class TestCuratedTips:
         ids = [t["id"] for t in tips]
         assert len(ids) == len(set(ids)), "curated tip ids must be unique"
         # A few known KiroCrew-native features must be present.
-        for expected in ("split-view", "command-palette", "warm-pool"):
+        for expected in ("split-view", "command-palette", "warm-pool", "secrets-vault"):
             assert expected in ids
+        # The secrets-vault tip routes to the Secrets settings tab.
+        by_id = {t["id"]: t for t in tips}
+        assert by_id["secrets-vault"]["action"] == {
+            "kind": "route",
+            "label": "Open Secrets settings",
+            "route": "/settings/secrets",
+        }
         for t in tips:
             for k in _TIP_ALLOWED_FIELDS:
                 assert isinstance(t.get(k), str), f"{t.get('id')}.{k} must be a string"


### PR DESCRIPTION
## Problem / Motivation

The encrypted secrets vault ships and works end to end — credentials are stored under **Settings › Secrets**, and a `secret://KEY` reference is resolved into an MCP server's environment at spawn time (ephemeral, in-memory only). But nothing in the product surfaces that the vault exists: a user has to already know to go looking for it. The Feature Tips catalog carries 21 curated tips today and none of them mention secrets, so the one feature whose purpose is to keep credentials out of config files and chat has zero discovery surface.

## Why it matters

Users who don't know the vault exists keep pasting API keys and tokens straight into config or chat — the exact exposure the vault was built to remove. A single curated tip, shown through the existing Feature Tips surface, makes the secure path discoverable at the moment it's relevant and routes the user one click away to set it up.

## What changed (motivation → approach → change)

Goal: surface the vault without any new UI. Approach: the curated Feature Tips catalog (`tips_curated.json`) already exists for KiroCrew-native, settings-gated features and renders through the existing TipCard with a route-action CTA — the same mechanism the `split-view`, `mcp-gateway`, and other tips use. So the right change is one data entry, not new code.

Added one curated tip, mirroring the existing entry shape exactly:

- `id` `secrets-vault`, `feature` "Secrets Vault"
- `title` "Store credentials in the encrypted vault"
- `body` points at **Settings › Secrets** and explains referencing a secret as `secret://KEY` for MCP server env values (markdown, matching sibling tips' formatting)
- `action` `{kind: "route", label: "Open Secrets settings", route: "/settings/secrets"}` — verified `/settings/secrets` is the registered Secrets tab route in `SettingsPage.tsx`

The entry passes the `_load_curated_tips` / `_validate_tip_fields` / `_sanitize_tip_action` validation in `tips.py`: all fields are strings, `id`/`title`/`body` are non-empty, the action `kind` is `route`, and the route is an internal path. `doc` is left empty so the tip cannot collide with a catalog-owned doc's dismissal identity.

## Tests

- Extended `test/test_tips.py::TestCuratedTips::test_curated_tips_ship_and_validate` to assert the `secrets-vault` tip is present and pins its action route to `/settings/secrets` with the expected label.
- The full existing curated-tip suite (route validity, no catalog-doc collision, highlight-anchor registry, serve path) passes unchanged.

## Manual verification

N/A — this is a backend data-file change validated by unit coverage. The tip renders through the existing `TipCard` with no frontend change.

## Related Issues

Fixes #6821

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, data-only change
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I agree to contribute this change under the project's Contribution License Agreement.
