### PR TITLE
fix(settings): update model and effort selectors optimistically

### DIFF
--- a/website/src/pages/settings/ChatPanel.tsx
+++ b/website/src/pages/settings/ChatPanel.tsx
@@ -95,6 +95,42 @@ const COMPLETION_KEEP_CHARS_MIN = 0
 const COMPLETION_KEEP_CHARS_MAX = 512000
 const COMPLETION_KEEP_CHARS_DEFAULT = 3000
 
+/** Shape of the kirocrewConfig query payload this panel reads and patches. */
+type KirocrewConfigShape = {
+  session?: { autocompact_pct?: number }
+  session_summary?: { enabled?: boolean }
+  agent?: {
+    model?: string
+    role_models?: { background?: string; subagent?: string }
+    role_efforts?: { background?: string; subagent?: string }
+    reasoning_effort?: string
+    soft_stop_budget_secs?: number
+    completion_keep?: CompletionKeepMode
+    completion_keep_chars?: number
+    fallback_model?: string
+  }
+  dashboard?: { user_role?: string; user_role_other?: string; user_technical_level?: string; prevent_sleep?: boolean }
+}
+
+/**
+ * Return a copy of `cfg` with the dot-separated `path` set to `value`,
+ * shallow-cloning only the objects along the path. Used to write a config
+ * PATCH into the query cache optimistically so a selector shows the chosen
+ * value immediately instead of waiting for the PATCH + refetch round-trip.
+ */
+function setConfigValue(cfg: KirocrewConfigShape, path: string, value: unknown): KirocrewConfigShape {
+  const keys = path.split('.')
+  const next: Record<string, unknown> = { ...cfg }
+  let cursor = next
+  for (let i = 0; i < keys.length - 1; i++) {
+    const child = cursor[keys[i]]
+    cursor[keys[i]] = typeof child === 'object' && child !== null ? { ...(child as Record<string, unknown>) } : {}
+    cursor = cursor[keys[i]] as Record<string, unknown>
+  }
+  cursor[keys[keys.length - 1]] = value
+  return next as KirocrewConfigShape
+}
+
 export function ChatPanel() {
   const qc = useQueryClient()
   const [chatCfg, setChatCfg] = useState<ChatConfig>(loadChatConfig)
@@ -149,25 +185,34 @@ export function ChatPanel() {
   })
 
   // ── KiroCrew config (server-side) ──
