### PR TITLE
fix(chat): drive mobile panel slides on the compositor

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -51,7 +51,11 @@ import AgentImportFlow from './components/AgentImportFlow'
 import PrivacyChapter from './components/PrivacyChapter'
 import { OnboardingShellHost } from './components/OnboardingChapterShell'
 import { PREVIEW_EXPAND_EVENT } from './components/WebPreviewPanel'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, useMotionValue } from 'framer-motion'
+import { animateDrawer, registerDrawerTargets, takeOverDrawer } from './hooks/useDrawerSwipe'
+
+/** Mobile nav drawer travel: its 220px width + the 8px mx-2 inset + border. */
+const MOBILE_NAV_TRAVEL = 240
 import { usePersistedBool } from './hooks/usePersistedBool'
 import { isMacElectron, isWinElectron, isLinuxFramelessElectron } from './lib/electron'
 import { DndContext, closestCenter, MouseSensor, TouchSensor, useSensor, useSensors, DragOverlay, type DragStartEvent, type DragEndEvent } from '@dnd-kit/core'
@@ -543,11 +547,18 @@ function NavItem({ path, label, icon, active, collapsed, badge, onClickOverride,
   pressed?: boolean
 }) {
   const navigate = useNavigate()
+  // On mobile this row lives inside the nav DRAWER, whose slide runs on the
+  // compositor (animateDrawer) — and a framer layout-projection node under a
+  // compositor-driven ancestor transform mis-attributes the panel's travel to
+  // itself, compounding a corrective offset (the ChatSidebar rows measured
+  // >4,000px of it). The desktop rail is framer-free motion-wise, so it keeps
+  // the row-reorder glide that `layout` buys there.
+  const isMobileRow = useIsMobile()
   const iconEl = <span className={`app-icon-nav w-4 h-4 flex items-center justify-center shrink-0 transition-opacity ${active ? 'opacity-100 text-accent is-lit' : 'opacity-70'}`}>{icon}</span>
   const { tip, tipOn, rowRef, showTip, hideTip } = useNavTip<HTMLDivElement>(collapsed)
   const activate = () => { onClick?.(); (onClickOverride || (() => navigate(path)))() }
   return (
-    <motion.div layout="position"
+    <motion.div layout={isMobileRow ? undefined : 'position'}
       ref={rowRef}
       data-onboarding-nav={navId}
       // role+tabIndex+key handler make this a real keyboard-operable control
@@ -772,11 +783,10 @@ function NotificationsBellButton() {
   const leavingProps = (closing
     ? { inert: '', 'aria-hidden': true }
     : {}) as HTMLAttributes<HTMLDivElement>
-  // Desktop slides a fixed 400px sheet by px; mobile is full-width, so it needs
-  // the percentage variant (see the keyframe comment in tailwind.config.js).
-  const sheetAnim = closing
-    ? (isMobile ? 'animate-nc-slide-out-full' : 'animate-nc-slide-out')
-    : (isMobile ? 'animate-nc-slide-in-full' : 'animate-nc-slide-in')
+  // One transform keyframe pair covers both widths: translateX percentages
+  // resolve against the element's own width (400px desktop sheet, full-width
+  // mobile), so the old px/percent variant split is gone.
+  const sheetAnim = closing ? 'animate-nc-slide-out' : 'animate-nc-slide-in'
 
   // Close popover when navigating (e.g. detail panel's "Go to Chat" buttons)
   const lastPathRef = useRef(location.pathname)
@@ -1432,7 +1442,46 @@ export default function App() {
     const t = window.setTimeout(() => setShellEntered(true), 600)
     return () => window.clearTimeout(t)
   }, [])
-  const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  /**
+   * Mobile nav drawer, as ONE phase value (mirrors ChatPage's sessions drawer):
+   * `closing` keeps the panel mounted while it slides out. The slide itself
+   * runs on the COMPOSITOR via animateDrawer — the shell shares its main
+   * thread with every streaming session, so a framer main-thread tween here
+   * dropped frames exactly when the app was busiest. The width used by the
+   * offset is the drawer's own 220px + its 8px inset, not the viewport.
+   */
+  const [mobileNavPhase, setMobileNavPhase] = useState<'closed' | 'open' | 'closing'>('closed')
+  const mobileNavMounted = mobileNavPhase !== 'closed'
+  const mobileNavPhaseRef = useRef(mobileNavPhase)
+  mobileNavPhaseRef.current = mobileNavPhase
+  /** Panel offset in px: -MOBILE_NAV_TRAVEL offscreen, 0 at rest. */
+  const mobileNavX = useMotionValue(0)
+  const mobileNavPanelRef = useRef<HTMLElement | null>(null)
+  const mobileNavScrimRef = useRef<HTMLDivElement | null>(null)
+  // Safe against the projection bug only because the drawer's nav rows drop
+  // their `layout` prop on mobile — see registerDrawerTargets' precondition.
+  useEffect(() => registerDrawerTargets(mobileNavX, {
+    panel: () => mobileNavPanelRef.current,
+    scrim: () => mobileNavScrimRef.current,
+    travel: () => MOBILE_NAV_TRAVEL,
+  }), [mobileNavX])
+  const openMobileNav = useCallback(() => {
+    if (mobileNavPhaseRef.current === 'open') return
+    if (mobileNavPhaseRef.current === 'closed') mobileNavX.set(-MOBILE_NAV_TRAVEL)
+    mobileNavPhaseRef.current = 'open'
+    setMobileNavPhase('open')
+    animateDrawer(mobileNavX, 0)
+  }, [mobileNavX])
+  const closeMobileNavDrawer = useCallback(() => {
+    if (mobileNavPhaseRef.current !== 'open') return
+    mobileNavPhaseRef.current = 'closing'
+    setMobileNavPhase('closing')
+    takeOverDrawer(mobileNavX)
+    animateDrawer(mobileNavX, -MOBILE_NAV_TRAVEL, () => {
+      mobileNavPhaseRef.current = 'closed'
+      setMobileNavPhase('closed')
+    })
+  }, [mobileNavX])
 
   // Dynamic app nav items — all apps (builtin + installed) with UI pages
   const [appNavItems, setAppNavItems] = useState<Array<{ path: string; id: string; label: string; group: string; icon: React.ReactElement }>>([])
@@ -2263,7 +2312,7 @@ export default function App() {
   }, [dispatch, navigate, colorTheme, appStore])
 
   const toggleNav = () => {
-    if (isMobile) { setMobileNavOpen(p => !p) }
+    if (isMobile) { if (mobileNavPhaseRef.current === 'open') closeMobileNavDrawer(); else openMobileNav() }
     else if (focusActive) {
       // The rail is a hover-held overlay in focus mode and always full width, so
       // there is no collapsed state to toggle into. The same control puts it away
@@ -2278,9 +2327,19 @@ export default function App() {
     }
   }
   // Close mobile nav on route change
-  useEffect(() => { if (isMobile) setMobileNavOpen(false) }, [location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { if (isMobile) closeMobileNavDrawer() }, [location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Escape closes the open drawer — the keyboard's dismissal path. The scrim's
+  // click-to-dismiss is pointer-only (it is aria-hidden and unfocusable, so a
+  // full-screen tab stop never appears in the tab order).
+  useEffect(() => {
+    if (!isMobile || mobileNavPhase !== 'open') return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') closeMobileNavDrawer() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [isMobile, mobileNavPhase, closeMobileNavDrawer])
   // Reset mobile nav state when leaving mobile viewport
-  useEffect(() => { if (!isMobile) setMobileNavOpen(false) }, [isMobile])
+  // Leaving mobile: drop the panel with no slide (no drawer exists on desktop).
+  useEffect(() => { if (!isMobile) { setMobileNavPhase('closed'); takeOverDrawer(mobileNavX) } }, [isMobile, mobileNavX])
   // Focus mode forces the rail EXPANDED regardless of the user's collapse
   // preference. A collapsed rail is 74px, and as a hover-held overlay that is a
   // hard target to keep the pointer inside — it puts itself away the moment you
@@ -2300,7 +2359,7 @@ export default function App() {
   // query. Nothing measures a cluster any more — the drag-region reporter
   // addresses the header itself and the layout tests match the group classes, so
   // the two cluster refs this used to keep are gone with the measurement.
-  const closeMobileNav = isMobile ? () => setMobileNavOpen(false) : undefined
+  const closeMobileNav = isMobile ? closeMobileNavDrawer : undefined
   const activePath = location.pathname
   // App Store split (PR1): two sidebar entries share the /apps namespace.
   //  - Library owns /apps/library and everything under it.
@@ -3058,20 +3117,25 @@ export default function App() {
         />
       </OnboardingShellHost>
 
-      {/* Mobile backdrop */}
-      <AnimatePresence>
-        {isMobile && mobileNavOpen && (
-          <motion.div
-            key="nav-backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.25 }}
-            className="fixed inset-0 z-[46] bg-black/50 backdrop-blur-sm"
-            onClick={() => setMobileNavOpen(false)}
-          />
-        )}
-      </AnimatePresence>
+      {/* Mobile backdrop — opacity is animated by animateDrawer in lockstep
+          with the panel (compositor), so there is no framer fade here; it
+          mounts at 0 and the slide carries it. Mounted for the whole phase so
+          the slide-out fade is not cut short.
+          aria-hidden: the scrim is decorative — its click-to-dismiss is a
+          pointer convenience, and keyboard users dismiss via Escape (handled
+          where the drawer state lives). A focusable full-screen scrim would
+          add a giant tab stop over the whole page, which is why this is NOT
+          the Clickable component. */}
+      {isMobile && mobileNavMounted && (
+        <div
+          ref={mobileNavScrimRef}
+          data-testid="nav-backdrop"
+          aria-hidden="true"
+          style={{ opacity: 0 }}
+          className="fixed inset-0 z-[46] bg-black/50 backdrop-blur-sm"
+          onClick={closeMobileNavDrawer}
+        />
+      )}
 
       {/* Nav */}
       {/* Desktop rail and mobile drawer share one body but get DIFFERENT
@@ -3450,8 +3514,8 @@ export default function App() {
         })()}
         </>)
         return isMobile ? (
-          <AnimatePresence>
-            {mobileNavOpen && (
+          <>
+            {mobileNavMounted && (
               /* mt-2, unlike the desktop rail's mt-0: this form is `fixed` to the
                  VIEWPORT top rather than sitting in the grid row below the
                  topbar, so mt-0 pressed the card's rounded top edge flat against
@@ -3459,20 +3523,23 @@ export default function App() {
                  the 8px inset on all four keeps the drawer reading as one
                  floating card. `top-0 bottom-0` with both margins resolves the
                  height to viewport-16px, so nothing is clipped. */
-              <motion.nav
+              /* Plain nav, not motion.nav: the slide runs on the COMPOSITOR
+                 (animateDrawer via mobileNavPanelRef), and framer must not own
+                 a competing transform on the same element. Seated offscreen by
+                 an inline transform so the first painted frame is the closed
+                 offset; the settle overwrites it. */
+              <nav
                 key="mobile-nav-drawer"
-                initial={{ x: -240 }}
-                animate={{ width: 220, x: 0 }}
-                exit={{ x: -240 }}
-                transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
+                ref={mobileNavPanelRef}
+                style={{ width: 220, transform: `translate3d(${mobileNavX.get()}px, 0, 0)` }}
                 className="bg-bg-elevated border border-border rounded-xl flex flex-col mx-2 mt-2 mb-2 shadow-sm z-50 overflow-hidden fixed top-safe left-safe bottom-safe"
                 role="navigation"
                 aria-label={i18nT('app.main_navigation')}
               >
                 {navBody}
-              </motion.nav>
+              </nav>
             )}
-          </AnimatePresence>
+          </>
         ) : (
           <nav
             ref={railPeekSurface}

--- a/website/src/components/OverlayDrawer.tsx
+++ b/website/src/components/OverlayDrawer.tsx
@@ -21,6 +21,12 @@ interface Props {
    * animation of its own.
    */
   slideX?: MotionValue<number>
+  /**
+   * Slide mode only: the panel element, so the caller can hand it to
+   * `registerDrawerTargets` and let the settle run on the compositor. Without
+   * it the settle falls back to sampling the MotionValue on the main thread.
+   */
+  slideRef?: React.Ref<HTMLDivElement>
   /** Morph mode: the panel's visible window (clip-path) collapses into
    *  `morphTarget` and expands back out — the content itself never moves or
    *  deforms. The outer width still animates for layout reflow. */
@@ -45,7 +51,7 @@ interface Props {
 const EASE = [0.32, 0.72, 0, 1] as const
 const DUR = 0.24
 
-export default function OverlayDrawer({ open, width, dragging, slideX, morph, morphTarget, expandFrom, contentH, className, children }: Props) {
+export default function OverlayDrawer({ open, width, dragging, slideX, slideRef, morph, morphTarget, expandFrom, contentH, className, children }: Props) {
   const reduce = useReducedMotion()
   // Gesture end settles from the live presentation value via a critically
   // damped spring (no overshoot, no visible jump) — never a fixed ease tween.
@@ -73,6 +79,7 @@ export default function OverlayDrawer({ open, width, dragging, slideX, morph, mo
         {open && (
           <motion.div
             key="drawer-slide"
+            ref={slideRef}
             style={{ width, x: slideX }}
             className={`shrink-0 pb-2 overflow-hidden ${className || ''}`}
           >

--- a/website/src/hooks/useDrawerSwipe.ts
+++ b/website/src/hooks/useDrawerSwipe.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { animate, type MotionValue } from 'framer-motion'
+import { holdStreamingFlushes, releaseStreamingFlushes } from '../lib/streamHold'
 
 /**
  * Finger-tracking open/close gesture for the mobile sessions drawer.
@@ -42,12 +43,71 @@ const EDGE_END = 120
 const COMMIT_DISTANCE = 0.5
 /** Release faster than this (px/ms) commits regardless of how far it got. */
 const COMMIT_VELOCITY = 0.4
-/** Critically damped: a panel that fills the screen must not overshoot its
- *  own edge, so this is bounce-free rather than a springy tween. */
-const DRAWER_SETTLE = { type: 'spring' as const, bounce: 0, duration: 0.32 }
+/**
+ * The settle curves, and their durations — ASYMMETRIC, one shape per direction.
+ *
+ * A cubic-bezier rather than a spring for two load-bearing reasons: the shape
+ * is stated rather than tuned by feel, and the compositor path below hands the
+ * curve to a `KeyframeEffect`, which a spring (no closed form) cannot express
+ * without sampling itself on the main thread every frame — the exact thing the
+ * compositor path exists to avoid.
+ *
+ * IN is iOS's sheet presentation curve: `(0.32, 0.72, 0, 1)`. That shape is not
+ * invented here — it is the curve Ionic ships for its iOS transitions and the one
+ * Vaul uses (a drawer library written to reproduce Apple's Sheet, whose author
+ * states the curve and 500ms as the iOS match). It is also already this repo's
+ * own drawer curve: `components/OverlayDrawer.tsx` has carried
+ * `EASE = [0.32, 0.72, 0, 1]` all along, with the reason spelled out there —
+ * "near-linear on purpose: a strong ease-out front-loads the travel, which
+ * visually freezes the near edges while the far edges are still sweeping."
+ *
+ * That is the constraint to respect. Three progressively more front-loaded
+ * easeOut shapes were tried on a device and each was rejected for reading as the
+ * panel appearing rather than sliding: easeOutExpo `(0.19, 1, 0.22, 1)` at 340ms
+ * (26% of the travel gone in the first painted frame), easeOutQuint
+ * `(0.16, 1, 0.3, 1)` at 320ms (30%), and `(0.1, 0.9, 0.2, 1)` at 320ms (39%).
+ * This pairing spends 10%. The FIRST FRAME is the measurement that tracks the
+ * complaint, which is why the guard is stated that way.
+ *
+ * 420ms rather than the iOS 500ms: the shape is what was being judged, and the
+ * shorter tail reads better on a side drawer than on a bottom sheet. Either is
+ * affordable only because the settle reaches the compositor — a longer tween used
+ * to mean more frames exposed to main-thread stalls, so length was a risk to be
+ * minimized. It no longer is, and the duration can be chosen for how it reads.
+ *
+ * OUT stays its own shape — an easeIN, spending 2% of the travel in the first
+ * 50ms and 10% by 100ms, so a dismissal starts from where the panel is and then
+ * leaves quickly. Reusing an easeOut for the exit does the opposite: it jumps off
+ * the edge and then crawls to a stop.
+ */
+const SETTLE_IN_EASE = [0.32, 0.72, 0, 1] as const
+const SETTLE_IN_SECS = 0.42
+const SETTLE_OUT_EASE = [0.3, 0, 0.8, 0.15] as const
+const SETTLE_OUT_SECS = 0.24
+
+/** The four control-point coordinates of a cubic-bezier. Kept as a TUPLE, not
+ *  `number[]` — framer's `Easing` accepts only the fixed-arity form, so widening
+ *  it here surfaces as a type error at the `animate` call. */
+type Bezier = readonly [number, number, number, number]
+
+/** Rest is offset 0 (see `scrimOpacity`), so the target alone says which
+ *  direction a settle is going, and every call site already spells it that way:
+ *  open animates to 0, close to ±travel. */
+function settleFor(to: number): { ease: Bezier; secs: number } {
+  return to === 0
+    ? { ease: SETTLE_IN_EASE, secs: SETTLE_IN_SECS }
+    : { ease: SETTLE_OUT_EASE, secs: SETTLE_OUT_SECS }
+}
+
+/** A settle in the spelling a `KeyframeEffect` takes — derived from the same
+ *  arrays, so the compositor and main-thread paths cannot drift apart. */
+function settleTiming(to: number): KeyframeAnimationOptions {
+  const { ease, secs } = settleFor(to)
+  return { duration: secs * 1000, easing: `cubic-bezier(${ease.join(', ')})`, fill: 'forwards' }
+}
 /** Reduced motion still needs the panel to ARRIVE — dragging is direct
  *  manipulation, and dropping the settle to 0 would teleport the panel out from
- *  under the finger. A short linear tween carries it there without the spring. */
+ *  under the finger. A short linear tween carries it there without the curve. */
 const DRAWER_SETTLE_REDUCED = { duration: 0.12, ease: 'linear' as const }
 
 function prefersReducedMotion(): boolean {
@@ -56,14 +116,261 @@ function prefersReducedMotion(): boolean {
     && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 }
 
+/**
+ * The DOM the settle animates, when it can reach the compositor.
+ *
+ * `travel` is a function, not a number: the closed offset is the viewport width
+ * and a rotation changes it between a register and a settle.
+ */
+export interface DrawerTargets {
+  panel: () => HTMLElement | null
+  scrim: () => HTMLElement | null
+  travel: () => number
+}
+
+interface DrawerRuntime {
+  targets: DrawerTargets
+  /** Compositor animations currently carrying the panel, so a new gesture can
+   *  take them over instead of writing the same channel underneath them. */
+  running: Animation[]
+}
+
+/**
+ * Per-MotionValue runtime, keyed weakly so a torn-down ChatPage takes its entry
+ * with it. A WeakMap rather than a hook argument because `animateDrawer` is
+ * called from four places that have no business knowing about DOM nodes (the
+ * header toggle, the scrim tap, the session-selected close, and this hook's own
+ * release), and threading the elements through all four would put the same
+ * lookup in each of them.
+ */
+const runtimes = new WeakMap<MotionValue<number>, DrawerRuntime>()
+
+/**
+ * Point `x`'s settles at real DOM. Returns a deregister for unmount.
+ *
+ * PRECONDITION, and the reason the first compositor attempt shipped a visible
+ * bug: nothing inside the registered panel may be a Framer layout-projection
+ * node (`layout` / `layoutId`). Projection only stays correct while framer owns
+ * every animated ancestor transform; under a WAAPI-driven ancestor it attributes
+ * the panel's travel to the descendants themselves and compounds a corrective
+ * transform per re-measure (measured: >4,000px — the sidebar rows visibly flew
+ * in from the panel's right edge). ChatSidebar therefore renders its rows
+ * WITHOUT projection when hosted in this drawer (`staticRows`), and that pairing
+ * is what makes this registration safe — see ChatSidebar.staticRows.test.tsx.
+ */
+export function registerDrawerTargets(x: MotionValue<number>, targets: DrawerTargets): () => void {
+  runtimes.set(x, { targets, running: [] })
+  return () => runtimes.delete(x)
+}
+
+/** Scrim opacity for a panel offset: 0 fully closed, 1 at rest. Direction-
+ *  agnostic — a LEFT drawer runs offset in [-travel, 0], a RIGHT drawer in
+ *  [0, +travel], and |offset| is the distance from rest either way. */
+function scrimOpacity(offset: number, travel: number): number {
+  if (travel <= 0) return 1
+  return Math.max(0, Math.min(1, 1 - Math.abs(offset) / travel))
+}
+
+/** Move `x` with NO animation and no inherited velocity, cancelling anything
+ *  running on it. `set` alone does not cancel — see the note in `settle` — so
+ *  `jump` is the correct verb here wherever the build provides it. */
+function jumpTo(x: MotionValue<number>, to: number): void {
+  if (typeof x.jump === 'function') x.jump(to)
+  else x.set(to)
+}
+
+/** Current translateX of an element, read from its resolved matrix — including
+ *  the value a running compositor animation is presenting this instant. */
+function currentTranslateX(el: HTMLElement): number | null {
+  if (typeof getComputedStyle !== 'function') return null
+  const t = getComputedStyle(el).transform
+  if (!t || t === 'none') return null
+  const nums = t.slice(t.indexOf('(') + 1, -1).split(',').map(v => parseFloat(v))
+  if (t.startsWith('matrix3d')) return Number.isFinite(nums[12]) ? nums[12] : null
+  return Number.isFinite(nums[4]) ? nums[4] : null
+}
+
+/**
+ * Hand `x` back the offset a compositor settle is presenting, and cancel it.
+ *
+ * Called wherever plain `x.stop()` used to go: a compositor animation is NOT an
+ * animation ON the value, so `stop`/`jump` do not reach it — left running, it
+ * would keep presenting its own offset over every write the finger makes, and
+ * the panel would refuse to follow until the animation ran out.
+ */
+export function takeOverDrawer(x: MotionValue<number>): void {
+  const rt = runtimes.get(x)
+  if (rt && rt.running.length > 0) {
+    const panel = rt.targets.panel()
+    const at = panel ? currentTranslateX(panel) : null
+    for (const a of rt.running) a.cancel()
+    rt.running = []
+    // Adopt the presented offset BEFORE anything repaints — into the element's
+    // OWN inline style as well as the value, for the same reason publishArrival
+    // does: cancel reverts to inline style, and only framer-bound panels get
+    // theirs rewritten by jumpTo.
+    if (at != null && panel) {
+      panel.style.transform = `translate3d(${at}px, 0, 0)`
+      const scrim = rt.targets.scrim()
+      if (scrim) scrim.style.opacity = String(scrimOpacity(at, rt.targets.travel()))
+      jumpTo(x, at)
+    }
+  }
+  x.stop()
+}
+
 /** Animate a drawer offset to its resting place with the shared settle curve.
  *  Exported so the tap/backdrop/programmatic paths land identically to a
  *  released gesture — two curves for one panel is how the two paths visibly
- *  drift apart. */
+ *  drift apart.
+ *
+ *  Runs on the COMPOSITOR when `registerDrawerTargets` has supplied elements:
+ *  `transform` and `opacity` keyframes on the panel and the scrim, which the
+ *  browser hands to the compositor thread. That is the point — the panel and
+ *  the chat pane behind it share one main thread, and with sessions streaming
+ *  that thread stalls unpredictably (chunk flushes are held, see
+ *  lib/streamHold.ts, but tool events, subagent status pushes and the panel's
+ *  own mount are not), so ONLY an animation that does not need the main thread
+ *  holds its frame rate through the slide. Falls back to the main-thread tween
+ *  when no element is registered (embed frames, tests) or under reduced motion.
+ *
+ *  The streaming-flush hold is kept on both paths: it starves the projection
+ *  re-measures and the transcript repaints of their per-frame trigger, which
+ *  is cheap insurance either way. */
 export function animateDrawer(x: MotionValue<number>, to: number, onDone?: () => void) {
-  const curve = prefersReducedMotion() ? DRAWER_SETTLE_REDUCED : DRAWER_SETTLE
-  const controls = animate(x, to, { ...curve, onComplete: onDone })
-  return () => controls.stop()
+  const reduce = prefersReducedMotion()
+  const rt = runtimes.get(x)
+
+  const mainThread = () => {
+    const curve = reduce ? DRAWER_SETTLE_REDUCED : { duration: settleFor(to).secs, ease: settleFor(to).ease }
+    holdStreamingFlushes(curve.duration * 1000 + 100)
+    /**
+     * Paint the tween onto the ELEMENTS' OWN inline styles, not just `x`.
+     *
+     * Framer writes a transform only where it is BOUND to `x` (the sessions
+     * drawer's `style={{ x }}`). The nav drawer is a plain <nav> and the right
+     * overlay carries a template-string transform serialized once per React
+     * render, so on this path their MotionValue would travel while their DOM
+     * never moved — the panel stays at the mounted CLOSED offset and is simply
+     * unreachable. Neither of those two has a drag gesture, so this fallback is
+     * their ONLY path whenever the compositor one is unavailable: under
+     * `prefers-reduced-motion`, and when the panel element has not appeared
+     * within the mount grace frames. Same root cause as the cancel-fill bounce
+     * (a non-framer-bound element needs the write spelled out), on the fallback
+     * path instead of the compositor one. Redundant where framer IS bound — it
+     * writes the same value from its own subscription.
+     */
+    const paint = rt
+      ? (at: number) => {
+        const panel = rt.targets.panel()
+        if (panel) panel.style.transform = `translate3d(${at}px, 0, 0)`
+        const scrim = rt.targets.scrim()
+        if (scrim) scrim.style.opacity = String(scrimOpacity(at, rt.targets.travel()))
+      }
+      : null
+    const unbind = paint ? x.on('change', paint) : null
+    paint?.(x.get())
+    const controls = animate(x, to, {
+      ...curve,
+      onComplete: () => { paint?.(to); unbind?.(); releaseStreamingFlushes(); onDone?.() },
+    })
+    return () => { unbind?.(); controls.stop() }
+  }
+  if (!rt || reduce) return mainThread()
+
+  let raf: number | null = null
+  let cancelled = false
+  let stopMain: (() => void) | null = null
+  /** Frames to wait for the panel to exist. The tap-open path calls this in the
+   *  same tick as the setState that MOUNTS the panel, so on that path there is
+   *  nothing to animate yet — and waiting is correct rather than merely
+   *  tolerable, because the first painted frame is supposed to be the closed
+   *  offset anyway. Bounded so a panel that never arrives degrades to the
+   *  main-thread path instead of silently never settling. */
+  let tries = 3
+
+  const start = () => {
+    if (cancelled) return
+    raf = null
+    /**
+     * Adopt whatever the PREVIOUS settle is presenting, and cancel it, before
+     * keyframing a replacement. Reversing mid-settle (close then re-open inside
+     * the 420ms) otherwise breaks twice over, and nothing else cleans up: no
+     * caller keeps this function's returned canceller.
+     *
+     * `x` does not move while the compositor owns the offset, so on a reversal
+     * `from` would still read the offset the OUTGOING settle started from — a
+     * close→open reversal keyframes 0→0 and snaps instead of sliding. And the
+     * outgoing animation is `fill: 'forwards'`: once the replacement is
+     * cancelled on arrival, that stale fill re-presents its own end state OVER
+     * the published inline style, so the panel lands open and then goes back
+     * offscreen while its phase still says `open` — unreachable.
+     */
+    takeOverDrawer(x)
+    const panel = rt.targets.panel()
+    if (!panel || typeof panel.animate !== 'function') {
+      if (panel || tries-- <= 0) { stopMain = mainThread(); return }
+      raf = requestAnimationFrame(start)
+      return
+    }
+    const timing = settleTiming(to)
+    holdStreamingFlushes(Number(timing.duration) + 100)
+    const from = x.get()
+    const travel = rt.targets.travel()
+    const anims: Animation[] = [panel.animate(
+      [{ transform: `translate3d(${from}px, 0, 0)` }, { transform: `translate3d(${to}px, 0, 0)` }],
+      timing,
+    )]
+    const scrim = rt.targets.scrim()
+    // The scrim's opacity is derived from the same offset, so it has to be
+    // animated in lockstep here: its own binding reads `x`, which does not move
+    // while the compositor owns the panel.
+    if (scrim && typeof scrim.animate === 'function') {
+      anims.push(scrim.animate(
+        [{ opacity: scrimOpacity(from, travel) }, { opacity: scrimOpacity(to, travel) }],
+        timing,
+      ))
+    }
+    rt.running = anims
+    /**
+     * Publish the arrival into the ELEMENTS' OWN inline styles FIRST, then the
+     * MotionValue, then cancel. Cancelling a `fill: 'forwards'` animation
+     * reverts each element to its inline style — and `jumpTo(x)` rewrites that
+     * style only where framer is BOUND to `x` (the sessions drawer's
+     * `style={{ x }}`). The nav drawer is a plain <nav> and the right overlay
+     * carries a template-string transform, so on those the inline style is
+     * whatever their last React render serialized — the CLOSED offset, for a
+     * panel that mounted closed. Cancelling without this write snapped the
+     * just-arrived panel offscreen until the next unrelated re-render popped it
+     * back: the recorded open→vanish→flash-open bounce.
+     */
+    const publishArrival = () => {
+      panel.style.transform = `translate3d(${to}px, 0, 0)`
+      if (scrim instanceof HTMLElement) scrim.style.opacity = String(scrimOpacity(to, travel))
+      jumpTo(x, to)
+    }
+    const settled = () => {
+      if (rt.running !== anims) return // taken over by a newer gesture
+      publishArrival()
+      for (const a of anims) a.cancel()
+      rt.running = []
+      releaseStreamingFlushes()
+      onDone?.()
+    }
+    anims[0].onfinish = settled
+    // A compositor animation on a hidden/backgrounded element can be cancelled
+    // by the browser rather than finished; the panel must still arrive.
+    anims[0].oncancel = () => { if (rt.running === anims) { rt.running = []; publishArrival(); releaseStreamingFlushes(); onDone?.() } }
+  }
+
+  start()
+  return () => {
+    cancelled = true
+    if (raf != null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(raf)
+    stopMain?.()
+    for (const a of rt.running) a.cancel()
+    rt.running = []
+  }
 }
 
 /**
@@ -165,7 +472,7 @@ export function useDrawerSwipe(
      * gesture's own outcome.
      */
     const settle = (to: number, open: boolean) => {
-      x.stop()
+      takeOverDrawer(x)
       animateDrawer(x, to, () => onSettleRef.current(open))
     }
 
@@ -251,8 +558,10 @@ export function useDrawerSwipe(
         // Take the value over from ANY animation still running on it — this
         // hook's own settle, or one the consumer started for the toggle, the
         // backdrop tap or a session-selected close. `x.set()` below does not
-        // cancel an animation, so without this both write every frame.
-        x.stop()
+        // cancel an animation, so without this both write every frame. And a
+        // compositor settle is not an animation ON the value at all, which is
+        // why this goes through takeOverDrawer rather than `x.stop()`.
+        takeOverDrawer(x)
         setDragging(true)
         if (!openRef.current) {
           // Seat the panel offscreen BEFORE it mounts, so the first painted
@@ -263,6 +572,9 @@ export function useDrawerSwipe(
       }
 
       if (phase.current !== 'locked') return
+      // The finger owns the panel: keep the flush pipelines quiet one rolling
+      // beat at a time, so the hold dies on its own if the gesture does.
+      holdStreamingFlushes(250)
       const dt = e.timeStamp - lastT.current
       if (dt > 0) velocity.current = (touch.clientX - lastX.current) / dt
       lastX.current = touch.clientX

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -8,6 +8,7 @@ import { sseStatus, sseYolo, sseConnected, sseDisconnected, sseSlots, sseTodoUpd
 import { addNotification, ackNotificationByTs, unackNotificationByTs, removeNotificationByTs, clearAllNotifications, fetchNotifications, markBootNotificationsFetched } from '../store/notificationsSlice'
 import { dispatchMcNotification, TURN_DONE_KIND, APPROVAL_KIND, shouldChimeOnTurnDone } from './notificationEvent'
 import { emitThemeSound } from './themeSound'
+import { streamingFlushHoldMs } from '../lib/streamHold'
 import {
   fetchHistory, missedChunkMarker, sseChatMessage, sseChatMessageUpdate, sseChatMessagePatchByTs, sseThinkingChunk, refreshSlot, warmSlotCache, sseContextUsage, clearMessages, clearSlotCache, setVoicePlaying, setVoiceAudio, resolveByApprovalId, clearSubagentsForSnapshot, sseSubagentPending, sseSubagentSpawn, sseSubagentQueued, sseSubagentTool, sseSubagentStalled, sseSubagentRetrying, sseSubagentDone, sseSubagentSnapshot, sseSubagentBatchUpdate, sseSubagentBatchChunks, sseToolActivity, sseToolResult, sseActivityEvent, sseSideResult, sseWorkflowEvent, setSlotStatusDetail, removeQueuedMessage, appendQueuedMessage, cancelQueuedMessage, editQueuedMessage, reorderQueuedMessages, appendSlotMessage, setQuestionCard, resolveQuestionCard, setFollowupCard, setFolderSuggestion, sseMcpAppRender, setGoalLoops, sseGoalLoop, sseSideQueue, reconcileWorkflowRuns
 } from '../store/chatSlice'
@@ -593,6 +594,13 @@ export function useWebSocket() {
   const scheduleChunkFlush = useCallback(() => {
     if (chunkFlushScheduledRef.current) return
     chunkFlushScheduledRef.current = true
+    // While a UI animation holds the pipelines (see lib/streamHold.ts), defer
+    // this flush to the hold's end instead of the next frame. The buffer keeps
+    // absorbing chunks meanwhile, and the guard flag stays set, so the whole
+    // burst lands as ONE flush when the hold lapses. A flush already scheduled
+    // when a hold STARTS still fires — at most one frame leaks into the slide.
+    const hold = streamingFlushHoldMs()
+    if (hold > 0) { chunkTimerRef.current = setTimeout(() => flushChunks(), hold + 16); return }
     if (typeof requestAnimationFrame === 'function') chunkRafRef.current = requestAnimationFrame(() => flushChunks())
     else chunkTimerRef.current = setTimeout(() => flushChunks(), 16)
   }, [flushChunks])
@@ -640,6 +648,10 @@ export function useWebSocket() {
   const scheduleSlotActivityFlush = useCallback(() => {
     if (slotActivityFlushScheduledRef.current) return
     slotActivityFlushScheduledRef.current = true
+    // Same hold as scheduleChunkFlush — a recency bump reorders sidebar rows,
+    // which is main-thread layout work mid-slide.
+    const hold = streamingFlushHoldMs()
+    if (hold > 0) { slotActivityTimerRef.current = setTimeout(() => flushSlotActivity(), hold + 16); return }
     if (typeof requestAnimationFrame === 'function') slotActivityRafRef.current = requestAnimationFrame(() => flushSlotActivity())
     else slotActivityTimerRef.current = setTimeout(() => flushSlotActivity(), 16)
   }, [flushSlotActivity])
@@ -679,6 +691,10 @@ export function useWebSocket() {
   const scheduleSubagentChunkFlush = useCallback(() => {
     if (subagentChunkFlushScheduledRef.current) return
     subagentChunkFlushScheduledRef.current = true
+    // Same hold as scheduleChunkFlush — several subagents streaming at once is
+    // exactly the reported worst case for the drawer slide.
+    const hold = streamingFlushHoldMs()
+    if (hold > 0) { subagentChunkTimerRef.current = setTimeout(() => flushSubagentChunks(), hold + 16); return }
     if (typeof requestAnimationFrame === 'function') subagentChunkRafRef.current = requestAnimationFrame(() => flushSubagentChunks())
     else subagentChunkTimerRef.current = setTimeout(() => flushSubagentChunks(), 16)
   }, [flushSubagentChunks])

--- a/website/src/lib/streamHold.ts
+++ b/website/src/lib/streamHold.ts
@@ -1,0 +1,53 @@
+/**
+ * A hold on per-frame streaming flushes while a UI surface is animating.
+ *
+ * WHY THIS EXISTS. The panel slides run on the compositor — `animateDrawer`
+ * (hooks/useDrawerSwipe.ts) carries that rationale and the projection
+ * precondition it rests on. This hold covers what the compositor cannot: the
+ * work still on the main thread during a slide — the panel's own mount, tool
+ * events, subagent status pushes — and the drag path, whose gesture-follow is
+ * main-thread by nature. Starving those of their per-frame trigger is cheap
+ * insurance on both paths.
+ *
+ * While a session streams, nearly all main-thread churn is the per-rAF flush
+ * pipelines in `useWebSocket` (chunk / subagent-chunk / slot-activity), each of
+ * which dispatches into the store and re-renders ChatPage once per frame. Those
+ * pipelines already BUFFER between flushes, so deferring the flush costs
+ * nothing but latency: this module is the shared clock that tells them to sit
+ * out the slide. Nothing is ever dropped — a deferred flush delivers the whole
+ * buffer when the hold lapses.
+ *
+ * Deliberately a deadline, not a lock: every hold carries its own expiry, so an
+ * animation that dies without releasing (a stopped tween, an unmounted page)
+ * degrades to a short delay instead of a stuck firehose. `HOLD_MAX_MS` caps
+ * hostile or buggy callers.
+ */
+
+/** No single hold may exceed this. A slide is ~420ms; a full second of frozen
+ *  transcript is already at the edge of what reads as "paused on purpose". */
+const HOLD_MAX_MS = 1_000
+
+let holdUntil = 0
+
+const now = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+
+/** Quiet the streaming flush pipelines for the next `ms` milliseconds.
+ *  Extends an active hold, never shortens it. */
+export function holdStreamingFlushes(ms: number): void {
+  const deadline = now() + Math.max(0, Math.min(ms, HOLD_MAX_MS))
+  if (deadline > holdUntil) holdUntil = deadline
+}
+
+/** The animation finished early (or was taken over): let flushes resume on the
+ *  next frame instead of waiting out the deadline. */
+export function releaseStreamingFlushes(): void {
+  holdUntil = 0
+}
+
+/** How much longer flushes should stay quiet, in ms. 0 = not held. */
+export function streamingFlushHoldMs(): number {
+  return Math.max(0, holdUntil - now())
+}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -13,7 +13,7 @@ import { isBrowseCommand } from '../utils/browseCommand'
 // importable from here; the implementation lives in `utils/browseCommand` so a
 // pure test need not pull ChatPage's module graph.
 export { isBrowseCommand }
-import { useDrawerSwipe, animateDrawer } from '../hooks/useDrawerSwipe'
+import { useDrawerSwipe, animateDrawer, registerDrawerTargets, takeOverDrawer } from '../hooks/useDrawerSwipe'
 import { shouldReplaceSessionUrl } from '../utils/sessionUrlHistory'
 import type { ResizeInfo } from '../utils/resizeImage'
 import { useAppSelector, useAppDispatch, store } from '../store'
@@ -1045,6 +1045,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // the composer, TipCard never renders, and an unblocked hook would fetch a
   // tip + record it as shown, silently burning the 6h cadence.
   const [splitMode, setSplitMode] = useState(false)
+  /**
+   * Passed to ChatSidebar as `onSelectSlot`. Stable BY CONTRACT, not by
+   * convenience: `ChatSidebar` is wrapped in `memo`, and an inline arrow here
+   * makes that memo bail on EVERY ChatPage render. ChatPage re-renders once per
+   * frame while anything is streaming (`useWebSocket` batches chunks per rAF
+   * and this page subscribes to the whole `chat.messages`), so an unstable
+   * identity re-rendered the entire sidebar ~60 times across the 0.32s mobile
+   * drawer slide — on the same main thread that drives the slide's transform.
+   * Keep every prop handed to ChatSidebar referentially stable.
+   */
+  const clearSplitOnSelect = useCallback(() => setSplitMode(false), [])
+  /** Same contract as `clearSplitOnSelect`, for the `embedMode === 'sessions'`
+   *  frame where the sidebar IS the whole page. */
+  const navigateToEmbeddedSlot = useCallback((key: string) => navigate(`/embed/chat/${key}`), [navigate])
   const [splitAnchor, setSplitAnchor] = useState<string | null>(null)
   // Temporary sessions ("no memory reads or writes") must never show
   // memory-personalized tips.
@@ -3650,7 +3664,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     if (opts?.background) return
     if (!connectedRef.current) return
     if (key !== activeSlotRef.current) dispatch(switchSlot(key))
-  }, [sessionTabs, dispatch])
+    // Depends on the ONE member it calls, not on `sessionTabs` — that hook
+    // returns a fresh object literal every render, so the whole object as a dep
+    // makes this callback (and thus ChatSidebar's `onOpenSlotInNewTab`, and thus
+    // the sidebar's `memo`) churn on every ChatPage render. `openInNewTab` is
+    // itself dep-free, so this identity is genuinely stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionTabs.openInNewTab, dispatch])
   const selectSessionTab = useCallback((key: string) => {
     if (key === activeSlotRef.current || !connectedRef.current) return
     dispatch(switchSlot(key))
@@ -6610,12 +6630,50 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   /** Panel offset in px: `-innerWidth` offscreen, `0` at rest. A MotionValue so
    *  the drag writes it at frame rate without re-rendering this component. */
   const drawerX = useMotionValue(0)
+  /** The sliding panel and the scrim behind it. Handed to
+   *  `registerDrawerTargets` so the settle animates THESE ELEMENTS (compositor)
+   *  instead of sampling `drawerX` on the main thread — the only way the slide
+   *  holds its frame rate while sessions stream. Refs rather than state:
+   *  nothing renders off them. */
+  const drawerPanelRef = useRef<HTMLDivElement | null>(null)
+  const drawerScrimRef = useRef<HTMLDivElement | null>(null)
+  /**
+   * RIGHT-side panel slide (mobile only). The inline side panel used to enter
+   * by animating `width: 0 → auto` — a LAYOUT animation the compositor cannot
+   * take, which re-laid-out the squeezed chat pane on every frame of the
+   * 400ms open. On mobile it covers the full window anyway, so it is rendered
+   * as a fixed overlay instead and slides in from the RIGHT on the compositor,
+   * mirroring the sessions drawer. Offsets run [0, +width] (closed = +width).
+   * Desktop keeps the width reveal: there the chat pane genuinely shares the
+   * row and the reflow is the point.
+   */
+  const sideOverlayX = useMotionValue(0)
+  const sideOverlayPanelRef = useRef<HTMLDivElement | null>(null)
+  const [sideOverlayPhase, setSideOverlayPhase] = useState<'closed' | 'open' | 'closing'>('closed')
+  const sideOverlayPhaseRef = useRef(sideOverlayPhase)
+  sideOverlayPhaseRef.current = sideOverlayPhase
+  useEffect(() => registerDrawerTargets(sideOverlayX, {
+    panel: () => sideOverlayPanelRef.current,
+    scrim: () => null,
+    travel: () => window.innerWidth || 0,
+  }), [sideOverlayX])
   /** The scrim tracks the panel instead of running its own fade, so a half-drag
    *  is half-dimmed and a cancelled drag un-dims with the finger. */
   const drawerScrim = useTransform(drawerX, x => {
     const w = typeof window === 'undefined' ? 1 : window.innerWidth || 1
     return Math.max(0, Math.min(1, 1 + x / w))
   })
+  // Point every settle on `drawerX` at real DOM. Registered once for the page's
+  // lifetime, reading the elements through the refs at animation time — the
+  // panel is mounted and unmounted per open, so binding the nodes themselves
+  // here would go stale on the first close. Safe ONLY because the drawer's
+  // ChatSidebar renders staticRows (no projection nodes under a compositor-
+  // driven transform — see registerDrawerTargets' precondition).
+  useEffect(() => registerDrawerTargets(drawerX, {
+    panel: () => drawerPanelRef.current,
+    scrim: () => drawerScrimRef.current,
+    travel: () => window.innerWidth || 0,
+  }), [drawerX])
   // Read for the transition guards below. The animation each transition starts
   // is a side effect, so it must not live inside a setState updater — React may
   // invoke an updater more than once, which would start the settle twice.
@@ -6702,6 +6760,33 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     mo.observe(document.body, { childList: true, subtree: true })
     return () => mo.disconnect()
   }, [isMobile, embedMode])
+  /** The inline panel's mount predicate, shared by the overlay phase effect
+   *  and the render below so the two cannot disagree. */
+  const sidePanelWantsMount = shouldMountSidePanel({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen })
+    && !isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen })
+  // Mobile right-panel overlay: slide in when the panel wants the screen,
+  // slide out (keeping it mounted for the travel) when it stops wanting it.
+  useEffect(() => {
+    if (!isMobile) { setSideOverlayPhase('closed'); takeOverDrawer(sideOverlayX); return }
+    if (sidePanelWantsMount) {
+      if (sideOverlayPhaseRef.current === 'open') return
+      if (sideOverlayPhaseRef.current === 'closed') sideOverlayX.set(window.innerWidth || 0)
+      sideOverlayPhaseRef.current = 'open'
+      setSideOverlayPhase('open')
+      takeOverDrawer(sideOverlayX)
+      animateDrawer(sideOverlayX, 0)
+    } else {
+      if (sideOverlayPhaseRef.current !== 'open') return
+      sideOverlayPhaseRef.current = 'closing'
+      setSideOverlayPhase('closing')
+      takeOverDrawer(sideOverlayX)
+      animateDrawer(sideOverlayX, window.innerWidth || 0, () => {
+        sideOverlayPhaseRef.current = 'closed'
+        setSideOverlayPhase('closed')
+      })
+    }
+  }, [isMobile, sidePanelWantsMount, sideOverlayX])
+
   /** True while the INLINE side panel (mobile / embed, no actbar column) is
    *  mounted AND visible.
    *
@@ -6930,8 +7015,19 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         {isMobile && drawerMounted && (
           <motion.div
             key="sessions-backdrop"
-            style={{ opacity: drawerScrim }}
+            data-testid="sessions-backdrop"
             className="fixed inset-0 z-[46] bg-black/50 backdrop-blur-sm"
+            // ^ Frosted, matching every other scrim in the app (App.tsx's own
+            // mobile nav backdrop is the same three classes). Kept adjacent to
+            // `key` — the composer-chrome occlusion guard anchors its z-order
+            // regex on that proximity. A full-viewport `backdrop-filter` does
+            // re-sample its backdrop on every repaint behind it — which under
+            // a streaming message list is every frame — and both alternatives
+            // were tried and rejected on how they LOOK: dropping it entirely,
+            // and deferring it to the settled state (the blur arriving after
+            // the panel had stopped read as a second event).
+            ref={drawerScrimRef}
+            style={{ opacity: drawerScrim }}
             // Ignored while a drag owns the panel: the release that ends a
             // close gesture lands here as a click, and treating it as a
             // tap-to-dismiss would run a second close over the settle.
@@ -7001,11 +7097,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
             mode={mode}
             onWidthChange={setSidebarWidth}
             onDragChange={setSidebarDragging}
-            onSelectSlot={(key) => navigate(`/embed/chat/${key}`)}
+            onSelectSlot={navigateToEmbeddedSlot}
           />
         </div>
       ) : (
-      <OverlayDrawer open={isMobile ? drawerMounted : sidebarOpen} width={isMobile ? winW : effectiveSidebarWidth} dragging={sidebarDragging} slideX={isMobile ? drawerX : undefined} morph={!isMobile} morphTarget={TOGGLE_RECT} expandFrom={expandFrom} contentH={Math.max(0, containerH - 8)} className={isMobile ? 'mobile-sessions-overlay fixed top-safe-offset-[42px] bottom-safe left-safe z-50 bg-bg-elevated !py-0 rounded-r-xl shadow-lg max-w-[calc(100vw-2.5rem)] [&>*]:!rounded-none [&>*]:!border-0 [&>*]:!m-0' : ''}>
+      <OverlayDrawer open={isMobile ? drawerMounted : sidebarOpen} width={isMobile ? winW : effectiveSidebarWidth} dragging={sidebarDragging} slideX={isMobile ? drawerX : undefined} slideRef={drawerPanelRef} morph={!isMobile} morphTarget={TOGGLE_RECT} expandFrom={expandFrom} contentH={Math.max(0, containerH - 8)} className={isMobile ? 'mobile-sessions-overlay fixed top-safe-offset-[42px] bottom-safe left-safe z-50 bg-bg-elevated !py-0 rounded-r-xl shadow-lg max-w-[calc(100vw-2.5rem)] [&>*]:!rounded-none [&>*]:!border-0 [&>*]:!m-0' : ''}>
         <ChatSidebar
           slots={filteredSlots}
           activeSlot={activeSlot}
@@ -7018,7 +7114,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
           onWidthChange={setSidebarWidth}
           onDragChange={setSidebarDragging}
           collapsible={!isMobile}
-          onSelectSlot={() => setSplitMode(false)}
+          staticRows={isMobile}
+          onSelectSlot={clearSplitOnSelect}
           onOpenSlotInNewTab={ownsSessionTabs ? openSlotInNewTab : undefined}
           onOpenSource={revealSourceLink}
           // Only offer the pane as a drop target when a composer exists to show
@@ -8110,18 +8207,43 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         )}
       <AnimatePresence initial={false}>
         {/* Inline side panel — mobile / embed frames where there's no actbar
-            grid column. Desktop uses the actbar portal below. */}
-        {shouldMountSidePanel({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) && !activitySlot && (
+            grid column. Desktop uses the actbar portal below.
+
+            MOBILE is a fixed overlay sliding in from the RIGHT on the
+            compositor (sideOverlayX / animateDrawer), mirroring the sessions
+            drawer: the old `width: 0 → auto` reveal is a LAYOUT animation, so
+            it re-laid-out the panel AND the squeezed chat pane every frame.
+            Mount is held through 'closing' so the slide-out is not cut short.
+            Embed frames keep the width reveal — they have no overlay chrome. */}
+        {(isMobile
+          // `hasLiveAppTab` keeps a closed-but-alive panel MOUNTED (display:none
+          // below) so its iframe — and the drawing inside it — survives the
+          // close, exactly as the width-reveal branch always did.
+          ? (sideOverlayPhase !== 'closed'
+              || (shouldMountSidePanel({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen })
+                  && isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }))) && !activitySlot
+          : shouldMountSidePanel({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) && !activitySlot) && (
           <motion.div
             key="side-panel-inline"
-            initial={{ width: 0 }}
-            animate={{ width: 'auto' }}
-            exit={{ width: 0 }}
-            transition={{ duration: 0.4, ease: [0.32, 0.72, 0, 1] }}
-            className="h-full overflow-hidden flex justify-end shrink-0"
+            ref={isMobile ? sideOverlayPanelRef : undefined}
+            initial={isMobile ? false : { width: 0 }}
+            animate={isMobile ? undefined : { width: 'auto' }}
+            exit={isMobile ? undefined : { width: 0 }}
+            transition={isMobile ? undefined : { duration: 0.4, ease: [0.32, 0.72, 0, 1] }}
+            // Below the 42px app topbar, like the sessions drawer — the panel
+            // takes over the CONTENT area, not the shell chrome.
+            className={isMobile
+              ? 'fixed top-safe-offset-[42px] bottom-safe left-safe right-safe z-[47] flex justify-end bg-bg'
+              : 'h-full overflow-hidden flex justify-end shrink-0'}
             // Kept mounted for a live app tab: hide instead of unmounting so the
-            // iframe (and the drawing inside it) survives a panel close.
-            style={isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) ? { display: 'none' } : undefined}
+            // iframe (and the drawing inside it) survives a panel close. On
+            // mobile the overlay phase already owns mount/hide timing; seating
+            // the closed offset inline keeps the first painted frame offscreen.
+            style={isMobile
+              ? (sideOverlayPhase === 'closed'
+                  ? { display: 'none' } // keep-alive: mounted for the iframe, invisible
+                  : { transform: `translate3d(${sideOverlayX.get()}px, 0, 0)` })
+              : (isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) ? { display: 'none' } : undefined)}
           >
             <SidePanel
               tabsCtl={tabsCtl}

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -2179,6 +2179,20 @@ interface ChatSidebarProps {
    *  When provided, this fires AFTER the switchSlot dispatch so consumers
    *  can react to user-driven selection (e.g. to navigate the URL). */
   onSelectSlot?: (key: string) => void
+  /**
+   * Render session rows WITHOUT Framer layout projection (`layout`/`layoutId`).
+   *
+   * Set by the mobile sessions drawer, whose slide runs on the COMPOSITOR
+   * (WAAPI — see `registerDrawerTargets` in useDrawerSwipe). Projection only
+   * stays correct while framer owns every animated ancestor transform: under a
+   * compositor-driven ancestor it attributes the panel's travel to the rows
+   * themselves and compounds a corrective transform per re-measure (measured
+   * >4,000px — the rows visibly flew in from the panel's right edge). The rows
+   * are the sidebar's ONLY projection nodes, so this one switch is the whole
+   * containment. Costs on mobile: reorders/pin moves snap instead of glide,
+   * and the flat↔tree toggle loses its row-morph continuity.
+   */
+  staticRows?: boolean
   /** Open a session as a TAB on the host surface instead of switching to it,
    *  bound to middle-click, modifier-click and the row menu's "Open in a session
    *  tab".
@@ -2325,7 +2339,7 @@ interface FilterDimension {
 function ChatSidebar({
   slots, activeSlot, unreadSlots, history, historyHasMore,
   defaultAgent, installedAgents, mode, onWidthChange, onDragChange, onSelectSlot, onOpenSlotInNewTab, onOpenSource, collapsible,
-  chatDropTarget, onDropSessionRef,
+  chatDropTarget, onDropSessionRef, staticRows,
 }: ChatSidebarProps) {
   useLanguageGeneration() // memo() bails out of the provider-level repaint; subscribe directly
   const dispatch = useAppDispatch()
@@ -4660,7 +4674,12 @@ function ChatSidebar({
         isRenaming={renamingSlot === s.key} renamingHere={renamingHere}
         renameValue={renamingHere ? renameValue : ''}
         revealFlash={revealFlash?.key === s.key ? (revealFlash.fading ? 'fade' : 'flash') : null}
-        dragInFlight={!!activeDrag} rowAnimEnabled={rowAnimEnabled}
+        dragInFlight={!!activeDrag}
+        // staticRows (the compositor drawer) folds into the one row-animation
+        // gate: projection under a WAAPI-driven ancestor mis-attributes the
+        // panel's motion to the rows, so the drawer disables row animation
+        // wholesale rather than growing SessionRow a second switch.
+        rowAnimEnabled={rowAnimEnabled && !staticRows}
         defaultAgent={defaultAgent} mode={mode} isMobile={isMobile} colorMode={colorMode}
         installedAgents={installedAgents} tagById={tagById}
         paletteColors={paletteColors} boost={boost} boostFor={boostFor}

--- a/website/src/test/App.notificationSheetExit.test.tsx
+++ b/website/src/test/App.notificationSheetExit.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { act, screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from './helpers'
+import tailwindConfig from '../../tailwind.config.js'
 
 vi.mock('../pages/ChatPage', () => ({ default: () => <div data-testid="chat-page">ChatPage</div> }))
 vi.mock('../pages/SystemPage', () => ({ default: () => null }))
@@ -120,5 +121,46 @@ describe('Notification Center sheet — slide-out on dismiss', () => {
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(document.activeElement).toBe(bell)
     expect(sheet()?.classList.contains('animate-nc-slide-out')).toBe(true)
+  })
+})
+
+/**
+ * Compositor guards — the sheet's slide must stay off the main thread.
+ *
+ * The keyframes originally animated `marginRight`: a layout property, so
+ * every animation frame reflowed the sheet and its whole subtree on the main
+ * thread — the same jank class as the old right-panel `width` animation, and
+ * exactly what makes an open/close stutter while sessions are streaming. The
+ * fix animates `transform` (compositor-driven). The old margin choice was
+ * justified by a claim that a transformed ancestor becomes a backdrop root
+ * and breaks the cards' backdrop-filter; a Chromium pixel probe (card blur
+ * measured mid-animation under a transformed ancestor) disproved that —
+ * transform is not in the backdrop-root trigger list.
+ *
+ * Percentage translateX resolves against the element's OWN width, which is
+ * why one keyframe pair now covers both the desktop 400px sheet and the
+ * mobile full-width sheet (the old `-full` variants are gone).
+ */
+describe('Notification Center sheet — compositor-driven slide', () => {
+  const keyframes = (tailwindConfig as { theme: { extend: { keyframes: Record<string, Record<string, Record<string, string>>> } } })
+    .theme.extend.keyframes
+
+  it('animates transform only, never a layout property', () => {
+    for (const name of ['nc-slide-in', 'nc-slide-out'] as const) {
+      const frames = keyframes[name]
+      expect(frames, `${name} keyframes must exist`).toBeTruthy()
+      for (const [stop, decl] of Object.entries(frames)) {
+        expect(Object.keys(decl), `${name} @${stop} must animate transform only`).toEqual(['transform'])
+      }
+    }
+  })
+
+  it('covers mobile via own-width percentages instead of a -full variant', () => {
+    // translateX(%) resolves against the element's own width, so the single
+    // pair covers the full-width mobile sheet; a resurrected -full variant
+    // means the margin split came back.
+    expect(keyframes['nc-slide-in-full']).toBeUndefined()
+    expect(keyframes['nc-slide-out-full']).toBeUndefined()
+    expect(keyframes['nc-slide-in'].from.transform).toContain('100%')
   })
 })

--- a/website/src/test/ChatPage.drawerFrameBudget.test.tsx
+++ b/website/src/test/ChatPage.drawerFrameBudget.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Frame budget of the mobile sessions drawer.
+ *
+ * The drawer slides on a main-thread rAF (a framer MotionValue the scrim also
+ * reads), so anything the main thread does during those ~0.32s is subtracted
+ * directly from the animation. Two things used to help themselves to it, and
+ * both got worse exactly when the user has a lot going on:
+ *
+ *  (1) ChatPage re-renders once per frame while anything streams — chunks are
+ *      batched per rAF by useWebSocket and this page subscribes to the whole
+ *      `chat.messages`. `ChatSidebar` is wrapped in `memo`, but ONE inline
+ *      arrow prop makes that memo bail, so every one of those frames re-rendered
+ *      the entire sidebar. Locked here as a property of ALL props, not of the
+ *      one that regressed: the stub is `memo`-wrapped and counts its own
+ *      renders, so any newly-unstable prop reddens this.
+ *
+ *  (2) The scrim's full-viewport `backdrop-filter` must re-sample its backdrop
+ *      whenever the backdrop changes — and a streaming message list under it
+ *      repaints every frame. Kept anyway, deliberately: both cheaper variants
+ *      looked worse on a real device. Locked here so the decision survives the
+ *      next perf pass, with the smoothness paid for on the compositor instead
+ *      (see animateDrawer.compositor.test.ts).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { memo } from 'react'
+import { render, act, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import { sseSlots } from '../store/dashboardSlice'
+import { sseChatMessage } from '../store/chatSlice'
+
+/** Renders of the memo-wrapped sidebar stub. A parent render that does NOT
+ *  bump this is a parent render the sidebar was insulated from. */
+const sidebarRenders = { n: 0 }
+
+/** Completion callbacks handed to framer's `animate`, fired manually so a test
+ *  can observe the window while the panel is still in motion. */
+const pendingSettles: (() => void)[] = []
+
+// Only `animate` is replaced. Everything else stays real: the scrim's class is
+// what this file asserts on, and a hand-rolled `motion` proxy would be one more
+// thing that can diverge from the component actually under test.
+vi.mock('framer-motion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('framer-motion')>()
+  return {
+    ...actual,
+    animate: (_v: unknown, _to: unknown, opts?: { onComplete?: () => void }) => {
+      if (opts?.onComplete) pendingSettles.push(opts.onComplete)
+      return { stop: () => {} }
+    },
+  }
+})
+
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../components/ChatInput', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat', () => ({ ChatFooter: () => null, AssistantMessage: () => null, McpInfoButton: () => null }))
+// memo-wrapped on purpose: it performs the SAME shallow prop comparison the
+// real `memo(ChatSidebar)` does, so its render count answers "would the real
+// sidebar have re-rendered here" without paying for the real sidebar.
+vi.mock('../pages/ChatSidebar', () => ({
+  default: memo(function ChatSidebarStub(props: { staticRows?: boolean }) {
+    sidebarRenders.n += 1
+    return <div data-testid="sidebar-stub" data-static-rows={String(!!props.staticRows)} />
+  }),
+  SIDEBAR_MIN: 200,
+  SIDEBAR_MAX: 500,
+}))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: { compact: { messages: '800px', input: '816px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } },
+}))
+vi.mock('../pages/chat/SidePanel', () => ({
+  default: () => null,
+  SIDE_PANEL_MIN_W: 320,
+  SIDE_PANEL_RESERVED_W: 560,
+  CHAT_PANE_MIN_W: 320,
+  measureSidePanelReservedW: () => 560,
+  sidePanelFillWidth: () => undefined,
+}))
+vi.mock('../hooks/usePanelState', () => ({ usePanelState: () => ({ isOpen: false, openPanel: vi.fn(), closePanel: vi.fn() }), useDiffPanel: () => ({ isOpen: false, filePath: '', original: '', modified: '', openDiff: vi.fn(), closeDiff: vi.fn() }) }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+// A stable object: the real hook holds `agents` in `useState`, so a mock that
+// rebuilt `[]` per render would fail this file for a reason production does not
+// have — and would mask the props that really are unstable.
+vi.mock('../hooks/useAgents', () => {
+  const AGENTS = { agents: [], defaultAgent: null }
+  return { useAgents: () => AGENTS }
+})
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => true }))
+vi.mock('../api/client', () => ({
+  api: Object.fromEntries(
+    ['sessions', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot', 'resumeChatSlot',
+      'deleteSession', 'agentDetail', 'approveChatSlot', 'chatSlotAgent', 'chatSlotModel',
+      'chatSlotWorkspace', 'models', 'planAction', 'planFromChat', 'renameSlot',
+      'resolveApproval', 'screenshot', 'slackChannels', 'slackLink', 'spawnList',
+      'stopChatSlot', 'uploadFiles', 'voiceSynthesize', 'workspaces', 'chatSlots',
+      'notifications', 'status', 'generateTitle'].map(k => [k, vi.fn().mockResolvedValue(
+      k === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {},
+    )]),
+  ),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as never
+globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as never
+
+import ChatPage from '../pages/ChatPage'
+
+function renderChat() {
+  const store = createTestStore()
+  act(() => { store.dispatch(sseSlots([{ key: 'slot-0', title: 'Session 0' } as never])) })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <Routes><Route path="/chat/:slug?" element={<ChatPage />} /></Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  return store
+}
+
+/** One batched streaming flush, i.e. one animation frame's worth of store churn
+ *  from a session that is producing tokens. */
+const streamFrame = (store: ReturnType<typeof createTestStore>, slot: string, text: string) =>
+  act(() => { store.dispatch(sseChatMessage({ slot, role: 'chunk', content: text, batched: true } as never)) })
+
+/** Open the drawer and let its slide finish, so the sidebar is mounted and at
+ *  rest. Two controls carry this label on mobile (the floating opener and the
+ *  in-header toggle); either one opens a closed drawer. */
+function openDrawer() {
+  fireEvent.click(screen.getAllByLabelText('Toggle sessions')[0])
+}
+const finishSlide = () => act(() => {
+  const queued = pendingSettles.splice(0)
+  queued.forEach(fn => fn())
+})
+
+describe('ChatPage — mobile sessions drawer frame budget', () => {
+  beforeEach(() => {
+    sidebarRenders.n = 0
+    pendingSettles.length = 0
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 390 })
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 844 })
+  })
+  afterEach(() => { vi.clearAllMocks() })
+
+  it('insulates the sidebar from per-frame streaming re-renders', () => {
+    const store = renderChat()
+    // The mobile drawer unmounts the sidebar while closed, so the window this
+    // guards is the one where it IS mounted: the slide and everything after.
+    openDrawer()
+    expect(screen.getByTestId('sidebar-stub')).toBeTruthy()
+    // The compositor pairing: the drawer-hosted sidebar must render staticRows,
+    // or its rows are projection nodes under a WAAPI transform — the fly-in bug.
+    expect(screen.getByTestId('sidebar-stub').getAttribute('data-static-rows')).toBe('true')
+    const afterMount = sidebarRenders.n
+    expect(afterMount).toBeGreaterThan(0)
+
+    // 20 frames ~= one 0.32s drawer slide with a session streaming through it.
+    for (let i = 0; i < 20; i++) streamFrame(store, 'slot-0', `tok${i} `)
+
+    // Every prop ChatPage hands the sidebar must be referentially stable, so
+    // none of those frames reaches it.
+    expect(sidebarRenders.n).toBe(afterMount)
+  })
+
+  /**
+   * The frosted scrim is a DECISION, not an oversight, so it gets a guard: it
+   * matches every other scrim in the app, and the two cheaper-looking variants
+   * (no blur at all; blur deferred to the settled state) were both tried on a
+   * real device and rejected on appearance. A future pass reading "full-viewport
+   * backdrop-filter" as free perf budget should have to delete this test.
+   */
+  it('keeps the frosted scrim, in motion and at rest', () => {
+    renderChat()
+    openDrawer()
+    expect(screen.getByTestId('sessions-backdrop').className).toContain('backdrop-blur-sm')
+    finishSlide()
+    expect(screen.getByTestId('sessions-backdrop').className).toContain('backdrop-blur-sm')
+  })
+})

--- a/website/src/test/ChatSidebar.staticRows.test.tsx
+++ b/website/src/test/ChatSidebar.staticRows.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * The staticRows half of the compositor-drawer pairing.
+ *
+ * The mobile drawer's slide runs on the compositor (WAAPI), which Framer's
+ * layout projection cannot see: a projection node (`layout`/`layoutId`) under a
+ * compositor-driven ancestor attributes the panel's travel to ITSELF and
+ * compounds a corrective transform per re-measure — measured at >4,000px, seen
+ * by the user as the session rows flying in from the panel's right edge.
+ *
+ * The session rows are the sidebar's only projection nodes, so `staticRows`
+ * is the whole containment:
+ *   - ON  (the drawer): rows carry NO layout/layoutId;
+ *   - OFF (desktop):    rows keep both, because the desktop panel's motion is
+ *     framer-owned and the row projection buys reorder/pin glide and the
+ *     flat↔tree morph there.
+ *
+ * Two-sided on purpose — this file failing on the OFF side means desktop lost
+ * its row animations; failing on the ON side means the mobile drawer regressed
+ * back to the fly-in bug (see animateDrawer.compositor.test.ts for the WAAPI
+ * half of the pairing).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import ChatSidebar from '../pages/ChatSidebar'
+
+/** layoutId values framer received, per render pass. The framer mock maps
+ *  layoutId onto data-layout-id, so the DOM carries the answer directly. */
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const FRAMER = new Set([
+    'layout', 'layoutId', 'layoutScroll', 'initial', 'animate', 'exit',
+    'transition', 'variants', 'whileHover', 'whileTap', 'whileInView',
+    'drag', 'dragConstraints', 'dragElastic', 'onAnimationComplete',
+  ])
+  const make = (tag: string) =>
+    React.forwardRef((props: Record<string, unknown>, ref: unknown) => {
+      const clean: Record<string, unknown> = {}
+      for (const k of Object.keys(props)) {
+        if (k === 'children') continue
+        if (k === 'layoutId') { clean['data-layout-id'] = props[k]; continue }
+        if (k === 'layout') { clean['data-layout'] = String(props[k]); continue }
+        if (FRAMER.has(k)) continue
+        clean[k] = props[k]
+      }
+      return React.createElement(tag, { ...clean, ref } as never, props.children as never)
+    })
+  return {
+    motion: new Proxy({}, { get: (_t, tag: string) => make(tag) }),
+    AnimatePresence: ({ children }: { children?: unknown }) => React.createElement(React.Fragment, null, children as never),
+    LayoutGroup: ({ children }: { children?: unknown }) => React.createElement(React.Fragment, null, children as never),
+  }
+})
+vi.mock('../components/ProjectPicker', () => ({ default: () => null }))
+vi.mock('../api/client', () => ({
+  SEARCH_MIN_CHARS: 2,
+  api: new Proxy({} as Record<string, unknown>, { get: () => vi.fn().mockResolvedValue([]) }),
+}))
+
+const SLOTS = [
+  { key: 's1', session_id: 'sid1', title: 'One', mode: 'default', agent: 'kirocrew', last_message_at: new Date().toISOString() },
+  { key: 's2', session_id: 'sid2', title: 'Two', mode: 'default', agent: 'kirocrew', last_message_at: new Date().toISOString() },
+] as never[]
+
+function renderSidebar(staticRows: boolean) {
+  const store = createTestStore({ dashboard: { slots: SLOTS, unreadSlots: [], slotsLoaded: true } as never })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <Provider store={store}><QueryClientProvider client={qc}><MemoryRouter><ThemeProvider>
+      <ChatSidebar
+        slots={SLOTS as never}
+        activeSlot={'s1'}
+        unreadSlots={[]}
+        history={[]}
+        historyHasMore={false}
+        defaultAgent={'kirocrew'}
+        installedAgents={[]}
+        mode={'default'}
+        staticRows={staticRows}
+      />
+    </ThemeProvider></MemoryRouter></QueryClientProvider></Provider>,
+  )
+}
+
+const rowNodes = (c: HTMLElement) => Array.from(c.querySelectorAll('[data-slot-key]'))
+
+describe('ChatSidebar staticRows — projection gated off inside the compositor drawer', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true, configurable: true,
+      value: vi.fn().mockImplementation((q: string) => ({
+        matches: false, media: q, onchange: null,
+        addListener: vi.fn(), removeListener: vi.fn(),
+        addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+      })),
+    })
+    globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as never
+  })
+  afterEach(() => vi.clearAllMocks())
+
+  it('staticRows strips layout AND layoutId from every session row', () => {
+    const { container } = renderSidebar(true)
+    const rows = rowNodes(container)
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(row.getAttribute('data-layout-id')).toBeNull()
+      // Projection off is spelled `layout={false}` (upstream's disable form);
+      // `undefined` is equally inert. Either way it must not be 'position' —
+      // the probe showed layoutId is the load-bearing half, pinned above.
+      expect(['undefined', 'false']).toContain(row.getAttribute('data-layout'))
+    }
+  })
+
+  it('desktop keeps the row projection (both halves of the tradeoff hold)', () => {
+    const { container } = renderSidebar(false)
+    const rows = rowNodes(container)
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(row.getAttribute('data-layout-id')).toMatch(/^slot-/)
+      expect(row.getAttribute('data-layout')).toBe('position')
+    }
+  })
+})

--- a/website/src/test/animateDrawer.compositor.test.ts
+++ b/website/src/test/animateDrawer.compositor.test.ts
@@ -1,0 +1,283 @@
+/**
+ * The drawer settle must reach the COMPOSITOR.
+ *
+ * The mobile panel and the chat pane behind it share one main thread, and with
+ * sessions streaming that thread stalls unpredictably (chunk flushes are held —
+ * see lib/streamHold — but tool events, subagent status pushes and the panel's
+ * own mount are not). Only an animation the main thread does not drive holds
+ * its frame rate through that. `animateDrawer` therefore animates the ELEMENTS
+ * (`transform` on the panel, `opacity` on the scrim) via `Element.animate`,
+ * falling back to the main-thread tween when no element is registered or under
+ * reduced motion.
+ *
+ * SAFE ONLY because the drawer's sidebar renders `staticRows` — no projection
+ * node may live under a compositor-driven transform (see
+ * ChatSidebar.staticRows.test.tsx for that half of the pairing).
+ *
+ * Beyond the mechanism, this pins the ORDER the arrival is published in:
+ * `x` is reconciled BEFORE the `fill: 'forwards'` animation is cancelled,
+ * because cancelling uncovers the inline style — a stale one is a visible snap
+ * back to where the settle began.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { motionValue } from 'framer-motion'
+import { animateDrawer, registerDrawerTargets, takeOverDrawer } from '../hooks/useDrawerSwipe'
+import { releaseStreamingFlushes, streamingFlushHoldMs } from '../lib/streamHold'
+
+interface FakeAnimation {
+  keyframes: Record<string, unknown>[]
+  timing: Record<string, unknown>
+  cancelled: boolean
+  onfinish: (() => void) | null
+  oncancel: (() => void) | null
+  cancel: () => void
+}
+
+/** Replace `animate` on one element with a recorder returning a fake Animation. */
+function stubAnimate(el: HTMLElement, log: FakeAnimation[]) {
+  ;(el as unknown as { animate: unknown }).animate = (keyframes: Record<string, unknown>[], timing: Record<string, unknown>) => {
+    const a: FakeAnimation = {
+      keyframes, timing, cancelled: false, onfinish: null, oncancel: null,
+      cancel() { this.cancelled = true },
+    }
+    log.push(a)
+    return a
+  }
+}
+
+const TRAVEL = 390
+
+describe('animateDrawer — compositor settle', () => {
+  let panel: HTMLDivElement
+  let scrim: HTMLDivElement
+  let panelAnims: FakeAnimation[]
+  let scrimAnims: FakeAnimation[]
+  let x: ReturnType<typeof motionValue<number>>
+  let unregister: () => void
+
+  beforeEach(() => {
+    document.body.replaceChildren()
+    releaseStreamingFlushes()
+    panel = document.createElement('div')
+    scrim = document.createElement('div')
+    document.body.append(panel, scrim)
+    panelAnims = []
+    scrimAnims = []
+    stubAnimate(panel, panelAnims)
+    stubAnimate(scrim, scrimAnims)
+    x = motionValue(-TRAVEL)
+    // No reduced-motion preference: that path is deliberately main-thread.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true, configurable: true,
+      value: vi.fn().mockImplementation((q: string) => ({ matches: false, media: q, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    })
+    unregister = registerDrawerTargets(x, {
+      panel: () => panel,
+      scrim: () => scrim,
+      travel: () => TRAVEL,
+    })
+  })
+
+  it('animates the panel element rather than sampling the value per frame', () => {
+    animateDrawer(x, 0)
+    expect(panelAnims).toHaveLength(1)
+    expect(panelAnims[0].keyframes).toEqual([
+      { transform: `translate3d(${-TRAVEL}px, 0, 0)` },
+      { transform: 'translate3d(0px, 0, 0)' },
+    ])
+    // The curve lives in the keyframe timing, which is what makes it expressible
+    // to the compositor at all — a spring would have to be sampled here instead.
+    // The exact control points and durations are pinned once, in
+    // animateDrawer.curve.test.ts; asserting them here too would mean a retune
+    // has to edit two files that are testing different things.
+    expect(panelAnims[0].timing.easing).toMatch(/^cubic-bezier\(/)
+    expect(panelAnims[0].timing.duration).toBeGreaterThan(0)
+    expect(panelAnims[0].timing.fill).toBe('forwards')
+    // `x` has NOT moved: the compositor owns the offset until it arrives.
+    expect(x.get()).toBe(-TRAVEL)
+  })
+
+  it('fades the scrim in lockstep, since its own binding reads a value that is not moving', () => {
+    animateDrawer(x, 0)
+    expect(scrimAnims).toHaveLength(1)
+    expect(scrimAnims[0].keyframes).toEqual([{ opacity: 0 }, { opacity: 1 }])
+    // Lockstep is the invariant: the scrim rides the panel's own timing object,
+    // so the two cannot be given different curves or durations by accident.
+    expect(scrimAnims[0].timing).toEqual(panelAnims[0].timing)
+  })
+
+  it('holds the streaming flushes for the slide and releases on arrival', () => {
+    animateDrawer(x, 0)
+    expect(streamingFlushHoldMs()).toBeGreaterThan(300)
+    panelAnims[0].onfinish?.()
+    expect(streamingFlushHoldMs()).toBe(0)
+  })
+
+  it('publishes the arrival into the ELEMENT inline styles before cancelling the fill', () => {
+    const order: string[] = []
+    const onDone = vi.fn(() => order.push('done'))
+    // The panel mounts CLOSED: its last React render serialized the closed
+    // offset. Cancelling a fill:'forwards' animation reverts to exactly this,
+    // so unless the arrival is written into the element itself first, the
+    // just-arrived panel snaps offscreen — recorded on a real device as the
+    // drawer opening, vanishing, then flashing back on the next re-render.
+    panel.style.transform = `translate3d(${-TRAVEL}px, 0, 0)`
+    animateDrawer(x, 0, onDone)
+    x.on('change', v => order.push(`x=${v}`))
+    panelAnims[0].cancel = function () { this.cancelled = true; order.push('cancel') }
+    panelAnims[0].onfinish?.()
+
+    // The element's OWN inline style carries the arrival — jumpTo(x) rewrites
+    // it only on framer-bound panels (the sessions drawer), and the nav drawer
+    // and right overlay are plain elements.
+    expect(panel.style.transform).toBe('translate3d(0px, 0, 0)')
+    expect(scrim.style.opacity).toBe('1')
+    expect(x.get()).toBe(0)
+    expect(panelAnims[0].cancelled).toBe(true)
+    expect(scrimAnims[0].cancelled).toBe(true)
+    expect(onDone).toHaveBeenCalledTimes(1)
+    // Reconcile, THEN uncover the inline style. The other order is a snap.
+    expect(order).toEqual(['x=0', 'cancel', 'done'])
+  })
+
+  it('a browser-cancelled animation still lands the element inline styles', () => {
+    panel.style.transform = `translate3d(${-TRAVEL}px, 0, 0)`
+    animateDrawer(x, 0)
+    panelAnims[0].oncancel?.()
+    expect(panel.style.transform).toBe('translate3d(0px, 0, 0)')
+    expect(x.get()).toBe(0)
+  })
+
+  it('takeOverDrawer adopts the presented offset into the element inline style', () => {
+    animateDrawer(x, 0)
+    // The compositor is presenting -100px mid-flight. stubGlobal so the real
+    // getComputedStyle comes back for the rest of the file (vi.unstubAllGlobals
+    // in this test), not just for whichever test happens to run next.
+    vi.stubGlobal('getComputedStyle', () => ({ transform: 'matrix(1, 0, 0, 1, -100, 0)' }))
+    try {
+      takeOverDrawer(x)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+    expect(panel.style.transform).toBe('translate3d(-100px, 0, 0)')
+    expect(x.get()).toBe(-100)
+  })
+
+  /**
+   * Reversing inside the settle window must retire the outgoing animation.
+   *
+   * Nothing else does: no caller keeps `animateDrawer`'s returned canceller. A
+   * survivor breaks the reversal twice — `x` is frozen while the compositor owns
+   * the offset, so the replacement would keyframe from the OUTGOING settle's
+   * start (a close→open reversal reading 0→0, i.e. a snap, not a slide), and the
+   * survivor's `fill: 'forwards'` then re-presents its own end state over the
+   * inline style published on arrival, parking the panel offscreen with its
+   * phase still `open`.
+   */
+  it('a mid-settle reversal cancels the outgoing animation and starts from where the panel IS', () => {
+    x.jump(0)
+    animateDrawer(x, -TRAVEL) // closing
+    expect(panelAnims).toHaveLength(1)
+    expect(panelAnims[0].cancelled).toBe(false)
+
+    // Reverse while the close is presenting -260px.
+    vi.stubGlobal('getComputedStyle', () => ({ transform: 'matrix(1, 0, 0, 1, -260, 0)' }))
+    try {
+      animateDrawer(x, 0) // re-opening
+    } finally {
+      vi.unstubAllGlobals()
+    }
+
+    // The outgoing close is retired rather than left filling forwards.
+    expect(panelAnims[0].cancelled).toBe(true)
+    // …and the replacement keyframes from the offset actually on screen, so the
+    // reopen slides. A stale `from` of 0 would make this a no-op 0->0 pair.
+    expect(panelAnims).toHaveLength(2)
+    expect(panelAnims[1].keyframes).toEqual([
+      { transform: 'translate3d(-260px, 0, 0)' },
+      { transform: 'translate3d(0px, 0, 0)' },
+    ])
+
+    // The retired close can no longer publish anything: its finish sees a newer
+    // owner and returns.
+    panelAnims[0].onfinish?.()
+    expect(panel.style.transform).toBe('translate3d(-260px, 0, 0)')
+
+    // The live reopen still arrives normally.
+    panelAnims[1].onfinish?.()
+    expect(panel.style.transform).toBe('translate3d(0px, 0, 0)')
+    expect(x.get()).toBe(0)
+  })
+
+  it('still arrives when the browser cancels the animation instead of finishing it', () => {
+    const onDone = vi.fn()
+    animateDrawer(x, 0, onDone)
+    panelAnims[0].oncancel?.()
+    expect(x.get()).toBe(0)
+    expect(onDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('takeOverDrawer cancels the running settle so the finger is not fought', () => {
+    animateDrawer(x, 0)
+    expect(panelAnims[0].cancelled).toBe(false)
+    takeOverDrawer(x)
+    expect(panelAnims[0].cancelled).toBe(true)
+    // A finish arriving after the takeover must not retroactively claim the
+    // panel — the gesture that took over owns where it ends up.
+    panelAnims[0].onfinish?.()
+    expect(x.get()).not.toBe(0)
+  })
+
+  it('falls back to the main thread when nothing is registered', () => {
+    unregister()
+    animateDrawer(x, 0)
+    expect(panelAnims).toHaveLength(0)
+  })
+
+  it('falls back to the main thread under reduced motion', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true, configurable: true,
+      value: vi.fn().mockImplementation((q: string) => ({ matches: true, media: q, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    })
+    animateDrawer(x, 0)
+    expect(panelAnims).toHaveLength(0)
+  })
+
+  /**
+   * The fallback path must still MOVE THE DOM, not just the value.
+   *
+   * The nav drawer and the right overlay have no drag gesture, so this path is
+   * their only one whenever the compositor is unavailable — and neither is bound
+   * to `x` (a plain <nav>; a template-string transform serialized once per React
+   * render). Tweening the MotionValue alone leaves both stuck at the mounted
+   * closed offset: under `prefers-reduced-motion` the panel would open into
+   * nowhere and be unreachable.
+   */
+  it('paints the fallback tween onto the elements, and stops when cancelled', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true, configurable: true,
+      value: vi.fn().mockImplementation((q: string) => ({ matches: true, media: q, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    })
+    // Mounted closed: the inline style the last React render left behind.
+    panel.style.transform = `translate3d(${-TRAVEL}px, 0, 0)`
+    const stop = animateDrawer(x, 0)
+    // Painted once up front, so the element starts from a known offset.
+    expect(panel.style.transform).toBe(`translate3d(${-TRAVEL}px, 0, 0)`)
+
+    // …and TRACKS the value for the rest of the tween. This is the load-bearing
+    // half: without the subscription the DOM never moves off the closed offset.
+    x.set(-100)
+    expect(panel.style.transform).toBe('translate3d(-100px, 0, 0)')
+    // The scrim moves in lockstep off the same offset (1 - |at|/travel).
+    expect(Number(scrim.style.opacity)).toBeCloseTo(1 - 100 / TRAVEL, 5)
+
+    x.set(0)
+    expect(panel.style.transform).toBe('translate3d(0px, 0, 0)')
+
+    // Cancelling the settle releases the subscription — a leaked one would keep
+    // writing this panel's transform from a later, unrelated owner of `x`.
+    stop?.()
+    x.set(-42)
+    expect(panel.style.transform).toBe('translate3d(0px, 0, 0)')
+  })
+})

--- a/website/src/test/animateDrawer.curve.test.ts
+++ b/website/src/test/animateDrawer.curve.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The drawer settle's CURVES, pinned with the numbers that chose them.
+ *
+ * The settle is ASYMMETRIC: arriving and leaving are different events.
+ *
+ * ENTRY — the guard here is a FIRST-FRAME budget, and it is a restored one. It
+ * existed, was deleted when a more front-loaded curve was adopted on the theory
+ * that front-loading was not what made an earlier shape read wrong, and three
+ * device verdicts then said otherwise: easeOutExpo `(0.19, 1, 0.22, 1)` at 340ms
+ * (26% of the travel gone in the first painted frame), easeOutQuint
+ * `(0.16, 1, 0.3, 1)` at 320ms (30%) and `(0.1, 0.9, 0.2, 1)` at 320ms (39%)
+ * were each rejected for reading as the panel appearing rather than sliding. The
+ * accepted shape is iOS's sheet curve `(0.32, 0.72, 0, 1)`, which spends 10% —
+ * and which `components/OverlayDrawer.tsx` had already been using all along, for
+ * the reason its own comment gives: "a strong ease-out front-loads the travel,
+ * which visually freezes the near edges while the far edges are still sweeping."
+ * So the budget is not a preference, it is the same conclusion reached twice.
+ *
+ * EXIT — its budget is at the front too, but inverted: a dismissal must start
+ * from where the panel IS. A shared easeOut exit jumps off the edge and then
+ * crawls to a stop, which is what the first symmetric pairing got wrong.
+ *
+ * The two curves are also the Notification Center sheet's, asserted here as one
+ * motion language across both files.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import tailwindConfig from '../../tailwind.config.js'
+
+const animateSpy = vi.fn(() => ({ stop: vi.fn() }))
+vi.mock('framer-motion', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('framer-motion')>()),
+  animate: (...args: unknown[]) => animateSpy(...(args as [])),
+}))
+
+const { animateDrawer } = await import('../hooks/useDrawerSwipe')
+const { motionValue } = await import('framer-motion')
+
+/** Eased progress at `x` for a cubic-bezier, by bisection on its x-polynomial. */
+function easedAt(p: readonly number[], x: number): number {
+  const [p1, p2, p3, p4] = p
+  const cx = (t: number) => 3 * p1 * t * (1 - t) ** 2 + 3 * p3 * t ** 2 * (1 - t) + t ** 3
+  const cy = (t: number) => 3 * p2 * t * (1 - t) ** 2 + 3 * p4 * t ** 2 * (1 - t) + t ** 3
+  let lo = 0, hi = 1, t = x
+  for (let i = 0; i < 40; i++) { t = (lo + hi) / 2; if (cx(t) < x) lo = t; else hi = t }
+  return cy(t)
+}
+
+const TRAVEL = 390
+/** Rest is offset 0, so the target is what picks the direction's curve. */
+const settle = (to: number) => {
+  animateSpy.mockClear()
+  animateDrawer(motionValue(to === 0 ? -TRAVEL : 0), to)
+  return animateSpy.mock.calls[0][2] as { ease: readonly number[]; duration: number; type?: string }
+}
+
+describe('animateDrawer — settle curves', () => {
+  beforeEach(() => {
+    animateSpy.mockClear()
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true, configurable: true,
+      value: vi.fn().mockImplementation((q: string) => ({ matches: false, media: q, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    })
+  })
+
+  it('settles on stated cubic-beziers, not springs', () => {
+    for (const to of [0, -TRAVEL]) {
+      const opts = settle(to)
+      expect(opts.type, 'a spring cannot be handed to a KeyframeEffect').toBeUndefined()
+      expect(Array.isArray(opts.ease)).toBe(true)
+      expect(opts.ease).toHaveLength(4)
+      expect(opts.duration).toBeGreaterThan(0)
+    }
+  })
+
+  it('uses a DIFFERENT curve and duration per direction', () => {
+    const inOpts = settle(0)
+    const outOpts = settle(-TRAVEL)
+    // The asymmetry IS the fix; collapsing back to one shared curve is the
+    // regression this pins.
+    expect(outOpts.ease).not.toEqual(inOpts.ease)
+    expect(outOpts.duration).not.toBe(inOpts.duration)
+    // A dismissal is shorter than a reveal — nothing is being disclosed.
+    expect(outOpts.duration).toBeLessThan(inOpts.duration)
+  })
+
+  it('leaves SLOWLY at first, so a dismissal starts where the panel is', () => {
+    const { ease, duration } = settle(-TRAVEL)
+    const ms = duration * 1000
+    const at = (t: number) => easedAt(ease, Math.min(1, t / ms))
+    // This is the budget the recording actually set. A shared easeOut exit
+    // measures ~40% by 50ms here and fails outright.
+    expect(at(50)).toBeLessThan(0.05)
+    expect(at(100)).toBeLessThan(0.15)
+    // Accelerating away: the second half must cover more ground than the first.
+    expect(at(ms) - at(ms / 2)).toBeGreaterThan(at(ms / 2))
+    expect(at(ms)).toBeCloseTo(1, 2)
+  })
+
+  it('arrives by DECELERATING into place, without front-loading the first frame', () => {
+    const { ease, duration } = settle(0)
+    const ms = duration * 1000
+    const at = (t: number) => easedAt(ease, Math.min(1, t / ms))
+    // The restored budget. One painted frame must still look like a start: the
+    // three shapes rejected on device measure 26%, 30% and 39% here, and the
+    // accepted one 10%. Stated against the real 17ms rather than a fraction of
+    // the duration, because shortening the duration is itself a way to put more
+    // travel in that first frame.
+    expect(at(17)).toBeLessThan(0.2)
+    // Mirror image of the exit: most of the travel is behind it at half time.
+    expect(at(ms / 2)).toBeGreaterThan(0.5)
+    expect(at(ms)).toBeCloseTo(1, 2)
+  })
+
+  it('shares one motion language with the Notification Center sheet', () => {
+    // Both files state the curves independently (a tailwind config cannot import
+    // a TS module), so the only thing keeping them in step is this assertion.
+    // Compared as NUMBERS: CSS spells the same control point `.16` where the TS
+    // array spells it `0.16`, and the invariant is the value, not the spelling.
+    const anim = (tailwindConfig as { theme: { extend: { animation: Record<string, string> } } })
+      .theme.extend.animation
+    const parse = (css: string) => {
+      const bezier = /cubic-bezier\(([^)]+)\)/.exec(css)
+      const secs = /(?:^|\s)(\.?\d*\.?\d+)s(?:\s|$)/.exec(css)
+      expect(bezier, `no cubic-bezier in "${css}"`).not.toBeNull()
+      expect(secs, `no duration in "${css}"`).not.toBeNull()
+      return { ease: bezier![1].split(',').map(Number), secs: Number(secs![1]) }
+    }
+
+    for (const [to, key] of [[0, 'nc-slide-in'], [-TRAVEL, 'nc-slide-out']] as const) {
+      const css = parse(anim[key])
+      const js = settle(to)
+      expect(css.ease, `${key} curve`).toEqual([...js.ease])
+      expect(css.secs, `${key} duration`).toBeCloseTo(js.duration, 5)
+    }
+  })
+
+  it('keeps reduced motion on its own short linear tween, both directions', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true, configurable: true,
+      value: vi.fn().mockImplementation((q: string) => ({ matches: true, media: q, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+    })
+    expect(settle(0)).toMatchObject({ ease: 'linear' })
+    expect(settle(-TRAVEL)).toMatchObject({ ease: 'linear' })
+  })
+
+  /**
+   * The compositor path states the curve as a CSS string and the main-thread
+   * fallback as a number array. `settleTiming` derives the string from the array
+   * so the two cannot disagree — but "derives" is an implementation detail a
+   * refactor can quietly replace with a literal, and then a reduced-motion or
+   * mount-grace fallback would settle on a different curve from the compositor
+   * one with nothing going red. This is the assertion that makes the derivation
+   * load-bearing rather than merely intended.
+   */
+  it('hands the compositor the SAME curve the main-thread fallback uses', async () => {
+    const { registerDrawerTargets } = await import('../hooks/useDrawerSwipe')
+    const panel = document.createElement('div')
+    const timings: Record<string, unknown>[] = []
+    ;(panel as unknown as { animate: unknown }).animate = (_k: unknown, timing: Record<string, unknown>) => {
+      timings.push(timing)
+      return { cancel() {}, onfinish: null, oncancel: null }
+    }
+
+    for (const to of [0, -TRAVEL]) {
+      // Main-thread spelling first (nothing registered -> framer tween).
+      const { ease, duration } = settle(to)
+
+      // …then the compositor spelling for the same direction.
+      timings.length = 0
+      const x = motionValue(to === 0 ? -TRAVEL : 0)
+      const unregister = registerDrawerTargets(x, {
+        panel: () => panel, scrim: () => null, travel: () => TRAVEL,
+      })
+      try {
+        animateDrawer(x, to)
+      } finally {
+        unregister()
+      }
+      expect(timings, `direction ${to} took the compositor path`).toHaveLength(1)
+
+      const css = /cubic-bezier\(([^)]+)\)/.exec(String(timings[0].easing))
+      expect(css, `compositor easing for ${to}: ${timings[0].easing}`).not.toBeNull()
+      expect(css![1].split(',').map(Number)).toEqual([...ease])
+      expect(timings[0].duration).toBeCloseTo(duration * 1000, 5)
+    }
+  })
+})

--- a/website/src/test/mobilePanels.compositor.test.ts
+++ b/website/src/test/mobilePanels.compositor.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The OTHER two mobile panels ride the same compositor machinery as the
+ * sessions drawer — pinned as SOURCE contracts, the way App.test.tsx pins the
+ * drawer's own wrapper: these are pairings ("compositor slide" ⟷ "no framer
+ * transform / no projection under it"), and one half regressing alone
+ * reintroduces a bug the other half was built around.
+ *
+ *  LEFT (App.tsx mobile nav drawer):
+ *   - the panel is a plain <nav> whose slide runs via animateDrawer — framer
+ *     must not own a competing transform on it;
+ *   - NavItem drops `layout` on mobile: a projection node under a
+ *     compositor-driven ancestor compounds a corrective offset (the ChatSidebar
+ *     rows measured >4,000px of it);
+ *   - the scrim's opacity is animated in lockstep by animateDrawer, not by a
+ *     framer fade of its own.
+ *
+ *  RIGHT (ChatPage inline side panel on mobile):
+ *   - the mobile branch must NEVER animate `width` — a layout animation the
+ *     compositor cannot take, which re-laid-out the squeezed chat pane every
+ *     frame (the original 400ms width reveal);
+ *   - it slides as a fixed overlay via sideOverlayX / animateDrawer;
+ *   - keep-alive survives: a closed-but-alive panel stays mounted display:none
+ *     so a live app tab's iframe is not torn down by the overlay conversion.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const app = readFileSync(resolve(__dirname, '../App.tsx'), 'utf8')
+const chat = readFileSync(resolve(__dirname, '../pages/ChatPage.tsx'), 'utf8')
+
+describe('mobile nav drawer (left) — compositor pairing', () => {
+  const drawer = app.slice(app.indexOf('key="mobile-nav-drawer"'), app.indexOf('key="mobile-nav-drawer"') + 900)
+
+  it('slides a plain <nav>, not a framer-owned motion.nav', () => {
+    expect(app.indexOf('key="mobile-nav-drawer"')).toBeGreaterThan(0)
+    // The element framer animates is the element the compositor cannot have:
+    // two writers to one transform is the judder the sessions drawer already
+    // debugged. The ref is what animateDrawer drives.
+    expect(drawer).toContain('ref={mobileNavPanelRef}')
+    expect(drawer).not.toContain('<motion.nav')
+    expect(drawer).not.toContain('animate={{')
+  })
+
+  it('registers panel+scrim with the drawer runtime', () => {
+    expect(app).toContain('registerDrawerTargets(mobileNavX')
+    expect(app).toMatch(/panel: \(\) => mobileNavPanelRef\.current/)
+    expect(app).toMatch(/scrim: \(\) => mobileNavScrimRef\.current/)
+  })
+
+  it('NavItem drops layout projection on mobile', () => {
+    expect(app).toContain("layout={isMobileRow ? undefined : 'position'}")
+  })
+
+  it('the scrim has no framer fade of its own (animateDrawer owns it)', () => {
+    const scrim = app.slice(app.indexOf('data-testid="nav-backdrop"') - 400, app.indexOf('data-testid="nav-backdrop"') + 400)
+    expect(scrim).toContain('ref={mobileNavScrimRef}')
+    expect(scrim).not.toContain('initial={{ opacity')
+  })
+
+  it('scrim is decorative (aria-hidden) and Escape is the keyboard dismissal', () => {
+    // The scrim's click-to-dismiss is a pointer convenience. It must stay out
+    // of the tab order and the accessibility tree (a focusable full-screen
+    // scrim is a giant tab stop), so the keyboard path is an Escape handler
+    // gated on the drawer being open — both halves pinned here.
+    const scrim = app.slice(app.indexOf('data-testid="nav-backdrop"') - 400, app.indexOf('data-testid="nav-backdrop"') + 400)
+    expect(scrim).toContain('aria-hidden="true"')
+    const esc = app.slice(app.indexOf("mobileNavPhase !== 'open'") - 200, app.indexOf("mobileNavPhase !== 'open'") + 400)
+    expect(esc).toContain("e.key === 'Escape'")
+    expect(esc).toContain('closeMobileNavDrawer()')
+  })
+})
+
+describe('inline side panel (right) — mobile overlay pairing', () => {
+  const start = chat.indexOf('key="side-panel-inline"')
+  // The mount predicate (with the keep-alive arm) sits a few hundred chars ABOVE the key.
+  const block = chat.slice(start - 1400, start + 2400)
+
+  it('mobile branch never animates width (layout animation)', () => {
+    expect(start).toBeGreaterThan(0)
+    // The width tween survives ONLY behind the desktop/embed ternary arm.
+    expect(block).toContain('initial={isMobile ? false : { width: 0 }}')
+    expect(block).toContain('animate={isMobile ? undefined : {')
+  })
+
+  it('mobile branch is a fixed overlay driven by the drawer runtime', () => {
+    expect(block).toContain('ref={isMobile ? sideOverlayPanelRef : undefined}')
+    expect(chat).toContain('registerDrawerTargets(sideOverlayX')
+    // Seated at the closed offset inline so the first painted frame is offscreen.
+    expect(block).toContain('translate3d(${sideOverlayX.get()}px, 0, 0)')
+  })
+
+  it('keep-alive: a closed-but-alive panel stays mounted display:none', () => {
+    // The mount predicate keeps a hidden live-app panel in the tree…
+    expect(block).toContain('|| (shouldMountSidePanel(')
+    // …and the closed phase renders it invisible rather than unmounting it.
+    expect(block).toMatch(/sideOverlayPhase === 'closed'\s*\n?\s*\? \{ display: 'none' \}/)
+  })
+})

--- a/website/src/test/useWebSocket.streamHold.test.ts
+++ b/website/src/test/useWebSocket.streamHold.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Streaming flushes sit out the drawer slide.
+ *
+ * The drawer slide runs on the compositor; this hold covers the main-thread work
+ * that remains during it — the panel's own mount, tool events, subagent status
+ * pushes — and the main-thread drag path. While a hold is open the per-frame
+ * flush pipelines in useWebSocket sit out, and the burst lands as one flush when
+ * it lapses. Nothing is dropped — the pipelines already buffer between flushes.
+ *
+ * Pinned here:
+ *  - a chat_chunk arriving under a hold does NOT reach the store within the
+ *    frame, and DOES land (whole buffer, one flush) once the hold lapses;
+ *  - animateDrawer opens a hold sized to its own duration and releases it on
+ *    completion;
+ *  - a locked drag keeps a rolling hold alive;
+ *  - a hold is a deadline, never a lock (caps at HOLD_MAX, releasable early).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { motionValue } from 'framer-motion'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store } from '../store'
+import { setActiveSlot, clearMessages, clearSlotState } from '../store/chatSlice'
+import { holdStreamingFlushes, releaseStreamingFlushes, streamingFlushHoldMs } from '../lib/streamHold'
+import { animateDrawer, useDrawerSwipe } from '../hooks/useDrawerSwipe'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    voiceSynthesize: vi.fn().mockResolvedValue({}),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+  constructor() { WS_INSTANCES.push(this) }
+  simulateOpen() { this.readyState = MockWebSocket.OPEN; this.onopen?.(new Event('open')) }
+  simulateMessage(data: object) { this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) })) }
+}
+
+const streamedText = () =>
+  store.getState().chat.messages.filter(m => m.role === 'streaming').map(m => m.content).join('')
+
+function renderWs() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    createElement(Provider, { store }, createElement(QueryClientProvider, { client: queryClient }, children))
+  const hook = renderHook(() => useWebSocket(), { wrapper })
+  const ws = WS_INSTANCES[WS_INSTANCES.length - 1]
+  act(() => ws.simulateOpen())
+  return { hook, ws }
+}
+
+describe('streaming flushes vs the drawer slide', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    releaseStreamingFlushes()
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // rAF must run the flush for the un-held baseline half of the test.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 16) as unknown as number)
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id))
+    store.dispatch(clearSlotState())
+    store.dispatch(clearMessages())
+    store.dispatch(setActiveSlot('slot-1'))
+  })
+  afterEach(() => {
+    releaseStreamingFlushes()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('defers a chunk flush while held, then lands the whole burst as one flush', async () => {
+    vi.useFakeTimers()
+    const { hook, ws } = renderWs()
+
+    holdStreamingFlushes(400)
+    act(() => {
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: 'hello ' } })
+      ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: 'world' } })
+    })
+    // A frame passes; the flush is deferred, so nothing has reached the store.
+    await act(async () => { vi.advanceTimersByTime(50) })
+    expect(streamedText()).toBe('')
+
+    // The hold lapses; the deferred timer fires and the buffer lands whole.
+    await act(async () => { vi.advanceTimersByTime(450) })
+    expect(streamedText()).toBe('hello world')
+    hook.unmount()
+  })
+
+  it('flushes on the next frame when nothing holds', async () => {
+    vi.useFakeTimers()
+    const { hook, ws } = renderWs()
+    act(() => { ws.simulateMessage({ type: 'chat_chunk', data: { slot: 'slot-1', content: 'now' } }) })
+    await act(async () => { vi.advanceTimersByTime(40) })
+    expect(streamedText()).toBe('now')
+    hook.unmount()
+  })
+
+  it('animateDrawer holds for its own duration and releases on arrival', async () => {
+    expect(streamingFlushHoldMs()).toBe(0)
+    const done = vi.fn()
+    animateDrawer(motionValue(-390), -390, done) // zero distance: arrives immediately
+    // The hold opens with the animation…
+    expect(streamingFlushHoldMs()).toBeGreaterThan(300)
+    // …and completion releases it, so a finished slide leaves no latency behind.
+    await vi.waitFor(() => expect(done).toHaveBeenCalled())
+    expect(streamingFlushHoldMs()).toBe(0)
+
+    const stop = animateDrawer(motionValue(-390), 0)
+    expect(streamingFlushHoldMs()).toBeGreaterThan(300)
+    stop()
+    // A stopped tween never completes: the deadline is the backstop.
+    expect(streamingFlushHoldMs()).toBeGreaterThan(0)
+    expect(streamingFlushHoldMs()).toBeLessThanOrEqual(1_000)
+  })
+
+  it('a locked drag keeps a rolling hold alive', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    const x = motionValue(0)
+    const touch = (type: string, clientX: number) => {
+      const t = { clientX, clientY: 0 } as Touch
+      const init: TouchEventInit = { bubbles: true }
+      if (type === 'touchstart' || type === 'touchmove') init.touches = [t]
+      if (type === 'touchend') init.changedTouches = [t]
+      return new TouchEvent(type, init)
+    }
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 400 })
+    // A STABLE ref object. Inlining `{ current: el }` in the render callback
+    // hands the effect a new dep every render — and the lock's own setDragging
+    // re-render then re-binds the listeners, whose cleanup resets the gesture.
+    const ref = { current: el }
+    const hook = renderHook(() => useDrawerSwipe(ref, {
+      enabled: true, open: true, x, onGestureOpen: () => {}, onSettle: () => {},
+    }))
+    act(() => { el.dispatchEvent(touch('touchstart', 200)) })
+    act(() => { el.dispatchEvent(touch('touchmove', 150)) }) // locks (leftward close)
+    releaseStreamingFlushes() // isolate: the NEXT sample must re-arm it
+    act(() => { el.dispatchEvent(touch('touchmove', 140)) })
+    expect(streamingFlushHoldMs()).toBeGreaterThan(0)
+    expect(streamingFlushHoldMs()).toBeLessThanOrEqual(250)
+    hook.unmount()
+    el.remove()
+  })
+
+  it('holds are deadlines: capped, extend-only, releasable early', () => {
+    holdStreamingFlushes(99_999)
+    expect(streamingFlushHoldMs()).toBeLessThanOrEqual(1_000)
+    const before = streamingFlushHoldMs()
+    holdStreamingFlushes(10) // shorter hold must not SHORTEN the active one
+    expect(streamingFlushHoldMs()).toBeGreaterThanOrEqual(before - 5)
+    releaseStreamingFlushes()
+    expect(streamingFlushHoldMs()).toBe(0)
+  })
+})

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -188,16 +188,20 @@ export default {
         'gradient-shift': { '0%': { backgroundPosition: '0% 50%' }, '50%': { backgroundPosition: '100% 50%' }, '100%': { backgroundPosition: '0% 50%' } },
         'msg-highlight': { '0%': { boxShadow: 'inset 0 0 0 2px var(--accent)' }, '100%': { boxShadow: 'inset 0 0 0 0px transparent' } },
         float: { '0%,100%': { transform: 'translateY(0)' }, '50%': { transform: 'translateY(-6px)' } },
-        /* margin-based (NOT transform): a transformed ancestor becomes a
-           backdrop root and breaks descendants' backdrop-filter blur.
-           Desktop is a fixed 400px sheet, so a px offset clears it. Mobile is
-           full-width up to the 767px breakpoint, where -420px would leave the
-           sheet half on screen — percentage margins resolve against the
-           containing block's width, so -100% always clears it exactly. */
-        'nc-slide-in': { from: { marginRight: '-420px' }, to: { marginRight: '0px' } },
-        'nc-slide-out': { from: { marginRight: '0px' }, to: { marginRight: '-420px' } },
-        'nc-slide-in-full': { from: { marginRight: '-100%' }, to: { marginRight: '0px' } },
-        'nc-slide-out-full': { from: { marginRight: '0px' }, to: { marginRight: '-100%' } },
+        /* transform-based (NOT margin): margin is a layout property, so a
+           margin keyframe reflows the sheet AND its subtree on the main
+           thread every frame — the same jank class as the old right-panel
+           width animation. transform runs on the compositor. An earlier
+           comment here claimed a transformed ancestor becomes a backdrop
+           root and breaks descendants' backdrop-filter; a pixel probe
+           (Chromium, card blur measured mid-animation under a transformed
+           ancestor) disproved that — transform is not in the backdrop-root
+           trigger list. translateX percentages resolve against the element's
+           OWN width, so one pair of keyframes covers both the desktop 400px
+           sheet and the mobile full-width sheet; +20px clears the sensor-
+           housing gutter the sheet keeps beside the viewport edge. */
+        'nc-slide-in': { from: { transform: 'translateX(calc(100% + 20px))' }, to: { transform: 'translateX(0)' } },
+        'nc-slide-out': { from: { transform: 'translateX(0)' }, to: { transform: 'translateX(calc(100% + 20px))' } },
       },
       animation: {
         'sage-sweep': 'sage-sweep 1.4s ease-in-out infinite',
@@ -219,10 +223,14 @@ export default {
         'gradient-shift': 'gradient-shift 20s ease infinite',
         'msg-highlight': 'msg-highlight 2s ease-out forwards',
         float: 'float 3s ease-in-out infinite',
-        'nc-slide-in': 'nc-slide-in .32s cubic-bezier(.16,1,.3,1) backwards',
+        /* Asymmetric by direction: iOS's sheet curve arriving, an easeIN
+           dismissal leaving. The drawer settles in `hooks/useDrawerSwipe.ts`
+           carry the SAME two curves and durations (`SETTLE_IN_EASE` /
+           `SETTLE_OUT_EASE`) so every sliding panel in the app shares one motion
+           language — move both or neither. `NC_CLOSE_MS` in App.tsx is the
+           unmount timer paired with the .24s exit. */
+        'nc-slide-in': 'nc-slide-in .42s cubic-bezier(.32,.72,0,1) backwards',
         'nc-slide-out': 'nc-slide-out .24s cubic-bezier(.3,0,.8,.15) forwards',
-        'nc-slide-in-full': 'nc-slide-in-full .32s cubic-bezier(.16,1,.3,1) backwards',
-        'nc-slide-out-full': 'nc-slide-out-full .24s cubic-bezier(.3,0,.8,.15) forwards',
       },
     },
   },


