### PR TITLE
fix(sel): open legacy lock keys in binary mode

### DIFF
--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -728,9 +728,15 @@ class SecurityEventLog:
             raise OSError(
                 f"SEL chain-lock sidecar {lock_path} is a link; refusing to lock it"
             )
+        # Windows' CRT text mode strips a trailing 0x1A while opening a file
+        # for update. The fallback lock path can be the raw HMAC key, so this
+        # descriptor must be binary even though the lock code never writes it.
         fd = os.open(
             lock_path,
-            os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0),
+            os.O_CREAT
+            | os.O_RDWR
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_BINARY", 0),
             0o600,
         )
         joined: _ChainHold | None = None

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -563,7 +563,10 @@ log.flush()
         signing fine.
         """
         legacy = tmp_path / kiro_crew_sel._HMAC_KEY_FILE
-        legacy.write_bytes(os.urandom(64))
+        # Windows' CRT text mode treats a trailing 0x1A as DOS EOF. Keep this
+        # input deterministic so opening the binary key as a lock can never
+        # regress to text mode and silently truncate its final byte.
+        legacy.write_bytes(b"k" * 63 + b"\x1a")
         trust = tmp_path / kiro_crew_sel._TRUST_SUBDIR
 
         real_mkdir = Path.mkdir


### PR DESCRIPTION
## Problem / Motivation

On Windows, the SEL fallback path may use the legacy HMAC key file itself as the byte-range lock target when the protected trust directory cannot be created. That descriptor was opened with `O_RDWR` but without `O_BINARY`.

The Windows CRT therefore treats the binary key as a text file. If a valid 64-byte random key ends in DOS EOF byte `0x1A`, opening it for update truncates it to 63 bytes before the lock helper receives the descriptor. The existing random fixture hit this with roughly 1/256 probability, so unrelated PRs could fail the cross-process SEL test.

## Why it matters

This is not only a flaky assertion: the test exposed real mutation of the audit log's signing key on a supported fallback path. Retrying the test would leave both CI attribution and key integrity unreliable.

## What changed

- Open the SEL chain-lock target with `getattr(os, "O_BINARY", 0)` in addition to the existing flags. It is a no-op off Windows.
- Make the regression fixture deterministic with a 64-byte key ending in `0x1A`, so removing `O_BINARY` always fails instead of relying on random chance.

No lock timing, retry, timeout, or production write semantics change.

## Tests

- Mutation check: removing `O_BINARY` makes the deterministic regression fail; restoring it passes consistently.
- Focused Windows regression passed before and after the final rebase to current `main`.
- Full `test_sel.py`: 231 passed, 25 skipped; the only host-specific failure is the existing symlink-privilege capability case owned by #6752.
- Four processes × 50 appends: 200/200 chain-valid events, key unchanged across restart.
- Single-process 1000-append stress passed.
- Related SEL/platform-lock tests, isort, Flake8, mypy, and `git diff --check` passed.
- Full OPEN PR audit found direct overlap only with larger, currently conflicting #4997; this smaller deterministic integrity fix should land first, then #4997 can replay on top. #6752 does not touch these files.

No retry, sleep, timeout increase, or random rerun is introduced.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes a Windows file-open flag and backend regression fixture; it has no rendered UI effect.