-  const mcQ = useQuery<{
-    session?: { autocompact_pct?: number }
-    session_summary?: { enabled?: boolean }
-    agent?: {
-      model?: string
-      role_models?: { background?: string; subagent?: string }
-      role_efforts?: { background?: string; subagent?: string }
-      reasoning_effort?: string
-      soft_stop_budget_secs?: number
-      completion_keep?: CompletionKeepMode
-      completion_keep_chars?: number
-      fallback_model?: string
-    }
-    dashboard?: { user_role?: string; user_role_other?: string; user_technical_level?: string; prevent_sleep?: boolean }
-  }>({
+  const mcQ = useQuery<KirocrewConfigShape>({
     queryKey: ['kirocrewConfig'],
     queryFn: () => api.kirocrewConfig(),
   })
   const mcCfg = mcQ.data
+
+  /**
+   * Mutation options for a config PATCH with an OPTIMISTIC cache write
+   * (issue #6848): the seven Model-section selectors are controlled by the
+   * query cache, so without this they keep showing the previous choice until
+   * the PATCH and refetch settle. Writes the picked value into the cache
+   * immediately, rolls back on error, and reconciles with the server on
+   * settle — same shape as tipsMut/dashMut above.
+   */
+  const optimisticConfigOpts = (path: string, errMsg: (err: unknown) => string) => ({
+    mutationFn: (v: string) => api.patchConfig(path, v),
+    onMutate: async (v: string) => {
+      await qc.cancelQueries({ queryKey: ['kirocrewConfig'] })
+      const prev = qc.getQueryData<KirocrewConfigShape>(['kirocrewConfig'])
+      if (prev) qc.setQueryData(['kirocrewConfig'], setConfigValue(prev, path, v))
+      return { prev }
+    },
+    onError: (err: unknown, _v: string, ctx?: { prev?: KirocrewConfigShape }) => {
+      if (ctx?.prev) qc.setQueryData(['kirocrewConfig'], ctx.prev)
+      setSaveError(errMsg(err))
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
+  })
 
   // ── User profile (About You) ──
   // Same slugs as onboarding step 2 (OnboardingFlow.tsx), validated by the
@@ -246,16 +291,14 @@ export function ChatPanel() {
   // "auto" (default) = backend availability-aware routing, concrete id =
   // tried first with "auto" as the final fallthrough.
   const fallbackModel = mcCfg?.agent?.fallback_model ?? 'auto'
-  const fallbackMut = useMutation({
-    mutationFn: (v: string) => api.patchConfig('agent.fallback_model', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: (err: unknown) => {
+  const fallbackMut = useMutation(
+    optimisticConfigOpts('agent.fallback_model', (err: unknown) => {
       // Surface the backend's actual deny reason (e.g. an unentitled id)
       // next to the generic failure line.
       const reason = err instanceof Error && err.message ? `: ${err.message}` : ''
-      setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_fallback_model') + reason)
-    },
-  })
+      return i18nT('pages.settings.chatPanel.failed_to_save_fallback_model') + reason
+    })
+  )
   const fallbackModelOptions = (current: string): string[] => {
     const opts = ['', 'auto', ...availableModels.map(m => m.name).filter(m => m !== 'auto')]
     if (current && !opts.includes(current)) opts.splice(2, 0, current)
@@ -310,22 +353,20 @@ export function ChatPanel() {
   // change event would overwrite the user's stored choice.
   if (!modelOptions.includes(defaultModel)) modelOptions.unshift(defaultModel)
 
-  const defaultModelMut = useMutation({
-    mutationFn: (v: string) => api.patchConfig('agent.model', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_default_model')),
-  })
+  const defaultModelMut = useMutation(
+    optimisticConfigOpts('agent.model', () => i18nT('pages.settings.chatPanel.failed_to_save_default_model'))
+  )
 
   const defaultEffort = mcCfg?.agent?.reasoning_effort ?? ''
   // Effort is only meaningful on reasoning-capable models. Rather than hide the
   // row (which would make the setting look absent), keep it visible and
   // disabled with an explanatory hint.
   const effortSupported = modelSupportsEffort(defaultModel)
-  const defaultEffortMut = useMutation({
-    mutationFn: (v: string) => api.patchConfig('agent.reasoning_effort', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_default_reasoning_effort')),
-  })
+  const defaultEffortMut = useMutation(
+    optimisticConfigOpts('agent.reasoning_effort', () =>
+      i18nT('pages.settings.chatPanel.failed_to_save_default_reasoning_effort')
+    )
+  )
 
   // ── Per-role model defaults (agent.role_models) ──
   // Same picker as the chat default above, but NOT the same precedence:
@@ -345,16 +386,12 @@ export function ChatPanel() {
   }
   const roleModelLabels = (opts: string[]): string[] =>
     opts.map(m => (m === 'auto' ? i18nT('pages.settings.chatPanel.role_model_auto') : m))
-  const backgroundModelMut = useMutation({
-    mutationFn: (v: string) => api.patchConfig('agent.role_models.background', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_model')),
-  })
-  const subagentModelMut = useMutation({
-    mutationFn: (v: string) => api.patchConfig('agent.role_models.subagent', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_model')),
-  })
+  const backgroundModelMut = useMutation(
+    optimisticConfigOpts('agent.role_models.background', () => i18nT('pages.settings.chatPanel.failed_to_save_role_model'))
+  )
+  const subagentModelMut = useMutation(
+    optimisticConfigOpts('agent.role_models.subagent', () => i18nT('pages.settings.chatPanel.failed_to_save_role_model'))
+  )
 
   // Per-role reasoning effort, paired with each role's model. Empty inherits the
   // the MODEL's own default: `RoleModels.resolve_effort` does not fall back to
@@ -371,16 +408,12 @@ export function ChatPanel() {
   const bgEffortSupported = modelSupportsEffort(backgroundModel !== 'auto' ? backgroundModel : defaultModel)
   const subEffortSupported = modelSupportsEffort(subagentModel !== 'auto' ? subagentModel : defaultModel)
   const effortLabels = EFFORT_LEVELS.map(l => (l === '' ? i18nT('pages.settings.chatPanel.model_default') : effortLabel(l)))
-  const backgroundEffortMut = useMutation({
-    mutationFn: (v: string) => api.patchConfig('agent.role_efforts.background', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_effort')),
-  })
-  const subagentEffortMut = useMutation({
-    mutationFn: (v: string) => api.patchConfig('agent.role_efforts.subagent', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_effort')),
-  })
+  const backgroundEffortMut = useMutation(
+    optimisticConfigOpts('agent.role_efforts.background', () => i18nT('pages.settings.chatPanel.failed_to_save_role_effort'))
+  )
+  const subagentEffortMut = useMutation(
+    optimisticConfigOpts('agent.role_efforts.subagent', () => i18nT('pages.settings.chatPanel.failed_to_save_role_effort'))
+  )
 
   // ── Local chat config (localStorage) ──
   const setChat = useCallback(<K extends keyof ChatConfig>(k: K, v: ChatConfig[K]) => {

--- a/website/src/test/SettingsChatPanelCoverage.test.tsx
+++ b/website/src/test/SettingsChatPanelCoverage.test.tsx
@@ -678,3 +678,69 @@ describe('ChatPanel — About You and Power', () => {
     expect(await screen.findByText(/Failed to save dashboard config/)).toBeInTheDocument()
   })
 })
+
+describe('ChatPanel — optimistic model selection (#6848)', () => {
+  /** A patchConfig that stays pending until `release()` is called. */
+  function pendingPatch() {
+    let release!: () => void
+    patchConfigMock.mockImplementationOnce(
+      () => new Promise(res => { release = () => res({}) }) as never
+    )
+    return () => release()
+  }
+
+  it.each([
+    ['Default Model', 'claude-opus-4.8'],
+    ['Background Model', 'claude-opus-4.8'],
+    ['Subagent Model', 'claude-opus-4.8'],
+    ['Fallback model', 'claude-opus-4.8'],
+  ])('%s shows the picked value immediately, before the PATCH settles', async (label, model) => {
+    const release = pendingPatch()
+    wrap()
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    await openSelect(label)
+    fireEvent.click(screen.getByRole('option', { name: model }))
+    // The PATCH is still in flight — the trigger must already show the choice.
+    const trigger = screen.getByRole('combobox', { name: label })
+    await waitFor(() => expect(trigger).toHaveTextContent(model))
+    expect(patchConfigMock).toHaveBeenCalledTimes(1)
+    release()
+  })
+
+  it('shows a picked reasoning effort immediately, before the PATCH settles', async () => {
+    seedMc({ agent: { model: 'claude-opus-4.8' } })
+    const release = pendingPatch()
+    wrap()
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    await openSelect('Default Reasoning Effort')
+    fireEvent.click(screen.getByRole('option', { name: 'High' }))
+    const trigger = screen.getByRole('combobox', { name: 'Default Reasoning Effort' })
+    await waitFor(() => expect(trigger).toHaveTextContent('High'))
+    expect(patchConfigMock).toHaveBeenCalledTimes(1)
+    release()
+  })
+
+  it('rolls the selector back to the server value when the PATCH fails', async () => {
+    rejectOnce(patchConfigMock)
+    wrap()
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    await openSelect('Default Model')
+    fireEvent.click(screen.getByRole('option', { name: 'claude-haiku-4.5' }))
+    expect(await screen.findByText(/Failed to save default model/)).toBeInTheDocument()
+    const trigger = screen.getByRole('combobox', { name: 'Default Model' })
+    await waitFor(() => expect(trigger).toHaveTextContent('Default (auto)'))
+    expect(trigger).not.toHaveTextContent('claude-haiku-4.5')
+  })
+
+  it('rolls a role model back when the PATCH fails', async () => {
+    seedMc({ agent: { role_models: { background: 'claude-opus-4.8' } } })
+    rejectOnce(patchConfigMock)
+    wrap()
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    await openSelect('Background Model')
+    fireEvent.click(screen.getByRole('option', { name: 'claude-haiku-4.5' }))
+    expect(await screen.findByText(/Failed to save role model/)).toBeInTheDocument()
+    const trigger = screen.getByRole('combobox', { name: 'Background Model' })
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->
## Problem / Motivation

The seven controlled selectors in Settings → Chat → Model (default model, default reasoning effort, background/subagent model and effort, and the throttle-fallback model) keep showing the previous choice until the config PATCH **and** the `kirocrewConfig` refetch complete. On a slow connection the trigger visibly snaps back to the old value after the user picks a new one, then flips to the choice seconds later.

## Why it matters

Successful changes appear to have been ignored. Users repeat the selection (issuing duplicate PATCHes) or leave the page unsure whether the setting saved. The `tipsMut` and `dashMut` writes on this panel already update optimistically; this PR brings the seven Model-section selectors — the surface #6848 names — in line with them. **Deliberately left out of scope:** five other query-cached writes on this panel share the same snap-back cause (`profileMut`, `preventSleepMut`, `summaryMut`, `keepModeMut`, and the inline autocompact patch) and are not converted here; two of those (`keepModeMut`, autocompact) fit the new factory verbatim, so a follow-up conversion is a two-call-site edit once this pattern is accepted.

## What changed (motivation → approach → change)

- **Symptom** → the selectors are controlled by `mcQ.data` (the `kirocrewConfig` query cache), and their mutations only ran `invalidateQueries` in `onSuccess`, so the cache — and therefore the trigger — held the old value for the whole PATCH + refetch round-trip.
- **Root cause** → no optimistic cache write, unlike the `tipsMut`/`dashMut` mutations a few lines above which already use the `onMutate` snapshot / `onError` rollback / `onSettled` reconcile pattern.
- **Change** → added `optimisticConfigOpts(path, errMsg)`, a small factory producing exactly that pattern for a dot-path config PATCH, plus a pure `setConfigValue` helper that shallow-clones along the path. Applied it to the seven Model-section mutations (`agent.model`, `agent.reasoning_effort`, `agent.role_models.{background,subagent}`, `agent.role_efforts.{background,subagent}`, `agent.fallback_model`). The fallback mutation keeps its richer error message (backend deny reason appended). Error paths now also roll the cache back to the pre-mutation snapshot, and `onSettled` still reconciles with authoritative server state (a failed save therefore also refetches config in the background, matching `tipsMut`/`dashMut`) — exactly the expected behavior described in #6848. The inline `mcQ` type was extracted to `KirocrewConfigShape` so the helper and the query share one definition; no behavior change from that extraction.

## Tests

New `ChatPanel — optimistic model selection (#6848)` block in `SettingsChatPanelCoverage.test.tsx`:

- `it.each` over Default Model / Background Model / Subagent Model / Fallback model: with the PATCH held pending, the trigger shows the picked value **before** the request settles.
- Default Reasoning Effort: same immediate-show assertion on a reasoning-capable model.
- Rollback: a rejected PATCH on Default Model surfaces the error banner and returns the trigger to the server value (`Default (auto)`), not the failed pick.
- Rollback for a pinned role model: Background Model returns to its pre-mutation pin on failure.

Full `SettingsChatPanelCoverage.test.tsx` + `ChatPanel.settings.test.tsx` suites pass (77 tests), including the pre-existing per-role failure-banner tests, which now also exercise the rollback arm.

## Manual verification

N/A — the change is update *timing* on unchanged UI, which the pending-PATCH unit tests pin directly (trigger text asserted while the request is still in flight, and after a rejected one).

**Why no screenshot:** there is no rendered delta at rest — the panel's layout, controls, and labels are pixel-identical before and after; the change is when the (unchanged) trigger text updates during an in-flight PATCH, which the pending-PATCH unit tests pin more precisely than a recording could.

## Related Issues

Fixes #6848

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
