### PR TITLE
test: remove full-suite load races

### DIFF
--- a/website/src/i18n/scriptFonts.test.ts
+++ b/website/src/i18n/scriptFonts.test.ts
@@ -39,8 +39,9 @@
  * leading unicode-ranged alias is deterministic regardless of what follows it.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { readFile, readdir } from 'node:fs/promises'
+import { basename, join, relative } from 'node:path'
 
 import { describe, it, expect } from 'vitest'
 
@@ -196,23 +197,32 @@ function scriptToken(block: string, mono = false): string {
 }
 
 /** Every file that DECLARES --font-body or --mono, found by walking the tree. */
-function declarationSites(): Array<{ file: string; line: number; text: string }> {
+async function declarationSites(): Promise<Array<{ file: string; line: number; text: string }>> {
   const out: Array<{ file: string; line: number; text: string }> = []
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir)) {
-      if (entry === 'node_modules' || entry.startsWith('.')) continue
-      const full = join(dir, entry)
-      if (statSync(full).isDirectory()) {
-        walk(full)
-        continue
-      }
-      if (!/\.(css|ts|tsx)$/.test(entry)) continue
+  const sourceFiles = async (dir: string): Promise<string[]> => {
+    const entries = await readdir(dir, { withFileTypes: true })
+    const nested = await Promise.all(entries.map(async (entry) => {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) return []
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) return sourceFiles(full)
+      return /\.(css|ts|tsx)$/.test(entry.name) ? [full] : []
+    }))
+    return nested.flat()
+  }
+
+  const files = await sourceFiles(SRC)
+  let next = 0
+  const scan = async () => {
+    while (next < files.length) {
+      const full = files[next++]
+      const entry = basename(full)
       // Tests never declare a font stack, and this file necessarily contains the
       // detection pattern as a literal — without the exclusion it matches itself.
       // The only false-negative this creates is a stack declared inside a test,
       // which would not reach the app.
       if (/\.test\.(ts|tsx)$/.test(entry)) continue
-      readFileSync(full, 'utf8')
+      const content = await readFile(full, 'utf8')
+      content
         .split('\n')
         .forEach((text, i) => {
           // A declaration, not a read: `--font-body:` / `--mono:` / a role token
@@ -226,9 +236,17 @@ function declarationSites(): Array<{ file: string; line: number; text: string }>
         })
     }
   }
-  walk(SRC)
-  return out
+  // Files are independent. A bounded worker set avoids both the serial OneDrive
+  // walk that exceeded Vitest's test budget under full-suite load and an
+  // unbounded Promise.all that could exhaust file descriptors on a larger tree.
+  await Promise.all(Array.from({ length: Math.min(16, files.length) }, scan))
+  return out.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)
 }
