### PR TITLE
chore(cloud): remove confirmed dead code in the ops surface

### DIFF
--- a/src/kiro_crew/cloud/ssm.py
+++ b/src/kiro_crew/cloud/ssm.py
@@ -191,21 +191,6 @@ def build_port_forward_argv(
     return argv
 
 
-def build_interactive_session_argv(
-    instance_id: str, profile: str = "", region: str = ""
-) -> list[str]:
-    """Build the plain ``aws ssm start-session`` argv (interactive shell).
-
-    Same absolute CLI resolution as :func:`build_port_forward_argv` (#4770).
-    """
-    argv = [resolve_aws_bin(), "ssm", "start-session", "--target", instance_id]
-    if region:
-        argv += ["--region", region]
-    if profile:
-        argv += ["--profile", profile]
-    return argv
-
-
 def session_manager_plugin_installed() -> bool:
     """True when the local AWS Session Manager plugin is available."""
     return shutil.which(_SESSION_MANAGER_PLUGIN) is not None
@@ -501,11 +486,6 @@ def instance_is_managed(instance_id: str, profile: str = "", region: str = "") -
 
 
 # --- small helpers ---------------------------------------------------------
-
-
-def _shq(s: str) -> str:
-    """Single-quote a string for safe embedding in a bash -lc argument."""
-    return "'" + s.replace("'", "'\\''") + "'"
 
 
 def _wrap_remote_command(command: str, run_as: str) -> str:

--- a/src/kiro_crew/deploy/pending.py
+++ b/src/kiro_crew/deploy/pending.py
@@ -123,14 +123,6 @@ def list_pending() -> list[dict[str, Any]]:
     return entries
 
 
-def get_pending(entry_id: str) -> dict[str, Any] | None:
-    """Get a single pending entry by id, or None if expired/missing."""
-    for e in _prune_expired(_load_raw()):
-        if e.get("id") == entry_id:
-            return e
-    return None
-
-
 def remove_pending(entry_id: str) -> bool:
     """Remove an entry (confirm or dismiss). Returns True if found."""
     lock_path = _store_path().with_suffix(".lock")

--- a/src/kiro_crew/deploy/scan.py
+++ b/src/kiro_crew/deploy/scan.py
@@ -97,10 +97,6 @@ def _build_line_index(text: str) -> list[int]:
     return offsets
 
 
-def _line_of(text: str, pos: int) -> int:
-    return text.count("\n", 0, pos) + 1
-
-
 def _line_of_fast(line_offsets: list[int], pos: int) -> int:
     """O(log n) line number lookup using precomputed offsets."""
     import bisect

--- a/src/kiro_crew/instances/registry.py
+++ b/src/kiro_crew/instances/registry.py
@@ -573,16 +573,3 @@ class InstancesRegistry:
             self._write(doc)
             logger.info("Removed instance %s", instance_id)
             return True
-
-    def set_last_active(self, instance_id: str) -> None:
-        """Mark *instance_id* as the one to auto-revive on next startup.
-
-        Raises :class:`InstanceNotFoundError` if the id is unknown so callers
-        can't silently point ``last_active_id`` at a non-existent instance.
-        """
-        with self._lock:
-            doc = self._read()
-            if _find(doc, instance_id) is None:
-                raise InstanceNotFoundError(f"no instance with id {instance_id!r}")
-            doc.last_active_id = instance_id
-            self._write(doc)

--- a/test/test_apps_instances_loop_offload.py
+++ b/test/test_apps_instances_loop_offload.py
@@ -72,9 +72,6 @@ class _RecordingRegistry:
         self.write_threads.append(threading.current_thread())
         return SimpleNamespace(id=instance_id)
 
-    def set_last_active(self, instance_id: str) -> None:
-        self.write_threads.append(threading.current_thread())
-
 
 def _tunnel_double(instance_id: str, *, pid: int = 4321, local_port: int = 18022) -> Any:
     """Stand-in for ``_SshTunnel`` carrying every attribute ``_mark_recovered`` reads.
@@ -394,7 +391,6 @@ def test_no_direct_registry_write_in_async_frames() -> None:
 
     write_methods = {
         "update",
-        "set_last_active",
         "remove",
         "get",
         "list",
@@ -428,7 +424,6 @@ def test_no_direct_registry_call_in_instances_handler_async_frames() -> None:
         "add",
         "update",
         "remove",
-        "set_last_active",
     }
     offenders: list[str] = []
     for owner, call in _calls_in_async_frames(_module_tree(handlers_instances_mod)):

--- a/test/test_cloud_ssm.py
+++ b/test/test_cloud_ssm.py
@@ -32,22 +32,8 @@ class TestArgvBuilders:
         assert "--profile" not in argv
         assert "--region" not in argv
 
-    def test_interactive_session_argv(self):
-        argv = ssm.build_interactive_session_argv("i-0abc", "dev", "us-east-1")
-        assert argv == [
-            "aws",
-            "ssm",
-            "start-session",
-            "--target",
-            "i-0abc",
-            "--region",
-            "us-east-1",
-            "--profile",
-            "dev",
-        ]
-
     def test_argv_heads_resolved_absolutely_under_minimal_path(self, monkeypatch, tmp_path):
-        """Both start-session builders must resolve the CLI absolutely under a
+        """``build_port_forward_argv`` must resolve the CLI absolutely under a
         GUI-launched gateway's minimal PATH via the deploy engine's shared
         well-known-dirs resolver (#4770)."""
         import os as _os
@@ -71,10 +57,6 @@ class TestArgvBuilders:
         pf = ssm.build_port_forward_argv("i-0abc", 5476, 5599, "dev", "us-east-1")
         assert pf[0] == str(fake_aws)
         assert pf[1:3] == ["ssm", "start-session"]
-
-        it = ssm.build_interactive_session_argv("i-0abc")
-        assert it[0] == str(fake_aws)
-        assert it[1:3] == ["ssm", "start-session"]
 
 
 class TestOpenPortForward:
@@ -421,9 +403,6 @@ class TestManaged:
 
 
 class TestShellQuote:
-    def test_quotes_single_quotes(self):
-        assert ssm._shq("it's") == "'it'\\''s'"
-
     def test_json_str_list(self):
         assert ssm._json_str_list(["a", "b"]) == '["a", "b"]'
 

--- a/test/test_cloud_ssm_cov80.py
+++ b/test/test_cloud_ssm_cov80.py
@@ -278,9 +278,6 @@ class TestSmallHelpers:
     def test_json_str_list_renders_a_json_array(self) -> None:
         assert ssm._json_str_list(["echo 'hi'"]) == "[\"echo 'hi'\"]"
 
-    def test_shell_quoting_escapes_embedded_quotes(self) -> None:
-        assert ssm._shq("it's") == "'it'\\''s'"
-
     def test_normalized_arch_maps_aarch64_to_arm64(self, monkeypatch) -> None:
         monkeypatch.setattr(ssm.platform, "machine", lambda: "AArch64")
         assert ssm._normalized_arch() == "arm64"

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -1124,8 +1124,6 @@ class TestRegistry:
             reg.update("cd-1", id="nope")
         with pytest.raises(InstanceNotFoundError):
             reg.update("ghost", name="z")
-        reg.set_last_active("cd-1")
-        assert reg.get_last_active().id == "cd-1"
 
     def test_update_mark_last_active_is_one_mutation(self, tmp_path):
         """update(mark_last_active=True) records the auto-revive target in the
@@ -1146,7 +1144,7 @@ class TestRegistry:
     def test_remove_clears_last_active_and_reload(self, tmp_path):
         reg = self._reg(tmp_path)
         reg.add(name="CD", ssh_host="cd-1", instance_id="cd-1")
-        reg.set_last_active("cd-1")
+        reg.update("cd-1", mark_last_active=True)
         assert reg.remove("cd-1") is True
         assert reg.remove("cd-1") is False
         assert reg.get_last_active() is None


### PR DESCRIPTION
## What

Removes five symbols in the ops / infrastructure surface (`cloud/`, `deploy/`, `instances/`) that have no production caller and no reachable indirect entry point. 78 deletions, 2 insertions, no behaviour change.

Candidates came from `vulture --min-confidence 60` over `cloud/ deploy/ instances/ pod/ service/ metrics/ monitoring/ tunnel/ beacon.py` (77 raw findings). Vulture is only the generator — every finding was then classified by repo-wide reference search, and only the survivors were confirmed individually. 63 findings had real cross-module callers vulture could not see; 9 more were confirmed *not* safe to delete and are listed at the bottom rather than removed.

## Confirmation applied to each symbol

Every deletion below cleared all of:

1. Repo-wide word-boundary search across `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1 *.cfg *.txt *.html Makefile`, including `test/`, `docs/`, `src/kiro_crew/builtin_skills/`, `.github/`, and the baseline files — no reference outside the definition.
2. Dynamic-reference sweep: `getattr` / `setattr` / `globals()` / `importlib` / `__getattr__`, `pyproject.toml` entry points, the `cli_cloud.py` `_DISPATCH` table, cron script SDK, decorator registries, `__all__`, and the quoted-string form of the name.
3. Not named in `src/kiro_crew/docs/`, `docs/system-specs/`, any `SKILL.md`, `install.sh`, `cloud-install.sh`, or `Makefile`.
4. Introduced more than 30 days ago (oldest 2026-07-14, newest 2026-07-20 — none is unwired new work).
5. Not a platform/compat shim, not a `# noqa` compat re-export, not a user-visible config key's only consumer.

## Deleted

### `_line_of` — `src/kiro_crew/deploy/scan.py`

Superseded by `_line_of_fast`, the `bisect`-based version. All six call sites in `scan_content` use `_line_of_fast`, and `scan_content`'s own docstring already states it "replaces the O(n) text.count approach". Zero references repo-wide outside the definition — no test, no doc. Introduced 2026-07-20.

### `get_pending` — `src/kiro_crew/deploy/pending.py`

Superseded by `claim_pending`, which performs the read-and-remove atomically under the file lock; `get_pending` was the non-atomic read half. Zero references repo-wide. The 22 apparent grep hits are `get_pending_skill` in `skills.py`, an unrelated symbol in a different module. Not in `__all__`, not re-exported by `deploy/__init__.py`. Introduced 2026-07-20.

### `build_interactive_session_argv` — `src/kiro_crew/cloud/ssm.py`

No production caller and no CLI route: `_DISPATCH` in `cli_cloud.py:414-431` has no shell / ssh / interactive action, and the only `ssm.*` calls there are the plugin-install and detect helpers. Not superseded — the bare `start-session --target` argv shape (no `--document-name`) appears nowhere else in `src/`. The live sibling `build_port_forward_argv` builds a *different* SSM document (`AWS-StartPortForwardingSession`) and is untouched. Introduced 2026-07-14.

### `_shq` — `src/kiro_crew/cloud/ssm.py`

Leftover from the pre-base64 quoting approach. `_wrap_remote_command` — the only place that ever needed shell quoting — now base64-encodes the whole script instead, precisely because "SSM's `AWS-RunShellScript` mangles multi-line command strings". Nothing else in `ssm.py` calls it. Deleting is safe rather than a weakening: the replacement is quoting-proof by construction, strictly stronger than the escaper it retired. Introduced 2026-07-16.

### `set_last_active` — `src/kiro_crew/instances/registry.py`

Superseded by `update(instance_id, mark_last_active=True)`, which folds the `last_active_id` write into the same read-modify-write as the other connect hints; its sole caller is `ssh_tunnel_manager.connect()` at `ssh_tunnel_manager.py:1558`. That superseding path landed in `0bc68d698` (2026-08-12), so the setter has been dead since. The persisted key `last_active_id` has no frontend consumer — the only `last_active` hit in `*.ts`/`*.tsx` is an unrelated `last_active_ts` members field in `website/src/api/client.ts`.

`get_last_active` is **kept**: it also has no production caller, but it is the read path the tests use to verify that the *live* `mark_last_active` write worked. `docs/system-specs/modules/instances.md:306-312` already documents this state, and its wording stays true after this change (it describes `connect()` writing the field and `get_last_active()` being the only reader; it never names the setter).

## Tests

**Deleted alongside a dead symbol**, because each existed only to test that symbol:

- `test/test_cloud_ssm.py` — `test_interactive_session_argv` (tested `build_interactive_session_argv` and nothing else).
- `test/test_cloud_ssm.py` — `TestShellQuote::test_quotes_single_quotes` (one assertion, on `_shq`). The class stays for its `_json_str_list` test.
- `test/test_cloud_ssm_cov80.py` — `test_shell_quoting_escapes_embedded_quotes` (one assertion, on `_shq`).
- `test/test_apps_instances_loop_offload.py` — the `set_last_active` stub on the duck-typed registry double, plus the two now-stale `"set_last_active"` entries in the AST-guard method-name sets. The guards themselves are unchanged and still valid.
- `test/test_instances.py` — the trailing `reg.set_last_active("cd-1")` + its assertion inside `test_update_validation_and_hints`. This pair was trailing setup, not the test's subject; the update-validation body is untouched.

**Adjusted, not deleted**, to keep a real subject that would otherwise have been lost:

- `test/test_cloud_ssm.py::test_argv_heads_resolved_absolutely_under_minimal_path` — keeps its `build_port_forward_argv` absolute-resolution coverage (#4770); only the three lines exercising the deleted interactive builder were trimmed, and the docstring narrowed from "Both start-session builders" accordingly.
- `test/test_instances.py::test_remove_clears_last_active_and_reload` — used the setter as a **fixture** to seed `last_active_id` before asserting `remove()` clears it. It now seeds through the live `update("cd-1", mark_last_active=True)` path, so the test keeps asserting exactly what it did before.

## Verification

- `flake8`, `isort --check-only`, `mypy src/kiro_crew/` (1167 files) — clean.
- Deterministic gates green: black-baseline, subprocess-encoding, lockdown-before-publish, brand, harness-parity, loop-bound-locks, testpaths-coverage, changelog-history, focus-cue, docs-lint, per-file-coverage, vendor-manifest, scrub-lint. Nine gate self-tests (`--test`) pass.
- `deploy/scan.py` remains listed in `.github/black-baseline.txt`; its formatting status is unchanged by this diff (it was already non-conforming, and deliberately still is — the gate fails when a baselined file becomes clean).
- Full backend suite: **74560 passed, 116 failed**. All 116 failures reproduce identically — same files, same per-file counts — on unmodified `origin/main` (954736180) in a clean detached worktree. They are host-environment failures (`/local/home` owned by uid 65534, `AF_UNIX path too long`, host `jq`/Node versions, playwright-cli installer bootstrap). **Zero new failures from this diff.**
- Targeted re-runs green: `test_cloud_ssm.py`, `test_cloud_ssm_cov80.py`, `test_apps_instances_loop_offload.py` (90 passed); `test_deploy_web_render_scan.py`, `test_deploy_pending_replace_retry.py`, `test_deploy_web_handlers.py`, `test_deploy_web_profiles.py`, `test_deploy_profiles_cov80.py`, `test_cse_2026_08_05_fixes.py`, `test_deploy_round21_fixes.py` (160 passed); `test_instances.py -k "last_active or update_validation"` (3 passed).
- No frontend files touched, so the frontend gate lane is out of scope for this diff.

## Deliberately NOT deleted

These were confirmed unreferenced but are **not** dead code. Listing them so the next audit does not re-litigate them.

**Unwired security / AWS-teardown paths — the deadness is itself the defect, so the fix is wiring, not deletion:**

| symbol | why |
|---|---|
| `deploy/engine.py::create_private_bucket` | PR #1990 landed — it now delegates to `_harden_bucket()` instead of duplicating it — but it still has no production caller, and it is the hardened bucket-create (BPA on, AES256 SSE, ACLs disabled). Two docs name it as a reusable building block: `docs/system-specs/features/aws-control.md:186` ("Bootstrap reuses `create_private_bucket`/`_harden_bucket`") and `docs/request-for-change/rfc-s3-backup.md:87,170`. |
| `cloud/source.py::delete_instance_boundary` | Deletes the shared `kirocrew-ec2-boundary` IAM managed policy. `docs/system-specs/modules/cloud.md:76` documents it as "for admin cleanup" — an intentionally unwired admin escape hatch. |
| `deploy/skills/artifact-deploy/scripts/reaper_lambda/index.py::_del_stack` | CloudFormation stack deletion in the reaper Lambda, unreachable from `handler` (full-file read: no dispatch dict, no `getattr`). The two live delete sites — Phase A and the Phase B `DELETE_FAILED` retry — each inline their own `_stack_site_tag_ok` check rather than funnelling through it, so **both live paths are gated**, and `test_f1_lambda_gates_every_delete_stack` (`test_deploy_round21_fixes.py:26-36`) does assert on each of them separately. Deleting `_del_stack` is therefore blocked only mechanically: that same test splits the source on `def _del_stack` to assert the third path is gated too, and would raise `IndexError` once the function is gone. The reason to keep it is structural rather than a live hole — with three independently maintained gates and a source-text test, a fourth delete site added later would be ungated while the test's `assert "_stack_site_tag_ok" in src` still passed. Wiring `_del_stack` in and collapsing the two inline copies into it turns three gates into one funnel; that is a design change, not this PR. |

**Public / documented surface, or a config key's only consumer:**

| symbol | why |
|---|---|
| `cloud/connect.py::ssm_proxy_ssh_host` | `docs/system-specs/modules/instances.md:1134` says verbatim "The legacy `ssm_proxy_ssh_host` helper is kept for reference only." |
| `monitoring/decision.py::decide_monitor` | Documented as a policy function in `docs/system-specs/modules/learn-cron-dashboard.md:916`. |
| `tunnel/manager.py::_tunnel_name` | The **only** consumer of the user-visible config keys `tunnel.name_mode` and `tunnel.name_override`, which are wired all the way in (`server.py:3863-3864` → `setup.py:124-125` → ctor). Deleting it would make two documented config keys terminally inert and leave `self._name_mode` / `self._name_override` as dead stores — a wiring gap to close, not dead code to remove. |

**Deletion would cost a real test, or require a refactor this PR is not:**

| symbol | why |
|---|---|
| `cloud/sizes.py::all_tiers` | Its one caller, `test_no_tier_below_working_set`, asserts a genuine catalog invariant across every tier (RAM ≥ 16, disk ≥ 40, vCPU ≥ 4, price > 0). Removing the accessor would force the test to reach into the private `_TIERS`. |
| `metrics/recorder.py::up_down_counter` | Not an ABC/Protocol override, so genuinely uncalled — but it is one of three symmetric facade methods (`counter` / `up_down_counter` / `histogram`) over the OTel instrument set, and `docs/system-specs/modules/metrics.md:107` makes that facade the mandatory path for app-authored metrics. Zero callers reflects "no shipped metric is an up/down counter yet", and removing it would weaken the "no-op recorder covers every instrument type" assertions. |
| `deploy/profiles.py::save_registry` | A textbook superseded helper — `locked_registry` inlines a byte-identical tmp → fsync → `replace_with_retry` sequence and holds the lock across the whole read-modify-write, and all six production write sites use it. But 7 of 9 test references use `save_registry` as a **setup/fixture** helper, one of them in an unrelated feature area (`test_artifacts_handlers.py`). Removing it means rewriting those seven seeds — worth doing as its own change. |
| `instances/registry.py::get_last_active` | See above: the only read path the tests use to verify the live `mark_last_active` write. |

**One vulture finding was a false positive:** `cloud/ec2.py::load_template` has no production caller (production passes `_template_path()` to `--template-file` instead of reading the text), but its 19 test call sites are load-bearing guards on the bundled CFN template — `!Sub` variable legality, the Node ≥ 22 floor, pinned tarball SHA-256s, non-ASCII property values, and the `DashboardPort` ↔ `DEFAULT_REMOTE_DASHBOARD_PORT` cross-check. It is the single named seam for reading the template and must stay.

Enum members and dataclass fields flagged by vulture (`monitoring/models.py`, `instances/constants.py`, `deploy/webapp_types.py`, `metrics/events.py`) were excluded wholesale: they are serialization surface and config ceilings, not call targets.

---

no linked issue: this is a self-directed dead-code audit, not a filed bug. The `#1990` / `#4770` / `#6588` references above are evidence citations pointing at merged PRs, not issues to close.
