### PR TITLE
test(sel): stabilize cross-process lock tests

### DIFF
--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 import pytest
 
 import kiro_crew.sel as sel_mod
+from conftest import requires_symlinks
 from kiro_crew import platform_compat
 from kiro_crew import sel as kiro_crew_sel
 from kiro_crew.sel import SecurityEvent, SecurityEventLog, _infer_source, sel, sel_hmac_key_path
@@ -902,6 +903,7 @@ log.flush()
         log.log(_make_event(event_id="after-release-1"))
         assert "after-release-1" in log._path.read_text(encoding="utf-8")
 
+    @requires_symlinks
     def test_symlinked_sidecar_is_refused(self, tmp_path):
         """A planted link is not a lock — following it defeats serialization.
 
@@ -1026,12 +1028,14 @@ log.flush()
     async def test_on_loop_contention_makes_exactly_one_nonblocking_attempt(
         self, tmp_path, monkeypatch
     ):
-        """The loop-side acquire must try ONCE and refuse — never poll.
+        """The loop-side acquire must try ONCE and refuse — never block or poll.
 
         A retry spin, however short each nap, sleeps the gateway event loop, so
         the stall is paid by every session it serves. This pins the contract:
         one ``try_acquire_lock`` call, an immediate fail-closed raise, and no
-        sleep anywhere on the path.
+        call to either blocking lock primitive. Wall time cannot prove that
+        contract: runner scheduling and the surrounding file work are outside
+        the lock algorithm but inside any elapsed-time measurement.
         """
         log = SecurityEventLog(base_dir=tmp_path, sync=True)
         log.log(_make_event(event_id="single-shot-preheat"))
@@ -1041,27 +1045,30 @@ log.flush()
         holder = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
         assert platform_compat.try_acquire_lock(holder, exclusive=True)
 
-        attempts = []
+        attempts: list[tuple[int, bool]] = []
         real_try = platform_compat.try_acquire_lock
 
         def _counting_try(fd: int, *, exclusive: bool = False) -> bool:
-            attempts.append(fd)
+            attempts.append((fd, exclusive))
             return real_try(fd, exclusive=exclusive)
 
+        def _blocking_acquire_is_a_bug(*_args, **_kwargs):
+            pytest.fail("on-loop chain-lock acquire used a blocking primitive")
+
+        monkeypatch.setattr(kiro_crew_sel.platform_compat, "try_acquire_lock", _counting_try)
         monkeypatch.setattr(
-            kiro_crew_sel.platform_compat, "try_acquire_lock", _counting_try
+            kiro_crew_sel.platform_compat, "acquire_lock", _blocking_acquire_is_a_bug
         )
+        monkeypatch.setattr(kiro_crew_sel.platform_compat, "file_lock", _blocking_acquire_is_a_bug)
         try:
-            started = time.monotonic()
             with pytest.raises(OSError):
                 log.log(_make_event(event_id="single-shot-critical"), critical=True)
-            elapsed = time.monotonic() - started
         finally:
             platform_compat.release_lock(holder)
             os.close(holder)
 
         assert len(attempts) == 1, f"on-loop acquire polled {len(attempts)} times"
-        assert elapsed < 0.05, f"on-loop acquire took {elapsed:.3f}s"
+        assert attempts[0][1] is True, "the single lock attempt was not exclusive"
         assert "single-shot-critical" not in log._path.read_text(encoding="utf-8")
 
     def test_on_loop_acquire_helper_never_sleeps(self):


### PR DESCRIPTION
## Problem / Motivation

Two cross-process SEL tests were nondeterministic on Windows:

- The nonblocking event-loop test asserted that the entire critical-log path completed in under 50 ms. A correct implementation made exactly one nonblocking lock attempt, yet shared-runner scheduling and file I/O produced 188 ms in CI and up to 470 ms locally.
- The sidecar symlink security test assumed every Windows runner could create symlinks, although that capability depends on privilege/developer-mode policy.

## Why it matters

These tests can reject unrelated PRs even when production lock behavior is correct. Raising the timeout or rerunning the shard would preserve the false signal. The tests should directly prove the lock contract and explicitly model platform capability.

## What changed

- Keep a real competing lock holder.
- Record calls to `try_acquire_lock` and require exactly one exclusive, nonblocking attempt.
- Replace blocking `acquire_lock` and `file_lock` primitives with fail-fast sentinels for this path.
- Remove the wall-clock assertion because scheduler and surrounding I/O latency are not the behavior under test.
- Apply the repository's existing `requires_symlinks` capability marker to the symlink-specific security case. Capable CI still runs it; incapable hosts skip explicitly.

Production SEL code is unchanged.

## Tests

- Targeted nonblocking test: serial and 2-worker xdist passed.
- Real contention stress: 500/500 passed.
- `TestCrossProcessSafety`: 17 passed, 1 capability skip.
- Full `test/test_sel.py`: 231 passed, 26 capability skips.
- Mutation checks:
  - routing through a blocking acquire makes the test fail immediately;
  - making two nonblocking attempts fails with `polled 2 times`.
- Independent final targeted run: 1 passed, 1 capability skip.
- isort, Flake8, Black gate, subprocess-encoding, brand, and diff checks passed.

No retry, rerun, sleep, timeout increase, threshold relaxation, or warning filter is used.

## Manual verification

N/A — the test now proves calls to the actual lock primitives under real contention; mutation checks prove the assertions reject both blocking and polling implementations.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes only backend tests and has no rendered UI effect.

## Merge order

Merge #6849 first. It fixes the separate Windows text-mode legacy lock-key flake in the same SEL test area. This PR is test-only and should then merge before replaying the much larger conflicting #4997.