### PR TITLE
fix(config): apply the autocompact threshold without a gateway restart

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -4714,15 +4714,19 @@ def _config_fingerprint() -> tuple:
     return tuple(sig)
 
 
-def _cached_validated_data() -> dict | None:
+def _cached_validated_data(fp: tuple | None = None) -> dict | None:
     """Return a deep copy of the cached validated config dict, or None on miss.
 
-    Thin wrapper over the :class:`~kiro_crew.config.validation.ConfigCache`:
-    the fingerprint is computed here (``_config_fingerprint`` stays in this
-    module because it reads ``config_path()``/``config_local_path()``, which the
-    test suite patches as ``kiro_crew.config.loader.config_path``).
+    Thin wrapper over the :class:`~kiro_crew.config.validation.ConfigCache`.
+    ``_config_fingerprint`` stays in this module because it reads
+    ``config_path()``/``config_local_path()``, which the test suite patches as
+    ``kiro_crew.config.loader.config_path``.
+
+    Pass *fp* when the caller has already computed the fingerprint, so one load
+    costs a single stat pass instead of one per consumer of it. Omitting it
+    stats, which suits a caller that has no fingerprint in hand.
     """
-    return _CONFIG_CACHE.get(_config_fingerprint())
+    return _CONFIG_CACHE.get(fp if fp is not None else _config_fingerprint())
 
 
 def _store_validated_data(data: dict, fp: tuple) -> None:
@@ -7620,7 +7624,11 @@ class KiroCrewConfig:
         The overlay is applied at load time but NOT persisted back by
         ``save()`` — only the base config is written to ``config.json``.
         """
-        cfg = cls._load_resolved()
+        # The ordering ticket comes back from the resolve step, drawn BEFORE the
+        # read, so a concurrent newer load cannot be overwritten by this one
+        # finishing later (see publish_autocompact_pct) and this method adds no
+        # filesystem I/O of its own on the event loop.
+        cfg, _autocompact_ticket = cls._load_resolved()
         # Push the MCP search-path setting to its consumer. It is PUSHED rather
         # than read there because kiro_crew.env.mcp_search_path is reached from
         # the event loop by every MCP probe and by the agent-config resolver, so
@@ -7651,15 +7659,33 @@ class KiroCrewConfig:
             # A publish failure must never make the config unloadable; the
             # resolver simply keeps reporting no divergence.
             logger.warning("Publishing agent alias snapshot failed: %s", e)
+        # Same placement and same reason again: the compaction gate reads this
+        # after every turn on the event loop, and publishing on EVERY return path
+        # is what lets a CLI write reach a gateway that is already running.
+        try:
+            publish_autocompact_pct(cfg, _autocompact_ticket)
+        except Exception as e:  # pragma: no cover - defensive
+            # A publish failure must never make the config unloadable; the gate
+            # keeps using the threshold it already had.
+            logger.warning("Publishing autocompact threshold failed: %s", e)
         return cfg
 
     @classmethod
-    def _load_resolved(cls) -> KiroCrewConfig:
+    def _load_resolved(cls) -> tuple[KiroCrewConfig, int]:
         """Resolve the config from disk (or defaults). See :meth:`load`.
 
         Split out so :meth:`load` owns the post-resolution publication on every
         return path; this method may return from more than one place.
