### PR TITLE
fix(dashboard): show folders created outside this tab without a reload

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -155,6 +155,7 @@ def _slots_ws_frame(
     channel_trusted: bool,
     gitlab_hosts_gen: object,
     folders: object,
+    folders_gen: object,
 ) -> str:
     """Serialize the dashboard-user ``slots`` WS frame.
 
@@ -185,6 +186,7 @@ def _slots_ws_frame(
             "channelTrusted": channel_trusted,
             "gitlabHostsGeneration": gitlab_hosts_gen,
             "folders": folders,
+            "foldersGeneration": folders_gen,
         }
     )
 
@@ -5143,6 +5145,10 @@ class DashboardState:
         # construction, so building it off-loop is safe — and it stays valid
         # across the loop changes this long-lived state survives (#4800).
         self._folders_lock = LoopBoundLock()
+        # Identifies the current folder-TREE snapshot; bumped by mutate_folders
+        # (the store's only writer) on each confirmed write. See
+        # folders_generation() for what the client does with it.
+        self._folders_generation = 0
         # Tag vocabulary: list of {id, name, color, order}. User-managed.
         self._tags: list[dict[str, Any]] = []
         # Malformed tags.json entries dropped at load time, kept verbatim so a
@@ -7704,6 +7710,26 @@ class DashboardState:
                 raise
             return removed
 
+    def folders_generation(self) -> int:
+        """Monotonic counter identifying the current folder-tree snapshot.
+
+        Rides the ``slots`` WS frame so an already-open tab can tell that the
+        folder store actually CHANGED and invalidate its cached
+        ``['chat-folders']`` query. Without it a folder created by anything other
+        than this tab's own mutation — an agent, a second tab, another device —
+        stayed invisible until a reload: the query carries the app-wide
+        ``staleTime: Infinity``, so nothing expires it, and the tree the frame
+        already carries cannot be written into the cache directly (that would
+        clobber an in-flight optimistic edit and, lacking ``history_count``, mark
+        the query fresh so the real GET never runs). A generation is the small
+        signal that lets the client re-GET instead of guess.
+
+        Read through ``getattr`` because this is reachable from the slots-push
+        hot path, which also runs on a ``__new__``-built state that never ran
+        ``__init__`` (several endpoint suites build their fixture that way).
+        """
+        return int(getattr(self, "_folders_generation", 0) or 0)
+
     async def mutate_folders(self, mutate: Callable[[list[dict[str, Any]]], tuple[bool, _T]]) -> _T:
         """Serialize one read-modify-write of the folder store; persist off-loop.
 
@@ -7751,6 +7777,12 @@ class DashboardState:
             except Exception:
                 self._folders[:] = before
                 raise
+            # After the confirmed write, never before it: a failed persist
+            # restores `before`, and a generation bumped for a rolled-back
+            # mutation would make every client re-GET state that never changed —
+            # and, worse, would let the NEXT real change land on the same number
+            # if it raced the rollback.
+            self._folders_generation = self.folders_generation() + 1
             return value
 
     async def read_folders(self, read: Callable[[list[dict[str, Any]]], _T]) -> _T:
@@ -8521,6 +8553,10 @@ class DashboardState:
                 # to dict entries carrying a string "id" so a corrupt store degrades
                 # to a smaller/empty tree instead of crashing the broadcast.
                 "folders": _safe_folder_tree(getattr(self, "_folders", None)),
+                # Lets the client distinguish "the tree changed" from "a session
+                # blinked": this frame fires on routine slot activity, so the
+                # tree alone is not a change signal.
+                "foldersGeneration": self.folders_generation(),
             }
         )
         # The owner frame is the owner's ONLY slots frame — `_send_ws_all` skips
@@ -8541,6 +8577,7 @@ class DashboardState:
                     channel_trusted=ch_trusted,
                     gitlab_hosts_gen=gitlab_hosts_generation(),
                     folders=_safe_folder_tree(getattr(self, "_folders", None)),
+                    folders_gen=self.folders_generation(),
                 )
             )
 
@@ -8652,6 +8689,7 @@ class DashboardState:
                     channel_trusted=bool(ws_data["channelTrusted"]),
                     gitlab_hosts_gen=note.get("gitlabHostsGeneration"),
                     folders=note.get("folders"),
