### PR TITLE
fix(appstore): report the installed version on an app's detail page

### DIFF
--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -315,7 +315,17 @@ export default function AppDetailPage() {
             name: installed.name,
             displayName: installed.displayName || m.displayName || installed.name,
             description: m.description || '',
-            version: registryEntry?.version || m.version || installed.version || '0.0.0',
+            // The installed record wins, and the registry row is the LAST
+            // resort. Version is the one field where the catalog does not get
+            // to speak for the machine: the row is fetched from the network and
+            // cached, so it can name an older version than the clone installed
+            // here — a repo publishing 0.1.0 while this machine runs 0.2.0. The
+            // built-in branch above resolves it the same way
+            // (`mergeBuiltinRow(registryEntry, { ...m, version: installed.version })`,
+            // whose contract names version as its one reversed field), so both
+            // branches agree rather than disagreeing the way the comment there
+            // records for `author`.
+            version: installed.version || m.version || registryEntry?.version || '0.0.0',
             author: m.author || registryEntry?.author || '',
             icon: registryEntry?.icon || m.ui?.pages?.[0]?.icon || '',
             // `iconPath` is preferred over a manifest-declared `iconUrl` for the

--- a/website/src/test/AppDetailPage.test.tsx
+++ b/website/src/test/AppDetailPage.test.tsx
@@ -295,3 +295,51 @@ describe('AppDetailPage — malformed registry guidance', () => {
     expect(screen.queryByText('Configuration')).toBeNull()
   })
 })