+
+        Returns the config PLUS the ordering ticket drawn before the read, which
+        is what lets :meth:`load` publish the compaction threshold in the correct
+        order relative to a concurrent load without any filesystem I/O of its own
+        on the event loop.
         """
+        # Drawn BEFORE any read below, so it records when this load began
+        # observing the files rather than when it finished. See
+        # next_config_load_ticket and publish_autocompact_pct.
+        ticket = next_config_load_ticket()
         path = config_path()
 
         # Hot-path cache: reuse the validated, merged dict when neither config
@@ -7667,16 +7693,22 @@ class KiroCrewConfig:
         # _deep_merge + the full jsonschema.validate. A deep copy is returned so
         # in-place mutation by callers (and the write-back migration below) can
         # never corrupt the cached original.
-        cached_data = _cached_validated_data()
+        #
+        # ONE stat pass serves both consumers of it below: the cache lookup and
+        # the pre-read TOCTOU fingerprint. load() runs on the event loop, so a
+        # second pass would be filesystem I/O there for information already in
+        # hand.
+        fp = _config_fingerprint()
+        cached_data = _cached_validated_data(fp)
         if cached_data is not None:
             data = cached_data
         else:
-            # Capture the fingerprint BEFORE reading so a write landing during
-            # the read is detected: we cache under this pre-read fp, which won't
-            # match the post-write on-disk stat, so the next load() re-reads
-            # instead of serving the content we read mid-write (read->store
-            # TOCTOU). _store_validated_data documents this contract.
-            pre_read_fp = _config_fingerprint()
+            # fp was captured BEFORE reading, so a write landing during the read
+            # is detected: we cache under it, it won't match the post-write
+            # on-disk stat, and the next load() re-reads instead of serving
+            # content read mid-write (read->store TOCTOU).
+            # _store_validated_data documents this contract.
+            pre_read_fp = fp
             data = {}
             loaded_base = False
             config_source_unreadable = False
@@ -7765,7 +7797,7 @@ class KiroCrewConfig:
                     memory_store="default",
                 )
                 cfg.default_agent = "default"
-                return cfg
+                return cfg, ticket
 
             # Preserve fail-closed security semantics before advisory schema
             # validation can replace malformed input with a missing-field default.
@@ -8996,7 +9028,7 @@ class KiroCrewConfig:
             # Migration write-back is best-effort; never block startup.
             logger.warning("Config write-back failed: %s", e)
 
-        return cfg
+        return cfg, ticket
 
     def to_dict(self) -> dict:
         """Serialize config to the JSON structure used by config.json."""
@@ -9818,6 +9850,117 @@ def publish_agent_alias_snapshot(config: "KiroCrewConfig") -> None:
 def agent_alias_snapshot() -> tuple[frozenset[str], str, bool]:
     """The published alias table as ``(aliases, default_alias, ready)``."""
     return _CONFIG_AGENT_ALIAS_SNAPSHOT
+
+
+# Snapshot of the auto-compaction threshold, refreshed by every successful
+# :meth:`KiroCrewConfig.load`, for the same reason as the two snapshots above:
+# the read path (``SessionManager._compaction_gate_decision``) runs on the event
+# loop after every turn, so it must never stat/read/validate config.json itself.
+#
+# What this specifically buys, beyond avoiding that I/O: a config write from ANY
+# writer reaches a running gateway. The dashboard PATCH handler and the CLI both
+# end at ``update_config_locked``, and only the handler could notify the manager
+# it had changed something -- so a ``kirocrew config set`` landed on disk while
+# the live threshold kept its startup value until a restart. Publishing on load
+# closes that without either writer having to know which live object holds it.
+#
+# Ordered by a monotonically increasing TICKET drawn before each load's read.
+# Loads run concurrently (prompt assembly, background threads), so without
+# ordering an older load finishing last would republish the value it read before
+# a newer write -- leaving live sessions compacting at an obsolete threshold
+# until something loaded again. The two snapshots above carry the same race; the
+# consequence there is a display marker, which is why only this one is ordered.
+#
+# A ticket rather than the files' newest ``st_mtime_ns``, because this ordering
+# must be monotonic and an mtime is not. Deleting the newer of the two config
+# files LOWERS that maximum, and so does restoring a backup with ``cp -p`` or any
+# other writer that preserves timestamps; each one makes the current state of the
+# filesystem look like an older read, so the publish that should win is dropped
+# and the live gate keeps a threshold the files no longer say. A ticket is
+# independent of the filesystem, so a deletion and a timestamp-preserving restore
+# both order as what they are: the newest read.
+_CONFIG_AUTOCOMPACT_PCT: float = DEFAULT_AUTOCOMPACT_PCT
+_CONFIG_AUTOCOMPACT_TICKET: int = 0
+
+#: Highest ticket handed out by :func:`next_config_load_ticket`. Distinct from the
+#: PUBLISHED ticket above: a load draws one and can still lose the comparison,
+#: which must not move the published mark.
+_CONFIG_AUTOCOMPACT_ISSUED: int = 0
+
+#: Serializes the ticket draw and the compare-and-set in
+#: :func:`publish_autocompact_pct`. Held ONLY on those two write paths, each of
+#: which runs inside ``load()`` and is therefore already doing file I/O and schema
+#: validation -- the lock is free by comparison. The READ path
+#: (:func:`published_autocompact_pct`) never takes it, which is what keeps the
+#: event loop lock-free; that is the objection the alias snapshot above avoids by
+#: publishing one immutable tuple, and it does not apply to a write-side lock.
+#:
+#: Needed because each path is a read followed by a write: without it two
+#: concurrent loads can draw the SAME ticket, or both pass the publish comparison
+#: and let whichever assigns LAST win, so an older read replaces a newer one and
+#: rolls the published ticket backwards with it.
+_CONFIG_AUTOCOMPACT_LOCK = threading.Lock()
+
+
+def next_config_load_ticket() -> int:
+    """Draw the next config-load ordering ticket.
+
+    Call this BEFORE the read whose result will be published, so the ticket
+    records when this load began observing the files. Two loads whose reads
+    interleave are then ordered by ticket rather than by anything on disk: the
+    loser's value is at most microseconds stale and the next load corrects it,
+    where an unordered publish can leave an obsolete threshold in force
+    indefinitely.
+
+    Never returns 0, so 0 means "nothing published yet".
+    """
+    global _CONFIG_AUTOCOMPACT_ISSUED
+    with _CONFIG_AUTOCOMPACT_LOCK:
+        _CONFIG_AUTOCOMPACT_ISSUED += 1
+        return _CONFIG_AUTOCOMPACT_ISSUED
+
+
+def publish_autocompact_pct(config: "KiroCrewConfig", ticket: int | None = None) -> None:
+    """Publish *config*'s compaction threshold for the filesystem-free read path.
+
+    Pure in-memory rebind -- safe from anywhere, including the event loop, and a
+    reader sees either the whole previous value or the whole new one. Called from
+    :meth:`KiroCrewConfig.load` so every successful load refreshes it, including
+    the degraded-defaults path, which must OVERWRITE a previous snapshot rather
+    than leave a stale threshold in force.
+
+    *ticket* orders this publish against concurrent ones. It must come from
+    :func:`next_config_load_ticket`, drawn BEFORE the read that produced *config*;
+    a ticket lower than the one already published is dropped. Omitting it draws a
+    fresh ticket, which therefore always wins -- correct for a caller that has
+    just built the config it is publishing (tests), and wrong for one replaying an
+    earlier read, which must pass the ticket it drew.
+
+    No ticket value is special-cased. "Neither config file exists" is the current
+    truth rather than an older read of the same file, and it arrives here on the
+    degraded-defaults path holding a freshly drawn ticket, so it wins by ordinary
+    comparison. Being able to state that without a carve-out is the reason the
+    ticket is independent of the files: an ordering read off their mtime drops to
+    a lower value when a file is removed, and so cannot express it.
+    """
+    global _CONFIG_AUTOCOMPACT_PCT, _CONFIG_AUTOCOMPACT_TICKET
+    # Drawn OUTSIDE the lock: next_config_load_ticket acquires the same
+    # non-reentrant lock, so drawing it inside the block below would deadlock.
+    if ticket is None:
+        ticket = next_config_load_ticket()
+    # Compare and BOTH assignments under one lock: they are a single
+    # compare-and-set, and splitting them lets two concurrent loads both pass the
+    # comparison and race the writes. See _CONFIG_AUTOCOMPACT_LOCK.
+    with _CONFIG_AUTOCOMPACT_LOCK:
+        if ticket < _CONFIG_AUTOCOMPACT_TICKET:
+            return
+        _CONFIG_AUTOCOMPACT_TICKET = ticket
+        _CONFIG_AUTOCOMPACT_PCT = config.session.autocompact_pct
+
+
+def published_autocompact_pct() -> float:
+    """The published compaction threshold."""
+    return _CONFIG_AUTOCOMPACT_PCT
 
 
 def resolve_effective_agent(agent_name: str | None, project_dir: str | None = None) -> str:

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -109,6 +109,7 @@ from kiro_crew.config.loader import (
     build_provider_factory,
     default_project_dir,
     normalize_agent_model,
+    published_autocompact_pct,
 )
 from kiro_crew.constants import COMPACT_WAIT_TIMEOUT_SECS
 from kiro_crew.executors import maintenance_executor, subprocess_executor
@@ -1496,6 +1497,12 @@ class SessionManager:
         provider_factory: ProviderFactory | None = None,
     ):
         self._cfg = cfg
+        # Baseline for adopt-on-change (see _sync_autocompact_pct). Captured here
+        # so a caller that hands in a config with its own threshold -- a test, or
+        # any embedder constructing a manager directly -- keeps that value until
+        # a LOAD publishes a different one, rather than having it replaced by
+        # whatever the last load in this process happened to publish.
+        self._adopted_autocompact_pct = published_autocompact_pct()
         self._provider_factory = provider_factory
         self._allocation_state = SessionRegistryState(
             start_sem=asyncio.Semaphore(_MAX_CONCURRENT_COLD_STARTS)
@@ -1591,6 +1598,31 @@ class SessionManager:
     async def refresh_defaults(self) -> None:
         """Adopt changed defaults for new sessions without touching live sessions."""
         await self._lifecycle_boundary().refresh_defaults()
+
+    def _sync_autocompact_pct(self) -> None:
+        """Adopt a newly published compaction threshold, if one arrived.
+
+        The threshold is captured on ``_cfg`` when the gateway starts, so a
+        config write used to reach disk and stop there. Every successful
+        ``KiroCrewConfig.load`` now publishes it, and prompt assembly loads
+        config once per turn, so a write from ANY writer -- the dashboard PATCH
+        handler or ``kirocrew config set`` -- is in force by the next context
+        reading without a restart.
+
+        Adopt-on-CHANGE rather than unconditional assignment: a manager
+        constructed with a config that carries its own threshold must keep it, so
+        only a value that differs from the last one this manager adopted wins.
+        That also makes the sync idempotent, which matters because the gate calls
+        it on every reading.
+
+        Reads a module-level snapshot, never config.json -- this runs on the
+        event loop, where a stat/read/validate is exactly what the publish idiom
+        exists to avoid.
+        """
+        published = published_autocompact_pct()
+        if published != self._adopted_autocompact_pct:
+            self._adopted_autocompact_pct = published
+            self._cfg.session.autocompact_pct = published
 
     async def reload_provider_factory(self) -> None:
         """Rebuild the provider factory and retire sessions created by the old one."""
@@ -1984,6 +2016,10 @@ class SessionManager:
 
     def _compaction_gate_decision(self, key: str, provider: LLMProvider, pct: float) -> str | None:
         """Delegate the ordered compaction gate ladder."""
+        # Adopt a newly published threshold before the ladder reads it: the
+        # coordinator resolves it through ``owner._cfg``, so syncing here is what
+        # makes a config write from any writer bind on the next reading.
+        self._sync_autocompact_pct()
         return self._compaction._compaction_gate_decision(key, provider, pct)
 
     def _trigger_compaction(

--- a/test/test_autocompact_default.py
+++ b/test/test_autocompact_default.py
@@ -75,6 +75,86 @@ def test_the_default_is_not_the_validation_ceiling() -> None:
     )
 
 
+def _reset_published_threshold() -> None:
+    """Return the process-global threshold snapshot to its shipped default.
+
+    The snapshot and its ordering ticket are module globals, so any test that
+    publishes MUST restore them from a ``finally`` block: a failed assertion
+    would otherwise hand every later test in the process a threshold it never
+    set. Resetting the ticket counters too is what keeps the next publish from
+    being dropped as older than the one this test installed -- including tests
+    that pass synthetic ticket numbers, which a real drawn ticket would outrank
+    once enough loads had run in the same worker.
+    """
+    from kiro_crew.config import loader as _loader
+
+    _loader._CONFIG_AUTOCOMPACT_PCT = DEFAULT_AUTOCOMPACT_PCT
+    _loader._CONFIG_AUTOCOMPACT_TICKET = 0
+    _loader._CONFIG_AUTOCOMPACT_ISSUED = 0
+
+
+def test_a_threshold_change_reaches_an_already_live_manager() -> None:
+    """A published threshold moves the gate for sessions already open.
+
+    The threshold is captured on the manager's ``_cfg`` when the gateway starts,
+    so before this a config write reached disk and stopped there. Publishing on
+    every ``load()`` is what lets ANY writer -- the dashboard PATCH handler or
+    ``kirocrew config set``, which never contacts the gateway -- take effect
+    without a restart.
+    """
+    from kiro_crew.config.loader import publish_autocompact_pct
+    from kiro_crew.session import SessionManager
+
+    # Reset first so this does not depend on what an earlier test in this
+    # process published, and pass explicit tickets for the same reason: the
+    # ordering guard drops a publish holding a ticket older than the current one.
+    _reset_published_threshold()
+
+    cfg = KiroCrewConfig()
+    mgr = SessionManager(cfg, provider_factory=lambda *a, **k: object())
+    provider = object()
+
+    # 65 sits below the shipped 70, so the gate declines.
+    assert cfg.session.autocompact_pct == 70.0
+    assert mgr._compaction_gate_decision("k", provider, 65.0) == "below_threshold"
+
+    lowered = KiroCrewConfig()
+    lowered.session.autocompact_pct = 60.0
+    try:
+        publish_autocompact_pct(lowered, 1000)
+
+        # Same reading, same manager, no restart: 65 is now over the bar.
+        # Asserting "not below_threshold" keeps this pinned to the threshold and
+        # indifferent to the later gates in the ladder.
+        assert mgr._compaction_gate_decision("k", provider, 65.0) != "below_threshold"
+        assert mgr._cfg.session.autocompact_pct == 60.0
+    finally:
+        # In a finally block because the snapshot is process-global: a failed
+        # assertion above would otherwise leave every later test in this process
+        # inheriting the 60.0 threshold.
+        _reset_published_threshold()
+
+
+def test_a_caller_supplied_threshold_survives_until_a_load_publishes() -> None:
+    """A manager built with its own threshold keeps it.
+
+    Adoption is on CHANGE, not unconditional, so constructing a manager with a
+    config that carries its own value cannot be silently overwritten by whatever
+    the last load in this process happened to publish. Without this, every test
+    (and any embedder) handing in a tuned config would race the global.
+    """
+    from kiro_crew.session import SessionManager
+
+    cfg = KiroCrewConfig()
+    cfg.session.autocompact_pct = 20.0
+    mgr = SessionManager(cfg, provider_factory=lambda *a, **k: object())
+
+    # 25 is above the caller's 20 but below the published default of 70; the
+    # caller's value is the one that must decide.
+    assert mgr._compaction_gate_decision("k", object(), 25.0) != "below_threshold"
+    assert mgr._cfg.session.autocompact_pct == 20.0
+
+
 def test_a_config_file_omitting_the_key_gets_the_new_default() -> None:
     """The load() path, not the dataclass path, is what installs use.
 
