### PR TITLE
chore(memory): remove confirmed dead code in the memory and skills surface

### DIFF
--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -158,9 +158,8 @@ MAX_EVENTS_PER_ARTIFACT = 500
 #: are dropped (a thread root + its replies together), never a reply orphaned.
 MAX_COMMENTS_PER_ARTIFACT = 500
 
-#: Maximum number of tags per artifact, and max length per tag.
+#: Maximum number of tags per artifact. Per-tag length is bounded by ``_TAG_RE``.
 MAX_TAGS = 16
-MAX_TAG_LEN = 64
 
 # Slug pattern: lowercase letters, digits, hyphens. 1-80 chars. No leading or
 # trailing hyphen. Single-character slugs are allowed for trivial names.
@@ -3933,13 +3932,6 @@ def get_default_store() -> ArtifactStore:
         return _default_store
 
 
-def reset_default_store() -> None:
-    """Drop the cached default store (test-only helper)."""
-    global _default_store
-    with _default_store_lock:
-        _default_store = None
-
-
 _default_folder_store: "ArtifactFolderStore | None" = None
 _default_folder_store_lock = threading.Lock()
 
@@ -3951,10 +3943,3 @@ def get_default_folder_store() -> "ArtifactFolderStore":
         if _default_folder_store is None:
             _default_folder_store = ArtifactFolderStore()
         return _default_folder_store
-
-
-def reset_default_folder_store() -> None:
-    """Drop the cached default folder store (test-only helper)."""
-    global _default_folder_store
-    with _default_folder_store_lock:
-        _default_folder_store = None

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -1241,18 +1241,6 @@ class KnowledgeStore:
             return []
         return [self._serialize_item(r) for r in rows]
 
-    def search_items_fts_count(self, query) -> int:
-        safe = self._sanitize_fts5(query)
-        if not safe:
-            return 0
-        try:
-            row = self.db.execute(
-                "SELECT COUNT(*) FROM items_fts WHERE items_fts MATCH ?",
-                (safe,)).fetchone()
-            return row[0] if row else 0
-        except sqlite3.OperationalError:
-            return 0
-
     @staticmethod
     def _sanitize_fts5(query: str) -> str:
         tokens = query.split()

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -219,12 +219,6 @@ def _emit_pending_consumed(payload: dict) -> None:
         logger.debug("pending-consumed hook failed", exc_info=True)
 
 
-# Derived lifecycle states for auto-skills (not persisted — computed from
-# usage recency at lifecycle-run time).
-SKILL_STATE_ACTIVE = "active"
-SKILL_STATE_STALE = "stale"
-SKILL_STATE_ARCHIVED = "archived"
-
 # Frontmatter field used to mark a skill as auto-generated.  Absence means
 # the skill is hand-authored (or legacy, pre-feature).
 AUTO_SKILL_SOURCE_VALUE = "auto"
@@ -279,24 +273,6 @@ class AutoSkillProvenance:
         if self.pinned:
             lines.append("pinned: true")
         return lines
