### PR TITLE
fix(dashboard): drop a slot's buffered stream text on slot_clear

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -1167,6 +1167,11 @@ export function useWebSocket() {
             // cached page instead, so neither a grid pane nor a failed-switch
             // restore can resurrect the discarded transcript (#6364 review).
             const clearSlot = data.slot as string
+            // Drop the slot's buffered stream text (content + thinking) too:
+            // an entry buffered before the /clear would otherwise flush on the
+            // next frame and resurrect discarded text into the just-cleared
+            // pane. Keyed delete — other slots' in-flight buffers are theirs.
+            chunkBufRef.current.delete(clearSlot)
             if (clearSlot === store.getState().chat.activeSlot) dispatch(clearMessages())
             else dispatch(clearSlotCache(clearSlot))
             break

--- a/website/src/test/useWebSocket.slotClearBuffer.test.ts
+++ b/website/src/test/useWebSocket.slotClearBuffer.test.ts
@@ -1,0 +1,179 @@
+/**
+ * `slot_clear` must drop the slot's buffered stream text along with the
+ * transcript. The chunk buffer flushes once per animation frame, so a chunk
+ * (or chat_thinking text — same entry) buffered just before a /clear lands
+ * would otherwise flush on the NEXT frame and resurrect discarded text into
+ * the just-cleared pane. The delete is keyed: clearing one slot must not
+ * touch another slot's in-flight buffer.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { store as globalStore } from '../store'
+import { setActiveSlot, clearSlotState } from '../store/chatSlice'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockReturnValue(new Promise(() => {})),  // never resolves
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+/** Deliberately the SINGLETON store: useWebSocket dispatches via useAppDispatch()
+ *  but reads state off the imported singleton, so a separate Provider store would
+ *  let reads and writes diverge. */
+function seedStore() {
+  globalStore.dispatch(clearSlotState())
+  globalStore.dispatch(setActiveSlot('slot-1'))
+  return globalStore
+}
+
+const streamingText = () =>
+  globalStore.getState().chat.messages.find(m => m.role === 'streaming')?.content ?? ''
+
+const thinkingText = () =>
+  globalStore.getState().chat.messages.find(m => m.role === 'thinking' && m.content)?.content ?? ''
+
+const chunk = (slot: string, content: string) => ({
+  type: 'chat_chunk',
+  data: { slot, content },
+})
+
+const thinking = (slot: string, content: string) => ({
+  type: 'chat_thinking',
+  data: { slot, content },
+})
+
+const slotClear = (slot: string) => ({
+  type: 'slot_clear',
+  data: { slot },
+})
+
+describe('useWebSocket slot_clear drops buffered chunks', () => {
+  let queryClient: QueryClient
+  let rafQueue: FrameRequestCallback[]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    rafQueue = []
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // Hand-driven frames: nothing flushes until runFrames() is called
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { rafQueue.push(cb); return rafQueue.length })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => { rafQueue[id - 1] = () => {} })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalStore.dispatch(clearSlotState())
+    globalStore.dispatch(setActiveSlot(null))
+  })
+
+  function runFrames() {
+    const pending = rafQueue
+    rafQueue = []
+    act(() => { pending.forEach(cb => cb(performance.now())) })
+  }
+
+  function mount() {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store: globalStore },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return { hook, ws }
+  }
+
+  it('a chunk buffered before slot_clear does not flush back into the cleared transcript', () => {
+    const { ws } = mount()
+    seedStore()
+
+    // Chunk arrives, buffered — the flush frame has NOT run yet (that gap is
+    // exactly the bug window: /clear lands between buffer-in and flush-out).
+    act(() => { ws.simulateMessage(chunk('slot-1', 'discarded tail')) })
+    expect(streamingText()).toBe('')
+
+    act(() => { ws.simulateMessage(slotClear('slot-1')) })
+
+    // The frame that would have flushed the pre-clear chunk now runs.
+    runFrames()
+
+    expect(streamingText()).toBe('')
+    expect(globalStore.getState().chat.messages.some(m => m.content?.includes('discarded tail'))).toBe(false)
+  })
+
+  it('buffered thinking text is discarded by slot_clear too (shared buffer entry)', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => { ws.simulateMessage(thinking('slot-1', 'discarded reasoning')) })
+    expect(thinkingText()).toBe('')
+
+    act(() => { ws.simulateMessage(slotClear('slot-1')) })
+    runFrames()
+
+    expect(thinkingText()).toBe('')
+  })
+
+  it('clearing one slot leaves another slot\'s in-flight buffer intact', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => {
+      ws.simulateMessage(chunk('slot-1', 'survivor'))
+      ws.simulateMessage(slotClear('slot-2'))
+    })
+    runFrames()
+
+    // slot-1 is the active slot; its buffered chunk must still land.
+    expect(streamingText()).toBe('survivor')
+  })
+
+  it('streaming resumes normally after a slot_clear', () => {
+    const { ws } = mount()
+    seedStore()
+
+    act(() => { ws.simulateMessage(chunk('slot-1', 'old ')) })
+    act(() => { ws.simulateMessage(slotClear('slot-1')) })
+    act(() => { ws.simulateMessage(chunk('slot-1', 'fresh start')) })
+    runFrames()
+
+    expect(streamingText()).toBe('fresh start')
+  })
+})


### PR DESCRIPTION
## Problem

`slot_clear` (the `/clear` command) clears the transcript but leaves the slot's entry in the streaming chunk buffer (`chunkBufRef`). The buffer flushes once per animation frame, so a `chat_chunk` — or `chat_thinking` text, which shares the same buffer entry since #6666 — that arrived just before the `/clear` landed flushes on the NEXT frame and resurrects discarded text into the just-cleared pane.

This gap predates recent work but was widened by it:

- #6666 routed `chat_thinking` into the same buffer, so buffered reasoning text now shares the leak.
- #6868 (open) defers flushes for up to ~1s while a panel slide holds the pipelines, widening the reproduction window from ~16ms to ~1s.

Flagged as a non-blocking finding while reviewing #6666 (see the review comment there); this PR is the promised follow-up fix.

## What changed

One line in the `slot_clear` case of `useWebSocket.ts`: delete the cleared slot's chunk-buffer entry alongside clearing the transcript. The delete is keyed — other slots' in-flight buffers are untouched. This mirrors what `chat_done` already does for a finished turn.

## Tests

New `useWebSocket.slotClearBuffer.test.ts` (4 cases), driving real WS envelopes through hand-driven rAF frames:

1. A chunk buffered before `slot_clear` does not flush back into the cleared transcript.
2. Buffered `chat_thinking` text is discarded too (shared buffer entry).
3. Clearing one slot leaves another slot's in-flight buffer intact.
4. Streaming resumes normally after a `slot_clear` (no stale prefix).

Mutation-verified:
- Remove the delete → tests 1, 2, 4 red (test 3 stays green, as it should).
- Replace the keyed delete with an over-broad `.clear()` → exactly test 3 red.

Full gates: `tsc -b` clean, eslint 0 errors on touched files, full vitest suite **26,049 passed** on the rebased head.

**Why no screenshot:** no visual delta — the fix prevents a transient race (discarded text flashing back after `/clear`) that cannot be captured in a static frame; behavior is pinned by the four deterministic tests above.

No linked issue — the defect was found during code review of #6666 and is fixed directly here.
