### PR TITLE
test(async): preserve awaitable ownership in test doubles

### DIFF
--- a/test/test_acp_session_provider_shutdown.py
+++ b/test/test_acp_session_provider_shutdown.py
@@ -33,6 +33,8 @@ production would deliver it. Event-driven; no sleeps.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -103,9 +105,16 @@ async def test_a_cancel_that_merely_times_out_still_destroys(tmp_path, monkeypat
     handle.cancel = _slow_cancel
     provider = AcpSessionProvider(handle, runtime, owns_runtime=False)
     monkeypatch.setattr("kiro_crew.acp.session_handle.kiro_sessions_dir", lambda: sessions)
+
+    async def _timeout(awaitable: Coroutine[Any, Any, None], *, timeout: float) -> None:
+        """Model ``wait_for`` taking ownership before its timeout fires."""
+        assert timeout == 5.0
+        awaitable.close()
+        raise asyncio.TimeoutError
+
     monkeypatch.setattr(
         "kiro_crew.acp.session_provider.asyncio.wait_for",
-        AsyncMock(side_effect=asyncio.TimeoutError()),
+        _timeout,
     )
 
     await provider.shutdown()

--- a/test/test_api_models_retry.py
+++ b/test/test_api_models_retry.py
@@ -316,8 +316,6 @@ def test_structured_context_window_seeds_central_authority(tmp_path):
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(
         agents.asyncio, "create_subprocess_exec", return_value=_FakeProc(payload)
-    ), patch.object(
-        agents.asyncio, "wait_for", return_value=(payload, b"")
     ):
         resp = _run(agents.api_models(_kiro_request(tmp_path)))
     assert resp.status == 200
@@ -361,8 +359,6 @@ def test_list_models_spawns_at_the_configured_sandbox_tier(tmp_path):
         "kiro_crew.sandbox.resource_limit_preexec", lambda: None
     ), patch.object(
         agents.asyncio, "create_subprocess_exec", return_value=_FakeProc(payload)
-    ), patch.object(
-        agents.asyncio, "wait_for", return_value=(payload, b"")
     ):
         resp = _run(agents.api_models(_kiro_request(tmp_path)))
 

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -893,8 +893,13 @@ class TestSandboxCleanupPathIsDropped:
         close(). finish() may leave the process draining, so the unlink belongs
         to close() alone — a refactor moving it into finish() fails here."""
         sandbox_patch, created = _cleanup_file_sandbox(tmp_path)
-        proc = AsyncMock()
+        # Process methods are mixed sync/async.  Making the whole process an
+        # AsyncMock turns stdin.is_closing() into an unawaited coroutine even
+        # though the real subprocess API is synchronous at that seam.
+        proc = Mock()
         proc.stdout.readline = AsyncMock(side_effect=[b'{"type": "ready"}\n', b""])
+        proc.stdin.is_closing.return_value = False
+        proc.wait = AsyncMock()
         proc.kill = Mock()
         proc.returncode = None
         session = apple_speech.StreamingSession()
@@ -906,6 +911,7 @@ class TestSandboxCleanupPathIsDropped:
         ):
             assert await session.start() == ""
             await session.finish()
+            proc.stdin.close.assert_called_once_with()
             assert created and all(f.exists() for f in created), "finish() must not unlink"
             await session.close()
             assert not any(f.exists() for f in created)

--- a/test/test_auto_approve.py
+++ b/test/test_auto_approve.py
@@ -114,6 +114,12 @@ class TestAutoApproveDefault:
 # ══════════════════════════════════════════════════════════════════════
 
 
+def _discard_scheduled_coroutine(coro):
+    """Model create_task ownership without running execute_plan's worker."""
+    coro.close()
+    return MagicMock()
+
+
 class TestSettersSetAutoApprove:
     @pytest.mark.asyncio
     async def test_execute_plan_sets_auto_approve(self, tmp_path: Path) -> None:
@@ -122,7 +128,10 @@ class TestSettersSetAutoApprove:
         run.tasks = [Step(index=1, title="A", description="d")]
         runner._runs = {"t1": run}
         # Prevent the background _execute task from actually running.
-        with patch("kiro_crew.taskrunner.asyncio.create_task", return_value=MagicMock()):
+        with patch(
+            "kiro_crew.taskrunner.asyncio.create_task",
+            side_effect=_discard_scheduled_coroutine,
+        ):
             await runner.execute_plan("t1", auto_approve=True)
         assert run.auto_approve is True
         assert safety_override().is_scope_active(_auto_approve_scope("t1")) is True
@@ -133,7 +142,10 @@ class TestSettersSetAutoApprove:
         run = TaskRun(spec_path="s.md", spec_content="s", status="planned", task_id="t1")
         run.tasks = [Step(index=1, title="A", description="d")]
         runner._runs = {"t1": run}
-        with patch("kiro_crew.taskrunner.asyncio.create_task", return_value=MagicMock()):
+        with patch(
+            "kiro_crew.taskrunner.asyncio.create_task",
+            side_effect=_discard_scheduled_coroutine,
+        ):
             await runner.execute_plan("t1")
         assert run.auto_approve is False
         assert safety_override().is_scope_active(_auto_approve_scope("t1")) is False

--- a/test/test_autonudge_approval_stall.py
+++ b/test/test_autonudge_approval_stall.py
@@ -100,6 +100,17 @@ async def _armed(svc, **kwargs) -> NudgeLoop:
     return loop
 
 
