### PR TITLE
docs: bring the Contributors block up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ make this tool possible:
 <a href="https://github.com/Abhishekmitra-slg" title="Abhishek Mitra"><img src="https://github.com/Abhishekmitra-slg.png?size=64" width="64" height="64" alt="Abhishek Mitra" /></a>
 <a href="https://github.com/abhishekshasthry" title="Abhishek Shasthry B M"><img src="https://github.com/abhishekshasthry.png?size=64" width="64" height="64" alt="Abhishek Shasthry B M" /></a>
 <a href="https://github.com/acdoussan" title="acdoussan"><img src="https://github.com/acdoussan.png?size=64" width="64" height="64" alt="acdoussan" /></a>
+<a href="https://github.com/acluft" title="acluft"><img src="https://github.com/acluft.png?size=64" width="64" height="64" alt="acluft" /></a>
 <a href="https://github.com/adam-dunc" title="Adam Duncan"><img src="https://github.com/adam-dunc.png?size=64" width="64" height="64" alt="Adam Duncan" /></a>
 <a href="https://github.com/AddisonTustin" title="AddisonTustin"><img src="https://github.com/AddisonTustin.png?size=64" width="64" height="64" alt="AddisonTustin" /></a>
 <a href="https://github.com/adiarora06" title="Adi Arora"><img src="https://github.com/adiarora06.png?size=64" width="64" height="64" alt="Adi Arora" /></a>
@@ -664,6 +665,7 @@ make this tool possible:
 <a href="https://github.com/Albisourous" title="Albin Shrestha"><img src="https://github.com/Albisourous.png?size=64" width="64" height="64" alt="Albin Shrestha" /></a>
 <a href="https://github.com/alecgdouglas" title="Alec Douglas"><img src="https://github.com/alecgdouglas.png?size=64" width="64" height="64" alt="Alec Douglas" /></a>
 <a href="https://github.com/alejacre" title="Alejandro"><img src="https://github.com/alejacre.png?size=64" width="64" height="64" alt="Alejandro" /></a>
+<a href="https://github.com/alekwo" title="Aleksander W. Oleszkiewicz (auticon)"><img src="https://github.com/alekwo.png?size=64" width="64" height="64" alt="Aleksander W. Oleszkiewicz (auticon)" /></a>
 <a href="https://github.com/Alexander-Yuan" title="Alexander-Yuan"><img src="https://github.com/Alexander-Yuan.png?size=64" width="64" height="64" alt="Alexander-Yuan" /></a>
 <a href="https://github.com/AlexShen101" title="Alex Shen"><img src="https://github.com/AlexShen101.png?size=64" width="64" height="64" alt="Alex Shen" /></a>
 <a href="https://github.com/amadsalmon" title="Amad Salmon"><img src="https://github.com/amadsalmon.png?size=64" width="64" height="64" alt="Amad Salmon" /></a>
@@ -671,6 +673,7 @@ make this tool possible:
 <a href="https://github.com/AmirNaghibi" title="Amir Naghibi"><img src="https://github.com/AmirNaghibi.png?size=64" width="64" height="64" alt="Amir Naghibi" /></a>
 <a href="https://github.com/amulya349" title="Amulya Kumar Sahoo"><img src="https://github.com/amulya349.png?size=64" width="64" height="64" alt="Amulya Kumar Sahoo" /></a>
 <a href="https://github.com/anant-kaushik" title="Anant Kaushik"><img src="https://github.com/anant-kaushik.png?size=64" width="64" height="64" alt="Anant Kaushik" /></a>
+<a href="https://github.com/AndrewSDHarsh" title="AndrewSDHarsh"><img src="https://github.com/AndrewSDHarsh.png?size=64" width="64" height="64" alt="AndrewSDHarsh" /></a>
 <a href="https://github.com/andrewtakeshi" title="Andrew Golightly"><img src="https://github.com/andrewtakeshi.png?size=64" width="64" height="64" alt="Andrew Golightly" /></a>
 <a href="https://github.com/andreyaurelien" title="andreyaurelien"><img src="https://github.com/andreyaurelien.png?size=64" width="64" height="64" alt="andreyaurelien" /></a>
 <a href="https://github.com/angeloyu" title="angeloyu"><img src="https://github.com/angeloyu.png?size=64" width="64" height="64" alt="angeloyu" /></a>
@@ -678,6 +681,7 @@ make this tool possible:
 <a href="https://github.com/aniruddhaadak80" title="ANIRUDDHA ADAK"><img src="https://github.com/aniruddhaadak80.png?size=64" width="64" height="64" alt="ANIRUDDHA ADAK" /></a>
 <a href="https://github.com/anjn98" title="anjn98"><img src="https://github.com/anjn98.png?size=64" width="64" height="64" alt="anjn98" /></a>
 <a href="https://github.com/anmolsaxena10" title="Anmol Saxena"><img src="https://github.com/anmolsaxena10.png?size=64" width="64" height="64" alt="Anmol Saxena" /></a>
+<a href="https://github.com/anshulgupta0803" title="Anshul Gupta"><img src="https://github.com/anshulgupta0803.png?size=64" width="64" height="64" alt="Anshul Gupta" /></a>
 <a href="https://github.com/Anthony-dominianni" title="Anthony-dominianni"><img src="https://github.com/Anthony-dominianni.png?size=64" width="64" height="64" alt="Anthony-dominianni" /></a>
 <a href="https://github.com/Anurag461" title="Anurag Kashyap"><img src="https://github.com/Anurag461.png?size=64" width="64" height="64" alt="Anurag Kashyap" /></a>
 <a href="https://github.com/apoorv06s" title="apoorv06s"><img src="https://github.com/apoorv06s.png?size=64" width="64" height="64" alt="apoorv06s" /></a>
@@ -687,6 +691,7 @@ make this tool possible:
 <a href="https://github.com/arjunsoota" title="Arjun Soota"><img src="https://github.com/arjunsoota.png?size=64" width="64" height="64" alt="Arjun Soota" /></a>
 <a href="https://github.com/arimorgan" title="Ariana Morgan"><img src="https://github.com/arimorgan.png?size=64" width="64" height="64" alt="Ariana Morgan" /></a>
 <a href="https://github.com/arpan98" title="Arpan Banerjee"><img src="https://github.com/arpan98.png?size=64" width="64" height="64" alt="Arpan Banerjee" /></a>
+<a href="https://github.com/artemu78" title="ArtemReva"><img src="https://github.com/artemu78.png?size=64" width="64" height="64" alt="ArtemReva" /></a>
 <a href="https://github.com/arvindsrinathus-tech" title="arvindsrinathus-tech"><img src="https://github.com/arvindsrinathus-tech.png?size=64" width="64" height="64" alt="arvindsrinathus-tech" /></a>
 <a href="https://github.com/AryPathania" title="Ary Pathania"><img src="https://github.com/AryPathania.png?size=64" width="64" height="64" alt="Ary Pathania" /></a>
 <a href="https://github.com/asaifuddin18" title="Aziz Saifuddin"><img src="https://github.com/asaifuddin18.png?size=64" width="64" height="64" alt="Aziz Saifuddin" /></a>
@@ -696,6 +701,7 @@ make this tool possible:
 <a href="https://github.com/atomsbaza" title="PISIT KOOLPLUKPOL"><img src="https://github.com/atomsbaza.png?size=64" width="64" height="64" alt="PISIT KOOLPLUKPOL" /></a>
 <a href="https://github.com/av-writes-code" title="av-writes-code"><img src="https://github.com/av-writes-code.png?size=64" width="64" height="64" alt="av-writes-code" /></a>
 <a href="https://github.com/avmikhli1" title="avmikhli1"><img src="https://github.com/avmikhli1.png?size=64" width="64" height="64" alt="avmikhli1" /></a>
+<a href="https://github.com/awsdataarchitect" title="Vivek V."><img src="https://github.com/awsdataarchitect.png?size=64" width="64" height="64" alt="Vivek V." /></a>
 <a href="https://github.com/ayahiro1729" title="ayahiro1729"><img src="https://github.com/ayahiro1729.png?size=64" width="64" height="64" alt="ayahiro1729" /></a>
 <a href="https://github.com/bayshanhai-dev" title="Steven Chen"><img src="https://github.com/bayshanhai-dev.png?size=64" width="64" height="64" alt="Steven Chen" /></a>
 <a href="https://github.com/beau-bright" title="beau-bright"><img src="https://github.com/beau-bright.png?size=64" width="64" height="64" alt="beau-bright" /></a>
@@ -704,19 +710,27 @@ make this tool possible:
 <a href="https://github.com/bgrubin-amzn" title="bgrubin-amzn"><img src="https://github.com/bgrubin-amzn.png?size=64" width="64" height="64" alt="bgrubin-amzn" /></a>
 <a href="https://github.com/bhargav5000" title="bhargav5000"><img src="https://github.com/bhargav5000.png?size=64" width="64" height="64" alt="bhargav5000" /></a>
 <a href="https://github.com/bigchkn" title="bigchkn"><img src="https://github.com/bigchkn.png?size=64" width="64" height="64" alt="bigchkn" /></a>
+<a href="https://github.com/billsbdb3" title="William Berry"><img src="https://github.com/billsbdb3.png?size=64" width="64" height="64" alt="William Berry" /></a>
 <a href="https://github.com/billygerhard" title="Billy Gerhard"><img src="https://github.com/billygerhard.png?size=64" width="64" height="64" alt="Billy Gerhard" /></a>
 <a href="https://github.com/bkarson" title="bkarson"><img src="https://github.com/bkarson.png?size=64" width="64" height="64" alt="bkarson" /></a>
+<a href="https://github.com/bl457hun73r" title="Matias Solis"><img src="https://github.com/bl457hun73r.png?size=64" width="64" height="64" alt="Matias Solis" /></a>
 <a href="https://github.com/BlumenthalJD" title="Joel Blumenthal"><img src="https://github.com/BlumenthalJD.png?size=64" width="64" height="64" alt="Joel Blumenthal" /></a>
 <a href="https://github.com/bobbyearl" title="Bobby Earl"><img src="https://github.com/bobbyearl.png?size=64" width="64" height="64" alt="Bobby Earl" /></a>
 <a href="https://github.com/bolichen97" title="Bolin Chen"><img src="https://github.com/bolichen97.png?size=64" width="64" height="64" alt="Bolin Chen" /></a>
+<a href="https://github.com/bowale01" title="Adeleke Adebowale J"><img src="https://github.com/bowale01.png?size=64" width="64" height="64" alt="Adeleke Adebowale J" /></a>
 <a href="https://github.com/brantai" title="Brent Naylor"><img src="https://github.com/brantai.png?size=64" width="64" height="64" alt="Brent Naylor" /></a>
