### PR TITLE
chore(core): remove confirmed dead code in the core runtime

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -2392,9 +2392,6 @@ class AcpRuntime:
         else:
             self._turn_active_sessions.discard(session_id)
 
-    # Alias for backward compat
-    remove_session = unregister_session
-
     async def terminate_session(self, session_id: str) -> None:
         """Evict a session from kiro-cli (freeing its memory), then unregister locally.
 

--- a/src/kiro_crew/acp/worker_pool.py
+++ b/src/kiro_crew/acp/worker_pool.py
@@ -153,14 +153,6 @@ class WorkerPool:
 
     # ── Introspection (status / tests) ──
     @property
-    def idle_count(self) -> int:
-        return len(self._idle)
-
-    @property
-    def created_count(self) -> int:
-        return self._created
-
-    @property
     def max_workers(self) -> int:
         return self._max_workers
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4325,16 +4325,6 @@ def _install_aim_capabilities() -> None:
     _install_lite_agent_fallback()
 
 
-def _remove_bare_lite_if_aim_installed() -> None:
-    """No-op on public installs (AIM package manager absent).
-
-    Symbol preserved for backward compatibility.  Previously removed the
-    bare ``kirocrew-lite.json`` when an AIM-installed duplicate existed; with
-    AIM install neutralized there is no AIM-managed copy to deduplicate.
-    """
-    return None
-
-
 def _install_lite_agent_fallback() -> None:
     """Write a bare kirocrew-lite config (cheap background agent)."""
     lite_path = kiro_agents_dir_path() / _LITE_AGENT_FILENAME

--- a/src/kiro_crew/agent_files.py
+++ b/src/kiro_crew/agent_files.py
@@ -1,8 +1,8 @@
 """Canonical filenames of the agent configs KiroCrew generates.
 
 Single source of truth for the on-disk names KiroCrew writes into
-``~/.kiro/agents/`` (kiro specs) and ``~/.claude/agents/`` (the Claude Code MCP
-sidecar). This is a **leaf module** (no intra-package imports) so both
+``~/.kiro/agents/`` (kiro specs). This is a **leaf module** (no intra-package
+imports) so both
 ``agent.py`` (which writes these files) and ``browser/setup.py`` (whose
 Playwright convergence sweep must touch only KiroCrew-owned files) can import it
 without an import cycle — ``agent.py`` imports ``converge_playwright_servers``
@@ -26,9 +26,6 @@ KNOWLEDGE_AGENT_FILENAME = "kirocrew-knowledge.json"
 RESEARCH_AGENT_FILENAME = "kirocrew-research.json"
 HEARTBEAT_AGENT_FILENAME = "kirocrew-heartbeat.json"
 
-# The Claude Code MCP sidecar filename under ~/.claude/agents/.
-CC_MCP_SIDECAR_FILENAME = "kirocrew.mcp.json"
-
 # Collective allowlists — the EXACT filenames KiroCrew owns in each dir. Used by
 # the Playwright convergence sweep (browser/setup.py) so it rewrites only files
 # KiroCrew generates, never a user's own agent config that happens to share a
@@ -41,7 +38,6 @@ OWNED_KIRO_AGENT_FILES = (
     RESEARCH_AGENT_FILENAME,
     HEARTBEAT_AGENT_FILENAME,
 )
-OWNED_CC_AGENT_FILES = (CC_MCP_SIDECAR_FILENAME,)
 
 # The specs that MUST exist for the product to work at all. kiro-cli resolves an
 # agent by reading ``<agents dir>/<name>.json``; with the file absent it answers

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -3506,17 +3506,6 @@ class ConversationLog:
             )
         return failures, retry_at
 