-
-
-def _auto_name_from_title(raw: str) -> str:
-    """Convert a free-form title into a safe ``auto/<slug>`` skill name.
-
-    Strategy:
-    - lowercase
-    - replace any run of non-alphanumerics with a single hyphen
-    - strip leading/trailing hyphens
-    - truncate to 62 chars (leaves room for uniqueness suffix)
-
-    Returns the slug component only; caller prepends the namespace.
-    Returns an empty string if the input can't be sanitized.
-    """
-    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")[:62].rstrip("-")
-    if not _AUTO_NAME_PATTERN.match(slug):
-        return ""
-    return slug
 
 
 def _build_auto_skill_content(

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -1199,41 +1199,6 @@ class TestListAutoSkills:
         assert auto_only[0]["key"] == "auto/generated-one"
 
 
-class TestAutoNameFromTitleTruncation:
-    """Regression test for #6: trailing hyphen after truncation would fail regex."""
-
-    def test_trailing_hyphen_stripped_after_truncation(self):
-        from kiro_crew.skills import _auto_name_from_title
-
-        # Build a title where the 62-char boundary lands in the middle of a
-        # word-separator run ("-") that would otherwise leave a trailing
-        # hyphen and silently fail _AUTO_NAME_PATTERN.
-        # 60 alphanumerics + 2 non-alphanumerics -> "a" * 60 + "-x"
-        # After truncation at [:62], you get "a"*60 + "-x" — 62 chars, still valid.
-        # A tricker case: 61 alphanumerics + non-alphanum + alphanum
-        # -> "a" * 61 + "-b" -> after re.sub + strip + truncate[:62] ->
-        # "a"*61 + "-" which ends in a hyphen.
-        title = "a" * 61 + " b"  # Space becomes hyphen during sanitization
-        slug = _auto_name_from_title(title)
-        # Post-fix: trailing hyphen stripped, slug is "a"*61 -> 61 chars, valid
-        assert slug
-        assert not slug.endswith("-")
-        assert slug == "a" * 61
-
-    def test_normal_title_unaffected(self):
-        from kiro_crew.skills import _auto_name_from_title
-
-        assert _auto_name_from_title("Debug Timber logs via SSH") == "debug-timber-logs-via-ssh"
-
-    def test_empty_and_invalid_inputs_still_return_empty(self):
-        from kiro_crew.skills import _auto_name_from_title
-
-        assert _auto_name_from_title("") == ""
-        assert _auto_name_from_title("!!!") == ""
-        # Single character is below the min length (3)
-        assert _auto_name_from_title("a") == ""
-
-
 class TestUpdateAutoSkillPreservesCreatedAt:
     """Regression test for #5: refine must not clobber created_at."""
 


### PR DESCRIPTION
## Problem / Motivation

The memory / knowledge / skills surface carries symbols that nothing calls any more. Each one costs a reader the same attention as live code — you have to trace it to find out it goes nowhere — and a constant that no longer participates in validation reads as if it still enforces something.

This PR removes only what was proven unreachable, and reports the rest rather than guessing.

## Why it matters

Dead code in this surface is worse than average because two of the shapes here actively mislead:

- `MAX_TAG_LEN = 64` sat next to the live `MAX_TAGS` in the artifact-validation block, reading as a bound that `_validate_tags` applies. It does not — the bound comes from `_TAG_RE`.
- `_auto_name_from_title` looked like the canonical title→slug converter for auto-skills. Nothing converts a title to a slug any more; both staging paths receive a slug and only validate it.

Deleting these makes the remaining code say what it does.

## What changed (motivation → approach → change)

**Approach — three independent scans, then a confirmation protocol.** A single scanner is not enough: vulture returned 205 findings over this scope, including whole classes that are very much alive (`VectorMemoryStore`, `SkillsLoader`, `HybridRetriever`, `KnowledgeWatcher`), because it cannot see cross-module method calls from `dashboard/handlers/*`. So candidates came from three passes — vulture, an AST pass (defined names minus `Name(Load)` / `Attribute` / string-constant / import / keyword uses across all 3051 repo `*.py`), and a tokenize pass that counts only real `NAME` tokens so a name inside a docstring or comment does not read as a reference.

Every candidate then went through: repo-wide `git grep -w` over `*.py *.ts *.tsx *.js *.jsx *.md *.json *.yml *.yaml *.toml *.sh *.ps1 *.cfg *.txt *.html *.mjs` (including `test/`, `docs/`, `docs/system-specs/`, `builtin_skills/`, `.github/`, `pyproject.toml` entry points); a dynamic-reference sweep (`getattr` / `setattr` / `globals()` / `importlib` / `__all__`, decorator + MCP-tool + hook registries, string spellings included); a reverse-direction check against `website/src` for route and tool names; a public-surface check; and a 30-day introduction gate.

**The scan itself had a bug worth recording.** The AST pass called `_read_docx` / `_read_html` / `_read_pptx` dead. They are dispatched *by string* from `FileReader._DISPATCH` in the same file, and the pass excluded same-file string constants. `git grep -w` matches inside strings and caught it. All three are alive; the authoritative step-1 sweep is the grep, not the AST pass.

Net result: **156 vulture non-variable findings → 135 rejected as alive**, and the eight symbols below confirmed.

### Deleted — with the evidence for each

| symbol | file | why it is dead |
|---|---|---|
| `MAX_TAG_LEN` | `src/kiro_crew/artifacts.py` | one grep hit repo-wide, its own definition. The 64-char bound it names is enforced by `_TAG_RE = ^[a-zA-Z0-9][a-zA-Z0-9_:.-]{0,63}$` at `artifacts.py:809`, so the constraint survives the deletion. `MAX_TAGS` beside it stays (used at `:806`). The comment above it is narrowed to say where the per-tag bound actually comes from. |
| `SKILL_STATE_ACTIVE` | `src/kiro_crew/skills.py` | one grep hit each. The lifecycle run at `skills.py:2842-2888` uses literal dict keys (`counts["archived"]`), never these names, and no persisted column uses them. Not named in `docs/`, `docs/system-specs/`, or any SKILL.md. |
| `SKILL_STATE_STALE` | `src/kiro_crew/skills.py` | as above |
| `SKILL_STATE_ARCHIVED` | `src/kiro_crew/skills.py` | as above |
| `_auto_name_from_title` | `src/kiro_crew/skills.py` | no production caller. Both staging paths (`skills.py:2451`, `:2927`) take an already-built `slug` and only validate it with `_AUTO_NAME_PATTERN`; nothing converts a free-form title into a slug. Its sole reference was its own unit test — see the test note below. `_AUTO_NAME_PATTERN` stays alive (three other call sites). |
| `reset_default_store` | `src/kiro_crew/artifacts.py` | its docstring says "(test-only helper)" and **no test uses it** — one grep hit repo-wide. There is no fixture to rewrite. `get_default_store` beside it is heavily used. |
| `reset_default_folder_store` | `src/kiro_crew/artifacts.py` | as above; `get_default_folder_store` stays. |
| `search_items_fts_count` | `src/kiro_crew/knowledge/store.py` | one grep hit repo-wide, including zero frontend and zero test hits. Its paging sibling `search_items_fts` and the shared `_sanitize_fts5` are retained. Retrieval goes through `HybridRetriever`. |

### Test deleted with its symbol

`test/test_skills.py::TestAutoNameFromTitleTruncation` (3 methods) is removed. It is the only reference to `_auto_name_from_title` anywhere in the repo, and it exercised nothing else — the slug callers it might otherwise have covered take `slug` as a parameter and validate through `_AUTO_NAME_PATTERN`, which keeps its own coverage. No surviving code loses coverage.

## Deliberately NOT deleted — reported instead

Two categories were left alone on purpose, because deleting them would either hide a defect or make a silent behaviour change.

**A dead symbol whose deadness is itself the bug — wiring it is the fix, not removing it:**

- **`SyncScheduler.sync_all`** (`knowledge/sync.py:80`) — `SyncScheduler` *is* instantiated (`dashboard/handlers/knowledge.py:2075`), but production only ever calls `get_connector` and `sync_source` (`:930`, `:1094`), the per-source on-demand path. The batch method has no production caller, so scheduled syncing of remote knowledge sources does not appear to run at all. It has a regression test (`test_knowledge.py:2279`, issue #3946).
- **`_github_raw_url` + `_fetch_text` + `_sync_fetch_text`** (`skill_providers/skillsh.py:228`, `:284`, `:293`) — the module docstring still says "Installation fetches the SKILL.md from the repo directly", but `fetch_skill_content` (`:143`) now goes through the skills.sh download-API bundle. `_sync_fetch_text` is reached only from `_fetch_text`, and `_fetch_text` from nothing: the whole direct-from-GitHub transport is orphaned (~45 lines), and `_github_raw_url` has only its own unit test. Deleting it silently removes a GitHub-raw fallback for when the skills.sh API fails and leaves the docstring false; the right call is either re-wiring it or deleting it together with that docstring claim. Needs a maintainer ruling, so it stays.
- **`unmark_webapp_expired`** (`artifacts.py:1899`) — lifecycle pair whose twin `mark_webapp_expired` is live (`deploy/handlers.py:2010`). Only half the expiry lifecycle is wired.
- **`is_auto_source_dismissed` / `undismiss_auto_source`** (`knowledge/store.py:991`, `:998`) — only `dismiss` is reached from production.
- **`rotate_events`** (`vector_memory.py:1681`) — an uncalled event-log rotation means the event log is unbounded in production.
- **`restore_auto_skill` / `list_archived_auto_skills`** (`skills.py:2780`, `:2801`) — archive is wired, restore and list are not.

**Deferred for other reasons:**

- `VALID_COMPONENTS` (`snapshot.py:465`) — named in `docs/request-for-change/rfc-s3-backup.md:53,148` and `docs/request-for-change/README.md:48` as the extension point for a future `sessions` component; also inside the 30-day window.
- `merge_entities` (`knowledge/store.py:1285`) — documented public surface.
- `has_edge` / `has_node` / `degree` (`knowledge/store.py:179-189`) and `search_items_fts` (`:1230`) — referenced by tests as assertion helpers and real FTS-index regression cover; removing them is a test-fixture rewrite, not a deletion, and would drop live coverage.
- Inside the 30-day gate: `load_toml` (`builtin_skills/kirocrew-dev/prepare-pr/scripts/resolve_profile.py:105`, introduced today), `remove_document` (`knowledge/agent_source.py:226`), `_update_last_seen` (`knowledge/folder_watcher.py:771`), `_record_builtin_provenance` (`skills.py:990`), `dismiss_all_pending` (`skills.py:3961`).

`builtin_skills/**/SKILL.md` was treated as public agent-facing surface throughout — any symbol a SKILL.md names counts as a live reference — and no SKILL.md is touched.

## Tests

No new tests: this PR only removes code, so the assertion is that nothing regresses.

- `TestAutoNameFromTitleTruncation` deleted with the symbol it was the sole caller of (reasoning above).
- Targeted suites for the whole affected surface pass: `test_skills.py`, `test_artifacts.py`, `test_knowledge.py`, `test_skill_lifecycle.py`, `test_skill_pending.py`, `test_skill_providers.py`, `test_vector_memory.py` — 659 passed after the final rebase, 705 passed + 11 skipped on the wider selection before it.

## Manual verification

- **Residual-reference sweep:** `git grep -w` for all eight deleted names across every tracked file type returns zero hits.
- **Deterministic gates, exit codes checked directly (not through a pipe):** `flake8 src/kiro_crew test` 0 · `isort --check-only src/kiro_crew test` 0 · `scripts/check_black_formatting.py` 0 · `mypy src/kiro_crew` clean, 1167 source files · plus `check_subprocess_encoding` (+ self-test), `check_lockdown_before_publish`, `check_brand_name` (+ self-test), `check_harness_parity` (+ self-test), `check_loop_bound_locks` (+ self-test), `check_testpaths_coverage` (+ self-test), `check_changelog_history` (+ self-test), `check_focus_cue` (+ self-test), `docs_lint` (+ self-test), `check_per_file_coverage --test`, `verify_vendor_manifest`, `scrub-lint --no-history` — all 0.
- **Full backend suite:** 115 pre-existing failures, all environment-caused on this host (`jq` version, `/local/home` owned by uid 65534, `AF_UNIX path too long`, no Node ≥ 20, `ps` path). Four touched the audited surface — `test_artifacts_handlers.py::TestCreate::test_copy_outside_allowed_roots_is_refused`, `TestPromoteVerdict::test_request_cannot_nominate_its_own_root`, and two `test_file_explorer_app.py::TestKirocrewGranularSensitive` cases — and all four reproduce **identically on unmodified `origin/main`**, so none is caused by this diff.
- **Local AI review:** both profile lanes ran against this head and returned **No findings**, having independently verified the residual-reference sweep and the `_TAG_RE` claim. The opus lane fell back to a substitute model, so treat its pass as lower-fidelity than the server lane.

N/A for anything user-visible: no frontend, config, docs, dependency, migration, or CI file is touched.

## Related Issues

N/A — no tracking issue; this is a scoped cleanup of one file group.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
