### PR TITLE
feat(agent-sdk): declare the boundary and ratchet the ACP import inventory

### DIFF
--- a/.github/agent-sdk-boundary-baseline.txt
+++ b/.github/agent-sdk-boundary-baseline.txt
@@ -1,0 +1,74 @@
+# Imports of the ACP layer from application code, as `<count> <path>`.
+# Both `kiro_crew.acp` and `kiro_crew.providers` count: providers re-exports ACP
+# shapes (LLMEvent, EVENT_*, is_claude_backend), so watching only `acp` would let
+# a consumer look migrated while still reading the backend's own types.
+#
+# The gate requires every OTHER file under src/ to be clean and none of these
+# counts to grow, so this list can only shrink. There is no inline opt-out
+# marker: "this consumer legitimately needs ACP" is the claim the boundary
+# refuses, so the baseline is the only exemption mechanism.
+#
+# Do NOT add or raise a line to make a red gate green -- route the dependency
+# through kiro_crew.agent_sdk instead. Design of record:
+# docs/request-for-change/rfc-crew-agent-sdk-boundary.md
+#
+# Refresh (after removing something listed here):
+#   python3 scripts/check_agent_sdk_boundary.py --update-baseline
+2 src/kiro_crew/agent.py
+1 src/kiro_crew/apps/builtins/auto_improvement/backend/pr_watchers.py
+1 src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
+1 src/kiro_crew/apps/builtins/auto_improvement/spine/agent_runner.py
+1 src/kiro_crew/apps/builtins/code_review_sage/sage_lib/followup.py
+2 src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
+1 src/kiro_crew/channel.py
+3 src/kiro_crew/cli_chat.py
+3 src/kiro_crew/cli_doctor.py
+1 src/kiro_crew/cli_setup.py
+1 src/kiro_crew/config/loader.py
+1 src/kiro_crew/connections/mint.py
+1 src/kiro_crew/cron.py
+3 src/kiro_crew/dashboard/chat_handlers.py
+5 src/kiro_crew/dashboard/chat_runner.py
+1 src/kiro_crew/dashboard/chat_summary.py
+1 src/kiro_crew/dashboard/chat_utils.py
+2 src/kiro_crew/dashboard/handlers/agents.py
+2 src/kiro_crew/dashboard/handlers/core.py
+1 src/kiro_crew/dashboard/handlers/hooks.py
+1 src/kiro_crew/dashboard/handlers/optimizer.py
+2 src/kiro_crew/dashboard/handlers/sessions.py
+1 src/kiro_crew/dashboard/handlers/side.py
+1 src/kiro_crew/dashboard/handlers/taskrunner.py
+1 src/kiro_crew/dashboard/handlers/usage.py
+1 src/kiro_crew/dashboard/session_memory.py
+1 src/kiro_crew/dashboard/stall_enrichment.py
+1 src/kiro_crew/dashboard/state.py
+1 src/kiro_crew/dashboard/steer_settle.py
+1 src/kiro_crew/dashboard/turn_dispatch.py
+1 src/kiro_crew/discord/renderer.py
+1 src/kiro_crew/eval/judge.py
+2 src/kiro_crew/eval/runner.py
+1 src/kiro_crew/knowledge/llm_pool.py
+5 src/kiro_crew/llm_helpers.py
+1 src/kiro_crew/mcp_shared.py
+1 src/kiro_crew/messaging/auto_title.py
+1 src/kiro_crew/messaging/dispatch.py
+1 src/kiro_crew/messaging/driver.py
+12 src/kiro_crew/session.py
+2 src/kiro_crew/session_allocation.py
+2 src/kiro_crew/session_background.py
+1 src/kiro_crew/session_cleanup.py
+2 src/kiro_crew/session_compaction.py
+1 src/kiro_crew/session_map.py
+3 src/kiro_crew/session_pid.py
+1 src/kiro_crew/session_pool.py
+3 src/kiro_crew/slack/gateway.py
+3 src/kiro_crew/slack/handler.py
+1 src/kiro_crew/slack/transport_dispatch.py
+9 src/kiro_crew/subagent.py
+2 src/kiro_crew/subagent_persistence.py
+2 src/kiro_crew/task_executor.py
+1 src/kiro_crew/task_planner.py
+1 src/kiro_crew/taskrunner.py
+1 src/kiro_crew/telegram/transport_dispatch.py
+1 src/kiro_crew/workflows/agent_pool.py
+2 src/kiro_crew/workflows/service.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,17 @@ jobs:
           python3 scripts/check_subprocess_encoding.py --test
           python3 scripts/check_subprocess_encoding.py
 
+      # Application code must reach the agent backend through kiro_crew.agent_sdk,
+      # not by importing kiro_crew.acp (or kiro_crew.providers, which re-exports
+      # the same ACP shapes and would otherwise be a laundering channel). Today's
+      # edges are carried in the baseline as pre-existing and it is shrink-only. Design
+      # record: docs/request-for-change/rfc-crew-agent-sdk-boundary.md.
+      # Self-test first, same reason as the gate above.
+      - name: Check agent-SDK import boundary (gate, baselined)
+        run: |
+          python3 scripts/check_agent_sdk_boundary.py --test
+          python3 scripts/check_agent_sdk_boundary.py
+
       # A secret-bearing file must be locked down BEFORE any content reaches it:
       # a post-publish lockdown leaves the payload at its final path under the
       # inherited DACL, which on Windows is not covered by atomic_write's POSIX

--- a/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
+++ b/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
@@ -149,6 +149,15 @@ provider map (`platform/defaults.py`), the prerequisite gate
 `_KIRO_IDENTITY_STORE`, …), so a consumer that wants to know "can this session be
 steered?" asks "is this backend in this set?" instead.
 
+One part of this is already fixed and PR 3 should build on it rather than redo it.
+`src/kiro_crew/acp_backends.py` is a deliberate leaf: it imports nothing from the
+ACP package, and it exists to own the selectable-backend list in one place,
+replacing three literals that had already drifted apart. It is not a boundary
+violation and the architecture test pins that — a prefix-match on `kiro_crew.acp`
+would flag it, which is why the gate matches on module boundaries instead. What
+§2.3 describes as unowned is the *comparison* behaviour: the constants and the
+seven frozensets in `acp/types.py`, which the leaf does not cover.
+
 ### 2.4 ACP lifecycle state lives outside the ACP package
 
 - `session.py:1108` `_warm_pool: asyncio.Queue[tuple[LLMProvider, float]]` — the
@@ -159,10 +168,22 @@ steered?" asks "is this backend in this set?" instead.
   runtime map.
 - `session.py:1160-1162` `_rss_max_mb`, whose settings loader is imported from
   *inside* the ACP package.
-- `session_pid.py` owns the whole PID lifecycle for agent processes, while
-  `acp/worker_pool.py:49` imports `register_protected_pid` /
-  `unregister_protected_pid` back from it behind a `try/except` — the import
-  cycle already exists and is already being worked around.
+- `session_pid.py` owns the whole PID lifecycle for agent processes, and the
+  import cycle already exists — but it runs the opposite way from what an earlier
+  draft of this section claimed, and the direction determines which phase can fix
+  it. `session_pid.py:311-312` and `:1888-1889` both carry
+  `# circular import: session_pid → acp.client → session → session_pid` above a
+  lazy `from kiro_crew.acp.client import _get_child_pids`. That is the cycle.
+  `acp/worker_pool.py:49`'s `try/except` around `register_protected_pid` /
+  `unregister_protected_pid` is **not** part of it: `session_pid.py` has no
+  module-level ACP import, so that edge is one-way, and the guard's own comment
+  says it exists so the engine stays importable standalone. It also catches
+  `Exception`, not `ImportError`.
+  The `:1888` copy sits inside `_kill_orphan_work_tree`, reached only from the
+  work-class orphan sweep — the half §12.1 deliberately leaves in place. And
+  `_kill_pid_tree` (`:300`), which holds the `:311` copy, is called from both
+  halves (`:475`, `:538`, `:907`), so the split has to place it rather than assume
+  it travels with one side.
 
 So the process supervision decision is currently made in **both** directions at
 once. No boundary can be drawn without settling it.
@@ -282,8 +303,29 @@ deleted at the end.
 |---|---|
 | Keep as-is | `kind`, `text`, `tool_call_id`, `title`, `tool_purpose`, `context_usage_pct`, `stop_reason`, `tool_input`, `tool_input_redacted`, `tool_output`, `usage`, `server_name`, `oauth_url`, `subagents`, `todo`, `is_shell`, `tool_name`, `mcp_server_name`, `diff_old_text`, `diff_path` |
 | Replace | `request_id` → `approval: ApprovalToken \| None`; `options` → `choices: tuple[ApprovalChoice, ...]`; `tool_final` → `status: ToolStatus`; `tool_kind` → a domain enum |
-| Do not cross | `raw_tool_params`, `raw_params_trusted`, `shell_classified`, `mcp_identity_trusted` |
+| Do not cross **as fields** (consumed by the driver to compute the four derived members below) | `raw_tool_params`, `raw_params_trusted`, `shell_classified`, `mcp_identity_trusted` |
 | Collapse | `runtime_global`, `sub_session_id`, `mcp_identity_ambiguous` → one `attribution: ChildAttribution \| None` value object, non-`None` only on subagent-related events (decided, §12.2) |
+
+`AcpEvent` is not only fields. It also carries four derived `@property` members —
+`shell_command` (`acp/types.py:572`), `child_low_fidelity` (`:626`),
+`child_mcp_identity_trusted` (`:654`) and `child_unconditional_grant_eligible`
+(`:697`) — every one of which is read outside `acp/` on the permission path, and
+every one of which is computed from fields in the *Do not cross* row. They are
+therefore **first-class SDK members** on `AgentEvent`, computed by the driver from
+the ACP event before the raw fields are discarded, carrying their fail-closed
+semantics unchanged (`child_low_fidelity` returns `True` on any missing
+provenance, `types.py:643-651`; `hooks.py:536-543` denies a shell tool whose
+command could not be recovered).
+
+That is why the fourth row reads *do not cross **as fields***. It does not mean
+the values are unused: `raw_tool_params` is passed as a security-decision argument
+at 20 sites in 12 non-ACP files — `hooks.on_tool_call(raw_params=…)`
+(`chat_runner.py:6637`), `approval_command(raw_tool_params=…)`
+(`:7235`, `:7242`), and so on — so it crosses as an opaque `Mapping | None` for
+the duration of PRs 2-5 and is deleted per-file by PR 5 alongside its last
+consumer. The other three are consumed by the driver only; their read count
+outside `acp/` is zero, which is exactly why an earlier draft missed that four
+properties depend on them.
 
 Event **kind string values stay byte-identical** (`"text_chunk"`,
 `"tool_call_update"`, `"end_turn"`, …). They are persisted and serialized; only
@@ -319,7 +361,7 @@ today:
 | Question | Asked today as |
 |---|---|
 | `can_steer` | `ACP_BACKENDS_STEER` membership (`acp/types.py:151`) |
-| `multiplexes_sessions` | `ACP_BACKENDS_ACP_RUNTIME` (`:180`) |
+| `multiplexes_sessions` | `ACP_BACKENDS_ACP_RUNTIME` (`:180`) — **post-session only**; see the pre-session query below |
 | `shares_subagent_session` | `ACP_BACKENDS_SESSION_SHARING` (`:148`) — a *subset* of the above, which one boolean cannot express |
 | `self_sandboxes` | `ACP_BACKENDS_INTERNAL_SANDBOX` (`:167`) |
 | `recyclable_on_host_logout` | `ACP_BACKENDS_KIRO_IDENTITY_STORE` (`:196`) |
@@ -344,6 +386,47 @@ retire this backend's live child — not ownership of a store. A CC session must
 never be recycled on a Kiro logout, so the polarity matters. And
 `shares_process` was one boolean over two sets that `acp/types.py:177-181`
 explicitly documents as a superset relation; it is split above.
+
+**Not every backend question is a session question, and one of these is not.**
+`SessionCapabilities` is read off a live session, which makes it the wrong home for
+a question asked in order to decide *how to build* that session.
+`ACP_BACKENDS_ACP_RUNTIME` is exactly that case: `session.py:399-400` computes
+`ACP_BACKENDS_ACP_RUNTIME & selectable_backends()` per call, and `:1398` and
+`:1610` consult it against the configured `agent.acp_backend` **string** to choose
+between the multiplexed-runtime path and the provider-backed `_Session` path
+serialized by `Semaphore(1)`. No value read off the session can answer it, because
+the session does not exist yet.
+
+It is also not a boolean. The second operand, `selectable_backends()`
+(`acp_backends.py:87`), is a **deployment** fact resolved after module import when
+an edition registers backends during boot — deliberately not frozen at import
+time. The intersection is the answer; collapsing it to one boolean reintroduces the
+"silently hands the capability to a third backend" failure the opt-in frozensets
+exist to prevent.
+
+So the pre-session half lives on the **driver registry**, not on the session:
+
+```python
+def spawnable_multiplexed_selections() -> frozenset[str]:
+    """Backend selections the SDK can serve with a multiplexed runtime.
+
+    Runtime-capable AND operator-selectable. Computed per call, never frozen at
+    import: selectability is a deployment fact an edition adds during boot.
+    """
+```
+
+`multiplexes_sessions` stays on `SessionCapabilities` for the post-session
+question (the existing spelling, `providers/acp.py:466-476`, needs a started
+process, which is what makes it post-session). A registry function was chosen over
+an `AgentSupervisor.can_multiplex(selection) -> bool` method for two reasons: the
+answer is genuinely set-valued, so a boolean accessor throws away the shape at
+every call site; and the fact being reported is about the deployment, not about any
+supervisor instance, so hanging it off the supervisor would imply per-instance
+variation that does not exist.
+
+`cli_doctor.py:30` and `:1993` compare `== ACP_BACKEND_KAS` against a config load
+with no session, and are the same pre-session shape. Both they and `session.py`'s
+three reads route through this function; §7 records which phase pays each off.
 
 ### 5.3 The SDK surface: presence-tested role protocols, not a flat interface
 
@@ -442,9 +525,22 @@ watchdog threshold and its settings loader (`:1162`), provider adoption
 
 This is the step that makes the boundary real. Without it `SessionManager` still
 holds ACP's guts and the SDK is decoration. It also settles §2.4: **the
