### PR TITLE
feat(ci): credit the reporters of issues that merged PRs closed

### DIFF
--- a/.github/workflows/add-contributor.yml
+++ b/.github/workflows/add-contributor.yml
@@ -1,6 +1,7 @@
 name: Add Contributor
 
-# Add the authors of merged pull requests to the README Contributors block.
+# Add the authors of merged pull requests, and the people who reported the issues
+# those pull requests closed, to the README Contributors block.
 # main is a protected branch, so this never commits directly -- it stages the
 # README edit on a single rolling feature branch, opens (or updates) one PR, and
 # arms GitHub auto-merge on it, like test-durations.yml. Auto-merge lets the
@@ -10,11 +11,14 @@ name: Add Contributor
 #
 # Why bespoke instead of an off-the-shelf tool (all-contributors bot, a
 # contrib.rocks embed): this repo's block is hand-curated with human display
-# names, credits by PULL-REQUEST-MERGE semantics (not the broader "contribution"
-# an embed counts), preserves maintainer-added entries verbatim, and must honor
-# an opt-out for removal requests. Those constraints are exactly what the generic
-# tools do not give, which is why the ~1k lines here earn their keep -- do not
-# replace this with the one-liner embed without re-checking all four.
+# names, credits by rules this repo chose and can change (merged PRs and the
+# issues they closed, not whatever an embed counts), preserves maintainer-added
+# entries verbatim, and must honor an opt-out for removal requests. Those
+# constraints are exactly what the generic tools do not give, which is why the ~1k
+# lines here earn their keep -- do not replace this with the one-liner embed
+# without re-checking all four. The all-contributors bot in particular has no
+# discovery of its own: every entry there needs a human comment naming the person,
+# which is the manual step this job exists to remove.
 #
 # Opening the PR is best-effort, not guaranteed: this repository does not allow
 # GitHub Actions to open pull requests ("Allow GitHub Actions to create and
@@ -25,28 +29,30 @@ name: Add Contributor
 # "fix" that by making the step fail again -- it did, daily, unnoticed for weeks.
 #
 # Trigger choice: a daily cron (plus manual dispatch), NOT pull_request_target.
-# Each run re-derives the complete author set by paginating every merged PR (see
-# below), so a per-merge trigger would do the exact same full sweep only sooner --
-# it buys at most 24h of immediacy while permanently carrying a write token in the
-# trusted base-repo context, where any future edit that touched a PR's title, body,
-# or head ref would inherit that privilege. A once-a-day batch also avoids
-# force-pushing the rolling branch on every merge (which would reset its review
-# approval and keep auto-merge from firing). Cron-only keeps the same result with
-# a smaller, static risk surface.
+# Each run re-derives the complete contributor set by paginating every merged PR
+# (see below), so a per-merge trigger would do the exact same full
+# sweep only sooner -- it buys at most 24h of immediacy while permanently carrying
+# a write token in the trusted base-repo context, where any future edit that
+# touched a PR's title, body, or head ref would inherit that privilege. A
+# once-a-day batch also avoids force-pushing the rolling branch on every merge
+# (which would reset its review approval and keep auto-merge from firing).
+# Cron-only keeps the same result with a smaller, static risk surface.
 #
 # Why the rolling branch is rebuilt from base every run AND we enumerate ALL
-# merged-PR authors: the branch is rebuilt from the protected branch each run so
-# it never drifts or carries a stale conflict. A rebuild is only safe if the
-# collection re-derives the COMPLETE set of authors who should appear, so it
-# paginates every merged PR -- not a recent-days window, which would silently drop
-# an author whose contributors PR stayed open past the window while newer PRs
-# merged. The script dedups against the README (which already holds everyone
-# previously credited), so scanning all merged PRs is cheap in effect: only
-# genuinely-new authors ever change the file.
+# merged PRs: the branch is rebuilt from the
+# protected branch each run so it never drifts or carries a stale conflict. A
+# rebuild is only safe if the collection re-derives the COMPLETE set of people who
+# should appear, so it paginates every merged PR -- not a
+# recent-days window, which would silently drop someone whose contributors PR
+# stayed open past the window while newer activity landed. The script dedups
+# against the README (which already holds everyone previously credited), so
+# scanning everything is cheap in effect: only genuinely-new contributors ever
+# change the file.
 
 on:
   schedule:
