### PR TITLE
refactor: extract subagent manager boundaries

### DIFF
--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1228,6 +1228,16 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # a third party — the surfaces that SHOW a refusal (the dashboard's
         # notice line) are the registered sinks.
         "name_grant.py",
+        # Internal coordinator partitions behind the single registered
+        # ``subagent.py`` output boundary.  They redact lifecycle payloads before
+        # handing them to facade-owned event/completion callbacks, but the split
+        # adds no new transport or audience and therefore no additional posture
+        # row.
+        "subagent_manager/admission.py",
+        "subagent_manager/continuation.py",
+        "subagent_manager/monitoring.py",
+        "subagent_manager/run.py",
+        "subagent_manager/terminal.py",
         # The shared recursive redactor helper itself — a pure scrubber, not an
         # egress boundary; the modules that CALL it (mochi routes/hooks) are the
         # registered sinks.

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -109,6 +109,17 @@ from kiro_crew.subagent_cost import (
     compact_cost_log,
     read_learned_cost,
 )
+from kiro_crew.subagent_manager import (
+    CancellationCoordinator,
+    ContinuationCoordinator,
+    OrphanStallMonitor,
+    RunEventCoordinator,
+    SpawnAdmissionCoordinator,
+    TerminalCoordinator,
+    WaveDigestCoordinator,
+    bind_component_globals,
+    copy_component_docs,
+)
 from kiro_crew.subagent_persistence import (
     _agent_dir,
     _cleanup_session_files_sync,
@@ -1428,6 +1439,26 @@ class SpawnApprovalCallback(Protocol):
 class SubagentManager:
     """Spawn and track isolated background agents."""
 
+    _COMPONENT_TYPES = {
+        "_monitor": OrphanStallMonitor,
+        "_terminal": TerminalCoordinator,
+        "_admission": SpawnAdmissionCoordinator,
+        "_continuation": ContinuationCoordinator,
+        "_waves": WaveDigestCoordinator,
+        "_run_events": RunEventCoordinator,
+        "_cancellation": CancellationCoordinator,
+    }
+    _reconcile_task: asyncio.Task | None  # type: ignore[type-arg]
+
+    def __getattr__(self, name: str) -> Any:
+        """Lazily compose a missing coordinator for minimal facade construction."""
+        component_type = self._COMPONENT_TYPES.get(name)
+        if component_type is None:
+            raise AttributeError(name)
+        component = component_type(self)
+        object.__setattr__(self, name, component)
+        return component
+
     def __init__(
         self,
         sessions: SessionManager,
@@ -1561,31 +1592,22 @@ class SubagentManager:
         except Exception:
             self._spawn_stagger_secs = 2.0
 
-    def _effective_turn_limit(self, info: SubagentInfo) -> int:
-        """Resolved turn cap for a run: per-spawn ``max_turns`` → config
-        default (``agent.subagent_max_turns``) → hardcoded ``_TURN_LIMIT``.
+        # The facade is the single owner of mutable registries and slot tokens.
+        # Coordinators own transition logic and route every cross-boundary call
+        # back through this object, preserving overrides and monkeypatch seams.
+        self._monitor = OrphanStallMonitor(self)
+        self._terminal = TerminalCoordinator(self)
+        self._admission = SpawnAdmissionCoordinator(self)
+        self._continuation = ContinuationCoordinator(self)
+        self._waves = WaveDigestCoordinator(self)
+        self._run_events = RunEventCoordinator(self)
+        self._cancellation = CancellationCoordinator(self)
 
-        ``0`` at any level means "not set" and falls through to the next.
-        """
-        return info.max_turns or self._default_turn_limit or _TURN_LIMIT
+    def _effective_turn_limit(self, info: SubagentInfo) -> int:
+        return self._run_events._effective_turn_limit_impl(info)
 
     def update_completion_keep(self, mode: str, max_chars: int) -> None:
-        """Update the live completion-keep mode and char budget.
-
-        Called from ``api_kirocrew_config_patch`` after the user changes
-        ``agent.completion_keep`` or ``agent.completion_keep_chars`` from
-        the Settings UI. The values are read once per subagent at
-        completion time (``apply_completion_keep`` call site), so swapping
-        them here takes effect for the next subagent to finish — including
-        ones already running. No torn-read possible under asyncio: both
-        reads happen in the same synchronous block.
-
-        ``mode`` is validated by ``_validated_completion_keep`` at config
-        load; this setter is intentionally permissive about ``max_chars``
-        so the loader / handler stays the validation choke-point.
-        """
-        self._completion_keep = mode
-        self._completion_keep_chars = max_chars
+        return self._run_events.update_completion_keep_impl(mode, max_chars)
 
     @staticmethod
     async def _approve_and_log(
@@ -1649,130 +1671,10 @@ class SubagentManager:
         )
 
     def start_reaper(self) -> None:
-        """Start the periodic reaper loop.  Call once after the event loop is running."""
-        if self._reaper_task is None:
-            self._reaper_task = asyncio.create_task(self._reaper_loop())
-            # One-shot orphan reconciliation on startup
-            self._reconcile_task = asyncio.create_task(self._reconcile_orphans())
+        return self._monitor.start_reaper_impl()
 
     async def _reconcile_orphans(self) -> None:
-        """Scan for orphaned agent folders from a prior gateway run.
-
-        For each orphan (folder with state.json but no tombstone.json
-        and not tracked in ``_agents``):
-        - PID alive → SIGKILL, tombstone (gateway_restart)
-        - PID dead + result → tombstone (gateway_restart, delivered)
-        - PID dead + no result → tombstone (gateway_restart, notification_pending)
-        """
-        try:
-
-            orphans = list_orphans()
-            if not orphans:
-                return
-            logger.info("Reconciling %d orphaned subagent(s)", len(orphans))
-            processed = 0
-            # DM-fallback messages are DIGESTED: collected across the whole
-            # scan and delivered as ONE message at the end — a restart with N
-            # in-flight agents must never produce N pings. (The session-
-            # injection path batches naturally via the parent slot's pending-
-            # failures drain.)
-            dm_pending: list[str] = []
-            for state in orphans:
-                agent_id = state.get("id", "")
-                if not agent_id or agent_id in self._agents:
-                    continue  # tracked in current run, skip
-                try:
-                    pid = state.get("pid")
-                    has_result = False
-                    try:
-
-                        rp = _agent_dir(agent_id) / "result.txt"
-                        has_result = rp.exists() and rp.stat().st_size > 0
-                    except OSError:
-                        pass
-
-                    recovery = "undeliverable"
-                    if pid and self._is_pid_alive(pid):
-                        # Use pid_recorded_at (when PID was actually written) instead of
-                        # started (folder creation time) to avoid false negatives under load
-                        pid_recorded_at = state.get("pid_recorded_at", state.get("started", 0))
-                        if self._is_orphan_process(pid, pid_recorded_at):
-                            self._kill_orphan_pid(pid)
-                            try:
-                                sel().log_tool_invocation(
-                                    session_key=f"subagent:{agent_id}",
-                                    source="subagent",
-                                    tool_name="orphan_reconcile_kill",
-                                    outcome="killed",
-                                    metadata={"subagent_id": agent_id, "pid": pid},
-                                )
-                            except Exception:
-                                logger.debug("SEL audit failed for orphan %s", agent_id)
-                        recovery = "result_available" if has_result else "notification_pending"
-                    elif has_result:
-                        recovery = "result_available"
-                    else:
-                        recovery = "notification_pending"
-
-                    try:
-                        write_tombstone(
-                            agent_id,
-                            cause="gateway_restart",
-                            recovery_action=recovery,
-                            pid=pid,
-                            turns=state.get("turns", 0),
-                            last_tool=state.get("last_tool", ""),
-                        )
-                    except Exception:
-                        logger.debug("Failed to tombstone orphan %s", agent_id, exc_info=True)
-
-                    # Retain-by-default: session files are deliberately NOT
-                    # deleted here — an orphaned run's transcript is still
-                    # spawn_continue resume material after the restart. The
-                    # tombstone pruner owns deletion (with the keep guard for
-                    # promoted conversations).
-
-                    logger.info(
-                        "Reconciled orphan %s: recovery=%s, pid=%s, has_result=%s",
-                        agent_id,
-                        recovery,
-                        pid,
-                        has_result,
-                    )
-                    # Notify user about the orphaned agent. Injection happens
-                    # per-orphan (it rides the parent slot's batched pending-
-                    # failures queue); DM fallback is deferred to the digest.
-                    try:
-                        undelivered = await self._notify_orphan(
-                            agent_id, state, recovery, has_result
-                        )
-                        if undelivered:
-                            dm_pending.append(undelivered)
-                    except Exception:
-                        logger.debug("Notification failed for orphan %s", agent_id, exc_info=True)
-                except Exception:
-                    logger.warning("Failed to reconcile orphan %s", agent_id, exc_info=True)
-
-                # Rate limit: yield to event loop every 50 entries
-                processed += 1
-                if processed % 50 == 0:
-                    await asyncio.sleep(0)
-
-            # Single digest for everything the injection path couldn't deliver.
-            if dm_pending:
-                if len(dm_pending) == 1:
-                    digest = dm_pending[0]
-                else:
-                    digest = (
-                        f"[Subagent restart digest] {len(dm_pending)} subagent(s) "
-                        f"orphaned by a gateway restart:\n\n" + "\n\n".join(dm_pending)
-                    )
-                try:
-                    await self._send_orphan_slack_dm(digest)
-                except Exception:
-                    logger.debug("Orphan digest DM failed", exc_info=True)
-        except Exception:
-            logger.warning("Orphan reconciliation failed", exc_info=True)
+        return await self._monitor._reconcile_orphans_impl()
 
     @staticmethod
     def _is_pid_alive(pid: int) -> bool:
@@ -1806,344 +1708,30 @@ class SubagentManager:
     async def _notify_orphan(
         self, agent_id: str, state: dict, recovery: str, has_result: bool
     ) -> str | None:
-        """Notify user about an orphaned subagent.
-
-        1. Try session injection if parent session still exists (delivered
-           messages return ``None``).
-        2. Otherwise return the redacted message so the caller can batch all
-           undelivered notifications into a SINGLE digest DM — never N pings.
-        """
-        task_preview = (state.get("task", "") or "")[:100]
-        parent_session = state.get("parent_session", "")
-        result_path = str(agent_dir_for_display(agent_id) / "result.txt")
-
-        if has_result:
-            msg = (
-                f"{SUBAGENT_COMPLETION_PREFIX}\n"
-                f"Agent `{agent_id}` ⚠️ orphaned by gateway restart\n"
-                f"Task: {task_preview}\n"
-                f"Result saved at: `{result_path}`\n"
-                f"Use the read tool to retrieve it."
-            )
-            # A restart orphan whose result survived on disk: interrupted, not a
-            # plain failure. The note is the only explanation the header carries.
-            row_meta = single_completion_meta(
-                agent_id=agent_id,
-                outcome=OUTCOME_INTERRUPTED,
-                task=task_preview,
-                note="orphaned by gateway restart",
-                requested_model=str(state.get("requested_model") or ""),
-                resolved_model=str(state.get("resolved_model") or ""),
-            )
-        else:
-            msg = (
-                f"{SUBAGENT_COMPLETION_PREFIX}\n"
-                f"Agent `{agent_id}` ❌ lost to gateway restart\n"
-                f"Task: {task_preview}\n"
-                f"No result was captured before the restart."
-            )
-            row_meta = single_completion_meta(
-                agent_id=agent_id,
-                outcome=OUTCOME_FAILED,
-                task=task_preview,
-                note="lost to gateway restart",
-                requested_model=str(state.get("requested_model") or ""),
-                resolved_model=str(state.get("resolved_model") or ""),
-            )
-
-        # Redact before any delivery path (injection or Slack DM)
-        msg = _redact(msg)
-
-        # Try session injection first. The question is whether a tab is OPEN to
-        # receive the notice, not where the conversation started — a channel-born
-        # parent keeps its channel session key while its tab is open, and with no
-        # tab the digest DM below is the only surface.
-        if has_dashboard_surface(parent_session):
-            try:
-                injected = await self._try_inject_orphan_notification(parent_session, msg, row_meta)
-                if injected:
-                    # Update tombstone recovery_action
-                    try:
-                        write_tombstone(
-                            agent_id,
-                            cause="gateway_restart",
-                            recovery_action="delivered",
-                            pid=state.get("pid"),
-                            turns=state.get("turns", 0),
-                            last_tool=state.get("last_tool", ""),
-                        )
-                    except Exception:
-                        pass
-                    return None
-            except Exception:
-                logger.debug("Injection failed for orphan %s", agent_id, exc_info=True)
-
-        # Undelivered: hand back for the caller's single digest DM.
-        return msg
+        return await self._monitor._notify_orphan_impl(agent_id, state, recovery, has_result)
 
     async def _try_inject_orphan_notification(
         self, parent_session: str, msg: str, meta: dict | None = None
     ) -> bool:
-        """Try to inject a message into the parent dashboard session.
-
-        Delegates to the gateway-wired ``on_orphan_notify`` callback, which
-        appends the (already-redacted) message to the parent slot's transcript
-        and queues it into ``slot._pending_subagent_failures`` so the LLM
-        learns about the orphan on its next turn. Returns True if delivered.
-
-        ``meta`` carries the structured completion facts for the dashboard card
-        (#1792) so the orphan row renders without re-parsing its prose header.
-        """
-        if self._on_orphan_notify is None:
-            return False
-        try:
-            delivered = bool(await self._on_orphan_notify(parent_session, msg, meta))
-        except Exception:
-            logger.debug("on_orphan_notify raised for %s", parent_session, exc_info=True)
-            return False
-        if delivered:
-            try:
-                sel().log_api_access(
-                    caller=parent_session,
-                    operation="subagent.orphan_notification_injected",
-                    outcome="ok",
-                    source="subagent",
-                )
-            except Exception:
-                logger.debug("SEL audit for orphan injection failed", exc_info=True)
-        return delivered
+        return await self._monitor._try_inject_orphan_notification_impl(parent_session, msg, meta)
 
     async def _send_orphan_slack_dm(self, msg: str) -> None:
-        """Deliver an orphan notification via the owner DM / notification path.
-
-        Delegates to the gateway-wired ``on_orphan_dm`` callback (Slack DM +
-        dashboard notification). Falls back to a log line when no callback is
-        wired (e.g. slack-only setups constructed without the gateway hooks).
-        """
-        if self._on_orphan_dm is not None:
-            try:
-                delivered = bool(await self._on_orphan_dm(msg))
-                if delivered:
-                    return
-            except Exception:
-                logger.debug("on_orphan_dm raised", exc_info=True)
-        logger.warning("Orphan notification (no delivery channel wired): %s", msg[:200])
+        return await self._monitor._send_orphan_slack_dm_impl(msg)
 
     def _live_shared_count(self, pid: int | None, agents: "list[SubagentInfo]") -> int:
-        """Count live session-shared subagents sharing runtime *pid* (>= 1).
-
-        Used to average the shared AcpRuntime's measured RSS/CPU across the
-        sessions currently running inside it, so each shared subagent is charged
-        an empirical per-session share rather than the whole process.
-
-        *agents* is the registry snapshot the caller already took, and is
-        required: the sole caller runs on a worker thread (see
-        ``_sample_live_costs``), where iterating the live registry would raise
-        ``RuntimeError`` the moment the event loop registered or evicted an
-        agent. An on-loop caller passes ``list(self._agents.values())``.
-        """
-        if not pid:
-            return 1
-        n = sum(1 for a in agents if not a.done and a._session_sharing and a._pid == pid)
-        return n if n > 0 else 1
+        return self._monitor._live_shared_count_impl(pid, agents)
 
     def _sample_live_costs(self) -> None:
-        """Sample high-water RSS/CPU for each live agent (reaper-loop piggyback).
-
-        Updates per-run peaks on ``SubagentInfo`` (dynamic-subagent-sizing.md
-        §4.1). RSS is the subtree VmRSS in GB; CPU is cores used since the last
-        sample = Δ(utime+stime jiffies) / (CLK_TCK × Δt). The first sample only
-        seeds the CPU baseline (no delta yet). Best-effort: a dead/unreadable
-        pid is simply skipped.
-
-        BLOCKING, and therefore off-loop: every live agent costs ONE ``/proc``
-        subtree walk (:func:`_proc_subtree_sample`, which returns RSS, CPU
-        jiffies and the process/stub counts from a single frontier), so the
-        caller hands this to :func:`maintenance_executor` and the body must stay
-        thread-safe. Concretely that means it takes ONE snapshot of the agent
-        registry up front and derives everything, sharer counts included, from
-        that list: iterating the live dict from a worker thread would raise
-        ``RuntimeError`` the moment the event loop registered or evicted an
-        agent mid-sweep. Writes are plain float/int field assignments on
-        ``SubagentInfo``, which the surface only ever reads.
-        """
-        now = time.monotonic()
-        agents = list(self._agents.values())
-        for info in agents:
-            if info.done or not info._pid:
-                continue
-            # Session-shared subagents run inside the parent's AcpRuntime process;
-            # every sharing subagent reports the SAME runtime PID, so naive
-            # per-PID sampling would attribute the whole shared process to each
-            # of them. Instead attribute the runtime's measured RSS/CPU divided
-            # by the number of concurrently-live shared sessions on that PID — an
-            # empirical per-session average, not a guessed constant
-            # (dynamic-subagent-sizing.md §session-sharing cost model).
-            #
-            # Sole tenant of its own process: the subtree reading IS this run's,
-            # which is a share of one.
-            shared_n = self._live_shared_count(info._pid, agents) if info._session_sharing else 1
-            sample = _proc_subtree_sample(info._pid)
-            if sample.rss_kb > 0 and shared_n > 0:
-                gb = (sample.rss_kb / (1024 * 1024)) / shared_n
-                info.last_rss_gb = gb
-                if gb > info.peak_rss_gb:
-                    info.peak_rss_gb = gb
-            info.last_procs = _attributed_count(sample.procs, shared_n, info.last_procs)
-            info.last_stubs = _attributed_count(sample.matched, shared_n, info.last_stubs)
-            jiffies = sample.jiffies
-            if info._cpu_sample_ts > 0.0 and jiffies >= info._cpu_jiffies_prev and shared_n > 0:
-                dt = now - info._cpu_sample_ts
-                if dt > 0:
-                    cores = ((jiffies - info._cpu_jiffies_prev) / (_CLK_TCK * dt)) / shared_n
-                    info.last_cpu_cores = cores
-                    if cores > info.peak_cpu_cores:
-                        info.peak_cpu_cores = cores
-            info._cpu_jiffies_prev = jiffies
-            info._cpu_sample_ts = now
+        return self._monitor._sample_live_costs_impl()
 
     def _record_cost(self, info: SubagentInfo) -> None:
-        """Persist this run's high-water RSS/CPU to the learned-cost store."""
-        if info.peak_rss_gb <= 0 and info.peak_cpu_cores <= 0:
-            return  # never sampled (e.g. finished before the first reaper sweep)
-        try:
-            append_cost_sample(info.agent, info.peak_rss_gb, info.peak_cpu_cores)
-        except Exception:
-            logger.debug("Failed to record subagent cost for %s", info.id, exc_info=True)
+        return self._monitor._record_cost_impl(info)
 
     async def _reaper_loop(self) -> None:
-        """Periodically force-kill subagents that exceed the timeout.
-
-        Defense-in-depth: catches cases where ``asyncio.wait_for`` in
-        ``_run()`` fails to fire (event-loop saturation, orphaned tasks,
-        or ``reset()`` hanging in the finally block).
-        """
-        try:
-            compact_cost_log()  # startup FIFO trim (§4.2)
-        except Exception:
-            logger.debug("Reaper: startup cost-log compaction failed", exc_info=True)
-        while True:
-            await asyncio.sleep(_REAPER_INTERVAL)
-            now = time.time()
-            if not self._conv_registry_rebuilt:
-                # First pass after (re)start: re-seed the conversation TTL
-                # registry from state.json so promoted conversations survive
-                # a gateway restart under sweep ownership (#1114). The flag
-                # is set only on SUCCESS — a failed rebuild retries on the
-                # next sweep instead of silently restoring the pre-#1114
-                # orphaning until the next restart (Arbiter, PR #1246).
-                try:
-                    await self._rebuild_conversation_registry()
-                    self._conv_registry_rebuilt = True
-                except Exception:
-                    logger.warning(
-                        "Reaper: conversation registry rebuild failed — retrying next sweep",
-                        exc_info=True,
-                    )
-            # Off the event loop: the sweep is several /proc walks per live agent,
-            # and the reaper shares the loop with every chat turn and heartbeat.
-            try:
-                await asyncio.get_running_loop().run_in_executor(
-                    maintenance_executor(), self._sample_live_costs
-                )
-            except Exception:
-                logger.debug("Reaper: live-cost sample failed", exc_info=True)
-            # Wave liveness backstop: reconcile waves wedged by submissions
-            # lost before the process boundary (see _sweep_stuck_waves).
-            try:
-                self._sweep_stuck_waves(now)
-            except Exception:
-                logger.debug("Reaper: stuck-wave sweep failed", exc_info=True)
-            # Digest hold deadline: release completed wave results that a
-            # straggler (or a hung member) has been withholding.
-            try:
-                self._sweep_digest_holds(now)
-            except Exception:
-                logger.debug("Reaper: digest-hold sweep failed", exc_info=True)
-            try:
-                self._sweep_conversations(now)
-            except Exception:
-                logger.debug("Reaper: conversation sweep failed", exc_info=True)
-            try:
-                compact_cost_log()  # periodic FIFO trim (also bounds a long-running gateway)
-            except Exception:
-                logger.debug("Reaper: cost-log compaction failed", exc_info=True)
-            for agent_id, info in list(self._agents.items()):
-                if info.done:
-                    continue
-                elapsed = now - info.started
-                # Startup watchdog: a subagent that entered execution but is
-                # still on turn 0 with no runtime PID after the startup window
-                # is wedged in startup (e.g. a hung provider/ACP handshake that
-                # never launches the child process). Reap it fast with a clear
-                # "failed to start" error instead of burning the full deadline
-                # and surfacing a misleading 30-minute turn-0 timeout.
-                if self._is_startup_stalled(info, now):
-                    logger.warning(
-                        "Reaper: subagent %s failed to start within %ds "
-                        "(turn 0, no runtime launched), force-killing",
-                        agent_id,
-                        self._startup_deadline,
-                    )
-                    try:
-                        await self._force_reap(
-                            agent_id,
-                            info,
-                            now - (info._exec_started or now),
-                            reason="startup_timeout",
-                        )
-                    except Exception:
-                        logger.exception("Reaper: failed to reap %s", agent_id)
-                    continue
-                # Idle-stall detection (see _maybe_flag_stall). The main-agent
-                # watchdog stack does not govern subagents; this is their
-                # equivalent — surface a "stalled" UI signal well before the
-                # 30-min ceiling. Surface-only: it never terminates the agent
-                # (users close it from the UX), so we always fall through to
-                # the wall-clock check below.
-                await self._maybe_flag_stall(agent_id, info, now)
-                if elapsed <= self._default_timeout:
-                    continue
-                logger.warning(
-                    "Reaper: subagent %s exceeded %ds (ran %.0fs), force-killing",
-                    agent_id,
-                    self._default_timeout,
-                    elapsed,
-                )
-                try:
-                    await self._force_reap(agent_id, info, elapsed)
-                except Exception:
-                    logger.exception("Reaper: failed to reap %s", agent_id)
-
-            # Prune stale tombstoned folders (>7 days old)
-            try:
-                pruned = await asyncio.get_running_loop().run_in_executor(
-                    maintenance_executor(),
-                    prune_stale_tombstones,
-                    7,
-                    self._result_ttl_secs,
-                )
-                if pruned:
-                    logger.info("Reaper: pruned %d stale tombstone(s)", pruned)
-            except Exception:
-                logger.debug("Reaper: tombstone pruning failed", exc_info=True)
+        return await self._monitor._reaper_loop_impl()
 
     def _is_startup_stalled(self, info: SubagentInfo, now: float) -> bool:
-        """True if a subagent is wedged in startup and should be reaped early.
-
-        A subagent qualifies only once it has actually entered execution
-        (``_exec_started`` set by ``_run_inner``) yet has launched no runtime
-        (``_pid is None``) and produced no turn (``turns == 0``) within
-        ``_startup_deadline`` seconds. Keying on ``_exec_started`` — not the
-        registration timestamp ``started`` — means an agent merely awaiting
-        spawn approval (never entered ``_run_inner``) is never caught here.
-        """
-        exec_started = info._exec_started
-        if exec_started is None:
-            return False
-        return (
-            info.turns == 0 and info._pid is None and (now - exec_started) > self._startup_deadline
-        )
+        return self._monitor._is_startup_stalled_impl(info, now)
 
     @staticmethod
     def _note_tool_dispatch(info: SubagentInfo, event: Any) -> None:
@@ -2203,200 +1791,10 @@ class SubagentManager:
         info._stall_gen += 1
 
     async def _stall_verdict(self, info: SubagentInfo) -> tuple[str, str]:
-        """Liveness verdict for an idle subagent: working, wedged, or unknown.
-
-        Idle time alone cannot separate a hung tool call from a slow silent one,
-        so this consults the same ``LivenessOracle`` the main agent's watchdog
-        uses (:mod:`kiro_crew.acp.liveness`) for ``/proc`` evidence.
-
-        The attribution is what makes it sound. With the in-flight tool's real
-        ``is_shell`` + command, the consult takes the oracle's shell-child
-        branch, which matches a live descendant by CMDLINE and then tracks that
-        pid — so the evidence belongs to THIS subagent's own child even when the
-        runtime is shared with sibling subagents. That is the distinction an
-        earlier whole-subtree attempt could not make: a subtree aggregate is
-        dominated by kiro-cli's own background socket/keepalive traffic, so a
-        ``sleep``-only subagent read as "working" and was never flagged.
-
-        Returns ``(verdict, evidence)``; any failure degrades to
-        ``(VERDICT_UNKNOWN, ...)`` so the caller falls back to idle time.
-        """
-        if not info._pid:
-            return VERDICT_UNKNOWN, "no runtime pid"
-        tool = info._inflight_tool
-        if tool is None:
-            # Idle with no tool in flight is a model-wait, not a hung command.
-            # The model-wait branch reads the whole runtime subtree, which is not
-            # attributable on a shared runtime — so decline rather than guess.
-            return VERDICT_UNKNOWN, "no tool in flight"
-        if not tool.is_shell:
-            # A non-shell MCP tool has no child process to match, so the oracle
-            # can only offer the same unattributable subtree aggregate. Decline.
-            return VERDICT_UNKNOWN, "non-shell tool — not attributable"
-        if info._stall_oracle is None:
-            info._stall_oracle = LivenessOracle()
-        # The consult is a SYNCHRONOUS /proc filesystem walk (``iter_descendants``
-        # over the runtime's descendant subtree, plus ``os.readlink`` on
-        # ``/proc/<pid>/fd/*``, which can block on the very wedged fd being
-        # investigated) — and this runs on the reaper's event loop, the same loop
-        # that serves every chat turn and the liveness heartbeat, sweeping agents
-        # serially. Inline, one wedged read freezes the gateway until the
-        # loop-stall watchdog kills it. Offload it exactly as the main-agent path
-        # does (``AcpSessionHandle._consult_oracle_offloaded``): bounded await,
-        # and at most ONE outstanding walk per agent so a permanently wedged read
-        # cannot leave a new blocked worker behind on every sweep.
-        # ``consult_offloaded`` owns that whole sequence -- one outstanding walk per
-        # holder, submission inside the guard, exception retrieval attached at
-        # submission, every failure degrading to UNKNOWN -- for the two watchdog
-        # paths that already depend on it, so a fix there lands here too.
-        # ``SubagentInfo`` satisfies its ``ConsultFutureHolder`` protocol via
-        # ``_consult_future``. That handle deliberately OUTLIVES snapshot
-        # retirement: ``_clear_tool_dispatch`` bumps ``_stall_gen`` (which
-        # invalidates a stale verdict, below) but leaves the future in place, so a
-        # walk still wedged on a stuck fd keeps suppressing resubmission instead
-        # of letting each later sweep strand another blocked worker.
-        submitted_gen = info._stall_gen
-        verdict = await consult_offloaded(
-            info,
-            info._stall_oracle.check_tool,
-            (info._pid, tool),
-            executor_factory=subprocess_executor,
-            log_label=f"stall consult for {info.id}",
-        )
-        # The consult awaits, so fresh activity, a final tool result, or the next
-        # dispatch can retire this snapshot while the walk is still running. A
-        # verdict about a tool that is no longer in flight must not be applied to
-        # whatever replaced it: DEAD/STUCK_INPUT skips the two-sweep confirmation,
-        # so a stale one would flag an agent that has demonstrably resumed working.
-        if info._stall_gen != submitted_gen:
-            return VERDICT_UNKNOWN, "superseded mid-consult"
-        return verdict
+        return await self._monitor._stall_verdict_impl(info)
 
     async def _maybe_flag_stall(self, agent_id: str, info: SubagentInfo, now: float) -> None:
-        """Idle-stall detection for a running subagent (surface-only).
-
-        A subagent that has started (>=1 turn or a live runtime PID) but has
-        emitted no stream activity for ``_stall_idle_secs`` may be wedged in a
-        hung tool call — or simply running one slow, silent command. Idle time
-        cannot tell those apart, so the flag is gated on a ``LivenessOracle``
-        consult (:meth:`_stall_verdict`) that attributes evidence to the
-        subagent's OWN child process by cmdline match:
-
-        * ``WORKING`` — a live matched child, so it is progressing: not flagged.
-        * ``DEAD`` / ``STUCK_INPUT`` — the child exited with no result frame, or
-          its subtree is flat and blocked on a tty/stdin read. That is positive
-          evidence of a wedge, so it flags IMMEDIATELY, skipping the two-sweep
-          confirmation the idle-time path needs.
-        * ``UNKNOWN`` — no attributable evidence (no shell child to match, no
-          tool in flight, unreadable ``/proc``). Falls back to idle time with the
-          two-sweep confirmation, i.e. exactly the previous behaviour.
-
-        Still deliberately *surface-only*: it emits a ``subagent_stalled`` UI
-        signal and records the slow command, but NEVER terminates the agent, so
-        a slow-but-healthy command can only ever produce a self-clearing badge.
-        Escalating a ``DEAD`` verdict to an early reap would be a change to kill
-        semantics and is intentionally NOT part of this; the wall-clock reaper at
-        ``_TIMEOUT_SECS`` remains the only automatic terminator.
-        """
-        if not (info.turns > 0 or info._pid is not None):
-            return
-        # A subagent blocked on a human tool-approval prompt is healthy, not
-        # stalled — the permission request bumps `turns` before the approval
-        # wait, so without this a slow approval would be mislabelled idle.
-        if info._awaiting_approval:
-            return
-        idle = now - info.last_activity
-        if not info.stalled and idle > self._stall_idle_secs:
-            verdict, evidence = await self._stall_verdict(info)
-            if verdict == VERDICT_WORKING and idle < self._stall_idle_secs * _SUPPRESS_CEILING:
-                # Attributable progress in this subagent's own child: silent, not
-                # stalled. Leave the suspicion open (do not reset
-                # _stall_suspect_at) so the badge appears as soon as that child
-                # stops moving or exits.
-                #
-                # The ceiling above bounds how long a WORKING reading may hold the
-                # badge back, because attribution is not infallible: under
-                # ``session_sharing`` two siblings running similar commands can
-                # cmdline-match the SAME child, so a wedged agent can read WORKING
-                # for as long as its sibling's child lives. Without a bound that
-                # turns an old true positive into a permanent false negative —
-                # strictly worse than the idle-time-only path it replaces. With
-                # it, misattribution costs latency, not the signal.
-                logger.debug(
-                    "Reaper: subagent %s idle %.0fs but working (%s) — not flagging",
-                    agent_id,
-                    idle,
-                    evidence,
-                )
-                return
-            # A wedged verdict normally skips it: DEAD/STUCK_INPUT is positive
-            # evidence about this agent's child rather than a guess from elapsed
-            # silence, so dampening it would only delay a signal already earned.
-            #
-            # BUT that trust is only warranted when the cmdline match cannot have
-            # landed on someone else's child. ``_SUPPRESS_CEILING`` exists
-            # precisely because the match is fallible under a shared runtime, and
-            # a DEAD derived from a fallible match is exactly as wrong as the
-            # WORKING the ceiling bounds — a sibling's matched child exiting would
-            # otherwise raise an immediate badge on a healthy agent, skipping the
-            # very dampening added to keep the badge trustworthy at scale. So the
-            # skip is withdrawn whenever another session could be the one being
-            # measured, and the wedged verdict then earns its badge the same way
-            # an idle-time guess does: by holding across two sweeps.
-            #
-            # The gate keys on ``session_sharing`` itself, not on a count of live
-            # siblings, because the confusable co-tenant is not only a sibling:
-            # ``_create_shared_session`` puts the subagent on the PARENT's
-            # AcpRuntime ("one process hosts everything"), so ``info._pid`` is the
-            # parent's process and the parent's own tool children are descendants
-            # of it too. ``_live_shared_count`` iterates the subagent registry and
-            # therefore cannot see the parent, so a LONE subagent counted 1 and
-            # kept the fast path while still able to cmdline-match the parent's
-            # child — and flag instantly when that child exited. Since a shared
-            # runtime always has the parent in it, "could this match belong to
-            # someone else?" is true for every session-sharing agent.
-            wedged = verdict in (VERDICT_DEAD, VERDICT_STUCK_INPUT)
-            if wedged and info._session_sharing:
-                wedged = False
-            # Two-sweep confirmation (scale dampening): at 60-100 concurrent
-            # agents a single-window trip ambers several healthy-slow agents at
-            # any moment, training users to ignore the badge. Require the idle
-            # threshold to hold across TWO consecutive reaper sweeps before
-            # flagging — a stream event between sweeps resets the suspicion
-            # (_touch_activity clears both flags). Adds at most one sweep
-            # interval (~60s) of latency to a genuine stall.
-            if not wedged and info._stall_suspect_at <= 0.0:
-                info._stall_suspect_at = now
-                return
-            info.stalled = True
-            logger.warning(
-                "Reaper: subagent %s idle %.0fs (verdict=%s; %s) — marking stalled",
-                agent_id,
-                idle,
-                verdict,
-                evidence,
-            )
-            # Persist the slow command for future analysis. Best-effort; must
-            # not disturb the still-running agent (NOT a tombstone — the agent
-            # is alive, not dead).
-            self._record_slow_command(info, idle)
-            try:
-                await self._fire_event(
-                    "subagent_stalled",
-                    info,
-                    # The verdict and its evidence are deliberately NOT on the
-                    # wire: no consumer reads them (the frontend narrows this
-                    # payload to {slot, id, stalled, idle_secs} on arrival, and
-                    # the coalesced batch update forwards only `stalled`), and the
-                    # event is app-sdk-forwarded, so shipping unread keys would
-                    # create semi-permanent surface. The log line above records
-                    # both for diagnosis; add them here when something renders it.
-                    {"stalled": True, "idle_secs": int(idle)},
-                )
-            except Exception:
-                logger.debug(
-                    "Reaper: failed to emit subagent_stalled for %s", agent_id, exc_info=True
-                )
+        return await self._monitor._maybe_flag_stall_impl(agent_id, info, now)
 
     @staticmethod
     def _record_slow_command(info: SubagentInfo, idle: float) -> None:
@@ -2423,52 +1821,7 @@ class SubagentManager:
             logger.debug("Failed to record slow command for %s", info.id, exc_info=True)
 
     def _claim_finalize(self, info: SubagentInfo, *, supersede_recovery: bool = False) -> bool:
-        """Claim the exclusive right to report ``info``'s terminal outcome.
-
-        Returns True for exactly one caller. Both the reap path and ``_run``'s
-        ``finally`` call this and report only if it returns True, so the parent
-        is notified exactly once no matter which wins the race or whether the
-        loser is cancelled part-way through its teardown.
-
-        Contains no ``await``, so on a single-threaded event loop the
-        check-and-set is atomic with respect to other tasks.
-
-        Returns False while ``_recovering`` — a cancel-recovery respawn is
-        pending and the agent must not be reported done yet — leaving the claim
-        OPEN so the respawned run can take it later.
-
-        ``supersede_recovery=True`` overrides that withholding and is used ONLY
-        by definitively-terminal callers (`_force_reap`, which also serves user
-        Stop). Without it a reap landing inside the recovery window stranded the
-        outcome: the reap was refused the claim, performed teardown and set
-        ``reaped``, reported nothing — and `_resume`'s ``reaped`` abort path
-        bare-returns, so no path ever reported and the agent sat unfinished
-        until the reaper's wall-clock deadline. Superseding also clears
-        ``_recovering``, because a killed agent has nothing left to respawn.
-
-        Scope note: this token governs REPORTING only, and it deliberately does
-        NOT consult ``info.done``. Gating it on ``done`` is wrong:
-        if ``_run_inner`` set ``done`` while the reap awaited its session reset,
-        the reaper refused the claim, still marked ``reaped``, and ``_run``'s
-        finally then skipped its own claim — nobody reported. The terminal RECORD
-        (tombstone/stat) keeps its own ``not info.done`` guard and slot accounting
-        has its own one-shot token (:meth:`_release_slot`); three concerns, three
-        guards. Session teardown stays keyed on ``reaped``.
-        """
-        if info._recovering and not supersede_recovery:
-            return False
-        if info._finalized:
-            return False
-        if info._recovering:
-            # A terminal reap/stop SUPERSEDES a pending cancel-recovery respawn:
-            # the agent is being killed, so there is nothing left to respawn.
-            # Clearing the flag here is what keeps `False` from meaning two
-            # different things to this caller ("someone else already reported"
-            # vs "withheld for a respawn that will report later") — the exact
-            # conflation this token exists to remove.
-            info._recovering = False
-        info._finalized = True
-        return True
+        return self._terminal._claim_finalize_impl(info, supersede_recovery=supersede_recovery)
 
     async def _report_terminal(
         self,
@@ -2480,150 +1833,14 @@ class SubagentManager:
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
     ) -> None:
-        """Deliver ``info``'s one-shot terminal report as a single unit.
-
-        This is the exact work the finalize claim guards: fire the
-        ``subagent_done`` WS event, then inject the completion into the parent
-        (``_on_done``) with its ``_ON_DONE_TIMEOUT`` cap, timeout handling, and
-        (for the ``_run`` path) the result.txt TTL / workspace-cleanup
-        bookkeeping.
-
-        Why this is a separate coroutine run under ``asyncio.shield`` (see
-        ``_run_terminal_report``): the claim makes reporting EXCLUSIVE but not
-        ATOMIC. A claimer cancelled mid-report (``_force_reap`` /
-        ``cancel_all()`` cancelling the task while it awaits ``_fire_event`` or
-        ``_on_done``) would exit without delivering, and the other path — seeing
-        the claim already taken — stays silent, so the completed outcome never
-        reaches the parent. Running the report on a shielded, strongly-held task
-        makes it complete independently of caller cancellation.
-
-        The two call sites (reap vs. ``_run``'s ``finally``) differ only in the
-        injection-timeout reason string, the log ``source`` prefix, and whether
-        a successful delivery marks the result delivered — those are passed as
-        arguments rather than unified away. The WS payload is identical (both
-        set ``info.elapsed`` before calling), so it is built from ``info`` here.
-        """
-        await self._fire_event(
-            "subagent_done",
+        return await self._terminal._report_terminal_impl(
             info,
-            {
-                "elapsed": info.elapsed,
-                "error": _redact(info.error) if info.error else None,
-                "stopped": info.user_stopped,
-                "outcome": info.outcome,
-                "task": _redact(info.task),
-                "agent": _redact(info.agent),
-                # The sub-agent's own session key (see build_subagent_snapshot):
-                # lets a client fetch this node's own context-trace even after
-                # it has finished.
-                "child_session": info.conversation_key or f"subagent:{info.id}",
-                # The model actually served (issue #3582). By the terminal
-                # report this is the authoritative value on every provider — the
-                # CC/raw path has completed at least one turn, so its
-                # ``_resolved_model_id`` is populated (refreshed in ``_run``).
-                "model": info.resolved_model,
-                # Carry the requested pin on the terminal report too, redacted
-                # like the spawn frame: after a reconnect the completed card is
-                # rebuilt from this event alone, so without it the live-downgrade
-                # amber chip would silently vanish from a downgraded finished run
-                # (Opus/Design/First-Principles review on #5326).
-                "requested_model": _redact(info.requested_model),
-                "result": _done_result(info.result),
-            },
+            source=source,
+            injection_timeout_reason=injection_timeout_reason,
+            mark_delivered_on_success=mark_delivered_on_success,
+            settle_digest=settle_digest,
+            teardown_done=teardown_done,
         )
-        if not self._on_done:
-            return
-        try:
-            await asyncio.wait_for(self._on_done(info), timeout=_ON_DONE_TIMEOUT)
-            # The outcome has REACHED the parent. Recorded before any further
-            # await so a shutdown cancellation landing in the teardown wait or
-            # the tombstone write below is not mistaken for a lost delivery by
-            # `cancel_all()` (which would re-deliver it on the next start).
-            info._reported_to_parent = True
-            if settle_digest:
-                # _on_done returned without raising, so the wave digest (if this
-                # was the final member) has been handed off. Only NOW settle the
-                # held members' delivery tombstones.
-                self._settle_digest_holds(info)
-            # Digest-held wave members are NOT marked delivered here: their
-            # result has not reached the parent yet (the gateway marks them when
-            # the digest fires), so a restart mid-wave leaves them visible to
-            # orphan reconciliation.
-            #
-            # A QUEUED injection is the same statement about a different wait:
-            # the announce is parked in the parent's slot queue, so the result is
-            # not in its context yet and the retention clock must not start (the
-            # drain settles it). Both flags are set by the gateway inside
-            # _on_done, above.
-            if (
-                mark_delivered_on_success
-                and not info.error
-                and not info._digest_held
-                and not info._delivery_queued
-            ):
-                # Wait for the caller's session teardown before writing the
-                # "delivered" tombstone. This report is deliberately SPAWNED
-                # ahead of teardown (so a cancellation cannot strand it), which
-                # opens a window the older post-teardown ordering did not have:
-                # a crash after the tombstone but before teardown finished would
-                # leave a surviving child process EXCLUDED from orphan
-                # reconciliation — invisible and never reaped. The wait is
-                # bounded because the caller's teardown is itself bounded
-                # (_RESET_TIMEOUT then SIGKILL) and runs in a `finally`, so the
-                # event is set even when the caller is cancelled.
-                if teardown_done is not None and not teardown_done.is_set():
-                    try:
-                        await asyncio.wait_for(teardown_done.wait(), timeout=_RESET_TIMEOUT + 30)
-                    except asyncio.TimeoutError:
-                        logger.warning(
-                            "Subagent %s: teardown did not complete before the "
-                            "delivered tombstone; writing it anyway",
-                            info.id,
-                        )
-                # Retain result.txt for a TTL grace window instead of deleting
-                # it now, so the parent can read the full transcript
-                # (spawn_status / read / grep) after the completion event. A
-                # "delivered" tombstone excludes it from orphan reconciliation;
-                # the reaper prunes it after agent.subagent_result_ttl_secs.
-                try:
-                    mark_delivered(info.id)
-                except Exception:
-                    logger.debug("Failed to mark subagent %s delivered", info.id, exc_info=True)
-                # Clean up workspace result file (agent-{id}.md in parent dir).
-                # The directory is named after the parent's SLOT, which a
-                # channel-born parent has while its session key stays the
-                # channel's own; without a tab there is no directory to clean.
-                try:
-                    # Lazy: the dashboard layer must not be imported by a core
-                    # module at import time.
-                    from kiro_crew.dashboard.chat_utils import dashboard_slot_key
-
-                    slot_key = dashboard_slot_key(info.parent_session_key)
-                    if slot_key:
-                        _ws_result_path(slot_key, info.id).unlink(missing_ok=True)
-                except Exception:
-                    logger.debug("Failed to clean workspace result for %s", info.id, exc_info=True)
-        except asyncio.TimeoutError:
-            logger.error(
-                "%s: completion injection timed out for %s after %.0fs",
-                source,
-                info.id,
-                _ON_DONE_TIMEOUT,
-            )
-            # Kill the parent session's kiro-cli process so the next agent's
-            # injection gets a clean provider instead of hitting "Prompt already
-            # in progress" on the stuck one.
-            try:
-                await self._sessions.reset(info.parent_session_key)
-            except Exception:
-                logger.debug(
-                    "Failed to reset parent session %s after injection timeout",
-                    info.parent_session_key,
-                    exc_info=True,
-                )
-            self.notify_injection_failed(info, reason=injection_timeout_reason)
-        except Exception:
-            logger.exception("%s: announce failed for %s", source, info.id)
 
     async def _run_terminal_report(
         self,
@@ -2635,26 +1852,13 @@ class SubagentManager:
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
     ) -> None:
-        """Spawn the shielded terminal report and block until it completes.
-
-        Convenience for callers that have no cancellable ``await`` between
-        taking the claim and reporting (``_force_reap``): there is no window in
-        which a cancellation could strand the outcome before the report task
-        exists, so spawning and awaiting can be adjacent. Callers that DO have a
-        teardown ``await`` between the claim and the report (``_run``'s
-        ``finally``) must instead :meth:`_spawn_terminal_report` BEFORE that
-        await and :meth:`_await_report` after, so the report task is already
-        live (and shielded) no matter where the cancellation lands.
-        """
-        await self._await_report(
-            self._spawn_terminal_report(
-                info,
-                source=source,
-                injection_timeout_reason=injection_timeout_reason,
-                mark_delivered_on_success=mark_delivered_on_success,
-                settle_digest=settle_digest,
-                teardown_done=teardown_done,
-            )
+        return await self._terminal._run_terminal_report_impl(
+            info,
+            source=source,
+            injection_timeout_reason=injection_timeout_reason,
+            mark_delivered_on_success=mark_delivered_on_success,
+            settle_digest=settle_digest,
+            teardown_done=teardown_done,
         )
 
     def _spawn_terminal_report(
@@ -2667,38 +1871,14 @@ class SubagentManager:
         settle_digest: bool = False,
         teardown_done: "asyncio.Event | None" = None,
     ) -> "asyncio.Task":  # type: ignore[type-arg]
-        """Launch :meth:`_report_terminal` on a strongly-referenced task.
-
-        Returns immediately (no ``await``) so the caller can start the report
-        BEFORE its own teardown awaits, guaranteeing the report exists and is
-        held alive independently of the caller's fate. The task is retained in
-        ``self._report_tasks`` (so it cannot be garbage-collected while its
-        awaiter is cancelled, and so ``cancel_all()`` can drain it) and
-        self-removes on completion.
-        """
-        task = asyncio.create_task(
-            self._report_terminal(
-                info,
-                source=source,
-                injection_timeout_reason=injection_timeout_reason,
-                mark_delivered_on_success=mark_delivered_on_success,
-                settle_digest=settle_digest,
-                teardown_done=teardown_done,
-            )
+        return self._terminal._spawn_terminal_report_impl(
+            info,
+            source=source,
+            injection_timeout_reason=injection_timeout_reason,
+            mark_delivered_on_success=mark_delivered_on_success,
+            settle_digest=settle_digest,
+            teardown_done=teardown_done,
         )
-        self._report_tasks.add(task)
-        # Owner map so `cancel_all()` can identify WHOSE outcome it is about to
-        # abandon (and re-admit it to orphan recovery). Kept alongside the set
-        # rather than replacing it: `_report_tasks` is the strong reference that
-        # keeps the task alive, and both are cleared by the one done callback.
-        self._report_owners[task] = info
-
-        def _forget(t: "asyncio.Task") -> None:  # type: ignore[type-arg]
-            self._report_tasks.discard(t)
-            self._report_owners.pop(t, None)
-
-        task.add_done_callback(_forget)
-        return task
 
     @staticmethod
     async def _await_report(task: "asyncio.Task") -> None:  # type: ignore[type-arg]
@@ -2713,343 +1893,20 @@ class SubagentManager:
         await asyncio.shield(task)
 
     def _release_slot(self, info: SubagentInfo) -> bool:
-        """Claim the exclusive right to free ``info``'s concurrency slot.
-
-        Returns True for exactly one caller; that caller decrements
-        ``_running_count`` once and drains the queue. Contains no ``await``, so
-        the check-and-set is atomic with respect to other tasks on the loop.
-
-        Why this is its OWN token rather than a side effect of ``done`` or
-        ``reaped``: both terminal paths (`_force_reap` and `_run`'s ``finally``)
-        can run for the same agent, and previous revisions inferred slot
-        ownership from whichever flag happened to be set. That produced a double
-        decrement in one interleaving and — after the flag order was changed to
-        fix a delivery bug — no decrement at all in another, inflating
-        ``_running_count`` and permanently starving the spawn queue. An explicit
-        one-shot token makes the count independent of report and record ordering.
-
-        Note the recovery respawn's own ``_running_count += 1`` re-admit is
-        unaffected: it runs after the interrupted run's ``finally`` has already
-        released, and this token is per-``SubagentInfo``.
-        """
-        if info._slot_released:
-            return False
-        info._slot_released = True
-        return True
+        return self._terminal._release_slot_impl(info)
 
     async def _force_reap(
         self, agent_id: str, info: SubagentInfo, elapsed: float, *, reason: str = ""
     ) -> None:
-        """Kill a subagent's session process and mark it done."""
-        session_key = f"subagent:{agent_id}"
-
-        # Reap-in-flight marker + recovery cancel BEFORE ANY await in this
-        # method. Both used to sit after the session teardown below, which yields
-        # (bounded by _RESET_TIMEOUT, longer still on the SIGKILL path). A
-        # cancel-recovery task whose bounded handshake expired inside that window
-        # respawned the very run being killed — tools executing after a user
-        # Stop, strictly worse than a duplicate report. Note this sets
-        # `_reap_started`, NOT `reaped`: setting `reaped` this early makes a run
-        # woken by our own session reset skip its error synthesis and report a
-        # false SUCCESS before we own the record. See `_reap_started`.
-        info._reap_started = True
-        # A pending cancel-recovery respawn is moot — this agent is being killed.
-        # Cancel it rather than letting it sit in its bounded handshake wait
-        # (_RESET_TIMEOUT + 60s) only to discover `reaped` and bare-return.
-        # The reap owns the terminal report from here (see the claim below).
-        recovery_task = self._tasks.pop(f"{agent_id}:recovery", None)
-        if recovery_task and not recovery_task.done():
-            recovery_task.cancel()
-
-        if info._session_sharing:
-            # Session-sharing subagent: NEVER SIGKILL the shared runtime —
-            # the parent session owns it and other co-tenants may be active.
-            # Conservative approach: shut down only this subagent's provider
-            # handle, leaving the shared runtime intact.
-            runtime_pid = info._pid
-            logger.info(
-                "Reaper: conservative shutdown for session-sharing %s — "
-                "runtime pid=%s kept alive (shared runtime, never SIGKILL)",
-                agent_id,
-                runtime_pid,
-            )
-            try:
-                sel().log_tool_invocation(
-                    session_key=session_key,
-                    source="subagent",
-                    tool_name="smart_hard_kill",
-                    outcome="conservative-shutdown",
-                    resources=f"runtime_pid={runtime_pid}",
-                    metadata={
-                        "subagent_id": agent_id,
-                        "runtime_pid": runtime_pid,
-                        "decision": "session-sharing-never-kill",
-                    },
-                )
-            except Exception:
-                logger.debug("SEL audit for conservative shutdown failed", exc_info=True)
-            # Shutdown the shared provider handle only
-            try:
-                if info._shared_provider:
-                    await info._shared_provider.shutdown()
-            except Exception:
-                logger.debug(
-                    "Reaper: shared session shutdown failed for %s", agent_id, exc_info=True
-                )
-        else:
-            # Kill the process FIRST so the pipe unblocks, then cancel the task.
-            try:
-                await asyncio.wait_for(self._sessions.reset(session_key), timeout=_RESET_TIMEOUT)
-            except asyncio.TimeoutError:
-                logger.warning("Reaper: reset hung for %s, attempting SIGKILL", agent_id)
-                await self._sigkill_session(session_key)
-            except Exception:
-                logger.exception("Reaper: reset failed for %s", agent_id)
-
-        task = self._tasks.pop(agent_id, None)
-        if task and not task.done():
-            # `reaped` is set HERE — late, immediately before the intentional
-            # cancel — not at the top of the method. Late enough that a run woken
-            # by the session reset above still synthesizes its own error (a run
-            # that sees `reaped` skips error synthesis, and reporting with no
-            # error set delivers a false success). Early enough to satisfy the
-            # intentional-cancel contract: visible when the task's
-            # CancelledError arm runs. The recovery scheduler reads the earlier
-            # `_reap_started` instead, so it is not affected by this placement.
-            info.reaped = True
-            self._cancel_task_intentionally(task, info, reason=reason or "reaped")
-
-        # No live task to cancel above (already exited) — the reap still owns
-        # teardown bookkeeping from here, so mark it now.
-        info.reaped = True
-        # Guard 1 of 3 — the terminal RECORD (done/error/stat/tombstone/cost) is
-        # first-arrival-wins on `info.done`, so it is never written twice.
-        if not info.done:
-            info.done = True
-            if not info.error and not info.user_stopped:
-                # A user stop is neutral — never synthesize a reap error for it.
-                if reason == "startup_timeout":
-                    info.error = f"Failed to start within {self._startup_deadline}s (no runtime launched, no turn produced) [{_timeout_context(info, include_elapsed=False, turn_limit=self._effective_turn_limit(info))}]"
-                else:
-                    info.error = f"Reaped after {int(elapsed)}s (exceeded {self._default_timeout}s deadline) [{_timeout_context(info, include_elapsed=False, turn_limit=self._effective_turn_limit(info))}]"
-            if not info.user_stopped:
-                # A user-initiated stop is a neutral outcome, not a failure.
-                Stats().inc_subagent_failed()
-            self._write_tombstone(info, reason or "reaped")
-            self._record_cost(info)
-        # Guard 2 of 3 — SLOT accounting, on its own one-shot token and therefore
-        # independent of both `done` (above) and `reaped`. A reap/cancel frees a
-        # slot but — unlike normal completion — does NOT otherwise pump the queue,
-        # so queued spawns would sit stranded until an unrelated agent finished.
-        # Drain here so the freed slot is used immediately.
-        if self._release_slot(info):
-            self._running_count = max(0, self._running_count - 1)
-            self._drain_queue()
-
-        try:
-            sel().log_tool_invocation(
-                session_key=session_key,
-                source="subagent",
-                tool_name="reaper_force_kill",
-                outcome="reaped",
-                metadata={
-                    "subagent_id": agent_id,
-                    "session_key": session_key,
-                    "elapsed": int(elapsed),
-                },
-            )
-        except Exception:
-            logger.exception("Reaper: SEL audit failed for %s", agent_id)
-
-        try:
-            # Retain-by-default: the reaped run's session files stay on disk
-            # (spawn_continue resume material); the tombstone pruner owns
-            # their deletion. A force-reaped long run is exactly the case
-            # retention exists for.
-            self._sessions.release(session_key, cleanup=False)
-        except Exception:
-            logger.warning("Reaper: release failed for %s", agent_id, exc_info=True)
-
-        # Guard 3 of 3 — the terminal REPORT (subagent_done + _on_done), owned by
-        # the finalize claim. The claim deliberately does NOT consult `info.done`:
-        # `_run_inner` may set `done` while the teardown above is suspended, and
-        # gating on it made the reaper decline while `_run`'s finally also declined
-        # (it sees `reaped`) — so nobody reported. The report runs SHIELDED, so a
-        # cancellation landing mid-report (cancel_all during shutdown) still
-        # delivers rather than stranding the outcome with the claim consumed.
-        info.elapsed = elapsed
-        if self._claim_finalize(info, supersede_recovery=True):
-            await self._run_terminal_report(
-                info,
-                source="Reaper",
-                injection_timeout_reason=(
-                    f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s (reaper)"
-                ),
-                mark_delivered_on_success=False,
-                # This member's own result is NOT marked delivered (it was
-                # reaped, not completed) — but if it was the wave member whose
-                # `_on_done` flushed the batch digest, its SIBLINGS' successful
-                # results HAVE now reached the parent. Settling is about their
-                # holds, not this member's outcome, so it must happen on this
-                # path too or held siblings stay visible to orphan
-                # reconciliation and get spuriously "recovered" after a restart.
-                settle_digest=True,
-            )
-
-        # Truncate retained text AFTER _on_done to preserve full output for result injection
-        if len(info.streaming_text) > 10_000:
-            info.streaming_text = info.streaming_text[:10_000] + "\n…(truncated)"
+        return await self._terminal._force_reap_impl(agent_id, info, elapsed, reason=reason)
 
     async def _sigkill_session(self, session_key: str) -> None:
-        """Best-effort SIGKILL when graceful reset hangs.
-
-        Uses killpg to kill the entire process group, then sweeps
-        escaped children in different PGIDs (MCP servers).
-
-        Async so the Windows ``taskkill`` spawn offloads to
-        :func:`kiro_crew.executors.subprocess_executor` via
-        :func:`platform_compat.kill_process_tree_async` / ``kill_pid_async``
-        instead of blocking the reaper loop's event loop for the duration of
-        ``taskkill.exe``.
-        """
-        try:
-            # circular import: subagent → acp.client → session → subagent
-            from kiro_crew.acp.client import (
-                _capture_child_records,
-                _get_child_pids,
-                _is_our_child,
-                _kill_escaped_children,
-            )
-
-            session = self._sessions._sessions.get(session_key)
-            if not session:
-                return
-            client = getattr(session.provider, "_client", None)
-            raw_pid = getattr(client, "_pid", None) if client else None
-            pid = raw_pid if isinstance(raw_pid, int) else None
-            if not pid:
-                return
-            # Snapshot child tree before killing — children in different
-            # PGIDs survive killpg. macOS pgrep/ps spawns are offloaded to
-            # subprocess_executor to keep the reaper loop responsive
-            loop = asyncio.get_running_loop()
-            raw_children = getattr(client, "_child_pids", None)
-            child_pids: dict = dict(raw_children) if isinstance(raw_children, dict) else {}
-            fresh = await loop.run_in_executor(subprocess_executor(), _get_child_pids, pid)
-            new_pids = [p for p in fresh if p not in child_pids]
-            if new_pids:
-                child_pids.update(
-                    await loop.run_in_executor(
-                        subprocess_executor(), _capture_child_records, new_pids
-                    )
-                )
-            # Validate PID hasn't been recycled before killing.
-            original_start = getattr(client, "_start_time", None)
-            if original_start is None:
-                logger.debug("Reaper: PID %d already dead for %s", pid, session_key)
-                await loop.run_in_executor(
-                    subprocess_executor(), _kill_escaped_children, child_pids
-                )
-                return
-            if not await loop.run_in_executor(
-                subprocess_executor(), _is_our_child, pid, original_start
-            ):
-                logger.warning("Reaper: PID %d recycled for %s, skipping killpg", pid, session_key)
-                stored = dict(raw_children) if isinstance(raw_children, dict) else {}
-                await loop.run_in_executor(subprocess_executor(), _kill_escaped_children, stored)
-                return
-            # Kill the entire process group first
-            logger.warning(
-                "Reaper: killpg for PID %d (%d children) for %s",
-                pid,
-                len(child_pids),
-                session_key,
-            )
-            try:
-                # Async variants offload Windows taskkill to
-                # subprocess_executor so the reaper loop never blocks the
-                # event loop on taskkill.exe.
-                await platform_compat.kill_process_tree_async(pid, platform_compat.SIGKILL)
-            except ValueError:
-                # Guard refused the pid outright (non-int/reserved) — nothing
-                # safe to signal. Mirrors CronService._sigkill_session so a
-                # broadcast-guard refusal is a clean log line, not the noisy
-                # generic `except Exception` traceback below.
-                logger.error("Reaper: kill guard refused pid %r for %s", pid, session_key)
-            except (ProcessLookupError, OSError):
-                try:
-                    await platform_compat.kill_pid_async(pid, platform_compat.SIGKILL)
-                except (ProcessLookupError, OSError):
-                    pass
-            # Sweep children that escaped to different PGIDs
-            await loop.run_in_executor(subprocess_executor(), _kill_escaped_children, child_pids)
-        except Exception:
-            logger.exception("Reaper: SIGKILL failed for %s", session_key)
+        return await self._terminal._sigkill_session_impl(session_key)
 
     def notify_injection_failed(
         self, info: SubagentInfo, reason: str = "delivery timed out"
     ) -> None:
-        """Notify UI and queue failure for LLM when injection times out.
-
-        Appends a synthetic error to the dashboard slot (UI) and queues a
-        failure message into ``slot._pending_subagent_failures`` so the LLM
-        learns about the failure on the next ``_run_chat`` turn and can read
-        the result from disk if needed. The notice's outcome line is derived
-        from the record (:func:`_injection_notice_outcome`) rather than
-        asserting completion: this path fires for every terminal state whose
-        report could not be injected, including runs cancelled or rejected
-        before they ever executed.
-        """
-        try:
-            # Lazy: the dashboard layer must not be imported by a core module at
-            # import time.
-            from kiro_crew.dashboard.chat_utils import dashboard_slot_key
-
-            # The failure is queued into a SLOT, so the gate is whether the
-            # parent has a tab — true for a channel-born parent whose session
-            # key is the channel's own. Without one there is nothing to append
-            # to and nothing to drain on the next turn.
-            slot_name = dashboard_slot_key(info.parent_session_key)
-            if not slot_name:
-                return
-
-            # Build failure message the LLM will see on next turn
-            task_preview = _redact((info.task or "")[:100])
-            result_hint = ""
-            if info.result_path:
-                try:
-                    size = os.path.getsize(info.result_path)
-                    size_str = f"{size:,} bytes"
-                except OSError:
-                    size_str = ""
-                result_hint = (
-                    f"\nResult saved at: {info.result_path}"
-                    + (f" ({size_str})" if size_str else "")
-                    + "\nUse the read tool to retrieve it if needed."
-                )
-            failure_msg = (
-                f"{SUBAGENT_COMPLETION_PREFIX}\n"
-                f"Agent `{info.id}` ❌ {reason}\n"
-                f"Task: {task_preview}\n"
-                f"{_injection_notice_outcome(info)}{result_hint}"
-            )
-
-            # Queue for LLM context drain on next _run_chat
-            if self._on_event:
-                _task = asyncio.ensure_future(
-                    self._fire_event(
-                        "subagent_injection_failed",
-                        info,
-                        {
-                            "error": reason,
-                            "slot": slot_name,
-                            "failure_msg": failure_msg,
-                        },
-                    )
-                )
-                _task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
-        except Exception:
-            logger.debug("notify_injection_failed failed for %s", info.id, exc_info=True)
+        return self._terminal.notify_injection_failed_impl(info, reason)
 
     @property
     def max_concurrent(self) -> int:
@@ -3060,66 +1917,10 @@ class SubagentManager:
         return self._running_count
 
     def running_agents_for(self, parent_key: str) -> list[dict]:
-        """Return summary dicts for agents belonging to *parent_key*."""
-        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-
-        def _r(s: str) -> str:
-            s, _ = redact_exfiltration_urls(s)
-            s, _ = redact_credentials(s)
-            return s
-
-        return [
-            {
-                "id": a.id,
-                "task": _r(a.task[:80]),
-                "agent": _r(a.agent),
-                "turns": a.turns,
-                "last_tool": _r(a.last_tool),
-                "tool_count": a.tool_count,
-                "stalled": a.stalled,
-                "startedAt": a.started,
-            }
-            for a in self._agents.values()
-            if not a.done and a.parent_session_key == parent_key
-        ]
+        return self._run_events.running_agents_for_impl(parent_key)
 
     def task_memory_rows(self) -> list[dict[str, object]]:
-        """Per-running-task memory/CPU rows for the session-memory surface.
-
-        Reads the samples the reaper sweep already takes (``_sample_live_costs``,
-        every ``_REAPER_INTERVAL`` seconds) — this method itself does no ``/proc``
-        work, so it is safe on the event loop. ``rss_mb`` is 0.0 until the first
-        sweep observes the agent, which is why ``sampled`` is reported separately:
-        a fresh task genuinely has no measurement yet, and rendering that as
-        "0 MB" would be a lie.
-
-        ``shared`` mirrors ``_session_sharing``: the value is that runtime's
-        measurement divided by the number of concurrently-live sharing sessions
-        on the same pid, i.e. an average share, not an exclusive figure. The same
-        split applies to ``procs``/``mcp`` (see ``_attributed_count``), which are
-        null until a sweep has counted them — a task row that reported no MCP
-        stubs because the field was simply absent read as "subagents do not use
-        the MCP pool", which is the opposite of what they do.
-        """
-        return [
-            {
-                "id": a.id,
-                "task": _redact_and_truncate(a.task, 80),
-                "agent": _redact(a.agent),
-                "parent": a.parent_session_key,
-                "rss_mb": round(a.last_rss_gb * 1024, 1),
-                "peak_rss_mb": round(a.peak_rss_gb * 1024, 1),
-                "cpu_cores": round(a.last_cpu_cores, 2),
-                "procs": a.last_procs,
-                "mcp": a.last_stubs,
-                "started_at": a.started,
-                "shared": a._session_sharing,
-                "pid": a._pid,
-                "sampled": a.last_rss_gb > 0.0 or a.peak_rss_gb > 0.0,
-            }
-            for a in self._agents.values()
-            if not a.done and not a.queued
-        ]
+        return self._monitor.task_memory_rows_impl()
 
     def spawn(
         self,
@@ -3146,696 +1947,58 @@ class SubagentManager:
         _from_queue: bool = False,
         _preassigned_id: str = "",
     ) -> SubagentInfo | None:
-        """Spawn a subagent for *task*.
-
-        Approval priority (first match wins):
-
-        1. YOLO mode → immediate execution
-        2. ``approval_mode="auto"`` from caller → immediate execution
-        3. ``auto_approve_subagent_spawn`` config → auto-approved execution
-        4. ``on_spawn_approval`` callback → interactive approval
-        5. Otherwise → rejected
-
-        When ``approval_mode="auto"`` is set, it has two effects:
-        - Skips the spawn approval gate (this method)
-        - Sets the subagent's session-level tool approval policy to
-          "auto" in ``_run_inner()``, meaning all tool calls within
-          the subagent are auto-approved for its entire lifetime.
-
-        This dual behavior is intentional for headless callers (e.g.
-        Mochi bg agent) that have no UI to respond to approval prompts.
-        The parameter is only accepted via the internal ``POST /api/spawn``
-        endpoint (requires X-Internal-Secret), not from LLM tool calls.
-
-        Args:
-            task (str): The prompt/task description for the subagent.
-            parent_session_key (str): Session key of the caller.
-            agent (str): Agent name override (default: "kirocrew").
-            model (str): Model override for CC provider (ignored for ACP).
-            reasoning_effort (str): Per-call reasoning-effort override; wins
-                over the ``role_efforts['subagent']`` pin. ``""`` defers to it.
-            allowed_tools (list): Tool allowlist for CC provider (ignored for ACP).
-            bare (bool): Launch CC in bare mode (ignored for ACP).
-            cwd (str): Optional absolute path where the subagent subprocess
-                launches instead of the default ``subagent_<id>`` sandbox.
-                Validated against ``AgentConfig.subagent_cwd_allowed_roots``;
-                rejected spawns return a done ``SubagentInfo`` with ``error``
-                set. Enables cwd-relative resource globs (``AGENTS.md``,
-                ``.kiro/steering``, ``CLAUDE.md``) to resolve correctly.
-            approval_mode (str | None): "auto" to skip spawn gate and
-                set session-level auto-approve.  Only honored from
-                authenticated internal callers (X-Internal-Secret).
-            silent (bool): Suppress completion notifications.
-
-        Returns:
-            SubagentInfo | None: Agent metadata, or None if at capacity.
-        """
-        # Identity is assigned ONCE, here, and used by every exit path — the
-        # queued return, each rejection, and the started record. That is what
-        # makes the id the caller is handed the id it will actually see again:
-        # ``spawn_run`` prints this id into its wave roster, and the dashboard
-        # resolves a wave by matching those printed ids against live per-agent
-        # events. A drained spawn passes the id it was queued under back in via
-        # ``_preassigned_id``, so a member that waits behind the stagger /
-        # concurrency gate keeps its identity across the round-trip instead of
-        # being announced under one id and starting under another.
-        agent_id: str = _preassigned_id or uuid.uuid4().hex[:8]
-        # Submission accounting: count this member as
-        # submitted BEFORE any rejection or queue/registration branching. A
-        # member refused below (empty task, low memory, bad cwd, governance)
-        # never registers and never completes — if it weren't counted here,
-        # batch_members_pending() would see submitted < expected FOREVER and
-        # the wave digest would never fire, permanently stranding every
-        # sibling's held result. A queued member re-enters
-        # spawn() via _drain_queue — never double-count it.
-        if batch_id and not _from_queue:
-            _bs = self._batch_submitted.setdefault(batch_id, [0, max(0, int(batch_total))])
-            _bs[0] += 1
-            self._batch_progress_ts[batch_id] = time.time()
-        # --- Task guard: refuse empty/whitespace-only tasks (defense in depth).
-        # The HTTP handler (api_spawn) and MCP tool schemas validate too, but
-        # direct Python callers reach this choke point unvalidated. An empty
-        # task produces a useless subagent and a blank Activity card. Must run
-        # BEFORE the redaction below, which would raise on a None task. ---
-        if not task or not task.strip():
-            logger.warning("Subagent spawn refused: empty task (parent=%s)", parent_session_key)
-            # Audit is best-effort: the rejection must be returned even if
-            # SEL is unavailable (a graceful refusal must not become an
-            # unhandled exception in api_spawn / MCP tool callers).
-            try:
-                sel().log_tool_invocation(
-                    session_key=parent_session_key or "",
-                    source="subagent",
-                    tool_name="spawn_run",
-                    outcome="rejected_empty_task",
-                    metadata={"agent": agent},
-                )
-            except Exception:
-                logger.debug("SEL audit failed for empty-task rejection", exc_info=True)
-            return self._announce_rejection(
-                SubagentInfo(
-                    id=agent_id,
-                    task="",
-                    agent=agent,
-                    parent_session_key=parent_session_key,
-                    done=True,
-                    error="spawn refused: task must be a non-empty string",
-                    batch_id=batch_id,
-                    batch_total=max(0, int(batch_total)),
-                )
-            )
-
-        # --- Redact task once for all SubagentInfo storage (raw task kept for kiro-cli prompt) ---
-        _redacted_task = redact_credentials(redact_exfiltration_urls(task)[0])[0]
-
-        # --- Memory guard: refuse to spawn if system memory is critically low ---
-        try:
-            min_mem = KiroCrewConfig.load().agent.spawn_min_memory_gb
-        except Exception:
-            min_mem = 4.0
-        mem_ok, avail_gb = check_memory_available(min_gb=min_mem)
-        if not mem_ok:
-            logger.warning(
-                "Subagent spawn refused: only %.2f GB available (min %.1f GB required)",
-                avail_gb,
-                min_mem,
-            )
-            sel().log_tool_invocation(
-                session_key=parent_session_key or "",
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="refused_low_memory",
-                metadata={
-                    "available_gb": avail_gb,
-                    "min_gb": min_mem,
-                    "task": _redacted_task[:120],
-                },
-            )
-            info = SubagentInfo(
-                id=agent_id,
-                task=_redacted_task,
-                agent=agent,
-                parent_session_key=parent_session_key,
-                done=True,
-                error=f"spawn refused: only {avail_gb:.1f} GB memory available (need {min_mem:.0f} GB)",
-                batch_id=batch_id,
-                batch_total=max(0, int(batch_total)),
-            )
-            return self._announce_rejection(info)
-
-        # --- Admission gate: refuse NEW spawns while host memory posture is
-        # critical. Complements the absolute spawn_min_memory_gb floor above
-        # with the posture tier (resource_critical_gb) and shares its
-        # off-switch (agent.admission_gate) with the cron scheduler's deferral
-        # gate. This method is sync and runs on the gateway event loop, so it
-        # reads the CACHED off-thread verdict — never inline config/procfs
-        # I/O; bounded staleness is acceptable for pressure-shedding.
-        # In-flight subagents are untouched; direct user chat turns are
-        # not gated; fails open on an unknown posture. ---
-        admission = cached_admission_check()
-        if not admission.admitted:
-            logger.warning("Subagent spawn refused: %s", admission.reason)
-            sel().log_tool_invocation(
-                session_key=parent_session_key or "",
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="refused_memory_critical",
-                metadata={
-                    "available_gb": admission.available_gb,
-                    "posture": admission.posture,
-                    "task": _redacted_task[:120],
-                },
-            )
-            info = SubagentInfo(
-                id=agent_id,
-                task=_redacted_task,
-                agent=agent,
-                parent_session_key=parent_session_key,
-                done=True,
-                error=f"spawn refused: {admission.reason}",
-                batch_id=batch_id,
-                batch_total=max(0, int(batch_total)),
-            )
-            return self._announce_rejection(info)
-
-        # --- CWD validation: reject bad paths before consuming a slot ---
-        resolved_cwd = ""
-        if cwd:
-            try:
-                allowed_roots = KiroCrewConfig.load().agent.subagent_cwd_allowed_roots
-            except Exception:
-                # Fail closed: if config is unavailable, treat cwd override as
-                # disabled. Defaulting to the permissive default here would
-                # silently re-enable the feature for admins who set
-                # subagent_cwd_allowed_roots=[] to disable it.
-                allowed_roots = []
-            resolved_cwd, cwd_err = validate_cwd(cwd, allowed_roots)
-            if cwd_err:
-                logger.warning("Subagent spawn refused: invalid cwd %r: %s", cwd, cwd_err)
-                sel().log_tool_invocation(
-                    session_key=parent_session_key or "",
-                    source="subagent",
-                    tool_name="spawn_run",
-                    outcome="rejected_invalid_cwd",
-                    metadata={"cwd": cwd[:200], "reason": cwd_err, "task": _redacted_task[:120]},
-                )
-                info = SubagentInfo(
-                    id=agent_id,
-                    task=_redacted_task,
-                    agent=agent,
-                    parent_session_key=parent_session_key,
-                    done=True,
-                    error=f"spawn refused: {cwd_err}",
-                    batch_id=batch_id,
-                    batch_total=max(0, int(batch_total)),
-                )
-                return self._announce_rejection(info)
-
-        # --- Governance: spawn capability gate (blast-radius containment) ---
-        # A policy/profile may disable sub-agent spawning entirely, or bound it
-        # to named agents (capabilities.spawn.scopes.agents).  Resolved against
-        # the PARENT surface so a per-app/per-surface profile contains what it
-        # can spawn — even if the kiro side would allow it.
-        gov_spawn_err = _vet_spawn_governance(parent_session_key, agent, app=app)
-        if gov_spawn_err:
-            logger.warning("Subagent spawn refused by governance: %s", gov_spawn_err)
-            sel().log_tool_invocation(
-                session_key=parent_session_key or "",
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="denied",
-                error=gov_spawn_err,
-                metadata={"agent": agent, "task": _redacted_task[:120]},
-            )
-            return self._announce_rejection(
-                SubagentInfo(
-                    id=agent_id,
-                    task=_redacted_task,
-                    agent=agent,
-                    parent_session_key=parent_session_key,
-                    done=True,
-                    error=f"spawn refused by governance: {gov_spawn_err}",
-                    batch_id=batch_id,
-                    batch_total=max(0, int(batch_total)),
-                )
-            )
-
-        now = time.monotonic()
-        should_queue, slot_free = self._should_stagger_queue(now)
-        if should_queue:
-            # A prevalidated app spawn must NOT sit in the queue. _agent_prevalidated
-            # skips the agent-directory ownership scan on drain (it was validated
-            # off the loop at request time); if it waited in the queue, the app
-            # could be disabled and its agent file removed meanwhile, and the drain
-            # would then run a same-named FOREIGN agent under the app's auto-approval
-            # without re-checking ownership. Fail closed: reject so the caller
-            # re-requests and re-validates ownership fresh. Only the app SpawnSDK
-            # sets _agent_prevalidated, and because such a spawn never enters the
-            # queue, a drain re-entry (_from_queue) never carries the flag.
-            if _agent_prevalidated:
-                logger.warning(
-                    "Rejecting prevalidated app spawn that would queue "
-                    "(agent=%s, app=%s): retry to revalidate ownership",
-                    agent,
-                    app,
-                )
-                return self._announce_rejection(
-                    SubagentInfo(
-                        id=agent_id,
-                        task=_redacted_task,
-                        agent=agent,
-                        parent_session_key=parent_session_key,
-                        done=True,
-                        error=(
-                            "spawn queue is at capacity; the app spawn was not queued "
-                            "to avoid a stale ownership check — retry to revalidate and "
-                            "spawn"
-                        ),
-                        batch_id=batch_id,
-                        batch_total=max(0, int(batch_total)),
-                    )
-                )
-            # Carry this spawn's id (assigned at the top) in the queue entry so
-            # the drained spawn runs under it. The identity must survive the
-            # round-trip because it is the only handle the caller gets: spawn_run
-            # prints the id this call returns, and the inline SubagentRunCard
-            # resolves a wave by matching those printed ids against live
-            # per-agent events. Returning a throwaway sentinel (the old
-            # ``q<n>``) and minting a fresh uuid on drain meant every wave member
-            # after the first was announced under an id no agent ever had — with
-            # the default 2s stagger that is EVERY member after the first, so a
-            # 2-agent wave permanently rendered "1 agent running" while the
-            # sidebar and Subagents panel correctly showed 2.
-            self._queue.append(
-                {
-                    "task": task,
-                    "parent_session_key": parent_session_key,
-                    "agent": agent,
-                    "max_turns": max_turns,
-                    "model": model,
-                    "reasoning_effort": reasoning_effort,
-                    "allowed_tools": allowed_tools,
-                    "bare": bare,
-                    "cwd": resolved_cwd,
-                    "approval_mode": approval_mode,
-                    "silent": silent,
-                    "batch_id": batch_id,
-                    "batch_total": batch_total,
-                    "keep": keep,
-                    "conversation_key": conversation_key,
-                    "app": app,
-                    "include_memory": include_memory,
-                    "include_lessons": include_lessons,
-                    "include_project": include_project,
-                    "_agent_prevalidated": _agent_prevalidated,
-                    "_preassigned_id": agent_id,
-                }
-            )
-            logger.info(
-                "Subagent queued (%d running, %d queued, slot_free=%s)",
-                self._running_count,
-                len(self._queue),
-                slot_free,
-            )
-            # Advisory UI signal: tell the chip how many agents are now waiting
-            # to start for this parent so it can appear immediately and show a
-            # "waiting" count instead of only running/completed ones.
-            self._emit_queue_depth(parent_session_key, batch_id)
-            # If a slot is free, no running agent will trigger the drain on
-            # completion — schedule the staggered pump at the interval boundary
-            # so the queued spawn still launches.
-            if slot_free:
-                delay = max(0.0, self._spawn_stagger_secs - (now - self._last_spawn_ts))
-                try:
-                    asyncio.get_event_loop().call_later(delay, self._drain_queue)
-                except RuntimeError:
-                    pass  # no running loop (sync/test context)
-            info = SubagentInfo(
-                id=agent_id,
-                task=_redacted_task,
-                agent=agent,
-                app=app,
-                queued=True,
-                batch_id=batch_id,
-                batch_total=max(0, int(batch_total)),
-                include_memory=include_memory,
-                include_lessons=include_lessons,
-                include_project=include_project,
-            )
-            return info
-
-        # `_agent_prevalidated` skips the on-loop agent-directory scan: a caller
-        # that already confirmed the agent exists OFF the loop (the app SpawnSDK
-        # validates via `list_agents()` in a thread) would otherwise make
-        # `_validate_agent` re-scan/stat every agent file synchronously here,
-        # stalling chat and the heartbeat on a populated agents directory. Only
-        # the app path sets it; every other caller still validates inline.
-        if agent and not _agent_prevalidated:
-            # Validate against the cwd the subagent will ACTUALLY run in. When no
-            # explicit cwd was given the runtime falls back to the session pool's
-            # cwd, so validating only the explicit value refused a project agent
-            # kiro-cli would have loaded — the same interface asymmetry the project
-            # scope exists to remove, just one layer down.
-            effective_cwd = resolved_cwd or str(getattr(self._sessions, "_pool_cwd", "") or "")
-            agent, err = _validate_agent(agent, effective_cwd)
-            if err:
-                info = SubagentInfo(
-                    id=agent_id,
-                    task=_redacted_task,
-                    agent="",
-                    parent_session_key=parent_session_key,
-                    done=True,
-                    error=err,
-                    batch_id=batch_id,
-                    batch_total=max(0, int(batch_total)),
-                )
-                return self._announce_rejection(info)
-
-        info = SubagentInfo(
-            id=agent_id,
-            task=_redacted_task,
-            parent_session_key=parent_session_key,
-            agent=agent,
-            app=app,
-            approval_mode=approval_mode or "",
-            silent=silent,
-            max_turns=max_turns,
-            model=model or "",
-            reasoning_effort=reasoning_effort or "",
-            allowed_tools=list(allowed_tools) if allowed_tools else [],
-            bare=bare,
-            cwd=resolved_cwd,
-            batch_id=batch_id,
-            batch_total=max(0, int(batch_total)),
-            keep=keep,
-            conversation_key=conversation_key,
-            include_memory=include_memory,
-            include_lessons=include_lessons,
-            include_project=include_project,
+        return self._admission.spawn_impl(
+            task,
+            parent_session_key,
+            agent,
+            max_turns,
+            model,
+            reasoning_effort,
+            allowed_tools,
+            bare,
+            cwd,
+            approval_mode,
+            silent,
+            batch_id,
+            batch_total,
+            keep,
+            conversation_key,
+            app,
+            include_memory,
+            include_lessons,
+            include_project,
+            _agent_prevalidated,
+            _from_queue,
+            _preassigned_id,
         )
-        info._raw_task = task  # unredacted prompt for kiro-cli execution
-        self._agents[agent_id] = info
-        self._running_count += 1
-        self._last_spawn_ts = time.monotonic()  # stagger gate: one start per interval
-        # Batch lifecycle: announce the wave ONCE, on its first member to
-        # actually start (queued members haven't started yet — the event marks
-        # execution begin, and the UI uses it to key batch progress).
-        if batch_id and batch_id not in self._seen_batches:
-            self._seen_batches.add(batch_id)
-            try:
-                loop = asyncio.get_event_loop()
-                loop.create_task(
-                    self._fire_event(
-                        "spawn_batch_started",
-                        info,
-                        {"batch_id": batch_id, "count": info.batch_total},
-                    )
-                )
-            except RuntimeError:
-                pass  # no running loop (sync/test context)
-
-        # Check parent session trust (approval_policy="auto") set by dashboard trust toggle.
-        parent_trusted = (
-            parent_session_key and self._sessions.get_approval_policy(parent_session_key) == "auto"
-        )
-
-        if self._is_yolo and self._is_yolo():
-            self._tasks[agent_id] = asyncio.create_task(self._run(info))
-            self._log_spawned(info)
-        elif approval_mode == "auto":
-            self._tasks[agent_id] = asyncio.create_task(self._run(info))
-            self._log_spawned(info)
-            sel().log_tool_invocation(
-                session_key=info.parent_session_key,
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="auto_approved_spawn",
-                metadata={"subagent_id": agent_id, "reason": "approval_mode_auto"},
-            )
-        elif parent_trusted:
-            self._tasks[agent_id] = asyncio.create_task(self._run(info))
-            self._log_spawned(info)
-            sel().log_tool_invocation(
-                session_key=info.parent_session_key,
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="auto_approved_spawn",
-                metadata={"subagent_id": agent_id, "reason": "parent_trusted"},
-            )
-        elif self._ctx_builder and self._ctx_builder.hooks:
-            if self._ctx_builder.hooks.auto_approve_subagent_spawn is True:
-                self._tasks[agent_id] = asyncio.create_task(self._run(info))
-                self._log_spawned(info)
-                sel().log_tool_invocation(
-                    session_key=info.parent_session_key,
-                    source="subagent",
-                    tool_name="spawn_run",
-                    outcome="auto_approved_spawn",
-                    metadata={"subagent_id": agent_id, "reason": "tool_calls_gated"},
-                )
-            elif self._on_spawn_approval:
-                self._tasks[agent_id] = asyncio.create_task(self._spawn_with_approval(info))
-            else:
-                info.done = True
-                info.error = "spawn rejected: no approval mechanism configured"
-                self._running_count -= 1
-                self._drain_queue()
-                sel().log_tool_invocation(
-                    session_key=info.parent_session_key,
-                    source="subagent",
-                    tool_name="spawn_run",
-                    outcome="rejected_spawn",
-                    metadata={"subagent_id": agent_id, "reason": "no_approval_mechanism"},
-                )
-                # Batch members must still reach the gateway's completion
-                # consumer: this is a REGISTERED rejection
-                # (done=True in _agents), so batch_members_pending() already
-                # counts it as complete — without an announce, a wave whose
-                # final member lands here closes with no event and every held
-                # sibling digest strands forever.
-                return self._announce_rejection(info)
-        elif self._on_spawn_approval:
-            self._tasks[agent_id] = asyncio.create_task(self._spawn_with_approval(info))
-        else:
-            info.done = True
-            info.error = "spawn rejected: no approval mechanism configured"
-            self._running_count -= 1
-            self._drain_queue()
-            sel().log_tool_invocation(
-                session_key=info.parent_session_key,
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="rejected",
-                metadata={"subagent_id": agent_id, "reason": "no approval mechanism"},
-            )
-            logger.warning("Subagent %s rejected: no approval callback", agent_id)
-            if self._on_done:
-                self._tasks[agent_id] = asyncio.ensure_future(self._safe_announce(info))
-
-        return info
 
     async def _safe_announce(self, info: SubagentInfo) -> None:
-        """Notify completion callback with error handling.
-
-        Args:
-            info (SubagentInfo): The subagent metadata.
-        """
-        assert self._on_done is not None
-        try:
-            await self._on_done(info)
-        except Exception:
-            logger.exception("Subagent announce failed for %s", info.id)
+        return await self._admission._safe_announce_impl(info)
 
     def _announce_rejection(self, info: SubagentInfo) -> SubagentInfo:
-        """Route a terminal spawn rejection through the done callback.
-
-        A rejected batch member is counted as submitted (top of ``spawn``)
-        but never registers and never reaches ``_run``'s completion path.
-        Without an announce, the gateway's wave accounting never sees its
-        terminal state — and when the rejection is the wave's FINAL
-        submission, no later completion event re-evaluates the wave, so
-        every sibling result already held for the digest strands forever.
-        Announcing lets ``_subagent_done`` count the member
-        as failed and release the digest when it closes the wave.
-
-        Non-batch rejections skip the announce: the caller already receives
-        the error synchronously in the returned info, and injecting a
-        completion turn for them would double-report. That holds for
-        queue-drained non-batch rejections too — ``_drain_queue`` announces
-        those itself off the returned info, so announcing here as well would
-        inject the completion twice.
-        """
-        if info.batch_id and self._on_done:
-            try:
-                self._tasks[f"reject-{info.id}"] = asyncio.ensure_future(self._safe_announce(info))
-            except RuntimeError:
-                pass  # no running loop (sync/test context)
-        return info
+        return self._admission._announce_rejection_impl(info)
 
     def _should_stagger_queue(self, now: float) -> tuple[bool, bool]:
-        """Decide whether a spawn arriving at *now* must be queued.
-
-        Returns ``(should_queue, slot_free)``. A spawn is queued when either no
-        slot is free (at capacity) OR a spawn started within the stagger window
-        (``subagent_spawn_stagger_secs``) — so the initial fill never bursts and
-        no two agents start within the interval (dynamic-subagent-sizing.md §5.3).
-        """
-        slot_free = self._running_count < self._max_concurrent
-        too_soon = (now - self._last_spawn_ts) < self._spawn_stagger_secs
-        return (not slot_free or too_soon, slot_free)
+        return self._admission._should_stagger_queue_impl(now)
 
     # ── Continuable conversations (keep=True) ─────────────────────────────
 
     def _conversation_busy(self, conv_key: str) -> SubagentInfo | None:
-        """Return the live or QUEUED run on *conv_key*, or None.
-
-        Queued members matter: a continuation waiting
-        in the spawn queue is not in ``_agents`` yet — missing it would let
-        ``spawn_release`` delete the session files it needs (the accepted run
-        would then die with ``resume_failed``), or let a second continue race
-        the same conversation.
-        """
-        for a in self._agents.values():
-            if not a.done and (a.conversation_key or f"subagent:{a.id}") == conv_key:
-                return a
-        for p in self._queue:
-            pkey = str(p.get("conversation_key") or "") or (
-                f"subagent:{p.get('_preassigned_id', '')}"
-            )
-            if pkey == conv_key:
-                return SubagentInfo(
-                    id=str(p.get("_preassigned_id") or "queued"),
-                    task="",
-                    queued=True,
-                )
-        return None
+        return self._continuation._conversation_busy_impl(conv_key)
 
     def _keep_recorded_on_disk(self, key: str) -> bool:
-        """Disk-truth continuable check for SessionManager's cache (#1115).
-
-        True iff *key* is a subagent conversation whose run's ``state.json``
-        records ``keep`` — the single persisted source of retention intent.
-        Non-subagent keys short-circuit without touching disk.
-        """
-        if not key.startswith("subagent:"):
-            return False
-        conv_id = key[len("subagent:") :]
-        try:
-            state = read_state(conv_id) or {}
-        except Exception:
-            return False
-        return bool(state.get("keep"))
+        return self._continuation._keep_recorded_on_disk_impl(key)
 
     def _promote_conversation(
         self, conv_id: str, conv_key: str, last_used: float | None = None
     ) -> None:
-        """Single choke point for promoting a conversation's retention (#1115).
-
-        Writes all three retention surfaces together so they cannot drift:
-        ``keep=True`` in state.json (the persisted source of truth), the
-        SessionManager continuable cache (file-deletion exemption), and the
-        TTL registry entry (sweep ownership).
-        """
-        try:
-            update_state(conv_id, keep=True)
-        except Exception:
-            logger.debug("promote: failed to persist keep for %s", conv_id, exc_info=True)
-        self._sessions.mark_continuable(conv_key)
-        self._conversations[conv_key] = last_used if last_used is not None else time.time()
+        return self._continuation._promote_conversation_impl(conv_id, conv_key, last_used)
 
     def _scan_keep_states(self) -> list[tuple[str, str, str, str, str, float]]:
-        """Blocking scan for keep runs (#1114): read every ``state.json``
-        under the subagents dir and collect the promoted conversations.
-
-        Returns ``(conv_id, conv_key, sid, provider, cwd, last_used)`` tuples.
-        Runs in an executor — no event-loop work here.
-        """
-        out: list[tuple[str, str, str, str, str, float]] = []
-        try:
-            base = _subagents_dir()
-            entries = list(base.iterdir()) if base.is_dir() else []
-        except Exception:
-            return out
-        for d in entries:
-            try:
-                if not d.is_dir():
-                    continue
-                state = read_state(d.name) or {}
-                if not state.get("keep"):
-                    continue
-                conv_key = str(state.get("conversation_key") or "") or f"subagent:{d.name}"
-                conv_id = conv_key[len("subagent:") :]
-                sid = str(state.get("session_id") or "")
-                last_used = float(state.get("updated_at") or state.get("started") or 0.0)
-                out.append(
-                    (
-                        conv_id,
-                        conv_key,
-                        sid,
-                        str(state.get("provider") or PROVIDER_LABEL_DEFAULT),
-                        str(state.get("cwd") or ""),
-                        last_used,
-                    )
-                )
-            except Exception:
-                logger.debug("registry rebuild: skipping %s", d, exc_info=True)
-        return out
+        return self._continuation._scan_keep_states_impl()
 
     async def _rebuild_conversation_registry(self) -> None:
-        """Re-seed the conversation TTL registry from disk after a restart (#1114).
-
-        The registry (``_conversations`` + the SessionManager continuable
-        cache + session map) is in-memory; without this, a gateway restart
-        orphans promoted conversations — the TTL sweep no longer knows them,
-        and nothing else deletes their session files (the tombstone pruner
-        skips keep runs by design). Runs on the reaper's first pass (retried
-        until it succeeds); entries already past TTL are released by the
-        very next sweep.
-
-        Threading contract (Arbiter, PR #1246): ONLY the pure-read
-        ``_scan_keep_states`` runs in the executor. All ``SessionMap``
-        access (``resumable_sid`` self-prune, ``seed_conversation`` writes)
-        stays on the event loop — the map is an unlocked dict with
-        whole-file saves, concurrently mutated by ``get_or_create`` /
-        ``close_all``, so touching it from a worker thread races restart
-        cold-starts (lost mappings / dict-changed-size errors). Per-entry
-        work is small and bounded by the keep-run count, and the loop
-        yields between entries so a large batch cannot stall chat turns
-        (the round-2 event-loop concern).
-        """
-        loop = asyncio.get_running_loop()
-        found = await loop.run_in_executor(None, self._scan_keep_states)
-        # Newest record wins: a conversation appears once per run that
-        # touched it (original + each continuation). The first record kept
-        # for a conv_key wins the `in self._conversations` guard below, so
-        # iterate newest-first — an oldest-first order would seed a stale
-        # last_used and let the SAME pass's sweep expire (and delete) a
-        # conversation whose real last-use is recent.
-        found.sort(key=lambda t: t[5], reverse=True)
-        seeded = 0
-        for conv_id, conv_key, sid, provider, cwd, last_used in found:
-            if conv_key in self._conversations:
-                continue  # live registration wins over the disk snapshot
-            # Same on-demand seeding as continue_conversation (also on-loop):
-            # the map entry is what makes release_conversation able to find
-            # and delete files.
-            if sid and not self._sessions.resumable_sid(conv_key):
-                self._sessions.seed_conversation(conv_key, sid, provider=provider, cwd=cwd)
-            # Resumability gate: SessionMap.get self-prunes entries whose
-            # session files are missing, so this also rejects RELEASED
-            # conversations whose continuation runs still carry a stale
-            # keep=True in their own state.json — their files are gone, and
-            # re-owning them would resurrect a released conversation.
-            if not self._sessions.resumable_sid(conv_key):
-                continue
-            self._sessions.mark_continuable(conv_key)
-            self._conversations[conv_key] = last_used or time.time()
-            seeded += 1
-            # Cooperative yield: keep restart cold-start turns responsive
-            # while a large keep batch seeds (one small file write each).
-            await asyncio.sleep(0)
-        if seeded:
-            logger.info("Rebuilt conversation TTL registry from disk: %d conversation(s)", seeded)
+        return await self._continuation._rebuild_conversation_registry_impl()
 
     def continue_conversation(
         self,
@@ -3848,226 +2011,18 @@ class SubagentManager:
         cwd: str = "",
         _preassigned_id: str = "",
     ) -> SubagentInfo | None:
-        """Dispatch a follow-up *task* into conversation *conv_id*.
-
-        ``_preassigned_id`` mirrors ``spawn``: a caller that must persist the
-        dispatch identity BEFORE the side effect (so a crash in between is
-        recoverable rather than ambiguous) supplies the id it already wrote
-        down, instead of discovering the minted one only on return.
-
-        Retain-by-default: works on ANY completed run whose session files are
-        still on disk — no keep flag needed at spawn time. Every run's sid /
-        provider / cwd are already recorded in its ``state.json``; this seeds
-        the session map on demand, so ``get_or_create`` finds the sid and arms
-        ``session/load``. Continuing a run PROMOTES it: retention extends from
-        the tombstone-prune window (~1h) to the conversation TTL, until
-        ``spawn_release``.
-
-        Mints a NEW run (new id, own state.json / result.txt / completion
-        event) on the SAME session key, so the follow-up executes with the
-        conversation's accumulated context.
-
-        Typed failures (returned as a done SubagentInfo with ``error``):
-        - ``conversation_busy`` — a run is in flight; use spawn_steer.
-        - ``conversation_gone`` — no resumable session files remain.
-        """
-        conv_key = f"subagent:{conv_id}"
-        busy = self._conversation_busy(conv_key)
-        if busy is not None:
-            info = SubagentInfo(
-                id=uuid.uuid4().hex[:8],
-                task=_redact(task),
-                done=True,
-                parent_session_key=parent_session_key,
-                error=(
-                    f"conversation_busy: run {busy.id} is in flight on this "
-                    "conversation — use spawn_steer to inject into it, or wait "
-                    "for its completion event"
-                ),
-            )
-            return info
-        # Seed the session map from the run's state.json when no mapping
-        # exists yet (default runs never write one at spawn; the map is also
-        # in-memory-lost across gateway restarts while state.json persists).
-        if not self._sessions.resumable_sid(conv_key):
-            state = read_state(conv_id) or {}
-            sid = str(state.get("session_id") or "")
-            if sid:
-                self._sessions.seed_conversation(
-                    conv_key,
-                    sid,
-                    provider=str(state.get("provider") or PROVIDER_LABEL_DEFAULT),
-                    cwd=str(state.get("cwd") or ""),
-                )
-        # Re-check: SessionMap.get self-prunes entries whose session files
-        # are missing, so a surviving mapping == resumable files on disk.
-        if not self._sessions.resumable_sid(conv_key):
-            # Point the caller at the prior result if the run folder survives
-            # (result.txt outlives the session under the tombstone TTL).
-            result_hint = ""
-            try:
-                _rp = agent_dir_for_display(conv_id) / "result.txt"
-                if _rp.exists():
-                    result_hint = f" Prior result still readable at: {_rp}"
-            except Exception:
-                pass
-            info = SubagentInfo(
-                id=uuid.uuid4().hex[:8],
-                task=_redact(task),
-                done=True,
-                parent_session_key=parent_session_key,
-                error=(
-                    "conversation_gone: no resumable session remains for "
-                    f"{conv_id} (expired, released, or files pruned)."
-                    + result_hint
-                    + " Re-spawn with a fresh task carrying a summary."
-                ),
-            )
-            return info
-        # Promote the run's retention through the single choke point
-        # (#1115): state.json keep=True (tombstone pruner skips deletion),
-        # the SessionManager continuable cache, and the TTL registry entry.
-        # The conversation TTL sweep / spawn_release owns deletion from here.
-        self._promote_conversation(conv_id, conv_key)
-        inc_memory, inc_lessons, inc_project = self._inherited_context_groups(conv_id)
-        # A continuation has to run WHERE THE RUN RAN. `spawn` resolves an empty
-        # cwd to the pool project before it validates the agent name, so a run
-        # spawned against a project-local agent (defined under that project's
-        # .kiro/agents/) came back "unknown agent" here — and the caller reads any
-        # non-busy error as unresumable and respawns from the digest alone,
-        # silently dropping the conversation this call exists to preserve.
-        #
-        # The cwd must come from the CALLER, not be discovered here. This method is
-        # synchronous and runs on the gateway's event loop, so probing the recorded
-        # path (`is_dir()`) would freeze the gateway for as long as a stalled
-        # network mount takes to answer. Async callers resolve it off-loop instead:
-        # crew passes its slot project, and `recorded_cwd()` gives the others the
-        # run's own recorded path to hand back in.
-        return self.spawn(
-            task,
-            _preassigned_id=_preassigned_id,
-            parent_session_key=parent_session_key,
-            agent=agent,
-            model=model,
-            max_turns=max_turns,
-            keep=True,
-            cwd=cwd,
-            conversation_key=conv_key,
-            include_memory=inc_memory,
-            include_lessons=inc_lessons,
-            include_project=inc_project,
+        return self._continuation.continue_conversation_impl(
+            conv_id, task, parent_session_key, agent, model, max_turns, cwd, _preassigned_id
         )
 
     def recorded_cwd(self, conv_id: str) -> str:
-        """The cwd run *conv_id* executed in, or "" if it never had one.
-
-        `continue_conversation` deliberately does NOT discover this itself: it is
-        synchronous and runs on the gateway's event loop, where the state read would
-        block for as long as a stalled network mount takes to answer. This helper
-        does the blocking work in one place so an async caller can hand it to
-        `asyncio.to_thread` and pass the result in.
-
-        A path that no longer exists is returned ANYWAY, so `spawn` refuses it.
-        Round 35 filtered it to "" to keep such a continuation working, which was
-        the wrong trade: an empty cwd resolves to the POOL project, so a follow-up
-        whose task names relative files would have edited an unrelated project's
-        working tree. A loud refusal is recoverable; a silent write to the wrong
-        repository is not. Only a run that never recorded a cwd returns "" — for it
-        the pool default is correct, because there is no project to miss.
-        """
-        return str((read_state(conv_id) or {}).get("cwd") or "")
+        return self._continuation.recorded_cwd_impl(conv_id)
 
     def _inherited_context_groups(self, conv_id: str) -> tuple[bool, bool, bool]:
-        """Recover the context scope of the run being continued.
-
-        A continuation DOES rebuild session context: ``get_or_create`` reports
-        ``is_new=True`` even when it restores the session via ``session/load``
-        (``resumed`` is the separate flag, and it gates only thread history), so
-        ``build_message`` runs the full session-context path for the follow-up
-        turn. Without inheriting the scope here, a run the parent deliberately
-        spawned without memory would silently regain it on continuation.
-
-        Prefers the live record; falls back to the scope persisted in the run's
-        ``state.json``. A run that predates the field records no scope at all,
-        which is distinguishable from "every group withheld" (an empty string)
-        and defaults to all-on.
-        """
-        live = self._agents.get(conv_id)
-        if live is not None:
-            return live.include_memory, live.include_lessons, live.include_project
-        raw = (read_state(conv_id) or {}).get("context_groups")
-        if raw is None:
-            return True, True, True
-        groups = {g for g in str(raw).split(",") if g}
-        return (
-            CONTEXT_GROUP_MEMORY in groups,
-            CONTEXT_GROUP_LESSONS in groups,
-            CONTEXT_GROUP_PROJECT in groups,
-        )
+        return self._continuation._inherited_context_groups_impl(conv_id)
 
     async def steer_run(self, agent_id: str, message: str) -> tuple[bool, str]:
-        """Inject *message* into the RUNNING turn of run *agent_id*.
-
-        Returns ``(ok, detail)``. Typed detail values on refusal:
-        ``not_found`` (unknown id), ``not_running`` (run finished — use
-        spawn_continue), ``session_starting`` (run alive but its session has
-        not registered yet — retry shortly), ``no_session`` (session not
-        reachable), or the provider's failure reason.
-
-        Startup grace (#1113): the window between spawn-return and session
-        registration is precisely when a parent most wants to steer (it just
-        realized the task text was wrong), so a missing provider on a live
-        run polls for up to ``_STEER_STARTUP_WAIT_SECS`` instead of failing
-        immediately with a bare ``no_session``.
-        """
-        info = self._agents.get(agent_id)
-        if info is None:
-            return False, "not_found"
-        if info.done:
-            return False, "not_running: run finished — use spawn_continue"
-
-        def _resolve_provider() -> Any:
-            if info._session_sharing and info._shared_provider is not None:
-                return info._shared_provider
-            session_key = info.conversation_key or f"subagent:{info.id}"
-            return self._sessions.get_provider(session_key)
-
-        provider: Any = _resolve_provider()
-        if provider is None or not hasattr(provider, "steer"):
-            # Bounded wait for session registration on a run that is still
-            # alive. Re-checks done-ness each tick: a run finishing while we
-            # wait flips the answer to not_running, never a stale inject.
-            deadline = time.monotonic() + _STEER_STARTUP_WAIT_SECS
-            while time.monotonic() < deadline:
-                await asyncio.sleep(_STEER_STARTUP_POLL_SECS)
-                if info.done:
-                    return False, "not_running: run finished — use spawn_continue"
-                provider = _resolve_provider()
-                if provider is not None and hasattr(provider, "steer"):
-                    break
-            else:
-                return False, (
-                    "session_starting: the run is alive but its session has "
-                    f"not registered within {_STEER_STARTUP_WAIT_SECS}s — "
-                    "retry in a few seconds"
-                )
-        try:
-            ok = await provider.steer(message)
-        except Exception as exc:  # pragma: no cover - provider-specific
-            logger.warning("steer_run %s failed", agent_id, exc_info=True)
-            return False, f"steer failed: {exc}"
-        if ok:
-            try:
-                sel().log_tool_invocation(
-                    session_key=info.parent_session_key or "",
-                    source="subagent",
-                    tool_name="spawn_steer",
-                    outcome="ok",
-                    metadata={"subagent_id": agent_id},
-                )
-            except Exception:
-                logger.debug("steer_run: SEL audit failed", exc_info=True)
-        return ok, "ok" if ok else "steer rejected by provider"
+        return await self._continuation.steer_run_impl(agent_id, message)
 
     # Bounds for the follow_up watcher: poll cadence, post-done busy retries
     # (finalization may briefly hold the conversation), and a hard deadline so
@@ -4077,198 +2032,13 @@ class SubagentManager:
     _FOLLOWUP_BUSY_RETRY_SECS = 3.0
 
     async def follow_up_run(self, agent_id: str, message: str) -> tuple[bool, str]:
-        """Queue *message* for delivery AFTER run *agent_id*'s turn completes.
-
-        The non-interrupting sibling of :meth:`steer_run` (spawn_steer
-        ``mode="follow_up"``): instead of injecting into the running turn —
-        which can derail critical work mid-execution — the message waits for
-        the run to finish and is then dispatched as a CONTINUATION on the
-        run's own conversation (``continue_conversation``), executing with its
-        accumulated context. The continuation is a new run whose result
-        arrives as a normal completion event on the same parent session.
-
-        Multiple queued follow-ups drain as ONE continuation (joined in
-        arrival order), so three corrections cost one run, not three.
-
-        Returns ``(ok, detail)``. Typed refusals mirror ``steer_run``:
-        ``not_found`` (unknown id) and ``not_running`` (already finished —
-        ``spawn_continue`` is the direct tool for that case). Queued
-        follow-ups are best-effort by design: if the conversation is gone by
-        the time the run ends, the failure is logged and audited, not raised.
-        """
-        info = self._agents.get(agent_id)
-        if info is None:
-            return False, "not_found"
-        if info.done:
-            return False, "not_running: run finished — use spawn_continue"
-        if self._shutting_down:
-            # Refuse rather than accept-and-drop: an accepted follow-up
-            # promises a completion event, and a shutting-down gateway can
-            # keep neither the watcher nor the continuation alive.
-            return False, "shutting_down: the gateway is stopping — re-send after restart"
-        info.pending_followups.append(message)
-        if not info._followup_watcher:
-            self._arm_followup_watcher(info)
-        try:
-            sel().log_tool_invocation(
-                session_key=info.parent_session_key or "",
-                source="subagent",
-                tool_name="spawn_steer",
-                outcome="followup_queued",
-                metadata={"subagent_id": agent_id, "queued": len(info.pending_followups)},
-            )
-        except Exception:
-            logger.debug("follow_up_run: SEL audit failed", exc_info=True)
-        return True, "queued"
+        return await self._continuation.follow_up_run_impl(agent_id, message)
 
     def _arm_followup_watcher(self, info: SubagentInfo) -> None:
-        """Arm the (single) follow-up watcher for *info*'s run.
-
-        The done-callback resets the one-watcher latch AND re-arms when
-        messages are still pending: a follow-up can be accepted while the
-        previous watcher is inside its final awaits (announcing an expiry) —
-        it sees the latch still true and arms nothing, so without the re-arm
-        that accepted message would be stranded with no dispatch and no event
-        (GPT review). Not re-armed during shutdown or once the run record is
-        gone (removal drops any leftovers deliberately).
-        """
-        info._followup_watcher = True
-        run_id = info.id
-        run_info = info  # narrowed local: mypy loses the None-narrow in closure defaults
-        task = asyncio.create_task(self._deliver_followups(info))
-        self._followup_watchers[run_id] = task
-
-        def _done(t: "asyncio.Task", _id: str = run_id, _info: SubagentInfo = run_info) -> None:
-            self._followup_watchers.pop(_id, None)
-            _info._followup_watcher = False
-            if not t.cancelled() and t.exception() is not None:
-                logger.warning("follow_up watcher for %s failed", _id, exc_info=t.exception())
-                return
-            if (
-                not t.cancelled()
-                and _info.pending_followups
-                and not self._shutting_down
-                and _id in self._agents
-            ):
-                self._arm_followup_watcher(_info)
-
-        task.add_done_callback(_done)
+        return self._continuation._arm_followup_watcher_impl(info)
 
     async def _deliver_followups(self, info: SubagentInfo) -> None:
-        """Watch run *info* until its turn completes, then dispatch the queue.
-
-        DELIBERATELY a per-run poller rather than a hook in ``_run``'s
-        finalization: completion is reached from many terminal paths (normal,
-        error, timeout, cancel-recovery, reaper), all guarded by a carefully
-        ordered 3-guard finally — a watcher observes the outcome without
-        adding a new obligation to any of them. Waits for the run's task to be
-        popped from ``self._tasks`` too, so teardown (session release) has
-        finished before the continuation tries to reuse the conversation; any
-        residual ``conversation_busy`` gets a bounded retry.
-
-        OUTCOME-AWARE: a run the user explicitly STOPPED does not get its
-        follow-ups dispatched — resurrecting work the user killed is the
-        opposite of "the correction can wait" (``followup_suppressed`` audit).
-        Other non-success terminals (error, timeout) still dispatch: the
-        continuation runs with the conversation's context, so "fix what just
-        broke" is a legitimate follow-up.
-
-        NEVER SILENT: the spawn_steer reply promised the parent a completion
-        event, so every path that cannot deliver one from a real continuation
-        (suppressed, expired, dispatch failure) announces a SYNTHETIC failure
-        completion event through the normal ``_on_done`` path — the parent
-        must not wait forever on an event that is not coming.
-
-        Hard-bounded and manager-owned: gives up at the manager's run timeout
-        plus a margin, and the task is registered in ``_followup_watchers`` so
-        ``cancel_all()`` cancels it — a watcher must never dispatch a fresh
-        run into a shutting-down gateway.
-        """
-        deadline = time.monotonic() + self._default_timeout + 300
-        while time.monotonic() < deadline:
-            if info.done and info.id not in self._tasks:
-                break
-            await asyncio.sleep(self._FOLLOWUP_POLL_SECS)
-        else:
-            dropped = list(info.pending_followups)
-            logger.warning(
-                "follow_up watcher for %s timed out before the run completed — "
-                "%d queued message(s) dropped",
-                info.id,
-                len(dropped),
-            )
-            self._audit_followup(info, "followup_expired")
-            await self._announce_followup_failure(
-                info,
-                "follow_up expired: the run never completed within its timeout "
-                "window; the queued follow-up message(s) were dropped",
-                messages=dropped,
-            )
-            # Drop ONLY what was just reported dropped, and only AFTER the
-            # announce settled — clearing first meant a shutdown cancelling
-            # this task mid-announce left the queue empty for cancel_all()'s
-            # sweep, so the messages vanished with no event. The slice keeps
-            # anything queued while we were announcing (the done-callback
-            # re-arms for it).
-            info.pending_followups = info.pending_followups[len(dropped) :]
-            return
-        # SNAPSHOT, do not drain: messages stay in ``pending_followups`` until
-        # their outcome is SETTLED (dispatched, or their failure announced).
-        # An eager drain lost messages when shutdown landed mid-await — e.g.
-        # during a conversation_busy retry sleep — because cancel_all() saw an
-        # empty queue, cancelled this task, and nothing was ever announced.
-        # Appends only ever happen at the tail, so removing the first
-        # ``len(messages)`` entries at settlement drops exactly this snapshot
-        # and preserves anything queued while we were dispatching.
-        messages = list(info.pending_followups)
-        if not messages:
-            return
-
-        def _settle() -> None:
-            info.pending_followups = info.pending_followups[len(messages) :]
-
-        if info.user_stopped:
-            logger.info("follow_up for %s suppressed — the user stopped the run", info.id)
-            self._audit_followup(info, "followup_suppressed")
-            _settle()
-            await self._announce_followup_failure(
-                info,
-                "follow_up suppressed: the user stopped this run, so its queued "
-                "follow-up message(s) were NOT dispatched",
-                messages=messages,
-            )
-            return
-        if self._shutting_down:
-            # Leave the queue intact: cancel_all()'s shutdown sweep owns the
-            # announce-and-drop for pending messages.
-            return
-        task = "\n\n---\n\n".join(messages)
-        # Finalization may hold the conversation for a beat after the task is
-        # popped (shielded report); retry a bounded number of times.
-        for _attempt in range(self._FOLLOWUP_BUSY_RETRIES):
-            child = self.continue_conversation(
-                info.id,
-                task,
-                parent_session_key=info.parent_session_key,
-                agent=info.agent,
-            )
-            err = "spawn_failed" if child is None else str(getattr(child, "error", "") or "")
-            if not err.startswith("conversation_busy"):
-                break
-            await asyncio.sleep(self._FOLLOWUP_BUSY_RETRY_SECS)
-        if err:
-            logger.warning("follow_up delivery for %s failed: %s", info.id, err.split(":", 1)[0])
-            self._audit_followup(info, "followup_failed")
-            _settle()
-            # continue_conversation's typed failures are already done
-            # SubagentInfo records — announce the real one when we have it.
-            if child is not None:
-                await self._announce_followup_failure(info, "", failure_info=child)
-            else:
-                await self._announce_followup_failure(info, f"follow_up dispatch failed: {err}")
-        else:
-            self._audit_followup(info, "followup_dispatched")
-            _settle()
+        return await self._continuation._deliver_followups_impl(info)
 
     async def _announce_followup_failure(
         self,
@@ -4277,267 +2047,27 @@ class SubagentManager:
         failure_info: SubagentInfo | None = None,
         messages: list | None = None,
     ) -> None:
-        """Deliver a SYNTHETIC failure completion event for an undeliverable
-        follow-up, through the same ``_on_done`` path as real completions.
-
-        Best-effort by design (a notification about a failure must not itself
-        take anything down), but never silent-by-default: without this the
-        parent — told by spawn_steer that a completion event would arrive —
-        blocks its plan on an event that only ever existed in SEL logs.
-        ``messages`` labels the synthetic event when the queue was already
-        drained by the caller (the expiry path clears before announcing so a
-        later watcher cannot resurrect messages reported dead).
-        """
-        if self._on_done is None:
-            return
-        label_msgs = messages if messages is not None else info.pending_followups
-        synthetic = failure_info or SubagentInfo(
-            id=uuid.uuid4().hex[:8],
-            task=f"[follow_up of run {info.id}] "
-            + _redact("; ".join(m[:120] for m in label_msgs) or "queued follow-up"),
-            done=True,
-            parent_session_key=info.parent_session_key,
-            error=reason,
+        return await self._continuation._announce_followup_failure_impl(
+            info, reason, failure_info, messages
         )
-        try:
-            await self._on_done(synthetic)
-        except Exception:
-            logger.warning("follow_up failure announce for %s failed", info.id, exc_info=True)
 
     def _audit_followup(self, info: SubagentInfo, outcome: str) -> None:
-        try:
-            sel().log_tool_invocation(
-                session_key=info.parent_session_key or "",
-                source="subagent",
-                tool_name="spawn_steer",
-                outcome=outcome,
-                metadata={"subagent_id": info.id},
-            )
-        except Exception:
-            logger.debug("follow_up audit failed", exc_info=True)
+        return self._continuation._audit_followup_impl(info, outcome)
 
     def release_conversation(self, conv_id: str) -> tuple[bool, str]:
-        """Release conversation *conv_id*: forget the sid and delete files.
-
-        Refuses (``conversation_busy``) while a run is in flight. Returns
-        ``(ok, detail)``.
-        """
-        conv_key = f"subagent:{conv_id}"
-        busy = self._conversation_busy(conv_key)
-        if busy is not None:
-            return False, f"conversation_busy: run {busy.id} is in flight"
-        provider_label = self._sessions.conversation_provider(conv_key) or PROVIDER_LABEL_DEFAULT
-        sid = self._sessions.forget_conversation(conv_key)
-        self._conversations.pop(conv_key, None)
-        # Demote the persisted source of truth too (#1115): with the disk
-        # fallback in place, a stale keep=True would re-warm the continuable
-        # cache after release and resurrect the conversation on the next
-        # restart's registry rebuild.
-        try:
-            update_state(conv_id, keep=False)
-        except Exception:
-            logger.debug("release: failed to demote state for %s", conv_id, exc_info=True)
-        if not sid:
-            return False, "conversation_gone: nothing to release"
-        try:
-            _cleanup_session_files_sync(sid, provider_label)
-        except Exception:
-            logger.debug("release_conversation: file cleanup failed", exc_info=True)
-        return True, "released"
+        return self._continuation.release_conversation_impl(conv_id)
 
     def _sweep_conversations(self, now: float) -> None:
-        """Reaper hook: expire continuable conversations idle past TTL."""
-        for conv_key, last_used in list(self._conversations.items()):
-            if now - last_used < _CONVERSATION_TTL_SECS:
-                continue
-            if self._conversation_busy(conv_key) is not None:
-                self._conversations[conv_key] = now  # active — refresh
-                continue
-            conv_id = conv_key[len("subagent:") :]
-            ok, detail = self.release_conversation(conv_id)
-            logger.info(
-                "Conversation %s expired after %ds idle: %s",
-                conv_id,
-                _CONVERSATION_TTL_SECS,
-                detail,
-            )
+        return self._continuation._sweep_conversations_impl(now)
 
     def _drain_queue(self) -> None:
-        """Spawn the next queued task if a slot is available and the stagger
-        interval has elapsed.
-
-        This is the single staggered pump: at most one start per
-        ``subagent_spawn_stagger_secs`` (dynamic-subagent-sizing.md §5.3). If a
-        slot is free but a spawn started too recently, it reschedules itself at
-        the interval boundary rather than bursting.
-        """
-        if not self._queue or self._running_count >= self._max_concurrent:
-            return
-        elapsed = time.monotonic() - self._last_spawn_ts
-        if elapsed < self._spawn_stagger_secs:
-            # Too soon since the last start — reschedule at the boundary.
-            try:
-                asyncio.get_event_loop().call_later(
-                    self._spawn_stagger_secs - elapsed, self._drain_queue
-                )
-            except RuntimeError:
-                pass  # no running loop (sync/test context)
-            return
-        params = self._queue.pop(0)
-        # A run can be cancelled WHILE it waits here — a user stop, or a session
-        # deleted out from under it. Starting it anyway would execute tools for
-        # work already reported as stopped, so skip it and drain the next one
-        # instead: `cancel()` marks the info terminal but cannot unqueue this.
-        queued_id = str(params.get("_preassigned_id") or "")
-        if queued_id:
-            waiting = self._agents.get(queued_id)
-            if waiting is not None and (waiting.done or waiting.user_stopped or waiting.reaped):
-                logger.info("Skipping queued spawn %s: cancelled while waiting", queued_id)
-                self._emit_queue_depth(
-                    str(params.get("parent_session_key", "")), str(params.get("batch_id", ""))
-                )
-                if self._queue:
-                    self._drain_queue()
-                return
-        logger.info(
-            "Draining queue: spawning '%s' (%d left)",
-            str(params.get("task", ""))[:40],
-            len(self._queue),
-        )
-        # The popped item's parent just lost one waiting agent — re-emit its
-        # queued depth (0 when this was its last) so the chip's "waiting" count
-        # tracks the drain. Done before spawn() so an immediate re-queue there
-        # (still too soon since last start) re-bumps it correctly afterwards.
-        self._emit_queue_depth(
-            str(params.get("parent_session_key", "")), str(params.get("batch_id", ""))
-        )
-        # spawn() re-checks the gate; since elapsed >= stagger and a slot is
-        # free, it starts immediately and updates _last_spawn_ts. Forward the FULL
-        # kwarg set so approval_mode / silent / model / allowed_tools / bare survive
-        # the queue round-trip — including `_preassigned_id`, which makes the agent
-        # start under the id its caller was already told (and, if the gate re-queues
-        # it, keeps that id across the second round-trip too).
-        drained = self.spawn(**params, _from_queue=True)
-        # A drained spawn has NO synchronous reader: this call site is a timer
-        # callback, and the original caller was handed a queued info long ago. So a
-        # terminal rejection here — the cwd was deleted while the run waited, the
-        # agent stopped resolving — was dropped on the floor: no completion event,
-        # and the caller's own bookkeeping showed the run as still going. Crew left
-        # such a topic `running` forever.
-        #
-        # Only for NON-batch runs, which is exactly the set `_announce_rejection`
-        # skips (it announces batch members itself, from inside `spawn`). Announcing
-        # regardless double-counted a queued batch rejection: the wave's own
-        # accounting closed early and emitted a duplicate or incomplete digest.
-        if (
-            drained is not None
-            and drained.done
-            and drained.error
-            and not drained.batch_id
-            and self._on_done
-        ):
-            try:
-                self._tasks[f"reject-{drained.id}"] = asyncio.ensure_future(
-                    self._safe_announce(drained)
-                )
-            except RuntimeError:
-                pass  # no running loop (sync/test context)
-        if self._queue and self._running_count < self._max_concurrent:
-            try:
-                asyncio.get_event_loop().call_later(self._spawn_stagger_secs, self._drain_queue)
-            except RuntimeError:
-                pass
+        return self._admission._drain_queue_impl()
 
     async def _spawn_with_approval(self, info: SubagentInfo) -> None:
-        """Request approval before starting the subagent.
-
-        If approval is denied the subagent is marked as done with an
-        error and the running count is decremented without executing.
-
-        Args:
-            info (SubagentInfo): The subagent metadata.
-        """
-        assert self._on_spawn_approval is not None
-        request_id: str = f"spawn:{info.id}"
-        try:
-            from kiro_crew.security import (
-                redact_credentials,
-                redact_exfiltration_urls,
-            )
-
-            task_safe, _ = redact_exfiltration_urls(info.task)
-            task_safe, _ = redact_credentials(task_safe)
-            task_preview: str = task_safe[:80]
-            approved: bool = await self._on_spawn_approval(
-                request_id, f"spawn_run({task_preview})", info.parent_session_key
-            )
-        except Exception:
-            logger.exception("Spawn approval failed for %s", info.id)
-            approved = False
-
-        if not approved:
-            info.done = True
-            info.error = "spawn rejected"
-            # Slot accounting through the one-shot token, NOT a bare decrement.
-            # A user Stop funnels into `_force_reap` and can land while this
-            # approval is still pending (a human prompt has no deadline), and
-            # `_force_reap` releases the slot and reports. A bare decrement here
-            # would double-release — driving `_running_count` negative — and the
-            # announce below would double-report the completion.
-            if self._release_slot(info):
-                self._running_count -= 1
-                self._drain_queue()
-            self._tasks.pop(info.id, None)
-            sel().log_tool_invocation(
-                session_key=info.parent_session_key,
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="rejected",
-                metadata={"subagent_id": info.id},
-            )
-            logger.info("Subagent %s spawn rejected", info.id)
-            # Report ownership through the same claim every other terminal path
-            # uses, so a concurrent reap/stop cannot also announce.
-            if self._on_done and self._claim_finalize(info):
-                await self._safe_announce(info)
-            return
-
-        self._log_spawned(info)
-        await self._run(info)
+        return await self._admission._spawn_with_approval_impl(info)
 
     def _log_spawned(self, info: SubagentInfo) -> None:
-        """Record spawn metrics and audit log entry.
-
-        Args:
-            info (SubagentInfo): The subagent metadata.
-        """
-        # Persist agent folder to disk for orphan recovery
-        try:
-
-            create_agent_folder(
-                info.id,
-                task=info.task,
-                agent=info.agent,
-                parent_session=info.parent_session_key,
-                max_turns=info.max_turns,
-                context_groups=_context_groups_field(info),
-            )
-        except Exception:
-            logger.warning("Failed to create agent folder for %s", info.id, exc_info=True)
-
-        Stats().inc_subagent_spawned()
-        sel().log_tool_invocation(
-            session_key=info.parent_session_key,
-            source="subagent",
-            tool_name="spawn_run",
-            outcome="spawned",
-            metadata={
-                "subagent_id": info.id,
-                "agent": info.agent or "kirocrew",
-                "cwd": info.cwd,
-            },
-        )
-        logger.info("Subagent %s spawned: %s", info.id, info.task[:80])
+        return self._admission._log_spawned_impl(info)
 
     @property
     def running(self) -> list[SubagentInfo]:
@@ -4550,33 +2080,10 @@ class SubagentManager:
         return list(self._agents.values())
 
     def batch_members_pending(self, batch_id: str) -> bool:
-        """True while ANY member of *batch_id* is still outstanding — running
-        (registered, not done), queued behind the stagger gate (not yet
-        registered), OR not yet submitted (sibling POSTs still in flight —
-        a fast-failing first member must not finalize the
-        wave and emit a partial digest before the rest of the batch even
-        arrives). The wave digest must also not be held hostage by unrelated
-        agents under the same parent."""
-        if not batch_id:
-            return False
-        _bs = self._batch_submitted.get(batch_id)
-        if _bs is not None and _bs[1] > 0 and _bs[0] < _bs[1]:
-            return True  # submissions still in flight
-        if any(a.batch_id == batch_id and not a.done for a in self._agents.values()):
-            return True
-        return any(p.get("batch_id") == batch_id for p in self._queue)
+        return self._waves.batch_members_pending_impl(batch_id)
 
     def finalize_batch(self, batch_id: str) -> None:
-        """Prune per-wave bookkeeping once the wave digest has fired.
-
-        Bounds `_seen_batches` / `_batch_submitted` growth: without
-        this, long-lived gateways accrete an entry per wave forever.
-        """
-        if not batch_id:
-            return
-        self._seen_batches.discard(batch_id)
-        self._batch_submitted.pop(batch_id, None)
-        self._batch_progress_ts.pop(batch_id, None)
+        return self._waves.finalize_batch_impl(batch_id)
 
     def record_lost_submission(
         self,
@@ -4585,152 +2092,15 @@ class SubagentManager:
         reason: str,
         parent_session_key: str = "",
     ) -> None:
-        """Reconcile a wave member whose spawn submission was LOST before it
-        reached :meth:`spawn` (transport error / timeout / pre-spawn HTTP
-        rejection in ``api_spawn``).
-
-        Every sibling POST carried ``batch_total`` counting the lost member,
-        but ``spawn()`` never ran for it — so ``submitted < expected``
-        forever, ``batch_members_pending()`` stays True, the digest chunk
-        never fires, and held sibling results strand until a gateway restart.
-        This helper counts the lost
-        member as submitted AND announces a synthetic terminal member through
-        the single completion consumer, so the wave's accounting sees a
-        failure line and can close.
-
-        Idempotent-ish by construction: each call reconciles exactly one lost
-        member; callers invoke it once per lost submission.
-        """
-        if not batch_id:
-            return
-        _bs = self._batch_submitted.setdefault(batch_id, [0, max(0, int(batch_total))])
-        _bs[0] += 1
-        self._batch_progress_ts[batch_id] = time.time()
-        try:
-            sel().log_tool_invocation(
-                session_key=parent_session_key or "",
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="submission_lost",
-                metadata={"batch_id": batch_id, "reason": reason[:200]},
-            )
-        except Exception:
-            logger.debug("SEL audit failed for lost submission", exc_info=True)
-        info = SubagentInfo(
-            id=uuid.uuid4().hex[:8],
-            task="(submission lost before spawn)",
-            agent="",
-            parent_session_key=parent_session_key,
-            done=True,
-            error=f"spawn submission lost: {reason[:300]}",
-            batch_id=batch_id,
-            batch_total=max(0, int(batch_total)),
+        return self._waves.record_lost_submission_impl(
+            batch_id, batch_total, reason, parent_session_key
         )
-        if self._on_done:
-            try:
-                self._tasks[f"lost-{info.id}"] = asyncio.ensure_future(self._safe_announce(info))
-            except RuntimeError:
-                pass  # no running loop (sync/test context)
 
     def _sweep_stuck_waves(self, now: float) -> None:
-        """Reaper backstop: force-reconcile waves wedged by lost submissions.
-
-        A wave is STUCK when ``submitted < expected``, every registered
-        member is terminal, nothing of the wave sits in the spawn queue, and
-        there has been no submission progress for ``_WAVE_STUCK_SECS``. The
-        count-driven ``batch_members_pending()`` can never close such a wave
-        on its own — no future completion event will arrive. Reconciling via
-        :meth:`record_lost_submission` (once per sweep per wave — waves with
-        multiple losses converge across sweeps) re-enters the completion
-        consumer so held sibling results deliver instead of stranding until
-        restart. Also bounds the ``_batch_submitted``/``_batch_progress_ts``
-        leak in the stuck case.
-        """
-        for batch_id, _bs in list(self._batch_submitted.items()):
-            if _bs[1] <= 0 or _bs[0] >= _bs[1]:
-                continue  # complete or unbounded — not wedged by lost POSTs
-            last = self._batch_progress_ts.get(batch_id, 0.0)
-            if now - last < _WAVE_STUCK_SECS:
-                continue  # still within the grace window
-            members = [a for a in self._agents.values() if a.batch_id == batch_id]
-            if any(not a.done for a in members):
-                continue  # live members will re-evaluate the wave on completion
-            if any(p.get("batch_id") == batch_id for p in self._queue):
-                continue  # queued members still pending — not stuck
-            parent = members[0].parent_session_key if members else ""
-            logger.warning(
-                "Reaper: wave %s stuck (%d/%d submitted, no progress for %.0fs)"
-                " — reconciling one lost submission",
-                batch_id,
-                _bs[0],
-                _bs[1],
-                now - last,
-            )
-            self.record_lost_submission(
-                batch_id,
-                _bs[1],
-                f"submission never arrived (wave stuck > {_WAVE_STUCK_SECS}s"
-                " — reconciled by reaper liveness backstop)",
-                parent_session_key=parent,
-            )
+        return self._waves._sweep_stuck_waves_impl(now)
 
     def _sweep_digest_holds(self, now: float) -> None:
-        """Reaper backstop: release wave results whose HOLD DEADLINE expired.
-
-        The gateway holds a completed member's per-agent injection until the
-        wave's digest chunk fires. Both of the chunk's triggers are event-driven
-        — a COUNT trigger (``SUBAGENT_DIGEST_CHUNK_SIZE`` completions pending)
-        and wave close — so neither can fire while a straggler is simply *not
-        finishing*. With the default count (10) above any realistic wave size,
-        the only flush that ever fires is the wave-close one, and a member that
-        HANGS rather than fails withholds every sibling's finished result for
-        the full ``_TIMEOUT_SECS`` reap window (issue #2215).
-
-        This sweep is the timer the event-driven triggers lack: when the OLDEST
-        outstanding hold in a wave has aged past :data:`DIGEST_HOLD_SECS` and
-        the wave is still live, it announces a synthetic *flush-only* record
-        through the single completion consumer (the same re-entry mechanism
-        :meth:`record_lost_submission` uses), which forces the partial digest
-        out. Ordinary fast waves never reach the deadline, so the deliberate
-        "small wave = one consolidated digest" behavior is untouched.
-        """
-        if DIGEST_HOLD_SECS <= 0 or self._on_done is None:
-            return  # deadline disabled — count-trigger-only
-        oldest: dict[str, float] = {}
-        parents: dict[str, str] = {}
-        totals: dict[str, int] = {}
-        for info in list(self._agents.values()):
-            _bid = info.batch_id
-            if not _bid or info._digest_held_at <= 0.0:
-                continue
-            _prev = oldest.get(_bid)
-            if _prev is None or info._digest_held_at < _prev:
-                oldest[_bid] = info._digest_held_at
-            parents.setdefault(_bid, info.parent_session_key)
-            totals.setdefault(_bid, info.batch_total)
-        for batch_id, held_at in oldest.items():
-            age = now - held_at
-            if age < DIGEST_HOLD_SECS:
-                continue  # still inside the grace window
-            if not self.batch_members_pending(batch_id):
-                # The wave is closing on its own — the real wave-close flush is
-                # already in flight (or the held flags are stale bookkeeping).
-                # Forcing a partial digest here would race it and could emit a
-                # duplicate chunk for the same members.
-                continue
-            logger.warning(
-                "Reaper: wave %s held results for %.0fs (deadline %.0fs) —"
-                " forcing partial digest flush",
-                batch_id,
-                age,
-                DIGEST_HOLD_SECS,
-            )
-            self.force_digest_flush(
-                batch_id,
-                parents.get(batch_id, ""),
-                totals.get(batch_id, 0),
-                age,
-            )
+        return self._waves._sweep_digest_holds_impl(now)
 
     def force_digest_flush(
         self,
@@ -4739,604 +2109,52 @@ class SubagentManager:
         batch_total: int,
         held_secs: float,
     ) -> None:
-        """Announce a synthetic *flush-only* record to release a wave's held
-        results without waiting for another member to complete.
-
-        The record is deliberately NOT a wave member: ``_digest_flush_only``
-        tells the gateway to skip every per-member side effect (terminal WS
-        event, orchestration accounting, done/ok/err counters, digest lines) and
-        only force the pending chunk out. Announcing it through ``_on_done`` —
-        rather than reaching into the gateway's digest buffers — reuses the one
-        completion consumer that owns digest composition, routing, and the
-        held-tombstone settle contract.
-        """
-        if not batch_id or self._on_done is None:
-            return
-        info = SubagentInfo(
-            id=uuid.uuid4().hex[:8],
-            task=f"(wave digest flush — results held {int(held_secs)}s)",
-            parent_session_key=parent_session_key,
-            done=True,
-            batch_id=batch_id,
-            batch_total=max(0, int(batch_total)),
+        return self._waves.force_digest_flush_impl(
+            batch_id, parent_session_key, batch_total, held_secs
         )
-        info._digest_flush_only = True
-        try:
-            sel().log_tool_invocation(
-                session_key=parent_session_key or "",
-                source="subagent",
-                tool_name="spawn_run",
-                outcome="digest_hold_expired",
-                metadata={"batch_id": batch_id, "held_secs": int(held_secs)},
-            )
-        except Exception:
-            logger.debug("SEL audit failed for digest hold expiry", exc_info=True)
-        try:
-            self._tasks[f"flush-{info.id}"] = asyncio.ensure_future(
-                self._announce_digest_flush(info)
-            )
-        except RuntimeError:
-            pass  # no running loop (sync/test context)
 
     async def _announce_digest_flush(self, info: SubagentInfo) -> None:
-        """Run the flush-only announce with the SAME settle contract as ``_run``.
-
-        ``_settle_digest_holds`` must run only after ``_on_done`` returns
-        cleanly: a routing failure has to leave the held members undelivered so
-        orphan reconciliation can still recover them after a restart. This path
-        has no run loop to enforce that ordering, so it enforces it here.
-        """
-        assert self._on_done is not None
-        try:
-            await self._on_done(info)
-        except Exception:
-            logger.warning(
-                "Digest hold flush announce failed for wave %s", info.batch_id, exc_info=True
-            )
-            return
-        self._settle_digest_holds(info)
+        return await self._waves._announce_digest_flush_impl(info)
 
     async def settle_queued_delivery(self, agent_ids: list[str]) -> None:
-        """Write the ``delivered`` tombstones for completions consumed from a queue.
-
-        The queued-injection path (issue #4839) deliberately leaves a completion
-        un-tombstoned until the parent's turn has consumed the announce, so the
-        write lands here — in the parent's drain — rather than in
-        :meth:`_report_terminal`. That is also why it must repeat the gate that
-        report holds: a ``delivered`` tombstone EXCLUDES the folder from restart
-        orphan reconciliation, and the drain can come due while the run's teardown
-        is still killing its child, so writing early would let a crash in that
-        window strand a live child that nothing would ever reap.
-
-        The wait is bounded exactly as the report's is (teardown is itself bounded
-        by ``_RESET_TIMEOUT`` then SIGKILL, and runs in a ``finally``), and a
-        timeout writes anyway rather than abandoning the retention bound — the same
-        trade the report makes. The gate is read from ``_teardown_gates``, which
-        outlives the run's ``_agents``/``_tasks`` records: a dashboard "clear
-        completed" or "cancel" pops both of those for a run that is done but still
-        tearing down, so inferring "record gone means child gone" would tombstone a
-        live child. No gate entry means teardown has finished (or never started).
-
-        The tombstone write itself is offloaded: it fsyncs, and this runs on the
-        gateway event loop.
-        """
-        for agent_id in agent_ids:
-            gate = self._teardown_gates.get(agent_id)
-            if gate is not None and not gate.is_set():
-                try:
-                    await asyncio.wait_for(gate.wait(), timeout=_RESET_TIMEOUT + 30)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "Subagent %s: teardown did not complete before the queued "
-                        "delivered tombstone; writing it anyway",
-                        agent_id,
-                    )
-            try:
-                await asyncio.to_thread(mark_delivered, agent_id)
-            except Exception:
-                logger.debug(
-                    "Failed to mark drained subagent %s delivered", agent_id, exc_info=True
-                )
+        return await self._waves.settle_queued_delivery_impl(agent_ids)
 
     def _settle_digest_holds(self, info: SubagentInfo) -> None:
-        """Settle delivery tombstones for wave members whose injection was
-        held for this member's digest. Called ONLY after ``_on_done`` returned
-        without raising — and it is a real settle only for the routes where
-        that return IS the confirmation. Both dashboard routes hand off
-        asynchronously, so they detach the ids before ``_on_done`` returns and
-        owe them to the parent's consumption instead (the queue branch via
-        ``_defer_queued_delivery``, the direct-injection branch via the same
-        slot ledger), leaving this a no-op there. Marking the held members
-        delivered no longer risks the restart-loss window here (settling at
-        digest composition, before routing, would).
-
-        The ids are taken off ``info`` BEFORE settling, so a re-entry cannot
-        write a second tombstone and a route that detached them first leaves
-        this a no-op.
-
-        A failing tombstone write is logged and skipped, never raised: one
-        unwritable run folder must not strand the rest of the chunk.
-        """
-        ids, info._digest_settle_ids = info._digest_settle_ids, []
-        for _hid in ids:
-            try:
-                mark_delivered(_hid)
-            except Exception:
-                logger.debug("Failed to settle held subagent %s", _hid, exc_info=True)
+        return self._waves._settle_digest_holds_impl(info)
 
     def get(self, agent_id: str) -> SubagentInfo | None:
-        """Get agent info by ID."""
-        return self._agents.get(agent_id)
+        return self._run_events.get_impl(agent_id)
 
     @property
     def count(self) -> int:
         return len(self.running)
 
     async def _teardown_run_session(self, info: SubagentInfo, session_key: str) -> None:
-        """Release and reset the run's own session (skipped when reaped).
-
-        Split out of ``_run``'s ``finally`` so the caller can wrap it in a nested
-        ``try/finally``: every statement here AWAITS, and a cancellation arriving
-        at one of those awaits propagates straight out of the enclosing
-        ``finally`` suite (the ``except Exception`` arms do not catch
-        ``CancelledError``). That skipped the slot release, the task-registry pop
-        and the teardown gate — leaking a concurrency slot, which is the very
-        class of bug this module's guard split exists to prevent.
-        """
-        try:
-            if info._session_sharing:
-                # Session-sharing subagents: destroy the session handle
-                # (unregister from shared runtime). Don't kill the runtime.
-                # Skip when the reaper already tore it down (info.reaped).
-                # Retain-by-default: keep the transcript files — they are
-                # spawn_continue's resume material. The tombstone pruner
-                # deletes them with the run folder (~1h after delivery)
-                # unless the conversation is promoted (continued / keep).
-                if info._shared_provider and not info.reaped:
-                    try:
-                        info._shared_provider.set_keep_transcript(True)
-                    except Exception:
-                        logger.debug("set_keep_transcript failed", exc_info=True)
-                    await info._shared_provider.shutdown()
-            else:
-                # Retain-by-default: never delete session files at teardown.
-                # The reset() below still expires the process, so an idle
-                # conversation costs a JSON file, not RSS. Deletion is owned
-                # by the tombstone pruner (default runs, ~1h) or the
-                # conversation TTL sweep / spawn_release (promoted runs).
-                self._sessions.release(session_key, cleanup=False)
-        except Exception:
-            logger.warning("Subagent %s: release failed", info.id, exc_info=True)
-        if not info._session_sharing:
-            try:
-                await asyncio.wait_for(self._sessions.reset(session_key), timeout=_RESET_TIMEOUT)
-            except asyncio.TimeoutError:
-                logger.warning("Subagent %s: reset timed out, force-killing", info.id)
-                await self._sigkill_session(session_key)
-                try:
-                    sel().log_tool_invocation(
-                        session_key=session_key,
-                        source="subagent",
-                        tool_name="run_finally_force_kill",
-                        outcome="sigkill",
-                        metadata={"subagent_id": info.id},
-                    )
-                except Exception:
-                    logger.exception("Subagent %s: SEL audit failed", info.id)
-            except Exception:
-                logger.exception("Subagent %s: reset failed", info.id)
+        return await self._run_events._teardown_run_session_impl(info, session_key)
 
     async def _run(self, info: SubagentInfo) -> None:
-        """Execute a subagent task in its own session."""
-        session_key = info.conversation_key or f"subagent:{info.id}"
-        try:
-            await asyncio.wait_for(
-                self._run_inner(info, session_key), timeout=self._default_timeout
-            )
-        except asyncio.TimeoutError:
-            if not info.reaped:
-                info.error = f"Timed out after {self._default_timeout // 60} minutes [{_timeout_context(info, turn_limit=self._effective_turn_limit(info))}]"
-                info.done = True
-                Stats().inc_subagent_failed()
-                self._write_tombstone(info, "timeout")
-            logger.warning("Subagent %s timed out", info.id)
-        except asyncio.CancelledError:
-            if not info.reaped:
-                if (
-                    not info.user_stopped
-                    and not self._shutting_down
-                    and not info._cancel_retry_used
-                    # A live diagnostics-write drain means a worker is still
-                    # (or may still be) writing state.json: respawning a
-                    # recovery writer now re-opens the stale-overwrite race
-                    # (#6306; reachable on 3.10 via a second outer cancel
-                    # interrupting wait_for's _cancel_and_wait).
-                    and not info._diag_drain_active
-                    and info.tool_count == 0
-                ):
-                    # UNEXPECTED cancellation (not user Stop, not shutdown):
-                    # one-shot auto-continue, mirroring the main path's
-                    # unexpected-cancel recovery. Skip terminal
-                    # finalization (via _recovering) and respawn on a fresh
-                    # task — this task is being cancelled and cannot continue.
-                    #
-                    # SIDE-EFFECT GATE (tool_count == 0): the respawn runs on a
-                    # FRESH session with no ledger of prior tool calls, so the
-                    # model cannot verify which side effects (files written,
-                    # messages sent, commands run) already happened — a
-                    # preamble alone cannot make re-running safe. Once any tool
-                    # has executed, we finalize with the partial preserved
-                    # instead of respawning. Text-only activity is safe to
-                    # resume (the partial is preserved and re-presented).
-                    info._cancel_retry_used = True
-                    info._recovering = True
-                    logger.warning(
-                        "Subagent %s unexpectedly cancelled — scheduling one-shot auto-continue",
-                        info.id,
-                    )
-                    try:
-                        sel().log_tool_invocation(
-                            session_key=session_key,
-                            source="subagent",
-                            tool_name="cancel_auto_continue",
-                            outcome="scheduled",
-                            metadata={"subagent_id": info.id},
-                        )
-                    except Exception:
-                        logger.debug("SEL audit for cancel recovery failed", exc_info=True)
-                    self._schedule_cancel_recovery(info)
-                else:
-                    info.done = True
-                    if info.tool_count > 0 and not info.user_stopped and not self._shutting_down:
-                        # Auto-continue deliberately suppressed (side-effect
-                        # gate above): be explicit so the parent/user knows the
-                        # run was interrupted and NOT resumed, and why.
-                        info.error = (
-                            "cancelled (auto-continue suppressed: tools already "
-                            "executed — resuming on a fresh session could repeat "
-                            "side effects)"
-                        )
-                    else:
-                        info.error = "cancelled"
-                    # Preserve whatever streamed before the cancel as a partial
-                    # result (delivered with the failure).
-                    if not info.result and info.streaming_text:
-                        info.result = info.streaming_text
-                    Stats().inc_subagent_failed()
-                    self._write_tombstone(info, "cancelled")
-            logger.info("Subagent %s cancelled", info.id)
-        except Exception as exc:
-            if not info.reaped:
-                # Story appended INSIDE the cap: info.error reaches a WS frame
-                # and the Subagents panel, so the rendered total stays bounded
-                # by _MAX_ERROR_DETAIL_LEN exactly as before — and the budget
-                # trims the ERROR text, never the story, so a verbose chain
-                # cannot push the walk out of the terminal error.
-                info.error = append_fallback_story(
-                    _describe_exception(exc), exc, budget=_MAX_ERROR_DETAIL_LEN
-                )
-                info.done = True
-                Stats().inc_subagent_failed()
-                self._write_tombstone(info, "error")
-            logger.exception("Subagent %s failed", info.id)
-        finally:
-            # Guard 3 of 3 — the terminal REPORT, owned by the finalize claim.
-            # Taken (and the report task SPAWNED) before the teardown awaits
-            # below, so a cancellation landing anywhere in teardown cannot
-            # strand the outcome: the shielded task is already live. The claim
-            # returns False while _recovering without consuming itself, so a
-            # pending cancel-recovery respawn is not reported done and its
-            # respawned run can claim later.
-            report_task = None
-            # Set once this finally's session teardown has finished, so the
-            # already-spawned report holds its "delivered" tombstone until the
-            # child is provably gone (see `_report_terminal`).
-            teardown_done = asyncio.Event()
-            # Published where it survives this record being evicted: a settlement
-            # that happens OUTSIDE this report (the parent's queue drain, issue
-            # #4839) can come due after a dashboard clear/cancel has removed the run
-            # from _agents AND _tasks, and it still must not tombstone a child that
-            # is being killed.
-            self._teardown_gates[info.id] = teardown_done
-            if self._claim_finalize(info):
-                info.elapsed = time.time() - info.started
-                self._record_cost(info)
-                report_task = self._spawn_terminal_report(
-                    info,
-                    source="Subagent",
-                    injection_timeout_reason=(
-                        f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s" " (queue + injection)"
-                    ),
-                    mark_delivered_on_success=True,
-                    settle_digest=True,
-                    teardown_done=teardown_done,
-                )
-            # Nested try/finally: the teardown awaits must never be able to skip
-            # the bookkeeping below (see `_teardown_run_session`).
-            try:
-                if not info.reaped:
-                    await self._teardown_run_session(info, session_key)
-            finally:
-                # Guard 2 of 3 — SLOT accounting on its own one-shot token, so
-                # the count is released exactly once whichever terminal path
-                # arrives first (and is NOT skipped just because the reaper set
-                # `reaped`, which is how an earlier revision leaked slots).
-                if self._release_slot(info):
-                    self._running_count -= 1
-                    self._drain_queue()
-                self._tasks.pop(info.id, None)
-                # Teardown is done (or was skipped because the reaper did it) —
-                # release the report's delivered-tombstone gate. Unconditional,
-                # so the report can never wedge on a cancelled teardown.
-                teardown_done.set()
-                # Set BEFORE the entry is dropped: a waiter that already holds the
-                # event is released by the line above, and one arriving after finds
-                # no entry, which now means exactly "nothing left to wait for".
-                self._teardown_gates.pop(info.id, None)
-
-        # The report itself already ran (or is running) on the shielded task
-        # spawned in the finally above; block until it completes so sequencing is
-        # unchanged for callers.
-        #
-        # NOT during shutdown. `_run`'s CancelledError arm deliberately does not
-        # re-raise, so by the time we reach this await the cancellation has been
-        # consumed and `shield` would simply wait out the full _ON_DONE_TIMEOUT
-        # injection cap — holding `cancel_all()`'s gather for up to 20 minutes.
-        # The report is registered in `self._report_tasks`, so `cancel_all()`'s
-        # bounded drain owns it from here.
-        if report_task is not None and not self._shutting_down:
-            await self._await_report(report_task)
+        return await self._run_events._run_impl(info)
 
     def _schedule_cancel_recovery(self, info: SubagentInfo) -> None:
-        """Respawn *info*'s run on a fresh task after an unexpected cancellation.
-
-        Called from ``_run``'s CancelledError handler — the current task is
-        being cancelled and cannot continue itself, so the continuation runs on
-        a new task. One-shot: gated by ``info._cancel_retry_used`` at the call
-        site. The original run's finally block still performs session cleanup
-        (release/reset) but skips terminal finalization while ``_recovering``.
-
-        **Cancellation-source contract.** This branch exists for cancellations
-        that arrive from OUTSIDE the manager's own lifecycle — in practice the
-        parent task tree being torn down around a live subagent (e.g. a
-        dashboard slot reset/removal cancelling background tasks, or an event
-        during gateway component re-init) — mirroring the main path's
-        unexpected-cancel recovery. Every INTENTIONAL cancel site in
-        this module sets a terminal marker before cancelling, and the recovery
-        branch defers to all of them: ``cancel()`` sets ``user_stopped``,
-        ``cancel_all()`` sets ``_shutting_down``, and ``_force_reap`` sets
-        ``reaped`` (checked before the recovery branch). Any NEW code path that
-        cancels a subagent task on purpose MUST set one of those markers first,
-        or the cancel will be treated as unexpected and recovered once.
-
-        Coordination is explicit, not timed: ``_resume`` awaits the ORIGINAL
-        task object to fully complete (its finally does session release/reset,
-        slot decrement, and pops the task registry) before respawning. This
-        guarantees the old finally can neither pop the new task out of
-        ``self._tasks`` nor emit a duplicate completion, and the respawn never
-        starts against a session whose reset is still in flight. The respawn
-        then re-acquires a slot by waiting for capacity (the old finally's
-        ``_drain_queue`` may have admitted a queued spawn into the freed slot),
-        so the concurrency ceiling is never exceeded.
-
-        The pending ``_resume`` task itself is registered in ``self._tasks``
-        (under ``"<id>:recovery"``) so ``cancel_all()`` reaches it during
-        shutdown — a recovery can never outlive or escape manager teardown.
-        """
-        orig_task = asyncio.current_task()
-        recovery_key = f"{info.id}:recovery"
-
-        async def _resume() -> None:
-            try:
-                # Explicit handshake: wait for the original task's finally
-                # (session release/reset, slot decrement, task-registry pop)
-                # to fully complete before respawning. The finally is bounded
-                # (_RESET_TIMEOUT-capped reset), so add slack on top of it.
-                if orig_task is not None:
-                    await asyncio.wait({orig_task}, timeout=_RESET_TIMEOUT + 60)
-                    if not orig_task.done():
-                        logger.error(
-                            "Subagent %s cancel-recovery: original task did not "
-                            "finish teardown in time — aborting recovery",
-                            info.id,
-                        )
-                        raise RuntimeError("original task teardown timed out")
-                if info.done or info._reap_started or info.reaped or self._shutting_down:
-                    info._recovering = False
-                    return
-                # Re-acquire a slot through capacity, not blind increment:
-                # the old finally freed our slot and may have drained a queued
-                # spawn into it. Wait (bounded) for a free slot so recovery
-                # never pushes the pool past max_concurrent.
-                deadline = time.time() + _RECOVERY_SLOT_WAIT_SECS
-                while self._running_count >= self._max_concurrent:
-                    if time.time() >= deadline or self._shutting_down:
-                        raise RuntimeError("no free slot for recovery respawn")
-                    await asyncio.sleep(0.25)
-                if info.done or info._reap_started or info.reaped or self._shutting_down:
-                    info._recovering = False
-                    return
-                info._recovering = False
-                # Claim the slot and launch the respawn ATOMICALLY (no await
-                # between capacity check, increment, and create_task). An await
-                # in that window would let a finishing subagent's _drain_queue
-                # admit a queued spawn into the same slot and push the pool
-                # past max_concurrent. The respawned _run owns the slot from
-                # here (its finally decrements). The informational
-                # subagent_recovering emit happens after, where a cancellation
-                # can no longer leak the counter.
-                self._running_count += 1
-                # The interrupted run's finally already consumed this info's
-                # slot token to free its slot. The respawn occupies a FRESH slot,
-                # so re-arm the token or the respawned run's finally would no-op
-                # and leave `_running_count` permanently inflated.
-                info._slot_released = False
-                self._tasks[info.id] = asyncio.create_task(self._run(info))
-                try:
-                    await self._fire_event("subagent_recovering", info, {"attempt": 1})
-                except Exception:
-                    logger.debug("subagent_recovering emit failed for %s", info.id, exc_info=True)
-            except Exception:
-                logger.exception("Subagent %s cancel-recovery respawn failed", info.id)
-                info._recovering = False
-                # The RECORD keeps its own first-arrival-wins `done` guard...
-                if not info.done and not info._reap_started and not info.reaped:
-                    # Full terminal finalization — the UI must never be left on
-                    # a running card and the parent must still hear about the
-                    # failure (with any partial result) even when the respawn
-                    # itself could not happen.
-                    info.done = True
-                    info.error = "cancelled (recovery failed)"
-                    info.elapsed = time.time() - info.started
-                    Stats().inc_subagent_failed()
-                    self._write_tombstone(info, "cancelled")
-                    self._record_cost(info)
-                if not info.elapsed:
-                    # Report needs an elapsed even when the record above was
-                    # skipped because another path had already set `done`.
-                    info.elapsed = time.time() - info.started
-                # ...and the REPORT goes through the one-shot claim, exactly like
-                # the reap and `_run`'s finally. Routing through the claim (not a
-                # direct `subagent_done`/`_on_done` fire) keeps this from being a
-                # fourth reporter outside the very claim this
-                # class uses to guarantee exactly-once delivery, so a reaper
-                # racing a failed respawn cannot deliver the outcome twice.
-                # Reporting via `_run_terminal_report` also shields the delivery,
-                # which matters here because `_force_reap` cancels this task.
-                if self._claim_finalize(info):
-                    await self._run_terminal_report(
-                        info,
-                        source="Recovery",
-                        injection_timeout_reason=(
-                            f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s "
-                            "(recovery failure)"
-                        ),
-                        mark_delivered_on_success=False,
-                        # Same reasoning as the reap path: settle siblings' holds.
-                        settle_digest=True,
-                    )
-            finally:
-                # Whether respawned, aborted, or cancelled: this pending
-                # recovery is no longer outstanding.
-                _reg = self._tasks.get(recovery_key)
-                if _reg is asyncio.current_task():
-                    self._tasks.pop(recovery_key, None)
-
-        async def _resume_guarded() -> None:
-            try:
-                await _resume()
-            except asyncio.CancelledError:
-                # The pending recovery itself was cancelled (cancel_all during
-                # shutdown, or manager teardown). Terminal by default — a
-                # cancelled recovery NEVER re-recovers; just make sure the
-                # record isn't left in limbo.
-                info._recovering = False
-                _live = self._tasks.get(info.id)
-                if _live is not None and not _live.done():
-                    # Respawn already launched — the live run owns the record
-                    # (its own CancelledError arm is terminal: one-shot flag is
-                    # spent). Don't finalize over it.
-                    raise
-                # `_reap_started`, not just `reaped`: `_force_reap` cancels this
-                # task BEFORE it sets `reaped` (which must stay false until the
-                # reaper owns the record — see `_reap_started`). Consulting only
-                # `reaped` made this arm win the race and persist a neutral user
-                # Stop as a FAILURE, with a failure stat and a "cancelled"
-                # tombstone the reaper could no longer correct.
-                if not info.done and not info._reap_started and not info.reaped:
-                    info.done = True
-                    info.error = "cancelled"
-                    info.elapsed = time.time() - info.started
-                    if not info.user_stopped:
-                        # A user-initiated stop is a neutral outcome, not a
-                        # failure — matching the reap path's own record guard.
-                        Stats().inc_subagent_failed()
-                    self._write_tombstone(info, "cancelled")
-                raise
-
-        _t = asyncio.create_task(_resume_guarded())
-        self._tasks[recovery_key] = _t
-        _t.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+        return self._cancellation._schedule_cancel_recovery_impl(info)
 
     async def _touch_activity(self, info: SubagentInfo) -> None:
-        """Record stream activity for idle-stall detection.
-
-        Updates ``last_activity`` and, if the subagent was previously flagged
-        stalled by the reaper, clears the flag and notifies the UI so the
-        running-card drops the "stalled" warning the moment work resumes.
-        """
-        info.last_activity = time.time()
-        info._stall_suspect_at = 0.0  # activity resets the 2-sweep confirmation
-        # Retire the oracle so the next suspicion samples a fresh baseline rather
-        # than differencing against counters from before this activity, and bump
-        # the generation so a consult submitted before this moment cannot land a
-        # stalled verdict on an agent that has just proven it is working.
-        if info._stall_oracle is not None:
-            info._stall_oracle = info._stall_oracle.fresh()
-        info._stall_gen += 1
-        if info.stalled:
-            info.stalled = False
-            await self._fire_event("subagent_stalled", info, {"stalled": False})
+        return await self._run_events._touch_activity_impl(info)
 
     async def _fire_event(self, etype: str, info: SubagentInfo, extra: dict | None = None) -> None:
-        if self._on_event:
-            try:
-                await self._on_event(etype, info, extra or {})
-            except Exception:
-                logger.warning("on_event failed for %s/%s", etype, info.id, exc_info=True)
+        return await self._run_events._fire_event_impl(etype, info, extra)
 
     def _queued_depth(self, parent_session_key: str) -> int:
-        """Number of spawns currently queued for *parent_session_key* (waiting
-        behind the concurrency cap / stagger gate, not yet started)."""
-        return sum(1 for q in self._queue if q.get("parent_session_key", "") == parent_session_key)
+        return self._run_events._queued_depth_impl(parent_session_key)
 
     def queued_count_for(self, parent_session_key: str) -> int:
-        """Public queued-spawn count for *parent_session_key*.
-
-        Spawns accepted behind the concurrency cap / stagger gate sit in
-        ``_queue`` with no ``SubagentInfo`` yet, so ``running``-based checks
-        read "no pending work" during exactly the window a wave is ramping.
-        Reset-deferral guards must consult this alongside ``running``.
-        """
-        return self._queued_depth(parent_session_key)
+        return self._run_events.queued_count_for_impl(parent_session_key)
 
     def has_pending_work_for(self, parent_session_key: str) -> bool:
-        """True while *parent_session_key* has sub-agents RUNNING or QUEUED.
-
-        The reset-deferral guards must consult this, not ``running`` alone —
-        see :meth:`queued_count_for` for why. A parent session reset while a
-        spawn is still queued strands that agent's completion on a
-        cold-started, context-free replacement session.
-        """
-        if self._queued_depth(parent_session_key) > 0:
-            return True
-        return any(a.parent_session_key == parent_session_key for a in self.running)
+        return self._run_events.has_pending_work_for_impl(parent_session_key)
 
     def _emit_queue_depth(self, parent_session_key: str, batch_id: str = "") -> None:
-        """Emit the current queued depth for *parent_session_key* as a
-        ``subagent_queued`` lifecycle event.
-
-        The chip is otherwise driven only by agents that have actually started
-        (``subagent_spawn``), so agents sitting behind the concurrency cap /
-        stagger gate are invisible and the chip can appear late or flicker.
-        This advisory count lets the UI show "N waiting to start" the moment a
-        wave is accepted, and stay mounted across the staggered ramp.
-
-        Fire-and-forget: scheduled on the running loop; a no-op in sync/test
-        contexts without a loop (the count is advisory UI signal, not state).
-        """
-        depth = self._queued_depth(parent_session_key)
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return  # no running loop (sync/test context) — advisory event skipped
-        info = SubagentInfo(
-            id="_queue",
-            task="",
-            parent_session_key=parent_session_key,
-            batch_id=batch_id,
-        )
-        loop.create_task(self._fire_event("subagent_queued", info, {"queued": depth}))
+        return self._run_events._emit_queue_depth_impl(parent_session_key, batch_id)
 
     @staticmethod
     def _write_tombstone(info: SubagentInfo, cause: str) -> None:
@@ -5361,1218 +2179,18 @@ class SubagentManager:
             logger.debug("Failed to write tombstone for %s", info.id, exc_info=True)
 
     async def _run_inner(self, info: SubagentInfo, session_key: str) -> None:
-        """Inner execution — called within timeout wrapper."""
-        # Mark the real start of execution BEFORE any await so the startup
-        # watchdog measures from here, not from registration (which may include
-        # an arbitrary spawn-approval wait). Must be the first statement.
-        info._exec_started = time.time()
-        # Reset the activity clock to execution start too: last_activity is set
-        # at registration (like ``started``), which can include a long spawn-
-        # approval / queue wait. Without this, _maybe_flag_stall would treat
-        # that pre-execution delay as idle time and prematurely surface a
-        # healthy, just-started subagent as "stalled".
-        info.last_activity = info._exec_started
-        # Inherit approval policy from parent session; yolo/trust overrides
-        parent_policy = self._sessions.get_approval_policy(info.parent_session_key)
-        # Explicit approval_mode from spawn caller (e.g. Mochi bg agent)
-        if not parent_policy and info.approval_mode == "auto":
-            parent_policy = "auto"
-            sel().log_api_access(
-                caller=info.parent_session_key or f"subagent:{info.id}",
-                operation="subagent.approval_mode_auto_policy",
-                outcome="ok",
-                source="subagent",
-                resources=f"subagent_id={info.id}",
-            )
-        if not parent_policy and self._is_yolo and self._is_yolo():
-            parent_policy = "auto"
-            sel().log_api_access(
-                caller=info.parent_session_key,
-                operation="subagent.yolo_policy_fallback",
-                outcome="ok",
-                source="subagent",
-                resources=f"subagent_id={info.id}",
-            )
-        if not parent_policy and self._global_approval_mode == "auto":
-            # Apply global config as fallback only when parent is absent or
-            # confirmed garbage-collected (no longer in session store).
-            # If parent session still exists but returned no policy, deny by
-            # default — the session is alive and intentionally non-auto.
-            if not info.parent_session_key:
-                _parent_gone = True  # no_parent
-            elif self._sessions.has_session(info.parent_session_key) is False:
-                _parent_gone = True  # parent_gc
-            else:
-                _parent_gone = False  # parent alive or store error → deny
-                sel().log_api_access(
-                    caller=f"subagent:{info.id}",
-                    operation="subagent.config_policy_fallback",
-                    outcome="denied",
-                    source="subagent",
-                    resources=f"subagent_id={info.id},reason=parent_alive_or_store_error",
-                )
-            if _parent_gone:
-                parent_policy = "auto"
-                _reason = "parent_gc" if info.parent_session_key else "no_parent"
-                sel().log_api_access(
-                    caller=f"subagent:{info.id}",
-                    operation="subagent.config_policy_fallback",
-                    outcome="ok",
-                    source="subagent",
-                    resources=f"subagent_id={info.id},reason={_reason}",
-                )
-        # auto_approve_subagent_tools auto-approves tool calls inside
-        # subagents (separate from the spawn gate, deny-by-default).
-        if not parent_policy and self._ctx_builder and self._ctx_builder.hooks:
-            if self._ctx_builder.hooks.auto_approve_subagent_tools is True:
-                parent_policy = "auto"
-                sel().log_api_access(
-                    caller=info.parent_session_key or f"subagent:{info.id}",
-                    operation="subagent.auto_approve_subagent_tools_policy",
-                    outcome="ok",
-                    source="subagent",
-                    resources=f"subagent_id={info.id}",
-                )
-        # Inherit agent from parent session when not explicitly specified
-        agent = info.agent or self._sessions.get_agent(info.parent_session_key)
-        if not info.agent and agent:
-            sel().log_api_access(
-                caller=f"subagent:{info.id}",
-                operation="subagent.agent_inheritance",
-                outcome="ok",
-                source="subagent",
-                resources=f"subagent_id={info.id},inherited_agent={agent}",
-            )
-        extra_kwargs: dict[str, Any] = {}
-        # An explicit per-spawn model wins; otherwise fall back to the
-        # configured sub-agent role model (agent.role_models['subagent']). When
-        # that role is unpinned the helper returns "" so we omit the kwarg and
-        # keep deferring to the provider's configured default, exactly as before.
-        eff_model = info.model or _subagent_default_model()
-        # Record the EFFECTIVE pin (per-spawn OR the role_models['subagent']
-        # config pin, via ``_subagent_default_model()``) as the requested side of
-        # the downgrade comparison — keying off the bare per-spawn ``model`` would
-        # miss a config-pinned run served a different model (Design review #3582).
-        # For completely unpinned spawns (no per-spawn pin, no role pin) ``eff_model``
-        # is ``""``; fall back to the literal ``"auto"`` sentinel so the frontend
-        # can show a neutral chip instead of nothing at all (#5869).
-        info.requested_model = eff_model or "auto"
-        if eff_model:
-            extra_kwargs["model"] = eff_model
-        # Sub-agent reasoning effort (per-call override -> role_efforts['subagent']
-        # -> chat default). Passed as an override so it wins over the factory's
-        # agent-derived default; "" leaves it to that default.
-        eff_effort = info.reasoning_effort or _subagent_default_effort()
-        if eff_effort:
-            extra_kwargs["reasoning_effort_override"] = eff_effort
-        if info.bare:
-            extra_kwargs["bare"] = True
-        if info.allowed_tools:
-            extra_kwargs["allowed_tools"] = info.allowed_tools
-        if info.cwd:
-            extra_kwargs["cwd"] = info.cwd
-
-        # ── Session sharing: reuse parent's shared AcpRuntime ──
-        # When enabled and eligible, subagents get a session on the parent's
-        # companion AcpRuntime (~200ms startup, ~0 memory) instead of spawning
-        # a fresh kiro-cli process (~3-5s, ~400MB).
-        #
-        # Retain-by-default: EVERY run keeps its session files (teardown skips
-        # deletion on both arms), so any completed run is continuable while
-        # its files survive. keep=True / continuation runs additionally take
-        # the dedicated arm: their resume path is the proven dashboard
-        # expire-and-session/load lifecycle, which owns its process. Whether a
-        # SHARED-runtime sid is loadable is the open Phase 0 question — until
-        # proven, a continue on a shared-arm run relies on the fail-closed
-        # resume guard below rather than a spawn-time guarantee.
-        if info.keep:
-            self._sessions.mark_continuable(session_key)
-            self._conversations[session_key] = time.time()
-        use_session_sharing = (not info.keep) and self._should_use_session_sharing(info)
-        # A per-spawn or per-role model / reasoning-effort override cannot be
-        # applied to the parent's already-started shared runtime (it was spawned
-        # with the parent's model and cannot switch model per session). Force the
-        # dedicated process path so the override in extra_kwargs actually reaches
-        # get_or_create -> the provider factory; otherwise a configured sub-agent
-        # model/effort would silently no-op on the default (session-sharing) path.
-        if eff_model or eff_effort:
-            use_session_sharing = False
-        if use_session_sharing:
-            try:
-                client = await self._create_shared_session(info, session_key, agent)
-            except Exception as exc:
-                # Fallback: shared runtime unavailable (dead, spawn failed, etc.)
-                # Revert to legacy per-process path transparently.
-                logger.warning(
-                    "Subagent %s: session sharing failed (%s), falling back to dedicated process",
-                    info.id,
-                    exc,
-                )
-                info._session_sharing = False
-                info._shared_provider = None
-                use_session_sharing = False
-                client, is_new, _resumed = await self._sessions.get_or_create(
-                    session_key,
-                    agent=agent or None,
-                    approval_policy=parent_policy,
-                    **extra_kwargs,
-                )
-                is_cc = self._is_cc_provider(client)
-            else:
-                is_new = True
-                _resumed = False
-                is_cc = False
-        else:
-            client, is_new, _resumed = await self._sessions.get_or_create(
-                session_key,
-                agent=agent or None,
-                approval_policy=parent_policy,
-                **extra_kwargs,
-            )
-            # Fail CLOSED on a continuation that did not actually resume:
-            # get_or_create silently falls back to a FRESH session when
-            # session/load fails (lock held, corrupt files, backend refusal).
-            # Executing the follow-up on that fresh session would silently run
-            # it context-free — worse than an honest error the parent can react
-            # to (re-spawn with a summary). conversation_key is only set by
-            # continue_conversation, so first spawns are unaffected.
-            if info.conversation_key and not _resumed:
-                raise RuntimeError(
-                    "resume_failed: session/load did not restore conversation "
-                    f"{info.conversation_key} — refusing to execute the "
-                    "follow-up without its prior context. The conversation "
-                    "may be locked by a live process or its files corrupt; "
-                    "re-spawn with a fresh task carrying a summary."
-                )
-            # Detect CC provider to skip permission event loop
-            is_cc = self._is_cc_provider(client)
-        # Intentionally check info.agent (not resolved `agent`) so only
-        # explicitly requested agents skip _SYSTEM_PREFIX (defense-in-depth).
-        named_agent = bool(info.agent and _AGENT_NAME_RE.fullmatch(info.agent))
-        raw_task = info._raw_task or info.task
-        message = raw_task if named_agent else (_SYSTEM_PREFIX + raw_task)
-        if info._cancel_retry_used and (info.streaming_text or info.tool_count > 0):
-            # One-shot auto-continue after an unexpected cancellation: tell the
-            # model the prior attempt was interrupted so it completes the task
-            # instead of assuming a fresh start. Same activity predicate as
-            # the transient-retry path: a mutating tool may
-            # have executed BEFORE the first text chunk, so tool_count must
-            # trigger the preamble too — a bare original prompt after tool
-            # activity invites duplicate side effects. (info.tool_count and
-            # streaming_text persist across the respawn; _run_inner never
-            # resets them.)
-            message = _CANCEL_RESUME_PREFIX + message
-        # Scale the injected-context budget to this subagent's model window (a
-        # subagent can be pinned to a smaller model). Resolved from the live
-        # client; None ⇒ 1M reference.
-        _sub_window = window_for_provider_client(client)
-        # Context scope this run was spawned with. Passed even when every group
-        # is on, so build_message applies one code path for sub-agents.
-        _groups = _context_groups_of(info)
-        # Off-loop: build_message embeds the episodic query (blocking urllib).
-        # A run's explicitly-given cwd IS its project for skill scoping: a
-        # dashboard spawn inherits the parent slot's project as its cwd, so the
-        # hands-off surface keeps the repo-scoped skills that surface exists for.
-        # The pool default is deliberately NOT substituted -- it is the
-        # workspace directory, not a checkout, so it can only ever mean "this
-        # run named no project", which is exactly the fail-closed case. Keeping
-        # one meaning for that makes the rule the same on every surface.
-        full_message, _ = await run_in_embed_pool(
-            self._ctx_builder.build_message,
-            message,
-            is_new,
-            session_key,
-            project=info.cwd or None,
-            provider_type=self._provider_label_of(client),
-            model_window=_sub_window,
-            context_groups=_groups,
-        )
-        # The one place the resolved scope and its cost are both known — without
-        # this, "the sub-agent didn't know X" is undebuggable after the fact.
-        logger.info(
-            "Subagent %s context: groups=%s, %d chars",
-            info.id,
-            ",".join(sorted(_groups)) or "conduct-only",
-            len(full_message),
-        )
-
-        result_text = ""
-        turns = 0
-        turn_limit = self._effective_turn_limit(info)
-        # Separate volume bound for child-origin permission escalations —
-        # they are exempt from the parent's turn budget (see the
-        # EVENT_PERMISSION_REQUEST branch) but must not be unbounded.
-        child_escalations = 0
-        child_escalation_limit = max(turn_limit * 3, 60)
-        # Reports inherited agent (not just info.agent) so telemetry shows
-        # the actual agent used for this subagent session.
-        #
-        # Read back the model the live session actually resolved to serve, so
-        # the panel shows what ran rather than only what was requested (issue
-        # #3582). Best-effort at spawn: the ACP session/new response already
-        # carries the served id (readable now, even on the backend default),
-        # while the raw CC path only knows it after the first turn — so this is
-        # refreshed authoritatively at completion below. Only overwrite a prior
-        # non-empty value with another non-empty one, so a spawn-time read that
-        # succeeded is never clobbered back to "" by a transient later miss.
-        _spawn_model = _resolved_model_of(client)
-        if _spawn_model:
-            info.resolved_model = _spawn_model
-        # Persist provenance to disk BEFORE the spawn event so a gateway restart
-        # in the window between the event and the later session_id state write
-        # cannot lose it — orphan recovery reads these from disk (GPT review on
-        # #3582). Off-loop (to_thread): update_state does a synchronous fsync, so
-        # a slow FS must not freeze the gateway/heartbeat. Best-effort with ONE
-        # bounded retry: this write is the SINGLE owner of these two fields on
-        # the spawn path (#5394) — the later session_id write no longer doubles
-        # as a fallback, so a transient failure gets its second chance HERE
-        # rather than from a second writer downstream. update_state reports a
-        # silently-skipped merge (unreadable state) as False, which counts as a
-        # failure for the retry — only a REPORTED write ends the loop. A
-        # persistence hiccup must still never block the spawn.
-        for _provenance_attempt in range(2):
-            try:
-                _wrote = await asyncio.to_thread(
-                    update_state,
-                    info.id,
-                    requested_model=info.requested_model,
-                    resolved_model=info.resolved_model,
-                )
-                if _wrote:
-                    break
-                logger.debug("Provenance write skipped (unreadable state) for %s", info.id)
-            except Exception:
-                logger.debug("Failed to persist model provenance for %s", info.id, exc_info=True)
-        await self._fire_event(
-            "subagent_spawn",
-            info,
-            {
-                "task": _redact(info.task),
-                "agent": agent or "",
-                "model": info.resolved_model,
-                # The requested pin is caller-supplied (spawn_run.model), so it
-                # is redacted like every other free-text field on the frame -- an
-                # unavailable/AKIA-shaped pin must never reach the dashboard
-                # socket raw (GPT review on #5326).
-                "requested_model": _redact(info.requested_model),
-                # The sub-agent's own session key (see build_subagent_snapshot):
-                # lets a client fetch this node's own context-trace.
-                "child_session": info.conversation_key or f"subagent:{info.id}",
-            },
-        )
-        # Stream results to disk for orchestrated chat.
-
-        # Record PID for orphan recovery
-        try:
-
-            pid = self._sessions.get_pid(session_key)
-            if pid:
-                info._pid = pid  # make available for _write_tombstone
-                update_state(info.id, pid=pid, pid_recorded_at=time.time())
-        except Exception:
-            logger.debug("Failed to record PID for %s", info.id, exc_info=True)
-
-        # Record session_id and provider type for session file cleanup
-        try:
-            session_id = client.session_id if hasattr(client, "session_id") else ""
-            provider_type = self._provider_label_of(client)
-            state_update: dict[str, object] = {
-                "session_id": session_id,
-                "provider": provider_type,
-                # Model provenance (requested_model/resolved_model) is NOT
-                # re-written here: the crash-safe write BEFORE the
-                # subagent_spawn event above is the single owner of those two
-                # fields on the spawn path, and a transient failure there is
-                # handled by that write's own bounded retry (#5394). This write
-                # still performs the same read-merge-rewrite either way, so the
-                # point is one authoritative writer, not saved I/O. The CC-path
-                # refinement below still updates resolved_model when it first
-                # becomes known.
-                # keep marks this run's session files as resume material: the
-                # orphan reconciler and tombstone pruner skip file deletion
-                # for keep runs (restart-safe — read from disk, not memory).
-                "keep": info.keep,
-                "conversation_key": session_key if info.keep else "",
-            }
-            # Store CWD for CC cleanup (needed to derive project-key path).
-            # info.cwd is only set when a caller passes an explicit cwd
-            # override (disabled by default), so for the common case derive
-            # the project dir from the provider's own work dir — that is the
-            # same path sent as ACP `cwd`, hence the encoded project key under
-            # ~/.claude/projects. Without this, CC cleanup is skipped (no cwd)
-            # and the transcript leaks.
-            if is_cc:
-                cc_cwd = info.cwd
-                if not cc_cwd:
-                    inner = getattr(client, "client", None)
-                    work_dir = getattr(inner, "_work_dir", None)
-                    if work_dir:
-                        cc_cwd = str(work_dir)
-                if cc_cwd:
-                    state_update["cwd"] = cc_cwd
-            update_state(info.id, **state_update)
-        except Exception:
-            logger.debug("Failed to record session_id for %s", info.id, exc_info=True)
-
-        _rp = agent_dir_for_display(info.id) / "result.txt"
-        info.result_path = str(_rp)
-        # Cache tool names by tool_call_id so PostToolUse can recover the tool name
-        # when EVENT_TOOL_RESULT arrives (which only carries tool_call_id and output).
-        # Mirrors kiro_crew.dashboard.chat_runner._pending_tools.
-        _pending_tools: dict[str, str] = {}
-
-        async def _stream_with_transient_retry():
-            """Yield stream events, retrying transient backend errors.
-
-            Parity with the main path's retry ladder (chat_runner B1/B2):
-            - Pre-token (no text streamed yet): re-send the SAME prompt on the
-              same live session, up to TRANSIENT_RETRIES with exp backoff.
-            - Post-token (partial already streamed): send a CONTINUE prompt so
-              the preserved partial is finished, not duplicated.
-            Non-transient errors and exhausted budgets propagate unchanged
-            (handled by _run's generic exception arm → error tombstone).
-            """
-            attempts = 0
-            # One-shot post-activity allowance, mirroring the main path's
-            # ``_posttoken_retry_used`` rule (dashboard/chat_runner.py ~L4324):
-            # each continuation turn issued AFTER observed activity is an
-            # independent opportunity for the model to repeat a side-effecting
-            # tool, so post-activity recovery gets exactly ONE attempt.
-            # TRANSIENT_RETRIES applies only while zero activity was observed
-            # (replaying the bare prompt is side-effect-free by definition).
-            # PARITY NOTE: this ladder and chat_runner's are two copies with
-            # intentionally identical semantics — a fix to either's activity
-            # predicate or budget rules must be mirrored in the other.
-            post_activity_attempts = 0
-            # Throttle-exhaustion fallback chain (agent.fallback_model):
-            # engaged only once the zero-activity budget above is spent, same
-            # trigger as stream_and_collect's Case 2.75 and the dashboard's
-            # fallback branch. State is per-run (this closure), matching
-            # "a slot/session-scoped equivalent" — the sticky marker for the
-            # session lives on the provider via TURN_FALLBACK_ATTR.
-            _fb_state = FallbackState(configured_fallback_chain())
-            msg = full_message
-            while True:
-                try:
-                    async for _ev in client.stream(msg):
-                        yield _ev
-                    return
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:
-                    if not acp_error_is_transient(exc):
-                        raise
-                    # Post-activity: continue instead of re-running. "Activity"
-                    # is ANY text chunk, approved tool turn, or auto-allowed
-                    # tool call — a mutating tool may have executed before the
-                    # first text chunk, and replaying the full prompt would
-                    # re-run it (duplicate writes/messages). Only a turn with
-                    # zero observed activity resends the original prompt.
-                    _had_activity = bool(result_text) or turns > 0 or info.tool_count > 0
-                    if _had_activity:
-                        if post_activity_attempts >= 1:
-                            raise
-                        post_activity_attempts += 1
-                    elif attempts >= TRANSIENT_RETRIES:
-                        # ── Throttle-exhaustion fallback chain ──
-                        # Zero-activity budget spent: walk agent.fallback_model
-                        # before surfacing (empty chain ⇒ raise exactly as
-                        # before this feature). Two attempts per candidate
-                        # (FALLBACK_CANDIDATE_ATTEMPTS), ~2s backoff each —
-                        # NOT the exponential same-model curve; see
-                        # llm_helpers Case 2.75 for the rationale.
-                        if not _fb_state.chain:
-                            raise
-                        if not _fb_state.should_retry_active():
-                            _cand = await advance_fallback_candidate(
-                                client,
-                                _fb_state,
-                                surface="subagent",
-                                log_suffix=f", id={info.id}",
-                            )
-                            if _cand is None:
-                                _story = _fb_state.exhaustion_story()
-                                if _story:
-                                    logger.warning(
-                                        "model fallback: chain exhausted (%s) for "
-                                        "subagent %s; surfacing original error",
-                                        _story,
-                                        info.id,
-                                    )
-                                    try:
-                                        setattr(exc, FALLBACK_STORY_ATTR, _story)
-                                    except Exception:
-                                        pass
-                                raise
-                        _fb_delay = transient_retry_delay(1)
-                        await self._fire_event(
-                            "subagent_retrying",
-                            info,
-                            {
-                                "attempt": _fb_state.attempts,
-                                "max": FALLBACK_CANDIDATE_ATTEMPTS,
-                                "fallback_model": _fb_state.active or "",
-                            },
-                        )
-                        try:
-                            sel().log_api_access(
-                                caller=info.parent_session_key or f"subagent:{info.id}",
-                                operation="subagent.model_fallback_retry",
-                                outcome="retrying",
-                                source="subagent",
-                                resources=(
-                                    f"subagent_id={info.id},"
-                                    f"model={_fb_state.active or ''},"
-                                    f"attempt={_fb_state.attempts}"
-                                ),
-                            )
-                        except Exception:
-                            logger.debug("SEL audit for fallback retry failed", exc_info=True)
-                        await asyncio.sleep(_fb_delay)
-                        # Zero activity by construction on this arm — replay
-                        # the original prompt, never a continuation.
-                        msg = full_message
-                        continue
-                    attempts += 1
-                    delay = transient_retry_delay(attempts)
-                    logger.warning(
-                        "Subagent %s: transient backend error (attempt %d/%d), "
-                        "retrying in %.1fs: %s",
-                        info.id,
-                        attempts,
-                        TRANSIENT_RETRIES,
-                        delay,
-                        exc,
-                    )
-                    await self._fire_event(
-                        "subagent_retrying",
-                        info,
-                        {"attempt": attempts, "max": TRANSIENT_RETRIES},
-                    )
-                    try:
-                        sel().log_api_access(
-                            caller=info.parent_session_key or f"subagent:{info.id}",
-                            operation="subagent.transient_retry",
-                            outcome="retrying",
-                            source="subagent",
-                            resources=f"subagent_id={info.id},attempt={attempts}",
-                        )
-                    except Exception:
-                        logger.debug("SEL audit for transient retry failed", exc_info=True)
-                    await asyncio.sleep(delay)
-                    msg = _TRANSIENT_CONTINUE_MSG if _had_activity else full_message
-
-        _complete_event: LLMEvent | None = None
-        # Wall clock for THIS subagent's own turn. Deliberately started here,
-        # at the subagent's own stream, not on the parent side: under session
-        # sharing this subagent reuses the parent's runtime, so a parent-side
-        # clock would charge the child for the parent's elapsed time. acp
-        # leaves TurnUsage.duration_ms at 0, so the row needs this.
-        # Includes transient-retry backoff, which is real wall time the caller
-        # waited for this turn.
-        _turn_t0 = time.monotonic()
-        async for event in _stream_with_transient_retry():
-            # Refresh the activity clock for every event kind that BELONGS to
-            # this session (thinking chunks, tool-call updates, etc.) before
-            # dispatch, so idle-stall detection only trips on a genuine no-event
-            # hang -- not on an event kind this switch does not special-case.
-            #
-            # ``runtime_global`` events are the one exclusion: the frame behind
-            # them carried no ``sessionId`` and the runtime fanned it out to
-            # several sessions sharing one kiro-cli process, so it is another
-            # tenant's traffic. Under ``agent.session_sharing`` (default true)
-            # co-tenant subagents are separate sessions on the parent's runtime,
-            # and counting the roster broadcast as activity reset
-            # ``last_activity`` for a whole batch of wedged subagents at the same
-            # instant, cleared their "stalled" badge and restarted the idle count
-            # on agents that had made no progress -- so the badge flapped and the
-            # reported ``idle_secs`` measured time since an unrelated agent's
-            # roster churn. Field data: three co-tenants flagged in one reaper
-            # sweep at idle 214s/214s/215s (one shared refresh instant) while
-            # their elapsed was 1445s/1447s/1538s.
-            #
-            # Deliberately a PROVENANCE test, not an event-kind test: the same
-            # kind reached through a routed frame (the KAS sub-agent lifecycle
-            # path) is this session's own progress and must still count, or a
-            # working agent gets falsely badged. Approval waits stay exempt via
-            # _awaiting_approval.
-            #
-            # Plain attribute access: every provider yields ``LLMEvent`` (an
-            # alias of ``AcpEvent``), which declares the field, so there is no
-            # shape here that could raise. A hop that forgets to carry the flag
-            # degrades to the default False, i.e. "counts as activity" -- the
-            # fail-open direction, which can only delay a badge, never invent
-            # one.
-            if not event.runtime_global:
-                await self._touch_activity(info)
-            if event.kind == EVENT_TEXT_CHUNK:
-                # The CC/raw provider only learns its served model once the
-                # backend answers the first turn — by the first text chunk that
-                # has happened, so refresh here. Runs once (guarded on a still-
-                # empty value) and stays cheap: covers every downstream exit
-                # path (normal, turn_limit, child-escalation, cancel) without
-                # threading the live client through each. Never overwrites a good
-                # spawn-time read with "".
-                if not info.resolved_model:
-                    _live_model = _resolved_model_of(client)
-                    if _live_model:
-                        info.resolved_model = _live_model
-                        # Persist the CC-path refinement so a restart after the
-                        # first turn still recovers the served model. Off-loop
-                        # (to_thread): synchronous fsync must not block the loop
-                        # (GPT review on #3582).
-                        try:
-                            await asyncio.to_thread(
-                                update_state, info.id, resolved_model=_live_model
-                            )
-                        except Exception:
-                            logger.debug(
-                                "Failed to persist refined model for %s", info.id, exc_info=True
-                            )
-                result_text += event.text
-                write_result_chunk(info.id, event.text)
-                redacted = _redact(event.text)
-                info.streaming_text += redacted
-                if len(info.streaming_text) > 50_000:
-                    info.streaming_text = "…(truncated)\n" + info.streaming_text[-40_000:]
-                await self._fire_event("subagent_chunk", info, {"text": redacted})
-            elif event.kind == EVENT_PERMISSION_REQUEST:
-                # Both kiro-cli and claude-agent-acp surface tool calls via
-                # session/request_permission. Run them through the same hook
-                # → parent_policy → interactive callback pipeline so the
-                # approve / reads / trust / yolo protocol applies uniformly.
-                #
-                # Child-origin escalations (runtime-routed backend subagents)
-                # do NOT consume the parent's turn budget: a child asking for
-                # enough permissions would otherwise trip the parent's
-                # turn_limit and kill the whole subagent run on activity that
-                # is not the parent's own turns. They get their OWN bound
-                # instead — without one, a chatty or adversarial backend
-                # child could generate unbounded approval prompts until the
-                # wall-clock reaper fires (the turn budget used to bound
-                # exactly this traffic). Generous multiple of the parent's
-                # limit: legitimate crews fan many small child tool calls.
-                if not event.sub_session_id:
-                    turns += 1
-                    info.turns = turns
-                else:
-                    # Child escalation: counted toward its own volume bound
-                    # here; side-effect activity (tool_count) is counted at
-                    # APPROVAL in _approve_and_log — a purely rejected
-                    # escalation executed nothing and must not consume the
-                    # run's replay budget (tool_count gates prompt replay
-                    # and cancel-respawn).
-                    child_escalations += 1
-                    if child_escalations > child_escalation_limit:
-                        # Answer the triggering request BEFORE bailing: this
-                        # event is already dequeued, so returning without a
-                        # response would strand the child's oneshot — under
-                        # session sharing the runtime outlives this subagent
-                        # and nothing else tears the connection down. The
-                        # "requests are answered on every queue path"
-                        # contract this PR establishes applies to limit
-                        # bails too.
-                        try:
-                            await self._reject_and_log(
-                                client,
-                                event.request_id,
-                                session_key,
-                                event,
-                                error="child_escalation_limit",
-                            )
-                        except Exception:
-                            logger.exception("failed to reject escalation-limit trigger request")
-                        info.result = result_text or "_Partial output._"
-                        info.error = f"child_escalation_limit:{child_escalation_limit}"
-                        info.done = True
-                        Stats().inc_subagent_failed()
-                        logger.warning(
-                            "Subagent %s hit child escalation limit (%d)",
-                            info.id,
-                            child_escalation_limit,
-                        )
-                        self._write_tombstone(info, "child_escalation_limit")
-                        return
-                # Diagnostic pointer is written for BOTH origins — orphan
-                # recovery must see child activity too; only the turn
-                # increment is parent-scoped.
-                info.last_tool = event.title or ""
-                self._note_tool_dispatch(info, event)
-                # Persist turn state for orphan recovery diagnostics. Off-loop
-                # (to_thread): update_state does a synchronous fsync, so a slow
-                # FS must not freeze the gateway/heartbeat (#6288; same shape
-                # as the provenance and CC-refinement writes above). Drained on
-                # cancellation: cancelling a to_thread await detaches the
-                # worker, and update_state is an unlocked read-merge-replace,
-                # so a stale detached worker could overwrite newer state
-                # written by a cancel-respawn recovery run. Hold cancellation
-                # open until the worker finishes — but BOUNDED: cancel_all()
-                # gathers run tasks with no timeout, so an unbounded drain on
-                # a wedged FS would hold gateway shutdown forever, and this
-                # module's convention is that bounded shutdown plus
-                # recoverable state beats unbounded shutdown (same posture as
-                # _REPORT_DRAIN_TIMEOUT). On expiry the worker is abandoned
-                # with a warning; the residual stale-write window then only
-                # exists on an FS already wedged past the deadline.
-                # asyncio.wait never cancels its members, so repeated cancels
-                # of this task keep the worker future intact while the drain
-                # loop keeps waiting out the same deadline.
-                _diag_write = asyncio.ensure_future(
-                    asyncio.to_thread(
-                        update_state, info.id, turns=turns, last_tool=event.title or ""
-                    )
-                )
-                try:
-                    await asyncio.shield(_diag_write)
-                except asyncio.CancelledError:
-                    # Latch for _run's recovery gate: on Python 3.10,
-                    # wait_for's _cancel_and_wait awaits a bare future that a
-                    # SECOND outer cancel can interrupt, delivering _run's
-                    # CancelledError handler while this drain is still in
-                    # flight — before expiry suppression lands. The latch lets
-                    # the gate see the live drain and skip scheduling a
-                    # recovery writer the worker could race (GPT review round
-                    # 4 on #6306). 3.11+ delivers the outer cancel only after
-                    # this child task completes, so there the latch is always
-                    # observed False.
-                    info._diag_drain_active = True
-                    try:
-                        _drain_deadline = time.monotonic() + _DIAG_DRAIN_TIMEOUT
-                        while not _diag_write.done():
-                            _remaining = _drain_deadline - time.monotonic()
-                            if _remaining <= 0:
-                                logger.warning(
-                                    "diagnostics write for %s did not drain in %.0fs on "
-                                    "cancellation — abandoning worker (its write may race "
-                                    "a recovery run's)",
-                                    info.id,
-                                    _DIAG_DRAIN_TIMEOUT,
-                                )
-                                # The abandoned worker is a live stale writer: a
-                                # cancel-respawn recovery run would write fresh
-                                # PID/session state that the zombie's read-merge-
-                                # replace could then roll back. Consume the
-                                # one-shot recovery so this cancellation finalizes
-                                # instead of respawning — losing one best-effort
-                                # auto-continue on an FS already wedged past the
-                                # deadline is strictly cheaper than resurrecting
-                                # stale state (GPT server review round 3 on #6306).
-                                info._cancel_retry_used = True
-
-                                # The zombie may still raise later; retrieve it so
-                                # it never surfaces as an asynchronous "exception
-                                # was never retrieved" warning.
-                                def _log_abandoned_diag(
-                                    fut: "asyncio.Future[Any]", _aid: str = info.id
-                                ) -> None:
-                                    if not fut.cancelled() and fut.exception() is not None:
-                                        logger.debug(
-                                            "Abandoned diagnostics write for %s failed",
-                                            _aid,
-                                            exc_info=fut.exception(),
-                                        )
-
-                                _diag_write.add_done_callback(_log_abandoned_diag)
-                                break
-                            try:
-                                await asyncio.wait({_diag_write}, timeout=_remaining)
-                            except asyncio.CancelledError:
-                                pass  # repeated cancel: keep draining to the deadline
-                        if _diag_write.done() and not _diag_write.cancelled():
-                            # Retrieve (never surfaces as an unretrieved-exception
-                            # warning) and log, matching the CC-refinement sibling.
-                            _diag_exc = _diag_write.exception()
-                            if _diag_exc is not None:
-                                logger.debug(
-                                    "Best-effort diagnostics write failed for %s during "
-                                    "cancel drain",
-                                    info.id,
-                                    exc_info=_diag_exc,
-                                )
-                    finally:
-                        info._diag_drain_active = False
-                    raise
-                except Exception:
-                    pass
-                await self._fire_event(
-                    "subagent_tool",
-                    info,
-                    {
-                        "tool": _redact(event.title or ""),
-                        "tool_kind": event.tool_kind,
-                        "turns": info.turns,
-                        "tool_count": info.tool_count,
-                    },
-                )
-                if turns > turn_limit:
-                    # Same contract as the child_escalation_limit bail: the
-                    # triggering request is already dequeued and must be
-                    # answered before this loop exits, or its oneshot strands.
-                    try:
-                        await self._reject_and_log(
-                            client, event.request_id, session_key, event, error="turn_limit"
-                        )
-                    except Exception:
-                        logger.exception("failed to reject turn-limit trigger request")
-                    info.result = result_text or "_Partial output._"
-                    info.error = f"turn_limit:{turn_limit}"
-                    info.done = True
-                    Stats().inc_subagent_failed()
-                    logger.warning("Subagent %s hit turn limit (%d)", info.id, turn_limit)
-                    self._write_tombstone(info, "turn_limit")
-                    return
-                tool_result = self._ctx_builder.hooks.on_tool_call(
-                    event.title,
-                    session_key=session_key,
-                    agent=info.agent or "",
-                    app=info.app or "",
-                    tool_kind=event.tool_kind,
-                    raw_params=event.raw_tool_params,
-                    command=event.shell_command,
-                    is_shell=event.is_shell,
-                    mcp_server_name=event.mcp_server_name,
-                    mcp_tool_name=event.tool_name,
-                )
-                if tool_result.action == TOOL_DENY:
-                    await self._reject_and_log(
-                        client, event.request_id, session_key, event, error="hook_deny"
-                    )
-                    continue
-                if event.child_low_fidelity:
-                    # UNCONDITIONAL parent grant: parent_policy=auto approves
-                    # regardless of event content, so it may honor a request
-                    # that is grant-eligible (see
-                    # AcpEvent.child_unconditional_grant_eligible — inside
-                    # this low-fidelity branch that means the canonical MCP
-                    # identity is verified and only the ARGUMENTS are
-                    # unverified, which this grant never reads). Honor the
-                    # grant instead of stalling a trusted fan-out on an
-                    # interactive card per call. The hook auto-approve below
-                    # stays fail-closed for these: its auto_approve_tools
-                    # patterns match the agent-authored title, which a child
-                    # could forge.
-                    if parent_policy == "auto" and event.child_unconditional_grant_eligible:
-                        await self._approve_and_log(
-                            client,
-                            event.request_id,
-                            session_key,
-                            event,
-                            metadata={
-                                "subagent_id": info.id,
-                                "reason": "parent_policy_auto",
-                                "child_mcp_identity": (
-                                    f"{event.mcp_server_name}/{event.tool_name}"
-                                ),
-                                "child_args_unverified": True,
-                            },
-                            info=info,
-                        )
-                        continue
-                    # Backend-internal child origin whose SECURITY context is
-                    # absent (structured params missing, unresolved shell
-                    # classification, or shell without a recoverable command —
-                    # AcpEvent.child_low_fidelity): any AUTO-approve would
-                    # rest on the LLM-authored title alone, so skip the hook
-                    # auto-approve and parent_policy=auto branches. When an
-                    # interactive approver IS configured — the per-subagent
-                    # factory, or the gateway-level _on_tool_approval
-                    # fallback the non-child path below also uses — hand the
-                    # decision to it: that is a human/host judgment, the same
-                    # downgrade the dashboard's card provides. Only a truly
-                    # headless consumer fails closed.
-                    _child_fallback = self._on_tool_approval
-                    if self._on_tool_approval_factory or _child_fallback is not None:
-                        # The human must know the title is ALL there is: the
-                        # structured params the policy gates would verify are
-                        # absent, so the displayed text is agent-authored and
-                        # unverifiable. Annotate the prompt so the approval
-                        # is an informed judgment, not a title-only rubber
-                        # stamp.
-                        event.title = (
-                            "⚠️ UNVERIFIED child request (security context "
-                            f"missing — title is agent-authored): {event.title or '<unknown tool>'}"
-                        )
-                        approved = False
-                        # Same human-wait lifecycle as the ordinary callback
-                        # branches below: without _awaiting_approval the
-                        # reaper reads a healthy approval wait as a stalled
-                        # subagent after the idle threshold.
-                        info._awaiting_approval = True
-                        try:
-                            if self._on_tool_approval_factory:
-                                approve_cb = self._on_tool_approval_factory(info)
-                                approved = bool(await approve_cb(event))
-                            elif _child_fallback is not None:
-                                approved = bool(
-                                    await _child_fallback(event, info.parent_session_key)
-                                )
-                        except Exception:
-                            logger.exception("child approval callback failed")
-                        finally:
-                            info._awaiting_approval = False
-                            info.last_activity = time.time()
-                        if approved:
-                            await self._approve_and_log(
-                                client,
-                                event.request_id,
-                                session_key,
-                                event,
-                                metadata={
-                                    "subagent_id": info.id,
-                                    "reason": "child_interactive_approved",
-                                },
-                                info=info,
-                            )
-                        else:
-                            await self._reject_and_log(
-                                client,
-                                event.request_id,
-                                session_key,
-                                event,
-                                error="child_interactive_rejected",
-                            )
-                        continue
-                    await self._reject_and_log(
-                        client,
-                        event.request_id,
-                        session_key,
-                        event,
-                        error="child_origin_no_command_context",
-                    )
-                    continue
-                if tool_result.action == TOOL_AUTO_APPROVE:
-                    # The hook granted this by NAME (its `auto_approve_tools`
-                    # globs, or the read-only allowlist). Honour it only while
-                    # each program name in the command still resolves to the
-                    # program it appears to name; a shadowed, agent-tree or
-                    # unidentified resolution DOWNGRADES to the remaining rungs
-                    # below (parent policy, the interactive factory, the
-                    # gateway fallback, or the headless fail-closed reject) —
-                    # never a hard block. This surface runs unattended, which
-                    # makes an unverified name the cheaper attack path here,
-                    # not the rarer one.
-                    _ng_refusal = await name_grant.refusal_for_event(event)
-                    if _ng_refusal is None:
-                        await self._approve_and_log(
-                            client,
-                            event.request_id,
-                            session_key,
-                            event,
-                            metadata={"subagent_id": info.id, "reason": "hook_auto_approve"},
-                            info=info,
-                        )
-                        continue
-                    logger.warning(
-                        "declining a hook auto-approve: %s; the request falls "
-                        "through to the subagent's normal approval path",
-                        _ng_refusal.log_text,
-                    )
-                    name_grant.log_decline(
-                        source="subagent",
-                        session_key=session_key,
-                        event=event,
-                        refusal=_ng_refusal,
-                        tier="hook_auto_approve",
-                        metadata={"subagent_id": info.id},
-                        sel_factory=sel,
-                    )
-                if parent_policy == "auto":
-                    await self._approve_and_log(
-                        client,
-                        event.request_id,
-                        session_key,
-                        event,
-                        metadata={"subagent_id": info.id, "reason": "parent_policy_auto"},
-                        info=info,
-                    )
-                    continue
-                if self._on_tool_approval_factory:
-                    approve_cb = self._on_tool_approval_factory(info)
-                    info._awaiting_approval = True
-                    try:
-                        approved = await approve_cb(event)
-                    finally:
-                        info._awaiting_approval = False
-                        info.last_activity = time.time()
-                    if not approved:
-                        await self._reject_and_log(
-                            client,
-                            event.request_id,
-                            session_key,
-                            event,
-                            metadata={"subagent_id": info.id, "reason": "factory_rejected"},
-                        )
-                        continue
-                    await self._approve_and_log(
-                        client,
-                        event.request_id,
-                        session_key,
-                        event,
-                        metadata={"subagent_id": info.id},
-                        info=info,
-                    )
-                elif self._on_tool_approval:
-                    info._awaiting_approval = True
-                    try:
-                        approved = await self._on_tool_approval(event, info.parent_session_key)
-                    finally:
-                        info._awaiting_approval = False
-                        info.last_activity = time.time()
-                    if not approved:
-                        await self._reject_and_log(client, event.request_id, session_key, event)
-                        continue
-                    await self._approve_and_log(
-                        client,
-                        event.request_id,
-                        session_key,
-                        event,
-                        metadata={"subagent_id": info.id},
-                        info=info,
-                    )
-                else:
-                    # No callback, no auto policy — deny by default
-                    await self._reject_and_log(
-                        client,
-                        event.request_id,
-                        session_key,
-                        event,
-                        metadata={"subagent_id": info.id, "reason": "no_policy_deny_default"},
-                    )
-                    continue
-            elif event.kind == EVENT_TOOL_CALL:
-                # Auto-allowed (kiro-internal) tools surface here as informational
-                # tool_call updates and NEVER as EVENT_PERMISSION_REQUEST, so this
-                # is the only progress signal a simple/read-only subagent task emits.
-                # Count it, record it, and broadcast the same subagent_tool event
-                # the permission path uses so the running-card shows live activity.
-                info.tool_count += 1
-                info.last_tool = event.title or info.last_tool
-                self._note_tool_dispatch(info, event)
-                await self._fire_event(
-                    "subagent_tool",
-                    info,
-                    {
-                        "tool": _redact(event.title or ""),
-                        "tool_kind": event.tool_kind,
-                        "turns": info.turns,
-                        "tool_count": info.tool_count,
-                    },
-                )
-                # Fire PreToolUse hooks for auto-approved tools (informational only)
-                sel().log_tool_invocation(
-                    session_key=session_key,
-                    source="subagent",
-                    tool_name=event.title,
-                    tool_kind=event.tool_kind,
-                    outcome="auto_approved",
-                    metadata={"subagent_id": info.id},
-                )
-                # Cache tool name so PostToolUse can recover it on EVENT_TOOL_RESULT.
-                # Strip "Running: " prefix to match the name passed to PreToolUse hooks.
-                _raw = event.title or ""
-                if _raw.startswith("Running: "):
-                    _raw = _raw[9:]
-                if event.tool_call_id:
-                    _pending_tools[event.tool_call_id] = _raw
-                await fire_tool_hooks(
-                    self.hook_store,
-                    event.title,
-                    event.tool_input,
-                    subagent_id=info.id,
-                    parent_session_key=info.parent_session_key or None,
-                    agent_role=info.agent or None,
-                )
-            elif event.kind == EVENT_TOOL_RESULT:
-                # A FINAL result means the tool is done: drop the attribution
-                # snapshot so a later idle stretch is not judged against a
-                # command that has already returned. A non-final progress frame
-                # is not the end of the tool — the gate is in _note_tool_result.
-                self._note_tool_result(info, event)
-                # Fire PostToolUse hooks (parity with chat_runner). Until this
-                # branch existed, hooks registered for subagent-spawned tools
-                # received PreToolUse but never PostToolUse — losing the
-                # tool_response payload.
-                if self.hook_store is not None:
-                    try:
-                        _tool_name = _pending_tools.pop(event.tool_call_id, "")
-                        _out = _redact((event.tool_output or "")[:2000])
-                        await self.hook_store.fire(
-                            HOOK_EVENT_POST_TOOL_USE,
-                            tool_name=_tool_name,
-                            tool_response={"output": _out},
-                            subagent_id=info.id,
-                            parent_session_key=info.parent_session_key or None,
-                            agent_role=info.agent or None,
-                        )
-                    except Exception:
-                        logger.debug(
-                            "PostToolUse hook error in subagent",
-                            exc_info=True,
-                        )
-            elif event.kind == EVENT_COMPLETE:
-                _complete_event = event
-                break
-
-        # Strip [OPTIONS: ...] tags and redact sensitive content
-        cleaned, _ = extract_options(result_text) if result_text else (result_text, [])
-        if cleaned:
-            from kiro_crew.security import (
-                redact_credentials,
-                redact_exfiltration_urls,
-            )
-
-            cleaned, _ = redact_exfiltration_urls(cleaned)
-            cleaned, _ = redact_credentials(cleaned)
-        # Model-fallback visibility (agent.fallback_model): a run served by a
-        # fallback model must say so in the delivered result — same contract as
-        # the cron/heartbeat annotation and the dashboard notice card. One
-        # shared spelling (llm_helpers.annotate_model_fallback) redacts the
-        # config-sourced model ids the same way as the result body.
-        cleaned = annotate_model_fallback(cleaned, client)
-        info.result = cleaned or "_No response._"
-        # Cap disk file and trim memory — gateway decides how much to show based on mode.
-        if info.result_path:
-            cap_result_file(Path(info.result_path))
-        # Flag whether the completion-event copy will drop content, so the gateway
-        # emits a summary + result_path pointer (read on demand) instead of a lossy
-        # blob. The full transcript stays in result.txt for the TTL grace window.
-        info.result_truncated = (
-            self._completion_keep_chars > 0 and len(info.result) > self._completion_keep_chars
-        )
-        info.result = apply_completion_keep(
-            info.result,
-            self._completion_keep,
-            self._completion_keep_chars,
-        )
-        evict_completed_agents(self._agents)
-
-        # ── Per-turn usage row: attribute subagent spend. ──
-        # Deliberately BEFORE `info.done`: the caller's cleanup (which awaits
-        # provider.shutdown() -> handle.destroy()) runs after this function
-        # returns, so an await placed after `done` sits inside the
-        # done-to-teardown window. Waiters that poll for `done` would then
-        # observe completion while this file write is still in flight — which
-        # widens that window on slow filesystems and lets teardown-observing
-        # callers race it. Writing first also means `done` never becomes
-        # visible with the usage row still missing.
-        try:
-            # circular import: reached while kiro_crew.slack.handler is still
-            # initialising (dashboard/handlers/files.py imports is_tracked_channel
-            # from it), so a module-scope import raises ImportError under the
-            # suite's import order.
-            from kiro_crew.dashboard.handlers.usage import (
-                persist_token_record_async,
-                read_context_tokens,
-                read_effective_agent,
-            )
-
-            _used, _window = read_context_tokens(client)
-            await persist_token_record_async(
-                session_key,
-                # Blank while a fallback serves this run: the explicit pin
-                # would bill the fallback's spend to a model that never
-                # executed; model_source reports what actually ran.
-                ("" if provider_fallback_active(client) else (info.model or "")),
-                _complete_event,
-                provider="claude_code" if is_cc else "acp",
-                surface="subagent",
-                # Ownership stamp (see _build_token_record): an app-dispatched
-                # subagent's spend must be readable by that app's audit — the
-                # illustrator lane of an app is exactly this path.
-                app=info.app or "",
-                # Explicit/inherited `agent` FIRST here — unlike every other
-                # surface. Under session sharing this subagent reuses the
-                # PARENT's runtime, so read_effective_agent() would report the
-                # parent's agent and misattribute a `spawn_run(agent="…")` turn.
-                # `agent` is already the resolved value (it inherits the parent
-                # session's agent when the spawn did not name one), and the
-                # helper stays as the fallback for when it is empty.
-                agent=agent or read_effective_agent(client) or "",
-                context_used=_used,
-                context_window=_window,
-                elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
-                model_source=client,
-            )
-        except Exception:
-            logger.debug("usage row (subagent) persist failed", exc_info=True)
-
-        info.done = True
-        self._sessions.record_success(session_key)
-
-        Stats().inc_subagent_completed()
-        logger.info("Subagent %s completed", info.id)
+        return await self._run_events._run_inner_impl(info, session_key)
 
     def _should_use_session_sharing(self, info: SubagentInfo) -> bool:
-        """Decide whether a subagent should use the shared-runtime path.
-
-        All must hold: session_sharing config True; parent session exists and
-        is ACP/kiro-backed (not CC); not a CC-specific spawn (model/allowed_tools/bare).
-        """
-        try:
-            cfg = KiroCrewConfig.load()
-            if not cfg.agent.session_sharing:
-                return False
-        except Exception:
-            return False
-        if info.model or info.allowed_tools or info.bare:
-            return False
-        if not info.parent_session_key:
-            return False
-        return self._sessions.is_session_sharing_eligible(info.parent_session_key)
+        return self._run_events._should_use_session_sharing_impl(info)
 
     async def _create_shared_session(
         self, info: SubagentInfo, session_key: str, agent: str
     ) -> "LLMProvider":
-        """Create a subagent session on the parent's AcpRuntime.
-
-        The parent session (provider=kiro) runs on an AcpRuntime via
-        AcpSessionProvider. Subagents create additional sessions on that SAME
-        runtime — one process hosts everything. Falls back to
-        get_subagent_runtime() (companion runtime) if the parent doesn't use
-        AcpSessionProvider. Marks info._session_sharing=True so cleanup calls
-        provider.shutdown() instead of SessionManager.release/reset.
-        """
-        runtime = self._get_parent_runtime(info.parent_session_key)
-        if runtime is None:
-            runtime = await self._sessions.get_subagent_runtime(info.parent_session_key)
-
-        cwd = info.cwd or str(getattr(self._sessions, "_pool_cwd", ""))
-        handle = await runtime.create_session(
-            cwd=cwd or None,
-            agent=agent or None,
-        )
-        provider = AcpSessionProvider(handle, runtime)
-        # This consumer implements the low-fidelity child downgrade (interactive
-        # approver when configured, reject when headless) — opt in so the
-        # handle-level fail-close gate yields those events instead of rejecting.
-        provider.child_fidelity_aware = True
-        info._session_sharing = True
-        info._shared_provider = provider
-        if runtime.pid:
-            info._pid = runtime.pid
-            update_state(info.id, pid=runtime.pid, pid_recorded_at=time.time())
-        logger.info(
-            "Subagent %s using session sharing on runtime PID %s (session %s, key %s)",
-            info.id,
-            runtime.pid,
-            handle.session_id,
-            session_key,
-        )
-        return provider
+        return await self._run_events._create_shared_session_impl(info, session_key, agent)
 
     def _get_parent_runtime(self, parent_session_key: str) -> "AcpRuntime | None":
-        """Extract the AcpRuntime from the parent session's provider.
-
-        Returns the runtime if the parent uses AcpSessionProvider (kiro unified
-        path), or None if the parent uses AcpClient (CC or legacy).
-        """
-        provider = self._sessions.get_provider(parent_session_key)
-        if provider is None:
-            return None
-        inner = getattr(provider, "client", None) or getattr(provider, "_client", None)
-        if isinstance(inner, AcpSessionProvider):
-            return inner._runtime
-        return None
+        return self._run_events._get_parent_runtime_impl(parent_session_key)
 
     @staticmethod
     def _is_cc_provider(provider: object) -> bool:
@@ -6646,185 +2264,103 @@ class SubagentManager:
         task.cancel()
 
     def _unqueue(self, agent_id: str) -> bool:
-        """Drop a not-yet-started spawn from the stagger queue. True if removed.
-
-        The queue is the only record of a waiting run — `spawn` returns its queued
-        SubagentInfo without registering it in ``_agents`` — so removing the entry
-        is what makes a cancel take effect before the work exists. Also re-emits the
-        parent's queued depth, or the chip keeps counting an agent that will never
-        run.
-        """
-        keep = [p for p in self._queue if str(p.get("_preassigned_id") or "") != agent_id]
-        if len(keep) == len(self._queue):
-            return False
-        dropped = [p for p in self._queue if str(p.get("_preassigned_id") or "") == agent_id]
-        self._queue = keep
-        for p in dropped:
-            try:
-                self._emit_queue_depth(
-                    str(p.get("parent_session_key", "")), str(p.get("batch_id", ""))
-                )
-            except Exception:
-                logger.debug("queue-depth re-emit failed after unqueue", exc_info=True)
-        return True
+        return self._cancellation._unqueue_impl(agent_id)
 
     async def cancel(self, agent_id: str) -> bool:
-        """Cancel a single running subagent. Returns True if found and cancelled.
-
-        User-initiated stop is a neutral terminal state, not an error: partial
-        output is preserved on the info record (and remains in result.txt), the
-        tombstone is written as ``user_stop``, and the ``subagent_done`` event
-        carries ``stopped: true`` so the UI renders a neutral "stopped" card.
-        """
-        info = self._agents.get(agent_id)
-        if not info or info.done:
-            # A run still WAITING behind the stagger has no `_agents` record at
-            # all: `spawn` builds its queued SubagentInfo and returns it without
-            # registering. So this used to answer False and leave the entry in the
-            # queue, which the drain later started — the stop was reported as
-            # ineffective while the work ran anyway, and a purge on a deleted
-            # session could not reach it. Unqueueing IS the cancel for that state.
-            if self._unqueue(agent_id):
-                logger.info("Cancelled queued subagent %s before it started", agent_id)
-                return True
-            return False
-        info.user_stopped = True
-        # Neutral semantics live in the RECORD, not just the live event: a user
-        # stop leaves ``error`` unset so every consumer (reconnect snapshots,
-        # tombstones, /api/spawn listing, orphan reconciliation) derives the
-        # same neutral "stopped" status without having to cross-check
-        # ``user_stopped``. _force_reap is also user_stopped-aware and will not
-        # synthesize a reap error for this path.
-        # Preserve whatever streamed before the stop as a partial result.
-        if not info.result and info.streaming_text:
-            info.result = info.streaming_text
-        # _force_reap emits the (single) stopped-aware ``subagent_done`` event
-        # and drives _on_done delivery — no second event here.
-        await self._force_reap(agent_id, info, time.time() - info.started, reason="user_stop")
-        return True
+        return await self._cancellation.cancel_impl(agent_id)
 
     async def cancel_all(self) -> None:
-        """Cancel all running subagents and wait for cleanup."""
-        # Shutdown-driven cancellations must never trigger the one-shot
-        # unexpected-cancel auto-continue (the loop is going away).
-        self._shutting_down = True
-        if self._reaper_task and not self._reaper_task.done():
-            self._reaper_task.cancel()
-            self._reaper_task = None
-        # follow_up watchers: CANCEL AND GATHER FIRST, announce after (GPT
-        # review). The announce awaits — _on_done injection can be slow — and
-        # a busy-retry watcher waking during that await could dispatch a
-        # continuation into the shutting-down gateway, so every watcher task
-        # must be DEAD before anything here yields. Announcing afterwards is
-        # safe: the settle-after-outcome protocol leaves undelivered messages
-        # in their queues, so each is still present to be reported. An
-        # ACCEPTED follow-up must not die silently: the spawn_steer reply
-        # promised the parent a completion event, so each non-empty queue is
-        # announced as a synthetic failure — the parent learns the message was
-        # dropped instead of waiting forever.
-        # Snapshot ids BEFORE cancelling: each watcher's done-callback pops it
-        # from the dict as the gather completes it, so a post-gather snapshot
-        # is already empty.
-        watcher_ids = list(self._followup_watchers)
-        followup_watchers = [t for t in self._followup_watchers.values() if not t.done()]
-        for followup_watcher in followup_watchers:
-            followup_watcher.cancel()
-        if followup_watchers:
-            await asyncio.gather(*followup_watchers, return_exceptions=True)
-        self._followup_watchers.clear()
-        for agent_id in watcher_ids:
-            watcher_info = self._agents.get(agent_id)
-            if watcher_info is not None and watcher_info.pending_followups:
-                dropped = list(watcher_info.pending_followups)
-                watcher_info.pending_followups = []
-                self._audit_followup(watcher_info, "followup_expired")
-                try:
-                    await self._announce_followup_failure(
-                        watcher_info,
-                        "follow_up dropped: the gateway is shutting down before "
-                        "the run completed; the queued message(s) were not "
-                        "dispatched",
-                        messages=dropped,
-                    )
-                except Exception:  # noqa: BLE001 - shutdown must not wedge here
-                    logger.debug(
-                        "shutdown follow_up announce failed for %s", agent_id, exc_info=True
-                    )
-        tasks_to_await: list[asyncio.Task] = []  # type: ignore[type-arg]
-        for agent_id, task in list(self._tasks.items()):
-            if not task.done():
-                # _shutting_down (set above) is the terminal marker for this
-                # site; the chokepoint enforces the contract mechanically.
-                self._cancel_task_intentionally(task, self._agents.get(agent_id), reason="shutdown")
-                tasks_to_await.append(task)
-        if tasks_to_await:
-            await asyncio.gather(*tasks_to_await, return_exceptions=True)
-        self._tasks.clear()
-        # Shielded terminal reports keep running after their awaiter is
-        # cancelled (that is the point). Drain them with a BOUNDED wait so a
-        # report is not orphaned by a closing event loop, without letting a
-        # wedged injection block shutdown indefinitely.
-        pending_reports = [t for t in self._report_tasks if not t.done()]
-        if pending_reports:
-            try:
-                await asyncio.wait(pending_reports, timeout=_REPORT_DRAIN_TIMEOUT)
-            except Exception:
-                logger.debug("cancel_all: report drain wait failed", exc_info=True)
-            # `asyncio.wait` RETURNS on timeout without touching the stragglers.
-            # Leaving them pending is worse than not shielding at all: shutdown
-            # would proceed while they keep invoking `_on_done` against
-            # tearing-down state, and they would then die when the loop closes —
-            # losing the very report the shield exists to guarantee. So cancel
-            # them explicitly and gather to completion, which also surfaces any
-            # exception into the log instead of an "exception was never
-            # retrieved" warning at interpreter exit.
-            stragglers = [t for t in pending_reports if not t.done()]
-            if stragglers:
-                logger.warning(
-                    "cancel_all: %d terminal report(s) did not drain in %.0fs — "
-                    "cancelling; their completions may not have been delivered",
-                    len(stragglers),
-                    _REPORT_DRAIN_TIMEOUT,
-                )
-                abandoned = [self._report_owners.get(t) for t in stragglers]
-                for report_task in stragglers:
-                    report_task.cancel()
-                try:
-                    await asyncio.gather(*stragglers, return_exceptions=True)
-                except Exception:
-                    logger.debug("cancel_all: straggler gather failed", exc_info=True)
-                # A cancelled report is a LOST delivery, and the terminal record
-                # for it was already written — including a tombstone, which is
-                # exactly what `list_orphans()` uses to exclude a folder from the
-                # next start's reconciliation. Left alone, the outcome is
-                # unrecoverable: never injected, and invisible to the one path
-                # that could still inject it.
-                #
-                # Extending the drain to `_ON_DONE_TIMEOUT` instead was rejected:
-                # it would hold gateway shutdown for up to 20 minutes on a single
-                # wedged injection, which is what the bounded drain exists to
-                # prevent. Bounded shutdown plus recoverable state is strictly
-                # better than unbounded shutdown.
-                #
-                # Only reports cancelled BEFORE `_on_done` returned are re-admitted
-                # — `_reported_to_parent` marks the ones that already reached the
-                # parent, so a cancellation in the later teardown/tombstone waits
-                # does not cause a duplicate delivery on restart.
-                for task, owner in zip(stragglers, abandoned):
-                    if owner is None or not task.cancelled():
-                        continue
-                    if owner._reported_to_parent:
-                        continue
-                    try:
-                        if clear_tombstone(owner.id):
-                            logger.warning(
-                                "cancel_all: %s's completion was not delivered — "
-                                "re-admitted to orphan recovery for the next start",
-                                owner.id,
-                            )
-                    except Exception:
-                        logger.debug(
-                            "cancel_all: failed to re-admit %s to orphan recovery",
-                            owner.id,
-                            exc_info=True,
-                        )
+        return await self._cancellation.cancel_all_impl()
+
+
+# Component implementations deliberately resolve globals through this module:
+# existing integrations patch ``kiro_crew.subagent.*`` after manager creation.
+_COMPONENT_GLOBAL_BINDINGS = (
+    AcpSessionProvider,
+    Any,
+    CONTEXT_GROUP_LESSONS,
+    CONTEXT_GROUP_MEMORY,
+    CONTEXT_GROUP_PROJECT,
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    EVENT_TOOL_CALL,
+    EVENT_TOOL_RESULT,
+    FALLBACK_CANDIDATE_ATTEMPTS,
+    FALLBACK_STORY_ATTR,
+    FallbackState,
+    HOOK_EVENT_POST_TOOL_USE,
+    KiroCrewConfig,
+    LLMEvent,
+    LivenessOracle,
+    OUTCOME_FAILED,
+    OUTCOME_INTERRUPTED,
+    PROVIDER_LABEL_DEFAULT,
+    Path,
+    SUBAGENT_COMPLETION_PREFIX,
+    Stats,
+    TOOL_AUTO_APPROVE,
+    TOOL_DENY,
+    TRANSIENT_RETRIES,
+    VERDICT_DEAD,
+    VERDICT_STUCK_INPUT,
+    VERDICT_UNKNOWN,
+    VERDICT_WORKING,
+    _AGENT_NAME_RE,
+    _agent_dir,
+    _cleanup_session_files_sync,
+    _subagents_dir,
+    _ws_result_path,
+    acp_error_is_transient,
+    advance_fallback_candidate,
+    agent_dir_for_display,
+    annotate_model_fallback,
+    append_cost_sample,
+    append_fallback_story,
+    apply_completion_keep,
+    asyncio,
+    cached_admission_check,
+    cap_result_file,
+    clear_tombstone,
+    compact_cost_log,
+    configured_fallback_chain,
+    consult_offloaded,
+    create_agent_folder,
+    evict_completed_agents,
+    extract_options,
+    fire_tool_hooks,
+    has_dashboard_surface,
+    list_orphans,
+    maintenance_executor,
+    mark_delivered,
+    name_grant,
+    os,
+    platform_compat,
+    provider_fallback_active,
+    prune_stale_tombstones,
+    read_state,
+    redact_credentials,
+    redact_exfiltration_urls,
+    run_in_embed_pool,
+    sel,
+    single_completion_meta,
+    subprocess_executor,
+    time,
+    transient_retry_delay,
+    update_state,
+    uuid,
+    window_for_provider_client,
+    write_result_chunk,
+    write_tombstone,
+)
+_MANAGER_COMPONENTS = (
+    OrphanStallMonitor,
+    TerminalCoordinator,
+    SpawnAdmissionCoordinator,
+    ContinuationCoordinator,
+    WaveDigestCoordinator,
+    RunEventCoordinator,
+    CancellationCoordinator,
+)
+bind_component_globals(_MANAGER_COMPONENTS, globals())
+copy_component_docs(SubagentManager, _MANAGER_COMPONENTS)

--- a/src/kiro_crew/subagent_manager/__init__.py
+++ b/src/kiro_crew/subagent_manager/__init__.py
@@ -1,0 +1,22 @@
+"""Focused coordinators behind the stable SubagentManager facade."""
+
+from ._component import bind_component_globals, copy_component_docs
+from .admission import SpawnAdmissionCoordinator
+from .cancellation import CancellationCoordinator
+from .continuation import ContinuationCoordinator
+from .monitoring import OrphanStallMonitor
+from .run import RunEventCoordinator
+from .terminal import TerminalCoordinator
+from .waves import WaveDigestCoordinator
+
+__all__ = [
+    "bind_component_globals",
+    "copy_component_docs",
+    "OrphanStallMonitor",
+    "TerminalCoordinator",
+    "SpawnAdmissionCoordinator",
+    "ContinuationCoordinator",
+    "WaveDigestCoordinator",
+    "RunEventCoordinator",
+    "CancellationCoordinator",
+]

--- a/src/kiro_crew/subagent_manager/_component.py
+++ b/src/kiro_crew/subagent_manager/_component.py
@@ -1,0 +1,57 @@
+"""Shared plumbing for composed SubagentManager coordinators."""
+
+from __future__ import annotations
+
+from types import FunctionType
+from typing import TYPE_CHECKING, Any, Iterable
+
+if TYPE_CHECKING:
+    from ..subagent import SubagentManager
+
+
+class ManagerComponent:
+    """Hold the facade that owns all mutable manager state."""
+
+    _manager: SubagentManager
+    __slots__ = ("_manager",)
+
+    def __init__(self, manager: SubagentManager) -> None:
+        object.__setattr__(self, "_manager", manager)
+
+
+def bind_component_globals(
+    component_types: Iterable[type[ManagerComponent]], namespace: dict[str, Any]
+) -> None:
+    """Bind implementations to ``subagent`` globals for patch compatibility."""
+    for component_type in component_types:
+        for name, implementation in tuple(vars(component_type).items()):
+            if not name.endswith("_impl") or not isinstance(implementation, FunctionType):
+                continue
+            if implementation.__globals__ is namespace:
+                continue
+            rebound = FunctionType(
+                implementation.__code__,
+                namespace,
+                implementation.__name__,
+                implementation.__defaults__,
+                implementation.__closure__,
+            )
+            rebound.__kwdefaults__ = implementation.__kwdefaults__
+            rebound.__annotations__ = implementation.__annotations__
+            rebound.__dict__.update(implementation.__dict__)
+            rebound.__doc__ = implementation.__doc__
+            rebound.__module__ = implementation.__module__
+            rebound.__qualname__ = implementation.__qualname__
+            setattr(component_type, name, rebound)
+
+
+def copy_component_docs(
+    facade_type: type[Any], component_types: Iterable[type[ManagerComponent]]
+) -> None:
+    """Keep the facade's runtime method documentation intact."""
+    for component_type in component_types:
+        for name, implementation in vars(component_type).items():
+            if not name.endswith("_impl") or not isinstance(implementation, FunctionType):
+                continue
+            facade_method = getattr(facade_type, name.removesuffix("_impl"))
+            facade_method.__doc__ = implementation.__doc__

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -1,0 +1,792 @@
+"""Admission behavior for the SubagentManager facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._component import ManagerComponent
+
+if TYPE_CHECKING:
+    from ..subagent import (
+        KiroCrewConfig,
+        Stats,
+        SubagentInfo,
+        _context_groups_field,
+        _validate_agent,
+        _vet_spawn_governance,
+        asyncio,
+        cached_admission_check,
+        check_memory_available,
+        create_agent_folder,
+        logger,
+        redact_credentials,
+        redact_exfiltration_urls,
+        sel,
+        time,
+        uuid,
+        validate_cwd,
+    )
+
+
+class SpawnAdmissionCoordinator(ManagerComponent):
+    """Own admission transitions while state remains facade-owned."""
+
+    __slots__ = ()
+
+    def spawn_impl(
+        self,
+        task: str,
+        parent_session_key: str = "",
+        agent: str = "",
+        max_turns: int = 0,
+        model: str | None = None,
+        reasoning_effort: str = "",
+        allowed_tools: list[str] | None = None,
+        bare: bool = False,
+        cwd: str = "",
+        approval_mode: str | None = None,
+        silent: bool = False,
+        batch_id: str = "",
+        batch_total: int = 0,
+        keep: bool = False,
+        conversation_key: str = "",
+        app: str = "",
+        include_memory: bool = True,
+        include_lessons: bool = True,
+        include_project: bool = True,
+        _agent_prevalidated: bool = False,
+        _from_queue: bool = False,
+        _preassigned_id: str = "",
+    ) -> SubagentInfo | None:
+        """Spawn a subagent for *task*.
+
+        Approval priority (first match wins):
+
+        1. YOLO mode → immediate execution
+        2. ``approval_mode="auto"`` from caller → immediate execution
+        3. ``auto_approve_subagent_spawn`` config → auto-approved execution
+        4. ``on_spawn_approval`` callback → interactive approval
+        5. Otherwise → rejected
+
+        When ``approval_mode="auto"`` is set, it has two effects:
+        - Skips the spawn approval gate (this method)
+        - Sets the subagent's session-level tool approval policy to
+          "auto" in ``_run_inner()``, meaning all tool calls within
+          the subagent are auto-approved for its entire lifetime.
+
+        This dual behavior is intentional for headless callers (e.g.
+        Mochi bg agent) that have no UI to respond to approval prompts.
+        The parameter is only accepted via the internal ``POST /api/spawn``
+        endpoint (requires X-Internal-Secret), not from LLM tool calls.
+
+        Args:
+            task (str): The prompt/task description for the subagent.
+            parent_session_key (str): Session key of the caller.
+            agent (str): Agent name override (default: "kirocrew").
+            model (str): Model override for CC provider (ignored for ACP).
+            reasoning_effort (str): Per-call reasoning-effort override; wins
+                over the ``role_efforts['subagent']`` pin. ``""`` defers to it.
+            allowed_tools (list): Tool allowlist for CC provider (ignored for ACP).
+            bare (bool): Launch CC in bare mode (ignored for ACP).
+            cwd (str): Optional absolute path where the subagent subprocess
+                launches instead of the default ``subagent_<id>`` sandbox.
+                Validated against ``AgentConfig.subagent_cwd_allowed_roots``;
+                rejected spawns return a done ``SubagentInfo`` with ``error``
+                set. Enables cwd-relative resource globs (``AGENTS.md``,
+                ``.kiro/steering``, ``CLAUDE.md``) to resolve correctly.
+            approval_mode (str | None): "auto" to skip spawn gate and
+                set session-level auto-approve.  Only honored from
+                authenticated internal callers (X-Internal-Secret).
+            silent (bool): Suppress completion notifications.
+
+        Returns:
+            SubagentInfo | None: Agent metadata, or None if at capacity.
+        """
+        # Identity is assigned ONCE, here, and used by every exit path — the
+        # queued return, each rejection, and the started record. That is what
+        # makes the id the caller is handed the id it will actually see again:
+        # ``spawn_run`` prints this id into its wave roster, and the dashboard
+        # resolves a wave by matching those printed ids against live per-agent
+        # events. A drained spawn passes the id it was queued under back in via
+        # ``_preassigned_id``, so a member that waits behind the stagger /
+        # concurrency gate keeps its identity across the round-trip instead of
+        # being announced under one id and starting under another.
+        agent_id: str = _preassigned_id or uuid.uuid4().hex[:8]
+        # Submission accounting: count this member as
+        # submitted BEFORE any rejection or queue/registration branching. A
+        # member refused below (empty task, low memory, bad cwd, governance)
+        # never registers and never completes — if it weren't counted here,
+        # batch_members_pending() would see submitted < expected FOREVER and
+        # the wave digest would never fire, permanently stranding every
+        # sibling's held result. A queued member re-enters
+        # spawn() via _drain_queue — never double-count it.
+        if batch_id and not _from_queue:
+            _bs = self._manager._batch_submitted.setdefault(batch_id, [0, max(0, int(batch_total))])
+            _bs[0] += 1
+            self._manager._batch_progress_ts[batch_id] = time.time()
+        # --- Task guard: refuse empty/whitespace-only tasks (defense in depth).
+        # The HTTP handler (api_spawn) and MCP tool schemas validate too, but
+        # direct Python callers reach this choke point unvalidated. An empty
+        # task produces a useless subagent and a blank Activity card. Must run
+        # BEFORE the redaction below, which would raise on a None task. ---
+        if not task or not task.strip():
+            logger.warning("Subagent spawn refused: empty task (parent=%s)", parent_session_key)
+            # Audit is best-effort: the rejection must be returned even if
+            # SEL is unavailable (a graceful refusal must not become an
+            # unhandled exception in api_spawn / MCP tool callers).
+            try:
+                sel().log_tool_invocation(
+                    session_key=parent_session_key or "",
+                    source="subagent",
+                    tool_name="spawn_run",
+                    outcome="rejected_empty_task",
+                    metadata={"agent": agent},
+                )
+            except Exception:
+                logger.debug("SEL audit failed for empty-task rejection", exc_info=True)
+            return self._manager._announce_rejection(
+                SubagentInfo(
+                    id=agent_id,
+                    task="",
+                    agent=agent,
+                    parent_session_key=parent_session_key,
+                    done=True,
+                    error="spawn refused: task must be a non-empty string",
+                    batch_id=batch_id,
+                    batch_total=max(0, int(batch_total)),
+                )
+            )
+
+        # --- Redact task once for all SubagentInfo storage (raw task kept for kiro-cli prompt) ---
+        _redacted_task = redact_credentials(redact_exfiltration_urls(task)[0])[0]
+
+        # --- Memory guard: refuse to spawn if system memory is critically low ---
+        try:
+            min_mem = KiroCrewConfig.load().agent.spawn_min_memory_gb
+        except Exception:
+            min_mem = 4.0
+        mem_ok, avail_gb = check_memory_available(min_gb=min_mem)
+        if not mem_ok:
+            logger.warning(
+                "Subagent spawn refused: only %.2f GB available (min %.1f GB required)",
+                avail_gb,
+                min_mem,
+            )
+            sel().log_tool_invocation(
+                session_key=parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="refused_low_memory",
+                metadata={
+                    "available_gb": avail_gb,
+                    "min_gb": min_mem,
+                    "task": _redacted_task[:120],
+                },
+            )
+            info = SubagentInfo(
+                id=agent_id,
+                task=_redacted_task,
+                agent=agent,
+                parent_session_key=parent_session_key,
+                done=True,
+                error=f"spawn refused: only {avail_gb:.1f} GB memory available (need {min_mem:.0f} GB)",
+                batch_id=batch_id,
+                batch_total=max(0, int(batch_total)),
+            )
+            return self._manager._announce_rejection(info)
+
+        # --- Admission gate: refuse NEW spawns while host memory posture is
+        # critical. Complements the absolute spawn_min_memory_gb floor above
+        # with the posture tier (resource_critical_gb) and shares its
+        # off-switch (agent.admission_gate) with the cron scheduler's deferral
+        # gate. This method is sync and runs on the gateway event loop, so it
+        # reads the CACHED off-thread verdict — never inline config/procfs
+        # I/O; bounded staleness is acceptable for pressure-shedding.
+        # In-flight subagents are untouched; direct user chat turns are
+        # not gated; fails open on an unknown posture. ---
+        admission = cached_admission_check()
+        if not admission.admitted:
+            logger.warning("Subagent spawn refused: %s", admission.reason)
+            sel().log_tool_invocation(
+                session_key=parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="refused_memory_critical",
+                metadata={
+                    "available_gb": admission.available_gb,
+                    "posture": admission.posture,
+                    "task": _redacted_task[:120],
+                },
+            )
+            info = SubagentInfo(
+                id=agent_id,
+                task=_redacted_task,
+                agent=agent,
+                parent_session_key=parent_session_key,
+                done=True,
+                error=f"spawn refused: {admission.reason}",
+                batch_id=batch_id,
+                batch_total=max(0, int(batch_total)),
+            )
+            return self._manager._announce_rejection(info)
+
+        # --- CWD validation: reject bad paths before consuming a slot ---
+        resolved_cwd = ""
+        if cwd:
+            try:
+                allowed_roots = KiroCrewConfig.load().agent.subagent_cwd_allowed_roots
+            except Exception:
+                # Fail closed: if config is unavailable, treat cwd override as
+                # disabled. Defaulting to the permissive default here would
+                # silently re-enable the feature for admins who set
+                # subagent_cwd_allowed_roots=[] to disable it.
+                allowed_roots = []
+            resolved_cwd, cwd_err = validate_cwd(cwd, allowed_roots)
+            if cwd_err:
+                logger.warning("Subagent spawn refused: invalid cwd %r: %s", cwd, cwd_err)
+                sel().log_tool_invocation(
+                    session_key=parent_session_key or "",
+                    source="subagent",
+                    tool_name="spawn_run",
+                    outcome="rejected_invalid_cwd",
+                    metadata={"cwd": cwd[:200], "reason": cwd_err, "task": _redacted_task[:120]},
+                )
+                info = SubagentInfo(
+                    id=agent_id,
+                    task=_redacted_task,
+                    agent=agent,
+                    parent_session_key=parent_session_key,
+                    done=True,
+                    error=f"spawn refused: {cwd_err}",
+                    batch_id=batch_id,
+                    batch_total=max(0, int(batch_total)),
+                )
+                return self._manager._announce_rejection(info)
+
+        # --- Governance: spawn capability gate (blast-radius containment) ---
+        # A policy/profile may disable sub-agent spawning entirely, or bound it
+        # to named agents (capabilities.spawn.scopes.agents).  Resolved against
+        # the PARENT surface so a per-app/per-surface profile contains what it
+        # can spawn — even if the kiro side would allow it.
+        gov_spawn_err = _vet_spawn_governance(parent_session_key, agent, app=app)
+        if gov_spawn_err:
+            logger.warning("Subagent spawn refused by governance: %s", gov_spawn_err)
+            sel().log_tool_invocation(
+                session_key=parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="denied",
+                error=gov_spawn_err,
+                metadata={"agent": agent, "task": _redacted_task[:120]},
+            )
+            return self._manager._announce_rejection(
+                SubagentInfo(
+                    id=agent_id,
+                    task=_redacted_task,
+                    agent=agent,
+                    parent_session_key=parent_session_key,
+                    done=True,
+                    error=f"spawn refused by governance: {gov_spawn_err}",
+                    batch_id=batch_id,
+                    batch_total=max(0, int(batch_total)),
+                )
+            )
+
+        now = time.monotonic()
+        should_queue, slot_free = self._manager._should_stagger_queue(now)
+        if should_queue:
+            # A prevalidated app spawn must NOT sit in the queue. _agent_prevalidated
+            # skips the agent-directory ownership scan on drain (it was validated
+            # off the loop at request time); if it waited in the queue, the app
+            # could be disabled and its agent file removed meanwhile, and the drain
+            # would then run a same-named FOREIGN agent under the app's auto-approval
+            # without re-checking ownership. Fail closed: reject so the caller
+            # re-requests and re-validates ownership fresh. Only the app SpawnSDK
+            # sets _agent_prevalidated, and because such a spawn never enters the
+            # queue, a drain re-entry (_from_queue) never carries the flag.
+            if _agent_prevalidated:
+                logger.warning(
+                    "Rejecting prevalidated app spawn that would queue "
+                    "(agent=%s, app=%s): retry to revalidate ownership",
+                    agent,
+                    app,
+                )
+                return self._manager._announce_rejection(
+                    SubagentInfo(
+                        id=agent_id,
+                        task=_redacted_task,
+                        agent=agent,
+                        parent_session_key=parent_session_key,
+                        done=True,
+                        error=(
+                            "spawn queue is at capacity; the app spawn was not queued "
+                            "to avoid a stale ownership check — retry to revalidate and "
+                            "spawn"
+                        ),
+                        batch_id=batch_id,
+                        batch_total=max(0, int(batch_total)),
+                    )
+                )
+            # Carry this spawn's id (assigned at the top) in the queue entry so
+            # the drained spawn runs under it. The identity must survive the
+            # round-trip because it is the only handle the caller gets: spawn_run
+            # prints the id this call returns, and the inline SubagentRunCard
+            # resolves a wave by matching those printed ids against live
+            # per-agent events. Returning a throwaway sentinel (the old
+            # ``q<n>``) and minting a fresh uuid on drain meant every wave member
+            # after the first was announced under an id no agent ever had — with
+            # the default 2s stagger that is EVERY member after the first, so a
+            # 2-agent wave permanently rendered "1 agent running" while the
+            # sidebar and Subagents panel correctly showed 2.
+            self._manager._queue.append(
+                {
+                    "task": task,
+                    "parent_session_key": parent_session_key,
+                    "agent": agent,
+                    "max_turns": max_turns,
+                    "model": model,
+                    "reasoning_effort": reasoning_effort,
+                    "allowed_tools": allowed_tools,
+                    "bare": bare,
+                    "cwd": resolved_cwd,
+                    "approval_mode": approval_mode,
+                    "silent": silent,
+                    "batch_id": batch_id,
+                    "batch_total": batch_total,
+                    "keep": keep,
+                    "conversation_key": conversation_key,
+                    "app": app,
+                    "include_memory": include_memory,
+                    "include_lessons": include_lessons,
+                    "include_project": include_project,
+                    "_agent_prevalidated": _agent_prevalidated,
+                    "_preassigned_id": agent_id,
+                }
+            )
+            logger.info(
+                "Subagent queued (%d running, %d queued, slot_free=%s)",
+                self._manager._running_count,
+                len(self._manager._queue),
+                slot_free,
+            )
+            # Advisory UI signal: tell the chip how many agents are now waiting
+            # to start for this parent so it can appear immediately and show a
+            # "waiting" count instead of only running/completed ones.
+            self._manager._emit_queue_depth(parent_session_key, batch_id)
+            # If a slot is free, no running agent will trigger the drain on
+            # completion — schedule the staggered pump at the interval boundary
+            # so the queued spawn still launches.
+            if slot_free:
+                delay = max(
+                    0.0, self._manager._spawn_stagger_secs - (now - self._manager._last_spawn_ts)
+                )
+                try:
+                    asyncio.get_event_loop().call_later(delay, self._manager._drain_queue)
+                except RuntimeError:
+                    pass  # no running loop (sync/test context)
+            info = SubagentInfo(
+                id=agent_id,
+                task=_redacted_task,
+                agent=agent,
+                app=app,
+                queued=True,
+                batch_id=batch_id,
+                batch_total=max(0, int(batch_total)),
+                include_memory=include_memory,
+                include_lessons=include_lessons,
+                include_project=include_project,
+            )
+            return info
+
+        # `_agent_prevalidated` skips the on-loop agent-directory scan: a caller
+        # that already confirmed the agent exists OFF the loop (the app SpawnSDK
+        # validates via `list_agents()` in a thread) would otherwise make
+        # `_validate_agent` re-scan/stat every agent file synchronously here,
+        # stalling chat and the heartbeat on a populated agents directory. Only
+        # the app path sets it; every other caller still validates inline.
+        if agent and not _agent_prevalidated:
+            # Validate against the cwd the subagent will ACTUALLY run in. When no
+            # explicit cwd was given the runtime falls back to the session pool's
+            # cwd, so validating only the explicit value refused a project agent
+            # kiro-cli would have loaded — the same interface asymmetry the project
+            # scope exists to remove, just one layer down.
+            effective_cwd = resolved_cwd or str(
+                getattr(self._manager._sessions, "_pool_cwd", "") or ""
+            )
+            agent, err = _validate_agent(agent, effective_cwd)
+            if err:
+                info = SubagentInfo(
+                    id=agent_id,
+                    task=_redacted_task,
+                    agent="",
+                    parent_session_key=parent_session_key,
+                    done=True,
+                    error=err,
+                    batch_id=batch_id,
+                    batch_total=max(0, int(batch_total)),
+                )
+                return self._manager._announce_rejection(info)
+
+        info = SubagentInfo(
+            id=agent_id,
+            task=_redacted_task,
+            parent_session_key=parent_session_key,
+            agent=agent,
+            app=app,
+            approval_mode=approval_mode or "",
+            silent=silent,
+            max_turns=max_turns,
+            model=model or "",
+            reasoning_effort=reasoning_effort or "",
+            allowed_tools=list(allowed_tools) if allowed_tools else [],
+            bare=bare,
+            cwd=resolved_cwd,
+            batch_id=batch_id,
+            batch_total=max(0, int(batch_total)),
+            keep=keep,
+            conversation_key=conversation_key,
+            include_memory=include_memory,
+            include_lessons=include_lessons,
+            include_project=include_project,
+        )
+        info._raw_task = task  # unredacted prompt for kiro-cli execution
+        self._manager._agents[agent_id] = info
+        self._manager._running_count += 1
+        self._manager._last_spawn_ts = time.monotonic()  # stagger gate: one start per interval
+        # Batch lifecycle: announce the wave ONCE, on its first member to
+        # actually start (queued members haven't started yet — the event marks
+        # execution begin, and the UI uses it to key batch progress).
+        if batch_id and batch_id not in self._manager._seen_batches:
+            self._manager._seen_batches.add(batch_id)
+            try:
+                loop = asyncio.get_event_loop()
+                loop.create_task(
+                    self._manager._fire_event(
+                        "spawn_batch_started",
+                        info,
+                        {"batch_id": batch_id, "count": info.batch_total},
+                    )
+                )
+            except RuntimeError:
+                pass  # no running loop (sync/test context)
+
+        # Check parent session trust (approval_policy="auto") set by dashboard trust toggle.
+        parent_trusted = (
+            parent_session_key
+            and self._manager._sessions.get_approval_policy(parent_session_key) == "auto"
+        )
+
+        if self._manager._is_yolo and self._manager._is_yolo():
+            self._manager._tasks[agent_id] = asyncio.create_task(self._manager._run(info))
+            self._manager._log_spawned(info)
+        elif approval_mode == "auto":
+            self._manager._tasks[agent_id] = asyncio.create_task(self._manager._run(info))
+            self._manager._log_spawned(info)
+            sel().log_tool_invocation(
+                session_key=info.parent_session_key,
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="auto_approved_spawn",
+                metadata={"subagent_id": agent_id, "reason": "approval_mode_auto"},
+            )
+        elif parent_trusted:
+            self._manager._tasks[agent_id] = asyncio.create_task(self._manager._run(info))
+            self._manager._log_spawned(info)
+            sel().log_tool_invocation(
+                session_key=info.parent_session_key,
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="auto_approved_spawn",
+                metadata={"subagent_id": agent_id, "reason": "parent_trusted"},
+            )
+        elif self._manager._ctx_builder and self._manager._ctx_builder.hooks:
+            if self._manager._ctx_builder.hooks.auto_approve_subagent_spawn is True:
+                self._manager._tasks[agent_id] = asyncio.create_task(self._manager._run(info))
+                self._manager._log_spawned(info)
+                sel().log_tool_invocation(
+                    session_key=info.parent_session_key,
+                    source="subagent",
+                    tool_name="spawn_run",
+                    outcome="auto_approved_spawn",
+                    metadata={"subagent_id": agent_id, "reason": "tool_calls_gated"},
+                )
+            elif self._manager._on_spawn_approval:
+                self._manager._tasks[agent_id] = asyncio.create_task(
+                    self._manager._spawn_with_approval(info)
+                )
+            else:
+                info.done = True
+                info.error = "spawn rejected: no approval mechanism configured"
+                self._manager._running_count -= 1
+                self._manager._drain_queue()
+                sel().log_tool_invocation(
+                    session_key=info.parent_session_key,
+                    source="subagent",
+                    tool_name="spawn_run",
+                    outcome="rejected_spawn",
+                    metadata={"subagent_id": agent_id, "reason": "no_approval_mechanism"},
+                )
+                # Batch members must still reach the gateway's completion
+                # consumer: this is a REGISTERED rejection
+                # (done=True in _agents), so batch_members_pending() already
+                # counts it as complete — without an announce, a wave whose
+                # final member lands here closes with no event and every held
+                # sibling digest strands forever.
+                return self._manager._announce_rejection(info)
+        elif self._manager._on_spawn_approval:
+            self._manager._tasks[agent_id] = asyncio.create_task(
+                self._manager._spawn_with_approval(info)
+            )
+        else:
+            info.done = True
+            info.error = "spawn rejected: no approval mechanism configured"
+            self._manager._running_count -= 1
+            self._manager._drain_queue()
+            sel().log_tool_invocation(
+                session_key=info.parent_session_key,
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="rejected",
+                metadata={"subagent_id": agent_id, "reason": "no approval mechanism"},
+            )
+            logger.warning("Subagent %s rejected: no approval callback", agent_id)
+            if self._manager._on_done:
+                self._manager._tasks[agent_id] = asyncio.ensure_future(
+                    self._manager._safe_announce(info)
+                )
+
+        return info
+
+    async def _safe_announce_impl(self, info: SubagentInfo) -> None:
+        """Notify completion callback with error handling.
+
+        Args:
+            info (SubagentInfo): The subagent metadata.
+        """
+        assert self._manager._on_done is not None
+        try:
+            await self._manager._on_done(info)
+        except Exception:
+            logger.exception("Subagent announce failed for %s", info.id)
+
+    def _announce_rejection_impl(self, info: SubagentInfo) -> SubagentInfo:
+        """Route a terminal spawn rejection through the done callback.
+
+        A rejected batch member is counted as submitted (top of ``spawn``)
+        but never registers and never reaches ``_run``'s completion path.
+        Without an announce, the gateway's wave accounting never sees its
+        terminal state — and when the rejection is the wave's FINAL
+        submission, no later completion event re-evaluates the wave, so
+        every sibling result already held for the digest strands forever.
+        Announcing lets ``_subagent_done`` count the member
+        as failed and release the digest when it closes the wave.
+
+        Non-batch rejections skip the announce: the caller already receives
+        the error synchronously in the returned info, and injecting a
+        completion turn for them would double-report. That holds for
+        queue-drained non-batch rejections too — ``_drain_queue`` announces
+        those itself off the returned info, so announcing here as well would
+        inject the completion twice.
+        """
+        if info.batch_id and self._manager._on_done:
+            try:
+                self._manager._tasks[f"reject-{info.id}"] = asyncio.ensure_future(
+                    self._manager._safe_announce(info)
+                )
+            except RuntimeError:
+                pass  # no running loop (sync/test context)
+        return info
+
+    def _should_stagger_queue_impl(self, now: float) -> tuple[bool, bool]:
+        """Decide whether a spawn arriving at *now* must be queued.
+
+        Returns ``(should_queue, slot_free)``. A spawn is queued when either no
+        slot is free (at capacity) OR a spawn started within the stagger window
+        (``subagent_spawn_stagger_secs``) — so the initial fill never bursts and
+        no two agents start within the interval (dynamic-subagent-sizing.md §5.3).
+        """
+        slot_free = self._manager._running_count < self._manager._max_concurrent
+        too_soon = (now - self._manager._last_spawn_ts) < self._manager._spawn_stagger_secs
+        return (not slot_free or too_soon, slot_free)
+
+    def _drain_queue_impl(self) -> None:
+        """Spawn the next queued task if a slot is available and the stagger
+        interval has elapsed.
+
+        This is the single staggered pump: at most one start per
+        ``subagent_spawn_stagger_secs`` (dynamic-subagent-sizing.md §5.3). If a
+        slot is free but a spawn started too recently, it reschedules itself at
+        the interval boundary rather than bursting.
+        """
+        if (
+            not self._manager._queue
+            or self._manager._running_count >= self._manager._max_concurrent
+        ):
+            return
+        elapsed = time.monotonic() - self._manager._last_spawn_ts
+        if elapsed < self._manager._spawn_stagger_secs:
+            # Too soon since the last start — reschedule at the boundary.
+            try:
+                asyncio.get_event_loop().call_later(
+                    self._manager._spawn_stagger_secs - elapsed, self._manager._drain_queue
+                )
+            except RuntimeError:
+                pass  # no running loop (sync/test context)
+            return
+        params = self._manager._queue.pop(0)
+        # A run can be cancelled WHILE it waits here — a user stop, or a session
+        # deleted out from under it. Starting it anyway would execute tools for
+        # work already reported as stopped, so skip it and drain the next one
+        # instead: `cancel()` marks the info terminal but cannot unqueue this.
+        queued_id = str(params.get("_preassigned_id") or "")
+        if queued_id:
+            waiting = self._manager._agents.get(queued_id)
+            if waiting is not None and (waiting.done or waiting.user_stopped or waiting.reaped):
+                logger.info("Skipping queued spawn %s: cancelled while waiting", queued_id)
+                self._manager._emit_queue_depth(
+                    str(params.get("parent_session_key", "")), str(params.get("batch_id", ""))
+                )
+                if self._manager._queue:
+                    self._manager._drain_queue()
+                return
+        logger.info(
+            "Draining queue: spawning '%s' (%d left)",
+            str(params.get("task", ""))[:40],
+            len(self._manager._queue),
+        )
+        # The popped item's parent just lost one waiting agent — re-emit its
+        # queued depth (0 when this was its last) so the chip's "waiting" count
+        # tracks the drain. Done before spawn() so an immediate re-queue there
+        # (still too soon since last start) re-bumps it correctly afterwards.
+        self._manager._emit_queue_depth(
+            str(params.get("parent_session_key", "")), str(params.get("batch_id", ""))
+        )
+        # spawn() re-checks the gate; since elapsed >= stagger and a slot is
+        # free, it starts immediately and updates _last_spawn_ts. Forward the FULL
+        # kwarg set so approval_mode / silent / model / allowed_tools / bare survive
+        # the queue round-trip — including `_preassigned_id`, which makes the agent
+        # start under the id its caller was already told (and, if the gate re-queues
+        # it, keeps that id across the second round-trip too).
+        drained = self._manager.spawn(**params, _from_queue=True)
+        # A drained spawn has NO synchronous reader: this call site is a timer
+        # callback, and the original caller was handed a queued info long ago. So a
+        # terminal rejection here — the cwd was deleted while the run waited, the
+        # agent stopped resolving — was dropped on the floor: no completion event,
+        # and the caller's own bookkeeping showed the run as still going. Crew left
+        # such a topic `running` forever.
+        #
+        # Only for NON-batch runs, which is exactly the set `_announce_rejection`
+        # skips (it announces batch members itself, from inside `spawn`). Announcing
+        # regardless double-counted a queued batch rejection: the wave's own
+        # accounting closed early and emitted a duplicate or incomplete digest.
+        if (
+            drained is not None
+            and drained.done
+            and drained.error
+            and not drained.batch_id
+            and self._manager._on_done
+        ):
+            try:
+                self._manager._tasks[f"reject-{drained.id}"] = asyncio.ensure_future(
+                    self._manager._safe_announce(drained)
+                )
+            except RuntimeError:
+                pass  # no running loop (sync/test context)
+        if self._manager._queue and self._manager._running_count < self._manager._max_concurrent:
+            try:
+                asyncio.get_event_loop().call_later(
+                    self._manager._spawn_stagger_secs, self._manager._drain_queue
+                )
+            except RuntimeError:
+                pass
+
+    async def _spawn_with_approval_impl(self, info: SubagentInfo) -> None:
+        """Request approval before starting the subagent.
+
+        If approval is denied the subagent is marked as done with an
+        error and the running count is decremented without executing.
+
+        Args:
+            info (SubagentInfo): The subagent metadata.
+        """
+        assert self._manager._on_spawn_approval is not None
+        request_id: str = f"spawn:{info.id}"
+        try:
+            from kiro_crew.security import (
+                redact_credentials,
+                redact_exfiltration_urls,
+            )
+
+            task_safe, _ = redact_exfiltration_urls(info.task)
+            task_safe, _ = redact_credentials(task_safe)
+            task_preview: str = task_safe[:80]
+            approved: bool = await self._manager._on_spawn_approval(
+                request_id, f"spawn_run({task_preview})", info.parent_session_key
+            )
+        except Exception:
+            logger.exception("Spawn approval failed for %s", info.id)
+            approved = False
+
+        if not approved:
+            info.done = True
+            info.error = "spawn rejected"
+            # Slot accounting through the one-shot token, NOT a bare decrement.
+            # A user Stop funnels into `_force_reap` and can land while this
+            # approval is still pending (a human prompt has no deadline), and
+            # `_force_reap` releases the slot and reports. A bare decrement here
+            # would double-release — driving `_running_count` negative — and the
+            # announce below would double-report the completion.
+            if self._manager._release_slot(info):
+                self._manager._running_count -= 1
+                self._manager._drain_queue()
+            self._manager._tasks.pop(info.id, None)
+            sel().log_tool_invocation(
+                session_key=info.parent_session_key,
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="rejected",
+                metadata={"subagent_id": info.id},
+            )
+            logger.info("Subagent %s spawn rejected", info.id)
+            # Report ownership through the same claim every other terminal path
+            # uses, so a concurrent reap/stop cannot also announce.
+            if self._manager._on_done and self._manager._claim_finalize(info):
+                await self._manager._safe_announce(info)
+            return
+
+        self._manager._log_spawned(info)
+        await self._manager._run(info)
+
+    def _log_spawned_impl(self, info: SubagentInfo) -> None:
+        """Record spawn metrics and audit log entry.
+
+        Args:
+            info (SubagentInfo): The subagent metadata.
+        """
+        # Persist agent folder to disk for orphan recovery
+        try:
+
+            create_agent_folder(
+                info.id,
+                task=info.task,
+                agent=info.agent,
+                parent_session=info.parent_session_key,
+                max_turns=info.max_turns,
+                context_groups=_context_groups_field(info),
+            )
+        except Exception:
+            logger.warning("Failed to create agent folder for %s", info.id, exc_info=True)
+
+        Stats().inc_subagent_spawned()
+        sel().log_tool_invocation(
+            session_key=info.parent_session_key,
+            source="subagent",
+            tool_name="spawn_run",
+            outcome="spawned",
+            metadata={
+                "subagent_id": info.id,
+                "agent": info.agent or "kirocrew",
+                "cwd": info.cwd,
+            },
+        )
+        logger.info("Subagent %s spawned: %s", info.id, info.task[:80])

--- a/src/kiro_crew/subagent_manager/cancellation.py
+++ b/src/kiro_crew/subagent_manager/cancellation.py
@@ -1,0 +1,388 @@
+"""Cancellation behavior for the SubagentManager facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._component import ManagerComponent
+
+if TYPE_CHECKING:
+    from ..subagent import (
+        _ON_DONE_TIMEOUT,
+        _RECOVERY_SLOT_WAIT_SECS,
+        _REPORT_DRAIN_TIMEOUT,
+        _RESET_TIMEOUT,
+        Stats,
+        SubagentInfo,
+        asyncio,
+        clear_tombstone,
+        logger,
+        time,
+    )
+
+
+class CancellationCoordinator(ManagerComponent):
+    """Own cancellation transitions while state remains facade-owned."""
+
+    __slots__ = ()
+
+    def _schedule_cancel_recovery_impl(self, info: SubagentInfo) -> None:
+        """Respawn *info*'s run on a fresh task after an unexpected cancellation.
+
+        Called from ``_run``'s CancelledError handler — the current task is
+        being cancelled and cannot continue itself, so the continuation runs on
+        a new task. One-shot: gated by ``info._cancel_retry_used`` at the call
+        site. The original run's finally block still performs session cleanup
+        (release/reset) but skips terminal finalization while ``_recovering``.
+
+        **Cancellation-source contract.** This branch exists for cancellations
+        that arrive from OUTSIDE the manager's own lifecycle — in practice the
+        parent task tree being torn down around a live subagent (e.g. a
+        dashboard slot reset/removal cancelling background tasks, or an event
+        during gateway component re-init) — mirroring the main path's
+        unexpected-cancel recovery. Every INTENTIONAL cancel site in
+        this module sets a terminal marker before cancelling, and the recovery
+        branch defers to all of them: ``cancel()`` sets ``user_stopped``,
+        ``cancel_all()`` sets ``_shutting_down``, and ``_force_reap`` sets
+        ``reaped`` (checked before the recovery branch). Any NEW code path that
+        cancels a subagent task on purpose MUST set one of those markers first,
+        or the cancel will be treated as unexpected and recovered once.
+
+        Coordination is explicit, not timed: ``_resume`` awaits the ORIGINAL
+        task object to fully complete (its finally does session release/reset,
+        slot decrement, and pops the task registry) before respawning. This
+        guarantees the old finally can neither pop the new task out of
+        ``self._tasks`` nor emit a duplicate completion, and the respawn never
+        starts against a session whose reset is still in flight. The respawn
+        then re-acquires a slot by waiting for capacity (the old finally's
+        ``_drain_queue`` may have admitted a queued spawn into the freed slot),
+        so the concurrency ceiling is never exceeded.
+
+        The pending ``_resume`` task itself is registered in ``self._tasks``
+        (under ``"<id>:recovery"``) so ``cancel_all()`` reaches it during
+        shutdown — a recovery can never outlive or escape manager teardown.
+        """
+        orig_task = asyncio.current_task()
+        recovery_key = f"{info.id}:recovery"
+
+        async def _resume() -> None:
+            try:
+                # Explicit handshake: wait for the original task's finally
+                # (session release/reset, slot decrement, task-registry pop)
+                # to fully complete before respawning. The finally is bounded
+                # (_RESET_TIMEOUT-capped reset), so add slack on top of it.
+                if orig_task is not None:
+                    await asyncio.wait({orig_task}, timeout=_RESET_TIMEOUT + 60)
+                    if not orig_task.done():
+                        logger.error(
+                            "Subagent %s cancel-recovery: original task did not "
+                            "finish teardown in time — aborting recovery",
+                            info.id,
+                        )
+                        raise RuntimeError("original task teardown timed out")
+                if info.done or info._reap_started or info.reaped or self._manager._shutting_down:
+                    info._recovering = False
+                    return
+                # Re-acquire a slot through capacity, not blind increment:
+                # the old finally freed our slot and may have drained a queued
+                # spawn into it. Wait (bounded) for a free slot so recovery
+                # never pushes the pool past max_concurrent.
+                deadline = time.time() + _RECOVERY_SLOT_WAIT_SECS
+                while self._manager._running_count >= self._manager._max_concurrent:
+                    if time.time() >= deadline or self._manager._shutting_down:
+                        raise RuntimeError("no free slot for recovery respawn")
+                    await asyncio.sleep(0.25)
+                if info.done or info._reap_started or info.reaped or self._manager._shutting_down:
+                    info._recovering = False
+                    return
+                info._recovering = False
+                # Claim the slot and launch the respawn ATOMICALLY (no await
+                # between capacity check, increment, and create_task). An await
+                # in that window would let a finishing subagent's _drain_queue
+                # admit a queued spawn into the same slot and push the pool
+                # past max_concurrent. The respawned _run owns the slot from
+                # here (its finally decrements). The informational
+                # subagent_recovering emit happens after, where a cancellation
+                # can no longer leak the counter.
+                self._manager._running_count += 1
+                # The interrupted run's finally already consumed this info's
+                # slot token to free its slot. The respawn occupies a FRESH slot,
+                # so re-arm the token or the respawned run's finally would no-op
+                # and leave `_running_count` permanently inflated.
+                info._slot_released = False
+                self._manager._tasks[info.id] = asyncio.create_task(self._manager._run(info))
+                try:
+                    await self._manager._fire_event("subagent_recovering", info, {"attempt": 1})
+                except Exception:
+                    logger.debug("subagent_recovering emit failed for %s", info.id, exc_info=True)
+            except Exception:
+                logger.exception("Subagent %s cancel-recovery respawn failed", info.id)
+                info._recovering = False
+                # The RECORD keeps its own first-arrival-wins `done` guard...
+                if not info.done and not info._reap_started and not info.reaped:
+                    # Full terminal finalization — the UI must never be left on
+                    # a running card and the parent must still hear about the
+                    # failure (with any partial result) even when the respawn
+                    # itself could not happen.
+                    info.done = True
+                    info.error = "cancelled (recovery failed)"
+                    info.elapsed = time.time() - info.started
+                    Stats().inc_subagent_failed()
+                    self._manager._write_tombstone(info, "cancelled")
+                    self._manager._record_cost(info)
+                if not info.elapsed:
+                    # Report needs an elapsed even when the record above was
+                    # skipped because another path had already set `done`.
+                    info.elapsed = time.time() - info.started
+                # ...and the REPORT goes through the one-shot claim, exactly like
+                # the reap and `_run`'s finally. Routing through the claim (not a
+                # direct `subagent_done`/`_on_done` fire) keeps this from being a
+                # fourth reporter outside the very claim this
+                # class uses to guarantee exactly-once delivery, so a reaper
+                # racing a failed respawn cannot deliver the outcome twice.
+                # Reporting via `_run_terminal_report` also shields the delivery,
+                # which matters here because `_force_reap` cancels this task.
+                if self._manager._claim_finalize(info):
+                    await self._manager._run_terminal_report(
+                        info,
+                        source="Recovery",
+                        injection_timeout_reason=(
+                            f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s "
+                            "(recovery failure)"
+                        ),
+                        mark_delivered_on_success=False,
+                        # Same reasoning as the reap path: settle siblings' holds.
+                        settle_digest=True,
+                    )
+            finally:
+                # Whether respawned, aborted, or cancelled: this pending
+                # recovery is no longer outstanding.
+                _reg = self._manager._tasks.get(recovery_key)
+                if _reg is asyncio.current_task():
+                    self._manager._tasks.pop(recovery_key, None)
+
+        async def _resume_guarded() -> None:
+            try:
+                await _resume()
+            except asyncio.CancelledError:
+                # The pending recovery itself was cancelled (cancel_all during
+                # shutdown, or manager teardown). Terminal by default — a
+                # cancelled recovery NEVER re-recovers; just make sure the
+                # record isn't left in limbo.
+                info._recovering = False
+                _live = self._manager._tasks.get(info.id)
+                if _live is not None and not _live.done():
+                    # Respawn already launched — the live run owns the record
+                    # (its own CancelledError arm is terminal: one-shot flag is
+                    # spent). Don't finalize over it.
+                    raise
+                # `_reap_started`, not just `reaped`: `_force_reap` cancels this
+                # task BEFORE it sets `reaped` (which must stay false until the
+                # reaper owns the record — see `_reap_started`). Consulting only
+                # `reaped` made this arm win the race and persist a neutral user
+                # Stop as a FAILURE, with a failure stat and a "cancelled"
+                # tombstone the reaper could no longer correct.
+                if not info.done and not info._reap_started and not info.reaped:
+                    info.done = True
+                    info.error = "cancelled"
+                    info.elapsed = time.time() - info.started
+                    if not info.user_stopped:
+                        # A user-initiated stop is a neutral outcome, not a
+                        # failure — matching the reap path's own record guard.
+                        Stats().inc_subagent_failed()
+                    self._manager._write_tombstone(info, "cancelled")
+                raise
+
+        _t = asyncio.create_task(_resume_guarded())
+        self._manager._tasks[recovery_key] = _t
+        _t.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+
+    def _unqueue_impl(self, agent_id: str) -> bool:
+        """Drop a not-yet-started spawn from the stagger queue. True if removed.
+
+        The queue is the only record of a waiting run — `spawn` returns its queued
+        SubagentInfo without registering it in ``_agents`` — so removing the entry
+        is what makes a cancel take effect before the work exists. Also re-emits the
+        parent's queued depth, or the chip keeps counting an agent that will never
+        run.
+        """
+        keep = [p for p in self._manager._queue if str(p.get("_preassigned_id") or "") != agent_id]
+        if len(keep) == len(self._manager._queue):
+            return False
+        dropped = [
+            p for p in self._manager._queue if str(p.get("_preassigned_id") or "") == agent_id
+        ]
+        self._manager._queue = keep
+        for p in dropped:
+            try:
+                self._manager._emit_queue_depth(
+                    str(p.get("parent_session_key", "")), str(p.get("batch_id", ""))
+                )
+            except Exception:
+                logger.debug("queue-depth re-emit failed after unqueue", exc_info=True)
+        return True
+
+    async def cancel_impl(self, agent_id: str) -> bool:
+        """Cancel a single running subagent. Returns True if found and cancelled.
+
+        User-initiated stop is a neutral terminal state, not an error: partial
+        output is preserved on the info record (and remains in result.txt), the
+        tombstone is written as ``user_stop``, and the ``subagent_done`` event
+        carries ``stopped: true`` so the UI renders a neutral "stopped" card.
+        """
+        info = self._manager._agents.get(agent_id)
+        if not info or info.done:
+            # A run still WAITING behind the stagger has no `_agents` record at
+            # all: `spawn` builds its queued SubagentInfo and returns it without
+            # registering. So this used to answer False and leave the entry in the
+            # queue, which the drain later started — the stop was reported as
+            # ineffective while the work ran anyway, and a purge on a deleted
+            # session could not reach it. Unqueueing IS the cancel for that state.
+            if self._manager._unqueue(agent_id):
+                logger.info("Cancelled queued subagent %s before it started", agent_id)
+                return True
+            return False
+        info.user_stopped = True
+        # Neutral semantics live in the RECORD, not just the live event: a user
+        # stop leaves ``error`` unset so every consumer (reconnect snapshots,
+        # tombstones, /api/spawn listing, orphan reconciliation) derives the
+        # same neutral "stopped" status without having to cross-check
+        # ``user_stopped``. _force_reap is also user_stopped-aware and will not
+        # synthesize a reap error for this path.
+        # Preserve whatever streamed before the stop as a partial result.
+        if not info.result and info.streaming_text:
+            info.result = info.streaming_text
+        # _force_reap emits the (single) stopped-aware ``subagent_done`` event
+        # and drives _on_done delivery — no second event here.
+        await self._manager._force_reap(
+            agent_id, info, time.time() - info.started, reason="user_stop"
+        )
+        return True
+
+    async def cancel_all_impl(self) -> None:
+        """Cancel all running subagents and wait for cleanup."""
+        # Shutdown-driven cancellations must never trigger the one-shot
+        # unexpected-cancel auto-continue (the loop is going away).
+        self._manager._shutting_down = True
+        if self._manager._reaper_task and not self._manager._reaper_task.done():
+            self._manager._reaper_task.cancel()
+            self._manager._reaper_task = None
+        # Follow-up watchers are cancelled and gathered before announcing.
+        # The announce awaits — _on_done injection can be slow — and
+        # a busy-retry watcher waking during that await could dispatch a
+        # continuation into the shutting-down gateway, so every watcher task
+        # must be DEAD before anything here yields. Announcing afterwards is
+        # safe: the settle-after-outcome protocol leaves undelivered messages
+        # in their queues, so each is still present to be reported. An
+        # ACCEPTED follow-up must not die silently: the spawn_steer reply
+        # promised the parent a completion event, so each non-empty queue is
+        # announced as a synthetic failure — the parent learns the message was
+        # dropped instead of waiting forever.
+        # Snapshot ids BEFORE cancelling: each watcher's done-callback pops it
+        # from the dict as the gather completes it, so a post-gather snapshot
+        # is already empty.
+        watcher_ids = list(self._manager._followup_watchers)
+        followup_watchers = [t for t in self._manager._followup_watchers.values() if not t.done()]
+        for followup_watcher in followup_watchers:
+            followup_watcher.cancel()
+        if followup_watchers:
+            await asyncio.gather(*followup_watchers, return_exceptions=True)
+        self._manager._followup_watchers.clear()
+        for agent_id in watcher_ids:
+            watcher_info = self._manager._agents.get(agent_id)
+            if watcher_info is not None and watcher_info.pending_followups:
+                dropped = list(watcher_info.pending_followups)
+                watcher_info.pending_followups = []
+                self._manager._audit_followup(watcher_info, "followup_expired")
+                try:
+                    await self._manager._announce_followup_failure(
+                        watcher_info,
+                        "follow_up dropped: the gateway is shutting down before "
+                        "the run completed; the queued message(s) were not "
+                        "dispatched",
+                        messages=dropped,
+                    )
+                except Exception:  # noqa: BLE001 - shutdown must not wedge here
+                    logger.debug(
+                        "shutdown follow_up announce failed for %s", agent_id, exc_info=True
+                    )
+        tasks_to_await: list[asyncio.Task] = []  # type: ignore[type-arg]
+        for agent_id, task in list(self._manager._tasks.items()):
+            if not task.done():
+                # _shutting_down (set above) is the terminal marker for this
+                # site; the chokepoint enforces the contract mechanically.
+                self._manager._cancel_task_intentionally(
+                    task, self._manager._agents.get(agent_id), reason="shutdown"
+                )
+                tasks_to_await.append(task)
+        if tasks_to_await:
+            await asyncio.gather(*tasks_to_await, return_exceptions=True)
+        self._manager._tasks.clear()
+        # Shielded terminal reports keep running after their awaiter is
+        # cancelled (that is the point). Drain them with a BOUNDED wait so a
+        # report is not orphaned by a closing event loop, without letting a
+        # wedged injection block shutdown indefinitely.
+        pending_reports = [t for t in self._manager._report_tasks if not t.done()]
+        if pending_reports:
+            try:
+                await asyncio.wait(pending_reports, timeout=_REPORT_DRAIN_TIMEOUT)
+            except Exception:
+                logger.debug("cancel_all: report drain wait failed", exc_info=True)
+            # `asyncio.wait` RETURNS on timeout without touching the stragglers.
+            # Leaving them pending is worse than not shielding at all: shutdown
+            # would proceed while they keep invoking `_on_done` against
+            # tearing-down state, and they would then die when the loop closes —
+            # losing the very report the shield exists to guarantee. So cancel
+            # them explicitly and gather to completion, which also surfaces any
+            # exception into the log instead of an "exception was never
+            # retrieved" warning at interpreter exit.
+            stragglers = [t for t in pending_reports if not t.done()]
+            if stragglers:
+                logger.warning(
+                    "cancel_all: %d terminal report(s) did not drain in %.0fs — "
+                    "cancelling; their completions may not have been delivered",
+                    len(stragglers),
+                    _REPORT_DRAIN_TIMEOUT,
+                )
+                abandoned = [self._manager._report_owners.get(t) for t in stragglers]
+                for report_task in stragglers:
+                    report_task.cancel()
+                try:
+                    await asyncio.gather(*stragglers, return_exceptions=True)
+                except Exception:
+                    logger.debug("cancel_all: straggler gather failed", exc_info=True)
+                # A cancelled report is a LOST delivery, and the terminal record
+                # for it was already written — including a tombstone, which is
+                # exactly what `list_orphans()` uses to exclude a folder from the
+                # next start's reconciliation. Left alone, the outcome is
+                # unrecoverable: never injected, and invisible to the one path
+                # that could still inject it.
+                #
+                # Extending the drain to `_ON_DONE_TIMEOUT` instead was rejected:
+                # it would hold gateway shutdown for up to 20 minutes on a single
+                # wedged injection, which is what the bounded drain exists to
+                # prevent. Bounded shutdown plus recoverable state is strictly
+                # better than unbounded shutdown.
+                #
+                # Only reports cancelled BEFORE `_on_done` returned are re-admitted
+                # — `_reported_to_parent` marks the ones that already reached the
+                # parent, so a cancellation in the later teardown/tombstone waits
+                # does not cause a duplicate delivery on restart.
+                for task, owner in zip(stragglers, abandoned):
+                    if owner is None or not task.cancelled():
+                        continue
+                    if owner._reported_to_parent:
+                        continue
+                    try:
+                        if clear_tombstone(owner.id):
+                            logger.warning(
+                                "cancel_all: %s's completion was not delivered — "
+                                "re-admitted to orphan recovery for the next start",
+                                owner.id,
+                            )
+                    except Exception:
+                        logger.debug(
+                            "cancel_all: failed to re-admit %s to orphan recovery",
+                            owner.id,
+                            exc_info=True,
+                        )

--- a/src/kiro_crew/subagent_manager/continuation.py
+++ b/src/kiro_crew/subagent_manager/continuation.py
@@ -1,0 +1,710 @@
+"""Continuation behavior for the SubagentManager facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._component import ManagerComponent
+
+if TYPE_CHECKING:
+    from ..subagent import (
+        _CONVERSATION_TTL_SECS,
+        _STEER_STARTUP_POLL_SECS,
+        _STEER_STARTUP_WAIT_SECS,
+        CONTEXT_GROUP_LESSONS,
+        CONTEXT_GROUP_MEMORY,
+        CONTEXT_GROUP_PROJECT,
+        PROVIDER_LABEL_DEFAULT,
+        Any,
+        SubagentInfo,
+        _cleanup_session_files_sync,
+        _redact,
+        _subagents_dir,
+        agent_dir_for_display,
+        asyncio,
+        logger,
+        read_state,
+        sel,
+        time,
+        update_state,
+        uuid,
+    )
+
+
+class ContinuationCoordinator(ManagerComponent):
+    """Own continuation transitions while state remains facade-owned."""
+
+    __slots__ = ()
+
+    def _conversation_busy_impl(self, conv_key: str) -> SubagentInfo | None:
+        """Return the live or QUEUED run on *conv_key*, or None.
+
+        Queued members matter: a continuation waiting
+        in the spawn queue is not in ``_agents`` yet — missing it would let
+        ``spawn_release`` delete the session files it needs (the accepted run
+        would then die with ``resume_failed``), or let a second continue race
+        the same conversation.
+        """
+        for a in self._manager._agents.values():
+            if not a.done and (a.conversation_key or f"subagent:{a.id}") == conv_key:
+                return a
+        for p in self._manager._queue:
+            pkey = str(p.get("conversation_key") or "") or (
+                f"subagent:{p.get('_preassigned_id', '')}"
+            )
+            if pkey == conv_key:
+                return SubagentInfo(
+                    id=str(p.get("_preassigned_id") or "queued"),
+                    task="",
+                    queued=True,
+                )
+        return None
+
+    def _keep_recorded_on_disk_impl(self, key: str) -> bool:
+        """Disk-truth continuable check for SessionManager's cache (#1115).
+
+        True iff *key* is a subagent conversation whose run's ``state.json``
+        records ``keep`` — the single persisted source of retention intent.
+        Non-subagent keys short-circuit without touching disk.
+        """
+        if not key.startswith("subagent:"):
+            return False
+        conv_id = key[len("subagent:") :]
+        try:
+            state = read_state(conv_id) or {}
+        except Exception:
+            return False
+        return bool(state.get("keep"))
+
+    def _promote_conversation_impl(
+        self, conv_id: str, conv_key: str, last_used: float | None = None
+    ) -> None:
+        """Single choke point for promoting a conversation's retention (#1115).
+
+        Writes all three retention surfaces together so they cannot drift:
+        ``keep=True`` in state.json (the persisted source of truth), the
+        SessionManager continuable cache (file-deletion exemption), and the
+        TTL registry entry (sweep ownership).
+        """
+        try:
+            update_state(conv_id, keep=True)
+        except Exception:
+            logger.debug("promote: failed to persist keep for %s", conv_id, exc_info=True)
+        self._manager._sessions.mark_continuable(conv_key)
+        self._manager._conversations[conv_key] = last_used if last_used is not None else time.time()
+
+    def _scan_keep_states_impl(self) -> list[tuple[str, str, str, str, str, float]]:
+        """Blocking scan for keep runs (#1114): read every ``state.json``
+        under the subagents dir and collect the promoted conversations.
+
+        Returns ``(conv_id, conv_key, sid, provider, cwd, last_used)`` tuples.
+        Runs in an executor — no event-loop work here.
+        """
+        out: list[tuple[str, str, str, str, str, float]] = []
+        try:
+            base = _subagents_dir()
+            entries = list(base.iterdir()) if base.is_dir() else []
+        except Exception:
+            return out
+        for d in entries:
+            try:
+                if not d.is_dir():
+                    continue
+                state = read_state(d.name) or {}
+                if not state.get("keep"):
+                    continue
+                conv_key = str(state.get("conversation_key") or "") or f"subagent:{d.name}"
+                conv_id = conv_key[len("subagent:") :]
+                sid = str(state.get("session_id") or "")
+                last_used = float(state.get("updated_at") or state.get("started") or 0.0)
+                out.append(
+                    (
+                        conv_id,
+                        conv_key,
+                        sid,
+                        str(state.get("provider") or PROVIDER_LABEL_DEFAULT),
+                        str(state.get("cwd") or ""),
+                        last_used,
+                    )
+                )
+            except Exception:
+                logger.debug("registry rebuild: skipping %s", d, exc_info=True)
+        return out
+
+    async def _rebuild_conversation_registry_impl(self) -> None:
+        """Re-seed the conversation TTL registry from disk after a restart (#1114).
+
+        The registry (``_conversations`` + the SessionManager continuable
+        cache + session map) is in-memory; without this, a gateway restart
+        orphans promoted conversations — the TTL sweep no longer knows them,
+        and nothing else deletes their session files (the tombstone pruner
+        skips keep runs by design). Runs on the reaper's first pass (retried
+        until it succeeds); entries already past TTL are released by the
+        very next sweep.
+
+        Threading contract (Arbiter, PR #1246): ONLY the pure-read
+        ``_scan_keep_states`` runs in the executor. All ``SessionMap``
+        access (``resumable_sid`` self-prune, ``seed_conversation`` writes)
+        stays on the event loop — the map is an unlocked dict with
+        whole-file saves, concurrently mutated by ``get_or_create`` /
+        ``close_all``, so touching it from a worker thread races restart
+        cold-starts (lost mappings / dict-changed-size errors). Per-entry
+        work is small and bounded by the keep-run count, and the loop
+        yields between entries so a large batch cannot stall chat turns
+        (the round-2 event-loop concern).
+        """
+        loop = asyncio.get_running_loop()
+        found = await loop.run_in_executor(None, self._manager._scan_keep_states)
+        # Newest record wins: a conversation appears once per run that
+        # touched it (original + each continuation). The first record kept
+        # for a conv_key wins the `in self._conversations` guard below, so
+        # iterate newest-first — an oldest-first order would seed a stale
+        # last_used and let the SAME pass's sweep expire (and delete) a
+        # conversation whose real last-use is recent.
+        found.sort(key=lambda t: t[5], reverse=True)
+        seeded = 0
+        for conv_id, conv_key, sid, provider, cwd, last_used in found:
+            if conv_key in self._manager._conversations:
+                continue  # live registration wins over the disk snapshot
+            # Same on-demand seeding as continue_conversation (also on-loop):
+            # the map entry is what makes release_conversation able to find
+            # and delete files.
+            if sid and not self._manager._sessions.resumable_sid(conv_key):
+                self._manager._sessions.seed_conversation(conv_key, sid, provider=provider, cwd=cwd)
+            # Resumability gate: SessionMap.get self-prunes entries whose
+            # session files are missing, so this also rejects RELEASED
+            # conversations whose continuation runs still carry a stale
+            # keep=True in their own state.json — their files are gone, and
+            # re-owning them would resurrect a released conversation.
+            if not self._manager._sessions.resumable_sid(conv_key):
+                continue
+            self._manager._sessions.mark_continuable(conv_key)
+            self._manager._conversations[conv_key] = last_used or time.time()
+            seeded += 1
+            # Cooperative yield: keep restart cold-start turns responsive
+            # while a large keep batch seeds (one small file write each).
+            await asyncio.sleep(0)
+        if seeded:
+            logger.info("Rebuilt conversation TTL registry from disk: %d conversation(s)", seeded)
+
+    def continue_conversation_impl(
+        self,
+        conv_id: str,
+        task: str,
+        parent_session_key: str = "",
+        agent: str = "",
+        model: str | None = None,
+        max_turns: int = 0,
+        cwd: str = "",
+        _preassigned_id: str = "",
+    ) -> SubagentInfo | None:
+        """Dispatch a follow-up *task* into conversation *conv_id*.
+
+        ``_preassigned_id`` mirrors ``spawn``: a caller that must persist the
+        dispatch identity BEFORE the side effect (so a crash in between is
+        recoverable rather than ambiguous) supplies the id it already wrote
+        down, instead of discovering the minted one only on return.
+
+        Retain-by-default: works on ANY completed run whose session files are
+        still on disk — no keep flag needed at spawn time. Every run's sid /
+        provider / cwd are already recorded in its ``state.json``; this seeds
+        the session map on demand, so ``get_or_create`` finds the sid and arms
+        ``session/load``. Continuing a run PROMOTES it: retention extends from
+        the tombstone-prune window (~1h) to the conversation TTL, until
+        ``spawn_release``.
+
+        Mints a NEW run (new id, own state.json / result.txt / completion
+        event) on the SAME session key, so the follow-up executes with the
+        conversation's accumulated context.
+
+        Typed failures (returned as a done SubagentInfo with ``error``):
+        - ``conversation_busy`` — a run is in flight; use spawn_steer.
+        - ``conversation_gone`` — no resumable session files remain.
+        """
+        conv_key = f"subagent:{conv_id}"
+        busy = self._manager._conversation_busy(conv_key)
+        if busy is not None:
+            info = SubagentInfo(
+                id=uuid.uuid4().hex[:8],
+                task=_redact(task),
+                done=True,
+                parent_session_key=parent_session_key,
+                error=(
+                    f"conversation_busy: run {busy.id} is in flight on this "
+                    "conversation — use spawn_steer to inject into it, or wait "
+                    "for its completion event"
+                ),
+            )
+            return info
+        # Seed the session map from the run's state.json when no mapping
+        # exists yet (default runs never write one at spawn; the map is also
+        # in-memory-lost across gateway restarts while state.json persists).
+        if not self._manager._sessions.resumable_sid(conv_key):
+            state = read_state(conv_id) or {}
+            sid = str(state.get("session_id") or "")
+            if sid:
+                self._manager._sessions.seed_conversation(
+                    conv_key,
+                    sid,
+                    provider=str(state.get("provider") or PROVIDER_LABEL_DEFAULT),
+                    cwd=str(state.get("cwd") or ""),
+                )
+        # Re-check: SessionMap.get self-prunes entries whose session files
+        # are missing, so a surviving mapping == resumable files on disk.
+        if not self._manager._sessions.resumable_sid(conv_key):
+            # Point the caller at the prior result if the run folder survives
+            # (result.txt outlives the session under the tombstone TTL).
+            result_hint = ""
+            try:
+                _rp = agent_dir_for_display(conv_id) / "result.txt"
+                if _rp.exists():
+                    result_hint = f" Prior result still readable at: {_rp}"
+            except Exception:
+                pass
+            info = SubagentInfo(
+                id=uuid.uuid4().hex[:8],
+                task=_redact(task),
+                done=True,
+                parent_session_key=parent_session_key,
+                error=(
+                    "conversation_gone: no resumable session remains for "
+                    f"{conv_id} (expired, released, or files pruned)."
+                    + result_hint
+                    + " Re-spawn with a fresh task carrying a summary."
+                ),
+            )
+            return info
+        # Promote the run's retention through the single choke point
+        # (#1115): state.json keep=True (tombstone pruner skips deletion),
+        # the SessionManager continuable cache, and the TTL registry entry.
+        # The conversation TTL sweep / spawn_release owns deletion from here.
+        self._manager._promote_conversation(conv_id, conv_key)
+        inc_memory, inc_lessons, inc_project = self._manager._inherited_context_groups(conv_id)
+        # A continuation has to run WHERE THE RUN RAN. `spawn` resolves an empty
+        # cwd to the pool project before it validates the agent name, so a run
+        # spawned against a project-local agent (defined under that project's
+        # .kiro/agents/) came back "unknown agent" here — and the caller reads any
+        # non-busy error as unresumable and respawns from the digest alone,
+        # silently dropping the conversation this call exists to preserve.
+        #
+        # The cwd must come from the CALLER, not be discovered here. This method is
+        # synchronous and runs on the gateway's event loop, so probing the recorded
+        # path (`is_dir()`) would freeze the gateway for as long as a stalled
+        # network mount takes to answer. Async callers resolve it off-loop instead:
+        # crew passes its slot project, and `recorded_cwd()` gives the others the
+        # run's own recorded path to hand back in.
+        return self._manager.spawn(
+            task,
+            _preassigned_id=_preassigned_id,
+            parent_session_key=parent_session_key,
+            agent=agent,
+            model=model,
+            max_turns=max_turns,
+            keep=True,
+            cwd=cwd,
+            conversation_key=conv_key,
+            include_memory=inc_memory,
+            include_lessons=inc_lessons,
+            include_project=inc_project,
+        )
+
+    def recorded_cwd_impl(self, conv_id: str) -> str:
+        """The cwd run *conv_id* executed in, or "" if it never had one.
+
+        `continue_conversation` deliberately does NOT discover this itself: it is
+        synchronous and runs on the gateway's event loop, where the state read would
+        block for as long as a stalled network mount takes to answer. This helper
+        does the blocking work in one place so an async caller can hand it to
+        `asyncio.to_thread` and pass the result in.
+
+        A path that no longer exists is returned ANYWAY, so `spawn` refuses it.
+        Filtering it to "" would keep such a continuation working but is unsafe:
+        an empty cwd resolves to the POOL project, so a follow-up
+        whose task names relative files would have edited an unrelated project's
+        working tree. A loud refusal is recoverable; a silent write to the wrong
+        repository is not. Only a run that never recorded a cwd returns "" — for it
+        the pool default is correct, because there is no project to miss.
+        """
+        return str((read_state(conv_id) or {}).get("cwd") or "")
+
+    def _inherited_context_groups_impl(self, conv_id: str) -> tuple[bool, bool, bool]:
+        """Recover the context scope of the run being continued.
+
+        A continuation DOES rebuild session context: ``get_or_create`` reports
+        ``is_new=True`` even when it restores the session via ``session/load``
+        (``resumed`` is the separate flag, and it gates only thread history), so
+        ``build_message`` runs the full session-context path for the follow-up
+        turn. Without inheriting the scope here, a run the parent deliberately
+        spawned without memory would silently regain it on continuation.
+
+        Prefers the live record; falls back to the scope persisted in the run's
+        ``state.json``. A run that predates the field records no scope at all,
+        which is distinguishable from "every group withheld" (an empty string)
+        and defaults to all-on.
+        """
+        live = self._manager._agents.get(conv_id)
+        if live is not None:
+            return live.include_memory, live.include_lessons, live.include_project
+        raw = (read_state(conv_id) or {}).get("context_groups")
+        if raw is None:
+            return True, True, True
+        groups = {g for g in str(raw).split(",") if g}
+        return (
+            CONTEXT_GROUP_MEMORY in groups,
+            CONTEXT_GROUP_LESSONS in groups,
+            CONTEXT_GROUP_PROJECT in groups,
+        )
+
+    async def steer_run_impl(self, agent_id: str, message: str) -> tuple[bool, str]:
+        """Inject *message* into the RUNNING turn of run *agent_id*.
+
+        Returns ``(ok, detail)``. Typed detail values on refusal:
+        ``not_found`` (unknown id), ``not_running`` (run finished — use
+        spawn_continue), ``session_starting`` (run alive but its session has
+        not registered yet — retry shortly), ``no_session`` (session not
+        reachable), or the provider's failure reason.
+
+        Startup grace (#1113): the window between spawn-return and session
+        registration is precisely when a parent most wants to steer (it just
+        realized the task text was wrong), so a missing provider on a live
+        run polls for up to ``_STEER_STARTUP_WAIT_SECS`` instead of failing
+        immediately with a bare ``no_session``.
+        """
+        info = self._manager._agents.get(agent_id)
+        if info is None:
+            return False, "not_found"
+        if info.done:
+            return False, "not_running: run finished — use spawn_continue"
+
+        def _resolve_provider() -> Any:
+            if info._session_sharing and info._shared_provider is not None:  # type: ignore[union-attr]
+                return info._shared_provider  # type: ignore[union-attr]
+            session_key = info.conversation_key or f"subagent:{info.id}"  # type: ignore[union-attr]
+            return self._manager._sessions.get_provider(session_key)
+
+        provider: Any = _resolve_provider()
+        if provider is None or not hasattr(provider, "steer"):
+            # Bounded wait for session registration on a run that is still
+            # alive. Re-checks done-ness each tick: a run finishing while we
+            # wait flips the answer to not_running, never a stale inject.
+            deadline = time.monotonic() + _STEER_STARTUP_WAIT_SECS
+            while time.monotonic() < deadline:
+                await asyncio.sleep(_STEER_STARTUP_POLL_SECS)
+                if info.done:
+                    return False, "not_running: run finished — use spawn_continue"
+                provider = _resolve_provider()
+                if provider is not None and hasattr(provider, "steer"):
+                    break
+            else:
+                return False, (
+                    "session_starting: the run is alive but its session has "
+                    f"not registered within {_STEER_STARTUP_WAIT_SECS}s — "
+                    "retry in a few seconds"
+                )
+        try:
+            ok = await provider.steer(message)
+        except Exception as exc:  # pragma: no cover - provider-specific
+            logger.warning("steer_run %s failed", agent_id, exc_info=True)
+            return False, f"steer failed: {exc}"
+        if ok:
+            try:
+                sel().log_tool_invocation(
+                    session_key=info.parent_session_key or "",
+                    source="subagent",
+                    tool_name="spawn_steer",
+                    outcome="ok",
+                    metadata={"subagent_id": agent_id},
+                )
+            except Exception:
+                logger.debug("steer_run: SEL audit failed", exc_info=True)
+        return ok, "ok" if ok else "steer rejected by provider"
+
+    async def follow_up_run_impl(self, agent_id: str, message: str) -> tuple[bool, str]:
+        """Queue *message* for delivery AFTER run *agent_id*'s turn completes.
+
+        The non-interrupting sibling of :meth:`steer_run` (spawn_steer
+        ``mode="follow_up"``): instead of injecting into the running turn —
+        which can derail critical work mid-execution — the message waits for
+        the run to finish and is then dispatched as a CONTINUATION on the
+        run's own conversation (``continue_conversation``), executing with its
+        accumulated context. The continuation is a new run whose result
+        arrives as a normal completion event on the same parent session.
+
+        Multiple queued follow-ups drain as ONE continuation (joined in
+        arrival order), so three corrections cost one run, not three.
+
+        Returns ``(ok, detail)``. Typed refusals mirror ``steer_run``:
+        ``not_found`` (unknown id) and ``not_running`` (already finished —
+        ``spawn_continue`` is the direct tool for that case). Queued
+        follow-ups are best-effort by design: if the conversation is gone by
+        the time the run ends, the failure is logged and audited, not raised.
+        """
+        info = self._manager._agents.get(agent_id)
+        if info is None:
+            return False, "not_found"
+        if info.done:
+            return False, "not_running: run finished — use spawn_continue"
+        if self._manager._shutting_down:
+            # Refuse rather than accept-and-drop: an accepted follow-up
+            # promises a completion event, and a shutting-down gateway can
+            # keep neither the watcher nor the continuation alive.
+            return False, "shutting_down: the gateway is stopping — re-send after restart"
+        info.pending_followups.append(message)
+        if not info._followup_watcher:
+            self._manager._arm_followup_watcher(info)
+        try:
+            sel().log_tool_invocation(
+                session_key=info.parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_steer",
+                outcome="followup_queued",
+                metadata={"subagent_id": agent_id, "queued": len(info.pending_followups)},
+            )
+        except Exception:
+            logger.debug("follow_up_run: SEL audit failed", exc_info=True)
+        return True, "queued"
+
+    def _arm_followup_watcher_impl(self, info: SubagentInfo) -> None:
+        """Arm the (single) follow-up watcher for *info*'s run.
+
+        The done-callback resets the one-watcher latch AND re-arms when
+        messages are still pending: a follow-up can be accepted while the
+        previous watcher is inside its final awaits (announcing an expiry) —
+        it sees the latch still true and arms nothing, so without the re-arm
+        that accepted message would be stranded with no dispatch and no event.
+        Not re-armed during shutdown or once the run record is
+        gone (removal drops any leftovers deliberately).
+        """
+        info._followup_watcher = True
+        run_id = info.id
+        run_info = info  # narrowed local: mypy loses the None-narrow in closure defaults
+        task = asyncio.create_task(self._manager._deliver_followups(info))
+        self._manager._followup_watchers[run_id] = task
+
+        def _done(t: "asyncio.Task", _id: str = run_id, _info: SubagentInfo = run_info) -> None:
+            self._manager._followup_watchers.pop(_id, None)
+            _info._followup_watcher = False
+            if not t.cancelled() and t.exception() is not None:
+                logger.warning("follow_up watcher for %s failed", _id, exc_info=t.exception())
+                return
+            if (
+                not t.cancelled()
+                and _info.pending_followups
+                and not self._manager._shutting_down
+                and _id in self._manager._agents
+            ):
+                self._manager._arm_followup_watcher(_info)
+
+        task.add_done_callback(_done)
+
+    async def _deliver_followups_impl(self, info: SubagentInfo) -> None:
+        """Watch run *info* until its turn completes, then dispatch the queue.
+
+        DELIBERATELY a per-run poller rather than a hook in ``_run``'s
+        finalization: completion is reached from many terminal paths (normal,
+        error, timeout, cancel-recovery, reaper), all guarded by a carefully
+        ordered 3-guard finally — a watcher observes the outcome without
+        adding a new obligation to any of them. Waits for the run's task to be
+        popped from ``self._tasks`` too, so teardown (session release) has
+        finished before the continuation tries to reuse the conversation; any
+        residual ``conversation_busy`` gets a bounded retry.
+
+        OUTCOME-AWARE: a run the user explicitly STOPPED does not get its
+        follow-ups dispatched — resurrecting work the user killed is the
+        opposite of "the correction can wait" (``followup_suppressed`` audit).
+        Other non-success terminals (error, timeout) still dispatch: the
+        continuation runs with the conversation's context, so "fix what just
+        broke" is a legitimate follow-up.
+
+        NEVER SILENT: the spawn_steer reply promised the parent a completion
+        event, so every path that cannot deliver one from a real continuation
+        (suppressed, expired, dispatch failure) announces a SYNTHETIC failure
+        completion event through the normal ``_on_done`` path — the parent
+        must not wait forever on an event that is not coming.
+
+        Hard-bounded and manager-owned: gives up at the manager's run timeout
+        plus a margin, and the task is registered in ``_followup_watchers`` so
+        ``cancel_all()`` cancels it — a watcher must never dispatch a fresh
+        run into a shutting-down gateway.
+        """
+        deadline = time.monotonic() + self._manager._default_timeout + 300
+        while time.monotonic() < deadline:
+            if info.done and info.id not in self._manager._tasks:
+                break
+            await asyncio.sleep(self._manager._FOLLOWUP_POLL_SECS)
+        else:
+            dropped = list(info.pending_followups)
+            logger.warning(
+                "follow_up watcher for %s timed out before the run completed — "
+                "%d queued message(s) dropped",
+                info.id,
+                len(dropped),
+            )
+            self._manager._audit_followup(info, "followup_expired")
+            await self._manager._announce_followup_failure(
+                info,
+                "follow_up expired: the run never completed within its timeout "
+                "window; the queued follow-up message(s) were dropped",
+                messages=dropped,
+            )
+            # Drop ONLY what was just reported dropped, and only AFTER the
+            # announce settled — clearing first meant a shutdown cancelling
+            # this task mid-announce left the queue empty for cancel_all()'s
+            # sweep, so the messages vanished with no event. The slice keeps
+            # anything queued while we were announcing (the done-callback
+            # re-arms for it).
+            info.pending_followups = info.pending_followups[len(dropped) :]
+            return
+        # SNAPSHOT, do not drain: messages stay in ``pending_followups`` until
+        # their outcome is SETTLED (dispatched, or their failure announced).
+        # An eager drain lost messages when shutdown landed mid-await — e.g.
+        # during a conversation_busy retry sleep — because cancel_all() saw an
+        # empty queue, cancelled this task, and nothing was ever announced.
+        # Appends only ever happen at the tail, so removing the first
+        # ``len(messages)`` entries at settlement drops exactly this snapshot
+        # and preserves anything queued while we were dispatching.
+        messages = list(info.pending_followups)
+        if not messages:
+            return
+
+        def _settle() -> None:
+            info.pending_followups = info.pending_followups[len(messages) :]
+
+        if info.user_stopped:
+            logger.info("follow_up for %s suppressed — the user stopped the run", info.id)
+            self._manager._audit_followup(info, "followup_suppressed")
+            _settle()
+            await self._manager._announce_followup_failure(
+                info,
+                "follow_up suppressed: the user stopped this run, so its queued "
+                "follow-up message(s) were NOT dispatched",
+                messages=messages,
+            )
+            return
+        if self._manager._shutting_down:
+            # Leave the queue intact: cancel_all()'s shutdown sweep owns the
+            # announce-and-drop for pending messages.
+            return
+        task = "\n\n---\n\n".join(messages)
+        # Finalization may hold the conversation for a beat after the task is
+        # popped (shielded report); retry a bounded number of times.
+        for _attempt in range(self._manager._FOLLOWUP_BUSY_RETRIES):
+            child = self._manager.continue_conversation(
+                info.id,
+                task,
+                parent_session_key=info.parent_session_key,
+                agent=info.agent,
+            )
+            err = "spawn_failed" if child is None else str(getattr(child, "error", "") or "")
+            if not err.startswith("conversation_busy"):
+                break
+            await asyncio.sleep(self._manager._FOLLOWUP_BUSY_RETRY_SECS)
+        if err:
+            logger.warning("follow_up delivery for %s failed: %s", info.id, err.split(":", 1)[0])
+            self._manager._audit_followup(info, "followup_failed")
+            _settle()
+            # continue_conversation's typed failures are already done
+            # SubagentInfo records — announce the real one when we have it.
+            if child is not None:
+                await self._manager._announce_followup_failure(info, "", failure_info=child)
+            else:
+                await self._manager._announce_followup_failure(
+                    info, f"follow_up dispatch failed: {err}"
+                )
+        else:
+            self._manager._audit_followup(info, "followup_dispatched")
+            _settle()
+
+    async def _announce_followup_failure_impl(
+        self,
+        info: SubagentInfo,
+        reason: str,
+        failure_info: SubagentInfo | None = None,
+        messages: list | None = None,
+    ) -> None:
+        """Deliver a SYNTHETIC failure completion event for an undeliverable
+        follow-up, through the same ``_on_done`` path as real completions.
+
+        Best-effort by design (a notification about a failure must not itself
+        take anything down), but never silent-by-default: without this the
+        parent — told by spawn_steer that a completion event would arrive —
+        blocks its plan on an event that only ever existed in SEL logs.
+        ``messages`` labels the synthetic event when the queue was already
+        drained by the caller (the expiry path clears before announcing so a
+        later watcher cannot resurrect messages reported dead).
+        """
+        if self._manager._on_done is None:
+            return
+        label_msgs = messages if messages is not None else info.pending_followups
+        synthetic = failure_info or SubagentInfo(
+            id=uuid.uuid4().hex[:8],
+            task=f"[follow_up of run {info.id}] "
+            + _redact("; ".join(m[:120] for m in label_msgs) or "queued follow-up"),
+            done=True,
+            parent_session_key=info.parent_session_key,
+            error=reason,
+        )
+        try:
+            await self._manager._on_done(synthetic)
+        except Exception:
+            logger.warning("follow_up failure announce for %s failed", info.id, exc_info=True)
+
+    def _audit_followup_impl(self, info: SubagentInfo, outcome: str) -> None:
+        try:
+            sel().log_tool_invocation(
+                session_key=info.parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_steer",
+                outcome=outcome,
+                metadata={"subagent_id": info.id},
+            )
+        except Exception:
+            logger.debug("follow_up audit failed", exc_info=True)
+
+    def release_conversation_impl(self, conv_id: str) -> tuple[bool, str]:
+        """Release conversation *conv_id*: forget the sid and delete files.
+
+        Refuses (``conversation_busy``) while a run is in flight. Returns
+        ``(ok, detail)``.
+        """
+        conv_key = f"subagent:{conv_id}"
+        busy = self._manager._conversation_busy(conv_key)
+        if busy is not None:
+            return False, f"conversation_busy: run {busy.id} is in flight"
+        provider_label = (
+            self._manager._sessions.conversation_provider(conv_key) or PROVIDER_LABEL_DEFAULT
+        )
+        sid = self._manager._sessions.forget_conversation(conv_key)
+        self._manager._conversations.pop(conv_key, None)
+        # Demote the persisted source of truth too (#1115): with the disk
+        # fallback in place, a stale keep=True would re-warm the continuable
+        # cache after release and resurrect the conversation on the next
+        # restart's registry rebuild.
+        try:
+            update_state(conv_id, keep=False)
+        except Exception:
+            logger.debug("release: failed to demote state for %s", conv_id, exc_info=True)
+        if not sid:
+            return False, "conversation_gone: nothing to release"
+        try:
+            _cleanup_session_files_sync(sid, provider_label)
+        except Exception:
+            logger.debug("release_conversation: file cleanup failed", exc_info=True)
+        return True, "released"
+
+    def _sweep_conversations_impl(self, now: float) -> None:
+        """Reaper hook: expire continuable conversations idle past TTL."""
+        for conv_key, last_used in list(self._manager._conversations.items()):
+            if now - last_used < _CONVERSATION_TTL_SECS:
+                continue
+            if self._manager._conversation_busy(conv_key) is not None:
+                self._manager._conversations[conv_key] = now  # active — refresh
+                continue
+            conv_id = conv_key[len("subagent:") :]
+            ok, detail = self._manager.release_conversation(conv_id)
+            logger.info(
+                "Conversation %s expired after %ds idle: %s",
+                conv_id,
+                _CONVERSATION_TTL_SECS,
+                detail,
+            )

--- a/src/kiro_crew/subagent_manager/monitoring.py
+++ b/src/kiro_crew/subagent_manager/monitoring.py
@@ -1,0 +1,760 @@
+"""Monitoring behavior for the SubagentManager facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._component import ManagerComponent
+
+if TYPE_CHECKING:
+    from ..subagent import (
+        _CLK_TCK,
+        _REAPER_INTERVAL,
+        _SUPPRESS_CEILING,
+        OUTCOME_FAILED,
+        OUTCOME_INTERRUPTED,
+        SUBAGENT_COMPLETION_PREFIX,
+        VERDICT_DEAD,
+        VERDICT_STUCK_INPUT,
+        VERDICT_UNKNOWN,
+        VERDICT_WORKING,
+        LivenessOracle,
+        SubagentInfo,
+        _agent_dir,
+        _attributed_count,
+        _proc_subtree_sample,
+        _redact,
+        _redact_and_truncate,
+        agent_dir_for_display,
+        append_cost_sample,
+        asyncio,
+        compact_cost_log,
+        consult_offloaded,
+        has_dashboard_surface,
+        list_orphans,
+        logger,
+        maintenance_executor,
+        prune_stale_tombstones,
+        sel,
+        single_completion_meta,
+        subprocess_executor,
+        time,
+        write_tombstone,
+    )
+
+
+class OrphanStallMonitor(ManagerComponent):
+    """Own monitoring transitions while state remains facade-owned."""
+
+    __slots__ = ()
+
+    def start_reaper_impl(self) -> None:
+        """Start the periodic reaper loop.  Call once after the event loop is running."""
+        if self._manager._reaper_task is None:
+            self._manager._reaper_task = asyncio.create_task(self._manager._reaper_loop())
+            # One-shot orphan reconciliation on startup
+            self._manager._reconcile_task = asyncio.create_task(self._manager._reconcile_orphans())
+
+    async def _reconcile_orphans_impl(self) -> None:
+        """Scan for orphaned agent folders from a prior gateway run.
+
+        For each orphan (folder with state.json but no tombstone.json
+        and not tracked in ``_agents``):
+        - PID alive → SIGKILL, tombstone (gateway_restart)
+        - PID dead + result → tombstone (gateway_restart, delivered)
+        - PID dead + no result → tombstone (gateway_restart, notification_pending)
+        """
+        try:
+
+            orphans = list_orphans()
+            if not orphans:
+                return
+            logger.info("Reconciling %d orphaned subagent(s)", len(orphans))
+            processed = 0
+            # DM-fallback messages are DIGESTED: collected across the whole
+            # scan and delivered as ONE message at the end — a restart with N
+            # in-flight agents must never produce N pings. (The session-
+            # injection path batches naturally via the parent slot's pending-
+            # failures drain.)
+            dm_pending: list[str] = []
+            for state in orphans:
+                agent_id = state.get("id", "")
+                if not agent_id or agent_id in self._manager._agents:
+                    continue  # tracked in current run, skip
+                try:
+                    pid = state.get("pid")
+                    has_result = False
+                    try:
+
+                        rp = _agent_dir(agent_id) / "result.txt"
+                        has_result = rp.exists() and rp.stat().st_size > 0
+                    except OSError:
+                        pass
+
+                    recovery = "undeliverable"
+                    if pid and self._manager._is_pid_alive(pid):
+                        # Use pid_recorded_at (when PID was actually written) instead of
+                        # started (folder creation time) to avoid false negatives under load
+                        pid_recorded_at = state.get("pid_recorded_at", state.get("started", 0))
+                        if self._manager._is_orphan_process(pid, pid_recorded_at):
+                            self._manager._kill_orphan_pid(pid)
+                            try:
+                                sel().log_tool_invocation(
+                                    session_key=f"subagent:{agent_id}",
+                                    source="subagent",
+                                    tool_name="orphan_reconcile_kill",
+                                    outcome="killed",
+                                    metadata={"subagent_id": agent_id, "pid": pid},
+                                )
+                            except Exception:
+                                logger.debug("SEL audit failed for orphan %s", agent_id)
+                        recovery = "result_available" if has_result else "notification_pending"
+                    elif has_result:
+                        recovery = "result_available"
+                    else:
+                        recovery = "notification_pending"
+
+                    try:
+                        write_tombstone(
+                            agent_id,
+                            cause="gateway_restart",
+                            recovery_action=recovery,
+                            pid=pid,
+                            turns=state.get("turns", 0),
+                            last_tool=state.get("last_tool", ""),
+                        )
+                    except Exception:
+                        logger.debug("Failed to tombstone orphan %s", agent_id, exc_info=True)
+
+                    # Retain-by-default: session files are deliberately NOT
+                    # deleted here — an orphaned run's transcript is still
+                    # spawn_continue resume material after the restart. The
+                    # tombstone pruner owns deletion (with the keep guard for
+                    # promoted conversations).
+
+                    logger.info(
+                        "Reconciled orphan %s: recovery=%s, pid=%s, has_result=%s",
+                        agent_id,
+                        recovery,
+                        pid,
+                        has_result,
+                    )
+                    # Notify user about the orphaned agent. Injection happens
+                    # per-orphan (it rides the parent slot's batched pending-
+                    # failures queue); DM fallback is deferred to the digest.
+                    try:
+                        undelivered = await self._manager._notify_orphan(
+                            agent_id, state, recovery, has_result
+                        )
+                        if undelivered:
+                            dm_pending.append(undelivered)
+                    except Exception:
+                        logger.debug("Notification failed for orphan %s", agent_id, exc_info=True)
+                except Exception:
+                    logger.warning("Failed to reconcile orphan %s", agent_id, exc_info=True)
+
+                # Rate limit: yield to event loop every 50 entries
+                processed += 1
+                if processed % 50 == 0:
+                    await asyncio.sleep(0)
+
+            # Single digest for everything the injection path couldn't deliver.
+            if dm_pending:
+                if len(dm_pending) == 1:
+                    digest = dm_pending[0]
+                else:
+                    digest = (
+                        f"[Subagent restart digest] {len(dm_pending)} subagent(s) "
+                        f"orphaned by a gateway restart:\n\n" + "\n\n".join(dm_pending)
+                    )
+                try:
+                    await self._manager._send_orphan_slack_dm(digest)
+                except Exception:
+                    logger.debug("Orphan digest DM failed", exc_info=True)
+        except Exception:
+            logger.warning("Orphan reconciliation failed", exc_info=True)
+
+    async def _notify_orphan_impl(
+        self, agent_id: str, state: dict, recovery: str, has_result: bool
+    ) -> str | None:
+        """Notify user about an orphaned subagent.
+
+        1. Try session injection if parent session still exists (delivered
+           messages return ``None``).
+        2. Otherwise return the redacted message so the caller can batch all
+           undelivered notifications into a SINGLE digest DM — never N pings.
+        """
+        task_preview = (state.get("task", "") or "")[:100]
+        parent_session = state.get("parent_session", "")
+        result_path = str(agent_dir_for_display(agent_id) / "result.txt")
+
+        if has_result:
+            msg = (
+                f"{SUBAGENT_COMPLETION_PREFIX}\n"
+                f"Agent `{agent_id}` ⚠️ orphaned by gateway restart\n"
+                f"Task: {task_preview}\n"
+                f"Result saved at: `{result_path}`\n"
+                f"Use the read tool to retrieve it."
+            )
+            # A restart orphan whose result survived on disk: interrupted, not a
+            # plain failure. The note is the only explanation the header carries.
+            row_meta = single_completion_meta(
+                agent_id=agent_id,
+                outcome=OUTCOME_INTERRUPTED,
+                task=task_preview,
+                note="orphaned by gateway restart",
+                requested_model=str(state.get("requested_model") or ""),
+                resolved_model=str(state.get("resolved_model") or ""),
+            )
+        else:
+            msg = (
+                f"{SUBAGENT_COMPLETION_PREFIX}\n"
+                f"Agent `{agent_id}` ❌ lost to gateway restart\n"
+                f"Task: {task_preview}\n"
+                f"No result was captured before the restart."
+            )
+            row_meta = single_completion_meta(
+                agent_id=agent_id,
+                outcome=OUTCOME_FAILED,
+                task=task_preview,
+                note="lost to gateway restart",
+                requested_model=str(state.get("requested_model") or ""),
+                resolved_model=str(state.get("resolved_model") or ""),
+            )
+
+        # Redact before any delivery path (injection or Slack DM)
+        msg = _redact(msg)
+
+        # Try session injection first. The question is whether a tab is OPEN to
+        # receive the notice, not where the conversation started — a channel-born
+        # parent keeps its channel session key while its tab is open, and with no
+        # tab the digest DM below is the only surface.
+        if has_dashboard_surface(parent_session):
+            try:
+                injected = await self._manager._try_inject_orphan_notification(
+                    parent_session, msg, row_meta
+                )
+                if injected:
+                    # Update tombstone recovery_action
+                    try:
+                        write_tombstone(
+                            agent_id,
+                            cause="gateway_restart",
+                            recovery_action="delivered",
+                            pid=state.get("pid"),
+                            turns=state.get("turns", 0),
+                            last_tool=state.get("last_tool", ""),
+                        )
+                    except Exception:
+                        pass
+                    return None
+            except Exception:
+                logger.debug("Injection failed for orphan %s", agent_id, exc_info=True)
+
+        # Undelivered: hand back for the caller's single digest DM.
+        return msg
+
+    async def _try_inject_orphan_notification_impl(
+        self, parent_session: str, msg: str, meta: dict | None = None
+    ) -> bool:
+        """Try to inject a message into the parent dashboard session.
+
+        Delegates to the gateway-wired ``on_orphan_notify`` callback, which
+        appends the (already-redacted) message to the parent slot's transcript
+        and queues it into ``slot._pending_subagent_failures`` so the LLM
+        learns about the orphan on its next turn. Returns True if delivered.
+
+        ``meta`` carries the structured completion facts for the dashboard card
+        (#1792) so the orphan row renders without re-parsing its prose header.
+        """
+        if self._manager._on_orphan_notify is None:
+            return False
+        try:
+            delivered = bool(await self._manager._on_orphan_notify(parent_session, msg, meta))
+        except Exception:
+            logger.debug("on_orphan_notify raised for %s", parent_session, exc_info=True)
+            return False
+        if delivered:
+            try:
+                sel().log_api_access(
+                    caller=parent_session,
+                    operation="subagent.orphan_notification_injected",
+                    outcome="ok",
+                    source="subagent",
+                )
+            except Exception:
+                logger.debug("SEL audit for orphan injection failed", exc_info=True)
+        return delivered
+
+    async def _send_orphan_slack_dm_impl(self, msg: str) -> None:
+        """Deliver an orphan notification via the owner DM / notification path.
+
+        Delegates to the gateway-wired ``on_orphan_dm`` callback (Slack DM +
+        dashboard notification). Falls back to a log line when no callback is
+        wired (e.g. slack-only setups constructed without the gateway hooks).
+        """
+        if self._manager._on_orphan_dm is not None:
+            try:
+                delivered = bool(await self._manager._on_orphan_dm(msg))
+                if delivered:
+                    return
+            except Exception:
+                logger.debug("on_orphan_dm raised", exc_info=True)
+        logger.warning("Orphan notification (no delivery channel wired): %s", msg[:200])
+
+    def _live_shared_count_impl(self, pid: int | None, agents: "list[SubagentInfo]") -> int:
+        """Count live session-shared subagents sharing runtime *pid* (>= 1).
+
+        Used to average the shared AcpRuntime's measured RSS/CPU across the
+        sessions currently running inside it, so each shared subagent is charged
+        an empirical per-session share rather than the whole process.
+
+        *agents* is the registry snapshot the caller already took, and is
+        required: the sole caller runs on a worker thread (see
+        ``_sample_live_costs``), where iterating the live registry would raise
+        ``RuntimeError`` the moment the event loop registered or evicted an
+        agent. An on-loop caller passes ``list(self._agents.values())``.
+        """
+        if not pid:
+            return 1
+        n = sum(1 for a in agents if not a.done and a._session_sharing and a._pid == pid)
+        return n if n > 0 else 1
+
+    def _sample_live_costs_impl(self) -> None:
+        """Sample high-water RSS/CPU for each live agent (reaper-loop piggyback).
+
+        Updates per-run peaks on ``SubagentInfo`` (dynamic-subagent-sizing.md
+        §4.1). RSS is the subtree VmRSS in GB; CPU is cores used since the last
+        sample = Δ(utime+stime jiffies) / (CLK_TCK × Δt). The first sample only
+        seeds the CPU baseline (no delta yet). Best-effort: a dead/unreadable
+        pid is simply skipped.
+
+        BLOCKING, and therefore off-loop: every live agent costs ONE ``/proc``
+        subtree walk (:func:`_proc_subtree_sample`, which returns RSS, CPU
+        jiffies and the process/stub counts from a single frontier), so the
+        caller hands this to :func:`maintenance_executor` and the body must stay
+        thread-safe. Concretely that means it takes ONE snapshot of the agent
+        registry up front and derives everything, sharer counts included, from
+        that list: iterating the live dict from a worker thread would raise
+        ``RuntimeError`` the moment the event loop registered or evicted an
+        agent mid-sweep. Writes are plain float/int field assignments on
+        ``SubagentInfo``, which the surface only ever reads.
+        """
+        now = time.monotonic()
+        agents = list(self._manager._agents.values())
+        for info in agents:
+            if info.done or not info._pid:
+                continue
+            # Session-shared subagents run inside the parent's AcpRuntime process;
+            # every sharing subagent reports the SAME runtime PID, so naive
+            # per-PID sampling would attribute the whole shared process to each
+            # of them. Instead attribute the runtime's measured RSS/CPU divided
+            # by the number of concurrently-live shared sessions on that PID — an
+            # empirical per-session average, not a guessed constant
+            # (dynamic-subagent-sizing.md §session-sharing cost model).
+            #
+            # Sole tenant of its own process: the subtree reading IS this run's,
+            # which is a share of one.
+            shared_n = (
+                self._manager._live_shared_count(info._pid, agents) if info._session_sharing else 1
+            )
+            sample = _proc_subtree_sample(info._pid)
+            if sample.rss_kb > 0 and shared_n > 0:
+                gb = (sample.rss_kb / (1024 * 1024)) / shared_n
+                info.last_rss_gb = gb
+                if gb > info.peak_rss_gb:
+                    info.peak_rss_gb = gb
+            info.last_procs = _attributed_count(sample.procs, shared_n, info.last_procs)
+            info.last_stubs = _attributed_count(sample.matched, shared_n, info.last_stubs)
+            jiffies = sample.jiffies
+            if info._cpu_sample_ts > 0.0 and jiffies >= info._cpu_jiffies_prev and shared_n > 0:
+                dt = now - info._cpu_sample_ts
+                if dt > 0:
+                    cores = ((jiffies - info._cpu_jiffies_prev) / (_CLK_TCK * dt)) / shared_n
+                    info.last_cpu_cores = cores
+                    if cores > info.peak_cpu_cores:
+                        info.peak_cpu_cores = cores
+            info._cpu_jiffies_prev = jiffies
+            info._cpu_sample_ts = now
+
+    def _record_cost_impl(self, info: SubagentInfo) -> None:
+        """Persist this run's high-water RSS/CPU to the learned-cost store."""
+        if info.peak_rss_gb <= 0 and info.peak_cpu_cores <= 0:
+            return  # never sampled (e.g. finished before the first reaper sweep)
+        try:
+            append_cost_sample(info.agent, info.peak_rss_gb, info.peak_cpu_cores)
+        except Exception:
+            logger.debug("Failed to record subagent cost for %s", info.id, exc_info=True)
+
+    async def _reaper_loop_impl(self) -> None:
+        """Periodically force-kill subagents that exceed the timeout.
+
+        Defense-in-depth: catches cases where ``asyncio.wait_for`` in
+        ``_run()`` fails to fire (event-loop saturation, orphaned tasks,
+        or ``reset()`` hanging in the finally block).
+        """
+        try:
+            compact_cost_log()  # startup FIFO trim (§4.2)
+        except Exception:
+            logger.debug("Reaper: startup cost-log compaction failed", exc_info=True)
+        while True:
+            await asyncio.sleep(_REAPER_INTERVAL)
+            now = time.time()
+            if not self._manager._conv_registry_rebuilt:
+                # First pass after (re)start: re-seed the conversation TTL
+                # registry from state.json so promoted conversations survive
+                # a gateway restart under sweep ownership (#1114). The flag
+                # is set only on SUCCESS — a failed rebuild retries on the
+                # next sweep instead of silently restoring the pre-#1114
+                # orphaning until the next restart (Arbiter, PR #1246).
+                try:
+                    await self._manager._rebuild_conversation_registry()
+                    self._manager._conv_registry_rebuilt = True
+                except Exception:
+                    logger.warning(
+                        "Reaper: conversation registry rebuild failed — retrying next sweep",
+                        exc_info=True,
+                    )
+            # Off the event loop: the sweep is several /proc walks per live agent,
+            # and the reaper shares the loop with every chat turn and heartbeat.
+            try:
+                await asyncio.get_running_loop().run_in_executor(
+                    maintenance_executor(), self._manager._sample_live_costs
+                )
+            except Exception:
+                logger.debug("Reaper: live-cost sample failed", exc_info=True)
+            # Wave liveness backstop: reconcile waves wedged by submissions
+            # lost before the process boundary (see _sweep_stuck_waves).
+            try:
+                self._manager._sweep_stuck_waves(now)
+            except Exception:
+                logger.debug("Reaper: stuck-wave sweep failed", exc_info=True)
+            # Digest hold deadline: release completed wave results that a
+            # straggler (or a hung member) has been withholding.
+            try:
+                self._manager._sweep_digest_holds(now)
+            except Exception:
+                logger.debug("Reaper: digest-hold sweep failed", exc_info=True)
+            try:
+                self._manager._sweep_conversations(now)
+            except Exception:
+                logger.debug("Reaper: conversation sweep failed", exc_info=True)
+            try:
+                compact_cost_log()  # periodic FIFO trim (also bounds a long-running gateway)
+            except Exception:
+                logger.debug("Reaper: cost-log compaction failed", exc_info=True)
+            for agent_id, info in list(self._manager._agents.items()):
+                if info.done:
+                    continue
+                elapsed = now - info.started
+                # Startup watchdog: a subagent that entered execution but is
+                # still on turn 0 with no runtime PID after the startup window
+                # is wedged in startup (e.g. a hung provider/ACP handshake that
+                # never launches the child process). Reap it fast with a clear
+                # "failed to start" error instead of burning the full deadline
+                # and surfacing a misleading 30-minute turn-0 timeout.
+                if self._manager._is_startup_stalled(info, now):
+                    logger.warning(
+                        "Reaper: subagent %s failed to start within %ds "
+                        "(turn 0, no runtime launched), force-killing",
+                        agent_id,
+                        self._manager._startup_deadline,
+                    )
+                    try:
+                        await self._manager._force_reap(
+                            agent_id,
+                            info,
+                            now - (info._exec_started or now),
+                            reason="startup_timeout",
+                        )
+                    except Exception:
+                        logger.exception("Reaper: failed to reap %s", agent_id)
+                    continue
+                # Idle-stall detection (see _maybe_flag_stall). The main-agent
+                # watchdog stack does not govern subagents; this is their
+                # equivalent — surface a "stalled" UI signal well before the
+                # 30-min ceiling. Surface-only: it never terminates the agent
+                # (users close it from the UX), so we always fall through to
+                # the wall-clock check below.
+                await self._manager._maybe_flag_stall(agent_id, info, now)
+                if elapsed <= self._manager._default_timeout:
+                    continue
+                logger.warning(
+                    "Reaper: subagent %s exceeded %ds (ran %.0fs), force-killing",
+                    agent_id,
+                    self._manager._default_timeout,
+                    elapsed,
+                )
+                try:
+                    await self._manager._force_reap(agent_id, info, elapsed)
+                except Exception:
+                    logger.exception("Reaper: failed to reap %s", agent_id)
+
+            # Prune stale tombstoned folders (>7 days old)
+            try:
+                pruned = await asyncio.get_running_loop().run_in_executor(
+                    maintenance_executor(),
+                    prune_stale_tombstones,
+                    7,
+                    self._manager._result_ttl_secs,
+                )
+                if pruned:
+                    logger.info("Reaper: pruned %d stale tombstone(s)", pruned)
+            except Exception:
+                logger.debug("Reaper: tombstone pruning failed", exc_info=True)
+
+    def _is_startup_stalled_impl(self, info: SubagentInfo, now: float) -> bool:
+        """True if a subagent is wedged in startup and should be reaped early.
+
+        A subagent qualifies only once it has actually entered execution
+        (``_exec_started`` set by ``_run_inner``) yet has launched no runtime
+        (``_pid is None``) and produced no turn (``turns == 0``) within
+        ``_startup_deadline`` seconds. Keying on ``_exec_started`` — not the
+        registration timestamp ``started`` — means an agent merely awaiting
+        spawn approval (never entered ``_run_inner``) is never caught here.
+        """
+        exec_started = info._exec_started
+        if exec_started is None:
+            return False
+        return (
+            info.turns == 0
+            and info._pid is None
+            and (now - exec_started) > self._manager._startup_deadline
+        )
+
+    async def _stall_verdict_impl(self, info: SubagentInfo) -> tuple[str, str]:
+        """Liveness verdict for an idle subagent: working, wedged, or unknown.
+
+        Idle time alone cannot separate a hung tool call from a slow silent one,
+        so this consults the same ``LivenessOracle`` the main agent's watchdog
+        uses (:mod:`kiro_crew.acp.liveness`) for ``/proc`` evidence.
+
+        The attribution is what makes it sound. With the in-flight tool's real
+        ``is_shell`` + command, the consult takes the oracle's shell-child
+        branch, which matches a live descendant by CMDLINE and then tracks that
+        pid — so the evidence belongs to THIS subagent's own child even when the
+        runtime is shared with sibling subagents. That is the distinction an
+        earlier whole-subtree attempt could not make: a subtree aggregate is
+        dominated by kiro-cli's own background socket/keepalive traffic, so a
+        ``sleep``-only subagent read as "working" and was never flagged.
+
+        Returns ``(verdict, evidence)``; any failure degrades to
+        ``(VERDICT_UNKNOWN, ...)`` so the caller falls back to idle time.
+        """
+        if not info._pid:
+            return VERDICT_UNKNOWN, "no runtime pid"
+        tool = info._inflight_tool
+        if tool is None:
+            # Idle with no tool in flight is a model-wait, not a hung command.
+            # The model-wait branch reads the whole runtime subtree, which is not
+            # attributable on a shared runtime — so decline rather than guess.
+            return VERDICT_UNKNOWN, "no tool in flight"
+        if not tool.is_shell:
+            # A non-shell MCP tool has no child process to match, so the oracle
+            # can only offer the same unattributable subtree aggregate. Decline.
+            return VERDICT_UNKNOWN, "non-shell tool — not attributable"
+        if info._stall_oracle is None:
+            info._stall_oracle = LivenessOracle()
+        # The consult is a SYNCHRONOUS /proc filesystem walk (``iter_descendants``
+        # over the runtime's descendant subtree, plus ``os.readlink`` on
+        # ``/proc/<pid>/fd/*``, which can block on the very wedged fd being
+        # investigated) — and this runs on the reaper's event loop, the same loop
+        # that serves every chat turn and the liveness heartbeat, sweeping agents
+        # serially. Inline, one wedged read freezes the gateway until the
+        # loop-stall watchdog kills it. Offload it exactly as the main-agent path
+        # does (``AcpSessionHandle._consult_oracle_offloaded``): bounded await,
+        # and at most ONE outstanding walk per agent so a permanently wedged read
+        # cannot leave a new blocked worker behind on every sweep.
+        # ``consult_offloaded`` owns that whole sequence -- one outstanding walk per
+        # holder, submission inside the guard, exception retrieval attached at
+        # submission, every failure degrading to UNKNOWN -- for the two watchdog
+        # paths that already depend on it, so a fix there lands here too.
+        # ``SubagentInfo`` satisfies its ``ConsultFutureHolder`` protocol via
+        # ``_consult_future``. That handle deliberately OUTLIVES snapshot
+        # retirement: ``_clear_tool_dispatch`` bumps ``_stall_gen`` (which
+        # invalidates a stale verdict, below) but leaves the future in place, so a
+        # walk still wedged on a stuck fd keeps suppressing resubmission instead
+        # of letting each later sweep strand another blocked worker.
+        submitted_gen = info._stall_gen
+        verdict = await consult_offloaded(
+            info,
+            info._stall_oracle.check_tool,
+            (info._pid, tool),
+            executor_factory=subprocess_executor,
+            log_label=f"stall consult for {info.id}",
+        )
+        # The consult awaits, so fresh activity, a final tool result, or the next
+        # dispatch can retire this snapshot while the walk is still running. A
+        # verdict about a tool that is no longer in flight must not be applied to
+        # whatever replaced it: DEAD/STUCK_INPUT skips the two-sweep confirmation,
+        # so a stale one would flag an agent that has demonstrably resumed working.
+        if info._stall_gen != submitted_gen:
+            return VERDICT_UNKNOWN, "superseded mid-consult"
+        return verdict
+
+    async def _maybe_flag_stall_impl(self, agent_id: str, info: SubagentInfo, now: float) -> None:
+        """Idle-stall detection for a running subagent (surface-only).
+
+        A subagent that has started (>=1 turn or a live runtime PID) but has
+        emitted no stream activity for ``_stall_idle_secs`` may be wedged in a
+        hung tool call — or simply running one slow, silent command. Idle time
+        cannot tell those apart, so the flag is gated on a ``LivenessOracle``
+        consult (:meth:`_stall_verdict`) that attributes evidence to the
+        subagent's OWN child process by cmdline match:
+
+        * ``WORKING`` — a live matched child, so it is progressing: not flagged.
+        * ``DEAD`` / ``STUCK_INPUT`` — the child exited with no result frame, or
+          its subtree is flat and blocked on a tty/stdin read. That is positive
+          evidence of a wedge, so it flags IMMEDIATELY, skipping the two-sweep
+          confirmation the idle-time path needs.
+        * ``UNKNOWN`` — no attributable evidence (no shell child to match, no
+          tool in flight, unreadable ``/proc``). Falls back to idle time with the
+          two-sweep confirmation, i.e. exactly the previous behaviour.
+
+        Still deliberately *surface-only*: it emits a ``subagent_stalled`` UI
+        signal and records the slow command, but NEVER terminates the agent, so
+        a slow-but-healthy command can only ever produce a self-clearing badge.
+        Escalating a ``DEAD`` verdict to an early reap would be a change to kill
+        semantics and is intentionally NOT part of this; the wall-clock reaper at
+        ``_TIMEOUT_SECS`` remains the only automatic terminator.
+        """
+        if not (info.turns > 0 or info._pid is not None):
+            return
+        # A subagent blocked on a human tool-approval prompt is healthy, not
+        # stalled — the permission request bumps `turns` before the approval
+        # wait, so without this a slow approval would be mislabelled idle.
+        if info._awaiting_approval:
+            return
+        idle = now - info.last_activity
+        if not info.stalled and idle > self._manager._stall_idle_secs:
+            verdict, evidence = await self._manager._stall_verdict(info)
+            if (
+                verdict == VERDICT_WORKING
+                and idle < self._manager._stall_idle_secs * _SUPPRESS_CEILING
+            ):
+                # Attributable progress in this subagent's own child: silent, not
+                # stalled. Leave the suspicion open (do not reset
+                # _stall_suspect_at) so the badge appears as soon as that child
+                # stops moving or exits.
+                #
+                # The ceiling above bounds how long a WORKING reading may hold the
+                # badge back, because attribution is not infallible: under
+                # ``session_sharing`` two siblings running similar commands can
+                # cmdline-match the SAME child, so a wedged agent can read WORKING
+                # for as long as its sibling's child lives. Without a bound that
+                # turns an old true positive into a permanent false negative —
+                # strictly worse than the idle-time-only path it replaces. With
+                # it, misattribution costs latency, not the signal.
+                logger.debug(
+                    "Reaper: subagent %s idle %.0fs but working (%s) — not flagging",
+                    agent_id,
+                    idle,
+                    evidence,
+                )
+                return
+            # A wedged verdict normally skips it: DEAD/STUCK_INPUT is positive
+            # evidence about this agent's child rather than a guess from elapsed
+            # silence, so dampening it would only delay a signal already earned.
+            #
+            # BUT that trust is only warranted when the cmdline match cannot have
+            # landed on someone else's child. ``_SUPPRESS_CEILING`` exists
+            # precisely because the match is fallible under a shared runtime, and
+            # a DEAD derived from a fallible match is exactly as wrong as the
+            # WORKING the ceiling bounds — a sibling's matched child exiting would
+            # otherwise raise an immediate badge on a healthy agent, skipping the
+            # very dampening added to keep the badge trustworthy at scale. So the
+            # skip is withdrawn whenever another session could be the one being
+            # measured, and the wedged verdict then earns its badge the same way
+            # an idle-time guess does: by holding across two sweeps.
+            #
+            # The gate keys on ``session_sharing`` itself, not on a count of live
+            # siblings, because the confusable co-tenant is not only a sibling:
+            # ``_create_shared_session`` puts the subagent on the PARENT's
+            # AcpRuntime ("one process hosts everything"), so ``info._pid`` is the
+            # parent's process and the parent's own tool children are descendants
+            # of it too. ``_live_shared_count`` iterates the subagent registry and
+            # therefore cannot see the parent, so a LONE subagent counted 1 and
+            # kept the fast path while still able to cmdline-match the parent's
+            # child — and flag instantly when that child exited. Since a shared
+            # runtime always has the parent in it, "could this match belong to
+            # someone else?" is true for every session-sharing agent.
+            wedged = verdict in (VERDICT_DEAD, VERDICT_STUCK_INPUT)
+            if wedged and info._session_sharing:
+                wedged = False
+            # Two-sweep confirmation (scale dampening): at 60-100 concurrent
+            # agents a single-window trip ambers several healthy-slow agents at
+            # any moment, training users to ignore the badge. Require the idle
+            # threshold to hold across TWO consecutive reaper sweeps before
+            # flagging — a stream event between sweeps resets the suspicion
+            # (_touch_activity clears both flags). Adds at most one sweep
+            # interval (~60s) of latency to a genuine stall.
+            if not wedged and info._stall_suspect_at <= 0.0:
+                info._stall_suspect_at = now
+                return
+            info.stalled = True
+            logger.warning(
+                "Reaper: subagent %s idle %.0fs (verdict=%s; %s) — marking stalled",
+                agent_id,
+                idle,
+                verdict,
+                evidence,
+            )
+            # Persist the slow command for future analysis. Best-effort; must
+            # not disturb the still-running agent (NOT a tombstone — the agent
+            # is alive, not dead).
+            self._manager._record_slow_command(info, idle)
+            try:
+                await self._manager._fire_event(
+                    "subagent_stalled",
+                    info,
+                    # The verdict and its evidence are deliberately NOT on the
+                    # wire: no consumer reads them (the frontend narrows this
+                    # payload to {slot, id, stalled, idle_secs} on arrival, and
+                    # the coalesced batch update forwards only `stalled`), and the
+                    # event is app-sdk-forwarded, so shipping unread keys would
+                    # create semi-permanent surface. The log line above records
+                    # both for diagnosis; add them here when something renders it.
+                    {"stalled": True, "idle_secs": int(idle)},
+                )
+            except Exception:
+                logger.debug(
+                    "Reaper: failed to emit subagent_stalled for %s", agent_id, exc_info=True
+                )
+
+    def task_memory_rows_impl(self) -> list[dict[str, object]]:
+        """Per-running-task memory/CPU rows for the session-memory surface.
+
+        Reads the samples the reaper sweep already takes (``_sample_live_costs``,
+        every ``_REAPER_INTERVAL`` seconds) — this method itself does no ``/proc``
+        work, so it is safe on the event loop. ``rss_mb`` is 0.0 until the first
+        sweep observes the agent, which is why ``sampled`` is reported separately:
+        a fresh task genuinely has no measurement yet, and rendering that as
+        "0 MB" would be a lie.
+
+        ``shared`` mirrors ``_session_sharing``: the value is that runtime's
+        measurement divided by the number of concurrently-live sharing sessions
+        on the same pid, i.e. an average share, not an exclusive figure. The same
+        split applies to ``procs``/``mcp`` (see ``_attributed_count``), which are
+        null until a sweep has counted them — a task row that reported no MCP
+        stubs because the field was simply absent read as "subagents do not use
+        the MCP pool", which is the opposite of what they do.
+        """
+        return [
+            {
+                "id": a.id,
+                "task": _redact_and_truncate(a.task, 80),
+                "agent": _redact(a.agent),
+                "parent": a.parent_session_key,
+                "rss_mb": round(a.last_rss_gb * 1024, 1),
+                "peak_rss_mb": round(a.peak_rss_gb * 1024, 1),
+                "cpu_cores": round(a.last_cpu_cores, 2),
+                "procs": a.last_procs,
+                "mcp": a.last_stubs,
+                "started_at": a.started,
+                "shared": a._session_sharing,
+                "pid": a._pid,
+                "sampled": a.last_rss_gb > 0.0 or a.peak_rss_gb > 0.0,
+            }
+            for a in self._manager._agents.values()
+            if not a.done and not a.queued
+        ]

--- a/src/kiro_crew/subagent_manager/run.py
+++ b/src/kiro_crew/subagent_manager/run.py
@@ -1,0 +1,1653 @@
+"""Run behavior for the SubagentManager facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._component import ManagerComponent
+
+if TYPE_CHECKING:
+    from ..subagent import (
+        _AGENT_NAME_RE,
+        _CANCEL_RESUME_PREFIX,
+        _DIAG_DRAIN_TIMEOUT,
+        _MAX_ERROR_DETAIL_LEN,
+        _ON_DONE_TIMEOUT,
+        _RESET_TIMEOUT,
+        _SYSTEM_PREFIX,
+        _TRANSIENT_CONTINUE_MSG,
+        _TURN_LIMIT,
+        EVENT_COMPLETE,
+        EVENT_PERMISSION_REQUEST,
+        EVENT_TEXT_CHUNK,
+        EVENT_TOOL_CALL,
+        EVENT_TOOL_RESULT,
+        FALLBACK_CANDIDATE_ATTEMPTS,
+        FALLBACK_STORY_ATTR,
+        HOOK_EVENT_POST_TOOL_USE,
+        TOOL_AUTO_APPROVE,
+        TOOL_DENY,
+        TRANSIENT_RETRIES,
+        AcpRuntime,
+        AcpSessionProvider,
+        Any,
+        FallbackState,
+        KiroCrewConfig,
+        LLMEvent,
+        LLMProvider,
+        Path,
+        Stats,
+        SubagentInfo,
+        _context_groups_of,
+        _describe_exception,
+        _redact,
+        _resolved_model_of,
+        _subagent_default_effort,
+        _subagent_default_model,
+        _timeout_context,
+        acp_error_is_transient,
+        advance_fallback_candidate,
+        agent_dir_for_display,
+        annotate_model_fallback,
+        append_fallback_story,
+        apply_completion_keep,
+        asyncio,
+        cap_result_file,
+        configured_fallback_chain,
+        evict_completed_agents,
+        extract_options,
+        fire_tool_hooks,
+        logger,
+        name_grant,
+        provider_fallback_active,
+        run_in_embed_pool,
+        sel,
+        time,
+        transient_retry_delay,
+        update_state,
+        window_for_provider_client,
+        write_result_chunk,
+    )
+
+
+class RunEventCoordinator(ManagerComponent):
+    """Own run transitions while state remains facade-owned."""
+
+    __slots__ = ()
+
+    def _effective_turn_limit_impl(self, info: SubagentInfo) -> int:
+        """Resolved turn cap for a run: per-spawn ``max_turns`` → config
+        default (``agent.subagent_max_turns``) → hardcoded ``_TURN_LIMIT``.
+
+        ``0`` at any level means "not set" and falls through to the next.
+        """
+        return info.max_turns or self._manager._default_turn_limit or _TURN_LIMIT
+
+    def update_completion_keep_impl(self, mode: str, max_chars: int) -> None:
+        """Update the live completion-keep mode and char budget.
+
+        Called from ``api_kirocrew_config_patch`` after the user changes
+        ``agent.completion_keep`` or ``agent.completion_keep_chars`` from
+        the Settings UI. The values are read once per subagent at
+        completion time (``apply_completion_keep`` call site), so swapping
+        them here takes effect for the next subagent to finish — including
+        ones already running. No torn-read possible under asyncio: both
+        reads happen in the same synchronous block.
+
+        ``mode`` is validated by ``_validated_completion_keep`` at config
+        load; this setter is intentionally permissive about ``max_chars``
+        so the loader / handler stays the validation choke-point.
+        """
+        self._manager._completion_keep = mode
+        self._manager._completion_keep_chars = max_chars
+
+    def running_agents_for_impl(self, parent_key: str) -> list[dict]:
+        """Return summary dicts for agents belonging to *parent_key*."""
+        from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+        def _r(s: str) -> str:
+            s, _ = redact_exfiltration_urls(s)
+            s, _ = redact_credentials(s)
+            return s
+
+        return [
+            {
+                "id": a.id,
+                "task": _r(a.task[:80]),
+                "agent": _r(a.agent),
+                "turns": a.turns,
+                "last_tool": _r(a.last_tool),
+                "tool_count": a.tool_count,
+                "stalled": a.stalled,
+                "startedAt": a.started,
+            }
+            for a in self._manager._agents.values()
+            if not a.done and a.parent_session_key == parent_key
+        ]
+
+    def get_impl(self, agent_id: str) -> SubagentInfo | None:
+        """Get agent info by ID."""
+        return self._manager._agents.get(agent_id)
+
+    async def _teardown_run_session_impl(self, info: SubagentInfo, session_key: str) -> None:
+        """Release and reset the run's own session (skipped when reaped).
+
+        Split out of ``_run``'s ``finally`` so the caller can wrap it in a nested
+        ``try/finally``: every statement here AWAITS, and a cancellation arriving
+        at one of those awaits propagates straight out of the enclosing
+        ``finally`` suite (the ``except Exception`` arms do not catch
+        ``CancelledError``). That skipped the slot release, the task-registry pop
+        and the teardown gate — leaking a concurrency slot, which is the very
+        class of bug this module's guard split exists to prevent.
+        """
+        try:
+            if info._session_sharing:
+                # Session-sharing subagents: destroy the session handle
+                # (unregister from shared runtime). Don't kill the runtime.
+                # Skip when the reaper already tore it down (info.reaped).
+                # Retain-by-default: keep the transcript files — they are
+                # spawn_continue's resume material. The tombstone pruner
+                # deletes them with the run folder (~1h after delivery)
+                # unless the conversation is promoted (continued / keep).
+                if info._shared_provider and not info.reaped:
+                    try:
+                        info._shared_provider.set_keep_transcript(True)
+                    except Exception:
+                        logger.debug("set_keep_transcript failed", exc_info=True)
+                    await info._shared_provider.shutdown()
+            else:
+                # Retain-by-default: never delete session files at teardown.
+                # The reset() below still expires the process, so an idle
+                # conversation costs a JSON file, not RSS. Deletion is owned
+                # by the tombstone pruner (default runs, ~1h) or the
+                # conversation TTL sweep / spawn_release (promoted runs).
+                self._manager._sessions.release(session_key, cleanup=False)
+        except Exception:
+            logger.warning("Subagent %s: release failed", info.id, exc_info=True)
+        if not info._session_sharing:
+            try:
+                await asyncio.wait_for(
+                    self._manager._sessions.reset(session_key), timeout=_RESET_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                logger.warning("Subagent %s: reset timed out, force-killing", info.id)
+                await self._manager._sigkill_session(session_key)
+                try:
+                    sel().log_tool_invocation(
+                        session_key=session_key,
+                        source="subagent",
+                        tool_name="run_finally_force_kill",
+                        outcome="sigkill",
+                        metadata={"subagent_id": info.id},
+                    )
+                except Exception:
+                    logger.exception("Subagent %s: SEL audit failed", info.id)
+            except Exception:
+                logger.exception("Subagent %s: reset failed", info.id)
+
+    async def _run_impl(self, info: SubagentInfo) -> None:
+        """Execute a subagent task in its own session."""
+        session_key = info.conversation_key or f"subagent:{info.id}"
+        try:
+            await asyncio.wait_for(
+                self._manager._run_inner(info, session_key), timeout=self._manager._default_timeout
+            )
+        except asyncio.TimeoutError:
+            if not info.reaped:
+                info.error = f"Timed out after {self._manager._default_timeout // 60} minutes [{_timeout_context(info, turn_limit=self._manager._effective_turn_limit(info))}]"
+                info.done = True
+                Stats().inc_subagent_failed()
+                self._manager._write_tombstone(info, "timeout")
+            logger.warning("Subagent %s timed out", info.id)
+        except asyncio.CancelledError:
+            if not info.reaped:
+                if (
+                    not info.user_stopped
+                    and not self._manager._shutting_down
+                    and not info._cancel_retry_used
+                    # A live diagnostics-write drain means a worker is still
+                    # (or may still be) writing state.json: respawning a
+                    # recovery writer now re-opens the stale-overwrite race
+                    # (#6306; reachable on 3.10 via a second outer cancel
+                    # interrupting wait_for's _cancel_and_wait).
+                    and not info._diag_drain_active
+                    and info.tool_count == 0
+                ):
+                    # UNEXPECTED cancellation (not user Stop, not shutdown):
+                    # one-shot auto-continue, mirroring the main path's
+                    # unexpected-cancel recovery. Skip terminal
+                    # finalization (via _recovering) and respawn on a fresh
+                    # task — this task is being cancelled and cannot continue.
+                    #
+                    # SIDE-EFFECT GATE (tool_count == 0): the respawn runs on a
+                    # FRESH session with no ledger of prior tool calls, so the
+                    # model cannot verify which side effects (files written,
+                    # messages sent, commands run) already happened — a
+                    # preamble alone cannot make re-running safe. Once any tool
+                    # has executed, we finalize with the partial preserved
+                    # instead of respawning. Text-only activity is safe to
+                    # resume (the partial is preserved and re-presented).
+                    info._cancel_retry_used = True
+                    info._recovering = True
+                    logger.warning(
+                        "Subagent %s unexpectedly cancelled — scheduling one-shot auto-continue",
+                        info.id,
+                    )
+                    try:
+                        sel().log_tool_invocation(
+                            session_key=session_key,
+                            source="subagent",
+                            tool_name="cancel_auto_continue",
+                            outcome="scheduled",
+                            metadata={"subagent_id": info.id},
+                        )
+                    except Exception:
+                        logger.debug("SEL audit for cancel recovery failed", exc_info=True)
+                    self._manager._schedule_cancel_recovery(info)
+                else:
+                    info.done = True
+                    if (
+                        info.tool_count > 0
+                        and not info.user_stopped
+                        and not self._manager._shutting_down
+                    ):
+                        # Auto-continue deliberately suppressed (side-effect
+                        # gate above): be explicit so the parent/user knows the
+                        # run was interrupted and NOT resumed, and why.
+                        info.error = (
+                            "cancelled (auto-continue suppressed: tools already "
+                            "executed — resuming on a fresh session could repeat "
+                            "side effects)"
+                        )
+                    else:
+                        info.error = "cancelled"
+                    # Preserve whatever streamed before the cancel as a partial
+                    # result (delivered with the failure).
+                    if not info.result and info.streaming_text:
+                        info.result = info.streaming_text
+                    Stats().inc_subagent_failed()
+                    self._manager._write_tombstone(info, "cancelled")
+            logger.info("Subagent %s cancelled", info.id)
+        except Exception as exc:
+            if not info.reaped:
+                # Story appended INSIDE the cap: info.error reaches a WS frame
+                # and the Subagents panel, so the rendered total stays bounded
+                # by _MAX_ERROR_DETAIL_LEN exactly as before — and the budget
+                # trims the ERROR text, never the story, so a verbose chain
+                # cannot push the walk out of the terminal error.
+                info.error = append_fallback_story(
+                    _describe_exception(exc), exc, budget=_MAX_ERROR_DETAIL_LEN
+                )
+                info.done = True
+                Stats().inc_subagent_failed()
+                self._manager._write_tombstone(info, "error")
+            logger.exception("Subagent %s failed", info.id)
+        finally:
+            # Guard 3 of 3 — the terminal REPORT, owned by the finalize claim.
+            # Taken (and the report task SPAWNED) before the teardown awaits
+            # below, so a cancellation landing anywhere in teardown cannot
+            # strand the outcome: the shielded task is already live. The claim
+            # returns False while _recovering without consuming itself, so a
+            # pending cancel-recovery respawn is not reported done and its
+            # respawned run can claim later.
+            report_task = None
+            # Set once this finally's session teardown has finished, so the
+            # already-spawned report holds its "delivered" tombstone until the
+            # child is provably gone (see `_report_terminal`).
+            teardown_done = asyncio.Event()
+            # Published where it survives this record being evicted: a settlement
+            # that happens OUTSIDE this report (the parent's queue drain, issue
+            # #4839) can come due after a dashboard clear/cancel has removed the run
+            # from _agents AND _tasks, and it still must not tombstone a child that
+            # is being killed.
+            self._manager._teardown_gates[info.id] = teardown_done
+            if self._manager._claim_finalize(info):
+                info.elapsed = time.time() - info.started
+                self._manager._record_cost(info)
+                report_task = self._manager._spawn_terminal_report(
+                    info,
+                    source="Subagent",
+                    injection_timeout_reason=(
+                        f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s" " (queue + injection)"
+                    ),
+                    mark_delivered_on_success=True,
+                    settle_digest=True,
+                    teardown_done=teardown_done,
+                )
+            # Nested try/finally: the teardown awaits must never be able to skip
+            # the bookkeeping below (see `_teardown_run_session`).
+            try:
+                if not info.reaped:
+                    await self._manager._teardown_run_session(info, session_key)
+            finally:
+                # Guard 2 of 3 — SLOT accounting on its own one-shot token, so
+                # the count is released exactly once whichever terminal path
+                # arrives first (and is NOT skipped just because the reaper set
+                # `reaped`, which is how an earlier revision leaked slots).
+                if self._manager._release_slot(info):
+                    self._manager._running_count -= 1
+                    self._manager._drain_queue()
+                self._manager._tasks.pop(info.id, None)
+                # Teardown is done (or was skipped because the reaper did it) —
+                # release the report's delivered-tombstone gate. Unconditional,
+                # so the report can never wedge on a cancelled teardown.
+                teardown_done.set()
+                # Set BEFORE the entry is dropped: a waiter that already holds the
+                # event is released by the line above, and one arriving after finds
+                # no entry, which now means exactly "nothing left to wait for".
+                self._manager._teardown_gates.pop(info.id, None)
+
+        # The report itself already ran (or is running) on the shielded task
+        # spawned in the finally above; block until it completes so sequencing is
+        # unchanged for callers.
+        #
+        # NOT during shutdown. `_run`'s CancelledError arm deliberately does not
+        # re-raise, so by the time we reach this await the cancellation has been
+        # consumed and `shield` would simply wait out the full _ON_DONE_TIMEOUT
+        # injection cap — holding `cancel_all()`'s gather for up to 20 minutes.
+        # The report is registered in `self._report_tasks`, so `cancel_all()`'s
+        # bounded drain owns it from here.
+        if report_task is not None and not self._manager._shutting_down:
+            await self._manager._await_report(report_task)
+
+    async def _touch_activity_impl(self, info: SubagentInfo) -> None:
+        """Record stream activity for idle-stall detection.
+
+        Updates ``last_activity`` and, if the subagent was previously flagged
+        stalled by the reaper, clears the flag and notifies the UI so the
+        running-card drops the "stalled" warning the moment work resumes.
+        """
+        info.last_activity = time.time()
+        info._stall_suspect_at = 0.0  # activity resets the 2-sweep confirmation
+        # Retire the oracle so the next suspicion samples a fresh baseline rather
+        # than differencing against counters from before this activity, and bump
+        # the generation so a consult submitted before this moment cannot land a
+        # stalled verdict on an agent that has just proven it is working.
+        if info._stall_oracle is not None:
+            info._stall_oracle = info._stall_oracle.fresh()
+        info._stall_gen += 1
+        if info.stalled:
+            info.stalled = False
+            await self._manager._fire_event("subagent_stalled", info, {"stalled": False})
+
+    async def _fire_event_impl(
+        self, etype: str, info: SubagentInfo, extra: dict | None = None
+    ) -> None:
+        if self._manager._on_event:
+            try:
+                await self._manager._on_event(etype, info, extra or {})
+            except Exception:
+                logger.warning("on_event failed for %s/%s", etype, info.id, exc_info=True)
+
+    def _queued_depth_impl(self, parent_session_key: str) -> int:
+        """Number of spawns currently queued for *parent_session_key* (waiting
+        behind the concurrency cap / stagger gate, not yet started)."""
+        return sum(
+            1 for q in self._manager._queue if q.get("parent_session_key", "") == parent_session_key
+        )
+
+    def queued_count_for_impl(self, parent_session_key: str) -> int:
+        """Public queued-spawn count for *parent_session_key*.
+
+        Spawns accepted behind the concurrency cap / stagger gate sit in
+        ``_queue`` with no ``SubagentInfo`` yet, so ``running``-based checks
+        read "no pending work" during exactly the window a wave is ramping.
+        Reset-deferral guards must consult this alongside ``running``.
+        """
+        return self._manager._queued_depth(parent_session_key)
+
+    def has_pending_work_for_impl(self, parent_session_key: str) -> bool:
+        """True while *parent_session_key* has sub-agents RUNNING or QUEUED.
+
+        The reset-deferral guards must consult this, not ``running`` alone —
+        see :meth:`queued_count_for` for why. A parent session reset while a
+        spawn is still queued strands that agent's completion on a
+        cold-started, context-free replacement session.
+        """
+        if self._manager._queued_depth(parent_session_key) > 0:
+            return True
+        return any(a.parent_session_key == parent_session_key for a in self._manager.running)
+
+    def _emit_queue_depth_impl(self, parent_session_key: str, batch_id: str = "") -> None:
+        """Emit the current queued depth for *parent_session_key* as a
+        ``subagent_queued`` lifecycle event.
+
+        The chip is otherwise driven only by agents that have actually started
+        (``subagent_spawn``), so agents sitting behind the concurrency cap /
+        stagger gate are invisible and the chip can appear late or flicker.
+        This advisory count lets the UI show "N waiting to start" the moment a
+        wave is accepted, and stay mounted across the staggered ramp.
+
+        Fire-and-forget: scheduled on the running loop; a no-op in sync/test
+        contexts without a loop (the count is advisory UI signal, not state).
+        """
+        depth = self._manager._queued_depth(parent_session_key)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no running loop (sync/test context) — advisory event skipped
+        info = SubagentInfo(
+            id="_queue",
+            task="",
+            parent_session_key=parent_session_key,
+            batch_id=batch_id,
+        )
+        loop.create_task(self._manager._fire_event("subagent_queued", info, {"queued": depth}))
+
+    async def _run_inner_impl(self, info: SubagentInfo, session_key: str) -> None:
+        """Inner execution — called within timeout wrapper."""
+        # Mark the real start of execution BEFORE any await so the startup
+        # watchdog measures from here, not from registration (which may include
+        # an arbitrary spawn-approval wait). Must be the first statement.
+        info._exec_started = time.time()
+        # Reset the activity clock to execution start too: last_activity is set
+        # at registration (like ``started``), which can include a long spawn-
+        # approval / queue wait. Without this, _maybe_flag_stall would treat
+        # that pre-execution delay as idle time and prematurely surface a
+        # healthy, just-started subagent as "stalled".
+        info.last_activity = info._exec_started
+        # Inherit approval policy from parent session; yolo/trust overrides
+        parent_policy = self._manager._sessions.get_approval_policy(info.parent_session_key)
+        # Explicit approval_mode from spawn caller (e.g. Mochi bg agent)
+        if not parent_policy and info.approval_mode == "auto":
+            parent_policy = "auto"
+            sel().log_api_access(
+                caller=info.parent_session_key or f"subagent:{info.id}",
+                operation="subagent.approval_mode_auto_policy",
+                outcome="ok",
+                source="subagent",
+                resources=f"subagent_id={info.id}",
+            )
+        if not parent_policy and self._manager._is_yolo and self._manager._is_yolo():
+            parent_policy = "auto"
+            sel().log_api_access(
+                caller=info.parent_session_key,
+                operation="subagent.yolo_policy_fallback",
+                outcome="ok",
+                source="subagent",
+                resources=f"subagent_id={info.id}",
+            )
+        if not parent_policy and self._manager._global_approval_mode == "auto":
+            # Apply global config as fallback only when parent is absent or
+            # confirmed garbage-collected (no longer in session store).
+            # If parent session still exists but returned no policy, deny by
+            # default — the session is alive and intentionally non-auto.
+            if not info.parent_session_key:
+                _parent_gone = True  # no_parent
+            elif self._manager._sessions.has_session(info.parent_session_key) is False:
+                _parent_gone = True  # parent_gc
+            else:
+                _parent_gone = False  # parent alive or store error → deny
+                sel().log_api_access(
+                    caller=f"subagent:{info.id}",
+                    operation="subagent.config_policy_fallback",
+                    outcome="denied",
+                    source="subagent",
+                    resources=f"subagent_id={info.id},reason=parent_alive_or_store_error",
+                )
+            if _parent_gone:
+                parent_policy = "auto"
+                _reason = "parent_gc" if info.parent_session_key else "no_parent"
+                sel().log_api_access(
+                    caller=f"subagent:{info.id}",
+                    operation="subagent.config_policy_fallback",
+                    outcome="ok",
+                    source="subagent",
+                    resources=f"subagent_id={info.id},reason={_reason}",
+                )
+        # auto_approve_subagent_tools auto-approves tool calls inside
+        # subagents (separate from the spawn gate, deny-by-default).
+        if not parent_policy and self._manager._ctx_builder and self._manager._ctx_builder.hooks:
+            if self._manager._ctx_builder.hooks.auto_approve_subagent_tools is True:
+                parent_policy = "auto"
+                sel().log_api_access(
+                    caller=info.parent_session_key or f"subagent:{info.id}",
+                    operation="subagent.auto_approve_subagent_tools_policy",
+                    outcome="ok",
+                    source="subagent",
+                    resources=f"subagent_id={info.id}",
+                )
+        # Inherit agent from parent session when not explicitly specified
+        agent = info.agent or self._manager._sessions.get_agent(info.parent_session_key)
+        if not info.agent and agent:
+            sel().log_api_access(
+                caller=f"subagent:{info.id}",
+                operation="subagent.agent_inheritance",
+                outcome="ok",
+                source="subagent",
+                resources=f"subagent_id={info.id},inherited_agent={agent}",
+            )
+        extra_kwargs: dict[str, Any] = {}
+        # An explicit per-spawn model wins; otherwise fall back to the
+        # configured sub-agent role model (agent.role_models['subagent']). When
+        # that role is unpinned the helper returns "" so we omit the kwarg and
+        # keep deferring to the provider's configured default, exactly as before.
+        eff_model = info.model or _subagent_default_model()
+        # Record the EFFECTIVE pin (per-spawn OR the role_models['subagent']
+        # config pin, via ``_subagent_default_model()``) as the requested side of
+        # the downgrade comparison — keying off the bare per-spawn ``model`` would
+        # miss a config-pinned run served a different model.
+        # For completely unpinned spawns (no per-spawn pin, no role pin) ``eff_model``
+        # is ``""``; fall back to the literal ``"auto"`` sentinel so the frontend
+        # can show a neutral chip instead of nothing at all (#5869).
+        info.requested_model = eff_model or "auto"
+        if eff_model:
+            extra_kwargs["model"] = eff_model
+        # Sub-agent reasoning effort (per-call override -> role_efforts['subagent']
+        # -> chat default). Passed as an override so it wins over the factory's
+        # agent-derived default; "" leaves it to that default.
+        eff_effort = info.reasoning_effort or _subagent_default_effort()
+        if eff_effort:
+            extra_kwargs["reasoning_effort_override"] = eff_effort
+        if info.bare:
+            extra_kwargs["bare"] = True
+        if info.allowed_tools:
+            extra_kwargs["allowed_tools"] = info.allowed_tools
+        if info.cwd:
+            extra_kwargs["cwd"] = info.cwd
+
+        # ── Session sharing: reuse parent's shared AcpRuntime ──
+        # When enabled and eligible, subagents get a session on the parent's
+        # companion AcpRuntime (~200ms startup, ~0 memory) instead of spawning
+        # a fresh kiro-cli process (~3-5s, ~400MB).
+        #
+        # Retain-by-default: EVERY run keeps its session files (teardown skips
+        # deletion on both arms), so any completed run is continuable while
+        # its files survive. keep=True / continuation runs additionally take
+        # the dedicated arm: their resume path is the proven dashboard
+        # expire-and-session/load lifecycle, which owns its process. Whether a
+        # SHARED-runtime sid is loadable is the open Phase 0 question — until
+        # proven, a continue on a shared-arm run relies on the fail-closed
+        # resume guard below rather than a spawn-time guarantee.
+        if info.keep:
+            self._manager._sessions.mark_continuable(session_key)
+            self._manager._conversations[session_key] = time.time()
+        use_session_sharing = (not info.keep) and self._manager._should_use_session_sharing(info)
+        # A per-spawn or per-role model / reasoning-effort override cannot be
+        # applied to the parent's already-started shared runtime (it was spawned
+        # with the parent's model and cannot switch model per session). Force the
+        # dedicated process path so the override in extra_kwargs actually reaches
+        # get_or_create -> the provider factory; otherwise a configured sub-agent
+        # model/effort would silently no-op on the default (session-sharing) path.
+        if eff_model or eff_effort:
+            use_session_sharing = False
+        if use_session_sharing:
+            try:
+                client = await self._manager._create_shared_session(info, session_key, agent)
+            except Exception as exc:
+                # Fallback: shared runtime unavailable (dead, spawn failed, etc.)
+                # Revert to legacy per-process path transparently.
+                logger.warning(
+                    "Subagent %s: session sharing failed (%s), falling back to dedicated process",
+                    info.id,
+                    exc,
+                )
+                info._session_sharing = False
+                info._shared_provider = None
+                use_session_sharing = False
+                client, is_new, _resumed = await self._manager._sessions.get_or_create(
+                    session_key,
+                    agent=agent or None,
+                    approval_policy=parent_policy,
+                    **extra_kwargs,
+                )
+                is_cc = self._manager._is_cc_provider(client)
+            else:
+                is_new = True
+                _resumed = False
+                is_cc = False
+        else:
+            client, is_new, _resumed = await self._manager._sessions.get_or_create(
+                session_key,
+                agent=agent or None,
+                approval_policy=parent_policy,
+                **extra_kwargs,
+            )
+            # Fail CLOSED on a continuation that did not actually resume:
+            # get_or_create silently falls back to a FRESH session when
+            # session/load fails (lock held, corrupt files, backend refusal).
+            # Executing the follow-up on that fresh session would silently run
+            # it context-free — worse than an honest error the parent can react
+            # to (re-spawn with a summary). conversation_key is only set by
+            # continue_conversation, so first spawns are unaffected.
+            if info.conversation_key and not _resumed:
+                raise RuntimeError(
+                    "resume_failed: session/load did not restore conversation "
+                    f"{info.conversation_key} — refusing to execute the "
+                    "follow-up without its prior context. The conversation "
+                    "may be locked by a live process or its files corrupt; "
+                    "re-spawn with a fresh task carrying a summary."
+                )
+            # Detect CC provider to skip permission event loop
+            is_cc = self._manager._is_cc_provider(client)
+        # Intentionally check info.agent (not resolved `agent`) so only
+        # explicitly requested agents skip _SYSTEM_PREFIX (defense-in-depth).
+        named_agent = bool(info.agent and _AGENT_NAME_RE.fullmatch(info.agent))
+        raw_task = info._raw_task or info.task
+        message = raw_task if named_agent else (_SYSTEM_PREFIX + raw_task)
+        if info._cancel_retry_used and (info.streaming_text or info.tool_count > 0):
+            # One-shot auto-continue after an unexpected cancellation: tell the
+            # model the prior attempt was interrupted so it completes the task
+            # instead of assuming a fresh start. Same activity predicate as
+            # the transient-retry path: a mutating tool may
+            # have executed BEFORE the first text chunk, so tool_count must
+            # trigger the preamble too — a bare original prompt after tool
+            # activity invites duplicate side effects. (info.tool_count and
+            # streaming_text persist across the respawn; _run_inner never
+            # resets them.)
+            message = _CANCEL_RESUME_PREFIX + message
+        # Scale the injected-context budget to this subagent's model window (a
+        # subagent can be pinned to a smaller model). Resolved from the live
+        # client; None ⇒ 1M reference.
+        _sub_window = window_for_provider_client(client)
+        # Context scope this run was spawned with. Passed even when every group
+        # is on, so build_message applies one code path for sub-agents.
+        _groups = _context_groups_of(info)
+        # Off-loop: build_message embeds the episodic query (blocking urllib).
+        # A run's explicitly-given cwd IS its project for skill scoping: a
+        # dashboard spawn inherits the parent slot's project as its cwd, so the
+        # hands-off surface keeps the repo-scoped skills that surface exists for.
+        # The pool default is deliberately NOT substituted -- it is the
+        # workspace directory, not a checkout, so it can only ever mean "this
+        # run named no project", which is exactly the fail-closed case. Keeping
+        # one meaning for that makes the rule the same on every surface.
+        full_message, _ = await run_in_embed_pool(
+            self._manager._ctx_builder.build_message,
+            message,
+            is_new,
+            session_key,
+            project=info.cwd or None,
+            provider_type=self._manager._provider_label_of(client),
+            model_window=_sub_window,
+            context_groups=_groups,
+        )
+        # The one place the resolved scope and its cost are both known — without
+        # this, "the sub-agent didn't know X" is undebuggable after the fact.
+        logger.info(
+            "Subagent %s context: groups=%s, %d chars",
+            info.id,
+            ",".join(sorted(_groups)) or "conduct-only",
+            len(full_message),
+        )
+
+        result_text = ""
+        turns = 0
+        turn_limit = self._manager._effective_turn_limit(info)
+        # Separate volume bound for child-origin permission escalations —
+        # they are exempt from the parent's turn budget (see the
+        # EVENT_PERMISSION_REQUEST branch) but must not be unbounded.
+        child_escalations = 0
+        child_escalation_limit = max(turn_limit * 3, 60)
+        # Reports inherited agent (not just info.agent) so telemetry shows
+        # the actual agent used for this subagent session.
+        #
+        # Read back the model the live session actually resolved to serve, so
+        # the panel shows what ran rather than only what was requested (issue
+        # #3582). Best-effort at spawn: the ACP session/new response already
+        # carries the served id (readable now, even on the backend default),
+        # while the raw CC path only knows it after the first turn — so this is
+        # refreshed authoritatively at completion below. Only overwrite a prior
+        # non-empty value with another non-empty one, so a spawn-time read that
+        # succeeded is never clobbered back to "" by a transient later miss.
+        _spawn_model = _resolved_model_of(client)
+        if _spawn_model:
+            info.resolved_model = _spawn_model
+        # Persist provenance to disk BEFORE the spawn event so a gateway restart
+        # in the window between the event and the later session_id state write
+        # cannot lose it — orphan recovery reads these from disk. Off-loop
+        # (to_thread): update_state does a synchronous fsync, so
+        # a slow FS must not freeze the gateway/heartbeat. Best-effort with ONE
+        # bounded retry: this write is the SINGLE owner of these two fields on
+        # the spawn path (#5394) — the later session_id write no longer doubles
+        # as a fallback, so a transient failure gets its second chance HERE
+        # rather than from a second writer downstream. update_state reports a
+        # silently-skipped merge (unreadable state) as False, which counts as a
+        # failure for the retry — only a REPORTED write ends the loop. A
+        # persistence hiccup must still never block the spawn.
+        for _provenance_attempt in range(2):
+            try:
+                _wrote = await asyncio.to_thread(
+                    update_state,
+                    info.id,
+                    requested_model=info.requested_model,
+                    resolved_model=info.resolved_model,
+                )
+                if _wrote:
+                    break
+                logger.debug("Provenance write skipped (unreadable state) for %s", info.id)
+            except Exception:
+                logger.debug("Failed to persist model provenance for %s", info.id, exc_info=True)
+        await self._manager._fire_event(
+            "subagent_spawn",
+            info,
+            {
+                "task": _redact(info.task),
+                "agent": agent or "",
+                "model": info.resolved_model,
+                # The requested pin is caller-supplied (spawn_run.model), so it
+                # is redacted like every other free-text field on the frame -- an
+                # unavailable/AKIA-shaped pin must never reach the dashboard
+                # socket raw.
+                "requested_model": _redact(info.requested_model),
+                # The sub-agent's own session key (see build_subagent_snapshot):
+                # lets a client fetch this node's own context-trace.
+                "child_session": info.conversation_key or f"subagent:{info.id}",
+            },
+        )
+        # Stream results to disk for orchestrated chat.
+
+        # Record PID for orphan recovery
+        try:
+
+            pid = self._manager._sessions.get_pid(session_key)
+            if pid:
+                info._pid = pid  # make available for _write_tombstone
+                update_state(info.id, pid=pid, pid_recorded_at=time.time())
+        except Exception:
+            logger.debug("Failed to record PID for %s", info.id, exc_info=True)
+
+        # Record session_id and provider type for session file cleanup
+        try:
+            session_id = client.session_id if hasattr(client, "session_id") else ""
+            provider_type = self._manager._provider_label_of(client)
+            state_update: dict[str, object] = {
+                "session_id": session_id,
+                "provider": provider_type,
+                # Model provenance (requested_model/resolved_model) is NOT
+                # re-written here: the crash-safe write BEFORE the
+                # subagent_spawn event above is the single owner of those two
+                # fields on the spawn path, and a transient failure there is
+                # handled by that write's own bounded retry (#5394). This write
+                # still performs the same read-merge-rewrite either way, so the
+                # point is one authoritative writer, not saved I/O. The CC-path
+                # refinement below still updates resolved_model when it first
+                # becomes known.
+                # keep marks this run's session files as resume material: the
+                # orphan reconciler and tombstone pruner skip file deletion
+                # for keep runs (restart-safe — read from disk, not memory).
+                "keep": info.keep,
+                "conversation_key": session_key if info.keep else "",
+            }
+            # Store CWD for CC cleanup (needed to derive project-key path).
+            # info.cwd is only set when a caller passes an explicit cwd
+            # override (disabled by default), so for the common case derive
+            # the project dir from the provider's own work dir — that is the
+            # same path sent as ACP `cwd`, hence the encoded project key under
+            # ~/.claude/projects. Without this, CC cleanup is skipped (no cwd)
+            # and the transcript leaks.
+            if is_cc:
+                cc_cwd = info.cwd
+                if not cc_cwd:
+                    inner = getattr(client, "client", None)
+                    work_dir = getattr(inner, "_work_dir", None)
+                    if work_dir:
+                        cc_cwd = str(work_dir)
+                if cc_cwd:
+                    state_update["cwd"] = cc_cwd
+            update_state(info.id, **state_update)
+        except Exception:
+            logger.debug("Failed to record session_id for %s", info.id, exc_info=True)
+
+        _rp = agent_dir_for_display(info.id) / "result.txt"
+        info.result_path = str(_rp)
+        # Cache tool names by tool_call_id so PostToolUse can recover the tool name
+        # when EVENT_TOOL_RESULT arrives (which only carries tool_call_id and output).
+        # Mirrors kiro_crew.dashboard.chat_runner._pending_tools.
+        _pending_tools: dict[str, str] = {}
+
+        async def _stream_with_transient_retry():
+            """Yield stream events, retrying transient backend errors.
+
+            Parity with the main path's retry ladder (chat_runner B1/B2):
+            - Pre-token (no text streamed yet): re-send the SAME prompt on the
+              same live session, up to TRANSIENT_RETRIES with exp backoff.
+            - Post-token (partial already streamed): send a CONTINUE prompt so
+              the preserved partial is finished, not duplicated.
+            Non-transient errors and exhausted budgets propagate unchanged
+            (handled by _run's generic exception arm → error tombstone).
+            """
+            attempts = 0
+            # One-shot post-activity allowance, mirroring the main path's
+            # ``_posttoken_retry_used`` rule (dashboard/chat_runner.py ~L4324):
+            # each continuation turn issued AFTER observed activity is an
+            # independent opportunity for the model to repeat a side-effecting
+            # tool, so post-activity recovery gets exactly ONE attempt.
+            # TRANSIENT_RETRIES applies only while zero activity was observed
+            # (replaying the bare prompt is side-effect-free by definition).
+            # PARITY NOTE: this ladder and chat_runner's are two copies with
+            # intentionally identical semantics — a fix to either's activity
+            # predicate or budget rules must be mirrored in the other.
+            post_activity_attempts = 0
+            # Throttle-exhaustion fallback chain (agent.fallback_model):
+            # engaged only once the zero-activity budget above is spent, same
+            # trigger as stream_and_collect's Case 2.75 and the dashboard's
+            # fallback branch. State is per-run (this closure), matching
+            # "a slot/session-scoped equivalent" — the sticky marker for the
+            # session lives on the provider via TURN_FALLBACK_ATTR.
+            _fb_state = FallbackState(configured_fallback_chain())
+            msg = full_message
+            while True:
+                try:
+                    async for _ev in client.stream(msg):
+                        yield _ev
+                    return
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    if not acp_error_is_transient(exc):
+                        raise
+                    # Post-activity: continue instead of re-running. "Activity"
+                    # is ANY text chunk, approved tool turn, or auto-allowed
+                    # tool call — a mutating tool may have executed before the
+                    # first text chunk, and replaying the full prompt would
+                    # re-run it (duplicate writes/messages). Only a turn with
+                    # zero observed activity resends the original prompt.
+                    _had_activity = bool(result_text) or turns > 0 or info.tool_count > 0
+                    if _had_activity:
+                        if post_activity_attempts >= 1:
+                            raise
+                        post_activity_attempts += 1
+                    elif attempts >= TRANSIENT_RETRIES:
+                        # ── Throttle-exhaustion fallback chain ──
+                        # Zero-activity budget spent: walk agent.fallback_model
+                        # before surfacing (empty chain ⇒ raise exactly as
+                        # before this feature). Two attempts per candidate
+                        # (FALLBACK_CANDIDATE_ATTEMPTS), ~2s backoff each —
+                        # NOT the exponential same-model curve; see
+                        # llm_helpers Case 2.75 for the rationale.
+                        if not _fb_state.chain:
+                            raise
+                        if not _fb_state.should_retry_active():
+                            _cand = await advance_fallback_candidate(
+                                client,
+                                _fb_state,
+                                surface="subagent",
+                                log_suffix=f", id={info.id}",
+                            )
+                            if _cand is None:
+                                _story = _fb_state.exhaustion_story()
+                                if _story:
+                                    logger.warning(
+                                        "model fallback: chain exhausted (%s) for "
+                                        "subagent %s; surfacing original error",
+                                        _story,
+                                        info.id,
+                                    )
+                                    try:
+                                        setattr(exc, FALLBACK_STORY_ATTR, _story)
+                                    except Exception:
+                                        pass
+                                raise
+                        _fb_delay = transient_retry_delay(1)
+                        await self._manager._fire_event(
+                            "subagent_retrying",
+                            info,
+                            {
+                                "attempt": _fb_state.attempts,
+                                "max": FALLBACK_CANDIDATE_ATTEMPTS,
+                                "fallback_model": _fb_state.active or "",
+                            },
+                        )
+                        try:
+                            sel().log_api_access(
+                                caller=info.parent_session_key or f"subagent:{info.id}",
+                                operation="subagent.model_fallback_retry",
+                                outcome="retrying",
+                                source="subagent",
+                                resources=(
+                                    f"subagent_id={info.id},"
+                                    f"model={_fb_state.active or ''},"
+                                    f"attempt={_fb_state.attempts}"
+                                ),
+                            )
+                        except Exception:
+                            logger.debug("SEL audit for fallback retry failed", exc_info=True)
+                        await asyncio.sleep(_fb_delay)
+                        # Zero activity by construction on this arm — replay
+                        # the original prompt, never a continuation.
+                        msg = full_message
+                        continue
+                    attempts += 1
+                    delay = transient_retry_delay(attempts)
+                    logger.warning(
+                        "Subagent %s: transient backend error (attempt %d/%d), "
+                        "retrying in %.1fs: %s",
+                        info.id,
+                        attempts,
+                        TRANSIENT_RETRIES,
+                        delay,
+                        exc,
+                    )
+                    await self._manager._fire_event(
+                        "subagent_retrying",
+                        info,
+                        {"attempt": attempts, "max": TRANSIENT_RETRIES},
+                    )
+                    try:
+                        sel().log_api_access(
+                            caller=info.parent_session_key or f"subagent:{info.id}",
+                            operation="subagent.transient_retry",
+                            outcome="retrying",
+                            source="subagent",
+                            resources=f"subagent_id={info.id},attempt={attempts}",
+                        )
+                    except Exception:
+                        logger.debug("SEL audit for transient retry failed", exc_info=True)
+                    await asyncio.sleep(delay)
+                    msg = _TRANSIENT_CONTINUE_MSG if _had_activity else full_message
+
+        _complete_event: LLMEvent | None = None
+        # Wall clock for THIS subagent's own turn. Deliberately started here,
+        # at the subagent's own stream, not on the parent side: under session
+        # sharing this subagent reuses the parent's runtime, so a parent-side
+        # clock would charge the child for the parent's elapsed time. acp
+        # leaves TurnUsage.duration_ms at 0, so the row needs this.
+        # Includes transient-retry backoff, which is real wall time the caller
+        # waited for this turn.
+        _turn_t0 = time.monotonic()
+        async for event in _stream_with_transient_retry():
+            # Refresh the activity clock for every event kind that BELONGS to
+            # this session (thinking chunks, tool-call updates, etc.) before
+            # dispatch, so idle-stall detection only trips on a genuine no-event
+            # hang -- not on an event kind this switch does not special-case.
+            #
+            # ``runtime_global`` events are the one exclusion: the frame behind
+            # them carried no ``sessionId`` and the runtime fanned it out to
+            # several sessions sharing one kiro-cli process, so it is another
+            # tenant's traffic. Under ``agent.session_sharing`` (default true)
+            # co-tenant subagents are separate sessions on the parent's runtime,
+            # and counting the roster broadcast as activity reset
+            # ``last_activity`` for a whole batch of wedged subagents at the same
+            # instant, cleared their "stalled" badge and restarted the idle count
+            # on agents that had made no progress -- so the badge flapped and the
+            # reported ``idle_secs`` measured time since an unrelated agent's
+            # roster churn. Field data: three co-tenants flagged in one reaper
+            # sweep at idle 214s/214s/215s (one shared refresh instant) while
+            # their elapsed was 1445s/1447s/1538s.
+            #
+            # Deliberately a PROVENANCE test, not an event-kind test: the same
+            # kind reached through a routed frame (the KAS sub-agent lifecycle
+            # path) is this session's own progress and must still count, or a
+            # working agent gets falsely badged. Approval waits stay exempt via
+            # _awaiting_approval.
+            #
+            # Plain attribute access: every provider yields ``LLMEvent`` (an
+            # alias of ``AcpEvent``), which declares the field, so there is no
+            # shape here that could raise. A hop that forgets to carry the flag
+            # degrades to the default False, i.e. "counts as activity" -- the
+            # fail-open direction, which can only delay a badge, never invent
+            # one.
+            if not event.runtime_global:
+                await self._manager._touch_activity(info)
+            if event.kind == EVENT_TEXT_CHUNK:
+                # The CC/raw provider only learns its served model once the
+                # backend answers the first turn — by the first text chunk that
+                # has happened, so refresh here. Runs once (guarded on a still-
+                # empty value) and stays cheap: covers every downstream exit
+                # path (normal, turn_limit, child-escalation, cancel) without
+                # threading the live client through each. Never overwrites a good
+                # spawn-time read with "".
+                if not info.resolved_model:
+                    _live_model = _resolved_model_of(client)
+                    if _live_model:
+                        info.resolved_model = _live_model
+                        # Persist the CC-path refinement so a restart after the
+                        # first turn still recovers the served model. Off-loop
+                        # (to_thread): synchronous fsync must not block the loop.
+                        try:
+                            await asyncio.to_thread(
+                                update_state, info.id, resolved_model=_live_model
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Failed to persist refined model for %s", info.id, exc_info=True
+                            )
+                result_text += event.text
+                write_result_chunk(info.id, event.text)
+                redacted = _redact(event.text)
+                info.streaming_text += redacted
+                if len(info.streaming_text) > 50_000:
+                    info.streaming_text = "…(truncated)\n" + info.streaming_text[-40_000:]
+                await self._manager._fire_event("subagent_chunk", info, {"text": redacted})
+            elif event.kind == EVENT_PERMISSION_REQUEST:
+                # Both kiro-cli and claude-agent-acp surface tool calls via
+                # session/request_permission. Run them through the same hook
+                # → parent_policy → interactive callback pipeline so the
+                # approve / reads / trust / yolo protocol applies uniformly.
+                #
+                # Child-origin escalations (runtime-routed backend subagents)
+                # do NOT consume the parent's turn budget: a child asking for
+                # enough permissions would otherwise trip the parent's
+                # turn_limit and kill the whole subagent run on activity that
+                # is not the parent's own turns. They get their OWN bound
+                # instead — without one, a chatty or adversarial backend
+                # child could generate unbounded approval prompts until the
+                # wall-clock reaper fires (the turn budget used to bound
+                # exactly this traffic). Generous multiple of the parent's
+                # limit: legitimate crews fan many small child tool calls.
+                if not event.sub_session_id:
+                    turns += 1
+                    info.turns = turns
+                else:
+                    # Child escalation: counted toward its own volume bound
+                    # here; side-effect activity (tool_count) is counted at
+                    # APPROVAL in _approve_and_log — a purely rejected
+                    # escalation executed nothing and must not consume the
+                    # run's replay budget (tool_count gates prompt replay
+                    # and cancel-respawn).
+                    child_escalations += 1
+                    if child_escalations > child_escalation_limit:
+                        # Answer the triggering request BEFORE bailing: this
+                        # event is already dequeued, so returning without a
+                        # response would strand the child's oneshot — under
+                        # session sharing the runtime outlives this subagent
+                        # and nothing else tears the connection down. The
+                        # "requests are answered on every queue path"
+                        # contract this PR establishes applies to limit
+                        # bails too.
+                        try:
+                            await self._manager._reject_and_log(
+                                client,
+                                event.request_id,
+                                session_key,
+                                event,
+                                error="child_escalation_limit",
+                            )
+                        except Exception:
+                            logger.exception("failed to reject escalation-limit trigger request")
+                        info.result = result_text or "_Partial output._"
+                        info.error = f"child_escalation_limit:{child_escalation_limit}"
+                        info.done = True
+                        Stats().inc_subagent_failed()
+                        logger.warning(
+                            "Subagent %s hit child escalation limit (%d)",
+                            info.id,
+                            child_escalation_limit,
+                        )
+                        self._manager._write_tombstone(info, "child_escalation_limit")
+                        return
+                # Diagnostic pointer is written for BOTH origins — orphan
+                # recovery must see child activity too; only the turn
+                # increment is parent-scoped.
+                info.last_tool = event.title or ""
+                self._manager._note_tool_dispatch(info, event)
+                # Persist turn state for orphan recovery diagnostics. Off-loop
+                # (to_thread): update_state does a synchronous fsync, so a slow
+                # FS must not freeze the gateway/heartbeat (#6288; same shape
+                # as the provenance and CC-refinement writes above). Drained on
+                # cancellation: cancelling a to_thread await detaches the
+                # worker, and update_state is an unlocked read-merge-replace,
+                # so a stale detached worker could overwrite newer state
+                # written by a cancel-respawn recovery run. Hold cancellation
+                # open until the worker finishes — but BOUNDED: cancel_all()
+                # gathers run tasks with no timeout, so an unbounded drain on
+                # a wedged FS would hold gateway shutdown forever, and this
+                # module's convention is that bounded shutdown plus
+                # recoverable state beats unbounded shutdown (same posture as
+                # _REPORT_DRAIN_TIMEOUT). On expiry the worker is abandoned
+                # with a warning; the residual stale-write window then only
+                # exists on an FS already wedged past the deadline.
+                # asyncio.wait never cancels its members, so repeated cancels
+                # of this task keep the worker future intact while the drain
+                # loop keeps waiting out the same deadline.
+                _diag_write = asyncio.ensure_future(
+                    asyncio.to_thread(
+                        update_state, info.id, turns=turns, last_tool=event.title or ""
+                    )
+                )
+                try:
+                    await asyncio.shield(_diag_write)
+                except asyncio.CancelledError:
+                    # Latch for _run's recovery gate: on Python 3.10,
+                    # wait_for's _cancel_and_wait awaits a bare future that a
+                    # SECOND outer cancel can interrupt, delivering _run's
+                    # CancelledError handler while this drain is still in
+                    # flight — before expiry suppression lands. The latch lets
+                    # the gate see the live drain and skip scheduling a
+                    # recovery writer the worker could race. 3.11+ delivers
+                    # the outer cancel only after
+                    # this child task completes, so there the latch is always
+                    # observed False.
+                    info._diag_drain_active = True
+                    try:
+                        _drain_deadline = time.monotonic() + _DIAG_DRAIN_TIMEOUT
+                        while not _diag_write.done():
+                            _remaining = _drain_deadline - time.monotonic()
+                            if _remaining <= 0:
+                                logger.warning(
+                                    "diagnostics write for %s did not drain in %.0fs on "
+                                    "cancellation — abandoning worker (its write may race "
+                                    "a recovery run's)",
+                                    info.id,
+                                    _DIAG_DRAIN_TIMEOUT,
+                                )
+                                # The abandoned worker is a live stale writer: a
+                                # cancel-respawn recovery run would write fresh
+                                # PID/session state that the zombie's read-merge-
+                                # replace could then roll back. Consume the
+                                # one-shot recovery so this cancellation finalizes
+                                # instead of respawning — losing one best-effort
+                                # auto-continue on an FS already wedged past the
+                                # deadline is strictly cheaper than resurrecting
+                                # stale state.
+                                info._cancel_retry_used = True
+
+                                # The zombie may still raise later; retrieve it so
+                                # it never surfaces as an asynchronous "exception
+                                # was never retrieved" warning.
+                                def _log_abandoned_diag(
+                                    fut: "asyncio.Future[Any]", _aid: str = info.id
+                                ) -> None:
+                                    if not fut.cancelled() and fut.exception() is not None:
+                                        logger.debug(
+                                            "Abandoned diagnostics write for %s failed",
+                                            _aid,
+                                            exc_info=fut.exception(),
+                                        )
+
+                                _diag_write.add_done_callback(_log_abandoned_diag)
+                                break
+                            try:
+                                await asyncio.wait({_diag_write}, timeout=_remaining)
+                            except asyncio.CancelledError:
+                                pass  # repeated cancel: keep draining to the deadline
+                        if _diag_write.done() and not _diag_write.cancelled():
+                            # Retrieve (never surfaces as an unretrieved-exception
+                            # warning) and log, matching the CC-refinement sibling.
+                            _diag_exc = _diag_write.exception()
+                            if _diag_exc is not None:
+                                logger.debug(
+                                    "Best-effort diagnostics write failed for %s during "
+                                    "cancel drain",
+                                    info.id,
+                                    exc_info=_diag_exc,
+                                )
+                    finally:
+                        info._diag_drain_active = False
+                    raise
+                except Exception:
+                    pass
+                await self._manager._fire_event(
+                    "subagent_tool",
+                    info,
+                    {
+                        "tool": _redact(event.title or ""),
+                        "tool_kind": event.tool_kind,
+                        "turns": info.turns,
+                        "tool_count": info.tool_count,
+                    },
+                )
+                if turns > turn_limit:
+                    # Same contract as the child_escalation_limit bail: the
+                    # triggering request is already dequeued and must be
+                    # answered before this loop exits, or its oneshot strands.
+                    try:
+                        await self._manager._reject_and_log(
+                            client, event.request_id, session_key, event, error="turn_limit"
+                        )
+                    except Exception:
+                        logger.exception("failed to reject turn-limit trigger request")
+                    info.result = result_text or "_Partial output._"
+                    info.error = f"turn_limit:{turn_limit}"
+                    info.done = True
+                    Stats().inc_subagent_failed()
+                    logger.warning("Subagent %s hit turn limit (%d)", info.id, turn_limit)
+                    self._manager._write_tombstone(info, "turn_limit")
+                    return
+                tool_result = self._manager._ctx_builder.hooks.on_tool_call(
+                    event.title,
+                    session_key=session_key,
+                    agent=info.agent or "",
+                    app=info.app or "",
+                    tool_kind=event.tool_kind,
+                    raw_params=event.raw_tool_params,
+                    command=event.shell_command,
+                    is_shell=event.is_shell,
+                    mcp_server_name=event.mcp_server_name,
+                    mcp_tool_name=event.tool_name,
+                )
+                if tool_result.action == TOOL_DENY:
+                    await self._manager._reject_and_log(
+                        client, event.request_id, session_key, event, error="hook_deny"
+                    )
+                    continue
+                if event.child_low_fidelity:
+                    # UNCONDITIONAL parent grant: parent_policy=auto approves
+                    # regardless of event content, so it may honor a request
+                    # that is grant-eligible (see
+                    # AcpEvent.child_unconditional_grant_eligible — inside
+                    # this low-fidelity branch that means the canonical MCP
+                    # identity is verified and only the ARGUMENTS are
+                    # unverified, which this grant never reads). Honor the
+                    # grant instead of stalling a trusted fan-out on an
+                    # interactive card per call. The hook auto-approve below
+                    # stays fail-closed for these: its auto_approve_tools
+                    # patterns match the agent-authored title, which a child
+                    # could forge.
+                    if parent_policy == "auto" and event.child_unconditional_grant_eligible:
+                        await self._manager._approve_and_log(
+                            client,
+                            event.request_id,
+                            session_key,
+                            event,
+                            metadata={
+                                "subagent_id": info.id,
+                                "reason": "parent_policy_auto",
+                                "child_mcp_identity": (
+                                    f"{event.mcp_server_name}/{event.tool_name}"
+                                ),
+                                "child_args_unverified": True,
+                            },
+                            info=info,
+                        )
+                        continue
+                    # Backend-internal child origin whose SECURITY context is
+                    # absent (structured params missing, unresolved shell
+                    # classification, or shell without a recoverable command —
+                    # AcpEvent.child_low_fidelity): any AUTO-approve would
+                    # rest on the LLM-authored title alone, so skip the hook
+                    # auto-approve and parent_policy=auto branches. When an
+                    # interactive approver IS configured — the per-subagent
+                    # factory, or the gateway-level _on_tool_approval
+                    # fallback the non-child path below also uses — hand the
+                    # decision to it: that is a human/host judgment, the same
+                    # downgrade the dashboard's card provides. Only a truly
+                    # headless consumer fails closed.
+                    _child_fallback = self._manager._on_tool_approval
+                    if self._manager._on_tool_approval_factory or _child_fallback is not None:
+                        # The human must know the title is ALL there is: the
+                        # structured params the policy gates would verify are
+                        # absent, so the displayed text is agent-authored and
+                        # unverifiable. Annotate the prompt so the approval
+                        # is an informed judgment, not a title-only rubber
+                        # stamp.
+                        event.title = (
+                            "⚠️ UNVERIFIED child request (security context "
+                            f"missing — title is agent-authored): {event.title or '<unknown tool>'}"
+                        )
+                        approved = False
+                        # Same human-wait lifecycle as the ordinary callback
+                        # branches below: without _awaiting_approval the
+                        # reaper reads a healthy approval wait as a stalled
+                        # subagent after the idle threshold.
+                        info._awaiting_approval = True
+                        try:
+                            if self._manager._on_tool_approval_factory:
+                                approve_cb = self._manager._on_tool_approval_factory(info)
+                                approved = bool(await approve_cb(event))
+                            elif _child_fallback is not None:
+                                approved = bool(
+                                    await _child_fallback(event, info.parent_session_key)
+                                )
+                        except Exception:
+                            logger.exception("child approval callback failed")
+                        finally:
+                            info._awaiting_approval = False
+                            info.last_activity = time.time()
+                        if approved:
+                            await self._manager._approve_and_log(
+                                client,
+                                event.request_id,
+                                session_key,
+                                event,
+                                metadata={
+                                    "subagent_id": info.id,
+                                    "reason": "child_interactive_approved",
+                                },
+                                info=info,
+                            )
+                        else:
+                            await self._manager._reject_and_log(
+                                client,
+                                event.request_id,
+                                session_key,
+                                event,
+                                error="child_interactive_rejected",
+                            )
+                        continue
+                    await self._manager._reject_and_log(
+                        client,
+                        event.request_id,
+                        session_key,
+                        event,
+                        error="child_origin_no_command_context",
+                    )
+                    continue
+                if tool_result.action == TOOL_AUTO_APPROVE:
+                    # The hook granted this by NAME (its `auto_approve_tools`
+                    # globs, or the read-only allowlist). Honour it only while
+                    # each program name in the command still resolves to the
+                    # program it appears to name; a shadowed, agent-tree or
+                    # unidentified resolution DOWNGRADES to the remaining rungs
+                    # below (parent policy, the interactive factory, the
+                    # gateway fallback, or the headless fail-closed reject) —
+                    # never a hard block. This surface runs unattended, which
+                    # makes an unverified name the cheaper attack path here,
+                    # not the rarer one.
+                    _ng_refusal = await name_grant.refusal_for_event(event)
+                    if _ng_refusal is None:
+                        await self._manager._approve_and_log(
+                            client,
+                            event.request_id,
+                            session_key,
+                            event,
+                            metadata={"subagent_id": info.id, "reason": "hook_auto_approve"},
+                            info=info,
+                        )
+                        continue
+                    logger.warning(
+                        "declining a hook auto-approve: %s; the request falls "
+                        "through to the subagent's normal approval path",
+                        _ng_refusal.log_text,
+                    )
+                    name_grant.log_decline(
+                        source="subagent",
+                        session_key=session_key,
+                        event=event,
+                        refusal=_ng_refusal,
+                        tier="hook_auto_approve",
+                        metadata={"subagent_id": info.id},
+                        sel_factory=sel,
+                    )
+                if parent_policy == "auto":
+                    await self._manager._approve_and_log(
+                        client,
+                        event.request_id,
+                        session_key,
+                        event,
+                        metadata={"subagent_id": info.id, "reason": "parent_policy_auto"},
+                        info=info,
+                    )
+                    continue
+                if self._manager._on_tool_approval_factory:
+                    approve_cb = self._manager._on_tool_approval_factory(info)
+                    info._awaiting_approval = True
+                    try:
+                        approved = await approve_cb(event)
+                    finally:
+                        info._awaiting_approval = False
+                        info.last_activity = time.time()
+                    if not approved:
+                        await self._manager._reject_and_log(
+                            client,
+                            event.request_id,
+                            session_key,
+                            event,
+                            metadata={"subagent_id": info.id, "reason": "factory_rejected"},
+                        )
+                        continue
+                    await self._manager._approve_and_log(
+                        client,
+                        event.request_id,
+                        session_key,
+                        event,
+                        metadata={"subagent_id": info.id},
+                        info=info,
+                    )
+                elif self._manager._on_tool_approval:
+                    info._awaiting_approval = True
+                    try:
+                        approved = await self._manager._on_tool_approval(
+                            event, info.parent_session_key
+                        )
+                    finally:
+                        info._awaiting_approval = False
+                        info.last_activity = time.time()
+                    if not approved:
+                        await self._manager._reject_and_log(
+                            client, event.request_id, session_key, event
+                        )
+                        continue
+                    await self._manager._approve_and_log(
+                        client,
+                        event.request_id,
+                        session_key,
+                        event,
+                        metadata={"subagent_id": info.id},
+                        info=info,
+                    )
+                else:
+                    # No callback, no auto policy — deny by default
+                    await self._manager._reject_and_log(
+                        client,
+                        event.request_id,
+                        session_key,
+                        event,
+                        metadata={"subagent_id": info.id, "reason": "no_policy_deny_default"},
+                    )
+                    continue
+            elif event.kind == EVENT_TOOL_CALL:
+                # Auto-allowed (kiro-internal) tools surface here as informational
+                # tool_call updates and NEVER as EVENT_PERMISSION_REQUEST, so this
+                # is the only progress signal a simple/read-only subagent task emits.
+                # Count it, record it, and broadcast the same subagent_tool event
+                # the permission path uses so the running-card shows live activity.
+                info.tool_count += 1
+                info.last_tool = event.title or info.last_tool
+                self._manager._note_tool_dispatch(info, event)
+                await self._manager._fire_event(
+                    "subagent_tool",
+                    info,
+                    {
+                        "tool": _redact(event.title or ""),
+                        "tool_kind": event.tool_kind,
+                        "turns": info.turns,
+                        "tool_count": info.tool_count,
+                    },
+                )
+                # Fire PreToolUse hooks for auto-approved tools (informational only)
+                sel().log_tool_invocation(
+                    session_key=session_key,
+                    source="subagent",
+                    tool_name=event.title,
+                    tool_kind=event.tool_kind,
+                    outcome="auto_approved",
+                    metadata={"subagent_id": info.id},
+                )
+                # Cache tool name so PostToolUse can recover it on EVENT_TOOL_RESULT.
+                # Strip "Running: " prefix to match the name passed to PreToolUse hooks.
+                _raw = event.title or ""
+                if _raw.startswith("Running: "):
+                    _raw = _raw[9:]
+                if event.tool_call_id:
+                    _pending_tools[event.tool_call_id] = _raw
+                await fire_tool_hooks(
+                    self._manager.hook_store,
+                    event.title,
+                    event.tool_input,
+                    subagent_id=info.id,
+                    parent_session_key=info.parent_session_key or None,
+                    agent_role=info.agent or None,
+                )
+            elif event.kind == EVENT_TOOL_RESULT:
+                # A FINAL result means the tool is done: drop the attribution
+                # snapshot so a later idle stretch is not judged against a
+                # command that has already returned. A non-final progress frame
+                # is not the end of the tool — the gate is in _note_tool_result.
+                self._manager._note_tool_result(info, event)
+                # Fire PostToolUse hooks (parity with chat_runner). Until this
+                # branch existed, hooks registered for subagent-spawned tools
+                # received PreToolUse but never PostToolUse — losing the
+                # tool_response payload.
+                if self._manager.hook_store is not None:
+                    try:
+                        _tool_name = _pending_tools.pop(event.tool_call_id, "")
+                        _out = _redact((event.tool_output or "")[:2000])
+                        await self._manager.hook_store.fire(
+                            HOOK_EVENT_POST_TOOL_USE,
+                            tool_name=_tool_name,
+                            tool_response={"output": _out},
+                            subagent_id=info.id,
+                            parent_session_key=info.parent_session_key or None,
+                            agent_role=info.agent or None,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "PostToolUse hook error in subagent",
+                            exc_info=True,
+                        )
+            elif event.kind == EVENT_COMPLETE:
+                _complete_event = event
+                break
+
+        # Strip [OPTIONS: ...] tags and redact sensitive content
+        cleaned, _ = extract_options(result_text) if result_text else (result_text, [])
+        if cleaned:
+            from kiro_crew.security import (
+                redact_credentials,
+                redact_exfiltration_urls,
+            )
+
+            cleaned, _ = redact_exfiltration_urls(cleaned)
+            cleaned, _ = redact_credentials(cleaned)
+        # Model-fallback visibility (agent.fallback_model): a run served by a
+        # fallback model must say so in the delivered result — same contract as
+        # the cron/heartbeat annotation and the dashboard notice card. One
+        # shared spelling (llm_helpers.annotate_model_fallback) redacts the
+        # config-sourced model ids the same way as the result body.
+        cleaned = annotate_model_fallback(cleaned, client)
+        info.result = cleaned or "_No response._"
+        # Cap disk file and trim memory — gateway decides how much to show based on mode.
+        if info.result_path:
+            cap_result_file(Path(info.result_path))
+        # Flag whether the completion-event copy will drop content, so the gateway
+        # emits a summary + result_path pointer (read on demand) instead of a lossy
+        # blob. The full transcript stays in result.txt for the TTL grace window.
+        info.result_truncated = (
+            self._manager._completion_keep_chars > 0
+            and len(info.result) > self._manager._completion_keep_chars
+        )
+        info.result = apply_completion_keep(
+            info.result,
+            self._manager._completion_keep,
+            self._manager._completion_keep_chars,
+        )
+        evict_completed_agents(self._manager._agents)
+
+        # ── Per-turn usage row: attribute subagent spend. ──
+        # Deliberately BEFORE `info.done`: the caller's cleanup (which awaits
+        # provider.shutdown() -> handle.destroy()) runs after this function
+        # returns, so an await placed after `done` sits inside the
+        # done-to-teardown window. Waiters that poll for `done` would then
+        # observe completion while this file write is still in flight — which
+        # widens that window on slow filesystems and lets teardown-observing
+        # callers race it. Writing first also means `done` never becomes
+        # visible with the usage row still missing.
+        try:
+            # circular import: reached while kiro_crew.slack.handler is still
+            # initialising (dashboard/handlers/files.py imports is_tracked_channel
+            # from it), so a module-scope import raises ImportError under the
+            # suite's import order.
+            from kiro_crew.dashboard.handlers.usage import (
+                persist_token_record_async,
+                read_context_tokens,
+                read_effective_agent,
+            )
+
+            _used, _window = read_context_tokens(client)
+            await persist_token_record_async(
+                session_key,
+                # Blank while a fallback serves this run: the explicit pin
+                # would bill the fallback's spend to a model that never
+                # executed; model_source reports what actually ran.
+                ("" if provider_fallback_active(client) else (info.model or "")),
+                _complete_event,
+                provider="claude_code" if is_cc else "acp",
+                surface="subagent",
+                # Ownership stamp (see _build_token_record): an app-dispatched
+                # subagent's spend must be readable by that app's audit — the
+                # illustrator lane of an app is exactly this path.
+                app=info.app or "",
+                # Explicit/inherited `agent` FIRST here — unlike every other
+                # surface. Under session sharing this subagent reuses the
+                # PARENT's runtime, so read_effective_agent() would report the
+                # parent's agent and misattribute a `spawn_run(agent="…")` turn.
+                # `agent` is already the resolved value (it inherits the parent
+                # session's agent when the spawn did not name one), and the
+                # helper stays as the fallback for when it is empty.
+                agent=agent or read_effective_agent(client) or "",
+                context_used=_used,
+                context_window=_window,
+                elapsed_ms=int((time.monotonic() - _turn_t0) * 1000),
+                model_source=client,
+            )
+        except Exception:
+            logger.debug("usage row (subagent) persist failed", exc_info=True)
+
+        info.done = True
+        self._manager._sessions.record_success(session_key)
+
+        Stats().inc_subagent_completed()
+        logger.info("Subagent %s completed", info.id)
+
+    def _should_use_session_sharing_impl(self, info: SubagentInfo) -> bool:
+        """Decide whether a subagent should use the shared-runtime path.
+
+        All must hold: session_sharing config True; parent session exists and
+        is ACP/kiro-backed (not CC); not a CC-specific spawn (model/allowed_tools/bare).
+        """
+        try:
+            cfg = KiroCrewConfig.load()
+            if not cfg.agent.session_sharing:
+                return False
+        except Exception:
+            return False
+        if info.model or info.allowed_tools or info.bare:
+            return False
+        if not info.parent_session_key:
+            return False
+        return self._manager._sessions.is_session_sharing_eligible(info.parent_session_key)
+
+    async def _create_shared_session_impl(
+        self, info: SubagentInfo, session_key: str, agent: str
+    ) -> "LLMProvider":
+        """Create a subagent session on the parent's AcpRuntime.
+
+        The parent session (provider=kiro) runs on an AcpRuntime via
+        AcpSessionProvider. Subagents create additional sessions on that SAME
+        runtime — one process hosts everything. Falls back to
+        get_subagent_runtime() (companion runtime) if the parent doesn't use
+        AcpSessionProvider. Marks info._session_sharing=True so cleanup calls
+        provider.shutdown() instead of SessionManager.release/reset.
+        """
+        runtime = self._manager._get_parent_runtime(info.parent_session_key)
+        if runtime is None:
+            runtime = await self._manager._sessions.get_subagent_runtime(info.parent_session_key)
+
+        cwd = info.cwd or str(getattr(self._manager._sessions, "_pool_cwd", ""))
+        handle = await runtime.create_session(
+            cwd=cwd or None,
+            agent=agent or None,
+        )
+        provider = AcpSessionProvider(handle, runtime)
+        # This consumer implements the low-fidelity child downgrade (interactive
+        # approver when configured, reject when headless) — opt in so the
+        # handle-level fail-close gate yields those events instead of rejecting.
+        provider.child_fidelity_aware = True
+        info._session_sharing = True
+        info._shared_provider = provider
+        if runtime.pid:
+            info._pid = runtime.pid
+            update_state(info.id, pid=runtime.pid, pid_recorded_at=time.time())
+        logger.info(
+            "Subagent %s using session sharing on runtime PID %s (session %s, key %s)",
+            info.id,
+            runtime.pid,
+            handle.session_id,
+            session_key,
+        )
+        return provider
+
+    def _get_parent_runtime_impl(self, parent_session_key: str) -> "AcpRuntime | None":
+        """Extract the AcpRuntime from the parent session's provider.
+
+        Returns the runtime if the parent uses AcpSessionProvider (kiro unified
+        path), or None if the parent uses AcpClient (CC or legacy).
+        """
+        provider = self._manager._sessions.get_provider(parent_session_key)
+        if provider is None:
+            return None
+        inner = getattr(provider, "client", None) or getattr(provider, "_client", None)
+        if isinstance(inner, AcpSessionProvider):
+            return inner._runtime
+        return None

--- a/src/kiro_crew/subagent_manager/terminal.py
+++ b/src/kiro_crew/subagent_manager/terminal.py
@@ -1,0 +1,652 @@
+"""Terminal behavior for the SubagentManager facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._component import ManagerComponent
+
+if TYPE_CHECKING:
+    from ..subagent import (
+        _ON_DONE_TIMEOUT,
+        _RESET_TIMEOUT,
+        SUBAGENT_COMPLETION_PREFIX,
+        Stats,
+        SubagentInfo,
+        _done_result,
+        _injection_notice_outcome,
+        _redact,
+        _timeout_context,
+        _ws_result_path,
+        asyncio,
+        logger,
+        mark_delivered,
+        os,
+        platform_compat,
+        sel,
+        subprocess_executor,
+    )
+
+
+class TerminalCoordinator(ManagerComponent):
+    """Own terminal transitions while state remains facade-owned."""
+
+    __slots__ = ()
+
+    def _claim_finalize_impl(self, info: SubagentInfo, *, supersede_recovery: bool = False) -> bool:
+        """Claim the exclusive right to report ``info``'s terminal outcome.
+
+        Returns True for exactly one caller. Both the reap path and ``_run``'s
+        ``finally`` call this and report only if it returns True, so the parent
+        is notified exactly once no matter which wins the race or whether the
+        loser is cancelled part-way through its teardown.
+
+        Contains no ``await``, so on a single-threaded event loop the
+        check-and-set is atomic with respect to other tasks.
+
+        Returns False while ``_recovering`` — a cancel-recovery respawn is
+        pending and the agent must not be reported done yet — leaving the claim
+        OPEN so the respawned run can take it later.
+
+        ``supersede_recovery=True`` overrides that withholding and is used ONLY
+        by definitively-terminal callers (`_force_reap`, which also serves user
+        Stop). Without it a reap landing inside the recovery window stranded the
+        outcome: the reap was refused the claim, performed teardown and set
+        ``reaped``, reported nothing — and `_resume`'s ``reaped`` abort path
+        bare-returns, so no path ever reported and the agent sat unfinished
+        until the reaper's wall-clock deadline. Superseding also clears
+        ``_recovering``, because a killed agent has nothing left to respawn.
+
+        Scope note: this token governs REPORTING only, and it deliberately does
+        NOT consult ``info.done``. Gating it on ``done`` is wrong:
+        if ``_run_inner`` set ``done`` while the reap awaited its session reset,
+        the reaper refused the claim, still marked ``reaped``, and ``_run``'s
+        finally then skipped its own claim — nobody reported. The terminal RECORD
+        (tombstone/stat) keeps its own ``not info.done`` guard and slot accounting
+        has its own one-shot token (:meth:`_release_slot`); three concerns, three
+        guards. Session teardown stays keyed on ``reaped``.
+        """
+        if info._recovering and not supersede_recovery:
+            return False
+        if info._finalized:
+            return False
+        if info._recovering:
+            # A terminal reap/stop SUPERSEDES a pending cancel-recovery respawn:
+            # the agent is being killed, so there is nothing left to respawn.
+            # Clearing the flag here is what keeps `False` from meaning two
+            # different things to this caller ("someone else already reported"
+            # vs "withheld for a respawn that will report later") — the exact
+            # conflation this token exists to remove.
+            info._recovering = False
+        info._finalized = True
+        return True
+
+    async def _report_terminal_impl(
+        self,
+        info: SubagentInfo,
+        *,
+        source: str,
+        injection_timeout_reason: str,
+        mark_delivered_on_success: bool,
+        settle_digest: bool = False,
+        teardown_done: "asyncio.Event | None" = None,
+    ) -> None:
+        """Deliver ``info``'s one-shot terminal report as a single unit.
+
+        This is the exact work the finalize claim guards: fire the
+        ``subagent_done`` WS event, then inject the completion into the parent
+        (``_on_done``) with its ``_ON_DONE_TIMEOUT`` cap, timeout handling, and
+        (for the ``_run`` path) the result.txt TTL / workspace-cleanup
+        bookkeeping.
+
+        Why this is a separate coroutine run under ``asyncio.shield`` (see
+        ``_run_terminal_report``): the claim makes reporting EXCLUSIVE but not
+        ATOMIC. A claimer cancelled mid-report (``_force_reap`` /
+        ``cancel_all()`` cancelling the task while it awaits ``_fire_event`` or
+        ``_on_done``) would exit without delivering, and the other path — seeing
+        the claim already taken — stays silent, so the completed outcome never
+        reaches the parent. Running the report on a shielded, strongly-held task
+        makes it complete independently of caller cancellation.
+
+        The two call sites (reap vs. ``_run``'s ``finally``) differ only in the
+        injection-timeout reason string, the log ``source`` prefix, and whether
+        a successful delivery marks the result delivered — those are passed as
+        arguments rather than unified away. The WS payload is identical (both
+        set ``info.elapsed`` before calling), so it is built from ``info`` here.
+        """
+        await self._manager._fire_event(
+            "subagent_done",
+            info,
+            {
+                "elapsed": info.elapsed,
+                "error": _redact(info.error) if info.error else None,
+                "stopped": info.user_stopped,
+                "outcome": info.outcome,
+                "task": _redact(info.task),
+                "agent": _redact(info.agent),
+                # The sub-agent's own session key (see build_subagent_snapshot):
+                # lets a client fetch this node's own context-trace even after
+                # it has finished.
+                "child_session": info.conversation_key or f"subagent:{info.id}",
+                # The model actually served (issue #3582). By the terminal
+                # report this is the authoritative value on every provider — the
+                # CC/raw path has completed at least one turn, so its
+                # ``_resolved_model_id`` is populated (refreshed in ``_run``).
+                "model": info.resolved_model,
+                # Carry the requested pin on the terminal report too, redacted
+                # like the spawn frame: after a reconnect the completed card is
+                # rebuilt from this event alone, so without it the live-downgrade
+                # amber chip would silently vanish from a downgraded finished run.
+                "requested_model": _redact(info.requested_model),
+                "result": _done_result(info.result),
+            },
+        )
+        if not self._manager._on_done:
+            return
+        try:
+            await asyncio.wait_for(self._manager._on_done(info), timeout=_ON_DONE_TIMEOUT)
+            # The outcome has REACHED the parent. Recorded before any further
+            # await so a shutdown cancellation landing in the teardown wait or
+            # the tombstone write below is not mistaken for a lost delivery by
+            # `cancel_all()` (which would re-deliver it on the next start).
+            info._reported_to_parent = True
+            if settle_digest:
+                # _on_done returned without raising, so the wave digest (if this
+                # was the final member) has been handed off. Only NOW settle the
+                # held members' delivery tombstones.
+                self._manager._settle_digest_holds(info)
+            # Digest-held wave members are NOT marked delivered here: their
+            # result has not reached the parent yet (the gateway marks them when
+            # the digest fires), so a restart mid-wave leaves them visible to
+            # orphan reconciliation.
+            #
+            # A QUEUED injection is the same statement about a different wait:
+            # the announce is parked in the parent's slot queue, so the result is
+            # not in its context yet and the retention clock must not start (the
+            # drain settles it). Both flags are set by the gateway inside
+            # _on_done, above.
+            if (
+                mark_delivered_on_success
+                and not info.error
+                and not info._digest_held
+                and not info._delivery_queued
+            ):
+                # Wait for the caller's session teardown before writing the
+                # "delivered" tombstone. This report is deliberately SPAWNED
+                # ahead of teardown (so a cancellation cannot strand it), which
+                # opens a window the older post-teardown ordering did not have:
+                # a crash after the tombstone but before teardown finished would
+                # leave a surviving child process EXCLUDED from orphan
+                # reconciliation — invisible and never reaped. The wait is
+                # bounded because the caller's teardown is itself bounded
+                # (_RESET_TIMEOUT then SIGKILL) and runs in a `finally`, so the
+                # event is set even when the caller is cancelled.
+                if teardown_done is not None and not teardown_done.is_set():
+                    try:
+                        await asyncio.wait_for(teardown_done.wait(), timeout=_RESET_TIMEOUT + 30)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "Subagent %s: teardown did not complete before the "
+                            "delivered tombstone; writing it anyway",
+                            info.id,
+                        )
+                # Retain result.txt for a TTL grace window instead of deleting
+                # it now, so the parent can read the full transcript
+                # (spawn_status / read / grep) after the completion event. A
+                # "delivered" tombstone excludes it from orphan reconciliation;
+                # the reaper prunes it after agent.subagent_result_ttl_secs.
+                try:
+                    mark_delivered(info.id)
+                except Exception:
+                    logger.debug("Failed to mark subagent %s delivered", info.id, exc_info=True)
+                # Clean up workspace result file (agent-{id}.md in parent dir).
+                # The directory is named after the parent's SLOT, which a
+                # channel-born parent has while its session key stays the
+                # channel's own; without a tab there is no directory to clean.
+                try:
+                    # Lazy: the dashboard layer must not be imported by a core
+                    # module at import time.
+                    from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+
+                    slot_key = dashboard_slot_key(info.parent_session_key)
+                    if slot_key:
+                        _ws_result_path(slot_key, info.id).unlink(missing_ok=True)
+                except Exception:
+                    logger.debug("Failed to clean workspace result for %s", info.id, exc_info=True)
+        except asyncio.TimeoutError:
+            logger.error(
+                "%s: completion injection timed out for %s after %.0fs",
+                source,
+                info.id,
+                _ON_DONE_TIMEOUT,
+            )
+            # Kill the parent session's kiro-cli process so the next agent's
+            # injection gets a clean provider instead of hitting "Prompt already
+            # in progress" on the stuck one.
+            try:
+                await self._manager._sessions.reset(info.parent_session_key)
+            except Exception:
+                logger.debug(
+                    "Failed to reset parent session %s after injection timeout",
+                    info.parent_session_key,
+                    exc_info=True,
+                )
+            self._manager.notify_injection_failed(info, reason=injection_timeout_reason)
+        except Exception:
+            logger.exception("%s: announce failed for %s", source, info.id)
+
+    async def _run_terminal_report_impl(
+        self,
+        info: SubagentInfo,
+        *,
+        source: str,
+        injection_timeout_reason: str,
+        mark_delivered_on_success: bool,
+        settle_digest: bool = False,
+        teardown_done: "asyncio.Event | None" = None,
+    ) -> None:
+        """Spawn the shielded terminal report and block until it completes.
+
+        Convenience for callers that have no cancellable ``await`` between
+        taking the claim and reporting (``_force_reap``): there is no window in
+        which a cancellation could strand the outcome before the report task
+        exists, so spawning and awaiting can be adjacent. Callers that DO have a
+        teardown ``await`` between the claim and the report (``_run``'s
+        ``finally``) must instead :meth:`_spawn_terminal_report` BEFORE that
+        await and :meth:`_await_report` after, so the report task is already
+        live (and shielded) no matter where the cancellation lands.
+        """
+        await self._manager._await_report(
+            self._manager._spawn_terminal_report(
+                info,
+                source=source,
+                injection_timeout_reason=injection_timeout_reason,
+                mark_delivered_on_success=mark_delivered_on_success,
+                settle_digest=settle_digest,
+                teardown_done=teardown_done,
+            )
+        )
+
+    def _spawn_terminal_report_impl(
+        self,
+        info: SubagentInfo,
+        *,
+        source: str,
+        injection_timeout_reason: str,
+        mark_delivered_on_success: bool,
+        settle_digest: bool = False,
+        teardown_done: "asyncio.Event | None" = None,
+    ) -> "asyncio.Task":  # type: ignore[type-arg]
+        """Launch :meth:`_report_terminal` on a strongly-referenced task.
+
+        Returns immediately (no ``await``) so the caller can start the report
+        BEFORE its own teardown awaits, guaranteeing the report exists and is
+        held alive independently of the caller's fate. The task is retained in
+        ``self._report_tasks`` (so it cannot be garbage-collected while its
+        awaiter is cancelled, and so ``cancel_all()`` can drain it) and
+        self-removes on completion.
+        """
+        task = asyncio.create_task(
+            self._manager._report_terminal(
+                info,
+                source=source,
+                injection_timeout_reason=injection_timeout_reason,
+                mark_delivered_on_success=mark_delivered_on_success,
+                settle_digest=settle_digest,
+                teardown_done=teardown_done,
+            )
+        )
+        self._manager._report_tasks.add(task)
+        # Owner map so `cancel_all()` can identify WHOSE outcome it is about to
+        # abandon (and re-admit it to orphan recovery). Kept alongside the set
+        # rather than replacing it: `_report_tasks` is the strong reference that
+        # keeps the task alive, and both are cleared by the one done callback.
+        self._manager._report_owners[task] = info
+
+        def _forget(t: "asyncio.Task") -> None:  # type: ignore[type-arg]
+            self._manager._report_tasks.discard(t)
+            self._manager._report_owners.pop(t, None)
+
+        task.add_done_callback(_forget)
+        return task
+
+    def _release_slot_impl(self, info: SubagentInfo) -> bool:
+        """Claim the exclusive right to free ``info``'s concurrency slot.
+
+        Returns True for exactly one caller; that caller decrements
+        ``_running_count`` once and drains the queue. Contains no ``await``, so
+        the check-and-set is atomic with respect to other tasks on the loop.
+
+        Why this is its OWN token rather than a side effect of ``done`` or
+        ``reaped``: both terminal paths (`_force_reap` and `_run`'s ``finally``)
+        can run for the same agent, and previous revisions inferred slot
+        ownership from whichever flag happened to be set. That produced a double
+        decrement in one interleaving and — after the flag order was changed to
+        fix a delivery bug — no decrement at all in another, inflating
+        ``_running_count`` and permanently starving the spawn queue. An explicit
+        one-shot token makes the count independent of report and record ordering.
+
+        Note the recovery respawn's own ``_running_count += 1`` re-admit is
+        unaffected: it runs after the interrupted run's ``finally`` has already
+        released, and this token is per-``SubagentInfo``.
+        """
+        if info._slot_released:
+            return False
+        info._slot_released = True
+        return True
+
+    async def _force_reap_impl(
+        self, agent_id: str, info: SubagentInfo, elapsed: float, *, reason: str = ""
+    ) -> None:
+        """Kill a subagent's session process and mark it done."""
+        session_key = f"subagent:{agent_id}"
+
+        # Reap-in-flight marker + recovery cancel BEFORE ANY await in this
+        # method. Both used to sit after the session teardown below, which yields
+        # (bounded by _RESET_TIMEOUT, longer still on the SIGKILL path). A
+        # cancel-recovery task whose bounded handshake expired inside that window
+        # respawned the very run being killed — tools executing after a user
+        # Stop, strictly worse than a duplicate report. Note this sets
+        # `_reap_started`, NOT `reaped`: setting `reaped` this early makes a run
+        # woken by our own session reset skip its error synthesis and report a
+        # false SUCCESS before we own the record. See `_reap_started`.
+        info._reap_started = True
+        # A pending cancel-recovery respawn is moot — this agent is being killed.
+        # Cancel it rather than letting it sit in its bounded handshake wait
+        # (_RESET_TIMEOUT + 60s) only to discover `reaped` and bare-return.
+        # The reap owns the terminal report from here (see the claim below).
+        recovery_task = self._manager._tasks.pop(f"{agent_id}:recovery", None)
+        if recovery_task and not recovery_task.done():
+            recovery_task.cancel()
+
+        if info._session_sharing:
+            # Session-sharing subagent: NEVER SIGKILL the shared runtime —
+            # the parent session owns it and other co-tenants may be active.
+            # Conservative approach: shut down only this subagent's provider
+            # handle, leaving the shared runtime intact.
+            runtime_pid = info._pid
+            logger.info(
+                "Reaper: conservative shutdown for session-sharing %s — "
+                "runtime pid=%s kept alive (shared runtime, never SIGKILL)",
+                agent_id,
+                runtime_pid,
+            )
+            try:
+                sel().log_tool_invocation(
+                    session_key=session_key,
+                    source="subagent",
+                    tool_name="smart_hard_kill",
+                    outcome="conservative-shutdown",
+                    resources=f"runtime_pid={runtime_pid}",
+                    metadata={
+                        "subagent_id": agent_id,
+                        "runtime_pid": runtime_pid,
+                        "decision": "session-sharing-never-kill",
+                    },
+                )
+            except Exception:
+                logger.debug("SEL audit for conservative shutdown failed", exc_info=True)
+            # Shutdown the shared provider handle only
+            try:
+                if info._shared_provider:
+                    await info._shared_provider.shutdown()
+            except Exception:
+                logger.debug(
+                    "Reaper: shared session shutdown failed for %s", agent_id, exc_info=True
+                )
+        else:
+            # Kill the process FIRST so the pipe unblocks, then cancel the task.
+            try:
+                await asyncio.wait_for(
+                    self._manager._sessions.reset(session_key), timeout=_RESET_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                logger.warning("Reaper: reset hung for %s, attempting SIGKILL", agent_id)
+                await self._manager._sigkill_session(session_key)
+            except Exception:
+                logger.exception("Reaper: reset failed for %s", agent_id)
+
+        task = self._manager._tasks.pop(agent_id, None)
+        if task and not task.done():
+            # `reaped` is set HERE — late, immediately before the intentional
+            # cancel — not at the top of the method. Late enough that a run woken
+            # by the session reset above still synthesizes its own error (a run
+            # that sees `reaped` skips error synthesis, and reporting with no
+            # error set delivers a false success). Early enough to satisfy the
+            # intentional-cancel contract: visible when the task's
+            # CancelledError arm runs. The recovery scheduler reads the earlier
+            # `_reap_started` instead, so it is not affected by this placement.
+            info.reaped = True
+            self._manager._cancel_task_intentionally(task, info, reason=reason or "reaped")
+
+        # No live task to cancel above (already exited) — the reap still owns
+        # teardown bookkeeping from here, so mark it now.
+        info.reaped = True
+        # Guard 1 of 3 — the terminal RECORD (done/error/stat/tombstone/cost) is
+        # first-arrival-wins on `info.done`, so it is never written twice.
+        if not info.done:
+            info.done = True
+            if not info.error and not info.user_stopped:
+                # A user stop is neutral — never synthesize a reap error for it.
+                if reason == "startup_timeout":
+                    info.error = f"Failed to start within {self._manager._startup_deadline}s (no runtime launched, no turn produced) [{_timeout_context(info, include_elapsed=False, turn_limit=self._manager._effective_turn_limit(info))}]"
+                else:
+                    info.error = f"Reaped after {int(elapsed)}s (exceeded {self._manager._default_timeout}s deadline) [{_timeout_context(info, include_elapsed=False, turn_limit=self._manager._effective_turn_limit(info))}]"
+            if not info.user_stopped:
+                # A user-initiated stop is a neutral outcome, not a failure.
+                Stats().inc_subagent_failed()
+            self._manager._write_tombstone(info, reason or "reaped")
+            self._manager._record_cost(info)
+        # Guard 2 of 3 — SLOT accounting, on its own one-shot token and therefore
+        # independent of both `done` (above) and `reaped`. A reap/cancel frees a
+        # slot but — unlike normal completion — does NOT otherwise pump the queue,
+        # so queued spawns would sit stranded until an unrelated agent finished.
+        # Drain here so the freed slot is used immediately.
+        if self._manager._release_slot(info):
+            self._manager._running_count = max(0, self._manager._running_count - 1)
+            self._manager._drain_queue()
+
+        try:
+            sel().log_tool_invocation(
+                session_key=session_key,
+                source="subagent",
+                tool_name="reaper_force_kill",
+                outcome="reaped",
+                metadata={
+                    "subagent_id": agent_id,
+                    "session_key": session_key,
+                    "elapsed": int(elapsed),
+                },
+            )
+        except Exception:
+            logger.exception("Reaper: SEL audit failed for %s", agent_id)
+
+        try:
+            # Retain-by-default: the reaped run's session files stay on disk
+            # (spawn_continue resume material); the tombstone pruner owns
+            # their deletion. A force-reaped long run is exactly the case
+            # retention exists for.
+            self._manager._sessions.release(session_key, cleanup=False)
+        except Exception:
+            logger.warning("Reaper: release failed for %s", agent_id, exc_info=True)
+
+        # Guard 3 of 3 — the terminal REPORT (subagent_done + _on_done), owned by
+        # the finalize claim. The claim deliberately does NOT consult `info.done`:
+        # `_run_inner` may set `done` while the teardown above is suspended, and
+        # gating on it made the reaper decline while `_run`'s finally also declined
+        # (it sees `reaped`) — so nobody reported. The report runs SHIELDED, so a
+        # cancellation landing mid-report (cancel_all during shutdown) still
+        # delivers rather than stranding the outcome with the claim consumed.
+        info.elapsed = elapsed
+        if self._manager._claim_finalize(info, supersede_recovery=True):
+            await self._manager._run_terminal_report(
+                info,
+                source="Reaper",
+                injection_timeout_reason=(
+                    f"delivery timed out after {int(_ON_DONE_TIMEOUT)}s (reaper)"
+                ),
+                mark_delivered_on_success=False,
+                # This member's own result is NOT marked delivered (it was
+                # reaped, not completed) — but if it was the wave member whose
+                # `_on_done` flushed the batch digest, its SIBLINGS' successful
+                # results HAVE now reached the parent. Settling is about their
+                # holds, not this member's outcome, so it must happen on this
+                # path too or held siblings stay visible to orphan
+                # reconciliation and get spuriously "recovered" after a restart.
+                settle_digest=True,
+            )
+
+        # Truncate retained text AFTER _on_done to preserve full output for result injection
+        if len(info.streaming_text) > 10_000:
+            info.streaming_text = info.streaming_text[:10_000] + "\n…(truncated)"
+
+    async def _sigkill_session_impl(self, session_key: str) -> None:
+        """Best-effort SIGKILL when graceful reset hangs.
+
+        Uses killpg to kill the entire process group, then sweeps
+        escaped children in different PGIDs (MCP servers).
+
+        Async so the Windows ``taskkill`` spawn offloads to
+        :func:`kiro_crew.executors.subprocess_executor` via
+        :func:`platform_compat.kill_process_tree_async` / ``kill_pid_async``
+        instead of blocking the reaper loop's event loop for the duration of
+        ``taskkill.exe``.
+        """
+        try:
+            # circular import: subagent → acp.client → session → subagent
+            from kiro_crew.acp.client import (
+                _capture_child_records,
+                _get_child_pids,
+                _is_our_child,
+                _kill_escaped_children,
+            )
+
+            session = self._manager._sessions._sessions.get(session_key)
+            if not session:
+                return
+            client = getattr(session.provider, "_client", None)
+            raw_pid = getattr(client, "_pid", None) if client else None
+            pid = raw_pid if isinstance(raw_pid, int) else None
+            if not pid:
+                return
+            # Snapshot child tree before killing — children in different
+            # PGIDs survive killpg. macOS pgrep/ps spawns are offloaded to
+            # subprocess_executor to keep the reaper loop responsive
+            loop = asyncio.get_running_loop()
+            raw_children = getattr(client, "_child_pids", None)
+            child_pids: dict = dict(raw_children) if isinstance(raw_children, dict) else {}
+            fresh = await loop.run_in_executor(subprocess_executor(), _get_child_pids, pid)
+            new_pids = [p for p in fresh if p not in child_pids]
+            if new_pids:
+                child_pids.update(
+                    await loop.run_in_executor(
+                        subprocess_executor(), _capture_child_records, new_pids
+                    )
+                )
+            # Validate PID hasn't been recycled before killing.
+            original_start = getattr(client, "_start_time", None)
+            if original_start is None:
+                logger.debug("Reaper: PID %d already dead for %s", pid, session_key)
+                await loop.run_in_executor(
+                    subprocess_executor(), _kill_escaped_children, child_pids
+                )
+                return
+            if not await loop.run_in_executor(
+                subprocess_executor(), _is_our_child, pid, original_start
+            ):
+                logger.warning("Reaper: PID %d recycled for %s, skipping killpg", pid, session_key)
+                stored = dict(raw_children) if isinstance(raw_children, dict) else {}
+                await loop.run_in_executor(subprocess_executor(), _kill_escaped_children, stored)
+                return
+            # Kill the entire process group first
+            logger.warning(
+                "Reaper: killpg for PID %d (%d children) for %s",
+                pid,
+                len(child_pids),
+                session_key,
+            )
+            try:
+                # Async variants offload Windows taskkill to
+                # subprocess_executor so the reaper loop never blocks the
+                # event loop on taskkill.exe.
+                await platform_compat.kill_process_tree_async(pid, platform_compat.SIGKILL)
+            except ValueError:
+                # Guard refused the pid outright (non-int/reserved) — nothing
+                # safe to signal. Mirrors CronService._sigkill_session so a
+                # broadcast-guard refusal is a clean log line, not the noisy
+                # generic `except Exception` traceback below.
+                logger.error("Reaper: kill guard refused pid %r for %s", pid, session_key)
+            except (ProcessLookupError, OSError):
+                try:
+                    await platform_compat.kill_pid_async(pid, platform_compat.SIGKILL)
+                except (ProcessLookupError, OSError):
+                    pass
+            # Sweep children that escaped to different PGIDs
+            await loop.run_in_executor(subprocess_executor(), _kill_escaped_children, child_pids)
+        except Exception:
+            logger.exception("Reaper: SIGKILL failed for %s", session_key)
+
+    def notify_injection_failed_impl(
+        self, info: SubagentInfo, reason: str = "delivery timed out"
+    ) -> None:
+        """Notify UI and queue failure for LLM when injection times out.
+
+        Appends a synthetic error to the dashboard slot (UI) and queues a
+        failure message into ``slot._pending_subagent_failures`` so the LLM
+        learns about the failure on the next ``_run_chat`` turn and can read
+        the result from disk if needed. The notice's outcome line is derived
+        from the record (:func:`_injection_notice_outcome`) rather than
+        asserting completion: this path fires for every terminal state whose
+        report could not be injected, including runs cancelled or rejected
+        before they ever executed.
+        """
+        try:
+            # Lazy: the dashboard layer must not be imported by a core module at
+            # import time.
+            from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+
+            # The failure is queued into a SLOT, so the gate is whether the
+            # parent has a tab — true for a channel-born parent whose session
+            # key is the channel's own. Without one there is nothing to append
+            # to and nothing to drain on the next turn.
+            slot_name = dashboard_slot_key(info.parent_session_key)
+            if not slot_name:
+                return
+
+            # Build failure message the LLM will see on next turn
+            task_preview = _redact((info.task or "")[:100])
+            result_hint = ""
+            if info.result_path:
+                try:
+                    size = os.path.getsize(info.result_path)
+                    size_str = f"{size:,} bytes"
+                except OSError:
+                    size_str = ""
+                result_hint = (
+                    f"\nResult saved at: {info.result_path}"
+                    + (f" ({size_str})" if size_str else "")
+                    + "\nUse the read tool to retrieve it if needed."
+                )
+            failure_msg = (
+                f"{SUBAGENT_COMPLETION_PREFIX}\n"
+                f"Agent `{info.id}` ❌ {reason}\n"
+                f"Task: {task_preview}\n"
+                f"{_injection_notice_outcome(info)}{result_hint}"
+            )
+
+            # Queue for LLM context drain on next _run_chat
+            if self._manager._on_event:
+                _task = asyncio.ensure_future(
+                    self._manager._fire_event(
+                        "subagent_injection_failed",
+                        info,
+                        {
+                            "error": reason,
+                            "slot": slot_name,
+                            "failure_msg": failure_msg,
+                        },
+                    )
+                )
+                _task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+        except Exception:
+            logger.debug("notify_injection_failed failed for %s", info.id, exc_info=True)

--- a/src/kiro_crew/subagent_manager/waves.py
+++ b/src/kiro_crew/subagent_manager/waves.py
@@ -1,0 +1,344 @@
+"""Waves behavior for the SubagentManager facade."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._component import ManagerComponent
+
+if TYPE_CHECKING:
+    from ..subagent import (
+        _RESET_TIMEOUT,
+        _WAVE_STUCK_SECS,
+        DIGEST_HOLD_SECS,
+        SubagentInfo,
+        asyncio,
+        logger,
+        mark_delivered,
+        sel,
+        time,
+        uuid,
+    )
+
+
+class WaveDigestCoordinator(ManagerComponent):
+    """Own waves transitions while state remains facade-owned."""
+
+    __slots__ = ()
+
+    def batch_members_pending_impl(self, batch_id: str) -> bool:
+        """True while ANY member of *batch_id* is still outstanding — running
+        (registered, not done), queued behind the stagger gate (not yet
+        registered), OR not yet submitted (sibling POSTs still in flight —
+        a fast-failing first member must not finalize the
+        wave and emit a partial digest before the rest of the batch even
+        arrives). The wave digest must also not be held hostage by unrelated
+        agents under the same parent."""
+        if not batch_id:
+            return False
+        _bs = self._manager._batch_submitted.get(batch_id)
+        if _bs is not None and _bs[1] > 0 and _bs[0] < _bs[1]:
+            return True  # submissions still in flight
+        if any(a.batch_id == batch_id and not a.done for a in self._manager._agents.values()):
+            return True
+        return any(p.get("batch_id") == batch_id for p in self._manager._queue)
+
+    def finalize_batch_impl(self, batch_id: str) -> None:
+        """Prune per-wave bookkeeping once the wave digest has fired.
+
+        Bounds `_seen_batches` / `_batch_submitted` growth: without
+        this, long-lived gateways accrete an entry per wave forever.
+        """
+        if not batch_id:
+            return
+        self._manager._seen_batches.discard(batch_id)
+        self._manager._batch_submitted.pop(batch_id, None)
+        self._manager._batch_progress_ts.pop(batch_id, None)
+
+    def record_lost_submission_impl(
+        self,
+        batch_id: str,
+        batch_total: int,
+        reason: str,
+        parent_session_key: str = "",
+    ) -> None:
+        """Reconcile a wave member whose spawn submission was LOST before it
+        reached :meth:`spawn` (transport error / timeout / pre-spawn HTTP
+        rejection in ``api_spawn``).
+
+        Every sibling POST carried ``batch_total`` counting the lost member,
+        but ``spawn()`` never ran for it — so ``submitted < expected``
+        forever, ``batch_members_pending()`` stays True, the digest chunk
+        never fires, and held sibling results strand until a gateway restart.
+        This helper counts the lost
+        member as submitted AND announces a synthetic terminal member through
+        the single completion consumer, so the wave's accounting sees a
+        failure line and can close.
+
+        Idempotent-ish by construction: each call reconciles exactly one lost
+        member; callers invoke it once per lost submission.
+        """
+        if not batch_id:
+            return
+        _bs = self._manager._batch_submitted.setdefault(batch_id, [0, max(0, int(batch_total))])
+        _bs[0] += 1
+        self._manager._batch_progress_ts[batch_id] = time.time()
+        try:
+            sel().log_tool_invocation(
+                session_key=parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="submission_lost",
+                metadata={"batch_id": batch_id, "reason": reason[:200]},
+            )
+        except Exception:
+            logger.debug("SEL audit failed for lost submission", exc_info=True)
+        info = SubagentInfo(
+            id=uuid.uuid4().hex[:8],
+            task="(submission lost before spawn)",
+            agent="",
+            parent_session_key=parent_session_key,
+            done=True,
+            error=f"spawn submission lost: {reason[:300]}",
+            batch_id=batch_id,
+            batch_total=max(0, int(batch_total)),
+        )
+        if self._manager._on_done:
+            try:
+                self._manager._tasks[f"lost-{info.id}"] = asyncio.ensure_future(
+                    self._manager._safe_announce(info)
+                )
+            except RuntimeError:
+                pass  # no running loop (sync/test context)
+
+    def _sweep_stuck_waves_impl(self, now: float) -> None:
+        """Reaper backstop: force-reconcile waves wedged by lost submissions.
+
+        A wave is STUCK when ``submitted < expected``, every registered
+        member is terminal, nothing of the wave sits in the spawn queue, and
+        there has been no submission progress for ``_WAVE_STUCK_SECS``. The
+        count-driven ``batch_members_pending()`` can never close such a wave
+        on its own — no future completion event will arrive. Reconciling via
+        :meth:`record_lost_submission` (once per sweep per wave — waves with
+        multiple losses converge across sweeps) re-enters the completion
+        consumer so held sibling results deliver instead of stranding until
+        restart. Also bounds the ``_batch_submitted``/``_batch_progress_ts``
+        leak in the stuck case.
+        """
+        for batch_id, _bs in list(self._manager._batch_submitted.items()):
+            if _bs[1] <= 0 or _bs[0] >= _bs[1]:
+                continue  # complete or unbounded — not wedged by lost POSTs
+            last = self._manager._batch_progress_ts.get(batch_id, 0.0)
+            if now - last < _WAVE_STUCK_SECS:
+                continue  # still within the grace window
+            members = [a for a in self._manager._agents.values() if a.batch_id == batch_id]
+            if any(not a.done for a in members):
+                continue  # live members will re-evaluate the wave on completion
+            if any(p.get("batch_id") == batch_id for p in self._manager._queue):
+                continue  # queued members still pending — not stuck
+            parent = members[0].parent_session_key if members else ""
+            logger.warning(
+                "Reaper: wave %s stuck (%d/%d submitted, no progress for %.0fs)"
+                " — reconciling one lost submission",
+                batch_id,
+                _bs[0],
+                _bs[1],
+                now - last,
+            )
+            self._manager.record_lost_submission(
+                batch_id,
+                _bs[1],
+                f"submission never arrived (wave stuck > {_WAVE_STUCK_SECS}s"
+                " — reconciled by reaper liveness backstop)",
+                parent_session_key=parent,
+            )
+
+    def _sweep_digest_holds_impl(self, now: float) -> None:
+        """Reaper backstop: release wave results whose HOLD DEADLINE expired.
+
+        The gateway holds a completed member's per-agent injection until the
+        wave's digest chunk fires. Both of the chunk's triggers are event-driven
+        — a COUNT trigger (``SUBAGENT_DIGEST_CHUNK_SIZE`` completions pending)
+        and wave close — so neither can fire while a straggler is simply *not
+        finishing*. With the default count (10) above any realistic wave size,
+        the only flush that ever fires is the wave-close one, and a member that
+        HANGS rather than fails withholds every sibling's finished result for
+        the full ``_TIMEOUT_SECS`` reap window (issue #2215).
+
+        This sweep is the timer the event-driven triggers lack: when the OLDEST
+        outstanding hold in a wave has aged past :data:`DIGEST_HOLD_SECS` and
+        the wave is still live, it announces a synthetic *flush-only* record
+        through the single completion consumer (the same re-entry mechanism
+        :meth:`record_lost_submission` uses), which forces the partial digest
+        out. Ordinary fast waves never reach the deadline, so the deliberate
+        "small wave = one consolidated digest" behavior is untouched.
+        """
+        if DIGEST_HOLD_SECS <= 0 or self._manager._on_done is None:
+            return  # deadline disabled — count-trigger-only
+        oldest: dict[str, float] = {}
+        parents: dict[str, str] = {}
+        totals: dict[str, int] = {}
+        for info in list(self._manager._agents.values()):
+            _bid = info.batch_id
+            if not _bid or info._digest_held_at <= 0.0:
+                continue
+            _prev = oldest.get(_bid)
+            if _prev is None or info._digest_held_at < _prev:
+                oldest[_bid] = info._digest_held_at
+            parents.setdefault(_bid, info.parent_session_key)
+            totals.setdefault(_bid, info.batch_total)
+        for batch_id, held_at in oldest.items():
+            age = now - held_at
+            if age < DIGEST_HOLD_SECS:
+                continue  # still inside the grace window
+            if not self._manager.batch_members_pending(batch_id):
+                # The wave is closing on its own — the real wave-close flush is
+                # already in flight (or the held flags are stale bookkeeping).
+                # Forcing a partial digest here would race it and could emit a
+                # duplicate chunk for the same members.
+                continue
+            logger.warning(
+                "Reaper: wave %s held results for %.0fs (deadline %.0fs) —"
+                " forcing partial digest flush",
+                batch_id,
+                age,
+                DIGEST_HOLD_SECS,
+            )
+            self._manager.force_digest_flush(
+                batch_id,
+                parents.get(batch_id, ""),
+                totals.get(batch_id, 0),
+                age,
+            )
+
+    def force_digest_flush_impl(
+        self,
+        batch_id: str,
+        parent_session_key: str,
+        batch_total: int,
+        held_secs: float,
+    ) -> None:
+        """Announce a synthetic *flush-only* record to release a wave's held
+        results without waiting for another member to complete.
+
+        The record is deliberately NOT a wave member: ``_digest_flush_only``
+        tells the gateway to skip every per-member side effect (terminal WS
+        event, orchestration accounting, done/ok/err counters, digest lines) and
+        only force the pending chunk out. Announcing it through ``_on_done`` —
+        rather than reaching into the gateway's digest buffers — reuses the one
+        completion consumer that owns digest composition, routing, and the
+        held-tombstone settle contract.
+        """
+        if not batch_id or self._manager._on_done is None:
+            return
+        info = SubagentInfo(
+            id=uuid.uuid4().hex[:8],
+            task=f"(wave digest flush — results held {int(held_secs)}s)",
+            parent_session_key=parent_session_key,
+            done=True,
+            batch_id=batch_id,
+            batch_total=max(0, int(batch_total)),
+        )
+        info._digest_flush_only = True
+        try:
+            sel().log_tool_invocation(
+                session_key=parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="digest_hold_expired",
+                metadata={"batch_id": batch_id, "held_secs": int(held_secs)},
+            )
+        except Exception:
+            logger.debug("SEL audit failed for digest hold expiry", exc_info=True)
+        try:
+            self._manager._tasks[f"flush-{info.id}"] = asyncio.ensure_future(
+                self._manager._announce_digest_flush(info)
+            )
+        except RuntimeError:
+            pass  # no running loop (sync/test context)
+
+    async def _announce_digest_flush_impl(self, info: SubagentInfo) -> None:
+        """Run the flush-only announce with the SAME settle contract as ``_run``.
+
+        ``_settle_digest_holds`` must run only after ``_on_done`` returns
+        cleanly: a routing failure has to leave the held members undelivered so
+        orphan reconciliation can still recover them after a restart. This path
+        has no run loop to enforce that ordering, so it enforces it here.
+        """
+        assert self._manager._on_done is not None
+        try:
+            await self._manager._on_done(info)
+        except Exception:
+            logger.warning(
+                "Digest hold flush announce failed for wave %s", info.batch_id, exc_info=True
+            )
+            return
+        self._manager._settle_digest_holds(info)
+
+    async def settle_queued_delivery_impl(self, agent_ids: list[str]) -> None:
+        """Write the ``delivered`` tombstones for completions consumed from a queue.
+
+        The queued-injection path (issue #4839) deliberately leaves a completion
+        un-tombstoned until the parent's turn has consumed the announce, so the
+        write lands here — in the parent's drain — rather than in
+        :meth:`_report_terminal`. That is also why it must repeat the gate that
+        report holds: a ``delivered`` tombstone EXCLUDES the folder from restart
+        orphan reconciliation, and the drain can come due while the run's teardown
+        is still killing its child, so writing early would let a crash in that
+        window strand a live child that nothing would ever reap.
+
+        The wait is bounded exactly as the report's is (teardown is itself bounded
+        by ``_RESET_TIMEOUT`` then SIGKILL, and runs in a ``finally``), and a
+        timeout writes anyway rather than abandoning the retention bound — the same
+        trade the report makes. The gate is read from ``_teardown_gates``, which
+        outlives the run's ``_agents``/``_tasks`` records: a dashboard "clear
+        completed" or "cancel" pops both of those for a run that is done but still
+        tearing down, so inferring "record gone means child gone" would tombstone a
+        live child. No gate entry means teardown has finished (or never started).
+
+        The tombstone write itself is offloaded: it fsyncs, and this runs on the
+        gateway event loop.
+        """
+        for agent_id in agent_ids:
+            gate = self._manager._teardown_gates.get(agent_id)
+            if gate is not None and not gate.is_set():
+                try:
+                    await asyncio.wait_for(gate.wait(), timeout=_RESET_TIMEOUT + 30)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Subagent %s: teardown did not complete before the queued "
+                        "delivered tombstone; writing it anyway",
+                        agent_id,
+                    )
+            try:
+                await asyncio.to_thread(mark_delivered, agent_id)
+            except Exception:
+                logger.debug(
+                    "Failed to mark drained subagent %s delivered", agent_id, exc_info=True
+                )
+
+    def _settle_digest_holds_impl(self, info: SubagentInfo) -> None:
+        """Settle delivery tombstones for wave members whose injection was
+        held for this member's digest. Called ONLY after ``_on_done`` returned
+        without raising — and it is a real settle only for the routes where
+        that return IS the confirmation. Both dashboard routes hand off
+        asynchronously, so they detach the ids before ``_on_done`` returns and
+        owe them to the parent's consumption instead (the queue branch via
+        ``_defer_queued_delivery``, the direct-injection branch via the same
+        slot ledger), leaving this a no-op there. Marking the held members
+        delivered no longer risks the restart-loss window here (settling at
+        digest composition, before routing, would).
+
+        The ids are taken off ``info`` BEFORE settling, so a re-entry cannot
+        write a second tombstone and a route that detached them first leaves
+        this a no-op.
+
+        A failing tombstone write is logged and skipped, never raised: one
+        unwritable run folder must not strand the rest of the chunk.
+        """
+        ids, info._digest_settle_ids = info._digest_settle_ids, []
+        for _hid in ids:
+            try:
+                mark_delivered(_hid)
+            except Exception:
+                logger.debug("Failed to settle held subagent %s", _hid, exc_info=True)

--- a/test/metrics/test_usage_turns.py
+++ b/test/metrics/test_usage_turns.py
@@ -8,6 +8,7 @@ test_context_trace's temp-shard fixture and drives the REAL reader over
 synthetic rows.
 """
 
+import ast
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -314,8 +315,21 @@ class TestWriteSiteStamping:
         assert 'app=getattr(slot, "_app", "") or ""' in src
 
     def test_subagent_completion_stamps_the_dispatching_app(self):
-        src = (self._ROOT / "src/kiro_crew/subagent.py").read_text(encoding="utf-8")
-        assert 'app=info.app or ""' in src
+        src = (self._ROOT / "src/kiro_crew/subagent_manager/run.py").read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "persist_token_record_async"
+        ]
+        assert len(calls) == 1
+        app_arg = next(keyword.value for keyword in calls[0].keywords if keyword.arg == "app")
+        expected = ast.parse('info.app or ""', mode="eval").body
+        assert ast.dump(app_arg, include_attributes=False) == ast.dump(
+            expected, include_attributes=False
+        )
 
 
 class TestExtremeTimestamps:

--- a/test/test_app_mcp_scoping.py
+++ b/test/test_app_mcp_scoping.py
@@ -1090,9 +1090,9 @@ class TestQueuedSpawnKeepsAppIdentity:
     def test_the_queued_params_include_app(self) -> None:
         import inspect
 
-        from kiro_crew import subagent
+        from kiro_crew.subagent_manager.admission import SpawnAdmissionCoordinator
 
-        src = inspect.getsource(subagent.SubagentManager.spawn)
+        src = inspect.getsource(SpawnAdmissionCoordinator.spawn_impl)
         assert '"app": app,' in src, "the queued params must carry the app identity"
 
 

--- a/test/test_app_spawn_capability.py
+++ b/test/test_app_spawn_capability.py
@@ -8,7 +8,9 @@ and a refusal is loud.
 
 from __future__ import annotations
 
+import ast
 import asyncio
+import textwrap
 import types
 
 import pytest
@@ -307,7 +309,9 @@ class TestSpawnSkipsTheScanWhenPrevalidated:
         # guard exists AND that the flag threads into the queued params.
         import inspect
 
-        src = inspect.getsource(subagent.SubagentManager.spawn)
+        from kiro_crew.subagent_manager.admission import SpawnAdmissionCoordinator
+
+        src = inspect.getsource(SpawnAdmissionCoordinator.spawn_impl)
         assert "and not _agent_prevalidated" in src
         assert '"_agent_prevalidated": _agent_prevalidated,' in src
 
@@ -429,8 +433,20 @@ class TestChildGateInheritsTheApp:
     def test_child_gate_forwards_the_app(self):
         import inspect
 
-        from kiro_crew import subagent
+        from kiro_crew.subagent_manager.run import RunEventCoordinator
 
-        src = inspect.getsource(subagent.SubagentManager)
-        assert "on_tool_call(" in src
-        assert 'app=info.app or ""' in src
+        src = inspect.getsource(RunEventCoordinator._run_inner_impl)
+        tree = ast.parse(textwrap.dedent(src))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "on_tool_call"
+        ]
+        assert len(calls) == 1
+        app_arg = next(keyword.value for keyword in calls[0].keywords if keyword.arg == "app")
+        expected = ast.parse('info.app or ""', mode="eval").body
+        assert ast.dump(app_arg, include_attributes=False) == ast.dump(
+            expected, include_attributes=False
+        )

--- a/test/test_subagent_context_group_plumbing.py
+++ b/test/test_subagent_context_group_plumbing.py
@@ -19,13 +19,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kiro_crew import subagent as subagent_mod
 from kiro_crew.subagent import (
     SubagentInfo,
     SubagentManager,
     _context_groups_field,
     _context_groups_of,
 )
+from kiro_crew.subagent_manager.continuation import ContinuationCoordinator
 from kiro_crew.subagent_persistence import create_agent_folder, read_state
 
 # ``SubagentManager.spawn`` refuses -- registering no task -- while the host
@@ -230,9 +230,9 @@ class TestContinuationInheritsScope:
         assert mgr.recorded_cwd("conv9") == str(proj)
 
         # A project that no longer exists is forwarded ANYWAY, so `spawn` refuses
-        # it. Round 35 filtered this to "" to keep the continuation working; that
-        # was the wrong trade, because an empty cwd resolves to the POOL project and
-        # a follow-up naming relative files would then edit an unrelated repository.
+        # it. Filtering this to "" would be unsafe because an empty cwd resolves
+        # to the POOL project, so a follow-up naming relative files would then edit
+        # an unrelated repository.
         # A loud refusal is recoverable; a silent write to the wrong tree is not.
         gone = tmp_path / "deleted-project"
         monkeypatch.setattr(
@@ -247,8 +247,9 @@ class TestContinuationInheritsScope:
         # And the synchronous path carries no probe of its own. Comments are
         # stripped first: the method explains the hazard by naming the call, and a
         # scan that counted prose would fail on its own documentation.
-        src = Path(subagent_mod.__file__).read_text(encoding="utf-8")
-        body = src.split("def continue_conversation")[1].split("\n    def ")[0]
+        src = Path(ContinuationCoordinator.__module__.replace(".", "/") + ".py")
+        src = (Path(__file__).parents[1] / "src" / src).read_text(encoding="utf-8")
+        body = src.split("def continue_conversation_impl")[1].split("\n    def ")[0]
         code = "\n".join(
             ln for ln in body.splitlines() if not ln.lstrip().startswith("#")
         )

--- a/test/test_subagent_manager_boundaries.py
+++ b/test/test_subagent_manager_boundaries.py
@@ -1,0 +1,139 @@
+"""Characterize the coordinator boundaries shared by run and reap paths."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import kiro_crew.subagent as subagent_module
+from kiro_crew.subagent import SubagentInfo, SubagentManager
+
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
+
+class _ControlledSessions:
+    """Session double whose reset boundary is controlled by the test."""
+
+    def __init__(self) -> None:
+        self.reset_entered = asyncio.Event()
+        self.allow_reset = asyncio.Event()
+        self.reset_calls: list[str] = []
+        self.release_calls: list[tuple[str, bool]] = []
+
+    def set_continuable_fallback(self, _fallback) -> None:
+        pass
+
+    async def reset(self, session_key: str) -> None:
+        self.reset_calls.append(session_key)
+        self.reset_entered.set()
+        await self.allow_reset.wait()
+
+    def release(self, session_key: str, *, cleanup: bool = True) -> None:
+        self.release_calls.append((session_key, cleanup))
+
+
+@pytest.mark.asyncio
+async def test_real_run_force_reap_race_reports_once_and_releases_slot_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reap owns each terminal concern once, even if its caller is cancelled."""
+    sessions = _ControlledSessions()
+    report_entered = asyncio.Event()
+    allow_report = asyncio.Event()
+    run_entered = asyncio.Event()
+    keep_running = asyncio.Event()
+    stats = MagicMock()
+
+    async def on_done(_info: SubagentInfo) -> None:
+        report_entered.set()
+        await allow_report.wait()
+
+    manager = SubagentManager(
+        sessions=sessions,
+        ctx_builder=MagicMock(),
+        on_done=on_done,
+        max_concurrent=1,
+    )
+    manager._fire_event = AsyncMock()
+    manager._write_tombstone = MagicMock()
+    manager._record_cost = MagicMock()
+    monkeypatch.setattr(subagent_module, "Stats", lambda: stats)
+    monkeypatch.setattr(subagent_module, "sel", lambda: MagicMock())
+
+    info = SubagentInfo(
+        id="race0001",
+        task="characterize terminal arbitration",
+        agent="",
+        started=time.time() - 5,
+    )
+    info._session_sharing = False
+    manager._agents[info.id] = info
+    manager._running_count = 1
+
+    async def controlled_run_inner(_info: SubagentInfo, _session_key: str) -> None:
+        run_entered.set()
+        await keep_running.wait()
+
+    monkeypatch.setattr(manager, "_run_inner", controlled_run_inner)
+
+    run_task = asyncio.create_task(manager._run(info))
+    manager._tasks[info.id] = run_task
+    reap_task: asyncio.Task | None = None
+    report_tasks: list[asyncio.Task] = []
+
+    try:
+        await asyncio.wait_for(run_entered.wait(), timeout=2)
+        reap_task = asyncio.create_task(
+            manager._force_reap(info.id, info, elapsed=5.0, reason="deadline")
+        )
+        await asyncio.wait_for(sessions.reset_entered.wait(), timeout=2)
+
+        sessions.allow_reset.set()
+        await asyncio.wait_for(report_entered.wait(), timeout=2)
+        report_tasks = list(manager._report_tasks)
+        assert len(report_tasks) == 1
+
+        # The finalize claim is already consumed, but cancellation of its caller
+        # must not cancel the independently owned terminal delivery.
+        reap_task.cancel()
+        await asyncio.gather(reap_task, return_exceptions=True)
+        assert not report_tasks[0].done()
+
+        allow_report.set()
+        await asyncio.wait_for(
+            asyncio.gather(run_task, *report_tasks, return_exceptions=True),
+            timeout=2,
+        )
+
+        done_events = [
+            call
+            for call in manager._fire_event.await_args_list
+            if call.args and call.args[0] == "subagent_done"
+        ]
+        assert len(done_events) == 1
+        assert info._reported_to_parent is True
+        assert info.done is True
+        assert info.reaped is True
+        assert info._finalized is True
+        assert info._slot_released is True
+        assert manager._running_count == 0
+        assert info.id not in manager._tasks
+        manager._write_tombstone.assert_called_once_with(info, "deadline")
+        manager._record_cost.assert_called_once_with(info)
+        stats.inc_subagent_failed.assert_called_once_with()
+        assert sessions.reset_calls == ["subagent:race0001"]
+        assert sessions.release_calls == [("subagent:race0001", False)]
+    finally:
+        sessions.allow_reset.set()
+        keep_running.set()
+        allow_report.set()
+        pending = [run_task, *(report_tasks or list(manager._report_tasks))]
+        if reap_task is not None:
+            pending.append(reap_task)
+        for task in pending:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)

--- a/test/test_subagent_result_path_spelling.py
+++ b/test/test_subagent_result_path_spelling.py
@@ -158,10 +158,13 @@ class TestNoEmissionSiteStillUsesTheResolvedHelper:
 
     def test_agent_dir_is_never_stringified_into_text(self):
         offenders = []
-        for rel in ("subagent.py", "mcp_tools/spawn.py"):
+        paths = [self._SRC / "subagent.py", self._SRC / "mcp_tools" / "spawn.py"]
+        paths.extend(sorted((self._SRC / "subagent_manager").glob("*.py")))
+        for path in paths:
+            rel = path.relative_to(self._SRC).as_posix()
             # Explicit utf-8: these sources carry non-ASCII in comments, and a
             # Windows runner's default cp1252 cannot decode them.
-            source = (self._SRC / rel).read_text(encoding="utf-8")
+            source = path.read_text(encoding="utf-8")
             for lineno, line in enumerate(source.splitlines(), 1):
                 stripped = line.strip()
                 if stripped.startswith("#") or "_agent_dir(" not in stripped:

--- a/test/test_subagent_scale.py
+++ b/test/test_subagent_scale.py
@@ -1071,10 +1071,10 @@ class TestWaveDigest:
         # unchanged, only its owning function moved.
         import inspect
 
-        from kiro_crew import subagent as _mod
-        src = inspect.getsource(_mod.SubagentManager._report_terminal)
-        on_done_pos = src.index("await asyncio.wait_for(self._on_done(info)")
-        settle_pos = src.index("self._settle_digest_holds(info)")
+        from kiro_crew.subagent_manager.terminal import TerminalCoordinator
+        src = inspect.getsource(TerminalCoordinator._report_terminal_impl)
+        on_done_pos = src.index("await asyncio.wait_for(self._manager._on_done(info)")
+        settle_pos = src.index("self._manager._settle_digest_holds(info)")
         assert settle_pos > on_done_pos
 
     @pytest.mark.asyncio

--- a/test/test_subagent_turn_resilience.py
+++ b/test/test_subagent_turn_resilience.py
@@ -662,6 +662,54 @@ async def test_orphan_injection_false_without_callback():
 
 
 @pytest.mark.asyncio
+async def test_orphan_injection_callback_error_returns_false():
+    notify = AsyncMock(side_effect=RuntimeError("dashboard unavailable"))
+    mgr = SubagentManager(sessions=MagicMock(), ctx_builder=None, on_orphan_notify=notify)
+
+    assert await mgr._try_inject_orphan_notification("dashboard:main", "msg") is False
+    notify.assert_awaited_once_with("dashboard:main", "msg", None)
+
+
+@pytest.mark.asyncio
+async def test_delivered_orphan_survives_audit_and_tombstone_failures():
+    notify = AsyncMock(return_value=True)
+    audit = MagicMock()
+    audit.log_api_access.side_effect = RuntimeError("audit unavailable")
+    mgr = SubagentManager(sessions=MagicMock(), ctx_builder=None, on_orphan_notify=notify)
+    state = {
+        "id": "orphan-1",
+        "task": "recover work",
+        "parent_session": "dashboard:main",
+    }
+
+    with (
+        patch("kiro_crew.subagent.has_dashboard_surface", return_value=True),
+        patch("kiro_crew.subagent.sel", return_value=audit),
+        patch(
+            "kiro_crew.subagent.write_tombstone", side_effect=OSError("disk unavailable")
+        ) as write_tombstone,
+    ):
+        result = await mgr._notify_orphan("orphan-1", state, "notification_pending", False)
+
+    assert result is None
+    notify.assert_awaited_once()
+    audit.log_api_access.assert_called_once_with(
+        caller="dashboard:main",
+        operation="subagent.orphan_notification_injected",
+        outcome="ok",
+        source="subagent",
+    )
+    write_tombstone.assert_called_once_with(
+        "orphan-1",
+        cause="gateway_restart",
+        recovery_action="delivered",
+        pid=None,
+        turns=0,
+        last_tool="",
+    )
+
+
+@pytest.mark.asyncio
 async def test_orphan_dm_delegates_to_callback():
     dm = AsyncMock(return_value=True)
     mgr = SubagentManager(sessions=MagicMock(), ctx_builder=None, on_orphan_dm=dm)
@@ -930,14 +978,17 @@ def test_no_raw_cancel_outside_chokepoint():
     pending cancel-recovery scheduler task — none of the latter two are managed
     runs, so the marker contract (and recovery) never applies to them."""
     import inspect
+    from pathlib import Path
 
     import kiro_crew.subagent as subagent_mod
 
-    source = inspect.getsource(subagent_mod)
-    lines = source.splitlines()
+    source_root = Path(subagent_mod.__file__).resolve().parent
+    source_paths = [Path(subagent_mod.__file__).resolve()]
+    source_paths.extend(sorted((source_root / "subagent_manager").glob("*.py")))
     raw_sites = [
-        (i + 1, line.strip())
-        for i, line in enumerate(lines)
+        (path.relative_to(source_root).as_posix(), i + 1, line.strip())
+        for path in source_paths
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines())
         if ".cancel()" in line
         and not line.strip().startswith("#")
         and "``" not in line  # docstring mentions, not call sites
@@ -959,19 +1010,19 @@ def test_no_raw_cancel_outside_chokepoint():
     )
     chokepoint_src = inspect.getsource(subagent_mod.SubagentManager._cancel_task_intentionally)
     assert "task.cancel()" in chokepoint_src
-    for lineno, line in raw_sites:
+    for rel, lineno, line in raw_sites:
         assert any(s in line for s in allowed_substrings), (
-            f"raw .cancel() at subagent.py:{lineno} ({line!r}) — route it "
+            f"raw .cancel() at {rel}:{lineno} ({line!r}) — route it "
             "through _cancel_task_intentionally with a terminal marker"
         )
     # The generic 'task.cancel()' form must appear ONLY inside the chokepoint.
     generic = [
-        (n, l)
-        for n, l in raw_sites
-        if "task.cancel()" in l
-        and "_reaper_task" not in l
-        and "recovery_task" not in l
-        and "report_task" not in l
+        (rel, n, line)
+        for rel, n, line in raw_sites
+        if "task.cancel()" in line
+        and "_reaper_task" not in line
+        and "recovery_task" not in line
+        and "report_task" not in line
     ]
     assert len(generic) == 1, (
         f"expected exactly one raw task.cancel() (the chokepoint body), " f"found: {generic}"

--- a/test/test_turn_duration_recorded.py
+++ b/test/test_turn_duration_recorded.py
@@ -94,7 +94,7 @@ EXPECTED_SITES = {
                                     # heartbeat + its timeout + monitor + its
                                     # timeout, extracted in issue #1086)
     "task_executor.py": 2,          # task step + self-review
-    "subagent.py": 1,
+    "subagent_manager/run.py": 1,
     "workflows/agent_exec.py": 1,
 }
 

--- a/test/test_ws_event_scoping.py
+++ b/test/test_ws_event_scoping.py
@@ -2430,10 +2430,10 @@ class TestEventTableCompleteness:
         declared, which is silent loss of the whole subagent stream rather than a
         loud error.
         """
-        src = (
-            Path(__file__).resolve().parents[1]
-            / "src" / "kiro_crew" / "subagent.py"
-        ).read_text(encoding="utf-8")
+        source_root = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+        source_paths = [source_root / "subagent.py"]
+        source_paths.extend(sorted((source_root / "subagent_manager").glob("*.py")))
+        src = "\n".join(path.read_text(encoding="utf-8") for path in source_paths)
         # `_fire_event(` then the first string literal, across a line break.
         fired = set(re.findall(r'_fire_event\(\s*\n?\s*"([a-z_]+)"', src))
         assert len(fired) >= 8, f"emitter scan found too few names: {sorted(fired)}"


### PR DESCRIPTION
## Problem / Motivation

`SubagentManager` had grown into a 6,957-line lifecycle coordinator. Admission, run/session handling, cancellation, continuation, monitoring, terminal settlement, and wave orchestration all lived in one class, making behavioral changes and focused review unnecessarily risky.

## Why it matters

The manager is concurrency-sensitive and exposes long-standing method, shared-state, and monkeypatch seams. Establishing explicit internal boundaries makes those paths easier to reason about and test while keeping the public `SubagentManager` contract stable.

## What changed (motivation → approach → change)

- Keep `SubagentManager` as the stable facade and owner of mutable registries, slots, callbacks, and configuration.
- Extract lifecycle coordination into focused components under `src/kiro_crew/subagent_manager/`: admission, cancellation, continuation, monitoring, run/session events, terminal settlement, and waves.
- Route 73 facade methods to component implementations without changing their signatures or async shape; retain facade-global rebinding so existing `kiro_crew.subagent.*` monkeypatch seams continue to work.
- Preserve the upstream subagent auto-approval identity check (`name_grant`) in the extracted run path during the final rebase.
- Classify the extracted coordinator modules as internal partitions of the existing `subagent.py` redaction sink, preserving the security-posture count while keeping omission detection explicit.
- Add a run/force-reap race characterization test and retarget source-shape checks to the extracted owners.

The facade is now 2,493 lines. The nine component files total 5,378 lines, with `run.py` the largest at 1,653 lines.

Known tradeoff: these are structural coordinator partitions, not standalone runtime namespaces. Implementation globals intentionally rebind to the facade so existing `kiro_crew.subagent.*` monkeypatch seams remain stable; component-owned runtime helpers/imports therefore require explicit care in future changes.

## Tests

- Targeted changed-module tests: 441 passed, 7 skipped.
- Name-grant integration and manager-boundary slice: 36 passed.
- Final-rebase overlap slice (`test_subagent_turn_resilience.py` plus security-posture omission checks): 38 passed.
- Two deterministic monitoring exception-path tests passed and cover the seven statements missing from the prior CI report, moving `monitoring.py` from 198/255 (77.6%) to an expected 205/255 (80.4%).
- The unrelated Windows diagnostic-race test passed on focused rerun.
- Electron tests: 1,437 passed, 2 skipped.
- Mypy: full repository pass (1,179 source files) and final focused pass (10 files).
- Black, isort, Flake8, compileall, and `git diff --check`: passed.
- Production and analyze Vite builds, TypeScript, ESLint, i18n checks, bundle-size gate, jscpd, and required repository policy/self-test gates: passed.
- The previous PR run passed every backend, frontend, platform, and model-review job; only the aggregate coverage gate remained. The final SHA reruns CI with the focused coverage tests above. Local surface selectors were not used as evidence because they expand to complete suites rather than a scoped slice.

## Manual verification

- Confirmed all 93 pre-existing manager methods retain their signatures, decorators, return annotations, and async shape.
- Confirmed 73 extracted implementations are AST-equivalent after normalizing the facade reference, and wrappers forward every argument to the matching implementation.
- Confirmed the branch remains one commit directly on the current `main` base with an exact 21-file change set.
- Confirmed latest-main changes outside this patch merge cleanly; no user-facing UI behavior is changed.

## Related Issues

No linked issue: internal behavior-preserving boundary refactor.

## Checklist

- [x] Added or updated characterization tests for the extracted boundaries.
- [x] Ran focused tests and static checks locally.
- [x] Preserved public signatures and existing monkeypatch seams.
- [x] Kept the branch to one commit on the current `main` base.
- [x] Documentation changes are not required for this internal refactor.