@@ -181,3 +261,241 @@ def test_no_consumer_hardcodes_its_own_warn_threshold() -> None:
         # And must not compare context pct against a bare float literal.
         stray = re.findall(r"pct\s*>=\s*\d+(?:\.\d+)?", src)
         assert not stray, f"{rel} compares context pct to a literal: {stray}"
+
+
+def test_load_publishes_the_threshold_it_resolved() -> None:
+    """Every ``load()`` refreshes the snapshot the gate reads.
+
+    This is the link that makes a CLI write reach a running gateway: prompt
+    assembly loads config once per turn, so a value written by any writer is
+    published without that writer knowing the gateway exists.
+    """
+    from kiro_crew.config.loader import published_autocompact_pct
+
+    try:
+        _load_with_session({"autocompact_pct": 42.0})
+        assert published_autocompact_pct() == 42.0
+    finally:
+        _reset_published_threshold()
+
+
+def test_an_older_load_cannot_republish_over_a_newer_one() -> None:
+    """A load that finishes late must not reinstate the value it read early.
+
+    Loads run concurrently, so without an ordering ticket an old load publishing
+    last would leave live sessions compacting at a threshold the operator had
+    already changed.
+    """
+    from kiro_crew.config.loader import publish_autocompact_pct, published_autocompact_pct
+
+    # Reset first: the tickets below are synthetic, and a higher one published by
+    # an earlier test in this worker would drop every publish here.
+    _reset_published_threshold()
+
+    newer = KiroCrewConfig()
+    newer.session.autocompact_pct = 55.0
+    older = KiroCrewConfig()
+    older.session.autocompact_pct = 85.0
+    try:
+        publish_autocompact_pct(newer, 2000)
+        assert published_autocompact_pct() == 55.0
+        # Same value an in-flight load read before the newer write landed.
+        publish_autocompact_pct(older, 1000)
+        assert published_autocompact_pct() == 55.0, "an older ticket must be dropped"
+        # An equal ticket still publishes: repeating an unchanged value is harmless.
+        publish_autocompact_pct(older, 2000)
+        assert published_autocompact_pct() == 85.0
+    finally:
+        _reset_published_threshold()
+
+
+def test_deleting_the_config_restores_the_default_threshold() -> None:
+    """A load that finds no config files must not lose to an earlier publish.
+
+    Ordering exists to stop an older READ overwriting a newer one, but "no config
+    file exists" is the current truth rather than a stale read -- and it is the
+    degraded-defaults path publish is documented to let through. It needs no
+    special ticket value: the defaults load draws a fresh one like any other load
+    and wins by ordinary comparison, which is the property an ordering read off
+    the files' mtime cannot provide.
+    """
+    from kiro_crew.config.loader import (
+        next_config_load_ticket,
+        publish_autocompact_pct,
+        published_autocompact_pct,
+    )
+
+    _reset_published_threshold()
+    tuned = KiroCrewConfig()
+    tuned.session.autocompact_pct = 45.0
+    try:
+        publish_autocompact_pct(tuned, next_config_load_ticket())
+        assert published_autocompact_pct() == 45.0
+
+        # Both files deleted: the loader takes its defaults path, holding a ticket
+        # drawn after the one above.
+        publish_autocompact_pct(KiroCrewConfig(), next_config_load_ticket())
+        assert published_autocompact_pct() == DEFAULT_AUTOCOMPACT_PCT
+
+        # A file recreated afterwards orders normally against the reset.
+        recreated = KiroCrewConfig()
+        recreated.session.autocompact_pct = 50.0
+        publish_autocompact_pct(recreated, next_config_load_ticket())
+        assert published_autocompact_pct() == 50.0
+    finally:
+        _reset_published_threshold()
+
+
+def test_deleting_a_newer_overlay_does_not_reinstate_its_threshold(tmp_path, monkeypatch) -> None:
+    """Removing the newer of the two config files must still publish the survivor.
+
+    End-to-end through the real ``load()``, because this is the case an ordering
+    key read off the files cannot express: deleting the newer file LOWERS the
+    newest mtime across the set, so the load that should win looks older than the
+    one that read the file now gone, and the live gate keeps the DELETED overlay's
+    threshold. A ticket drawn per load always advances, so the survivor wins.
+
+    The first ``load()`` is load-bearing, not setup: the write-back migration
+    rewrites ``config.json`` during it, and doing that AFTER the overlay is
+    created would push the base's mtime past the overlay's and mask the very
+    rollback under test.
+    """
+    from kiro_crew.config import loader as _loader
+
+    base = tmp_path / "config.json"
+    overlay = tmp_path / "config.local.json"
+    monkeypatch.setattr(_loader, "config_path", lambda: base)
+    monkeypatch.setattr(_loader, "config_local_path", lambda: overlay)
+
+    base.write_text(json.dumps({"session": {"autocompact_pct": 70.0}}))
+
+    _reset_published_threshold()
+    try:
+        # Settle the base: this load runs the write-back migration, so afterwards
+        # the base's mtime no longer moves under us.
+        _loader._invalidate_config_cache()
+        _loader.KiroCrewConfig.load()
+        assert _loader.published_autocompact_pct() == 70.0
+
+        # Overlay created second, so it is the NEWER file of the two.
+        overlay.write_text(json.dumps({"session": {"autocompact_pct": 50.0}}))
+        _loader._invalidate_config_cache()
+        _loader.KiroCrewConfig.load()
+        assert _loader.published_autocompact_pct() == 50.0, "the overlay must apply"
+
+        # Remove it. The newest mtime across the set now goes BACKWARDS to the
+        # base's, which is what an mtime-derived ordering key mistakes for a
+        # stale read.
+        overlay.unlink()
+        _loader._invalidate_config_cache()
+        _loader.KiroCrewConfig.load()
+        assert _loader.published_autocompact_pct() == 70.0, (
+            "deleting the overlay must publish the base's threshold, not leave "
+            "the deleted file's value in force"
+        )
+    finally:
+        _loader._invalidate_config_cache()
+        _reset_published_threshold()
+
+
+def test_concurrent_publishes_never_let_an_older_ticket_win() -> None:
+    """The compare-and-set must be atomic across threads.
+
+    ``load()`` runs on worker threads as well as the loop, so a compare followed
+    by a separate assignment lets two loads both pass the comparison and race the
+    writes -- leaving the older read installed and the ticket rolled backwards.
+    Interleaving is forced here rather than hoped for: a patched comparison blocks
+    the low-ticket writer between its check and its write while the high-ticket
+    writer completes.
+    """
+    import threading
+
+    from kiro_crew.config import loader as _loader
+    from kiro_crew.config.loader import publish_autocompact_pct, published_autocompact_pct
+
+    _reset_published_threshold()
+    older = KiroCrewConfig()
+    older.session.autocompact_pct = 30.0
+    newer = KiroCrewConfig()
+    newer.session.autocompact_pct = 80.0
+
+    entered = threading.Event()
+    release = threading.Event()
+    real_lock = _loader._CONFIG_AUTOCOMPACT_LOCK
+
+    class _StallOnce:
+        """Lock stand-in that parks the FIRST holder inside the critical section."""
+
+        def __init__(self) -> None:
+            self._first = True
+
+        def __enter__(self):
+            real_lock.acquire()
+            if self._first:
+                self._first = False
+                entered.set()
+                release.wait(timeout=5)
+            return self
+
+        def __exit__(self, *exc) -> None:
+            real_lock.release()
+
+    try:
+        _loader._CONFIG_AUTOCOMPACT_LOCK = _StallOnce()
+        low = threading.Thread(target=publish_autocompact_pct, args=(older, 1000))
+        low.start()
+        assert entered.wait(timeout=5), "the first publisher never entered"
+
+        # The high-ticket publisher cannot interleave: it blocks on the same lock.
+        high = threading.Thread(target=publish_autocompact_pct, args=(newer, 9000))
+        high.start()
+        release.set()
+        low.join(timeout=5)
+        high.join(timeout=5)
+
+        assert published_autocompact_pct() == 80.0, "the newer ticket must win"
+        assert _loader._CONFIG_AUTOCOMPACT_TICKET == 9000
+    finally:
+        _loader._CONFIG_AUTOCOMPACT_LOCK = real_lock
+        _reset_published_threshold()
+
+
+def test_load_publishes_without_a_second_stat_pass(tmp_path, monkeypatch) -> None:
+    """Publishing the threshold must add no filesystem I/O to ``load()``.
+
+    ``load()`` is reached from the event loop, so a stat pass taken just to
+    order the publish would be blocking I/O for information the cache lookup
+    already fetched. One fingerprint pass per load is the contract: it serves
+    the cache lookup and the pre-read TOCTOU capture.
+    """
+    from kiro_crew.config import loader as _loader
+
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"session": {"autocompact_pct": 41.0}}))
+    monkeypatch.setattr(_loader, "config_path", lambda: cfg_file)
+    monkeypatch.setattr(_loader, "config_local_path", lambda: tmp_path / "config.local.json")
+
+    passes = {"n": 0}
+    real_fingerprint = _loader._config_fingerprint
+
+    def counting_fingerprint():
+        passes["n"] += 1
+        return real_fingerprint()
+
+    monkeypatch.setattr(_loader, "_config_fingerprint", counting_fingerprint)
+
+    _reset_published_threshold()
+    try:
+        _loader._invalidate_config_cache()
+
+        passes["n"] = 0
+        _loader.KiroCrewConfig.load()
+        assert passes["n"] == 1, f"cache-miss load took {passes['n']} stat passes, want 1"
+        assert _loader.published_autocompact_pct() == 41.0
+
+        passes["n"] = 0
+        _loader.KiroCrewConfig.load()
+        assert passes["n"] == 1, f"cache-hit load took {passes['n']} stat passes, want 1"
+    finally:
+        _loader._invalidate_config_cache()
+        _reset_published_threshold()