### PR DESCRIPTION
## Problem / Motivation

On mobile, opening or closing any of the three panels — the sessions drawer, the left nav drawer, the right side panel — dropped frames whenever the main thread was busy: long message lists, multiple sessions streaming. Every panel animated on the main thread, each in its own way:

- the **sessions drawer** settled via a framer tween (per-frame main-thread `transform` writes);
- the **nav drawer** likewise, plus an independently-tweened scrim;
- the **right side panel** animated `width: 0 → auto` — a layout property, so every frame reflowed the panel *and* the chat column it squeezes;
- the **notification sheet**'s keyframes animated `margin-right` — also layout, same jank class.

A main-thread animation cannot be protected by throttling work: streamed chunks, tool events, subagent status, and panel mount cost are an open-ended list. The only structural fix is to move the slide off the main thread.

## What changed

**1. Compositor-driven settle (`useDrawerSwipe.ts`).** `animateDrawer` now drives the panel's `transform` and the scrim's `opacity` via WAAPI (`Element.animate`) when targets are registered (`registerDrawerTargets`), so the settle runs on the compositor regardless of main-thread load. Dragging stays on the main thread (the finger is a main-thread event source). Fallbacks (no registered element, `prefers-reduced-motion`, embed frames) keep the original framer tween.

   *Arrival ordering matters:* on finish/cancel/gesture-takeover, `publishArrival` writes the terminal value into the element's **own inline style first**, then updates the MotionValue, then cancels the `fill: forwards` animation. For framer-bound panels this is harmless redundancy; for plain elements (nav drawer, right panel) it is the only correct order — cancelling first snaps the element back to its mounted (closed) inline style, which shipped as a visible "opens, then vanishes, then flashes back" bug during development and is pinned by tests.