+                    folders_gen=note.get("foldersGeneration"),
                 )
             elif msg_type == "slot_title":
                 ws_data = {"key": note["key"], "title": note["title"]}

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -433,6 +433,13 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
         # malformed entry (see its docstring).
         if ws.get("_is_dashboard_user", False):
             envelope_extras["folders"] = _safe_folder_tree(getattr(state, "_folders", None))
+            # Baseline for the change comparison, alongside the tree it describes
+            # — the client treats a connection's first generation as "unknown,
+            # refetch", so this seeds the number a later bump is measured against.
+            # Gated with `folders` rather than sent unconditionally: an app token
+            # never receives the tree, so its generation would describe data the
+            # app does not have.
+            envelope_extras["foldersGeneration"] = state.folders_generation()
         if not ws.get("_is_dashboard_user", False) and "yolo" in envelope_extras:
             # Handing an app token the live blanket-approval override is a
             # grant of operator security posture, not slot data, and this

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -183,6 +183,77 @@ class TestSlotsBroadcastCarriesFolders:
         frame = json.loads(ws.send_str.call_args[0][0])
         assert frame["folders"] == []
 
+    def test_frame_carries_the_folder_generation(self, state: DashboardState) -> None:
+        # The tree alone is not a change signal — this frame fires on routine
+        # session activity — so the client needs the generation to tell "the
+        # store changed" from "a session blinked".
+        state.serialize_slots = MagicMock(return_value=[])  # type: ignore[method-assign]
+        state._folders_generation = 3
+        ws = self._DashboardWS()
+        state.register_ws(ws)  # type: ignore[arg-type]
+
+        state._do_slots_broadcast()
+
+        frame = json.loads(ws.send_str.call_args[0][0])
+        assert frame["foldersGeneration"] == 3
+
+    def test_slot_activity_alone_does_not_advance_the_generation(
+        self, state: DashboardState
+    ) -> None:
+        # THE guardrail. The client refetches whenever this number moves, so a
+        # generation that crept up on ordinary slot churn would refetch the
+        # session-scanning GET /api/chat/folders on every session event and land
+        # that refetch over any in-flight optimistic folder edit.
+        state.serialize_slots = MagicMock(return_value=[{"key": "chat-1"}])  # type: ignore[method-assign]
+        state._folders = [{"id": "f1", "name": "Work", "order": 0}]
+        ws = self._DashboardWS()
+        state.register_ws(ws)  # type: ignore[arg-type]
+
+        state._do_slots_broadcast()
+        state.serialize_slots = MagicMock(  # type: ignore[method-assign]
+            return_value=[{"key": "chat-1", "title": "renamed"}, {"key": "chat-2"}]
+        )
+        state._do_slots_broadcast()
+
+        generations = [
+            json.loads(call[0][0])["foldersGeneration"] for call in ws.send_str.call_args_list
+        ]
+        assert len(generations) == 2
+        assert generations[0] == generations[1]
+
+    @pytest.mark.asyncio
+    async def test_folder_mutation_advances_the_generation(
+        self, state: DashboardState
+    ) -> None:
+        # Bumped in the mutate_folders funnel rather than at each call site, so a
+        # new folder-writing endpoint cannot forget to do it.
+        before = state.folders_generation()
+
+        await state.mutate_folders(
+            lambda folders: (True, folders.append({"id": "f9", "name": "New", "order": 0}))
+        )
+
+        state.serialize_slots = MagicMock(return_value=[])  # type: ignore[method-assign]
+        ws = self._DashboardWS()
+        state.register_ws(ws)  # type: ignore[arg-type]
+        state._do_slots_broadcast()
+
+        frame = json.loads(ws.send_str.call_args[0][0])
+        assert frame["foldersGeneration"] == before + 1
+        assert frame["folders"] == [{"id": "f9", "name": "New", "order": 0}]
+
+    @pytest.mark.asyncio
+    async def test_a_no_op_folder_transaction_does_not_advance_the_generation(
+        self, state: DashboardState
+    ) -> None:
+        # `changed=False` returns before the write; nothing changed, so no client
+        # should be told to refetch.
+        before = state.folders_generation()
+
+        await state.mutate_folders(lambda folders: (False, None))
+
+        assert state.folders_generation() == before
+
 
 class TestOwnerScopedBroadcast:
     """Owner-only typed broadcast + its delivery count (PR #461)."""

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -226,6 +226,7 @@ export function useWebSocket() {
   const reconnectingRef = useRef(false)  // suppress markSlotUnread during reconnect catch-up
   const lastVersionRef = useRef<string | null>(null)
   const lastGitlabHostsGenRef = useRef<number | null>(null)
+  const lastFoldersGenRef = useRef<number | null>(null)
   const lastSlotsRawRef = useRef<string | null>(null)
   const lastSlotsArrayRef = useRef<ChatSlot[] | null>(null)
   const voiceQueueRef = useRef<string[]>([])
@@ -692,6 +693,8 @@ export function useWebSocket() {
       // gateway, so after a restart an equal number can mean a different
       // allowlist. Clearing it makes the next generation frame refetch.
       lastGitlabHostsGenRef.current = null
+      // Same process-local reasoning for the folder-tree generation.
+      lastFoldersGenRef.current = null
       // Forget the last raw slots frame too, so a reconnect whose first frame
       // repeats the last one before it cannot swallow that first frame.
       lastSlotsRawRef.current = null
@@ -910,6 +913,32 @@ export function useWebSocket() {
                 queryClient.setQueryData<ChatFolder[]>(['chat-folders'], msg.folders as ChatFolder[])
                 // Backfill history_count (omitted from the WS payload) — the seed
                 // marked the query fresh, so nudge the real GET to run.
+                queryClient.invalidateQueries({ queryKey: ['chat-folders'] })
+              }
+            }
+            // Refetch the folder tree when the STORE changed, for every source of
+            // change — an agent, another tab, another device — not just this tab's
+            // own mutation. The seed above deliberately fires once, so without
+            // this a folder created anywhere else stays invisible until a reload:
+            // ['chat-folders'] carries the app-wide staleTime: Infinity, and the
+            // sessions do arrive (their folder_id points at a folder this tab has
+            // never heard of, so they render as Unfiled and the folder looks like
+            // it was never created).
+            //
+            // invalidate, never setQueryData: a refetch is what brings back the
+            // `history_count` the WS payload omits, and the generation only moves
+            // on a real store write, so the value a refetch resolves to already
+            // includes the mutation whose optimistic window it might land in.
+            //
+            // Same process-local trap as gitlabHostsGeneration below: the counter
+            // resets with the gateway, so a restart can hand back a number equal
+            // to the one this client last saw over a different tree. The first
+            // generation frame of each connection is therefore "unknown, refetch",
+            // and comparison only happens within one connection.
+            if (typeof msg.foldersGeneration === 'number') {
+              const prevFoldersGen = lastFoldersGenRef.current
+              lastFoldersGenRef.current = msg.foldersGeneration
+              if (prevFoldersGen === null || prevFoldersGen !== msg.foldersGeneration) {
                 queryClient.invalidateQueries({ queryKey: ['chat-folders'] })
               }
             }

--- a/website/src/test/useWebSocket.folderGeneration.test.ts
+++ b/website/src/test/useWebSocket.folderGeneration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * A folder created outside this tab — by an agent, a second tab, another device —
+ * was invisible here until a reload. The sessions arrived on the `slots` frame,
+ * but their `folder_id` named a folder this tab had never heard of, so they
+ * rendered as Unfiled and the folder looked like it had never been created.
+ *
+ * Why nothing recovered on its own: `['chat-folders']` inherits the app-wide
+ * `staleTime: Infinity` (queryClient.ts), the sidebar's useQuery does not poll,
+ * and the `folders` payload the frame already carries is deliberately seeded ONCE
+ * (see useWebSocket.folderSeed.test.ts for why re-seeding is unsafe). So the tree
+ * only ever changed through a mutation THIS tab issued.
+ *
+ * The fix is a generation number on the frame: when it moves, the store really
+ * changed, and the client invalidates so the real GET refills the tree — counts
+ * included. These tests pin the three properties that make it safe:
+ *
+ *   1. a changed generation invalidates (the bug being fixed),
+ *   2. an UNCHANGED generation does not (the guardrail: a `slots` frame fires on
+ *      routine session activity, and invalidating on every one of them would
+ *      refetch over an in-flight optimistic folder edit and hammer the
+ *      session-scanning GET),
+ *   3. the first generation frame of a connection always invalidates, because
+ *      the counter is process-local to the gateway and a restart can hand back a
+ *      number equal to the one this client last saw over a different tree.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ChatFolder } from '../types'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+describe('useWebSocket folder-tree generation invalidation', () => {
+  let testStore: ReturnType<typeof createTestStore>
+  let invalidated: unknown[][]
+  let qc: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    invalidated = []
+    testStore = createTestStore({})
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    // Populated up front in every case: an EMPTY cache takes the separate
+    // first-paint seed arm, which invalidates for its own reason (backfilling
+    // history_count) and would mask what these tests measure.
+    qc.setQueryData<ChatFolder[]>(['chat-folders'], [
+      { id: 'f1', name: 'Work', order: 0, history_count: 2 } as ChatFolder,
+    ])
+    const realInvalidate = qc.invalidateQueries.bind(qc)
+    qc.invalidateQueries = ((filters?: { queryKey?: unknown[] }) => {
+      if (filters?.queryKey) invalidated.push(filters.queryKey)
+      return realInvalidate(filters as never)
+    }) as typeof qc.invalidateQueries
+    return createElement(Provider, { store: testStore },
+      createElement(QueryClientProvider, { client: qc }, children),
+    )
+  }
+
+  const folderInvalidations = () =>
+    invalidated.filter(key => Array.isArray(key) && key[0] === 'chat-folders').length
+
+  function mountOpened(): MockWebSocket {
+    renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return ws
+  }
+
+  it('invalidates on the first generation frame of a connection', () => {
+    const ws = mountOpened()
+
+    act(() => { ws.simulateMessage({ type: 'slots', data: [], foldersGeneration: 4 }) })
+
+    expect(folderInvalidations()).toBe(1)
+  })
+
+  it('invalidates when the generation moves — an agent created a folder', () => {
+    const ws = mountOpened()
+    act(() => { ws.simulateMessage({ type: 'slots', data: [], foldersGeneration: 4 }) })
+    expect(folderInvalidations()).toBe(1)
+
+    // The agent's create landed: same tab, same connection, new tree.
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [{ key: 'chat-1', title: 's', agent: 'kirocrew', folder_id: 'f2' }],
+        folders: [{ id: 'f1', name: 'Work', order: 0 }, { id: 'f2', name: 'Crew', order: 1 }],
+        foldersGeneration: 5,
+      })
+    })
+
+    expect(folderInvalidations()).toBe(2)
+  })
+
+  it('does NOT invalidate when the generation is unchanged (optimistic edits survive)', () => {
+    const ws = mountOpened()
+    act(() => { ws.simulateMessage({ type: 'slots', data: [], foldersGeneration: 4 }) })
+    expect(folderInvalidations()).toBe(1)
+
+    // Routine session activity: three more frames, same tree. A refetch here
+    // would land over an in-flight collapse/rename/reorder and snap it back.
+    act(() => { ws.simulateMessage({ type: 'slots', data: [{ key: 'a', title: 'x', agent: 'kirocrew' }], foldersGeneration: 4 }) })
+    act(() => { ws.simulateMessage({ type: 'slots', data: [{ key: 'b', title: 'y', agent: 'kirocrew' }], foldersGeneration: 4 }) })
+    act(() => { ws.simulateMessage({ type: 'slots', data: [{ key: 'c', title: 'z', agent: 'kirocrew' }], foldersGeneration: 4 }) })
+
+    expect(folderInvalidations()).toBe(1)
+  })
+
+  it('invalidates after a reconnect even when the generation is unchanged', () => {
+    vi.useFakeTimers()
+    const ws1 = mountOpened()
+    act(() => { ws1.simulateMessage({ type: 'slots', data: [], foldersGeneration: 4 }) })
+    expect(folderInvalidations()).toBe(1)
+
+    // Gateway restarts: the counter is process-local, so generation 4 on the new
+    // process is a different tree than generation 4 on the old one.
+    act(() => { ws1.onclose?.(new CloseEvent('close')) })
+    act(() => { vi.advanceTimersByTime(2000) })
+    const ws2 = WS_INSTANCES[1]
+    act(() => { ws2.simulateOpen() })
+    act(() => { ws2.simulateMessage({ type: 'slots', data: [], foldersGeneration: 4 }) })
+
+    expect(folderInvalidations()).toBe(2)
+  })
+
+  it('ignores a frame with no generation field (older gateway)', () => {
+    const ws = mountOpened()
+
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [],
+        folders: [{ id: 'f1', name: 'Work', order: 0 }],
+      })
+    })
+
+    expect(folderInvalidations()).toBe(0)
+  })
+})

