### PR TITLE
docs: drop a stale pre-rename login from the Contributors block

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,7 +947,6 @@ make this tool possible:
 <a href="https://github.com/pierrms" title="pierrms"><img src="https://github.com/pierrms.png?size=64" width="64" height="64" alt="pierrms" /></a>
 <a href="https://github.com/pilami" title="Sai Chaitanya Manchikatla"><img src="https://github.com/pilami.png?size=64" width="64" height="64" alt="Sai Chaitanya Manchikatla" /></a>
 <a href="https://github.com/piyushrajyadav" title="Piyush Yadav"><img src="https://github.com/piyushrajyadav.png?size=64" width="64" height="64" alt="Piyush Yadav" /></a>
-<a href="https://github.com/pkot1980" title="PK98121"><img src="https://github.com/pkot1980.png?size=64" width="64" height="64" alt="PK98121" /></a>
 <a href="https://github.com/pkot98121" title="PK98121"><img src="https://github.com/pkot98121.png?size=64" width="64" height="64" alt="PK98121" /></a>
 <a href="https://github.com/PNg-HA" title="PNg HA"><img src="https://github.com/PNg-HA.png?size=64" width="64" height="64" alt="PNg HA" /></a>
 <a href="https://github.com/popematt" title="Matthew Pope"><img src="https://github.com/popematt.png?size=64" width="64" height="64" alt="Matthew Pope" /></a>


### PR DESCRIPTION
## Problem

The README Contributors block carries this entry:

```html
<a href="https://github.com/pkot1980" title="PK98121"><img src="https://github.com/pkot1980.png?size=64" ... /></a>
```

`GET /users/pkot1980` returns **404**, so on the project's front page that entry
renders a broken avatar and links to a dead profile.

It is also a duplicate. The line directly below it credits `pkot98121` with the
same display name, and the API now reports `pkot98121` as the author of the pull
requests the older login was credited for (checked #5416 — `.user.login` is
`pkot98121`). Git history shows the rename: the 2026-08-16 run (#3932) credited
`pkot1980`, the 2026-08-25 run (#5968) credited `pkot98121`. The collector looks up
each login's display name through the API, so `pkot1980` did resolve when it was
added — it went stale afterwards, and nothing in the pipeline can notice that two
logins are one person.

## Why it matters

A broken link and a doubled name in the one place the project thanks people is
worse than an omission — it looks like the list is not maintained, and it
misrepresents the count.

## Fix

Delete the `pkot1980` line. One line, nothing else.

Removed rather than corrected because the correction target is already present:
rewriting the URL to `pkot98121` would produce two identical entries.

Nothing re-adds it. The collector derives logins from each merged PR's *current*
author, which GitHub resolves through the account's id, so it now yields
`pkot98121` for every one of those PRs. Verified against the login set the live
collector actually produced: `pkot1980` appears 0 times, `pkot98121` once. No
`.github/contributors-optout.txt` entry is needed, and adding one would be dead
config.

## Tests

No code changes. `scripts/update_contributors.py --test` — PASS, all 15 cases.

## Manual verification

1. `gh api users/pkot1980` → 404. `gh api users/pkot98121` → `{"login":
   "pkot98121", "name": "PK98121", "type": "User"}`, 15 items of repository
   activity.
2. `gh api repos/kirodotdev/KiroCrew/pulls/5416 --jq .user.login` → `pkot98121`.
3. Swept the whole block for the same defect: extracted all **455** logins and
   resolved each against `GET /users/<login>`. Exactly **one** dead login —
   this one. So this is an isolated stale entry, not a class of breakage.
4. After the deletion the block still parses as one contiguous run of anchors: a
   no-op `--login pkot98121` run returns `No new contributors; README already up
   to date.` rather than the loud `contributor block is not a contiguous run`
   failure.
5. Diff is 1 file, +0, −1.

## Note for whoever merges

Two other pull requests touch the same block right now —
[PR #6917](https://github.com/kirodotdev/KiroCrew/pull/6917) (+95 generated
entries) and [PR #6919](https://github.com/kirodotdev/KiroCrew/pull/6919) (+1
manual entry). Whichever lands second may need a rebase; the conflicts are textual
only, since every side is a pure single-line insert or delete at a sorted position.
