### PR TITLE
test: make memory graph integration deterministic

### DIFF
--- a/website/integration/MemoryGraphTab.integration.test.tsx
+++ b/website/integration/MemoryGraphTab.integration.test.tsx
@@ -1,40 +1,119 @@
-import { describe, it, expect, vi } from 'vitest'
-import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { act, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { http, HttpResponse } from 'msw'
 import { renderWithProviders } from './helpers'
-import { server } from './mocks/server'
+import { mockMemoryGraph } from './mocks/server'
+
+const memoryGraph = vi.hoisted(() => vi.fn())
+const sigmaConstructorFailure = vi.hoisted(() => ({ current: null as Error | null }))
+const sigmaInstances = vi.hoisted(() => [] as Array<{
+  graph: { order: number; size: number }
+  on: ReturnType<typeof vi.fn>
+  refresh: ReturnType<typeof vi.fn>
+  kill: ReturnType<typeof vi.fn>
+  setSetting: ReturnType<typeof vi.fn>
+}>)
+
+vi.mock('../src/api/client', () => ({
+  api: { memoryGraph },
+}))
 
 // sigma renders via WebGL, which jsdom doesn't provide. Mock Sigma so the
 // component's UI shell (filters, search, counts) can be tested headlessly.
 // graphology is pure JS (no WebGL) so it does not need mocking.
 vi.mock('sigma', () => {
-  const MockSigma = vi.fn().mockImplementation(() => ({
-    on: vi.fn(),
-    refresh: vi.fn(),
-    kill: vi.fn(),
-  }))
+  class MockSigma {
+    readonly on = vi.fn()
+    readonly refresh = vi.fn()
+    readonly kill = vi.fn()
+    readonly setSetting = vi.fn()
+
+    constructor(readonly graph: { order: number; size: number }) {
+      if (sigmaConstructorFailure.current) throw sigmaConstructorFailure.current
+      sigmaInstances.push(this)
+    }
+  }
   return { default: MockSigma }
+})
+
+// Layout is not this integration test's subject. Keep the dynamic-import seam,
+// but replace d3's real 250ms force pass with the same fluent contract and a
+// synchronous tick so a loaded runner cannot decide when the UI becomes ready.
+vi.mock('d3', () => {
+  const force = () => {
+    const instance = {
+      id: () => instance,
+      distance: () => instance,
+      strength: () => instance,
+      distanceMax: () => instance,
+    }
+    return instance
+  }
+  return {
+    forceSimulation: () => {
+      const simulation = {
+        force: () => simulation,
+        alphaDecay: () => simulation,
+        stop: () => simulation,
+        tick: () => simulation,
+      }
+      return simulation
+    },
+    forceLink: force,
+    forceManyBody: force,
+    forceCollide: force,
+    forceX: force,
+    forceY: force,
+  }
 })
 
 import MemoryGraphTab from '../src/pages/overview/MemoryGraphTab'
 
 describe('MemoryGraphTab Integration Tests', () => {
+  beforeEach(() => {
+    memoryGraph.mockReset()
+    memoryGraph.mockResolvedValue(mockMemoryGraph)
+    sigmaConstructorFailure.current = null
+    sigmaInstances.length = 0
+  })
+
+  async function graphReady() {
+    expect(await screen.findByText(/All \(7\)/)).toBeInTheDocument()
+    await waitFor(() => expect(sigmaInstances).toHaveLength(1))
+    return sigmaInstances[0]
+  }
+
   it('renders graph container with nodes after loading', async () => {
     renderWithProviders(<MemoryGraphTab />)
 
-    // Should show node count in filter buttons
-    await waitFor(() => {
-      expect(screen.getByText(/All \(7\)/)).toBeInTheDocument()
-    })
+    const sigma = await graphReady()
+    expect(sigma.graph.order).toBe(7)
+    expect(sigma.graph.size).toBe(2)
+  })
+
+  it('keeps the data controls available when the renderer cannot initialize', async () => {
+    const failure = new Error('WebGL unavailable')
+    sigmaConstructorFailure.current = failure
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    try {
+      renderWithProviders(<MemoryGraphTab />)
+
+      expect(await screen.findByText(/All \(7\)/)).toBeInTheDocument()
+      await waitFor(() => {
+        expect(warn).toHaveBeenCalledWith('MemoryGraph: sigma init failed', failure)
+      })
+      expect(sigmaInstances).toHaveLength(0)
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('displays filter buttons with correct group counts', async () => {
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/Preferences \(2\)/)).toBeInTheDocument()
-    })
+    await graphReady()
+    expect(screen.getByText(/Preferences \(2\)/)).toBeInTheDocument()
     expect(screen.getByText(/Projects \(2\)/)).toBeInTheDocument()
     expect(screen.getByText(/Semantic \(1\)/)).toBeInTheDocument()
     expect(screen.getByText(/Lessons \(1\)/)).toBeInTheDocument()
@@ -45,9 +124,7 @@ describe('MemoryGraphTab Integration Tests', () => {
     const user = userEvent.setup()
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/All \(7\)/)).toBeInTheDocument()
-    })
+    await graphReady()
 
     await user.click(screen.getByText(/Projects \(2\)/))
     // Active filter button gets accent styling
@@ -58,9 +135,7 @@ describe('MemoryGraphTab Integration Tests', () => {
     const user = userEvent.setup()
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/All \(7\)/)).toBeInTheDocument()
-    })
+    await graphReady()
 
     const btn = screen.getByText(/Lessons \(1\)/)
     await user.click(btn)