### PR DESCRIPTION
## Problem / Motivation

Changing **Autocompact %** in Settings does nothing until the gateway restarts, and nothing says so.

`website/src/pages/settings/ChatPanel.tsx` renders the control and `PATCH`es `session.autocompact_pct`, which validates and writes `config.json`. But the threshold is consumed off `SessionManager._cfg`, captured when the gateway starts, so the running process keeps its old value. The write reports success, the number in the UI updates, and compaction keeps firing at the previous threshold.

Two properties make it silent rather than merely limited:

- Refreshing or forking a session does not help. `_cfg` is per **manager** (one per gateway), not per session, so a brand-new tab inherits the stale value.
- `kirocrew config set session.autocompact_pct` is worse: `cli_config.py` calls `update_config_locked()` and never contacts the gateway at all.

## Why it matters

#4388 lowered the default from 90.0 to 70.0 because credits scale with context and steepen near the ceiling (measured there over 808 turns). An install that materialized before it keeps 90.0 — exactly the case `SUPERSEDED_DEFAULTS` was added to report (issue #4389).

So the operators most likely to change this setting are the ones already paying the most for context, and both routes they would reach for appear to work and do not.

## What changed (motivation → approach → change)

Symptom above → root cause is that the value is captured once at startup while the gate re-reads it every turn → publish it on load so any writer reaches a running gateway.