--- a/website/src/test/useWebSocket.folderSeed.test.ts
+++ b/website/src/test/useWebSocket.folderSeed.test.ts
@@ -14,6 +14,13 @@
  * GET has loaded counts, leaves the cache alone — and (3) the first-paint seed
  * invalidates the query so the real GET backfills the omitted `history_count`.
  *
+ * Property (2) is about the SEED arm only, and every frame here deliberately
+ * carries no `foldersGeneration`. Keeping a tab up to date with folder changes
+ * made elsewhere is the separate generation arm's job (see
+ * useWebSocket.folderGeneration.test.ts): it invalidates — never writes the
+ * cache — and only when the store's generation actually moved, so it cannot
+ * clobber an optimistic edit the way a re-seed would.
+ *
  * Uses the SINGLETON store for the same reason as slotsFrameDedupe: the hook
  * reads slots off the imported singleton.
  */


### PR DESCRIPTION
## Problem

A chat folder created by anything other than **this tab's own mutation** — an agent, a second tab, another device — never appeared here. A reload was the only way to see it.

It did not look like a stale sidebar; it looked like the folder had never been created. The sessions *did* arrive on the live `slots` frame, but their `folder_id` named a folder this tab had never heard of, so they fell into the Unfiled bucket and rendered exactly like unfiled sessions.