-    # Daily: credit the previous day's merged-PR authors.
+    # Daily: credit the previous day's merged-PR authors and the reporters of the
+    # issues those PRs closed.
     - cron: "37 6 * * *"
   workflow_dispatch: {}
 
@@ -63,7 +69,7 @@ concurrency:
 
 jobs:
   add:
-    name: Add merged-PR authors to README
+    name: Add contributors to README
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -80,36 +86,97 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Collect merged-PR authors
+      - name: Collect merged-PR authors and the reporters they fixed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          # Enumerate EVERY merged PR's author (paginated), not a recent window:
-          # the branch is rebuilt from base each run, so the collection must
-          # re-derive the complete set or an author whose rolling PR outlived a
-          # bounded window would be dropped. The script dedups against the README,
-          # so only genuinely-new authors ever change the file.
+          # One paginated GraphQL sweep over EVERY merged pull request yields both
+          # sets of people this job credits:
           #
-          # Guard .user != null first: a deleted account returns a null user, and
-          # a bare filter would emit {login: null} and inject a github.com/None
-          # entry. .user.type == "User" then excludes bots (dependabot, renovate,
-          # github-actions, ...), whose type is "Bot". `merged_at != null`
-          # distinguishes a merged PR from one merely closed.
-          gh api --paginate "repos/$REPO/pulls?state=closed&per_page=100&sort=updated&direction=desc" \
-            --jq '.[] | select(.merged_at != null and .user != null and .user.type == "User")
-                      | .user.login' \
-            | sort -u >/tmp/logins.txt
+          #   1. the PR's own author, and
+          #   2. the authors of the issues that PR declared it closes.
+          #
+          # Crediting issue REPORTERS this way, rather than by listing every
+          # issue, is the whole point of the shape: `closingIssuesReferences` is
+          # populated only when a pull request says it closes the issue (a
+          # "Fixes #N" style link), and we only look at MERGED pull requests, so
+          # an entry here is evidence the report actually changed the product.
+          # Listing all issues instead would credit a duplicate, an invalid
+          # report, or an issue opened purely to farm a contribution -- which is
+          # exactly what this filter exists to keep out. The trade-off is a known
+          # UNDERCOUNT: a real bug fixed by a PR that forgot the closing keyword
+          # is not visible here, and the remedy is the manual --login path, not
+          # loosening this to "any issue".
+          #
+          # Enumerate every merged PR, not a recent window: the branch is rebuilt
+          # from base each run, so the collection must re-derive the COMPLETE set
+          # or someone whose rolling PR outlived a bounded window would be
+          # dropped. The script dedups against the README, so only genuinely-new
+          # contributors ever change the file.
+          #
+          # Guard `author != null` first: a deleted account yields a null author,
+          # and a bare filter would emit {login: null} and inject a
+          # github.com/None entry. `__typename == "User"` then excludes bots
+          # (dependabot, renovate, github-actions, ...), whose author type is
+          # "Bot" -- the GraphQL analogue of REST's `.user.type == "User"`.
+          #
+          # `first: 50` on the nested connection is a cap, not a page: a single PR
+          # closing more than 50 issues would truncate. None come close, and the
+          # miss would be a missing credit, never a wrong one.
+          gh api graphql --paginate \
+            -f owner="${REPO%/*}" -f name="${REPO#*/}" \
+            -f query='
+              query($owner: String!, $name: String!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequests(states: MERGED, first: 100, after: $endCursor,
+                               orderBy: {field: UPDATED_AT, direction: DESC}) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      author { login __typename }
+                      closingIssuesReferences(first: 50) {
+                        nodes { author { login __typename } }
+                      }
+                    }
+                  }
+                }
+              }' \
+            --jq '.data.repository.pullRequests.nodes[]' >/tmp/merged.jsonl
+
+          jq -r 'select(.author != null and .author.__typename == "User")
+                 | .author.login' /tmp/merged.jsonl | sort -u >/tmp/pr_logins.txt
+
+          jq -r '.closingIssuesReferences.nodes[]?
+                 | select(.author != null and .author.__typename == "User")
+                 | .author.login' /tmp/merged.jsonl | sort -u >/tmp/issue_logins.txt
+
+          # Union, deduped: someone who both authored a merged PR and reported a
+          # fixed issue appears in both files and must be credited exactly once.
+          # `sort -u` across both is the first of two dedup layers; the second is
+          # the script's own README scan, which is what keeps a daily full rebuild
+          # from ever duplicating an existing entry.
+          sort -u /tmp/pr_logins.txt /tmp/issue_logins.txt >/tmp/logins.txt
+
+          echo "Merged PRs scanned: $(wc -l </tmp/merged.jsonl)."
+          echo "PR authors: $(wc -l </tmp/pr_logins.txt);" \
+               "reporters of closed issues: $(wc -l </tmp/issue_logins.txt);" \
+               "union: $(wc -l </tmp/logins.txt)."
 
           # A coarse set of logins already mentioned in the README, lowercased.
