### PR TITLE
chore(mcp): remove confirmed dead code in the MCP subsystem

### DIFF
--- a/src/kiro_crew/mcp_gateway/pool.py
+++ b/src/kiro_crew/mcp_gateway/pool.py
@@ -494,33 +494,14 @@ class BackendPool:
             "exclusive": len(self._exclusive),
         }
 
-    def _metrics_snapshot(self) -> dict[str, Any]:
-        """Sync per-backend snapshot. PRIVATE: it does a blocking /proc RSS
-        walk, so it must never run on the event loop — callers use
-        :meth:`metrics_snapshot_async`, which offloads the walk via to_thread."""
-        now = time.monotonic()
-        backends = [
-            {
-                "server": b.pool_key.server_name,
-                "agent": b.pool_key.agent_name,
-                "pid": b.pid,
-                "sessions": b.refcount,
-                "idle_s": round(max(0.0, now - b.last_used_at), 1),
-                "rss_kb": _proc_rss_kb(b.pid),
-            }
-            for b in self._backends.values()
-            if b.is_alive
-        ]
-        return {**self.stats(), "backends": backends}
-
     async def metrics_snapshot_async(self) -> dict[str, Any]:
-        """Race-free, off-loop variant of :meth:`_metrics_snapshot`.
+        """Per-backend snapshot, taken off the event loop.
 
         Snapshots per-backend identity under the pool lock (fast, on-loop),
         then performs the blocking ``/proc`` RSS walk off the event loop via
