### PR TITLE
test: drain DOM tasks before MSW shutdown

### DIFF
--- a/website/integration/setup.ts
+++ b/website/integration/setup.ts
@@ -3,43 +3,6 @@ import '@testing-library/jest-dom'
 import { server } from './mocks/server'
 import { initI18n, i18next } from '../src/i18n'
 
-// --- happy-dom teardown AbortError guard -------------------------------------
-// happy-dom navigates a live `<iframe src>` by scheduling an async fetch task on
-// DOM insertion. When a fork worker tears the window down between files, vitest's
-// teardownWindow calls AsyncTaskManager.abortAll(), which rejects any still
-// in-flight iframe/sub-resource Fetch with `DOMException [AbortError]`. The test
-// that mounted the iframe has already finished, so nothing awaits that rejection:
-// it surfaces as a run-level unhandled rejection and fails the whole shard with
-// zero failing tests — a teardown-timing race whose exposure shifts with worker
-// and file count. The blob-iframe path is closed by stubbing createObjectURL
-// (below), but a direct `<iframe src="http://host/...">` (e.g. InstancesViewport,
-// InstanceTabBar) still schedules a real fetch task. Swallow ONLY happy-dom's
-// teardown abort — every other unhandled rejection still propagates and fails
-// the run as it should.
-process.on('unhandledRejection', (reason) => {
-  const isTeardownAbort =
-    reason instanceof Error &&
-    reason.name === 'AbortError' &&
-    typeof reason.stack === 'string' &&
-    reason.stack.includes('onAsyncTaskManagerAbort')
-  if (isTeardownAbort) return  // orphaned iframe fetch aborted during window teardown
-
-  // ECONNREFUSED from a stale happy-dom async fetch that fires AFTER msw's
-  // server.close() — the request escapes interception, dials the real TCP stack,
-  // and gets refused because no gateway is listening on the test-document origin
-  // (localhost:6776). Same teardown-timing race, different symptom: AggregateError
-  // wrapping ECONNREFUSED from node:net instead of AbortError from happy-dom.
-  // Scoped to port 6776 (the test document origin pinned in vite.config.ts) so a
-  // genuine test dial to an unexpected port still fails the run.
-  const isPostMswDial =
-    reason instanceof Error &&
-    (reason as NodeJS.ErrnoException).code === 'ECONNREFUSED' &&
-    String(reason).includes('6776')
-  if (isPostMswDial) return  // orphaned fetch hit real TCP after msw closed
-
-  throw reason  // re-raise anything else so the run still fails on a real leak
-})
-
 // lottie-web registers a module-scoped `setInterval(checkReady, 100)` purely by
 // being IMPORTED (`readyStateCheckInterval` in the prebuilt player bundles). That
 // interval belongs to no AnimationItem, so neither `anim.destroy()` nor RTL
@@ -188,14 +151,6 @@ export function beginTimerTeardown(): number {
   timersTearingDown = true
   return clearLeakedTimers()
 }
-
-// Registered FIRST on purpose: vitest runs after-hooks in reverse registration
-// order, so this executes after the msw `server.close()` below -- immediately
-// before environment teardown, when anything still pending is by definition a
-// leak about to fire into a torn-down document.
-afterAll(() => {
-  beginTimerTeardown()
-})
 
 // Initialize i18n for EVERY test file, pinned to English.
 //