+<a href="https://github.com/breadcentric" title="breadcentric"><img src="https://github.com/breadcentric.png?size=64" width="64" height="64" alt="breadcentric" /></a>
 <a href="https://github.com/brianwthomas" title="Brian Thomas"><img src="https://github.com/brianwthomas.png?size=64" width="64" height="64" alt="Brian Thomas" /></a>
+<a href="https://github.com/btyrrell-mn" title="Bryson Tyrrell"><img src="https://github.com/btyrrell-mn.png?size=64" width="64" height="64" alt="Bryson Tyrrell" /></a>
 <a href="https://github.com/buluoray" title="Ray Xu"><img src="https://github.com/buluoray.png?size=64" width="64" height="64" alt="Ray Xu" /></a>
 <a href="https://github.com/c020627" title="XiaoChen"><img src="https://github.com/c020627.png?size=64" width="64" height="64" alt="XiaoChen" /></a>
 <a href="https://github.com/cabbey" title="Chris Abbey"><img src="https://github.com/cabbey.png?size=64" width="64" height="64" alt="Chris Abbey" /></a>
+<a href="https://github.com/Canaut" title="Canaut"><img src="https://github.com/Canaut.png?size=64" width="64" height="64" alt="Canaut" /></a>
 <a href="https://github.com/caribbeansteve" title="George Coll"><img src="https://github.com/caribbeansteve.png?size=64" width="64" height="64" alt="George Coll" /></a>
 <a href="https://github.com/carttrp" title="carttrp"><img src="https://github.com/carttrp.png?size=64" width="64" height="64" alt="carttrp" /></a>
 <a href="https://github.com/cathar" title="cathar"><img src="https://github.com/cathar.png?size=64" width="64" height="64" alt="cathar" /></a>
+<a href="https://github.com/cbarlow1993" title="cbarlow1993"><img src="https://github.com/cbarlow1993.png?size=64" width="64" height="64" alt="cbarlow1993" /></a>
+<a href="https://github.com/ccidral" title="Celio Cidral"><img src="https://github.com/ccidral.png?size=64" width="64" height="64" alt="Celio Cidral" /></a>
 <a href="https://github.com/chancepants" title="Chance"><img src="https://github.com/chancepants.png?size=64" width="64" height="64" alt="Chance" /></a>
 <a href="https://github.com/ChaonengQuan" title="ChaonengQuan"><img src="https://github.com/ChaonengQuan.png?size=64" width="64" height="64" alt="ChaonengQuan" /></a>
 <a href="https://github.com/chenmingwei23" title="Raymond Chen"><img src="https://github.com/chenmingwei23.png?size=64" width="64" height="64" alt="Raymond Chen" /></a>
@@ -729,28 +743,43 @@ make this tool possible:
 <a href="https://github.com/clareliguori" title="Clare Liguori"><img src="https://github.com/clareliguori.png?size=64" width="64" height="64" alt="Clare Liguori" /></a>
 <a href="https://github.com/cohilla" title="Cody Hill"><img src="https://github.com/cohilla.png?size=64" width="64" height="64" alt="Cody Hill" /></a>
 <a href="https://github.com/colewhitley" title="Cole Whitley"><img src="https://github.com/colewhitley.png?size=64" width="64" height="64" alt="Cole Whitley" /></a>
+<a href="https://github.com/comdaze" title="Sean Yang"><img src="https://github.com/comdaze.png?size=64" width="64" height="64" alt="Sean Yang" /></a>
 <a href="https://github.com/ConnorLoP" title="Connor LoPresti"><img src="https://github.com/ConnorLoP.png?size=64" width="64" height="64" alt="Connor LoPresti" /></a>
 <a href="https://github.com/ConstantineWang" title="Jiacheng Wang"><img src="https://github.com/ConstantineWang.png?size=64" width="64" height="64" alt="Jiacheng Wang" /></a>
 <a href="https://github.com/coozgan" title="Joshyfruit"><img src="https://github.com/coozgan.png?size=64" width="64" height="64" alt="Joshyfruit" /></a>
+<a href="https://github.com/cplieger" title="Christopher Plieger"><img src="https://github.com/cplieger.png?size=64" width="64" height="64" alt="Christopher Plieger" /></a>
 <a href="https://github.com/cruisercohen" title="Matt Cohen"><img src="https://github.com/cruisercohen.png?size=64" width="64" height="64" alt="Matt Cohen" /></a>
 <a href="https://github.com/CrysisDeu" title="Zezhen Xu"><img src="https://github.com/CrysisDeu.png?size=64" width="64" height="64" alt="Zezhen Xu" /></a>
 <a href="https://github.com/Csan25" title="Csan25"><img src="https://github.com/Csan25.png?size=64" width="64" height="64" alt="Csan25" /></a>
+<a href="https://github.com/cschnidr" title="cschnidr"><img src="https://github.com/cschnidr.png?size=64" width="64" height="64" alt="cschnidr" /></a>
+<a href="https://github.com/ctodd" title="Chris Miller"><img src="https://github.com/ctodd.png?size=64" width="64" height="64" alt="Chris Miller" /></a>
 <a href="https://github.com/ctyndall" title="ctyndall"><img src="https://github.com/ctyndall.png?size=64" width="64" height="64" alt="ctyndall" /></a>
 <a href="https://github.com/dagayev1" title="Dagadansbot"><img src="https://github.com/dagayev1.png?size=64" width="64" height="64" alt="Dagadansbot" /></a>
 <a href="https://github.com/DallinKooyman" title="Dallin Kooyman"><img src="https://github.com/DallinKooyman.png?size=64" width="64" height="64" alt="Dallin Kooyman" /></a>
+<a href="https://github.com/dan-alex-nistor" title="Daniel-Alexandru Nistor"><img src="https://github.com/dan-alex-nistor.png?size=64" width="64" height="64" alt="Daniel-Alexandru Nistor" /></a>
 <a href="https://github.com/danmcclain" title="Dan McClain"><img src="https://github.com/danmcclain.png?size=64" width="64" height="64" alt="Dan McClain" /></a>
 <a href="https://github.com/darko-mesaros" title="Darko Mesaros"><img src="https://github.com/darko-mesaros.png?size=64" width="64" height="64" alt="Darko Mesaros" /></a>
+<a href="https://github.com/datoastmachine" title="datoastmachine"><img src="https://github.com/datoastmachine.png?size=64" width="64" height="64" alt="datoastmachine" /></a>
 <a href="https://github.com/davidtlee-amzn" title="davidtlee-amzn"><img src="https://github.com/davidtlee-amzn.png?size=64" width="64" height="64" alt="davidtlee-amzn" /></a>
+<a href="https://github.com/davihara" title="David Hara"><img src="https://github.com/davihara.png?size=64" width="64" height="64" alt="David Hara" /></a>
 <a href="https://github.com/dcorelibran" title="dcorelibran"><img src="https://github.com/dcorelibran.png?size=64" width="64" height="64" alt="dcorelibran" /></a>
+<a href="https://github.com/DebasishTripathy13" title="Debasish Tripathy"><img src="https://github.com/DebasishTripathy13.png?size=64" width="64" height="64" alt="Debasish Tripathy" /></a>
 <a href="https://github.com/derrick0714" title="Xu Deng"><img src="https://github.com/derrick0714.png?size=64" width="64" height="64" alt="Xu Deng" /></a>
 <a href="https://github.com/DeryFerd" title="Dery Ferdika"><img src="https://github.com/DeryFerd.png?size=64" width="64" height="64" alt="Dery Ferdika" /></a>
 <a href="https://github.com/desaip05" title="Parikshit Desai"><img src="https://github.com/desaip05.png?size=64" width="64" height="64" alt="Parikshit Desai" /></a>
+<a href="https://github.com/developer-front" title="Pylyp Borysov"><img src="https://github.com/developer-front.png?size=64" width="64" height="64" alt="Pylyp Borysov" /></a>
 <a href="https://github.com/DFayerman" title="DFayerman"><img src="https://github.com/DFayerman.png?size=64" width="64" height="64" alt="DFayerman" /></a>
 <a href="https://github.com/dgomesbr" title="Diego Magalhães"><img src="https://github.com/dgomesbr.png?size=64" width="64" height="64" alt="Diego Magalhães" /></a>
 <a href="https://github.com/Dhaivat717" title="Dhaivat Patel"><img src="https://github.com/Dhaivat717.png?size=64" width="64" height="64" alt="Dhaivat Patel" /></a>
+<a href="https://github.com/dixitrathod16" title="Dixit R Jain"><img src="https://github.com/dixitrathod16.png?size=64" width="64" height="64" alt="Dixit R Jain" /></a>
+<a href="https://github.com/dmast3r" title="Sourabh Khandelwal"><img src="https://github.com/dmast3r.png?size=64" width="64" height="64" alt="Sourabh Khandelwal" /></a>
 <a href="https://github.com/doc88129" title="Doc"><img src="https://github.com/doc88129.png?size=64" width="64" height="64" alt="Doc" /></a>
+<a href="https://github.com/donisewell" title="donisewell"><img src="https://github.com/donisewell.png?size=64" width="64" height="64" alt="donisewell" /></a>
 <a href="https://github.com/dougclauson" title="dougclauson"><img src="https://github.com/dougclauson.png?size=64" width="64" height="64" alt="dougclauson" /></a>
+<a href="https://github.com/dscriptX" title="dscriptX"><img src="https://github.com/dscriptX.png?size=64" width="64" height="64" alt="dscriptX" /></a>
 <a href="https://github.com/dsm0709" title="Siming Deng"><img src="https://github.com/dsm0709.png?size=64" width="64" height="64" alt="Siming Deng" /></a>
+<a href="https://github.com/dvddpl" title="Davide de Paolis"><img src="https://github.com/dvddpl.png?size=64" width="64" height="64" alt="Davide de Paolis" /></a>
+<a href="https://github.com/dwalleck" title="Daryl Walleck"><img src="https://github.com/dwalleck.png?size=64" width="64" height="64" alt="Daryl Walleck" /></a>
 <a href="https://github.com/dwu96" title="Di Wu"><img src="https://github.com/dwu96.png?size=64" width="64" height="64" alt="Di Wu" /></a>
 <a href="https://github.com/dwzhangx" title="dwzhangx"><img src="https://github.com/dwzhangx.png?size=64" width="64" height="64" alt="dwzhangx" /></a>
 <a href="https://github.com/eajajhossain" title="Eajaj Hossain"><img src="https://github.com/eajajhossain.png?size=64" width="64" height="64" alt="Eajaj Hossain" /></a>
