### PR TITLE
chore(security): remove confirmed dead code in the platform and security surface

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -11137,28 +11137,6 @@ def normalize_shell_command(cmd: str) -> list[str]:
     return resolved
 
 
-def resolve_command_paths(tokens: list[str]) -> list[str]:
-    """Resolve path-like tokens to their canonical absolute form.
-
-    Runs os.path.realpath() on tokens that look like filesystem paths
-    (start with /, ~, ./, or ../) to resolve symlinks and directory traversal.
-    Non-path tokens are returned unchanged.
-
-    Args:
-        tokens: List of shell tokens (typically from normalize_shell_command).
-
-    Returns:
-        New list with path-like tokens resolved to their realpath.
-    """
-    resolved: list[str] = []
-    for token in tokens:
-        if _is_path_like(token):
-            resolved.append(os.path.realpath(token))
-        else:
-            resolved.append(token)
-    return resolved
-
-
 # Drive-letter absolute path (``C:\...`` or ``C:/...``). Anchored to a single
 # ASCII letter + colon + separator so ``key:value`` option tokens do not match.
 _WIN_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
@@ -11385,14 +11363,6 @@ _IMDS_IP = "169.254.169.254"
 # because canonicalize_ip returns native IPv6 unchanged; mirrors embeddings.py's
 # SSRF gate which also blocks it (CWE-918 dual-stack parity).
 _IMDS_IPV6 = "fd00:ec2::254"
-
-# HTTP tools that can fetch IMDS -- broader than just curl/wget
-_HTTP_TOOLS_RE = re.compile(
-    r"(?:curl|wget|http|https|fetch|lwp-request|lynx|links|"
-    r"python|ruby|perl|node|nc|ncat|socat|telnet|"
-    r"Invoke-WebRequest|Invoke-RestMethod|iwr|irm)\b",
-    re.IGNORECASE,
-)
 
 
 def _check_imds_access(command: str) -> str | None:


### PR DESCRIPTION
Dead-code audit of the platform / security surface: `src/kiro_crew/platform/`, `platform_compat.py`, `security.py`, `security_posture.py`, `sel.py`, `sandbox.py`, `src/kiro_crew/secrets/`, `src/kiro_crew/auth/` — 46,127 lines, 1,797 module/class-level definitions.

This group is audited at a deliberately higher bar than the others, so the result is small on purpose: **2 symbols, 30 lines, one file, zero behaviour change.** Everything else that scanned as unreferenced is either exempt by construction or reported below rather than deleted.

## Candidate generation — three independent scans

| Scan | Method | Findings |
|---|---|---|
| vulture | `--min-confidence 60` | 374 |
| AST | defined names minus repo-wide `Load` / `Attribute` / `ImportFrom` / `keyword` names | — |
| tokenize | real `NAME` tokens only (docstrings, comments and same-spelled strings excluded), repo-wide, minus self-definitions | — |

**Triple intersection: 12 candidates.** A supplementary module-level-only pass (top-level funcs/classes with zero AST references, excluding structurally exempt files) returned 2, both already inside the 12 — so the strict intersection missed nothing at module level.

A separate unreachable-branch pass (statements after `return` / `raise` / `break` / `continue`, and constant-valued `if` / `while` tests) returned 12 hits that are **all idiomatic `while True:`**. There is no genuinely unreachable branch in this surface.

### Why vulture's 374 findings do not become candidates

Three categories dominate and are exempt by construction:

- **`platform/interfaces.py`** (1,271 lines) — Protocol definitions; every method is definitionally uncalled. The codebase already carries a formal registry for exactly this: `platform/context.py:141 RESERVED_METHODS` is a *declared-inert contract surface* documenting, per slot, why a Protocol method has no core call site (e.g. `agent_runtime.managed_mcp_servers`, `identity.whoami`). Their uncalledness is documented design, not decay.
- **`platform/defaults.py`** (511 lines) — the OSS default implementations of those Protocols, reached through the adapter table rather than by name.
- **`platform_compat.py`** (5,224 lines) — platform shims. Windows/macOS branches unreachable on a Linux host are live elsewhere.

`sel.py` audit emit sites were not considered for deletion at all: a missing emit is a missing audit record.

## Deleted (2 symbols, 30 lines)

### `resolve_command_paths` — `security.py:11140-11159` (20 lines)

- Exactly one occurrence repo-wide before this change (its own definition), across `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1`, plus `test/`, `docs/`, `docs/system-specs/`, `.github/`, `pyproject.toml`. No string, `getattr`, dispatch-table, `globals()`, `importlib` or entry-point consumer.
- `security.py` declares no `__all__`; the symbol is not re-exported from `kiro_crew/__init__.py` and appears in no spec or SKILL.md.
- Its whole job — realpath-canonicalizing path-like tokens out of `normalize_shell_command` — is done inside `is_sensitive_path()` (`security.py:6268`) via `_candidate_forms()` (`security.py:5967`), which applies realpath, `Path.resolve`, lexical normalization, expansion and fallback forms **and then matches**. The live path `_check_sensitive_via_normalizer` routes every path-like operand through it at `security.py:7532` and `:7767`; `docs/system-specs/modules/security.md:155` names that path authoritative ("one implementation is authoritative on both surfaces").
- Redundant, not an unwired guard: it only canonicalized and never blocked, so it was never a gate nor part of one. Introduced 2026-07-16 (45 days).

