### PR TITLE
chore(channels): remove confirmed dead code in the messaging channels

### DIFF
--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -1301,9 +1301,3 @@ class DiscordRenderer(Renderer):
         ladder, self._ladder = self._ladder, None
         if ladder is not None:
             await ladder.close()
-
-    # -- helpers ------------------------------------------------------------
-    def _options(self) -> list[str]:
-        raw = "".join(self._buf).strip()
-        _, opts = _extract_options(raw)
-        return opts

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -120,18 +120,6 @@ async def _replay_preview(text: str, limit: int, *, reserve: int) -> str:
     return first + _REPLAY_TRUNCATED
 
 
-def _history_dashboard_key(raw_key: object) -> str | None:
-    """Restore the canonical dashboard session key from a JSONL file stem."""
-    key = str(raw_key or "")
-    if key.startswith("dashboard:"):
-        return key
-    if key.startswith("dashboard_"):
-        while key.startswith("dashboard_"):
-            key = key[len("dashboard_") :]
-        return f"dashboard:{key}" if key else None
-    return None
-
-
 def _picker_components(nonce: str, choices: tuple[SessionChoice, ...]) -> list[dict]:
     rows: list[dict] = []
     buttons: list[dict] = []

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -878,12 +878,6 @@ class DiscordDispatcher:
             session_key, self._receipt_surface(channel_id), answered, deferred
         )
 
-    async def _receipt_finish_cancelled_locked(self, session_key: str, channel_id: str) -> None:
-        """Finalize the receipt to a "🛑 Cancelled" record, if present. Caller
-        MUST hold ``self._queue.lock``."""
-        assert self.client is not None
-        await self._queue.finish_cancelled_locked(session_key, self._receipt_surface(channel_id))
-
     def _receipt_surface(self, channel_id: str) -> ReceiptSurface:
         """A receipt surface with this channel's address already bound."""
         # cast, not assert: mypy does not carry an assert-narrowed local

--- a/src/kiro_crew/slack/blocks.py
+++ b/src/kiro_crew/slack/blocks.py
@@ -91,65 +91,6 @@ def session_task_card(
     return blocks
 
 
-def config_panel(settings: dict) -> list[dict]:
-    """Toggle and select blocks for each setting in the dict.
-
-    Supported value types: bool → toggle, list → static_select, str → plain display.
-    """
-    blocks: list[dict] = []
-    for key, val in settings.items():
-        if isinstance(val, bool):
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"*{key}*"},
-                    "accessory": {
-                        "type": "checkboxes",
-                        "action_id": f"mc_config_{key}",
-                        "options": [
-                            {
-                                "text": {"type": "plain_text", "text": "Enabled"},
-                                "value": key,
-                            }
-                        ],
-                        "initial_options": (
-                            [
-                                {
-                                    "text": {"type": "plain_text", "text": "Enabled"},
-                                    "value": key,
-                                }
-                            ]
-                            if val
-                            else []
-                        ),
-                    },
-                }
-            )
-        elif isinstance(val, list):
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"*{key}*"},
-                    "accessory": {
-                        "type": "static_select",
-                        "action_id": f"mc_config_{key}",
-                        "options": [
-                            {"text": {"type": "plain_text", "text": str(v)}, "value": str(v)}
-                            for v in val
-                        ],
-                    },
-                }
-            )
-        else:
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"*{key}:* {val}"},
-                }
-            )
-    return blocks
-
-
 def confirmation_dialog(title: str, text: str, confirm_text: str, deny_text: str, action_prefix: str = "mc_stop") -> list[dict]:
     """Section with confirm/deny action buttons."""
     return [
@@ -198,45 +139,6 @@ def dashboard_link_block(url: str, link_mins: int, session_mins: int) -> list[di
             },
         },
     ]
-
-
-def agent_buttons(agents: list[str], current: str) -> list[dict]:
-    """Buttons for each available agent, current one marked with ✅."""
-    buttons = []
-    for name in agents:
-        label = f"✅ {name}" if name == current else name
-        btn: dict = {
-            "type": "button",
-            "text": {"type": "plain_text", "text": label[:75]},
-            "action_id": f"mc_agent_select_{name}",
-            "value": name,
-        }
-        if name == current:
-            btn["style"] = "primary"
-        buttons.append(btn)
-    # "Off" button to reset to default
-    off_label = "✅ off" if not current else "off"
-    buttons.append(
-        {
-            "type": "button",
-            "text": {"type": "plain_text", "text": off_label},
-            "action_id": "mc_agent_select_off",
-            "value": "off",
-        }
-    )
-    blocks: list[dict] = [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"*Current agent:* {current or 'default (kirocrew)'}",
-            },
-        },
-    ]
-    # Slack limits 5 buttons per actions block
-    for i in range(0, len(buttons), 5):
-        blocks.append({"type": "actions", "elements": buttons[i : i + 5]})
-    return blocks
 
 
 def deprecation_warning_block(old_cmd: str, new_cmd: str) -> dict:


### PR DESCRIPTION
## What

Removes five symbols from the messaging-channels group that have **zero references anywhere in the repository**. 122 deleted lines, 0 added, no behaviour change.

Scope was `src/kiro_crew/{slack,discord,telegram,teams,webex,wecom,weixin,whatsapp,imessage,feishu,messaging}/` plus `channel.py`, `channels.py`, `channel_history.py`, `channel_transcript_migration.py`. Nothing outside that group is touched.

## How the candidates were found

Three independent passes, because one scanner is not enough here:

| pass | method | result |
|---|---|---|
| 1 | `vulture --min-confidence 60` | 120 function/class/method findings |
| 2 | AST: defined names − (Name-Load ∪ Attribute-attr ∪ str-const ∪ import ∪ kwarg) repo-wide | 1714 defs scanned → 23 zero-ref |
| 3 | `tokenize` real NAME tokens repo-wide, def sites subtracted (docstrings/comments cannot register as references) | 21 zero-ref |

Intersection: 18. Each survivor then went through a five-step confirmation: repo-wide word-boundary sweep across `.py .ts .tsx .js .md .json .yml .yaml .toml .sh .ps1` including `test/`, `docs/`, `system-specs/`, `builtin_skills/`, `error-code-baseline.json`, `config-baseline.json`, `.github/` and `website/src`; dynamic-reference sweep (`getattr` / `setattr` / `globals()` / `importlib` / `__all__` / string-form names); **action-id routing-table check** against `slack/interactions.py`; public-surface check; and a 30-day introduction gate.

The cross-channel copy-paste risk was real and it caught things. Vulture's largest block — `fetch_history` / `configured_targets` / `may_send_to` across nine `transport.py` files — is **Protocol implementation** dispatched through `messaging.transport.MessageTransport`, not duplicated dead code. Rejected wholesale. The six WhatsApp `_on_qr` / `_on_pair` / `_on_connected` / `_on_disconnected` / `_on_logged_out` / `_on_ban` functions are `@client.event(QREv)`-registered whatsmeow handlers — the exact event-dispatch trap. Also rejected.

## Deleted

| symbol | location | why it is dead, specifically |
|---|---|---|
| `config_panel` | `slack/blocks.py:94` | **Unroutable.** Emits inline `action_id=mc_config_{key}` toggles. The router has no `== "mc_config_*"` branch and no `startswith("mc_config")` branch. The live config path is the modal view handler `register_view_handler("mc_config_panel", ...)` reading `values["channels_block"]["mc_config_channels"]` (`interactions.py:220,262`) — a different mechanism entirely. First-add 2026-07-16. |
| `agent_buttons` | `slack/blocks.py:203` | **Unroutable.** Emits `mc_agent_select_{name}` / `mc_agent_select_off`, but the router matches `action_id == "mc_agent_select"` by *exact equality* (`interactions.py:859`) and the live producer is the static_select at `events.py:334`. Superseded pre-select-menu implementation. First-add 2026-07-16. |
| `_receipt_finish_cancelled_locked` | `discord/transport_dispatch.py:881` | Orphaned member of a live family. The sibling `_receipt_flip_locked` **is** called (`transport_dispatch.py:808`), and teams/webex call `self._queue.finish_cancelled_locked(...)` directly instead of wrapping it. No dispatch pairing. First-add 2026-07-21. |
| `_history_dashboard_key` | `discord/session_resume.py:123` | Superseded by the shared `messaging/session_resume.py::history_dashboard_key`, which **is** used (`session_resume.py:236`) and tested (`test/test_teams_sessions.py:858-862`). Private copy left behind when the helper was hoisted to `messaging/`. First-add 2026-07-30. |
| `_options` | `discord/renderer.py:1306` | Orphaned by #5716 "give the `[OPTIONS:]` trailer parse one owner". The 6 grep hits for the name are unrelated `_options` *parameters* in `website/vite.config.ts`, `website/electron/test/windows-port.test.js` and `test/test_platform_compat_coverage.py`. `_extract_options` itself stays — still used at `renderer.py:675,831,833`. First-add 2026-07-21. |