-          # Used ONLY to skip the display-name lookup for authors already
+          # Used ONLY to skip the display-name lookup for people already
           # present, so a steady-state daily run makes ~0 extra API calls while
           # new entries still get the curated "Full Name" convention. The add/skip
           # decision itself is the script's job (precise regex); over-matching
-          # here at worst falls a genuinely-new author back to login-as-name, so
-          # this greedy grep needs no repo-link exclusion.
+          # here at worst falls a genuinely-new contributor back to login-as-name,
+          # so this greedy grep needs no repo-link exclusion.
+          #
+          # The FIRST run after issue reporters were added is the one expensive
+          # run: every reporter not already credited costs one users/<login>
+          # lookup, roughly 90 of them on top of the ~40 GraphQL pages. That is
+          # well inside GITHUB_TOKEN's hourly budget, and it happens once -- from
+          # the next run on they are all in /tmp/known.txt.
           grep -oiE 'https?://(www\.)?github\.com/[A-Za-z0-9][A-Za-z0-9-]*' README.md \
             | sed -E 's#.*/##' | tr '[:upper:]' '[:lower:]' | sort -u >/tmp/known.txt
 
@@ -206,7 +273,7 @@ jobs:
             rc=0
             out="$(gh pr create --repo "$REPO" --base "$BASE" --head "$BRANCH" \
               --title "docs: add new contributors to README" \
-              --body "Automated update of the README Contributors block for authors of recently merged pull requests. Generated by the Add Contributor workflow (\`.github/workflows/add-contributor.yml\`); entries are inserted in sorted order and existing lines are preserved verbatim." 2>&1)" || rc=$?
+              --body "Automated update of the README Contributors block for authors of merged pull requests and the people who reported the issues those pull requests closed. Generated by the Add Contributor workflow (\`.github/workflows/add-contributor.yml\`); entries are inserted in sorted order and existing lines are preserved verbatim." 2>&1)" || rc=$?
             printf '%s\n' "$out"
             if [ "$rc" -ne 0 ]; then
               case "$out" in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -537,17 +537,26 @@ There is one contributor list, the Contributors block in [README.md](README.md).
 Deliberately one: a second table for "other" contributions would rank one kind of
 help above another, and split recognition across two places nobody reads twice.
 
-Merged pull requests are credited automatically — a daily job adds their authors.
-Contributions that never were a pull request are credited in the same block, on
-request: a bug report, a code review, a translation, an idea, a design, a
-private security report. Open an issue naming the person (yourself is fine), and
-a maintainer records it:
+Two things are credited automatically by a daily job: authoring a merged pull
+request, and reporting an issue that a merged pull request closed. You do not need
+to ask for either.
+
+The second rule is deliberately about outcome, not volume. Credit follows a report
+that changed the product, which is why the job reads each merged PR's closing
+references rather than listing every issue — that keeps duplicates, invalid
+reports, and issues opened to farm a credit out of the list. It undercounts on
+purpose: if a pull request fixed your report without writing a closing keyword,
+the link does not exist and the job cannot see it. Ask, and it gets added by hand.
+
+Everything else is credited in the same block on request: a code review, a
+translation, an idea, a design, a private security report. Open an issue naming
+the person (yourself is fine), and a maintainer records it:
 
 ```sh
 python3 scripts/update_contributors.py --login <github-login> --name "Display Name"
 ```
 
-The daily job re-derives the full merged-PR author set and rebuilds its branch
+The daily job re-derives the full contributor set and rebuilds its branch
 from scratch, but it never rewrites or drops an existing line, so a
 manually-added entry survives every later run. A login listed in
 `.github/contributors-optout.txt` is never added by the job, which is how a

--- a/README.md
+++ b/README.md
@@ -1101,9 +1101,11 @@ make this tool possible:
 
 Listed alphabetically by GitHub username. Internal contributors appear here if they
 consented to public recognition in the contributor survey; open-source contributors are
-included from this repository's pull request history, and from contributions that were
-never a pull request at all — a bug report, a code review, a translation, an idea, a
-private security report — added on request. If you contributed and would like to be
+collected automatically from this repository's merged pull requests — both the author of
+each pull request and the people who reported the issues it closed, so a report that
+led to a real change is credited like the change itself. Contributions that leave
+neither trace — a code review, a translation, an idea, a private security report — are
+added on request. If you contributed and would like to be
 added, corrected, or removed, please open an issue or a pull request.
 
 ## License

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -74,13 +74,24 @@ Out-of-band lanes that never gate a PR:
   button, not a CI comment), `pr-merge-conflict-label.yml` and `fork-pr-label.yml`
   (both mirror a fact GitHub does not surface in the `/pulls` list onto a label), and
   `add-contributor.yml` (a daily cron, plus manual dispatch, adds each merged
-  PR's author to the README Contributors block via
+  PR's author AND the reporters of the issues that PR closed to the README
+  Contributors block via
   `scripts/update_contributors.py`; because the default branch is protected it
   opens a rolling PR rather than committing directly, like `test-durations.yml`.
   A login in `.github/contributors-optout.txt` is never added, which keeps the
   README's removal promise enforceable against the full-rebuild collector).
-  The same block also holds contributors whose contribution was never a pull
-  request — a bug report, a review, a private security report — added with
+  One paginated GraphQL sweep over `pullRequests(states: MERGED)` drives it,
+  reading each node's `author` and its `closingIssuesReferences` authors. The
+  reporter side is deliberately keyed on that link rather than on listing
+  `/issues`: the connection is populated only when a PR declares it closes the
+  issue, and only merged PRs are scanned, so an entry is evidence the report
+  changed the product — which keeps duplicates, invalid reports and
+  credit-farming issues out. It undercounts by design (a fix that omitted the
+  closing keyword is invisible), and the remedy is the manual `--login` path, not
+  loosening the rule. Dedup is two-layered: `sort -u` over the union, because
+  someone can be both a PR author and a reporter, then the script's own README
+  scan. The same block also holds contributors whose contribution left neither
+  trace — a review, a translation, a private security report — added with
   `scripts/update_contributors.py --login`. Those entries survive every later run
   because the collector only ever inserts and never rewrites an existing line;
   that preservation is what makes one shared list workable instead of a second

--- a/scripts/update_contributors.py
+++ b/scripts/update_contributors.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Insert merged-PR authors into the README Contributors block.
+"""Insert contributors into the README Contributors block.
+
+The workflow feeds this the authors of merged pull requests and the people who
+reported the issues those pull requests closed; a maintainer can add anyone else by
+hand with --login. This script only WRITES: it never queries GitHub, so which
+contributions count is decided by the caller, not here.
 
 Usage:
     # Add contributors read as JSON from stdin ([{"login", "name"}, ...]).
@@ -379,7 +384,7 @@ def _self_test() -> int:
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
-        description="Add merged-PR authors to the README Contributors block."
+        description="Add contributors to the README Contributors block."
     )
     parser.add_argument("--test", action="store_true", help="run the built-in self-test and exit")
     parser.add_argument("--login", help="single contributor login (alternative to JSON on stdin)")


### PR DESCRIPTION
## Problem

`add-contributor.yml` has exactly one discovery query — merged pull requests:

```
gh api --paginate "repos/$REPO/pulls?state=closed&..." | jq 'select(.merged_at != null ...)'
```

That is the whole set of eyes in this system. `scripts/update_contributors.py`
makes no network calls at all — it reads `[{"login","name"}, ...]` from stdin and
inserts into the README block — so anyone the workflow does not ask GitHub about is
credited nowhere. Someone who reported a bug that then got fixed, without sending
the pull request themselves, falls in that gap.

Since #6656 the README paragraph promises the opposite: it says contributions that
were never a pull request are included. The only mechanism behind that promise was
a maintainer running `--login` by hand, one person at a time.

## Why it matters

**1193** of this repository's issues were closed by a merged pull request, and the
**160** people who reported them are recognised only if a maintainer notices and
types a command. A promise in the README with no collector behind it is the same as
no promise.

## Fix

Symptom: reporters uncredited. Root cause: the finding step asks GitHub only about
pull requests, and the writer cannot compensate because it never queries anything.
So the fix belongs in the collection step, not in the script.

Replace the REST sweep with one paginated GraphQL sweep that returns both sets at
once — each merged PR's author, and the authors of the issues that PR declared it
closes:

```graphql
pullRequests(states: MERGED, first: 100, after: $endCursor,
             orderBy: {field: UPDATED_AT, direction: DESC}) {
  pageInfo { hasNextPage endCursor }
  nodes {
    author { login __typename }
    closingIssuesReferences(first: 50) { nodes { author { login __typename } } }
  }
}
```

**Why the reporter side is keyed on that link and not on listing `/issues`.**
`closingIssuesReferences` is populated only when a pull request declares it closes
the issue, and only MERGED pull requests are scanned. So an entry is evidence the
report actually changed the product. Listing every issue instead would credit
duplicates, invalid reports, and issues opened purely to farm a contribution —
exactly what this rule keeps out. Measured: listing all issues yields 386
reporters; requiring the closing link yields 160.

The trade-off is a deliberate **undercount**: a real bug fixed by a pull request
that forgot the closing keyword is invisible here (1193 of 2193 issues carry the
link, so a little over half). The remedy is the existing manual `--login` path, not
loosening the rule — a rule that can be satisfied by opening an issue is a rule
that gets farmed.

**Dedup, since a person can be both an author and a reporter.** Two layers, and
the first is new: `sort -u` across the two login files, because 72 people appear in
both sets — 147 + 160 = 307 rows collapse to a union of 235. The second layer is
the one that already existed: the script scans the whole README for profile links
and skips anyone present, which is what keeps the daily full rebuild from ever
duplicating an entry.

`__typename == "User"` is the GraphQL analogue of REST's `.user.type == "User"`
(excludes dependabot, renovate, github-actions), and `author != null` guards
deleted accounts, which would otherwise inject a `github.com/None` entry.
`first: 50` on the nested connection is a cap, not a page: a PR closing more than
50 issues would truncate, and the miss would be a missing credit, never a wrong
one.

`scripts/update_contributors.py` needs no behaviour change. Its docstring and
`--help` said "merged-PR authors", which is now wrong, so those are corrected and
it now states plainly that it only writes and never queries.

Riding along, for the same reason: the job name, the collect step's name and the
rolling PR's body text all said "merged-PR authors" and are relabeled, and the
collect step now echoes the three counts (PRs scanned, authors, reporters, union)
so a run's log says what it decided instead of only what it wrote.

The 92-entry backfill is deliberately NOT committed here. The job's own next run
produces it, which keeps this diff the mechanism instead of burying it under 92
README lines, and exercises the handoff path from #6675 end to end.

Docs updated in the same commit: the README paragraph, `CONTRIBUTING.md` (what is
automatic, the outcome rule, and that it undercounts on purpose), and
`docs/ci/ci-and-reviews.md` (the query, the reason for the link requirement, and
both dedup layers).

## Cost

Cheaper than what it replaces: ~40 GraphQL pages over 3744 merged PRs, against 45
REST pages for PRs plus 67 for issues before. The first run additionally spends one
`users/<login>` display-name lookup per uncredited person (~92); from the next run
on they are all in the README, which is what the existing `/tmp/known.txt`
short-circuit checks.

## Tests

`test/test_update_contributors.py` — 55 passed. `scripts/update_contributors.py
--test` — PASS, all 15 cases. `flake8` and `mypy` clean on the script. The workflow
YAML parses with the expected 7 steps and `bash -n` is clean on all 5 `run` blocks.

## Manual verification

Extracted the collect step's `run` body out of the YAML and executed it **verbatim**
against `kirodotdev/KiroCrew` (only its `/tmp` paths redirected into a scratch dir),
then fed the union through the real writer on a **copy** of the README:

1. Step output: `Merged PRs scanned: 3744.` / `PR authors: 147; reporters of closed
   issues: 160; union: 235.`
2. Dedup asserted, not eyeballed: 72 logins in both sets, `sum=307 union=235`, and
   the union file checked to equal the set union and to contain no duplicates.
3. `update_contributors.py --readme <copy>` → `Added 92 contributor(s)`, avatar
   entries **453 → 545**, exit 0, no `contributor block is not a contiguous run`
   error.
4. Re-ran the same records → `No new contributors; README already up to date.`, so
   the daily full rebuild is idempotent.
5. Transport swap proven behaviour-preserving: the GraphQL author set and the REST
   set it replaces are both 147 logins with **zero** difference (`comm -3` empty).