The evidence, four sites that compose into the defect:

- `website/src/api/queryClient.ts:52` — a global `staleTime: Infinity`. No query expires on its own; freshness comes **exclusively** from a WebSocket push calling `invalidateQueries`.
- `website/src/pages/ChatSidebar.tsx:2239` — the sidebar reads folders through `useQuery(['chat-folders'])` with no polling, so there is no timer to recover.
- `website/src/hooks/useWebSocket.ts:908` — the `slots` frame **does** carry `msg.folders`, but the arm is guarded on `existing === undefined`: it seeds first paint and every later frame is *deliberately* ignored.
- `src/kiro_crew/dashboard/chat_folders.py:558` — create already calls `state.push_slots_update()`, and the frame it emits already contains the new folder. The client looked at it and dropped it.

Net effect: `['chat-folders']` only ever changed through the `mutation → invalidate` path a tab drives itself. Every other writer was invisible to it.

## Why the obvious fix is wrong

"Just seed on every frame" is what the `existing === undefined` guard exists to prevent, for two reasons that both still hold and are preserved here:

1. A `slots` frame fires on **routine session activity**, so one will land inside an in-flight folder mutation's optimistic window (collapse / reorder / rename / move). A direct `setQueryData` overwrites the optimistic value with backend state, and the mutation's `cancelQueries` cannot cancel a synchronous cache write — the folder snaps back to its pre-action state until `onSettled` refetches.
2. The WS payload carries no `history_count` (the backend computes it with a synchronous session scan that must not run on this hot path). Seeding count-less data marks the query **fresh**, so a mount-time query skips `GET /api/chat/folders` and the counts — the "hide when empty" filter's input — never load at all.