@@ -765,9 +794,12 @@ make this tool possible:
 <a href="https://github.com/erichays" title="Eric Hays"><img src="https://github.com/erichays.png?size=64" width="64" height="64" alt="Eric Hays" /></a>
 <a href="https://github.com/erikbomb" title="Erik Schweiss"><img src="https://github.com/erikbomb.png?size=64" width="64" height="64" alt="Erik Schweiss" /></a>
 <a href="https://github.com/estenger" title="Evan Stenger"><img src="https://github.com/estenger.png?size=64" width="64" height="64" alt="Evan Stenger" /></a>
+<a href="https://github.com/estesp" title="Phil Estes"><img src="https://github.com/estesp.png?size=64" width="64" height="64" alt="Phil Estes" /></a>
 <a href="https://github.com/ethanlevine" title="ethanlevine"><img src="https://github.com/ethanlevine.png?size=64" width="64" height="64" alt="ethanlevine" /></a>
+<a href="https://github.com/evajcwork-max" title="evajcwork-max"><img src="https://github.com/evajcwork-max.png?size=64" width="64" height="64" alt="evajcwork-max" /></a>
 <a href="https://github.com/EzzatQ" title="Ezzat Qupty"><img src="https://github.com/EzzatQ.png?size=64" width="64" height="64" alt="Ezzat Qupty" /></a>
 <a href="https://github.com/fanhongy" title="Stan Fan"><img src="https://github.com/fanhongy.png?size=64" width="64" height="64" alt="Stan Fan" /></a>
+<a href="https://github.com/fatihcaliss" title="Fatih Çalış"><img src="https://github.com/fatihcaliss.png?size=64" width="64" height="64" alt="Fatih Çalış" /></a>
 <a href="https://github.com/felipeb" title="Felipe"><img src="https://github.com/felipeb.png?size=64" width="64" height="64" alt="Felipe" /></a>
 <a href="https://github.com/FelixWang1994" title="Kejian Wang"><img src="https://github.com/FelixWang1994.png?size=64" width="64" height="64" alt="Kejian Wang" /></a>
 <a href="https://github.com/filipgodina" title="filipgodina"><img src="https://github.com/filipgodina.png?size=64" width="64" height="64" alt="filipgodina" /></a>
@@ -775,9 +807,12 @@ make this tool possible:
 <a href="https://github.com/FlameFrost" title="FlameFrost"><img src="https://github.com/FlameFrost.png?size=64" width="64" height="64" alt="FlameFrost" /></a>
 <a href="https://github.com/FlowTable0" title="FlowTable0"><img src="https://github.com/FlowTable0.png?size=64" width="64" height="64" alt="FlowTable0" /></a>
 <a href="https://github.com/floze-the-genius" title="Floze"><img src="https://github.com/floze-the-genius.png?size=64" width="64" height="64" alt="Floze" /></a>
+<a href="https://github.com/flukschander" title="Florian Lukschander"><img src="https://github.com/flukschander.png?size=64" width="64" height="64" alt="Florian Lukschander" /></a>
 <a href="https://github.com/fo2rist" title="Dmitry Sitnikov"><img src="https://github.com/fo2rist.png?size=64" width="64" height="64" alt="Dmitry Sitnikov" /></a>
 <a href="https://github.com/forkercat" title="Junhao Wang"><img src="https://github.com/forkercat.png?size=64" width="64" height="64" alt="Junhao Wang" /></a>
 <a href="https://github.com/Frxnesvo" title="Francesco Gallo"><img src="https://github.com/Frxnesvo.png?size=64" width="64" height="64" alt="Francesco Gallo" /></a>
+<a href="https://github.com/fsiegwald" title="François Siegwald"><img src="https://github.com/fsiegwald.png?size=64" width="64" height="64" alt="François Siegwald" /></a>
+<a href="https://github.com/gabrielmateitoma" title="gabrielmateitoma"><img src="https://github.com/gabrielmateitoma.png?size=64" width="64" height="64" alt="gabrielmateitoma" /></a>
 <a href="https://github.com/Garnethil" title="Gabriel Sanchez"><img src="https://github.com/Garnethil.png?size=64" width="64" height="64" alt="Gabriel Sanchez" /></a>
 <a href="https://github.com/gbrunoo" title="Gabriel"><img src="https://github.com/gbrunoo.png?size=64" width="64" height="64" alt="Gabriel" /></a>
 <a href="https://github.com/geetsawhney" title="geet sawhney"><img src="https://github.com/geetsawhney.png?size=64" width="64" height="64" alt="geet sawhney" /></a>
@@ -792,6 +827,8 @@ make this tool possible:
 <a href="https://github.com/greysonevins" title="Greyson Nevins"><img src="https://github.com/greysonevins.png?size=64" width="64" height="64" alt="Greyson Nevins" /></a>
 <a href="https://github.com/gspivey" title="Gerard Spivey"><img src="https://github.com/gspivey.png?size=64" width="64" height="64" alt="Gerard Spivey" /></a>
 <a href="https://github.com/haozihong" title="haozihong"><img src="https://github.com/haozihong.png?size=64" width="64" height="64" alt="haozihong" /></a>
+<a href="https://github.com/hardjaso" title="Jason Harding"><img src="https://github.com/hardjaso.png?size=64" width="64" height="64" alt="Jason Harding" /></a>
+<a href="https://github.com/harking" title="George Montana Harkin"><img src="https://github.com/harking.png?size=64" width="64" height="64" alt="George Montana Harkin" /></a>
 <a href="https://github.com/harpreetmultani1994" title="Harpreet Singh"><img src="https://github.com/harpreetmultani1994.png?size=64" width="64" height="64" alt="Harpreet Singh" /></a>
 <a href="https://github.com/hazlijohar95" title="Hazli Johar"><img src="https://github.com/hazlijohar95.png?size=64" width="64" height="64" alt="Hazli Johar" /></a>
 <a href="https://github.com/hchy0422" title="Kathy Han"><img src="https://github.com/hchy0422.png?size=64" width="64" height="64" alt="Kathy Han" /></a>
@@ -800,6 +837,7 @@ make this tool possible:
 <a href="https://github.com/HermiteBai" title="Hermite Bai"><img src="https://github.com/HermiteBai.png?size=64" width="64" height="64" alt="Hermite Bai" /></a>
 <a href="https://github.com/hhllii" title="hhllii"><img src="https://github.com/hhllii.png?size=64" width="64" height="64" alt="hhllii" /></a>
 <a href="https://github.com/hilljm-418" title="hilljm-418"><img src="https://github.com/hilljm-418.png?size=64" width="64" height="64" alt="hilljm-418" /></a>
+<a href="https://github.com/hlbence" title="hlbence"><img src="https://github.com/hlbence.png?size=64" width="64" height="64" alt="hlbence" /></a>
 <a href="https://github.com/hoang-phan98" title="Hoang "><img src="https://github.com/hoang-phan98.png?size=64" width="64" height="64" alt="Hoang " /></a>
 <a href="https://github.com/huanghang111" title="Zihang Huang"><img src="https://github.com/huanghang111.png?size=64" width="64" height="64" alt="Zihang Huang" /></a>
 <a href="https://github.com/hugoncosta" title="Hugo Costa"><img src="https://github.com/hugoncosta.png?size=64" width="64" height="64" alt="Hugo Costa" /></a>
@@ -809,6 +847,7 @@ make this tool possible:
 <a href="https://github.com/inaoy" title="inaoy"><img src="https://github.com/inaoy.png?size=64" width="64" height="64" alt="inaoy" /></a>
 <a href="https://github.com/IngridMorstrad" title="IngridMorstrad"><img src="https://github.com/IngridMorstrad.png?size=64" width="64" height="64" alt="IngridMorstrad" /></a>
 <a href="https://github.com/ishansmishra" title="Ishan Mishra"><img src="https://github.com/ishansmishra.png?size=64" width="64" height="64" alt="Ishan Mishra" /></a>
+<a href="https://github.com/IskanderNovena" title="Sebastiaan Brozius"><img src="https://github.com/IskanderNovena.png?size=64" width="64" height="64" alt="Sebastiaan Brozius" /></a>
 <a href="https://github.com/isotope14" title="isotope14"><img src="https://github.com/isotope14.png?size=64" width="64" height="64" alt="isotope14" /></a>
 <a href="https://github.com/j20120307" title="j20120307"><img src="https://github.com/j20120307.png?size=64" width="64" height="64" alt="j20120307" /></a>
 <a href="https://github.com/JainSid96" title="Siddhant Jain"><img src="https://github.com/JainSid96.png?size=64" width="64" height="64" alt="Siddhant Jain" /></a>
@@ -820,13 +859,17 @@ make this tool possible:
 <a href="https://github.com/jaydedm" title="Jayde Mitchell"><img src="https://github.com/jaydedm.png?size=64" width="64" height="64" alt="Jayde Mitchell" /></a>
 <a href="https://github.com/jbandon" title="Jack Bandon"><img src="https://github.com/jbandon.png?size=64" width="64" height="64" alt="Jack Bandon" /></a>
 <a href="https://github.com/jbnunn" title="Jeff Nunn"><img src="https://github.com/jbnunn.png?size=64" width="64" height="64" alt="Jeff Nunn" /></a>
+<a href="https://github.com/jdrahoz" title="Julia Drahozal"><img src="https://github.com/jdrahoz.png?size=64" width="64" height="64" alt="Julia Drahozal" /></a>
 <a href="https://github.com/jeeshofone" title="Will Laws"><img src="https://github.com/jeeshofone.png?size=64" width="64" height="64" alt="Will Laws" /></a>
 <a href="https://github.com/jeffn12" title="Jeff Neuberger"><img src="https://github.com/jeffn12.png?size=64" width="64" height="64" alt="Jeff Neuberger" /></a>
 <a href="https://github.com/jfnlewis-aws" title="Jeffrey Lewis"><img src="https://github.com/jfnlewis-aws.png?size=64" width="64" height="64" alt="Jeffrey Lewis" /></a>
+<a href="https://github.com/jgericke" title="Julian Gericke"><img src="https://github.com/jgericke.png?size=64" width="64" height="64" alt="Julian Gericke" /></a>
 <a href="https://github.com/jianwenl" title="jianwenl"><img src="https://github.com/jianwenl.png?size=64" width="64" height="64" alt="jianwenl" /></a>
+<a href="https://github.com/Jim-Kincaid-CSTG" title="Jim Kincaid"><img src="https://github.com/Jim-Kincaid-CSTG.png?size=64" width="64" height="64" alt="Jim Kincaid" /></a>
 <a href="https://github.com/jingchaodev" title="chao"><img src="https://github.com/jingchaodev.png?size=64" width="64" height="64" alt="chao" /></a>
 <a href="https://github.com/jkasiraj" title="jkasiraj"><img src="https://github.com/jkasiraj.png?size=64" width="64" height="64" alt="jkasiraj" /></a>
 <a href="https://github.com/jkiepert" title="jkiepert"><img src="https://github.com/jkiepert.png?size=64" width="64" height="64" alt="jkiepert" /></a>