`KiroCrewConfig.load()` already publishes two values for exactly this reason: `publish_config_path_dirs` and `publish_agent_alias_snapshot`, both because their read paths run on the event loop and must not stat/read/validate `config.json`. The compaction gate is the same shape — it runs after every turn — so the threshold gets the same treatment:

- `publish_autocompact_pct()` / `published_autocompact_pct()` in `config/loader.py`, called from `load()` on every return path including degraded-defaults.
- `SessionManager._sync_autocompact_pct()` adopts a published value **only when it changes**, called at the top of `_compaction_gate_decision`.

Prompt assembly loads config once per turn, so a write from either writer is in force by the next context reading. No endpoint, no auth change, no watcher, no polling.

Two alternatives were tried and rejected:

- **`refresh_defaults()`**, which already re-reads config and swaps `_cfg`: its contract is "adopt config changes that only affect NEW sessions" and it deliberately leaves live sessions alone. A threshold is not a default — it governs every later reading on sessions that already exist — and it pays a provider-factory rebuild and warm-pool drain this does not need.
- **Having the CLI notify the gateway over HTTP.** It targets `/api/config/kirocrew`, which is in no internal allowlist, so the call 403s. `test_mcp_call_site_auth_coverage.py` caught this. Making it work would mean granting every internal-secret caller arbitrary config writes, which is a far larger change than the defect warrants.