-supervisor owns process supervision**, `session_pid.py`'s agent-process half
-moves in, and the `worker_pool.py:49` `try/except` cycle guard is deleted rather
-than re-pointed.
+supervisor owns process supervision**, and `session_pid.py`'s agent-process half
+moves in.
+
+What that has to accomplish is the cycle `session_pid → acp.client → session →
+session_pid`, whose two live sites are `session_pid.py:311` and `:1888` (both a
+lazy `from kiro_crew.acp.client import _get_child_pids`). Deleting the
+`worker_pool.py:49` guard is a *consequence* of the move, not the proof it worked —
+that edge is one-way and the guard exists for standalone importability (§2.4). The
+move must therefore place two pieces of shared surface: `_get_child_pids`, or a
+PID-enumeration primitive it can be replaced by, so `session_pid.py` retains no
+`kiro_crew.acp` import at any scope; and `_kill_pid_tree` (`session_pid.py:300`)
+plus the `_MANAGED_AGENT_MARKERS` vocabulary (`:229`), both of which are consulted
+from the agent half and the work half. The non-agent sweeps gate their kill sets
+*negatively* on that marker vocabulary (`:1454`, `:1561`) and consume the protected
+set through `_collect_active_pids` (`:267`), so a careless split makes the
+work-class sweep less safe, not merely less tidy.
 
 Deliberately *not* moved: `SessionManager`'s slot/transcript/channel
 responsibilities. The supervisor takes the agent-process concerns only.
@@ -525,17 +621,43 @@ Each phase is independently shippable and independently abandonable.
 ### PR 1 — declare the boundary and ratchet the inventory
 
 Create `src/kiro_crew/agent_sdk/` with the layer docstring and nothing else.
-Add `scripts/check_acp_import_boundary.py` and
-`.github/acp-import-baseline.txt` seeded with today's counts. No code moves.
-The host-contract spec already exists
-(`docs/system-specs/features/agent-host-contract.md`, added with this RFC), so
-PR 1 only keeps it reachable and in sync.
+Add `scripts/check_agent_sdk_boundary.py` and
+`.github/agent-sdk-boundary-baseline.txt`, wire the gate into `ci.yml` beside the
+sibling baselined gates, and add the architecture test. No code moves. The
+host-contract spec already exists
+(`docs/system-specs/features/agent-host-contract.md`), so PR 1 only keeps it
+reachable and in sync.
 
-- Exit: the checker exits 0 on `dc88f142b`'s tree with the seeded baseline, and
-  exits non-zero when a new `kiro_crew.acp` import is added to any file.
-- Exit: the baseline records 68 edges across 42 files.
-- Exit: `--test` plants one probe per rule family and is run first in the same CI
-  step.
+**The gate watches two roots, not one.** `kiro_crew.acp` is the obvious one;
+`kiro_crew.providers` is the one that makes the number honest. `providers/base.py`
+re-exports `LLMEvent` and the `EVENT_*` constants, so a consumer can depend on
+ACP shapes without naming ACP. A gate watching only `acp` would let a file look
+migrated while nothing decoupled, and the baseline would fall for free.
+
+**The baseline is derived, never transcribed.** `--seed-baseline` writes the first
+file from a live scan and refuses to overwrite an existing one, because re-seeding
+is exactly the "regenerate and absorb every new offender" move the missing-file
+error exists to prevent. `--update-baseline` only lowers counts and deletes lines.
+An earlier draft of this section hardcoded "68 edges across 42 files"; that number
+came from a regex whose `kiro_crew\.acp` prefix also matched
+`kiro_crew.acp_backends`, a sibling leaf module that imports no ACP at all. The
+AST scan is authoritative, and the exit criteria below name the mechanism rather
+than a figure that rots.
+
+- Exit: `--test` plants one probe per rule family (plain, module, relative,
+  multi-line, `TYPE_CHECKING`-only, dynamic `import_module`, `__import__`, and the
+  `providers` re-export channel) plus clean probes for the SDK, an unrelated
+  `kiro_crew` module, and the `acp_backends` prefix neighbour — and is run first
+  in the same CI step.
+- Exit: the gate exits 0 on the seeded tree, and non-zero when an import of
+  either forbidden root is added to any file under `src/`.
+- Exit: the seeded baseline records what the scan finds, and the gate prints the
+  split per root so both halves of the migration are visible.
+- Exit: `--seed-baseline` refuses when the baseline already exists.
+- Exit: the architecture test pins the exempt set to exactly the three boundary
+  trees, fails when a baseline entry has been paid off but not pruned, and asserts
+  the scan visited a non-trivial number of consumer files so a broken walk cannot
+  read as a clean tree.
 - Exit: `./scripts/docs-lint.sh` passes and the host-contract spec is reachable
   from `docs/system-specs/features/README.md`.
 - Blocked on: nothing.
@@ -544,32 +666,115 @@ PR 1 only keeps it reachable and in sync.
 
 `AgentEvent`, `ApprovalToken`, `ToolStatus`, `CompactionResult`,
 `SessionCapabilities`, the error taxonomy including `AgentRuntimeMissing`, and the
-driver translation. `providers/base.py` stops aliasing `AcpEvent`. Consumers keep
-working through the deprecated shim (§9).
+driver translation. `providers/base.py` stops aliasing `AcpEvent`.
+
+**PR 2 is additive only if `AgentEvent` carries deprecation shims, and it must.**
+An earlier draft claimed consumers "keep working through the deprecated shim"
+while also removing `request_id`, `options`, `raw_tool_params`, `tool_final` and
+`tool_kind` from the event. Those two cannot both be true: a shim can re-export a
+*name*, it cannot keep a *deleted field* readable. Measured on `d7b7d65c3`,
+outside `acp/` and `providers/`:
+
+| What PR 2 changes | Consumer reads today |
+|---|---|
+| `request_id` → `approval: ApprovalToken` | **131** event-shaped reads across **17 files** |
+| `approve_tool` / `reject_tool` signatures | **87** call sites |
+| `tool_kind` → a domain enum | 52 |
+| `raw_tool_params` → does not cross | **20** call-argument sites in **12** files |
+| `options` → `choices` | 6 |
+| `tool_final` → `status` | 2 |
+
+The 17 files include `dashboard/chat_runner.py`, `subagent.py`,
+`slack/handler.py`, `slack/gateway.py`, `messaging/driver.py`,
+`messaging/renderer.py`, `channel.py`, `task_executor.py`, `task_planner.py`,
+`llm_helpers.py`, `cli_chat.py`, `eval/runner.py` and `eval/judge.py`. Landing the
+removal in PR 2 would make it a 17-file breaking change, which contradicts the
+four-wave consumer migration this plan puts in PR 5.
+
+So PR 2 ships `AgentEvent` with a deprecated read-only member for each field it
+removes, each emitting a `DeprecationWarning`. Two mechanisms, not one, because the
+disposition table has two kinds of removal:
+
+- A **Replace** field has an SDK successor, so its shim is *derived*: `request_id`
+  from `approval`, `tool_kind` from the domain enum, `status` from `tool_final`.
+- A **Do not cross** field has no successor — that is what the row means — so a
+  derived property is impossible. `raw_tool_params` therefore ships as a
+  carried-through field, deprecated by warning only, and is deleted in PR 5
+  alongside the consumer that reads it. The other three (`raw_params_trusted`,
+  `shell_classified`, `mcp_identity_trusted`) have zero consumer readers and are
+  consumed by the driver to compute the four derived members of §5.2, so they do
+  not need a shim at all.
+
+The four derived members are not shims. `shell_command`, `child_low_fidelity`,
+`child_mcp_identity_trusted` and `child_unconditional_grant_eligible` land as
+first-class SDK members computed by the driver (§5.2), because they are read on the
+permission path and losing them is not a deprecation — it is a security regression.
+Dropping `raw_tool_params` without them makes `shell_command` return `None` on
+`tool_call` events, every such shell call then hits `hooks.py:539`'s
+deny-by-default, and the `use_aws` regression `types.py:596-605` exists to prevent
+comes back.
+
+PR 5's waves delete the shims per file as each consumer moves, and PR 6's exit
+asserts none remain. The "no `request_id` on `AgentEvent`" criterion therefore
+belongs to PR 6, not here.
 
 - Exit: `grep -rn "AcpEvent" src/kiro_crew` outside `acp/` and the driver returns
   zero hits.
 - Exit: a parity test asserts every SDK event-kind and stop-reason string equals
   its ACP counterpart.
-- Exit: `approve`/`reject` accept only `ApprovalToken`; the browser payload at
+- Exit: `approve`/`reject` accept an `ApprovalToken`, and the browser payload at
   `chat_runner.py` is byte-identical before and after.
-- Exit: no `request_id`, `options`, `raw_tool_params`, `runtime_global` on
-  `AgentEvent`.
+- Exit: every deprecated member is covered by a test asserting both the value it
+  derives (or carries) and the `DeprecationWarning` it raises, so PR 5 can delete
+  each one against a known contract.
+- Exit: a test asserts each of the four derived members returns the same value on
+  `AgentEvent` as on the source `AcpEvent`, **including the fail-closed branches**:
+  `raw_params_trusted` False, `shell_classified` False, and `is_shell` with an
+  unrecoverable command. A parity test over fields only would pass while these
+  four silently invert.
+- Exit: no consumer file changes in this PR. If one has to, the shim set is
+  incomplete.
+- Exit: a test asserts no name exported from `agent_sdk` **is** its ACP
+  counterpart object. The import gate exempts `agent_sdk/` wholly, so the one
+  channel it cannot see is a verbatim re-export *inside* the SDK — precisely the
+  `providers/base.py` aliasing (`LLMEvent = AcpEvent`) that made two forbidden
+  roots necessary in the first place. A consumer importing `agent_sdk` would read
+  as migrated while holding the ACP object, and the baseline would shrink for
+  free. Identity (`is`), not equality: a parity test over field values passes on
+  the same object. PR 1 cannot carry this test, because the package it guards is
+  empty until this PR populates it.
 - Blocked on: nothing. §12.2 settled the attribution shape (`ChildAttribution`
   value object).
 
 ### PR 3 — capabilities and protocols replace backend ids
 
 `SessionCapabilities` on every session, and the presence-tested role protocols of
-§5.3 declared as `runtime_checkable`. The seven `ACP_BACKENDS_*` frozensets stop
-being read outside the driver. This PR also lands the two promoted host-contract
-contracts: a declared per-session `mcp_servers` extension point on
+§5.3 declared as `runtime_checkable`. This PR also lands the two promoted
+host-contract contracts: a declared per-session `mcp_servers` extension point on
 `SessionRequest`, replacing the `_claude_session_mcp_servers() -> []` override
 hole, and `writes_own_transcripts` + `AgentSupervisor.cleanup_session` as the
 declared home of transcript ownership.
 
-- Exit: zero `ACP_BACKEND_*` imports outside `acp/` and the driver.
-- Exit: zero `== ACP_BACKEND_` comparisons anywhere in consumer code.
+Six of the seven `ACP_BACKENDS_*` frozensets stop being read outside the driver.
+The seventh, `ACP_BACKENDS_ACP_RUNTIME`, is asked **before a session exists** —
+`session.py:1398` and `:1610` consult it against a config string to choose which
+path builds the session — so no `SessionCapabilities` value can answer it. §5.2
+puts the pre-session half on the driver registry as
+`spawnable_multiplexed_selections() -> frozenset[str]`, and this PR routes
+`session.py`'s three reads and `cli_doctor.py`'s two through it. Rewriting the
+call sites to stop *dispatching* on the answer is PR 4's move; PR 3 only changes
+where the answer comes from, which is why the exits below record the two files as
+carried rather than clean.
+
+- Exit: zero `ACP_BACKEND_*` imports outside `acp/` and the driver, **except**
+  `session.py` and `cli_doctor.py`, which reach the answer through
+  `spawnable_multiplexed_selections()` and are recorded as carried — paid off in
+  PR 4 and PR 5 wave 4 respectively.
+- Exit: zero `== ACP_BACKEND_` comparisons in consumer code, except the two
+  carried sites above.
+- Exit: the pre-session multiplex query is reached only through
+  `spawnable_multiplexed_selections()`, and no consumer computes
+  `ACP_BACKENDS_ACP_RUNTIME & selectable_backends()` itself.
 - Exit: every optional operation is reached through an `isinstance` protocol test,
   and no consumer calls a method that a driver implements only to raise.
 - Exit: a test asserts each capability question in §5.2 has exactly one consumer
@@ -579,39 +784,122 @@ declared home of transcript ownership.
 ### PR 4 — the supervisor takes the lifecycle
 
 Warm pool, background runtime, per-parent runtime map, RSS watchdog, adoption,
-and agent-process PID tracking move into `agent_sdk`. The
-`worker_pool.py:49` cycle guard is deleted. `preflight()` lands here.
+and agent-process PID tracking move into `agent_sdk`. `preflight()` lands here.
+This is also where `session.py` stops dispatching on the pre-session multiplex
+answer at all, because the construction choice moves with the pool.
+
+Breaking the cycle is the point, and the cycle is `session_pid → acp.client →
+session → session_pid` (§2.4). So this phase moves `_get_child_pids` — or replaces
+it with a PID-enumeration primitive the SDK owns — and places `_kill_pid_tree`
+plus `_MANAGED_AGENT_MARKERS`, both of which the work-class sweep also depends on.
+Deleting the `worker_pool.py:49` guard follows from the move; it is not the proof.
 
 - Exit: `session.py` declares no `AcpRuntime`-typed attribute.
-- Exit: `acp/worker_pool.py` contains no `from kiro_crew.session_pid import`, and
-  no `try/except ImportError` around it.
-- Exit: `dashboard/session_memory.py` and `dashboard/stall_enrichment.py` import
-  no underscore-prefixed ACP names.
+- Exit: `session_pid.py` contains no `kiro_crew.acp` import at any scope,
+  including lazy in-function imports. This is the cycle criterion; it fails today.
+- Exit: `acp/worker_pool.py` contains no `from kiro_crew.session_pid import`.
+  (Stated without the `ImportError` wording: the guard catches `Exception`, so a
+  grep for `try/except ImportError` matches nothing and would pass vacuously.)
+- Exit: `dashboard/session_memory.py` imports no underscore-prefixed ACP names
+  (`_get_rss_tree_mb`, `_iter_descendant_pids` today).
+- Exit: `dashboard/stall_enrichment.py` imports no `kiro_crew.acp` name at all.
+  The underscore form of this criterion passes today — its only ACP import is
+  `acp.liveness.socket_inodes` — so it certifies nothing; the `/proc` primitive has
+  to move behind the SDK or into a shared module for this to go green.
 - Blocked on: PRs 2-3. §12.1 settled PID ownership on the supervisor, so this
   phase is design-unblocked.
 
 ### PR 5 — consumer migration waves
 
