### PR TITLE
fix(i18n): keep the key-reference gate within budget

### DIFF
--- a/website/scripts/check-i18n-keys.mjs
+++ b/website/scripts/check-i18n-keys.mjs
@@ -153,11 +153,12 @@ for (const arg of process.argv.slice(2)) {
  * reference keys that do not exist, to assert the missing-key fallback behaviour
  * (`pseudoBracket.test.tsx` builds fixture keys, `navLabels.test.tsx` composes
  * `settings.tabs.${k}.${field}`). Failing on those would make the gate punish the
- * tests that exist to prove the failure mode. They are still parsed, and still
- * reported under `--report`, so the exclusion is visible rather than assumed.
+ * tests that exist to prove the failure mode. A normal gate run skips them before
+ * filesystem metadata or source parsing; `--report` still parses and reports them,
+ * so the exclusion stays visible without making every CI gate scan the test corpus.
  */
 const DECLARATION_FILE = 'i18n/t.ts'
-const isTestFile = (rel) => /\.test\.tsx?$/.test(rel) || rel.startsWith('test/')
+const isTestFile = (rel) => /\.test\.tsx?$/.test(rel) || rel === 'test' || rel.startsWith('test/')
 
 /**
  * Property names whose string-literal value IS a catalog key.
@@ -240,6 +241,11 @@ function walk(dir, out = []) {
   for (const entry of fs.readdirSync(dir)) {
     if (entry === 'node_modules' || entry === 'locales') continue
     const full = path.join(dir, entry)
+    const rel = path.relative(SRC, full).split(path.sep).join('/')
+    // Test references never affect the default verdict or its production-only
+    // coverage count. Skip their filesystem and AST work from the blocking gate;
+    // `--report` deliberately keeps the wider diagnostic scan.
+    if (!REPORT && isTestFile(rel)) continue
     if (fs.statSync(full).isDirectory()) walk(full, out)
     else if (/\.tsx?$/.test(entry)) out.push(full)
   }

--- a/website/src/i18n/keyReference.test.ts
+++ b/website/src/i18n/keyReference.test.ts
@@ -411,14 +411,22 @@ export function Shadowed(KEY: string) {
 describe('scope', () => {
   it('treats a shadowed name as dynamic rather than resolving the outer binding', () => {
     const clean = run({
-      files: withPadding({ 'src/probe/Shadow.tsx': SHADOW_SOURCE }),
+      files: withPadding({
+        'src/probe/Shadow.tsx': SHADOW_SOURCE,
+        // Normal gate runs do not need test sources for their verdict, but report mode
+        // keeps scanning them so the exclusion remains visible and auditable.
+        'src/probe/ReportOnly.test.ts': `import { i18nT } from '../i18n/t'
+export const value = i18nT('probe.report_only.absent')
+`,
+      }),
       keys: [],
       baseline: { 'probe/Shadow.tsx': 1 },
-    })
+    }, ['--report'])
     expect(clean.status, `stdout:\n${clean.stdout}\nstderr:\n${clean.stderr}`).toBe(0)
     // The outer key must NOT be reported: the call site cannot reach it, and asserting a
     // key the code never asks for is how a gate loses its reader's trust.
     expect(clean.stderr).not.toContain('probe.shadow.outer')
+    expect(clean.stdout).toContain('probe.report_only.absent')
   })
 })
 
@@ -537,6 +545,14 @@ describe('the gate refuses to report a pass it cannot justify', () => {
 // ------------------------------------------------------------------ wiring
 
 describe('wiring', () => {
+  it('skips test-only sources before the normal real-tree filesystem scan', () => {
+    const source = fs.readFileSync(GATE, 'utf-8')
+    const walk = source.slice(source.indexOf('function walk('), source.indexOf('/**\n * Is a bare `t`'))
+    const skip = walk.indexOf('if (!REPORT && isTestFile(rel)) continue')
+    expect(skip).toBeGreaterThan(-1)
+    expect(skip).toBeLessThan(walk.indexOf('fs.statSync(full)'))
+  })
+
   it('is invoked by npm run i18n:check', () => {
     // The gate lives in a script, so nothing in the vitest suite would notice it being
     // dropped from the chain CI runs. `englishIdentity.test.ts` reads codemod source for


### PR DESCRIPTION
## Problem / Motivation

The hard-zero i18n key-reference gate scanned and parsed the entire test corpus even though test references do not participate in its verdict or production coverage count. On the real tree this could overrun the Vitest budget and fail nondeterministically under CI load.

## Why it matters

A blocking correctness gate that sometimes exceeds its own test budget makes unrelated changes fail nondeterministically. The redundant work also obscures the gate's actual production-only contract.

## What changed

Skip test-only paths during the normal blocking walk before filesystem metadata and AST work. Report mode deliberately retains the wider scan, so test-only references remain visible and auditable.

The production scan drops from 2,892 to 1,257 TypeScript files without changing the hard-zero result.

## Tests

- keyReference tests: 30/30
- three focused stress runs: 30/30 each
- real-tree gate, five runs: 4.84–5.26s
- report mode still includes test diagnostics
- full npm run i18n:check: 19/19, 13,931 references, 0 dangling
- TypeScript, changed-file ESLint, Node syntax, and diff checks pass
- deleting the early-skip guard makes the regression test fail deterministically
- audited all open PRs: no direct owner of either changed file; merge-tree clean with the adjacent teardown PR

No retries, sleeps, timeout increases, warning filters, or assertion weakening were added.

## Screenshot evidence

<!-- no-visual-delta -->
**Why no screenshot:** This changes only the CI key-reference scanner and its tests; rendered UI output is unchanged.