## What changed

A **generation number** on the folder tree. When it moves, the store really changed, and the client invalidates so the real `GET` refills the tree — `history_count` included. Nothing is ever written into the cache from a frame, so neither reason above is reintroduced.

**Backend — the counter lives in the single funnel.**

- `DashboardState._folders_generation` + `folders_generation()` (`src/kiro_crew/dashboard/state.py`). Read through `getattr`, because the slots-push hot path also runs on a `__new__`-built state that never ran `__init__`.
- Bumped inside `mutate_folders`, **after** the confirmed write. In the funnel rather than at each call site so a future folder-writing endpoint cannot forget to do it; after the write because a failed persist restores the pre-callback list, and a generation bumped for a rolled-back mutation would make every client re-GET state that never changed. A `changed=False` transaction returns before the bump.
- Shipped on the frame via `_slots_ws_frame`, the one builder both the generic fan-out and the owner frame go through, so the key cannot reach one envelope and not the other. `ws.py` seeds the baseline on the connect-time push, gated with `folders` — an app token never receives the tree, so it has no use for the tree's generation, and the app envelope (`_serialize_for_client`) is rebuilt key-by-key and unchanged.

**Frontend — `website/src/hooks/useWebSocket.ts`.** One arm, modelled on the `gitlabHostsGeneration` precedent in the same handler, **including its load-bearing subtlety**: the counter is *process-local* to the gateway, so a restart can hand back a number equal to the one this client last saw over a different tree. Each connection therefore treats its **first** generation frame as "unknown, refetch" (`lastFoldersGenRef` is reset in `onopen`) and compares only within one connection.