-Four waves, each driving the ratchet down: dashboard; messaging plus the seven
-channels; apps plus workflows plus knowledge; CLI plus config plus platform.
+Four waves, each driving the ratchet down. The waves are defined by the baseline,
+not by category, because a category list is how a consumer ends up owned by nobody:
+
+1. **dashboard** — `dashboard/` and its handlers.
+2. **messaging and the channels** — `messaging/`, `slack/`, `discord/`,
+   `telegram/`, `teams/`, `webex/`, `wecom/`, `whatsapp/`, `imessage/`.
+3. **apps, workflows, knowledge** — `apps/`, `workflows/`, `knowledge/`.
+4. **CLI, config, platform, and the top level** — `cli_*.py`, `config/`,
+   `platform/`, `eval/`, `connections/`, and the top-level modules. This wave is
+   the named catch-all and the largest: `session.py` and the five modules
+   `#6921` split out of it (`session_allocation.py`, `session_background.py`,
+   `session_cleanup.py`, `session_compaction.py`, `session_pool.py`),
+   `session_pid.py`, `subagent.py`, `channel.py`, `llm_helpers.py`,
+   `task_executor.py`, `task_planner.py`, `cli_doctor.py` and the rest of the
+   top-level files. `channel.py` is wave 4, not wave 2 — it is a top-level
+   module, and the "seven channels" of wave 2 are the transport packages.
+
+Deliberately no edge counts here. The gate prints the live per-root split on
+every run and the baseline is the per-file record, so a count written into this
+document is a second source of truth that goes stale on the next upstream
+refactor — `#6921` moved eight ACP edges out of `session.py` into five new files
+between this RFC being merged and PR 1 being raised, which is exactly how.
+
+Every baselined path must fall in exactly one wave; a path that
+falls in none is a defect in this list, not a file to be improvised over.
+
 Each wave is its own commit and can ship alone.
 
+Each wave does two things per file, not one: route the dependency through
+`agent_sdk`, and delete the `AgentEvent` deprecation shims that file was the last
+reader of (PR 2). A wave that moves the import but leaves a shim alive has not
+finished — the shim is what let PR 2 be additive, and it is dead weight from the
+moment its last consumer is gone.
+
+Both halves of the baseline move here. The `kiro_crew.providers` edges are not a
+PR 6 problem: roughly two fifths of the recorded edges reach the shim rather than
+the ACP package, spread across more files than the `acp` half. If the waves only
+chase `kiro_crew.acp`, PR 6 arrives with that whole half still pointing at a
+package it is supposed to delete. The gate prints the live split on every run —
+read it there rather than from this paragraph.
+
+One spelling deserves naming because it is easy to miss: `config/loader.py`
+constructs `AcpProvider` directly, and that construction **is**
+`create_provider_factory`. Other files import the name without constructing it,
+so "route it through the factory" is already true — what PR 5 has to change is
+which module they import the name *from*, not how they build it.
+
 - Exit: after each wave the baseline shrinks and never grows.
+- Exit: each wave's commit reduces the per-root split the gate prints, and by the
+  end of wave four the `kiro_crew.providers` half is at zero.
 - Exit: `mcp_tools/spawn.py` remains at zero, unmodified.
 - Blocked on: PRs 2-4.
 
 ### PR 6 — seal the import boundary
 
-Baseline reaches zero for every path except the driver. `kiro_crew.providers` is
-deleted. The checker's allowlist is reduced to the single driver module. Specs
-updated in the same commit per `docs/README.md`.
+The baseline reaches zero and is empty. **The driver never appears in it.** The
+gate exempts by directory prefix and `_scan` skips exempt files, so
+`agent_sdk/drivers/acp.py` is carried by the exempt set, not by a baseline
+count — and PR 1's own test already pins that
+(`assert gate._is_exempt("src/kiro_crew/agent_sdk/drivers/acp.py")`). A
+hand-written baseline entry for it would fail
+`test_every_recorded_violation_still_exists` and be erased by
+`--update-baseline`.
+
+`kiro_crew.providers` is deleted, and with it the `providers/` entry in the gate's
+exempt set — the exemption was always temporary and the architecture test pins the
+set, so forgetting to remove it fails a test rather than silently widening the
+boundary.
+
+The exempt set is reduced to **two** trees, `agent_sdk/` and `acp/`, not to one
+module. `acp/` stays exempt because 30 of its own internal imports across 8 files
+would otherwise become unbaselined violations with no legal remedy — the baseline
+header forbids adding a line to make a red gate green. A prefix naming the driver
+file directly also fails `test_every_exempt_prefix_points_at_a_real_tree`, which
+asserts `.is_dir()`.
+
+Specs updated in the same commit per `docs/README.md`.
 
 "Sealed" here means the **import** boundary. The host contract is not sealed by
 this PR and must not be described as such: four of its eight buckets still have no
 seam, and the spec doc names them.
 
-- Exit: `.github/acp-import-baseline.txt` lists only
-  `src/kiro_crew/agent_sdk/drivers/acp.py`.
+- Exit: `.github/agent-sdk-boundary-baseline.txt` is empty (header only), and the
+  gate's exempt set — `agent_sdk/` and `acp/` — is the only remaining
+  exemption, with the pinned exempt-set test updated to those two prefixes in
+  the same commit.
+- Exit: no `request_id`, `options`, `raw_tool_params`, `tool_final`, `tool_kind` or
+  `runtime_global` attribute survives on `AgentEvent`, and no deprecated property
+  from PR 2 remains.
 - Exit: `docs/system-specs/modules/providers.md` and `acp-client.md` describe the
   boundary as built.
 - Exit: the host-contract spec's seam-status table is re-audited in the same
@@ -647,6 +935,126 @@ import rule on all four properties we need:
 `config-baseline.json` is rejected because regenerating it is expected, so it
 does not ratchet. `lint:theme-colors` is rejected because it exits 0 by design.
 
+The gate ships as `scripts/check_agent_sdk_boundary.py` with
+`.github/agent-sdk-boundary-baseline.txt`, and three of its decisions are load
+bearing rather than incidental:
+
+**It watches two roots, not one.** `kiro_crew.acp` alone would be a hole.
+`providers/base.py` re-exports `LLMEvent` and the `EVENT_*` constants from ACP
+verbatim, so a consumer that swapped `from kiro_crew.acp import
+LLMEvent` for `from kiro_crew.providers import LLMEvent` would read as migrated
+while still depending on ACP event shapes — and the baseline would shrink for
+free. The forbidden roots are therefore `kiro_crew.acp` **and**
+`kiro_crew.providers`, the exempt prefixes are `agent_sdk/`, `acp/` and
+`providers/` themselves, and the gate prints the per-root split on every run, so a
+wave that moves one half and stalls on the other is visible rather than merely
+smaller.
+
+**It matches bound names, not just the from-target.** `from kiro_crew import acp`
+has `node.module == "kiro_crew"`, which matches no forbidden root — the forbidden
+package is the *name being bound*. A gate that inspects only the from-target lets
+that spelling, plus `from kiro_crew import providers` and `from .. import acp`,
+through untouched. Since there is no inline opt-out marker, that would not have
+been an obscure edge case: it would have become the standard way around the rule,
+with the baseline still shrinking and dependence unchanged. So each bound name is
+resolved against the from-target and checked too, with a self-test probe per
+spelling. `*` is skipped, because a star-import of an ancestor names no forbidden
+root. Two reviewers found this independently on PR 1; it is recorded here because
+the fix is a property of the rule, not an implementation detail.
+
+The same completeness rule applies to the dynamic branch, and there it forced a
+change of shape rather than another patch. `import_module` and `__import__` each
+carry the module in more than one argument position: `name` may be a keyword,
+`__import__`'s real target lives in `fromlist` when `name` is only the package, a
+leading-dot `name` with `package=` is relative, `level > 0` is relative to the
+calling module, and the importer itself can be renamed
+(`from importlib import import_module as _im`) or bound by assignment. Each of
+those is a distinct spelling and all of them are checked.
+
+`fromlist` is different in kind, and it is worth recording why. Three review
+rounds each closed one container shape and revealed the next — tuple and list,
+then set and dict keys, then starred unpacking, dict-unpack and literal
+concatenation. That sequence does not converge, because `('acp',) * 1`,
+`('a' + 'cp',)`, `frozenset({'acp'})` and a comprehension all import the same
+package: enumerating the shapes a reader happens to recognise is an open-ended
+game against Python's expression grammar, and every round of it ships a gate that
+looks complete and is not.
+
+So the question is posed the other way round. When `name` is an **ancestor** of a
+forbidden root, `fromlist` alone decides whether the call crosses the boundary —
+and the gate reports it unless it can **prove** the `fromlist` names nothing
+forbidden. A fully-readable literal is decided exactly; anything the scanner
+cannot read completely is reported. That closes the whole class at once, including
+the shapes an earlier draft had classified as "not statically decidable, therefore
+out of scope" — an argument that only held while the alternative was believed to
+be silence.
+
+Two properties keep this from being merely conservative. Ancestry is required, so
+`__import__("kiro_crew.sandbox", fromlist=[...])` — which this tree really does
+call — is untouched, because no forbidden root lives under `kiro_crew.sandbox`. And
+a bare string is decided rather than feared: iterating `"acp"` yields single
+characters, so it can only ever name one-letter submodules.
+
+One argument-parsing bug is worth recording separately, because it was not a
+container shape and no amount of enumeration would have found it. `__import__("")`
+with a `level` is how a purely relative import spells itself, and
+`__import__("", globals(), locals(), ("acp",), 2)` from two levels under
+`kiro_crew` really does import `kiro_crew.acp`. The scanner read the module name as
+`positional or keyword`, and `""` is falsy — so a legal name was treated as "no
+name given" and the whole relative branch never ran. The rule is to test for
+absence, not for truth. Its mirror is equally load-bearing:
+`import_module("", package=...)` raises `ValueError: Empty module name` and imports
+nothing, so it stays clean — both directions were checked against the interpreter
+rather than reasoned about.
+
+One gap remains open on purpose and is recorded as a clean probe: a non-literal
+*module* target (`mod = cfg.name; import_module(mod)`). Unlike `fromlist`, there is
+no ancestry signal to key a conservative rule on — the module name is the whole
+input — so reporting every dynamic import would flag the app loader and the plugin
+registry, and the gate would be turned off within a week.
+
+**Every verdict is scoped to the files the change touched.** The gate resolves
+the changed set through the same resolver the black gate uses, and *all four*
+verdicts — new offender, grown count, edge on an added line, entry to prune — are
+gated on it. One of them, `grown`, was written without that guard, and the
+asymmetry is worth recording because it turns a per-PR check into a shared
+tripwire: an edge landing anywhere in the tree fails the *next* unrelated PR, whose
+author has no fix available inside their own diff, and the only way out is to
+touch a file they had no reason to open. Whoever grew the file still gets the
+error, because the file is in *their* scope. Full-tree runs (no change scope) keep
+reporting everything, so the unscoped view is still available on demand.
+
+**Re-seeding is legitimate exactly once, inside PR 1.** The refuse-if-exists guard
+is what stops the baseline being laundered, but it also blocks the one honest
+reason to regenerate: an upstream refactor that moves edges between paths while
+PR 1 is still open. That happened here — `#6921` split `SessionManager` into five
+new modules between this RFC merging and PR 1 being raised, moving eight ACP edges
+out of `session.py` and adding one. `--update-baseline` can only lower and prune,
+so it cannot record the new paths, and leaving them unrecorded would fail the next
+person to touch them for a leak they did not introduce. The resolution is narrow
+and worth stating so it is not mistaken for a precedent: while PR 1 is unmerged the
+baseline has no history to protect, so deleting and re-seeding it is a correction.
+After PR 1 merges it does have history, and the guard is absolute — a path that
+appears later is a violation to route through `agent_sdk`, not a line to add.
+
+**Seeding and updating are separate verbs.** `--update-baseline` can only lower
+counts and delete lines; it refuses to introduce a path. Creating the file at all
+requires `--seed-baseline`, which **refuses to run when the baseline already
+exists**. Without that split, laundering the boundary is one command: delete the
+file, re-run the updater, and every new violation is absorbed as pre-existing.
+
+**There is no inline opt-out marker.** The sibling gates allow a per-line comment
+to exempt a call site; this one deliberately does not. "This consumer legitimately
+needs ACP" is precisely the claim the boundary exists to refuse, so a marker would
+not be an escape hatch for edge cases — it would be the standard way to defeat the
+rule, one line at a time, with no review signal. The baseline is the only
+exemption mechanism, and it only ever shrinks.
+
+`test/` is out of scope: a test that exercises the driver must import the
+driver's dependencies, so gating test files would make the boundary untestable.
+A file that fails to parse is a hard error, never "clean" — otherwise a
+shrink-only prune could silently delete a real entry.
+
 ### 8.2 The architecture test
 
 An `ast`-based test in house style, modelled on
@@ -654,9 +1062,15 @@ An `ast`-based test in house style, modelled on
 
 - Forbidden set **derived**, not hand-listed — a hand-kept list fails open, which
   is exactly how the messaging test previously missed two channels.
-- A coverage-of-the-contract test asserting every module under `src/kiro_crew` is
-  classified as consumer, SDK, or driver, so a new package cannot appear
-  unclassified.
+- The exempt set is a **ratchet, not a comment**: the test asserts the gate's
+  exempt prefixes equal an expected tuple, and that each one names a directory
+  that exists. Widening the boundary — or leaving `providers/` exempt after PR 6
+  deletes it — fails a test instead of passing quietly. A
+  "every module is classified" assertion was considered and rejected: every path
+  under `src/` begins with `src/kiro_crew/`, so such a test can never fail and
+  reads as coverage it does not provide.
+- A neighbouring-name probe: `kiro_crew.acp_backends` is not `kiro_crew.acp`, and
+  the test pins that a prefix-match regression does not start flagging it.
 - `test_every_recorded_violation_still_exists` — a stale exemption fails.
 - Negative probes: a violation outside the table is still caught; a
   `TYPE_CHECKING`-only import is still refused; `importlib.import_module` and
@@ -667,7 +1081,10 @@ An `ast`-based test in house style, modelled on
 
 - Event-kind and stop-reason string equality between SDK and ACP constants.
 - A translation test per `AcpEvent` field: kept fields round-trip, dropped fields
-  have no SDK attribute, replaced fields map correctly.
+  have no SDK attribute, replaced fields map correctly. **Per property as well as
+  per field** — `AcpEvent` carries four derived members (§5.2) and a field-only
+  test passes while all four silently invert, which is why this list previously
+  read as complete and was not.
 - An approval test proving a token from turn N is refused on turn N+1 and on a
   different session.
 - A protocol-conformance test per driver: for every optional protocol, the driver
@@ -682,9 +1099,16 @@ An `ast`-based test in house style, modelled on
   today's `{"id": "..."}` payload. No frontend change in any phase.
 - **Event kind values unchanged.** Persisted transcripts and channel payloads
   keep working; only the Python import path moves.
