### PR TITLE
chore: add joyboy5477 to the contributors block

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ make this tool possible:
 <a href="https://github.com/johnnynaught" title="johnnynaught"><img src="https://github.com/johnnynaught.png?size=64" width="64" height="64" alt="johnnynaught" /></a>
 <a href="https://github.com/josej4m" title="James Joseph"><img src="https://github.com/josej4m.png?size=64" width="64" height="64" alt="James Joseph" /></a>
 <a href="https://github.com/joshymle" title="Joshua Yeung"><img src="https://github.com/joshymle.png?size=64" width="64" height="64" alt="Joshua Yeung" /></a>
+<a href="https://github.com/joyboy5477" title="Akash Vishwakarma"><img src="https://github.com/joyboy5477.png?size=64" width="64" height="64" alt="Akash Vishwakarma" /></a>
 <a href="https://github.com/JPLachance" title="Jean-Philippe Lachance"><img src="https://github.com/JPLachance.png?size=64" width="64" height="64" alt="Jean-Philippe Lachance" /></a>
 <a href="https://github.com/Jpontone" title="JPontone"><img src="https://github.com/Jpontone.png?size=64" width="64" height="64" alt="JPontone" /></a>
 <a href="https://github.com/jtoloui" title="Jamie Toloui"><img src="https://github.com/jtoloui.png?size=64" width="64" height="64" alt="Jamie Toloui" /></a>


### PR DESCRIPTION
## Summary
Adds @joyboy5477 (Akash Vishwakarma) to the README Contributors block via `scripts/update_contributors.py --login joyboy5477 --name "Akash Vishwakarma"`.

Their work landed through a cherry-pick with a Co-authored-by trailer (#2603 carrying the substance of #2320), which `add-contributor.yml` cannot see because it only credits merged-PR authors. Per the Recognizing Contributions section of CONTRIBUTING.md (policy set in #6656), collector-invisible contributions are added by hand on request; #2678 is that request.

## Testing
Generated by the repo's own script (idempotent, validates login grammar, HTML-escapes the name); diff is a single alphabetically-placed line in README.md.

Closes #2678