**2. Rows opt out of layout projection inside the drawer (`ChatSidebar.tsx`, `App.tsx`).** Framer's layout projection requires framer to *own* the ancestor transform. Under a WAAPI-driven ancestor, any mid-slide re-render re-measures rows against a moved viewport box and mis-attributes the panel's motion to the rows — the corrective transform accumulates (probe: 12px → 4,170px) and rows visibly "fly in from the right". The drawer mount composes `rowAnimEnabled={rowAnimEnabled && !staticRows}` into `SessionRow`'s existing animation gate (post-#6703), and `NavItem`'s `layout="position"` is gated off on mobile. Desktop keeps projection and its row-reorder animations.

   *Interaction with #6703:* row memoization reduces how often rows re-render mid-slide, but any single re-render (drawer mount, a displaced row) still re-measures — reduction is not elimination, so both changes are needed. The probe also showed the "half-fix" (dropping `layout` but keeping `layoutId`) still flies; the guard test pins both halves.

**3. Right side panel becomes a slide-in overlay on mobile (`ChatPage.tsx`).** `width` cannot run on the compositor, and the old reveal reflowed the squeezed chat column every frame. Mobile now mirrors the sessions drawer (fixed overlay, `transform` slide); desktop and embed keep the deliberate width reveal. The live-app iframe keep-alive path (closed panel stays mounted, hidden) is preserved and pinned by tests.