**No test companions were deleted** — all five have zero references under `test/` as well, so nothing had to be rewritten.

## Deliberately NOT deleted

Six symbols the scanners flagged and I am holding. Four of them are not cleanup questions at all — they are unwired features whose *deadness is itself the defect*, and the right fix is wiring, not deletion.

| symbol | location | why held |
|---|---|---|
| `prompt_allowlist` | `slack/allowlist.py:95` | **Unwired access control.** Zero Python callers, yet `docs/system-specs/modules/slack-gateway.md:12,28,231` documents it as live behaviour: "When a user joins a monitored channel, `prompt_allowlist()` sends Allow/Deny to the owner". Its sibling `prompt_track_channel` **is** wired (`events.py:62,1429`). This is an authorization gate that never fires. Needs a maintainer decision. |
| `confirmation_dialog` | `slack/blocks.py:153` | Sole producer of `mc_stop_confirm` / `mc_stop_cancel`, both of which have **live handlers** (`interactions.py:724,727`). Zero callers ⇒ that confirm flow is currently unreachable. Deleting the builder is behaviour-neutral today but removes the only path to a shipped handler. Wire-or-remove is a product call. |
| `build_subagent_ack_block` | `slack/format.py:315` | Byte-identical to `build_cron_ack_block`, which **is** called (`gateway.py:4633`), with the prefix swapped. Sole producer of `SUBAGENT_ACK_ACTION_PREFIX`, whose handler `_handle_subagent_ack` is live (`interactions.py:687,2077`) but therefore unreachable — subagent notifications lost their Acknowledge button. Same wire-or-remove call. |
| `send_message_draft` | `telegram/client.py:876` | Complete, working Bot API 9.3+ ephemeral-draft streaming with no production caller. Its only reference is the protocol-conformance stub in `test/test_telegram.py:125`, so removal is a refactor (rewrite the test double), not a deletion — and dropping a shipped streaming feature is a product decision. |
| `MessageContext` | `slack/handler.py:1351` | Design-uncalled facade: `handler.py:2607` actively advertises it ("New callers can use `MessageContext` to group the service parameters"). Deleting it would also mean editing a docstring in `slack/handler.py`, a hot conflict file. |
| `CallableReactionSink` | `messaging/status_reactions.py:186` | Named in `docs/system-specs/modules/messaging.md:397`, and first-add 2026-08-23 — inside the 30-day new-code gate. |

Also held under the 30-day gate: `_display` (`discord/session_resume.py:226`, first-add 2026-08-18), and `ResumeSurface` / `post_picker` / `settle_picker` (`messaging/session_resume.py`, first-add 2026-08-23) which are a `Protocol` declaration and its method stubs, implemented structurally per channel.

## Verification

- Channel-scoped suite: **3968 passed, 2 skipped, 0 failed** (`pytest -k "discord or slack or blocks or receipt or session_resume"`).
- Targeted: `test_discord*.py`, `test_queue_receipt.py`, `test_slack_interactions_coverage.py`, `test_slack_events_coverage.py`, `test_action_interactions.py`, `test_slack_renderer.py`, `test_telegram.py`, `test_slash_task_tracking.py`, `test_teams_sessions.py`, `test_security_posture.py` — all green.
- `flake8` 0 · `isort --check-only` 0 · `mypy src/kiro_crew/` clean across 1167 files · black gate 0 (baseline-aware; the pre-existing unformatted spans in `slack/blocks.py` are untouched, and this diff removes one of them).
- Deterministic gates: subprocess-encoding, lockdown-before-publish, loop-bound-locks, testpaths-coverage, brand, changelog-history, focus-cue, harness-parity — all pass.
- AST post-check confirms each deleted symbol is gone and every surviving neighbour (`confirmation_dialog`, `deprecation_warning_block`, `voice_config_modal`, `session_task_card`, `command_hint_block`, `dashboard_link_block`, `_receipt_flip_locked`, `_receipt_surface`, `_picker_components`) is intact.
- File-overlap gate: 265 open PRs scanned. Six touch `discord/transport_dispatch.py` (#6600, #6595, #6504, #6307, #5184, #5182), all additive and none within the deleted hunk — verified by diffing #5184 (the largest, +188/-97) against the receipt-wrapper region.

---

No linked issue: this is a self-directed cleanup pass over one file group; the `#NNNN` references above are provenance citations for when a symbol was orphaned, not issues this PR closes.
