### PR TITLE
fix: per-path optimistic overlay for settings model pickers (#6875)

### DIFF
--- a/website/src/pages/settings/ChatPanel.tsx
+++ b/website/src/pages/settings/ChatPanel.tsx
@@ -114,9 +114,10 @@ type KirocrewConfigShape = {
 
 /**
  * Return a copy of `cfg` with the dot-separated `path` set to `value`,
- * shallow-cloning only the objects along the path. Used to write a config
- * PATCH into the query cache optimistically so a selector shows the chosen
- * value immediately instead of waiting for the PATCH + refetch round-trip.
+ * shallow-cloning only the objects along the path. Used on a config PATCH's
+ * success to write the ACCEPTED value into the query cache at that one path,
+ * so a transiently failed settle-time refetch cannot leave the display on a
+ * pre-PATCH value the server no longer holds.
  */
 function setConfigValue(cfg: KirocrewConfigShape, path: string, value: unknown): KirocrewConfigShape {
   const keys = path.split('.')
@@ -134,7 +135,63 @@ function setConfigValue(cfg: KirocrewConfigShape, path: string, value: unknown):
 export function ChatPanel() {
   const qc = useQueryClient()
   const [chatCfg, setChatCfg] = useState<ChatConfig>(loadChatConfig)
-  const [saveError, setSaveError] = useState('')
+  const [saveError, rawSetSaveError] = useState('')
+  // The failure banner is one shared slot written by every save on this panel,
+  // so a pick may only auto-clear a failure that came from the SAME picker —
+  // its own config path. Clearing more than that (another picker's failure,
+  // or a non-picker save's) would dismiss an unresolved error and leave the
+  // user believing that setting persisted. The ref records which config path
+  // produced the current banner; null = not a picker failure.
+  const saveErrorPathRef = useRef<string | null>(null)
+  const setSaveError = (msg: string) => {
+    saveErrorPathRef.current = null
+    rawSetSaveError(msg)
+  }
+  const setPickerSaveError = (path: string, msg: string) => {
+    saveErrorPathRef.current = path
+    rawSetSaveError(msg)
+  }
+
+  // ── Optimistic pending values for the model/effort pickers ──
+  // Each picker renders `pending ?? server`, so a pick shows in the trigger
+  // immediately instead of after the PATCH → invalidate → refetch round-trip.
+  // The overlay is keyed by config path, so concurrent picks on different
+  // pickers cannot touch each other's display: a failed mutation only stops
+  // masking its OWN path, and a settle-time refetch lands in the query cache
+  // UNDER every still-pending overlay rather than clobbering it.
+  //
+  // Ownership is a monotonic token, not the picked value: `setPending`
+  // returns the token from `onMutate` (react-query hands it back to
+  // `onSettled` as the mutation context), and only the entry's own token may
+  // clear it. Guarding on the value instead would let pick A → pick B →
+  // pick A on one picker have A₁'s settle clear the entry A₃ owns, flashing
+  // the stale cache value while A₃ is still in flight.
+  const pendingSeqRef = useRef(0)
+  // Latest token per path, readable synchronously from mutation callbacks
+  // (state would be a stale closure there): lets a superseded mutation's
+  // late failure recognise it no longer owns the path's display.
+  const latestTokenRef = useRef<Record<string, number>>({})
+  const [pendingCfg, setPendingCfg] = useState<Record<string, { value: string; token: number } | undefined>>({})
+  const setPending = (path: string, value: string): number => {
+    const token = ++pendingSeqRef.current
+    latestTokenRef.current[path] = token
+    setPendingCfg(prev => ({ ...prev, [path]: { value, token } }))
+    // A fresh attempt supersedes a stale failure banner from THIS picker:
+    // without this the trigger would show the new pick while its own last
+    // pick's error still hangs above it in the same frame. Failures from any
+    // other source — another picker included — stay up: this pick says
+    // nothing about whether that other setting saved.
+    if (saveErrorPathRef.current === path) setSaveError('')
+    return token
+  }
+  const clearPending = (path: string, token: unknown) =>
+    setPendingCfg(prev => {
+      // A newer pick on the same path owns the display now; leave it alone.
+      if (prev[path]?.token !== token) return prev
+      const next = { ...prev }
+      delete next[path]
+      return next
+    })
 
   // ── Dashboard config (server-side) ──
   const dashQ = useQuery<DashboardConfig>({
@@ -192,26 +249,62 @@ export function ChatPanel() {
   const mcCfg = mcQ.data
 
   /**
-   * Mutation options for a config PATCH with an OPTIMISTIC cache write
-   * (issue #6848): the seven Model-section selectors are controlled by the
-   * query cache, so without this they keep showing the previous choice until
-   * the PATCH and refetch settle. Writes the picked value into the cache
-   * immediately, rolls back on error, and reconciles with the server on
-   * settle — same shape as tipsMut/dashMut above.
+   * Mutation options for a config PATCH with an OPTIMISTIC display: the seven
+   * Model-section selectors render `pending ?? server`, so a pick shows
+   * immediately instead of waiting for the PATCH + refetch round-trip.
+   *
+   * The pending entry is per config PATH, never a whole-config snapshot:
+   * snapshotting the whole object would capture another picker's in-flight
+   * optimistic value and restore it on this mutation's failure, transiently
+   * reverting a pick the user never undid. With the overlay, an error only
+   * stops masking this mutation's own path.
+   *
+   * On success the ACCEPTED value is first written into the cache at this
+   * path only, so a transiently failed settle-time refetch (which
+   * invalidateQueries swallows) cannot leave the display on a pre-PATCH
+   * value the server no longer holds. `onSuccess` then RETURNS the
+   * invalidateQueries promise — react-query awaits it before `onSettled` —
+   * so by the time the pending entry clears, a completed refetch has already
+   * replaced that write with the server's authoritative answer (which may
+   * differ from the pick when the backend normalises it). The refetch cannot
+   * clobber a DIFFERENT picker's in-flight pick, because that picker's
+   * overlay still masks the cache until its own settle. On error the cache
+   * was never written, but the refetch still runs: a PATCH can fail after
+   * persisting (5xx after apply, proxy timeout), and only the server can say
+   * which value survived. `''` is a meaningful value here ("model default" /
+   * fallback "disabled"), hence `??` over truthiness everywhere the overlay
+   * is read.
+   *
+   * The failure banner is token-guarded: a pick that has been superseded by
+   * a newer pick on the same path reports nothing when it eventually fails —
+   * the newer pick owns the display, and a stale "failed to save" beside a
+   * value that did persist is exactly the co-render this fix removes.
    */
   const optimisticConfigOpts = (path: string, errMsg: (err: unknown) => string) => ({
     mutationFn: (v: string) => api.patchConfig(path, v),
-    onMutate: async (v: string) => {
-      await qc.cancelQueries({ queryKey: ['kirocrewConfig'] })
-      const prev = qc.getQueryData<KirocrewConfigShape>(['kirocrewConfig'])
-      if (prev) qc.setQueryData(['kirocrewConfig'], setConfigValue(prev, path, v))
-      return { prev }
+    onMutate: (v: string) => setPending(path, v),
+    onSuccess: (_data: unknown, v: string, token: unknown) => {
+      // Only the path's LATEST pick may write its accepted value: with A→B
+      // in flight on one picker and B settling first, A's later settle would
+      // otherwise overwrite B in the cache, and a failed refetch would leave
+      // stale A displayed while the server holds B.
+      if (latestTokenRef.current[path] === token) {
+        const cur = qc.getQueryData<KirocrewConfigShape>(['kirocrewConfig'])
+        if (cur) qc.setQueryData(['kirocrewConfig'], setConfigValue(cur, path, v))
+      }
+      return qc.invalidateQueries({ queryKey: ['kirocrewConfig'] })
     },
-    onError: (err: unknown, _v: string, ctx?: { prev?: KirocrewConfigShape }) => {
-      if (ctx?.prev) qc.setQueryData(['kirocrewConfig'], ctx.prev)
-      setSaveError(errMsg(err))
+    onError: (err: unknown, _v: string, token: unknown) => {
+      // Stop masking immediately (token-guarded and idempotent with the
+      // onSettled clear) so no intermediate frame shows the failed pick
+      // beside its own failure banner.
+      clearPending(path, token)
+      if (latestTokenRef.current[path] === token) setPickerSaveError(path, errMsg(err))
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
+    onSettled: (_data: unknown, err: unknown, _v: string, token: unknown) => {
+      clearPending(path, token)
+      if (err) qc.invalidateQueries({ queryKey: ['kirocrewConfig'] })
+    },
   })
 
   // ── User profile (About You) ──
@@ -291,6 +384,7 @@ export function ChatPanel() {
   // "auto" (default) = backend availability-aware routing, concrete id =
   // tried first with "auto" as the final fallthrough.
   const fallbackModel = mcCfg?.agent?.fallback_model ?? 'auto'
+  const shownFallbackModel = pendingCfg['agent.fallback_model']?.value ?? fallbackModel
   const fallbackMut = useMutation(
     optimisticConfigOpts('agent.fallback_model', (err: unknown) => {
       // Surface the backend's actual deny reason (e.g. an unentitled id)
@@ -299,9 +393,14 @@ export function ChatPanel() {
       return i18nT('pages.settings.chatPanel.failed_to_save_fallback_model') + reason
     })
   )
-  const fallbackModelOptions = (current: string): string[] => {
+  const fallbackModelOptions = (shown: string, server: string): string[] => {
     const opts = ['', 'auto', ...availableModels.map(m => m.name).filter(m => m !== 'auto')]
-    if (current && !opts.includes(current)) opts.splice(2, 0, current)
+    // Keep both the shown and the persisted id selectable while they differ:
+    // an in-flight pick must not drop the server's unadvertised id from the
+    // list, or the user could not switch back to it during that window.
+    for (const kept of [server, shown]) {
+      if (kept && !opts.includes(kept)) opts.splice(2, 0, kept)
+    }
     return opts
   }
   const fallbackModelLabels = (opts: string[]): string[] =>
@@ -347,21 +446,30 @@ export function ChatPanel() {
   // '' in config means "unset" and resolves the same way 'auto' does, so both
   // render as the 'auto' option rather than as a missing selection.
   const defaultModel = mcCfg?.agent?.model || 'auto'
+  const shownDefaultModel = pendingCfg['agent.model']?.value ?? defaultModel
   const modelOptions = availableModels.map(m => m.name)
   // A model the live backend no longer advertises must still be selectable,
   // otherwise the select would silently jump to another entry and a stray
-  // change event would overwrite the user's stored choice.
-  if (!modelOptions.includes(defaultModel)) modelOptions.unshift(defaultModel)
+  // change event would overwrite the user's stored choice. Both the SHOWN and
+  // the persisted value are kept: while a pick is in flight the server's
+  // unadvertised id must not vanish from the list, or the user could not
+  // change back to it during that window.
+  for (const kept of [defaultModel, shownDefaultModel]) {
+    if (!modelOptions.includes(kept)) modelOptions.unshift(kept)
+  }
 
   const defaultModelMut = useMutation(
     optimisticConfigOpts('agent.model', () => i18nT('pages.settings.chatPanel.failed_to_save_default_model'))
   )
 
   const defaultEffort = mcCfg?.agent?.reasoning_effort ?? ''
+  const shownDefaultEffort = pendingCfg['agent.reasoning_effort']?.value ?? defaultEffort
   // Effort is only meaningful on reasoning-capable models. Rather than hide the
   // row (which would make the setting look absent), keep it visible and
-  // disabled with an explanatory hint.
-  const effortSupported = modelSupportsEffort(defaultModel)
+  // disabled with an explanatory hint. Gated on the SHOWN model so the row's
+  // enabled state tracks the trigger the user is looking at, not a value the
+  // refetch has yet to replace.
+  const effortSupported = modelSupportsEffort(shownDefaultModel)
   const defaultEffortMut = useMutation(
     optimisticConfigOpts('agent.reasoning_effort', () =>
       i18nT('pages.settings.chatPanel.failed_to_save_default_reasoning_effort')
@@ -377,15 +485,26 @@ export function ChatPanel() {
   // these rows label it differently from the chat row's Default (auto).
   const backgroundModel = mcCfg?.agent?.role_models?.background || 'auto'
   const subagentModel = mcCfg?.agent?.role_models?.subagent || 'auto'
+  const shownBackgroundModel = pendingCfg['agent.role_models.background']?.value ?? backgroundModel
+  const shownSubagentModel = pendingCfg['agent.role_models.subagent']?.value ?? subagentModel
   // A pinned model the live backend no longer advertises must stay selectable
-  // (same reasoning as the chat-default picker), so prepend it when missing.
-  const roleModelOptions = (current: string): string[] => {
+  // (same reasoning as the chat-default picker), so prepend what is missing —
+  // both the shown value and the persisted one, so neither vanishes while a
+  // pick is in flight.
+  const roleModelOptions = (shown: string, server: string): string[] => {
     const opts = availableModels.map(m => m.name)
-    if (!opts.includes(current)) opts.unshift(current)
+    for (const kept of [server, shown]) {
+      if (!opts.includes(kept)) opts.unshift(kept)
+    }
     return opts
   }
   const roleModelLabels = (opts: string[]): string[] =>
     opts.map(m => (m === 'auto' ? i18nT('pages.settings.chatPanel.role_model_auto') : m))
+  // One array per row, shared by `options` and `optionLabels`: SettingsSelect
+  // pairs a label to a value by INDEX, so both props must read the same list.
+  const backgroundModelOpts = roleModelOptions(shownBackgroundModel, backgroundModel)
+  const subagentModelOpts = roleModelOptions(shownSubagentModel, subagentModel)
+  const fallbackOpts = fallbackModelOptions(shownFallbackModel, fallbackModel)
   const backgroundModelMut = useMutation(
     optimisticConfigOpts('agent.role_models.background', () => i18nT('pages.settings.chatPanel.failed_to_save_role_model'))
   )
@@ -405,8 +524,10 @@ export function ChatPanel() {
   // rather than folded into this copy fix.
   const backgroundEffort = mcCfg?.agent?.role_efforts?.background ?? ''
   const subagentEffort = mcCfg?.agent?.role_efforts?.subagent ?? ''
-  const bgEffortSupported = modelSupportsEffort(backgroundModel !== 'auto' ? backgroundModel : defaultModel)
-  const subEffortSupported = modelSupportsEffort(subagentModel !== 'auto' ? subagentModel : defaultModel)
+  const shownBackgroundEffort = pendingCfg['agent.role_efforts.background']?.value ?? backgroundEffort
+  const shownSubagentEffort = pendingCfg['agent.role_efforts.subagent']?.value ?? subagentEffort
+  const bgEffortSupported = modelSupportsEffort(shownBackgroundModel !== 'auto' ? shownBackgroundModel : shownDefaultModel)
+  const subEffortSupported = modelSupportsEffort(shownSubagentModel !== 'auto' ? shownSubagentModel : shownDefaultModel)
   const effortLabels = EFFORT_LEVELS.map(l => (l === '' ? i18nT('pages.settings.chatPanel.model_default') : effortLabel(l)))
   const backgroundEffortMut = useMutation(
     optimisticConfigOpts('agent.role_efforts.background', () => i18nT('pages.settings.chatPanel.failed_to_save_role_effort'))
@@ -457,7 +578,7 @@ export function ChatPanel() {
             label={i18nT('pages.settings.chatPanel.default_model')}
             description={i18nT('pages.settings.chatPanel.which_model_new_sessions_start_with_pick_a_model')}
             hint={i18nT('pages.settings.chatPanel.default_defers_to_your_agent_config_and_then_to')}
-            value={defaultModel}
+            value={shownDefaultModel}
             options={modelOptions}
             optionLabels={modelOptions.map(m => (m === 'auto' ? i18nT('pages.settings.chatPanel.default_auto') : m))}
             onChange={v => defaultModelMut.mutate(v)}
@@ -471,7 +592,7 @@ export function ChatPanel() {
                 ? i18nT('pages.settings.chatPanel.model_default_applies_no_override_the_model_pick')
                 : i18nT('pages.settings.chatPanel.effort_needs_reasoning_model')
             }
-            value={defaultEffort}
+            value={shownDefaultEffort}
             options={[...EFFORT_LEVELS]}
             optionLabels={effortLabels}
             onChange={v => defaultEffortMut.mutate(v)}
@@ -485,16 +606,16 @@ export function ChatPanel() {
           <SettingsSelect
             label={i18nT('pages.settings.chatPanel.background_model')}
             hint={i18nT('pages.settings.chatPanel.role_model_auto_hint')}
-            value={backgroundModel}
-            options={roleModelOptions(backgroundModel)}
-            optionLabels={roleModelLabels(roleModelOptions(backgroundModel))}
+            value={shownBackgroundModel}
+            options={backgroundModelOpts}
+            optionLabels={roleModelLabels(backgroundModelOpts)}
             onChange={v => backgroundModelMut.mutate(v)}
             disabled={!mcQ.isSuccess}
           />
           <SettingsSelect
             label={i18nT('pages.settings.chatPanel.background_effort')}
             hint={i18nT('pages.settings.chatPanel.role_effort_hint')}
-            value={backgroundEffort}
+            value={shownBackgroundEffort}
             options={[...EFFORT_LEVELS]}
             optionLabels={effortLabels}
             onChange={v => backgroundEffortMut.mutate(v)}
@@ -508,16 +629,16 @@ export function ChatPanel() {
           <SettingsSelect
             label={i18nT('pages.settings.chatPanel.subagent_model')}
             hint={i18nT('pages.settings.chatPanel.role_model_auto_hint')}
-            value={subagentModel}
-            options={roleModelOptions(subagentModel)}
-            optionLabels={roleModelLabels(roleModelOptions(subagentModel))}
+            value={shownSubagentModel}
+            options={subagentModelOpts}
+            optionLabels={roleModelLabels(subagentModelOpts)}
             onChange={v => subagentModelMut.mutate(v)}
             disabled={!mcQ.isSuccess}
           />
           <SettingsSelect
             label={i18nT('pages.settings.chatPanel.subagent_effort')}
             hint={i18nT('pages.settings.chatPanel.role_effort_hint')}
-            value={subagentEffort}
+            value={shownSubagentEffort}
             options={[...EFFORT_LEVELS]}
             optionLabels={effortLabels}
             onChange={v => subagentEffortMut.mutate(v)}
@@ -531,9 +652,9 @@ export function ChatPanel() {
           <SettingsSelect
             label={i18nT('pages.settings.chatPanel.fallback_model')}
             hint={i18nT('pages.settings.chatPanel.fallback_auto_hint')}
-            value={fallbackModel}
-            options={fallbackModelOptions(fallbackModel)}
-            optionLabels={fallbackModelLabels(fallbackModelOptions(fallbackModel))}
+            value={shownFallbackModel}
+            options={fallbackOpts}
+            optionLabels={fallbackModelLabels(fallbackOpts)}
             onChange={v => fallbackMut.mutate(v)}
             disabled={!mcQ.isSuccess}
             configKey="agent.fallback_model"

--- a/website/src/test/ChatPanel.optimisticPickers.test.tsx
+++ b/website/src/test/ChatPanel.optimisticPickers.test.tsx
@@ -1,0 +1,473 @@
+// Settings ▸ Chat ▸ Model — optimistic picker display consistency (#6875).
+//
+// The seven model/effort selects render `pending ?? server`: a pick must show
+// in the trigger IMMEDIATELY (while the config PATCH is still in flight), roll
+// back beside the existing failed-to-save banner when the PATCH rejects, and
+// reconcile to whatever the refetched config reports once the mutation
+// settles — the server stays authoritative, even when it answers with a
+// different value than the one picked.
+//
+// The pending display is per config PATH with monotonic ownership: concurrent
+// picks on two pickers never revert each other, an older settle never clears
+// a newer pick on the same picker (A→B→A), a persisted-but-unadvertised id
+// stays selectable mid-flight, and the shared failure banner is only
+// auto-cleared by a retry on the SAME path.
+//
+// Every display test here pins the pre-settle state with the PATCH promise
+// held open — the window where the query cache still holds the pre-pick
+// config, so only the pending overlay can produce the asserted trigger text.
+//
+// SettingsSelect wraps Radix Select, which needs pointer APIs jsdom lacks —
+// use the same lightweight mock the sibling ChatPanel suites use so options
+// are real role="option" nodes.
+vi.mock('@radix-ui/react-select', async () => await import('./__mocks__/@radix-ui/react-select'))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+const { patchConfigMock, kirocrewConfigMock, modelsMock } = vi.hoisted(() => ({
+  patchConfigMock: vi.fn(() => Promise.resolve({})),
+  kirocrewConfigMock: vi.fn(() =>
+    Promise.resolve({ agent: { model: 'auto', reasoning_effort: '' } })
+  ),
+  modelsMock: vi.fn(() =>
+    Promise.resolve([
+      { model_name: 'auto', description: 'Default' },
+      { model_name: 'claude-opus-4.8', description: 'Opus' },
+      { model_name: 'claude-haiku-4.5', description: 'Haiku' },
+    ])
+  ),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    dashboardConfig: () => Promise.resolve({ restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more' }),
+    kirocrewConfig: kirocrewConfigMock,
+    models: modelsMock,
+    patchConfig: patchConfigMock,
+    updateDashboardConfig: () => Promise.resolve({}),
+    tipsStatus: () => Promise.resolve({ enabled_config: true, opted_out: false }),
+    tipsFeedback: () => Promise.resolve({ ok: true }),
+  },
+}))
+
+import { ChatPanel } from '../pages/settings/ChatPanel'
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+/** The agent block the config mock serves. Reassigned mid-test to stand in for
+ *  the server's post-PATCH state: the refetch that follows a successful PATCH
+ *  reads whatever this holds at that moment. */
+let serverAgent: Record<string, unknown> = {}
+const seed = (agent: Record<string, unknown>) => {
+  serverAgent = agent
+  kirocrewConfigMock.mockImplementation(() => Promise.resolve({ agent: serverAgent }) as never)
+}
+
+/** A PATCH whose settle the test controls. While `resolve`/`reject` has not
+ *  been called the request is in flight — the window the optimistic display
+ *  must already be visible in. */
+function deferPatch() {
+  let resolve!: (v: unknown) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  patchConfigMock.mockImplementation(() => promise as never)
+  return { resolve, reject }
+}
+
+/** N independently controlled PATCHes, handed out call-by-call in order. */
+function deferPatches(n: number) {
+  const ds = Array.from({ length: n }, () => {
+    let resolve!: (v: unknown) => void
+    let reject!: (e: unknown) => void
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+    return { promise, resolve, reject }
+  })
+  let i = 0
+  patchConfigMock.mockImplementation(() => ds[Math.min(i++, n - 1)].promise as never)
+  return ds
+}
+
+/** Open a SettingsSelect by label and return its option nodes.
+ *  Waits for the control to leave its loading-disabled state first — the
+ *  trigger exists (inert) while the config query is still in flight. */
+async function openSelect(label: string) {
+  const trigger = await screen.findByRole('combobox', { name: label })
+  await waitFor(() => expect(trigger).not.toHaveAttribute('data-disabled'))
+  fireEvent.click(trigger)
+  return trigger
+}
+
+async function pick(label: string, optionName: string) {
+  const trigger = await openSelect(label)
+  fireEvent.click(screen.getByRole('option', { name: optionName }))
+  return trigger
+}
+
+beforeEach(() => {
+  patchConfigMock.mockReset()
+  patchConfigMock.mockImplementation(() => Promise.resolve({}) as never)
+  kirocrewConfigMock.mockClear()
+  modelsMock.mockClear()
+  seed({ model: 'auto', reasoning_effort: '' })
+})
+
+describe('ChatPanel — optimistic default model', () => {
+  it('shows the picked model before the PATCH resolves', async () => {
+    const { resolve } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+
+    // Pre-settle: the trigger already shows the pick while the PATCH promise
+    // is still open, and the config has NOT been refetched — the only way to
+    // display it this early is the optimistic pending value.
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+    expect(patchConfigMock).toHaveBeenCalledWith('agent.model', 'claude-opus-4.8')
+    expect(kirocrewConfigMock).toHaveBeenCalledTimes(1)
+
+    // Settle: the refetch reports the same value; the display keeps it.
+    serverAgent = { model: 'claude-opus-4.8', reasoning_effort: '' }
+    resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    expect(trigger).toHaveTextContent('claude-opus-4.8')
+  })
+
+  it('reconciles to the server value when the refetch reports a different one', async () => {
+    const { resolve } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+
+    // The backend normalises the pick to something else; once the mutation
+    // settles the picker must show the SERVER's answer, not the local one.
+    serverAgent = { model: 'claude-haiku-4.5', reasoning_effort: '' }
+    resolve({})
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+  })
+
+  it('rolls back to the persisted model when the PATCH rejects', async () => {
+    const { reject } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+
+    reject(new Error('boom'))
+    expect(await screen.findByText(/Failed to save default model/)).toBeInTheDocument()
+    await waitFor(() => expect(trigger).toHaveTextContent('Default (auto)'))
+  })
+
+  it('enables the effort row against the optimistic model, not the stale one', async () => {
+    // Effort gating is derived from the SHOWN model, so picking a
+    // reasoning-capable model unlocks the effort row while the PATCH is
+    // still in flight — the panel stays self-consistent with its triggers.
+    const { resolve } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const effortTrigger = await screen.findByRole('combobox', { name: 'Default Reasoning Effort' })
+    await waitFor(() => expect(effortTrigger).toHaveAttribute('data-disabled'))
+
+    await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(effortTrigger).not.toHaveAttribute('data-disabled'))
+    resolve({})
+  })
+})
+
+describe('ChatPanel — optimistic role effort (the empty-string value)', () => {
+  it('shows "Model default" ("") before the PATCH resolves and keeps it after settle', async () => {
+    // '' is a MEANINGFUL value (inherit the model's own default): a truthiness
+    // test would drop the pending pick and keep showing 'High'.
+    seed({ role_models: { background: 'claude-opus-4.8' }, role_efforts: { background: 'high' } })
+    const { resolve } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Background Effort', 'Model default')
+
+    await waitFor(() => expect(trigger).toHaveTextContent('Model default'))
+    expect(patchConfigMock).toHaveBeenCalledWith('agent.role_efforts.background', '')
+    expect(kirocrewConfigMock).toHaveBeenCalledTimes(1)
+
+    serverAgent = { role_models: { background: 'claude-opus-4.8' }, role_efforts: { background: '' } }
+    resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    expect(trigger).toHaveTextContent('Model default')
+  })
+
+  it('rolls back to the persisted effort when the PATCH rejects', async () => {
+    seed({ role_models: { background: 'claude-opus-4.8' }, role_efforts: { background: '' } })
+    const { reject } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Background Effort', 'Max')
+    await waitFor(() => expect(trigger).toHaveTextContent('Max'))
+
+    reject(new Error('boom'))
+    expect(await screen.findByText(/Failed to save role effort/)).toBeInTheDocument()
+    await waitFor(() => expect(trigger).toHaveTextContent('Model default'))
+  })
+})
+
+describe('ChatPanel — optimistic fallback model', () => {
+  it('shows the picked model before the PATCH resolves and keeps the refetched value', async () => {
+    seed({ fallback_model: 'auto' })
+    const { resolve } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Fallback model', 'claude-opus-4.8')
+
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+    expect(patchConfigMock).toHaveBeenCalledWith('agent.fallback_model', 'claude-opus-4.8')
+    expect(kirocrewConfigMock).toHaveBeenCalledTimes(1)
+
+    serverAgent = { fallback_model: 'claude-opus-4.8' }
+    resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    expect(trigger).toHaveTextContent('claude-opus-4.8')
+  })
+
+  it('shows "Disabled" ("") optimistically and rolls it back when the PATCH rejects', async () => {
+    // The fallback picker's other meaningful '' value: Disabled. It must
+    // render optimistically (?? semantics again) and snap back to the
+    // persisted choice beside the existing error copy on failure.
+    seed({ fallback_model: 'auto' })
+    const { reject } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Fallback model', 'Disabled')
+    await waitFor(() => expect(trigger).toHaveTextContent('Disabled'))
+    expect(patchConfigMock).toHaveBeenCalledWith('agent.fallback_model', '')
+
+    reject(new Error('boom'))
+    expect(await screen.findByText(/Failed to save fallback model/)).toBeInTheDocument()
+    await waitFor(() => expect(trigger).toHaveTextContent('Auto (recommended)'))
+  })
+})
+
+describe('ChatPanel — pending ownership and reconciliation edges', () => {
+  it('concurrent picks on two pickers never revert each other (error + refetch paths)', async () => {
+    // The headline race: with a whole-config snapshot, Y's failure restores a
+    // state captured before X's pick (erasing X's display), and X's settle
+    // refetch returns server state that lacks Y's un-applied PATCH (reverting
+    // Y's display). Per-path pending entries make both directions impossible.
+    seed({ model: 'auto', reasoning_effort: '', fallback_model: 'auto' })
+    const ds = deferPatches(2)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const fallbackTrigger = await pick('Fallback model', 'claude-haiku-4.5')
+    const modelTrigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(fallbackTrigger).toHaveTextContent('claude-haiku-4.5'))
+    await waitFor(() => expect(modelTrigger).toHaveTextContent('claude-opus-4.8'))
+
+    // Y (fallback) FAILS while X (default model) is still in flight: only the
+    // fallback display may roll back — the model pick must survive.
+    ds[0].reject(new Error('boom'))
+    expect(await screen.findByText(/Failed to save fallback model/)).toBeInTheDocument()
+    await waitFor(() => expect(fallbackTrigger).toHaveTextContent('Auto (recommended)'))
+    expect(modelTrigger).toHaveTextContent('claude-opus-4.8')
+
+    // X SUCCEEDS: its settle-time refetch reports the model as persisted. The
+    // display keeps it, and nothing else on the panel moved.
+    serverAgent = { model: 'claude-opus-4.8', reasoning_effort: '', fallback_model: 'auto' }
+    ds[1].resolve({})
+    await waitFor(() => expect(kirocrewConfigMock.mock.calls.length).toBeGreaterThan(1))
+    expect(modelTrigger).toHaveTextContent('claude-opus-4.8')
+    expect(fallbackTrigger).toHaveTextContent('Auto (recommended)')
+  })
+
+  it('keeps the latest pick displayed when an older same-value PATCH settles first (A→B→A)', async () => {
+    // Ownership must be a token, not the picked value: after pick A → pick B
+    // → pick A, the FIRST A's settle must not clear the pending entry the
+    // THIRD pick owns. The server still reports the stale value here, so a
+    // wrongful clear is visible as the trigger falling back to it.
+    const ds = deferPatches(3)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await pick('Default Model', 'claude-haiku-4.5')
+    await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+    expect(patchConfigMock).toHaveBeenCalledTimes(3)
+
+    // First A settles (serverAgent still 'auto'); B and the second A are in
+    // flight, so the trigger must keep showing the latest pick.
+    ds[0].resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    expect(trigger).toHaveTextContent('claude-opus-4.8')
+
+    // The remaining mutations settle. The server reports a normalised value,
+    // so the trigger moving to it proves BOTH later mutations settled, the
+    // pending entry cleared, and the server stayed authoritative.
+    serverAgent = { model: 'claude-haiku-4.5', reasoning_effort: '' }
+    ds[1].resolve({})
+    ds[2].resolve({})
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+  })
+
+  it('clears a stale failure banner when a new pick starts', async () => {
+    // A failed save leaves the banner up; the next attempt must not show a
+    // fresh optimistic value under last attempt's error in the same frame.
+    patchConfigMock.mockImplementationOnce(() => Promise.reject(new Error('boom')) as never)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    expect(await screen.findByText(/Failed to save default model/)).toBeInTheDocument()
+
+    serverAgent = { model: 'claude-haiku-4.5', reasoning_effort: '' }
+    await pick('Default Model', 'claude-haiku-4.5')
+    await waitFor(() =>
+      expect(screen.queryByText(/Failed to save default model/)).not.toBeInTheDocument()
+    )
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+  })
+
+  it('does NOT clear a failure banner that came from a non-picker save', async () => {
+    // The banner is one shared slot for ~12 failure sources on this panel. A
+    // picker pick may only auto-clear a PICKER failure: dismissing, say, an
+    // unresolved auto-compact error would leave the user believing that
+    // setting persisted.
+    patchConfigMock.mockImplementationOnce(() => Promise.reject(new Error('boom')) as never)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    // Fail a non-picker save (Auto-Compact Threshold PATCHes via .then/.catch,
+    // not a picker mutation) to raise its banner.
+    await pick('Auto-Compact Threshold', '90%')
+    expect(await screen.findByText(/Failed to save auto-compact threshold/)).toBeInTheDocument()
+
+    // A model pick must leave that unresolved failure visible. The PATCH
+    // resolves instantly here, so seed the refetched config with the pick —
+    // asserting the pre-settle overlay against an already-settled mutation
+    // would race the microtask cascade.
+    serverAgent = { model: 'claude-opus-4.8', reasoning_effort: '' }
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+    expect(screen.getByText(/Failed to save auto-compact threshold/)).toBeInTheDocument()
+  })
+
+  it("does NOT clear ANOTHER picker's failure banner", async () => {
+    // Banner ownership is per config path, not per picker-kind: a fallback
+    // save failure must survive a subsequent Default Model pick — that pick
+    // says nothing about whether the fallback persisted.
+    seed({ model: 'auto', reasoning_effort: '', fallback_model: 'auto' })
+    patchConfigMock.mockImplementationOnce(() => Promise.reject(new Error('boom')) as never)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    await pick('Fallback model', 'claude-haiku-4.5')
+    expect(await screen.findByText(/Failed to save fallback model/)).toBeInTheDocument()
+
+    // Instant-resolve PATCH: seed the refetched config with the pick so the
+    // assertion holds past settle (same reasoning as the test above).
+    serverAgent = { model: 'claude-opus-4.8', reasoning_effort: '', fallback_model: 'auto' }
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+    expect(screen.getByText(/Failed to save fallback model/)).toBeInTheDocument()
+
+    // Re-picking the FALLBACK itself does clear its own stale failure.
+    await pick('Fallback model', 'claude-opus-4.8')
+    await waitFor(() =>
+      expect(screen.queryByText(/Failed to save fallback model/)).not.toBeInTheDocument()
+    )
+  })
+
+  it('suppresses the failure banner of a pick superseded by a newer one on the same path', async () => {
+    // Pick A, then pick B before A settles; A then FAILS. B owns the display
+    // now — A's late failure must not install a stale "failed to save" beside
+    // the value B is about to persist.
+    const ds = deferPatches(2)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await pick('Default Model', 'claude-haiku-4.5')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+
+    ds[0].reject(new Error('boom'))
+    serverAgent = { model: 'claude-haiku-4.5', reasoning_effort: '' }
+    ds[1].resolve({})
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+    expect(screen.queryByText(/Failed to save default model/)).not.toBeInTheDocument()
+  })
+
+  it('keeps the accepted value displayed when the settle-time refetch fails', async () => {
+    // invalidateQueries swallows refetch rejections, so onSettled clears the
+    // overlay either way. The success-path cache write of the ACCEPTED value
+    // is what keeps the display truthful when the refetch transiently fails.
+    const { resolve } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+
+    kirocrewConfigMock.mockImplementationOnce(() => Promise.reject(new Error('offline')) as never)
+    resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    // Overlay cleared, refetch failed — the cache write keeps the pick shown.
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+  })
+
+  it("a superseded pick's own settle never writes its value over a newer settled pick", async () => {
+    // A→B on one picker, B settles FIRST: A's later success must not write
+    // its stale value into the cache. A failed refetch after A's settle
+    // makes a wrongful write visible — the display would fall back to A
+    // while the server holds B.
+    const ds = deferPatches(2)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await pick('Default Model', 'claude-haiku-4.5')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+
+    // B (the newer pick) settles first; the server reports B.
+    serverAgent = { model: 'claude-haiku-4.5', reasoning_effort: '' }
+    ds[1].resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+
+    // A settles late and its refetch fails: only a wrongful cache write
+    // could change the display now.
+    kirocrewConfigMock.mockImplementationOnce(() => Promise.reject(new Error('offline')) as never)
+    ds[0].resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(3))
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-haiku-4.5'))
+  })
+
+  it('refetches after a failed PATCH so a server-side apply is not rolled back blind', async () => {
+    // A PATCH can fail after persisting (5xx after apply). The error path
+    // must still refetch: only the server can say which value survived.
+    const { reject } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+
+    // The server actually applied the write before answering 5xx.
+    serverAgent = { model: 'claude-opus-4.8', reasoning_effort: '' }
+    reject(new Error('boom'))
+    expect(await screen.findByText(/Failed to save default model/)).toBeInTheDocument()
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+  })
+
+  it('keeps the server\'s unadvertised model listed while a pick is in flight', async () => {
+    // The stored id may have dropped off the advertised list; picking a new
+    // model must not remove it from the options during the in-flight window,
+    // or the user could not change back to it.
+    seed({ model: 'claude-opus-4.7-retired', reasoning_effort: '' })
+    const { resolve } = deferPatch()
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(modelsMock).toHaveBeenCalled())
+    const trigger = await pick('Default Model', 'claude-opus-4.8')
+    await waitFor(() => expect(trigger).toHaveTextContent('claude-opus-4.8'))
+
+    fireEvent.click(trigger)
+    const labels = screen.getAllByRole('option').map(o => o.textContent)
+    expect(labels).toContain('claude-opus-4.7-retired')
+    expect(labels).toContain('claude-opus-4.8')
+    resolve({})
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to the merged optimistic write for the Settings ▸ Chat ▸ Model pickers (`optimisticConfigOpts` in `website/src/pages/settings/ChatPanel.tsx`). Three transient display residuals remained — none is data loss (the server PATCH is always correct; only the in-flight display was wrong):

- **(a) Cross-picker revert.** Each mutation's `onMutate` snapshot captured the WHOLE config object (including another picker's in-flight optimistic value) and each settle ran an unconditional `invalidateQueries`, so concurrent picks on two pickers could transiently revert each other — the error path by restoring a pre-pick snapshot, the success path by refetching server state that did not yet include the other picker's un-applied PATCH.
- **(b) Mid-flight option dropout.** The option builders kept only the CURRENT (optimistically overwritten) value, so a persisted-but-unadvertised model id vanished from the dropdown during the round-trip.
- **(c) Stale banner co-render.** A stale `saveError` banner co-rendered with a fresh optimistic value in the same frame.

## Fix

Replace the whole-object cache write with a **per-config-path pending overlay**: each picker renders `pending ?? server`, so a failed mutation only stops masking its own path, and a settle-time refetch lands in the query cache *under* every still-pending overlay instead of clobbering it.

- **Monotonic ownership tokens**: `onMutate` returns a token; only the entry's own token may clear it, so an older settle never clears a newer pick's overlay (A→B→A on one picker), and a superseded pick's late failure installs no stale banner.
- **On success**, the accepted value is written into the cache at this one path before the invalidate, so a transiently failed refetch (which `invalidateQueries` swallows) cannot revert the display to a value the server no longer holds; the awaited refetch then reconciles to the server's authoritative answer (backend normalisation included).
- **On error**, the refetch still runs: a PATCH can fail after persisting, and only the server can say which value survived.
- **Option builders** keep BOTH the shown and the last-persisted value, deduped, so an unadvertised stored id stays selectable mid-flight.
- **Path-scoped banner ownership**: a pick auto-clears only its own path's stale failure — never another picker's, and never a non-picker save's.

Effort-row gating now reads the SHOWN model, so the row's enabled state tracks the trigger the user is looking at.

## Tests

New 18-test module `website/src/test/ChatPanel.optimisticPickers.test.tsx` (salvaged from the converged reference branch `fix/settings-model-picker-optimistic-6848` and adapted to the merged shape, plus 5 added here): pre-settle display, per-path rollback, server-normalisation reconciliation, A→B→A ordering, concurrent cross-picker isolation (error and refetch paths), superseded-pick banner suppression, token-guarded success cache write (an older settle never poisons the cache), refetch-failure resilience, error-path refetch, cross-picker/non-picker banner ownership, mid-flight option preservation, and the `''`-value paths ("Model default" / fallback "Disabled").

6 of the salvaged/added display tests fail on the unfixed main shape (mutation-verified by stashing the fix).

- `npx tsc -b` clean
- Full frontend suite green (26k+ tests), all 8 ChatPanel suites re-run green after review fixes
- eslint 0 errors; brand/black/subprocess-encoding/isort/flake8/mypy gates green
- Pre-push dual model review: GPT lane 2 findings adopted + 1 rebutted (same-picker server write ordering is pre-existing behavior, outside this display-consistency fix's contract — the issue states the server PATCH is always correct); Opus lane PASS with 5 advisories, all adopted.

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** this is a display-timing race with no capturable static visual delta — the fixed and unfixed UIs render identically except during a sub-second in-flight window under concurrent PATCHes; the behavior is locked by the 18-test module instead.

Closes #6875