### `_HTTP_TOOLS_RE` — `security.py:11390-11395` (6 lines, net 8 with spacing)

- Exactly one occurrence repo-wide before this change (its own definition).
- Its unambiguous intended consumer `_check_imds_access` (live — called at `security.py:6647`, tested in `test/test_security.py:4601-4624`, spec'd at `docs/system-specs/modules/security.md:617`) **deliberately declines to narrow by tool**. Inline comment at the block point: *"Found IMDS IP -- block regardless of tool since even echo piped into nc could exfil credentials from the metadata service."* The narrowing was abandoned by design, not left pending, so removing the pattern cannot weaken the gate.
- No other URL, credential or exfiltration guard in the module wants a tool-name pattern; each carries its own purpose-built one. Introduced 2026-07-16 (45 days).

Neither symbol had a test, so no test was deleted and no source-presence assertion was relaxed. `_is_path_like` remains live (`security.py:7532`, `:7767`); `os` and `re` remain in heavy use.

## Deferred — 30-day new-code gate

Confirmed unreferenced but too new to delete:

| Symbol | File:line | Introduced | Age |
|---|---|---|---|
| `bind_allowed_port` | `auth/login/portal.py:64-76` | 2026-08-27 | 3d |
| `BUILDER_ID_REGION` | `auth/login/endpoints.py:37` | 2026-08-27 | 3d |
| `AMZN_START_URL` | `auth/login/endpoints.py:39` | 2026-08-27 | 3d |
| `ProfileStore.for_bind` | `platform/governance_profiles.py:770-776` | 2026-08-26 | 4d |
| `MANAGED_BY_NONE` | `platform/update_capability.py:40` | 2026-08-20 | 10d |
| `MODE_AUTO` | `platform/update_capability.py:43` | 2026-08-20 | 10d |
| `CHECK_CHECKING` | `platform/update_capability.py:51` | 2026-08-20 | 10d |
| `SecretValue.__hash__` | `secrets/vault.py:73-74` | 2026-08-19 | 11d |
| `_SENSITIVE_SEGMENT_ALT` | `security.py:6525` | 2026-08-12 | 18d |

## Needs a decision — deadness here is a defect, not dead code

Reported rather than deleted. Each wants wiring or an explicit call, which is a design decision outside a cleanup PR.

1. **`auth/login/portal.py` is an unwired login flow.** `wait_for_callback` (docstring: "Serve the **pre-bound** loopback socket") requires a bound socket, and `bind_allowed_port` is the only function that produces one — yet nothing in production calls either. `bind_allowed_port` is also the enforcement point for the Cognito **port allowlist** (`CALLBACK_PORTS`): binding anywhere else is what it exists to prevent. Every sibling helper in the module (`generate_code_verifier`, `generate_code_challenge`, `generate_state`, `build_auth_url`, `rebuild_redirect_uri`, `exchange_code`) is exercised only by `test/test_kas_auth_helpers.py` and `test/test_kas_auth_flows.py`. The production login path is the **device** flow (`auth/service.py:57 KasLoginService` → `dashboard/handlers/kas_login.py`); the portal/loopback flow looks built but never connected.

2. **`BUILDER_ID_REGION = "us-east-1"` sits unused while `auth/refresh.py:167` hardcodes the same literal** (`region = token.region or "us-east-1"`). That constant should almost certainly be imported there rather than deleted.

3. **`PlatformContext.is_enterprise`** (`platform/context.py:356-357`) has zero real references — the only other hit, `test/test_cpp_wiring_enterprise.py:192 test_identity_is_enterprise`, is a **test function name**, a substring rather than a call. It is nonetheless a public property on `PlatformContext`, which `platform/__init__.py` exports in `__all__` and whose module docstring defines the CPP seam: *"an enterprise companion imports `build_default_context` + the interfaces and supplies its own adapters."* An out-of-tree companion reading `ctx.is_enterprise` is invisible from here, so it is kept. If the seam is meant to be closed it is deletable; otherwise it likely belongs in the `RESERVED_METHODS`-style declared-inert documentation so the next audit does not re-raise it.

## Verification

- `test/test_security.py` — 995 passed, 1 skipped.
- `test/test_denied_commands_security.py`, `test/test_governance_self_protection.py`, `test/test_platform_context.py`, `test/test_kas_auth_helpers.py` — 674 passed.
- `flake8` clean, `isort --check` clean, `mypy src/kiro_crew/security.py` clean.
- `black --check` fails on `security.py` identically on unmodified `origin/main` (Python 3.12 parsing a `py314` target; the reported hunks are at lines 210 / 2443 / 2808, nowhere near this diff) — pre-existing and environmental, deliberately not touched.
- Post-deletion grep confirms zero residual references to either symbol.
- Two local AI reviewer lanes run before pushing (reachability / unwired-guard, and public-surface / hygiene): both returned no findings. One wording nit — "strictly stronger" in the original commit message — was corrected, since the deleted helper only canonicalized while `is_sensitive_path()` canonicalizes *and* matches, making them non-equivalent rather than one being a stronger form of the other.
