### PR TITLE
docs: credit Debasish Tripathy for a private security report

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@ make this tool possible:
 <a href="https://github.com/darko-mesaros" title="Darko Mesaros"><img src="https://github.com/darko-mesaros.png?size=64" width="64" height="64" alt="Darko Mesaros" /></a>
 <a href="https://github.com/davidtlee-amzn" title="davidtlee-amzn"><img src="https://github.com/davidtlee-amzn.png?size=64" width="64" height="64" alt="davidtlee-amzn" /></a>
 <a href="https://github.com/dcorelibran" title="dcorelibran"><img src="https://github.com/dcorelibran.png?size=64" width="64" height="64" alt="dcorelibran" /></a>
+<a href="https://github.com/DebasishTripathy13" title="Debasish Tripathy"><img src="https://github.com/DebasishTripathy13.png?size=64" width="64" height="64" alt="Debasish Tripathy" /></a>
 <a href="https://github.com/derrick0714" title="Xu Deng"><img src="https://github.com/derrick0714.png?size=64" width="64" height="64" alt="Xu Deng" /></a>
 <a href="https://github.com/DeryFerd" title="Dery Ferdika"><img src="https://github.com/DeryFerd.png?size=64" width="64" height="64" alt="Dery Ferdika" /></a>
 <a href="https://github.com/desaip05" title="Parikshit Desai"><img src="https://github.com/desaip05.png?size=64" width="64" height="64" alt="Parikshit Desai" /></a>


### PR DESCRIPTION
## Problem

Debasish Tripathy (@DebasishTripathy13) reported a security issue to this project
by email. That leaves no trace in the repository — no issue, no pull request, no
comment, no advisory credit — so the daily `add-contributor.yml` job cannot see the
contribution by construction, and he appears nowhere in the README Contributors
block.

## Why it matters

A private disclosure is the contribution we most want people to make instead of
opening a public issue. Recognising it only when it happens to leave a GitHub
artifact would reward the wrong channel.

## Fix

Add him to the same Contributors block via the manual path the one-list model
reserves for exactly this case:

```sh
python3 scripts/update_contributors.py --login DebasishTripathy13 --name "Debasish Tripathy"
```

Using the script rather than hand-editing matters for two reasons: the entry comes
out byte-identical in shape to the 548 generated ones, and it lands at its
case-insensitive sorted position, so the block stays the single contiguous run of
anchors that the collector requires (it fails loud otherwise).

The entry survives the daily job, which rebuilds its rolling branch from base and
re-derives the full contributor set every run: the script only ever INSERTS at a
sorted position and never rewrites or drops an existing line. That property is what
makes one shared list workable for both automatic and hand-added credit, and it is
pinned by the `bob line preserved` and `manual credit outside block not re-added`
self-tests.

Login capitalisation is the canonical `DebasishTripathy13` from the GitHub API, not
the lowercase form, so the avatar URL and profile link resolve exactly.

## Tests

No code changes. `scripts/update_contributors.py --test` — PASS, all 15 cases.

## Manual verification

1. `gh api users/debasishtripathy13` → `{"login": "DebasishTripathy13", "name":
   "Debasish Tripathy", "type": "User"}` — real account, canonical casing taken
   from there.
2. Confirmed not already credited: 0 occurrences of `github.com/debasishtripathy13`
   in `origin/main`'s README.
3. `--login DebasishTripathy13 --name "Debasish Tripathy"` → `Added 1
   contributor(s)`, one line at `README.md:745`, diff is 1 file / +1 / −0.
4. Re-ran the identical command → `No new contributors; README already up to
   date.`, so a later duplicate add is a no-op.

## Note for whoever merges

[PR #6917](https://github.com/kirodotdev/KiroCrew/pull/6917) adds 95 entries to the
same block, several of them neighbouring `d…` logins, so whichever of the two lands
second may need a rebase. The conflict is textual only — both sides are pure
insertions and the script re-derives the sorted position.
