### PR TITLE
test(browser): make relay cap fixture concurrent

### DIFF
--- a/test/test_browser_cli_view.py
+++ b/test/test_browser_cli_view.py
@@ -96,8 +96,19 @@ class _RedirectHandler(http.server.BaseHTTPRequestHandler):
 
 @pytest.fixture
 def redirecting_server() -> Iterator[int]:
-    """A loopback HTTP server whose root answers 302."""
-    srv = http.server.HTTPServer(("127.0.0.1", 0), _RedirectHandler)
+    """A concurrent loopback HTTP server whose root answers 302.
+
+    Relay tests hold more than one connection open at a time.  A serial
+    ``HTTPServer`` leaves one upstream leg queued behind another, so closing
+    that queued connection cannot finish both relay pumps until the unrelated
+    active connection also closes.  Which relay worker reaches the server
+    first is scheduler-dependent.  Match the real dashboard's concurrent
+    connection handling so each test connection owns an independent handler.
+    """
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _RedirectHandler)
+    # Make server_close() join every request thread after the clients are torn
+    # down; no daemon handler may leak into the next test.
+    srv.daemon_threads = False
     thread = threading.Thread(target=srv.serve_forever, daemon=True)
     thread.start()
     try:


### PR DESCRIPTION
## Problem / Motivation

`test_relay_caps_concurrent_connections` can fail even when the relay's connection cap is correct. The shared test fixture used a serial `HTTPServer`, while this test deliberately holds two relay connections open.

Scheduler order determines which upstream connection enters the only request handler. If the test closes the connection still queued in the server backlog, one relay pump closes but the other remains blocked behind the unrelated live handler. The relay correctly keeps that socket tracked until both pumps finish, so the assertion intermittently observes two entries instead of one.

## Why it matters

A scheduler-dependent test can reject unrelated PRs and obscure real failures. Weakening relay cleanup or retrying the assertion would be worse: the relay must retain a capped connection until both pumps actually finish. The fixture must model the concurrency the test claims to exercise.

## What changed

- Use `ThreadingHTTPServer` for the redirecting-server fixture so every held relay connection gets an independent upstream handler.
- Set `daemon_threads = False` so fixture teardown joins request handlers after clients and the relay are closed.

Production relay code is unchanged. In particular, a slot is still held until both pumps finish; weakening that invariant would hide the fixture race and reduce the connection cap's DoS protection.

## Tests

- Controlled reversed-order reproduction: old fixture retained 2 tracked sockets; new fixture released the closed connection and retained 1.
- 300 real-socket cap/cleanup stress iterations: 0 failures.
- `test/test_browser_cli_view.py -n0`: 30 passed.
- `test/test_browser_cli_view.py -n2`: 30 passed, including after rebasing to latest main.
- Black, Flake8, and `git diff --check` passed.
- All OPEN PR changed-file audit found no competing edit to the fixture or production relay.

No timeout, sleep increase, retry, or production semantic weakening is used to hide the flake.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes only a backend test fixture and has no rendered UI effect.