-    def load_transcript(self, key: str) -> str:
-        """Load full session as formatted text for LLM summarization."""
-        messages = self._read_messages(key)
-        if not messages:
-            return ""
-        lines: list[str] = []
-        for m in messages:
-            role = m["role"].title()
-            lines.append(f"{role}: {m['content']}")
-        return "\n\n".join(lines)
-
     @staticmethod
     def _canonical_key(key: str) -> str:
         """Collapse stacked ``dashboard_`` prefixes to a single one.

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -5764,9 +5764,6 @@ class SessionManager:
         """Highest persisted DM generation for a session bucket (see SessionMap)."""
         return self._session_map.max_generation(bucket)
 
-    def delete_session_map_entry(self, key: str) -> None:
-        self._session_map.delete(key)
-
     async def set_thread(self, key: str, thread_ts: str) -> None:
         """Set thread for a session. Prefer set_slack_link for new code."""
         _, channel_id = self.get_slack_link(key)

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -91,18 +91,6 @@ class TestConversationLog:
         log = ConversationLog(base_dir=tmp_path)
         log.mark_consolidated("nonexistent", 5)  # should not raise
 
-    def test_load_transcript(self, tmp_path):
-        log = ConversationLog(base_dir=tmp_path)
-        log.append("t1", "user", "what is 2+2?")
-        log.append("t1", "assistant", "4")
-        transcript = log.load_transcript("t1")
-        assert "User: what is 2+2?" in transcript
-        assert "Assistant: 4" in transcript
-
-    def test_load_transcript_empty(self, tmp_path):
-        log = ConversationLog(base_dir=tmp_path)
-        assert log.load_transcript("nonexistent") == ""
-
     def test_safe_key_sanitizes(self, tmp_path):
         log = ConversationLog(base_dir=tmp_path)
         log.append("thread:with/special chars!", "user", "hi")
@@ -4077,7 +4065,7 @@ class TestTailReads:
         log._msg_cache.clear()
         log.recent("t1", max_messages=3)
         # Tail path returned a partial view — the full cache must stay empty
-        # so load_transcript()/search still parse the whole file.
+        # so search still parses the whole file.
         assert "t1" not in log._msg_cache
 
     def test_tail_window_grows_when_insufficient(self, tmp_path):

--- a/test/test_lite_agent_duplicate.py
+++ b/test/test_lite_agent_duplicate.py
@@ -8,11 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from kiro_crew.agent import (
-    _LITE_AGENT_FILENAME,
-    _install_lite_agent_fallback,
-    _remove_bare_lite_if_aim_installed,
-)
+from kiro_crew.agent import _LITE_AGENT_FILENAME, _install_lite_agent_fallback
 
 
 @pytest.fixture
@@ -55,41 +51,3 @@ class TestLiteAgentDuplicate:
 
         bare = agents_dir / _LITE_AGENT_FILENAME
         assert bare.exists(), "bare fallback should be written when AIM version missing"
-
-    def test_cleanup_is_noop_when_both_exist(self, agents_dir: Path) -> None:
-        """Cleanup is a no-op on public installs (no AIM package manager).
-
-        The AIM-managed duplicate path is removed on the de-Amazoned fork, so
-        there is no AIM-owned copy to deduplicate against — the cleanup leaves
-        any existing files untouched.
-        """
-        bare = agents_dir / _LITE_AGENT_FILENAME
-        bare.write_text(json.dumps({"name": "kirocrew-lite"}))
-        aim_file = agents_dir / AIM_LITE_FILENAME
-        aim_file.write_text(json.dumps({"name": "kirocrew-lite"}))
-
-        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", agents_dir):
-            _remove_bare_lite_if_aim_installed()
-
-        assert bare.exists(), "bare file should remain (cleanup is a no-op)"
-        assert aim_file.exists(), "legacy AIM-named file should remain"
-
-    def test_cleanup_noop_when_only_aim_exists(self, agents_dir: Path) -> None:
-        """Cleanup should be safe when bare file already gone."""
-        aim_file = agents_dir / AIM_LITE_FILENAME
-        aim_file.write_text(json.dumps({"name": "kirocrew-lite"}))
-
-        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", agents_dir):
-            _remove_bare_lite_if_aim_installed()
-
-        assert aim_file.exists()
-
-    def test_cleanup_preserves_bare_when_aim_missing(self, agents_dir: Path) -> None:
-        """Cleanup should NOT remove bare file when AIM version is absent."""
-        bare = agents_dir / _LITE_AGENT_FILENAME
-        bare.write_text(json.dumps({"name": "kirocrew-lite"}))
-
-        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", agents_dir):
-            _remove_bare_lite_if_aim_installed()
-
-        assert bare.exists(), "bare should remain when AIM version not installed"

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2977,12 +2977,6 @@ class TestSlackLinkHelpers:
         assert mgr.find_key_by_sid("sid-abc") == "k1"
         assert mgr.find_key_by_sid("unknown") is None
 
-    def test_delete_session_map_entry(self, cfg):
-        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
-        mgr._session_map.set("k1", "sid-abc")
-        mgr.delete_session_map_entry("k1")
-        assert mgr.find_key_by_sid("sid-abc") is None
-
 
 class TestGetPid:
     """Tests for get_pid."""


### PR DESCRIPTION
## What

Removes 7 confirmed-dead symbols from the core runtime (104 deleted lines), plus their companion tests. No behaviour change, no refactor, no reformatting.

Scope audited: `agent.py`, `agent_discovery.py`, `agent_files.py`, `agent_scratch.py`, `agent_state.py`, `agents_janitor.py`, `session.py`, `session_storage.py`, `subagent.py`, `context.py`, `context_blocks.py`, `context_management.py`, `history.py`, `acp/` — 51,898 lines.

## How the candidates were found

Four independent passes, because no single scanner is trustworthy here:

| Pass | Mechanism | Candidates |
|---|---|---|
| vulture | `--min-confidence 60`, scope files only | 235 |
| AST, repo-aware | names defined in scope minus names Loaded anywhere in repo | 10 |
| tokenize, repo-aware | real NAME tokens only — no docstring, comment or substring matches | 10 |
| production/test split | refs outside own body, split prod vs test | 43 |

Vulture's 235 is nearly all noise: it only sees the files handed to it, so every cross-module caller is invisible. It flagged `HistoryConsolidator` (1679 lines) and `WorkerPool` (209 lines), both heavily live. The two repo-aware passes converge on the same 10. The production/test split found the rest.

**The blind spot that matters:** those passes count NAME tokens and ignore STRING tokens, so a symbol reached through `getattr(obj, "name")` reads as dead. Every candidate was therefore put through a reverse-direction reachability check, and that check rejected six of them — see "Rejected" below.

## Deleted

| Symbol | File:line | Evidence |
|---|---|---|
| `OWNED_CC_AGENT_FILES` | `agent_files.py:44` | Zero refs in any extension. It was the allowlist for the Playwright convergence sweep in `browser/setup.py` — that module *and* `converge_playwright_servers` are both already deleted (`test_installer_shim_and_cleanup.py:790` refers to "the deleted converge_playwright_servers"). Sibling `OWNED_KIRO_AGENT_FILES` survived because three other consumers adopted it (`agent.py:4986`, `connections/mint.py:234`, `doctor_deadpath.py:37`); the CC allowlist got no second life. Introduced 2026-07-24 (#308), 36 days. |
| `CC_MCP_SIDECAR_FILENAME` | `agent_files.py:30` | Cascade — its only reader was `OWNED_CC_AGENT_FILES` one line below. Not the authoritative path for `~/.claude/agents/kirocrew.mcp.json`: `dashboard/handlers/mcp.py::_KIROCREW_MCP_JSON` is, and it is exercised by `test_mcp_apply.py` / `test_mcp_custom_api.py`. An orphaned duplicate source of truth. |
| `AcpRuntime.remove_session` | `acp/runtime.py:2396` | `remove_session = unregister_session`, commented "Alias for backward compat". Zero refs across `*.py *.ts *.tsx *.md *.json *.yml`, zero as a string literal, absent from `__all__` (`acp/__init__.py` exports classes only) and from `_dispatch.py`'s JSON-RPC method table. No `getattr` reaches it. Introduced 2026-07-16, 44 days. |
| `WorkerPool.idle_count` | `acp/worker_pool.py:155` | Zero refs including tests. Superseded by live sibling `stats()`, which returns `{"workers": self._created, ...}` and derives busy from `len(self._idle)` — the same two numbers. `WorkerPool` itself is live (`workflows/agent_pool.py`); only these two accessors are dead. |
| `WorkerPool.created_count` | `acp/worker_pool.py:159` | As above. The surviving `max_workers` / `max_starting` keep the `# ── Introspection (status / tests) ──` header. |
| `SessionManager.delete_session_map_entry` | `session.py:5767` | Unfolded one-line passthrough to `self._session_map.delete(key)`, one dedicated test, no production caller, no dynamic reach. Not a cleanup gap — session-map deletion is already covered by `forget_conversation`, the session-destroyed path, and `SessionMap.get` self-pruning. |
| `_remove_bare_lite_if_aim_installed` | `agent.py:4328` | Body is `return None` — an explicit "symbol preserved for backward compatibility" stub whose real behaviour was removed when the AIM install path was neutralized on this fork. Nothing calls it, in any language or as a string. |
| `ConversationLog.load_transcript` | `history.py:3509` | Zero production, dynamic, doc and cross-language refs. Consolidation formats its own prompt rather than calling this. Its only references are its own two dedicated tests. |

Companion tests deleted: `test_delete_session_map_entry`; `TestLiteAgentDuplicate::test_cleanup_is_noop_when_both_exist` / `test_cleanup_noop_when_only_aim_exists` / `test_cleanup_preserves_bare_when_aim_missing`; `test_load_transcript`; `test_load_transcript_empty`. One comment at `test_history.py:4080` citing `load_transcript()` reworded.

The three lite-agent tests were vacuous: each called the `return None` stub and then asserted files still existed, so they guarded no property. The file's two surviving tests cover `_install_lite_agent_fallback` and stand on their own.

`agent_files.py`'s module docstring lost the clause describing the deleted Claude-Code sidecar constants. Its remaining reference to `browser/setup.py` / `converge_playwright_servers` is **pre-existing** drift on lines this diff does not touch, and is deliberately left alone.

## Rejected — live via string dispatch or documented API

Each of these reads as zero-reference to a name-based scan and would have been a bad deletion.

| Symbol | Why it is live |
|---|---|
| `ConversationLog.read_file_change_messages` (67L) | Called at `artifacts.py:749` through a `getattr` string literal, reachable from `GET /api/artifacts/session-docs` on every Artifacts page load. |
| `AcpSessionHandle.parked_for_secs` / `awaiting_permission` / `parked_since` (35L) | One indivisible mechanism read via `getattr` at `session.py:6172`/`6178`/`6186` by the registered `stuck_turn` cleanup hook: one is the stall signal, one suppresses false positives while a human sits at an approval prompt, one dedups the warning. Deleting the middle one would report every long approval as a stalled turn. |
| `SubagentManager.settle_queued_delivery` (41L) | Called at `chat_runner.py:3817` via `getattr(mgr, "settle_queued_delivery", None)`, with a contract test asserting that exact string. It is the delivery-integrity write whose absence strands live children. |
| `AcpClient.send_message_stream` (65L) | Documented public API in `docs/system-specs/modules/acp-client.md`, load-bearing in its "all three prompt paths" invariant, plus a cross-entry-point `getattr` contract test. |
| `TurnUsage.cache_creation_tokens` / `cache_read_tokens` / `num_turns` | Dataclass fields read **by name** via `getattr` in `usage.py::_token_record` (lines 1269/1270/1273) into the persisted token row, then aggregated and rendered as `tokens.cacheCreation` / `tokens.cacheRead` / `totalTurns` in `website/src/pages/overview/UsageTab.tsx`. Deleting them would silently zero cache-token accounting. |
| `allow_on_loop_persist` (13L) | A deliberate test-only escape hatch whose docstring forbids production use; 46 `with` blocks depend on it. Zero production refs is the intended contract. |

## Deferred

**Inside the 30-day gate** — too recent to trust a no-caller reading: `SessionIndex.stems_for` (21d), `EVERY_TURN_LABELS` (25d, also a documented cross-language mirror that `ContextBreakdownPanel.tsx:50` hardcodes), `_effective_prompt_timeout` (16d), `_safe_fire` (21d), `SessionManager.unmark_continuable` (28d), `SessionManager.is_continuable` (27d), `clear_project_agent_cache` (20d), `_reset_ps_table_cache` (21d).

The last two are additionally **legitimate test-isolation hooks, not dead code** — their caches self-invalidate in production (stat signature / 1s TTL) and 17 + 2 test call sites depend on the forced reset.

**Test-only reference = refactor, not deletion:** `rewrite_session` (34 refs across 5 test files seed state for unrelated invariants), `get_unconsolidated` (superseded by `snapshot_for_consolidation`, but its 2 refs are read-back helpers in unrelated tests), `AcpSessionProvider.set_permission_mode` (genuinely zero-ref, but its twin `supports_permission_mode` is test-pinned — deleting one half leaves an asymmetric capability interface).

**Documented public surface:** `CC_PERMISSION_MODE_DEFAULT` / `CC_PERMISSION_MODE_AUTO` (`docs/system-specs/modules/platform-context.md:950-951`); `agent.py::_CC_MCP_JSON` (pinned by `conftest.py:1797`, ratcheted by `test_host_isolation_floor.py`, documented at `docs/architecture/mcp.md:53`); `ConversationLog.sliding_window` — RFC S3 names it for deletion **as a set** with `rewrite_session` / `_rewrite_session_locked`, so executing a third of that refactor would only make `docs/request-for-change/README.md:50` stale.

## Escalations — deadness is itself the bug, so not deleted

- **`cleanup_stale_sessions`** (`context_management.py:480`) — unbounded-growth gap. `sessions/<slot>/stage_N_result.md` dirs are written on every autopilot stage and only *empty* ones get reclaimed. `session.py:6216 _cleanup_loop` should call this alongside `cleanup_orphaned_session_roots`.
- **`cap_streaming_text`** (`:366`) — the cap *is* enforced in production, by hardcoded duplicates at `subagent.py:6044-6046` and `subagent.py:3015-3016`. Those call sites should adopt the helper rather than the helper being deleted in favour of magic numbers.
- **`check_session_budget`** (`:455`) and **`cap_history`** (`:448`) — unwired 5 MB and 500-entry caps whose only writers (`session_workspace.write_result` / `append_history`) have no production callers. Adjudicate the dormant `session_workspace` layer, not these leaves.
- **`ConversationLog.recent_from_source`** (52L) — confirmed dead with a clean 44-day gate, but `TestCrossTabPrivacy` (`test_ephemeral_sessions.py:707`) asserts the incognito/temporary-session exclusion invariant *exclusively* through it; it was the "Other chat tabs" context builder. Deleting it retires a privacy suite on the assumption another path re-enforces the filter. Open question worth answering before anyone removes it: is that context still built, by what, and does that path filter restricted sessions?
- **`_aim_skill_paths`** (`agent.py:1294`) — **latent test defect.** The alias `_aim_skill_paths = _all_skill_paths` is never read by production, yet 4 sites do `patch("kiro_crew.agent._aim_skill_paths", return_value=[])` (`test_agent.py:76/1422/4444`, `test_computer_use_registration.py:124`). `patch` rebinds that module key while production resolves the separate global `_all_skill_paths`, so those patches are **silent no-ops** and those tests never actually suppress skill discovery. Fixing it changes test behaviour, which is out of scope for a dead-code removal.

`context_management.py` is a live module (9 importers), so these are dead leaves on a live branch, not an orphaned module.

## Verification

- `flake8`, `isort --check-only`: exit 0.
- `mypy src/kiro_crew/`: no issues in 1167 source files.
- Baselined black gate (`scripts/check_black_formatting.py`) passes with real scope, 9 changed files. A bare `black --check` flags 4 of them but flags the **identical set** on pristine `origin/main` — they are among the 1243 known-unformatted baseline files.
- Gates green: `check_lockdown_before_publish`, `check_subprocess_encoding`, `check_loop_bound_locks`, `check_testpaths_coverage`, `check_brand_name`, `check_changelog_history`, `check_harness_parity`, `check_focus_cue`, `docs-lint`.
- Targeted suites: `test_history.py` + `test_session.py` + `test_agent.py` + `test_acp_runtime.py` → 1092 passed. `test_lite_agent_duplicate.py` + `test_worker_pool.py` → 5 passed. All `agent_files.py` consumers pass.
- Full backend suite: 74640 passed. Its 121 reds contain **no** failure in any file or module this diff touches, and are a strict subset of pristine `origin/main`'s reds for the same files (baseline 84 vs 81 for the top-6 failing files; `comm -13` yields nothing). The 11 `test_host_isolation_floor.py` failures are byte-identical to baseline — this box's HOME is not sandboxed.
- Local review lanes before push, both **no findings**: `gpt-5.6-sol` and `claude-opus-4.8`, each briefed specifically to falsify the deadness claim via string-dispatch reachability.

Full audit table (four passes, per-symbol evidence, every rejection and deferral): recorded during the audit and summarized above.

---

no linked issue: this is a self-directed dead-code audit of the core-runtime file group, not a fix for a filed report. The `#308` reference above is the PR that introduced one of the deleted constants, not an issue to close.