+<a href="https://github.com/joaogac" title="Joao Guilherme Almeida Cesar"><img src="https://github.com/joaogac.png?size=64" width="64" height="64" alt="Joao Guilherme Almeida Cesar" /></a>
 <a href="https://github.com/jodoyodo" title="David Qian"><img src="https://github.com/jodoyodo.png?size=64" width="64" height="64" alt="David Qian" /></a>
 <a href="https://github.com/JoernZheng" title="Yaowen Zheng"><img src="https://github.com/JoernZheng.png?size=64" width="64" height="64" alt="Yaowen Zheng" /></a>
 <a href="https://github.com/johann-sew" title="johann-sew"><img src="https://github.com/johann-sew.png?size=64" width="64" height="64" alt="johann-sew" /></a>
@@ -834,34 +877,43 @@ make this tool possible:
 <a href="https://github.com/JohnEspenhahn" title="John Espenhahn"><img src="https://github.com/JohnEspenhahn.png?size=64" width="64" height="64" alt="John Espenhahn" /></a>
 <a href="https://github.com/johnnymastin" title="Johnny Mastin"><img src="https://github.com/johnnymastin.png?size=64" width="64" height="64" alt="Johnny Mastin" /></a>
 <a href="https://github.com/johnnynaught" title="johnnynaught"><img src="https://github.com/johnnynaught.png?size=64" width="64" height="64" alt="johnnynaught" /></a>
+<a href="https://github.com/jorgerubio-tech" title="jorgerubio-tech"><img src="https://github.com/jorgerubio-tech.png?size=64" width="64" height="64" alt="jorgerubio-tech" /></a>
+<a href="https://github.com/Jos-HJD" title="joseph hu"><img src="https://github.com/Jos-HJD.png?size=64" width="64" height="64" alt="joseph hu" /></a>
 <a href="https://github.com/josej4m" title="James Joseph"><img src="https://github.com/josej4m.png?size=64" width="64" height="64" alt="James Joseph" /></a>
+<a href="https://github.com/josephcoombe" title="Joseph Coombe"><img src="https://github.com/josephcoombe.png?size=64" width="64" height="64" alt="Joseph Coombe" /></a>
 <a href="https://github.com/joshymle" title="Joshua Yeung"><img src="https://github.com/joshymle.png?size=64" width="64" height="64" alt="Joshua Yeung" /></a>
 <a href="https://github.com/joyboy5477" title="Akash Vishwakarma"><img src="https://github.com/joyboy5477.png?size=64" width="64" height="64" alt="Akash Vishwakarma" /></a>
 <a href="https://github.com/JPLachance" title="Jean-Philippe Lachance"><img src="https://github.com/JPLachance.png?size=64" width="64" height="64" alt="Jean-Philippe Lachance" /></a>
 <a href="https://github.com/Jpontone" title="JPontone"><img src="https://github.com/Jpontone.png?size=64" width="64" height="64" alt="JPontone" /></a>
 <a href="https://github.com/jtoloui" title="Jamie Toloui"><img src="https://github.com/jtoloui.png?size=64" width="64" height="64" alt="Jamie Toloui" /></a>
 <a href="https://github.com/Jus973" title="Justin Z"><img src="https://github.com/Jus973.png?size=64" width="64" height="64" alt="Justin Z" /></a>
+<a href="https://github.com/jwoehrle" title="jwoehrle"><img src="https://github.com/jwoehrle.png?size=64" width="64" height="64" alt="jwoehrle" /></a>
 <a href="https://github.com/jyuros" title="Jaden Yuros"><img src="https://github.com/jyuros.png?size=64" width="64" height="64" alt="Jaden Yuros" /></a>
 <a href="https://github.com/k33bz" title="Matthew Kastro"><img src="https://github.com/k33bz.png?size=64" width="64" height="64" alt="Matthew Kastro" /></a>
 <a href="https://github.com/KaiqueGovani" title="Kaique Govani"><img src="https://github.com/KaiqueGovani.png?size=64" width="64" height="64" alt="Kaique Govani" /></a>
 <a href="https://github.com/kaizawa97" title="Kai Mitsuzawa"><img src="https://github.com/kaizawa97.png?size=64" width="64" height="64" alt="Kai Mitsuzawa" /></a>
 <a href="https://github.com/KarlLeen" title="karl4c"><img src="https://github.com/KarlLeen.png?size=64" width="64" height="64" alt="karl4c" /></a>
+<a href="https://github.com/kawaji" title="kawaji"><img src="https://github.com/kawaji.png?size=64" width="64" height="64" alt="kawaji" /></a>
 <a href="https://github.com/kazimovzaman2" title="Zaman Kazimov"><img src="https://github.com/kazimovzaman2.png?size=64" width="64" height="64" alt="Zaman Kazimov" /></a>
 <a href="https://github.com/kesh97-hub" title="kesh97-hub"><img src="https://github.com/kesh97-hub.png?size=64" width="64" height="64" alt="kesh97-hub" /></a>
 <a href="https://github.com/keyejia" title="Kellen Jia"><img src="https://github.com/keyejia.png?size=64" width="64" height="64" alt="Kellen Jia" /></a>
+<a href="https://github.com/kian-zh" title="张景源"><img src="https://github.com/kian-zh.png?size=64" width="64" height="64" alt="张景源" /></a>
 <a href="https://github.com/kiavashsamadi" title="Kiavash"><img src="https://github.com/kiavashsamadi.png?size=64" width="64" height="64" alt="Kiavash" /></a>
 <a href="https://github.com/kishoreb95" title="Kishore Baskar"><img src="https://github.com/kishoreb95.png?size=64" width="64" height="64" alt="Kishore Baskar" /></a>
 <a href="https://github.com/Kive1ru" title="Jiahao Guo"><img src="https://github.com/Kive1ru.png?size=64" width="64" height="64" alt="Jiahao Guo" /></a>
 <a href="https://github.com/kondisettyravi" title="Ravi Teja Kondisetty"><img src="https://github.com/kondisettyravi.png?size=64" width="64" height="64" alt="Ravi Teja Kondisetty" /></a>
 <a href="https://github.com/konippi" title="Kyosuke Konishi"><img src="https://github.com/konippi.png?size=64" width="64" height="64" alt="Kyosuke Konishi" /></a>
 <a href="https://github.com/kotyara1005" title="Artem Krivonos"><img src="https://github.com/kotyara1005.png?size=64" width="64" height="64" alt="Artem Krivonos" /></a>
+<a href="https://github.com/koushal2018" title="Koushal"><img src="https://github.com/koushal2018.png?size=64" width="64" height="64" alt="Koushal" /></a>
 <a href="https://github.com/koushikginjupally" title="koushikginjupally"><img src="https://github.com/koushikginjupally.png?size=64" width="64" height="64" alt="koushikginjupally" /></a>
 <a href="https://github.com/krishdhasmana" title="Krish Dhasmana"><img src="https://github.com/krishdhasmana.png?size=64" width="64" height="64" alt="Krish Dhasmana" /></a>
 <a href="https://github.com/krunalpa-amzn" title="krunalpa-amzn"><img src="https://github.com/krunalpa-amzn.png?size=64" width="64" height="64" alt="krunalpa-amzn" /></a>
 <a href="https://github.com/ksarieddine" title="ksarieddine"><img src="https://github.com/ksarieddine.png?size=64" width="64" height="64" alt="ksarieddine" /></a>
 <a href="https://github.com/ktreharrison" title="Ken Harrison"><img src="https://github.com/ktreharrison.png?size=64" width="64" height="64" alt="Ken Harrison" /></a>
+<a href="https://github.com/kumardushyant" title="Dushyant Kumar"><img src="https://github.com/kumardushyant.png?size=64" width="64" height="64" alt="Dushyant Kumar" /></a>
 <a href="https://github.com/Kyle-Helmick" title="Kyle Helmick"><img src="https://github.com/Kyle-Helmick.png?size=64" width="64" height="64" alt="Kyle Helmick" /></a>
 <a href="https://github.com/kyleseaman" title="Kyle Seaman"><img src="https://github.com/kyleseaman.png?size=64" width="64" height="64" alt="Kyle Seaman" /></a>
+<a href="https://github.com/Kyngo" title="Arnau Martín"><img src="https://github.com/Kyngo.png?size=64" width="64" height="64" alt="Arnau Martín" /></a>
 <a href="https://github.com/LachlanLindsay" title="Lachlan Lindsay"><img src="https://github.com/LachlanLindsay.png?size=64" width="64" height="64" alt="Lachlan Lindsay" /></a>
 <a href="https://github.com/lagrider" title="Bojin Li"><img src="https://github.com/lagrider.png?size=64" width="64" height="64" alt="Bojin Li" /></a>
 <a href="https://github.com/LandonCoe" title="LandonCoe"><img src="https://github.com/LandonCoe.png?size=64" width="64" height="64" alt="LandonCoe" /></a>
@@ -874,6 +926,7 @@ make this tool possible:
 <a href="https://github.com/LeTeutz" title="Teodor Oprescu"><img src="https://github.com/LeTeutz.png?size=64" width="64" height="64" alt="Teodor Oprescu" /></a>
 <a href="https://github.com/Liam-Wirth" title="Liam Wirth"><img src="https://github.com/Liam-Wirth.png?size=64" width="64" height="64" alt="Liam Wirth" /></a>
 <a href="https://github.com/LiptonJumboTeaBag" title="John Li"><img src="https://github.com/LiptonJumboTeaBag.png?size=64" width="64" height="64" alt="John Li" /></a>
+<a href="https://github.com/ljsimpkin" title="Liam"><img src="https://github.com/ljsimpkin.png?size=64" width="64" height="64" alt="Liam" /></a>
 <a href="https://github.com/lmambr2" title="lmambr2"><img src="https://github.com/lmambr2.png?size=64" width="64" height="64" alt="lmambr2" /></a>
 <a href="https://github.com/Lock128" title="Johannes Koch"><img src="https://github.com/Lock128.png?size=64" width="64" height="64" alt="Johannes Koch" /></a>
 <a href="https://github.com/logesh4v" title="LOGESH S"><img src="https://github.com/logesh4v.png?size=64" width="64" height="64" alt="LOGESH S" /></a>
