### PR TITLE
fix(members): order the roster by the newest message, not file mtime

### DIFF
--- a/src/kiro_crew/dashboard/handlers/members.py
+++ b/src/kiro_crew/dashboard/handlers/members.py
@@ -163,8 +163,12 @@ async def api_members(request: web.Request) -> web.Response:
             mt = state.conversation_log.session_mtime(log_key)
             if not mt:
                 continue
-            preview = state.conversation_log.last_message_preview(log_key, sanitize=_sanitize)
-            out[row["slot_key"]] = (mt, preview)
+            preview, msg_ts = state.conversation_log.last_message_info(log_key, sanitize=_sanitize)
+            # Order by the newest MESSAGE, not the file: metadata writes and
+            # rehydration bump the mtime without any new message, which made
+            # rows reorder with no visible cause. mtime remains only as the
+            # fallback for pre-timestamp transcript rows.
+            out[row["slot_key"]] = (msg_ts or mt, preview)
         return out
 
     tails = await asyncio.to_thread(_read_transcript_tails)

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -5381,6 +5381,20 @@ class ConversationLog:
     def last_message_preview(self, key: str, sanitize=None) -> str:
         """Return a short preview of the session's last message ('' if none).
 
+        Thin wrapper over :meth:`last_message_info` — see it for the tail-read
+        mechanics and the ``sanitize`` ordering contract.
+        """
+        return self.last_message_info(key, sanitize=sanitize)[0]
+
+    def last_message_info(self, key: str, sanitize=None) -> tuple[str, float]:
+        """Return ``(preview, message_ts)`` for the session's newest message.
+
+        ``message_ts`` is the epoch seconds of the SAME row the preview came
+        from — the newest user/assistant message — so a caller ordering rows by
+        it sorts by what the preview shows, not by the file's mtime (which any
+        non-message write also bumps). ``0.0`` when the row has no parseable
+        ``ts`` (pre-timestamp transcripts) or no message exists.
+
         Reads only the tail of the JSONL file (bounded), scanning backwards
         for the newest parseable message line — cheap even on large sessions.
         Handles both plain-string ``content`` and structured list-form content
@@ -5401,7 +5415,7 @@ class ConversationLog:
         try:
             size = path.stat().st_size
         except OSError:
-            return ""
+            return "", 0.0
         for window in (self._PREVIEW_TAIL_BYTES, self._PREVIEW_TAIL_BYTES * 16):
             try:
                 with open(path, "rb") as f:
@@ -5410,7 +5424,7 @@ class ConversationLog:
                         f.readline()  # discard the (likely partial) first line
                     tail = f.read().decode("utf-8", errors="replace")
             except OSError:
-                return ""
+                return "", 0.0
             for line in reversed(tail.splitlines()):
                 line = line.strip()
                 if not line:
@@ -5432,10 +5446,19 @@ class ConversationLog:
                     preview = sanitize(preview)
                 if len(preview) > self._PREVIEW_MAX_CHARS:
                     preview = preview[: self._PREVIEW_MAX_CHARS].rstrip() + "…"
-                return preview
+                ts_raw = data.get("ts")
+                ts_epoch = 0.0
+                if isinstance(ts_raw, str) and ts_raw:
+                    try:
+                        ts_epoch = datetime.fromisoformat(
+                            ts_raw.strip().replace("Z", "+00:00")
+                        ).timestamp()
+                    except ValueError:
+                        pass  # unparseable ts — the row still previews
+                return preview, ts_epoch
             if size <= window:
                 break  # the window already covered the whole file — no retry
-        return ""
+        return "", 0.0
 
     @staticmethod
     def _content_text(content: object) -> str:

--- a/test/test_members_dm_thread.py
+++ b/test/test_members_dm_thread.py
@@ -227,6 +227,40 @@ class TestMemberRoutes:
         assert "AKIA" not in preview
 
     @pytest.mark.asyncio
+    async def test_roster_orders_by_message_ts_not_file_mtime(self, tmp_path):
+        """last_active_ts is the newest MESSAGE's own timestamp.
+
+        Non-message writes (metadata, rehydration) bump the transcript file's
+        mtime without any new message; ordering on mtime made rows reorder
+        with no visible cause. Bumping the older thread's file mtime to the
+        newest time must NOT promote it above the thread whose message is
+        actually newer.
+        """
+        import os
+        import time
+
+        state = _make_state(tmp_path)
+        write_dm_binding(CREW, member=CREW, slot_key=member_slot_key(CREW))
+        write_dm_binding(
+            "docs-writer", member="Docs_Writer", slot_key=member_slot_key("docs-writer")
+        )
+        old_key = f"dashboard:{member_slot_key(CREW)}"
+        new_key = f"dashboard:{member_slot_key('docs-writer')}"
+        state.conversation_log.append(old_key, "user", "older message")
+        state.conversation_log.append(new_key, "user", "newer message")
+        # Touch the OLDER thread's file so its mtime is the newest of the two.
+        old_path = state.conversation_log._path(old_key)
+        now = time.time() + 60
+        os.utime(old_path, (now, now))
+        with _patched_config([CREW, "Docs_Writer"]):
+            async with TestClient(TestServer(_make_members_app(state))) as client:
+                resp = await client.get("/api/members")
+                assert resp.status == 200
+                data = await resp.json()
+        rows = {r["name"]: r for r in data["members"]}
+        assert rows[CREW]["last_active_ts"] < rows["Docs_Writer"]["last_active_ts"]
+
+    @pytest.mark.asyncio
     async def test_thread_create_then_roster_reports_bound(self, tmp_path):
         state = _make_state(tmp_path)
         with _patched_config([CREW]):


### PR DESCRIPTION
## Problem / Motivation

PM feedback on the Crew Members page: rows should order by the latest user/agent **message**. The roster's `last_active_ts` was the DM transcript's file mtime — which metadata writes and rehydration also bump — so rows could reorder between visits with no new message and no visible cause.

## Why it matters

The roster's recency order is only trustworthy if it tracks what the row's preview shows. An mtime-driven order contradicts the preview: a thread can jump to the top while its last message is days old.

## What changed

`last_message_preview`'s tail scan already lands on the newest user/assistant row; it now also returns that row's own `ts` as `last_message_info(key, sanitize)` (epoch seconds; `0.0` for pre-timestamp rows). `last_message_preview` becomes a thin wrapper, so the sessions-list caller is untouched. The members roster orders by the message timestamp, with mtime surviving only as the fallback for transcripts whose rows carry no `ts`. Preview and sort key come from the SAME row, so the order always matches what the row shows.

## Tests

378 backend tests green, including a new pin: two threads with ordered messages, the older thread's file mtime bumped above the newer — the newer-message thread must still sort first.

## Manual verification

N/A — the pinning test exercises the full route (`GET /api/members`) end to end.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only ordering-key change; the rendered roster is identical for any given order.

no linked issue: PM chat feedback on the shipped page.
