### PR TITLE
fix(chat): stop a bounded switch refetch shrinking a painted transcript

### DIFF
--- a/website/src/store/chatSlice.boundedRefetchShrink.test.ts
+++ b/website/src/store/chatSlice.boundedRefetchShrink.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+// `switchSlot` (100) and `warmSlotCache` (50) bound their fetch while `refreshSlot`
+// is unbounded, so the three write one slot's transcript at three sizes.
+const TOTAL = 300
+const BOUND = 100
+const WARM = 50
+
+type FakeMsg = { role: string; content: string; ts: string; meta?: Record<string, unknown> }
+
+/** Persisted history. `chunk`/`done` are wire-only and never reach disk (measured: 0
+ *  of 330789 rows), so the corpus a limit slices is already one row per message. */
+function makeHistory(withMid: boolean): FakeMsg[] {
+  return Array.from({ length: TOTAL }, (_, i) => ({
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `m${i}`,
+    ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+    ...(withMid ? { meta: { mid: `mid-${i}` } } : {}),
+  }))
+}
+
+let HISTORY: FakeMsg[] = makeHistory(true)
+let RUNNING = false
+
+vi.mock('../api/client', () => ({
+  api: {
+    // Mirrors the handler: `_collapse_wire_rows` folds the in-flight run and drops
+    // `done` BEFORE `total` and the slice, so a limit takes collapsed rows.
+    chatSlotDetail: vi.fn((_slot: string, limit?: number, before?: number) => {
+      const collapsed = RUNNING
+        ? [...HISTORY, { role: 'streaming', content: 'partial', ts: 'x' }]
+        : [...HISTORY]
+      const total = collapsed.length
+      const end = before !== undefined ? Math.max(0, Math.min(before, total)) : total
+      const start = limit === undefined ? 0 : Math.max(0, end - limit)
+      return Promise.resolve({
+        messages: collapsed.slice(start, end),
+        has_more: start > 0,
+        total,
+        next_before: start,
+        running: RUNNING,
+      })
+    }),
+    resumeChatSlot: vi.fn(() => Promise.resolve({ ok: true })),
+  },
+}))
+
+import chatReducer, {
+  setActiveSlot, refreshSlot, switchSlot, warmSlotCache, hydrateSlotMessages,
+} from './chatSlice'
+import { api } from '../api/client'
+
+function makeStore() {
+  return configureStore({
+    reducer: { chat: chatReducer },
+    middleware: (getDefault) => getDefault({ serializableCheck: false, immutableCheck: false }),
+  })
+}
+
+const visible = (s: ReturnType<typeof makeStore>) => s.getState().chat.messages.length
+/** The limits sent for a slot. The defect signal is the `limit` field, never a
+ *  `returned` vs `total` comparison -- `total` is inflated while streaming. */
+const limitsFor = (slot: string) =>
+  (api.chatSlotDetail as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    .filter(c => c[0] === slot).map(c => c[1])
+
+describe('a bounded refetch must not shrink what is already loaded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    HISTORY = makeHistory(true)
+    RUNNING = false
+  })
+
+  it('holds the full transcript across refreshSlot -> switchSlot -> refreshSlot', async () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('active'))
+
+    await store.dispatch(refreshSlot('active'))
+    const full = visible(store)
+    expect(full).toBe(TOTAL)
+
+    await store.dispatch(switchSlot('active'))
+    const afterSwitch = visible(store)
+
+    await store.dispatch(refreshSlot('active'))
+    expect({ afterSwitch, afterRefresh: visible(store) })
+      .toEqual({ afterSwitch: full, afterRefresh: full })
+  })
+
+  it('holds the transcript when the page carries no row identity', async () => {
+    HISTORY = makeHistory(false)
+    const store = makeStore()
+    store.dispatch(setActiveSlot('active'))
+
+    await store.dispatch(refreshSlot('active'))
+    const full = visible(store)
+    await store.dispatch(switchSlot('active'))
+    expect(visible(store)).toBe(full)
+  })
+
+  // Correction 1: `slotRun` has only two writers and is never seeded from the slots
+  // list, so a stream this client never witnessed reads `?? 'idle'` and bounds.
+  it('does not bound a painted slot the client wrongly believes is idle', async () => {
+    RUNNING = true
+    const store = makeStore()
+    store.dispatch(setActiveSlot('active'))
+
+    await store.dispatch(refreshSlot('active'))
+    const full = visible(store)
+    expect(store.getState().chat.slotRun?.active).toBeUndefined()
+
+    await store.dispatch(switchSlot('active'))
+    expect(limitsFor('active').at(-1)).toBeUndefined()
+    expect(visible(store)).toBe(full)
+  })
+
+  // The decisive live capture: a background slot that had returned 111 rows unbounded
+  // was refetched at limit=50. `switchSlot.pending` paints from this cache.
+  it('does not let a warm shrink a background slot cache below what it holds', async () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('other'))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'bg', messages: HISTORY.slice(0, 111), hasMore: false,
+      bounded: false, total: TOTAL, running: false,
+    }))
+    expect(store.getState().chat.slotMessages.bg.length).toBe(111)
+
+    await store.dispatch(warmSlotCache('bg'))
+    expect(limitsFor('bg')).toEqual([undefined])
+    expect(store.getState().chat.slotMessages.bg.length).toBeGreaterThanOrEqual(111)
+  })
+
+  // A cache at or below the limit still loses rows: unseen server growth moves the
+  // window clear of it, and rows without `meta.mid` are replaced rather than merged.
+  it('does not bound a small cache the server has grown past', async () => {
+    HISTORY = makeHistory(false)
+    const store = makeStore()
+    // Seeded while backgrounded, then switched into -- `hydrateSlotMessages` refuses
+    // the active slot, so seeding it directly would be a silent no-op.
+    store.dispatch(setActiveSlot('other'))
+    const painted = HISTORY.slice(0, 40)
+    store.dispatch(hydrateSlotMessages({
+      slot: 'active', messages: painted, hasMore: false,
+      bounded: false, total: 40, running: false,
+    }))
+    expect(store.getState().chat.slotMessages.active?.length).toBe(40)
+
+    await store.dispatch(switchSlot('active'))
+
+    const shown = new Set(store.getState().chat.messages.map(m => m.content))
+    const dropped = painted.filter(m => !shown.has(m.content)).map(m => m.content)
+    expect({ limit: limitsFor('active').at(-1), dropped }).toEqual({ limit: undefined, dropped: [] })
+  })
+
+  it('does not bound a small background cache the server has grown past', async () => {
+    HISTORY = makeHistory(false)
+    const store = makeStore()
+    store.dispatch(setActiveSlot('other'))
+    const painted = HISTORY.slice(0, 30)
+    store.dispatch(hydrateSlotMessages({
+      slot: 'bg', messages: painted, hasMore: false,
+      bounded: false, total: 30, running: false,
+    }))
+
+    await store.dispatch(warmSlotCache('bg'))
+
+    const cache = new Set(store.getState().chat.slotMessages.bg.map(m => m.content))
+    const dropped = painted.filter(m => !cache.has(m.content)).map(m => m.content)
+    expect({ limit: limitsFor('bg').at(-1), dropped }).toEqual({ limit: undefined, dropped: [] })
+  })
+
+  // Negative control: the bound must SURVIVE where it was designed to help, so the
+  // tests above passing cannot mean it was simply removed.
+  it('still bounds a cold open and a cold warm', async () => {
+    const store = makeStore()
+    await store.dispatch(switchSlot('cold'))
+    expect(limitsFor('cold')).toEqual([BOUND])
+
+    store.dispatch(setActiveSlot('other'))
+    await store.dispatch(warmSlotCache('coldwarm'))
+    expect(limitsFor('coldwarm')).toEqual([WARM])
+  })
+
+  it('leaves the cursor consistent with what is loaded', async () => {
+    const store = makeStore()
+    store.dispatch(setActiveSlot('active'))
+    await store.dispatch(refreshSlot('active'))
+    await store.dispatch(switchSlot('active'))
+
+    const s = store.getState().chat
+    expect({ hasMore: s.slotHasMore, paneHasMore: s.slotPaneHasMore?.active })
+      .toEqual({ hasMore: false, paneHasMore: false })
+  })
+})

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1534,8 +1534,11 @@ export const switchSlot = createAsyncThunk<
     // can omit `slotRun` entirely, and throwing here would skip the fetch.
     const state = (getState() as { chat: ChatState }).chat
     const streaming = (state.slotRun?.[key]?.state ?? 'idle') !== 'idle'