@@ -885,33 +938,46 @@ make this tool possible:
 <a href="https://github.com/luokaiwei" title="Kaiwei Luo"><img src="https://github.com/luokaiwei.png?size=64" width="64" height="64" alt="Kaiwei Luo" /></a>
 <a href="https://github.com/luudtran" title="luudtran"><img src="https://github.com/luudtran.png?size=64" width="64" height="64" alt="luudtran" /></a>
 <a href="https://github.com/lzyraining" title="Zhuoyu Li"><img src="https://github.com/lzyraining.png?size=64" width="64" height="64" alt="Zhuoyu Li" /></a>
+<a href="https://github.com/m2kinare" title="m2kinare"><img src="https://github.com/m2kinare.png?size=64" width="64" height="64" alt="m2kinare" /></a>
 <a href="https://github.com/MacintoshPlus89" title="MacintoshPlus89"><img src="https://github.com/MacintoshPlus89.png?size=64" width="64" height="64" alt="MacintoshPlus89" /></a>
 <a href="https://github.com/maitianqcc" title="maitianqcc"><img src="https://github.com/maitianqcc.png?size=64" width="64" height="64" alt="maitianqcc" /></a>
 <a href="https://github.com/mamaiti" title="mamaiti"><img src="https://github.com/mamaiti.png?size=64" width="64" height="64" alt="mamaiti" /></a>
 <a href="https://github.com/mannitrkl2006" title="manish.gupta"><img src="https://github.com/mannitrkl2006.png?size=64" width="64" height="64" alt="manish.gupta" /></a>
+<a href="https://github.com/marcschuricht" title="Marc Schuricht"><img src="https://github.com/marcschuricht.png?size=64" width="64" height="64" alt="Marc Schuricht" /></a>
 <a href="https://github.com/mariamalaidi" title="mariamalaidi"><img src="https://github.com/mariamalaidi.png?size=64" width="64" height="64" alt="mariamalaidi" /></a>
 <a href="https://github.com/martchellop" title="Marcello Pagano"><img src="https://github.com/martchellop.png?size=64" width="64" height="64" alt="Marcello Pagano" /></a>
 <a href="https://github.com/MarvellousCodes" title="Marvellous Adedapo"><img src="https://github.com/MarvellousCodes.png?size=64" width="64" height="64" alt="Marvellous Adedapo" /></a>
+<a href="https://github.com/masterkoppa" title="Andres Ruiz"><img src="https://github.com/masterkoppa.png?size=64" width="64" height="64" alt="Andres Ruiz" /></a> <!-- wokeignore:rule=master -->
+<a href="https://github.com/mathisen99" title="Tommy Mathisen"><img src="https://github.com/mathisen99.png?size=64" width="64" height="64" alt="Tommy Mathisen" /></a>
+<a href="https://github.com/matt-emara" title="mattemara"><img src="https://github.com/matt-emara.png?size=64" width="64" height="64" alt="mattemara" /></a>
 <a href="https://github.com/MattMCloudy" title="Matthew McLeod"><img src="https://github.com/MattMCloudy.png?size=64" width="64" height="64" alt="Matthew McLeod" /></a>
 <a href="https://github.com/maufee" title="maufee"><img src="https://github.com/maufee.png?size=64" width="64" height="64" alt="maufee" /></a>
+<a href="https://github.com/max2me" title="Maxim Soloviev"><img src="https://github.com/max2me.png?size=64" width="64" height="64" alt="Maxim Soloviev" /></a>
 <a href="https://github.com/mbajaj92" title="Madhur Bajaj"><img src="https://github.com/mbajaj92.png?size=64" width="64" height="64" alt="Madhur Bajaj" /></a>
 <a href="https://github.com/mbriones98" title="Matthew Briones"><img src="https://github.com/mbriones98.png?size=64" width="64" height="64" alt="Matthew Briones" /></a>
 <a href="https://github.com/mchaloupka" title="Milos Chaloupka"><img src="https://github.com/mchaloupka.png?size=64" width="64" height="64" alt="Milos Chaloupka" /></a>
 <a href="https://github.com/mclawben" title="mclawben"><img src="https://github.com/mclawben.png?size=64" width="64" height="64" alt="mclawben" /></a>
+<a href="https://github.com/mcmathews" title="Michael Mathews"><img src="https://github.com/mcmathews.png?size=64" width="64" height="64" alt="Michael Mathews" /></a>
 <a href="https://github.com/mcryan77" title="mcryan"><img src="https://github.com/mcryan77.png?size=64" width="64" height="64" alt="mcryan" /></a>
 <a href="https://github.com/md-abusayeed" title="Md Abu Sayeed"><img src="https://github.com/md-abusayeed.png?size=64" width="64" height="64" alt="Md Abu Sayeed" /></a>
 <a href="https://github.com/Mdkar" title="Mihir Dhamankar"><img src="https://github.com/Mdkar.png?size=64" width="64" height="64" alt="Mihir Dhamankar" /></a>
 <a href="https://github.com/mdwyer223" title="Matthew Dwyer"><img src="https://github.com/mdwyer223.png?size=64" width="64" height="64" alt="Matthew Dwyer" /></a>
 <a href="https://github.com/miamanav" title="miamanav"><img src="https://github.com/miamanav.png?size=64" width="64" height="64" alt="miamanav" /></a>
 <a href="https://github.com/michellemxm" title="Michelle Ma"><img src="https://github.com/michellemxm.png?size=64" width="64" height="64" alt="Michelle Ma" /></a>
+<a href="https://github.com/midega-g" title="George Midega"><img src="https://github.com/midega-g.png?size=64" width="64" height="64" alt="George Midega" /></a>
 <a href="https://github.com/MikeMayer" title="Mike Mayer"><img src="https://github.com/MikeMayer.png?size=64" width="64" height="64" alt="Mike Mayer" /></a>
 <a href="https://github.com/miketheman" title="Mike Fiedler"><img src="https://github.com/miketheman.png?size=64" width="64" height="64" alt="Mike Fiedler" /></a>
 <a href="https://github.com/mikkuzne" title="Mikhail Kuznetsov"><img src="https://github.com/mikkuzne.png?size=64" width="64" height="64" alt="Mikhail Kuznetsov" /></a>
+<a href="https://github.com/mimmus" title="mimmus"><img src="https://github.com/mimmus.png?size=64" width="64" height="64" alt="mimmus" /></a>
 <a href="https://github.com/minglong51" title="Minglong Pan"><img src="https://github.com/minglong51.png?size=64" width="64" height="64" alt="Minglong Pan" /></a>
+<a href="https://github.com/mitrajparmar93" title="MRP"><img src="https://github.com/mitrajparmar93.png?size=64" width="64" height="64" alt="MRP" /></a>
 <a href="https://github.com/mkbarnum" title="mkbarnum"><img src="https://github.com/mkbarnum.png?size=64" width="64" height="64" alt="mkbarnum" /></a>
+<a href="https://github.com/mlwood-dev" title="Michael"><img src="https://github.com/mlwood-dev.png?size=64" width="64" height="64" alt="Michael" /></a>
 <a href="https://github.com/mnaameh" title="Marc El Naameh"><img src="https://github.com/mnaameh.png?size=64" width="64" height="64" alt="Marc El Naameh" /></a>
 <a href="https://github.com/MohammedAnes" title="MohammedAnes"><img src="https://github.com/MohammedAnes.png?size=64" width="64" height="64" alt="MohammedAnes" /></a>
 <a href="https://github.com/molladair" title="Molly Adair"><img src="https://github.com/molladair.png?size=64" width="64" height="64" alt="Molly Adair" /></a>
+<a href="https://github.com/mrbeag" title="mrbeag"><img src="https://github.com/mrbeag.png?size=64" width="64" height="64" alt="mrbeag" /></a>
+<a href="https://github.com/mrdoro" title="Luke Dorosz"><img src="https://github.com/mrdoro.png?size=64" width="64" height="64" alt="Luke Dorosz" /></a>
 <a href="https://github.com/mrkayhyun" title="DongHyun Kim"><img src="https://github.com/mrkayhyun.png?size=64" width="64" height="64" alt="DongHyun Kim" /></a>
 <a href="https://github.com/musaprg" title="Kotaro Inoue"><img src="https://github.com/musaprg.png?size=64" width="64" height="64" alt="Kotaro Inoue" /></a>
 <a href="https://github.com/mustafaonuraydin" title="Mustafa Onur AYDIN"><img src="https://github.com/mustafaonuraydin.png?size=64" width="64" height="64" alt="Mustafa Onur AYDIN" /></a>
@@ -924,37 +990,45 @@ make this tool possible:
 <a href="https://github.com/nazarenkod" title="Dmitriy"><img src="https://github.com/nazarenkod.png?size=64" width="64" height="64" alt="Dmitriy" /></a>
 <a href="https://github.com/ndbeals" title="Nathan Beals"><img src="https://github.com/ndbeals.png?size=64" width="64" height="64" alt="Nathan Beals" /></a>
 <a href="https://github.com/NDNey" title="David Ney"><img src="https://github.com/NDNey.png?size=64" width="64" height="64" alt="David Ney" /></a>
+<a href="https://github.com/newgenappsa" title="Anurag"><img src="https://github.com/newgenappsa.png?size=64" width="64" height="64" alt="Anurag" /></a>
 <a href="https://github.com/NguyenMatthew" title="Matthew Nguyen"><img src="https://github.com/NguyenMatthew.png?size=64" width="64" height="64" alt="Matthew Nguyen" /></a>
 <a href="https://github.com/NicholasRBowers" title="Nicholas Bowers"><img src="https://github.com/NicholasRBowers.png?size=64" width="64" height="64" alt="Nicholas Bowers" /></a>
+<a href="https://github.com/nicktruby" title="Nick Truby"><img src="https://github.com/nicktruby.png?size=64" width="64" height="64" alt="Nick Truby" /></a>
 <a href="https://github.com/nihal111" title="Nihal Singh"><img src="https://github.com/nihal111.png?size=64" width="64" height="64" alt="Nihal Singh" /></a>
 <a href="https://github.com/nikhil-m-amazon" title="Nikhil Menon"><img src="https://github.com/nikhil-m-amazon.png?size=64" width="64" height="64" alt="Nikhil Menon" /></a>
 <a href="https://github.com/nikithajain888" title="nikithajain888"><img src="https://github.com/nikithajain888.png?size=64" width="64" height="64" alt="nikithajain888" /></a>
 <a href="https://github.com/NikolasPpd" title="Nick Papadopoulos"><img src="https://github.com/NikolasPpd.png?size=64" width="64" height="64" alt="Nick Papadopoulos" /></a>
 <a href="https://github.com/nishi7409" title="Nishant Srivastava"><img src="https://github.com/nishi7409.png?size=64" width="64" height="64" alt="Nishant Srivastava" /></a>
 <a href="https://github.com/nitan2k" title="nitan2k"><img src="https://github.com/nitan2k.png?size=64" width="64" height="64" alt="nitan2k" /></a>
