### PR TITLE
chore(cli): remove confirmed dead code in the CLI surface

### DIFF
--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -1,19 +1,15 @@
-"""CLI chat and TUI subcommands."""
+"""CLI chat subcommands."""
 
 from __future__ import annotations
 
-import argparse
 import asyncio
 import gc
 import logging
 import os
 import re
-import shutil
-import subprocess
 import sys
 import threading
 from dataclasses import dataclass
-from pathlib import Path
 
 from kiro_crew.acp._dispatch import is_shell_kind
 from kiro_crew.acp.client import AcpError, AcpTimeoutError
@@ -26,7 +22,7 @@ from kiro_crew.config.loader import (
     read_config_for_update,
     write_config_atomically,
 )
-from kiro_crew.constants import BANNER, DATA_WARNING, MIN_NODE_MAJOR
+from kiro_crew.constants import BANNER, DATA_WARNING
 from kiro_crew.hooks import (
     TOOL_DENY,
     HookManager,
@@ -262,80 +258,6 @@ def _build_tool_gate(agent: str = "") -> _ToolGate:
         hooks=HookManager(hooks_config_from_config_dict(KiroCrewConfig.load().hooks)),
         agent=agent,
     )
-
-
-def _tui(args: argparse.Namespace) -> None:
-    """Launch the Ink TUI, replacing the current process."""
-    cfg = KiroCrewConfig.load()
-    port = getattr(args, "port", None) or cfg.to_dict().get("dashboard", {}).get("port", 5476)
-
-    # Find TUI — prefer self-contained bundle, fall back to source tree
-    base = Path(__file__).resolve().parent.parent.parent
-    tui_js = None
-
-    # 1. Bundled (no node_modules needed) — check tui_dist/ and source tree
-    for candidate in [
-        Path(__file__).resolve().parent / "tui_dist" / "bundle.mjs",
-        base / "tui" / "dist" / "bundle.mjs",
-    ]:
-        if candidate.is_file():
-            tui_js = candidate
-            break
-
-    # 2. Walk up to workspace src tree for bundle.mjs or index.js+node_modules
-    if not tui_js:
-        p = Path(__file__).resolve()
-        for _ in range(15):
-            p = p.parent
-            bundle = p / "src" / "KiroCrew" / "tui" / "dist" / "bundle.mjs"
-            if bundle.is_file():
-                tui_js = bundle
-                break
-            idx = p / "src" / "KiroCrew" / "tui" / "dist" / "index.js"
-            if idx.is_file() and (p / "src" / "KiroCrew" / "tui" / "node_modules").is_dir():
-                tui_js = idx
-                break
-
-    if not tui_js:
-        print("TUI not built. Run: cd tui && npm install && npm run build")
-        print("  (or use: kirocrew chat  /  kirocrew gateway)")
-        sys.exit(1)
-
-    # Check node against the shared floor
-    if not shutil.which("node"):
-        print(f"Node.js not found. Install Node.js >= {MIN_NODE_MAJOR}.")
-        sys.exit(1)
-    try:
-        ret = subprocess.call(
-            [
-                "node",
-                "-e",
-                f"process.exit(Number(process.version.slice(1).split('.')[0]) < {MIN_NODE_MAJOR} ? 1 : 0)",
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        if ret != 0:
-            print(f"Node.js >= {MIN_NODE_MAJOR} required. Current version is too old.")
-            sys.exit(1)
-    except FileNotFoundError:
-        print("Node.js not found.")
-        sys.exit(1)
-
-    cmd = ["node", str(tui_js), "--port", str(port), "--cwd", os.getcwd()]
-    if getattr(args, "yolo", False):
-        cmd.append("--yolo")
-    if getattr(args, "session", None):
-        cmd.extend(["--session", args.session])
-    if getattr(args, "workspace", None):
-        cmd.extend(["--workspace", args.workspace])
-    if getattr(args, "agent", None):
-        cmd.extend(["--agent", args.agent])
-    home_override = getattr(args, "home", None) or os.environ.get("KIROCREW_HOME", "")
-    if home_override:
-        cmd.extend(["--home", home_override])
-
-    os.execvp("node", cmd)
 
 
 async def _chat(message: str | None, model: str | None, agent: str | None = None) -> None:
@@ -1082,23 +1004,6 @@ async def _interactive(
             print(f"\n⚠️  Context at {pct:.0f}%", file=sys.stderr)
 
         print()
-
-
-def _ensure_config_key(section: str, key: str, default: object) -> None:
-    """Write a default value to config.json if the key is missing.
-
-    Seeding a default is never worth destroying real settings, so an unreadable
-    config skips the write entirely rather than seeding onto ``{}``.
-    """
-    p = config_path()
-    try:
-        data = read_config_for_update(p)
-    except ConfigReadError:
-        logger.warning("Skipping config seed for %s.%s: config unreadable", section, key)
-        return
-    if key not in data.get(section, {}):
-        data.setdefault(section, {})[key] = default
-        write_config_atomically(p, data)
 
 
 def _ensure_default_agent_in_config() -> None:

--- a/test/test_cron_approval_mode.py
+++ b/test/test_cron_approval_mode.py
@@ -770,7 +770,7 @@ class TestNoCronsFlag:
 
         with patch("kiro_crew.cli_server.config_path") as mock_cp, patch(
             "kiro_crew.cli_server.KiroCrewConfig"
-        ) as mock_cfg_cls, patch("kiro_crew.cli_chat._ensure_config_key"), patch(
+        ) as mock_cfg_cls, patch(
             "kiro_crew.cli_server.run_gateway", new_callable=AsyncMock
         ) as mock_run:
             mock_cp.return_value.exists.return_value = True

--- a/test/test_pod_self_contained.py
+++ b/test/test_pod_self_contained.py
@@ -438,17 +438,18 @@ def test_run_is_refused_because_it_writes_beside_the_spec():
         rt.require_pod_safe_verb(["run", "/host/TASK.md"], "wt-feature")
 
 
-def test_chat_is_refused_because_chat_tui_reaches_the_live_port():
-    """`cli_chat._tui` resolves the CONFIG dashboard port with a literal 5476
-    fallback and never reads KIROCREW_PORT, and `chat --tui` branches into it — so
-    excluding only `tui` left the hole open."""
-    import inspect
+def test_chat_and_tui_verbs_stay_refused_in_a_pod():
+    """Both verbs stay on the exclusion list.
 
-    from kiro_crew import cli_chat
-
-    src = inspect.getsource(cli_chat)
-    assert "5476" in src, "premise: _tui carries a hardcoded live-port fallback"
-    assert "resolve_client_port" not in src, "premise: _tui bypasses the port resolver"
+    The original premise was `cli_chat._tui`: it resolved the CONFIG dashboard
+    port with a literal 5476 fallback, never `KIROCREW_PORT`, so a pod landed on
+    the LIVE gateway — and `chat` was excluded with it because `chat --tui`
+    branched into the same function. `_tui` has since been deleted as dead code
+    (the `tui` subcommand and its Ink bundle were already gone), so that source
+    premise can no longer be asserted. The exclusion is kept in force rather
+    than relaxed: admitting either verb is a pod-safety decision on its own
+    evidence, not a side effect of removing an unreachable function.
+    """
     for verb in ("chat", "tui"):
         with pytest.raises(rt.PodError, match=f"refusing `{verb}`"):
             rt.require_pod_safe_verb([verb], "wt-feature")

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -779,7 +779,6 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli.py::_node_ok",
         "cli.py::main",
         "cli_chat.py::_run_chat",
-        "cli_chat.py::_tui",
         # NOT a subprocess spawn: the AST heuristic matches ``asyncio.run`` (attr
         # ``run`` on base ``asyncio``), here used only to drive the now-async
         # ``deregister_app_crons_from_service`` coroutine from the loop-less CLI


### PR DESCRIPTION
## Problem / Motivation

Two functions in `src/kiro_crew/cli_chat.py` have no reachable caller and have been unreachable for some time.

`_tui` (72 lines) launched the Ink TUI by `os.execvp`-ing into a Node bundle. The `tui` subcommand it served is already gone: `cli.py` imports only `_run_chat` from `cli_chat`, `tui` is absent from `_JAILED_COMMANDS`, and `test/test_cpp_seam_failclosed.py:414` already pins that removal (`assert "tui" not in cli._JAILED_COMMANDS  # removed: TUI command surface hidden`). The bundle went with it — the repo has no `tui/` and no `src/kiro_crew/tui_dist/` — so even if the function were reachable, every path through it ended at `print("TUI not built")` + `sys.exit(1)` before reaching the exec.

`_ensure_config_key` (15 lines) had exactly two references repo-wide: its own `def`, and one `patch("kiro_crew.cli_chat._ensure_config_key")` in `test/test_cron_approval_mode.py`. That test exercises `cli_server._gateway`, which never called it, so the patch was a no-op left over from earlier wiring.

## Why it matters

Unreachable code is read as if it were live. `_tui` in particular is actively misleading: it is the stated justification, in a comment in `pod/runtime.py`, for a pod-safety exclusion that is still enforced — so a reader tracing that policy lands on a function that can no longer run. Deleting it also removes five imports from a module that no longer needs them, and a module docstring that advertised a subcommand the CLI does not have.

## What changed (motivation → approach → change)

**Approach — confirm before deleting, not the reverse.** `vulture` was used only as a candidate generator, and deliberately over the whole tree (`src/ test/ scripts/`) rather than over the target files: a file-scoped run reports every cross-module callee as unused. Candidates were then confirmed against a repo-wide `git grep -w` covering `*.py *.ts *.tsx *.js *.jsx *.md *.json *.yml *.yaml *.toml *.sh *.ps1`, including `test/`, `docs/`, `src/kiro_crew/builtin_skills/`, the baselines, and `.github/`.

Reference *counting* is where this kind of change goes wrong, so hits were classified with `tokenize` and a hit counts only when the identifier appears as a real `NAME` token. Two earlier passes were discarded for miscounting in opposite directions: one counted `# see _tui` prose as a live caller, and one counted the whole line of `"destroy": _cloud_destroy,` as a docstring because a single-line string constant sat on it. Both were caught by spot-checking symbols known to be live (`_cloud_destroy`, `parse_time_selector`, `add_topic`) before any conclusion was drawn.

Also checked per symbol: no `getattr`/`setattr`/`globals()`/`importlib`/`__getattr__` dispatch; not an entry point (`pyproject.toml` ships one, `kiro_crew._bootstrap:main`); no registry, decorator, or string-keyed table; absent from `__all__` (the module has none), from `docs/`, `docs/system-specs/`, `skills/`, `config-baseline.json` and `error-code-baseline.json`. Both date to `849a03fff` (2026-07-16), so neither is recently-added code that is merely not wired up yet.

**The change.** `_tui` and `_ensure_config_key` are deleted. Removing `_tui` orphaned `argparse`, `shutil`, `subprocess`, `Path` and `MIN_NODE_MAJOR`, which go with it (flake8 confirms no remaining use), and the module docstring drops the TUI it no longer has.

Separate scans for unreachable statements (after `return`/`raise`/`sys.exit`/`os.execvp`) and for unused module-level constants across the whole CLI group came back **empty**, so nothing else in this surface qualified.

Two symbols with zero production callers were deliberately **left in place**, and are recorded here so the next pass does not re-litigate them:

- `_FdTrackingRotatingFileHandler.doRollover` (`cli.py`) — an override the logging framework calls on rollover. Zero in-repo callers is the expected shape for a framework hook, and `test/test_cli_logging.py:210` pins the hook itself.
- `CrewStore.add_msg` (`crew_chat.py`) — 17 days old (`d09258881`, Crew Mode) and carrying 89 test call sites. Removing it is a test refactor, not a deletion.

## Tests

No new behaviour, so no new tests. Three test edits are **forced by the deletion** rather than optional cleanup:

- `test/test_spawn_audit.py` — `"cli_chat.py::_tui"` leaves `BENIGN_SPAWNS`. `test_benign_allowlist_has_no_stale_entries` computes `BENIGN_SPAWNS - _collect_unrouted_spawns()` and fails on any entry that no longer names a live spawn site, so the entry cannot outlive the function it exempted.
- `test/test_cron_approval_mode.py` — the `patch()` of the deleted function is dropped; left in place it would raise `AttributeError` on an attribute that no longer exists.
- `test/test_pod_self_contained.py` — `test_chat_is_refused_because_chat_tui_reaches_the_live_port` asserted `"5476" in inspect.getsource(cli_chat)`. That literal occurred only inside `_tui`, so the premise is no longer assertable. The load-bearing half is kept verbatim — a pod still refuses both the `chat` and `tui` verbs — and the test is renamed to `test_chat_and_tui_verbs_stay_refused_in_a_pod` so the name states what it actually pins. The docstring records the original `_tui` premise and why it can no longer be asserted.

  **The exclusion is not relaxed.** `require_pod_safe_verb` (`pod/runtime.py:1391`) is a fail-closed allowlist — `chat` and `tui` are absent from `_POD_SAFE_VERBS`, so both raise `PodError` regardless of anything in `cli_chat`. The retained behavioural assertion tests that allowlist directly, which is a stronger guard than the two source-text tripwires it replaces: `"5476" in src` asserted an *unsafe* literal was present (so it could never catch a forward regression), and `"resolve_client_port" not in src` was inverted — wiring `cli_chat` to the safe resolver would have tripped it.

## Manual verification

N/A — no behaviour changes, and the deletions are covered by the existing suites above.

Gates run locally, all green: full backend suite via `scripts/run_scoped_tests.py --surface backend` (it escalates to full suite because the diff touches that surface), `flake8`, `isort --check-only`, `mypy`, `check_black_formatting.py`, `check_brand_name.py`, `check_changelog_history.py`, `check_lockdown_before_publish.py`, `check_testpaths_coverage.py`, `check_subprocess_encoding.py`, `verify_vendor_manifest.py`, `scrub-lint.sh`, `docs-lint.sh`, plus the `--test` self-checks. Frontend gates are N/A — the diff touches no `website/` file.

The backend suite reports 116 failures on this machine that are **not** from this diff: they are environmental (`jq` missing, no Node ≥ 20, no usable `gh`, `/local/home` owned by uid 65534, `AF_UNIX path too long`), none names a file this PR touches, and 31 of the same tests were re-run on a pristine `origin/main` worktree and fail identically there.

Local AI review ran both profile reviewers against their CI contracts (`gpt-5.6-sol` per `codex-review.yml`, `claude-opus-4.8` per `claude-review.yml` + base-ref `AUTOSDE.yaml`): **no findings** from either. Opus raised the dropped test assertions as a possible removed-guard candidate and falsified it in its own second stage, on the fail-closed-allowlist reasoning given above.

## Related Issues

no linked issue: this is self-directed cleanup with no filed report behind it — the two functions were found by a dead-code sweep of the CLI file group, not by a bug.

## Follow-up left deliberately undone

`src/kiro_crew/pod/runtime.py:1324-1333` still justifies excluding the `chat` verb from pods on the grounds that `chat --tui` branched into `_tui`, and states "this hazard is confined to `_tui`". That reasoning is now stale. The file is **not** modified here: the exclusion is enforced by allowlist membership rather than by the comment, so nothing is broken, and rewriting pod verb policy is a separate change with its own argument to make. Flagged so it is not mistaken for an oversight.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
