### PR TITLE
fix(ci): give the render stub a real knowledge stats fixture

### DIFF
--- a/website/scripts/lib/stub-dashboard-api.mjs
+++ b/website/scripts/lib/stub-dashboard-api.mjs
@@ -62,6 +62,44 @@ export const KIROCREW_CONFIG_FIXTURE = {
 /** The `/api/agent/config` body — the per-agent MCP view. */
 export const AGENT_CONFIG_FIXTURE = { name: 'kirocrew', mcpServers: {} }
 
+/**
+ * The `/api/knowledge/stats` body, matching `get_stats` in
+ * `src/kiro_crew/dashboard/handlers/knowledge.py`.
+ *
+ * Named ahead of the catch-all for the same reason as KIROCREW_CONFIG_FIXTURE,
+ * but with a failure mode that is intermittent rather than fatal. `stats` does
+ * not match `objectish`, so the guess is `[]` — and `[]` is TRUTHY, so the
+ * knowledge page's `{stats && (…)}` stats bar renders, with every
+ * `{stats.items}` resolving to `undefined`. React prints nothing for those, so
+ * the bar appears carrying only its labels.
+ *
+ * That makes the surface's rendered text depend on whether the query has
+ * resolved when a scanner reads the DOM: before it resolves `stats` is
+ * `undefined` and the bar is absent; after, it is present with several spans.
+ * The i18n render gate compares a surface against the same surface on the base
+ * branch, so a surface that renders two different ways reports a difference
+ * that neither branch's diff contains — a red gate on a PR that never touched
+ * the page.
+ *
+ * Widening `objectish` to match `stats` would NOT fix it: `{}` is truthy too,
+ * so the bar would still render with `undefined` counts. The shape has to be
+ * real, which is what makes this a fixture rather than a regex change.
+ *
+ * The counts are zeros because the rest of this stub serves an empty world —
+ * `/api/knowledge/sources` and `/namespaces` both fall through to `[]`. A
+ * fixture claiming items here would contradict the sources list on the same
+ * page. `embeddings.enabled` is false for the same reason: the backend sets
+ * that whenever `knowledge_embedder` is absent, and gateway-free is exactly
+ * that case.
+ */
+export const KNOWLEDGE_STATS_FIXTURE = {
+  items: 0,
+  entities: 0,
+  relations: 0,
+  sources: 0,
+  embeddings: { enabled: false },
+}
+
 /** Whether an unmapped path should be guessed as an object rather than a list. */
 const objectish = path =>
   /(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
@@ -150,6 +188,7 @@ export async function stubDashboardApi(page, opts = {}) {
     // KIROCREW_CONFIG_FIXTURE for why).
     if (path === '/api/config/kirocrew') return json(route, KIROCREW_CONFIG_FIXTURE)
     if (path === '/api/agent/config') return json(route, AGENT_CONFIG_FIXTURE)
+    if (path === '/api/knowledge/stats') return json(route, KNOWLEDGE_STATS_FIXTURE)
     // Endpoints not worth naming individually: anything object-shaped gets {},
     // everything else gets []. Guessing wrong only costs an empty panel — in
     // the cases where it does not, the endpoint belongs above this line.


### PR DESCRIPTION
## What

`/api/knowledge/stats` had no fixture in the shared render/screenshot stub, so it fell through to the catch-all. That catch-all guesses `{}` for object-shaped paths and `[]` for everything else, and its test is

```js
/(config|tips|voice|autonudge|branding|status|usage-summary)/.test(path)
```

`stats` does not match `status`, so the guess is **`[]`** — which is **truthy**. The knowledge page gates its stats bar on `{stats && (…)}`, so the bar renders, with every `{stats.items}` resolving to `undefined`. React prints nothing for `undefined`, so the harness scans and photographs a bar carrying labels and no numbers — a state the real product never shows.

Measured under the en-XA scan, before and after this change, at `src/pages/knowledge/index.tsx:685`:

```
before   " [ìţèɱş ········][èñţìţìèş ············][ŕèĺàţìøñş ··············][şøùŕçèş ·········…"
after    "0 [ìţèɱş ········]0 [èñţìţìèş ············]0 [ŕèĺàţìøñş ··············]0 [şøùŕçèş ····…"
```

and `/api/knowledge/stats` drops off the stub's own `STUB: no fixture for …` list.

This is the failure class the file's catch-all comment already names — *"guessing wrong only costs an empty panel — in the cases where it does not, the endpoint belongs above this line"* — and the same shape as the `/api/config/kirocrew` gap that `KIROCREW_CONFIG_FIXTURE` documents, differing only in that this one renders wrong rather than blank.

## Why not just widen `objectish`

`{}` is truthy too, so the bar would still render with `undefined` counts. The shape has to be real, which is what makes this a fixture rather than a one-word regex change.

## Why zeros

The rest of the stub serves an empty world: `/api/knowledge/sources` and `/namespaces` both fall through to `[]`. A fixture claiming items here would contradict the sources list on the same page. `embeddings.enabled` is `false` because that is what `get_stats` returns whenever `knowledge_embedder` is absent, and gateway-free is exactly that case — so the fixture stays readable as "what the server sends".

## Scope — deliberately one endpoint

I checked the knowledge page's other four GETs rather than fixturing them on principle, and the catch-all's guess is already correct or already harmless for all of them:

| endpoint | guess | expected | verdict |
|---|---|---|---|
| `/stats` | `[]` | object | **wrong — this PR** |
| `/sources` | `[]` | `Source[]` | correct |
| `/namespaces` | `[]` | `NamespaceInfo[]` | correct |
| `/config` | `{}` | `{enabled, supported_formats}` | harmless — `index.tsx:265` guards with `config?.supported_formats && …length` and falls back to a constant |
| `/embedding/status` | `{}` | `KnowledgeEmbedStatus` | harmless — `EmbeddingStatus` returns `null` while `total === 0`, in both timings |

## Verification

- Full gate against this PR's base: `PASS [vs-base] — no surface got worse`, `base text=692 layout=2 latent=12 -> head text=692 layout=2 latent=12`, EXIT=0. The change alters one surface's rendered text without moving any total.
- `--surface knowledge --locale en-XA`, 5 runs each with and without the fixture: `text=1` in all 10.
- eslint clean on the changed file.

## What this does NOT claim

This came out of investigating a red `i18n render-time gate` on #6868, where CI reported `base text=1 -> head text=2` for this very surface across three SHAs and a same-SHA rerun, while the identical tree pair passes locally. **This PR is not demonstrated to fix that.** I could not reproduce the instability on my host — 5/5 stable both with and without the fixture — so the honest claim is narrower: the stub was serving a shape the frontend cannot consume, and it no longer is.

## Follow-ups found while measuring (not in this PR)

1. The finding this surface reports is a **real pre-existing i18n defect**, not harness noise: `index.tsx:686-689` render `{stats.items} {i18nT('…items_2')}`, a number glued to a separately-translated label, which the gate classifies `fragment/multi-unit` and whose remedy it names — merge the adjacent keys into one key with `{{vars}}`, per AGENTS.md "merge, not join". Fixing that drives this site's count to `0`, where base and head cannot differ; it is 4 keys across 12 locales, so it wants its own PR.
2. `index.tsx:691` has a hardcoded English string in a `title`: `` `${model} — ${embedded_items} embedded` ``, outside any catalog. It is invisible to the gate today only because this fixture reports `embeddings.enabled: false`; a fixture with `available: true` would surface it.