+<a href="https://github.com/noah-guillory" title="Noah Guillory"><img src="https://github.com/noah-guillory.png?size=64" width="64" height="64" alt="Noah Guillory" /></a>
 <a href="https://github.com/NovaPlasm" title="Beau Taylor"><img src="https://github.com/NovaPlasm.png?size=64" width="64" height="64" alt="Beau Taylor" /></a>
 <a href="https://github.com/nullabe" title="Antoine Belluard"><img src="https://github.com/nullabe.png?size=64" width="64" height="64" alt="Antoine Belluard" /></a>
 <a href="https://github.com/nyclord" title="Mark Lord"><img src="https://github.com/nyclord.png?size=64" width="64" height="64" alt="Mark Lord" /></a>
+<a href="https://github.com/oddisej" title="oddisej"><img src="https://github.com/oddisej.png?size=64" width="64" height="64" alt="oddisej" /></a>
+<a href="https://github.com/odinwang" title="Odin Wang"><img src="https://github.com/odinwang.png?size=64" width="64" height="64" alt="Odin Wang" /></a>
 <a href="https://github.com/officialprosingh" title="Parwinder Singh"><img src="https://github.com/officialprosingh.png?size=64" width="64" height="64" alt="Parwinder Singh" /></a>
 <a href="https://github.com/omarMokh" title="Omar Abo Mokh"><img src="https://github.com/omarMokh.png?size=64" width="64" height="64" alt="Omar Abo Mokh" /></a>
 <a href="https://github.com/OnlyOneByte" title="Rengang (Angelo) Yang"><img src="https://github.com/OnlyOneByte.png?size=64" width="64" height="64" alt="Rengang (Angelo) Yang" /></a>
 <a href="https://github.com/parimaldeshmukh" title="Parimal Deshmukh"><img src="https://github.com/parimaldeshmukh.png?size=64" width="64" height="64" alt="Parimal Deshmukh" /></a>
 <a href="https://github.com/patrigao" title="patrigao"><img src="https://github.com/patrigao.png?size=64" width="64" height="64" alt="patrigao" /></a>
+<a href="https://github.com/PatryckSans" title="Patryck Sans"><img src="https://github.com/PatryckSans.png?size=64" width="64" height="64" alt="Patryck Sans" /></a>
 <a href="https://github.com/pbcoder" title="pbcoder"><img src="https://github.com/pbcoder.png?size=64" width="64" height="64" alt="pbcoder" /></a>
+<a href="https://github.com/Pearcekieser" title="Pearcekieser"><img src="https://github.com/Pearcekieser.png?size=64" width="64" height="64" alt="Pearcekieser" /></a>
 <a href="https://github.com/pepmach" title="Stan Tian"><img src="https://github.com/pepmach.png?size=64" width="64" height="64" alt="Stan Tian" /></a>
 <a href="https://github.com/peterhieuvu" title="peterhieuvu"><img src="https://github.com/peterhieuvu.png?size=64" width="64" height="64" alt="peterhieuvu" /></a>
 <a href="https://github.com/philipjk" title="philipjk"><img src="https://github.com/philipjk.png?size=64" width="64" height="64" alt="philipjk" /></a>
 <a href="https://github.com/pierrms" title="pierrms"><img src="https://github.com/pierrms.png?size=64" width="64" height="64" alt="pierrms" /></a>
 <a href="https://github.com/pilami" title="Sai Chaitanya Manchikatla"><img src="https://github.com/pilami.png?size=64" width="64" height="64" alt="Sai Chaitanya Manchikatla" /></a>
 <a href="https://github.com/piyushrajyadav" title="Piyush Yadav"><img src="https://github.com/piyushrajyadav.png?size=64" width="64" height="64" alt="Piyush Yadav" /></a>
-<a href="https://github.com/pkot1980" title="PK98121"><img src="https://github.com/pkot1980.png?size=64" width="64" height="64" alt="PK98121" /></a>
 <a href="https://github.com/pkot98121" title="PK98121"><img src="https://github.com/pkot98121.png?size=64" width="64" height="64" alt="PK98121" /></a>
+<a href="https://github.com/playerjamesbattleground" title="james jiang"><img src="https://github.com/playerjamesbattleground.png?size=64" width="64" height="64" alt="james jiang" /></a>
 <a href="https://github.com/PNg-HA" title="PNg HA"><img src="https://github.com/PNg-HA.png?size=64" width="64" height="64" alt="PNg HA" /></a>
 <a href="https://github.com/popematt" title="Matthew Pope"><img src="https://github.com/popematt.png?size=64" width="64" height="64" alt="Matthew Pope" /></a>
 <a href="https://github.com/poyea" title="John Law"><img src="https://github.com/poyea.png?size=64" width="64" height="64" alt="John Law" /></a>
 <a href="https://github.com/pramod-123" title="Pramod Dudhi"><img src="https://github.com/pramod-123.png?size=64" width="64" height="64" alt="Pramod Dudhi" /></a>
 <a href="https://github.com/Premshay" title="Premshay"><img src="https://github.com/Premshay.png?size=64" width="64" height="64" alt="Premshay" /></a>
 <a href="https://github.com/presidentarrow" title="presidentarrow"><img src="https://github.com/presidentarrow.png?size=64" width="64" height="64" alt="presidentarrow" /></a>
+<a href="https://github.com/psantus" title="Paul SANTUS"><img src="https://github.com/psantus.png?size=64" width="64" height="64" alt="Paul SANTUS" /></a>
 <a href="https://github.com/ptias" title="ptias"><img src="https://github.com/ptias.png?size=64" width="64" height="64" alt="ptias" /></a>
 <a href="https://github.com/ptomooka" title="ptomooka"><img src="https://github.com/ptomooka.png?size=64" width="64" height="64" alt="ptomooka" /></a>
 <a href="https://github.com/qh2244" title="Qifeng Huang"><img src="https://github.com/qh2244.png?size=64" width="64" height="64" alt="Qifeng Huang" /></a>
@@ -971,9 +1045,13 @@ make this tool possible:
 <a href="https://github.com/ramdavid" title="ramdavid"><img src="https://github.com/ramdavid.png?size=64" width="64" height="64" alt="ramdavid" /></a>
 <a href="https://github.com/randallwc" title="William Randall"><img src="https://github.com/randallwc.png?size=64" width="64" height="64" alt="William Randall" /></a>
 <a href="https://github.com/raphael-shin" title="Jungseob Shin"><img src="https://github.com/raphael-shin.png?size=64" width="64" height="64" alt="Jungseob Shin" /></a>
+<a href="https://github.com/RawTech" title="Luke"><img src="https://github.com/RawTech.png?size=64" width="64" height="64" alt="Luke" /></a>
 <a href="https://github.com/rbcommits" title="Raghav Bhardwaj"><img src="https://github.com/rbcommits.png?size=64" width="64" height="64" alt="Raghav Bhardwaj" /></a>
 <a href="https://github.com/rcidadef" title="Roberto Cidade Fonseca"><img src="https://github.com/rcidadef.png?size=64" width="64" height="64" alt="Roberto Cidade Fonseca" /></a>
+<a href="https://github.com/realktmr" title="realktmr"><img src="https://github.com/realktmr.png?size=64" width="64" height="64" alt="realktmr" /></a>
 <a href="https://github.com/Remicks1" title="Jimmy Kilpatrick"><img src="https://github.com/Remicks1.png?size=64" width="64" height="64" alt="Jimmy Kilpatrick" /></a>
+<a href="https://github.com/rencewang" title="Lawrence Wang"><img src="https://github.com/rencewang.png?size=64" width="64" height="64" alt="Lawrence Wang" /></a>
+<a href="https://github.com/reprodev" title="ReproDev"><img src="https://github.com/reprodev.png?size=64" width="64" height="64" alt="ReproDev" /></a>
 <a href="https://github.com/rishabhagrawal1" title="Rishabh Agrawal"><img src="https://github.com/rishabhagrawal1.png?size=64" width="64" height="64" alt="Rishabh Agrawal" /></a>
 <a href="https://github.com/rittikg-amazon" title="rittikg-amazon"><img src="https://github.com/rittikg-amazon.png?size=64" width="64" height="64" alt="rittikg-amazon" /></a>
 <a href="https://github.com/rlunar" title="Roberto Luna-Rojas"><img src="https://github.com/rlunar.png?size=64" width="64" height="64" alt="Roberto Luna-Rojas" /></a>
@@ -985,6 +1063,7 @@ make this tool possible:
 <a href="https://github.com/RohanK6" title="RohanK6"><img src="https://github.com/RohanK6.png?size=64" width="64" height="64" alt="RohanK6" /></a>
 <a href="https://github.com/rohit-mehra" title="Rohit Mehra"><img src="https://github.com/rohit-mehra.png?size=64" width="64" height="64" alt="Rohit Mehra" /></a>
 <a href="https://github.com/rohitjose" title="Rohit Jose"><img src="https://github.com/rohitjose.png?size=64" width="64" height="64" alt="Rohit Jose" /></a>
+<a href="https://github.com/ronaldtfaws" title="ronaldtfaws"><img src="https://github.com/ronaldtfaws.png?size=64" width="64" height="64" alt="ronaldtfaws" /></a>
 <a href="https://github.com/ronyjacobjohn-tech" title="ronyjacobjohn-tech"><img src="https://github.com/ronyjacobjohn-tech.png?size=64" width="64" height="64" alt="ronyjacobjohn-tech" /></a>
 <a href="https://github.com/royosherove" title="Roy Osherove"><img src="https://github.com/royosherove.png?size=64" width="64" height="64" alt="Roy Osherove" /></a>
 <a href="https://github.com/rpranshu" title="Pranshu Ranakoti"><img src="https://github.com/rpranshu.png?size=64" width="64" height="64" alt="Pranshu Ranakoti" /></a>
@@ -995,12 +1074,15 @@ make this tool possible:
 <a href="https://github.com/sandlerr" title="Roman Sandler"><img src="https://github.com/sandlerr.png?size=64" width="64" height="64" alt="Roman Sandler" /></a>
 <a href="https://github.com/Sapientia-PT" title="João Miguel"><img src="https://github.com/Sapientia-PT.png?size=64" width="64" height="64" alt="João Miguel" /></a>
 <a href="https://github.com/sarankota" title="Saran Kota"><img src="https://github.com/sarankota.png?size=64" width="64" height="64" alt="Saran Kota" /></a>
