### PR TITLE
test: make inline tool card property deterministic

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -780,7 +780,6 @@ test/test_host_isolation_floor.py
 test/test_host_service_guard.py
 test/test_image_artifacts.py
 test/test_inbound_unbind_notice.py
-test/test_inline_tool_cards_props.py
 test/test_install_receipt.py
 test/test_installer_distro.py
 test/test_installer_node_floor.py

--- a/test/test_inline_tool_cards_props.py
+++ b/test/test_inline_tool_cards_props.py
@@ -10,18 +10,17 @@ unittest.mock.patch instead.
 
 from __future__ import annotations
 
-import platform
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from kiro_crew.dashboard.chat import _flush_segment, _prepare_messages
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import ConversationLog
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 # ── Helpers ──
 
@@ -47,6 +46,47 @@ def _make_state_no_fixture(**kwargs):
         **kwargs,
     )
     return state, tmp_dir
+
+
+class _SegmentSlotStub:
+    """Small in-memory seam for properties that exercise only ``_flush_segment``.
+
+    Building ``DashboardState`` and two temporary directories inside every
+    Hypothesis example made the property measure filesystem/antivirus startup,
+    not segment ordering.  The production helper's contract at this seam is
+    only the message window, pending-chunk release, append, variants, and key.
+    Keeping those concrete (rather than a ``MagicMock``) means a missing call or
+    a wrong mutation still fails the property.
+    """
+
+    def __init__(self) -> None:
+        self.key = "prop1"
+        self.messages: list[dict] = []
+        self._pending_variants: list[dict] = []
+        self.pending_chunks_released = False
+
+    def append(
+        self,
+        role: str,
+        content: str,
+        cls: str = "",
+        *,
+        broadcast: bool = True,
+    ) -> dict:
+        message = {"role": role, "content": content, "cls": cls, "ts": ""}
+        self.messages.append(message)
+        return message
+
+    def release_pending_chunks(self) -> None:
+        self.pending_chunks_released = True
+
+
+class _BroadcastStateStub:
+    def __init__(self) -> None:
+        self.broadcasts: list[tuple[str, dict]] = []
+
+    def broadcast_ws(self, event_type: str, data: dict) -> None:
+        self.broadcasts.append((event_type, data))
 
 
 # Strategy: non-empty printable text (no control chars that break redaction)