-- **`LLMProvider` survives migration.** `kiro_crew.providers.base` becomes a
-  deprecation shim re-exporting the SDK role protocols, so PR 2 does not have to
-  land with all 42 consumer files. It is deleted in PR 6, not before.
+- **`LLMProvider` survives migration, and `AgentEvent` ships deprecation shims.**
+  `kiro_crew.providers.base` becomes a deprecation shim re-exporting the SDK role
+  protocols, so PR 2 does not have to land with all 42 consumer files. That alone
+  is not enough to make PR 2 additive: the five ACP-shaped fields PR 2 drops from
+  the event object are read at over 200 sites across 17 files
+  (`event.request_id` alone is 131 reads in 17 files). PR 2 therefore lands each
+  dropped field as a read-only derived property on `AgentEvent` that raises
+  `DeprecationWarning` — so every existing reader keeps working on the day PR 2
+  merges. PR 5's waves delete each shim as they migrate its last reader, and PR 6
+  asserts none survive. Both shim families are deleted in PR 6, not before.
 - **Config keys unchanged.** `agent.acp_backend` and
   `agent.acp_backend_allow_ungated_tools` keep their names and values; the SDK
   reads them through the driver. Renaming them is a separate change with its own
@@ -836,16 +1260,25 @@ reopens it.
 
 1. **Who owns agent-process supervision? — DECIDED: the supervisor.**
    `session_pid.py`'s agent-process half moves into `agent_sdk`; its non-agent
-   PID duties (MCP probes, cron scripts) stay where they are. The
-   `acp/worker_pool.py:49` `try/except ImportError` guard is **deleted**, not
-   re-pointed.
+   PID duties (MCP probes, cron scripts) stay where they are. The cycle this
+   settles is `session_pid → acp.client → session → session_pid`
+   (`session_pid.py:311`, `:1888`), so the move has to relocate `_get_child_pids`
+   and place `_kill_pid_tree` + `_MANAGED_AGENT_MARKERS`, which both halves use.
+   The `acp/worker_pool.py:49` guard is deleted as a consequence; it is a
+   one-way standalone-importability fallback, not the cycle, and it catches
+   `Exception` rather than `ImportError`.
    *Rationale:* the warm pool and background runtime move in PR 4 regardless,
    and kill authority has to travel with the pool it kills. The rejected
    alternative — SDK depends on `session_pid` — preserves the cycle and only
    renames it.
    *Revisit if:* a non-agent consumer turns out to depend on the agent-process
    tracking file format, in which case the file stays put and the supervisor
-   writes through a narrow interface instead of owning it.
+   writes through a narrow interface instead of owning it. **Note this condition
+   is already partly met and PR 4 must plan for it:** the work-class sweeps gate
+   their kill sets negatively on `_MANAGED_AGENT_MARKERS` (`:1454`, `:1561`) and
+   the MCP sweep consumes the protected set through `_collect_active_pids`
+   (`:267`). That is shared *safety* input, not file format, so the decision
+   stands — but the split must preserve both, not discover them.
    **PR 4 is unblocked.**
 
 2. **Does `AgentEvent` carry child attribution as an object, or flatten it? —
@@ -865,10 +1298,19 @@ reopens it.
    **PR 2 is unblocked.**
 
 3. **Is runtime multiplexing part of the SDK contract or driver-private? —
-   DISPOSITION: driver-private, provisionally.** `AgentSupervisor` exposes "give
-   me a session", never "give me a runtime". The capability split introduced in
-   §5.2 (`multiplexes_sessions` versus `shares_subagent_session`) answers the
+   DISPOSITION: driver-private, provisionally, and the question is asked in two
+   places rather than one.** `AgentSupervisor` exposes "give me a session", never
+   "give me a runtime". The capability split introduced in §5.2
+   (`multiplexes_sessions` versus `shares_subagent_session`) answers the
    consumer-facing question without exposing a runtime object.
+   What an earlier draft of this item missed is that the *pre-session* half is not
+   a session question at all: `session.py:1398` and `:1610` ask it off a config
+   string to choose which path builds the session, and the answer is
+   `ACP_BACKENDS_ACP_RUNTIME & selectable_backends()` — a set, whose second
+   operand is a deployment fact resolved during boot. §5.2 puts that on the driver
+   registry as `spawnable_multiplexed_selections()`; a `SessionCapabilities` value
+   could not express it, and a boolean would discard the intersection that keeps a
+   runtime-capable-but-unregistered backend out.
    *Revisit if:* PR 4 cannot express warm-pool or background-runtime behaviour
    without a runtime-shaped argument crossing the boundary. Not blocking — PR 4
    produces the answer as a side effect of doing the move.
@@ -889,12 +1331,27 @@ reopens it.
    omitted declaration should fail at import rather than at runtime.
 
 5. **Does the deprecated `providers` shim need a release window? —
-   DISPOSITION: check, then decide inside PR 6.** Before PR 6 deletes
+   DISPOSITION: check, then decide inside PR 6.** The question is not only about
+   external consumers. `from kiro_crew.providers` is a substantial minority of the
+   baseline — the gate prints the exact split on every run — and it pulls the role
+   protocols (`LLMProvider`), the provider class (`AcpProvider`), the event type
+   and `EVENT_*` constants that `providers/base.py` re-exports from ACP, plus
+   `provider_label` and `is_claude_backend`, which `providers/acp.py` defines
+   rather than re-exports. An earlier draft of this item carried per-symbol
+   counts; they were wrong on most entries and stale on the rest within two days,
+   so they are gone. The distinction that survives is the one that matters:
+   `LLMEvent` and the `EVENT_*` names are ACP shapes wearing a `providers` label,
+   so an edge that pulls them is not more migrated than a direct `acp` import —
+   which is why the gate watches both roots.
+   So the in-repo half is PR 5's work, not a release-window question, and PR 6
+   must not arrive with it outstanding.
+   What remains genuinely open is the *external* half: before PR 6 deletes
    `kiro_crew.providers`, grep the internal companion and the app catalogue for
    `kiro_crew.providers.base`. Zero hits → delete in PR 6. Any hit → one release
    window, and the shim carries its deprecation warning from PR 2 rather than
    PR 6.
-   *Not blocking* — the check is cheap and belongs to PR 6's own checklist.
+   *Not blocking* — the in-repo count is already tracked by the gate's per-root
+   split, and the external check is cheap and belongs to PR 6's own checklist.
 
 6. **Is protocol-presence testing the right consumer ergonomic? —
    DISPOSITION: yes for optional *operations*, no for optional *facts*.**

