### PR TITLE
fix(channels): remove duplicate Modal import

### DIFF
--- a/website/src/pages/ChannelPage.tsx
+++ b/website/src/pages/ChannelPage.tsx
@@ -13,7 +13,6 @@ import { useImeGuard } from '../hooks/useImeGuard'
 import { useMenuKeyboard, menuItemsOf } from '../hooks/useMenuKeyboard'
 import { AnimatePresence } from 'framer-motion'
 import DetailPanel from '../components/DetailPanel'
-import Modal from '../components/Modal'
 
 import { i18nT } from '../i18n/t'
 import { useListDetailView } from '../hooks/useListDetailView'


### PR DESCRIPTION
## Problem / Motivation

Main no longer typechecks after #5570 added a second default import for Modal in ChannelPage. The same symbol was already imported by #6796, so TypeScript fails deterministically with TS2300 at lines 2 and 16.

## Why it matters

This is a main-branch compile regression and makes unrelated PRs fail the frontend typecheck gate.

## What changed

Remove only the later duplicate import. The original shared Modal import and all Channel behavior remain unchanged.

## Tests

- red-before: npm run typecheck fails deterministically with duplicate identifier Modal
- fixed final main snapshot: npm run typecheck passes
- ChannelPage coverage, clear-context, IME, menu-keyboard, and narrow-layout suites: 106/106 passed
- changed-file ESLint and diff checks pass
- audited all open PRs: the only exact-file overlap, #5248, changes approval trust tiers and does not own this import regression

No retries, sleeps, timeout changes, warning filters, or assertion changes were added.

## Screenshot evidence

<!-- no-visual-delta -->
**Why no screenshot:** This removes a duplicate import only; runtime UI output is unchanged.