### PR TITLE
fix(ui): give scrollbar-overlay a thumb where hover cannot fire

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1624,6 +1624,17 @@ file-tree-container{
 .scroll-fade:hover::-webkit-scrollbar-thumb{background:var(--border)}
 .scroll-fade{scrollbar-width:thin;scrollbar-color:transparent transparent}
 .scroll-fade:hover{scrollbar-color:var(--border) transparent}
+/* Same defect, same remedy as the overlay utility below: a finger never produces
+   the :hover that reveals the thumb, so a code block wide enough to scroll shows
+   no cue that it does. Predicate and token deliberately match that block rather
+   than making a second decision — one rung, so the two cannot drift. Separate
+   block because it sits with the utility it covers, and because it must follow
+   this utility's own transparent base rules: a media query adds no specificity,
+   so it ties them and wins on source order alone. */
+@media (pointer: coarse) {
+  .scroll-fade{scrollbar-color:var(--border) transparent}
+  .scroll-fade::-webkit-scrollbar-thumb{background:var(--border)}
+}
 
 /* ── Overlay auto-hiding vertical scrollbar ──
  * Reveals the thumb only on hover and overlays the content so it never

--- a/website/src/test/scrollbarOverlayTouch.test.ts
+++ b/website/src/test/scrollbarOverlayTouch.test.ts
@@ -1,0 +1,79 @@
+/**
+ * A hover-revealed scrollbar thumb must still show where `:hover` cannot fire.
+ *
+ * Two utilities share the pattern: `.scroll-fade` (horizontal, code and diff
+ * blocks) and `.scrollbar-overlay` (vertical). Both hide the thumb on BOTH
+ * engines in their base rules — Firefox via `scrollbar-color`, WebKit/Blink via
+ * `::-webkit-scrollbar-thumb` — and paint it only under `:hover`, so a finger
+ * gets no affordance at all.
+ *
+ * `.scrollbar-overlay`'s branch and its chosen predicate/token are pinned by
+ * ChatPage.composerChromeOcclusion.test.tsx; those assertions are deliberately
+ * NOT repeated here. What this file adds is the PATTERN: the members are derived
+ * from the stylesheet, so a utility with a hover-only thumb and no touch branch
+ * fails here by construction rather than by someone remembering to add a case.
+ *
+ * Asserted against SOURCE TEXT, as that spec and noPageZoom.test.ts already do
+ * for this stylesheet: jsdom never loads index.css, and a media query has no
+ * computed representation to read even if it did.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const CSS = readFileSync(resolve(__dirname, '../index.css'), 'utf8')
+
+/** Every class whose thumb is revealed ONLY by `:hover` — the pattern's members. */
+const HOVER_ONLY = [...CSS.matchAll(/\.([a-zA-Z0-9_-]+):hover::-webkit-scrollbar-thumb\{/g)].map(m => m[1])
+/** The `:hover` reveal, whose token the touch branches reuse rather than re-decide. */
+const HOVER_THUMB = /\.scroll-fade:hover::-webkit-scrollbar-thumb\{background:([^}]+)\}/.exec(CSS)
+/** Bodies of every `@media (pointer: coarse)` block, concatenated. */
+const COARSE = [...CSS.matchAll(/@media \(pointer: coarse\) \{\n([\s\S]*?)\n\}/g)].map(m => m[1]).join('\n')
+
+describe('a hover-revealed thumb keeps an affordance where hover cannot fire', () => {
+  it('anchors the premise: the pattern has members and a coarse-pointer branch exists', () => {
+    // A regex that silently stopped matching would make the cases below pass on
+    // an empty haystack.
+    expect(HOVER_ONLY.length, 'no hover-only thumb rules found in index.css').toBeGreaterThan(1)
+    expect(HOVER_THUMB, '.scroll-fade :hover thumb rule not found').not.toBeNull()
+    expect(COARSE, 'no @media (pointer: coarse) body found').not.toBe('')
+  })
+
+  it('covers EVERY hover-only thumb in the stylesheet, not just the one reported', () => {
+    // The pattern, not the utility, is the unit: `.scroll-fade` was missed when
+    // the overlay utility got its branch, and a third member would be missed the
+    // same way. Deriving the list is what makes that impossible.
+    for (const cls of HOVER_ONLY) {
+      expect(COARSE, `.${cls} has a hover-only thumb but no coarse-pointer branch`)
+        .toContain(`.${cls}::-webkit-scrollbar-thumb{`)
+      expect(COARSE, `.${cls} has no coarse-pointer scrollbar-color`).toContain(`.${cls}{scrollbar-color:`)
+    }
+  })
+
+  it('reuses the hover reveal\'s token, so touch and hover cannot drift apart', () => {
+    // Both engines and both utilities name one token. A second value here would
+    // be a design decision nobody made, diverging the next time either is retuned.
+    const decls = [...COARSE.matchAll(/\{(?:background|scrollbar-color):(var\([^)]+\))/g)].map(m => m[1])
+    expect(decls.length).toBe(HOVER_ONLY.length * 2)
+    for (const d of decls) expect(d).toBe(HOVER_THUMB![1].trim())
+  })
+
+  it('declares each branch after the base rule it overrides, which makes it win', () => {
+    // A media query adds no specificity, so a branch TIES its utility's
+    // transparent base rule and wins on source order alone; hoisted above it the
+    // branch is inert while the stylesheet still reads as though it were present.
+    for (const cls of HOVER_ONLY) {
+      const base = CSS.indexOf(`.${cls}::-webkit-scrollbar-thumb{background:transparent`)
+      expect(base, `.${cls} base thumb rule not found`).toBeGreaterThan(-1)
+      const branch = CSS.indexOf(`.${cls}::-webkit-scrollbar-thumb{background:var(`, base)
+      expect(branch, `.${cls} coarse-pointer thumb rule not found after its base rule`).toBeGreaterThan(base)
+    }
+  })
+
+  it('changes colour only, so no call site can reflow', () => {
+    // The reserved gutter comes from `::-webkit-scrollbar{width|height}` and
+    // `scrollbar-width`; re-declaring any of them here would be a layout change.
+    expect(COARSE).not.toMatch(/scrollbar-width/)
+    expect(COARSE).not.toMatch(/::-webkit-scrollbar\{/)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`#7059` fixed the hover-gated scrollbar thumb on `.scrollbar-overlay`. The same
stylesheet has a **second utility with the identical defect**, and it is still
uncovered on `main`:

```css
/* website/src/index.css:1622-1626 */
.scroll-fade::-webkit-scrollbar{height:6px}
.scroll-fade::-webkit-scrollbar-thumb{background:transparent;…}
.scroll-fade:hover::-webkit-scrollbar-thumb{background:var(--border)}
.scroll-fade{scrollbar-width:thin;scrollbar-color:transparent transparent}
.scroll-fade:hover{scrollbar-color:var(--border) transparent}
```

The base rules hide the thumb on both engines — Firefox via `scrollbar-color`,
WebKit/Blink via `::-webkit-scrollbar-thumb` — and only `:hover` paints it. A
finger never produces that `:hover`, so on touch the thumb is permanently
invisible even when the container genuinely scrolls.

`.scroll-fade` is the horizontal scroller on **every code and diff block**
(`website/src/components/CodeBlock.tsx:37`).

Verified against `main` at the time of writing: zero of the four
`@media (pointer: coarse)` blocks in `index.css` name `.scroll-fade`.

## Why it matters

Code blocks are the widest-reach instance of this defect: any assistant answer
containing a line wider than the pane is horizontally scrollable with nothing to
say so, and nothing to show position within it. Unlike a transient hover cue, the
touch case has no second state to fall back on — the affordance is simply absent.

## What changed (motivation → approach → change)

**Root cause.** The reveal is gated on `:hover`, a state a hover-incapable pointer
cannot enter. That is a property of the *pattern*, and the stylesheet has two
members of it. `#7059` fixed one; this fixes the other.

**Deliberately NOT re-deciding the predicate or the token.** `#7059` chose
`@media (pointer: coarse)` and `var(--border)`. This change adopts both verbatim
rather than introducing a second answer, so the two rules agree instead of
competing — one rung across the pattern, which cannot drift when either is
retuned. **Upstream's block is left byte-identical**; the diff is purely additive.

```css
/* after .scroll-fade's own base rules */
@media (pointer: coarse) {
  .scroll-fade{scrollbar-color:var(--border) transparent}
  .scroll-fade::-webkit-scrollbar-thumb{background:var(--border)}
}
```

Both declarations are load-bearing: Firefox reads only `scrollbar-color`,
WebKit/Blink only the pseudo-element, so dropping either leaves one whole engine
family unfixed.

**A separate block, not an extension of upstream's**, for two reasons: it sits
with the utility it covers, matching the file's utility-grouped layout; and it
must follow `.scroll-fade`'s own transparent base rules, because a media query
adds no specificity — the branch *ties* those rules and wins on source order
alone. Hoisted above them it would be inert while the stylesheet still read as
though the fix were present. A test pins that ordering.

**Colour only, so nothing reflows.** `::-webkit-scrollbar{height:6px}` and
`scrollbar-width:thin` are untouched and both already unconditional, so whatever
gutter the engine reserves today it reserves unchanged.

Diff: **2 files, +90, −0.**

## Tests

`website/src/test/scrollbarOverlayTouch.test.ts` — 5 source-text cases. jsdom does
not load `index.css`, and a media query has no computed representation to read even
if it did; this is how `ChatPage.composerChromeOcclusion.test.tsx` and
`noPageZoom.test.ts` already guard this stylesheet.

The assertions `#7059`'s own spec already makes — that a `pointer: coarse` block
carries `.scrollbar-overlay`'s two declarations — are **not repeated here**. What
this file adds is the pattern:

| Case | What it locks in |
| ---- | ---------------- |
| premise anchor | the pattern has members and a coarse-pointer block exists, so the cases below cannot pass on an empty haystack |
| **pattern coverage** | the members are **derived from the stylesheet** — every class with a hover-only thumb must have a coarse-pointer branch on both engines |
| token reuse | every touch declaration names the same token as the `:hover` reveal, so touch and hover cannot drift apart |
| source order | each branch is declared **after** the base rule it overrides, which is what makes it win |
| colour only | the blocks re-declare neither `scrollbar-width` nor `::-webkit-scrollbar{…}` |

Deriving the member list is the point: `.scroll-fade` was missed when the overlay
utility got its branch, and a third member would be missed the same way. The guard
fails by construction rather than by someone remembering to add a case.

Every case is negative-controlled: **8 perturbations** of `index.css` applied one
at a time, **all 8 detected**, baseline and restored file both passing —
`.scroll-fade` block removed; each engine line dropped; its token drifted to
`--border-strong`; **upstream's own block removed** (proving the derived guard
covers that member too, not just the one this PR adds); the block hoisted above its
base rules; `scrollbar-width` re-declared; and a hypothetical third hover-only
utility added with no branch.

`#7059`'s spec still passes unchanged — its block is not modified.

Also green on this tree: `npm run typecheck` (0 errors), `npm run lint` (0 errors),
`npm run lint:phantom-classes`, and 126 tests across the CSS-adjacent specs.

## Manual verification

Measured in a real Chromium under touch emulation (`hasTouch: true`, with
Playwright's default `--hide-scrollbars` disabled, which otherwise suppresses
scrollbar painting outright), reading
`getComputedStyle(el, '::-webkit-scrollbar-thumb').backgroundColor` on live
elements in the built SPA:

| Pointer | `.scroll-fade` thumb | `.scrollbar-overlay` thumb |
| ------- | -------------------- | -------------------------- |
| fine (desktop) | `rgba(0, 0, 0, 0)` | `rgba(0, 0, 0, 0)` |
| coarse, kiro-dark | `rgb(53, 47, 61)` = `--border` | `rgb(53, 47, 61)` |
| coarse, kiro-light | `rgb(228, 228, 231)` = `--border` | `rgb(228, 228, 231)` |

So the branch reaches a real `.scroll-fade` element with the intended token, and
fine pointers are unchanged.

**No screenshot, and the reason is specific rather than an omission.**
`.scroll-fade`'s scroller is a code block whose content comes from the syntax
highlighter, which renders nothing in an offline harness — so the block never
overflows and has no thumb to photograph. The `!complete` fallback path does not
help either: it renders its own `overflow-x-auto` `<pre>`, so `.scroll-fade` is not
the scroller there. A prior revision of this PR carried before/after frames, but
those illustrated a different token (`--border-strong`) and a different predicate
on `.scrollbar-overlay`; they were removed rather than shipped alongside a change
they no longer depict.

## Related Issues

- Follows `#7059`, which fixed `.scrollbar-overlay` for `#6852`. This covers the
  sibling utility that fix left uncovered.
- Contrast is explicitly **not** in scope here: this change makes no token
  decision, it adopts `#7059`'s. Whether `--border` is a strong enough resting cue
  (it measures ~1.2–1.4:1 against the page, under the 3:1 non-text guideline, and
  no border token in any palette clears it) is a separate design question about the
  palette, not about which selectors the rule covers.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