--- a/scripts/check_agent_sdk_boundary.py
+++ b/scripts/check_agent_sdk_boundary.py
@@ -1,0 +1,792 @@
+#!/usr/bin/env python3
+"""check_agent_sdk_boundary.py -- application code must not import the ACP layer.
+
+## The failure class
+
+`kiro_crew.providers` is positioned as the boundary between application code and
+the agent backend, and is not one. It re-exports ACP symbols rather than
+translating them -- `providers/base.py` aliases `kiro_crew.acp.types.AcpEvent` as
+`LLMEvent`, so the "provider-agnostic" event type IS the ACP dataclass, complete
+with a raw JSON-RPC `request_id` -- and dozens of modules skip it and import
+`kiro_crew.acp` directly, several reaching underscore-private names. The
+consequence is that switching agent backends is not a driver swap; it is an edit
+across the whole tree.
+
+`docs/request-for-change/rfc-crew-agent-sdk-boundary.md` proposes
+`kiro_crew.agent_sdk` as the single import surface, with `kiro_crew.acp` private
+to one driver behind it. This gate is that RFC's Phase 1: it does not move any
+code, it records today's leak and refuses to let it grow.
+
+## What counts as a violation
+
+An import, in a file under `src/` that is NOT part of the boundary itself, whose
+target resolves to `kiro_crew.acp*` or `kiro_crew.providers*`.
+
+Both targets are forbidden, and the second one is the point. A gate that watched
+only `kiro_crew.acp` would report progress that is not real: `providers` is a
+legal laundering channel for exactly the vocabulary the boundary exists to
+contain (`LLMEvent` and the `EVENT_*` constants), so a
+consumer could be "migrated" off `acp` while still reading ACP shapes, and the
+count would fall. Watching both means the number only drops when a consumer
+stops depending on the backend at all.
+
+Three source trees are exempt, because they ARE the boundary:
+
+* `src/kiro_crew/agent_sdk/` -- the SDK and its driver, the one place allowed to
+  reach the ACP layer.
+* `src/kiro_crew/acp/` -- itself.
+* `src/kiro_crew/providers/` -- the shim being retired. **This exemption is
+  temporary**: the RFC's final phase deletes the package, and when it goes this
+  entry should go with it.
+
+`test/` is out of scope on purpose. A test that exercises the driver must import
+the driver's own dependencies, and gating that would make the boundary
+untestable.
+
+Matching is AST-based, so a multi-line import is judged as one statement and a
+`if TYPE_CHECKING:` import is still a violation -- a type-only dependency is
+still boundary knowledge, and it is how a consumer keeps hold of an ACP class
+after the runtime call is gone. `importlib.import_module("kiro_crew.acp...")`
+and `__import__` with a literal argument are caught for the same reason. A file
+that does not parse is a hard ERROR, never "clean": under a shrink-only ratchet
+a parse failure that read as zero violations would invite a prune that deletes
+the file's real entry.
+
+## No opt-out marker, deliberately
+
+Sibling gates in this repository offer an inline marker for a site that is
+correct-by-intent. This one does not. "This consumer legitimately needs the ACP
+layer" is precisely the claim the boundary exists to refuse, so a marker would
+be the hole rather than the audit trail. The baseline below is the only
+exemption mechanism, and it can only shrink.
+
+## The ratchet
+
+Existing edges are recorded in `.github/agent-sdk-boundary-baseline.txt` as
+`<count> <path>` lines. The rules mirror `check_subprocess_encoding.py` and
+`check_black_formatting.py` (same problem: a large pre-existing violation set
+that must only shrink):
+
+* a file NOT in the baseline must be clean;
+* a baselined file may not grow its count;
+* in a file this change touches, an edge sitting on an ADDED line is a new
+  offender even when the count is level -- otherwise deleting one old import
+  while adding one new one would slip through unchanged;
+* a baselined file whose count has shrunk (or that is clean or gone) must be
+  pruned so the list only shrinks -- run `--update-baseline`, which only ever
+  lowers counts and deletes lines, never adds or raises one.
+
+The "new offender" and "prune" verdicts are scoped to the files this change
+touches, for the reason the sibling gates document: CI evaluates a merge ref, so
+an unscoped gate would redden a PR for files the base branch merged after the
+baseline was recorded, and a stale count caused by someone else's cleanup is
+their prune to record.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASELINE = ROOT / ".github" / "agent-sdk-boundary-baseline.txt"
+
+# Only shipped runtime code. See the module docstring for why test/ is excluded.
+DEFAULT_TARGETS = ("src",)
+
+# Import targets application code may not reach.
+FORBIDDEN_ROOTS = ("kiro_crew.acp", "kiro_crew.providers")
+
+# Source trees that ARE the boundary. providers/ is temporary -- it goes when the
+# package is deleted in the RFC's final phase.
+EXEMPT_PREFIXES = (
+    "src/kiro_crew/agent_sdk/",
+    "src/kiro_crew/acp/",
+    "src/kiro_crew/providers/",
+)
+
+DYNAMIC_IMPORTERS = ("import_module", "__import__")
+
+HEADER = """\
+# Imports of the ACP layer from application code, as `<count> <path>`.
+# Both `kiro_crew.acp` and `kiro_crew.providers` count: providers re-exports ACP
+# shapes (LLMEvent and the EVENT_* constants), so watching only `acp` would let
+# a consumer look migrated while still reading the backend's own types.
+#
+# The gate requires every OTHER file under src/ to be clean and none of these
+# counts to grow, so this list can only shrink. There is no inline opt-out
+# marker: "this consumer legitimately needs ACP" is the claim the boundary
+# refuses, so the baseline is the only exemption mechanism.
+#
+# Do NOT add or raise a line to make a red gate green -- route the dependency
+# through kiro_crew.agent_sdk instead. Design of record:
+# docs/request-for-change/rfc-crew-agent-sdk-boundary.md
+#
+# Refresh (after removing something listed here):
+#   python3 scripts/check_agent_sdk_boundary.py --update-baseline
+"""
+
+
+def _load_changed_paths():
+    """Reuse the black gate's change-scope resolver instead of duplicating it.
+
+    Every baselined gate here needs the identical answer to "which files does
+    THIS change touch", including the merge-ref subtleties documented there.
+    """
+    script = ROOT / "scripts" / "check_black_formatting.py"
+    spec = importlib.util.spec_from_file_location("check_black_formatting", script)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {script}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._changed_paths
+
+
+def _load_added_lines():
+    """Reuse the subprocess gate's added-line resolver for the same reason."""
+    script = ROOT / "scripts" / "check_subprocess_encoding.py"
+    spec = importlib.util.spec_from_file_location("check_subprocess_encoding", script)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {script}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._added_lines
+
+
+def _is_exempt(rel: str) -> bool:
+    return any(rel.startswith(prefix) for prefix in EXEMPT_PREFIXES)
+
+
+def _forbidden(dotted: str) -> bool:
+    """True when a dotted module path lands inside a forbidden root."""
+    return any(dotted == root or dotted.startswith(root + ".") for root in FORBIDDEN_ROOTS)
+
+
+def _absolute_from_relative(rel_path: str, level: int, module: str | None) -> str:
+    """Resolve `from ..acp.types import x` to its dotted absolute form.
+
+    `rel_path` is repo-relative and starts with `src/`. A package's own path is
+    its directory; a module's is its parent directory. Level 1 addresses that
+    package, and each extra level strips one more component.
+    """
+    parts = list(Path(rel_path).with_suffix("").parts)
+    if parts and parts[0] == "src":
+        parts = parts[1:]
+    # Dropping the last component gives the containing package either way:
+    # a module loses its own name, `__init__` loses the marker.
+    package = parts[:-1]
+    ascend = max(level - 1, 0)
+    base = package[: len(package) - ascend] if ascend <= len(package) else []
+    if module:
+        base = base + [module]
+    return ".".join(base)
+
+
+def _matched_root(dotted: str) -> str | None:
+    """The forbidden root a dotted path lands in, longest match first."""
+    for root in sorted(FORBIDDEN_ROOTS, key=len, reverse=True):
+        if dotted == root or dotted.startswith(root + "."):
+            return root
+    return None
+
+
+def _str_const(node: ast.AST | None) -> str | None:
+    """The value of a string literal, or None for anything not statically known."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _kwarg(call: ast.Call, name: str) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _positional(call: ast.Call, index: int) -> ast.AST | None:
+    return call.args[index] if len(call.args) > index else None
+
+
+def _dynamic_importer_names(tree: ast.AST) -> set[str]:
+    """Every local name that refers to `import_module` or `__import__`.
+
+    The bare spellings are always in scope, but an importer can be renamed --
+    `from importlib import import_module as _im`, or `_im = importlib.import_module`
+    -- and a gate that matches only the canonical name misses the call entirely.
+    Collected in one pre-pass so the order of definition and use does not matter.
+
+    The canonical names stay in the set unconditionally, so a module that defines
+    its own `def import_module(...)` and passes it a `kiro_crew.acp.*` string is
+    flagged. That is deliberate: no such definition exists in this tree, and the
+    gate must prefer a visible false red -- which a reader corrects -- over a
+    silent false green, the same reason a file that fails to parse is a hard error
+    rather than "clean".
+    """
+    names = set(DYNAMIC_IMPORTERS)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name in DYNAMIC_IMPORTERS:
+                    names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Assign):
+            value = node.value
+            referenced = (
+                value.attr
+                if isinstance(value, ast.Attribute)
+                else value.id if isinstance(value, ast.Name) else ""
+            )
+            if referenced in DYNAMIC_IMPORTERS:
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+    return names
+
+
+def _is_ancestor_of_forbidden(dotted: str) -> bool:
+    """True when a forbidden root lives strictly under `dotted`.
+
+    `kiro_crew` is an ancestor of `kiro_crew.acp`; `kiro_crew.sandbox` is not.
+    This is what decides whether a `fromlist` can reach the boundary at all.
+    """
+    return any(root.startswith(f"{dotted}.") for root in FORBIDDEN_ROOTS)
+
+
+def _literal_strings(node: ast.AST) -> tuple[list[str], bool]:
+    """The strings an iterable literal yields, and whether that list is COMPLETE.
+
+    The second value is the whole point. Three rounds of review on this function
+    each closed one container shape and revealed the next -- tuple, list, set,
+    then dict keys, then starred unpacking, dict-unpack and literal concatenation
+    -- because enumerating shapes is a game the reader of the code cannot win:
+    `('acp',) * 1`, `('a' + 'cp',)`, `frozenset({'acp'})` and a comprehension all
+    import the same package. So the question asked here is inverted. Not "can I
+    find a forbidden name in this expression?" but "can I prove this expression
+    contains none?" -- and anything not fully understood answers no.
+    """
+    if isinstance(node, ast.Constant):
+        # A bare string is iterated CHARACTER by character, so it can only ever
+        # name single-letter submodules -- decidable, and never a forbidden root.
+        if isinstance(node.value, str):
+            return list(node.value), True
+        return [], True
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        elements = list(node.elts)
+    elif isinstance(node, ast.Dict):
+        # A `**` unpack has a None key: the keys it contributes are unknown.
+        if any(key is None for key in node.keys):
+            return [], False
+        elements = [key for key in node.keys if key is not None]
+    else:
+        return [], False
+
+    found: list[str] = []
+    for element in elements:
+        if isinstance(element, ast.Constant):
+            if isinstance(element.value, str):
+                found.append(element.value)
+            continue
+        # Starred, BinOp, Call, Name, comprehension, f-string: not decidable.
+        return found, False
+    return found, True
+
+
+def _dynamic_import_targets(rel: str, call: ast.Call) -> list[str]:
+    """Dotted targets a dynamic-import call reaches, across every argument form.
+
+    `import_module(name, package=None)` and
+    `__import__(name, globals, locals, fromlist=(), level=0)` each carry the module
+    in more than one place, and a gate that reads only the first positional
+    argument is bypassed by every other spelling:
+
+    - `name` may be a keyword (`import_module(name="kiro_crew.acp.client")`).
+    - `fromlist` holds the real target when `name` is only the package
+      (`__import__("kiro_crew", fromlist=("acp",))` imports `kiro_crew.acp`).
+    - a leading-dot `name` plus a `package` is relative, in either slot
+      (`import_module(".acp", package="kiro_crew")` and the positional
+      `import_module(".acp", "kiro_crew")`).
+    - `level` > 0 is relative to the calling module's own package
+      (`__import__("acp", level=1)`).
+
+    A non-literal argument is deliberately NOT resolved: `mod = cfg.name;
+    import_module(mod)` cannot be decided statically, and guessing would either
+    miss it anyway or flag innocent code. That gap is recorded as a clean probe in
+    the self-test so it stays a known limit rather than an assumed capability.
+    """
+    # `or` would be wrong here: `_str_const` returns "" for `__import__("", ...)`,
+    # which is FALSY but a perfectly legal module name -- it is how a purely
+    # relative import spells itself, and `__import__("", globals(), locals(),
+    # ("acp",), 2)` really does import `kiro_crew.acp`. Chaining with `or` treated
+    # that as "no name given" and returned early, so the whole relative branch
+    # below never ran. Test for None, not for truth.
+    name = _str_const(_positional(call, 0))
+    if name is None:
+        name = _str_const(_kwarg(call, "name"))
+    if name is None:
+        return []
+
+    level_node = _positional(call, 4) or _kwarg(call, "level")
+    level = (
+        level_node.value
+        if isinstance(level_node, ast.Constant) and isinstance(level_node.value, int)
+        else 0
+    )
+    # `package` is argument 1 of `import_module(name, package=None)`, so reading
+    # only the keyword left the positional spelling `import_module(".acp",
+    # "kiro_crew")` with package=None. The relative branch then fell back to
+    # resolving against the CALLING file's package, and for any nested consumer
+    # that lands on a non-forbidden target (`dashboard/foo.py` ->
+    # `kiro_crew.dashboard.acp`) -- a false green, in the one branch whose whole
+    # claim is that it closes every spelling. Slot 1 is `globals` for
+    # `__import__`, but a dict literal is not a string constant, so reading it
+    # here cannot produce a name.
+    package = _str_const(_kwarg(call, "package"))
+    if package is None:
+        package = _str_const(_positional(call, 1))
+
+    if name.startswith("."):
+        dots = len(name) - len(name.lstrip("."))
+        remainder = name[dots:]
+        if package:
+            base = package if dots <= 1 else ".".join(package.split(".")[: -(dots - 1)])
+            name = f"{base}.{remainder}" if remainder else base
+        else:
+            name = _absolute_from_relative(rel, dots, remainder or None)
+    elif level:
+        name = _absolute_from_relative(rel, level, name)
+
+    targets = [name]
+    fromlist = _positional(call, 3) or _kwarg(call, "fromlist")
+    if fromlist is not None and _is_ancestor_of_forbidden(name):
+        # `name` alone is innocent, so whether this call crosses the boundary is
+        # decided entirely by `fromlist`. Clean requires PROOF that it names no
+        # forbidden package; an expression this scanner cannot fully read is
+        # reported, because the alternative is a silent green on a real import.
+        # See `_literal_strings` for why the question is posed that way round.
+        items, decidable = _literal_strings(fromlist)
+        if decidable:
+            targets.extend(f"{name}.{item}" for item in items if item != "*")
+        else:
+            targets.extend(root for root in FORBIDDEN_ROOTS if root.startswith(f"{name}."))
+    return targets
+
+
+def _violations_in_source(rel: str, source: str) -> dict[int, str]:
+    """Line number -> the forbidden root that line reaches, in line order.
+
+    Keyed by line so two imports of the same root on one line count once, and
+    carrying the root so the passing message can report both halves of the
+    migration separately instead of guessing from the line's text.
+    """
+    tree = ast.parse(source)
+    hits: dict[int, str] = {}
+    importers = _dynamic_importer_names(tree)
+    for node in ast.walk(tree):
+        # These are the only nodes that can name a module, and narrowing to them
+        # here is also what lets `node.lineno` below be read off a known type
+        # instead of the bare `ast.AST` that `ast.walk` yields.
+        if not isinstance(node, (ast.Import, ast.ImportFrom, ast.Call)):
+            continue
+        targets: list[str] = []
+        if isinstance(node, ast.Import):
+            targets = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            base = (
+                _absolute_from_relative(rel, node.level, node.module)
+                if node.level
+                else (node.module or "")
+            )
+            # The from-target alone is not enough. `from kiro_crew import acp`
+            # has `node.module == "kiro_crew"`, which matches no forbidden root,
+            # while the NAME it binds is the forbidden package itself -- and with
+            # no inline opt-out marker this ordinary spelling would have been the
+            # standard way around the gate. So each bound name is also resolved
+            # against the from-target. `*` is skipped: a star-import of an
+            # ancestor does not name a forbidden root.
+            targets = [base] + [
+                f"{base}.{alias.name}" if base else alias.name
+                for alias in node.names
+                if alias.name != "*"
+            ]
+        elif isinstance(node, ast.Call):
+            callee = node.func
+            name = (
+                callee.attr
+                if isinstance(callee, ast.Attribute)
+                else callee.id if isinstance(callee, ast.Name) else ""
+            )
+            if name in importers:
+                targets = _dynamic_import_targets(rel, node)
+        for dotted in targets:
+            root = _matched_root(dotted)
+            if root is not None:
+                hits.setdefault(node.lineno, root)
+    return dict(sorted(hits.items()))
+
+
+def _scan(targets: tuple[str, ...]) -> dict[str, dict[int, str]]:
+    found: dict[str, dict[int, str]] = {}
+    for target in targets:
+        base = ROOT / target
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            rel = path.relative_to(ROOT).as_posix()
+            if _is_exempt(rel):
+                continue
+            try:
+                source = path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:  # pragma: no cover - unreadable file
+                raise SystemExit(f"cannot read {rel}: {exc}") from exc
+            try:
+                lines = _violations_in_source(rel, source)
+            except SyntaxError as exc:
+                raise SystemExit(
+                    f"{rel} does not parse ({exc}); refusing to report it as clean, "
+                    "because a shrink-only ratchet would then prune its real entry"
+                ) from exc
+            if lines:
+                found[rel] = lines
+    return found
+
+
+def _read_baseline(path: Path) -> dict[str, int]:
+    if not path.is_file():
+        raise SystemExit(
+            f"baseline {path} is missing; restore it from git rather than "
+            "regenerating it, since a regenerated baseline would silently absorb "
+            "every edge added since it was recorded"
+        )
+    entries: dict[str, int] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        count_str, _, rel = line.partition(" ")
+        if not count_str.isdigit() or not rel:
+            raise SystemExit(f"malformed baseline line: {line!r}")
+        if rel in entries:
+            raise SystemExit(
+                f"duplicate baseline entry for {rel}; a later duplicate would "
+                "silently override the recorded ceiling"
+            )
+        entries[rel] = int(count_str)
+    return entries
+
+
+def _write_baseline(path: Path, entries: dict[str, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "".join(f"{count} {rel}\n" for rel, count in sorted(entries.items()))
+    path.write_text(HEADER + body, encoding="utf-8")
+
+
+def _display(path: Path) -> str:
+    """Render a path for humans: repo-relative when it is inside the checkout.
+
+    `--baseline` accepts an arbitrary path, so `relative_to(ROOT)` is not total.
+    It used to be called in the seed success line -- AFTER the file had already
+    been written -- so seeding to a path outside the checkout wrote the baseline
+    and then died with a bare ValueError and a non-zero exit, which reads as
+    "seeding failed" for a seed that in fact succeeded.
+    """
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _shrunken_baseline(baseline: dict[str, int], current: dict[str, int]) -> dict[str, int]:
+    """The refresh result: counts only ever lowered, clean/gone entries dropped."""
+    survivors: dict[str, int] = {}
+    for rel, recorded in baseline.items():
+        now = current.get(rel, 0)
+        if now > 0:
+            survivors[rel] = min(recorded, now)
+    return survivors
+
+
+def _verdicts(
+    violations: dict[str, dict[int, str]],
+    baseline: dict[str, int],
+    changed: set[str] | None,
+    added: dict[str, set[int]] | None,
+) -> tuple[list[str], list[str], dict[str, list[int]], list[str]]:
+    """Split the scan against the baseline into the four things worth printing.
+
+    Every verdict is gated on `in_scope`, so a PR is only ever failed for a file
+    it actually touched. Without that the gate is not a per-PR check but a shared
+    tripwire: an edge landing anywhere in the tree turns the next unrelated PR
+    red, and the author has no fix available in their own diff. Whoever grew the
+    file is the PR that gets the error, because the file is in THEIR scope.
+    """
+    current = {rel: len(lines) for rel, lines in violations.items()}
+    in_scope = (lambda rel: True) if changed is None else (lambda rel: rel in changed)
+
+    new_offenders = sorted(rel for rel in current if rel not in baseline and in_scope(rel))
+    grown = sorted(
+        rel for rel in current if rel in baseline and current[rel] > baseline[rel] and in_scope(rel)
+    )
+    shrunk = sorted(
+        rel for rel in baseline if current.get(rel, 0) < baseline[rel] and in_scope(rel)
+    )
+
+    added_line_offenders: dict[str, list[int]] = {}
+    if added is not None:
+        for rel, lines in violations.items():
+            if rel in new_offenders or rel in grown or rel not in baseline:
+                continue
+            touched = sorted(set(lines) & added.get(rel, set()))
+            if touched:
+                added_line_offenders[rel] = touched
+
+    return new_offenders, grown, added_line_offenders, shrunk
+
+
+def _split_counts(violations: dict[str, dict[int, str]]) -> dict[str, int]:
+    """Edge count per forbidden root, so both halves of the migration are visible."""
+    counts = {root: 0 for root in FORBIDDEN_ROOTS}
+    for roots in violations.values():
+        for root in roots.values():
+            counts[root] = counts.get(root, 0) + 1
+    return counts
+
+
+def seed_baseline(baseline_path: Path) -> int:
+    """Write the first baseline. Refuses to overwrite an existing one.
+
+    `--update-baseline` can only lower and prune, so it cannot produce the
+    initial file, and `_read_baseline` deliberately fails closed when the file is
+    absent. This flag closes that one gap without opening a laundering hole: if
+    the baseline already exists, re-seeding is exactly the "regenerate and absorb
+    every new offender" move the missing-file error exists to prevent, so it is
+    refused and the caller is sent to `--update-baseline`.
+    """
+    if baseline_path.exists():
+        raise SystemExit(
+            f"{baseline_path} already exists; seeding again would absorb every "
+            "edge added since it was recorded. Use --update-baseline, which only "
+            "lowers counts and deletes lines."
+        )
+    violations = _scan(DEFAULT_TARGETS)
+    entries = {rel: len(lines) for rel, lines in violations.items()}
+    _write_baseline(baseline_path, entries)
+    by_root = _split_counts(violations)
+    print(
+        f"seeded {_display(baseline_path)}: {sum(entries.values())} edge(s) "
+        f"in {len(entries)} file(s) ("
+        + ", ".join(f"{n} via {r}" for r, n in by_root.items())
+        + ")."
+    )
+    return 0
+
+
+def run_gate(baseline_path: Path, update: bool) -> int:
+    violations = _scan(DEFAULT_TARGETS)
+    current = {rel: len(lines) for rel, lines in violations.items()}
+    baseline = _read_baseline(baseline_path)
+
+    if update:
+        survivors = _shrunken_baseline(baseline, current)
+        pruned = len(baseline) - len(survivors)
+        lowered = sum(1 for rel in survivors if survivors[rel] < baseline[rel])
+        _write_baseline(baseline_path, survivors)
+        print(f"pruned {pruned} entr(y/ies), lowered {lowered}; {len(survivors)} remain")
+        return 0
+
+    changed, scope_label = _load_changed_paths()()
+    print(f"agent-sdk-boundary gate scope: {scope_label}", end="")
+    print("" if changed is None else f" ({len(changed)} changed file(s))")
+    added = _load_added_lines()(scope_label) if changed is not None else None
+
+    new_offenders, grown, added_line_offenders, shrunk = _verdicts(
+        violations, baseline, changed, added
+    )
+
+    for rel in new_offenders:
+        print(
+            f"::error file={rel}::imports the ACP layer. Application code must "
+            "reach the agent backend through kiro_crew.agent_sdk."
+        )
+        for line in violations[rel]:
+            print(f"  {rel}:{line}")
+    for rel in grown:
+        print(
+            f"::error file={rel}::ACP-layer imports grew from {baseline[rel]} to "
+            f"{current[rel]}. The baseline is shrink-only."
+        )
+        for line in violations[rel]:
+            print(f"  {rel}:{line}")
+    for rel, lines in added_line_offenders.items():
+        print(
+            f"::error file={rel}::this change ADDS an ACP-layer import (the "
+            "baseline covers only pre-existing lines)."
+        )
+        for line in lines:
+            print(f"  {rel}:{line}")
+    if shrunk:
+        print(
+            f"::error::{len(shrunk)} baselined file(s) now have fewer ACP-layer "
+            "imports. Record the progress so the baseline keeps shrinking: "
+            "python3 scripts/check_agent_sdk_boundary.py --update-baseline"
+        )
+        for rel in shrunk:
+            print(f"  {rel}: {baseline[rel]} -> {current.get(rel, 0)}")
+
+    if new_offenders or grown or added_line_offenders or shrunk:
+        print(
+            f"\nagent-sdk-boundary gate FAILED: {len(new_offenders)} new "
+            f"offender(s), {len(grown)} grown count(s), "
+            f"{len(added_line_offenders)} file(s) with new edges on added lines, "
+            f"{len(shrunk)} entr(y/ies) to prune."
+        )
+        return 1
+
+    by_root = _split_counts(violations)
+    breakdown = ", ".join(f"{n} via {r}" for r, n in by_root.items())
+    print(
+        "agent-sdk-boundary gate passed: nothing in scope imports the ACP layer "
+        f"outside the baseline ({sum(baseline.values())} known edge(s) in "
+        f"{len(baseline)} file(s) still listed; {breakdown})."
+    )
+    return 0
+
+
+def _self_test() -> int:
+    """Plant one probe per rule family; a broken rule fails here, not in prod."""
+    rel = "src/kiro_crew/dashboard/probe.py"
+    flagged = {
+        "plain from-import": "from kiro_crew.acp.types import AcpEvent\n",
+        "module import": "import kiro_crew.acp.client\n",
+        "providers re-export": "from kiro_crew.providers.base import LLMEvent\n",
+        "package root": "import kiro_crew.providers\n",
+        "multi-line": (
+            "from kiro_crew.acp.types import (\n    AcpEvent,\n    EVENT_COMPLETE,\n)\n"
+        ),
+        "TYPE_CHECKING only": (
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    from kiro_crew.acp.runtime import AcpRuntime\n"
+        ),
+        "relative import": "from ..acp.types import AcpEvent\n",
+        "dynamic import_module": (
+            "import importlib\n" "importlib.import_module('kiro_crew.acp.client')\n"
+        ),
+        "dunder import": "__import__('kiro_crew.providers.acp')\n",
+        "dynamic keyword name=": (
+            "import importlib\n" "importlib.import_module(name='kiro_crew.acp.client')\n"
+        ),
+        "dynamic aliased importer": (
+            "from importlib import import_module as _im\n" "_im('kiro_crew.acp.client')\n"
+        ),
+        "dynamic importer bound by assignment": (
+            "import importlib\n"
+            "_im = importlib.import_module\n"
+            "_im('kiro_crew.providers.acp')\n"
+        ),
+        "dunder fromlist names the package": ("__import__('kiro_crew', fromlist=('acp',))\n"),
+        "dunder fromlist list form": ("__import__('kiro_crew', fromlist=['providers'])\n"),
+        "dunder fromlist dict keys": ("__import__('kiro_crew', fromlist={'acp': True})\n"),
+        "fromlist starred unpack": ("x = ['acp']\n__import__('kiro_crew', fromlist=(*x,))\n"),
+        "fromlist dict unpack": ("__import__('kiro_crew', fromlist={**{'acp': True}})\n"),
+        "fromlist literal concat": ("__import__('kiro_crew', fromlist=('acp',) + ())\n"),
+        "fromlist opaque call": ("__import__('kiro_crew', fromlist=frozenset({'acp'}))\n"),
+        "fromlist comprehension": ("__import__('kiro_crew', fromlist=[m for m in ('acp',)])\n"),
+        "fromlist name reference": ("f = ['acp']\n__import__('kiro_crew', fromlist=f)\n"),
+        "dunder fromlist set": "__import__('kiro_crew', fromlist={'providers'})\n",
+        "dynamic relative via positional package": (
+            "import importlib\n" "importlib.import_module('.acp', 'kiro_crew')\n"
+        ),
+        "dynamic relative via two-dot positional package": (
+            "import importlib\n" "importlib.import_module('..acp', 'kiro_crew.dashboard')\n"
+        ),
+        "dynamic relative via package=": (
+            "import importlib\n" "importlib.import_module('.acp', package='kiro_crew')\n"
+        ),
+        "dunder relative via level=": ("__import__('acp', level=2)\n"),
+        "empty name, purely relative": ("__import__('', globals(), locals(), ('acp',), 2)\n"),
+        "empty name, relative by keyword": ("__import__('', fromlist=('providers',), level=2)\n"),
+        "bound name is the package (acp)": "from kiro_crew import acp\n",
+        "bound name is the package (providers)": "from kiro_crew import providers\n",
+        "bound name via relative ancestor": "from .. import acp\n",
+        "bound name aliased": "from kiro_crew import acp as _a\n",
+    }
+    clean = {
+        "sdk import": "from kiro_crew.agent_sdk import AgentEvent\n",
+        "unrelated kiro_crew": "from kiro_crew.session import SessionManager\n",
+        "name collision": "from kiro_crew.acpx import thing\n",
+        "bound name is an unrelated sibling": "from kiro_crew import session\n",
+        "star-import of an ancestor": "from kiro_crew import *\n",
+        "string mention only": "MSG = 'see kiro_crew.acp.types for the event'\n",
+        "dynamic fromlist on an unrelated package": (
+            "__import__('kiro_crew', fromlist=('session',))\n"
+        ),
+        "dynamic star fromlist names no root": ("__import__('kiro_crew', fromlist=('*',))\n"),
+        "opaque fromlist under a sibling package": (
+            "f = compute()\n__import__('kiro_crew.sandbox', fromlist=f)\n"
+        ),
+        "empty fromlist": "__import__('kiro_crew', fromlist=())\n",
+        "empty name with no level": "__import__('')\n",
+        "import_module with an empty name raises at runtime": (
+            "import importlib\nimportlib.import_module('', package='kiro_crew.acp')\n"
+        ),
+        "dynamic non-literal": (
+            "import importlib\n" "mod = 'kiro_crew.acp'\n" "importlib.import_module(mod)\n"
+        ),
+    }
+
+    failures: list[str] = []
+    for label, source in flagged.items():
+        if not _violations_in_source(rel, source):
+            failures.append(f"probe NOT flagged (rule is dead): {label}")
+    for label, source in clean.items():
+        if _violations_in_source(rel, source):
+            failures.append(f"clean probe WAS flagged (rule is too wide): {label}")
+
+    if not _is_exempt("src/kiro_crew/agent_sdk/drivers/acp.py"):
+        failures.append("the SDK driver tree is not exempt")
+    if _is_exempt("src/kiro_crew/dashboard/chat_runner.py"):
+        failures.append("a consumer tree is exempt")
+
+    for line in failures:
+        print(f"::error::{line}")
+    if failures:
+        print(f"\nself-test FAILED: {len(failures)} broken rule(s).")
+        return 1
+    print(
+        f"self-test passed: {len(flagged)} violation probe(s) flagged, "
+        f"{len(clean)} clean probe(s) ignored."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="prune and lower recorded counts; never adds or raises one",
+    )
+    parser.add_argument(
+        "--seed-baseline",
+        action="store_true",
+        help="write the FIRST baseline; refuses if one already exists",
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="run the rule self-test instead of the gate",
+    )
+    args = parser.parse_args(argv)
+    if args.test:
+        return _self_test()
+    if args.seed_baseline:
+        return seed_baseline(args.baseline)
+    return run_gate(args.baseline, args.update_baseline)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kiro_crew/agent_sdk/__init__.py
+++ b/src/kiro_crew/agent_sdk/__init__.py
@@ -1,0 +1,38 @@
+"""The one import surface between application code and an agent backend.
+
+Nothing lives here yet. This package is declared first, on purpose: the boundary
+it names is enforced from the moment it exists, by
+``scripts/check_agent_sdk_boundary.py`` and ``test/test_agent_sdk_boundary.py``,
+so the leak it is meant to drain cannot grow while the contents are still being
+designed.
+
+Layering, once populated::
+
+    consumers        dashboard/  slack/  discord/  telegram/  messaging/
+                     session.py  subagent.py  apps/  cli_*.py  workflows/
+                            |
+                            |  may import ONLY kiro_crew.agent_sdk
+                            v
+                     kiro_crew.agent_sdk          domain types, role protocols,
+                                                  capabilities, supervisor
+                            |
+                            |  resolves drivers through a registry
+                            v
+                     kiro_crew.agent_sdk.drivers.acp
+                                                  the ONLY module permitted to
+                                                  import kiro_crew.acp
+                            v
+                     kiro_crew.acp   (private)    wire, dialects, adapters,
+                                                  session handles, worker pool
+
+If the gate goes red you introduced a boundary violation: fix the import
+direction rather than relaxing the rule, and never add or raise a line in
+``.github/agent-sdk-boundary-baseline.txt`` to make it green.
+
+Design of record, including what each later phase moves in here:
+``docs/request-for-change/rfc-crew-agent-sdk-boundary.md``.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -11,6 +11,8 @@
     "python3 scripts/check_black_formatting.py",
     "python3 scripts/check_subprocess_encoding.py --test",
     "python3 scripts/check_subprocess_encoding.py",
