### PR TITLE
fix(settings): update model and effort selectors immediately

### DIFF
--- a/website/src/pages/settings/ChatPanel.tsx
+++ b/website/src/pages/settings/ChatPanel.tsx
@@ -169,6 +169,28 @@ export function ChatPanel() {
   })
   const mcCfg = mcQ.data
 
+  const optimisticAgentMutation = (
+    updateAgent: (
+      agent: NonNullable<NonNullable<typeof mcCfg>['agent']>,
+      value: string,
+    ) => NonNullable<NonNullable<typeof mcCfg>['agent']>,
+    errorMessage: (error: unknown) => string,
+  ) => ({
+    onMutate: async (value: string) => {
+      await qc.cancelQueries({ queryKey: ['kirocrewConfig'] })
+      const previous = qc.getQueryData<typeof mcCfg>(['kirocrewConfig'])
+      qc.setQueryData<typeof mcCfg>(['kirocrewConfig'], current => current
+        ? { ...current, agent: updateAgent(current.agent ?? {}, value) }
+        : current)
+      return { previous }
+    },
+    onError: (error: unknown, _value: string, ctx: { previous: typeof mcCfg } | undefined) => {
+      if (ctx?.previous) qc.setQueryData(['kirocrewConfig'], ctx.previous)
+      setSaveError(errorMessage(error))
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
+  })
+
   // ── User profile (About You) ──
   // Same slugs as onboarding step 2 (OnboardingFlow.tsx), validated by the
   // config PATCH allowlist (handlers/core.py) and mapped to the prompt's
@@ -248,13 +270,13 @@ export function ChatPanel() {
   const fallbackModel = mcCfg?.agent?.fallback_model ?? 'auto'
   const fallbackMut = useMutation({
     mutationFn: (v: string) => api.patchConfig('agent.fallback_model', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: (err: unknown) => {
-      // Surface the backend's actual deny reason (e.g. an unentitled id)
-      // next to the generic failure line.
-      const reason = err instanceof Error && err.message ? `: ${err.message}` : ''
-      setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_fallback_model') + reason)
-    },
+    ...optimisticAgentMutation(
+      (agent, value) => ({ ...agent, fallback_model: value }),
+      (err) => {
+        const reason = err instanceof Error && err.message ? `: ${err.message}` : ''
+        return i18nT('pages.settings.chatPanel.failed_to_save_fallback_model') + reason
+      },
+    ),
   })
   const fallbackModelOptions = (current: string): string[] => {
     const opts = ['', 'auto', ...availableModels.map(m => m.name).filter(m => m !== 'auto')]
@@ -312,8 +334,10 @@ export function ChatPanel() {
 
   const defaultModelMut = useMutation({
     mutationFn: (v: string) => api.patchConfig('agent.model', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_default_model')),
+    ...optimisticAgentMutation(
+      (agent, value) => ({ ...agent, model: value }),
+      () => i18nT('pages.settings.chatPanel.failed_to_save_default_model'),
+    ),
   })
 
   const defaultEffort = mcCfg?.agent?.reasoning_effort ?? ''
@@ -323,8 +347,10 @@ export function ChatPanel() {
   const effortSupported = modelSupportsEffort(defaultModel)
   const defaultEffortMut = useMutation({
     mutationFn: (v: string) => api.patchConfig('agent.reasoning_effort', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_default_reasoning_effort')),
+    ...optimisticAgentMutation(
+      (agent, value) => ({ ...agent, reasoning_effort: value }),
+      () => i18nT('pages.settings.chatPanel.failed_to_save_default_reasoning_effort'),
+    ),
   })
 
   // ── Per-role model defaults (agent.role_models) ──
@@ -347,13 +373,23 @@ export function ChatPanel() {
     opts.map(m => (m === 'auto' ? i18nT('pages.settings.chatPanel.role_model_auto') : m))
   const backgroundModelMut = useMutation({
     mutationFn: (v: string) => api.patchConfig('agent.role_models.background', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_model')),
+    ...optimisticAgentMutation(
+      (agent, value) => ({
+        ...agent,
+        role_models: { ...agent.role_models, background: value },
+      }),
+      () => i18nT('pages.settings.chatPanel.failed_to_save_role_model'),
+    ),
   })
   const subagentModelMut = useMutation({
     mutationFn: (v: string) => api.patchConfig('agent.role_models.subagent', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_model')),
+    ...optimisticAgentMutation(
+      (agent, value) => ({
+        ...agent,
+        role_models: { ...agent.role_models, subagent: value },
+      }),
+      () => i18nT('pages.settings.chatPanel.failed_to_save_role_model'),
+    ),
   })
 
   // Per-role reasoning effort, paired with each role's model. Empty inherits the
@@ -373,13 +409,23 @@ export function ChatPanel() {
   const effortLabels = EFFORT_LEVELS.map(l => (l === '' ? i18nT('pages.settings.chatPanel.model_default') : effortLabel(l)))
   const backgroundEffortMut = useMutation({
     mutationFn: (v: string) => api.patchConfig('agent.role_efforts.background', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_effort')),
+    ...optimisticAgentMutation(
+      (agent, value) => ({
+        ...agent,
+        role_efforts: { ...agent.role_efforts, background: value },
+      }),
+      () => i18nT('pages.settings.chatPanel.failed_to_save_role_effort'),
+    ),
   })
   const subagentEffortMut = useMutation({
     mutationFn: (v: string) => api.patchConfig('agent.role_efforts.subagent', v),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-    onError: () => setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_role_effort')),
+    ...optimisticAgentMutation(
+      (agent, value) => ({
+        ...agent,
+        role_efforts: { ...agent.role_efforts, subagent: value },
+      }),
+      () => i18nT('pages.settings.chatPanel.failed_to_save_role_effort'),
+    ),
   })
 
   // ── Local chat config (localStorage) ──

--- a/website/src/test/ChatPanel.defaultModel.test.tsx
+++ b/website/src/test/ChatPanel.defaultModel.test.tsx
@@ -167,6 +167,22 @@ describe('ChatPanel — default reasoning effort', () => {
     )
   })
 
+  it('updates the selected effort before the PATCH finishes', async () => {
+    let resolvePatch: (() => void) | undefined
+    patchConfigMock.mockImplementationOnce(() => new Promise<void>(resolve => { resolvePatch = resolve }) as never)
+    wrap(<ChatPanel />)
+    await openSelect('Default Reasoning Effort')
+    fireEvent.click(screen.getByRole('option', { name: 'Extra High' }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: 'Default Reasoning Effort' })).toHaveTextContent(
+        'Extra High'
+      )
+    )
+    expect(resolvePatch).toBeTypeOf('function')
+    resolvePatch?.()
+  })
+
   it('clears back to the model default with an empty value, not a sentinel', async () => {
     seed({ model: 'claude-opus-4.8', reasoning_effort: 'high' })
     wrap(<ChatPanel />)
@@ -192,11 +208,21 @@ describe('ChatPanel — default reasoning effort', () => {
     expect(screen.getAllByTitle(/reasoning-capable/).length).toBeGreaterThan(0)
   })
 
-  it('surfaces an error banner when the write fails', async () => {
+  it('surfaces an error banner and rolls back when the write fails', async () => {
     patchConfigMock.mockImplementationOnce(() => Promise.reject(new Error('boom')) as never)
+    kirocrewConfigMock
+      .mockImplementationOnce(() => Promise.resolve({
+        agent: { model: 'claude-opus-4.8', reasoning_effort: '' },
+      }) as never)
+      .mockImplementation(() => new Promise(() => {}) as never)
     wrap(<ChatPanel />)
     await openSelect('Default Reasoning Effort')
     fireEvent.click(screen.getByRole('option', { name: 'High' }))
     expect(await screen.findByText(/Failed to save default reasoning effort/)).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: 'Default Reasoning Effort' })).toHaveTextContent(
+        'Model default'
+      )
+    )
   })
 })

--- a/website/src/test/SettingsChatPanelCoverage.test.tsx
+++ b/website/src/test/SettingsChatPanelCoverage.test.tsx
@@ -524,6 +524,31 @@ describe('ChatPanel — Subagents', () => {
   })
 })
 
+describe('ChatPanel — Model section immediate feedback', () => {
+  it.each([
+    ['Default Model', 'claude-opus-4.8', 'claude-opus-4.8', { model: 'auto' }],
+    ['Background Model', 'claude-opus-4.8', 'claude-opus-4.8', {}],
+    ['Subagent Model', 'claude-opus-4.8', 'claude-opus-4.8', {}],
+    ['Fallback model', 'Disabled', 'Disabled', {}],
+    ['Default Reasoning Effort', 'High', 'High', { model: 'claude-opus-4.8' }],
+    ['Background Effort', 'High', 'High', {
+      role_models: { background: 'claude-opus-4.8' },
+    }],
+    ['Subagent Effort', 'High', 'High', {
+      role_models: { subagent: 'claude-opus-4.8' },
+    }],
+  ])('%s reflects its selection while the PATCH is pending', async (label, option, expected, agent) => {
+    seedMc({ agent })
+    patchConfigMock.mockImplementationOnce(() => new Promise(() => {}) as never)
+    wrap()
+    await openSelect(label)
+    fireEvent.click(screen.getByRole('option', { name: option }))
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: label })).toHaveTextContent(expected)
+    )
+  })
+})
+
 describe('ChatPanel — per-role models', () => {
   it.each([
     ['Background Model', 'agent.role_models.background'],


### PR DESCRIPTION
## Problem / Motivation

The seven controlled selectors in Settings → Chat → Model keep showing the previous choice until the config PATCH and `kirocrewConfig` refetch complete. This affects the default, background, and subagent model and effort selectors plus the fallback model selector.

## Why it matters

Successful changes can appear ignored, especially over slower connections. Users may repeat a selection or leave Settings unsure whether the value was saved.

## What changed (motivation → approach → change)

The selectors derive their displayed value from the React Query `kirocrewConfig` cache, but their mutations previously updated that cache only after a PATCH succeeded and an invalidation refetched the full config.

This change adds one shared optimistic mutation path for all seven selectors. Before each PATCH it cancels stale config reads, snapshots the cache, and updates only the selected nested agent field while preserving sibling values. A failed write restores the snapshot and keeps the existing field-specific error message; every settled request invalidates the query to reconcile with authoritative server state.

## Tests

- Added pending-PATCH coverage for all seven selectors, proving each controlled trigger updates before network completion.
- Strengthened the default-effort error test so its rollback assertion cannot be satisfied by the later refetch.
- Passed 82 focused Vitest tests across both affected suites.
- Passed TypeScript, changed-file ESLint, production build, i18n, docs, mypy, formatting, jscpd, scrub, vendor, CloudFormation, and bundle-size gates.
- Broad local baseline limitations are unrelated to this frontend diff: two backend ownership tests reject this host's uid-65534 `/workplace` parent, and the existing Electron `gateway-stop.test.js` hung-promise case cancels later tests. CI runs on a normal hosted filesystem.

## Manual verification

N/A — the defect is request timing, and the tests hold PATCH promises unresolved while asserting the controlled UI value. A static manual screenshot cannot distinguish the fixed timing from the prior rendering.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** The same selector states render before and after; only when the selected value appears changes, which is covered deterministically by pending-PATCH tests.

## Related Issues

Fixes #6848

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no public API or documented behavior changed)
- [x] No secrets, credentials, or internal references in the diff
