### PR TITLE
refactor(sidebar): extract the move-undo primitive behind one hook

### DIFF
--- a/website/src/components/MoveUndoBar.tsx
+++ b/website/src/components/MoveUndoBar.tsx
@@ -9,20 +9,27 @@ import { isMac, platformShortcut } from '../utils/platform'
 /**
  * How long a drag-move stays undoable.
  *
- * Long enough to notice the bar, read where the session went, and aim for the
+ * Long enough to notice the bar, read where the item went, and aim for the
  * button; short enough that the offer never outlives the mistake it belongs to.
  *
- * The DEADLINE is enforced by the owner of the offer (ChatSidebar), not here:
- * an offer whose optimistic move never became visible has no bar to run a
+ * The DEADLINE is enforced by the owner of the offer ({@link useMoveUndo}), not
+ * here: an offer whose optimistic move never became visible has no bar to run a
  * timer, and must still die on this same clock. This component only draws the
  * remaining time.
  */
 export const MOVE_UNDO_MS = 8000
 
-/** The inverse of one drag-move, i.e. everything undo needs to put it back. */
-export type MovedSession = {
-  /** Slot that moved. */
-  slotKey: string
+/**
+ * The inverse of one drag-move, i.e. everything undo needs to put it back.
+ *
+ * Deliberately names the moved thing `item` rather than `session`: the sidebar's
+ * session drag is the first caller, not the only intended one, and a field
+ * called `slotKey` would be a lie the moment an artifact or a folder subtree
+ * arms the same offer.
+ */
+export type MovedItem = {
+  /** Item that moved — a slot key, artifact slug, or folder id. */
+  itemKey: string
   /** Folder it came FROM — where undo puts it back (`null` = unfiled root). */
   fromFolderId: string | null
   /** Folder it landed in. Compared against live state to drop a stale offer. */
@@ -31,12 +38,12 @@ export type MovedSession = {
   toFolderName: string | null
   /** Destination folder color, for the glyph tint. */
   toFolderColor?: string
-  /** Title of the moved session — the hover tooltip, since the row has no room. */
-  sessionTitle: string
+  /** Title of the moved item — the hover tooltip, since the row has no room. */
+  itemTitle: string
 }
 
 type Props = {
-  moved: MovedSession
+  moved: MovedItem
   onUndo: () => void
   /** Reports whether the pointer is over the bar or focus is inside it, so the
    *  owner can suspend the expiry deadline rather than pull the button out from
@@ -68,12 +75,17 @@ type Props = {
 }
 
 /**
- * Confirmation + undo for a session dragged into a folder.
+ * Confirmation + undo for an item dragged into a folder.
  *
- * A drag is a coarse gesture: drop a session one row off and it vanishes into a
+ * A drag is a coarse gesture: drop an item one row off and it vanishes into a
  * folder the user never sees, with nothing on screen saying where it went. This
  * bar names the destination and offers the inverse move back for
  * {@link MOVE_UNDO_MS}.
+ *
+ * The `session*` i18n keys and `session-move-undo*` test ids are retained rather
+ * than renamed with the component: the strings are translated in every locale
+ * catalogue and the ids are what the screenshot capture script selects on, so
+ * renaming them would be churn and breakage for no behavioural gain.
  *
  * ## Why it lives in the flow rather than floating
  *
@@ -90,11 +102,11 @@ type Props = {
  * ⌘C (copy). The handler stands down while focus is in a text field so the
  * composer keeps its own undo history, and ignores ⇧⌘Z (redo).
  *
- * ## The offer's lifecycle (owned by ChatSidebar, documented here)
+ * ## The offer's lifecycle (owned by {@link useMoveUndo}, documented here)
  *
- * This component only renders an offer; `ChatSidebar` decides when one exists.
- * That state machine is the part a future editor is most likely to break, so it
- * is written down once, here, rather than inferred from scattered comments:
+ * This component only renders an offer; the hook decides when one exists. That
+ * state machine is the part a future editor is most likely to break, so it is
+ * written down once, here, rather than inferred from scattered comments:
  *
  * ```
  *   drag drop ──► PENDING ──ack──► LIVE ──► (undo | expiry | mismatch) ──► gone
@@ -112,11 +124,11 @@ type Props = {
  *    latched, because by ack time live state may match the destination again
  *    (a move away and back) and nothing later could tell.
  *  - **LIVE** — the server acknowledged and nothing was latched. The bar
- *    renders; an 8s deadline owned by the sidebar retires it.
+ *    renders; an 8s deadline owned by the hook retires it.
  *  - **gone** — one-way. An offer is dropped, never re-validated, so a retired
  *    offer cannot come back and replay its inverse over a newer move.
  */
-export default function SessionMoveUndoBar({
+export default function MoveUndoBar({
   moved,
   onUndo,
   onHoldChange,
@@ -162,8 +174,8 @@ export default function SessionMoveUndoBar({
         <span
           className="flex min-w-0 flex-1 items-center gap-1 text-[12px] text-text"
           title={moved.toFolderName === null
-            ? `${i18nT('components.sessionMoveUndoBar.removed_from_folder')} — ${moved.sessionTitle}`
-            : `${i18nT('components.sessionMoveUndoBar.moved_to')} ${moved.toFolderName} — ${moved.sessionTitle}`}
+            ? `${i18nT('components.sessionMoveUndoBar.removed_from_folder')} — ${moved.itemTitle}`
+            : `${i18nT('components.sessionMoveUndoBar.moved_to')} ${moved.toFolderName} — ${moved.itemTitle}`}
         >
           {/* The root case is its own sentence, not "Moved to <noun>": the sidebar
               calls this "remove from folder" on its own drop zone, and "Unfiled"

--- a/website/src/hooks/useMoveUndo.ts
+++ b/website/src/hooks/useMoveUndo.ts
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { MOVE_UNDO_MS, type MovedItem } from '../components/MoveUndoBar'
+
+/** A live offer: one {@link MovedItem} plus the lifecycle the hook enforces. */
+export type MoveUndoOffer = MovedItem & {
+  /** Identity of THIS offer. Every hold, remainder and undo is keyed to it. */
+  id: number
+  /** One-way: false until the server acknowledges, never true→false. */
+  live: boolean
+  /** Latched when a placement neither we nor the origin made is observed. */
+  superseded: boolean
+}
+
+/**
+ * The surface-specific half of the primitive: how to read where an item is, how
+ * to move it, and whether a folder still exists.
+ *
+ * All three are called during effects and callbacks, so a caller must keep them
+ * referentially stable (`useCallback`) for the same reason the pre-extraction
+ * code depended on `slots` directly: a fresh identity every render re-runs the
+ * reconciliation effect, and re-running it is only free because it is idempotent.
+ */
+export type MoveUndoDeps = {
+  /**
+   * Where `itemKey` sits right now.
+   *
+   * `null` means unfiled root. `undefined` means the item is GONE — that
+   * distinction is load-bearing: a closed session has nothing to put back and
+   * must retire the offer, while an unfiled one is a legitimate placement.
+   */
+  locate: (itemKey: string) => string | null | undefined
+  /**
+   * Performs the move. Must be optimistic (so the destination is visible at
+   * once) and must call `onCommitted` only once the SERVER has acknowledged.
+   */
+  apply: (itemKey: string, folderId: string | null, opts?: { onCommitted?: () => void }) => void
+  /** Whether a folder id is still real; undo degrades to unfiled when it is not. */
+  folderExists: (folderId: string) => boolean
+}
+
+export type MoveUndoController = {
+  /** The current offer, or `null`. Render the bar only when `offer.live`. */
+  offer: MoveUndoOffer | null
+  /** Perform a drag-move AND park its inverse. A no-op move arms nothing. */
+  arm: (moved: MovedItem) => void
+  /** Replay the inverse of `offerId`, if that is still the live offer. */
+  undo: (offerId: number) => void
+  /** Props the bar needs from its owner: the remainder, and the hold channel. */
+  bar: {
+    remainingMs: number
+    paused: boolean
+    onHoldChange: (held: boolean) => void
+  }
+}
+
+/**
+ * "Last reversible move + its inverse", owned in one place.
+ *
+ * A drag is the one folder move a user can make WITHOUT naming the destination:
+ * drop an item a row off and it disappears into a folder they never chose, with
+ * nothing on screen saying where it went. So every DRAG-initiated move parks its
+ * inverse here and {@link MoveUndoBar} offers it back. Moves that name their
+ * destination (a "Move to folder…" menu) do not arm it.
+ *
+ * ## Why this is a hook and not a copy per surface
+ *
+ * The offer's lifecycle is the whole feature, and it is almost entirely made of
+ * guards against races that are invisible in a happy-path read:
+ *
+ *  - `live` flips true only on the server's ACKNOWLEDGEMENT. Waiting is
+ *    load-bearing, not caution: the move is optimistic, so the store shows the
+ *    destination immediately, and an offer that went live on that would let the
+ *    user undo while the original PATCH is still in flight. Undo's write would
+ *    be applied against the old folder and the original write would then land —
+ *    silently reversing the undo the user just asked for.
+ *  - Once live, the offer is DROPPED — never re-validated — the moment live
+ *    state stops matching. Deriving visibility from live state instead let a
+ *    dropped offer come back: drag A→B, then move B→C→B from a row menu, and the
+ *    old A inverse matched again and would have overwritten the newer,
+ *    intentional move.
+ *  - `superseded` latches a third-party placement seen during the pending
+ *    window, because by ack time live state may match the destination again (a
+ *    move away and back) and nothing later could tell.
+ *
+ * Every surface that arms an undo needs all three, and a second hand-rolled copy
+ * would get one of them subtly wrong. Callers supply only {@link MoveUndoDeps}.
+ */
+export default function useMoveUndo({ locate, apply, folderExists }: MoveUndoDeps): MoveUndoController {
+  const [offer, setOffer] = useState<MoveUndoOffer | null>(null)
+
+  // Read through a ref, not the closure: AnimatePresence keeps the retired bar
+  // mounted for its 150ms exit, and that instance still holds the props (and the
+  // captured state) it had while live. A click or ⌘Z in that window would fire a
+  // stale undo and overwrite the newer placement, so the offer's identity is
+  // re-checked against CURRENT state at invocation time.
+  const offerRef = useRef(offer)
+  offerRef.current = offer
+
+  const arm = useCallback((moved: MovedItem) => {
+    // A drop back onto the folder the item already sits in is not a move —
+    // arming undo for it would offer to undo nothing.
+    if (moved.fromFolderId === moved.toFolderId) return
+    const id = Date.now()
+    setOffer({ ...moved, id, live: false, superseded: false })
+    // No failure branch is needed: a move that never lands never acknowledges,
+    // so the offer never goes live and the deadline clears the record. There is
+    // no path from "failed" back to a visible bar.
+    apply(moved.itemKey, moved.toFolderId, {
+      onCommitted: () => setOffer(m => (
+        m && m.id === id
+          // A mismatch latched during the pending window means someone else's
+          // move landed inside it, so this inverse is already stale — drop the
+          // offer instead of arming it on an ack that is no longer the last word.
+          ? (m.superseded ? null : { ...m, live: true })
+          : m
+      )),
+    })
+  }, [apply])
+
+  const undo = useCallback((offerId: number) => {
+    const current = offerRef.current
+    if (!current || current.id !== offerId) return
+    // Unconditional write, matching every other folder move in the product (the
+    // row menus, the session header, the drag itself). The offer's own lifecycle
+    // is what keeps it honest: it arms only on the server's acknowledgement, the
+    // pending window latches any placement it did not make, and an armed offer is
+    // dropped the moment live state stops matching its destination. What remains
+    // is a move this client has not been told about yet — the same broadcast gap
+    // every other write here lives with, where a wrong undo is visible on screen
+    // and re-correctable.
+    //
+    // A `fromFolderId` whose folder was DELETED meanwhile is degraded to unfiled
+    // rather than replayed: the endpoint rejects an unknown id with 400, and the
+    // sidebar already renders an unknown folder as unfiled, so posting it would
+    // leave Undo doing nothing at all.
+    const origin = current.fromFolderId && folderExists(current.fromFolderId)
+      ? current.fromFolderId
+      : null
+    apply(current.itemKey, origin)
+    setOffer(null)
+  }, [folderExists, apply])
+
+  // The deadline lives HERE, not in the bar: an offer whose optimistic move
+  // never became visible (the request failed and rolled back) has no bar to run
+  // a timer, and must still die on the same clock rather than linger where a
+  // later, unrelated move could make it match again.
+  // Suspended while the pointer is over the bar or focus is inside it: the
+  // deadline must not expire under a hand that is already reaching for Undo,
+  // which would take the affordance away from exactly the slower reader it
+  // exists for — and the footer shifts up into the spot the button just left.
+  // The hold and the remainder are both keyed to the OFFER they belong to, and
+  // an id that does not match the live offer reads as "full, running". A new
+  // drag therefore cannot inherit a suspended clock (the pointer never leaves a
+  // bar that is REPLACED, so nothing else would clear the hold) or a part-spent
+  // window — by construction, rather than by a reset a later edit could forget.
+  // That cross-offer case carries no test: a second drag needs a board drop
+  // zone, and the zones unmount once the first move lands. Hence the shape above
+  // over an explicit reset — there is no branch left to get wrong.
+  const [heldOffer, setHeldOffer] = useState<number | null>(null)
+  const [spent, setSpent] = useState<{ id: number; remaining: number } | null>(null)
+  const paused = offer != null && heldOffer === offer.id
+  const remainingMs = offer && spent?.id === offer.id ? spent.remaining : MOVE_UNDO_MS
+  const deadlineRef = useRef(0)
+  useEffect(() => {
+    if (!offer) return
+    if (paused) {
+      setSpent({ id: offer.id, remaining: Math.max(0, deadlineRef.current - Date.now()) })
+      return
+    }
+    deadlineRef.current = Date.now() + remainingMs
+    const timer = setTimeout(() => setOffer(null), remainingMs)
+    return () => clearTimeout(timer)
+    // Keyed on the offer's id and the hold ALONE: flipping `live` must not
+    // restart the clock, and neither must the remainder this effect writes when
+    // it freezes — that write is the input to the NEXT resume, not a new window.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [offer?.id, paused])
+
+  useEffect(() => {
+    if (!offer) return
+    const here = locate(offer.itemKey)
+    if (here === undefined) { setOffer(null); return }   // item gone — nothing to put back
+    if (offer.live) {
+      if (here !== offer.toFolderId) setOffer(null)
+      return
+    }
+    // Still PENDING the server's acknowledgement. Two placements are legitimate
+    // here: the ORIGIN (our optimistic write has not been applied or was rolled
+    // back) and the DESTINATION (it has). Any third value is another client's
+    // move landing inside our window, and it must not be forgotten just because
+    // the offer is not armed yet: the ack that follows would otherwise arm an
+    // inverse that now overwrites that newer placement. Latch it instead.
+    if (here !== offer.fromFolderId && here !== offer.toFolderId && !offer.superseded) {
+      setOffer(m => (m && m.id === offer.id ? { ...m, superseded: true } : m))
+    }
+  }, [offer, locate])
+
+  // Carries the id that was current when THIS callback was handed to a bar, so a
+  // retiring bar's hover reports the retired offer (which matches nothing and
+  // reads as "full, running") instead of freezing a newer offer's clock.
+  const currentId = offer?.id ?? null
+  const onHoldChange = useCallback((held: boolean) => {
+    setHeldOffer(held ? currentId : null)
+  }, [currentId])
+
+  return { offer, arm, undo, bar: { remainingMs, paused, onHoldChange } }
+}

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -37,6 +37,7 @@ import { useAvailableModels } from '../hooks/useAvailableModels'
 import { useListboxKeyboard } from '../hooks/useListboxKeyboard'
 import { useSessionPalette } from '../hooks/useSessionPalette'
 import { useMoveSlotToFolder } from '../hooks/useMoveSlotToFolder'
+import useMoveUndo from '../hooks/useMoveUndo'
 import { useSelectInstance } from '../hooks/useSelectInstance'
 import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
 import { useLanguage } from '../i18n/LanguageProvider'
@@ -51,7 +52,7 @@ import { safeSetItem } from '../utils/safeStorage'
 import { LAYOUT } from '../components/layout'
 import { resolveFolderAgent, resolveFolderProjectDir } from '../utils/folderAgent'
 import FolderMoveSubmenu from '../components/FolderMoveSubmenu'
-import SessionMoveUndoBar, { MOVE_UNDO_MS, type MovedSession } from '../components/SessionMoveUndoBar'
+import MoveUndoBar from '../components/MoveUndoBar'
 import SessionActionsMenu from '../components/SessionActionsMenu'
 import { ChannelBrandIcon, hasChannelBrandIcon } from '../components/ChannelBrandIcon'
 import TagManagerList from '../components/TagManagerList'
@@ -4118,146 +4119,42 @@ function ChatSidebar({
   // the menu "Move to folder" submenus and drag-to-folder route through this.
   const assignToFolder = useMoveSlotToFolder()
   // ── Drag-move undo ────────────────────────────────────────────────────────
-  // A drag is the one folder move the user can make WITHOUT naming the
-  // destination: drop a session a row off and it disappears into a folder they
-  // never chose, with nothing on screen saying where it went. So every
-  // DRAG-initiated move parks its inverse here and the bar below the lanes
-  // offers it back. Menu moves ("Move to folder…") pick the destination by name
-  // and do not arm it.
+  // The offer's whole lifecycle — pending until the server acks, one-way to
+  // gone, superseded latched on a third-party placement, plus the 8s deadline
+  // and its hover hold — lives in useMoveUndo. This surface supplies only the
+  // three things that are specific to sessions: where a slot sits, how to move
+  // it, and whether a folder id is still real.
   //
-  // `live` is the offer's ONE-WAY lifecycle. It flips true only once the SERVER
-  // has acknowledged the drag move, and once true the offer is DROPPED — never
-  // re-validated — the moment live state stops matching.
-  //
-  // Waiting for the acknowledgement is load-bearing, not caution: the move is
-  // optimistic, so the store shows the destination immediately, and an offer that
-  // went live on that would let the user undo while the original PATCH is still
-  // in flight. Undo's compare-and-set would be refused (the server still has the
-  // old folder) and the original write would then land — silently reversing the
-  // undo the user just asked for.
-  //
-  // Dropping rather than re-validating matters too: deriving the bar's visibility
-  // from live state let a dropped offer come back (drag A→B, then move B→C→B from
-  // a row menu, and the old A inverse matched again and would have overwritten
-  // the newer, intentional move).
-  const [dragMove, setDragMove] = useState<(MovedSession & { id: number; live: boolean; superseded: boolean }) | null>(null)
+  // Only DRAG-initiated moves arm it. Menu moves ("Move to folder…") pick the
+  // destination by name, so there is nothing unnamed to confirm.
+  const locateSlotFolder = useCallback((slotKey: string) => {
+    const slot = slots.find(s => s.key === slotKey)
+    // `undefined` = session closed (retire the offer); `null` = unfiled root.
+    return slot ? (slot.folder_id || null) : undefined
+  }, [slots])
+  const folderStillExists = useCallback(
+    (folderId: string) => folders.some(f => f.id === folderId),
+    [folders],
+  )
+  const {
+    offer: dragMove,
+    arm: armDragMove,
+    undo: undoDragMove,
+    bar: undoBar,
+  } = useMoveUndo({ locate: locateSlotFolder, apply: assignToFolder, folderExists: folderStillExists })
   const moveByDrag = useCallback((slotKey: string, folderId: string | null) => {
     const slot = slots.find(s => s.key === slotKey)
-    const from = slot?.folder_id || null
     const to = folderId || null
-    // A drop back onto the folder the session already sits in is not a move —
-    // arming undo for it would offer to undo nothing.
-    if (from === to) return
     const dest = to ? folders.find(f => f.id === to) : undefined
-    const id = Date.now()
-    setDragMove({
-      id,
-      live: false,
-      superseded: false,
-      slotKey,
-      fromFolderId: from,
+    armDragMove({
+      itemKey: slotKey,
+      fromFolderId: slot?.folder_id || null,
       toFolderId: to,
       toFolderName: dest?.name ?? null,
       toFolderColor: dest?.color,
-      sessionTitle: slot?.title || slotKey,
+      itemTitle: slot?.title || slotKey,
     })
-    // No failure branch is needed: a move that never lands never acknowledges,
-    // so the offer never goes live and the deadline clears the record. There is
-    // no path from "failed" back to a visible bar.
-    assignToFolder(slotKey, to, {
-      onCommitted: () => setDragMove(m => (
-        m && m.id === id
-          // A mismatch latched during the pending window means someone else's
-          // move landed inside it, so this inverse is already stale — drop the
-          // offer instead of arming it on an ack that is no longer the last word.
-          ? (m.superseded ? null : { ...m, live: true })
-          : m
-      )),
-    })
-  }, [slots, folders, assignToFolder])
-  // Read through a ref, not the closure: AnimatePresence keeps the retired bar
-  // mounted for its 150ms exit, and that instance still holds the props (and the
-  // captured state) it had while live. A click or ⌘Z in that window would fire a
-  // stale undo and overwrite the newer placement, so the offer's identity is
-  // re-checked against CURRENT state at invocation time.
-  const dragMoveRef = useRef(dragMove)
-  dragMoveRef.current = dragMove
-  const undoDragMove = useCallback((offerId: number) => {
-    const dragMove = dragMoveRef.current
-    if (!dragMove || dragMove.id !== offerId) return
-    // Unconditional write, matching every other folder move in the product (the
-    // row menus, the session header, the drag itself). The offer's own lifecycle
-    // is what keeps it honest: it arms only on the server's acknowledgement, the
-    // pending window latches any placement it did not make, and an armed offer is
-    // dropped the moment live state stops matching its destination. What remains
-    // is a move this client has not been told about yet — the same broadcast gap
-    // every other write here lives with, where a wrong undo is visible on screen
-    // and re-correctable.
-    //
-    // A `fromFolderId` whose folder was DELETED meanwhile is degraded to unfiled
-    // rather than replayed: the endpoint rejects an unknown id with 400, and the
-    // sidebar already renders an unknown folder as unfiled, so posting it would
-    // leave Undo doing nothing at all.
-    const origin = dragMove.fromFolderId && folders.some(f => f.id === dragMove.fromFolderId)
-      ? dragMove.fromFolderId
-      : null
-    assignToFolder(dragMove.slotKey, origin)
-    setDragMove(null)
-  }, [folders, assignToFolder])
-  // The deadline lives HERE, not in the bar: an offer whose optimistic move
-  // never became visible (the request failed and rolled back) has no bar to run
-  // a timer, and must still die on the same clock rather than linger where a
-  // later, unrelated move could make it match again.
-  // Suspended while the pointer is over the bar or focus is inside it: the
-  // deadline must not expire under a hand that is already reaching for Undo,
-  // which would take the affordance away from exactly the slower reader it
-  // exists for — and the footer shifts up into the spot the button just left.
-  // The hold and the remainder are both keyed to the OFFER they belong to, and
-  // an id that does not match the live offer reads as "full, running". A new
-  // drag therefore cannot inherit a suspended clock (the pointer never leaves a
-  // bar that is REPLACED, so nothing else would clear the hold) or a part-spent
-  // window — by construction, rather than by a reset a later edit could forget.
-  // That cross-offer case carries no test: a second drag needs a board drop
-  // zone, and the zones unmount once the first move lands. Hence the shape above
-  // over an explicit reset — there is no branch left to get wrong.
-  const [heldOffer, setHeldOffer] = useState<number | null>(null)
-  const [spent, setSpent] = useState<{ id: number; remaining: number } | null>(null)
-  const undoHeld = dragMove != null && heldOffer === dragMove.id
-  const undoRemaining = dragMove && spent?.id === dragMove.id ? spent.remaining : MOVE_UNDO_MS
-  const undoDeadlineRef = useRef(0)
-  useEffect(() => {
-    if (!dragMove) return
-    if (undoHeld) {
-      setSpent({ id: dragMove.id, remaining: Math.max(0, undoDeadlineRef.current - Date.now()) })
-      return
-    }
-    undoDeadlineRef.current = Date.now() + undoRemaining
-    const timer = setTimeout(() => setDragMove(null), undoRemaining)
-    return () => clearTimeout(timer)
-    // Keyed on the offer's id and the hold ALONE: flipping `live` must not
-    // restart the clock, and neither must the remainder this effect writes when
-    // it freezes — that write is the input to the NEXT resume, not a new window.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dragMove?.id, undoHeld])
-  useEffect(() => {
-    if (!dragMove) return
-    const slot = slots.find(s => s.key === dragMove.slotKey)
-    if (!slot) { setDragMove(null); return }   // session closed — nothing to put back
-    const here = slot.folder_id || null
-    if (dragMove.live) {
-      if (here !== dragMove.toFolderId) setDragMove(null)
-      return
-    }
-    // Still PENDING the server's acknowledgement. Two placements are legitimate
-    // here: the ORIGIN (our optimistic write has not been applied or was rolled
-    // back) and the DESTINATION (it has). Any third value is another client's
-    // move landing inside our window, and it must not be forgotten just because
-    // the offer is not armed yet: the ack that follows would otherwise arm an
-    // inverse that now overwrites that newer placement. Latch it instead.
-    if (here !== dragMove.fromFolderId && here !== dragMove.toFolderId && !dragMove.superseded) {
-      setDragMove(m => (m && m.id === dragMove.id ? { ...m, superseded: true } : m))
-    }
-  }, [dragMove, slots])
+  }, [slots, folders, armDragMove])
   // Surface-agnostic session actions (duplicate/read/pin/copy/move/close) shared
   // by all three row menus AND the row's non-menu buttons (Duplicate/Close) so
   // each behaviour has one definition. Rename + Tags stay local (they drive this
@@ -6252,11 +6149,11 @@ function ChatSidebar({
           footer shifts down by its height while it is up. */}
       <AnimatePresence initial={false}>
         {dragMove?.live && (
-          <SessionMoveUndoBar key={dragMove.id} moved={dragMove}
+          <MoveUndoBar key={dragMove.id} moved={dragMove}
             onUndo={() => undoDragMove(dragMove.id)}
-            onHoldChange={held => { setHeldOffer(held ? dragMove.id : null) }}
-            remainingMs={undoRemaining}
-            paused={undoHeld}
+            onHoldChange={undoBar.onHoldChange}
+            remainingMs={undoBar.remainingMs}
+            paused={undoBar.paused}
             /* Same width ladder as the header's compact/tiny steps: below this the
                prefix + shortcut would eat the row and truncate the destination. */
             compact={sidebarWidth < 220} />

--- a/website/src/test/ChatSidebar.moveUndo.test.tsx
+++ b/website/src/test/ChatSidebar.moveUndo.test.tsx
@@ -76,7 +76,7 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 import ChatSidebar from '../pages/ChatSidebar'
-import { MOVE_UNDO_MS } from '../components/SessionMoveUndoBar'
+import { MOVE_UNDO_MS } from '../components/MoveUndoBar'
 
 const TAG = '11111111-1111-1111-1111-111111111111'
 const COL = 'col-aaaa'

--- a/website/src/test/ChatSidebar.moveUndoStale.test.tsx
+++ b/website/src/test/ChatSidebar.moveUndoStale.test.tsx
@@ -51,7 +51,7 @@ vi.mock('../api/client', () => ({
 
 // Stub the bar: this suite is about the OWNER's guard, not the bar's rendering,
 // and a stub is what lets the retained callback be invoked after retirement.
-vi.mock('../components/SessionMoveUndoBar', () => ({
+vi.mock('../components/MoveUndoBar', () => ({
   MOVE_UNDO_MS: 8000,
   default: ({ onUndo }: { onUndo: () => void }) => {
     mocks.lastOnUndo.current = onUndo

--- a/website/src/test/MoveUndoBar.test.tsx
+++ b/website/src/test/MoveUndoBar.test.tsx
@@ -42,23 +42,23 @@ vi.mock('framer-motion', async () => {
   return { motion: new Proxy({}, { get: (_t, tag: string) => make(tag) }) }
 })
 
-import SessionMoveUndoBar, { MOVE_UNDO_MS, type MovedSession } from '../components/SessionMoveUndoBar'
+import MoveUndoBar, { MOVE_UNDO_MS, type MovedItem } from '../components/MoveUndoBar'
 
-const moved: MovedSession = {
-  slotKey: 'chat-1',
+const moved: MovedItem = {
+  itemKey: 'chat-1',
   fromFolderId: null,
   toFolderId: 'f-archive',
   toFolderName: 'Archive',
-  sessionTitle: 'Session drag lands in the wrong folder',
+  itemTitle: 'Session drag lands in the wrong folder',
 }
 
-function renderBar(over: Partial<MovedSession> = {}, handlers: { onUndo?: () => void } = {}) {
+function renderBar(over: Partial<MovedItem> = {}, handlers: { onUndo?: () => void } = {}) {
   const onUndo = handlers.onUndo ?? vi.fn()
-  const utils = render(<SessionMoveUndoBar moved={{ ...moved, ...over }} onUndo={onUndo} />)
+  const utils = render(<MoveUndoBar moved={{ ...moved, ...over }} onUndo={onUndo} />)
   return { ...utils, onUndo }
 }
 
-describe('SessionMoveUndoBar', () => {
+describe('MoveUndoBar', () => {
   it('names the destination folder', () => {
     renderBar()
     expect(screen.getByText('Archive')).toBeTruthy()
@@ -76,7 +76,7 @@ describe('SessionMoveUndoBar', () => {
   it('reports hold state so the owner can suspend the expiry deadline', () => {
     const onHoldChange = vi.fn()
     const { container } = render(
-      <SessionMoveUndoBar moved={moved} onUndo={vi.fn()} onHoldChange={onHoldChange} />,
+      <MoveUndoBar moved={moved} onUndo={vi.fn()} onHoldChange={onHoldChange} />,
     )
     const bar = container.querySelector('[data-testid="session-move-undo"]')!
     fireEvent.mouseEnter(bar)
@@ -89,7 +89,7 @@ describe('SessionMoveUndoBar', () => {
 
   it('carries the session title as the row tooltip, since the row has no width for it', () => {
     const { container } = renderBar()
-    expect(container.querySelector(`[title*="${moved.sessionTitle}"]`)).toBeTruthy()
+    expect(container.querySelector(`[title*="${moved.itemTitle}"]`)).toBeTruthy()
   })
 
   // ── Narrow sidebar (down to SIDEBAR_MIN = 180px) ───────────────────────────
@@ -98,7 +98,7 @@ describe('SessionMoveUndoBar', () => {
 
   it('keeps the destination and drops the prefix when compact', () => {
     const { container } = render(
-      <SessionMoveUndoBar moved={moved} onUndo={vi.fn()} compact />,
+      <MoveUndoBar moved={moved} onUndo={vi.fn()} compact />,
     )
     expect(screen.getByText('Archive')).toBeTruthy()
     expect(screen.queryByText('Moved to')).toBeNull()
@@ -108,7 +108,7 @@ describe('SessionMoveUndoBar', () => {
 
   it('still fires the chord when compact', () => {
     const onUndo = vi.fn()
-    render(<SessionMoveUndoBar moved={moved} onUndo={onUndo} compact />)
+    render(<MoveUndoBar moved={moved} onUndo={onUndo} compact />)
     fireEvent.keyDown(window, { key: 'z', ctrlKey: true })
     expect(onUndo).toHaveBeenCalledTimes(1)
   })
@@ -167,7 +167,7 @@ describe('SessionMoveUndoBar', () => {
   })
 })
 
-describe('SessionMoveUndoBar on macOS', () => {
+describe('MoveUndoBar on macOS', () => {
   beforeEach(() => vi.resetModules())
 
   it('binds ⌘Z, not Ctrl+Z', async () => {
@@ -175,7 +175,7 @@ describe('SessionMoveUndoBar on macOS', () => {
       isMac: true,
       platformShortcut: (s: string) => s.replace(/Cmd\+/g, '⌘'),
     }))
-    const { default: MacBar } = await import('../components/SessionMoveUndoBar')
+    const { default: MacBar } = await import('../components/MoveUndoBar')
     const onUndo = vi.fn()
     render(<MacBar moved={moved} onUndo={onUndo} />)
     // The Mac chord is advertised in the tooltip, not on the face…
@@ -201,7 +201,7 @@ describe('SessionMoveUndoBar on macOS', () => {
     // Running: head for empty over exactly the time the owner says is left — not
     // over a fixed MOVE_UNDO_MS measured from this component's own mount.
     const { rerender } = render(
-      <SessionMoveUndoBar moved={moved} onUndo={onUndo} remainingMs={3000} />,
+      <MoveUndoBar moved={moved} onUndo={onUndo} remainingMs={3000} />,
     )
     expect(animate().scaleX).toBe(0)
     expect(transition().duration).toBe(3)
@@ -209,13 +209,13 @@ describe('SessionMoveUndoBar on macOS', () => {
     // Paused: hold the width at the remaining FRACTION. Continuing to 0 here is
     // the defect — the bar would empty while the deadline was suspended, telling
     // the user the offer expired at the exact moment it is guaranteed alive.
-    rerender(<SessionMoveUndoBar moved={moved} onUndo={onUndo} remainingMs={3000} paused />)
+    rerender(<MoveUndoBar moved={moved} onUndo={onUndo} remainingMs={3000} paused />)
     expect(animate().scaleX).toBeCloseTo(3000 / MOVE_UNDO_MS)
     expect(transition().duration).toBe(0)
 
     // Resumed: pick up from that fraction over the same remainder, so scaleX
     // stays equal to remaining / MOVE_UNDO_MS at every instant.
-    rerender(<SessionMoveUndoBar moved={moved} onUndo={onUndo} remainingMs={3000} />)
+    rerender(<MoveUndoBar moved={moved} onUndo={onUndo} remainingMs={3000} />)
     expect(animate().scaleX).toBe(0)
     expect(transition().duration).toBe(3)
   })


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** pure refactor with no rendered delta -- the bar's markup, Tailwind classes, i18n keys and `data-testid`s are byte-for-byte unchanged; only the module it lives in and which hook owns its state moved.

Stage 1 of #4626. A pure refactor: zero observable behaviour change, zero new surface armed.

## Why extract before arming anything

The drag-move undo that landed in #4617 works for **session drags only**. Its substance is not the bar — it is a lifecycle that is invisible on a happy-path read:

- an offer stays **PENDING** until the server acknowledges, because the move is optimistic and an offer armed on the store would let undo fire while the original PATCH is still in flight (the original write then lands and silently reverses the undo);
- it latches **`superseded`** when a third party's placement arrives inside that window, because by ack time live state may match the destination again (a move away and back) and nothing later could tell;
- once **LIVE** it is *dropped, never re-validated* — deriving visibility from live state let a retired offer come back and overwrite a newer, intentional move.

Stage 2 arms artifacts and folder-into-folder moves. `moveFolderTo` moves a whole subtree, so it needs exactly these staleness guards — which is why the mechanism is extracted rather than copied. A second hand-rolled copy would get one of the three subtly wrong.

## What changed

- **`website/src/hooks/useMoveUndo.ts`** (new) owns the offer state machine, the `MOVE_UNDO_MS` deadline, and the hover hold that suspends it. Callers inject only the surface-specific parts:
  - `locate(itemKey)` — where the item sits now; `undefined` = gone (retire), `null` = unfiled root
  - `apply(itemKey, folderId, { onCommitted })` — the optimistic move, acknowledging on server success
  - `folderExists(id)` — so undo degrades a deleted origin to unfiled instead of posting a 400
- **`SessionMoveUndoBar` → `MoveUndoBar`**, `MovedSession` → `MovedItem`, and its `slotKey` / `sessionTitle` fields → `itemKey` / `itemTitle`. Those two names would be lies the moment an artifact or a folder subtree arms the same offer.
- **`ChatSidebar` is the SOLE caller.** ~120 lines of offer machinery collapse to three memoised deps plus a descriptor built at the drag site.

`MOVE_UNDO_MS` and the one-way `live` / `superseded` semantics are preserved exactly, including two details a re-implementation would drop:

- the deadline effect's deps stay pinned to `[offer?.id, paused]` — flipping `live`, or writing the frozen remainder, must not restart the clock;
- `onHoldChange` captures the id that was current when it was handed to a bar, so a bar retiring through its 150ms `AnimatePresence` exit cannot freeze a *newer* offer's clock.

### Deliberately NOT renamed

The `components.sessionMoveUndoBar.*` i18n keys and the `session-move-undo*` test ids keep their names. The strings are translated in every locale catalogue, and the ids are what `website/scripts/capture-session-move-undo.mjs` selects on — renaming them would be churn plus breakage for no behavioural gain.

## Proof of no behaviour change

The existing tests pass with **their assertions untouched** — only the module path, the component identifier, and the two renamed field names change:

- `website/src/test/MoveUndoBar.test.tsx` (renamed from `SessionMoveUndoBar.test.tsx`) — 15 tests
- `website/src/test/ChatSidebar.moveUndo.test.tsx` — 15 tests
- `website/src/test/ChatSidebar.moveUndoStale.test.tsx` — 2 tests

## Testing

- Targeted: 32/32 green across the three suites above
- Full frontend suite: `1665 passed / 1666 files`, `26,340 tests passed`
  - one pre-existing failure, `src/i18n/productName.test.ts`, is **main-inherited** — it flags product-name strings in `pullRequestPanel.owner_not_configured_guidance` and `sttSettings.the_bundled_audio_decoder_is_missing_or_damaged`, fails identically on pristine `d7b7d65c3`, and this diff touches no locale file
- `npm run typecheck` clean, `npm run lint` 0 errors

## Out of scope (stage 2, separate PR against the same issue)

- `ArtifactsPage.tsx` `handleDragEnd` — `moveArtifact` and folder nesting via `updateFolderMut`, both currently silent
- `moveFolderTo` in the sidebar and its drag routes + menu picks

no linked issue: intentional. This is stage 1 of two, and the tracked issue
(kirodotdev/KiroCrew#4626) must stay open until stage 2 arms artifacts drags and
folder-into-folder moves, which is what its report actually asks for. The closing
trailer therefore belongs on the stage 2 PR, not this one.