+    "python3 scripts/check_agent_sdk_boundary.py --test",
+    "python3 scripts/check_agent_sdk_boundary.py",
     "python3 scripts/check_lockdown_before_publish.py",
     "isort --check-only src/kiro_crew test",
     "flake8 src/kiro_crew test",

--- a/test/test_agent_sdk_boundary.py
+++ b/test/test_agent_sdk_boundary.py
@@ -1,0 +1,451 @@
+"""GATE — the agent-SDK boundary is declared, classified, and shrink-only.
+
+``scripts/check_agent_sdk_boundary.py`` refuses new imports of the ACP layer from
+application code. This test pins the three properties that make that gate
+trustworthy rather than decorative, in the shape the sibling architecture gates
+use (``test_messaging_import_purity.py``, ``test_workflows_architecture.py``):
+
+1. **The exempt set is exactly the boundary.** Only ``agent_sdk/``, ``acp/`` and
+   ``providers/`` may reach the ACP layer, the set is pinned here, and each
+   prefix must name a directory that exists. Widening the boundary fails a test
+   rather than passing quietly.
+2. **The recorded violations still exist.** A baseline entry that has been paid
+   off must be pruned, or the list stops shrinking and starts lying.
+3. **The scan cannot be walked around.** ``TYPE_CHECKING``-only imports,
+   relative imports, ``importlib.import_module`` and a bound name that IS the
+   forbidden package (``from kiro_crew import acp``) are all in scope, and the
+   probes below fail if any of them stops being caught.
+
+If this goes RED you either added an ACP import outside the boundary or paid one
+off without recording it. Fix the import direction or run
+``--update-baseline`` — do not relax the rule.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE = ROOT / "scripts" / "check_agent_sdk_boundary.py"
+BASELINE = ROOT / ".github" / "agent-sdk-boundary-baseline.txt"
+
+
+def _gate():
+    spec = importlib.util.spec_from_file_location("check_agent_sdk_boundary", GATE)
+    assert spec is not None and spec.loader is not None, f"cannot load {GATE}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gate():
+    return _gate()
+
+
+def test_the_sdk_package_exists_and_is_exempt(gate):
+    """The boundary cannot be enforced before the package it names exists."""
+    assert (ROOT / "src" / "kiro_crew" / "agent_sdk" / "__init__.py").is_file()
+    assert gate._is_exempt("src/kiro_crew/agent_sdk/drivers/acp.py")
+
+
+def test_the_exempt_set_is_exactly_the_boundary(gate):
+    """A fourth exemption is someone widening the boundary; ratchet the set.
+
+    Hand-listing all 230-odd top-level modules as "consumers" would rot on every
+    new module and prove nothing. What is worth pinning is the SHORT side: the
+    trees allowed to reach the ACP layer. providers/ is on it only until the
+    RFC's final phase deletes the package.
+    """
+    assert set(gate.EXEMPT_PREFIXES) == {
+        "src/kiro_crew/agent_sdk/",
+        "src/kiro_crew/acp/",
+        "src/kiro_crew/providers/",
+    }
+
+
+def test_every_exempt_prefix_points_at_a_real_tree(gate):
+    """A typo'd or stale prefix exempts nothing, or exempts a tree that is gone."""
+    missing = [p for p in gate.EXEMPT_PREFIXES if not (ROOT / p).is_dir()]
+    assert not missing, f"exempt prefixes with no directory: {missing}"
+
+
+def test_the_scan_actually_walks_the_tree(gate):
+    """A broken walk must not read as a clean tree.
+
+    The gate is shrink-only, so a scan that silently visited nothing would look
+    like total success and invite a prune that deletes the whole baseline.
+    """
+    scanned = 0
+    for path in (ROOT / "src").rglob("*.py"):
+        if not gate._is_exempt(path.relative_to(ROOT).as_posix()):
+            scanned += 1
+    assert scanned > 500, f"only {scanned} consumer file(s) in scope; the walk is broken"
+
+
+def test_the_forbidden_roots_include_the_re_export_channel(gate):
+    """Watching only kiro_crew.acp would let providers launder ACP shapes.
+
+    ``providers/base.py`` aliases ``acp.types.AcpEvent`` as ``LLMEvent`` and
+    re-exports the ``EVENT_*`` constants, so a consumer can depend on the backend
+    without naming it. If this drops to acp-only, the baseline can fall while
+    nothing is actually decoupled.
+    """
+    assert "kiro_crew.acp" in gate.FORBIDDEN_ROOTS
+    assert "kiro_crew.providers" in gate.FORBIDDEN_ROOTS
+
+
+def test_every_recorded_violation_still_exists(gate):
+    """A paid-off entry must be pruned; a stale baseline stops shrinking."""
+    baseline = gate._read_baseline(BASELINE)
+    current = {rel: len(hits) for rel, hits in gate._scan(gate.DEFAULT_TARGETS).items()}
+    stale = {
+        rel: (recorded, current.get(rel, 0))
+        for rel, recorded in baseline.items()
+        if current.get(rel, 0) < recorded
+    }
+    assert not stale, (
+        "these baseline entries are now lower than recorded; record the progress "
+        "with `python3 scripts/check_agent_sdk_boundary.py --update-baseline`: "
+        f"{stale}"
+    )
+
+
+def test_a_violation_outside_the_baseline_is_caught(gate):
+    """The plain case: an ACP import in a file the baseline does not list."""
+    hits = gate._violations_in_source(
+        "src/kiro_crew/dashboard/brand_new.py",
+        "from kiro_crew.acp.types import AcpEvent\n",
+    )
+    assert hits, "a fresh ACP import must be flagged"
+
+
+def test_a_type_checking_only_import_is_still_refused(gate):
+    """A type-only dependency is still boundary knowledge."""
+    hits = gate._violations_in_source(
+        "src/kiro_crew/dashboard/brand_new.py",
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    from kiro_crew.acp.runtime import AcpRuntime\n",
+    )
+    assert hits, "a TYPE_CHECKING import must not escape the scan"
+
+
+def test_a_dynamic_import_does_not_escape_the_scan(gate):
+    hits = gate._violations_in_source(
+        "src/kiro_crew/dashboard/brand_new.py",
+        "import importlib\nimportlib.import_module('kiro_crew.acp.client')\n",
+    )
+    assert hits, "importlib.import_module with a literal must be flagged"
+
+
+def test_a_relative_import_resolves_to_its_absolute_target(gate):
+    """`from ..acp.types import x` inside kiro_crew is the same violation."""
+    hits = gate._violations_in_source(
+        "src/kiro_crew/dashboard/brand_new.py",
+        "from ..acp.types import AcpEvent\n",
+    )
+    assert hits, "a relative ACP import must resolve and be flagged"
+
+
+def test_a_neighbouring_name_is_not_a_violation(gate):
+    """`kiro_crew.acp_backends` is a leaf that imports no ACP; prefix-matching it
+    would flag four consumers for depending on the module that exists to keep
+    them off the ACP package."""
+    hits = gate._violations_in_source(
+        "src/kiro_crew/session.py",
+        "from kiro_crew.acp_backends import selectable_backends\n",
+    )
+    assert not hits, "a sibling module sharing the prefix must not be flagged"
+
+
+def test_a_bound_name_that_is_the_forbidden_package_is_a_violation(gate):
+    """`from kiro_crew import acp` binds the forbidden package by NAME.
+
+    The from-target is `kiro_crew`, which matches no forbidden root, so a gate
+    that reads only `node.module` misses it. With no inline opt-out marker this
+    ordinary spelling would have been the standard way around the rule, with the
+    baseline still shrinking while dependence stayed put.
+    """
+    rel = "src/kiro_crew/dashboard/probe.py"
+    for source in (
+        "from kiro_crew import acp\n",
+        "from kiro_crew import providers\n",
+        "from kiro_crew import acp as _a\n",
+        "from .. import acp\n",
+    ):
+        assert gate._violations_in_source(rel, source), f"not flagged: {source!r}"
+
+
+def test_a_bound_name_that_is_an_unrelated_sibling_is_clean(gate):
+    """The rule must not widen to every `from kiro_crew import ...` line."""
+    rel = "src/kiro_crew/dashboard/probe.py"
+    for source in (
+        "from kiro_crew import session\n",
+        "from kiro_crew import config\n",
+        "from kiro_crew import *\n",
+    ):
+        assert not gate._violations_in_source(rel, source), f"flagged: {source!r}"
+
+
+def test_every_dynamic_import_spelling_is_a_violation(gate):
+    """One case per argument form a dynamic import can carry the module in.
+
+    A gate that reads only the first positional argument is bypassed by every
+    other spelling, and a reviewer hands these out one per round -- so the whole
+    branch table is asserted at once rather than the one that was reported.
+    """
+    rel = "src/kiro_crew/dashboard/probe.py"
+    spellings = {
+        "canonical attribute call": (
+            "import importlib\nimportlib.import_module('kiro_crew.acp.client')\n"
+        ),
+        "canonical dunder": "__import__('kiro_crew.acp.client')\n",
+        "module alias": ("import importlib as _il\n_il.import_module('kiro_crew.acp.types')\n"),
+        "bare from-import": (
+            "from importlib import import_module\nimport_module('kiro_crew.acp')\n"
+        ),
+        "renamed from-import": (
+            "from importlib import import_module as _im\n_im('kiro_crew.acp')\n"
+        ),
+        "bound by assignment": (
+            "import importlib\n_im = importlib.import_module\n_im('kiro_crew.providers')\n"
+        ),
+        "keyword name": ("import importlib\nimportlib.import_module(name='kiro_crew.acp')\n"),
+        "dunder fromlist tuple": "__import__('kiro_crew', fromlist=('acp',))\n",
+        "dunder fromlist list": "__import__('kiro_crew', fromlist=['providers'])\n",
+        "dunder fromlist set": "__import__('kiro_crew', fromlist={'acp'})\n",
+        "dunder fromlist dict keys": ("__import__('kiro_crew', fromlist={'acp': True})\n"),
+        "relative via package": (
+            "import importlib\nimportlib.import_module('.acp', package='kiro_crew')\n"
+        ),
+        "relative via level": "__import__('acp', level=2)\n",
+    }
+    missed = [
+        label for label, source in spellings.items() if not gate._violations_in_source(rel, source)
+    ]
+    assert not missed, f"dynamic-import spellings that escape the gate: {missed}"
+
+
+def test_a_positional_package_resolves_a_relative_dynamic_import(gate):
+    """`package` is argument 1, so reading only the keyword form is a false green.
+
+    With `package` unread, `import_module(".acp", "kiro_crew")` fell through to
+    resolving against the CALLING file's package. From a nested consumer that
+    lands on `kiro_crew.dashboard.acp` -- not a forbidden root -- so the file read
+    as clean while importing `kiro_crew.acp`.
+    """
+    rel = "src/kiro_crew/dashboard/probe.py"
+    flagged = {
+        "positional package": ("import importlib\nimportlib.import_module('.acp', 'kiro_crew')\n"),
+        "positional package, two dots": (
+            "import importlib\n" "importlib.import_module('..providers', 'kiro_crew.dashboard')\n"
+        ),
+        "keyword package": (
+            "import importlib\nimportlib.import_module('.acp', package='kiro_crew')\n"
+        ),
+    }
+    for label, source in flagged.items():
+        assert gate._violations_in_source(rel, source), f"{label} was not flagged"
+
+    clean = {
+        "positional package on a sibling": (
+            "import importlib\nimportlib.import_module('.userns', 'kiro_crew.sandbox')\n"
+        ),
+        # `__import__`'s slot 1 is `globals`, not `package`. A dict literal is not
+        # a string constant, so reading that slot cannot invent a package name.
+        "dunder globals in slot 1 is not a package": ("__import__('.acp', {}, {}, ('x',), 0)\n"),
+    }
+    for label, source in clean.items():
+        assert not gate._violations_in_source(rel, source), f"{label} was flagged"
+
+
+def test_dynamic_import_of_an_unrelated_module_is_clean(gate):
+    """The dynamic branch must not widen to every importlib call."""
+    rel = "src/kiro_crew/dashboard/probe.py"
+    clean = {
+        "unrelated module": ("import importlib\nimportlib.import_module('kiro_crew.session')\n"),
+        "unrelated fromlist": "__import__('kiro_crew', fromlist=('session',))\n",
+        "star fromlist": "__import__('kiro_crew', fromlist=('*',))\n",
+        "fromlist bare string": "__import__('kiro_crew', fromlist='acp')\n",
+        "non-literal target": (
+            "import importlib\nmod = 'kiro_crew.acp'\nimportlib.import_module(mod)\n"
+        ),
+    }
+    flagged = [label for label, source in clean.items() if gate._violations_in_source(rel, source)]
+    assert not flagged, f"clean dynamic imports wrongly flagged: {flagged}"
+
+
+def test_an_undecidable_fromlist_under_the_boundary_is_a_violation(gate):
+    """The invariant, not a list of container shapes.
+
+    Three review rounds each closed one `fromlist` shape and revealed the next --
+    tuple/list, then set and dict keys, then starred unpacking, dict-unpack and
+    literal concatenation. Enumerating shapes cannot converge: `('acp',) * 1`,
+    `('a' + 'cp',)`, `frozenset({'acp'})` and a comprehension all import the same
+    package. So the rule is inverted: when `name` is an ancestor of a forbidden
+    root, CLEAN requires proving the `fromlist` names none of it, and anything the
+    scanner cannot fully read is reported.
+    """
+    rel = "src/kiro_crew/dashboard/probe.py"
+    undecidable = {
+        "starred": "x = ['acp']\n__import__('kiro_crew', fromlist=(*x,))\n",
+        "dict unpack": "__import__('kiro_crew', fromlist={**{'acp': True}})\n",
+        "concatenation": "__import__('kiro_crew', fromlist=('acp',) + ())\n",
+        "repetition": "__import__('kiro_crew', fromlist=('acp',) * 1)\n",
+        "opaque call": "__import__('kiro_crew', fromlist=frozenset({'acp'}))\n",
+        "comprehension": "__import__('kiro_crew', fromlist=[m for m in ('acp',)])\n",
+        "generator": "__import__('kiro_crew', fromlist=(m for m in ('acp',)))\n",
+        "name reference": "f = ['acp']\n__import__('kiro_crew', fromlist=f)\n",
+        "element concat": "__import__('kiro_crew', fromlist=('a' + 'cp',))\n",
+    }
+    missed = [
+        label
+        for label, source in undecidable.items()
+        if not gate._violations_in_source(rel, source)
+    ]
+    assert not missed, f"an unreadable fromlist under the boundary passed: {missed}"
+
+
+def test_the_invariant_does_not_flag_a_sibling_package(gate):
+    """`kiro_crew.sandbox` is a sibling of the boundary, not an ancestor of it.
+
+    The tree really does call `__import__('kiro_crew.sandbox',
+    fromlist=['userns_available'])`, so a rule that reported every opaque
+    `fromlist` regardless of the package would red the gate on existing code.
+    """
+    rel = "src/kiro_crew/dashboard/probe.py"
+    clean = {
+        "real in-tree usage": ("__import__('kiro_crew.sandbox', fromlist=['userns_available'])\n"),
+        "opaque under a sibling": ("f = compute()\n__import__('kiro_crew.sandbox', fromlist=f)\n"),
+        "decidable and forbidden-free": ("__import__('kiro_crew', fromlist=('session',))\n"),
+        "empty": "__import__('kiro_crew', fromlist=())\n",
+        "non-strings only": "__import__('kiro_crew', fromlist=(1, 2))\n",
+        "bare string iterates characters": ("__import__('kiro_crew', fromlist='acp')\n"),
+    }
+    flagged = [label for label, source in clean.items() if gate._violations_in_source(rel, source)]
+    assert not flagged, f"the invariant is too wide: {flagged}"
+
+
+def test_an_empty_module_name_is_a_relative_import_not_a_missing_one(gate):
+    """`__import__("")` with a level is how a purely relative import spells itself.
+
+    `_str_const` returns `""` for it, which is falsy but a legal name, so chaining
+    the positional and keyword lookups with `or` treated it as "no name given" and
+    returned before the relative branch ran. Verified against the interpreter:
+    `__import__("", globals(), locals(), ("acp",), 2)` from a module two levels
+    under `kiro_crew` really imports `kiro_crew.acp`.
+    """
+    rel = "src/kiro_crew/dashboard/probe.py"
+    relative = {
+        "positional level": "__import__('', globals(), locals(), ('acp',), 2)\n",
+        "keyword level": "__import__('', fromlist=('providers',), level=2)\n",
+        "name by keyword": "__import__(name='', fromlist=('acp',), level=2)\n",
+        "opaque fromlist": "f = compute()\n__import__('', fromlist=f, level=2)\n",
+    }
+    missed = [
+        label for label, source in relative.items() if not gate._violations_in_source(rel, source)
+    ]
+    assert not missed, f"an empty-name relative import escaped: {missed}"
+
+
+def test_an_empty_name_that_imports_nothing_stays_clean(gate):
+    """Only the forms that actually reach a forbidden package are reported.
+
+    `importlib.import_module("", package=...)` raises `ValueError: Empty module
+    name` and imports nothing, and level 1 from `dashboard/` resolves to
+    `kiro_crew.dashboard.acp`, which is not the boundary. Flagging either would be
+    a false red on code that cannot cross.
+    """
+    rel = "src/kiro_crew/dashboard/probe.py"
+    clean = {
+        "import_module empty name raises": (
+            "import importlib\nimportlib.import_module('', package='kiro_crew.acp')\n"
+        ),
+        "no level at all": "__import__('')\n",
+        "level one lands in dashboard": ("__import__('', fromlist=('acp',), level=1)\n"),
+        "unrelated fromlist": "__import__('', fromlist=('session',), level=2)\n",
+        "no fromlist": "__import__('', level=2)\n",
+    }
+    flagged = [label for label, source in clean.items() if gate._violations_in_source(rel, source)]
+    assert not flagged, f"a harmless empty-name import was flagged: {flagged}"
+
+
+def test_the_self_test_passes(gate, capsys):
+    """The gate's own probes must pass, so a dead rule fails here too."""
+    assert gate._self_test() == 0
+    assert "self-test passed" in capsys.readouterr().out
+
+
+def test_seeding_refuses_to_overwrite_an_existing_baseline(gate):
+    """Re-seeding is the laundering move the missing-file error exists to stop."""
+    with pytest.raises(SystemExit) as excinfo:
+        gate.seed_baseline(BASELINE)
+    assert "already exists" in str(excinfo.value)
+
+
+def test_seeding_outside_the_checkout_reports_the_file_it_wrote(gate, tmp_path, capsys):
+    """`--baseline` takes any path, so the success line must not assume repo-relative.
+
+    The seed wrote the file and THEN rendered its name with `relative_to(ROOT)`,
+    which raises for a target outside the checkout: the baseline existed on disk
+    but the command died with a bare ValueError and a non-zero exit.
+    """
+    target = tmp_path / "outside-the-checkout.txt"
+    assert gate.seed_baseline(target) == 0
+    assert target.is_file() and target.read_text(encoding="utf-8").strip()
+    assert str(target) in capsys.readouterr().out
+
+
+def test_growth_in_an_untouched_file_is_not_this_prs_problem(gate):
+    """Every verdict is scope-gated, so no PR is failed for a file it never touched.
+
+    `grown` was the one verdict missing the `in_scope` guard its siblings have,
+    which made an edge landing anywhere in the tree fail the NEXT unrelated PR --
+    with no fix available inside that PR's own diff.
+    """
+    rel = "src/kiro_crew/dashboard/untouched.py"
+    violations = {rel: {10: "kiro_crew.acp", 11: "kiro_crew.acp"}}
+    baseline = {rel: 1}
+
+    _, grown, added_line_offenders, _ = gate._verdicts(
+        violations, baseline, {"src/kiro_crew/somewhere/else.py"}, {}
+    )
+    assert grown == [], "an untouched file's growth was charged to this PR"
+    assert added_line_offenders == {}, "and it must not resurface as an added-line error"
+
+    _, grown_when_touched, _, _ = gate._verdicts(violations, baseline, {rel}, {})
+    assert grown_when_touched == [rel], "the PR that grew the file must still be failed"
+
+
+def test_every_verdict_is_scope_gated(gate):
+    """Guard the shape, not just the two cases: no verdict may ignore `changed`."""
+    rels = {
+        "new": "src/kiro_crew/dashboard/brand_new.py",
+        "grown": "src/kiro_crew/dashboard/grew.py",
+        "shrunk": "src/kiro_crew/dashboard/shrank.py",
+    }
+    violations = {
+        rels["new"]: {1: "kiro_crew.acp"},
+        rels["grown"]: {1: "kiro_crew.acp", 2: "kiro_crew.acp"},
+        rels["shrunk"]: {1: "kiro_crew.acp"},
+    }
+    baseline = {rels["grown"]: 1, rels["shrunk"]: 2}
+
+    new_offenders, grown, added_line_offenders, shrunk = gate._verdicts(
+        violations, baseline, set(), {}
+    )
+    assert (new_offenders, grown, added_line_offenders, shrunk) == (
+        [],
+        [],
+        {},
+        [],
+    ), "an empty scope must produce no verdicts at all"
+
+    new_offenders, grown, _, shrunk = gate._verdicts(violations, baseline, None, None)
+    assert new_offenders == [rels["new"]]
+    assert grown == [rels["grown"]]
+    assert shrunk == [rels["shrunk"]]