@@ -77,66 +117,57 @@ class TestProperty1SegmentFlushOnInterrupt:
     Validates: Requirements 1.1, 1.2, 1.4
     """
 
-    @pytest.mark.skipif(platform.system() == "Darwin", reason="Hypothesis flaky on macOS CI (timing-sensitive)")
     @given(
         text_chunks=st.lists(_text_st, min_size=1, max_size=5),
         tool_name=_tool_name_st,
     )
     @settings(deadline=2000)
-    @pytest.mark.asyncio
-    async def test_flush_segment_broadcasts_before_tool(self, text_chunks, tool_name):
+    def test_flush_segment_broadcasts_before_tool(self, text_chunks, tool_name):
         """**Validates: Requirements 1.1, 1.2**
 
         Generate random text chunks followed by a tool call.  Verify
         _flush_segment broadcasts chat_segment and clears chunks from
         the slot.
         """
-        with tempfile.TemporaryDirectory() as config_tmp:
-            with patch("kiro_crew.dashboard.state.config_dir", return_value=Path(config_tmp)):
-                state, tmp_dir = _make_state_no_fixture()
-                try:
-                    slot = state.get_or_create_slot("prop1")
+        state = _BroadcastStateStub()
+        slot = _SegmentSlotStub()
 
-                    # Accumulate text chunks in the slot
-                    assistant_text = ""
-                    for chunk in text_chunks:
-                        slot.append("chunk", chunk, "chunk")
-                        assistant_text += chunk
+        # Accumulate text chunks in the slot.
+        assistant_text = ""
+        for chunk in text_chunks:
+            slot.append("chunk", chunk, "chunk")
+            assistant_text += chunk
 
-                    # Record broadcasts
-                    broadcasts: list[tuple[str, dict]] = []
-                    state.broadcast_ws = lambda t, d: broadcasts.append((t, d))
+        # Flush segment (simulates what _run_chat does on EVENT_TOOL_CALL).
+        assert assistant_text != ""
+        expected_text, _ = redact_exfiltration_urls(assistant_text)
+        expected_text, _ = redact_credentials(expected_text)
+        _flush_segment(state, slot, assistant_text)  # type: ignore[arg-type]
+        assistant_text = ""
 
-                    # Flush segment (simulates what _run_chat does on EVENT_TOOL_CALL)
-                    assert assistant_text != ""
-                    _flush_segment(state, slot, assistant_text)
-                    assistant_text = ""
+        # Broadcast the tool_call after flush.
+        state.broadcast_ws("tool_call", {"slot": slot.key, "tool": tool_name, "kind": "read"})
 
-                    # Broadcast the tool_call after flush
-                    state.broadcast_ws(
-                        "tool_call", {"slot": slot.key, "tool": tool_name, "kind": "read"}
-                    )
+        # Verify: chat_segment comes before tool_call.
+        types = [event_type for event_type, _data in state.broadcasts]
+        assert "chat_segment" in types, "chat_segment must be broadcast"
+        assert "tool_call" in types, "tool_call must be broadcast"
+        seg_idx = types.index("chat_segment")
+        tool_idx = types.index("tool_call")
+        assert seg_idx < tool_idx, "chat_segment must precede tool_call"
 
-                    # Verify: chat_segment comes before tool_call
-                    types = [b[0] for b in broadcasts]
-                    assert "chat_segment" in types, "chat_segment must be broadcast"
-                    assert "tool_call" in types, "tool_call must be broadcast"
-                    seg_idx = types.index("chat_segment")
-                    tool_idx = types.index("tool_call")
-                    assert seg_idx < tool_idx, "chat_segment must precede tool_call"
+        # Verify: assistant_text is reset.
+        assert assistant_text == ""
 
-                    # Verify: assistant_text is reset
-                    assert assistant_text == ""
+        # Verify: both representations of pending chunks were released.
+        chunk_count = sum(1 for m in slot.messages if m.get("role") == "chunk")
+        assert chunk_count == 0, "chunks must be removed after flush"
+        assert slot.pending_chunks_released
 
-                    # Verify: no chunk messages remain in slot
-                    chunk_count = sum(1 for m in slot.messages if m.get("role") == "chunk")
-                    assert chunk_count == 0, "chunks must be removed after flush"
-
-                    # Verify: an assistant message was persisted
-                    assistant_msgs = [m for m in slot.messages if m.get("role") == "assistant"]
-                    assert len(assistant_msgs) >= 1, "flushed text must be persisted as assistant"
-                finally:
-                    tmp_dir.cleanup()
+        # Verify: an assistant message was persisted with the complete segment.
+        assistant_msgs = [m for m in slot.messages if m.get("role") == "assistant"]
+        assert len(assistant_msgs) == 1, "flushed text must be persisted once"
+        assert assistant_msgs[0]["content"] == expected_text
 
     @given(text_chunks=st.lists(_text_st, min_size=1, max_size=5))
     @settings(deadline=None)


### PR DESCRIPTION
## Problem / Motivation

The inline-tool-card property test rebuilt DashboardState, ConversationLog, and two temporary directories inside every Hypothesis example. Under CI filesystem/antivirus load, the first example took 2625.33ms, the identical example reran in 2.90ms, and Hypothesis correctly reported a flaky deadline failure.

## Why it matters

The property is supposed to verify segment ordering. Instead, its 2000ms deadline measured unrelated filesystem startup and made unrelated PRs intermittently red.

## What changed

Exercise the real _flush_segment helper through a small concrete in-memory state/slot seam that implements exactly the message window, pending-chunk release, append, variants, key, and broadcast contract used by the helper. The test now verifies:

- chat_segment is emitted before tool_call;
- both pending-chunk representations are released;
- the assistant segment is persisted exactly once;
- persisted content matches the real credential and exfiltration redaction pipeline.

The unnecessary async wrapper and Darwin skip are removed. The 2000ms Hypothesis deadline remains enabled.

## Tests

- strict focused file: 7/7 passed with RuntimeWarning and PytestUnraisableExceptionWarning promoted to errors
- Black scope gate, targeted isort, flake8, and diff checks pass
- red-before CI evidence: first run 2625.33ms, rerun 2.90ms in actions run 32728811641 / job 97436594634
- audited open PRs: no open PR owns test_inline_tool_cards_props.py

No retries, sleeps, timeout/deadline increases, warning filters, tolerance changes, or assertion weakening were added.

## Screenshot evidence

<!-- no-visual-delta -->
**Why no screenshot:** This changes a backend property-test seam only; production and rendered UI output are unchanged.