+    // A bounded page is a WINDOW, and unseen server growth can push that window clear
+    // of a small cache entirely, so only a slot with nothing painted may be bounded.
+    const cached = state.slotMessages?.[safeKey(key)]?.length ?? 0
     try {
-      return await fetchSlotDetail(key, streaming ? undefined : OLDER_PAGE_LIMIT)
+      return await fetchSlotDetail(key, streaming || cached > 0 ? undefined : OLDER_PAGE_LIMIT)
     } catch (e) {
       // A thrown error crosses the thunk boundary as `miniSerializeError(e)`,
       // which keeps string fields only -- `ApiError.status` (a number) never
@@ -2133,7 +2136,10 @@ export const warmSlotCache = createAsyncThunk(
     // Captured BEFORE the fetch: two warms for one slot resolve in any order,
     // and the later-dispatched response is the newer view of the transcript.
     const warmSeq = nextWarmSeq()
-    return { ...(await fetchSlotDetail(key, streaming ? undefined : PANE_HYDRATE_LIMIT)), warmSeq }
+    // `switchSlot.pending` paints the active view from this cache, and a window can miss
+    // a small cache entirely once the server has grown, so refetch any of it whole.
+    const cached = state.slotMessages?.[safeKey(key)]?.length ?? 0
+    return { ...(await fetchSlotDetail(key, streaming || cached > 0 ? undefined : PANE_HYDRATE_LIMIT)), warmSeq }
   },
 )
 


