### PR TITLE
test(cli): avoid leaking mocked gateway coroutine

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4833,15 +4833,19 @@ class TestSeedDispatch:
         """When --seed is provided, seed_cmd should be called before gateway."""
         monkeypatch.setattr(sys, "argv", ["kirocrew", "gateway", "--seed", "demo"])
         mock_seed = MagicMock(return_value=0)
+        gateway_call = object()
+        mock_gateway = MagicMock(return_value=gateway_call)
         with (
             patch("kiro_crew.cli.seed_cmd", mock_seed),
-            patch("kiro_crew.cli_server._gateway"),
-            patch("kiro_crew.cli.asyncio.run"),
+            patch("kiro_crew.cli_server._gateway", mock_gateway),
+            patch("kiro_crew.cli.asyncio.run") as mock_run,
         ):
             from kiro_crew.cli import main
 
             main()
         mock_seed.assert_called_once()
+        mock_gateway.assert_called_once()
+        mock_run.assert_called_once_with(gateway_call)
 
     def test_seed_nonzero_exits(self, monkeypatch):
         """When seed_cmd returns non-zero, CLI should sys.exit with that code."""
@@ -4858,15 +4862,19 @@ class TestSeedDispatch:
         """When --seed is not provided, seed_cmd should not be called."""
         monkeypatch.setattr(sys, "argv", ["kirocrew", "gateway"])
         mock_seed = MagicMock()
+        gateway_call = object()
+        mock_gateway = MagicMock(return_value=gateway_call)
         with (
             patch("kiro_crew.cli.seed_cmd", mock_seed),
-            patch("kiro_crew.cli_server._gateway"),
-            patch("asyncio.run"),
+            patch("kiro_crew.cli_server._gateway", mock_gateway),
+            patch("kiro_crew.cli.asyncio.run") as mock_run,
         ):
             from kiro_crew.cli import main
 
             main()
         mock_seed.assert_not_called()
+        mock_gateway.assert_called_once()
+        mock_run.assert_called_once_with(gateway_call)
 
     def test_seed_with_replace_flag(self, monkeypatch):
         """--seed with --seed-replace should call seed_cmd."""
@@ -4876,15 +4884,19 @@ class TestSeedDispatch:
             ["kirocrew", "gateway", "--seed", "demo", "--seed-replace"],
         )
         mock_seed = MagicMock(return_value=0)
+        gateway_call = object()
+        mock_gateway = MagicMock(return_value=gateway_call)
         with (
             patch("kiro_crew.cli.seed_cmd", mock_seed),
-            patch("kiro_crew.cli_server._gateway"),
-            patch("asyncio.run"),
+            patch("kiro_crew.cli_server._gateway", mock_gateway),
+            patch("kiro_crew.cli.asyncio.run") as mock_run,
         ):
             from kiro_crew.cli import main
 
             main()
         mock_seed.assert_called_once()
+        mock_gateway.assert_called_once()
+        mock_run.assert_called_once_with(gateway_call)
 
 
 class TestDoctorEmbeddings:


### PR DESCRIPTION
## Problem / Motivation

Three `TestSeedDispatch` cases patch the async `_gateway` function without supplying a replacement, so `unittest.mock` creates an `AsyncMock`. The CLI calls it and gets a coroutine, but the same test mocks the synchronous `asyncio.run` boundary, leaving that coroutine unconsumed. Garbage collection can then emit an unawaited-coroutine warning during a later, unrelated test.

## Why it matters

The warning is scheduler- and GC-timing-dependent, so it can fail an innocent test or shard instead of the test that created it. Retrying, sleeping, or filtering the warning would preserve the leak and make CI attribution less trustworthy.

## What changed

- Give the async gateway seam an explicit synchronous `MagicMock` that returns an ordinary sentinel.
- Patch `asyncio.run` in the namespace read by the CLI.
- Assert both the gateway call and the exact `asyncio.run(sentinel)` handoff.

Production code is unchanged.

## Tests

- Strict warning mode on `TestSeedDispatch`: 4 passed with `RuntimeWarning` and `PytestUnraisableExceptionWarning` promoted to errors.
- Strict full `test_cli.py`: 353 passed, 14 skipped.
- Strict target repeated 10 times: 10/10 passed.
- Two-worker xdist target: 4 passed.
- Flake8, isort, Black baseline, subprocess-encoding, and changed-source diff gates passed.
- A full OPEN PR inventory found no competing change to `test/test_cli.py`.

No retry, sleep, timeout increase, or warning filter is introduced.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes only Python test doubles and assertions; it has no rendered UI effect.
