### PR TITLE
feat: grant the foreground Mochi agent built-in core/cron access

### DIFF
--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -419,6 +419,12 @@ def _apply_agent_mcp_policy(
         merged = {**base, **spec}
         merged.pop("neutralized", None)
         merged.pop("disabled", None)  # a grant un-disables a previously denied server
+        # `mountOnly` (set by a policy for a built-in grant) means: mount the
+        # server so the tool is visible, but keep it OFF allowedTools no matter
+        # what the ceiling says, so every call routes through the approval gate
+        # and the user's tool-trust settings decide. It is a policy directive,
+        # not part of the kiro-cli server spec, so pop it before writing.
+        mount_only = bool(merged.pop("mountOnly", False))
         # The POLICY is a third source of `autoApprove` (after the app manifest and
         # the managed specs), so the whole map is filtered once below rather than
         # here — see the pass at the end of this function.
@@ -431,18 +437,42 @@ def _apply_agent_mcp_policy(
         # resolves to "rejected" -- the user asked for this server explicitly, so
         # granting it means granting its use.
         #
-        # ...EXCEPT where the enterprise ceiling forbids it. Auto-approve is the
-        # one path that never reaches `hooks.on_tool_call`: kiro-cli only sends
-        # `session/request_permission` for tools it must ask about, and the gate
-        # (where the governance deny runs) hangs off that request. Writing a
-        # ceiling-denied server here would therefore route around the ONE control
-        # the docs promise cannot be routed around. So the grant is intersected
-        # with the ceiling at write time: permitted -> auto-approve as before;
-        # denied -> the grant stays in `tools` but NOT here, which forces every
-        # call through request_permission, where the gate denies it. A user may
-        # grant anything; whether it RUNS remains the policy's call.
-        if ref not in allowed and _may_auto_approve(f"@{name}"):
+        # ...EXCEPT where the enterprise ceiling forbids it, OR the grant is
+        # mountOnly. Auto-approve is the one path that never reaches
+        # `hooks.on_tool_call`: kiro-cli only sends `session/request_permission`
+        # for tools it must ask about, and the gate (where the governance deny
+        # runs) hangs off that request. Writing a ceiling-denied — or mountOnly —
+        # server here would route around the ONE control the docs promise cannot
+        # be routed around. So the grant is intersected with the ceiling at write
+        # time AND skipped entirely when mountOnly: permitted & not mountOnly ->
+        # auto-approve as before; otherwise the grant stays in `tools` but NOT
+        # here, which forces every call through request_permission / the approval
+        # gate. A user may grant anything; whether it auto-runs remains the
+        # policy's (and the user's trust settings') call.
+        if ref not in allowed and not mount_only and _may_auto_approve(f"@{name}"):
             allowed.append(ref)
+        elif ref not in allowed and mount_only:
+            # A mountOnly grant deliberately withholds auto-approve — the same
+            # permission DECISION the ceiling filter makes, so it emits the same
+            # SEL audit event rather than being the one withhold path with no
+            # trail. (The ceiling case is covered by _ceiling_filtered_allowed;
+            # this is the mountOnly case, which never reaches that filter because
+            # the ref was never added to `allowed`.) Never fail the rebuild on an
+            # audit error.
+            try:
+                sel().log_api_access(
+                    caller="system",
+                    operation="mcp_auto_approve_withheld",
+                    outcome="ok",
+                    source="app_agent_materialization",
+                    resources=(
+                        f"@{name} mounted without auto-approve (mount-only grant) "
+                        f"for agent {agent_name or '?'}; calls go through the "
+                        "approval gate"
+                    ),
+                )
+            except Exception:  # noqa: BLE001 — audit must not break materialization
+                logger.debug("SEL audit unavailable for mount-only withhold", exc_info=True)
 
     for name, disabled in neutralized.items():
         if name in granted:

--- a/src/kiro_crew/apps/builtins/mochi/agent_policy.py
+++ b/src/kiro_crew/apps/builtins/mochi/agent_policy.py
@@ -54,6 +54,27 @@ _AUDIENCE_TO_AGENT = {"chat": CHAT_AGENT, "bg": BG_AGENT}
 #: and it is declared by the manifest rather than by the user.
 _OWN_SERVER_PREFIX = "mochi"
 
+#: Built-in grants that do NOT depend on the user's Settings -> MCP choices.
+#: The foreground pet's own prompt tells it to ``spawn_run`` for heavy work,
+#: ``learn_add`` on a correction, and ``cron_add`` for recurring jobs — all of
+#: which live in ``kirocrew-core`` / ``kirocrew-cron``. Leaving those to the
+#: fail-closed neutralize pass stranded every spawn/learn/cron instruction the
+#: chat prompt makes, so the foreground agent is granted both here.
+#:
+#: ONLY the foreground agent. ``mochi-bg`` is itself a spawned SUBAGENT (its
+#: prompt opens "You are a background subagent … you cannot spawn other agents")
+#: and the platform pins "subagents cannot spawn other subagents"
+#: (``subagent.py`` module docstring). Its ``managedToolPolicy`` unmounting of
+#: ``spawn_run`` is the structural enforcement of that invariant; granting it
+#: core would swap that hard denial for a prompt-only one on an untrusted-content
+#: path (bg runs unattended and ``web_fetch``es watch targets), with no gateway
+#: check refusing a subagent-originated spawn. So bg gets neither core nor cron.
+#: A user grant for the same server in Settings still wins (see the merge in
+#: :func:`build_policy`), so this only sets the floor, never overrides intent.
+_BUILTIN_GRANTS: dict[str, list[str]] = {
+    CHAT_AGENT: ["kirocrew-core", "kirocrew-cron"],
+}
+
 
 def policy_path(data_dir: Path) -> Path:
     return data_dir / POLICY_FILENAME
@@ -159,6 +180,27 @@ def build_policy(settings: dict[str, Any], data_dir: Path | None = None) -> dict
             agent = _AUDIENCE_TO_AGENT.get(str(audience))
             if agent is not None:
                 granted[agent][name] = dict(spec)
+
+    # Built-in grants (core/cron) come AFTER the user's entries so a user grant
+    # for the same server keeps its own autoApprove/disabledTools — setdefault
+    # never overwrites an explicit choice, it only fills the floor.
+    #
+    # `mountOnly` marks these built-in grants so the bridge mounts the server
+    # (the tool becomes visible, no longer stranded) but does NOT add it to
+    # `allowedTools`. allowedTools is kiro-cli's auto-approve list, the one path
+    # that never reaches hooks.on_tool_call — writing spawn_run/cron_add there
+    # would let prompt-injected content (the pet web_fetches watch targets)
+    # silently spawn agents or install recurring commands on a host with no
+    # governance ceiling. Left off allowedTools, every call routes through the
+    # approval gate, where the user's tool-trust settings decide auto-approve vs
+    # prompt — so trust is a user choice, not a hardcoded default. A user's own
+    # Settings grant for the same server (no mountOnly) still auto-approves as
+    # before, since setdefault below does not overwrite it.
+    for agent, builtin_names in _BUILTIN_GRANTS.items():
+        for name in builtin_names:
+            granted[agent].setdefault(
+                name, {"autoApprove": [], "disabledTools": [], "mountOnly": True}
+            )
 
     agents: dict[str, dict[str, Any]] = {}
     for agent, servers in granted.items():

--- a/test/test_mochi_agent_policy.py
+++ b/test/test_mochi_agent_policy.py
@@ -11,6 +11,7 @@ import json
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -37,8 +38,12 @@ class TestBuildPolicy:
                 ]
             }
         )