**4. Streaming flush pipelines pause while a drawer moves (`useWebSocket.ts` + `lib/streamHold.ts`).** The three per-frame rAF flush lanes (chat chunks, subagent chunks, slot activity) defer their flush while a slide is in flight (drag extends the hold per sample; a 1s hard cap guarantees streaming can never be starved). Data is delayed, never dropped — the buffers already existed. This removes the projection re-measure trigger *and* keeps the transcript from competing for GPU during the slide.

**5. Notification sheet keyframes animate `transform` (`tailwind.config.js`, `App.tsx`).** Percentage `translateX` resolves against the element's own width, so one keyframe pair (`calc(100% + 20px)`) replaces the desktop-px/mobile-percent variant split; the `-full` variants and the `isMobile` animation branch are gone. The old margin choice was justified by a comment claiming a transformed ancestor becomes a backdrop root and breaks descendants' `backdrop-filter`; a Chromium pixel probe (card blur measured mid-animation under a transformed ancestor) disproved that — `transform` is not in the backdrop-root trigger list. At rest neither animation fills, so the element carries no transform either way.

   *Its entry timing is retuned with them, and that is a separable choice:* `nc-slide-in` goes `.32s cubic-bezier(.16,1,.3,1)` → `.42s cubic-bezier(.32,.72,0,1)`, putting the sheet on the same entry curve as the four panels rather than leaving it on its own. That curve is not introduced here — `main` already uses `[0.32, 0.72, 0, 1]` in five places, including `OverlayDrawer.tsx:45` where it is the named `EASE` constant and `ChatPage.tsx:7174` as a literal `cubic-bezier(.32,.72,0,1)` — so this converges the sheet onto the established overlay curve, and `animateDrawer.curve.test.ts` pins the two in step from then on. The threading fix (the keyframe-property change) does **not** require it; it is here because shipping one surface on a different entry curve from the panels it sits beside is the kind of drift that never gets cleaned up later. Revertable on its own by restoring the two literals in `tailwind.config.js` and dropping one assertion.