Adopt-on-**change** rather than unconditional assignment is what keeps a caller-supplied threshold intact: `test_session.py` has eleven-plus tests that set `cfg.session.autocompact_pct` on the config they pass in, and that per-manager scoping is correct rather than incidental.

## Tests

- `test_a_threshold_change_reaches_an_already_live_manager` — the behavioural one: on a single manager, 65% reads `below_threshold`, then after a publish of 60.0 the same reading no longer does. Asserting "not `below_threshold`" keeps it pinned to the threshold and indifferent to the later gates in the ladder.
- `test_a_caller_supplied_threshold_survives_until_a_load_publishes` — a manager built with 20.0 keeps it against a published default of 70.0, pinning the adopt-on-change rule.
- `test_load_publishes_the_threshold_it_resolved` — `load()` publishes what it resolved, which is the link that makes a CLI write reach a running gateway.

## Manual verification

N/A — unit coverage is sufficient. The behaviour under change is a numeric comparison in `_compaction_gate_decision`, and the tests exercise it on a real `SessionManager` rather than a mock.

Full backend suite on an earlier revision of this branch: **74,617 passed, 52 failed**, all 52 in `apps/builtins/auto_improvement/tests/test_pr_watchers.py` and `apps/builtins/code_review_sage/tests/test_review_driver.py`. Pre-existing and flaky, not attributable here: they fail on an unmodified `upstream/main` checkout, and three consecutive runs of one file with identical code gave 3, 3, then 4 failures.

Gate scripts run locally, all green: `scrub-lint`, `verify_vendor_manifest`, `check_brand_name`, `check_focus_cue`, `check_changelog_history`, `check_harness_parity`, `check_loop_bound_locks`, `check_testpaths_coverage`, `docs-lint`, `check_black_formatting`, plus `isort`, `flake8`, and `mypy` over the whole package. `check_subprocess_encoding` fails identically on a pristine `upstream/main` checkout, flagging two files this diff does not touch.

## Related Issues

no linked issue: this is a follow-through defect found by reading the code, not a filed report. Context is #4388 (which lowered the default) and #4389 (the drift it left behind) — neither should close on this merge, since this PR fixes the live-apply path they left untouched rather than the drift itself.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented API or schema changed
- [x] No secrets, credentials, or internal references in the diff
