### PR TITLE
ci: commit the review CLI manifest and lockfile

### DIFF
--- a/.github/review-cli/package-lock.json
+++ b/.github/review-cli/package-lock.json
@@ -1,0 +1,137 @@
+{
+  "name": "kirocrew-review-cli",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kirocrew-review-cli",
+      "version": "0.0.0",
+      "dependencies": {
+        "@openai/codex": "0.150.1"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.150.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.150.1.tgz",
+      "integrity": "sha512-knrbhpJH3mEULAVStcZW4F5WEt9MQhBj6KFOonBSIUGTLcHlu9CE7FRmr95E33y94+sWNZSeVBBV/kYvlfgxkQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.150.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.150.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.150.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.150.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.150.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.150.1-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.150.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.150.1-darwin-arm64.tgz",
+      "integrity": "sha512-Z614kKSI3/p+YMotBJMxCc4kvRCYEgsVmnaCG6U8HDraqTFxYcQYQ79B4/GBCBS88/KtacHI6qzjA+4Mu5BynA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.150.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.150.1-darwin-x64.tgz",
+      "integrity": "sha512-vcvJ7Q4IP2vA5ZR3v9Pj9VLKtlhD7efujxHqqW/NJ8F2/XqTD4iPjErV07190Om3wONW48yploTgul16QUk9Mg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.150.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.150.1-linux-arm64.tgz",
+      "integrity": "sha512-U0BY5UDsCy1up/O2YzGtVtDbcumNerVyZVVx55PW9gGQsFOL0utOyBJiG/UiocFAXix8JNvNJxYMRt2Jx0FJKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.150.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.150.1-linux-x64.tgz",
+      "integrity": "sha512-B3Bu5MF/G9qFhbSMrdyZz9ocknXOo45DnOdWrREJaxWTjiuUO1ogoDR0/ttdc29JRFkbbXs3aC+Td8vIx3X0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.150.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.150.1-win32-arm64.tgz",
+      "integrity": "sha512-8I7N3ppKS1ql9GUr2RHS5Gw+KkRCKfIMIDDK/brxq6HizLgHoDK4CIR0OTvEgdX3Yh/2reBbxr9P4L1e+61e+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.150.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.150.1-win32-x64.tgz",
+      "integrity": "sha512-1P1tscFnw4A4ip/WN1R5WYPdfuAlxLctPpcE1QAPQnOtbkJR5NX8da4kNTQmiDN/Flx3TLJPDTRHP9Jn435eJg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/.github/review-cli/package.json
+++ b/.github/review-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "kirocrew-review-cli",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Locked manifest for the AI review lanes' CLI. Not shipped, not part of the product build -- it exists so codex-review.yml and fork-gpt-review.yml install from a committed lockfile (npm ci) instead of resolving a floating registry version at job time. Those jobs hold Bedrock credentials and read PR content, so the exact code they execute must change only by a commit to this repo. Bump deliberately: edit the exact version below, run `npm install --package-lock-only` in this directory, and commit both files.",
+  "dependencies": {
+    "@openai/codex": "0.150.1"
+  }
+}


### PR DESCRIPTION
## Problem / Motivation

The two AI review lanes install their CLI with an unpinned global install:

```yaml
# .github/workflows/codex-review.yml
- name: Install review CLI
  run: npm install -g @openai/codex
```

No version pin, no lockfile. Those jobs hold Bedrock credentials (`id-token: write` → OIDC) and read PR content, so the exact code they execute is resolved fresh from the registry on every run and can change without any commit to this repository. zizmor reports this as `adhoc-packages`.

This PR commits the manifest and lockfile that pin it. It deliberately does **not** wire them up yet — see below.

## Why it matters

A floating dependency tree in a credentialed job is a supply-chain hole: a compromised release of `@openai/codex`, or of anything in its transitive closure, reaches a runner holding Bedrock credentials with no commit and no review in this repo. A version pin alone does not close it — `npm install -g pkg@X` re-resolves the package's own dependencies on every run, so the transitive tree stays floating. Pinning the closure requires a committed lockfile and `npm ci`.

## What changed (motivation → approach → change)

**Goal:** make the code those credentialed jobs execute change only by a reviewed commit to this repo.

**Approach — why this is split in two:** the consuming change ([#6639](https://github.com/kirodotdev/KiroCrew/pull/6639)) switches the install step to `npm ci` against a manifest **materialized from the base commit**, never from the PR checkout:

```bash
git show "$BASE_SHA:.github/review-cli/$f" > "$CLI_DIR/$f" || true
[ -s "$CLI_DIR/$f" ] || { echo "::error::... absent or empty on the base commit"; exit 1; }
npm ci --prefix "$CLI_DIR"
```

Reading from base is the point: the binary is executed *after* the Bedrock role is assumed, so a manifest read from the PR under review would let its author point it at any package and receive the job's AWS credentials.

That guard has a precondition — the manifest must exist on the base commit — which **the PR that introduces the manifest cannot satisfy**, because no base commit carries it yet. Any code path that would let that PR pass must read the manifest from the PR itself, which is exactly what the guard exists to prevent. So the precondition cannot be patched around; it has to be *satisfied*, by landing the manifest one merge earlier.

**What this PR actually builds:** the two manifest files, and nothing else.

- `.github/review-cli/package.json` — pins `@openai/codex` to `0.150.1`, with the bump procedure recorded in its `description` field.
- `.github/review-cli/package-lock.json` — the full resolved closure with integrity hashes.

**This commit is inert.** `git grep review-cli origin/main` returns nothing: no workflow, script, or test on main references `.github/review-cli`. The install step still runs `npm install -g @openai/codex` until #6639 lands, so these files change no behavior and cannot break any job. Once merged they sit on the base commit of every subsequent PR, and #6639's guard is satisfiable from the moment it opens.

## Tests

N/A — this PR adds no behavior to test. Nothing reads these files at this commit, so there is no code path a test could exercise.

The ratchets that lock in the consuming change ship with it in #6639 (`test/test_workflow_secret_and_cache_scope.py`), including assertions that the install step uses `npm ci`, materializes both files from `$BASE_SHA`, and installs outside the worktree. Those are mutation-verified there: each fails when its guard is reverted.

## Manual verification

Verified the lockfile is valid and self-contained — the one thing that could be wrong with an otherwise inert change. Copied *only* the two committed files into an empty directory and installed from them:

```
$ npm ci          # exit 0
$ ./node_modules/.bin/codex --version
codex-cli 0.150.1
```

Confirms `npm ci` resolves with no `package.json`/lockfile drift and produces the intended pinned version, so #6639's install step will succeed once this is on base.

Also confirmed inertness: `git grep -l review-cli origin/main` → no matches.

## Related Issues

Prerequisite for [#6639](https://github.com/kirodotdev/KiroCrew/pull/6639) (`ci/zizmor-round2`), which closes the `adhoc-packages` findings by consuming these files. Part of the zizmor workflow-hardening series that began with #6492.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — N/A, no new functionality; see Tests
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the bump procedure is documented in `package.json`'s `description`
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
