### PR TITLE
docs: add reachable App Store listing submission channel (#6811)

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-store-listing.yml
+++ b/.github/ISSUE_TEMPLATE/app-store-listing.yml
@@ -1,0 +1,148 @@
+name: App Store listing request
+description: Request that your Kiro Crew app be listed in the official App Store catalog.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The official App Store catalog is maintainer-curated: its repository is
+        not publicly writable, so outside authors do not open the listing pull
+        request themselves. This issue is how you request a listing — a
+        maintainer authors the catalog entry from what you provide here.
+
+        Before filing, self-run the review checklist in
+        [publishing-guide.md section 14](https://github.com/kirodotdev/KiroCrew/blob/main/docs/app-kit/publishing-guide.md).
+        Your app repository must be public and git-cloneable so the publish
+        pipeline can resolve and pin a commit. If your app has any **executable**
+        surface (install scripts, backend, hooks, lifecycle scripts,
+        `detectInstalled`, `openCommand`), your README must say so: a user who
+        has not set `agent.apps_allow_third_party` to `true` in `config.json`
+        will see `app_execution_denied` rather than a working install (see
+        section 9).
+
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched open issues and this app is not already listed or requested.
+          required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: App name
+      description: >-
+        kebab-case, and must match the `name` in your `app.json`.
+      placeholder: commit-oracle
+    validations:
+      required: true
+
+  - type: input
+    id: git-url
+    attributes:
+      label: Git repository URL
+      description: >-
+        A public, git-cloneable URL for the app source.
+      placeholder: https://github.com/you/your-app
+    validations:
+      required: true
+
+  - type: input
+    id: ref
+    attributes:
+      label: Ref to pin
+      description: >-
+        The branch, tag, or commit SHA the publish pipeline should resolve and
+        pin. A specific SHA is safest; a branch or tag is fine and will be
+        resolved to the commit it points at.
+      placeholder: main, or a 40-character commit SHA
+    validations:
+      required: true
+
+  - type: input
+    id: display-name
+    attributes:
+      label: Display name
+      description: The human-readable name shown in the store.
+      placeholder: Commit Oracle
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: >-
+        Plain text, no markdown. Two or three sentences describing what the app
+        does — this becomes the store `description`, which Discover truncates to
+        one or two lines and the detail page shows in full.
+    validations:
+      required: true
+
+  - type: input
+    id: categories-tags
+    attributes:
+      label: Category and tags
+      description: >-
+        Lowercase tags. These decide the app's Discover category (see section 3
+        of the publishing guide); pick tags that land it in the right one.
+      placeholder: developer-tools, code-quality, git, code-review
+    validations:
+      required: false
+
+  - type: input
+    id: author
+    attributes:
+      label: Author name and profile URL
+      description: >-
+        Shown as provenance next to the app's category and source. Include a
+        display name and a profile URL.
+      placeholder: reprodev — https://github.com/reprodev
+    validations:
+      required: true
+
+  - type: input
+    id: license
+    attributes:
+      label: License
+      description: SPDX identifier for the app's license.
+      placeholder: MIT
+    validations:
+      required: false
+
+  - type: textarea
+    id: entry-json
+    attributes:
+      label: Ready-to-paste entry (optional)
+      description: >-
+        If you have already drafted a published-schema catalog entry against the
+        schema served at `apps.crew.kiro.dev/official-registry.json`, paste it
+        here. This is a convenience for the maintainer authoring the entry — it
+        is not authoritative and the pipeline pins whatever commit it resolves.
+      render: json
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: review-checklist
+    attributes:
+      label: Review checklist (self-attestation)
+      description: >-
+        These mirror the review checklist in section 14 of the publishing guide.
+        Confirm each item for your app.
+      options:
+        - label: "`app.json` validates: kebab-case `name`, semver `version`, all required fields non-empty."
+          required: true
+        - label: "No `..` or absolute paths in `agents`, `skills`, `sops`, `ui.entry`, `ui.pages[].entryPoint`, `backend.entryPoint`."
+          required: true
+        - label: "UI bundle built and committed (`ui/dist/index.mjs`) if the app ships a UI."
+          required: true
+        - label: "Agent JSON files are valid, and each skill `SKILL.md` has proper frontmatter."
+          required: true
+        - label: "Opaque icon committed, square, 256x256 or larger, plus a hero image (16:9), a detail banner, and at least one screenshot committed."
+          required: true
+        - label: "`README.md` documents what the app does, how to use it, and the `agent.apps_allow_third_party` prerequisite if any executable surface is present."
+          required: true
+        - label: "The app installs and enables cleanly from a local clone."
+          required: true

--- a/.github/ISSUE_TEMPLATE/app-store-listing.yml
+++ b/.github/ISSUE_TEMPLATE/app-store-listing.yml
@@ -89,7 +89,7 @@ body:
         of the publishing guide); pick tags that land it in the right one.
       placeholder: developer-tools, code-quality, git, code-review
     validations:
-      required: false
+      required: true
 
   - type: input
     id: author
@@ -140,7 +140,7 @@ body:
           required: true
         - label: "Agent JSON files are valid, and each skill `SKILL.md` has proper frontmatter."
           required: true
-        - label: "Opaque icon committed, square, 256x256 or larger, plus a hero image (16:9), a detail banner, and at least one screenshot committed."
+        - label: "Opaque icon committed, square, 512x512, plus a hero image (16:9), a detail banner, and at least one screenshot committed."
           required: true
         - label: "`README.md` documents what the app does, how to use it, and the `agent.apps_allow_third_party` prerequisite if any executable surface is present."
           required: true

--- a/docs/app-kit/publishing-guide.md
+++ b/docs/app-kit/publishing-guide.md
@@ -351,17 +351,28 @@ MyAppRepo/
 
 There are two listing surfaces, and they take different paths:
 
-**The official App Store catalog** lives in its own repository,
-[KiroCrewApps](https://github.com/kirodotdev/KiroCrewApps) — not in the Kiro Crew
-repo. Since the catalog became the store's inventory, publishing an entry there
-is what makes your app appear in the store *and installable*, with **no Kiro
-Crew release involved**. You author a `git` source (URL + a branch or tag; the
-publish pipeline resolves and pins the exact commit) plus a category, and open a
-pull request on that repository. Its README documents the authored schema, the
-validators, and the two-schema (authored vs published) contract. Clients install
-the pinned commit exactly and read update availability from the published
-entry's `version` field, so publishing a new revision of the catalog is also how
-an update reaches users.
+**The official App Store catalog** is the store's inventory, and it is
+maintainer-curated. Its authoring repository is private and not publicly
+writable, so outside authors do not open the listing pull request themselves —
+there is no self-serve PR path for third-party apps. A published entry is what
+makes your app appear in the store *and installable*, with **no Kiro Crew
+release involved**: a maintainer authors a `git` source (URL + a branch or tag;
+the publish pipeline resolves and pins the exact commit) plus a category against
+the authored schema, and the pipeline emits the published document that clients
+read. The authored-vs-published two-schema contract is unchanged — you supply
+the source and category, the pipeline pins the commit and bakes `version` from
+your `app.json` into the published entry. Clients install the pinned commit
+exactly and read update availability from the published entry's `version` field,
+so republishing a revised entry is also how an update reaches users.
+
+To request a listing, open an **App Store listing request** issue using the
+[listing request template](https://github.com/kirodotdev/KiroCrew/issues/new?template=app-store-listing.yml).
+Provide the git source, the ref to pin, the display name, a summary, the
+category/tags, and author credit, and confirm the section 14 review checklist.
+A maintainer picks it up and authors the catalog entry with full author credit.
+(Opening the catalog repository up to outside contributors is a possible
+alternative, but it is a maintainer-only org-visibility decision, not something
+an author can do.)
 
 **The bundled seed** (`src/kiro_crew/apps/app-registry.json` in the Kiro Crew
 repo) is the catalog's offline snapshot, not the listing surface: it is what a
@@ -393,10 +404,11 @@ The seed (and any federated registry index) uses this row shape:
 | `detectInstalled` | | Shell command that exits 0 when the app is already present on the machine (for self-managed apps). It runs sandboxed with a 5s timeout. |
 | `featured` | | Curator flag for the Discover editorial layer. `true` marks the app featured; a number both marks it and orders the slots (lower first). It lives on the registry entry, not in `app.json`, and is honored only for core-registry entries: a `featured` flag from an external registry is ignored, so adding a registry cannot seize the spotlight. With nothing flagged, the store falls back to a deterministic pick (apps with hero art first, then verified publishers, then name). |
 
-To reach the official store, open the pull request on **KiroCrewApps** (add your
-entry to `catalog/official-registry.json` there; run its `tools/validate.py`
-first). A seed change in the Kiro Crew repo follows the normal contribution flow
-and ships with the next release.
+To reach the official store, open an **App Store listing request** issue with the
+[listing request template](https://github.com/kirodotdev/KiroCrew/issues/new?template=app-store-listing.yml)
+— that is the reachable path for an outside author, since the catalog repository
+is not publicly writable. A seed change in the Kiro Crew repo, by contrast,
+follows the normal contribution flow and ships with the next release.
 
 ## 11. Federated external registries
 
@@ -570,7 +582,7 @@ useful to Kiro Crew users.
 | Enable | `POST /api/apps/{name}/enable`, or `kirocrew app enable <name>` |
 | Live reload | `kirocrew app dev <name>` |
 | Update local copy | `POST /api/apps/{name}/update` |
-| List a registry app | Add an entry to `app-registry.json`, open a pull request |
+| List a registry app | Official catalog: open an [App Store listing request](https://github.com/kirodotdev/KiroCrew/issues/new?template=app-store-listing.yml) issue (maintainer-curated). Bundled seed or a federated registry: add an entry to `app-registry.json`, open a pull request |
 | User install | Apps page, Discover, Install |
 | Ship an update | Bump `version`, push |
 


### PR DESCRIPTION
## Summary

Resolves the store-listing process/docs gap reported in #6811 (same gap as #6452), entirely within the KiroCrew repo.

The official App Store catalog lives in the private `kirodotdev/KiroCrewApps` repo, so `docs/app-kit/publishing-guide.md` §10's self-serve "open a PR on `catalog/official-registry.json`" path 404s and is unreachable for outside authors. A maintainer confirmed on the issue that `KiroCrewApps` is genuinely private (`"private": true`, org property `visibility-allow-public: false`), so the 404 is correct behavior, not a broken link. No alternative submission channel existed: `.github/ISSUE_TEMPLATE/` had only bug_report, documentation, feature_request, and config.

## Changes

- **New submission channel** `.github/ISSUE_TEMPLATE/app-store-listing.yml` — a GitHub issue form modeled on the existing forms (`labels: ["enhancement"]`, within the allowed triage type set). It captures what a maintainer needs to hand-author a catalog entry: app name (kebab-case), git repo URL, ref to pin, display name, summary, category/tags, author name+URL, license, an optional ready-to-paste published-schema JSON blob, and a §14-derived self-attestation checklist. A leading note explains that listings are maintainer-curated and calls out the public-repo and `agent.apps_allow_third_party` prerequisites.
- **`docs/app-kit/publishing-guide.md` rewrite** — §10 now states the official catalog is maintainer-curated with a non-publicly-writable authoring repo and routes outside authors to the new issue template (`issues/new?template=app-store-listing.yml`); the §15 quick-reference row is updated in lockstep. The official-catalog-vs-bundled-seed (two-surface) and authored-vs-published (two-schema) distinctions are preserved. No stale `KiroCrewApps` / `catalog/official-registry.json` self-serve PR instruction remains.

## Scope / what this does NOT do

- The private `KiroCrewApps` repo is untouched and never referenced as a writable path (it is out of scope and inaccessible under the current network mode).
- The bundled seed `src/kiro_crew/apps/app-registry.json` is unchanged; the motivating Commit Oracle app is NOT added to any registry/seed (it appears only as an illustrative placeholder in the form).

## Maintainer decision to surface

This addresses only the actionable half within this repo (docs + submission channel). The alternative the issue raised — opening `KiroCrewApps` to outside contributors — requires flipping the org `visibility-allow-public` property and is a maintainer-only action outside this workspace. The same gap affects #6452, so the two are worth handling together. Listing the Commit Oracle app itself is a separate maintainer action against the private catalog.

## Testing

Docs + GitHub issue-form change only; no application code. Validation performed:
- `app-store-listing.yml` parses cleanly (validated with ruamel.yaml; PyYAML is not installed under the current network mode). Structural assertions pass: top-level `name/description/labels/body` present, all body element types in {markdown, input, textarea, checkboxes}, label within the allowed set.
- Guide links resolve to the committed template filename; `git diff` touches only the two intended files.
- A semantic review returned APPROVED; its two non-blocking notes were applied (icon self-attestation aligned to 512x512 per §4; category/tags field made required).

Closes #6811