### PR TITLE
test(website): await Mochi config before mount completes

### DIFF
--- a/website/src/test/MochiChatAppCoverage.test.tsx
+++ b/website/src/test/MochiChatAppCoverage.test.tsx
@@ -194,7 +194,12 @@ afterEach(() => {
 async function mountApp(): Promise<void> {
   render(<ChatApp />)
   await waitFor(() => {
-    expect(screen.getByTestId('stub-pinned-panel').getAttribute('data-pet')).not.toBe('')
+    // The component's initial value is already the non-empty string "Mochi".
+    // Waiting only for non-empty therefore returned before getMochiConfig's
+    // resolved promise committed, and the following Nimbus assertion raced it
+    // under a loaded shard. Wait for the configured value itself on both rails.
+    expect(screen.getByTestId('stub-pinned-panel').getAttribute('data-pet')).toBe('Nimbus')
+    expect(screen.getByTestId('stub-watch-panel').getAttribute('data-pet')).toBe('Nimbus')
   }, { timeout: 5_000 })
 }
 
@@ -279,7 +284,21 @@ describe('Mochi ChatApp — view selection', () => {
 
 describe('Mochi ChatApp — pet name', () => {
   it('passes the stored name to both rails', async () => {
-    await mountApp()
+    let resolveConfig!: (value: { petName: string }) => void
+    api.getMochiConfig.mockReturnValue(new Promise(resolve => { resolveConfig = resolve }))
+
+    let mountFinished = false
+    const mounted = mountApp().then(() => { mountFinished = true })
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+
+    // Prove the helper did not mistake the component's non-empty default for a
+    // completed config read. This makes the old `.not.toBe('')` predicate fail
+    // deterministically instead of only when a busy shard delays the microtask.
+    expect(pinnedPanel().getAttribute('data-pet')).toBe('Mochi')
+    expect(mountFinished).toBe(false)
+
+    await act(async () => { resolveConfig({ petName: 'Nimbus' }) })
+    await mounted
 
     expect(pinnedPanel().getAttribute('data-pet')).toBe('Nimbus')
     expect(watchPanel().getAttribute('data-pet')).toBe('Nimbus')


### PR DESCRIPTION
## Problem / Motivation

`mountApp()` treated any non-empty Mochi pet name as proof that the asynchronous config read had settled. The component starts with the already-nonempty default `Mochi`, so the helper could return before `getMochiConfig()` committed `Nimbus`; the immediately following assertions then depended on shard scheduling.

## Why it matters

This made an unrelated full frontend shard intermittently red even though the Mochi behavior was correct. A retry only changed scheduling and did not address the missing synchronization contract.

## What changed (motivation → approach → change)

- Make the mount helper wait for the configured `Nimbus` value on both pinned and watch rails.
- Hold `getMochiConfig()` behind a controlled promise in the pet-name test.
- Explicitly drain Testing Library's known fake `setTimeout(0)` wrapper step and prove the mount promise is still pending while both rails show the default `Mochi`.
- Resolve the config gate, await mount completion, and retain the exact `Nimbus` assertions on both consumers.

No retry, sleep, timeout increase, warning filter, tolerance, or assertion weakening was added.

## Tests

- Deterministic red-before: with the controlled-promise test but the old non-empty helper, the focused test fails because `mountFinished` is already `true` before config resolution.
- `vitest run src/test/MochiChatAppCoverage.test.tsx -t "passes the stored name to both rails" --reporter=verbose` — 1 passed.
- `vitest run src/test/MochiChatAppCoverage.test.tsx --reporter=verbose` — 21 passed.
- `eslint src/test/MochiChatAppCoverage.test.tsx` — passed.
- `git diff --check` and merge-tree against the push base — passed.

## Manual verification

N/A — this is test-only synchronization; rendered UI and production code are unchanged.

## Related Issues

Extracted from the unrelated CI failure found while resolving #6061; this PR does not modify #6061.

## Checklist

- [x] One Conventional Commit
- [x] Existing focused tests pass and the race has a deterministic regression test
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation not applicable — test-only change
- [x] No secrets, credentials, or internal references in the diff