+
+describe('AppDetailPage — version reported for an installed app', () => {
+  beforeEach(() => {
+    getApp.mockReset()
+    listRegistry.mockReset()
+    system.mockReset()
+    system.mockResolvedValue({ hostname: '' })
+  })
+
+  // The registry row is fetched from the network and cached, so it can name an
+  // OLDER version than the one on this machine — a repo still publishing 1.0.0
+  // while the user installed a 1.2.0 clone from a local directory. The header
+  // must report what is installed; letting the row win makes the page state a
+  // version the user does not have.
+  it('reports the installed version, not the version the registry row publishes', async () => {
+    getApp.mockResolvedValue(EXTERNAL)
+    listRegistry.mockResolvedValue({
+      apps: [{ ...ART_LESS_ROW, version: '1.0.0' }],
+      serverPlatform: { os: 'linux', arch: 'x86_64' },
+    })
+    renderDetail('some-app')
+
+    await screen.findByTestId('app-icon')
+    // Rendered as `<author> v<version>` in the detail header.
+    expect(screen.getByText(/v1\.2\.0/)).toBeTruthy()
+    expect(screen.queryByText(/v1\.0\.0/)).toBeNull()
+  })
+
+  // The '0.0.0' floor is what `normalizeRegistryApp` substitutes for a row that
+  // carries no version — the shape a private or unreachable app repo produces,
+  // since the backend sources a row's `version` only from the fetched `app.json`
+  // and the registry index cannot supply it. This page reads an unnormalized row
+  // today, so it is the other two call sites that see the floor; pinning it here
+  // keeps the floor from displacing the installed version if this page is ever
+  // switched onto the normalized shape.
+  it('reports the installed version over a registry row pinned at the 0.0.0 floor', async () => {
+    getApp.mockResolvedValue(EXTERNAL)
+    listRegistry.mockResolvedValue({
+      apps: [{ ...ART_LESS_ROW, version: '0.0.0' }],
+      serverPlatform: { os: 'linux', arch: 'x86_64' },
+    })
+    renderDetail('some-app')
+
+    await screen.findByTestId('app-icon')
+    expect(screen.getByText(/v1\.2\.0/)).toBeTruthy()
+    expect(screen.queryByText(/v0\.0\.0/)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

An app's detail page can state a version the user does not have.

For an installed non-built-in app, the version shown in the header resolved as
`registryEntry?.version || m.version || installed.version`, so a registry row
outranked the machine's own installed record. That row is fetched from the
network and cached, so it can name an **older** version than the clone installed
here — a repo still publishing `1.0.0` while this machine runs a `1.2.0` local
clone. The header then reads `1.0.0`.

## Why it matters

The version on that page is the one thing a user consults to answer "am I
current?". When it reports the catalog's number instead of the machine's, it
answers that question wrongly, and in the direction that costs something: it
tells someone who already upgraded that they have not, so they re-run an update
that changes nothing — or, with a catalog *ahead* of a failed local update, hides
that the update did not land.

This surfaced from a real report: an app installed from a local clone displayed
`v0.0.0` while the app itself reported `0.1.251`.

## What changed (motivation → approach → change)

Symptom: the detail header shows a version the installed record contradicts.

Root cause: the fallback chain ranks the catalog above the local install. That is
the correct ranking for nearly every field — the store renders catalog rows
precisely so a republished document can correct artwork, taxonomy or author
without shipping a wheel — but version is the documented exception, because it is
a fact about this machine rather than catalog metadata.

The exception is already spelled out in `mergeBuiltinRow.ts`, whose contract
names `version` as its one reversed field ("the installed value wins even when
the document publishes one"), and the built-in branch a few lines above this site
already resolves it that way:
`mergeBuiltinRow(registryEntry, { ...m, version: installed.version })`. So the
two branches of the same function disagreed — the same class of split the comment
there records for `author`.

Change: reorder the chain so the installed record wins and the registry row is
the last resort. One expression; the built-in branch is untouched and the two
now agree.

## Tests

`website/src/test/AppDetailPage.test.tsx`, two cases, both mutation-verified
(reverting the chain order turns each red):

- **`reports the installed version, not the version the registry row publishes`** —
  installed record at `1.2.0`, registry row publishing `1.0.0`. Pins the reported
  bug: the header must read the installed version. This is the reachable case.
- **`reports the installed version over a registry row pinned at the 0.0.0 floor`** —
  a row carrying `0.0.0`, which is what `normalizeRegistryApp` substitutes for a
  row with no version at all. That shape comes from a private or unreachable app
  repo, since the backend sources a row's `version` only from the fetched
  `app.json` and the registry index cannot supply it (`_REGISTRY_ROW_KEYS`
  deliberately excludes it). This page reads an *unnormalized* row today, so the
  floor is substituted at the other two call sites rather than here — the guard
  keeps it from displacing the installed version if this page is ever switched
  onto the normalized shape.

Full frontend suite green: 25948 passed, `tsc -b` clean, `eslint` within the
CI-pinned warning cap, i18n and phantom-class gates clean.

## Manual verification

N/A — unit coverage sufficient. The change is a single resolution expression, and
both branches of it are pinned by rendered-DOM assertions (the tests render the
page and read the header text, not the source).

## Screenshots / video

**A rendered delta exists, and I have not captured it.** The header's version
string is what changes, so this is not a no-visual-delta case and I am not
claiming the waiver.

The delta only appears while the registry row and the installed record disagree
about the version. On a machine where the catalog and the install agree — every
app in the normal state — the rendered output is byte-identical before and after.
Reproducing it for a screenshot therefore needs seeded state on both sides: an
installed app plus a registry row publishing a different version, which is a pod
with a faked catalog row rather than a page I can simply open.

To reproduce by hand: install an app from a local directory, then serve a
registry row for it whose `app.json` names an older version, and open
`/apps/detail/<name>`. Before this change the header reads the row's version;
after, the installed one.

Happy to capture the pod evidence if a reviewer wants it on the PR rather than
described.

## Related Issues

no linked issue: found while investigating a partner team's report that an app's
listing showed `v0.0.0` against an installed `0.1.251`. The version-reporting
defect fixed here is a distinct, independently reachable bug from that report's
own root cause (a registry row whose per-app `app.json` cannot be fetched), so it
is not filed as closing it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changes
- [x] No secrets, credentials, or internal references in the diff