-        assert sorted(pol["agents"][CHAT_AGENT]["servers"]) == ["a", "c"]
-        assert sorted(pol["agents"][BG_AGENT]["servers"]) == ["b", "c"]
+        # servers now carry the built-in core/cron grants on top of the user's
+        # entries, so assert membership of the user grants rather than equality.
+        chat = pol["agents"][CHAT_AGENT]["servers"]
+        bg = pol["agents"][BG_AGENT]["servers"]
+        assert {"a", "c"} <= set(chat)
+        assert {"b", "c"} <= set(bg)
 
     def test_string_entry_defaults_to_chat_only(self, monkeypatch):
         """Legacy settings stored bare strings; they must not silently grant bg."""
@@ -107,6 +112,57 @@ class TestBuildPolicy:
         # them: see TestAmbientEnumerationFailsClosed.
         assert pol["agents"][CHAT_AGENT]["neutralize"] == {}
 
+    def test_builtin_core_cron_grants_are_foreground_only(self, monkeypatch):
+        """core/cron are granted from code, not from the user's Settings, and ONLY
+        to the foreground agent.
+
+        The chat prompt tells the pet to spawn_run, learn_add, and cron_add — all
+        in kirocrew-core / kirocrew-cron. Leaving those to the fail-closed
+        neutralize pass stranded every such instruction. But mochi-bg is itself a
+        spawned subagent whose contract forbids these tools ("subagents cannot
+        spawn other subagents"), so bg gets NEITHER — its managedToolPolicy
+        unmount of spawn_run is the structural enforcement of that invariant, and
+        a grant would swap it for a prompt-only one on an untrusted-content path.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.apps.builtins.mochi.agent_policy._ambient_servers",
+            lambda: {"kirocrew-core": ["spawn_run"], "kirocrew-cron": ["cron_add"]},
+        )
+        pol = build_policy({"extraMcpServers": []})
+        chat, bg = pol["agents"][CHAT_AGENT], pol["agents"][BG_AGENT]
+        # foreground: both granted, neither neutralized
+        assert "kirocrew-core" in chat["servers"]
+        assert "kirocrew-cron" in chat["servers"]
+        assert "kirocrew-core" not in chat["neutralize"]
+        assert "kirocrew-cron" not in chat["neutralize"]
+        # ...and granted mountOnly, so the bridge keeps them off allowedTools:
+        # spawn_run/cron_add route through the approval gate, never auto-approve
+        # on a ceiling-less host (this is the fix for the GPT-flagged bypass).
+        assert chat["servers"]["kirocrew-core"]["mountOnly"] is True
+        assert chat["servers"]["kirocrew-cron"]["mountOnly"] is True
+        # background: NEITHER granted, BOTH denied (a subagent must not spawn)
+        assert "kirocrew-core" not in bg["servers"]
+        assert "kirocrew-cron" not in bg["servers"]
+        assert "kirocrew-core" in bg["neutralize"]
+        assert "kirocrew-cron" in bg["neutralize"]
+
+    def test_user_grant_still_wins_over_builtin_floor(self, monkeypatch):
+        """A user's own Settings entry for core keeps its autoApprove/disabledTools
+        — the built-in floor uses setdefault and never overwrites intent.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.apps.builtins.mochi.agent_policy._ambient_servers",
+            lambda: {"kirocrew-core": ["spawn_run"]},
+        )
+        pol = build_policy(
+            {
+                "extraMcpServers": [
+                    {"name": "kirocrew-core", "agents": ["chat"], "autoApprove": ["spawn_run"]},
+                ]
+            }
+        )
+        assert pol["agents"][CHAT_AGENT]["servers"]["kirocrew-core"]["autoApprove"] == ["spawn_run"]
+
     def test_write_policy_lands_where_the_framework_reads_it(self, tmp_path, monkeypatch):
         from kiro_crew.apps import bridges
 
