### PR TITLE
fix(website): drop a duplicate Modal import that broke every build

### DIFF
--- a/website/src/pages/ChannelPage.tsx
+++ b/website/src/pages/ChannelPage.tsx
@@ -13,7 +13,6 @@ import { useImeGuard } from '../hooks/useImeGuard'
 import { useMenuKeyboard, menuItemsOf } from '../hooks/useMenuKeyboard'
 import { AnimatePresence } from 'framer-motion'
 import DetailPanel from '../components/DetailPanel'
-import Modal from '../components/Modal'
 
 import { i18nT } from '../i18n/t'
 import { useListDetailView } from '../hooks/useListDetailView'


### PR DESCRIPTION
## Problem

`website/src/pages/ChannelPage.tsx` imports `Modal` twice — line 2 and line 16 —
so the TypeScript compiler reports:

```
src/pages/ChannelPage.tsx(2,8): error TS2300: Duplicate identifier 'Modal'.
src/pages/ChannelPage.tsx(16,8): error TS2300: Duplicate identifier 'Modal'.
```

This is on `main` (`ba65da1e8`), not on a feature branch.

## Why it matters

Every build and typecheck lane runs `tsc`, so this single line fails five checks
at once — Frontend Lint & Type Check, Build Wheel, Build Desktop
(`ubuntu-22.04`), Build Desktop (`ubuntu-22.04-arm`) and E2E — on `main` and
therefore on **every open pull request in the repository**, none of which can
reach a green state until it is fixed. I hit it as an unrelated README-only
change showing five build failures.

## Fix

Symptom: five unrelated-looking build failures on a diff that touches no
TypeScript. Root cause: not the diff at all — `tsc` runs in every one of those
lanes, so one duplicate identifier on the merge base fans out across the whole
matrix. Delete one of the two identical imports.

`git log` shows how it got there: line 2 already had the import, and
`07eaab978` (`fix(channels): name errors with shared modal`) added a second one
next to the `DetailPanel` import. Removed the later one, so line 2 — the original
— stays and the import block keeps its existing order.

## Tests

- `tsc --noEmit` — clean (was 2 errors).
- `eslint src/pages/ChannelPage.tsx --max-warnings 0` — clean.
- `vitest run` on the four ChannelPage suites
  (`ChannelPage.clearContext`, `ChannelPage.ime`, `ChannelPage.menuKeyboard`,
  `ChannelPageCoverage`) — 84 passed.

## Manual verification

1. `grep -n "components/Modal" website/src/pages/ChannelPage.tsx` before: lines 2
   and 16. After: line 2 only.
2. Confirmed the duplicate is on `origin/main` itself, so this is a
   base-branch breakage rather than a merge artifact.
3. Diff is 1 file, +0, −1.

<!-- no-visual-delta -->

**Why no screenshot:** the diff deletes a second `import Modal from
'../components/Modal'` — the identical import of the identical module that line 2
already performs — so the binding `Modal` refers to the same component before and
after, no JSX changes, and the emitted bundle is unchanged. The file only tripped
the frontend-surface path filter; there is no rendered state to capture, and a
screenshot of ChannelPage would be evidence of nothing.