+async def _stop_and_drain(svc: AutoNudgeService) -> None:
+    """Stop work this test started before pytest closes its event loop."""
+    timers = list(svc._timers.values())
+    svc.stop()
+    if timers:
+        await asyncio.gather(*timers, return_exceptions=True)
+    inflight = list(svc._inflight_adds)
+    if inflight:
+        await asyncio.gather(*inflight, return_exceptions=True)
+
+
 @pytest.mark.asyncio
 async def test_starting_publishes_the_service_and_stopping_unpublishes_it(store_dir):
     """The contract the teardown above depends on.
@@ -305,10 +316,12 @@ async def test_stall_evidence_persists_across_restart(store_dir, _nosleep):
 
     svc2 = AutoNudgeService(base_dir=store_dir)
     await svc2.start()
-
-    restored = svc2.get_by_slot("chat-1-123")
-    assert restored is not None
-    assert restored.approval_stalled is True
+    try:
+        restored = svc2.get_by_slot("chat-1-123")
+        assert restored is not None
+        assert restored.approval_stalled is True
+    finally:
+        await _stop_and_drain(svc2)
 
 
 @pytest.mark.asyncio

--- a/test/test_channel_activation.py
+++ b/test/test_channel_activation.py
@@ -365,8 +365,8 @@ class TestRouteMessageStop:
     async def test_stop_cancels_active_task_and_cleans_up(self):
         """!stop in _route_message cancels the asyncio task and cleans _session_tasks."""
         orch = _make_orch()
-        orch.sessions = AsyncMock()
-        orch.sessions.has_session.return_value = True
+        orch.sessions = MagicMock()
+        orch.sessions.has_session = MagicMock(return_value=True)
         orch.sessions.stop_turn = AsyncMock(return_value="soft")
         orch.sessions.enqueue = MagicMock(return_value=False)
         orch.sessions.dequeue = MagicMock(return_value=None)
@@ -410,8 +410,8 @@ class TestRouteMessageStop:
     async def test_stop_bypasses_semaphore(self):
         """!stop is handled before handle_message — never enters the semaphore path."""
         orch = _make_orch()
-        orch.sessions = AsyncMock()
-        orch.sessions.has_session.return_value = True
+        orch.sessions = MagicMock()
+        orch.sessions.has_session = MagicMock(return_value=True)
         orch.sessions.stop_turn = AsyncMock(return_value="soft")
         orch.sessions.enqueue = MagicMock(return_value=False)
         orch.sessions.dequeue = MagicMock(return_value=None)


### PR DESCRIPTION
## Problem / Motivation

The Windows backend log exposed several tests whose doubles did not preserve
ownership of coroutine arguments or the real sync/async method boundary. Their
assertions usually passed; a later garbage collection then emitted `was never
awaited`, so the warning was attributed to whichever unrelated test happened to
collect next.

Reproduced ownership defects:

- ACP shutdown: a fake `wait_for` raised before taking the `_slow_cancel`
  coroutine.
- API model listing: two fake `wait_for` returns bypassed two deterministic
  `_FakeProc.communicate()` coroutines.
- Apple Speech: an entire fake subprocess was an `AsyncMock`, turning the
  synchronous `stdin.is_closing()` API into a coroutine used as a boolean.
- TaskRunner: two fake `create_task` calls returned a mock without taking the
  nested `_execute` coroutine.
- Slack `!stop`: two session containers were `AsyncMock`, turning the synchronous
  `has_session()` accessor into an unawaited coroutine.
- AutoNudge restart: the test stopped a first service, restarted a second one,
  then left the new timer and shielded persistence task alive when its event loop
  closed. That surfaced `_update_locked` plus two destroyed pending tasks.

## Why it matters

These are deterministic ownership bugs in tests, but garbage collection timing
made their warnings appear under unrelated cases and shards. That makes CI look
flaky, obscures the test that actually leaked the coroutine, and can hide a new
resource leak among pre-existing warning noise.

## What changed (motivation → approach → change)

Each double now models the relevant real ownership contract:

- accept and close a deliberately unscheduled coroutine before simulating a
  timeout or discarded background task;
- let deterministic fake subprocess communication actually be awaited;
- use a synchronous process/session mock and reserve `AsyncMock` for genuinely
  awaited methods;
- asynchronously stop and drain the restarted AutoNudge service's owned timer
  and in-flight persistence work before test teardown.

Production behavior is unchanged. There is no retry, sleep, warning filter, or
timeout relaxation.

Open-PR overlap audit:

- No open PR touches the ACP shutdown, Slack activation, or AutoNudge
  approval-stall test files.
- #6702 touches the API model test file only in the distinct API-key fixture.
- #6746 and #5907 touch other Apple Speech sections; this change also avoids
  #5907's import line.
- #2129 touches a later auto-approve API fixture, not the scheduler tests here.

No contributor change from those PRs is replaced.

## Tests

- Every defect was first reproduced from `main` with RuntimeWarning and
  PytestUnraisableExceptionWarning promoted to errors.
- After rebasing onto `645eb77`, all six changed test files pass in strict mode:
  132 passed, 5 platform skips.
- Focused strict runs also pass: API models 14/14, ACP shutdown 3/3, TaskRunner
  auto-approve 26/26, Slack stop 2/2, Apple streaming teardown 2/2, and AutoNudge
  approval-stall 11/11.
- Repository Black baseline gate, isort, flake8, and `git diff --check` pass.

## Manual verification

N/A — these changes only correct test-double lifecycle contracts; the strict
automated runs exercise the affected teardown paths directly.

## Related Issues

N/A — found while tracing coroutine warnings from backend CI shards.

## Checklist

- [x] At most two commits (exactly one), with a Conventional Commits title
- [x] Existing affected tests pass; lifecycle regressions are covered
- [x] Self-review completed; repository style gates pass
- [x] Documentation updated (not applicable: test-only change)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the repository template does not yet supply CLA wording.