@@ -532,3 +487,27 @@ afterEach(() => {
 
 // Clean up after all tests are done
 afterAll(() => server.close())
+
+/**
+ * Stop late Node-timer registrations, then let happy-dom finish every task it
+ * already owns while MSW is still listening.  This fixes the lifecycle rather
+ * than hiding AbortError/ECONNREFUSED after the responsible test has finished.
+ *
+ * The API is passed in so the ordering contract has a deterministic unit test;
+ * production passes `window.happyDOM` below.
+ */
+export async function settleDOMTasksBeforeMockShutdown(
+  happyDOM: { waitUntilComplete: () => Promise<void> } | undefined,
+): Promise<void> {
+  beginTimerTeardown()
+  // A handful of suites opt into jsdom and still load this shared setup. They
+  // have no happy-dom task queue to drain, but timer teardown remains required.
+  if (happyDOM) await happyDOM.waitUntilComplete()
+}
+
+// Vitest runs after-hooks in reverse registration order. Register this AFTER
+// server.close() so the task drain completes first and no deferred iframe or
+// resource fetch can escape interception and dial localhost during teardown.
+afterAll(async () => {
+  await settleDOMTasksBeforeMockShutdown(window.happyDOM)
+})

--- a/website/src/test/lottieTeardownGuard.test.ts
+++ b/website/src/test/lottieTeardownGuard.test.ts
@@ -27,8 +27,14 @@
  * so it must stay LAST in this file.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { setTimeout as sleep } from 'node:timers/promises'
-import { clearLeakedTimers, beginTimerTeardown } from '../../integration/setup'
+import {
+  setImmediate as nextImmediate,
+  setTimeout as nextTimer,
+} from 'node:timers/promises'
+import {
+  clearLeakedTimers,
+  settleDOMTasksBeforeMockShutdown,
+} from '../../integration/setup'
 
 describe('lottie-web import-time timer neutralization', () => {
   it('serves the setup mock for BOTH runtime specifiers, so the real bundle never registers its interval', async () => {
@@ -45,13 +51,14 @@ describe('lottie-web import-time timer neutralization', () => {
     // dereferences `document` on each tick. No await between registration and
     // the sweep, so the tick cannot run first -- the assertion is deterministic.
     const tick = vi.fn(() => document.readyState)
-    setInterval(tick, 100)
+    setInterval(tick, 0)
     expect(clearLeakedTimers()).toBeGreaterThan(0)
 
-    // Wait past the interval period on a raw Node timer imported directly from
-    // node:timers/promises (independent of the wrapped globals). If the sweep
-    // failed, the tick fires within 100ms and this catches it.
-    await sleep(250)
+    // A raw Node timer registered after the interval is an event-loop barrier:
+    // without the sweep, the earlier zero-delay interval fires before it. This
+    // proves cancellation without a wall-clock allowance that can flake on a
+    // loaded worker.
+    await nextTimer(0)
     expect(tick).not.toHaveBeenCalled()
   })
 
@@ -59,34 +66,37 @@ describe('lottie-web import-time timer neutralization', () => {
     const soon = vi.fn(() => document.readyState)
     setImmediate(soon)
     clearLeakedTimers()
-    await sleep(20)
+    // Registered after `soon`, so this raw immediate runs later in the same
+    // check phase unless the wrapped immediate was cancelled.
+    await nextImmediate()
     expect(soon).not.toHaveBeenCalled()
   })
 
   it('clearTimeout/clearInterval through the wrappers stay functional', async () => {
     const late = vi.fn()
-    const handle = setTimeout(late, 100)
+    const handle = setTimeout(late, 0)
     clearTimeout(handle)
-    await sleep(150)
+    await nextTimer(0)
     expect(late).not.toHaveBeenCalled()
   })
 
   it('a fired one-shot self-evicts from the ledger (the Set tracks live timers, not total creations)', async () => {
     clearLeakedTimers() // drain anything earlier tests or React left pending
     const ran = vi.fn()
-    setTimeout(ran, 1)
-    await sleep(30)
+    setTimeout(ran, 0)
+    // FIFO within the timers phase: the wrapped callback was registered first,
+    // so it fires and self-evicts before this raw timer resolves.
+    await nextTimer(0)
     expect(ran).toHaveBeenCalledTimes(1)
     // The fired handle must be gone from the ledger; only timers created by
     // OTHER code between the drain and here could remain, and none were.
     expect(clearLeakedTimers()).toBe(0)
   })
 
-  it('setup.ts wires the sweep into an afterAll (structural pin)', async () => {
-    // The behavioral tests above exercise the sweep directly; this pins that it
-    // is actually REGISTERED to run at file teardown. A refactor that keeps the
-    // function but drops the hook re-opens the race silently -- the leak only
-    // fires under specific worker/file-count timing.
+  it('setup.ts drains happy-dom before closing MSW (structural pin)', async () => {
+    // The behavioral tests exercise the drain directly; this pins reverse hook
+    // registration order. Moving server.close() below the drain would close the
+    // interceptor first and restore the deferred localhost dial.
     const { readFile } = await import('node:fs/promises')
     const { resolve } = await import('node:path')
     // Resolved from cwd (vitest runs with cwd at the website root, where
@@ -94,16 +104,31 @@ describe('lottie-web import-time timer neutralization', () => {
     // suite's happy-dom environment it carries the environment's http URL,
     // not a file: URL, so fileURLToPath throws.
     const source = await readFile(resolve(process.cwd(), 'integration/setup.ts'), 'utf8')
-    expect(source).toMatch(/afterAll\([\s\S]{0,120}?beginTimerTeardown\(/)
+    const closeHook = source.indexOf('afterAll(() => server.close())')
+    const drainHook = source.indexOf(
+      'afterAll(async () => {\n  await settleDOMTasksBeforeMockShutdown(window.happyDOM)',
+    )
+    expect(closeHook).toBeGreaterThan(-1)
+    expect(drainHook).toBeGreaterThan(closeHook)
+    expect(source).not.toContain("process.on('unhandledRejection'")
   })
 
-  it('after teardown begins, a late registration is cancelled on the spot (MUST BE LAST)', async () => {
-    beginTimerTeardown()
+  it('drains owned DOM tasks before teardown and cancels late timers (MUST BE LAST)', async () => {
+    const order: string[] = []
+    await settleDOMTasksBeforeMockShutdown({
+      waitUntilComplete: async () => { order.push('dom-drained') },
+    })
+    expect(order).toEqual(['dom-drained'])
+    // Shared setup also runs in explicit jsdom suites, where window.happyDOM is
+    // absent. That environment still arms timer teardown and must not fail.
+    await expect(settleDOMTasksBeforeMockShutdown(undefined)).resolves.toBeUndefined()
+
     const straggler = vi.fn(() => document.readyState)
-    setTimeout(straggler, 1)
-    setInterval(straggler, 10)
-    await sleep(80)
+    setTimeout(straggler, 0)
+    setInterval(straggler, 0)
+    await nextTimer(0)
     expect(straggler).not.toHaveBeenCalled()
-    // The file's own afterAll calls beginTimerTeardown() again -- idempotent.
+    // The file's own afterAll calls the drain again -- both operations are
+    // idempotent, and the real happy-dom queue is already empty here.
   })
 })

--- a/website/src/test/vitestMemoryConfig.test.ts
+++ b/website/src/test/vitestMemoryConfig.test.ts
@@ -22,6 +22,8 @@ describe('vitest worker memory configuration', () => {
     expect(Number(workers![1])).toBeGreaterThanOrEqual(1)
     expect(Number(workers![1])).toBeLessThanOrEqual(4)
 
-    expect(config).toMatch(/execArgv:\s*\['--max-old-space-size=3072'\],/)
+    expect(config).toMatch(
+      /execArgv:\s*\['--max-old-space-size=3072',\s*'--no-experimental-webstorage'\],/,
+    )
   })
 })

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -617,7 +617,14 @@ export default defineConfig({
     // 3 is both the fastest and cheaper in memory than 4; peak single-fork RSS
     // was ~1.0-1.4 GB against the 3072 MB per-fork heap ceiling below.
     maxWorkers: 3,
-    execArgv: ['--max-old-space-size=3072'],
+    // Node 25 enables its process-global experimental Web Storage in forks but
+    // gives those workers no persistence path, emitting one
+    // "--localstorage-file ... without a valid path" warning per test file.
+    // happy-dom supplies the window-scoped Storage this suite actually tests,
+    // and setup.ts replaces it with a deterministic in-memory implementation,
+    // so disable the unrelated Node global instead of sharing a disk file
+    // across concurrent workers.
+    execArgv: ['--max-old-space-size=3072', '--no-experimental-webstorage'],
     // Default 5s is too tight for tests that ``await import(...)`` inside the
     // body: under a full concurrent forks run the collect phase can starve the
     // dynamic import past 5s and it times out. 15s gives headroom for


### PR DESCRIPTION
## Problem / Motivation

The full Vitest suite could finish every assertion and still fail during worker teardown. happy-dom could leave an iframe or resource fetch queued until after MSW closed, producing an unhandled `AbortError` or a real `ECONNREFUSED` dial to the test origin. Node 25 workers also exposed process-global experimental Web Storage without a persistence path, emitting a warning for every test file.

## Why it matters

These failures move between shards with worker timing and obscure real failures. A global rejection filter would also risk hiding genuine application defects, so the test lifecycle itself needs to be deterministic.

## What changed

- register the happy-dom task drain after the MSW close hook, so Vitest's reverse teardown order drains DOM work while interception is still live
- begin timer teardown before the drain so late registrations cannot create new work
- keep shared setup compatible with suites that explicitly use jsdom and have no `window.happyDOM`
- remove process-level `unhandledRejection` suppression for `AbortError` and `ECONNREFUSED`
- replace wall-clock timer assertions with zero-delay FIFO event-loop barriers
- disable Node 25's unrelated process-global experimental Web Storage in Vitest forks; happy-dom's deterministic window storage remains in use
- structurally pin the worker and teardown contracts

## Global overlap audit

All open PRs were checked for the four changed files. #4913 touches the build-plugin list in `vite.config.ts`; #5274 touches the coverage exclude list. This PR changes only the Vitest worker `execArgv` region, so neither contributor's behavior or hunk is replaced.

## Tests

- six focused setup/jsdom suites: 84 passed
- `npm run typecheck`
- changed-test ESLint: 0 errors
- `git diff --check`
- clean merge-tree against current `main`
- full-suite reproduction after removing the rejection filter: no teardown `ECONNREFUSED` or process-global localStorage warning; unrelated deterministic failures found there are being fixed separately rather than hidden here

## Screenshot evidence

<!-- no-visual-delta -->
**Why no screenshot:** This changes only the Vitest worker environment, shared test teardown, and deterministic test coverage; no rendered component, layout, style, motion, or interaction behavior changes.

## Checklist

- [x] One Conventional Commit
- [x] No retry, sleep, timeout increase, warning filter, or rejection suppression
- [x] Existing open-PR changes preserved
- [x] No secrets or generated artifacts