### PR TITLE
fix(mcp-gateway): re-check an adopted daemon's target coverage while it serves

### DIFF
--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -24,6 +24,7 @@ import logging
 import os
 import signal
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -88,6 +89,16 @@ _ELECTION_ROUNDS = 2
 # authorised successor; that is a protocol design and is deliberately not
 # invented here.
 _MAX_STAND_DOWN_REQUESTS = 3
+# How often the watchdog RE-checks an adopted daemon's target coverage.
+# Deliberately much slower than the liveness ping: drift is a
+# config-vs-daemon mismatch that only changes when a gateway restarts or
+# its stub_servers set is edited, so probing it on every ping would buy
+# nothing and would spend the _MAX_STAND_DOWN_REQUESTS budget within ~90s
+# against an incumbent that refuses to yield. At five minutes a genuinely
+# stale survivor is repaired within one interval instead of living until
+# the next full gateway start, while a refusing incumbent still settles
+# after three asks -- bounded contention, not an unbounded loop.
+_DRIFT_RECHECK_INTERVAL_SECS = 300.0
 
 # What to do about the daemon holding the socket. Plain strings rather than an
 # Enum so they read the same in a log line as in a branch.
@@ -181,6 +192,10 @@ class GatewayManager:
     #: ``__init__``, and an instance-only attribute would raise AttributeError on
     #: every such path the moment the adoption gate reads it.
     _stand_downs_issued: int = 0
+    #: Monotonic stamp of the last adopted-daemon drift re-check. Same
+    #: class-level-default reasoning as ``_stand_downs_issued`` above: the
+    #: watchdog reads it on paths that build this object via ``__new__``.
+    _last_drift_check: float = 0.0
 
     def __init__(self, spec: GatewaySpec) -> None:
         self._spec = spec
@@ -189,6 +204,7 @@ class GatewayManager:
         self._stopping = False
         self._adopted = False
         self._stand_downs_issued = 0
+        self._last_drift_check = 0.0
         self._lifecycle_lock = asyncio.Lock()
 
     @property
@@ -293,6 +309,10 @@ class GatewayManager:
         """Adopt the daemon on the socket and supervise it. Always ``True``."""
         self._adopted = True
         self._process = None
