### PR TITLE
fix: serve app UI files from a pinned descriptor, not a re-opened path

### DIFF
--- a/src/kiro_crew/apps/dev_mode.py
+++ b/src/kiro_crew/apps/dev_mode.py
@@ -9,6 +9,13 @@ When an installed app has ``dev: true`` in its ``installed.json``:
   and broadcasts an ``app_reload`` WebSocket event whenever any file changes.
   The dashboard's AppHost reloads so edits appear without a manual refresh.
 
+Link the whole ``ui/`` DIRECTORY, never individual files inside it: since
+#6809 the UI route opens the final name with ``O_NOFOLLOW`` (the swap-resistant
+open that closed the check-then-reopen window), so a per-file symlink like
+``ln -s ~/src/app/dist/index.mjs ui/index.mjs`` answers 404 — indistinguishable
+from "not built yet". The directory link keeps working because the route
+resolves the ui root before validating against it.
+
 Toggling dev mode is a metadata-only change (``installed.json``), picked up by
 the watcher within one poll interval — no gateway restart needed.
 
@@ -29,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -43,6 +51,7 @@ from kiro_crew.apps.manager import (
     apps_dir,
 )
 from kiro_crew.atomic_write import atomic_write
+from kiro_crew.security import is_sensitive_path, path_contains_sensitive
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +67,26 @@ _DIGEST_MASK = (1 << 63) - 1
 #: Sentinel file (a JSON array of app names in dev mode) under ``apps_dir()``.
 #: ``list_apps()`` skips non-directory entries, so this file is invisible to it.
 _DEV_SENTINEL = ".dev-apps.json"
+
+#: Operator grant record (a JSON object mapping app name -> the RESOLVED ui
+#: root granted, as ``os.path.realpath`` of ``<install>/ui`` at toggle time)
+#: under ``apps_dir()``, written ONLY by :func:`set_dev_mode` /
+#: :func:`remove_dev_app` — never created by the startup reconcile. The
+#: sentinel above is a WATCH/no-store convenience that
+#: :func:`_reconcile_sentinel_from_installed` rebuilds from each app's own
+#: (app-writable) ``installed.json``, so a sentinel entry can be laundered by
+#: an app that writes ``dev: true`` to its own metadata and waits for a
+#: restart. This record is the AUTHORIZATION half the UI route requires
+#: (#6809). Binding the grant to the SPECIFIC resolved root (not a bare name)
+#: is load-bearing: it makes the grant self-invalidating — repointing ``ui``
+#: after the toggle (an app update, a swapped link, a reinstall under the same
+#: name) yields a root that no longer equals the granted one, so any grant
+#: left behind by a crash mid-revoke or an uninstall race authorizes at most
+#: the exact tree the operator approved, never a new target. The two files
+#: stay separate on purpose — merging them would either re-open the
+#: laundering path (reconcile adds) or break the documented out-of-band
+#: ``dev: true`` watch contract (reconcile stops adding).
+_DEV_GRANTS = ".dev-grants.json"
 
 _watch_task: asyncio.Task | None = None
 
@@ -134,6 +163,37 @@ def _write_dev_sentinel(names: set[str]) -> None:
     atomic_write(path, json.dumps(sorted(names), indent=2) + "\n")
 
 
