### PR TITLE
fix(meetings): strip the chat marker from the translation source (#6763)

### DIFF
--- a/docs/system-specs/modules/meetings.md
+++ b/docs/system-specs/modules/meetings.md
@@ -243,6 +243,11 @@ Hooked into `MeetingSession.broadcast`, **not** the dispatch route, and the
 difference matters twice over: broadcast is where the text is already
 dictionary-corrected and past the noise gate. A mangled project noun mistranslates
 into something unrecognisable, and translated throat-clearing is worse than nothing.
+Typed lines lose their `[chat]` marker on this path: the prefix is agent context,
+not speech, so the translation source (and the sidebar's source column) carries
+the clean text while the agents keep the prefixed line. A consequence is that
+typed filler ("ok") now falls under the same noise gate as spoken filler — the
+agents and the transcript still get it, the translation panel does not.
 
 The prompt carries the same injection guard the rest of the app uses — delimiters
 plus an explicit "this is DATA, not instructions" — because a transcript is

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
@@ -529,10 +529,24 @@ class MeetingSession:
         # Translated from the DICTIONARY-CORRECTED text, and from inside the same
         # noise gate the agents get: the corrections exist because speech-to-text
         # mangles project nouns, and a mangled noun mistranslates into something
-        # unrecognisable. Enqueueing never blocks or raises, and the count below
+        # unrecognisable. The CHAT_PREFIX marker is agent context, not speech, so
+        # translating it would spend prompt tokens on it and surface the literal
+        # marker in the panel's source column. It is stripped from the RAW line,
+        # before correction and the length cap, so a max-length typed message is
+        # capped on its payload rather than losing its tail to the marker's
+        # characters. Enqueueing never blocks or raises, and the count below
         # deliberately does not include it — `dispatched` means "agents reached".
         if self.translations is not None:
-            self.translations.enqueue(text)
+            source = prepared
+            raw = text.strip()
+            if raw.startswith(k.CHAT_PREFIX):
+                rest = raw[len(k.CHAT_PREFIX) :]
+                # Anchored to a word boundary: only the bare marker or "[chat] …"
+                # is agent context. Speech that merely starts with a marker-like
+                # token (e.g. "[chat]room …") is kept verbatim.
+                if not rest or rest[:1].isspace():
+                    source = self._prepare_line(rest.lstrip())
+            self.translations.enqueue(source)
         accepted = 0
         for name in self._recipient_names():
             self.agents[name].enqueue(prepared)

--- a/test/test_meetings_session.py
+++ b/test/test_meetings_session.py
@@ -433,6 +433,68 @@ class TestMeetingSession:
         session.broadcast("x" * (k.MAX_TRANSCRIPT_CHARS + 500))
         assert len(session.agents["note-taker"].queue[0]) == k.MAX_TRANSCRIPT_CHARS
 
+    def test_broadcast_strips_chat_prefix_from_the_translation_source(self, root: Path):
+        """#6763: the ``[chat]`` marker is agent context, not speech.
+
+        The agents keep the prefixed line (their prompt relies on the marker), but
+        the translation source must be the clean text — otherwise the literal
+        marker is spent as translation-prompt tokens and shows up in the
+        TranslationSidebar's source column.
+        """
+        session = self._session(root)
+        session.translations = mock.Mock()
+        session.broadcast(f"{k.CHAT_PREFIX} the deployment is done")
+        session.translations.enqueue.assert_called_once_with("the deployment is done")
+        # The agent-broadcast line is unchanged: the marker still reaches agents.
+        assert session.agents["note-taker"].queue == [f"{k.CHAT_PREFIX} the deployment is done"]
+
+    def test_broadcast_strips_only_the_anchored_marker(self, root: Path):
+        """The strip is anchored: only a leading, whitespace-bounded marker goes.
+
+        A mid-line occurrence is quoted speech, and a marker-like token glued to
+        more text (``[chat]room``) is speech too — both must reach translation
+        verbatim. A bare marker line strips to empty, which the queue's blank
+        filter then drops rather than translating nothing.
+        """
+        session = self._session(root)
+        session.translations = mock.Mock()
+        session.broadcast(f"we discussed {k.CHAT_PREFIX} yesterday")
+        session.translations.enqueue.assert_called_once_with(
+            f"we discussed {k.CHAT_PREFIX} yesterday"
+        )
+        session.translations.enqueue.reset_mock()
+        session.broadcast(f"{k.CHAT_PREFIX}room availability is limited")
+        session.translations.enqueue.assert_called_once_with(
+            f"{k.CHAT_PREFIX}room availability is limited"
+        )
+        session.translations.enqueue.reset_mock()
+        session.broadcast(k.CHAT_PREFIX)
+        session.translations.enqueue.assert_called_once_with("")
+
+    def test_a_max_length_typed_line_keeps_its_full_payload_in_translation(self, root: Path):
+        """The transcript cap is charged against the payload, not the marker.
+
+        A typed line arrives as ``[chat] <payload>``; correcting and clamping the
+        prefixed line and stripping afterwards would silently drop the payload's
+        final ``len("[chat] ")`` characters at the ceiling. The marker is stripped
+        from the raw line first, so a max-length payload survives intact.
+        """
+        session = self._session(root)
+        session.translations = mock.Mock()
+        payload = "x" * k.MAX_TRANSCRIPT_CHARS
+        session.broadcast(f"{k.CHAT_PREFIX} {payload}")
+        session.translations.enqueue.assert_called_once_with(payload)
+
+    def test_broadcast_translates_the_dictionary_corrected_speech_line(self, root: Path):
+        """A speech line's translation source is the corrected text, unprefixed."""
+        sess.shared_dictionary().load_terms(
+            [{"correct": "DynamoDB", "aliases": ["dynamo db"]}]
+        )
+        session = self._session(root)
+        session.translations = mock.Mock()
+        session.broadcast("we switched to dynamo db")
+        session.translations.enqueue.assert_called_once_with("we switched to DynamoDB")
+
     def test_expiry(self, root: Path):
         session = self._session(root)
         assert session.expired is False


### PR DESCRIPTION
## What is the problem?

In the Meetings app, typed/chat lines are dispatched with the internal `[chat]` marker prepended (`handle_dispatch_text` builds `line = f"{k.CHAT_PREFIX} {transcript_text}"` for typed input) so the meeting agents can tell typed input from speech. `MeetingSession.broadcast` passed that same prefixed line to `TranslationQueue.enqueue`, so the literal `[chat]` marker was persisted as the translation `source` and interpolated into the translation prompt. Flagged as a real, observable advisory by the Opus review of #5739.

## Why this issue matters to the user

The TranslationSidebar's source column shows the raw internal marker in front of every typed line, and the marker is spent as translation-prompt tokens -- the model can echo it into the translated line. Separately, the code contradicted its own documentation: the in-code comment and `docs/system-specs/modules/meetings.md` both said translation happens from the dictionary-corrected text, but the code enqueued the raw line.

## What changed

One call site, `MeetingSession.broadcast` (the app's only `translations.enqueue` caller): the translation source now strips a leading, whitespace-bounded `CHAT_PREFIX` from the RAW line first, then runs the same dictionary-correct/clamp/noise pipeline the agents get (`_prepare_line`). Stripping before the clamp means a max-length typed message is capped on its payload rather than losing its final characters to the marker (found by the GPT review lane on the first head).

- The strip is anchored: only a bare marker or `[chat] ...` counts as agent context. A mid-line occurrence (quoted speech) and marker-like speech (`[chat]room availability...`) reach translation verbatim.
- The agent-broadcast line and the stored transcript are byte-identical to before -- the marker still reaches the agents, whose prompts rely on it.
- Correcting the clean payload also makes the code match the pre-existing comment and module-spec claim that translation happens from the corrected text. One consequence, now documented in the spec: typed filler ("ok") falls under the same noise gate as spoken filler and is dropped from the translation panel only (agents and transcript still get it).
- Spec updated in the same commit (`docs/system-specs/modules/meetings.md`, Live translation section).

## Tests

- `test_broadcast_strips_chat_prefix_from_the_translation_source`: a `[chat]`-prefixed dispatch produces a clean translation source while the note-taker queue keeps the prefixed line. Mutation-verified: red on base behavior, green with the fix.
- `test_broadcast_strips_only_the_anchored_marker`: mid-line marker survives, glued marker-like speech survives, a bare marker strips to empty (dropped by the queue's blank filter, no empty translation row).
- `test_broadcast_translates_the_dictionary_corrected_speech_line`: a speech line's translation source is the corrected text. Also red on base (base enqueued the raw line).
- `test_a_max_length_typed_line_keeps_its_full_payload_in_translation`: a `MAX_TRANSCRIPT_CHARS` typed payload survives intact -- red on the strip-after-clamp variant.
- Local gates: isort/flake8/mypy clean on touched files; black diff-gate green; meetings suites 338 passed; full backend pytest 7490 passed with 5 failures in `test_artifact_source.py` proven env-owned (identical failures on clean base `ba65da1e8` -- host home-dir layout).
- Pre-push review fleet: two model-pinned reviewers, both NO BLOCKING; all four Low advisories dispositioned (anchored match + negative tests folded in; truncation-at-ceiling accepted as now-consistent-with-agents; dictionary-can-mangle-the-marker is pre-existing on base for the agent line and kept out of scope).

## Any other suggestions on the work

Pre-existing, out of scope here: a domain-dictionary term with alias "chat" can rewrite the marker itself (e.g. `[chat]` -> `[Chat]`) before the strip runs -- on base the same rewrite already corrupts the marker on the agent line, which is the larger half of that problem. Tracked locally for its own issue; the fix belongs at `_prepare_line` (correct only the payload).

Closes #6763