**6. Sidebar memo repair (`ChatPage.tsx`).** Two inline callbacks (`onSelectSlot` in both branches) and `openSlotInNewTab` depending on the whole `sessionTabs` object defeated `memo(ChatSidebar)` at the shell boundary — the sidebar re-rendered ~3× per streamed frame. Complements #6703, which memoizes *inside* the sidebar; this makes the outer boundary hold (measured 41 → 1 renders across 20 streamed frames in the guard test).

**7. Escape closes the mobile nav drawer (`App.tsx`).** The nav drawer's scrim is `aria-hidden` and decorative — it is a paint surface, not a control — so this PR adds a keydown handler rather than making a full-viewport element focusable. Dismissal is therefore keyboard-reachable two ways: the nav toggle `<button>` and Escape. Small enough to have ridden along unmentioned in the first draft of this description; called out here because it is also the load-bearing half of the scrim's accessibility argument.

## Verification

- Full frontend suite green: 1648 files / 26,027 tests; `tsc -b` clean; 0 new lint errors.
- 7 new/extended test files; **every guard was mutation-verified** (~20 mutations across the session: easing/curve swaps, jump-vs-cancel order, inline-style arrival writes, staticRows half-fixes, forgotten pairings, hold-scheduling drops — each turns its specific test red).
- The one deliberate tradeoff is documented in code: inside the mobile drawer, row reorder/pin animations become instant and the flat↔tree shared-element transition is off (`rowAnimEnabled` composition); desktop unchanged.
- Verified on-device (iPhone) across all four panels: smooth open/close while multiple sessions stream; no row fly-in; no arrival bounce; live-app iframe content survives right-panel close/reopen.

## Known limitations

- The Chromium probe covers Blink; if Safari treats a transformed ancestor as a backdrop root (notification sheet, cards' frosted material), the blur would drop only during the 320ms slide and restore at rest. On-device spot check showed no visible artifact.
- `test:electron` fails locally on this host (no `website/electron` dev deps installed); the diff touches no electron files, so the `electron-test` CI job sees identical bytes to main.


**Why no screenshot:** The change is animation threading (main-thread tween → compositor WAAPI) and timing curves — frame pacing cannot be shown in a still image, and the panels' at-rest states are unchanged except that the mobile right side panel now overlays the chat column instead of squeezing it (verified on-device by the author across all four panels, streaming and idle).