+def _grants_path() -> Path:
+    return apps_dir() / _DEV_GRANTS
+
+
+def _read_dev_grants() -> dict[str, str]:
+    """Read the operator grant map (empty on any error — absent means no grants).
+
+    Maps app name -> the resolved ui root granted. A legacy/foreign shape
+    (anything but a str->str object) reads as empty: an unparseable grant
+    record must fail closed, never open.
+    """
+    try:
+        data = json.loads(_grants_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if isinstance(data, dict):
+        return {
+            str(k): str(v)
+            for k, v in data.items()
+            if isinstance(k, str) and isinstance(v, str)
+        }
+    return {}
+
+
+def _write_dev_grants(grants: dict[str, str]) -> None:
+    """Atomically write the operator grant map to the grants file."""
+    path = _grants_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(path, json.dumps(grants, indent=2, sort_keys=True) + "\n")
+
+
 def _scan_installed_dev_apps() -> set[str]:
     """Return the dev-app set derived authoritatively from every ``installed.json``.
 
@@ -191,6 +251,31 @@ def _reconcile_sentinel_from_installed() -> set[str]:
                 sorted(installed),
             )
             _write_dev_sentinel(installed)
+        # The grant record is REMOVE-ONLY here: prune grants whose app no
+        # longer has VALID installed metadata (a crash between uninstall and
+        # :func:`remove_dev_app`'s revoke), so a later reinstall under the
+        # same name cannot inherit the authorization. Existence is tested via
+        # ``_read_installed`` rather than ``is_dir()`` because an uninstall
+        # with ``keep_data`` can leave (or recreate) the directory for the
+        # preserved data while the app itself — its ``installed.json`` — is
+        # gone. Never ADD a grant from ``installed.json`` — that is
+        # app-writable metadata, and deriving the grant from it is exactly
+        # the laundering path #6809 closes.
+        grants = _read_dev_grants()
+        live: dict[str, str] = {}
+        for gname, groot in grants.items():
+            try:
+                gmeta = _read_installed(gname)
+            except Exception:
+                gmeta = None
+            if gmeta is not None:
+                live[gname] = groot
+        if live != grants:
+            logger.info(
+                "app dev-mode: pruning grants for absent apps (%s)",
+                sorted(set(grants) - set(live)),
+            )
+            _write_dev_grants(live)
         _set_dev_cache(installed)
     return installed
 
@@ -237,6 +322,60 @@ def set_dev_mode(name: str, enabled: bool) -> dict[str, Any]:
         meta = _read_installed(name)
         if meta is None:
             return {"error": f"app {name!r} is not installed"}
+        granted_root: str | None = None
+        if enabled:
+            # VALIDATE BEFORE ANY WRITE: a refusal must leave prior state
+            # exactly as it was — an already-enabled app whose `ui` was
+            # repointed to a sensitive root and then re-toggled must not have
+            # its existing dev mode silently torn down by the refusal (the
+            # old shape wrote metadata/sentinel first and "rolled back" by
+            # unconditionally disabling, destroying prior state). The grant
+            # binds the ui root's CURRENT resolved path, so it authorizes
+            # exactly the tree the operator saw when toggling — anything that
+            # later repoints ``ui`` invalidates it (re-toggle after
+            # re-pointing to re-bind). A root escaping the install dir into a
+            # SENSITIVE location (credential stores, key material) is refused
+            # outright — no dev workflow legitimately serves those, and the
+            # unauthenticated UI route must never be grantable onto them
+            # (#6809).
+            granted_root = os.path.realpath(apps_dir() / name / "ui")
+            try:
+                # Anchor = resolved apps ROOT + literal name (same rule as the
+                # route): re-resolving through the app's own entry would race
+                # a concurrent swap of that entry.
+                Path(granted_root).relative_to(
+                    Path(os.path.realpath(apps_dir())) / name
+                )
+            except ValueError:
+                # BOTH directions of the sensitivity test: a root that IS
+                # sensitive (inside `~/.ssh`) and a root that CONTAINS
+                # sensitive leaves (`~/.docker` is not itself on the list —
+                # only its `config.json` is — and `~` contains everything).
+                # Either shape would let the unauthenticated UI route serve
+                # credential material out of an allowlisted extension.
+                if is_sensitive_path(granted_root) or path_contains_sensitive(
+                    granted_root
+                ):
+                    return {
+                        "error": (
+                            f"app {name!r} has a ui root resolving to a "
+                            f"sensitive location ({granted_root}) — the "
+                            "dev-mode grant is refused"
+                        )
+                    }
+        else:
+            # Revoke the AUTHORIZATION first: every write below narrows state,
+            # so a crash after any prefix of them leaves the SAFER remainder
+            # (grant gone, metadata/sentinel possibly stale — watching without
+            # authorization). The old order (grant last) failed open: a crash
+            # after the metadata write left a live grant for a still-installed
+            # app, which the reconcile never expires because the app still
+            # exists — and the app could then write ``dev: true`` back into
+            # its own metadata and re-satisfy the grant check unaided.
+            grants = _read_dev_grants()
+            if name in grants:
+                grants.pop(name)
+                _write_dev_grants(grants)
         meta.dev = enabled
         _write_installed(name, meta)
         names = _read_dev_sentinel()
@@ -245,6 +384,13 @@ def set_dev_mode(name: str, enabled: bool) -> dict[str, Any]:
         else:
             names.discard(name)
         _write_dev_sentinel(names)
+        if enabled and granted_root is not None:
+            # The AUTHORIZATION record, written LAST on enable (mirror of the
+            # revoke-first rule above: a crash mid-toggle must always leave
+            # the un-granted state) and only here / in :func:`remove_dev_app`.
+            grants = _read_dev_grants()
+            grants[name] = granted_root
+            _write_dev_grants(grants)
         # Update the in-process cache immediately so a same-process POST toggle
         # takes effect on the very next UI request (no wait for a watcher tick).
         _set_dev_cache(names)
@@ -262,11 +408,22 @@ def remove_dev_app(name: str) -> None:
     try:
         with _sentinel_lock():
             names = _read_dev_sentinel()
-            if name not in names:
+            grants = _read_dev_grants()
+            if name not in names and name not in grants:
                 return
-            names.discard(name)
-            _write_dev_sentinel(names)
-            _set_dev_cache(names)
+            if name in grants:
+                # Revoke the operator grant with the uninstall: a DIFFERENT app
+                # later reinstalled under the same name must not inherit the
+                # authorization to serve an out-of-install ui root. (Even when
+                # this best-effort cleanup is skipped by a crash, the grant is
+                # bound to the OLD resolved root and pruned at the next
+                # reconcile once the app's metadata is gone.)
+                grants.pop(name)
+                _write_dev_grants(grants)
+            if name in names:
+                names.discard(name)
+                _write_dev_sentinel(names)
+                _set_dev_cache(names)
     except Exception:
         logger.debug("dev-mode sentinel cleanup for %r failed", name, exc_info=True)
 
@@ -276,11 +433,56 @@ def is_dev_mode(name: str) -> bool:
 
     Blocking IO — do NOT call on the event loop per-request; use
     :func:`is_dev_mode_cached` on hot paths.
+
+    Reads only the app's own ``installed.json`` — a file inside the install
+    directory the APP ITSELF can write — so this answers "does the metadata say
+    dev" and must never AUTHORIZE anything security-relevant. For an
+    authorization decision use :func:`dev_mode_granted_root`, which also requires
+    the gateway-owned sentinel.
     """
     if not _check_path_safety(name):
         return False
     meta = _read_installed(name)
     return bool(meta and meta.dev)
+
+
+def dev_mode_granted_root(name: str) -> str | None:
+    """The RESOLVED ui root the operator's dev-mode grant covers, or ``None``.
+
+    Requires BOTH the operator grant record (:data:`_DEV_GRANTS`, a file at
+    the apps ROOT written only by :func:`set_dev_mode` — never created by the
+    startup reconcile) AND the app's ``installed.json`` ``dev`` flag.
+    ``installed.json`` alone is the app's own writable metadata — an app that
+    edits it to ``dev: true`` must not thereby authorize itself (#6809: the UI
+    route relaxes root containment only under this grant, and a self-granted
+    app could point its ui root at a credential directory). The watch
+    sentinel is deliberately NOT consulted: the reconcile rebuilds it from
+    app-writable metadata at every startup, so it proves watching, not
+    authorization.
+
+    The returned path is the root that was RESOLVED AND BOUND at toggle time;
+    the caller must require its current resolved root to EQUAL this value,
+    which is what makes a stale or inherited grant harmless — it covers one
+    exact tree the operator approved, never whatever ``ui`` points at now.
+    (The toggle endpoint itself carries no app-vs-operator identity — a
+    same-origin caller reaches it too — which is why the binding, the
+    sensitive-path screen at grant time, and this equality check carry the
+    guarantee rather than the file's authorship alone.)
+
+    Blocking IO — do NOT call on the event loop; callers run it off-loop, and
+    it sits on an exceptional path (an out-of-install ui root), never on
+    normal serving.
+    """
+    if not _check_path_safety(name):
+        return None
+    try:
+        granted = _read_dev_grants().get(name)
+    except Exception:
+        # An unreadable grant record means the grant cannot be proven: fail closed.
+        return None
+    if granted is None or not is_dev_mode(name):
+        return None
+    return granted
 
 
 def is_dev_mode_cached(name: str) -> bool:

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -21,6 +21,7 @@ import stat
 import sys
 import time
 import urllib.parse
+from email.utils import formatdate
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,7 @@ from kiro_crew.apps.dependency_ledger import (
     classify_for_uninstall,
     declared_capability_keys,
 )
+from kiro_crew.apps.dev_mode import dev_mode_granted_root, is_dev_mode_cached
 from kiro_crew.apps.event_bus import build_broadcast_fn
 from kiro_crew.apps.execution import app_execution_denied
 from kiro_crew.apps.hooks_integration import (
@@ -123,6 +125,7 @@ from kiro_crew.config.loader import (
 )
 from kiro_crew.cron import CronStoreBusy, CronStoreUnreadable
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.hooks import _fd_real_path
 from kiro_crew.pinned_fs import (
     PinnedPathRefusal,
     is_reparse_point,
@@ -2447,40 +2450,325 @@ async def handle_app_config(request: web.Request) -> web.Response:
     return web.json_response({"ok": True, "name": name})
 
 
-async def handle_app_ui_file(request: web.Request) -> web.Response:
-    """GET /apps/{name}/ui/{path:.*} — serve app UI bundle files."""
+#: Ceiling on one UI-bundle file this route will serve. With streaming (see
+#: :func:`handle_app_ui_file`) the ceiling no longer bounds gateway memory —
+#: per-request memory is one :data:`_UI_STREAM_CHUNK` regardless of file size —
+#: it bounds the WORK one unauthenticated request can command (bytes read and
+#: sent per request; the route bypasses token auth). Measured reality: the
+#: largest UI asset a bundled app in this tree ships is ~9 KB
+#: (``website/public/apps/agent-worlds/ui/index.mjs`` — the scaffold's vite
+#: config externalizes react/react-dom/the SDK, so bundles stay small). 8 MiB
+#: is ~900x that, matches the posture already accepted for ``_ART_MAX_BYTES``
+#: above, and still clears any plausible self-bundled entry chunk. The one
+#: class it can refuse is the sourcemap of an app that bundles a very heavy
+#: dependency — a ``.map`` 404 degrades only devtools debugging of that app,
+#: never the app itself.
+_UI_MAX_BYTES = 8 * 1024 * 1024
+
+#: Read granularity when streaming a UI file from its validated descriptor.
+#: This — not the file size — is what one in-flight request pins in memory, so
+#: N slow clients cost N chunks, not N files. 256 KiB keeps the thread-hop
+#: count low (an 8 MiB worst case is 32 hops) while staying far below any
+#: amplification concern.
+_UI_STREAM_CHUNK = 256 * 1024
+
+#: Max concurrent requests HOLDING AN OPEN DESCRIPTOR on this route. Acquired
+#: before `_open_ui_file` and released after the descriptor closes: bounding
+#: only the streaming loop would let every QUEUED request already hold an fd
+#: while waiting for a slot, so slow-paced unauthenticated GETs could walk the
+#: gateway to `EMFILE`. Under this scope at most 8 descriptors exist at once
+#: and everyone else waits fd-less. It also bounds the per-chunk `to_thread`
+#: hops on the SHARED default executor (same reason `_BLOB_FETCH_SEMAPHORE`
+#: bounds git fetches). Refusals and body-less 304s hold a slot only for
+#: microseconds; 8 comfortably covers a dashboard loading assets in parallel.
+_UI_STREAM_SEMAPHORE = asyncio.Semaphore(8)
+
+
+def _open_ui_file(name: str, file_path: str) -> tuple[int, os.stat_result] | str:
+    """An OPEN validated descriptor for *file_path* under *name*'s ui/ root
+    plus its ``fstat``, or a refusal code: ``"invalid"`` (containment failure
+    -> 400, the status this route has always answered escapes with) or
+    ``"not_found"`` (-> 404). On the tuple path the CALLER owns closing the fd.
+
+    Handing back the descriptor rather than a path is the security-relevant
+    part, and it is the same fix :func:`_read_declared_art` carries (#6794):
+    validating a path and then handing it to ``FileResponse`` opens it a SECOND
+    time, so the app that owns this directory can swap a validated name for a
+    symlink between the check and that open and have the gateway read the
+    target instead — and the gateway is NOT sandboxed, so this launders a read
+    the app's own code can be refused. This route serves the SAME app-owned
+    directory with a BROADER extension allowlist (``.json``, ``.mjs``), so it
+    must not keep the weaker open. One open, validated as a DESCRIPTOR, is the
+    only shape without that window; everything after it reads the fd, which
+    cannot be re-pointed.
+
+    One thread hop for the whole decision — resolve, containment, open and
+    stat — because every part is a blocking syscall and the gateway runs on one
+    event loop (``no-blocking-call-on-event-loop``).
+    """
+    ui_root = apps_dir() / name / "ui"
+    target = ui_root / file_path
+    try:
+        # Resolved ONCE, here, because `pin_parent` requires the CALLER to do
+        # it: resolving inside would re-follow whatever an ancestor points at by
+        # then. The ui root itself is resolved THROUGH: the documented dev-mode
+        # setup links ui/ at the developer's source tree, so the ROOT being a
+        # link is legitimate — containment is proven against wherever it really
+        # lands, not against the link's own name.
+        resolved_root = Path(os.path.realpath(ui_root))
+        # But a root that lands OUTSIDE the app's own install directory is only
+        # legitimate under the OPERATOR's dev-mode grant. Without this check an
+        # app could ship `ui` as a symlink to a credential directory
+        # (`ui -> ~/.docker`) and have this UNAUTHENTICATED route (the
+        # `/apps/{name}/ui/` token-auth bypass) serve `config.json` — `.json`
+        # is in the allowlist — laundering a read the app's own sandboxed code
+        # is refused. `dev_mode_granted_root`, not `is_dev_mode`: the latter
+        # reads only the app's own writable `installed.json`, which the app
+        # could edit to authorize itself — the grant is the operator record
+        # at the apps ROOT (written by the dev-mode toggle, never by the
+        # startup reconcile, and refused outright for sensitive targets), and
+        # it BINDS the specific resolved root granted: the current root must
+        # EQUAL it, so a grant left behind by a crash, an update, or a
+        # reinstall authorizes only the exact tree the operator approved,
+        # never wherever `ui` points now. The disk reads are paid only on
+        # this exceptional path.
+        #
+        # The containment ANCHOR resolves only the gateway-owned apps root
+        # and then appends the literal `name` — it must NOT re-resolve
+        # through the app's own entry (`realpath(apps_dir()/name)`): the two
+        # realpath calls in this function would then race, and an app
+        # alternating its install entry between them could get an escaping
+        # `resolved_root` accepted as "inside the install". The apps root
+        # itself is not app-writable, so this anchor cannot be swapped; an
+        # install entry that IS a link makes its resolved ui root land
+        # outside this anchor and take the grant path like any other escape.
+        resolved_install = Path(os.path.realpath(apps_dir())) / name
+        try:
+            resolved_root.relative_to(resolved_install)
+        except ValueError:
+            if str(resolved_root) != dev_mode_granted_root(name):
+                return "invalid"
+        resolved_parent = Path(os.path.realpath(target.parent))
+        # The PARENT containment is load-bearing, not belt-and-braces:
+        # `pin_parent`'s contract is that a component swapped BEFORE parent
+        # resolution is followed by that resolution, so an already-symlinked
+        # ancestor is caught only here.
+        resolved_parent.relative_to(resolved_root)
+        # The full path too: a link at the FINAL name whose target escapes the
+        # root is answered 400 like every other escape (the contract this route
+        # has always had). This is a pre-check, not the enforcement — the pinned
+        # open below refuses ANY link at the final name, escaping or not.
+        Path(os.path.realpath(target)).relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError):
+        # `RuntimeError` because path resolution raises THAT — not an OSError —
+        # on a symlink loop, and the app that plants one is the app whose UI
+        # this serves.
+        return "invalid"
+
+    # `O_NONBLOCK` is what makes the descriptor checks REACHABLE, not an
+    # optimisation: opening a FIFO blocks until a writer appears, and this runs
+    # inside `asyncio.to_thread`, so an app shipping a FIFO as a UI asset would
+    # park a thread-pool worker forever. With the flag the open returns
+    # immediately and `S_ISREG` below refuses it. On a plain file it changes
+    # nothing. Same rationale as `_read_declared_art`.
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    if supports_pinned_walk():
+        try:
+            fd = open_in_pinned_parent(
+                str(resolved_parent),
+                Path(file_path).name,
+                flags=flags,
+                mode=0o600,
+                what="app UI bundle file",
+            )
+        except (PinnedPathRefusal, OSError, ValueError):
+            # `ValueError` is NOT redundant with `OSError`: `os.open` raises it
+            # — never an OSError — for a name the OS layer cannot encode (an
+            # embedded NUL, a lone surrogate). Such a name survives every
+            # earlier check: the extension allowlist reads the suffix AFTER the
+            # bad byte, and containment resolves the PARENT, which is clean when
+            # the bad byte sits in the final component.
+            return "not_found"
+    else:
+        # Windows: no `O_NOFOLLOW` and no descriptor-relative open, so the
+        # pinned walk is unavailable. An unprivileged process there cannot
+        # create a FILE symlink at all, so the reachable swap is a junction —
+        # refused by the reparse-point probe. Same degradation as the art
+        # route; the ui-root link (dev mode) sits ABOVE the resolved root and
+        # is deliberately outside the screen. The probe is name-based, so a
+        # junction planted BETWEEN the probe and the open would still be
+        # followed — which is why the DESCRIPTOR's own final path is
+        # validated below, after the open, closing the residual window on
+        # the descriptor rather than the name.
+        try:
+            if any(
+                is_reparse_point(p)
+                for p in (target, *target.parents)
+                if p == resolved_root or resolved_root in p.parents or p == target
+            ):
+                return "not_found"
+            fd = os.open(target, flags)
+        except (OSError, ValueError):
+            return "not_found"
+        # Race-free containment on the OPENED handle: resolve the descriptor's
+        # final path (`GetFinalPathNameByHandleW` there; /proc/F_GETPATH on
+        # the POSIX hosts the tests run on) and require it to still sit under
+        # the resolved root. Fail closed when it cannot be read — on this
+        # branch the descriptor is the only trustworthy witness.
+        fd_real = _fd_real_path(fd)
+        if fd_real is None:
+            os.close(fd)
+            return "not_found"
+        try:
+            Path(fd_real).relative_to(resolved_root)
+        except ValueError:
+            os.close(fd)
+            return "not_found"
+
+    try:
+        st = os.fstat(fd)
+        # `st_nlink != 1` is the one gate that can see a HARDLINK: the alias
+        # shares the target's inode, so `is_symlink()` is False, `realpath`
+        # yields the alias's own name (containment passes), and `O_NOFOLLOW`
+        # has no link to refuse. Checked on the DESCRIPTOR, which is what makes
+        # it race-free. Inline rather than `pinned_fs.refuse_hardlink_alias`
+        # for the same double-close reason `_read_declared_art` documents.
+        if (
+            not stat.S_ISREG(st.st_mode)
+            or st.st_nlink != 1
+            or st.st_size > _UI_MAX_BYTES
+        ):
+            os.close(fd)
+            return "not_found"
+    except OSError:
+        os.close(fd)
+        return "not_found"
+    return fd, st
+
+
+async def handle_app_ui_file(request: web.Request) -> web.StreamResponse:
+    """GET /apps/{name}/ui/{path:.*} — serve app UI bundle files.
+
+    Serves bytes STREAMED from a pinned descriptor (see :func:`_open_ui_file`)
+    rather than handing a validated path to ``FileResponse``, which re-opens it
+    and re-introduces the check-then-reopen window #6794 closed on the art
+    route. Streaming rather than buffering is itself load-bearing: this route
+    is UNAUTHENTICATED (the ``/apps/{name}/ui/`` token-auth bypass), so a
+    buffered body would let N outstanding requests each pin a whole file in
+    gateway memory — with streaming, per-request memory is one chunk
+    (:data:`_UI_STREAM_CHUNK`) regardless of file size or client speed.
+    Behaviour contract preserved: 400 on ``..``/absolute/escaping paths, 403 on
+    a disallowed extension, 404 on a missing file, Content-Type from
+    ``_CONTENT_TYPES``, and conditional requests (If-None-Match /
+    If-Modified-Since) still answer a body-less 304.
+    """
     name = request.match_info["name"]
     file_path = request.match_info.get("path", "")
     if ".." in file_path or file_path.startswith("/"):
         return web.json_response({"error": "invalid path"}, status=400)
-    from pathlib import Path
-
     ext = Path(file_path).suffix.lower()
     if ext not in _ALLOWED_EXTENSIONS:
         return web.json_response({"error": f"file type {ext!r} not allowed"}, status=403)
-    full_path = apps_dir() / name / "ui" / file_path
-    if not full_path.is_file():
-        return web.json_response({"error": "not found"}, status=404)
-    ui_root = (apps_dir() / name / "ui").resolve()
-    try:
-        full_path.resolve().relative_to(ui_root)
-    except ValueError:
-        return web.json_response({"error": "invalid path"}, status=400)
-    content_type = _CONTENT_TYPES.get(ext, "application/octet-stream")
-    # Dev-mode apps: never cache — the file-watch live-reload reloads on every
-    # change and must always see the latest bytes. Use the in-memory cache
-    # (maintained by the dev-mode watcher) so this hot path does NO disk IO on
-    # the event loop for every asset served (no-blocking-call-on-event-loop).
-    # Everything else: no-cache (NOT no-store) — the browser may cache but MUST
-    # revalidate each load. FileResponse answers conditional requests
-    # (If-Modified-Since / If-None-Match from its Last-Modified/ETag) with a
-    # body-less 304, so unchanged files stay cheap while app updates are picked
-    # up on a plain refresh. A long ``public,max-age=...`` instead would serve an
-    # app's UI stale for that whole window after an update.
-    from kiro_crew.apps.dev_mode import is_dev_mode_cached
-
-    cache = "no-store" if is_dev_mode_cached(name) else "no-cache"
-    return web.FileResponse(full_path, headers={"Content-Type": content_type, "Cache-Control": cache})  # type: ignore[return-value]
+    # The semaphore is acquired BEFORE the descriptor exists and released only
+    # after it is closed. Bounding just the streaming loop would cap streams at
+    # 8 while every QUEUED request already held an open fd waiting for a slot —
+    # an unauthenticated client could then drive the gateway to `EMFILE` with
+    # slow-paced GETs. Under this scope, at most 8 requests hold a descriptor
+    # at any instant and everyone else waits fd-less. The refusal paths inside
+    # (400/403/404, body-less 304) hold their slot only microseconds.
+    async with _UI_STREAM_SEMAPHORE:
+        result = await asyncio.to_thread(_open_ui_file, name, file_path)
+        if result == "invalid":
+            return web.json_response({"error": "invalid path"}, status=400)
+        if isinstance(result, str):
+            return web.json_response({"error": "not found"}, status=404)
+        fd, st = result
+        try:
+            content_type = _CONTENT_TYPES.get(ext, "application/octet-stream")
+            # Dev-mode apps: never cache — the file-watch live-reload reloads on
+            # every change and must always see the latest bytes. `is_dev_mode_cached`
+            # is the watcher-maintained in-memory flag, so this hot path does NO
+            # disk IO on the event loop for the mode lookup
+            # (no-blocking-call-on-event-loop). Everything else: no-cache (NOT
+            # no-store) — the browser may cache but MUST revalidate each load. The
+            # validators are derived from the DESCRIPTOR being served, not a second
+            # stat of the path, so unchanged files stay a body-less 304 while app
+            # updates are picked up on a plain refresh. A long
+            # ``public,max-age=...`` instead would serve an app's UI stale for that
+            # whole window after an update.
+            cache = "no-store" if is_dev_mode_cached(name) else "no-cache"
+            etag_value = f"{st.st_ino:x}-{st.st_size:x}-{st.st_mtime_ns:x}"
+            # `nosniff` because the Content-Type is derived from the EXTENSION, not
+            # the bytes; the CSP neuters a scripted `.svg` opened as a TOP-LEVEL
+            # document on the dashboard's own origin (a response CSP does not apply
+            # when the bytes are consumed as a subresource, so module/style/img
+            # loads are unaffected). Same pair, same reasons, as the art route.
+            headers = {
+                "Cache-Control": cache,
+                "ETag": f'"{etag_value}"',
+                "Last-Modified": formatdate(st.st_mtime, usegmt=True),
+                "Content-Security-Policy": "default-src 'none'; sandbox",
+                "X-Content-Type-Options": "nosniff",
+            }
+            # aiohttp's parsed accessors, not raw header strings: If-None-Match may
+            # carry a list, a weak `W/"..."` form, or `*`, and If-Modified-Since
+            # needs HTTP-date parsing that forces UTC (a raw `parsedate_to_datetime`
+            # hands back a NAIVE datetime for `-0000`/asctime forms, which
+            # `.timestamp()` then reads as server-LOCAL time — a stale 304 for up to
+            # a whole UTC offset after an app update). Mirrors what `FileResponse`
+            # did.
+            if_none_match = request.if_none_match
+            if if_none_match:
+                # RFC 7232 §3.2: If-None-Match uses the WEAK comparison, so a weak
+                # form of the current tag matches too.
+                if (len(if_none_match) == 1 and if_none_match[0].value == "*") or any(
+                    t.value == etag_value for t in if_none_match
+                ):
+                    return web.Response(status=304, headers=headers)
+            else:
+                # RFC 7232 §3.3: If-Modified-Since is evaluated only when no
+                # If-None-Match was sent. Both sides are second-granular (HTTP
+                # dates carry no sub-second part, so `st_mtime` is truncated).
+                since = request.if_modified_since
+                if since is not None and int(st.st_mtime) <= since.timestamp():
+                    return web.Response(status=304, headers=headers)
+            resp = web.StreamResponse(status=200, headers={**headers, "Content-Type": content_type})
+            # Length pinned to the fstat that was validated: a file the app GROWS
+            # after the open must not stream past the length the client was told,
+            # so the loop below caps at `remaining` as well as EOF.
+            resp.content_length = st.st_size
+            await resp.prepare(request)
+            remaining = st.st_size
+            # The enclosing `_UI_STREAM_SEMAPHORE` scope (acquired before the
+            # open, released after the close) is what bounds this loop's
+            # `to_thread` hops on the shared default executor — no second
+            # acquisition here: a nested acquire under the same semaphore
+            # would deadlock once 8 holders each waited for a 9th permit.
+            while remaining > 0:
+                chunk = await asyncio.to_thread(os.read, fd, min(_UI_STREAM_CHUNK, remaining))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+                await resp.write(chunk)
+            await resp.write_eof()
+            return resp
+        finally:
+            # Off the loop: `os.close` is on the no-blocking-call-on-event-loop
+            # deny list (it can block in the kernel), and this `finally` runs on
+            # the loop for every request, error paths included. `shield` is
+            # load-bearing, not decoration: a client disconnect CANCELS this
+            # handler, and an unshielded `to_thread` awaited during cancellation
+            # can have its work item cancelled while still queued — the close
+            # never runs and the descriptor leaks, on an UNAUTHENTICATED route
+            # where repeated connect-then-drop would walk the gateway into
+            # RLIMIT_NOFILE. Shielded, the close task runs to completion even
+            # when this await is interrupted.
+            await asyncio.shield(asyncio.to_thread(os.close, fd))
 
 
 async def handle_app_dev_mode(request: web.Request) -> web.Response:

--- a/test/test_app_dev_mode.py
+++ b/test/test_app_dev_mode.py
@@ -760,3 +760,239 @@ def test_reconcile_scans_inside_lock_preserves_racing_toggle(tmp_path, monkeypat
     assert reconciled == {"dev-mode-app"}
     assert _read_dev_sentinel() == {"dev-mode-app"}
     assert is_dev_mode_cached("dev-mode-app") is True
+
+
+# ---------------------------------------------------------------------------
+# Operator grant record (#6809) — the authorization half the reconcile never
+# writes. These lock in that a forged installed.json `dev: true` gains WATCHING
+# at most across a restart, never `dev_mode_granted_root`.
+# ---------------------------------------------------------------------------
+
+
+def test_set_dev_mode_writes_and_revokes_the_grant(tmp_path, monkeypatch):
+    """The operator toggle is the ONLY writer of the grant record, and the
+    grant binds the ui root's resolved path at toggle time."""
+    import os
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") is None
+    set_dev_mode("dev-mode-app", True)
+    expected_root = os.path.realpath(dev_mode.apps_dir() / "dev-mode-app" / "ui")
+    assert dev_mode._read_dev_grants() == {"dev-mode-app": expected_root}
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") == expected_root
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") is not None
+    set_dev_mode("dev-mode-app", False)
+    assert dev_mode._read_dev_grants() == {}
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") is None
+
+
+def test_reconcile_never_launders_a_forged_dev_flag_into_a_grant(tmp_path, monkeypatch):
+    """The #6809 GPT-review vector, closed at the root.
+
+    An app writes ``dev: true`` to its OWN ``installed.json`` (app-writable)
+    and waits for a gateway restart. The startup reconcile rebuilds the WATCH
+    sentinel from that metadata — documented behavior, kept — but must not
+    thereby authorize the app: ``dev_mode_granted_root`` reads the separate
+    grant record the reconcile never creates, so the forged flag buys watching
+    and no-store serving at most, never an out-of-install ui root.
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+    from kiro_crew.apps.manager import _write_installed
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+
+    # The app forges its own metadata (no operator toggle ran).
+    meta = _read_installed("dev-mode-app")
+    meta.dev = True
+    _write_installed("dev-mode-app", meta)
+
+    # Restart: the reconcile honors the documented field for WATCHING...
+    reconciled = _reconcile_sentinel_from_installed()
+    assert reconciled == {"dev-mode-app"}
+    assert _read_dev_sentinel() == {"dev-mode-app"}
+
+    # ...but the AUTHORIZATION is not derivable from app-writable state.
+    assert dev_mode._read_dev_grants() == {}
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") is None
+
+
+def test_reconcile_prunes_grants_for_absent_apps_but_keeps_live_ones(
+    tmp_path, monkeypatch
+):
+    """Remove-only grant maintenance at startup, keyed on VALID metadata.
+
+    A crash between an uninstall and ``remove_dev_app``'s revoke can leave a
+    grant for an app that is gone; a later reinstall under the same name must
+    not inherit it. The prune tests ``_read_installed`` rather than the
+    directory's existence because an uninstall with ``keep_data`` leaves (or
+    recreates) the directory for preserved data while ``installed.json`` is
+    gone — the ghost here has exactly that shape. A grant whose app still
+    exists survives.
+    """
+    import os
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    set_dev_mode("dev-mode-app", True)
+    live_root = os.path.realpath(dev_mode.apps_dir() / "dev-mode-app" / "ui")
+    # The crash leftover: a grant for an app whose DIRECTORY still exists
+    # (keep_data) but whose installed.json is gone.
+    (dev_mode.apps_dir() / "ghost-app" / "data").mkdir(parents=True)
+    dev_mode._write_dev_grants(
+        {"dev-mode-app": live_root, "ghost-app": str(tmp_path / "anywhere")}
+    )
+
+    _reconcile_sentinel_from_installed()
+
+    assert dev_mode._read_dev_grants() == {"dev-mode-app": live_root}
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") is not None
+    assert dev_mode.dev_mode_granted_root("ghost-app") is None
+
+
+def test_uninstall_revokes_the_grant(tmp_path, monkeypatch):
+    """``remove_dev_app`` (the uninstall hook) revokes the operator grant."""
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    set_dev_mode("dev-mode-app", True)
+    assert set(dev_mode._read_dev_grants()) == {"dev-mode-app"}
+
+    dev_mode.remove_dev_app("dev-mode-app")
+
+    assert dev_mode._read_dev_grants() == {}
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode_cached("dev-mode-app") is False
+
+
+def test_disable_revokes_the_grant_FIRST(tmp_path, monkeypatch):
+    """Crash-ordering on disable fails CLOSED.
+
+    The grant is the authorization, so on disable it must be the FIRST write:
+    a crash after any prefix of the toggle's writes then leaves watching
+    without authorization (harmless), never a live grant on a still-installed
+    app — which the reconcile would never expire, and which the app could
+    re-arm by forging ``dev: true`` back into its own metadata. Simulated by
+    making the metadata write (the SECOND step) blow up and checking the
+    grant is already gone.
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    set_dev_mode("dev-mode-app", True)
+    assert set(dev_mode._read_dev_grants()) == {"dev-mode-app"}
+
+    def _crash(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(dev_mode, "_write_installed", _crash)
+    with pytest.raises(OSError):
+        set_dev_mode("dev-mode-app", False)
+
+    # The crash interrupted the toggle AFTER the revoke: fail-closed state.
+    assert dev_mode._read_dev_grants() == {}
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") is None
+
+
+def test_enable_refuses_to_bind_a_sensitive_escaping_root(tmp_path, monkeypatch):
+    """A ui root escaping the install dir INTO A SENSITIVE LOCATION is never
+    grantable — not even by the real operator: no dev workflow legitimately
+    serves credential stores over the unauthenticated UI route. The toggle is
+    rolled back whole (no grant, no metadata flag, no sentinel entry)."""
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    # Repoint ui outside the install dir; mark the target sensitive.
+    app_ui = dev_mode.apps_dir() / "dev-mode-app" / "ui"
+    import shutil
+
+    shutil.rmtree(app_ui)
+    outside = tmp_path / "credential-store"
+    outside.mkdir()
+    from conftest import make_dir_link
+
+    make_dir_link(app_ui, outside)
+    monkeypatch.setattr(dev_mode, "is_sensitive_path", lambda p: True)
+
+    result = set_dev_mode("dev-mode-app", True)
+
+    assert "error" in result and "sensitive location" in result["error"]
+    assert dev_mode._read_dev_grants() == {}
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode("dev-mode-app") is False
+
+
+def test_a_refused_reenable_preserves_prior_dev_state(tmp_path, monkeypatch):
+    """A refusal validates BEFORE writing, so prior state survives it.
+
+    An app already in dev mode (contained root, valid grant) repoints ``ui``
+    to a sensitive root; the operator re-toggles enable and is refused. The
+    refusal must be a pure no-op on the prior state: metadata still says
+    dev, the sentinel still carries the name (watching continues), and the
+    OLD grant — bound to the previously-approved root — is untouched. The
+    earlier shape wrote metadata/sentinel first and "rolled back" by
+    unconditionally disabling, silently tearing down working dev mode.
+    """
+    import shutil
+
+    import kiro_crew.apps.dev_mode as dev_mode
+    from conftest import make_dir_link
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    set_dev_mode("dev-mode-app", True)
+    prior_grants = dev_mode._read_dev_grants()
+    assert set(prior_grants) == {"dev-mode-app"}
+
+    # The app repoints ui at a (simulated) sensitive root...
+    app_ui = dev_mode.apps_dir() / "dev-mode-app" / "ui"
+    shutil.rmtree(app_ui)
+    outside = tmp_path / "credential-store"
+    outside.mkdir()
+    make_dir_link(app_ui, outside)
+    monkeypatch.setattr(dev_mode, "is_sensitive_path", lambda p: True)
+
+    # ...and the re-toggle is refused WITHOUT touching prior state.
+    result = set_dev_mode("dev-mode-app", True)
+
+    assert "error" in result and "sensitive location" in result["error"]
+    assert is_dev_mode("dev-mode-app") is True, "metadata dev flag preserved"
+    assert _read_dev_sentinel() == {"dev-mode-app"}, "watching preserved"
+    assert dev_mode._read_dev_grants() == prior_grants, "old grant untouched"
+
+
+def test_enable_refuses_a_root_CONTAINING_sensitive_leaves(tmp_path, monkeypatch):
+    """The reverse direction of the screen: a root that is not itself on the
+    sensitive list but CONTAINS a credential leaf (``~/.docker`` is clean,
+    ``~/.docker/config.json`` is not; ``~`` contains everything) is equally
+    ungrantable — the UI route would serve the leaf out of an allowlisted
+    extension."""
+    import shutil
+
+    import kiro_crew.apps.dev_mode as dev_mode
+    from conftest import make_dir_link
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    app_ui = dev_mode.apps_dir() / "dev-mode-app" / "ui"
+    shutil.rmtree(app_ui)
+    outside = tmp_path / "contains-credentials"
+    outside.mkdir()
+    make_dir_link(app_ui, outside)
+    monkeypatch.setattr(dev_mode, "is_sensitive_path", lambda p: False)
+    monkeypatch.setattr(dev_mode, "path_contains_sensitive", lambda p: True)
+
+    result = set_dev_mode("dev-mode-app", True)
+
+    assert "error" in result and "sensitive location" in result["error"]
+    assert dev_mode._read_dev_grants() == {}
+    assert is_dev_mode("dev-mode-app") is False

--- a/test/test_app_routes.py
+++ b/test/test_app_routes.py
@@ -427,7 +427,7 @@ async def test_ui_file_no_cache_revalidation(tmp_path, monkeypatch):
         assert resp.headers.get("Cache-Control") == "no-cache"
         assert "max-age" not in resp.headers.get("Cache-Control", "")
         last_modified = resp.headers.get("Last-Modified")
-        assert last_modified  # FileResponse provides the validator
+        assert last_modified  # descriptor-derived validator (see _read_ui_file)
 
         # A revalidation request with the validator must yield 304 (no body).
         resp304 = await client.get(

--- a/test/test_app_ui_file_route.py
+++ b/test/test_app_ui_file_route.py
@@ -1,0 +1,566 @@
+"""Serving an app's UI bundle through a pinned descriptor (#6809).
+
+``/apps/{name}/ui/{path}`` serves the SAME app-owned directory the art route
+serves, and until #6809 it kept the validate-then-``FileResponse`` shape #6794
+removed from that sibling: validating a path and then handing it to
+``FileResponse`` opens it a SECOND time, so the app that owns the directory can
+swap a validated name for a symlink between the check and that open and have
+the unsandboxed gateway read the target on its behalf. Worse than parity: this
+route's extension allowlist admits ``.json`` and ``.mjs``, so the route with
+the weaker open had the broader reach.
+
+The suite mirrors ``test_app_art_route.py`` (the #6794 shape) with this
+route's own behaviour contract: 400 on ``..``/absolute/escaping paths, 403 on
+a disallowed extension, 404 on anything else unservable, Content-Type from the
+extension map, and body-less 304s for conditional requests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from conftest import make_dir_link, requires_symlinks
+from kiro_crew.apps import dev_mode
+from kiro_crew.apps import routes as app_routes
+
+APP = "demo-app"
+
+
+def _make_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/apps/{name}/ui/{path:.*}", app_routes.handle_app_ui_file)
+    return app
+
+
+@pytest.fixture()
+def ui_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An installed app carrying one real UI asset per allowed extension."""
+    root = tmp_path / "apps"
+    ui = root / APP / "ui"
+    (ui / "chunks").mkdir(parents=True)
+    for ext in sorted(app_routes._ALLOWED_EXTENSIONS):
+        (ui / f"asset{ext}").write_bytes(f"bytes-for-{ext}".encode())
+    (ui / "chunks" / "lazy.mjs").write_bytes(b"chunk-bytes")
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    return ui
+
+
+async def _get(path: str, **kw: object) -> tuple[int, bytes]:
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(path, **kw)  # type: ignore[arg-type]
+        return resp.status, await resp.read()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ext", sorted(app_routes._ALLOWED_EXTENSIONS))
+async def test_each_allowed_extension_serves_with_its_content_type(ui_root: Path, ext: str) -> None:
+    """The happy path, per extension: the pinned open must keep ADMITTING every
+    file the old open admitted, with the same Content-Type."""
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"/apps/{APP}/ui/asset{ext}")
+        assert resp.status == 200
+        assert await resp.read() == f"bytes-for-{ext}".encode()
+        assert resp.headers["Content-Type"] == app_routes._CONTENT_TYPES[ext]
+        assert resp.headers["Cache-Control"] == "no-cache"
+
+
+@pytest.mark.asyncio
+async def test_a_nested_path_is_served(ui_root: Path) -> None:
+    """Vite code-splits into ``chunks/``, so multi-component paths are the
+    normal case, not an edge."""
+    status, body = await _get(f"/apps/{APP}/ui/chunks/lazy.mjs")
+    assert status == 200
+    assert body == b"chunk-bytes"
+
+
+@requires_symlinks
+@pytest.mark.asyncio
+async def test_a_symlink_at_the_final_NAME_is_refused_even_inside_the_root(
+    ui_root: Path,
+) -> None:
+    """The property that closes the check-to-use swap.
+
+    A link pointing at a perfectly legitimate file INSIDE the root is refused
+    too: it is the indirection that is refused, not the destination, because
+    only the indirection is swappable. The old code served this with a 200 —
+    the resolved path sat inside the root, so containment passed, and
+    ``FileResponse`` followed the link on its second open.
+    """
+    real = ui_root / "asset.js"
+    assert real.is_file(), "fixture precondition: the link's target is a real asset"
+    link = ui_root / "aliased.js"
+    link.symlink_to("asset.js")  # inside the root, and a real file
+    status, body = await _get(f"/apps/{APP}/ui/aliased.js")
+    assert status == 404
+    assert b"bytes-for-.js" not in body, "the link's target must not be served"
+
+
+@requires_symlinks
+@pytest.mark.asyncio
+async def test_a_mutual_symlink_pair_answers_404(ui_root: Path) -> None:
+    """The two-file loop form, which a single-file guard can miss."""
+    a = ui_root / "a.css"
+    b = ui_root / "b.css"
+    a.symlink_to("b.css")
+    b.symlink_to("a.css")
+    status, _ = await _get(f"/apps/{APP}/ui/a.css")
+    assert status == 404
+
+
+@requires_symlinks
+@pytest.mark.asyncio
+async def test_an_escaping_symlink_at_the_final_name_keeps_answering_400(
+    ui_root: Path, tmp_path: Path
+) -> None:
+    """The historic contract: an escape answers 400 ``invalid path``. Pinned
+    open or not, the status must not drift under the refactor."""
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"secret": true}', encoding="utf-8")
+    (ui_root / "escape.json").symlink_to(outside)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"/apps/{APP}/ui/escape.json")
+        assert resp.status == 400
+        assert (await resp.json())["error"] == "invalid path"
+        assert b"secret" not in await resp.read()
+
+
+@pytest.mark.asyncio
+async def test_a_symlinked_ANCESTOR_is_refused(ui_root: Path, tmp_path: Path) -> None:
+    """What the caller-side containment check is still for, once the pinned
+    open exists.
+
+    ``O_NOFOLLOW`` refuses a link at the final NAME, and the handler's own
+    guard refuses ``..`` — so the one route left into the containment check is
+    an ANCESTOR that is a link. ``pin_parent`` deliberately does not close that
+    case (its contract: a component swapped BEFORE the parent was resolved is
+    followed by that resolution), so resolving the parent and proving it lands
+    under the resolved root is load-bearing — a genuine #6794 coverage gap
+    until a mutation surfaced it. ``make_dir_link`` so Windows gets a junction
+    and the branch without the pinned walk is covered by the same test.
+    """
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "app.js").write_bytes(b"outside-bytes")
+    make_dir_link(ui_root / "vendor", outside)
+    status, body = await _get(f"/apps/{APP}/ui/vendor/app.js")
+    assert status == 400
+    assert b"outside-bytes" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_LINKED_ui_root_still_serves_under_the_dev_grant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The legitimate link the hardening must NOT refuse.
+
+    The documented dev-mode setup links ``ui/`` at the developer's source tree
+    (junction on Windows). The root is resolved BEFORE containment, so the walk
+    and the check both happen where the link really lands — and the escape from
+    the install directory is allowed exactly because the OPERATOR granted dev
+    mode: a grant record (written only by the dev-mode toggle, never created
+    by the startup reconcile) BOUND to this resolved root, plus the metadata
+    flag — the grant half exercised for real here.
+    """
+    root = tmp_path / "apps"
+    (root / APP).mkdir(parents=True)
+    real = tmp_path / "source-ui"
+    real.mkdir()
+    (real / "index.mjs").write_bytes(b"dev-bytes")
+    make_dir_link(root / APP / "ui", real)
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(dev_mode, "apps_dir", lambda: root)
+    # The operator's half of the grant, bound to the root they approved.
+    dev_mode._write_dev_grants({APP: os.path.realpath(real)})
+    monkeypatch.setattr(dev_mode, "is_dev_mode", lambda name: name == APP)
+    status, body = await _get(f"/apps/{APP}/ui/index.mjs")
+    assert status == 200
+    assert body == b"dev-bytes"
+
+
+@pytest.mark.asyncio
+async def test_a_linked_ui_root_WITHOUT_the_grant_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The vector the install-containment check closes: an app SHIPS ``ui`` as
+    a link to a credential directory (a git install preserves symlinks), and
+    this route bypasses token auth — so without the check, an unauthenticated
+    request serves ``config.json`` out of it (``.json`` is in the allowlist),
+    laundering a read the app's own sandboxed code is refused."""
+    root = tmp_path / "apps"
+    (root / APP).mkdir(parents=True)
+    outside = tmp_path / "not-the-install"
+    outside.mkdir()
+    (outside / "config.json").write_bytes(b'{"auths": "CREDENTIAL-BYTES"}')
+    make_dir_link(root / APP / "ui", outside)
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(dev_mode, "apps_dir", lambda: root)  # no sentinel exists
+    status, body = await _get(f"/apps/{APP}/ui/config.json")
+    assert status == 400
+    assert b"CREDENTIAL-BYTES" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_SELF_GRANTED_dev_flag_does_not_authorize_the_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Why the grant is a separate operator record, not metadata-backed.
+
+    ``installed.json`` lives inside the install directory the APP ITSELF can
+    write, so an app that edits it to ``dev: true`` must not thereby authorize
+    its own out-of-install ui root — the grant record at the apps ROOT, which
+    only the owner's dashboard toggle writes, is the half it cannot forge.
+    ``is_dev_mode`` is forced True here (the forged metadata); with no grant
+    record the check must still refuse.
+    """
+    root = tmp_path / "apps"
+    (root / APP).mkdir(parents=True)
+    outside = tmp_path / "not-the-install"
+    outside.mkdir()
+    (outside / "config.json").write_bytes(b'{"auths": "CREDENTIAL-BYTES"}')
+    make_dir_link(root / APP / "ui", outside)
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(dev_mode, "apps_dir", lambda: root)
+    monkeypatch.setattr(dev_mode, "is_dev_mode", lambda name: True)  # forged
+    status, body = await _get(f"/apps/{APP}/ui/config.json")
+    assert status == 400
+    assert b"CREDENTIAL-BYTES" not in body
+
+
+@pytest.mark.asyncio
+async def test_the_reconciled_sentinel_alone_does_not_authorize_the_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The restart-laundering vector: sentinel != grant.
+
+    The startup reconcile rebuilds the WATCH sentinel from each app's own
+    (app-writable) ``installed.json`` — so across a restart, a forged
+    ``dev: true`` DOES put the app's name in the sentinel. That must buy
+    watching and no-store serving at most: the authorization half is the
+    separate grant record only the operator toggle writes. Sentinel present +
+    metadata forged + no grant record → the out-of-install ui root is still
+    refused.
+    """
+    root = tmp_path / "apps"
+    (root / APP).mkdir(parents=True)
+    outside = tmp_path / "not-the-install"
+    outside.mkdir()
+    (outside / "config.json").write_bytes(b'{"auths": "CREDENTIAL-BYTES"}')
+    make_dir_link(root / APP / "ui", outside)
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(dev_mode, "apps_dir", lambda: root)
+    dev_mode._write_dev_sentinel({APP})  # what the restart reconcile rebuilds
+    monkeypatch.setattr(dev_mode, "is_dev_mode", lambda name: True)  # forged
+    status, body = await _get(f"/apps/{APP}/ui/config.json")
+    assert status == 400
+    assert b"CREDENTIAL-BYTES" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_symlinked_INSTALL_ENTRY_cannot_vouch_for_its_own_containment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The containment anchor is the resolved apps ROOT + the literal name.
+
+    Re-resolving through the app's own install entry would let that entry
+    vouch for itself: an install entry that IS a link to an outside tree made
+    `realpath(apps_dir()/name)` land in that same outside tree, so the
+    escaping ui root read as "inside the install" and served with no grant —
+    and the two independent realpath calls could be raced by swapping the
+    entry between them. With the literal-name anchor the resolved root lands
+    outside and takes the grant path like any other escape: refused without
+    an operator grant.
+    """
+    root = tmp_path / "apps"
+    root.mkdir()
+    outside = tmp_path / "not-the-install"
+    (outside / "ui").mkdir(parents=True)
+    (outside / "ui" / "config.json").write_bytes(b'{"auths": "CREDENTIAL-BYTES"}')
+    # The app's install-dir ENTRY is itself a link to the outside tree.
+    make_dir_link(root / APP, outside)
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(dev_mode, "apps_dir", lambda: root)
+    status, body = await _get(f"/apps/{APP}/ui/config.json")
+    assert status == 400
+    assert b"CREDENTIAL-BYTES" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_grant_bound_to_a_DIFFERENT_root_does_not_authorize_the_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The grant covers ONE resolved root — the one the operator approved.
+
+    A stale or inherited grant (crash mid-revoke, an app update that repoints
+    ``ui``, a reinstall under the same name) must authorize only the exact
+    tree bound at toggle time: the current resolved root must EQUAL the
+    granted root. Here the operator granted a legitimate source tree, then
+    ``ui`` was repointed at a credential directory — refused, credential
+    bytes never leaked.
+    """
+    root = tmp_path / "apps"
+    (root / APP).mkdir(parents=True)
+    approved = tmp_path / "approved-source"
+    approved.mkdir()
+    outside = tmp_path / "not-the-install"
+    outside.mkdir()
+    (outside / "config.json").write_bytes(b'{"auths": "CREDENTIAL-BYTES"}')
+    # ui points at the credential dir, but the grant binds the approved tree.
+    make_dir_link(root / APP / "ui", outside)
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(dev_mode, "apps_dir", lambda: root)
+    dev_mode._write_dev_grants({APP: os.path.realpath(approved)})
+    monkeypatch.setattr(dev_mode, "is_dev_mode", lambda name: True)
+    status, body = await _get(f"/apps/{APP}/ui/config.json")
+    assert status == 400
+    assert b"CREDENTIAL-BYTES" not in body
+
+
+@pytest.mark.asyncio
+async def test_the_windows_branch_validates_the_OPENED_descriptor_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The name-based reparse probe leaves a probe-to-open window; the
+    descriptor's own final path is the race-free witness. Simulate a swap that
+    beat the probe: the opened descriptor's real path resolves OUTSIDE the
+    root — refused, even though every name-based check passed."""
+    root = tmp_path / "apps"
+    ui = root / APP / "ui"
+    ui.mkdir(parents=True)
+    (ui / "app.js").write_bytes(b"const x = 1\n")
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(app_routes, "supports_pinned_walk", lambda: False)
+    monkeypatch.setattr(
+        app_routes, "_fd_real_path", lambda fd: str(tmp_path / "elsewhere" / "app.js")
+    )
+    status, body = await _get(f"/apps/{APP}/ui/app.js")
+    assert status == 404
+    assert b"const x" not in body
+
+
+@pytest.mark.asyncio
+async def test_the_windows_branch_fails_closed_when_the_fd_path_is_unreadable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On the no-pinned-walk branch the descriptor is the only trustworthy
+    witness: if its final path cannot be read, refuse rather than serve."""
+    root = tmp_path / "apps"
+    ui = root / APP / "ui"
+    ui.mkdir(parents=True)
+    (ui / "app.js").write_bytes(b"const x = 1\n")
+    monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
+    monkeypatch.setattr(app_routes, "supports_pinned_walk", lambda: False)
+    monkeypatch.setattr(app_routes, "_fd_real_path", lambda fd: None)
+    status, _body = await _get(f"/apps/{APP}/ui/app.js")
+    assert status == 404
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_file_revalidates_to_a_bodyless_304(ui_root: Path) -> None:
+    """Buffered bytes must not cost a full 200 per load: ``no-cache`` means the
+    browser revalidates every time, so the validator — derived from the
+    DESCRIPTOR the bytes were read from, not a second stat — answers
+    If-None-Match with a body-less 304."""
+    async with TestClient(TestServer(_make_app())) as client:
+        first = await client.get(f"/apps/{APP}/ui/asset.js")
+        assert first.status == 200
+        etag = first.headers["ETag"]
+        assert etag
+        again = await client.get(f"/apps/{APP}/ui/asset.js", headers={"If-None-Match": etag})
+        assert again.status == 304
+        assert await again.read() == b"", "a 304 carries no body"
+
+
+@pytest.mark.asyncio
+async def test_if_modified_since_still_revalidates_to_304(ui_root: Path) -> None:
+    """``FileResponse`` answered If-Modified-Since, so clients that revalidate
+    by date (no ETag support) must keep getting their 304 after the refactor."""
+    async with TestClient(TestServer(_make_app())) as client:
+        first = await client.get(f"/apps/{APP}/ui/asset.js")
+        assert first.status == 200
+        last_modified = first.headers["Last-Modified"]
+        assert last_modified
+        again = await client.get(
+            f"/apps/{APP}/ui/asset.js", headers={"If-Modified-Since": last_modified}
+        )
+        assert again.status == 304
+        assert await again.read() == b""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header_fmt",
+    [
+        'W/"{etag}"',  # RFC 7232 §3.2: If-None-Match uses the WEAK comparison
+        '"unrelated", "{etag}"',  # a list containing the current tag
+        "*",  # any current representation
+    ],
+)
+async def test_non_trivial_if_none_match_forms_still_revalidate(
+    ui_root: Path, header_fmt: str
+) -> None:
+    """A raw string-equality check missed every one of these and re-sent the
+    full body; the parsed accessor applies RFC 7232 semantics."""
+    async with TestClient(TestServer(_make_app())) as client:
+        first = await client.get(f"/apps/{APP}/ui/asset.js")
+        assert first.status == 200
+        etag = first.headers["ETag"].strip('"')
+        again = await client.get(
+            f"/apps/{APP}/ui/asset.js",
+            headers={"If-None-Match": header_fmt.format(etag=etag)},
+        )
+        assert again.status == 304
+        assert await again.read() == b""
+
+
+@pytest.mark.asyncio
+async def test_a_non_matching_etag_gets_the_full_body(ui_root: Path) -> None:
+    """The mirror: revalidation must not 304 a changed representation."""
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(
+            f"/apps/{APP}/ui/asset.js", headers={"If-None-Match": '"stale-tag"'}
+        )
+        assert resp.status == 200
+        assert await resp.read() == b"bytes-for-.js"
+
+
+@pytest.mark.asyncio
+async def test_a_file_over_the_size_ceiling_is_refused(
+    ui_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bytes are held rather than streamed, so without a cap an app could
+    make the gateway buffer whatever it ships."""
+    monkeypatch.setattr(app_routes, "_UI_MAX_BYTES", 64)
+    (ui_root / "big.js").write_bytes(b"x" * 65)
+    status, _ = await _get(f"/apps/{APP}/ui/big.js")
+    assert status == 404, "over the ceiling is not servable, same answer as missing"
+
+
+@pytest.mark.asyncio
+async def test_a_file_at_exactly_the_ceiling_is_served(
+    ui_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The mirror: the ceiling is a bound, not an off-by-one."""
+    monkeypatch.setattr(app_routes, "_UI_MAX_BYTES", 64)
+    (ui_root / "exact.js").write_bytes(b"x" * 64)
+    status, body = await _get(f"/apps/{APP}/ui/exact.js")
+    assert status == 200
+    assert body == b"x" * 64
+
+
+@pytest.mark.asyncio
+async def test_a_HARDLINK_alias_is_refused(ui_root: Path, tmp_path: Path) -> None:
+    """The one alias ``O_NOFOLLOW`` cannot see: a hardlink shares its target's
+    inode, so ``is_symlink()`` is False, ``realpath`` yields the alias's OWN
+    name (containment passes), and there is no link for the pinned open to
+    refuse. ``st_nlink`` on the DESCRIPTOR is the only signal."""
+    outside = tmp_path / "not-ui-at-all"
+    outside.write_bytes(b"SENSITIVE-BYTES")
+    alias = ui_root / "aliased-asset.js"
+    os.link(outside, alias)  # a HARDLINK, not a symlink
+    assert not alias.is_symlink(), "precondition: no symlink guard can see this"
+    assert alias.stat().st_nlink == 2, "precondition: the alias is a second name"
+    status, body = await _get(f"/apps/{APP}/ui/aliased-asset.js")
+    assert status == 404
+    assert b"SENSITIVE-BYTES" not in body
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_single_link_file_is_still_served(ui_root: Path) -> None:
+    """The mirror: the nlink gate must not refuse a normal asset."""
+    assert (ui_root / "asset.js").stat().st_nlink == 1
+    status, body = await _get(f"/apps/{APP}/ui/asset.js")
+    assert status == 200
+    assert body == b"bytes-for-.js"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are POSIX-only")
+@pytest.mark.asyncio
+async def test_a_FIFO_does_not_hang_the_request(ui_root: Path) -> None:
+    """Why the flags carry ``O_NONBLOCK``: opening a FIFO blocks until a writer
+    appears, and this handler runs inside ``asyncio.to_thread``, so a shipped
+    FIFO would park a thread-pool worker forever. If this test ever hangs
+    rather than failing, that IS the regression."""
+    os.mkfifo(ui_root / "piped.js")
+    status, _ = await asyncio.wait_for(_get(f"/apps/{APP}/ui/piped.js"), timeout=10)
+    assert status == 404, "a FIFO is not a plain file, so it is not servable"
+
+
+@pytest.mark.asyncio
+async def test_a_DIRECTORY_with_an_allowed_extension_is_refused(ui_root: Path) -> None:
+    """The other non-regular shape: a directory opens fine under ``O_RDONLY``,
+    so ``S_ISREG`` on the descriptor is what refuses it."""
+    (ui_root / "adir.js").mkdir()
+    status, _ = await _get(f"/apps/{APP}/ui/adir.js")
+    assert status == 404
+
+
+def test_a_NUL_in_the_final_name_is_refused_at_the_resolver(ui_root: Path) -> None:
+    """``os.open`` raises ``ValueError`` — never an OSError — for a name the OS
+    cannot encode, and such a name survives the earlier checks (the extension
+    allowlist reads the suffix AFTER the bad byte, and containment resolves the
+    PARENT). Asserted at the resolver because a NUL does not survive the HTTP
+    round trip."""
+    assert app_routes._open_ui_file(APP, "bad\x00.js") in ("invalid", "not_found")
+
+
+def test_the_windows_branch_also_refuses_an_unencodable_name(
+    ui_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The no-pinned-walk branch needs its own coverage on a POSIX runner —
+    ``supports_pinned_walk()`` is True here, so nothing above exercises it."""
+    monkeypatch.setattr(app_routes, "supports_pinned_walk", lambda: False)
+    assert app_routes._open_ui_file(APP, "bad\x00.js") in ("invalid", "not_found")
+
+
+def test_the_windows_branch_still_serves_a_normal_file(
+    ui_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """And it must still WORK — a branch that refuses everything would pass the
+    test above while breaking the route on the platform it exists for."""
+    monkeypatch.setattr(app_routes, "supports_pinned_walk", lambda: False)
+    out = app_routes._open_ui_file(APP, "asset.js")
+    assert isinstance(out, tuple)
+    fd, st = out
+    try:
+        assert os.read(fd, st.st_size) == b"bytes-for-.js"
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.asyncio
+async def test_a_multi_chunk_file_streams_complete_and_bounded(
+    ui_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The OOM-class fix: the body is STREAMED from the validated descriptor,
+    so per-request memory is one chunk, not the file. Forcing a tiny chunk
+    proves the loop reassembles a multi-chunk body byte-for-byte with the
+    right Content-Length."""
+    monkeypatch.setattr(app_routes, "_UI_STREAM_CHUNK", 7)  # force many chunks
+    payload = bytes(range(256)) * 13  # 3328 bytes, not chunk-aligned
+    (ui_root / "big-ish.js").write_bytes(payload)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"/apps/{APP}/ui/big-ish.js")
+        assert resp.status == 200
+        assert resp.headers["Content-Length"] == str(len(payload))
+        assert await resp.read() == payload
+
+
+@pytest.mark.asyncio
+async def test_the_response_neuters_a_navigated_document(ui_root: Path) -> None:
+    """The allowlist admits ``.svg`` and the Content-Type comes from the
+    EXTENSION, so a top-level navigation to this URL must not become a scripted
+    document on the dashboard's origin. Response CSP does not apply to
+    subresource loads, so app module/style/img fetches are unaffected."""
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"/apps/{APP}/ui/asset.svg")
+        assert resp.status == 200
+        csp = resp.headers.get("Content-Security-Policy", "")
+        assert "sandbox" in csp, csp
+        assert "default-src 'none'" in csp, csp
+        assert resp.headers.get("X-Content-Type-Options") == "nosniff"


