### PR TITLE
test(mcp): remove zombie diagnostic file race

### DIFF
--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -1510,17 +1510,25 @@ class TestZombieDiagnostic:
     async def test_dead_accept_loop_is_dumped_and_stops_the_daemon(self, monkeypatch, tmp_path):
         diag = tmp_path / "diag.jsonl"
         monkeypatch.setattr(gw, "_zombie_diagnostic_path", lambda: diag)
-        monkeypatch.setattr(gw, "_ZOMBIE_PROBE_INTERVAL_SECS", 0.01)
+        writes: list[tuple[Path, tuple[dict[str, Any], ...]]] = []
+
+        def capture_write(path: Path, *records: dict[str, Any]) -> None:
+            writes.append((path, records))
+
+        monkeypatch.setattr(gw, "_write_diagnostic", capture_write)
         server = MagicMock()
         server.is_serving.return_value = False
         stop = asyncio.Event()
+        monkeypatch.setattr(stop, "wait", AsyncMock(side_effect=asyncio.TimeoutError))
 
-        await asyncio.wait_for(
-            gw._zombie_diagnostic(cast(Any, server), BackendPool(max_backends=1), set(), stop),
-            timeout=5,
+        await gw._zombie_diagnostic(
+            cast(Any, server), BackendPool(max_backends=1), set(), stop
         )
 
-        records = [json.loads(line) for line in diag.read_text().strip().splitlines()]
+        assert len(writes) == 1
+        written_path, records = writes[0]
+        assert written_path == diag
+        assert [record["tag"] for record in records] == ["probe", "zombie_detected"]
         assert records[-1]["tag"] == "zombie_detected"
         assert isinstance(records[-1]["tasks"], list)
         assert isinstance(records[-1]["traceback"], list)


### PR DESCRIPTION
## Problem / Motivation

The Windows backend shard exposed a race in `TestZombieDiagnostic.test_dead_accept_loop_is_dumped_and_stops_the_daemon`: the test delegated the diagnostic write to a real worker thread and temporary file, but the production writer intentionally swallows `OSError` so diagnostics can never crash the daemon. A transient Windows file error therefore let the coroutine complete and made the test race a file that legitimately did not exist.

## What changed

- Replace that test's real filesystem write with an in-memory capture of `_write_diagnostic`.
- Drive the first watchdog probe immediately with an async event double instead of a 10 ms wall-clock interval.
- Assert the path, the single atomic write call, ordered `probe`/`zombie_detected` records, task/traceback payloads, and daemon stop signal.

Production behavior is unchanged. The separate writer tests continue to cover JSONL persistence and the Windows sharing-violation regression.

## Tests

- `TestZombieDiagnostic`: 5 passed on Windows with xdist disabled for the narrow run.
- RuntimeWarning and PytestUnraisableExceptionWarning were treated as errors.
- Baseline-aware Black, isort, Flake8, and diff-check passed.

No retry, sleep, timeout increase, tolerance, warning suppression, or flaky-test rerun is used by the fix.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** Test-only determinism change; there is no rendered UI effect.