@@ -144,6 +200,45 @@ class TestApplyAgentMcpPolicy:
         # allowedTools too: a server only in `tools` still prompts per call,
         # which for an unattended agent resolves to "rejected".
         assert "@srv" in out["allowedTools"]
+
+    def test_mountonly_grant_mounts_but_is_not_auto_approved(self, monkeypatch):
+        # A mountOnly grant (the built-in core/cron floor) must MOUNT the server
+        # so the tool is visible, but stay OFF allowedTools so every call routes
+        # through the approval gate instead of auto-approving — this is the fix
+        # for the prompt-injection cron/spawn bypass. The marker must not leak
+        # into the kiro-cli server spec.
+        from kiro_crew.apps import bridges
+
+        monkeypatch.setattr(
+            bridges, "_global_mcp_specs", lambda: {"srv": {"command": "srv-cmd", "args": []}}
+        )
+        events: list[dict] = []
+        monkeypatch.setattr(
+            bridges,
+            "sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        out = _apply_agent_mcp_policy(
+            {"name": CHAT_AGENT, "tools": ["fs_read"], "allowedTools": ["fs_read"]},
+            CHAT_AGENT,
+            self._policy(
+                servers={"srv": {"autoApprove": [], "disabledTools": [], "mountOnly": True}}
+            ),
+        )
+        assert out["mcpServers"]["srv"]["command"] == "srv-cmd"  # mounted
+        assert "@srv" in out["tools"]  # visible, not stranded
+        assert "@srv" not in out["allowedTools"]  # NOT auto-approved
+        assert "mountOnly" not in out["mcpServers"]["srv"]  # marker stripped
+        # the withhold is a permission DECISION and must leave an audit trail,
+        # matching the ceiling-withhold path (not a silent drop).
+        srv_withheld = [
+            e
+            for e in events
+            if e.get("operation") == "mcp_auto_approve_withheld"
+            and "mount-only grant" in e.get("resources", "")
+        ]
+        assert len(srv_withheld) == 1
+        assert "@srv" in srv_withheld[0]["resources"]
 
     def test_grant_without_any_launch_spec_is_skipped(self, monkeypatch):
         from kiro_crew.apps import bridges