-        ``asyncio.to_thread``. A plain ``to_thread(_metrics_snapshot)`` would
-        iterate ``_backends`` in the worker thread and can race a concurrent
-        add/evict ("dict changed size during iteration").
+        ``asyncio.to_thread``. Snapshotting first is load-bearing: iterating
+        ``_backends`` in the worker thread can race a concurrent add/evict
+        ("dict changed size during iteration").
         """
         now = time.monotonic()
         async with self._lock:

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -1835,11 +1835,6 @@ def overlay_ready(overlay_dir: Path) -> bool:
         return False
 
 
-def is_wrapped_entry(entry: Any) -> bool:
-    """Diagnostic helper: ``True`` iff ``entry`` was produced by the rewriter."""
-    return isinstance(entry, dict) and entry.get(_WRAPPER_MARKER) is True
-
-
 def default_overlay_dir() -> Path:
     """Return ``$KIROCREW_HOME/mcp-gateway/agents`` (follows ``config_dir``)."""
     home = os.environ.get("KIROCREW_HOME")

--- a/src/kiro_crew/mcp_gateway/spill.py
+++ b/src/kiro_crew/mcp_gateway/spill.py
@@ -20,7 +20,6 @@ import re
 import stat as stat_mod
 import time
 from pathlib import Path
-from typing import Any, Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
@@ -36,10 +35,6 @@ _SPILL_DIR_NAME = "mcp_spill"
 
 # Max age (seconds) for spill files — older ones are cleaned on startup.
 _SPILL_MAX_AGE_SECS = 24 * 60 * 60  # 24 hours
-
-# Regex to extract a JSON-RPC id from the first ~4 KiB of a drained oversize
-# chunk. Handles both string ids ("id":"some-string") and integer ids (id:42).
-_ID_REGEX = re.compile(rb'"id"\s*:\s*("(?:[^"\\]|\\.)*?"|\d+)')
 
 
 def _spill_dir() -> Path:
@@ -83,28 +78,6 @@ def cleanup_old_spill_files() -> int:
     if deleted:
         logger.info("spill cleanup: removed %d files older than 24h", deleted)
     return deleted
-
-
-def extract_id_from_bytes(data: bytes) -> Optional[Any]:
-    """Parse the JSON-RPC 'id' field from the first ~4 KiB of raw bytes.
-
-    Returns the id value (str or int) or None if unparseable.
-    """
-    prefix = data[:4096]
-    m = _ID_REGEX.search(prefix)
-    if m is None:
-        return None
-    raw = m.group(1)
-    if raw.startswith(b'"'):
-        try:
-            return json.loads(raw.decode("utf-8"))
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return None
-    else:
-        try:
-            return int(raw)
-        except ValueError:
-            return None
 
 
 def maybe_spill_response(

--- a/test/test_mcp_gateway_oversize.py
+++ b/test/test_mcp_gateway_oversize.py
@@ -2,8 +2,6 @@
 
 Covers:
 (a) Response under limit passes untouched
-(b) Over transport limit + parseable id -> only that request fast-failed -32000
-(c) Id unparseable -> all pending failed, none hanging
 (d) Over spill threshold -> spill file has full content, in-band truncated
 (e) Spill failure (unwritable dir) -> original forwarded unmodified
 (f) Non-tool-result frames over threshold pass through untouched
@@ -21,7 +19,6 @@ from unittest.mock import patch
 from kiro_crew import platform_compat as pc
 from kiro_crew.mcp_gateway.spill import (
     cleanup_old_spill_files,
-    extract_id_from_bytes,
     maybe_spill_response,
 )
 
@@ -39,33 +36,6 @@ class TestUnderThresholdPassthrough:
     def test_empty_line_passthrough(self):
         """An empty or whitespace line passes through."""
         assert maybe_spill_response(b"\n", "test-server", 100) == b"\n"
-
-
-# --- (b) Over transport limit + parseable id -> per-request fast-fail ---
-
-
-class TestExtractId:
-    def test_string_id(self):
-        data = b'{"jsonrpc":"2.0","id":"gw-12345-7","result":{}}'
-        assert extract_id_from_bytes(data) == "gw-12345-7"
-
-    def test_integer_id(self):
-        data = b'{"jsonrpc":"2.0","id":42,"result":{}}'
-        assert extract_id_from_bytes(data) == 42
-
-    def test_no_id(self):
-        data = b'{"jsonrpc":"2.0","method":"notify"}'
-        assert extract_id_from_bytes(data) is None
-
-    def test_garbage(self):
-        data = b'\x00\x01\x02binary garbage'
-        assert extract_id_from_bytes(data) is None
-
-    def test_id_in_first_4kb(self):
-        """Id within first 4KB is found even with large payload after."""
-        prefix = b'{"jsonrpc":"2.0","id":"found-it","result":{"content":[{"type":"text","text":"'
-        payload = prefix + b"x" * 10000 + b'"}]}}\n'
-        assert extract_id_from_bytes(payload) == "found-it"
 
 
 # --- (d) Over spill threshold -> spill file with full content ---


### PR DESCRIPTION
## What

Removes three symbols in `src/kiro_crew/mcp_gateway/` that have no production caller, plus the one test class that existed only to exercise one of them. **No behaviour change** — every deletion is code nothing can reach.

`-85 / +4` across 4 files.

## Why this needed a confirmation protocol, not a linter

MCP tools reach the agent through a *registry keyed by name strings*, so static analysis reliably reports live handlers as uncalled. vulture at `--min-confidence 60` produced 60 candidates for this scope; **57 of them were false positives**, including four whole modules (`mcp_tools/{knowledge,sessions,skills,workflows}.py`) that appear to have zero referrers but are loaded via `importlib.import_module` over `DOMAIN_MODULES` in `mcp_tools/__init__.py`.

Every symbol below cleared all of:

1. Repo-wide literal scan of the symbol name across **6928 files** — `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1 *.cfg *.ini *.txt` — including `test/`, `docs/`, `docs/system-specs/`, `src/kiro_crew/builtin_skills/` and `.github/`.
2. Dynamic-reference sweep: `getattr`/`setattr`/`globals()`/`importlib`/`__getattr__`, `pyproject.toml` entry points, the MCP tool registry and `tools/list` response, the gateway JSON-RPC method table, agent-spec `allowedTools`, cron script SDK, hook name tables, decorator registries, and `__all__` — string-form names included.
3. Not present in `__all__`, `docs/`, `docs/system-specs/`, or any `SKILL.md`.
4. `git log -1 -S'<symbol>'` older than 30 days, so it is not an unwired new feature.
5. Not a platform/compat shim, `# noqa` re-export, or deprecated-but-public config key / tool name.

## Deleted symbols and the evidence

### 1. `rewriter.is_wrapped_entry` — `src/kiro_crew/mcp_gateway/rewriter.py:1838`

```python
def is_wrapped_entry(entry: Any) -> bool:
    """Diagnostic helper: ``True`` iff ``entry`` was produced by the rewriter."""
    return isinstance(entry, dict) and entry.get(_WRAPPER_MARKER) is True
```

The repo-wide scan returns **exactly one hit: this definition**. No test, no doc, no spec, no skill; `rewriter.py` has no `__all__`. Self-described as a diagnostic helper that nothing ever diagnosed with. Introduced 2026-07-11 in `6447a7a8b`, 49 days ago.

`_WRAPPER_MARKER` itself stays — 9 other live call sites in `rewriter.py`.

### 2. `BackendPool._metrics_snapshot` — `src/kiro_crew/mcp_gateway/pool.py:497`

Three repo-wide hits: the definition, plus two **docstring** mentions inside the sibling that replaced it. It is superseded by `metrics_snapshot_async` (`pool.py:516`), which reimplements the same body under the pool lock — and whose own docstring says why the sync variant is not callable:

> A plain `to_thread(_metrics_snapshot)` would iterate `_backends` in the worker thread and can race a concurrent add/evict ("dict changed size during iteration").

So the method existed only as the thing the working implementation warns you not to call. The only caller of the async variant is `gatewayd.py:2275`; no test patches, spies on, or asserts against `_metrics_snapshot`. Introduced 2026-07-11 in `6447a7a8b`.

The async docstring is reworded so it no longer references a method that no longer exists — the invariant it documents (snapshot identity under the lock *first*, RSS walk off-loop *after*) is preserved verbatim. `self.stats()` and `_proc_rss_kb` stay: the async variant uses both.

### 3. `spill.extract_id_from_bytes` + `_ID_REGEX` — `src/kiro_crew/mcp_gateway/spill.py:88`, `:42`

Seven repo-wide hits: the definition, one test import, and five assertions — **all inside `TestExtractId`** in `test/test_mcp_gateway_oversize.py`. Zero production callers: `backend.py:59` imports only `maybe_spill_response`, `gatewayd.py:91` only `cleanup_old_spill_files`.

The oversize-response id extraction it was written for **is implemented, independently and inline**, in `Backend._fail_oversize_request` (`backend.py:3302-3330`) — its own prefix-JSON parse plus its own `re.search(r'"id"\s*:\s*("(?:[^"\\]|\\.)*?"|\d+|null)')`, over a 512/256-byte prefix rather than 4 KiB. That real path is covered in `test_mcp_gateway_backend_coverage.py` (`"oversize initialize response"`, `"unrecoverable request id"`). Introduced 2026-07-18 in `daafab255`, 42 days ago.

`_ID_REGEX` had `extract_id_from_bytes` as its sole consumer and goes with it. `from typing import Any, Optional` in `spill.py` is dropped because those names were used only by the deleted signature; `re` and `json` stay (still used at `spill.py:48`, `:124`, `:202`).

### 4. `TestExtractId` (5 tests) — `test/test_mcp_gateway_oversize.py:47`

**This test is deleted along with the symbol, because it only tested this dead symbol.** It asserts nothing about `maybe_spill_response`, `cleanup_old_spill_files`, or any live path — its whole body is five direct calls to `extract_id_from_bytes`.

The file's docstring bullets `(b)` and `(c)` are removed with it. They named behaviour that lives in `Backend._fail_oversize_request` and is tested there; note the file already had **no `(c)` test class at all**, so that bullet was aspirational before this change. Sections `(a)`, `(d)`, `(e)`, `(f)`, `(g)`, `(h)` are untouched — the file still runs 20 tests covering the real spill path.

## Reported, deliberately NOT deleted

Found during the audit and left alone, so a reviewer does not have to re-derive them:

| Symbol | Why it stays |
|---|---|
| **`mcp_gateway/seed.py`** — `plan_seed`, `apply_seed`, `SeedPlan` (~114 lines) | Referenced only by `test/test_mcp_seed.py` and `test/test_mcp_shareability.py`, but `docs/system-specs/modules/mcp-shareability.md:160` **documents it, and documents it as having no call site**: "nothing on the startup path calls `plan_seed` or `apply_seed`". A documented public surface is a maintainer decision (wire it up, or retire the module and its spec section together), not a janitorial one. **This is the single largest dead-code candidate in the MCP group and it needs a ruling.** |
| `hazards.clear_observed` | Test-only, but introduced 2026-08-14 (`62da81781`) — 15 days. Likely not yet wired. |
| `rewriter.overlay_ready` | Test-only, but introduced 2026-08-12 (`2b3adb13c`) — 17 days; also load-bearing in the comment at `rewriter.py:55`. |
| `transport.is_pipe` | Test-only, introduced 2026-08-08 (`df608eea9`) — 21 days. |
| `session_servers.injection_server_names` | Test-only, introduced 2026-08-04 (`ba383df0b`) — 25 days. |
| `ProviderRegistry.provider_names` | Test-only, but mirrors `skill_providers/base.py:117` as a parallel public registry API, and `test_external_access_seam.py:127`/`:142` use it to assert the external-access gate. Deleting it would push real security assertions onto the private `_providers`. |
| `Backend.dead_reason`, `BackendPool.draining_count` | Test-only, but they are the observability properties that 22 and 15 assertions respectively use to verify the backend-death and pool-drain state machines. Removing them means rewriting live tests, not removing dead weight. |

## Verification

- 17 backend gates green: `check_black_formatting`, `check_subprocess_encoding`, `check_lockdown_before_publish`, `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test`, `mypy src/kiro_crew/`, `check_loop_bound_locks`, `check_testpaths_coverage`, `verify_vendor_manifest`, `check_brand_name`, `check_harness_parity`, `check_changelog_history`, `check_focus_cue`, `docs-lint.sh`, `check_per_file_coverage --test`, `scrub-lint.sh --no-history`.
- `pytest -k "mcp or gateway"` → **6023 passed, 17 skipped, 2 xfailed**.
- `test/test_mcp_gateway_oversize.py` + `test_mcp_gateway_rewriter_fingerprint.py` + `test_gatewayd_more_coverage.py` + `test_mcp_gateway_bluegreen.py` → **150 passed**.
- Local AI review (both pinned models from `codex-review.yml` / `claude-review.yml`, two stages each): **no findings**.
- `test/test_host_isolation_floor.py` reports 11 failed / 58 passed **identically on this branch and on the base commit** — an artifact of this host's home layout, not this diff.

## Scope

`src/kiro_crew/mcp_gateway/` only. No dependency, config, CI, or frontend change. Nothing renamed, nothing reformatted, no refactor riding along.
