### PR TITLE
chore(dashboard): remove confirmed dead code in the dashboard core

### DIFF
--- a/src/kiro_crew/dashboard/crash_dump_store.py
+++ b/src/kiro_crew/dashboard/crash_dump_store.py
@@ -692,8 +692,3 @@ def dump_replay_lines(
         result.append(ln)
         total += len(ln)
     return result, False
-
-
-def get_active_dump_file() -> DumpFile | None:
-    """Return the currently active dump file (for passing to faulthandler)."""
-    return _active_dump_file

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -6623,10 +6623,6 @@ class DashboardState:
         except ValueError:
             pass
 
-    def mark_notifications_read(self) -> None:
-        """Reset unread counter (called when client opens notification panel)."""
-        self._unread_count = 0
-
     async def _rewrite_notifications_async(self) -> None:
         """Rewrite the notifications file on the I/O executor and await it.
 

--- a/src/kiro_crew/dashboard/theme_validate.py
+++ b/src/kiro_crew/dashboard/theme_validate.py
@@ -1600,7 +1600,3 @@ def _resolve_theme_asset(slug: str, subpath: str) -> tuple[Path | None, str | No
     if not target.is_file() or target.is_symlink():
         return None, "not found"
     return target, None
-
-
-def _read_theme_text(target: Path) -> str:
-    return target.read_text(encoding="utf-8", errors="replace")


### PR DESCRIPTION
Removes three symbols (13 lines) from the dashboard core that no code reaches. No behaviour change, no refactor, no reformatting.

Scope: top-level `src/kiro_crew/dashboard/*.py` only. `handlers/`, `routes/`, `handlers_instances.py` and `handlers_system.py` are excluded — they are covered separately. Those excluded paths were still scanned as *callers*, so a symbol consumed by a handler is correctly treated as alive.

## Deleted

### `get_active_dump_file()` — `crash_dump_store.py:697-699`

Exactly one repo-wide occurrence: its own definition. Searched `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1` including `test/`, `docs/`, `docs/system-specs/`, `src/kiro_crew/builtin_skills/`, `.github/` and `pyproject.toml` entry points, plus the bare-string form and every `getattr` / `globals()` / `importlib` / dispatch-table / `unittest.mock.patch`-target path. Not in any `__all__`. Last touched 44 days ago.

Its docstring ("for passing to faulthandler") invites the reading that this is a half-wired link, so that was checked specifically: faulthandler is already wired through `open_dump_file()`'s **return value** — `server.py:3525` `_dump_file = await asyncio.to_thread(open_dump_file)` → `server.py:3538` `LoopStallWatchdog(dump_file=_dump_file, …)`. The accessor was never on that path.

The `_active_dump_file` module global at `crash_dump_store.py:60` is deliberately **kept**, even though it now has no production reader. `open_dump_file` publishes it at `:518` to hold the `DumpFile` — and therefore faulthandler's fd — alive, and `test/test_crash_dump_store.py` reads and restores it directly (`:59`, `:72`, `:603`, `:617`, `:620`, `:624`, `:644`) including an assertion that `open_dump_file` must publish it. Removing it would reintroduce an fd-lifetime bug.

### `DashboardState.mark_notifications_read()` — `state.py:6626-6628`

Exactly one repo-wide occurrence: its own definition.

Its docstring says "called when client opens notification panel" and nothing calls it, so the lifecycle pair was traced end to end before deleting. `_unread_count` is incremented at `state.py:6591` and reset at `state.py:6739` by the **live** `clear_notifications()`, so this was not the only reset path. The actual read flow is per-note `acked` — `ack_notification`, `POST /api/notifications/ack-all` (`handlers/messaging.py:883`), `unack` — and the frontend's "mark all as read" dispatches `ackAllNotifications()` → `/api/notifications/ack-all`, which flips `acked`; it never asks for a server-side unread reset. The badge is derived client-side (`website/src/App.tsx:733`, `NotificationFeed.tsx:217`). The server-side `unread` field (`handlers/messaging.py:814`) is consumed only by test mocks.

### `_read_theme_text()` — `theme_validate.py:1605-1606`

Exactly one repo-wide occurrence: its own definition. No string or `getattr` dispatch; theme validation does not build a by-name reader table. Not in `__all__`, `docs/`, `docs/system-specs/`, or the theme-pack-authoring skill. Last touched 37 days ago.

Because `theme_validate.py` is a security surface (path traversal, symlink refusal, CSS denylist), this was checked as a possibly-bypassed validation step rather than assumed dead. It is not one: every live asset / overlay / topbar route reads through the hardened `_read_theme_bytes_nolink`, which re-checks the symlink (TOCTOU-safe) and then decodes with `errors="replace"` — consistently, everywhere. `_read_theme_text` was a plain `read_text` that skipped the symlink recheck. Nothing routes through it and nothing should, so this removes an unused *weaker* reader.

## Reported, not deleted

**`_REASONING_EFFORT_VALUES` (`chat_persistence.py:154`) — dead, but withheld because the fix spans two scopes.** It has zero references of any kind (no import, no dotted access, no `patch` target string) and is a duplicate binding of the same `EFFORT_VALUES` object already bound live nine lines above as `_REASONING_EFFORT_FALLBACK` (`:145`); the "back-compat caller" its comment invokes does not exist anywhere in the repo. But `src/kiro_crew/effort.py:42` describes `EFFORT_VALUES` as the "Single source for `_REASONING_EFFORT_VALUES`", so deleting the alias alone would leave that comment naming a symbol that no longer exists. `effort.py` is outside this PR's file scope, so the alias and that one-line comment fix should land together in a follow-up rather than be split.

**`PIN_SCOPES` (`tailnet.py:845`) — not dead code, a drift hazard.** It has zero references, but the validator it should back exists as an inline duplicate literal `("node", "login")` at `config/loader.py:3036`. Two independent definitions of the allowed pin-scope set on a security path is the finding; the fix is to point the validator at `PIN_SCOPES`, not to delete it.

## Deferred

| Symbol | Reason |
|---|---|
| `_mutate_tags_locked` (`chat_tags.py:73`) | Unreachable with zero cascade, but its sole commit landed 2026-08-08 (22 d) — inside the 30-day gate, and it reads as a new abstraction whose handler migration may still be in flight. |
| `broadcast_browser_event` (`state.py:9268`) | Statically dead (sole caller removed 2026-08-13) with no frontend consumer — `browser_event` appears nowhere in `website/src`. Withheld only because unmerged branch `refactor/dashboard-state-boundaries` relocated this exact method into `websocket_hub.py` on 2026-08-29; deleting it here would collide. |
| `_PROJECT_LOCAL_SEGMENTS` (`terminal_commands.py:365`) | Unused, and the shared-definition guarantee its comment claims is actually delivered by `_is_project_local` at `:367`, so no security coupling is lost. But last touched 3 d ago by an in-flight security fix. |
| `_bump_revocation_gen` (`token_auth.py:94`) | Inert alias whose comment is provably stale (zero importers, zero patch targets); the public `bump_revocation_gen` is fully live on the logout path. Last touched 20 d ago — gate clears 2026-09-08. |
| 17 test-only symbols | Referenced only by test fixtures that use them as state seeding (`save_folders`, `save_tag_boards`, `ws_client_count`, `enable_yolo`, `check_token_ip`, `reset_cache`, `extract_claims_from_token`, `build_transfer_bundle`, and 9 more). Deleting them means rewriting fixtures that reach unrelated suites — refactor, not deletion. |

## How the candidates were found

Three independent scanners, then a confirmation protocol on the intersection:

| Pass | Mechanism | Raw findings in scope |
|---|---|---|
| vulture `--min-confidence 60` | heuristic | 342 (238 func/method/class) |
| AST | defs in scope minus every `Name(Load)` / `Attribute` / import target across all repo `.py` files | 9 |
| tokenize | real `NAME` tokens repo-wide with docstrings/comments/strings excluded; absent from every file but its own | 650 |

The three-way intersection was 9 symbols; the protocol (repo-wide multi-filetype search, string-dispatch sweep, frontend-consumer check, public-surface check, 30-day gate, test-only rule, half-wired-lifecycle rule, security-surface rule) reduced that to the 3 deleted here.

A fourth pass split all 238 vulture func/method/class findings by production-vs-test references: 24 had zero production references outside their own file, of which 17 were test-only and 2 were module dunders (`__getattr__` / `__dir__`, called by the import protocol).

Vulture over-reports roughly 25x on this surface because nearly every `api_*` symbol it flags is an aiohttp route handler referenced from `handlers/` or `routes/`, and the constants it flags are imported by `handlers/*`. Four of its 90%-confidence "unused import" findings are also false — `NudgeLoop`, `LLMEvent`, `CronJob` and `typing` are each used inside a quoted annotation it cannot see (`chat_handlers.py:3338`, `chat_utils.py:363`, `cron_inject.py:70`, `loop_watchdog.py:72`).

## Verification

- Affected-scope pytest: **1119 passed, 0 failed** — crash-dump store, theme install / CSS security / config / coverage / authoring-skill, notification settings / bus / phase5 / legacy-actions / push, dashboard, handlers-messaging coverage, dashboard-state-ws, effort.
- `flake8`, `isort --check-only` and `mypy` clean on all touched files.
- `black --check` flags two reformats (`crash_dump_store.py` ~119, `theme_validate.py` ~291) that reproduce **identically on the unmodified tree** — local version drift, pre-existing, untouched.
- Two local reviewer lanes ran on the diff before it was pushed. One returned no findings after failing every falsification attempt; the other raised the `_REASONING_EFFORT_VALUES` coupling, which is why that symbol was withheld from this PR.
