### PR TITLE
fix: carry claude seam cost and cache fields through background usage consumers (#6758)

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -184,6 +184,7 @@ from kiro_crew.llm_helpers import (
     record_interaction_event,
     run_bg_oneliner,
     transient_retry_delay,
+    usage_has_billing,
 )
 from kiro_crew.mcp_discovery import kirocrew_managed_names
 from kiro_crew.members import record_activity
@@ -7877,7 +7878,12 @@ async def _run_chat(
                 # with a missing measurement. Still never guesses: an
                 # unattributable turn stays "" and the footer omits the field.
                 _turn_model = read_turn_model(client)
-                if _u.input_tokens or _u.output_tokens or _u.credits:
+                # One shared predicate across every persist gate (#6758): a
+                # claude-seam turn ending via a synthetic EVENT_COMPLETE
+                # (timeout, tool-stall, cancel-unacked) can carry cost or cache
+                # tokens with zero fresh tokens and zero credits, and the
+                # footer above already reads _u.cost_usd for the same event.
+                if usage_has_billing(_u):
                     try:
                         _provider_name = cfg.agent.provider  # type: ignore[possibly-undefined]
                     except (NameError, AttributeError):

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -1081,7 +1081,11 @@ async def run_bg_oneliner(
                 from kiro_crew.dashboard.handlers.usage import persist_token_record_async
 
                 usage = provider_last_turn_usage(session, since=stats_before)
-                if usage.credits or usage.input_tokens or usage.output_tokens:
+                # One shared predicate across every persist gate: a claude-seam
+                # turn recovered through the live-stats path can bill cost or
+                # cache tokens with zero credits AND zero fresh token counts;
+                # a gate testing only the kiro dimensions silently drops it.
+                if usage_has_billing(usage):
                     await persist_token_record_async(
                         sel_session_key,
                         # The model the session SERVED, never the one requested: a
@@ -1135,10 +1139,46 @@ def _attempt_usage(provider: Any, *, since: Any = _NO_PRIOR_STATS) -> TurnUsage:
     if since is not _NO_PRIOR_STATS and stats is since:
         return TurnUsage()
     try:
+        # Prefer the stats object's own converter: it is the single source of
+        # truth for stats -> TurnUsage and carries every billing dimension the
+        # turn filled (claude seam: token counts + cache fields + cost_usd; kiro:
+        # credits). Duck-typed so the doubles in tests (and any stats holder
+        # predating the converter) fall through to the credits-only constructor,
+        # which is byte-identical for the kiro seam. The converter's failure is
+        # contained so a faulty to_turn_usage degrades to the credits read
+        # rather than silently zeroing a turn that previously billed.
+        to_usage = getattr(stats, "to_turn_usage", None)
+        if callable(to_usage):
+            try:
+                usage = to_usage()
+            except Exception:
+                logger.debug("to_turn_usage failed; falling back to credits", exc_info=True)
+                usage = None
+            if isinstance(usage, TurnUsage):
+                return usage
         return TurnUsage(credits=float(getattr(stats, "credits", 0.0) or 0.0))
     except Exception:
         logger.debug("attempt usage read failed", exc_info=True)
     return TurnUsage()
+
+
+def usage_has_billing(usage: TurnUsage) -> bool:
+    """True when *usage* carries any billing dimension worth a row.
+
+    The single predicate behind every persist gate. Three hand-maintained
+    copies of ``credits or input_tokens or output_tokens`` is how the claude
+    seam's ``cost_usd`` (and a cost-free cache-only turn) got dropped in the
+    first place (#6758); a gate that reads this cannot drift from its siblings
+    when the next billing dimension is added.
+    """
+    return bool(
+        usage.credits
+        or usage.cost_usd
+        or usage.input_tokens
+        or usage.output_tokens
+        or usage.cache_creation_tokens
+        or usage.cache_read_tokens
+    )
 
 
 def _sum_usage(left: TurnUsage, right: TurnUsage) -> TurnUsage:
@@ -1150,6 +1190,12 @@ def _sum_usage(left: TurnUsage, right: TurnUsage) -> TurnUsage:
             + int(getattr(right, "input_tokens", 0) or 0),
             output_tokens=int(getattr(left, "output_tokens", 0) or 0)
             + int(getattr(right, "output_tokens", 0) or 0),
+            cache_creation_tokens=int(getattr(left, "cache_creation_tokens", 0) or 0)
+            + int(getattr(right, "cache_creation_tokens", 0) or 0),
+            cache_read_tokens=int(getattr(left, "cache_read_tokens", 0) or 0)
+            + int(getattr(right, "cache_read_tokens", 0) or 0),
+            cost_usd=float(getattr(left, "cost_usd", 0.0) or 0.0)
+            + float(getattr(right, "cost_usd", 0.0) or 0.0),
         )
     except Exception:
         logger.debug("usage sum failed", exc_info=True)
@@ -1186,8 +1232,10 @@ def provider_last_turn_usage(provider: Any, *, since: Any = _NO_PRIOR_STATS) -> 
     next caller preserving that pairing. A fresh turn installs fresh stats, so a
     stale total simply fails the identity check and the live read takes over.
 
-    On the ACP backend the only non-zero per-turn billing signal is ``credits``;
-    the token fields stay 0, matching the real usage record. Providers that expose
+    On the kiro (acp) seam the only non-zero per-turn billing signal is
+    ``credits``; on the claude seam the token counts, cache fields, and
+    ``cost_usd`` are filled instead. Whichever dimensions the turn's stats
+    carried come through :meth:`to_turn_usage` intact. Providers that expose
     no stats (non-ACP backends, test doubles) yield an empty ``TurnUsage``
     (credits=0). Never raises.
     """
@@ -1354,8 +1402,10 @@ async def background_turn(
 
                 # A turn that never reached the provider bills nothing and has no
                 # row to write; the same guard the chat path applies keeps
-                # acquire-time failures from landing as zero-credit noise.
-                if usage.credits or usage.input_tokens or usage.output_tokens:
+                # acquire-time failures from landing as zero-credit noise. The
+                # shared predicate covers the claude seam's cost and cache
+                # dimensions alongside the kiro credits/token signals.
+                if usage_has_billing(usage):
                     await persist_token_record_async(
                         BACKGROUND_KEY,
                         "",

--- a/test/test_background_turn_accounting.py
+++ b/test/test_background_turn_accounting.py
@@ -351,3 +351,132 @@ class TestBilledAttemptsSurviveARetry(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class _ClaudeStats:
+    """Claude-seam per-turn stats: ``credits`` stays 0 and the billing travels
+    through ``to_turn_usage()`` (the stats -> event contract from #6757)."""
+
+    def __init__(self, usage) -> None:
+        self.credits = 0.0
+        self._usage = usage
+
+    def to_turn_usage(self):
+        return self._usage
+
+
+class TestClaudeSeamBackgroundAccounting(unittest.IsolatedAsyncioTestCase):
+    async def test_a_cost_only_turn_still_writes_its_row(self):
+        """The #6758 shape: cost_usd billed with credits and both token counts
+        at zero. Dropping the gate's cost_usd conjunct, or bypassing the
+        duck-typed to_turn_usage read in _attempt_usage (whose credits-only
+        fallback zeroes every claude dimension), makes this fail."""
+        from kiro_crew.acp.types import TurnUsage
+
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET) as persist:
+            async with background_turn(sessions, task="consolidation") as client:
+                client.last_prompt_stats = _ClaudeStats(
+                    TurnUsage(cost_usd=0.42, cache_creation_tokens=20, cache_read_tokens=30)
+                )
+
+        self.assertEqual(persist.await_count, 1)
+        recorded = persist.await_args.args[2]
+        self.assertAlmostEqual(recorded.cost_usd, 0.42)
+        self.assertEqual(recorded.cache_creation_tokens, 20)
+        self.assertEqual(recorded.cache_read_tokens, 30)
+        self.assertEqual(recorded.credits, 0.0)
+
+    async def test_an_all_zero_claude_turn_writes_no_row(self):
+        from kiro_crew.acp.types import TurnUsage
+
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET) as persist:
+            async with background_turn(sessions, task="consolidation") as client:
+                client.last_prompt_stats = _ClaudeStats(TurnUsage())
+
+        persist.assert_not_awaited()
+
+
+class TestSumUsageCarriesTheBilledDimensions(unittest.TestCase):
+    def test_claude_seam_dimensions_survive_the_sum(self):
+        """A retried turn sums its attempts through _sum_usage; a dimension the
+        sum drops is spend an earlier billed attempt silently loses.
+
+        num_turns and duration_ms are deliberately absent: to_turn_usage never
+        fills them and every persist site passes elapsed_ms explicitly.
+        """
+        from kiro_crew.acp.types import TurnUsage
+        from kiro_crew.llm_helpers import _sum_usage
+
+        left = TurnUsage(
+            input_tokens=10,
+            output_tokens=20,
+            cache_creation_tokens=1,
+            cache_read_tokens=2,
+            cost_usd=0.1,
+            credits=0.5,
+        )
+        right = TurnUsage(
+            input_tokens=30,
+            output_tokens=40,
+            cache_creation_tokens=3,
+            cache_read_tokens=4,
+            cost_usd=0.2,
+            credits=1.5,
+        )
+        total = _sum_usage(left, right)
+        self.assertEqual(total.input_tokens, 40)
+        self.assertEqual(total.output_tokens, 60)
+        self.assertEqual(total.cache_creation_tokens, 4)
+        self.assertEqual(total.cache_read_tokens, 6)
+        self.assertAlmostEqual(total.cost_usd, 0.3)
+        self.assertAlmostEqual(total.credits, 2.0)
+
+
+class TestUsageHasBilling(unittest.TestCase):
+    """The single predicate behind every persist gate: each billing dimension
+    alone must open the gate, and an all-zero turn must not."""
+
+    def test_each_dimension_alone_opens_the_gate(self):
+        from kiro_crew.acp.types import TurnUsage
+        from kiro_crew.llm_helpers import usage_has_billing
+
+        for kwargs in (
+            {"credits": 0.5},
+            {"cost_usd": 0.42},
+            {"input_tokens": 1},
+            {"output_tokens": 1},
+            {"cache_creation_tokens": 1},
+            {"cache_read_tokens": 1},
+        ):
+            with self.subTest(**kwargs):
+                self.assertTrue(usage_has_billing(TurnUsage(**kwargs)))
+
+    def test_an_all_zero_turn_stays_out(self):
+        from kiro_crew.acp.types import TurnUsage
+        from kiro_crew.llm_helpers import usage_has_billing
+
+        self.assertFalse(usage_has_billing(TurnUsage()))
+
+
+class _FaultyConverterStats:
+    """A stats holder whose to_turn_usage exists but raises: the converter's
+    failure must degrade to the credits read, not zero the turn's billing."""
+
+    def __init__(self, credits: float) -> None:
+        self.credits = credits
+
+    def to_turn_usage(self):
+        raise RuntimeError("converter boom")
+
+
+class TestFaultyConverterFallsBackToCredits(unittest.IsolatedAsyncioTestCase):
+    async def test_credits_still_bill_when_the_converter_raises(self):
+        sessions = _Sessions(_Client())
+        with patch(_USAGE_TARGET) as persist:
+            async with background_turn(sessions, task="consolidation") as client:
+                client.last_prompt_stats = _FaultyConverterStats(credits=3.5)
+
+        self.assertEqual(persist.await_count, 1)
+        self.assertEqual(persist.await_args.args[2].credits, 3.5)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6301,6 +6301,59 @@ class TestTokenUsageSurface:
         assert persist.await_args.kwargs["surface"] == "slack"
 
 
+class TestCostOnlyTurnPersistGate:
+    """The chat_runner turn-end persist gate must fire on ``cost_usd`` alone.
+
+    A claude-seam turn ending via a synthetic EVENT_COMPLETE (timeout,
+    tool-stall, cancel-unacked) can carry cost with zero tokens and zero
+    credits; the footer already reads ``_u.cost_usd`` off the same event, so
+    only the gate stood between the cost and the usage store (#6758).
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_cost_only_turn_persists_its_row(self, tmp_path, monkeypatch):
+        """Mutation guard: dropping the gate's ``cost_usd`` conjunct makes the
+        persist call disappear and this fail."""
+        from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+
+        events = [LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(cost_usd=0.42))]
+        state = TestTokenPersistenceBackfill._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = TestTokenPersistenceBackfill._make_mock_client(events)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        persist = AsyncMock()
+        monkeypatch.setattr("kiro_crew.dashboard.chat_runner.persist_token_record_async", persist)
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "hello")
+
+        assert persist.await_count == 1
+        assert persist.await_args.args[2].usage.cost_usd == pytest.approx(0.42)
+
+    @pytest.mark.asyncio
+    async def test_an_all_zero_turn_still_writes_no_row(self, tmp_path, monkeypatch):
+        """The widened gate must not have become unconditional: a turn whose
+        usage carries no billing dimension at all stays out of the store."""
+        from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+
+        events = [LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage())]
+        state = TestTokenPersistenceBackfill._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        client = TestTokenPersistenceBackfill._make_mock_client(events)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        persist = AsyncMock()
+        monkeypatch.setattr("kiro_crew.dashboard.chat_runner.persist_token_record_async", persist)
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "hello")
+
+        persist.assert_not_awaited()
+
+
 class TestKiroBackfillProfileGuard:
     """Regression tests for the kiro/acp backfill must NOT store a
     resolved Bedrock inference-profile id into slot.model.

--- a/test/test_run_bg_oneliner.py
+++ b/test/test_run_bg_oneliner.py
@@ -12,7 +12,12 @@ from unittest.mock import patch
 import pytest
 
 from kiro_crew.acp.client import AcpError, _rejected_model_from_error
-from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK
+from kiro_crew.acp.types import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    TurnUsage,
+)
 from kiro_crew.llm_helpers import run_bg_oneliner
 
 
@@ -460,3 +465,83 @@ async def test_the_turn_duration_reaches_the_row():
             await run_bg_oneliner(_FakeSessions(sess), "p")
 
     assert persist.await_args.kwargs["elapsed_ms"] == 250
+
+
+class _ClaudeSeamStats:
+    """Mirrors AcpPromptStats on the claude seam: ``credits`` stays 0 and the
+    billing dimensions travel through ``to_turn_usage()`` (the post-#6757
+    stats -> event contract that ``_attempt_usage`` duck-types on)."""
+
+    def __init__(self, usage: TurnUsage) -> None:
+        self.credits = 0.0
+        self._usage = usage
+
+    def to_turn_usage(self) -> TurnUsage:
+        return self._usage
+
+
+class _ClaudeSeamSession(_FakeSession):
+    """Installs claude-seam per-turn stats once the turn begins."""
+
+    def __init__(self, events, *, turn_stats: _ClaudeSeamStats) -> None:
+        super().__init__(events)
+        self._turn_stats = turn_stats
+
+    async def prompt(self, _prompt):
+        self.last_prompt_stats = self._turn_stats
+        for e in self._events:
+            yield e
+
+
+@pytest.mark.asyncio
+async def test_a_cost_only_claude_seam_turn_writes_a_row_with_cost_and_cache_intact():
+    """On the claude seam a background turn can bill ``cost_usd`` with credits
+    AND both token counts at zero -- the #6758 shape. The row must be written
+    (mutation guard on the gate's ``cost_usd`` conjunct) and must carry the
+    cost and cache fields through ``_attempt_usage``'s ``to_turn_usage`` path
+    (mutation guard on the duck-typed converter: the credits-only fallback
+    constructor would zero every field and skip the row)."""
+    stats = _ClaudeSeamStats(
+        TurnUsage(cost_usd=0.42, cache_creation_tokens=20, cache_read_tokens=30)
+    )
+    sess = _ClaudeSeamSession([SimpleNamespace(kind=EVENT_COMPLETE, text="")], turn_stats=stats)
+
+    with patch(_USAGE_TARGET) as persist:
+        await run_bg_oneliner(_FakeSessions(sess), "p")
+
+    assert persist.await_count == 1
+    recorded = persist.await_args.args[2]
+    assert recorded.cost_usd == pytest.approx(0.42)
+    assert recorded.cache_creation_tokens == 20
+    assert recorded.cache_read_tokens == 30
+    assert recorded.credits == 0.0
+
+
+@pytest.mark.asyncio
+async def test_a_cache_only_claude_seam_turn_still_writes_its_row():
+    """A claude-seam turn can report cache tokens with no cost (the adapter
+    fills PromptResponse token counts but sends no usage_update.cost) and zero
+    fresh input/output. The shared gate predicate must not drop it -- the
+    narrower sibling of the cost-only shape."""
+    stats = _ClaudeSeamStats(TurnUsage(cache_read_tokens=30))
+    sess = _ClaudeSeamSession([SimpleNamespace(kind=EVENT_COMPLETE, text="")], turn_stats=stats)
+
+    with patch(_USAGE_TARGET) as persist:
+        await run_bg_oneliner(_FakeSessions(sess), "p")
+
+    assert persist.await_count == 1
+    assert persist.await_args.args[2].cache_read_tokens == 30
+
+
+@pytest.mark.asyncio
+async def test_a_claude_seam_turn_that_billed_nothing_still_records_nothing():
+    """The all-zero guard survives the wider gate: a claude-seam turn whose
+    stats carried no billing at all must not land as zero-value noise."""
+    sess = _ClaudeSeamSession(
+        [SimpleNamespace(kind=EVENT_COMPLETE, text="")], turn_stats=_ClaudeSeamStats(TurnUsage())
+    )
+
+    with patch(_USAGE_TARGET) as persist:
+        await run_bg_oneliner(_FakeSessions(sess), "p")
+
+    persist.assert_not_awaited()


### PR DESCRIPTION
## Problem / Motivation

The two `TurnUsage`-from-stats consumers outside `acp/` predate the claude-seam billing dimensions and read only the kiro-seam `credits` signal, so claude-seam cost/cache data recovered outside the `EVENT_COMPLETE` path is dropped:

- `llm_helpers._attempt_usage` built `TurnUsage(credits=...)` only, and `_sum_usage` summed only credits + fresh token counts — `cost_usd` and both cache fields vanished on every background surface (cron, heartbeat, autonudge, workflow, task-runner, background one-liner).
- All three persist gates tested only `credits or input_tokens or output_tokens`. On the claude seam via background paths all three are 0, so **no usage row was written at all** — the #6750 symptom persisting on background surfaces. The `chat_runner` turn-end gate had the same hole for turns ending via a synthetic `EVENT_COMPLETE` (timeout, tool-stall, cancel-unacked): the footer at the same site already reads `_u.cost_usd`, only the gate ignored it.

## Why it matters

Claude-seam spend on background and synthetic-completion turns is silently unaccounted: the bill moves while the usage store stays empty, so the usage page under-reports real cost with no error anywhere. This is the remaining half of #6750 after PR #6757 landed the `to_turn_usage()` stats→event contract.

## What changed (motivation → approach → change)

Root cause is N hand-maintained copies of the same "is this turn billed?" logic drifting from the billing model, so the fix centralizes rather than patching each copy in place:

- `_attempt_usage` now prefers `stats.to_turn_usage()` (the single source of truth for stats→`TurnUsage` merged in #6757), duck-typed with a contained failure path: a faulty converter degrades to the credits-only read instead of silently zeroing a turn that previously billed. The kiro seam stays byte-identical (its `to_turn_usage()` yields `TurnUsage(credits=...)` with every other field at default).
- `_sum_usage` sums `cost_usd`, `cache_creation_tokens`, and `cache_read_tokens` alongside credits and fresh tokens, so a retried turn's earlier billed attempt no longer loses those dimensions.
- New `usage_has_billing(usage)` predicate covering all six billing dimensions gates all three persist sites (`run_bg_oneliner` teardown, `background_turn` teardown, `chat_runner` turn-end). One predicate cannot drift from its siblings when the next billing dimension is added, and it also covers the narrower cost-free cache-only shape.
- Refreshed the stale `provider_last_turn_usage` docstring claim that credits is the only non-zero billing signal.

Scope discipline per the issue: `acp/` internals untouched (`to_turn_usage` is the already-merged contract), kiro-seam credits behavior unchanged (credits-only turns persist exactly as before; all-zero turns never persist).

## Tests

All mutation-verified (each dropped conjunct / bypassed branch makes a named test fail; 7 mutations killed):

- `test_run_bg_oneliner.py`: cost-only claude-seam turn writes a row with cost + cache fields intact (kills the gate's `cost_usd` conjunct AND the converter bypass); cache-only turn still writes its row (kills the cache conjuncts); all-zero claude turn records nothing (guards against the gate becoming unconditional).
- `test_background_turn_accounting.py`: same cost-only/all-zero pair through `background_turn`; `usage_has_billing` unit tests (each dimension alone opens the gate, all-zero stays out); faulty `to_turn_usage` falls back to the credits read (kills the containment); `_sum_usage` carries every billed dimension across a retry.
- `test_dashboard_chat.py`: cost-only turn through the real `_run_chat` path persists its row (kills the chat_runner gate mutation); all-zero turn still writes no row.

## Manual verification

N/A — unit coverage exercises all three persist gates behaviorally through their real call paths (`run_bg_oneliner`, `background_turn`, `_run_chat`), and the kiro-seam parity claim is locked by the existing credits-only tests continuing to pass unchanged.

## Pre-push review

Two model-pinned blind reviewers (mirroring codex-review.yml / claude-review.yml), two rounds: R1 GPT PASS 0 findings; R1 Opus PASS 0 blocking + 6 advisories — adopted 3 (contained converter failure, shared gate predicate incl. cache dimensions, test-name overclaim), dispositioned 3 (duck-type probe shape is outside harness-parity file-patterns and accommodates test doubles; test-fixture lift deferred as this file's existing pattern; non-finite `cost_usd` is sanitized downstream by `_write_token_record`). R2 fresh reviewer on the amended diff: PASS 0 findings.

Closes #6758