### PR DESCRIPTION
## Problem / Motivation

Application code reaches the agent backend by importing `kiro_crew.acp` directly. Measured with an AST walk over `src/`: **109 edges across 58 files** — 67 via `kiro_crew.acp` and 42 via `kiro_crew.providers`, which re-exports the same ACP event shapes.

There is no rule saying it should not, so the number only goes up. Every one of those edges is a place a second provider has to be threaded through by hand, and `providers/base.py` — the thing that looks like the seam — is an alias module, not a translation layer.

## Why it matters

The immediate cost is that adding a non-Kiro backend is not a change in one place, it is a change in 58. The subtler cost: while there is no gate, the six-phase migration in the RFC has no floor. A wave can migrate ten files this week and three new consumers can import ACP directly next week, and nothing notices. Draining a leak that is still filling is not a plan.

Freezing the inventory first is what makes the rest of the work finite.

## What changed

**Motivation → approach.** The boundary has to be enforceable before anything moves, so this PR declares it and freezes today's violations as a shrink-only baseline. No code moves and no behaviour changes — deliberately, so the ratchet lands with a diff reviewers can actually check.

**Change.**

- **`scripts/check_agent_sdk_boundary.py`** — AST-based gate over `src/`, pure stdlib, modelled on `scripts/check_subprocess_encoding.py`. Six decisions are load bearing:
  - **Two forbidden roots, not one.** `providers/base.py` re-exports `LLMEvent` and the `EVENT_*` constants from ACP verbatim. Watching only `kiro_crew.acp` would let a consumer swap one import line for the other, read as migrated while still depending on the backend's own event shapes, and *shrink the baseline for free*. The gate prints the per-root split on every run, so a wave that moves one half and stalls on the other is visible rather than merely smaller.
  - **Bound names are checked, not just the from-target.** `from kiro_crew import acp` has `node.module == "kiro_crew"`, which matches no forbidden root — the forbidden package is the *name being bound*. Inspecting only the from-target lets that spelling, `from kiro_crew import providers`, and `from .. import acp` through untouched. Since there is deliberately no inline opt-out marker, that would not have stayed an edge case: it was the standard way around the rule, with the baseline still shrinking while dependence stayed put. Each bound name is now resolved against the from-target and checked; `*` is skipped, because a star-import of an ancestor names no forbidden root. **Found by two reviewers independently on the first revision of this PR.**
  - **Every dynamic-import spelling, not the three that were reported.** `import_module` and `__import__` each carry the module in more than one argument position: `name` as a keyword, `__import__`'s real target in `fromlist` when `name` is only the package, a leading-dot `name` with a `package` in either the keyword or the positional slot, `level > 0`, and the importer itself renamed (`from importlib import import_module as _im`) or bound by assignment. All are checked, with a self-test probe per spelling.
  - **`fromlist` is decided by an invariant, not by enumeration.** Three review rounds each closed one container shape and revealed the next — tuple/list, then set/dict keys, then starred unpacking and literal concatenation. That sequence does not converge: `('acp',) * 1`, `('a' + 'cp',)` and `frozenset({'acp'})` all import the same package. So the question is posed the other way round — when `name` is an **ancestor** of a forbidden root, the gate reports the call unless it can *prove* the `fromlist` names nothing forbidden. Ancestry is required, which is what keeps this tree's real `__import__("kiro_crew.sandbox", fromlist=[...])` calls untouched.
  - **Seeding and updating are separate verbs.** `--update-baseline` can only lower counts and delete lines; it refuses to introduce a path. Creating the baseline requires `--seed-baseline`, which **refuses to run when the file already exists**. Without that split, laundering the boundary is one command: delete the baseline, re-seed, and every new violation is absorbed as history.
  - **Every verdict is scoped to the files the change touched.** New offender, grown count, edge on an added line, entry to prune — all four are gated on the changed set, resolved through the same resolver the black gate uses. An unscoped verdict turns a per-PR check into a shared tripwire: an edge landing anywhere in the tree fails the *next* unrelated PR, whose author has no fix inside their own diff. Whoever grew the file still gets the error, because the file is in *their* scope. Full-tree runs still report everything.
  - **No inline opt-out marker.** The sibling gates allow a per-line comment to exempt a call site; this one does not. "This consumer legitimately needs ACP" is precisely the claim the boundary exists to refuse, so a marker would not be an escape hatch for edge cases — it would be the standard way to defeat the rule, one line at a time, with no review signal.
  - `TYPE_CHECKING`-only imports and relative imports are in scope. A file that fails to parse is a hard error, never "clean" — otherwise a shrink-only prune could silently delete a real entry.
