### PR TITLE
fix(notes): serialize save barriers before moves

### DIFF
--- a/docs/system-specs/modules/md-notebook.md
+++ b/docs/system-specs/modules/md-notebook.md
@@ -160,7 +160,9 @@ The word "save" means three different things here, and only the last needs a but
 1. **Disk.** A note edit is written to the file after `SAVE_DEBOUNCE_MS` (1s) of quiet,
    and flushed unconditionally before anything that could lose it — opening another note,
    switching vaults, moving/renaming/deleting, syncing, and `beforeunload`. The user never
-   saves the file by hand.
+   saves the file by hand. Disk saves are single-flight: a mutation that reaches its flush
+   barrier while the debounced save is active joins that request, so a failed save cannot be
+   hidden by a competing write that lets the mutation proceed.
 2. **Local git history (autosave).** `POST /api/commit` runs every `AUTO_COMMIT_MINS`
    (5) while `LS.autoCommit` is on — **default ON** (`DEFAULT_AUTO_COMMIT`). It commits and
    stops; it cannot reach a remote. It stages **exactly** the changed `.md` paths it saves,

--- a/website/src/apps/md-notebook/MdNotebookPage.tsx
+++ b/website/src/apps/md-notebook/MdNotebookPage.tsx
@@ -465,6 +465,15 @@ export default function MdNotebookPage() {
    * not the response -- that makes the wait sufficient.
    */
   const writesInFlightRef = useRef(new Set<Promise<void>>())
+  /**
+   * The active disk save, shared by every caller that reaches the save barrier.
+   *
+   * A debounce and a rename/move can ask to flush the same dirty buffer at the
+   * same time. Sending both requests lets one success clear `dirtyRef` after the
+   * other request failed, so the mutation can move a note whose save was never
+   * reconciled. Joining the active request makes its one outcome authoritative.
+   */
+  const saveInFlightRef = useRef<Promise<void> | null>(null)
   const contentRef = useRef('')
   const pathRef = useRef<string | null>(null)
   const vaultRef = useRef(activeVaultId)
@@ -732,6 +741,13 @@ export default function MdNotebookPage() {
       window.clearTimeout(saveTimer.current)
       saveTimer.current = null
     }
+    // A mutation arriving while the debounce save is active must observe that
+    // request's outcome. Starting a second save here could clear `dirtyRef`
+    // after the first one failed and let the mutation cross a failed barrier.
+    if (saveInFlightRef.current) {
+      await saveInFlightRef.current
+      return
+    }
     if (!pathRef.current || !dirtyRef.current) return
     // The note this flush is persisting, as a VAULT + PATH pair. A save can still
     // be in flight when the user deletes that note from the row action bar, and
@@ -742,54 +758,62 @@ export default function MdNotebookPage() {
     // and the banner offers "Use the file on disk" against the NEW vault's buffer.
     const savingPath = pathRef.current
     const saving = { vault: vaultRef.current, path: savingPath }
-    const doneSave = trackWrite()
-    try {
-      // Save until what landed matches what the editor holds. `contentRef` can
-      // move while the request is in flight, and the debounce timer was
-      // cancelled above — clearing `dirty` against a stale snapshot would leave
-      // that newer text with nothing scheduled to persist it. Bounded so a fast
-      // typist cannot spin here; whatever is left stays dirty for the next
-      // debounce to pick up.
-      for (let attempt = 0; attempt < 3; attempt++) {
-        // The CONTENT is re-read live each attempt — that is the point of the
-        // loop. The TARGET is the captured pair, never the live refs: a vault
-        // switch or a rename during the round trip would otherwise redirect
-        // attempt 2 at whatever is open by then, writing this note's text
-        // somewhere the user never asked for.
-        const sent = contentRef.current
-        const res = await notesApi.saveNote(
-          saving.vault,
-          saving.path,
-          sent,
-          mtimeRef.current ?? undefined,
-        )
-        mtimeRef.current = res.mtime
-        if (contentRef.current === sent) {
-          setDirty(false)
-          dirtyRef.current = false
-          break
+    const run = (async () => {
+      const doneSave = trackWrite()
+      try {
+        // Save until what landed matches what the editor holds. `contentRef` can
+        // move while the request is in flight, and the debounce timer was
+        // cancelled above — clearing `dirty` against a stale snapshot would leave
+        // that newer text with nothing scheduled to persist it. Bounded so a fast
+        // typist cannot spin here; whatever is left stays dirty for the next
+        // debounce to pick up.
+        for (let attempt = 0; attempt < 3; attempt++) {
+          // The CONTENT is re-read live each attempt — that is the point of the
+          // loop. The TARGET is the captured pair, never the live refs: a vault
+          // switch or a rename during the round trip would otherwise redirect
+          // attempt 2 at whatever is open by then, writing this note's text
+          // somewhere the user never asked for.
+          const sent = contentRef.current
+          const res = await notesApi.saveNote(
+            saving.vault,
+            saving.path,
+            sent,
+            mtimeRef.current ?? undefined,
+          )
+          mtimeRef.current = res.mtime
+          if (contentRef.current === sent) {
+            setDirty(false)
+            dirtyRef.current = false
+            break
+          }
+          // The buffer moved on. Only keep retrying while it is still THIS note in
+          // THIS vault; otherwise the dirty flag being cleared below would belong to
+          // a different buffer entirely.
+          if (!targetsSameNote(saving, vaultRef.current, pathRef.current)) return
         }
-        // The buffer moved on. Only keep retrying while it is still THIS note in
-        // THIS vault; otherwise the dirty flag being cleared below would belong to
-        // a different buffer entirely.
-        if (!targetsSameNote(saving, vaultRef.current, pathRef.current)) return
+      } catch (e) {
+        const body = (e as { body?: { code?: string; mtime?: number; disk?: string } }).body
+        if (body?.code === 'ESTALE') {
+          // The note changed on disk since it was opened. Surface both versions
+          // rather than clobbering either — but ONLY while that note is still
+          // open. Deleting a note mid-flush also lands here (the backend refuses
+          // to resurrect it and returns the recreate sentinel), and showing the
+          // banner then would offer "Keep my version" for a note the user just
+          // deleted — accepting it would put the file back.
+          if (!targetsSameNote(saving, vaultRef.current, pathRef.current)) return
+          setFileConflict({ mtime: body.mtime ?? 0, disk: body.disk ?? '' })
+        } else {
+          setError(e instanceof Error ? e.message : String(e))
+        }
+      } finally {
+        doneSave()
       }
-    } catch (e) {
-      const body = (e as { body?: { code?: string; mtime?: number; disk?: string } }).body
-      if (body?.code === 'ESTALE') {
-        // The note changed on disk since it was opened. Surface both versions
-        // rather than clobbering either — but ONLY while that note is still
-        // open. Deleting a note mid-flush also lands here (the backend refuses
-        // to resurrect it and returns the recreate sentinel), and showing the
-        // banner then would offer "Keep my version" for a note the user just
-        // deleted — accepting it would put the file back.
-        if (!targetsSameNote(saving, vaultRef.current, pathRef.current)) return
-        setFileConflict({ mtime: body.mtime ?? 0, disk: body.disk ?? '' })
-      } else {
-        setError(e instanceof Error ? e.message : String(e))
-      }
+    })()
+    saveInFlightRef.current = run
+    try {
+      await run
     } finally {
-      doneSave()
+      if (saveInFlightRef.current === run) saveInFlightRef.current = null
     }
   }, [trackWrite])
 

--- a/website/src/test/MdNotebookPageCoverage.test.tsx
+++ b/website/src/test/MdNotebookPageCoverage.test.tsx
@@ -133,13 +133,19 @@ function pending<T>(): Promise<T> {
   return new Promise<T>(() => undefined)
 }
 
-/** A promise whose resolution this test controls, for ordering two reads. */
-function deferred<T>(): { promise: Promise<T>; settle: (value: T) => void } {
+/** A promise whose outcome this test controls, for ordering async operations. */
+function deferred<T>(): {
+  promise: Promise<T>
+  settle: (value: T) => void
+  reject: (reason?: unknown) => void
+} {
   let settle!: (value: T) => void
-  const promise = new Promise<T>(resolve => {
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolve, rejectPromise) => {
     settle = resolve
+    reject = rejectPromise
   })
-  return { promise, settle }
+  return { promise, settle, reject }
 }
 
 /** An ESTALE rejection, the shape the save guard recognises. */
@@ -791,17 +797,34 @@ describe('MdNotebookPage — settings, guarded mutations and editor keys', () =>
     expect(api.moveNote).not.toHaveBeenCalled()
   })
 
-  it('refuses to move a note whose pending save was rejected', async () => {
-    await mountDirty()
-    api.saveNote.mockRejectedValueOnce(staleRejection())
-    // Back to the rendered pane so the row action bar is reachable.
-    await userEvent.click(screen.getByRole('button', { name: 'Rendered' }))
-    rowAction('One', 'Rename note')
-    const field = await screen.findByRole('textbox', { name: 'Note name' })
-    await userEvent.clear(field)
-    await userEvent.type(field, 'Renamed{Enter}')
+  it('joins an active debounced save and refuses to move when that save fails', async () => {
+    const save = deferred<{ ok: boolean; mtime: number }>()
+    api.saveNote.mockImplementationOnce(() => save.promise)
+    await mountWithNote()
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    vi.useFakeTimers()
+    fireEvent.change(rawEditor(), { target: { value: '# Hello\n\nunsaved rename' } })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS)
+    })
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
 
-    await waitFor(() => expect(api.saveNote).toHaveBeenCalled())
+    // Rename while the debounce save is still unresolved. This second save
+    // barrier must JOIN the active request instead of issuing a competing save
+    // whose success could hide the first request's failure.
+    fireEvent.click(screen.getByRole('button', { name: 'Rendered' }))
+    rowAction('One', 'Rename note')
+    const field = screen.getByRole('textbox', { name: 'Note name' })
+    fireEvent.change(field, { target: { value: 'Renamed' } })
+    fireEvent.keyDown(field, { key: 'Enter', code: 'Enter' })
+    expect(api.saveNote).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      save.reject(staleRejection())
+      await save.promise.catch(() => undefined)
+    })
+    vi.useRealTimers()
+    expect(await screen.findByText('This note changed on disk since you opened it.')).toBeTruthy()
     // Renaming would retarget the editor without ever reconciling its content.
     expect(api.moveNote).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Problem / Motivation

A debounced note save and a rename or move flush could run concurrently. If the earlier save failed but the competing request succeeded later, that success could clear the dirty state and let the mutation proceed, hiding the failed save.

## Why it matters

Moving a note after an unobserved save failure can retarget the editor while its content was never safely persisted. The UI can then report a successful mutation while the user's latest text remains unresolved.

## What changed

Make disk saves single-flight. Any mutation that reaches its save barrier while a debounced save is active now joins the same promise and observes the same outcome. A failed save therefore blocks the move and preserves the conflict path instead of being overwritten by a competing write.

The system specification now records this invariant.

## Tests

- deterministic deferred-promise regression asserts one save, ESTALE surfaced, and move never called
- focused stress batch: 5/5
- MdNotebookPageCoverage: 64/64
- all 13 MdNotebook suites: 335/335
- TypeScript, build, changed-file ESLint, and diff checks pass
- audited all open PRs: no owner of the MdNotebook files, tests, or Notes API
- latest-main merge-tree clean

No retries, sleeps, timeout increases, tolerance changes, or error suppression were added.

## Screenshot evidence

<!-- no-visual-delta -->
**Why no screenshot:** The change affects save ordering and failure handling only; it does not alter layout, styling, or rendered content.