+<a href="https://github.com/SaRedfiche" title="SaRedfiche"><img src="https://github.com/SaRedfiche.png?size=64" width="64" height="64" alt="SaRedfiche" /></a>
 <a href="https://github.com/sauravgpt" title="Saurav Kumar Gupta"><img src="https://github.com/sauravgpt.png?size=64" width="64" height="64" alt="Saurav Kumar Gupta" /></a>
 <a href="https://github.com/schebotarev" title="schebotarev"><img src="https://github.com/schebotarev.png?size=64" width="64" height="64" alt="schebotarev" /></a>
 <a href="https://github.com/scuthbert" title="Sam Cuthbertson"><img src="https://github.com/scuthbert.png?size=64" width="64" height="64" alt="Sam Cuthbertson" /></a>
 <a href="https://github.com/SebastianYuSun" title="Sebastian (Yu) Sun"><img src="https://github.com/SebastianYuSun.png?size=64" width="64" height="64" alt="Sebastian (Yu) Sun" /></a>
+<a href="https://github.com/seshbalannagendran" title="Sesh Balan"><img src="https://github.com/seshbalannagendran.png?size=64" width="64" height="64" alt="Sesh Balan" /></a>
 <a href="https://github.com/Setul0712" title="Setul0712"><img src="https://github.com/Setul0712.png?size=64" width="64" height="64" alt="Setul0712" /></a>
 <a href="https://github.com/severity1" title="John Reilly Pospos"><img src="https://github.com/severity1.png?size=64" width="64" height="64" alt="John Reilly Pospos" /></a>
+<a href="https://github.com/sgpjesus" title="Sérgio Jesus"><img src="https://github.com/sgpjesus.png?size=64" width="64" height="64" alt="Sérgio Jesus" /></a>
 <a href="https://github.com/shaochew" title="shaochew"><img src="https://github.com/shaochew.png?size=64" width="64" height="64" alt="shaochew" /></a>
 <a href="https://github.com/shawnxli" title="Shawn Li"><img src="https://github.com/shawnxli.png?size=64" width="64" height="64" alt="Shawn Li" /></a>
 <a href="https://github.com/ShayanYaseen" title="Shayan"><img src="https://github.com/ShayanYaseen.png?size=64" width="64" height="64" alt="Shayan" /></a>
@@ -1017,18 +1099,23 @@ make this tool possible:
 <a href="https://github.com/so0k" title="so0k"><img src="https://github.com/so0k.png?size=64" width="64" height="64" alt="so0k" /></a>
 <a href="https://github.com/solnikhil" title="Nikhil Solanki"><img src="https://github.com/solnikhil.png?size=64" width="64" height="64" alt="Nikhil Solanki" /></a>
 <a href="https://github.com/Soneji" title="Dhaval Soneji"><img src="https://github.com/Soneji.png?size=64" width="64" height="64" alt="Dhaval Soneji" /></a>
+<a href="https://github.com/Souperrman" title="Divan van Biljon"><img src="https://github.com/Souperrman.png?size=64" width="64" height="64" alt="Divan van Biljon" /></a>
 <a href="https://github.com/Souptik96" title="Souptik Chakraborty"><img src="https://github.com/Souptik96.png?size=64" width="64" height="64" alt="Souptik Chakraborty" /></a>
 <a href="https://github.com/spandanagrawal" title="Spandan Gopal Agrawal"><img src="https://github.com/spandanagrawal.png?size=64" width="64" height="64" alt="Spandan Gopal Agrawal" /></a>
 <a href="https://github.com/srinivasrk" title="Srini Kulkarni"><img src="https://github.com/srinivasrk.png?size=64" width="64" height="64" alt="Srini Kulkarni" /></a>
+<a href="https://github.com/stephenwiebe" title="stephenwiebe"><img src="https://github.com/stephenwiebe.png?size=64" width="64" height="64" alt="stephenwiebe" /></a>
+<a href="https://github.com/stevenjmiklovic" title="Steven J. Miklovic"><img src="https://github.com/stevenjmiklovic.png?size=64" width="64" height="64" alt="Steven J. Miklovic" /></a>
 <a href="https://github.com/stifspear" title="stifspear"><img src="https://github.com/stifspear.png?size=64" width="64" height="64" alt="stifspear" /></a>
 <a href="https://github.com/sudhamsu" title="Sudhamsu Manne"><img src="https://github.com/sudhamsu.png?size=64" width="64" height="64" alt="Sudhamsu Manne" /></a>
 <a href="https://github.com/sugan-kumar" title="sugan-kumar"><img src="https://github.com/sugan-kumar.png?size=64" width="64" height="64" alt="sugan-kumar" /></a>
 <a href="https://github.com/sugavaneshb" title="Sugavanesh B"><img src="https://github.com/sugavaneshb.png?size=64" width="64" height="64" alt="Sugavanesh B" /></a>
+<a href="https://github.com/sujeito-operator" title="Sujeito Operator"><img src="https://github.com/sujeito-operator.png?size=64" width="64" height="64" alt="Sujeito Operator" /></a>
 <a href="https://github.com/sujoydc" title="Sujoy Datta Choudhury"><img src="https://github.com/sujoydc.png?size=64" width="64" height="64" alt="Sujoy Datta Choudhury" /></a>
 <a href="https://github.com/SungjinYoo" title="Sungjin Yoo"><img src="https://github.com/SungjinYoo.png?size=64" width="64" height="64" alt="Sungjin Yoo" /></a>
 <a href="https://github.com/SwapDixit" title="Swapnil Dixit"><img src="https://github.com/SwapDixit.png?size=64" width="64" height="64" alt="Swapnil Dixit" /></a>
 <a href="https://github.com/sxhmilyoyo" title="sxhmilyoyo"><img src="https://github.com/sxhmilyoyo.png?size=64" width="64" height="64" alt="sxhmilyoyo" /></a>
 <a href="https://github.com/syedmujahedalih" title="Mujahed Syed"><img src="https://github.com/syedmujahedalih.png?size=64" width="64" height="64" alt="Mujahed Syed" /></a>
+<a href="https://github.com/syncrisis" title="Syncd"><img src="https://github.com/syncrisis.png?size=64" width="64" height="64" alt="Syncd" /></a>
 <a href="https://github.com/szto" title="SoonKim"><img src="https://github.com/szto.png?size=64" width="64" height="64" alt="SoonKim" /></a>
 <a href="https://github.com/t-jones" title="Tim Jones"><img src="https://github.com/t-jones.png?size=64" width="64" height="64" alt="Tim Jones" /></a>
 <a href="https://github.com/TakahiroIshii" title="Takahiro Ishii"><img src="https://github.com/TakahiroIshii.png?size=64" width="64" height="64" alt="Takahiro Ishii" /></a>
@@ -1039,11 +1126,13 @@ make this tool possible:
 <a href="https://github.com/thethomaslane" title="Thomas Lane"><img src="https://github.com/thethomaslane.png?size=64" width="64" height="64" alt="Thomas Lane" /></a>
 <a href="https://github.com/thiagoh" title="thiagoh"><img src="https://github.com/thiagoh.png?size=64" width="64" height="64" alt="thiagoh" /></a>
 <a href="https://github.com/think-imbaig" title="think-imbaig"><img src="https://github.com/think-imbaig.png?size=64" width="64" height="64" alt="think-imbaig" /></a>
+<a href="https://github.com/ThomasthWolff" title="ThomasthWolff"><img src="https://github.com/ThomasthWolff.png?size=64" width="64" height="64" alt="ThomasthWolff" /></a>
 <a href="https://github.com/ThR3742" title="ThR3742"><img src="https://github.com/ThR3742.png?size=64" width="64" height="64" alt="ThR3742" /></a>
 <a href="https://github.com/Tiger-0512" title="Taiga Matsunaga"><img src="https://github.com/Tiger-0512.png?size=64" width="64" height="64" alt="Taiga Matsunaga" /></a>
 <a href="https://github.com/tjdwlsdlaek" title="seongjin"><img src="https://github.com/tjdwlsdlaek.png?size=64" width="64" height="64" alt="seongjin" /></a>
 <a href="https://github.com/tlauda" title="Tomasz Lauda"><img src="https://github.com/tlauda.png?size=64" width="64" height="64" alt="Tomasz Lauda" /></a>
 <a href="https://github.com/tlobinger" title="Thomas Lobinger"><img src="https://github.com/tlobinger.png?size=64" width="64" height="64" alt="Thomas Lobinger" /></a>
+<a href="https://github.com/tmack8001" title="Trevor Mack"><img src="https://github.com/tmack8001.png?size=64" width="64" height="64" alt="Trevor Mack" /></a>
 <a href="https://github.com/toby-wong" title="Toby Wong"><img src="https://github.com/toby-wong.png?size=64" width="64" height="64" alt="Toby Wong" /></a>
 <a href="https://github.com/trekie86" title="Rob Wolinski"><img src="https://github.com/trekie86.png?size=64" width="64" height="64" alt="Rob Wolinski" /></a>
 <a href="https://github.com/tudit" title="Udit Tumuluri"><img src="https://github.com/tudit.png?size=64" width="64" height="64" alt="Udit Tumuluri" /></a>
@@ -1053,12 +1142,15 @@ make this tool possible:
 <a href="https://github.com/uzumakichillu" title="uzumakichillu"><img src="https://github.com/uzumakichillu.png?size=64" width="64" height="64" alt="uzumakichillu" /></a>
 <a href="https://github.com/vaibhavbhatiadev" title="Vaibhav Bhatia"><img src="https://github.com/vaibhavbhatiadev.png?size=64" width="64" height="64" alt="Vaibhav Bhatia" /></a>
 <a href="https://github.com/vamgan" title="Vamil Gandhi"><img src="https://github.com/vamgan.png?size=64" width="64" height="64" alt="Vamil Gandhi" /></a>
+<a href="https://github.com/vardaan-amzn" title="vardaan-amzn"><img src="https://github.com/vardaan-amzn.png?size=64" width="64" height="64" alt="vardaan-amzn" /></a>
 <a href="https://github.com/vdurante" title="Vitor Durante"><img src="https://github.com/vdurante.png?size=64" width="64" height="64" alt="Vitor Durante" /></a>
 <a href="https://github.com/veerjain-1" title="Veer Jain"><img src="https://github.com/veerjain-1.png?size=64" width="64" height="64" alt="Veer Jain" /></a>
 <a href="https://github.com/venkatvb" title="Venkatesh Babu AR"><img src="https://github.com/venkatvb.png?size=64" width="64" height="64" alt="Venkatesh Babu AR" /></a>