### Funnel coverage

Every folder-store writer goes through `mutate_folders`, so all of these bump:

| Path | Site |
|---|---|
| create | `chat_folders.py:530` |
| rename / reorder / reparent | `chat_folders.py:701` |
| delete | `chat_folders.py:868` |
| un-hide an empty folder | `chat_folders.py:211` |
| channel folder find-or-adopt | `channel_folders.py:299` |
| Sage follow-up folder find-or-adopt | `code_review_sage/backend/routes.py:2186` |

`save_folders()` has no remaining direct callers in `src/`, so there is no writer outside the funnel.

**One path deliberately does not bump, and should not:** moving a session into or out of a folder (`api_chat_slot_folder`, `chat_folders.py:911`, and the same assignment in `chat_handlers.py:2160`) writes `slot.folder_id` — **slot** state, not the folder store. It already reaches the client inside the frame's `data` array via `sseSlots`, and it leaves the tree itself untouched, so there is nothing for a tree generation to signal. The one exception behaves correctly for the same reason: when the destination folder was hidden, that move goes through `_unhide_folder` → `mutate_folders`, the `hidden` flag really changes, and the generation moves with it.

## Tests

**Frontend — `website/src/test/useWebSocket.folderGeneration.test.ts` (new, 5 cases).** A changed generation invalidates (the bug). An **unchanged** generation across three further frames does not — this is the guardrail against reintroducing the snap-back, and it is why the arm compares rather than firing on arrival. A connection's first frame always invalidates. A reconnect at the *same* number still invalidates (the process-local trap). A frame with no generation field is ignored.

**Backend — `test/test_dashboard_state_ws.py::TestSlotsBroadcastCarriesFolders` (+4 cases).** The frame carries the generation; two broadcasts of pure slot churn keep it equal; a real `mutate_folders` write advances it by exactly one and the tree ships with it; a `changed=False` transaction leaves it alone.

**`useWebSocket.folderSeed.test.ts`** gains a header note only: its "a later frame must not invalidate" property is about the *seed* arm, and every frame in it carries no generation. Recorded so the two files do not read as contradicting each other.

### Revert-verify

Each production change was reverted one at a time (in-memory snapshot, restored in a `finally`) and the matching test confirmed **red** — 8 for 8, then the tree restored and re-confirmed green:

| Reverted | Test that went red |
|---|---|
| `foldersGeneration` off the broadcast note | `test_frame_carries_the_folder_generation` |
| `foldersGeneration` off `_slots_ws_frame` | `test_frame_carries_the_folder_generation` |
| the bump in `mutate_folders` | `test_folder_mutation_advances_the_generation` |
| bump moved onto every slots broadcast | `test_slot_activity_alone_does_not_advance_the_generation` |
| bump moved before the `changed` check | `test_a_no_op_folder_transaction_does_not_advance_the_generation` |
| the whole frontend generation arm | `invalidates when the generation moves` |
| the change comparison (invalidate always) | `does NOT invalidate when the generation is unchanged` |
| the per-connection `onopen` reset | `invalidates after a reconnect even when the generation is unchanged` |

## Manual verification

Local gates, all exit 0: `tsc -b`, `eslint src/` (0 errors), `i18n:check` (run with `I18N_BASE_REF=$(git merge-base HEAD origin/main)` — without it the branch-diff gates silently skip and report a false green), vitest on the three `useWebSocket` folder/generation specs, `pytest` across the 7 folder + WS backend suites (194 passed), `mypy` (1167 files), `flake8`, `isort`, black-formatting, loop-bound-locks, testpaths-coverage.

Both pinned local reviewers ran on the CI-extracted contracts and returned **zero findings** (`gpt-5.6-sol`, `claude-opus-4.8`).

No screenshot: the diff touches `website/src/hooks/` and test files only — none of the surfaces the screenshot gate watches (`components/`, `pages/`, `apps/`, CSS, `index.html`) — and it renders no pixel of its own. Its visible effect is an existing sidebar folder appearing on schedule, which needs a live agent plus two tabs to stage and is covered by the invalidation tests above.

no linked issue: found while verifying agent-created sessions in the sidebar, not filed first.