- **`.github/agent-sdk-boundary-baseline.txt`** — 109 edges / 58 files.
- **`src/kiro_crew/agent_sdk/__init__.py`** — empty on purpose, with the target layering in the docstring. Declared first so the rule is enforceable while its contents are still being designed.
- **`test/test_agent_sdk_boundary.py`** — 25 tests. The exempt set is pinned as a ratchet: widening the boundary, or leaving `providers/` exempt after PR 6 deletes it, fails a test rather than passing quietly. Includes a neighbouring-name probe — `kiro_crew.acp_backends` is a deliberate leaf that imports no ACP, and a prefix-match regression that started flagging it would fail.
- **`.github/workflows/ci.yml`** plus the prepare-pr floor in **`profiles/kirocrew.json`** — the gate runs in both, self-test first, per `docs/ci/harness-parity-gate.md` (a gate that has silently stopped matching reads as green, which is worse than no gate). An installed copy of the skill would otherwise never learn about a scan CI gained after release.
- **`docs/request-for-change/rfc-crew-agent-sdk-boundary.md`** — revised here rather than in a docs-only PR, so the plan and its first phase land together. Five defects from an adversarial review of phases 2-6:
  1. **PR 2 was not additive.** It claimed to ship without touching consumers while removing five ACP-shaped fields read at 200+ sites across 17 files. It now ships read-only derived members with `DeprecationWarning`, and the two kinds of removal are distinguished: a *Replace* field derives from its successor, a *Do not cross* field has none and is carried through instead.
  2. **§5.2 tabled fields and omitted four properties.** `shell_command`, `child_low_fidelity`, `child_mcp_identity_trusted` and `child_unconditional_grant_eligible` are read outside `acp/` on the permission path and are computed from the *Do not cross* row, so no derived shim could produce them. Dropping `raw_tool_params` without them makes `shell_command` return `None` on `tool_call` events, every such shell call hits `hooks.py`'s deny-by-default, and a documented `use_aws` regression comes back.
  3. **PR 3's capability was asked before a session existed.** `session.py` consults `ACP_BACKENDS_ACP_RUNTIME & selectable_backends()` against a config string to choose which path *builds* the session. The pre-session half moves to the driver registry as `spawnable_multiplexed_selections()`.
  4. **PR 4 deleted the wrong edge.** `acp/worker_pool.py`'s guard is one-way and exists for standalone importability. The cycle is `session_pid → acp.client → session → session_pid`, documented verbatim in the code, and its second copy sits in the sweep §12.1 leaves in place.
  5. **PR 6's seal was unreachable.** The gate exempts by directory prefix and never scans exempt files, so the driver can never enter the baseline. Restated as a two-tree exempt set and an empty baseline.

  Plus, from a mechanical citation audit: PR 5's waves are now defined against the baseline rather than by category (`session.py` fell in no wave); hardcoded edge counts are removed in favour of the gate's own split; `hooks.py` was named as a baselined path but has no forbidden imports at all; "six construct `AcpProvider` directly" is one site and that site *is* the factory; and `is_claude_backend` is defined by `providers/acp.py`, not re-exported by `providers/base.py`.

  And one exit criterion added from this PR's design review: PR 2 must assert by **identity** that no name exported from `agent_sdk` *is* its ACP counterpart object. `agent_sdk/` is wholly exempt, so a verbatim re-export inside the SDK is the one channel this gate cannot see — the same `LLMEvent = AcpEvent` aliasing that made two forbidden roots necessary. PR 1 cannot carry that test, because the package is empty until PR 2 populates it.

## Tests

`test/test_agent_sdk_boundary.py`, 25 tests:

- baseline is parseable, shrink-only, and every recorded path still exists
- a violation outside the baseline is caught; a `TYPE_CHECKING`-only import is still refused; dynamic imports do not escape
- `from kiro_crew import acp` / `import providers` / `from .. import acp` / an aliased bind are all violations
- `from kiro_crew import session` / `config` / `*` stay clean, so the rule did not widen
- every dynamic-import spelling is a violation, and an unrelated module through the same call is clean
- a relative dynamic import resolves its `package` from either slot, so `import_module(".acp", "kiro_crew")` cannot read as clean by falling back to the calling file's own package
- an undecidable `fromlist` under the boundary is a violation, while the same shape on a sibling package (`kiro_crew.sandbox`) is not
- `__import__("", ..., ("acp",), 2)` is a relative import, not a missing name; `import_module("", package=...)` imports nothing and stays clean
- every verdict is scope-gated: an untouched file's growth is not charged to this PR, and an empty scope produces no verdicts at all
- exempt set equals the expected tuple and each prefix names a real directory
- `kiro_crew.acp_backends` is not treated as `kiro_crew.acp`
- `scanned > 500` so an empty walk cannot pass green
- `--seed-baseline` refuses when the baseline exists, and reports the file it wrote when seeding outside the checkout

The gate's own `--test` plants 45 probes (32 violations, 13 clean) and runs before the gate in the same CI step.

## Manual verification

```
$ python3 scripts/check_agent_sdk_boundary.py --test
self-test passed: 32 violation probe(s) flagged, 13 clean probe(s) ignored.

$ python3 scripts/check_agent_sdk_boundary.py
agent-sdk-boundary gate passed: nothing in scope imports the ACP layer outside the
baseline (109 known edge(s) in 58 file(s) still listed; 67 via kiro_crew.acp,
42 via kiro_crew.providers).

$ python3 scripts/check_agent_sdk_boundary.py --seed-baseline
.../agent-sdk-boundary-baseline.txt already exists; seeding again would absorb
every edge added since it was recorded. Use --update-baseline, which only lowers
counts and deletes lines.
[exit 1]

$ python3 scripts/check_agent_sdk_boundary.py --seed-baseline --baseline /tmp/outside.txt
seeded /tmp/outside.txt: 109 edge(s) in 58 file(s) (67 via kiro_crew.acp, 42 via
kiro_crew.providers).
[exit 0]

$ python3 -m pytest -q test/test_agent_sdk_boundary.py test/test_prepare_pr_profiles.py
66 passed
```

A full-tree rescan was diffed against the committed baseline line by line — 109 edges in 58 files on both sides, so the frozen inventory is the real one and not a snapshot of a partial walk.

Also green locally: `mypy`, `./scripts/docs-lint.sh` (245 files), `check_brand_name.py`, `check_changelog_history.py`, `check_loop_bound_locks.py`, `check_black_formatting.py`, `isort --check-only`, `flake8`, and both `ci.yml` and `profiles/kirocrew.json` parse. Verified under Python 3.9, 3.11 and 3.12.

### On the re-seed

The baseline was first seeded at 108/53. `#6921` (`refactor(session): split manager into composed services`) landed between the RFC merging and this PR, moving eight ACP edges out of `session.py` into five new modules and adding one — so the recorded paths no longer existed. `--update-baseline` can only lower and prune, so it could not record the new paths, and leaving them unrecorded would have failed the next person to touch them for a leak they did not introduce. §8.1 now states the window explicitly: while PR 1 is unmerged the baseline has no history to protect, so re-seeding is a correction; once it merges, the refuse-if-exists guard is absolute and a path that appears later is a violation to route through `agent_sdk`, not a line to add.

## Screenshots / video

n/a — no user-visible surface.

## Related Issues

No linked issue: this PR executes phase 1 of an accepted RFC, so the design of record is the RFC rather than a tracking issue — `docs/request-for-change/rfc-crew-agent-sdk-boundary.md`, merged in #6662. The #6662 and #6921 references above are history, not work this PR closes. This is PR 1 of six. Follow-ups per the RFC: PR 2 SDK types, PR 3 capabilities, PR 4 supervisor lifecycle, PR 5 consumer waves, PR 6 seal.

## Checklist

- [x] Design of record exists and is linked
- [x] Gate self-tests before it runs, per `docs/ci/harness-parity-gate.md`
- [x] Gate is in both `ci.yml` and the prepare-pr floor
- [x] Baseline is shrink-only and cannot be re-seeded in place after merge
- [x] Every verdict is scoped to the change, so no PR is failed for a file it did not touch
- [x] No behaviour change; no code moved
- [x] Docs updated in the same commit per `docs/README.md`
- [x] Lint, format, type, and doc gates green locally

## Contribution License Agreement

By submitting this pull request I confirm that my contribution is made under the terms of the project's license.
