### PR TITLE
fix(website): stop global chords at the shared Modal panel (#6800)

### DIFF
--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -3618,8 +3618,18 @@ export function Lightbox() {
         if (cur) void downloadLightboxImage(cur.images[cur.index])
       }
     }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    // CAPTURE phase, matching DiagramLightbox: dialog panels (Modal, the Radix
+    // ui/dialog family) stop bubble-phase keydown propagation so the page's
+    // global shortcuts don't fire under them, and this viewer opens ABOVE
+    // those dialogs (a README image inside SkillBrowserModal / McpBrowserModal
+    // etc). With focus still inside the dialog panel, a bubble-phase listener
+    // here never sees the key — arrows/zoom go dead while Escape still works.
+    // Capture runs before any panel handler. It also fixes Escape ordering
+    // over a Modal: this handler's preventDefault now lands BEFORE Modal's
+    // bubble-phase window listener, so its defaultPrevented skip keeps the
+    // modal open and Escape closes only the viewer.
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
   }, [isOpen, zoomIn, zoomOut])
   if (!state) return null
   const img = state.images[state.index]

--- a/website/src/components/Modal.tsx
+++ b/website/src/components/Modal.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { X } from 'lucide-react'
 
 import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap'
+import { useDocumentImeLatch } from '../hooks/useImeGuard'
 import { i18nT } from '../i18n/t'
 interface ModalProps {
   /** Whether the modal is open */
@@ -61,10 +62,47 @@ function ModalDialog({ onClose, title, ariaLabel, footer, headerActions, maxWidt
   // Focus in on open, restore to whatever opened the dialog on close, Escape
   // dismissal, and the Tab/Shift+Tab trap — one implementation shared with the
   // hand-rolled dialogs (see hooks/useDialogFocusTrap). Implemented here rather
-  // than per call site so all ~14 `Modal` users get it.
+  // than per call site so all ~24 `Modal` users get it.
   // Escape remains on Modal's bubble-phase listener so a nested layer can
   // consume it with preventDefault before the outer dialog decides to close.
   useDialogFocusTrap(dialogRef, dismiss, true, false)
+
+  // Keyboard isolation for the whole dialog, the header X button included. The
+  // page's global shortcuts bind bubble-phase `document` keydown
+  // (useKeyboardShortcuts), and some chords deliberately fire while an input
+  // has focus (the Ctrl+digit session jumps, the Settings chord) — unguarded,
+  // one of those typed into a part-filled form navigates away and unmounts the
+  // dialog with the draft still in it. Modal portals its panel to
+  // document.body, but portal events still propagate through the React tree,
+  // so this one handler on the PANEL (not the backdrop) sees every keystroke
+  // inside the dialog and stops it before the page's document-level listener.
+  //
+  // Escape is excepted, and the exception is load-bearing: Modal's own
+  // dismissal is a bubble-phase `window` listener (see the `open` effect
+  // below), and stopPropagation() on the synthetic event also stops the native
+  // event from travelling on to `window` — a blanket stop would break
+  // dismissal for every consumer. (The Radix `ui/dialog` family CAN stop
+  // everything because its dismissal is capture-phase; see
+  // DialogKeyboardIsolation.test.tsx.) Modal's own Escape/Tab handling is
+  // otherwise capture-phase (`useDialogFocusTrap` on window), so the trap
+  // survives the stop.
+  //
+  // One exception to the exception: an Escape the IME owns is cancelling a
+  // candidate list, not the dialog — the latch claims it (consuming the native
+  // event) so it never reaches the window listener and cannot discard a
+  // part-composed draft. The latch is document-tracked because the composing
+  // input can be anywhere inside the dialog; ModalDialog is mounted only while
+  // open, which is the lifecycle the tracking keys on.
+  const imeLatch = useDocumentImeLatch()
+  const isolateKeys = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      // A declined claim consumed the NATIVE event; React walks its own flag
+      // when dispatching to component ancestors, so stop the synthetic too.
+      if (!imeLatch.claimKey(e.nativeEvent)) e.stopPropagation()
+      return
+    }
+    e.stopPropagation()
+  }
 
   // When layoutId is provided, use layout animation (card morph) — no initial/animate/exit needed.
   // Otherwise, use scale+opacity entrance.
@@ -87,6 +125,7 @@ function ModalDialog({ onClose, title, ariaLabel, footer, headerActions, maxWidt
       aria-label={ariaLabel}
       aria-labelledby={ariaLabel ? undefined : titleId}
       tabIndex={-1}
+      onKeyDown={isolateKeys}
       {...motionProps}
       className="bg-card border border-border rounded-xl shadow-2xl w-full flex flex-col pointer-events-auto overflow-hidden outline-none"
       style={{ maxWidth, height, maxHeight: '90vh' }}

--- a/website/src/pages/ChannelPage.tsx
+++ b/website/src/pages/ChannelPage.tsx
@@ -330,7 +330,6 @@ function NewChannelDialog({ onClose, onCreate, presets }: { onClose: () => void;
   const [topic, setTopic] = useState('')
   const [preset, setPreset] = useState(presets[0]?.id || 'custom')
   const topicRef = useRef<HTMLInputElement>(null)
-  const ime = useImeGuard()
 
   // Initial focus belongs on the Topic field — the one input this dialog
   // exists to collect. Modal's shared focus trap focuses the dialog's FIRST
@@ -345,73 +344,52 @@ function NewChannelDialog({ onClose, onCreate, presets }: { onClose: () => void;
     onCreate(topic.trim(), preset)
   }
 
-  // The page's global shortcuts bind bubble-phase document keydown, and some
-  // chords deliberately fire from inside inputs (Ctrl+digit session jumps, the
-  // Settings chord) — unguarded, one of those typed into a part-filled form
-  // navigates away and unmounts the dialog with the text still in it. The old
-  // overlay stopped ALL keydown propagation; Escape must keep bubbling now,
-  // because Modal's own dismissal listens bubble-phase on window (unlike the
-  // Radix dialog family, whose capture-phase dismissal survives a blanket
-  // stop — see DialogKeyboardIsolation.test.tsx). One exception to the
-  // exception: an Escape the IME owns is cancelling a candidate list, not the
-  // dialog — claimKey consumes it (stops propagation) so it never reaches
-  // Modal's listener and cannot discard the composed topic.
-  const isolateKeys = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') { ime.claimKey(e); return }
-    e.stopPropagation()
-  }
-
   return (
-    // The shared Modal owns the backdrop, Escape dismissal, scroll lock, and the
-    // focus trap/restore the hand-rolled overlay lacked. `open` is constant
+    // The shared Modal owns the backdrop, Escape dismissal, keyboard isolation
+    // (global chords stopped at the dialog panel, header X included; Escape
+    // excepted; an IME-owned Escape claimed — see Modal.tsx), scroll lock, and
+    // the focus trap/restore the hand-rolled overlay lacked. `open` is constant
     // because the call site conditionally mounts this component — that is what
     // resets topic/preset on every open (an always-mounted dialog would compute
     // the default preset once, before the presets fetch resolves).
     // `ariaLabel` keeps the dialog's established accessible name ("New channel"),
     // which predates this conversion and differs from the rendered title only in
-    // case.
-    //
-    // The wrapper is the keyboard-isolation boundary for the WHOLE dialog,
-    // header X button included: Modal portals its panel to document.body, but
-    // portal events still propagate through the React tree, so this one
-    // handler sees every keystroke inside the dialog and stops it before the
-    // page's document-level shortcut listener. Modal's own Escape/Tab handling
-    // is capture-phase (window) or excepted by isolateKeys, so dismissal and
-    // the focus trap survive. Not an interactive control — eslint disables
-    // below cover the isolation handler and the label/Input association
+    // case. The eslint disable below covers the label/Input association
     // (label-has-for cannot see through the custom <Input>).
-    /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/label-has-for */
-    <div className="contents" onKeyDown={isolateKeys}>
-      <Modal
-        open
-        onClose={onClose}
-        title={i18nT('pages.channelPage.new_channel_2')}
-        ariaLabel={i18nT('pages.channelPage.new_channel')}
-        maxWidth={384}
-        footer={
-          <>
-            <Btn onClick={onClose}>{i18nT('pages.channelPage.cancel')}</Btn>
-            <Btn onClick={handleCreate} disabled={!topic.trim()} primary>{i18nT('pages.channelPage.create')}</Btn>
-          </>
-        }
-      >
-        <label htmlFor="new-channel-topic" className="block text-[13px] font-medium text-muted mb-1">{i18nT('pages.channelPage.topic')}</label>
-        <Input ref={topicRef} id="new-channel-topic" aria-label={i18nT('pages.channelPage.topic')} value={topic} onChange={e => setTopic(e.target.value)}
-          className="w-full mb-4" {...ime.bindComposition()}
-          placeholder={i18nT('pages.channelPage.e_g_investigate_gamma_deployment_failure')} />
-        <span id="new-channel-preset-label" className="block text-[13px] font-medium text-muted mb-1">{i18nT('pages.channelPage.team_preset')}</span>
-        <div role="radiogroup" aria-labelledby="new-channel-preset-label" className="space-y-1.5">
-          {presets.map(p => (
-            <Btn key={p.id} onClick={() => setPreset(p.id)}
-              className={`w-full text-left px-3 py-2 !rounded-lg text-sm ${preset === p.id ? '!border-accent bg-accent/10 text-text-strong' : '!border-border text-muted hover:bg-bg-hover'}`}>
-              <span className="font-medium">{presetLabel(p)}</span>
-              {p.agents.length > 0 && <span className="text-[13px] text-muted ml-2">({p.agents.map(a => a.role).join(', ')})</span>}
-            </Btn>
-          ))}
-        </div>
-      </Modal>
-    </div>
-    /* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/label-has-for */
+    /* eslint-disable jsx-a11y/label-has-for */
+    <Modal
+      open
+      onClose={onClose}
+      title={i18nT('pages.channelPage.new_channel_2')}
+      ariaLabel={i18nT('pages.channelPage.new_channel')}
+      maxWidth={384}
+      footer={
+        <>
+          <Btn onClick={onClose}>{i18nT('pages.channelPage.cancel')}</Btn>
+          <Btn onClick={handleCreate} disabled={!topic.trim()} primary>{i18nT('pages.channelPage.create')}</Btn>
+        </>
+      }
+    >
+      <label htmlFor="new-channel-topic" className="block text-[13px] font-medium text-muted mb-1">{i18nT('pages.channelPage.topic')}</label>
+      {/* No composition tracking here: the IME-owned-Escape claim moved into
+        * Modal with the keyboard boundary, and Modal's document-tracked latch
+        * hears this input's composition events natively — a local latch would
+        * have no reader. */}
+      <Input ref={topicRef} id="new-channel-topic" aria-label={i18nT('pages.channelPage.topic')} value={topic} onChange={e => setTopic(e.target.value)}
+        className="w-full mb-4"
+        placeholder={i18nT('pages.channelPage.e_g_investigate_gamma_deployment_failure')} />
+      <span id="new-channel-preset-label" className="block text-[13px] font-medium text-muted mb-1">{i18nT('pages.channelPage.team_preset')}</span>
+      <div role="radiogroup" aria-labelledby="new-channel-preset-label" className="space-y-1.5">
+        {presets.map(p => (
+          <Btn key={p.id} onClick={() => setPreset(p.id)}
+            className={`w-full text-left px-3 py-2 !rounded-lg text-sm ${preset === p.id ? '!border-accent bg-accent/10 text-text-strong' : '!border-border text-muted hover:bg-bg-hover'}`}>
+            <span className="font-medium">{presetLabel(p)}</span>
+            {p.agents.length > 0 && <span className="text-[13px] text-muted ml-2">({p.agents.map(a => a.role).join(', ')})</span>}
+          </Btn>
+        ))}
+      </div>
+    </Modal>
+    /* eslint-enable jsx-a11y/label-has-for */
   )
 }
 

--- a/website/src/test/Modal.keyboardIsolation.test.tsx
+++ b/website/src/test/Modal.keyboardIsolation.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Modal — keyboard isolation.
+ *
+ * A dialog holding unsaved input must not let the page's global shortcuts fire
+ * underneath it. `useKeyboardShortcuts` binds `document.addEventListener
+ * ('keydown', ...)` in the BUBBLE phase (plus a `window` binding for the
+ * Ctrl-held badge), and several chords deliberately fire while an input has
+ * focus — so a Ctrl+digit typed into a half-filled form would otherwise reach
+ * it, navigate away, and unmount the dialog with the input still in it. The
+ * `ui/dialog` family carries this guard (see DialogKeyboardIsolation.test.tsx);
+ * the shared Modal has to as well — in the component, not per call site, so
+ * all ~24 consumers get it.
+ *
+ * The guard must be surgical, and the surgical part differs from ui/dialog:
+ * Modal's own dismissal is a BUBBLE-phase `window` listener, so unlike Radix's
+ * capture-phase dismissal it does NOT survive a blanket stop. Escape must keep
+ * bubbling (asserted here), except an Escape the IME owns — that one is
+ * cancelling a candidate list, not the dialog, and must NOT dismiss (also
+ * asserted here).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import Modal from '../components/Modal'
+import { Lightbox } from '../components/MarkdownRenderer'
+
+function renderModal(onClose = vi.fn()) {
+  render(
+    <Modal open onClose={onClose} title="T">
+      <input aria-label="field" />
+    </Modal>,
+  )
+  return onClose
+}
+
+describe('Modal — keyboard isolation', () => {
+  it('does not let a chord from inside reach a bubble-phase document or window listener', () => {
+    const documentShortcut = vi.fn()
+    const windowShortcut = vi.fn()
+    document.addEventListener('keydown', documentShortcut)
+    window.addEventListener('keydown', windowShortcut)
+    try {
+      renderModal()
+      // A real Ctrl+3 (a session-jump chord that deliberately fires from
+      // inside inputs), dispatched AT the field so it bubbles the way a
+      // browser would deliver it.
+      fireEvent.keyDown(screen.getByLabelText('field'), { key: '3', code: 'Digit3', ctrlKey: true })
+      expect(documentShortcut).not.toHaveBeenCalled()
+      expect(windowShortcut).not.toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('keydown', documentShortcut)
+      window.removeEventListener('keydown', windowShortcut)
+    }
+  })
+
+  it('keeps the header X button inside the boundary', () => {
+    // The X button is one Shift+Tab from any form field; a chord fired while
+    // it holds focus must not leak either. It lives in the dialog header,
+    // OUTSIDE any caller-rendered content, so only a boundary owned by Modal
+    // itself can cover it — this is the assertion a call-site wrapper cannot
+    // strengthen.
+    const globalShortcut = vi.fn()
+    document.addEventListener('keydown', globalShortcut)
+    try {
+      renderModal()
+      fireEvent.keyDown(screen.getByLabelText('Close'), { key: ',', code: 'Comma', metaKey: true })
+      expect(globalShortcut).not.toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('keydown', globalShortcut)
+    }
+  })
+
+  it('still dismisses on a plain Escape fired from inside the dialog', () => {
+    // The half that makes the guard surgical rather than a dismissal bug:
+    // Modal listens for Escape on window BUBBLE phase, and stopPropagation()
+    // on the synthetic event also stops the native event from travelling on
+    // to window — so a blanket stop would break every consumer's Escape. This
+    // pins that Escape is excepted from the boundary.
+    const onClose = renderModal()
+    fireEvent.keyDown(screen.getByLabelText('field'), { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dismiss on an Escape the IME owns (candidate-list cancel)', async () => {
+    // A CJK user cancelling the IME candidate list mid-composition is not
+    // cancelling the dialog: that Escape must never reach Modal's window
+    // listener, or the part-composed draft is destroyed with the dialog.
+    const onClose = renderModal()
+    const field = screen.getByLabelText('field')
+    fireEvent.change(field, { target: { value: '频道' } })
+    fireEvent.compositionStart(field)
+    fireEvent.keyDown(field, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+    // After the composition ends (and its post-composition window passes), a
+    // real Escape dismisses again. 60ms clears POST_COMPOSITION_MS (50ms in
+    // useImeGuard.ts — not exported; the sibling ChannelPageCoverage test
+    // carries the same margin).
+    fireEvent.compositionEnd(field)
+    await new Promise(r => setTimeout(r, 60))
+    fireEvent.keyDown(field, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reaches a CAPTURE-phase document listener with a non-Escape key', () => {
+    // The property that keeps Modal's own machinery alive: useDialogFocusTrap's
+    // Tab trap listens on window CAPTURE, and useKeyboardShortcuts has two
+    // capture-phase document listeners. Capture runs before the event descends
+    // to the panel, so the boundary cannot (and must not) starve them. A future
+    // "hardening" that moved the guard to a capture-phase or document-level
+    // listener would pass every other test here while breaking the trap — this
+    // is the rail against that.
+    const capturing = vi.fn()
+    document.addEventListener('keydown', capturing, { capture: true })
+    try {
+      renderModal()
+      fireEvent.keyDown(screen.getByLabelText('field'), { key: '3', code: 'Digit3', ctrlKey: true })
+      expect(capturing).toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('keydown', capturing, { capture: true })
+    }
+  })
+
+  it('keeps the image Lightbox keyboard alive above a Modal', () => {
+    // The Lightbox is an App-level singleton rendered OUTSIDE any modal, but a
+    // README image inside a Modal body (SkillBrowserModal, McpBrowserModal,
+    // SteeringTab) opens it while focus stays inside the dialog panel — the
+    // panel is tabIndex={-1}, so even clicking the image focuses the panel,
+    // not body. The viewer's keydown listener is window CAPTURE
+    // (MarkdownRenderer's Lightbox effect, matching DiagramLightbox), which
+    // runs before the panel boundary; a bubble-phase listener there would go
+    // silently dead for every key but Escape.
+    render(<Lightbox />)
+    renderModal()
+    act(() => {
+      window.dispatchEvent(new CustomEvent('lightbox', {
+        detail: { images: [{ src: 'a.png', alt: 'a' }, { src: 'b.png', alt: 'b' }], index: 0 },
+      }))
+    })
+    expect(screen.getByAltText('a')).toBeInTheDocument()
+    // ArrowRight dispatched AT the field inside the panel — the exact path the
+    // boundary stops for bubble-phase listeners.
+    act(() => {
+      fireEvent.keyDown(screen.getByLabelText('field'), { key: 'ArrowRight' })
+    })
+    expect(screen.getByAltText('b')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

A dialog holding a form must not let the page's global keyboard shortcuts fire from inside it. `useKeyboardShortcuts` binds bubble-phase `document` keydown (plus a `window` binding for the Ctrl-held badge), and several chords deliberately fire while an input has focus (the Ctrl+digit session jumps, the Settings chord). The shared `Modal` had no keyboard boundary on its dialog panel, so a chord typed into a part-filled form navigated away and unmounted the dialog with the draft still in it.

PR #6796 shipped the guard at exactly one call site (the new-channel dialog in `ChannelPage`). This PR lifts that already-reviewed guard into `Modal` itself, so all ~24 consumers get it, and deletes the call-site wrapper.

Closes #6800

## What changed

- **`website/src/components/Modal.tsx`** — bubble-phase `onKeyDown` on the dialog PANEL (`ModalDialog`'s `role="dialog"` element, not the backdrop). It stops propagation of every key EXCEPT Escape:
  - Escape must keep bubbling: Modal's own dismissal is a bubble-phase `window` listener, and `stopPropagation()` on the synthetic event also stops the native event from travelling on to `window` — a blanket stop (the shape the Radix `ui/dialog` family can afford, because its dismissal is capture-phase) would break dismissal for every consumer.
  - An Escape the IME owns (candidate-list cancel) is claimed via the shared `useDocumentImeLatch`, so it never reaches the window listener and cannot discard a part-composed draft. The claim consumes the native event; the synthetic propagation flag is stopped too, per the `claimKey` contract.
  - The `defaultPrevented` skip (nested overlays consuming their own Escape) and `guardAccidentalDismiss` semantics are untouched. The focus trap is unaffected: `useDialogFocusTrap` listens on `window` CAPTURE, which runs before the panel handler.
- **`website/src/pages/ChannelPage.tsx`** — the #6796 wrapper (`isolateKeys` + the `className="contents"` div) is deleted. The dialog's `useImeGuard` instance goes with it: with the keydown claim moved into Modal (whose document-tracked latch hears this input's composition events natively), the local latch had no remaining reader, and an unread `bindComposition` spread can mask a future unguarded Enter branch from the `ImeEnterClaimRatchet` scans. The sibling `onKeyDown` handlers of the rename/error dialogs are untouched.
- **`website/src/components/MarkdownRenderer.tsx`** — the image Lightbox's `window` keydown listener moves to CAPTURE phase, matching its sibling `DiagramLightbox`. Found by pre-push review (see below): the viewer opens ABOVE dialog panels that stop bubble-phase keydown, and the panel is `tabIndex={-1}` so focus stays inside it — with a bubble listener, arrows/zoom/download went silently dead while Escape kept working. This was already the live behavior inside the Radix `ui/dialog` family on main (its `DialogContent` blanket-stops keydown); the flip retires the defect class instead of adding a second instance. It also corrects Escape layering over a Modal: the viewer's `preventDefault` now lands before Modal's `defaultPrevented` skip, so Escape closes only the viewer instead of both.
- **`website/src/test/Modal.keyboardIsolation.test.tsx`** — six tests modeled on `DialogKeyboardIsolation.test.tsx`: a chord from inside reaches neither `document` nor `window` bubble listeners; the header X button is inside the boundary; a plain Escape from inside still dismisses; an IME-owned Escape does not (and dismissal recovers after the composition window); a capture-phase listener still sees non-Escape keys (the rail protecting the focus trap and the capture-phase shortcut handlers); the Lightbox stays keyboard-alive above a Modal.

## Consumer survey (issue Fix Strategy step 4)

All 24 non-test `Modal` importers were surveyed. No consumer relies on a global chord firing from inside a Modal. The only native bubble-phase global keydown listeners among them serve page-level menus outside any Modal span (`ChannelPage:237`, `DevFleetPage:370`; `DevFleetPage:511` is capture-phase). In-modal `onKeyDown` handlers (McpBrowserModal, SkillBrowserModal, FolderConfigModal, etc.) run on descendants before the panel handler and are unaffected.

**Disclosed interaction — overlays that portal ABOVE a Modal as React siblings.** The panel boundary covers the Modal's own React subtree (portal events propagate through the React tree, which is also how the #6796 wrapper worked). Overlay components rendered as React *siblings* of the Modal — `ProjectPicker` in `FolderConfigModal` (portals at z-9999 next to `</Modal>`), `SimpleSelect`'s popup in the same dialog — are outside it, so a chord typed inside those popovers still reaches the global listener, exactly as it did before this PR (that dialog previously had no guard at all; the #6796 wrapper never covered any picker either). This PR strictly adds protection and removes none. Fixing the sibling-portal overlay class needs its own design decision (wrap them into the dialog's React subtree vs. give the overlay layer its own boundary) — filed as a follow-up rather than invented here, per the issue's own scope discipline. The `Lightbox` singleton was the one member of that class actually regressed by the new boundary (it is keyboard-driven while visually above the modal), and it is fixed in this PR via the capture flip.

## Pre-push review (dual model-pinned)

- **GPT 5.6 Sol** — BLOCKING(1): the `ProjectPicker`-over-`FolderConfigModal` path still reaches the global listener. Verified accurate as a *description* but rebutted as a defect of this change: it is pre-existing on the base commit (that dialog had no guard anywhere), unmodified by this diff, and out of the issue's stated scope; disclosed above and tracked in a follow-up issue.
- **Opus 5** — BLOCKING(1): the Lightbox bubble-listener starvation, with the correct observation that the panel's `tabIndex={-1}` keeps focus inside the panel (defeating the "focus lands on body" assumption). Adopted: capture flip + differential regression test. Advisories adopted: dead IME latch removed from `NewChannelDialog`, capture-phase rail test added, stale "~14 users" comment corrected. Declined with cause: deduplicating the two `useDocumentImeLatch` instances (requires changing `useDialogFocusTrap`'s public API for a 3-listener saving — follow-up material, not this fix); importing `POST_COMPOSITION_MS` into the test (the constant is unexported and `useImeGuard.ts` is reference-only for this change; the 60ms margin is documented and matches the sibling `ChannelPageCoverage` test).

## Overlap note

Open issue #5481 also proposes edits to Modal's Escape/IME handling (IME-guarding the two `handleEscape=false` consumers). It is held under a human flag and is NOT implemented here; this PR touches neither `useDialogFocusTrap`'s `handleEscape=false` path nor any consumer's own Escape listener, but expect file overlap in `Modal.tsx` if #5481 moves.

## Verification

- New tests differentially red: 3/6 fail on pre-change code (missing boundary), 2/6 fail against a blanket-`stopPropagation` mis-implementation (the dismissal regression), the Lightbox test fails against the bubble-phase listener. The capture-rail test is green pre- and post-change by design (it pins an invariant both share).
- Full frontend suite: 1639 files / 25950 tests passed (plus 1 expected-fail, 3 skipped). `npx tsc -b` clean; `eslint src/ --max-warnings 659` passes with zero new warnings; jscpd 0 clones; i18n untouched (no new user-facing strings).
- Backend gates: isort/flake8/mypy clean; full pytest run 74619 passed with 85 failures + 2 errors, all in the known host-environment class (file_explorer/design_tweak/host_isolation_floor sandbox limitations), none in any file this website-only diff touches.
- No UI pixels change; no screenshots required (pure event plumbing).

<!-- no-visual-delta -->
**Why no screenshot:** Pure keyboard-event plumbing — the diff adds/removes keydown handlers and comments only; no layout, style, markup structure, or rendered pixel changes on any surface (the one markup deletion, ChannelPage's `display: contents` wrapper div, is by definition box-less and paints nothing).