### PR DESCRIPTION
## Problem / Motivation

`GET /apps/{name}/ui/{path}` validated a path (`..` guard, extension allowlist, `is_file()`, `resolve().relative_to(ui_root)`) and then handed it to `web.FileResponse`, which opens the path a **second** time. That is the check-then-reopen (TOCTOU) window #6794 closed on the art route — over the **same app-owned directory** (`apps_dir()/<name>/…`). The app that owns its install directory can swap a validated name for a symlink (or plant a hardlink alias, which no path-based guard can see) between the check and the re-open, and the unsandboxed gateway then reads the target on the app's behalf. This route was the one remaining sibling in that position, and its allowlist admits `.json` and `.mjs` — so the route with the weaker open had the broader reach. It was deliberately deferred out of #6794 with the fix plan recorded on the issue.

## Why it matters

An installed app's code runs sandboxed; the gateway does not. A swap through this route launders a read the app's own code would be refused — any file the gateway user can read, served over an **unauthenticated** static route (the `/apps/{name}/ui/` token-auth bypass). Measured before the fix: a symlink planted at a validated name inside `ui/` was served with a 200, and so was a hardlink alias of an outside file.

## What changed (motivation → approach → change)

Symptom: validate-then-`FileResponse` re-opens the path, so validation and the served inode can differ. Root cause: the decision is made about a *path* and acted on a *re-resolution* of it. The fix mirrors the hardened art-route shape already in this file (`_read_declared_art`, #6794) rather than inventing a second answer:

- One `pinned_fs.open_in_pinned_parent` open (one `openat` per component, each `O_NOFOLLOW`), then every check runs on the **descriptor**: `S_ISREG`, `st_nlink == 1` (the hardlink gate), a size ceiling — and the bytes served are read from that fd.
- The ui root is resolved **once, through** — so the documented dev-mode setup (`ui/` itself symlinked at the developer's source tree) keeps serving — and containment of the resolved parent against the resolved root is proven **before** the pinned walk. That check is load-bearing, not belt-and-braces: `pin_parent`'s contract is that an already-symlinked ancestor is followed by the caller's resolution, so only this check refuses it. The install-containment **anchor is the resolved apps ROOT plus the literal app name**, never a `realpath` through the app's own install entry — re-resolving through that entry would let it vouch for itself (an entry linked to an outside tree "contained" its own escape) and the two independent resolutions could be raced by swapping the entry between them; the apps root is not app-writable, so the anchor cannot be swapped. The same anchor rule applies at grant time in `set_dev_mode`. A per-**file** link inside `ui/` is now refused by `O_NOFOLLOW` (404); documented next to the recommended directory-link setup in `dev_mode.py`.
- Windows (no `O_NOFOLLOW`/`dir_fd`): the art route's existing degradation — refuse any reparse point below the resolved root, then a plain open — **plus a race-free check the art route lacks**: the reparse probe is name-based, so a junction planted between the probe and the open would still be followed; the opened **descriptor's own final path** (`GetFinalPathNameByHandleW`; `/proc`/`F_GETPATH` on the POSIX hosts the tests run on) must still sit under the resolved root, failing closed when it cannot be read.
- The body is **streamed from the validated descriptor** in bounded chunks (`_UI_STREAM_CHUNK` = 256 KiB) rather than buffered: this route bypasses token auth, so a buffered body would let N outstanding requests each pin a whole file in gateway memory — with streaming, per-request memory is one chunk regardless of file size or client speed, and `Content-Length` is pinned to the validated `fstat` so a file the app grows mid-serve cannot stream past the declared length. Two hardening consequences of streaming are handled: the descriptor close runs off the event loop **inside `asyncio.shield`** (an unshielded `to_thread` awaited during a client-disconnect cancellation can have its work item cancelled while queued, leaking fds on an unauthenticated route until `RLIMIT_NOFILE` wedges the gateway), and `_UI_STREAM_SEMAPHORE` (8, same pattern as `_BLOB_FETCH_SEMAPHORE`) is held from **before the descriptor open until after its close** — scoping it to just the streaming loop would let every queued request already hold an open fd while waiting for a slot, so slow-paced unauthenticated GETs could still walk the gateway to `EMFILE`; under the open-to-close scope at most 8 descriptors exist at once, everyone else waits fd-less, and the same bound caps the per-chunk `to_thread` pressure on the shared default executor. Refusals and body-less 304s hold a slot only microseconds.
- A ui root resolving **outside the app's own install directory is refused unless the operator granted dev mode**: an app could otherwise ship `ui` as a symlink to a credential directory (a git install preserves symlinks) and have this unauthenticated route serve `config.json` (`.json` is in the allowlist). The grant (new `dev_mode.dev_mode_granted_root`) requires the app's metadata flag AND a **separate operator grant record** at the apps root (`.dev-grants.json`) written only by the `set_dev_mode` toggle — deliberately NOT the watch sentinel, because the startup reconcile rebuilds that sentinel from each app's own (app-writable) `installed.json`, so a forged `dev: true` would launder into it across a restart. The record **binds the specific resolved ui root granted** and the route requires the current resolved root to *equal* it, which makes the grant self-invalidating: a repointed `ui` (app update, swapped link, reinstall under the same name) no longer matches, so a grant left behind by any crash window authorizes only the exact tree the operator approved. Belt-and-braces around that: the toggle **revokes first on disable / grants last on enable** (every crash prefix leaves the un-granted state), and on enable it **validates before any write**: a root resolving into a **sensitive location or containing sensitive leaves** (`is_sensitive_path` + `path_contains_sensitive`) is refused as a pure no-op — an already-enabled app whose `ui` was repointed and re-toggled keeps its existing dev mode, sentinel entry, and previously-bound grant untouched — and the reconcile only **prunes** grants whose app no longer has valid installed metadata (`keep_data` directory leftovers don't count as alive). A forged flag buys watching/no-store serving at most. The documented link-at-source setup keeps working exactly when it was granted (re-toggle after re-pointing the link to re-bind). **Upgrade note:** a dev-mode app whose ui root already escaped the install dir before this change has no grant record, so it answers 400 until the operator re-toggles dev mode once — deliberate, since nothing on disk proves the escape was ever operator-approved.
- Losing `FileResponse` means hand-carrying conditional handling: the response derives `ETag` + `Last-Modified` from the served descriptor's `fstat` and answers a body-less 304 via aiohttp's parsed accessors — `request.if_none_match` with RFC 7232 weak comparison (weak forms, lists, `*`) and `request.if_modified_since` (which forces UTC — a hand-rolled `parsedate_to_datetime` yields naive datetimes for `-0000`/asctime forms and would shift the comparison by the host's UTC offset). Cache-Control semantics preserved: `no-store` for dev-mode apps, `no-cache` otherwise.
- `_UI_MAX_BYTES = 8 MiB`, a named constant matching `_ART_MAX_BYTES`' accepted posture (~900× the largest UI asset a bundled in-tree app ships, ~9 KB — the scaffold's vite config externalizes react/react-dom/the SDK). With streaming it bounds the work one unauthenticated request can command, not memory. The one class it can refuse is a self-bundled heavy dependency's sourcemap, and a `.map` 404 degrades only devtools debugging, never the app.
- Behaviour contract preserved: 400 on `..`/absolute/escaping paths, 403 on a disallowed extension, 404 on anything else unservable, Content-Type from `_CONTENT_TYPES`. `nosniff` + `default-src 'none'; sandbox` CSP added, same pair and reasons as the art route (extension-derived Content-Type; a top-level navigation to a scripted `.svg` must not become a document on the dashboard origin).

## Tests

New module `test/test_app_ui_file_route.py`, mirroring the #6794 art-route suite shape, with red-before-green verified against the pre-fix code (the two swap tests returned 200):

- symlink at the final name refused **even when the target is legitimate and inside the root** (the swappable indirection is what is refused) — 200 before, 404 after
- hardlink alias of an outside file refused (`st_nlink` on the descriptor; invisible to every path guard) — 200 before, 404 after
- a mutual symlink pair answers 404, not a hang or 500
- a symlinked **ancestor** refused (proves the caller-side containment check is load-bearing; junction via `make_dir_link` so the Windows branch is covered by the same test)
- an escaping symlink at the final name keeps the historic 400 `invalid path`
- the dev-mode **linked ui root** still serves under the operator's real grant record (the legitimate link the hardening must not refuse); the same link **without** the grant is refused with the credential bytes never leaked (200 before, 400 after); a **forged `dev: true` in the app's own `installed.json` does not authorize the escape** (no grant record → 400); the **restart-laundering vector is closed** — the reconcile-rebuilt watch sentinel alone (what a forged flag produces across a restart) does not authorize (red-before: 200 serving the credential bytes on the prior sentinel-backed grant); and a **grant bound to a different root does not authorize** — `ui` repointed at a credential directory after the operator granted a legitimate source tree answers 400 (red-before: the earlier name-only grant shape had no root binding, so the repointed root was served)
- **grant lifecycle unit tests**: the toggle writes/revokes the path-bound grant; the reconcile never adds one from `installed.json` and prunes by **valid installed metadata** (a `keep_data` directory leftover does not keep a grant alive) while keeping live ones; uninstall revokes; **disable revokes the grant FIRST** (a simulated crash on the metadata write leaves the fail-closed un-granted state); a ui root resolving into a **sensitive location is refused at grant time as a pure no-op** (a refused re-enable preserves existing dev state — metadata, sentinel, and the previously-bound grant; red-before: the old rollback shape silently disabled working dev mode), and a root merely **containing** sensitive leaves is refused the same way
- the **Windows branch validates the OPENED descriptor's final path** against the resolved root (a swap that beats the name-based reparse probe is refused on the descriptor) and **fails closed when the descriptor path cannot be read**
- a **multi-chunk body streams complete and bounded** (tiny forced chunk size; byte-for-byte reassembly with the right Content-Length)
- `If-None-Match` → body-less 304, including weak `W/"…"`, list, and `*` forms (red-before against raw string equality); a non-matching tag still gets the full body; `If-Modified-Since` → 304
- oversize refused at the ceiling; a file at exactly the ceiling served
- FIFO does not hang the request (`O_NONBLOCK` is why); a directory with an allowed extension refused
- NUL/unencodable names answer a refusal, not a 500, on both the pinned and the Windows branch; the Windows branch still serves a normal file
- every allowed extension served with its Content-Type; nested `chunks/` paths; CSP/nosniff present

Existing suites pass unchanged except one stale comment in `test_app_routes.py` (`FileResponse provides the validator` → descriptor-derived). The pre-existing `TestAppUiFile` contract tests (400/403/404, escaping symlink → 400) pass as-is.

## Manual verification

Full backend suite run locally: 74,849 passed; the 88 failures + 2 errors on this dev box are byte-identical on pristine `main` (environment: uid mapping, `AF_UNIX` path length) — zero introduced. `isort`/`flake8`/`mypy`/black gate clean.

## Screenshots / video

N/A — backend-only change; no rendered surface differs (the route serves the same bytes with the same Cache-Control).

## Related Issues

Fixes #6809

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