@@ -72,64 +147,56 @@ describe('MemoryGraphTab Integration Tests', () => {
   it('has a working search input', async () => {
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText('Search nodes…')).toBeInTheDocument()
-    })
+    await graphReady()
 
     fireEvent.change(screen.getByPlaceholderText('Search nodes…'), { target: { value: 'typescript' } })
     expect(screen.getByPlaceholderText('Search nodes…')).toHaveValue('typescript')
   })
 
   it('shows empty state when API returns no data', async () => {
-    server.use(
-      http.get('/api/memory/graph', () => HttpResponse.json({ nodes: [], edges: [] }))
-    )
+    memoryGraph.mockResolvedValueOnce({ nodes: [], edges: [] })
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/No memory data to visualize/)).toBeInTheDocument()
-    })
+    expect(await screen.findByText(/No memory data to visualize/)).toBeInTheDocument()
   })
 
   it('shows loading state initially', async () => {
-    server.use(
-      http.get('/api/memory/graph', () => new Promise(() => {})) // never resolves
-    )
+    let release!: (value: typeof mockMemoryGraph) => void
+    const pending = new Promise<typeof mockMemoryGraph>(resolve => { release = resolve })
+    memoryGraph.mockReturnValueOnce(pending)
     renderWithProviders(<MemoryGraphTab />)
     expect(screen.getByText(/Loading graph data/)).toBeInTheDocument()
+
+    await act(async () => {
+      release(mockMemoryGraph)
+      await pending
+    })
+    await graphReady()
   })
 
   it('handles API error gracefully', async () => {
-    server.use(
-      http.get('/api/memory/graph', () => HttpResponse.error())
-    )
+    memoryGraph.mockRejectedValueOnce(new Error('memory graph unavailable'))
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/No memory data to visualize/)).toBeInTheDocument()
-    })
+    expect(await screen.findByText(/No memory data to visualize/)).toBeInTheDocument()
   })
 
   it('refresh button reloads data', async () => {
     const user = userEvent.setup()
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/Refresh/)).toBeInTheDocument()
-    })
+    await graphReady()
+    expect(memoryGraph).toHaveBeenCalledTimes(1)
 
     await user.click(screen.getByText(/Refresh/))
-    // After refresh, data should still be visible
-    await waitFor(() => {
-      expect(screen.getByText(/All \(7\)/)).toBeInTheDocument()
-    })
+    await waitFor(() => expect(memoryGraph).toHaveBeenCalledTimes(2))
+    expect(screen.getByText(/All \(7\)/)).toBeInTheDocument()
   })
 
   it('renders the graph title and info tooltip', async () => {
     renderWithProviders(<MemoryGraphTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText(/Memory Graph/)).toBeInTheDocument()
-    })
+    await graphReady()
+    expect(screen.getByText(/Memory Graph/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Problem / Motivation  `MemoryGraphTab.integration.test.tsx` passed alone but its first graph-count test timed out at 15 seconds in the 1,654-file Vitest run. The file mixed a real MSW request, a real dynamic d3 force layout, and a Sigma mock that Vitest 4 cannot construct with `new`.  ## Why it matters  A test that only passes in isolation can hide a broken renderer contract and can fail unrelated full-suite shards under load. Deterministic API, layout, constructor, and teardown boundaries make the test prove the production integration it claims to cover without extending its time budget.  ## Root cause  The component caught the Sigma constructor `TypeError`, so the tests never proved that the graph renderer initialized. At the same time, network scheduling and the real force pass made readiness depend on loaded-worker timing. The loading case also installed an MSW handler whose request promise never settled, leaking request lifecycle beyond the assertion.  ## What changed  - mock the `api.memoryGraph` boundary directly with the existing graph fixture - reset and explicitly control the API result for every test - replace d3 only at its module boundary with a synchronous fluent force contract; layout physics are not the UI-shell integration subject - replace the non-constructable Sigma function mock with a real class fake that implements every method the component uses - use one `graphReady` contract that waits for both API-rendered DOM and an actual Sigma mount - assert graphology received 7 nodes and 2 edges - make the loading case use a controlled deferred promise and settle it before teardown - prove Refresh performs a second API call  No production, MSW server, shared setup, timeout, retry, or warning behavior changed.  ## Global overlap audit  All open PRs were checked across this test, `MemoryGraphTab`, API, setup, MSW helpers, Vite config, and dependency manifests. No pending PR owns this test or the Sigma/d3 behavior. #6895 fixes the complementary global happy-dom teardown race and its combined merge-tree is clean; #5983 changes only the backend memory handler.  ## Tests  - focused: 11 passed - five consecutive focused runs after the coverage assertion was added: 55/55 passed - coverage mode: 11/11 passed; MemoryGraphTab line coverage 67.62% (gate floor 66.3%) - related Memory/Overview/Knowledge matrix: 8 files, 117/117 passed - negative mutation proved the renderer assertion fails when no Sigma instance mounts - `npm run typecheck` - full unfiltered `npm run lint`: 0 errors - jscpd: 2,425 files, 0 clones - `git diff --check` and clean merge-tree  ## Screenshot evidence  <!-- no-visual-delta --> **Why no screenshot:** This changes only headless integration-test doubles and synchronization; production rendering, layout, styles, motion, and interaction behavior are unchanged.  ## Checklist  - [x] One Conventional Commit - [x] No retry, sleep, timeout increase, tolerance, or warning filter - [x] No existing PR changes overwritten - [x] No secrets or generated artifacts