### PR TITLE
fix(chat): close coroutines across dispatch and mocks

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -252,7 +252,6 @@ src/kiro_crew/dashboard/tailnet_serve.py
 src/kiro_crew/dashboard/terminal_commands.py
 src/kiro_crew/dashboard/theme_validate.py
 src/kiro_crew/dashboard/token_secret.py
-src/kiro_crew/dashboard/turn_dispatch.py
 src/kiro_crew/dashboard/urls.py
 src/kiro_crew/dashboard/workflow_inject.py
 src/kiro_crew/dashboard/ws_event_scope.py

--- a/src/kiro_crew/dashboard/turn_dispatch.py
+++ b/src/kiro_crew/dashboard/turn_dispatch.py
@@ -292,7 +292,12 @@ def finish_turn_task(
     )
 
 
-async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -> Any:
+async def _bounded_turn(
+    coro: "Coroutine[Any, Any, Any]",
+    timeout_secs: float,
+    *,
+    _started: "list[None] | None" = None,
+) -> Any:
     """Run *coro* under a wall-clock ceiling, raising even on a suppressed deadline.
 
     ``asyncio.wait_for`` cannot be used directly here. It cancels the coroutine
@@ -313,12 +318,19 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
     result. ``_run_chat``'s cancellation semantics are untouched — they are
     shared with the user's Stop button.
     """
+    # ``spawn_guarded_turn`` uses this yield-free marker to distinguish a
+    # wrapper that claimed its input coroutine from one cancelled before its
+    # first event-loop step.  In the latter case this function's ``finally``
+    # never runs, so the dispatch helper must close the still-unclaimed input.
+    if _started is not None:
+        _started.append(None)
+
     loop = asyncio.get_running_loop()
     deadline_fired = False
 
     def _on_deadline() -> None:
         nonlocal deadline_fired
-        if not task.done():
+        if task is not None and not task.done():
             deadline_fired = True
             task.cancel()
 
@@ -330,17 +342,27 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
     # turn dispatched there.
     previous_deadline = _TURN_DEADLINE.get()
     _TURN_DEADLINE.set(loop.time() + timeout_secs)
-    task: "asyncio.Task[Any]" = asyncio.ensure_future(coro)
-    handle = loop.call_later(timeout_secs, _on_deadline)
+    task: "asyncio.Task[Any] | None" = None
+    handle: "asyncio.TimerHandle | None" = None
     try:
+        try:
+            task = asyncio.ensure_future(coro)
+        except BaseException:
+            # Ownership was not transferred to a Task.
+            coro.close()
+            raise
+
+        # Keep timer creation inside the same ownership transaction.  Although
+        # the real event loop almost never rejects ``call_later``, a closing or
+        # instrumented loop can: the just-created Task must not outlive that
+        # failed dispatch.
+        handle = loop.call_later(timeout_secs, _on_deadline)
         try:
             result = await task
         except asyncio.CancelledError:
             if deadline_fired:
                 # Our ceiling cut it and the turn let the cancellation through.
-                raise TimeoutError(
-                    f"turn exceeded the {timeout_secs:.0f}s ceiling"
-                ) from None
+                raise TimeoutError(f"turn exceeded the {timeout_secs:.0f}s ceiling") from None
             # Cancelled by something else (Stop button, shutdown) — propagate.
             raise
         if deadline_fired:
@@ -349,15 +371,24 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
             raise TimeoutError(f"turn exceeded the {timeout_secs:.0f}s ceiling")
         return result
     finally:
-        handle.cancel()
+        if handle is not None:
+            handle.cancel()
         # Restore by value instead of retaining a ContextVar token. Test and
         # shutdown harnesses may resume coroutine finalization in a copied
         # Context (notably Windows xdist); reset(token) then raises and can take
         # down the whole worker because tokens are context-bound.
         _TURN_DEADLINE.set(previous_deadline)
-        if not task.done():
-            # The wrapper itself was cancelled; don't orphan the turn.
+        if task is not None and not task.done():
+            # The wrapper itself was cancelled, or setup failed after Task
+            # creation.  Cancel AND join it: cancellation alone can leave an
+            # unstarted coroutine pending until a later GC cycle.
             task.cancel()
+            try:
+                await task
+            except BaseException:
+                # Cleanup must preserve the exception already leaving the
+                # wrapper (setup failure or caller cancellation).
+                pass
 
 
 async def bounded_chat_turn(coro: "Coroutine[Any, Any, Any]") -> Any:
@@ -391,8 +422,27 @@ def spawn_guarded_turn(
     keep doing so; this helper deliberately does not own those fields, because
     they carry site-specific stop/steer semantics.
     """
-    timeout = chat_turn_timeout_secs() if timeout_secs is None else timeout_secs
-    task = asyncio.create_task(_bounded_turn(coro, timeout))
+    started: list[None] = []
+    bounded = None
+    try:
+        timeout = chat_turn_timeout_secs() if timeout_secs is None else timeout_secs
+        bounded = _bounded_turn(coro, timeout, _started=started)
+        task = asyncio.create_task(bounded)
+    except BaseException:
+        # The caller created ``coro`` before entering this helper.  If timeout
+        # resolution or task creation fails, no Task owns either coroutine.
+        if bounded is not None:
+            bounded.close()
+        coro.close()
+        raise
     state._background_tasks.add(task)
-    task.add_done_callback(lambda t: finish_turn_task(state, slot, t, timeout))
+
+    def _finish(t: "asyncio.Task[Any]") -> None:
+        if not started:
+            # A Task cancelled before its first loop step closes the bounded
+            # wrapper but not the input coroutine stored in its arguments.
+            coro.close()
+        finish_turn_task(state, slot, t, timeout)
+
+    task.add_done_callback(_finish)
     return task

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -9336,6 +9336,11 @@ class TestOrchestratorPlanGateArming:
     def _make_mock_client(events):
         client = AsyncMock()
         client.context_usage_pct = MagicMock(return_value=10.0)
+        client.context_window_tokens = MagicMock(return_value=0)
+        client.context_used_tokens = MagicMock(return_value=0)
+        client.available_models = MagicMock(return_value=[])
+        client.client = MagicMock()
+        client.client.pop_pending_oauth_requests = MagicMock(return_value=[])
 
         async def _stream(msg):
             for ev in events:

--- a/test/test_turn_dispatch.py
+++ b/test/test_turn_dispatch.py
@@ -146,8 +146,9 @@ class TestBoundedTurnSetup:
     async def test_task_creation_failure_restores_deadline_and_closes_turn(
         self, monkeypatch
     ) -> None:
+        original_deadline = td._TURN_DEADLINE.get()
         previous_deadline = 12345.0
-        token = td._TURN_DEADLINE.set(previous_deadline)
+        td._TURN_DEADLINE.set(previous_deadline)
 
         async def _turn() -> None:
             raise AssertionError("failed setup must not start the turn")
@@ -164,12 +165,13 @@ class TestBoundedTurnSetup:
             assert td._TURN_DEADLINE.get() == previous_deadline
             assert turn.cr_frame is None
         finally:
-            td._TURN_DEADLINE.reset(token)
+            td._TURN_DEADLINE.set(original_deadline)
 
     @pytest.mark.asyncio
     async def test_timer_creation_failure_cancels_and_joins_owned_turn(self, monkeypatch) -> None:
+        original_deadline = td._TURN_DEADLINE.get()
         previous_deadline = 67890.0
-        token = td._TURN_DEADLINE.set(previous_deadline)
+        td._TURN_DEADLINE.set(previous_deadline)
         created_tasks: list[asyncio.Task[None]] = []
         real_ensure_future = asyncio.ensure_future
 
@@ -197,7 +199,7 @@ class TestBoundedTurnSetup:
             assert created_tasks[0].cancelled()
             assert turn.cr_frame is None
         finally:
-            td._TURN_DEADLINE.reset(token)
+            td._TURN_DEADLINE.set(original_deadline)
 
 
 class TestTimeoutCard:

--- a/test/test_turn_dispatch.py
+++ b/test/test_turn_dispatch.py
@@ -141,6 +141,65 @@ class TestCeilingResolution:
         assert td.chat_turn_timeout_secs() == CHAT_TURN_TIMEOUT
 
 
+class TestBoundedTurnSetup:
+    @pytest.mark.asyncio
+    async def test_task_creation_failure_restores_deadline_and_closes_turn(
+        self, monkeypatch
+    ) -> None:
+        previous_deadline = 12345.0
+        token = td._TURN_DEADLINE.set(previous_deadline)
+
+        async def _turn() -> None:
+            raise AssertionError("failed setup must not start the turn")
+
+        turn = _turn()
+        monkeypatch.setattr(
+            td.asyncio,
+            "ensure_future",
+            MagicMock(side_effect=RuntimeError("task factory rejected turn")),
+        )
+        try:
+            with pytest.raises(RuntimeError, match="task factory rejected turn"):
+                await td._bounded_turn(turn, 60)
+            assert td._TURN_DEADLINE.get() == previous_deadline
+            assert turn.cr_frame is None
+        finally:
+            td._TURN_DEADLINE.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_timer_creation_failure_cancels_and_joins_owned_turn(self, monkeypatch) -> None:
+        previous_deadline = 67890.0
+        token = td._TURN_DEADLINE.set(previous_deadline)
+        created_tasks: list[asyncio.Task[None]] = []
+        real_ensure_future = asyncio.ensure_future
+
+        async def _turn() -> None:
+            raise AssertionError("failed setup must not start the turn")
+
+        def _record_task(coro):
+            task = real_ensure_future(coro)
+            created_tasks.append(task)
+            return task
+
+        loop = asyncio.get_running_loop()
+        turn = _turn()
+        monkeypatch.setattr(td.asyncio, "ensure_future", _record_task)
+        monkeypatch.setattr(
+            loop,
+            "call_later",
+            MagicMock(side_effect=RuntimeError("timer rejected deadline")),
+        )
+        try:
+            with pytest.raises(RuntimeError, match="timer rejected deadline"):
+                await td._bounded_turn(turn, 60)
+            assert td._TURN_DEADLINE.get() == previous_deadline
+            assert len(created_tasks) == 1
+            assert created_tasks[0].cancelled()
+            assert turn.cr_frame is None
+        finally:
+            td._TURN_DEADLINE.reset(token)
+
+
 class TestTimeoutCard:
     def test_names_the_limit_in_hours(self) -> None:
         assert "2-hour" in td.format_turn_timeout_card(7200.0)
@@ -154,6 +213,29 @@ class TestTimeoutCard:
 
 
 class TestFinishTurnTask:
+    @pytest.mark.asyncio
+    async def test_cancel_before_first_loop_step_closes_the_unclaimed_turn(self) -> None:
+        """Immediate cancellation must not leak the input coroutine.
+
+        The bounded wrapper has not started yet, so its ``finally`` cannot own
+        cleanup.  This is the exact dispatch race exercised when a completed
+        chat turn starts a queued successor and its test/teardown immediately
+        cancels ``slot.task``.
+        """
+        state, slot = _state(), _slot()
+
+        async def _turn() -> None:
+            raise AssertionError("the turn should never start")
+
+        turn = _turn()
+        task = td.spawn_guarded_turn(state, slot, turn, timeout_secs=60)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert turn.cr_frame is None
+
     @pytest.mark.asyncio
     async def test_timeout_renders_a_visible_card(self) -> None:
         """The headline regression: a ceiling hit must not be silent."""


### PR DESCRIPTION
## Problem

Two independent coroutine-ownership defects make otherwise passing chat tests emit `RuntimeWarning: coroutine ... was never awaited` and can turn the following test into a setup failure:

1. A guarded chat turn can be cancelled before its wrapper receives its first event-loop step. The wrapper never claims the input coroutine, so its `finally` cannot close it.
2. `TestOrchestratorPlanGateArming` models provider objects with a blanket `AsyncMock`, but several provider methods are synchronous. Their returned coroutine objects leak when production calls them synchronously.

The first case also exists in production whenever a queued successor is dispatched and immediately cancelled during stop or shutdown; it is not only test cleanup.

## Change

- Make ownership transfer in `spawn_guarded_turn` explicit. If timeout resolution or task creation fails, close every unowned coroutine. If the wrapper is cancelled before its first step, its done callback closes the still-unclaimed turn.
- Make `_bounded_turn` cancel and join an owned task on setup failure or wrapper cancellation, while preserving the original exception and restoring the deadline context.
- Model only the affected provider's synchronous accessors and OAuth dequeue method as `MagicMock` in the plan-gate fixture.

No retry, sleep, timeout increase, warning filter, or tolerance was added.

## Evidence

Red before, on current main:

- an immediate cancel-before-first-step reproduction emits `RuntimeWarning: coroutine 'turn' was never awaited`;
- running the plan-gate planning test immediately before the stage test yields one pass followed by one setup error from an unawaited `AsyncMock` coroutine.

Green after:

- 7 focused tests pass with `RuntimeWarning` and `PytestUnraisableExceptionWarning` promoted to errors;
- Black, isort, flake8, mypy for the production module, and `git diff --check` pass.

## Scope

Three files, two commits. The production lifecycle fix and the test-double ownership fix are kept separate. No broad fixture cleanup or unrelated warning suppression is included.

## Screenshots

N/A — backend coroutine lifecycle and test-double behavior only.
