### PR TITLE
chore(dashboard): remove confirmed dead code in the dashboard handlers

### DIFF
--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -55,7 +55,6 @@ from kiro_crew.dashboard.handlers._shared import (  # noqa: E402, F401
 
 # ── Agents (extracted to handlers/agents.py) ──
 from kiro_crew.dashboard.handlers.agents import (  # noqa: E402, F401
-    _auto_install_agent,
     _find_agent_config,
     _get_config_lock,
     _installed_agent_config,

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -1430,7 +1430,6 @@ def list_skill_tree(skill_root: Path) -> list[dict[str, Any]]:
     real path escapes *skill_root* are omitted.
     """
     out: list[dict[str, Any]] = []
-    skipped = 0
     for dirpath, dirnames, filenames in os.walk(skill_root, followlinks=False):
         # Stable order — reproducible across runs / tests.
         dirnames.sort()
@@ -1447,18 +1446,15 @@ def list_skill_tree(skill_root: Path) -> list[dict[str, Any]]:
         for f in filenames:
             full = Path(dirpath) / f
             if is_sensitive_path(str(full)):
-                skipped += 1
                 continue
             try:
                 if full.is_symlink():
                     real = full.resolve(strict=True)
                     real.relative_to(skill_root.resolve(strict=True))
                     if is_sensitive_path(str(real)):
-                        skipped += 1
                         continue
                 stat = full.stat()
             except (OSError, ValueError):
-                skipped += 1
                 continue
             rel = full.relative_to(skill_root).as_posix()
             out.append({"path": rel, "type": "file", "size": int(stat.st_size)})

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -150,15 +150,6 @@ async def _require_owner(request: web.Request, operation: str) -> web.Response |
 # ── Agent Config ──
 
 
-def _auto_install_agent() -> None:
-    """Re-install agent config to kiro-cli so changes take effect immediately."""
-    try:
-        install_agent()
-        logger.info("Auto-applied agent config via dashboard")
-    except Exception:
-        logger.debug("Auto-apply agent config failed", exc_info=True)
-
-
 def _find_agent_config() -> Path:
     """Find agents/defaults.json — delegates to centralized resolver."""
     return resolve_agent_config_path()

--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -35,12 +35,10 @@ from kiro_crew.security import (
 if platform_compat.IS_POSIX:
     import fcntl
     import pty as _pty
-    import signal
     import termios
 else:  # pragma: no cover — Windows fallback
     fcntl = None  # type: ignore[assignment]
     _pty = None  # type: ignore[assignment]
-    signal = None  # type: ignore[assignment]
     termios = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -2115,7 +2115,6 @@ async def api_update_channel(request: web.Request) -> web.Response:
     # Same reason as the write above: a config read is disk I/O on a path the
     # operator may have put on a network mount.
     cfg = await asyncio.to_thread(KiroCrewConfig.load)
-    _, artifact_base = _cdn_bases()
     return web.json_response(
         {
             "ok": True,


### PR DESCRIPTION
## What

Removes four dead symbols (17 lines) from the dashboard handlers group: `src/kiro_crew/dashboard/handlers/`, `src/kiro_crew/dashboard/routes/`, `handlers_instances.py`, `handlers_system.py` — 77 files, 2235 module-level names.

No behaviour change. No test deleted: none of the four is referenced by any test.

## Deleted, with evidence

### 1. `_auto_install_agent` — `handlers/agents.py:153-159` + re-export `handlers/__init__.py:58`

Exactly **one** real NAME token repo-wide, and it is the re-export line. `handlers/__init__.py` has no `__all__` — it is a `# noqa: F401` shim — so a name listed there with no importer is unreachable. Zero string refs, zero non-Python refs, zero `getattr`/dispatch-table/`importlib`/entry-point refs.

Not a missing wire: a dashboard agent-config change **is** applied to kiro-cli today by a different mechanism. `api_agent_config`'s PUT commits through `_commit_agent_config`, whose step (4) is `_write_installed_config_locked(installed_path, config)` — a direct write to the live spec kiro-cli reads. `install_agent` keeps four live callers on the catalog-changing paths (skill install/uninstall, agent-package install/uninstall), so its import stays and there is no F401.

### 2. `import signal` + its Windows `= None` stub — `handlers/terminal.py:38, 43`

The whole-word name occurs on exactly those two lines. The later hits (541, 918, 1586, 1602) are the English word "signal" in comments — `tokenize` classifies them `COMMENT`, not `NAME`. No `signal.` attribute access anywhere in the module, on either platform branch. Since the name is never Loaded, its absence raises no `NameError` and the `# type: ignore[assignment]` guarded nothing. Both halves of the shim pair were dead, so removing both keeps the POSIX/Windows structure symmetric for the still-used `fcntl`, `_pty` and `termios`.

### 3. The `skipped` tally in `list_skill_tree` — `handlers/_shared.py:1433, 1450, 1457, 1461`

Initialised and incremented in three branches, never read: not returned, not logged, not in the response. `AugAssign` is a Store-only node, so the name is never Loaded.

**The sensitive-path guard is untouched.** Every `is_sensitive_path(...)` gate, the symlink-escape `real.relative_to(skill_root...)` check, the exception handler, and all four `continue` statements are unchanged — withheld entries are still withheld. The sole caller (`handlers/prompts.py:573`) binds only the returned list, and this path's SEL event (`prompts.py:600-604`) logs `count=len(entries)` — the count of *returned* entries, never a withheld count. No response field, log line, metric or SEL event consumed the tally, and sibling listing paths report no withheld-entry count either, so no existing convention breaks.

### 4. `_, artifact_base = _cdn_bases()` — `handlers/updates.py:2118`

Inside `api_update_channel`; neither binding is read afterwards. `cdn_bases()` (`platform/update_layout.py:167-175`) reads `KIROCREW_CDN_BASE`, normalizes, and returns a tuple — no caching, no validation, no HTTPS pin, no governance call, so discarding the call is a no-op.

Validation is a *separate* function (`cdn_bases_are_safe()`, `update_layout.py:186-196`, with the pin in `_SAFE_CDN_BASE_RE`), and the approval-time safety gate that actually consumes it is intact at `updates.py:2309-2343` — `update_blocked_reason(feed_base) or update_blocked_reason(artifact_base)` plus `_cdn_safe()`. The sibling read at `updates.py:1040` already used the `feed_base, _artifact_base` convention and is unaffected.

## How the candidates were found

Vulture is ~80% noise in this group: an HTTP handler has no Python caller by construction — `routes/*.py` reaches it via `app.router.add_get(path, handlers.api_x)` and the request comes from `website/src`. So "has a caller" was replaced with "is registered", then with "is reached".

| pass | method | raw | kept |
|---|---|---|---|
| A | vulture `--min-confidence 60` | 190 | ~150 were route-registered `api_*` |
| B | AST (module defs minus repo-wide `Name(Load)`/`Attribute`/`ImportFrom`) | 1 | attribute-name collisions across 3065 files swamp it |
| C | tokenize — real `NAME` tokens only, docstrings/comments excluded | 1 | the authoritative pass |
| D | route reachability (`add_*` graph over `routes/` + `server.py`; 637 literal paths, 813 handler names) | 4 apparent orphans | **0** real |
| E | reverse index over 6987 files (`*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1 *.cfg *.txt`) bucketed self/scope/prod/tests/docs/config/web | 1 zero-ref, 8 test-only | |
| F | AST unused-assigned-locals inside scope functions | 2 | both confirmed |
| G | endpoint-path reachability (registered stem vs `website/`, `mcp*`, `apps/`, `skills/`, `cli*`, `cron*`, `docs/`) | 6 | 1 in-scope, reported below |

Pass D's four apparent orphans — `api_session_control_create` / `_stop` / `_send` / `_read` — are all **string-dispatch registered** via `server.py:1286` `_deferred_session_control("api_session_control_create")` and are alive. A name-based scanner cannot see any of them. A module-level pass also confirmed every one of the 74 modules in the group has external references, so there are no dead modules.

## Deferred — 30-day gate

- **`_RELEASE_CHANNELS`** (`handlers/updates.py:152`) — the only symbol in the group with **zero** real NAME tokens repo-wide, and a byte-identical duplicate of the live validator `platform/update_layout.RELEASE_CHANNELS:25` (which does the real work at lines 124 and 147, so validation is not missing). Refactor residue from #2856. Held because `git log -S` dates its introduction to 2026-08-05 and its last occurrence change to 2026-08-20 — both inside 30 days.

## Deferred — test-only, removal would be a refactor

Zero production callers, N test call sites; deleting the symbol means rewriting every fixture that uses it as a state seed or a differential oracle.

| symbol | tests | shape |
|---|---|---|
| `reset_link_meta_cache` (`link_meta.py:519`) | 3 | test-support reset seam living in production code |
| `_reset_hook_inflight` (`hooks.py:403`) | 4 | same, across two test modules |
| `_resolve_loaded_by_agents` (`_shared.py:828`) | 14 | **differential oracle** — tests assert `s["loaded_by_agents"] == _resolve_loaded_by_agents(p)` against the bulk production path |
| `_list_completions` (`terminal.py:1272`) | 18 | superseded wrapper; the production path inlines `_resolve_completion_dir` + `_vetted_completion_dir` + `_list_vetted_completions` directly |
| `REGISTRAR_NAMES` (`routes/__init__.py:58`) | 9 | not dead — it is the route-table ratchet `test_dashboard_route_table.py` pins order against |

## Reported for a maintainer decision, not deleted

**Half-wired lifecycle** (the fix is wiring, not deletion):

- **`_cached_parse_sessions`** (`usage.py:1798`) — the module comment at line 56 says this cache is "used by `api_usage`". It is not: no production caller exists, and `usage.py:1859` re-implements the off-loop call as a bare `run_in_executor(None, _parse_sessions)` **without** the 120s TTL cache or the `_SESSIONS_CACHE_LOCK` cold-cache collapse, so a concurrent burst re-runs the full `iterdir` + per-file `stat` + line-by-line parse every time.
- **`_RingLogHandler._max`** (`updates.py:1828`) — written, never read; the only cap that exists is the deque's own `maxlen`, so `_RingLogHandler(ring, max_size)` silently ignores `max_size`. `test_dashboard_updates_coverage.py:892` passes it, so removing the parameter is a test-touching change.

**Registered but unreachable endpoint:**

- **`GET /api/sso-ttl`** — `handlers_system.py:750` `api_sso_ttl`, registered `routes/realtime.py:55`, re-exported `handlers/__init__.py:19`. The literal path appears nowhere else: not in `website/`, `test/`, `docs/`, nor any MCP tool, app, skill, cron or CLI path. Introduced by the de-Amazoning scrub #168 — in the Amazon edition the companion adapter returned a real SSO TTL; in the OSS build `current_context().identity.status` hits the Default adapter, which spawns **up to 4 subprocesses at a 5s timeout each**. An authenticated GET with real cost and no caller. Held because it *is* registered, so it fails condition (1) of the death test, and removing an endpoint is a product decision that would also move the `(method, path, handler)` sequence pinned by `test_dashboard_route_table.py`.

**Security surface — reported, not touched:**

- `count_effective_denied_commands` (`security.py:338`) — zero production callers; only `test_denied_commands_api.py:158` asserts on it. It computes the effective denied-command count and nothing surfaces it; the deadness may itself be the gap.
- `_load_bearer_token` (`kiro_usage_api.py:492`) — zero production callers, 10 test sites, but superseded **by design**: its own docstring says it "applies NO ownership proof, so it must not be used to choose the credential a request is made with", and `fetch_usage_limits` uses `_candidate_tokens()` directly.

**Out of scope, flagged for whoever audits `handlers_project.py`:** `routes/connections.py:62-65` registers `GET /api/activities`, `POST /api/comments`, `GET /api/comments` and `DELETE /api/comments/{id}`, whose paths appear nowhere outside the registration and `test_project_alias.py`. The handlers live in `dashboard/handlers_project.py`, outside this group.

## Verification

- 17 deterministic backend gates green (black, isort, flake8, subprocess-encoding, lockdown-before-publish, brand-name, harness-parity, loop-bound-locks, testpaths-coverage, changelog-history, plus each one's self-test).
- `mypy src/kiro_crew/` — no issues in 1170 source files.
- Affected-surface pytest (74 test files selected by the seams this diff touches): **3210 passed**, 2 skipped. The 2 failures in `test_artifacts_handlers.py` reproduce identically on unmodified `origin/main` (`artifacts.py` is not in this diff) and are left alone.
- Two local AI review lanes (`gpt-5.6-sol`, `claude-opus-4.8`) each returned **No findings** after independently checking dynamic dispatch, guard-behaviour equivalence, `cdn_bases` purity, the F401 risk, and doc/spec staleness.