+<a href="https://github.com/vidanov" title="Alexey Vidanov"><img src="https://github.com/vidanov.png?size=64" width="64" height="64" alt="Alexey Vidanov" /></a>
 <a href="https://github.com/vinayshah1998" title="Vinay Shah"><img src="https://github.com/vinayshah1998.png?size=64" width="64" height="64" alt="Vinay Shah" /></a>
 <a href="https://github.com/vishal-sahoo" title="Vishal Sahoo"><img src="https://github.com/vishal-sahoo.png?size=64" width="64" height="64" alt="Vishal Sahoo" /></a>
 <a href="https://github.com/vishalvignesh" title="Vishal Vignesh"><img src="https://github.com/vishalvignesh.png?size=64" width="64" height="64" alt="Vishal Vignesh" /></a>
+<a href="https://github.com/vivek-tiwari-amazon" title="vivek-tiwari-amazon"><img src="https://github.com/vivek-tiwari-amazon.png?size=64" width="64" height="64" alt="vivek-tiwari-amazon" /></a>
 <a href="https://github.com/w-wei105" title="w-wei105"><img src="https://github.com/w-wei105.png?size=64" width="64" height="64" alt="w-wei105" /></a>
 <a href="https://github.com/warren830" title="Warren Chen"><img src="https://github.com/warren830.png?size=64" width="64" height="64" alt="Warren Chen" /></a>
 <a href="https://github.com/WBui" title="WBui"><img src="https://github.com/WBui.png?size=64" width="64" height="64" alt="WBui" /></a>
@@ -1073,6 +1165,7 @@ make this tool possible:
 <a href="https://github.com/wmaillard" title="Will Maillard"><img src="https://github.com/wmaillard.png?size=64" width="64" height="64" alt="Will Maillard" /></a>
 <a href="https://github.com/wu5bocheng" title="wu5bocheng"><img src="https://github.com/wu5bocheng.png?size=64" width="64" height="64" alt="wu5bocheng" /></a>
 <a href="https://github.com/wundram" title="wundram"><img src="https://github.com/wundram.png?size=64" width="64" height="64" alt="wundram" /></a>
+<a href="https://github.com/xcom923" title="xcom923"><img src="https://github.com/xcom923.png?size=64" width="64" height="64" alt="xcom923" /></a>
 <a href="https://github.com/Xianwen-Peng" title="Xianwen-Peng"><img src="https://github.com/Xianwen-Peng.png?size=64" width="64" height="64" alt="Xianwen-Peng" /></a>
 <a href="https://github.com/xiaochao17" title="xiaochao17"><img src="https://github.com/xiaochao17.png?size=64" width="64" height="64" alt="xiaochao17" /></a>
 <a href="https://github.com/XTX-TXT" title="XTX-TXT"><img src="https://github.com/XTX-TXT.png?size=64" width="64" height="64" alt="XTX-TXT" /></a>
@@ -1082,10 +1175,12 @@ make this tool possible:
 <a href="https://github.com/yashwanthkorla" title="Yashwanth Korla"><img src="https://github.com/yashwanthkorla.png?size=64" width="64" height="64" alt="Yashwanth Korla" /></a>
 <a href="https://github.com/yehuizhang" title="Yehui"><img src="https://github.com/yehuizhang.png?size=64" width="64" height="64" alt="Yehui" /></a>
 <a href="https://github.com/YifanL9" title="Yifan"><img src="https://github.com/YifanL9.png?size=64" width="64" height="64" alt="Yifan" /></a>
+<a href="https://github.com/yilong016" title="yilong016"><img src="https://github.com/yilong016.png?size=64" width="64" height="64" alt="yilong016" /></a>
 <a href="https://github.com/yogeshselvarajan" title="Yogesh Selvarajan"><img src="https://github.com/yogeshselvarajan.png?size=64" width="64" height="64" alt="Yogesh Selvarajan" /></a>
 <a href="https://github.com/yohanesss" title="Yohanes Setiawan"><img src="https://github.com/yohanesss.png?size=64" width="64" height="64" alt="Yohanes Setiawan" /></a>
 <a href="https://github.com/yoshidashingo" title="Shingo YOSHIDA 吉田真吾"><img src="https://github.com/yoshidashingo.png?size=64" width="64" height="64" alt="Shingo YOSHIDA 吉田真吾" /></a>
 <a href="https://github.com/yuwesu" title="Sypher Su"><img src="https://github.com/yuwesu.png?size=64" width="64" height="64" alt="Sypher Su" /></a>
+<a href="https://github.com/yystats78-uk" title="yystats78-uk"><img src="https://github.com/yystats78-uk.png?size=64" width="64" height="64" alt="yystats78-uk" /></a>
 <a href="https://github.com/yytdfc" title="yytdfc"><img src="https://github.com/yytdfc.png?size=64" width="64" height="64" alt="yytdfc" /></a>
 <a href="https://github.com/zach-herridge" title="Zach Herridge"><img src="https://github.com/zach-herridge.png?size=64" width="64" height="64" alt="Zach Herridge" /></a>
 <a href="https://github.com/zachakin" title="Zach Akin-Amland"><img src="https://github.com/zachakin.png?size=64" width="64" height="64" alt="Zach Akin-Amland" /></a>


### PR DESCRIPTION
## Problem

Three things are wrong or missing in the README Contributors block, and all three
are edits to that one block:

1. **95 people are absent.** #6824 taught `add-contributor.yml` to credit the
   reporters of issues that a merged pull request closed, but the backfill was
   deliberately kept out of that diff so the mechanism could be reviewed on its
   own.
2. **A private security report is uncredited.** Debasish Tripathy
   (@DebasishTripathy13) reported a security issue by email. That leaves no issue,
   pull request, comment or advisory credit in the repository, so no collector can
   ever see the contribution.
3. **One entry is a dead link and a duplicate.** `github.com/pkot1980` returns
   **404**, so it renders a broken avatar and links nowhere.

## Why it matters

This block is the project's only public recognition surface. A missing third of the
people it should name understates the community; a broken link and a doubled name
make the list look unmaintained and misstate the count.

## Fix

### 1. The 95 generated entries

Cherry-picked verbatim from the job's own commit `a603f1995`, produced by
`add-contributor.yml` run
[33293383298](https://github.com/kirodotdev/KiroCrew/actions/runs/33293383298)
(`workflow_dispatch`). The tree is unchanged from what the job wrote — its log
states what it decided:

```
Merged PRs scanned: 3846.
PR authors: 148; reporters of closed issues: 164; union: 239.
Collected 239 candidate author(s).
Added 95 contributor(s): ...
```

239 rather than 148 + 164 = 312 because 73 people are both a PR author and a
reporter and are credited once; 95 rather than 239 because the script skips anyone
already linked in the README.

### 2. Debasish Tripathy

Added through the manual path the one-list model reserves for contributions that
leave no repository artifact:

```sh
python3 scripts/update_contributors.py --login DebasishTripathy13 --name "Debasish Tripathy"
```

Login casing is the canonical `DebasishTripathy13` from the API, so the avatar and
profile URLs resolve exactly. Using the script rather than hand-editing keeps the
entry byte-identical in shape and at its sorted position.

### 3. The stale login

Deleted. It is the same person as the `pkot98121` entry directly below it: same
display name, and the API now reports `pkot98121` as the author of the pull requests
the old login was credited for (`pulls/5416` → `pkot98121`). Git history shows the
rename — the 2026-08-16 run (#3932) credited `pkot1980`, the 2026-08-25 run (#5968)
credited `pkot98121`. The collector resolves each login's display name through the
API, so `pkot1980` did work when it was added and went stale afterwards; nothing in
the pipeline can notice that two logins are one person.

Removed rather than corrected, because rewriting the URL to `pkot98121` would
duplicate an entry that is already there. Nothing re-adds it: the collector derives
logins from each merged PR's *current* author, and `pkot1980` appears 0 times in the
login set the live collector actually produced. No opt-out entry is needed, and
adding one would be dead config.

### 4. One generated entry carries a `wokeignore` marker

The Inclusive Language gate scans added lines with `woke` and fails on
`severity: error` findings. One of the 95 generated entries is
`github.com/masterkoppa`, so the `master` rule fires twice on that line — once for
the profile URL and once for the avatar URL.

Nobody's login gets rewritten. The line is marked instead:

```html
... alt="Andres Ruiz" /></a> <!-- wokeignore:rule=master -->
```

This is the established pattern here, not a new escape hatch: `README.md:821`
already carries the identical marker for `github.com/Godivamasterpiece`, and
`test/test_update_contributors.py::test_existing_lines_preserved_byte_for_byte`
exists specifically to pin that a contributor line with a trailing inline comment
"(like the repo's wokeignore marker)" survives untouched when new entries are
inserted. `.woke.yml` cannot express this case any other way — it offers only
`ignore_files` globs, and ignoring all of `README.md` would drop the gate over real
prose.

Known gap this does not close: the generator does not emit the marker itself, so the
next contributor whose login contains a flagged term will fail this gate again and
block the rolling PR until a human adds the marker. Worth fixing in
`scripts/update_contributors.py`, separately from this list update.

### Why one pull request, and why this branch

All three are the same kind of change — maintenance of one list, which the block's
own paragraph describes as entries being "added, corrected, or removed". The reason
they briefly lived on three branches is not scope but ownership: the job's rolling
branch `chore/add-contributors` is rebuilt from base and force-pushed on every run,
so a manual commit placed there is silently discarded on the next run. Inverting it
— cherry-picking the job's commit onto this branch — puts all three in one review
with nothing at risk of being overwritten.

Supersedes #6917, #6919 and #6922.

## Tests

No code changes. `scripts/update_contributors.py --test` — PASS, all 15 cases.

## Manual verification

1. Cherry-pick left the job's tree untouched: `+95 / −0` against `main` before the
   two manual edits.
2. `gh api users/debasishtripathy13` → `{"login": "DebasishTripathy13", "name":
   "Debasish Tripathy", "type": "User"}`.
3. `gh api users/pkot1980` → 404; `gh api users/pkot98121` → live, 15 items of
   repository activity; `pulls/5416 .user.login` → `pkot98121`.
4. Swept the whole block for the same defect: extracted all **455** logins and
   resolved each against `GET /users/<login>`. Exactly **one** dead login — the one
   removed here. This is an isolated stale entry, not a class of breakage.
5. The block still parses as a single contiguous run of anchors after all three
   edits: a no-op `--login pkot98121` run returns `No new contributors; README
   already up to date.` instead of the loud `contributor block is not a contiguous
   run` failure the script raises otherwise.
6. The `wokeignore` marker does not break the collector: with it in place, a no-op
   `--login masterkoppa` returns `No new contributors` (so the profile scan still
   matches that line), and inserting an unrelated probe login still lands correctly
   (so the marked line does not split the run). Probe reverted.
7. Final diff: 1 file, **+96 / −1**.