+        # The caller just assessed coverage, so start the watchdog's
+        # re-check clock here: the first re-check lands one full interval
+        # from now rather than immediately repeating that assessment.
+        self._last_drift_check = time.monotonic()
         logger.info(
             "mcp-gateway: a healthy daemon already owns %s — adopting "
             "(no spawn)", self._spec.socket_path,
@@ -376,7 +396,19 @@ class GatewayManager:
         coverage, which is why this returns the frame rather than a bool.
         """
         # Clear any stale socket from a prior crash.
-        await self._clear_stale_socket()
+        #
+        # These two setup steps touch the filesystem, so they can raise (a full
+        # disk, a vanished parent dir, a permission change on the socket dir)
+        # -- and they sit OUTSIDE the try that guards _spawn_once below. Guard
+        # them here, at the producer, rather than at a caller: both call sites
+        # (_start_locked and the watchdog's _reconcile_adopted) already treat a
+        # None return as "the start failed outright", which is this method's
+        # documented contract, and only a guard here makes start()'s own
+        # "Never raises" contract true. An escape from this method reaches
+        # `await manager.start()` in the gateway bootstrap and, from the
+        # watchdog, terminates the supervisor task outright.
+        try:
+            await self._clear_stale_socket()
         # Owner-only containing directory: the socketsec model calls this the
         # primary access boundary (a 0600 socket alone is insufficient on a
         # shared host), and on Windows it is where the singleton lock file and
@@ -387,7 +419,14 @@ class GatewayManager:
         # -> start()), so calling it inline stalls chat turns and the liveness
         # heartbeat. Mirrors the log-file hunk below, which offloads the same
         # helper.
-        await asyncio.to_thread(transport.prepare_dir, self._spec.socket_path)
+            await asyncio.to_thread(transport.prepare_dir, self._spec.socket_path)
+        except Exception:
+            logger.exception(
+                "mcp-gateway: could not prepare %s for a daemon — "
+                "starting without a shared broker",
+                self._spec.socket_path,
+            )
+            return None
 
         try:
             await self._spawn_once()
@@ -829,6 +868,76 @@ class GatewayManager:
             except Exception:
                 pass
 
+    async def _reconcile_adopted(self, pong: dict) -> bool:
+        """Re-assess an adopted daemon's target coverage and repair a drift.
+
+        Returns ``True`` when this call CHANGED who serves the socket (or who
+        this manager thinks serves it), so the watchdog should re-enter its loop
+        immediately instead of sleeping; ``False`` means nothing moved and the
+        caller should sleep out its normal liveness interval.
+
+        This closes the one gap the start-time repair cannot reach. A target map
+        is baked into a daemon's process env at ``_spawn_once`` and a frozen
+        ``GatewaySpec`` is never re-applied, so coverage is only ever assessed at
+        a transition: adoption, or a pre-respawn gate. An adopted daemon that
+        keeps answering ping sits in neither -- it is supervised purely for
+        liveness -- so a survivor that goes stale AFTER adoption (the gateway
+        restarts with a new ``stub_servers`` set while the daemon lives on) stays
+        stale for as long as it holds the socket. That is the 25-day-old daemon
+        from the field, and the reason the repair had to wait for a full gateway
+        start to fire.
+
+        Rechecking costs nothing extra on the wire: the liveness ping's own reply
+        already carries the coverage report, so this reads a frame the watchdog
+        was fetching anyway.
+        """
+        now = time.monotonic()
+        if now - self._last_drift_check < _DRIFT_RECHECK_INTERVAL_SECS:
+            return False
+        self._last_drift_check = now
+        missing = self._adoption_drift(pong)
+        if not missing:
+            return False
+        verdict = await self._repair_or_adopt(missing)
+        if verdict != _SPAWN:
+            # _ADOPT: it will not yield (or this manager has spent its
+            # stand-down budget) and the cost is already on the record via
+            # _adoption_drift/_repair_or_adopt. _ABORT: it accepted but is still
+            # draining, so right now it is neither adoptable nor replaceable --
+            # the next cycle either finds the socket free (the ping fails and
+            # the death path spawns a replacement) or finds a new daemon to
+            # assess. Either way, keep supervising and do not spin.
+            return False
+        # It released the socket. Take it the same way a start would, so the
+        # flock still arbitrates if a sibling gateway races us for the freed
+        # lock. Drop adoption first: _spawn_and_confirm sets _process, and
+        # leaving _adopted True alongside it would put the watchdog in both
+        # branches at once.
+        self._adopted = False
+        # A setup failure inside _spawn_and_confirm surfaces as None (it guards
+        # its own filesystem steps), so it lands in the restore branch below
+        # rather than escaping and killing this watchdog task.
+        spawned = await self._spawn_and_confirm()
+        if spawned is None or not self.is_running:
+            # Either nothing serves the socket now, or our spawn lost the freed
+            # lock to another gateway instance. This manager holds no usable
+            # process either way, so go back to adopted and let the next
+            # iteration assess whoever answers -- re-checking it is bounded by
+            # _MAX_STAND_DOWN_REQUESTS, so a foreign daemon that also drifted
+            # cannot make this trade sockets forever. Deliberately NOT via
+            # _adopt_incumbent(), which starts a second watchdog task.
+            self._adopted = True
+            self._process = None
+            self._last_drift_check = time.monotonic()
+            return True
+        logger.info(
+            "mcp-gateway: replaced a drifted adopted daemon on %s -- pid=%s now "
+            "serves the current target map",
+            self._spec.socket_path,
+            self._process.pid if self._process else "?",
+        )
+        return True
+
     async def _run_watchdog(self) -> None:
         """Supervise the daemon: respawn on exit or on liveness failure.
 
@@ -849,7 +958,16 @@ class GatewayManager:
                     # adoption and try to become the owner. The flock
                     # arbitrates if a sibling races us; a flock-loser exits
                     # rc=0 and we re-adopt on the next loop.
-                    if await self._ping_once():
+                    #
+                    # The reply also carries the daemon's target coverage,
+                    # so the round-trip that proves liveness re-checks
+                    # drift too: an adopted daemon never re-applies a spec,
+                    # so without this a survivor that goes stale after
+                    # adoption stays stale for its whole life.
+                    pong = await self._ping_payload()
+                    if pong is not None:
+                        if await self._reconcile_adopted(pong):
+                            continue
                         await asyncio.sleep(_LIVENESS_PING_INTERVAL_SECS)
                         continue
                     logger.warning(
@@ -988,6 +1106,13 @@ class GatewayManager:
                     continue
                 if verdict == _ADOPT:
                     self._adopted = True
+                    # Coverage was just assessed above, so start the
+                    # drift re-check clock here as _adopt_incumbent
+                    # does. Without it this manager's _last_drift_check
+                    # stays 0.0 and the adopted branch re-assesses on
+                    # its very first iteration, spending a stand-down
+                    # from the cap for no new information.
+                    self._last_drift_check = time.monotonic()
                     logger.info(
                         "mcp-gateway: socket %s already served by another daemon "
                         "— adopting; watchdog will supervise it via ping",

--- a/test/test_mcp_gateway_adopted_daemon_repair.py
+++ b/test/test_mcp_gateway_adopted_daemon_repair.py
@@ -362,6 +362,341 @@ class TestOscillationCap:
         assert bare._stand_downs_issued == 0
 
 
+class TestAdoptedDriftRecheck:
+    """Re-checking coverage while the daemon is merely being kept alive.
+
+    ``TestElection`` pins the start-time repair. That fires only at a
+    transition -- adoption, or the pre-respawn gate -- and an adopted daemon
+    that keeps answering ping is in neither: the watchdog supervises it for
+    LIVENESS alone. So a survivor that goes stale AFTER adoption (the gateway
+    restarts with a new stub_servers set while the daemon lives on) kept its
+    stale map for as long as it held the socket. That is the 25-day-old daemon
+    from the field; this class pins the loop that now catches it.
+
+    The re-check rides the liveness ping's own reply, so it costs nothing extra
+    on the wire -- the coverage report is in a frame the watchdog already reads.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_fit_adopted_daemon_is_left_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        asked = AsyncMock(return_value=mgr._SPAWN)
+        monkeypatch.setattr(manager, "_repair_or_adopt", asked)
+        assert await manager._reconcile_adopted({"type": "pong", "targets": ["CORE"]}) is False
+        asked.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_recheck_is_rate_limited_to_its_own_interval(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cadence is the whole reason this is safe to run in the loop.
+
+        The liveness ping is every 30s and a manager may only ever issue
+        _MAX_STAND_DOWN_REQUESTS stand-downs, so re-assessing on every ping
+        would spend that entire budget within ~90s against an incumbent that
+        refuses to yield -- and then never ask again for the life of the
+        process. One assessment per interval is what keeps the repair available.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        asked = AsyncMock(return_value=mgr._ADOPT)
+        monkeypatch.setattr(manager, "_repair_or_adopt", asked)
+        pong = {"type": "pong", "targets": []}
+
+        assert await manager._reconcile_adopted(pong) is False
+        assert asked.await_count == 1, "the first call assesses"
+        for _ in range(5):
+            assert await manager._reconcile_adopted(pong) is False
+        assert asked.await_count == 1, "further pings inside the interval must not re-ask"
+
+        manager._last_drift_check -= mgr._DRIFT_RECHECK_INTERVAL_SECS
+        assert await manager._reconcile_adopted(pong) is False
+        assert asked.await_count == 2, "a new interval assesses again"
+
+    @pytest.mark.asyncio
+    async def test_a_drifted_adopted_daemon_is_repaired_and_replaced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        # _reconcile_adopted is only ever reached from the watchdog's adopted
+        # branch, so anything asserting on _adopted must start there.
+        manager._adopted = True
+        monkeypatch.setattr(manager, "_repair_or_adopt", AsyncMock(return_value=mgr._SPAWN))
+        ours = MagicMock()
+        ours.pid = 4242
+        ours.returncode = None
+
+        async def _spawned() -> dict:
+            manager._process = ours
+            return {"type": "pong", "targets": ["CORE"]}
+
+        monkeypatch.setattr(manager, "_spawn_and_confirm", AsyncMock(side_effect=_spawned))
+        assert await manager._reconcile_adopted({"type": "pong", "targets": []}) is True
+        assert manager._adopted is False, "we own the daemon now"
+        assert manager.is_running
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("verdict", [mgr._ADOPT, mgr._ABORT])
+    async def test_an_unyielding_incumbent_stays_adopted_without_spinning(
+        self, verdict: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Neither refusal nor draining may make the watchdog hot-loop.
+
+        Returning True here would send the loop straight back around with no
+        sleep, re-pinging a daemon that just declined -- burning CPU for as long
+        as the drift lasts. False means the caller sleeps out its liveness
+        interval, which is also what gives a draining daemon time to finish (the
+        next ping then fails and the death path spawns a replacement).
+
+        Note this differs from ``start()``, which FAILS on _ABORT: a start that
+        reported ready would hand sessions a daemon accepting nothing, whereas
+        the watchdog is already supervising and simply keeps doing so.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        # _reconcile_adopted is only ever reached from the watchdog's adopted
+        # branch, so anything asserting on _adopted must start there.
+        manager._adopted = True
+        monkeypatch.setattr(manager, "_repair_or_adopt", AsyncMock(return_value=verdict))
+        spawn = AsyncMock()
+        monkeypatch.setattr(manager, "_spawn_and_confirm", spawn)
+        assert await manager._reconcile_adopted({"type": "pong", "targets": []}) is False
+        assert manager._adopted is True
+        spawn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("outcome", ["nothing_serves", "lost_the_race"])
+    async def test_a_yield_we_could_not_capitalise_on_returns_to_adoption(
+        self, outcome: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two ways our spawn does not end up ours, one recovery.
+
+        The incumbent released the socket, but either the spawn failed outright
+        or a sibling gateway won the freed lock first. Either way this manager
+        holds no usable process, so it must go back to the adopted branch --
+        leaving _adopted False with _process None idles the watchdog forever
+        with no daemon and no retry.
+
+        Recovery deliberately does NOT go through _adopt_incumbent(), which
+        starts a watchdog task: calling it from inside the watchdog would leave
+        a second, uncancellable supervisor running.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        # _reconcile_adopted is only ever reached from the watchdog's adopted
+        # branch, so anything asserting on _adopted must start there.
+        manager._adopted = True
+        monkeypatch.setattr(manager, "_repair_or_adopt", AsyncMock(return_value=mgr._SPAWN))
+        # A foreign daemon answering (flock loser exits rc=0, so _process stays
+        # unusable) vs the spawn failing outright.
+        reply = None if outcome == "nothing_serves" else {"type": "pong", "targets": ["CORE"]}
+        monkeypatch.setattr(manager, "_spawn_and_confirm", AsyncMock(return_value=reply))
+        watchdogs: list[object] = []
+        monkeypatch.setattr(
+            manager, "_adopt_incumbent", lambda: watchdogs.append("started") or True
+        )
+
+        assert await manager._reconcile_adopted({"type": "pong", "targets": []}) is True
+        assert manager._adopted is True, "must return to the adopted branch"
+        assert manager._process is None
+        assert not watchdogs, "must not re-enter _adopt_incumbent (it starts a watchdog)"
+
+    @pytest.mark.asyncio
+    async def test_adoption_starts_the_recheck_clock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Coverage was just assessed, so the first re-check waits a full interval.
+
+        Without this the watchdog's very first ping would repeat the assessment
+        the adoption gate had just made, and against a refusing incumbent that
+        spends a stand-down from the cap for no new information.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        monkeypatch.setattr(manager, "_run_watchdog", AsyncMock())
+        assert manager._last_drift_check == 0.0
+        assert manager._adopt_incumbent() is True
+        assert manager._last_drift_check > 0.0
+        if manager._watchdog is not None:
+            manager._watchdog.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await manager._watchdog
+
+        asked = AsyncMock(return_value=mgr._SPAWN)
+        monkeypatch.setattr(manager, "_repair_or_adopt", asked)
+        assert await manager._reconcile_adopted({"type": "pong", "targets": []}) is False
+        asked.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_spawn_setup_failure_does_not_kill_the_watchdog(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The repair may not cost us the supervisor.
+
+        _spawn_and_confirm guards _spawn_once, but its _clear_stale_socket and
+        prepare_dir steps run OUTSIDE that guard, so an OSError there (a full
+        disk, a vanished parent dir, a permission change) propagates. Unguarded,
+        it escapes the watchdog's adopted branch and terminates the supervisor
+        task -- the daemon then has NO watchdog at all, which is strictly worse
+        than the drift the repair came to fix.
+
+        Asserted on the loop, not just the helper: a passing return value proves
+        nothing if the exception killed the caller.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        manager._adopted = True
+        manager._process = None
+        pong = {"type": "pong", "targets": []}
+        pings = 0
+
+        async def _ping() -> dict:
+            nonlocal pings
+            pings += 1
+            # Stop after this cycle: a True return `continue`s to the loop
+            # condition, so the watchdog exits without sleeping out its
+            # liveness interval. An UNGUARDED OSError never reaches here at
+            # all -- it propagates and _run_watchdog raises, which is the
+            # regression this pins.
+            manager._stopping = True
+            return pong
+
+        monkeypatch.setattr(manager, "_ping_payload", _ping)
+        monkeypatch.setattr(manager, "_repair_or_adopt", AsyncMock(return_value=mgr._SPAWN))
+        # Raise from the real producer step, not from _spawn_and_confirm itself:
+        # the guard lives inside that method, so mocking it to raise would pin a
+        # guard that no longer exists there and would miss a regression at its
+        # other call site.
+        monkeypatch.setattr(
+            manager,
+            "_clear_stale_socket",
+            AsyncMock(side_effect=OSError("no space left on device")),
+        )
+        monkeypatch.setattr(manager, "_spawn_once", AsyncMock())
+
+        # Must not raise: the watchdog has to survive its own repair attempt.
+        await asyncio.wait_for(manager._run_watchdog(), timeout=5)
+
+        assert pings == 1
+        assert manager._adopted is True, "adoption must be restored, not left dangling"
+        assert manager._process is None
+
+    @pytest.mark.asyncio
+    async def test_the_respawn_gate_adoption_also_starts_the_recheck_clock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every path that ADOPTS owes the clock stamp, not just _adopt_incumbent.
+
+        The watchdog's pre-respawn gate adopts an incumbent inline (it must not
+        call _adopt_incumbent, which would start a second watchdog). It had
+        assessed coverage one line earlier but left _last_drift_check at 0.0, so
+        the adopted branch's very first iteration saw an elapsed interval of
+        `now - 0.0` and re-assessed immediately -- spending a stand-down from the
+        lifetime cap to re-derive what the gate had just decided.
+        """
+        monkeypatch.setattr(mgr, "_RESPAWN_BACKOFF_START_SECS", 0.0)
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        manager._adopted = False
+
+        exited = MagicMock()
+        exited.pid = 999
+        exited.returncode = 0
+        exited.wait = AsyncMock(return_value=0)
+        manager._process = exited
+
+        async def _never() -> str:
+            await asyncio.sleep(3600)
+            return "unreachable"
+
+        monkeypatch.setattr(manager, "_liveness_probe_loop", _never)
+        # A fit incumbent holds the socket: drift is empty, so the gate adopts.
+        monkeypatch.setattr(
+            manager,
+            "_ping_payload",
+            AsyncMock(return_value={"type": "pong", "targets": ["CORE"]}),
+        )
+        seen: list[float] = []
+
+        async def _capture(frame: dict) -> bool:
+            seen.append(manager._last_drift_check)
+            manager._stopping = True
+            return True
+
+        monkeypatch.setattr(manager, "_reconcile_adopted", AsyncMock(side_effect=_capture))
+        await asyncio.wait_for(manager._run_watchdog(), timeout=5)
+
+        assert manager._adopted is True
+        assert seen, "the adopted branch never ran, so the gate was not exercised"
+        assert seen[0] > 0.0, "the respawn gate adopted without starting the clock"
+
+    @pytest.mark.asyncio
+    async def test_start_returns_false_rather_than_raising_on_a_setup_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sibling call site, and the contract that made it matter.
+
+        `_spawn_and_confirm` has two callers. Guarding only the watchdog's would
+        leave `_start_locked`'s untouched, where the same OSError escapes
+        `start()` -- whose docstring promises "Never raises -- callers treat a
+        False return as fall back to per-session MCP" -- and reaches the
+        unguarded `await manager.start()` in the gateway bootstrap, failing
+        gateway startup instead of degrading to per-session MCP.
+
+        Guarding the producer covers both callers at once, which is why this
+        test lives beside the watchdog one: they are the same defect.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        # Nobody holds the socket, so the election goes straight to spawning.
+        monkeypatch.setattr(manager, "_ping_payload", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            manager,
+            "_clear_stale_socket",
+            AsyncMock(side_effect=OSError("no space left on device")),
+        )
+        spawn = AsyncMock()
+        monkeypatch.setattr(manager, "_spawn_once", spawn)
+
+        assert await manager.start() is False, "start() must fall back, not raise"
+        spawn.assert_not_awaited(), "a failed setup must not proceed to spawn"
+        assert manager._watchdog is None, "no supervisor for a start that failed"
+
+    def test_the_stamp_is_total_without_init(self) -> None:
+        """Built via __new__, as several call sites and tests do."""
+        bare = mgr.GatewayManager.__new__(mgr.GatewayManager)
+        assert bare._last_drift_check == 0.0
+
+    @pytest.mark.asyncio
+    async def test_the_watchdog_reconciles_on_the_liveness_reply(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The wiring: the adopted branch must read the pong, not just a bool.
+
+        _ping_once() throws the payload away, so a watchdog built on it could
+        never see coverage. This pins that the branch reads _ping_payload and
+        hands the frame to the reconciler.
+        """
+        manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
+        manager._adopted = True
+        manager._process = None
+        pong = {"type": "pong", "targets": []}
+        monkeypatch.setattr(manager, "_ping_payload", AsyncMock(return_value=pong))
+        monkeypatch.setattr(
+            manager,
+            "_ping_once",
+            AsyncMock(
+                side_effect=AssertionError(
+                    "the adopted branch must read the pong payload, not a bare bool"
+                )
+            ),
+        )
+
+        async def _stop_after_one(frame: dict) -> bool:
+            assert frame is pong
+            manager._stopping = True
+            return True  # True short-circuits the sleep, so the loop exits at once
+
+        monkeypatch.setattr(manager, "_reconcile_adopted", AsyncMock(side_effect=_stop_after_one))
+        await asyncio.wait_for(manager._run_watchdog(), timeout=5)
+        assert manager._reconcile_adopted.await_count == 1  # type: ignore[attr-defined]
+
+
 # ── the election ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem / Motivation

A gateway daemon's MCP target map is baked into its process env at `_spawn_once`, and a frozen `GatewaySpec` is never re-applied to a survivor. #6535 repairs a stale adopted daemon, but only at a **transition**: coverage is assessed at adoption (`_start_locked`) and at the watchdog's pre-respawn gate.

An adopted daemon that keeps answering ping is in neither. The watchdog's adopted branch called `_ping_once()`, which throws the pong away, so it supervised **liveness alone** — never coverage. A survivor that went stale *after* adoption (the gateway restarts with a new `stub_servers` set while the daemon lives on) therefore kept its stale map for as long as it held the socket.

Observed in the field: a 25-day-old daemon that had silently removed `kirocrew-core`'s entire tool surface from every session — 25 registrations, 0 recalls, while its `excalidraw`/`pdf` peers sat at a healthy 65–70%. Repaired only when somebody restarted the gateway or killed the process by hand.

## Why it matters

The degradation is invisible and self-perpetuating. Tools still work (the `ensure_backend` pre-flight answers an unknown target with `fallback: true`, so a stub degrades to a per-session exec instead of dying), so nothing *looks* broken — the session silently loses backend pooling and the strict session key for every drifted server, on every session, for the daemon's whole life.

Because a stale daemon keeps answering ping, no existing signal fires. #6535's repair exists and works; nothing was reaching it once the loop was running.

## What changed (motivation → approach → change)

**Symptom:** a drifted adopted daemon serves a stale map indefinitely.
**Direct cause:** the watchdog's adopted branch read a bool, not the pong — it had no coverage information to act on.
**Root cause:** coverage was only ever assessed at a lifecycle transition, and a healthy-but-stale adopted daemon never reaches one.

**Fix.** The adopted branch now reads `_ping_payload()` — the coverage report is already in the frame it was fetching — and hands it to a new `_reconcile_adopted`, which runs the *existing* `_adoption_drift` → `_repair_or_adopt` path. No new wire traffic, no new repair mechanism; this only reaches the one already there.

**Cadence is what makes it safe in the loop.** Re-checking on every ping (30s) would spend the whole `_MAX_STAND_DOWN_REQUESTS` budget within ~90s against an incumbent that refuses to yield, and then never ask again for the life of the process. `_DRIFT_RECHECK_INTERVAL_SECS = 300` repairs a genuinely stale survivor within one interval while keeping contention bounded, and **every path that adopts** starts the clock so the first re-check does not simply repeat the assessment the adopting caller just made.

**It also closes a pre-existing hole that the new caller exposed.** `_spawn_and_confirm` guarded `_spawn_once` but *not* its own `_clear_stale_socket` / `prepare_dir` steps, so a filesystem error there escaped the method — from the watchdog it terminated the supervisor task outright, and from `_start_locked` it escaped `start()`, whose docstring promises *"Never raises — callers treat a `False` return as fall back to per-session MCP"*, reaching the unguarded `await manager.start()` in the gateway bootstrap. The guard therefore lives in `_spawn_and_confirm` itself, returning the `None` its docstring already defines as *"the start failed outright"*: **one guard covers both call sites**, `start()`'s contract becomes true, and no caller-side handler is needed because both callers already treat `None` as failure. That made the diff smaller than the version first reviewed.

Behaviours the tests pin, each a hazard found in review:

- **a spawn SETUP failure kills neither the watchdog nor gateway startup** — pinned at *both* call sites, and removing the single producer-side guard fails both tests.
- **both adopting paths stamp the re-check clock.** The pre-respawn gate adopts inline (it must not call `_adopt_incumbent`, which would start a second watchdog) and left `_last_drift_check` at `0.0`, so a fresh owner manager re-assessed on its very first adopted-branch iteration and spent a stand-down re-deriving what the gate had just decided.
- a non-`_SPAWN` verdict returns `False` so the caller sleeps — returning `True` would hot-loop the watchdog for as long as the drift lasted.
- a yield we could not capitalise on (spawn failed, or a sibling gateway won the freed lock) restores `_adopted`, or the watchdog idles forever with no daemon and no retry.
- that restore deliberately does **not** go through `_adopt_incumbent()`, which starts a watchdog task — calling it from inside the watchdog would leave a second, uncancellable supervisor running.

**Deliberately NOT done:** persisting `_stand_downs_issued` across manager instances. A restart re-arming the budget is correct, not a leak — the counter exists to stop two *live* gateways trading a socket, and an operator who just fixed `stub_servers` and restarted must not inherit a spent budget that refuses to repair.

## Tests

`TestAdoptedDriftRecheck` in `test/test_mcp_gateway_adopted_daemon_repair.py` — 13 cases:

| Test | Behaviour locked in |
|---|---|
| `test_a_fit_adopted_daemon_is_left_alone` | full coverage ⇒ no stand-down attempted |
| `test_the_recheck_is_rate_limited_to_its_own_interval` | one assessment per interval; further pings inside it must not re-ask (this is what preserves the stand-down budget) |
| `test_a_drifted_adopted_daemon_is_repaired_and_replaced` | drift + yield ⇒ adoption cleared, our process owns the socket |
| `test_a_spawn_setup_failure_does_not_kill_the_watchdog` | an `OSError` from the real producer step is absorbed, adoption restored, and **`_run_watchdog` returns instead of raising** — asserted on the loop, since a helper's return value proves nothing if the exception killed its caller |
| `test_start_returns_false_rather_than_raising_on_a_setup_failure` | the sibling call site: `start()` honours its documented "never raises" contract and falls back instead of failing gateway startup |
| `test_the_respawn_gate_adoption_also_starts_the_recheck_clock` | the inline adoption at the pre-respawn gate stamps the clock, so the adopted branch does not immediately re-assess |
| `test_an_unyielding_incumbent_stays_adopted_without_spinning` (×2: `_ADOPT`, `_ABORT`) | returns `False` so the caller sleeps; no spawn attempted; adoption untouched |
| `test_a_yield_we_could_not_capitalise_on_returns_to_adoption` (×2: spawn failed, lost the race) | adoption restored, `_process` cleared, `_adopt_incumbent()` not re-entered |
| `test_adoption_starts_the_recheck_clock` | first re-check waits a full interval instead of repeating the adoption gate's assessment |
| `test_the_stamp_is_total_without_init` | class-level default survives the `__new__` construction path |
| `test_the_watchdog_reconciles_on_the_liveness_reply` | the wiring: the branch reads `_ping_payload`, not a bare bool, and hands the frame over |

**Mutation-verified** — each guard broken in turn, each caught:

| Mutation | Result |
|---|---|
| interval guard removed (re-assess every ping) | 2 failed |
| watchdog reads a bare bool again (`_ping_once`) | 1 failed |
| adoption not restored after an unusable yield | 2 failed |
| non-`_SPAWN` verdict returns `True` (spins) | 3 failed |
| adoption does not start the re-check clock | 1 failed |
| respawn gate adopts without starting the clock | 1 failed |
| **producer-side setup guard removed** | **2 failed — one per call site** |

Source restored and re-run clean after each (13 passed). Full suite: **1210 passed / 12 skipped** across the `mcp_gateway` + `gatewayd` suites.

## Manual verification

N/A — unit coverage sufficient. The repair path itself (`_request_stand_down` → real daemon yields → replacement binds) is already covered end-to-end by the existing `TestElection` / `TestRequestStandDown` suites in this file, which spawn real daemons; this change only adds a new *caller* of that path, and the caller's decision table is what the new tests pin.

Field state was confirmed separately before writing the fix: on that host `kirocrew-core` registered 33 times against `excalidraw` 33 / `pdf` 33 with zero rejections, 12 stubs across 4 sessions sharing 3 pooled backends — i.e. the drift class was already repaired there, which is why this fix targets **recurrence** rather than a live symptom.

## Related Issues

no linked issue: this is a follow-up to two merged PRs, not a tracked issue. #6432 added detection + safe degradation and #6535 added the repair at start; this closes the reachability gap the latter left, so its repair now also fires while the daemon is merely being kept alive.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Local gates green: flake8, isort, mypy, black-baseline, subprocess-encoding, loop-bound-locks
- [x] Local review lanes run before each push — GPT (`gpt-5.6-sol`) and Opus (`claude-opus-4.8`) against their CI-extracted contracts
- [x] Every raised concern answered on the PR: GPT blocking (fixed), Opus advisory (fixed), First Principles CONCERNS (fixed, subtraction applied as proposed)
- [x] Single commit, 0 behind `origin/main`
- [x] No user-visible UI change (Screenshots section deleted per template)
