### PR TITLE
test(acp): avoid comparing live RSS samples

### DIFF
--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -1447,16 +1447,20 @@ def test_get_rss_mb_real_process():
 
 
 def test_get_rss_tree_mb_real_process():
-    """_get_rss_tree_mb sums at least this process's RSS (>0); nonexistent
-    PID returns None. Skips where RSS introspection is unavailable (see
-    test_get_rss_mb_real_process)."""
-    from kiro_crew.acp.runtime import _get_rss_mb, _get_rss_tree_mb
+    """The real tree probe returns a positive sample for this process and None
+    for a nonexistent PID.
 
-    self_rss = _get_rss_mb(os.getpid())
-    if self_rss is None:
-        pytest.skip("RSS introspection unavailable in this environment")
+    Do not compare this sample with a separate single-process RSS read: resident
+    sets are live values and Windows may trim the working set between the two
+    calls.  The deterministic root-plus-descendants arithmetic is covered with
+    fixed values in ``test_platform_compat_coverage.py``.
+    """
+    from kiro_crew.acp.runtime import _get_rss_tree_mb
+
     tree = _get_rss_tree_mb(os.getpid())
-    assert tree is not None and tree >= self_rss  # tree includes self (+ children)
+    if tree is None:
+        pytest.skip("RSS introspection unavailable in this environment")
+    assert tree > 0.0
     assert _get_rss_tree_mb(2**31 - 1) is None
 
 

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -779,12 +779,11 @@ class TestResourceShims:
         if not pc.IS_WINDOWS:
             assert result is None
             return
-        # On Windows self (no children spawned by this test) reads a positive
-        # tree total that is at least the single-process RSS.
+        # This is a real-boundary smoke test only. Comparing it with a second RSS
+        # sample is scheduler-dependent: Windows may trim this process's working
+        # set between the tree and single-process reads. Fixed-value tests in
+        # TestProcRssTree pin the root-plus-descendants sum deterministically.
         assert result is not None and result > 0
-        single = pc.proc_rss_bytes_for_pid(os.getpid())
-        assert single is not None
-        assert result >= single / (1024 * 1024) - 1  # -1: sampled microseconds apart
 
     def test_proc_rss_tree_mb_for_pid_rejects_reserved_pid(self):
         # A reserved/non-int pid must not anchor a tree walk (recycled-root risk).


### PR DESCRIPTION
## Problem / Motivation

Two real-process RSS smoke tests compared measurements taken at different instants and assumed the later value could not be lower. A Windows CI shard observed the opposite while running an unrelated TLS PR:

`tree=1156.46484375 MiB`, `self=1157.0078125 MiB`

That is valid operating-system behavior. Resident set size is a live working-set sample, and Windows may trim it between calls. The one-MiB tolerance in the lower-level smoke test only made the same race less frequent.

## Why it matters

The assertion fails according to allocator, scheduler, and working-set timing rather than a product regression. It can therefore make an unrelated PR red after more than twelve minutes and misattribute the failure to whichever change happened to own that shard.

Rerunning, sleeping, or widening the tolerance would preserve the race.

## What changed

- Keep each real-process check as a boundary smoke test: the tree probe must return a positive value for the current process (or the documented unavailable result on an unsupported host).
- Remove comparisons against a second live RSS sample.
- Keep the nonexistent/reserved PID contracts.
- Point the comments at the deterministic fixed-value coverage in `TestProcRssTree`, which already proves that the root and validated descendants are summed exactly and that all handles are closed.

Production code is unchanged.

## Tests

- Windows real-process RSS tree probes: 2 passed serially.
- The fixed-value tree-sum regression remains in the POSIX-hosted platform simulation used by coverage CI.
- Black, isort, Flake8, and diff-whitespace checks passed.
- The old cross-sample assertion was observed failing in CI with the values above; the new tests take only one live sample, so working-set trimming cannot affect their predicate.

No retry, repeat-until-green loop, sleep, duration threshold, timeout increase, warning filter, or tolerance was added.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** This changes only Python process-metric tests and has no rendered UI effect.