+
+// The three assertions inspect the same immutable source snapshot. Scan once so
+// later assertions cannot pay another full-tree I/O pass or observe a different
+// tree halfway through the file.
+const allDeclarationSites = declarationSites()
 
 describe('script fallback faces', () => {
   it.each(ALIASES)('defines %s with a unicode-range and local()-only sources', (family) => {
@@ -338,14 +356,14 @@ describe('script fallback faces', () => {
 })
 
 describe('font stack declarations', () => {
-  it('finds every declaration site the tree actually contains', () => {
+  it('finds every declaration site the tree actually contains', async () => {
     // Guards the walker itself: if this drops to a handful, the glob broke and the
     // next assertion would pass vacuously.
-    expect(declarationSites().length).toBeGreaterThanOrEqual(12)
+    expect((await allDeclarationSites).length).toBeGreaterThanOrEqual(12)
   })
 
-  it('references the alias token at every declaration site', () => {
-    const offenders = declarationSites()
+  it('references the alias token at every declaration site', async () => {
+    const offenders = (await allDeclarationSites)
       .filter((s) => !/var\(--script-fallbacks(-mono)?\)/.test(s.text))
       .map((s) => `${s.file}:${s.line}: ${s.text.trim().slice(0, 96)}`)
     expect(
@@ -354,9 +372,9 @@ describe('font stack declarations', () => {
     ).toEqual([])
   })
 
-  it('puts the aliases ahead of every Latin base family', () => {
+  it('puts the aliases ahead of every Latin base family', async () => {
     const offenders: string[] = []
-    for (const site of declarationSites()) {
+    for (const site of await allDeclarationSites) {
       const aliasAt = site.text.search(/var\(--script-fallbacks(-mono)?\)/)
       if (aliasAt < 0) continue
       for (const base of BASE_FAMILIES) {

--- a/website/src/test/ArtifactsPageCoverage.test.tsx
+++ b/website/src/test/ArtifactsPageCoverage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { act, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ComponentType } from 'react'
 import ArtifactsPage from '../pages/ArtifactsPage'
@@ -79,6 +79,13 @@ function seed({
   m.artifactFolders = vi.fn().mockResolvedValue({ folders })
   m.artifactSessionDocs = vi.fn().mockResolvedValue({ docs })
   m.getArtifactPublishProviders = vi.fn().mockResolvedValue({ providers: [], kind: 'widget' })
+  // Most coverage cases exercise the public-deploy edition. Keep that product
+  // capability stable from the query's loading state through its resolved
+  // state; an empty provider list legitimately removes "Not deployed" labels
+  // and made the webapp assertions race the provider response.
+  m.publishProviders = vi.fn().mockResolvedValue({
+    providers: [{ id: 'deploy-web-aws', endpoint: '/api/deploy/deploy' }],
+  })
   m.themeBoot = vi.fn().mockResolvedValue({})
   m.artifact = vi.fn().mockImplementation((slug: string) => {
     const base = artifacts.find((a) => a.slug === slug) ?? mkArtifact(slug)
@@ -117,9 +124,29 @@ afterEach(() => {
 describe('ArtifactsPage — card previews per kind', () => {
   it('renders a markdown artifact through the markdown renderer', async () => {
     const arts = [mkArtifact('daily-notes', { kind: 'markdown' })]
-    seed({ artifacts: arts, full: { content: '# Heading one\n\nbody text' } })
+    const m = seed({ artifacts: arts })
+    let resolveArtifact!: (artifact: Artifact) => void
+    let signalArtifactRequest!: () => void
+    const artifactRequested = new Promise<void>((resolve) => {
+      signalArtifactRequest = resolve
+    })
+    const pending = new Promise<Artifact>((resolve) => {
+      resolveArtifact = resolve
+    })
+    m.artifact.mockImplementation(() => {
+      signalArtifactRequest()
+      return pending
+    })
     renderWithProviders(<ArtifactsPage />)
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Heading one' })).toBeInTheDocument())
+    // Wait on the actual query call, not a polling deadline: resolving before
+    // LocalCardBody mounts can leave the cache notification behind its
+    // subscriber under a loaded full suite.
+    await artifactRequested
+    await act(async () => {
+      resolveArtifact({ ...arts[0], content: '# Heading one\n\nbody text' })
+      await pending
+    })
+    expect(screen.getByRole('heading', { name: 'Heading one' })).toBeInTheDocument()
     expect(screen.getByText('body text')).toBeInTheDocument()
   })
 

--- a/website/src/test/MdNotebookPage.coverage.test.tsx
+++ b/website/src/test/MdNotebookPage.coverage.test.tsx
@@ -77,6 +77,11 @@ vi.mock('../apps/md-notebook/api', async () => {
   return { ...actual, notesApi: mockApi }
 })
 
+// Load the page during test-module collection, not inside every test's 15-second
+// budget. Under a loaded full-suite worker, the first dynamic import alone could
+// consume that budget before the loading-state assertion ran.
+const MdNotebookPage = (await import('../apps/md-notebook/MdNotebookPage')).default
+
 function vault(over: Partial<Vault> = {}): Vault {
   return {
     id: 'v1',
@@ -117,8 +122,7 @@ const DOC = {
   backlinks: [{ sourcePath: 'folder/Two.md', line: 3, context: 'see [[One]]' }],
 }
 
-async function renderPage() {
-  const { default: MdNotebookPage } = await import('../apps/md-notebook/MdNotebookPage')
+function renderPage() {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, refetchInterval: false } },
   })
@@ -206,11 +210,20 @@ describe('MdNotebookPage', () => {
   // ── boot states ───────────────────────────────────────────────────────────
 
   it('shows a loading line until the vault list arrives', async () => {
-    // Never resolves: the point is the state BEFORE any reply, which the page
-    // reaches by `vaults === null` rather than a separate flag.
-    mockApi.listVaults.mockReturnValue(new Promise(() => {}))
-    await renderPage()
-    expect(await screen.findByText('Loading…')).toBeTruthy()
+    // Hold the reply only until the loading state is observed, then settle it so
+    // this test owns and drains every promise it creates before teardown.
+    let resolveVaults!: (value: { vaults: Vault[]; hasPat: boolean; hasGhAuth: boolean }) => void
+    const pending = new Promise<{ vaults: Vault[]; hasPat: boolean; hasGhAuth: boolean }>((resolve) => {
+      resolveVaults = resolve
+    })
+    mockApi.listVaults.mockReturnValue(pending)
+    renderPage()
+    expect(screen.getByText('Loading…')).toBeTruthy()
+    await act(async () => {
+      resolveVaults({ vaults: [], hasPat: false, hasGhAuth: false })
+      await pending
+    })
+    expect(screen.getByText('Clone a repo')).toBeTruthy()
   })
 
   it('names the backend as unreachable when the vault list fails', async () => {


### PR DESCRIPTION
## Problem / Motivation

Three frontend tests were deterministic in isolation but could fail under the real full-suite load:

- the script-font gate synchronously walked and read the entire source tree once per assertion;
- the Artifacts coverage fixture raced its markdown query subscription and changed product edition after an asynchronous provider response;
- the Notes coverage suite charged its first dynamic import to a test budget and left a never-settled vault request alive through teardown.

## Why it matters

These failures make unrelated PRs intermittently red and make a passing retry depend on machine load rather than behavior. They were reproduced in the combined 26k-test suite, not inferred from isolated timing.

## What changed

- Walk the script-font tree asynchronously, scan files with 16 bounded workers, cache one immutable declaration-site snapshot for all three assertions, and sort diagnostics deterministically.
- Seed the Artifacts public-deploy capability explicitly and coordinate the markdown response with the actual query request instead of a polling deadline.
- Load MdNotebookPage during module collection, assert the loading state synchronously, then resolve and drain the test-owned vault promise before teardown.

All production behavior and assertions remain unchanged or stronger.

## Tests

- final focused stress batch: 5 x 178 = 890/890 passed
- additional loaded stress batch before the final rebase: 5 x 178 = 890/890 passed
- full frontend suite: 26,146 passed; the sole failure was the pre-existing Windows path-separator assertion owned by #6300, which is now merged into main
- TypeScript typecheck, changed-file ESLint, and diff checks pass
- latest-main rebase is clean; final post-rebase focused run: 178/178
- audited open PR ownership: no open PR directly owns scriptFonts.test.ts or ArtifactsPageCoverage.test.tsx; the adjacent Notes production fix #6901 is already merged

No retries, sleeps, timeout/deadline increases, tolerance changes, warning filters, or assertion weakening were added.

## Screenshot evidence

<!-- no-visual-delta -->
**Why no screenshot:** This changes only test scheduling, fixtures, and teardown ownership; rendered UI output is unchanged.