### PR DESCRIPTION
## Problem / Motivation

Three callers refetch one slot's transcript at three different page sizes, and all three feed what the user sees:

| caller | limit sent |
| ------ | ---------- |
| `switchSlot` | `OLDER_PAGE_LIMIT` (**100**), unless it believes the slot is streaming |
| `warmSlotCache` | `PANE_HYDRATE_LIMIT` (**50**), unless it believes the slot is streaming |
| `refreshSlot` | always **unbounded** |

`refreshSlot` is unbounded deliberately — `fetchSlotDetail`'s own comment says "a bound would shrink history the user already paged in". The other two apply a bound to the same state anyway. That opens two routes:

**The active view.** A turn ends → `refreshSlot` → `messages` is the full transcript. Any `switchSlot` on the now-idle slot (sidebar click, keyboard shortcut, `?sid=` effect, `ChatPage` mount effect, split-pane anchor) → a 100-row window → older rows go. The next turn end restores them.

**The background cache.** `warmSlotCache` is dispatched from the `chat_done` handler for every *background* slot that finishes a turn, and writes `slotMessages[key]` at 50 rows. `switchSlot.pending` paints the active view from that cache, so switching to that slot renders 50 rows of a long transcript before any fetch resolves. This route needs no reconnect and no streaming — only a background turn finishing.

`switchSlot.fulfilled` already carries a repair (`olderHeadAbovePage`) that splices the prior head back above a bounded page, but it keys on `meta.mid` **only** and returns an empty head when the page's first row carries none.

Separately, the "believes it is streaming" test reads `state.slotRun`, which has exactly two writers — `applyNonActiveFrame`, and `warmSlotCache.fulfilled`, which writes only in the *idle* direction and deliberately never promotes to running. It is never seeded from the slots list: `fetchSlots.fulfilled` passes the payload to `reconcileSlotResidue`, typed `readonly { key: string }[]`, so `ChatSlot.running` is discarded. A stream this client never witnessed therefore reads `?? 'idle'` and takes the bounded branch against a live slot.

## Why it matters

Measured across 1,797 stored session transcripts: **808 exceed the 100-row bound**, and for **697 of those (86%)** the first row of the bounded page carries no `meta.mid`, so the repair declines and the page replaces the transcript wholesale. The largest case drops from **5,029 rows to 100**.

**A note on magnitude, because an earlier revision of this description had it wrong.** The server calls `_collapse_wire_rows` *before* computing `total` and applying the limit, and that helper folds even an *unterminated* in-flight `chunk` run into a single row. So a limit takes N **collapsed** rows — one row per displayed message. An earlier test fixture modelled the bound as slicing raw rows and reported a 200 → 66 shrink; that amplification does not exist and the claim is withdrawn. `chunk`/`done` are wire-only and never persisted (measured: **0 of 330,789 stored rows** across those 1,797 transcripts), so for history read from disk the collapsed corpus equals the stored one and the shrink is simply everything beyond the newest page — **300 → 100** in the test fixture.

## What changed (motivation → approach → change)

Root cause: a bounded page is *requested* for a slot that already has rows painted. Repairing that afterwards means reconstructing the head from an identity most rows do not carry, which is why the existing repair is inert for the dominant case.

So don't request it. A bounded page advertises `has_more`, which means it is by construction a **window** and can never be evidence that history shrank — so it may only ever be asked for where it cannot shrink anything:

```ts
// switchSlot
const cached = state.slotMessages?.[safeKey(key)]?.length ?? 0
fetchSlotDetail(key, streaming || cached > 0 ? undefined : OLDER_PAGE_LIMIT)

// warmSlotCache
fetchSlotDetail(key, streaming || cached > 0 ? undefined : PANE_HYDRATE_LIMIT)
```

The invariant: **a refetch must never reduce what the user can see without a user action that asked for it.**

The threshold is zero, not each caller's own page size. Keying on the page size looks tighter and is wrong: it assumes the server transcript has not grown since the cache was written. Under growth the newest-N window need not overlap a smaller cache at all, and `olderHeadAbovePage` then declines (it keys on `page[0].meta.mid` only, and returns an empty head without one), so the page replaces the cache and previously-painted rows disappear — the case `chatSlice.ts:1541`'s comment names. A proportional bound cannot close that either: covering the cache would require knowing how much the server grew, which is unknowable before the fetch. So for a slot with anything painted, unbounded is forced rather than chosen.

