### PR TITLE
fix(members): mount the detail drawer with the chat side panel's motion

### DIFF
--- a/website/src/pages/members/MembersPage.test.tsx
+++ b/website/src/pages/members/MembersPage.test.tsx
@@ -208,7 +208,9 @@ describe('MembersPage drawer and edit jump', () => {
     fireEvent.click(await screen.findByText('oncall'))
     expect(await screen.findByTestId('member-drawer')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    expect(screen.queryByTestId('member-drawer')).toBeNull()
+    // AnimatePresence keeps the drawer mounted for the exit tween — wait for
+    // the removal instead of asserting synchronously.
+    await waitFor(() => expect(screen.queryByTestId('member-drawer')).toBeNull())
   })
 
   it('the edit affordance lives in the drawer only and navigates to the crew manager crews tab', async () => {

--- a/website/src/pages/members/MembersPage.tsx
+++ b/website/src/pages/members/MembersPage.tsx
@@ -30,6 +30,8 @@ import CrewAvatar from '../../components/CrewAvatar'
 import ChatPane from '../../components/ChatPane'
 import ErrorBoundary from '../../components/ErrorBoundary'
 import { SearchInput } from '../../components/ui'
+import { AnimatePresence, motion } from 'framer-motion'
+import { sidePanelDockMotion } from '../chat/sidePanelMount'
 import ResizeHandle from '../../components/ResizeHandle'
 import { useColumnResize } from '../../hooks/useColumnResize'
 import { loadColumnWidth } from '../../lib/columnWidth'
@@ -121,6 +123,9 @@ export default function MembersPage() {
   // members fall to the bottom alphabetically. Sorted once from the roster
   // snapshot — live re-sorting mid-session would move rows under the cursor.
   const [filter, setFilter] = useState('')
+  // The chat side panel's right-dock mount preset — module-pure, so one
+  // constant serves every render.
+  const drawerMotion = sidePanelDockMotion('right')
   const sortedMembers = useMemo(() => {
     const ordered = [...members].sort(
       (a, b) =>
@@ -358,14 +363,28 @@ export default function MembersPage() {
 
       {/* Detail drawer — read-only observation; writes live in the crew manager.
           Below md it overlays the thread instead of claiming 300px of row
-          width, and it starts closed there (the width-gated useState above). */}
-      {active && drawerOpen && (
-        <aside
-          id="member-drawer"
-          className="fixed top-safe bottom-safe right-safe z-40 w-[300px] max-w-full bg-bg-elevated border-l border-border p-4 overflow-y-auto md:static md:z-auto md:shrink-0 md:border md:rounded-xl md:shadow-sm"
-          data-testid="member-drawer"
-          aria-label={t('pages.membersPage.details')}
-        >
+          width, and it starts closed there (the width-gated useState above).
+          Mount/unmount reuses the chat page's side-panel motion preset
+          (sidePanelDockMotion + the same 0.18s ease), so the two right panels
+          open with one gesture AND one animation. On mobile the aside is
+          position:fixed (out of flow), so the width tween is inert there and
+          only the opacity fade applies — acceptable, not a defect. */}
+      <AnimatePresence>
+        {active && drawerOpen && (
+          <motion.div
+            key="member-drawer-motion"
+            initial={drawerMotion.initial}
+            animate={drawerMotion.animate}
+            exit={drawerMotion.exit}
+            transition={{ duration: 0.18, ease: [0.2, 0, 0, 1] }}
+            className="h-full overflow-visible flex justify-end md:shrink-0"
+          >
+            <aside
+              id="member-drawer"
+              className="fixed top-safe bottom-safe right-safe z-40 w-[300px] max-w-full bg-bg-elevated border-l border-border p-4 overflow-y-auto md:static md:z-auto md:shrink-0 md:border md:rounded-xl md:shadow-sm"
+              data-testid="member-drawer"
+              aria-label={t('pages.membersPage.details')}
+            >
           <div className="flex items-center mb-2">
             <div className="text-[11px] font-semibold tracking-wide text-muted flex-1">
               {t('pages.membersPage.configuration')}
@@ -419,7 +438,9 @@ export default function MembersPage() {
             {t('pages.membersPage.edit_in_crew_manager')}
           </button>
         </aside>
-      )}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   )
 }


### PR DESCRIPTION
## Problem / Motivation

PM review of the Crew Members page: the detail drawer pops in and out with no transition, while the chat page's right side panel — the sibling surface users learned first — slides in through `sidePanelDockMotion` + `AnimatePresence`. Two right panels opening with different physics reads as two products.

## Why it matters

Motion is part of the panel idiom, not decoration: the chat page's slide teaches "a panel is arriving from the right edge", and the drawer's instant pop breaks that learned expectation on every open.

## What changed

The drawer mounts through the chat page's exact preset: `AnimatePresence` + `sidePanelDockMotion('right')` + the identical `0.18s` / `[0.2, 0, 0, 1]` ease. The full `SidePanel` component is deliberately **not** reused — it is a multi-tab chat host with 20+ slot-coupled props, and this drawer is a read-only config card; the shared piece is the motion contract, not the component. On mobile the aside is `position:fixed` (out of flow), so the width tween is inert there and only the opacity fade applies.

## Tests

15/15 — the drawer-toggle test now waits for the exit tween's unmount (`waitFor` on removal) instead of asserting synchronously; all other pins unchanged. Capture harness all frames verified.

## Manual verification

Capture harness frames re-verified (drawer content and layout unchanged at rest; the change is the mount/unmount transition).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the rendered at-rest layout is pixel-identical; the change is a 0.18s mount/unmount transition a still frame cannot show. The motion preset and curve are byte-shared with the chat page's already-shipped side panel.

no linked issue: PM chat feedback on the shipped page.