### PR DESCRIPTION
## What

Mochi's fail-closed agent policy (`agent_policy.py`) neutralizes every ungranted ambient MCP server, so `kirocrew-core` and `kirocrew-cron` were denied to the foreground Mochi agent even though the pet's own prompt tells it to `spawn_run`, `learn_add`, and `cron_add`. Every such instruction was stranded on a tool that never mounted. Those are first-party capabilities, not user opt-ins, so they are granted from code, to the **foreground `mochi` agent only**.

## Mount-only, never auto-approved

The grant is **mount-only**: the server is mounted so the tool is visible (no longer stranded), but it is kept **off `allowedTools`**. `allowedTools` is kiro-cli's auto-approve list — the one path that never reaches `hooks.on_tool_call`, because kiro-cli only sends `session/request_permission` for tools it must ask about. Writing `spawn_run`/`cron_add` there would let prompt-injected content (the pet `web_fetch`es watch targets) silently spawn agents or install recurring commands on a host with **no governance ceiling** (`may_skip_gate_now` returns "keep every grant" when `current_context().governance is None`, i.e. every default OSS host).

Left off `allowedTools`, every `spawn_run`/`cron_add` call routes through the approval gate, where the **user's tool-trust settings** decide auto-approve vs prompt — trust is a user choice, not a hardcoded default. A user's own Settings -> MCP grant for the same server (no `mountOnly`) still auto-approves exactly as before.

The mount-only withhold is a **permission decision**, so it emits the same `mcp_auto_approve_withheld` SEL audit event the ceiling-withhold path (`_ceiling_filtered_allowed`) already emits — it is not a silent drop.

## Why bg is excluded entirely

`mochi-bg` gets NEITHER core nor cron. It is a **spawned subagent** — its prompt opens *"you cannot spawn other agents"* and `subagent.py` pins *"subagents cannot spawn other subagents."* Its `managedToolPolicy` unmount of `spawn_run` is the structural enforcement of that invariant, so `mochi-bg.json` is left at its shipped mainline contract.

## How

- `agent_policy.py`: `_BUILTIN_GRANTS` (`mochi` -> core+cron), injected via `setdefault` with `mountOnly=True` so a user Settings grant still wins.
- `bridges.py`: a `mountOnly` grant mounts the server and adds the `@ref` to `tools`, but is skipped for `allowedTools` regardless of the ceiling; the withhold emits an `mcp_auto_approve_withheld` SEL event (fail-soft — an audit error never breaks materialization); the marker is popped from the kiro-cli server spec so it never leaks into the agent file. Zero effect on any other app's grants (they carry no `mountOnly`).
- `mochi.json` already listed `@kirocrew-cron` + `@kirocrew-core`; unchanged. `mochi-bg.json`: unchanged from mainline.

## Tests

`test/test_mochi_agent_policy.py`:
- `test_builtin_core_cron_grants_are_foreground_only` — chat gets core+cron un-neutralized and marked `mountOnly`; bg gets neither and both stay neutralized.
- `test_mountonly_grant_mounts_but_is_not_auto_approved` — a mountOnly grant mounts + appears in `tools` but NOT `allowedTools`, the marker is stripped, and a `mcp_auto_approve_withheld` audit event is emitted for it.
- `test_user_grant_still_wins_over_builtin_floor` — a user's own core grant keeps its `autoApprove`.

219 passed locally (`test_mochi_agent_policy.py` + `test_app_bridges.py`).

**Why no screenshot:** backend/config-only change (agent MCP policy + bridge + tests); no user-visible frontend surface is touched.
