### PR TITLE
fix(packaging): retry electron-builder on a retryable HTTP status, not just an errno

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -191,11 +191,13 @@ _eb_invoke() {
 #   - transient network/TLS failures in electron-builder's OWN mid-build
 #     fetches: the AppImage and NSIS/Squirrel targets pull their own tooling
 #     through `got` AFTER the electron zip has already reported
-#     progress=100%. A dropped connection ("socket hang up") or a
-#     TLS-intercepted response ("self-signed certificate") aborts the whole
-#     build there. These are per-execution network events, not build errors --
-#     the same commit passes on a plain re-run, and one matrix leg can fail
-#     while its siblings go green in the same attempt (#3088).
+#     progress=100%. A dropped connection ("socket hang up"), a
+#     TLS-intercepted response ("self-signed certificate"), or an HTTP-level
+#     answer from the artifact CDN that is retryable rather than final
+#     ("Response code 504") aborts the whole build there. These are
+#     per-execution network events, not build errors -- the same commit
+#     passes on a plain re-run, and one matrix leg can fail while its
+#     siblings go green in the same attempt (#3088, #6795).
 #
 # Split out of the packaging step (rather than left inline) so the
 # retry/classification logic is testable in isolation, mirroring
@@ -215,7 +217,16 @@ run_electron_builder_with_retry() {
     eb_transient=""
     if grep -q "ENOTEMPTY" "$eb_log"; then
       eb_transient="ds_store"
-    elif grep -qE "socket hang up|self[- ]signed certificate|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND" "$eb_log"; then
+    # Socket-level errno strings and HTTP-level statuses share ONE class
+    # because the class boundary here is cleanup, not protocol layer (see the
+    # header comment): both arise in the same `got` fetches, and both recover
+    # by simply re-fetching on the next attempt with nothing to sweep first.
+    # A 5xx is transient by definition and a 429 is a rate limit that clears;
+    # every OTHER 4xx (401/403/404/400) is a configuration or authorisation
+    # fault that would fail identically on all three attempts, so it stays
+    # unrecognised and still aborts on the first one.
+    elif grep -qE "socket hang up|self[- ]signed certificate|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND" "$eb_log" \
+      || grep -qE "Response code (429|5[0-9][0-9])" "$eb_log"; then
       eb_transient="network"
     fi
     if [ -n "$eb_transient" ] && [ "$attempt" -lt "$max_attempts" ]; then
@@ -225,7 +236,7 @@ run_electron_builder_with_retry() {
         rm -rf dist/*-temp 2>/dev/null || true
         eb_backoff=2
       else
-        echo "  ⚠ transient network/TLS failure in an electron-builder fetch (attempt $attempt/$max_attempts); retrying…" >&2
+        echo "  ⚠ transient network/TLS/HTTP failure in an electron-builder fetch (attempt $attempt/$max_attempts); retrying…" >&2
         eb_backoff=$((attempt * 10))
       fi
       rm -f "$eb_log"; attempt=$((attempt + 1)); sleep "$eb_backoff"; continue

--- a/test/test_build_desktop_electron_retry.py
+++ b/test/test_build_desktop_electron_retry.py
@@ -13,6 +13,14 @@ electron zip itself has already downloaded) — fell straight through to
 ``exit 1`` with zero retries, even though the same commit reliably passed on
 a plain re-run.
 
+The same hole then reopened one layer up (#6795): every pattern in the
+network class was a socket-level errno, so a fetch the CDN answered with an
+HTTP ``504`` matched none of them and aborted on attempt 1 with the
+three-attempt budget unspent. Retryable statuses (``5xx`` and ``429``) now
+land in that class too; every other ``4xx`` deliberately does not, because a
+401/403/404 is a configuration fault that fails identically on all three
+attempts.
+
 ``run_electron_builder_with_retry`` classifies a failure into one of two
 transient classes (each with its own cleanup/backoff) or "unknown", and only
 the two known classes get a bounded retry; anything else — or the budget
@@ -129,6 +137,18 @@ class TestTransientClassesRetry:
             "self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca",
             "Error: connect ECONNRESET",
             "Error: connect ETIMEDOUT",
+            # HTTP-level failures from the SAME `got` fetches. Every case above
+            # is a socket-level errno; a CDN that answers with a 5xx/429
+            # instead of dropping the connection is the same per-execution
+            # event one layer up, and used to fall through to a hard abort on
+            # attempt 1 with the 3-attempt budget unspent. The first case is
+            # the verbatim line from PR #6795, Build Desktop (ubuntu-22.04).
+            "⨯ Response code 504 (Gateway Time-out)  failedTask=build "
+            "stackTrace=HTTPError: Response code 504 (Gateway Time-out)",
+            "HTTPError: Response code 500 (Internal Server Error)",
+            "HTTPError: Response code 502 (Bad Gateway)",
+            "HTTPError: Response code 503 (Service Unavailable)",
+            "HTTPError: Response code 429 (Too Many Requests)",
         ],
     )
     def test_retries_on_transient_network_failure(self, tmp_path: Path, error_line: str) -> None:
@@ -150,14 +170,28 @@ class TestTransientClassesRetry:
         assert "EXIT=1" in proc.stdout, proc.stdout + proc.stderr
         assert len(counter.read_text()) == 3, "must stop at max_attempts, not retry forever"
 
-    def test_does_not_retry_an_unrecognised_failure(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "error_line",
+        [
+            "Error: Cannot find module 'some-broken-config-key'",
+            # A 4xx that is NOT 429 is a configuration/authorisation fault, not
+            # a transient one: retrying a bad URL or a missing credential just
+            # spends the budget and delays the real verdict by two backoffs.
+            # These pin that widening the class to HTTP did not widen it to
+            # ALL of HTTP -- without them the 5xx pattern could be a bare
+            # "Response code" match and every test above would still pass.
+            "HTTPError: Response code 404 (Not Found)",
+            "HTTPError: Response code 403 (Forbidden)",
+            "HTTPError: Response code 401 (Unauthorized)",
+            "HTTPError: Response code 400 (Bad Request)",
+        ],
+    )
+    def test_does_not_retry_an_unrecognised_failure(self, tmp_path: Path, error_line: str) -> None:
         """A genuine build error (e.g. a real packaging/config mistake) must
         abort on its FIRST occurrence with no retries -- only the two known
         transient classes get a second chance."""
         (tmp_path / "dist").mkdir()
-        stub, counter = _counting_stub(
-            tmp_path, fail_times=99, error_line="Error: Cannot find module 'some-broken-config-key'"
-        )
+        stub, counter = _counting_stub(tmp_path, fail_times=99, error_line=error_line)
         proc = _run(stub, 'run_electron_builder_with_retry; echo "EXIT=$?"', tmp_path)
         assert "EXIT=1" in proc.stdout, proc.stdout + proc.stderr
         assert len(counter.read_text()) == 1, "an unrecognised error must not be retried at all"


### PR DESCRIPTION
## Problem / Motivation

`run_electron_builder_with_retry()` in `packaging/build-desktop.sh` classifies a failure before
deciding whether to spend its `max_attempts=3` budget. Every pattern in its `network` class is a
**socket-level errno / transport** string:

```sh
elif grep -qE "socket hang up|self[- ]signed certificate|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND" "$eb_log"; then
```

An **HTTP-level** failure from the artifact CDN matches none of them. electron-builder's own
mid-build fetches (the AppImage and NSIS/Squirrel tooling, pulled through `got` *after* the electron
zip has already reported `progress=100%`) can be answered with a status rather than a dropped
connection — and that fell straight through to the abort arm on **attempt 1**, with the whole
three-attempt budget unspent.

Measured on PR #6795, job `Build Desktop (ubuntu-22.04)`, step `Build desktop app (PBS + uv venv)`:

```
⨯ Response code 504 (Gateway Time-out)  failedTask=build stackTrace=HTTPError: Response code 504 (Gateway Time-out)
❌ electron-builder failed (not a known transient class, or retries exhausted).
make: *** [Makefile:107: desktop] Error 1
```

## Why it matters

`Build Desktop` is a **required** check. A 504 Gateway Time-out is transient by definition, and a
later sha of the same tree went green with no code change — so this turned a CDN hiccup into a hard
red on a required gate, and the retry loop that exists precisely to absorb it never engaged. That is
a gate defect, not a build defect: the cost is a re-run and a maintainer's attention on every
unlucky fetch.

## What changed

Retryable HTTP statuses now land in the **existing `network` class** rather than a new one:

```sh
elif grep -qE "socket hang up|self[- ]signed certificate|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND" "$eb_log" \
  || grep -qE "Response code (429|5[0-9][0-9])" "$eb_log"; then
  eb_transient="network"
```

**Why one class, not two.** The function's own header comment states the reason the classes are
split: *"each transient class needs its own cleanup"* — `ds_store` sweeps `.DS_Store` and
`dist/*-temp` and backs off 2s; `network` sweeps nothing and backs off `attempt * 10`. By that
criterion an HTTP 5xx/429 belongs in `network`: it arises in the *same* `got` fetches, needs the
*same* cleanup (none — nothing partial is left behind to sweep), and recovers by the *same* action
(plain re-fetch on the next attempt). The `attempt * 10` backoff is already the
wait-for-a-remote-to-recover shape rather than the 2s local-race shape. A third class would have
duplicated that branch to change nothing, and electron-builder's log line carries no `Retry-After`
to key a distinct 429 backoff on.

**Why not all of HTTP.** `5xx` and `429` only. A `401`/`403`/`404`/`400` is a configuration or
authorisation fault that would fail identically on all three attempts, so retrying it spends the
budget and delays the real verdict by two backoffs. Those stay *unrecognised* and still abort on the
first failure — that boundary is the substance of this change, so it is pinned by a test rather than
asserted.

Also updated: the class header comment, and the retry log line (`network/TLS` → `network/TLS/HTTP`,
so an HTTP failure is not mislabelled as a TLS one in the build log).

## Tests

`test/test_build_desktop_electron_retry.py` already extracts the real shell function via
`_extract_function()` and shadows `_eb_invoke` with a counting stub, so the shipped classification
logic is what runs. No new harness — the new cases were added to the two existing parametrized
tests.

`TestTransientClassesRetry::test_retries_on_transient_network_failure` — 5 new cases, including the
verbatim 504 line from #6795, plus 500 / 502 / 503 / 429. **All five fail against the unmodified
script** (`EXIT=1`, `❌ … not a known transient class`, stub called once) and pass after the change
(`EXIT=0`, stub called twice — retried exactly once, then succeeded).

`TestTransientClassesRetry::test_does_not_retry_an_unrecognised_failure` — parametrized and given
`404` / `403` / `401` / `400` as the **negative control**. Each asserts `EXIT=1` with the stub called
**exactly once**, so a bare `Response code` match would fail here while leaving every positive case
green. Without these, "we did not over-widen" would be an assertion instead of a pin.

Gates run locally on `0457ccc5d`:

| Gate                                                | Result                                                  |
| --------------------------------------------------- | ------------------------------------------------------- |
| `pytest test/test_build_desktop_electron_retry.py`   | 18 passed (13 before the new cases, 5 pre-fix failures) |
| `python3 scripts/check_black_formatting.py`          | passed, nothing in scope unformatted                    |
| `mypy src/kiro_crew/`                                | Success: no issues found in 1167 source files           |
| `bash -n packaging/build-desktop.sh`                 | OK                                                      |