**Why not key on the authoritative `running` instead?** That is the obvious alternative — the slots list carries `ChatSlot.running`, so the misclassification above could be fixed at its source. It was considered and rejected. Because the server collapses before slicing, misclassifying a stream costs only a *legitimate* bounded first page on a cold open, where nothing is loaded to lose; the harm actually measured is bounding a slot that already has rows painted. The cached-length test names that condition directly, needs no belief about run state at all, and so cannot be defeated by a second source of truth going stale. Seeding `slotRun` from the slots list may still be worth doing on its own merits, but it would not stop a bounded page shrinking a loaded corpus.

This keeps the bound where it was designed to help. On a cold open `pending` sets `messages = []` and `slotLoading = true`, so the bound genuinely cuts time-to-first-paint; a cold warm has no cache and still fetches 50. On a revisit `pending` has already painted the cache, so the fetch is off the critical path and its size decides only whether the reconcile may shrink the view.

**Cost — the bound is now one-shot per slot per page load, so state it plainly.** Once anything is cached for a slot, every later `switchSlot` and every turn-end `warmSlotCache` for it fetches the whole transcript. `warmSlotCache` fires from `chat_done` for each background slot that finishes a turn, so a single 50-row warm flips that slot to full-transcript fetches for the rest of the page's life.

Measured over 1,774 stored transcripts, comparing a prepared-payload proxy against the ~29 KB a 50-row page costs (mean 593 B/row):

| | payload | vs a 50-row page |
| --- | --- | --- |
| median (of the 1,029 transcripts over 50 rows) | 0.11 MB | ~4× |
| p90 | 0.33 MB | ~11× |
| largest | 2.80 MB | ~96× |

Three things bound the impact. The transport is loopback to the local gateway, so this is serialization and memory rather than network egress. `refreshSlot` already issues exactly this unbounded fetch for the *active* slot at every turn end, so the pattern is pre-existing rather than new — the change extends it to background slots. And `slotMessages` is not persisted, so a reload returns every slot to a cold open where the bound applies again.

The residual worth a reviewer's eye: `_prepare_messages` runs a regex-heavy redaction pass over the whole history, and that path has a recorded history of blocking the event loop on multi-MB sessions (which is why it was moved off-loop into a thread). Several long background sessions completing turns together therefore means several multi-MB redaction passes in the same window. Correctness has to win here — the alternative is silently dropping messages the user could already see — but the concurrency ceiling is a deliberate trade being flagged, not one being claimed as free.

`olderHeadAbovePage` and the rest of the repair are deliberately left in place: they still cover the cold-open-then-page-in path and the warm merge.

## Tests

New `website/src/store/chatSlice.boundedRefetchShrink.test.ts` (8 tests). The mock mirrors the handler — collapse first, folding the in-flight run, then slice — so a limit takes collapsed rows. Assertions are on the **limit sent**, never on `returned` vs `total`: on the unbounded path `total` is inflated by rows that have not collapsed yet, so a row-count assertion would encode that accounting artifact as a requirement.

| test | on `main` |
| ---- | --------- |
| holds the full transcript across `refreshSlot` → `switchSlot` → `refreshSlot` | passes — the `mid`-present repair works; regression guard |
| holds the transcript when the page carries **no row identity** | **fails, 300 → 100** |
| does not bound a painted slot the client wrongly believes is idle | **fails**, limit `100` sent while the server reports running |
| does not let a warm shrink a background slot cache below what it holds | **fails**, limit `50` sent against a 111-row cache |
| does not bound a small cache the server has grown past | **fails**, 40 painted rows dropped |
| does not bound a small background cache the server has grown past | **fails**, limit `50` sent against a 30-row cache, all 30 dropped |
| leaves the cursor consistent with what is loaded | **fails**, the per-slot pane flag advertises more |
| negative control: still bounds a cold open and a cold warm | passes — the bound survives |

So 6 of 8 fail against unpatched `main`, each for its own reason, and the two that pass are a regression guard and a control proving the bound was not simply removed. The last two rows are the small-cache-plus-growth case the threshold rewrite above exists for; each was observed failing before the change and passing after.

Full store suite: **112 passing** (104 before this change, +8 new), no regressions.

## Manual verification

Confirmed at `fetch` level in a running dashboard, which is what prompted generalising the fix beyond `switchSlot`: a background slot that had earlier returned **111** rows on an unbounded fetch was refetched at **`limit=50`** while idle, and separately a slot the client believed idle was fetched at `limit=100` while the server reported `running: true`. Both are post-preparation counts on the same slot, so they are directly comparable.

## Related Issues

None.

