### PR TITLE
docs(system-specs): reconcile the remaining 14 feature specs with the code

### DIFF
--- a/docs/system-specs/features/agent-interrupt-controller.md
+++ b/docs/system-specs/features/agent-interrupt-controller.md
@@ -1,375 +1,169 @@
 # Agent Interrupt Controller (`kiro_crew.irq`)
 
-Status: implemented (this PR)
-Owners: gateway core (`irq.py`), first probe (`builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py`)
+Status: implemented
 
-## 1. Problem
+Owners: `kiro_crew.irq`; in-tree GitHub pull-request probe:
+`builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py`.
 
-A model turn is the expensive execution context in this system, the way a CPU
-is in an operating system. Today it does its own polling: a `monitor_start`
-babysit loop wakes on an interval, spends a full turn asking "anything new?",
-answers "no", and sleeps. That is the arrangement OS designers abandoned —
-having the expensive party poll — and the fix has a name: an interrupt.
+## Purpose
 
-Script crons already provide the cheap half. A `script` cron runs a Python
-function in a subprocess with no model call at all, and communicates its
-verdict to the gateway through one line of JSON: `Skip` (silent), `Report`
-(deliver and keep running), `Done` (deliver and remove the job). A poller built
-on that costs nothing on a quiet tick.
+`kiro_crew.irq` lets a script cron perform cheap observation and request an
+agent turn only when a probe reports an actionable condition. `Probe` supplies
+subject identity and a `Tick`; `irq.run` owns persisted state, deduplication,
+coalescing, and the `Skip` / `Report` / `Done` verdict. The controller's
+verdict ownership keeps probes from each encoding different retry and delivery
+policies. See `irq.Probe`, `irq.Tick`, and `irq.run`.
 
-What is missing is the controller between the two halves. Every poller that
-wants the shape re-implements the same machinery, and each piece has a failure
-mode that looks like success:
+The in-tree consumer is `PrWatchProbe`. It reads a pull request through `gh`,
+classifies pull-request state and checks, and passes its result to `irq.run`
+through `watch`. See `pr_watch.PrWatchProbe.observe` and `pr_watch.watch`.
 
-- **Dedupe.** A permanent "already alerted" marker turns one lost delivery into
-  a permanently suppressed signal — the script raises `Report` and exits, so it
-  can never observe whether delivery happened.
-- **State identity.** Two cron jobs watching one subject that share a state file
-  let one job's dedupe suppress the other's delivery.
-- **Error backstop.** A probe whose command starts failing skips quietly. It
-  looks healthy and is blind. Measured on this codebase: a watch running in an
-  environment where `gh` could not resolve produced five consecutive silent
-  skips before anything was said.
-- **Convergence.** Alerting on the first anomaly wakes the agent before the
-  subject has settled, producing a turn that cannot decide anything.
+## Authoring contract
 
-The scale of the duplication is worse than it appears from the repository. Only
-one poller (`pr_watch.py`) has an in-repo source; roughly fifteen others exist
-only as agent-authored copies in the operator's data home, where they are not
-version-controlled and not reviewed. Two of those have no persisted state at
-all. That is a separate defect — see §7 — but it is why the in-repo poller is
-the only one whose contract is correct, and why the correct contract belongs in
-a shared module rather than in a file that gets copied.
+`Observation` carries a stable key, a severity, a delivery brief, and whether
+its identity belongs to the current epoch. `Tick` carries the current epoch,
+observations, pending work, fetch status, and a quiet-tick detail. The public
+surface is `irq.__all__`; `test_probe_tuning_overrides_a_bound` and
+`test_probe_tuning_cannot_hand_the_kernel_a_fatal_bound` pin the exercised
+probe-tuning contract.
 
-## 2. Solution overview
+A probe implements:
 
-`kiro_crew.irq` is an interrupt controller for agent sessions. It owns
-everything generic and leaves the caller exactly two domain decisions: what to
-poll, and what counts as an anomaly.
+* `Probe.identity(ctx) -> (subject_kind, subject_id)`. `irq.run` calls it once
+  per tick. A `ValueError` becomes `Done`, so a permanently invalid cron
+  message removes the job instead of raising on every tick. This is pinned by
+  `test_identity_value_error_becomes_done` and
+  `test_identity_called_exactly_once_per_tick`.
+* `Probe.observe(ctx) -> Tick`. A probe that cannot read its subject returns
+  `Tick(fetch_ok=False)`. `irq.run` ignores observations in such a tick and
+  uses the persisted error streak instead; treating an unreadable subject as a
+  quiet subject would hide a blind watch. `test_observations_ignored_when_fetch_failed`
+  pins that distinction.
+* Optional `Probe.tuning()` and `Probe.wake_suffix()`. `irq.run` calls both
+  after identity parsing, accepts only the exercised tuning key, validates
+  numeric bounds, and drops a broken or non-string suffix. The suffix is
+  appended once to a delivered wake, not once for each observation. See
+  `irq.run`, `test_probe_tuning_raising_does_not_kill_the_tick`, and
+  `test_the_wake_footer_is_emitted_once_not_once_per_observation`.
 
-| Interrupt concept | Here |
-|---|---|
-| Interrupt source | a `Probe`, polled once per cron tick |
-| ISR | the agent turn the gateway schedules on a wake |
-| Masking | time-bounded dedupe, so one condition wakes once |
-| Coalescing | several anomalies folded into a single wake |
-| NMI | `Severity.NMI` — never delayed by coalescing |
-| Clearing a pending bit | epoch reset, when the subject becomes another one |
-| Stuck / spurious IRQ | the consecutive-error backstop |
-| Unregistering an IRQ line | `Severity.TERMINAL` — the job removes itself |
+`Severity.TERMINAL` ends the watch with `Done`. `Severity.NMI` reports
+immediately but still participates in deduplication. `Severity.WAKE` enters
+the regular coalescing path. Terminal handling precedes NMI and coalescing in
+`irq.run`; `test_terminal_wins_over_an_open_window` and
+`test_nmi_bypasses_the_coalescing_window` pin the ordering.
 
-The division of labour follows Linux's top half / bottom half: the probe is the
-top half (fast, cheap, decides only *whether* something happened) and the woken
-agent turn is the bottom half (does the real work, may be slow).
+## State identity and recovery
 
-The seam is narrow on purpose. A probe returns data; the kernel decides
-quiet-versus-wake and is the **only** place `Skip` / `Report` / `Done` are
-raised. A probe that raised them would be re-deciding the policy the kernel
-exists to own, so a probe does not import them at all.
+`state_path` creates one state path for each subject and cron job. It folds the
+human-readable path components and includes the unfolded identity in its digest.
+This keeps watches of the same subject independent and prevents folded subject
+identities from sharing state; see `test_state_path_separates_two_jobs_on_one_subject`
+and `test_state_path_does_not_collide_on_fold_equivalent_subjects`.
 
-## 3. Contract
+`load_state` accepts only the expected state shapes and converts malformed or
+unusable persisted data to fresh state. This trades possible repeat delivery
+for keeping the cron alive; a parse failure must not become a crash loop. See
+`irq.load_state` and `test_malformed_state_degrades_to_fresh`.
 
-```python
-class Severity(Enum):
-    WAKE      # an anomaly; masked, and folded into a coalesced wake
-    TERMINAL  # subject reached an end state: deliver, then remove the job
-    NMI       # an anomaly that bypasses coalescing (still masked)
+`save_state` persists state through `atomic_write` with owner-only file mode.
+If persistence fails, the watch remains active and wakes include the persistence
+warning. Coalescing then delivers the current window rather than retaining an
+unrememberable delay. This is load-bearing because a new cron process otherwise
+loads an empty window on each tick and the withheld signal never reaches its
+fire condition. See `irq.save_state`, `irq.run`,
+`test_unwritable_state_delivers_instead_of_swallowing_the_window`, and
+`test_a_partial_fire_defers_to_the_unwritable_state_fallback`.
 
-@dataclass(frozen=True)
-class Observation:
-    key: str            # dedupe identity within an epoch
-    severity: Severity
-    brief: str = ""     # operator-facing text if this wakes
-    epoch_scoped: bool = True   # False: identity does NOT depend on the epoch
+## Dedupe and epochs
 
-@dataclass
-class Tick:
-    epoch: str = ""     # identity token of the subject THIS tick
-    observations: list[Observation] = ...
-    pending: int = 0    # sub-observations not yet settled
-    fetch_ok: bool = True    # False when the subject could not be observed
-    detail: str = ""    # one line echoed into the Skip message
+`irq.run` stores epoch-scoped and epoch-independent keys in separate sentinel
+spaces. The same probe key in both spaces remains two signals; see
+`test_the_two_key_spaces_do_not_collide`.
 
-class Probe:
-    def identity(self, ctx) -> tuple[str, str]: ...   # (subject_kind, subject_id)
-    def observe(self, ctx) -> Tick: ...
-    def tuning(self) -> dict[str, float]: ...          # optional bound overrides
-    def wake_suffix(self) -> str: ...                  # appended ONCE per wake
+When a nonempty `Tick.epoch` changes, `irq.run` removes epoch-scoped alerts and
+open-window entries, then retains epoch-independent alerts and open-window
+entries. Check-derived observations must not survive a head change, or an old
+head can be reported as current. Conversation-derived observations must survive,
+or a head change replays already-reported discussion. The carried window receives
+a fresh start stamp: this preserves the pending delivery while ensuring a fresh
+head receives its full settling floor. These invariants are pinned by
+`test_an_open_epoch_scoped_window_is_dropped_by_an_epoch_change`,
+`test_a_sticky_key_survives_an_epoch_change`,
+`test_a_fresh_epoch_anomaly_still_gets_a_full_settling_floor`, and
+`test_a_carried_sticky_entry_is_delayed_not_lost_by_the_restart`.
 
-def run(ctx, probe, *, realert_secs=6*3600, max_consecutive_errors=6,
-        coalesce_secs=240, coalesce_max_secs=1800) -> None: ...
-```
+Dedupe re-arms after the configured re-alert interval. Future timestamps read
+as stale, and recovery clears the blind marker. The error threshold comparison
+uses `>=`, so a missed delivery cannot leave a persisted count permanently past
+the only reporting value. See `irq.run`,
+`test_dedupe_rearms_after_the_realert_window`,
+`test_future_timestamp_reads_as_stale_not_as_forever_suppression`,
+`test_recovered_streak_clears_blind_marker`, and
+`test_blind_probe_reports_at_threshold_not_only_at_equality`.
 
-A probe filters out conditions the operator already knows about (a check red on
-the base branch, a known-degraded dependency) inside its own `observe()` and
-simply does not return them. An earlier revision carried an `expected` flag on
-`Observation` that the kernel recorded but nothing read — a write with no
-reader, which is the shape of state that rots — and it was removed: the probe's
-own filter already did the suppression.
+## Coalescing
 
-`identity()` raises `ValueError` for a configuration that can never become
-valid; the kernel converts that to `Done`, because a malformed parameter cannot
-self-heal and retrying it forever is a crash loop with extra steps. It is called
-exactly once per tick, so the message is parsed once and every parse failure is
-inside that conversion.
+A non-NMI `WAKE` observation opens a persisted window. The window fires all
+entries when the convergence floor has passed and `Tick.pending` is zero, or
+when the hard cap has passed; the hard cap is independent of the floor. The
+floor prevents a newly changed subject from reporting a transient empty rollup
+as convergence. The cap prevents a permanently pending subject from losing an
+otherwise actionable wake. These properties are pinned by
+`test_floor_blocks_a_premature_converged_wake`,
+`test_hard_cap_fires_when_pending_never_drains`, and
+`test_hard_cap_outranks_a_floor_set_above_it`.
 
-### Two dedupe key spaces
+While pending work remains after the floor, epoch-independent entries fire and
+epoch-scoped entries remain in the window. The partial fire retains the original
+window start time for the remaining entries, so repeated discussion cannot keep
+postponing a check-derived observation. See
+`test_a_sticky_wake_fires_at_the_floor_while_checks_are_still_pending` and
+`test_the_sticky_half_fires_while_the_epoch_scoped_half_keeps_waiting`.
 
-`epoch` names what the subject IS this tick, and when it changes the kernel
-wipes dedupe memory — the anomalies it held were observations of something that
-no longer exists. That is right for anything the epoch is a property of, which
-is the default.
+`irq.run` prunes an epoch-scoped entry when the probe no longer observes it,
+which prevents a cleared check from appearing in a later wake. It retains an
+epoch-independent entry that the probe stops observing, because a conversation
+horizon means "not currently inspected," not "cleared." See
+`test_cleared_anomaly_is_pruned_from_an_open_window`,
+`test_an_open_sticky_wake_is_not_pruned_when_the_probe_stops_reporting_it`, and
+`test_an_open_epoch_scoped_wake_is_still_pruned_when_it_clears`.
 
-It is wrong for a signal a probe observes through the same tick that the epoch is
-NOT a property of. A comment on a pull request belongs to the conversation, not
-to the commit under review, and has not stopped having happened because the head
-moved: left epoch scoped, pushing a fix minutes after a reviewer commented would
-replay that comment as though it had just arrived. `epoch_scoped=False` keeps
-such a key across the reset.
+A zero coalescing floor uses immediate `WAKE` delivery. The behavior is pinned
+by `test_coalesce_secs_zero_restores_fire_on_first_anomaly`.
 
-The kernel prefixes every stored key with a sentinel identifying its space, so
-the two can never be confused and a reset can filter without inspecting probe
-text. Two consequences worth knowing:
+## GitHub pull-request probe
 
-- The same probe key in both spaces is two independent signals, not one.
-- Epoch-scoped keys are bounded by the reset that wipes them; sticky keys are
-  not, so the kernel drops them once they pass `realert_secs`. A probe that must
-  never re-report such a signal has to age it out on its own side — which is why
-  the pull-request probe ignores comments older than its horizon, and why that
-  horizon has to stay under `realert_secs`.
+`PrWatchProbe.identity` validates the message's repository, pull-request
+identifier, inherited-failure list, and coalescing value before returning the
+watch identity. `PrWatchProbe.tuning` supplies the message-derived coalescing
+override. `watch` constructs the probe and calls `irq.run`.
 
-## 4. Coalescing
+`PrWatchProbe.observe`:
 
-A window opens on the first non-NMI anomaly of the current epoch. Each POPULATION
-in it then fires on its own readiness:
+* returns terminal observations for merged and closed pull requests;
+* emits an NMI observation for conflicting or dirty pull requests;
+* collapses duplicate check rows, filters known inherited failures, and emits
+  `WAKE` observations for unexpected failures;
+* emits a review-ready observation only when checks are present, no checks are
+  pending, and no unexpected failures remain; and
+* emits epoch-independent observations for recent comments and submitted
+  reviews, without including their bodies in a wake brief.
 
-```
-elapsed >= coalesce_max_secs                  -> fire the whole window
-elapsed >= coalesce_secs and pending == 0     -> fire the whole window
-elapsed >= coalesce_secs                      -> fire the epoch-INDEPENDENT half
-```
+`_collapse`, `_conversation`, and `observe` implement those classifications.
+The comment horizon has an import-time assertion that it expires before the
+controller's re-alert interval, so expired sticky dedupe state cannot replay an
+old comment. See `pr_watch.DEFAULT_COMMENT_HORIZON_SECS` and
+`PrWatchProbe._conversation`.
 
-The split exists because `pending` counts sub-observations of the SUBJECT'S
-current epoch — checks on a commit. That makes it the right gate for an
-epoch-scoped anomaly, which a still-draining check can genuinely resolve, and the
-wrong gate for an epoch-independent one: a comment is complete the moment it is
-observed and does not become truer when a check finishes, so holding it on that
-count buys no observation and costs up to `coalesce_max_secs`. Measured on a real
-pull request with 18 checks in flight, a fresh review comment was held the full 30
-minutes.
+`PrWatchProbe._fetch` returns `None` for an unavailable or malformed `gh`
+response. `PrWatchProbe.observe` converts that result to an unreadable tick,
+feeding the controller's error backstop rather than raising from the cron entry
+point. `pr_watch._run_gh` routes the command through `github_runner.run_gh`.
 
-A partial fire keeps the remaining entries AND the window's original start stamp:
-those entries have been waiting since it, and restarting their clock on every
-partial fire would let a talkative subject defer the check anomaly beside them
-indefinitely. It is also skipped entirely when the state write failed — see
-§5, where withholding half a window becomes a loss rather than a delay.
+## Non-goals
 
-`coalesce_secs` is a **floor, not a timeout**. The distinction is load-bearing:
-immediately after a subject changes epoch its sub-observations may not exist yet
-— a freshly pushed commit has an almost-empty check rollup — so `pending == 0`
-can be briefly true while nothing has run. Firing then reports a convergence
-that never happened. `coalesce_max_secs` is the wall-clock wall for a `pending`
-count that never drains, measured from the first anomaly and independent of
-`pending`, which is what makes the worst case a delayed wake rather than a
-dropped one.
-
-`NMI` and `TERMINAL` bypass the window entirely. For `NMI` the reason is
-specific: the conditions classified that way are ones under which waiting
-observes nothing further. A pull request with a merge conflict dispatches no
-checks, so its `pending` count will never drain and the delay would strand the
-operator for the full hard cap on a signal that was already actionable.
-
-**Why coalesce at all**, given that this module's interrupt frequency is
-minutes apart rather than a NIC's tens of thousands per second — the volume
-argument does not apply. Two other things do:
-
-1. **A wake raised before the subject settles cannot be serviced.** Waking an
-   agent about one failing check while twenty-four others are still running
-   produces a turn that structurally cannot decide anything: it does not know
-   whether more failures are coming or whether they share a cause. That turn
-   has no output regardless of what it costs.
-2. **The follow-up action is usually shared.** Two failing checks on one pull
-   request are fixed by one edit and one push. Servicing them separately means
-   two pushes and two full CI rounds; the waste is wall-clock and CI capacity.
-
-So the test for whether to coalesce is **whether servicing the signals shares
-an action**, not how many there are. Signals on different subjects never
-coalesce, because state is keyed per subject and per cron job.
-
-Deliberately *not* claimed: a token saving. Per-request cached-versus-uncached
-token accounting is not currently measurable in this codebase (usage records
-carry credits only), and appending a turn does not invalidate the KV cache —
-only compaction does. Both justifications above are wall-clock and
-decidability arguments, which are verifiable without that instrumentation.
-
-**Cost.** A window cannot open and fire within one tick — `elapsed` is zero at
-the moment it opens — so a coalesced wake costs at least one cron interval of
-added latency. On a 60-second cron that is at least 60 seconds.
-`coalesce_secs=0` disables the window and restores fire-on-first-anomaly, for
-callers that would rather be woken early than woken once. It is also the
-migration setting for an EXISTING poller moving onto the kernel: it ports with
-the window off, which is a pure structural change with no shift in wake timing,
-and enables the window as a separate, attributable step.
-
-The first probe is deliberately the exception, named here so the rule does not
-read as violated by the change that introduces it: the window exists because of
-a defect measured on `pr_watch`, so porting it with the window off would ship a
-change that fixes nothing. The rule is about not bundling a timing change with
-an unrelated structural move — here the timing change *is* the change.
-
-## 5. Mechanics
-
-**State.** One JSON document per watch at
-`<data home>/watch/<subject_kind>/<folded subject>-<digest>.json`, mode `0600`,
-written through `atomic_write` (a `mkstemp` temporary with an unpredictable name
-plus rename, so a pre-planted symlink at a guessable `.tmp` path cannot
-redirect the write). The digest is `sha256(kind#subject#job_id)[:10]`: the cron
-job id is part of the identity so two watches on one subject keep independent
-memories, and the digest covers the exact unfolded subject id so two ids that
-fold to the same filesystem-safe characters cannot collide.
-
-Fields: `epoch`, `alerted` (key → timestamp), `errors`, `coalescing`
-(key → brief), `coalesce_started_at`.
-
-**Degradation.** `load_state` coerces every field and returns fresh state for
-anything malformed — hand-edited, truncated, or written by another version.
-`json.loads` yields arbitrary-precision integers and accepts `Infinity` / `NaN`
-literals, so a corrupt timestamp that overflows `float()` or is not finite drops
-that entry. The cost of all of this is one duplicate wake; the alternative is a
-crash loop, which auto-pauses the cron and takes the watch down entirely.
-
-**Unwritable state directory** never removes or silences a watch. Dedupe
-degrades to per-tick repeats and every wake carries a warning naming the
-directory. One case is escalated immediately: if the probe is failing *and*
-state cannot persist, the counted-threshold alert can never fire because every
-fresh process reloads zero, so the kernel reports on the first such tick.
-
-Coalescing has its own consequence there, and it is the reason the partial fire
-of §4 is gated on the write succeeding. A window has to REMEMBER when it opened;
-with an unwritable directory every cron subprocess reloads an empty one, `elapsed`
-is always zero and the fire condition is unreachable — so a withheld signal is not
-delayed, it is lost. Both paths therefore deliver everything immediately rather
-than holding anything back: the whole window when the write failed, and never just
-the epoch-independent half.
-
-**Wake body.** The briefs of the fired observations are joined, then the probe's
-`wake_suffix()` is appended ONCE. A brief describes one observation; the footer
-describes the WAKE — standing instructions to the woken agent, and the operator's
-context note. Putting them in the brief instead makes the kernel pay for them per
-observation, so the waste grows exactly as coalescing improves: measured at 56% of
-the delivered bytes on a real six-observation wake. A `wake_suffix()` that raises
-or returns a non-string costs the footer, not the tick.
-
-**Masking** re-arms after `realert_secs` rather than acknowledging permanently,
-and treats a future timestamp (clock rollback, corrupt state) as stale so it
-cannot suppress indefinitely. The error backstop fires at `>=` threshold, not
-`==`: an equality gate turns one lost delivery into permanent silence, since the
-persisted count passes the threshold and never equals it again. A recovered
-streak clears the blind marker so the next streak alerts promptly instead of
-inheriting hours of dedupe.
-
-## 6. SDK for app authors
-
-**Provisional.** There is exactly one probe today, so the contract has not yet
-been tested by a second consumer, and the pollers it was derived from cannot
-migrate until they are under version control (see §7). The surface is published
-because an app that wants this shape otherwise hand-rolls the four things this
-module exists to get right — but it is published as provisional, not stable:
-expect `Observation` / `Tick` to gain fields once a second probe exercises them.
-
-`kiro_crew.irq` is a supported surface for external apps. An app that needs to
-watch something ships a script cron, subclasses `Probe`, and gets masking,
-coalescing, epoch resets, atomic state and the error backstop without writing
-any of them. `__all__` marks the surface; anything outside it is internal.
-
-A complete probe:
-
-```python
-import json
-
-from kiro_crew.irq import Observation, Probe, Severity, Tick, run
-
-
-class DeployProbe(Probe):
-    def identity(self, ctx):
-        self.env = (json.loads(ctx.message or "{}") or {}).get("env") or ""
-        if not self.env:
-            raise ValueError('needs {"env": "..."}')   # kernel -> Done
-        return ("deploy", self.env)
-
-    def observe(self, ctx):
-        status = read_deploy_status(self.env)          # your bounded call
-        if status is None:
-            return Tick(fetch_ok=False)               # kernel owns the backstop
-        if status.finished:
-            return Tick(epoch=status.id, observations=[
-                Observation("done", Severity.TERMINAL, f"{self.env} deployed."),
-            ])
-        obs = []
-        if status.rolled_back:
-            # Nothing improves by waiting: a rolled-back deploy runs no
-            # further stages. NMI, so it is neither masked nor delayed.
-            obs.append(Observation("rollback", Severity.NMI,
-                                   f"{self.env} rolled back."))
-        for stage in status.failed_stages:
-            obs.append(Observation(f"stage:{stage}", Severity.WAKE,
-                                   f"{self.env}: stage {stage} failed."))
-        return Tick(epoch=status.id, observations=obs,
-                    pending=status.running_stages)
-
-
-def watch(ctx):
-    run(ctx, DeployProbe())
-```
-
-Rules an app author must follow:
-
-- Never raise `Skip` / `Report` / `Done`. Return data; the kernel decides.
-- A failed observation returns `Tick(fetch_ok=False)`, never an empty `Tick` —
-  an empty tick reads as "nothing is wrong".
-- Classify as `NMI` only what genuinely cannot improve by waiting. Using it to
-  mean "important" defeats coalescing.
-- Supply an `epoch` when the subject has an identity token. Without one there
-  are no resets, so a re-triggered subject inherits the previous run's masks.
-- Keep `observe()` to one bounded call. The top half must not be slow.
-
-A probe may override the coalescing window by implementing
-`tuning() -> dict[str, float]`, which the kernel calls after `identity()` so an
-override can be derived from the cron message (`pr_watch` does exactly that for
-`coalesce_secs`). It is a declared method rather than an attribute the kernel
-reads off the probe: an implicit back-channel is a second, undocumented way to
-configure the kernel, and the second probe would have copied it.
-
-`coalesce_secs` is the only recognized key, because it is the only one a probe
-produces. The kernel has three other bounds and the mechanism is generic over the
-mapping, so admitting all four would cost nothing mechanically — but a recognized
-key with no producer is a contract nobody has exercised, and the second probe
-would build on a shape that was never tested. The other three stay settable
-through `run()`'s own arguments, which is how the tests drive the error backstop
-and the hard cap on small bounds. The returned value goes through the same bound
-validation as `run()`'s arguments, so a probe cannot hand the kernel a number
-that makes every tick raise.
-
-## 7. Non-goals and known gaps
-
-- **Not a scheduler.** Cadence, retries and job lifecycle stay with the cron
-  service. This module runs one tick.
-- **Does not read discussion.** A probe may observe THAT discussion happened --
-  the first one reports new comments and submitted reviews by identity and
-  timestamp -- but nothing in the top half parses prose. Noticing "something was
-  said" is the top half's job; reading it carefully is the bottom half's, and a
-  watcher that interpreted verdict text would need the judgment this design
-  exists to avoid paying for on every quiet tick.
-- **Migrating the other pollers is blocked on version control, not on this
-  module.** Roughly fifteen script crons live only in the operator's data home
-  because their skills instruct an agent to hand-write them, rather than
-  shipping them as repository assets the way the babysit skill does. They cannot
-  be migrated by pull request until that is fixed, and fixing it is worth more
-  than the migration: it is why their contracts drifted.
-- **The probe's own external call is not verifiable in an agent sandbox.** The
-  first probe's `gh` resolution refuses inside the tool sandbox, whose user
-  namespace maps every uid to `nobody`, so probe-level end-to-end behaviour must
-  be verified by a real cron tick. This is not incidental: the defect that
-  motivated the coalescing window was found by running a watch for four
-  minutes, and was *not* found by a full read of the same file, because it is a
-  property of real CI timing rather than of the code.
+The controller runs a single tick; cron cadence, retries, and job registration
+belong to the cron service. The pull-request probe detects comment and review
+metadata, not their prose. The woken agent reads and judges discussion after a
+wake; `PrWatchProbe._conversation` deliberately keeps body text out of the
+probe's observations.

--- a/docs/system-specs/features/app-notifications.md
+++ b/docs/system-specs/features/app-notifications.md
@@ -1,48 +1,47 @@
-# App Notification Producers (Push Endpoint) — Design Document
+# App notification producers
 
 ## Overview
 
-Phase 2 of the local notification bus (`docs/request-for-change/rfc-local-notification-bus.md`): installed apps become first-class notification producers. An app declares its channels in `app.json`, then pushes notifications through `POST /api/notifications/push` authenticated with its app token. The gateway resolves the producer identity server-side from the verified token (never from the request body), enforces manifest-declared channels, and applies a per-app rate limit. Delivered notes flow through the Phase 1 `NotificationBus` sink (`DashboardState._deliver_note`), which redacts, broadcasts to SSE clients, and persists.
+Installed apps declare notification channels in `app.json` and publish through `POST /api/notifications/push` with an app token. `dashboard.handlers.notifications_push.api_push_notification` resolves the producer from the verified token rather than the request body, requires a manifest-declared channel, and uses the state-owned rate limiter. `NotificationBus.push` enriches the payload and calls `DashboardState._deliver_note`, which redacts, applies channel settings, appends the note, broadcasts it, and queues persistence.
 
 ## API
 
 ### POST /api/notifications/push
 
-App-token-only endpoint (dashboard-user tokens are rejected with 403: they have no app identity, and the endpoint is for producers). Registered in `server.py` `_register_mcp_routes`, so it serves both the dashboard app and the headless gateway.
+This endpoint requires an app token. Dashboard-user tokens carry no `request["app"]` identity and `api_push_notification` rejects them. `dashboard.server._register_mcp_routes` registers the route for both dashboard and headless gateway servers.
 
-Request body (JSON, max 64 KB — enforced on Content-Length AND incrementally on the raw stream so chunked transfer-encoding cannot bypass it):
+The JSON object contains:
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `channel` | string | yes | A channel id declared in the app's manifest (bare id, not the full dotted name) |
-| `title` | string | yes | Validated by `NotificationPayload.validate()` (length caps) |
-| `body` | string | yes | Length-capped |
-| `priority` | string | no | `critical` / `default` / `passive`; defaults to the channel's `defaultPriority` |
-| `group_key`, `url`, `icon`, `ttl`, `actions`, `meta` | — | no | Passed through payload validation; `url` must be a dashboard-internal path. Each `actions[]` entry requires `id` + `label`; an entry MAY carry a `url`, validated with the same dashboard-internal-path rule at persistence time (the trust root — no stored action can hold an external link) |
+| `channel` | string | yes | A bare channel id declared in the app manifest. |
+| `title` | string | yes | `NotificationPayload.validate` applies the title cap. |
+| `body` | string | yes | `NotificationPayload.validate` applies the body cap. |
+| `priority` | string | no | `critical`, `default`, or `passive`; absent values use the channel default. |
+| `group_key`, `url`, `icon`, `ttl`, `actions`, `meta` | — | no | `NotificationPayload.validate` validates the payload. Note and action URLs must be dashboard-internal paths, making persistence the trust root: no stored action can carry an external link. |
 
-The note's `source` is always `app:<name>` resolved from the verified token; `channel` becomes `<app-name>.<channel-id>`.
+`read_bounded_json` enforces the request-size bound before decoding, both from `Content-Length` and while incrementally reading a chunked stream; `test_notifications_push.py::test_body_size_boundary_exact` and `::test_oversized_chunked_body_rejected` pin that boundary. `api_push_notification` sets `source` to `app:<name>` from the verified token and expands `channel` to `<app-name>.<channel-id>`.
 
-Responses: `200` with `{"ok": true, "note": {...}}` where `note` is the enriched note (resolved `source`, full `channel`, effective `priority`, server timestamp `ts`); `400` (validation failure — including a corrupt on-disk manifest `defaultPriority`), `403` (no app token / app disabled or unknown / channel not declared), `413` (oversized body), `429` (rate limited), `500` (delivery or persistence failure, SEL-audited). A `200` is a durability guarantee: the handler awaits the persist job before acknowledging, so an accepted push cannot be silently lost to a disk failure. Legacy system producers remain best-effort fire-and-forget.
+The endpoint returns the enriched note on success, including resolved source, full channel, effective priority, and `ts`. Validation and registration failures return `400`, including undeclared channels and an invalid manifest channel priority; missing or disabled app identity returns `403`; oversized bodies return `413`; exhausted budgets return `429`; and delivery or persistence failures return `500`. `test_notifications_push.py::TestPushDurability` pins the durability invariant: the handler awaits `DashboardState.last_notification_persist`, so it does not return success when the queued persist fails. Legacy `DashboardState.notify` remains best-effort.
 
 ### Deep-linking a push back to its notification
 
-`ts` is the note's store id — every mutating notification API keys on it, and both the push response and the WS notification envelope carry it. A producer relaying pushes off the gateway (e.g. an ntfy bridge setting a Click URL) can therefore link the tap straight to the notification it is about:
+`NotificationBus.push` creates `ts` as the note store id. The push response and notification envelope carry it, and the per-note mutation APIs key on it. Producers can link to a note with:
 
 ```
 /notifications?note=<url-encoded ts>
 ```
 
-`ts` is an ISO-8601 UTC string (e.g. `2026-08-10T09:47:47.726985+00:00`), so the value MUST be percent-encoded: the embedded `+` would otherwise decode as a space and never match.
-
-The dashboard notifications page resolves the `note` param through the same select path as a tapped row (so it auto-acks and opens the detail — full-width on mobile, scrolled into view in the feed on desktop), then consumes the param with a history replace so reload/back does not re-select or re-ack. An id that no longer exists (expired past the ring cap, deleted, or cleared) degrades to the plain page with nothing selected and no error. The param name is part of the page's contract with external pushers; it is defined as `NOTE_DEEP_LINK_PARAM` in `website/src/pages/NotificationsPage.tsx`.
+`ts` is an ISO-8601 UTC value, so callers must percent-encode it: an unencoded `+` decodes as a space and cannot match the stored value. `website/src/pages/NotificationsPage.tsx` exports `NOTE_DEEP_LINK_PARAM`, captures and removes the parameter with history replacement, and resolves it through the same selection path as a tapped row. That path preserves acknowledgement, mobile detail, stack expansion, and scroll behavior; an unmatched id leaves the page unselected without an error.
 
 ### Request pipeline order
 
-`validate -> register-channel-once -> rate-limit token -> bus.push`, chosen so that:
+`api_push_notification` performs bounded parsing and app/channel resolution, registers an unregistered channel while holding `app_lifecycle_lock`, validates the payload, consumes a rate-limit token, then calls `NotificationBus.push`. The order is load-bearing:
 
-- Invalid payloads and corrupt-manifest 400s never consume a rate-limit token (the budget caps DELIVERED notifications).
-- Channel registration happens at most once per channel (re-registering every push would stomp future runtime priority overrides).
-- A `NotificationValidationError` escaping `bus.push` (unreachable today; safety net) refunds the token. A sink failure (e.g. disk full) deliberately does NOT refund: delivery may be partial, and throttling a producer while the gateway is failing is protective.
+- `test_invalid_payload_does_not_consume_rate_token` and `test_corrupt_manifest_400_does_not_consume_rate_token` ensure non-delivering `400` paths do not drain the budget.
+- `test_register_once_does_not_stomp_runtime_priority_override` ensures lazy registration cannot reset a runtime channel priority.
+- The lifecycle lock serializes enablement and registration with disable/uninstall. If a channel becomes unavailable before `NotificationBus.push`, the handler fails the push and refunds the token (`notifications_push.py`).
+- A `NotificationValidationError` from `NotificationBus.push` refunds the consumed token. Delivery and persistence errors do not refund because the note may already have been broadcast.
 
 ## Manifest schema: `notifications.channels`
 
@@ -56,61 +55,48 @@ The dashboard notifications page resolves the `note` param through the same sele
 }
 ```
 
-Validation (`apps/manifest.py`): max 8 channels per app, kebab-case ids, unique ids, `defaultPriority` in the priority enum. The `notifications` block is covered by `signing_payload()` when non-empty, so channel declarations (including any `critical` default priority) are tamper-evident post-signing; manifests without channels produce a byte-identical signing payload to pre-Phase-2 manifests (backward compatible).
+`apps.manifest.NotificationsConfig.validate` requires unique kebab-case ids, names, and enum priorities; `test_notifications_push.py::TestNotificationsManifest::test_channel_cap_enforced` pins the channel-count bound. `AppManifest.signing_payload` includes non-empty channel declarations, so signed declarations and their defaults are tamper-evident. `test_no_channels_keeps_pre_phase2_payload_shape` pins the empty-channel payload shape.
 
 ## Authorization
 
-- **Token gate** (`token_auth.py` `app_token_path_allowed`): app tokens are deny-by-default; a single carve-out grants every app token exactly `/api/notifications/push`. Deliberately NOT `/api/notifications` — that path also serves GET (read history) and DELETE, which app tokens must not reach.
-- **Handler checks**: app must be installed AND enabled (`is_app_enabled`, a read-only accessor safe for `asyncio.to_thread` — unlike `get_app` it has no version-sync write side effect), and the channel must be declared in the manifest. Manifest reads run off-loop via `asyncio.to_thread` (TOCTOU window accepted: one final notification from a just-disabled app).
-- **Auditing**: every denial, error, and grant emits SEL `log_api_access` with the caller identity.
+- `dashboard.token_auth.app_token_path_allowed` denies app-token paths by default and explicitly permits `/api/notifications/push`; it does not grant `/api/notifications`, which includes notification-history reads and deletes.
+- `_resolve_app_channels` requires an installed, enabled app and manifest declaration. It runs in `asyncio.to_thread` and uses the read-only `is_app_enabled`/`get_app_manifest` path rather than `get_app`, whose version synchronization can write metadata.
+- `api_push_notification` SEL-audits token-identity, disabled/unknown-app, undeclared-channel, rate-limit, delivery, persistence, and successful-grant outcomes. Bounded-body, channel-registration, and payload-validation responses return directly without a `log_api_access` call.
 
 ## Rate limiting
 
-`notifications/rate_limit.py` `AppRateLimiter`: per-app token bucket, 30 notifications per 5 minutes with burst 10. State-owned (`DashboardState.notification_rate_limiter`), not a module global, so its lifecycle matches the gateway instance and tests get isolation. Buckets are never evicted; growth is bounded because only installed, enabled apps reach the limiter (unknown apps 403 earlier). `refund(app_name)` returns one token (capped at burst) for requests that consumed a token but delivered nothing.
+`notifications.rate_limit.AppRateLimiter` maintains a per-app token bucket. `DashboardState.notification_rate_limiter` owns the limiter, keeping lifecycle and test isolation scoped to a gateway instance; `test_rate_limiter_is_state_owned_not_module_global` enforces that invariant. `test_burst_allowed_then_limited` and `test_refund_returns_token_capped_at_burst` pin the bucket configuration and refund ceiling. The handler reaches the limiter only after installed/enabled authorization, so its never-evicted buckets are bounded by authorized app names.
 
 ## Delivery and event-loop safety
 
-`bus.push` delivers synchronously into `DashboardState._deliver_note` (redact, append to in-memory log, SSE broadcast). Persistence (JSONL append + trim) does blocking file I/O; because the sink is externally drivable in Phase 2, ALL notification file mutations run on a dedicated single-worker executor when a loop is running: appends from the delivery sink AND whole-file rewrites from delete/ack/unack/clear. Single-worker execution means strict submission order — a rewrite submitted after an append can never be overtaken by that append, so a deleted notification cannot be resurrected by a still-queued persist. Mutation endpoints (`delete_notification`, `ack_notification`, `unack_notification`, `clear_notifications`) are async and await durability before responding; the delivery sink stays fire-and-forget (a push response does not need to wait for disk). Snapshot copies are handed to the executor so later loop-side mutation (e.g. ack flags) cannot race serialization. No locks are taken on the event loop and no file I/O runs on it. Sync callers (tests, CLI) persist inline.
+`DashboardState._deliver_note` redacts the note, applies settings, appends it to the in-memory log, broadcasts it, and queues `_persist_notification`. On a running event loop, delivery appends and rewrite mutations share `_notification_io_executor`, a single-worker executor; `DashboardState._rewrite_notifications_async` awaits rewrites for delete, acknowledgement, unacknowledgement, clear, and acknowledge-all paths. Submission order is load-bearing: a rewrite queued after an append cannot be overtaken, preventing deleted rows from reappearing. Snapshot copies prevent later loop-side mutations from changing the data being serialized. `test_dashboard.py::test_deliver_note_offloads_persist_on_running_loop` and `::test_ack_persists_durably_before_return` cover these guarantees; synchronous callers persist inline.
 
 ## Testing
 
-`test/test_notifications_push.py` (39 tests): auth bypass attempts, undeclared channels, oversized/chunked bodies, rate limit + refund semantics, falsy-but-valid fields, signing-payload coverage, register-once behavior, sink-failure 500. `test/test_dashboard.py` covers persistence, load-time redaction, and the executor-offloaded persist path.
+`test/test_notifications_push.py` covers app-token authorization, manifest channel enforcement, bounded/chunked bodies, rate-limit and refund semantics, falsy valid fields, signing-payload coverage, lazy registration, and sink/persistence failure paths. `test/test_dashboard.py` covers persistence, load-time redaction, ordered executor persistence, and durable rewrite behavior. `test/test_notification_settings.py` covers settings persistence, protected channels, sink application, badge behavior, and settings APIs.
 
 ## Channel lifecycle
 
-Channels register lazily on an app's first push to each declared channel. On app uninstall or disable, `NotificationBus.unregister_app_channels(app_name)` removes every `<app>.*` channel from the registry (wired in `apps/routes.py`); re-enabling re-registers lazily on the next push. System channels are never removable. The app name `system` is rejected at manifest validation (`RESERVED_APP_NAMES`) AND denied defense-in-depth at the push endpoint, so app channels can never shadow the reserved `system.*` namespace.
+Channels register lazily on the first push to each declared channel. App lifecycle routes call `NotificationBus.unregister_app_channels(app_name)` while holding the app lifecycle lock; disabling or uninstalling an app removes its registered `<app>.*` channels, and a later enabled push registers them again. `test_notifications_push.py::TestUnregisterAppChannels` pins boundary-safe removal and preservation of system channels. `RESERVED_APP_NAMES` rejects `system` during manifest validation, and `_resolve_app_channels` rejects it again, preventing app channels from shadowing `system.*`.
 
-## Per-channel settings (Phase 3)
+## Per-channel settings
 
-User preferences per channel, stored in `~/.kiro/crew/notification_settings.json` (`notifications/settings.py`, state-owned `ChannelSettings`, atomic-rename writes, corrupt file falls back to defaults):
+`notifications.settings.ChannelSettings` is state-owned, writes atomically, and loads an invalid settings file as empty defaults. `ChannelSettings.apply` runs in `DashboardState._deliver_note` before append and broadcast, so disk and clients receive the same user view while `NotificationBus` remains policy-free.
 
-- **Mute**: the note still lands in history (mute silences, it does not destroy) but is stamped `silenced: true` with priority forced to `passive`, so every attention surface skips it — the unread badge counts only non-passive rows, and sound/banner/feed styling key off the same fields.
-- **Priority override**: the user's value replaces the producer-requested priority and channel default.
-- **Protected channels** (`system.approval`): cannot be muted and cannot have priority lowered — enforced at the settings API (400) AND at apply time, so even a hand-edited settings file cannot silence approvals (RFC exit criteria: approval still interrupts while heartbeat can be silenced everywhere).
+- A muted non-protected channel remains in history but receives `silenced: true` and passive priority. `test_apply_mute_forces_passive_and_silenced` and `test_muted_channel_excluded_from_badge` pin the visibility and badge invariant.
+- A priority override replaces the effective producer or channel priority.
+- `system.approval` is protected. `ChannelSettings.update` rejects muting or lowering it, and `ChannelSettings.apply` enforces the same floor for hand-edited settings; `test_protected_channel_cannot_be_muted_or_lowered` and `test_apply_ignores_noncritical_override_on_protected_channel` cover both boundaries.
 
-Settings are applied at the delivery sink (`_deliver_note`), before append/broadcast, so SSE clients and disk both see the user's view; the bus stays pure.
+Dashboard-user settings routes expose the union of registered channels and stored settings through `api_notification_channels`; `api_notification_channel_settings` accepts mute and priority updates, clears an override for `priority: null`, and broadcasts `notification_channel_settings`.
 
-API (dashboard-user only; app tokens have no grant here):
-- `GET /api/notifications/channels` — every registered channel plus channels with stored settings (even if currently unregistered, e.g. app disabled), each with `source`, `default_priority`, `protected`, and `settings`.
-- `PUT /api/notifications/channels/settings` — body `{"channel", "muted"?, "priority"?}`; `priority: null` clears the override. Changes broadcast over WS as `notification_channel_settings`.
+## Agent notifications and expiration
 
-## Phase 5: cleanup and agent tool (delivered)
+`mcp_tools.messaging.send_notification` requires a verified caller identity, applies the messaging governance gate, and denies channel-agent callers. `dashboard.handlers.messaging.api_notification_agent_push` fixes agent notes to the `system.agent` channel and server-derived source before `NotificationPayload` validation. The agent endpoint and the app push handler both await queued persistence before returning success.
 
-- **`send_notification` MCP tool**: agent sessions publish schema-v2 notifications through the fixed `system.agent` channel via `POST /api/notifications/agent` (`source`/`channel` are server-fixed, never body-supplied; full payload validation applies — internal-path urls, action caps, length caps; a `200` awaits the persist like the app push; app tokens are refused at the handler — apps publish through their own token-verified endpoint). Governed by the same messaging capability gate as `send_message`. Caller identity resolves strictly, in order: (0) the gateway-injected per-call caller context (`_meta.kirocrew.caller`, installed by the stdio dispatch loop via `mcp_caller.set_current_caller` — the authoritative identity in the pooled/warm-pool topology, where gatewayd strips client-forged blocks and injects its own from the claim-push at `rekey()`), (1) `KIROCREW_SESSION_KEY` env, (2) HMAC-verified `KIROCREW_HOST_PID` pid file; the tool fails closed with no verified identity. Channel agents (`channel:*` caller keys) are denied at MCP dispatch for BOTH `send_message` and `send_notification` — the interactive `channel.py` guard only fires on permission-request events, which auto-approved calls never emit.
-- **TTL sweeper**: passive notes carrying a positive integer `ttl` (seconds) expire once `ts + ttl` passes. Swept in-memory at load and lazily on every delivery (the log is capped, so the scan is cheap); disk catches up on the next full rewrite. Only passive notes sweep — critical/default history has recall value. Ambiguous timestamps are kept, never destroyed.
-- **Delivery to additional channels: planned, superseding the earlier Slack-escalation design**. A per-channel routing preference (`deliver_to`: a set of connected chat transports — Slack/Discord/Telegram/Webex/WeCom — plus a minimum-priority filter) will fan matching notes out to those transports, governed per transport through the `channels/<transport>` allowlist via the shared `vet_and_audit` seam. The earlier Slack-only, away-detection escalation shape was rejected (transport-specific and presence-sniffing); it never shipped.
-- **Kind-fallback cleanup: deferred (precondition unmet)**. The RFC gates removal on telemetry showing no legacy rows in the active window, but all system producers still route through the legacy `notify()` adapter by design (backward-compat table: "Signature unchanged; adapter forwards to bus indefinitely"), so legacy-shaped rows are permanent in the active window. The `kind` field remains load-normalized and presentation-only.
+`DashboardState.sweep_expired_notifications` removes only passive notes with a positive integer `ttl` whose parseable timestamp has elapsed; ambiguous timestamps and other priorities remain. `DashboardState` invokes the sweep while loading persisted history and before each delivery. The in-memory sweep becomes durable on a later full rewrite, so already-open clients retain an expired row until their next reload or refresh.
 
-## Phase 4: inline actions and grouping (delivered)
+## Inline actions and grouping
 
-- **Action contract**: an `actions[]` entry is `{id, label, url?}`. `id` + `label` are required non-empty strings; `url` is optional and validated at persistence time with the dashboard-internal-path rule (same validator as the note-level `url` — `_validate_internal_url` in `notifications/bus.py`). Caps at validation: at most 4 actions per notification, `id` ≤ 64 chars, `label` ≤ 40 chars, `url` ≤ 500 chars (every action renders as a button on every surface, so unbounded counts/lengths would distort feed layout). The frontend renders an action as a navigation button only when it carries a `url` (`safeInternalUrl` in `notifMeta.tsx` re-checks client-side as defense-in-depth, plus string-type guards for legacy persisted rows); **url-less actions are legal, persist, and render nothing today** — they reserve dispatch semantics for a future phase.
-- **Approval inline resolution**: unacked `approval` notes render one-click Approve/Reject in the feed (bell popover and page), dispatching to the existing `POST /api/approvals/{id}/{action}` endpoint.
-- **`group_key` stacking**: notes sharing a `group_key` within a date group collapse to the newest head. The mac sheet renders a layered deck (click the collapsed head to expand, quiet "Show less" capsule); the panel variant uses an explicit "N more" pill.
-- **Deep links**: the detail panel renders an Open button for a note-level `url` and buttons for url-carrying actions (same validation).
-- **Dock badge**: the renderer mirrors the unread (non-passive, non-silenced) count to `app.setBadgeCount` via a `badge:set` IPC bridge; clamp lives in `electron/badge.js`.
+`NotificationPayload.validate` accepts action entries with non-empty `id` and `label`, and validates each optional action URL at the persistence trust root. `test_notification_bus.py::test_action_count_capped` and `::test_action_field_lengths_capped` pin action bounds. URL-less actions persist but do not render; `test_action_without_url_accepted` pins that contract.
 
-## Known follow-ups
-
-- Phase 3 frontend: settings UI section (channel list grouped by source), priority tiers wired through sound/native banner/feed styling, provisional keep/mute prompt for the first notification from a new app channel.
-- Phase 4 follow-ups: surface inline-approval failures as a per-row transient error state (currently a console diagnostic; the row stays retryable); hoist dock-badge mirroring from `NotificationsBellButton` to an app-level effect with badge cleanup on teardown.
-- Phase 5 follow-ups: run the TTL sweep in the GET handler too (today it runs at load and on delivery); propagate sweep removals to connected clients (broadcast expired timestamps over WS/SSE or trigger a list refetch — today an active dashboard retains an expired passive row until reload); add `ttl` to the `send_notification` tool schema (purely additive); per-channel delivery routing to additional chat transports (see the planned bullet above).
+`website/src/components/notifications/NotificationDetailPanel.tsx` and `NotificationFeed.tsx` render navigation actions only after `safeInternalUrl` rechecks a dashboard-internal URL. Unacknowledged approval notes render Approve and Reject controls that use the approval API. `NotificationFeed` collapses notes sharing a `group_key` within a date group to the newest row and expands the stack on demand. `NotificationsBellButton` sends the unread attention count through `badge:set`; `electron/badge.js` clamps it before `app.setBadgeCount`.

--- a/docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md
+++ b/docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md
@@ -1,359 +1,106 @@
 # App SDK: durable jobs and view state
 
-> **Status: proposed, not implemented.** Nothing described here exists in the
-> code yet — `JobSDK`, `useAppJob` and `useAppViewState` are the design this spec
-> is asking for, and §7 is the order in which they would land. The rest of this
-> directory documents shipped behaviour; treat this file as the plan until a
-> phase merges and this banner is cut. §1's account of the *existing* code is
-> current and citation-checked, and is the only part safe to rely on today.
-
-Two capabilities the App SDK does not offer today, so every app either re-invents
-them or ships without them: a **durable record of a task in progress**, and a
-**URL-expressible record of where the user is inside an app**. Both are the same
-mistake in two places — a fact that only ever exists in a React component, and so
-dies when that component unmounts.
-
-This spec fixes them as SDK surfaces rather than per-app patches, because the
-evidence in §1 shows per-app effort does not converge.
-
-## 1. Problem
-
-### 1.1 A task in progress has no server-side existence
-
-AWS Control runs a backup inline in the HTTP request
-(`src/kiro_crew/apps/builtins/aws_control/backend/routes.py:1014`):
-
-```python
-record = await asyncio.to_thread(runner, _account, profile, region, bucket)
-```
-
-There is no job id and no in-flight registry. The only server-side state is the
-*terminal* run record, written by `_record_run` (`backend/backup.py:128`) as the
-last statement of each runner — and written **inside the worker thread**
-(`backend/backup.py:268`, `:448`), so it lands even with nobody listening.
-
-The consequences are precise:
-
-- When the client goes away, **nothing stops the work.** The gateway never sets
-  aiohttp's `handler_cancellation` (`src/kiro_crew/dashboard/slowloris.py:157`
-  passes the base config's value through and no caller enables it), so aiohttp's
-  default applies and the handler is *not* cancelled on disconnect: it runs to
-  completion, as does the OS thread `asyncio.to_thread` started. Even had the
-  coroutine been cancelled, the thread could not be — the only stop primitive,
-  `_STOP` (`backend/backup.py:163`), is set at app teardown only. **The work
-  finishes; the response has nowhere to go.**
-- `GET /backup/{account}` reports `runs` from `last_runs`
-  (`backend/backup.py:530`) — the last *completed* run per kind. There is no
-  in-flight field.
-- The UI's running indicator is
-  `runMut.isPending && runMut.variables === kind`
-  (`website/src/apps/aws-control/DrivePage.tsx:795`) — TanStack Query mutation
-  state, destroyed on unmount. No `AbortController` is wired anywhere in the
-  app's request layer (`website/src/apps/aws-control/api.ts:50`).
-
-So after navigating away and back, the UI shows the *previous* completed run and
-reads as "stopped" while the backup is still running. A user who believes it
-acts on that belief and starts a second one: a second archive build, a second S3
-upload, a second month of storage. **The bug is not lost work, it is a UI that
-lies in the direction of duplicate spend.**
-
-### 1.2 Dev Fleet solved it, halfway, for two of its actions
-
-Dev Fleet does keep run state server-side: `_SYNC_RID`
-(`src/kiro_crew/apps/builtins/dev_fleet/server.py:3574`, set at `:3898`, never
-cleared) is overlaid onto every fleet payload as a live read (`:4340`), and the
-frontend reattaches on mount (`website/src/pages/DevFleetPage.tsx:844`). SPA
-navigation alone does **not** break it.
-
-What breaks it is durability. `_RUNS` is a module-memory dict
-(`src/kiro_crew/apps/builtins/dev_fleet/server.py:501`), so a
-gateway restart empties it and `GET /api/run?id=` answers `404`. Pull + Build on
-the main row auto-restarts the gateway on success, which is exactly how a
-*completed* run becomes un-reattachable and surfaces as the explicit
-"gateway restarted mid sync, run lost" message. And because `dev_fleet_cleanup`
-(`src/kiro_crew/apps/builtins/dev_fleet/server.py:4694`) snapshots `_ACTIVE_RUNS`
-(`:4706`) and kills each run's process tree (`_kill_tree`, `:4711`) — its own
-comment gives the reason, "otherwise a gateway restart leaves pip/npm mutating
-shared checkouts" — a restart *during* a run genuinely kills the run.
-
-The load-bearing observation is narrower and harder: **Dev Fleet applied its own
-mechanism to two of its long actions and not the rest.** Pull + Build and
-provision reattach; pod up / down / restart do not, and prune polls
-`/prune-status` from component state with no `prune_run_id` advertised, so it
-cannot reattach either. The app that invented the correct pattern could not
-afford to use it consistently *inside itself*. That is the argument for a
-default, not a recipe.
-
-### 1.3 Nothing global rescues either half
-
-The shared QueryClient (`website/src/api/queryClient.ts:41`) configures `queries`
-defaults only — no `mutationKey` defaults, no `setMutationDefaults`, no
-persister. Every `useMutation` running-state handle in the dashboard is therefore
-component-local: all of AWS Control's actions, Artifact Deploy, app install, MCP
-install, and the settings panels.
-
-### 1.4 View position cannot be expressed at all
-
-`website/src/App.tsx:3563` gives a builtin app exactly one URL segment:
-
-```tsx
-<Route path="/:builtinApp" element={<BuiltinAppRoute />} />
-```
-
-`website/src/apps/BuiltinAppRoute.tsx` resolves that one segment to one
-component and renders it with no `<Outlet/>` and no child `<Routes>`. So an app
-cannot own a **sub-path** — but it *can* already read the query string, because
-React Router matches on pathname only:
-`website/src/apps/code-review-sage/CodeReviewSagePage.tsx:13` calls
-`useSearchParams()` today under this very route. Nothing forces an app to keep
-its position in memory; the SDK simply never offered a way to put it in the URL,
-so no app does. AWS Control's three levels — accounts list, one account's
-console, that account's drive — are consequently plain `useState`, which the code
-states outright (`AwsControlPage.tsx:252-255`, `:278-282`;
-`apps/aws-control/ConsoleView.tsx:5-6`). Refresh, back, and navigate-away all
-reset to the accounts list, and no link can point at an account's drive.
-
-### 1.5 Neither gap was a known deferral
-
-`.kiro/specs/app-sdk-gateway-hooks/design.md` — the workstream that produced
-`Route_Registry`, `CronSDK`, `App_Context` and `AppStorage` — closes with seven
-"Known Limitations and Future Directions" (storage quota, event scoping,
-dependency ordering, hot reload, route middleware, metrics, manifest schema
-evolution). Durable jobs and view state are not among them. This spec is the
-continuation of that line, not a revision of it.
-
-## 2. Solution overview
-
-Two SDK surfaces, both shaped like the SDK's existing `CronSDK`
-(`src/kiro_crew/apps/cron_sdk.py`): app-scoped, ownership-enforced, persisted by
-the gateway, with sync/async twins where a caller may be on the loop. `CronSDK`
-is the template; neither surface invents a new shape.
-
-| Fact | Lives today | Moves to |
-|---|---|---|
-| "a task of mine is running" | one component's `useMutation` | gateway-side run record, on disk, re-advertised to any fresh mount |
-| "the run's progress so far" | component state, or nowhere | bounded progress tail on the run record |
-| "where the user is in my app" | `useState` in the page component | namespaced URL search params |
-
-`CronSDK` schedules work for later; the Job SDK tracks work a human started and
-is watching now. They are siblings, not alternatives.
-
-## 3. Job SDK — backend
-
-Exposed on `App_Context` beside `cron`, `storage` and `events`.
-
-```python
-class JobSDK:
-    # A runner is REGISTERED once, at app init (the manifest's on_startup hook),
-    # binding a kind to the callable that services it. This is what lets a
-    # caller that cannot hold a Python callable -- the browser, and the
-    # restart-reconciliation pass -- name a run by `kind` alone.
-    def register(self, kind: str, fn: JobFn, *, cancellable: bool = False) -> None: ...
-
-    # Mutators come as sync/async twins, exactly like CronSDK's
-    # add_job / add_job_async: a caller already on the event loop must not
-    # block on the persisting write.
-    def start(self, kind: str, *, params: dict | None = None,
-              dedupe_key: str | None = None) -> str: ...      # -> run_id
-    async def start_async(self, kind: str, *, params: dict | None = None,
-                          dedupe_key: str | None = None) -> str: ...
-    def cancel(self, run_id: str) -> bool: ...
-    async def cancel_async(self, run_id: str) -> bool: ...
-
-    # Reads
-    def get(self, run_id: str) -> Run | None: ...
-    def list_active(self, kind: str | None = None) -> list[Run]: ...
-    def list_recent(self, kind: str | None = None, limit: int = 20) -> list[Run]: ...
-```
-
-**The wire contract, because the seam is the load-bearing joint.** `useAppJob`
-is not allowed to invent app routes, so the SDK mounts these itself under the
-app's own namespace, and they are the only path between the two halves:
-
-| Route | Maps to |
-|---|---|
-| `POST {app}/_jobs/{kind}/start` | `start(kind, params=…, dedupe_key=…)` |
-| `GET {app}/_jobs/active?kind=` | `list_active(kind)` |
-| `GET {app}/_jobs/recent?kind=&limit=` | `list_recent(kind, limit)` |
-| `GET {app}/_jobs/{run_id}` | `get(run_id)` |
-| `POST {app}/_jobs/{run_id}/cancel` | `cancel(run_id)` |
-
-They are registered by the Route Registry like any app route, so the existing
-`permissions.api` deny-by-default gate and the token-authenticated boundary apply
-unchanged — an app reaches only its own runs, and a `kind` with no registered
-runner is a 404 rather than a queued run nothing will ever service. Fixing the
-seam is a P1 obligation, not a P2 discovery: getting it wrong is exactly what
-would force a breaking reshape of the backend API once the first consumer lands.
-
-**Ownership.** `get`, `list_active` and `cancel` see only this app's runs, and
-`cancel` refuses a run it does not own — the same discipline as
-`CronSDK.list_jobs` / `remove_job`.
-
-**Persistence.** A run record is written to the app's own data directory as a
-single document via `kiro_crew.atomic_write` (already imported by
-`backend/backup.py:49`). This is the one thing Dev Fleet gets wrong: in-memory
-run state cannot survive the restart that its own action triggers.
-
-**States.** `queued → running → (done | failed | cancelled | interrupted)`.
-
-**Cooperative cancellation is mandatory, not decorative.** `fn` receives a
-handle:
-
-```python
-def run(handle: JobHandle, **params) -> dict: ...
-#   handle.cancelled   -> threading.Event, checked at the runner's own checkpoints
-#   handle.progress(pct=None, step=None, line=None)
-```
-
-A worker thread cannot be killed, which is why AWS Control's `_STOP` is
-teardown-only and why a `cancel()` that cannot reach the runner would be a lie.
-The SDK cannot inspect arbitrary `fn` code to find out whether it ever checks the
-event, so **cancellability is declared, not inferred**: `register(..., cancellable=True)`
-is the app's assertion that this kind's runner has checkpoints, and the default is
-`False`. A run recorded `cancellable: false` has the control hidden in the UI
-rather than offering a button that does nothing, and `cancel()` on it returns
-`False` instead of pretending.
-
-**Restart reconciliation.** On startup, after every app has registered its
-runners, a persisted run still marked `running` whose owning process is gone is
-resolved to `interrupted`, keeping its last progress. The registry is what makes
-this decidable: a run whose `kind` no longer has a registered runner — the app was
-disabled, or the kind was removed — is reconciled the same way rather than left
-addressable by a hook that no longer exists. A run must never be left `running`
-forever, and must never silently vanish — Dev Fleet's two failure directions
-respectively.
-
-**Deduplication.** `dedupe_key` makes a second `start` with a live key adopt the
-existing run instead of beginning a second one. This is the direct remedy for
-§1.1's duplicate-spend hazard: a double click, or two tabs, join one run.
-
-**Observability, for free.** One registry means one place to emit run-level
-records. Today `gateway.log` is WARNING-only with no per-run lines, so a single
-run id cannot be traced at all; this investigation could only infer a restart
-from a PID rollover.
-
-## 4. Job SDK — frontend
-
-```tsx
-import { useAppJob } from '@kirocrew/app-sdk'
-
-const job = useAppJob('backup')
-//  job.active   : Run | null   — adopted on mount via list_active, no app code required
-//  job.start(params) / job.cancel()
-//  job.history  : Run[]        — from list_recent, so a fresh mount can populate it
-```
-
-On mount the hook calls `list_active(kind)` and adopts any in-flight run. That
-single behaviour is what makes "navigate away and come back" correct by default.
-Polling or streaming the progress tail is the SDK's business, not the app's.
-
-Scope: this replaces `useMutation.isPending` as the *running* indicator for long
-actions only. A short mutation — saving a setting — keeps `useMutation`, which is
-the right tool for a request whose whole lifetime fits inside one view.
-
-**Explicitly forbidden alternative:** do not configure a global mutation
-persister to "also fix" this. Persisting a mutation cache asserts something
-different from "the server has a run", and it invites replay of a mutation whose
-effect already landed. The running fact must be server-owned; the client only
-reattaches.
-
-## 5. View-state SDK
-
-**No host change is required.** React Router matches on pathname, so the query
-string is already available under the flat `/:builtinApp` route — a builtin app
-does it today (`website/src/apps/code-review-sage/CodeReviewSagePage.tsx:13`).
-What is missing is not the capability but the contract:
-
-```tsx
-const [view, setView] = useAppViewState({ account: '', view: 'overview' })
-setView({ account: '740412361337', view: 'drive' })   // -> ?ac.account=…&ac.view=drive
-```
-
-The app declares its keys and their defaults; the SDK owns serialization,
-replace-vs-push semantics, and a per-app namespace so an app key can never
-collide with a host param. Refresh, back, forward, and navigate-away-and-return
-all follow from the URL being the source of truth.
-
-This also unlocks a capability that is impossible today rather than merely
-broken: a **shareable deep link into an app's internal position** — one account's
-drive, one incident, one note.
-
-Blast radius: none. `useAppViewState` is a pure addition to the SDK, so it ships
-with its first consumer instead of needing a host PR of its own.
-
-**Deferred, and genuinely optional:** *path*-backed view state
-(`/aws-control/740412361337/drive`) would need `<Route path="/:builtinApp/*">`.
-That change is safe — `App.tsx` already ships the same pattern for `/settings/*`,
-a splat matches zero trailing segments, `BuiltinAppRoute` reads only the
-`:builtinApp` param, and no builtin owns a sub-path today — but nothing in this
-spec needs it, so it is not in the plan. Take it only if prettier URLs later
-justify a host-wide route change on their own merits.
-
-## 6. Reference consumers
-
-**Job SDK — AWS Control backup** (`backup_run`, both kinds). The smallest change
-with the clearest user-visible win, and it retires the duplicate-spend hazard via
-`dedupe_key`. The runner is already idempotent in the way that matters: its S3
-key is stamp-named, so an interrupted run cannot corrupt a previous archive.
-
-**Job SDK — Dev Fleet prune**, second. Deliberately the action Dev Fleet's own
-hand-rolled mechanism skipped, so the SDK is proven on the case that a per-app
-effort did not reach.
-
-**View-state SDK — AWS Control's three levels.** The code comments already name
-the missing URL position as the reason all three are `useState`, so this consumer
-converts a documented limitation into a deleted one.
-
-## 7. Migration path
-
-Each phase ships independently; no app is forced to move.
-
-| Phase | Scope | User-visible |
-|---|---|---|
-| P1 | `JobSDK` incl. the runner registry and the `_jobs/*` wire routes, persistence, restart reconciliation; no consumers | none (additive) |
-| P2 | `useAppJob`; AWS Control backup migrated | backup survives navigation; no duplicate runs |
-| P3 | Dev Fleet onto the SDK — pull+build/provision drop `_RUNS`/`_SYNC_RID`; pod up/down and prune gain reattachment | pull survives the gateway restart it triggers |
-| P4 | `useAppViewState` + AWS Control view state on the URL | lands where you left; drive links shareable |
-| P5 | `docs/app-kit/api-reference.md` gains a `### Jobs` section beside `### Cron Jobs`, and both hooks join the `## App SDK Hooks` list; `getting-started.md` follows | app authors get the contract |
-
-P5 is last on purpose. The app-kit docs are a contract with app authors, so they
-describe an API that exists, not one that is planned.
-
-## 8. Non-goals
-
-- **Not a work queue or scheduler.** No fan-out, no priorities, no retry
-  policies. `CronSDK` owns work-for-later; this owns work-a-human-is-watching.
-- **Not distributed.** One gateway process on one host. A run record is
-  meaningful only to the gateway that owns the app.
-- **Not a replacement for the session work ledger.** That records an *agent's*
-  state across context compaction; this records a *task's* state across unmount
-  and restart. Same underlying move — promote a fact out of a volatile medium
-  into a recoverable record — but different owners, different lifetimes, separate
-  stores.
-- **Not automatic retry.** An `interrupted` or `failed` run is reported, never
-  silently re-run; the side effect may be half-applied and only the app knows if
-  that is safe.
-- **Not general UI-state persistence.** View state is URL-expressible view
-  coordinates. Scroll offsets, draft text and transient selection stay local.
-
-## 9. Failure modes
-
-- **A runner declared `cancellable=True` that never checks `handle.cancelled`.**
-  `cancel()` cannot reach it and the UI offers a control that does nothing. The
-  declaration is the app's assertion and the SDK cannot verify it, so the
-  migration checklist for a consumer includes naming the runner's checkpoints.
-- **Gateway killed mid-run.** The run reconciles to `interrupted` on next
-  startup with its last progress. The side effect may be partially applied, so a
-  runner is expected to be idempotent or to name its own recovery.
-- **Two clients watching one run.** Both adopt it through `list_active`; there is
-  one owner record, and `dedupe_key` prevents a second start.
-- **Unbounded run record.** The progress tail is bounded, on the same discipline
-  as the session work ledger's event tail; a run keeps a window, not a
-  transcript.
-- **Two apps, or an app and the host, claim the same query key.** The per-app
-  namespace prefix is what prevents it, so the prefix is part of the contract
-  rather than a convention — an app writing bare keys can collide with a host
-  param on a shared URL.
-- **A migrated app double-reports.** During P2/P3 an action must not keep both
-  `useMutation.isPending` and `job.active` as running indicators; the migration
-  removes the former in the same commit that adds the latter.
+## Current SDK boundary
+
+The App SDK does not provide a shared durable-job or URL-view-state contract.
+`AppContext` exposes `cron`, `events`, `storage`, and `spawn` when their
+permissions allow them; it has no job service (`src/kiro_crew/apps/context.py`,
+`AppContext` and `build_app_context`). The frontend barrel exports app API,
+event, metadata, navigation, and chat surfaces, but no `useAppJob` or
+`useAppViewState` hook (`website/src/app-sdk/index.ts`, `useAppApi`,
+`useAppEvents`, `useAppInfo`, `useNavigate`, and the barrel exports).
+
+This boundary is load-bearing: an app that needs to report or recover
+long-running work must own its server route, persistence, lifecycle recovery,
+and frontend reattachment. A common SDK cannot be assumed to supply those
+semantics.
+
+`CronSDK` is a separate app-scoped scheduling surface (`src/kiro_crew/apps/cron_sdk.py`,
+`CronSDK`). It does not establish a job-run registry for app-initiated HTTP
+work.
+
+## Durable work is currently app-specific
+
+### AWS Control backups
+
+`_handle_backup_run` executes the selected backup runner in a worker thread and
+returns its terminal record (`src/kiro_crew/apps/builtins/aws_control/backend/routes.py`,
+`_handle_backup_run`). The runner records completed backup metadata through
+`_record_run`, and `last_runs` reads that per-account terminal ledger
+(`backend/backup.py`, `_record_run` and `last_runs`). The status endpoint
+returns that ledger as `runs` (`backend/routes.py`, `_handle_backup_status`).
+There is no backup job identifier or persisted in-flight registry in this path.
+
+A worker thread cannot be killed by cancelling the awaiting coroutine, and
+`_STOP` only prevents an upload reached after app teardown (`backend/backup.py`,
+`_STOP` and `_authorize_upload`). A client disconnect therefore does not create
+a cancelable or reattachable backup job.
+
+The backup UI starts the request with a component-owned React Query mutation and
+derives its running indicator from that mutation (`website/src/apps/aws-control/DrivePage.tsx`,
+`BackupSection` and `runMut.isPending`). The API client posts directly to the
+backup route (`website/src/apps/aws-control/api.ts`, `backupRun`). A fresh mount
+can read prior terminal records through the status query, but it has no
+server-owned in-flight record to adopt.
+
+### Code Review Sage review runs
+
+Code Review Sage implements its own durable review-run registry. Its backend
+stores lightweight run descriptors in `_RUNS`, writes the registry to
+`runs.json`, and reloads it at startup (`src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py`,
+`_RUNS`, `_runs_file`, `_save_runs`, and `_load_runs`). On load,
+`_load_runs` marks a persisted `running` review as `interrupted` because the
+in-process driver did not survive the restart. The test
+`test_orphaned_running_becomes_interrupted_on_load` enforces that recovery
+rule (`src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py`).
+
+That recovery is load-bearing: leaving an orphaned run marked running would
+advertise work that no process can complete and could block follow-up actions.
+The registry is an app implementation, not an App SDK surface.
+
+### Dev Fleet runs
+
+Dev Fleet tracks run descriptors in the module-memory `_RUNS` registry and
+keeps active tasks and subprocesses in `_ACTIVE_RUNS`
+(`src/kiro_crew/apps/builtins/dev_fleet/server.py`, `_RUNS` and `_ACTIVE_RUNS`).
+Its fleet payload overlays `sync_run_id` and per-worktree provision run IDs at
+request time in `_with_live_run_pointers`; `DevFleetPage` uses those pointers
+to reattach a mounted page to a current run (`server.py`,
+`_with_live_run_pointers`; `website/src/pages/DevFleetPage.tsx`, sync and
+provision reattach effects).
+
+The run records and pointers are process memory, so this reattachment applies
+within the current gateway process rather than supplying restart durability.
+During `dev_fleet_cleanup`, the app closes admission for new runs, snapshots
+active work, and kills tracked process trees (`server.py`,
+`dev_fleet_cleanup` and `_kill_tree`). That cleanup prevents a stopped gateway
+from leaving Dev Fleet subprocesses behind; it also shows why a durable record
+cannot imply that its original process is still executable.
+
+## View position is not an App SDK contract
+
+Builtin apps are mounted by the single-segment `/:builtinApp` route, and
+`BuiltinAppRoute` resolves that parameter to one component
+(`website/src/App.tsx`, builtin-app `Route`; `website/src/apps/BuiltinAppRoute.tsx`,
+`BuiltinAppRoute`). The host does not provide a builtin-app sub-route contract.
+
+Apps can already read URL search parameters: `CodeReviewSagePage` calls
+`useSearchParams` to select an initial run (`website/src/apps/code-review-sage/CodeReviewSagePage.tsx`,
+`CodeReviewSagePage`). The App SDK does not namespace, serialize, or synchronize
+view keys for apps, so each app that needs URL-backed state must define that
+contract itself.
+
+AWS Control keeps its selected account and drive in local component state
+(`website/src/apps/aws-control/AwsControlPage.tsx`, `AwsControlPage`). Those
+values are not encoded in its URL, so they cannot identify an account or drive
+in a shareable link. This local-state boundary is load-bearing: a URL can only
+restore coordinates that the application has made part of its URL contract.
+
+## Query-client scope
+
+The shared `QueryClient` configures query defaults
+(`website/src/api/queryClient.ts`, `queryClient`). It does not make a mutation's
+component-owned pending state a server-owned work record. Durable work therefore
+requires an app-owned registry or another explicit server contract; persisting
+or reusing a client-side pending flag would not establish whether the backend
+still has work in progress.

--- a/docs/system-specs/features/aws-control.md
+++ b/docs/system-specs/features/aws-control.md
@@ -1,319 +1,156 @@
-# AWS Control — account portal and S3-backed cloud drive
+# AWS Control
 
-Status: draft (delivered as ONE PR shipping the approved two-page design end
-to end; Tasks and Sites remain ghost cards)
+AWS Control is the builtin account portal and S3-backed drive. It registers
+selected local AWS profiles, groups their live identity probes by AWS account,
+and exposes Drive, Library, Backup, cost, share, and IAM-policy views. The
+builtin is declared by `kiro_crew.apps.builtins` and mounted by
+`aws_control.backend.routes.register_routes`; the dashboard surface is
+`website/src/apps/aws-control/`.
 
-## 1. Problem
+## Access boundary
 
-Kiro Crew already touches the user's AWS account in several disconnected places:
-deploy-web publishes static sites to S3 + CloudFront, artifact-deploy ships app
-stacks, voice features bill Polly/Transcribe behind per-service consent, and
-agents run read-only AWS CLI calls. What is missing:
+Every AWS Control route passes `routes._guarded`. It refuses a disabled app and
+any caller that is not the dashboard owner, and records either denial in SEL.
+`test_aws_control_app.py::TestRouteRegistration.test_every_route_refuses_non_owner_when_enabled`
+pins the owner boundary.
 
-- No single place to see which accounts Kiro Crew can use, whether each one's
-  credentials still work, what Kiro Crew has created in them, and what that
-  costs this month.
-- No durable cloud home for the gateway's own data. Artifacts, sessions,
-  memory and workspace files live on one machine; there is no backup and no
-  way to hand a file to someone who does not run Kiro Crew.
-- Every new AWS capability re-invents account selection, consent,
-  confirmation and cost display.
+Every mutating route additionally passes `routes._mutating`. It refuses
+restricted sessions and emits an SEL outcome for success, refusal, or an
+`AWSError`; this is load-bearing because a restricted or non-owner session must
+not turn an ordinary dashboard request into an AWS mutation. The mutating route
+registrations in `routes.register_routes` cover profile registration, drive
+operations, shares, library publication, and backup operations.
 
-AWS Control is one builtin app that answers all three with a surface a
-non-technical user can operate: an account portal, plus an S3-backed drive
-that holds files, cloud copies of artifacts, and backups, with sharing.
+Account-targeted operations resolve the registered profile and then re-probe
+its live identity in `routes._account_target`. A profile that has been repointed
+to another account is refused instead of being used for the account named in
+the URL. `test_aws_control_storage.py::TestFindDrive.test_a_bucket_owned_by_another_account_is_refused`
+pins the related storage ownership check.
 
-S3 is the substrate because it is cheap enough to hold everything: ~27 GB of
-cold sessions is roughly $0.62/month in Standard storage (about $0.11/month
-in Glacier Instant Retrieval); uploads are free and downloads are $0.09/GB.
+## Credentials and paid-service consent
 
-## 2. Product shape
+The profile registry in `deploy.profiles` stores profile metadata, not keys or
+tokens. It discovers names through the AWS CLI and writes only its allowlisted
+configuration keys through `aws configure`; `credential_process` is a stored
+command, not credential material. This separation is load-bearing because the
+gateway passes profile names to the CLI provider chain rather than persisting
+AWS secrets itself.
 
-The surface speaks outcomes, not services: Drive, Library, Backup, Sites,
-Tasks, Bill, Access. AWS service names (S3, Lambda, IAM, CloudFront, ARN)
-never appear at the top layer — they appear only inside the per-section
-"under the hood" drawer (§2.4).
+`aws_consent.GATED_SERVICES` includes S3 and Cost Explorer. A grant is scoped
+to service, profile, region, and the account returned by the identity probe.
+`aws_consent.authorize` consults a short-cached live identity probe before it
+allows a gated call and withdraws a mismatched grant; unreadable, absent,
+changed, or unresolved grants refuse the operation.
+`test_aws_control_app.py::TestConsentExtension` pins the AWS Control service
+registrations, and
+`test_aws_control_app.py::TestDriveGuards.test_consent_refusal_answers_409_before_any_aws_call`
+pins refusal before the drive handler calls AWS.
 
-Visual direction is fixed by the approved two-page mockup (artifact
-`aws-control-home-mockups` v2), which uses the dashboard's real design
-tokens.
+AWS Control reaches AWS through deploy-engine helpers: account inspection uses
+`deploy.engine.run_aws`, while storage uses `deploy.engine._checked`. The engine
+constructs fixed AWS CLI argument vectors with a profile name and runs the CLI
+through the standard subprocess sandbox. The app does not import an AWS SDK.
 
-### 2.1 Page 1 — Accounts
+## Drive and destructive operations
 
-A thin list-plus-summary page:
+`storage.find_drive` discovers a drive by its managed tags, validates the bucket
+name, and verifies bucket ownership against the requested account. Ambiguous or
+unverifiable discovery refuses. The result is deliberately not cached: a bucket
+identity is an authorization decision, not a display value.
 
-- One row/card per account: name, health light, account-id tail, a one-line
-  summary (storage · sites · tasks · backup state), month-to-date cost.
-- A cross-account totals strip: total spend, total storage (with cost
-  estimate), sites, tasks.
-- A degraded account shows exactly one repair action inline (Reconnect).
-- `+ Connect account` starts the onboarding ceremony (§2.5).
+`storage.create_drive` creates a bucket only after the bootstrap handler's
+preview-plus-confirm flow. `routes._handle_drive_bootstrap` rechecks the
+account target and S3 consent after confirmation and serializes creation so
+concurrent confirmations cannot create competing drives.
+`test_aws_control_app.py::TestDriveGuards.test_bootstrap_without_confirm_previews_and_creates_nothing`,
+`TestDriveGuards.test_concurrent_bootstrap_confirms_create_exactly_one_drive`,
+and `TestDriveGuards.test_consent_withdrawn_mid_create_refuses_and_creates_nothing`
+pin those guarantees.
 
-### 2.2 Page 2 — Account Console
+A created drive is ownership-checked before it becomes discoverable. The storage
+layer enables versioning and then calls `deploy.engine._harden_bucket`, which
+sets S3 Block Public Access, bucket-owner-enforced ownership controls, default
+SSE, and the discovery tags. The order is load-bearing: a partially configured
+bucket is left untagged rather than becoming a usable drive without versioning.
+`test_aws_control_storage.py::TestCreateDrive.test_versioning_is_enabled_before_hardening_tags_land`
+pins the sequence.
 
-Opening an account shows one console:
+Drive objects live beneath the `artifacts/`, `drive/`, and `backup/` prefixes.
+`storage.validate_key` rejects paths that could escape a section. Folder deletion
+uses a validated, slash-anchored prefix, so it cannot target an empty section,
+the bucket root, or a sibling with a common name prefix.
+`test_aws_control_routes.py::TestFolderDelete.test_delete_rejects_an_empty_path`
+and `test_aws_control_storage.py::TestDeletePrefix.test_deletes_every_object_and_returns_the_count`
+pin that guard.
 
-- Header: account name, id, connection state, `Open AWS Console ↗`
-  (federation URL), `Ask crew`.
-- Overview stats: month-to-date cost + projection, storage used + cost
-  estimate, sites, tasks; a Guard statement line (§3, invariant G1).
-- **Library** — cloud copies of artifacts, aligned to artifact kinds
-  (widget / markdown / html / json / webapp filter chips), each with version,
-  timestamp, shared marker. Syncs with the local artifact library.
-  ("Library" is the working name; final naming is an open question, §9.)
-- **Drive** — general file area: folder/file tiles, upload/download, share.
-  Deliberately no quota bar: S3 is not a subscription, so the display is
-  "space used + estimated monthly cost", never "space remaining".
-- **Backup** — session archives (cold storage) and nightly memory/workspace
-  backup; shows last run, size, cost share, and a Restore entry.
-- **Access** — who can see what, remaining validity, Revoke/Change.
-  Posture line: "Nothing is public unless you say so."
-- **Apps** (ghost placeholder cards) — Tasks (scheduled crawlers whose
-  output lands in Drive) and Sites (publish from Library). Later phases
-  plug into the same console pattern.
-- A persistent Ask-crew input bar at the bottom.
+At the API layer, object and folder deletion do not require a `confirm`
+parameter. The dashboard shows a confirmation strip before either deletion, and
+`routes._handle_drive_delete` and `routes._handle_drive_folder_delete` then
+execute after the owner, restricted-session, S3-consent, and key-scope guards.
+On the versioned drive, `storage.delete_key` writes an S3 delete marker rather
+than purging historical versions. This is the current recovery property; the
+app does not implement a version purge.
 
-### 2.3 Conversation is the operation
+## Publishing and sharing
 
-The UI is read-only by design; every mutation goes through the crew ("share
-this folder with Wang, read-only, 7 days") or through an explicit dashboard
-confirmation card. Consent cards speak plain language ("Kiro wants to create
-a storage space for the drive, estimated under $1/month — Allow / Not now").
-The approval flow is itself the UX, not a hurdle bolted onto it.
+`routes._publish_gate` applies the shared fail-closed publish-governance decision
+before a library push, a download presign, or a share presign. This guard is
+load-bearing because each operation makes bytes reachable outside the local
+machine.
 
-`Ask crew` opens a dedicated agent session seeded with AWS Control context —
-the same launch pattern Issue Radar uses for Investigate (create a chat slot
-in an app folder, seed the first prompt, persist the slot mapping so a second
-click resumes instead of duplicating). It is not an embedded mini-chat.
+The share implementation is a presigned URL and a local metadata ledger only.
+`storage.presign` clamps the requested lifetime to the S3 signing limit, while
+`shares.record_share` stores metadata and expiry but never the URL. A presigned
+URL cannot be revoked by this app before it expires; `shares.forget_share` only
+removes its ledger record. Backup objects are not shareable.
+`test_aws_control_app.py::TestDriveGuards.test_share_of_backup_section_is_refused_outright`
+and `test_aws_control_routes.py::TestSharesListForget.test_forget_removes_a_known_share`
+pin those boundaries.
 
-### 2.4 Two-layer disclosure
+AWS Control does not create bucket-policy account grants or public CDN shares.
+The IAM-policy endpoint renders `deploy.iam.policy_json` for the operator to
+apply; it does not write IAM policy.
 
-Each console section carries a `</>` drawer showing what is really
-underneath: the actual bucket name, the equivalent CLI command, the raw
-policy. The top layer stays jargon-free; the drawer builds trust and serves
-engineer users. Progressive disclosure is the premium feel, not hidden power.
+## Library, costs, and backup
 
-### 2.5 One-button health and onboarding
+`library.push_artifact` copies a selected artifact through the Drive storage
+layer after the route's S3-consent and publish-governance checks. It refuses
+credential-bearing artifact content; `test_aws_control_app.py::TestLibraryScan.test_credential_bearing_artifact_is_refused`
+pins that egress boundary.
 
-Each account has one health light. A degraded light converges to exactly two
-actions: **Reconnect** (one click where the profile type allows it) or
-**Let Kiro look** (hands diagnosis to the crew). The user never needs to
-learn what a credential is.
+`costs.fetch_month_costs` calls Cost Explorer for the requested linked account
+and groups results by service. `routes._handle_costs` serves a fresh local cache
+without a new consent check; a stale cache is returned with its stale state when
+Cost Explorer consent is absent or a refresh fails. This keeps the Bill view
+available without misrepresenting a cached value as fresh.
 
-Reconnect degrades by profile type: SSO profiles can be re-authenticated
-gateway-side (`aws sso login`, surfacing the device-flow URL/code in the UI);
-`credential_process`-backed profiles get terminal guidance instead. The
-gateway-side feasibility of each type is validated in P0 before the UI
-promises it.
+`backup.run_snapshot_backup` uploads a generated snapshot archive, and
+`backup.run_sessions_backup` archives session material only when descriptor-based
+traversal pinning is available. `backup._authorize_upload` requires the app to
+remain enabled, the S3 grant to still name the target account, and shutdown not
+to be in progress before upload. `backup.restore_download` stages an archive
+locally; it does not restore it into live gateway state.
+`test_aws_control_app.py::TestRound22Hardening.test_restore_refuses_a_symlinked_destination`
+pins the staged restore safety boundary.
 
-Connecting an account runs a short ceremony: the crew lays out the drive,
-installs a spend alert, applies the guardrail policy, and ends with "your
-cloud is ready" — zero-to-first-share in about three minutes.
+The nightly toggle records whether an account is eligible for a scheduled
+snapshot. `aws_control.hooks._run_once` resolves an account and drive, checks
+S3 consent, runs only due backups, and SEL-audits invocation, success, and
+failure. It skips unavailable accounts or absent drives rather than creating
+resources itself.
 
-### 2.6 Bill
+## HTTP surface
 
-Phone-bill mental model: this month, projected, versus last month, and one
-slider — "tell me when it goes over $X". The crew flags anomalous growth
-proactively. Costs come from the Cost Explorer API (~$0.01/query, ~24 h
-latency) cached daily per account; the budget guard is computed locally.
-No AWS Budgets resources are created — that would be another account-level
-resource requiring permissions that a non-technical user never needs to
-know exists.
+`routes.register_routes` exposes owner-gated reads for accounts, available
+profiles, reconnect guidance, drive status/list/download, costs, library,
+backup status, share metadata, and rendered IAM policy. Its mutations are
+profile registration; drive bootstrap, upload, delete, folder create/delete,
+and share; share-ledger removal; library push; backup run, nightly toggle, and
+staged restore.
 
-## 3. Security invariants
-
-These carry over from the deploy subsystem and the AWS consent feature, and
-any PR touching them must update this section in the same commit.
-
-- **G1 — Guard (human confirmation for billable resources).** Any operation
-  that creates a new billable resource (create storage, deploy a task,
-  publish a site) requires an explicit human confirmation in the dashboard.
-  Pure reads are consent-gated (G3) but confirmation-free. Implemented on
-  the deploy two-phase pattern: a preview call echoes the resources and
-  costs, a pending record is stored, and only an owner-authenticated
-  dashboard confirm executes. Agent/MCP callers get `confirm` stripped
-  server-side — an agent can request, never execute.
-- **G2 — Names-only credentials.** The account registry stores profile
-  names, regions and display metadata only. Credential material is never
-  read, stored, or written; profile writes go through the existing allowlist
-  (`region`, `credential_process`) in `deploy/profiles.py`. Credential
-  resolution happens inside the external `aws` CLI process.
-- **G3 — Per-service usage consent.** Every paid AWS service the app touches
-  (`s3`, `ce`, later `lambda`/`events`/`logs`) is gated by the existing
-  aws-usage-consent mechanism: a grant per (service, profile, region)
-  recording the confirmed account id, stored in the keystone-fenced
-  `aws_service_consent.json` leaf, re-verified against a live
-  `sts:GetCallerIdentity` probe on every authorization, revoked on account
-  drift. Fails closed.
-- **G4 — Single CLI chokepoint, gateway-side.** All AWS calls go through
-  `deploy/engine.run_aws` (AWS CLI subprocess, `--profile`, fixed argv, OS
-  sandbox) on the gateway. Agents interact only with the app API; no boto3,
-  no SDK, no agent-side credential access.
-- **G5 — Private by default.** The drive bucket is created private: Block
-  Public Access on, SSE enabled, ACLs disabled, versioning on. Nothing under
-  it is reachable externally except through an explicit share (§4.5), and
-  every share has an expiry or an explicit revocation path.
-- **G6 — Audited mutations.** Every mutating endpoint is owner-gated,
-  refused for restricted sessions, and SEL-audited, matching the deploy
-  handler discipline.
-
-## 4. Architecture
-
-### 4.1 App shell
-
-`aws-control` is a builtin app (added to `BUILTIN_NAMES`) using the
-in-process route pattern (`backend.routes:register_routes` dispatched through
-`RouteRegistry`), because it needs gateway-side access to the profile
-registry, consent store, and engine — the same reasons Issue Radar is
-in-process. Frontend lives at `website/src/apps/aws-control/` with a
-`builtinRegistry.ts` entry and nav coming from the manifest's `ui.pages`.
-
-### 4.2 Account center
-
-`deploy/profiles.py` stays the registry engine (single flock-guarded
-`profiles.json`, unchanged format, deploy-web keeps working). A new
-`aws_control` backend module aggregates registry entries **by account id**:
-an account owns one or more profiles ("keys"), a default region, health
-state, and cached cost/storage summaries. Profiles demote to a detail-page
-concept; the account is the top-level object. Health = the existing
-read-only identity probe; per-account state caches under the app data dir.
-
-### 4.3 Storage engine — one bucket, three prefixes
-
-Per account, one private bucket `kirocrew-drive-<12hex>` (opaque name),
-discovered stateless-by-tag (`kirocrew:managed=true` +
-`kirocrew:drive=<drive-id>`) exactly like deploy-web's `find_site_by_tag`.
-Bootstrap reuses `create_private_bucket`/`_harden_bucket` plus **versioning
-enabled** — a deliberate delta from deploy-web (which keeps versioning off
-for teardown safety); teardown therefore needs a version-aware purge.
-Artifact versions map naturally onto S3 object versions.
-
-Three prefixes, one engine, three views: `artifacts/` (Library), `drive/`
-(Drive), `backup/` (Backup). New primitives built on `run_aws`:
-`put_object`, `get_object`, `list_prefix`, `delete_object`, `presign`
-(bounded expiry), and a daily storage-usage read. deploy-web's `sync_dir`
-is reused for directory pushes.
-
-### 4.4 Costs
-
-A new `ce get-cost-and-usage` wrapper (month granularity, grouped by
-service), consent-gated as service `ce`, cached 24 h per account. The
-existing `pricing.py` (unit prices) stays for what-if estimates like "this
-drive costs about $0.62/month". Budget thresholds and anomaly detection are
-computed locally from the cache.
-
-### 4.5 Sharing — three compilation targets
-
-A share is metadata compiled to one of three mechanisms, in escalating
-scope: presigned URL (time-boxed, anyone with the link) → bucket policy
-grant (a specific AWS account) → public CDN via the existing deploy-web
-path. The P4 access model (owner/group/other × read/write) compiles onto
-these three targets; the product never promises real POSIX ACLs. Creating
-or widening a share is access-granting and is human-confirmed (G1 applies);
-revocation is one click and never gated.
-
-### 4.6 Consent extension
-
-`GATED_SERVICES` grows from Polly/Transcribe to `s3` and `ce` (P0), later
-`lambda`/`events`/`logs` (P3). The mechanism is unchanged; per-service
-`(profile, region)` resolution extends `_effective_target`, and the app
-mounts the existing `AwsConsentGate` component per account. IAM guardrails
-remain user-applied (Option A: the app renders policy JSON to paste, and
-extends the existing boundary-policy document for drive/tasks scopes; the
-gateway itself never writes IAM).
-
-### 4.7 Library sync
-
-Cloud copies of artifacts record publication state on the artifact record
-(provider, version map, content hash), following the existing artifact
-publication metadata shape and its no-force-push conflict discipline.
-Whether this registers through the `PublishProvider` seam or a parallel
-record is a P1 implementation decision.
-
-### 4.8 Backup
-
-Session archive plugs into the session-storage inventory as a third action
-("Archive to cloud") next to trash/restore, honoring the "both halves move
-together" invariant (transcript + CLI replay log). Memory/workspace nightly
-backup reuses the snapshot component map (`memory`, `config`, `skills`,
-`workspace`, …) pushed to `backup/` — optionally on a Glacier IR lifecycle
-rule for cold pricing.
-
-## 5. API surface (P1 shape)
-
-Routes under `/api/apps/aws-control/`:
-
-- `GET  /accounts` — aggregated account list with health + summaries
-- `GET  /accounts/{id}` — console payload (stats, sections)
-- `POST /accounts/{id}/reconnect` — SSO re-auth (or guidance payload)
-- `GET  /accounts/{id}/costs` — cached CE summary
-- `GET  /drive/{account}/list?prefix=` — object listing
-- `POST /drive/{account}/put|get|delete` — object I/O (G1/G3/G6 as applicable)
-- `POST /drive/{account}/bootstrap` — bucket creation (two-phase, G1)
-- `POST /share` / `DELETE /share/{id}` — share create (two-phase) / revoke
-- `POST /library/{account}/push|pull` — artifact sync
-- `GET  /pending` / `POST /pending/{id}/confirm|dismiss` — the Guard queue
-
-Agent access goes through the internal-secret path with `confirm` stripped
-(G1); read endpoints require an existing consent grant (G3).
-
-## 6. Delivery — one PR
-
-The whole two-page design ships in a single PR (Closes #5496), in this
-internal build order:
-
-1. Foundations: app shell + nav entry; account aggregation over the existing
-   registry; Accounts page with health lights and reconnect guidance;
-   consent extension (`s3`, `ce`).
-2. Storage engine: object put/get/list/delete + presign primitives on
-   `run_aws`; bucket bootstrap (private + SSE + versioning, tag-discovered)
-   behind the two-phase confirmation flow.
-3. Console: overview stats; Bill (CE wrapper + daily cache); Library
-   (artifact push/pull + shared marker); Drive (browse/upload/download/
-   delete); share via presigned link with a local share ledger; Access
-   section listing live shares with time remaining.
-4. Backup: memory/workspace snapshot push to `backup/` (manual now + nightly
-   cron), session archive (both halves together), listing + restore.
-
-Shipped share semantics (honest subset of §4.5): presigned links only, expiry
-capped at 7 days (the SigV4 ceiling). The Access section shows each live
-share with its countdown; a presigned link cannot be revoked before expiry,
-so the UI says "expires in N days" and never offers a fake Revoke. Recipient-
-account grants (bucket policy) and the owner/group/other model compile onto
-the same ledger later.
-
-Out of this PR (future work, sections stay visible as ghost cards where the
-mockup shows them): Tasks (scheduled crawlers), Sites consolidation,
-recipient-account and public share tiers, spend-threshold notifications.
-
-## 7. Non-goals
-
-- Not a general AWS console replacement; the app manages only what Kiro Crew
-  created (tagged resources) plus account-level health and cost readouts.
-- No boto3/SDK dependency; no credential storage or agent-side credential
-  access, ever.
-- No real POSIX ACLs; the access model is metadata compiled to §4.5 targets.
-- No AWS Budgets or other hidden account-level resources for the bill guard.
-- No quota/storage-cap mental model in the UI.
-
-## 8. Failure modes
-
-- Consent absent or account drifted → all engine calls refuse (G3 fails
-  closed) and the console shows the consent card, not an error wall.
-- Identity probe fails → health light degrades; every section header shows
-  the single Reconnect action; cached summaries render greyed with their
-  age labelled.
-- CE query fails → last cached bill with age label; never blocks the page.
-- Bucket tag lookup ambiguous (two tagged buckets) → refuse and surface,
-  matching deploy-web's ambiguity discipline.
-- Presign/share on a missing object → 404 mapped to a plain-language card;
-  share records are reconciled against bucket state on console load.
-
-## 9. Open questions
-
-1. Final section naming: Library vs Vault vs Archive ("Artifactory" is
-   excluded — trademark and internal-service collision).
-2. `credential_process` resolution feasibility on the gateway host (P0
-   test decides how far Reconnect can be automated per profile type).
-3. Library sync vehicle: `PublishProvider` seam vs parallel publication
-   record (P1 decision).
+Drive bootstrap is the only API-level preview-plus-confirm flow. Upload, profile
+registration, library push, share creation, and backup mutations have no
+separate confirmation request; the dashboard separately confirms object and
+folder deletion. Every mutation is owner-gated, restricted-session refused, and
+SEL-audited. Account-targeted AWS operations additionally enforce live identity
+and service consent, and egress paths enforce publish governance.

--- a/docs/system-specs/features/babysit-pr-watch.md
+++ b/docs/system-specs/features/babysit-pr-watch.md
@@ -1,245 +1,188 @@
-# Babysit PR Watch
+# Babysit PR watch
 
-Status: implemented (this PR)
-Owners: babysit builtin skill (`builtin_skills/kirocrew-dev/babysit/`), on the
-interrupt controller in `irq.py` (see `agent-interrupt-controller.md`)
+## Purpose
 
-## 1. Problem
+The babysit feature offers two current monitoring modes.
 
-A PR babysit spends most of its life waiting. The `monitor_start` loop that
-drives it re-injects a full agent turn every cycle — session context included —
-and on a quiet PR the turn's entire output is "nothing changed". Measured on
-real babysit sessions: roughly two thirds of cycles were pure status checks
-that needed no judgment, while a saturated session pays a context-window-scale
-input bill to produce each of them. The check itself is deterministic
-(`gh pr view` and a diff against the last observation); only the *reaction*
-to a change needs a brain.
+* `monitor_start` creates a same-session AutoNudge loop. Its stateless MCP
+  directive is validated by `mcp_tools.control.monitor_start`, then applied by
+  `dashboard.session_directive_apply._monitor_start` through
+  `autonudge_authz.authorize_and_add_nudge`. `AutoNudgeService` persists and
+  schedules the loop.
+* `pr_watch.py:watch` is a script cron for a quiet pull-request waiting phase.
+  `builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py:watch` polls one
+  PR without an LLM turn and uses `irq.run` to decide whether to `Skip`,
+  `Report`, or `Done`.
 
-## 2. Solution overview
+The modes are not interchangeable. `monitor_start` re-injects an instruction
+into the same conversation on every delivered cycle; `PrWatchProbe` reports
+only a state that needs judgment. This boundary is load-bearing: repeated
+quiet CI polls do not grow the session transcript, while a wake retains the
+session that owns the work and its tools. The babysit skill documents when to
+use each mode.
 
-Split detection from judgment:
+## Same-session monitor contract
 
-- **Detection** becomes a zero-token `script` cron
-  (`babysit/scripts/pr_watch.py`) polling one PR every few minutes. Quiet
-  ticks raise `Skip` — no delivery, no tokens, no transcript growth.
-- **Judgment** stays in the babysit session. On an unexpected state the
-  script raises `Report`, and the existing script-cron delivery path
-  (`_deliver_script_result`) injects the brief into the session that armed
-  the cron **as a real agent turn** (queued if a turn is running, spawned if
-  idle). No gateway changes: the wake primitive already exists.
-- **Terminal states** (merged, closed) raise `Done`: one final message, and
-  the cron removes itself.
+`monitor_start`, `monitor_update`, and `autonudge_stop` are session directives,
+not direct AutoNudge mutations. `mcp_tools.control` validates the tool payload,
+uses strict session-key resolution only as a context guard, and returns an
+encoded directive. `dashboard.session_directive_apply.apply_session_directive`
+applies that directive on the user-facing session. The split prevents a cron,
+hook, or subagent from using inherited process identity to arm, rewrite, or
+stop another session's unattended loop; `test_autonudge_stop_auth.py` pins the
+binding-key-only targeting and the non-nudgeable-session refusals.
 
-The babysit skill's decision table gains a watch-mode branch: `monitor_start`
-for phases where the agent acts most cycles, the watch cron for pure-wait
-phases, and an explicit composition pattern for switching between them.
+`monitor_start` binds one loop to the calling session. `AutoNudgeService._add_unserialized`
+replaces an existing loop on that binding before it persists and arms the new
+one. `test_autonudge_stop_auth.py::test_applier_monitor_start_arms_via_the_session_binding_key`
+pins that the binding comes from the session rather than tool input.
 
-The generic half of that split now lives in `kiro_crew.irq`, the interrupt
-controller: state identity, masking, epoch resets, the coalescing window and
-the error backstop. This file is its first probe and owns only the two GitHub
-decisions — how to observe a pull request, and what counts as an anomaly. The
-probe never raises `Skip` / `Report` / `Done`; it returns a `Tick` of
-`Observation`s and the kernel raises the verdict.
+`NudgeLoop.next_due_ts`, `notify_user_input`, and `notify_turn_complete` make
+dashboard-loop cadence deadline-preserving: user activity cancels a pending
+timer but does not move its deadline, and a delivered nudge begins its next
+full interval when that nudge turn ends. This prevents active conversation
+from postponing monitoring forever while avoiding a nudge racing a user turn;
+`test_autonudge_deadline.py::test_user_turn_resumes_remaining_time_not_full_interval`
+and `test_delivered_fire_clears_deadline_then_turn_end_starts_fresh` pin both
+sides of the contract. Channel-bound loops re-arm after their unattended turn
+in `AutoNudgeService._run_fire_cycle` because they do not use the dashboard
+turn-lifecycle hooks.
 
-## 3. Wake predicates
+The schemas in `validation.MONITOR_START_SCHEMA` and
+`validation.MONITOR_UPDATE_SCHEMA` bound the message, interval, cycle cap, and
+wall-clock budget. `mcp_tools.control.monitor_start` supplies the bounded
+cycle-cap default from `mcp_tools._limits`; its default and explicit unlimited
+form are pinned by `test_autonudge_stop_auth.py::test_monitor_start_defaults_interval_300_and_bounded_cap`
+and `test_monitor_start_explicit_zero_cap_stays_zero`. The cap is a runaway
+backstop, not evidence that the watched work completed: `AutoNudgeService._timer`
+deactivates a capped loop and emits `expired`.
 
-Each fires once per dedupe window (while a condition persists, the alert
-re-arms after a few hours — the script cannot observe delivery, so dedupe is
-time-bounded rather than a permanent acknowledgement, and a delivery lost to
-a gateway failure costs a bounded delay, never a permanently suppressed
-signal). Check-derived predicates are additionally scoped **per head SHA**, so
-a force-push resets their memory immediately; conversation predicates are not,
-because a comment is not a property of the commit (see below):
+`AutoNudgeService.runtime_budget_exceeded` measures a configured wall-clock
+budget from the persisted creation time. `_timer` checks it before a fire and
+`_run_fire_cycle` checks it after a delivered turn, so a running turn is not
+cancelled but an expired loop is not re-armed. `test_autonudge.py` pins budget
+persistence across restart and the post-delivery check.
 
-| Reason | Trigger | Why it needs a brain |
-|---|---|---|
-| `conflict` | `mergeable` CONFLICTING / `mergeStateStatus` DIRTY | Checks freeze on a dirty PR; waiting observes nothing. Rebase needed. |
-| `new-red` | A check in a failing bucket whose name is not in `known_reds` and not yet alerted for this head | Read the job log / reviewer comment for the current head; run conclusions alone are unreliable. |
-| `ready` | Zero pending and zero failing after the `known_reds` filter, non-empty rollup | Verify reviewer verdicts on this head and tell the user. Suppressed with `wake_on_green: false`. |
-| `watch-error` | `gh` failed several consecutive ticks | The watch is blind (expired auth, network); it says so once instead of rotting silently. |
+`monitor_update` resolves the loop only by the calling session's binding and
+patches its message or limits through `authorize_and_update_nudge`. It does
+not accept a loop identifier. `_monitor_update` refuses a new cap or budget
+that cannot yield another fire and never revives a manual pause as a side
+effect. It may re-arm a loop stopped by its own cycle cap or runtime budget
+only when the relevant bound is raised; the paused-loop and bound-revival
+tests in `test_autonudge_stop_auth.py` pin those distinctions.
 
-`known_reds` carries the check names that are red on the base branch itself —
-the inherited-breakage filter that a human babysitter applies mentally. The
-watch never wakes for them, and counts them as green for the `ready`
-predicate. The probe filters them inside `observe()` and does not return them
-as observations at all. `known_reds` matches EITHER the bare check name (what
-an operator reads off GitHub's UI) or the workflow-qualified spelling the alert
-key uses, so a hand-written allow-list works while two workflows sharing a
-check name stay distinguishable.
+`autonudge_stop` is deliberately non-confirming at tool-call time because the
+consumer applies it after the turn result is processed. The applier removes an
+ordinary monitor loop on the calling binding and reports an idempotent local
+miss. It never exposes a cross-session target; `test_autonudge_stop_auth.py`
+pins both the request wording and the local-binding behavior.
 
-`new-red` and `ready` are **coalesced**; `conflict` is an `NMI` and fires
-immediately. The distinction is not importance but whether waiting can produce
-more information: a dirty PR dispatches no checks, so its `pending` count never
-drains and delaying the conflict signal would strand the operator on something
-already actionable.
+## PR watch probe
 
-Coalescing was added because of a measured defect, not a hypothesis. Before it,
-`new-red` fired on the first failing check with no gate on `pending`. On this
-repository — roughly sixty-five checks finishing over about twenty minutes — one
-head woke the operator twice within four minutes, at 34 seconds for a body gate
-and at 4m55s for a reviewer lane, while twenty-four checks were still running.
-Neither wake could act: the first turn did not know whether more failures were
-coming, and both would have been serviced by the same edit and the same push.
-Notably a full read of the same file concluded it had no defects — the fault is
-a property of real CI timing, not of the code, and only running it exposed it.
+`PrWatchProbe.identity` accepts a JSON cron message describing one GitHub
+repository and pull request, optional inherited-red check names, green-wake
+preference, coalescing override, and contextual note. Invalid permanent
+configuration raises `ValueError`; `irq.run` converts that to `Done`, so a
+malformed job removes itself instead of retrying indefinitely. The malformed
+message tests in `test_babysit_pr_watch.py` pin this behavior.
 
-The conversation IS watched -- comments and submitted reviews -- but only as
-*events*. The probe reports that something was
-said, naming the author and the timestamp, and never quotes the body. Reading
-the text, deciding whether a verdict is real, checking marker freshness and
-composing a rebuttal remain the woken agent's job, done with the session's own
-trust rather than a cron script's. That boundary is what keeps the judgment this
-design exists to stop paying for per-cycle out of the script, while still
-closing the gap that made the watch insufficient on its own: a comment moves no
-check, and a reviewer lane on this repository can report success while its
-comment body carries findings, so a rollup-only watch sits quiet on a green PR
-nobody has read.
+`PrWatchProbe._fetch` runs one bounded `gh pr view` through
+`github_runner.resolve_gh` and `github_runner.run_gh`. The shared runner
+validates the executable, supplies the restricted GitHub environment, and
+audits the spawn. A failed or malformed fetch becomes `Tick(fetch_ok=False)`;
+it does not make the script crash.
 
-Two consequences of watching a conversation rather than a commit:
+`PrWatchProbe.observe` produces these observations:
 
-- Conversation dedupe keys are **epoch-independent** (`epoch_scoped=False`) and
-  survive the force-push reset. A comment belongs to the pull request, not to
-  the commit under review, so pushing a fix minutes after a review must not
-  replay that review.
-- Comments the watcher's own account authored are ignored (`viewerDidAuthor`).
-  Without that the watch is a feedback loop: the woken agent posts a
-  disposition, the next tick sees a new comment and wakes it to read what it
-  just wrote.
-- A signal older than five hours is never new (`DEFAULT_COMMENT_HORIZON_SECS`, a
-  constant rather than a cron parameter -- as a knob it had no caller, so it
-  offered only a misconfiguration path; its one constraint is now asserted at
-  import against the kernel's own `DEFAULT_REALERT_SECS` rather than merely
-  documented). The probe holds no state of its own, so the horizon is
-  what stops arming a watch on a long-discussed PR from reporting its whole
-  history on the first tick.
+* A merged PR or a closed unmerged PR is `Severity.TERMINAL`, so `irq.run`
+  reports it and removes the cron job. `test_merged_pr_completes_the_watch` and
+  `test_closed_unmerged_completes_the_watch` pin both terminal paths.
+* A conflicting or dirty PR is `Severity.NMI`. `irq.run` bypasses coalescing
+  delay but still deduplicates it, because waiting cannot produce checks on a
+  dirty PR and unmasked repetition would wake every tick. The conflict and
+  re-alert tests pin this behavior.
+* `_collapse` buckets check-rollup rows, retains the current row for a check
+  identity, treats unknown conclusion vocabulary conservatively, and treats
+  cancelled or stale rows as noise. A failure that is not listed in
+  `known_reds` produces a `red:` wake; matching accepts the qualified alert
+  identity or a bare UI check name. Tests cover inherited-red filtering,
+  same-name workflow separation, rerun handling, unknown conclusions, and
+  cancelled rows.
+* With a non-empty rollup, no pending rows, and no unexpected failures,
+  `wake_on_green` permits a `ready` wake. An empty rollup is not evidence that
+  checks passed; `test_empty_rollup_never_reports_ready` pins that guard.
+* `_conversation` emits epoch-independent wakes for recent comments not
+  authored by the viewer and for recent submitted reviews. It identifies the
+  author and timestamp but does not quote comment text. `reviewDecision` is
+  not observed because it has no timestamp suitable for age filtering. The
+  comment-horizon and conversation tests in `test_babysit_pr_watch.py` pin
+  these rules.
 
-  ASYMMETRY, and it is what sets the value. The two ends of this number do NOT
-  cost the same. Too large costs arm-time replay: bounded, folded into ONE
-  coalesced brief naming N events, deduped forever after. Too small costs a MISS
-  -- a watch that stops ticking for longer than the horizon (machine asleep,
-  gateway down, cron auto-paused) never sees conversation posted in the gap, and
-  unlike the `blind` backstop it leaves no trace. This feature also retires the
-  nudge loop that would otherwise have read that comment eventually, so it removes
-  the backstop at the same time as it opens the window. One annoying wake is not
-  the price of a lost signal, so the horizon is pushed as close to `realert_secs`
-  as the kernel permits (five hours against six) rather than kept small, and the
-  relationship is asserted in code rather than only documented.
+The probe returns observations, not cron-control exceptions. `irq.Probe` and
+`irq.run` own the verdict so every probe receives the same terminal handling,
+deduplication, coalescing, state persistence, and failure backstop.
 
-  An earlier revision of this spec claimed raising the horizon "trades the loss
-  window for arm-time replay in equal measure, the same knob read from opposite
-  ends". That was wrong and is recorded here because the wrong version was the
-  stated reason for keeping the value low. The residual gap is now bounded by
-  five hours rather than one; closing it entirely still needs the probe-owned
-  state channel below, which lets a probe record its own baseline instead of
-  inferring one from wall-clock age.
-- The overall `reviewDecision` is deliberately NOT observed. It carries no
-  timestamp, so it cannot be aged against the horizon, and a PR that has sat in
-  `CHANGES_REQUESTED` for a week would wake once the moment a watch is armed --
-  the exact arm-time replay the horizon exists to prevent. It is also
-  near-redundant, since the decision is computed from reviews and a review that
-  moves it emits its own timestamped observation. The residue is a decision that
-  changes with no new review (a dismissal, or approvals invalidated by a push):
-  real, but nothing to act on urgently and undatable from this payload.
+## Watch kernel invariants
 
-CANCELLED check runs are classified as noise (force-push twins and re-run
-leftovers dominate); the rare real one surfaces through the checks it cancelled
-around.
+`irq.state_path` includes the subject identity and cron job identifier. Two
+jobs watching one PR therefore do not suppress each other's alerts. `load_state`
+treats missing or malformed state as fresh and `save_state` uses `atomic_write`;
+the degradation is a possible duplicate wake, not a crash-loop. If persistence
+fails while a coalescing window is open, `irq.run` reports immediately with a
+warning rather than delaying an observation into state it cannot recover.
 
-## 4. Mechanics
+A `Tick.epoch` changes when the PR head changes. `irq.run` clears
+epoch-scoped dedupe and coalescing state on that change, so failures on the new
+head can wake again. Conversation observations set `epoch_scoped=False`, so a
+force-push does not replay an already-seen comment or review. These distinct
+key spaces are load-bearing: treating every signal as head-scoped loses
+conversation dedupe, while treating every signal as sticky hides failures on a
+new head.
 
-- **Script home**: `builtin_skills/kirocrew-dev/babysit/scripts/pr_watch.py`,
-  synced to the user's skills directory by the builtin-skills loader like
-  every other bundled skill asset. It is a cron-only script: never imported
-  by gateway code. Cron scripts must live under `<config_dir>/crons/`
-  (`resolve_script_path` enforces the root, and a symlink out of it is
-  rejected after resolution), so the skill's arm recipe copies the synced
-  asset into `crons/` on every arm — keeping the copy current — and registers
-  `cron_add(script=".../crons/pr_watch.py:watch", every=300, timeout=120,
-  message=<JSON>)`. The script body is security-scanned at registration and
-  sandboxed at execution like any other script cron.
-- **gh inside the sandbox**: the script-cron sandbox is a single-uid Linux
-  user namespace, so every root-owned path component (`/`, `/usr`, `/home`)
-  stats as the overflow uid and `resolve_gh`'s ownership walk would refuse
-  ANY gh on the host. The gateway therefore pre-resolves gh with the full
-  validation OUTSIDE the sandbox and hands the child
-  `_KIROCREW_GH_PREVALIDATED=<path>|<st_dev>:<st_ino>`; the child re-checks
-  what the namespace leaves intact (regular file, executable, not
-  world-writable, outside the agent-writable tree) and pins the device:inode
-  identity, so a binary swapped after the parent's check is refused. Hosts
-  without a usable gh omit the variable and the child fails with the
-  ordinary setup message.
-- **Polling**: one bounded `gh pr view --json
-  state,mergedAt,mergeable,mergeStateStatus,headRefOid,statusCheckRollup`
-  call per tick (25s subprocess timeout). The rollup is bucketed tolerantly
-  across the CheckRun and StatusContext shapes; unknown conclusion vocabulary
-  buckets as failing — when in doubt, wake a brain.
-- **State**: owned by the kernel at
-  `<data home>/watch/gh-pr/<subject-fold>-<digest>.json`, where the digest
-  covers `gh-pr#<repo>#<pr>#<cron job id>` — so two sessions babysitting one PR
-  keep independent alert memories and neither can suppress the other's
-  delivery. It holds the last head (the kernel's `epoch`), the per-head alert
-  memory, the consecutive-error streak, and any open coalescing window.
-  Corrupt or missing state reads as fresh; the cost of lost state is one
-  duplicate wake, never a lost signal. **This path differs from the previous
-  `<data home>/pr-watch/...`**, so the first tick after upgrading is a cache
-  miss and any currently-open anomaly wakes once more. That is expected, not a
-  regression.
-- **Wake targeting**: the cron must be armed FROM the babysit session — the
-  cron system captures the calling session key at `cron_add` time and the
-  delivery path resolves it back to that slot (rehydrating it from history if
-  the tab was closed). Armed headless, delivery degrades to a bell
-  notification.
-- **Wake brief**: each observation's line names the PR, head and reason. The
-  caller-supplied `note` (worktree/branch orientation) and the direction to read
-  the session work ledger are the WAKE's footer, not each observation's, so the
-  kernel appends them once per delivery through `Probe.wake_suffix()` — a
-  coalesced wake carrying six signals used to repeat both of them six times,
-  measured at 56% of the delivered bytes. A conversation signal also omits the
-  `(head ...)` tag, because a comment belongs to the pull request rather than to
-  any one commit.
-- Check names are attacker-influenceable text (a workflow names its jobs);
-  they are charset-folded before entering state keys or the wake brief.
+`irq.run` coalesces ordinary wake observations until the configured floor has
+elapsed and the check rollup settles, or until its hard wall elapses. The hard
+wall ensures a permanently pending check delays a wake instead of losing it.
+Sticky conversation observations can fire once the floor elapses even while
+checks remain pending; they do not become more informative by waiting for CI.
+`Severity.NMI` and `Severity.TERMINAL` bypass the ordinary window. The
+coalescing and sticky-observation tests in `test_irq.py` pin these cases.
 
-## 5. Non-goals
+Dedupe is time-bounded. The kernel re-alerts a persistent condition after its
+window because a script cannot observe whether gateway delivery succeeded;
+permanent acknowledgement could turn one lost delivery into permanent silence.
+The comment horizon in `pr_watch.py` is asserted below the kernel's re-alert
+window, so stale conversation entries age out before a sticky dedupe key is
+removed. `test_alert_rearms_after_the_dedupe_window` and the horizon tests pin
+both sides.
 
-- **Replacing `monitor_start` entirely.** Watch mode now covers the whole
-  waiting phase, conversation included, so a PR babysit no longer needs a nudge
-  loop merely to notice a comment. Two things still keep `monitor_start`: an
-  active-fix phase, where the next step is driven by the agent's own unfinished
-  work rather than by anything observable on the PR, and watching subjects that
-  are not pull requests at all (a deployment, a ticket, someone else's CI run).
-  Retiring it for those needs a probe each, which is not this feature.
-- **Parsing verdict text in the watcher.** See §3: the probe reports that a
-  comment or review exists, never what it says.
-- **Multi-PR watches.** One cron per PR; the state file and the wake brief
-  are per-PR, and `cron_list` stays legible.
-- **A new wake primitive.** The script-cron `Report` delivery path already
-  injects an agent turn into the origin session; this feature adds zero
-  gateway surface.
+`Tick(fetch_ok=False)` increments the kernel-owned error streak. A persistent
+failure reports that the watch is blind; a successful fetch clears the streak
+and its blind marker. If state cannot be written, the kernel reports on the
+first failed tick because a counted threshold would otherwise be unreachable.
+The watch-health tests in `test_babysit_pr_watch.py` pin recovery, re-alerting,
+and the unwritable-state path.
 
-## 6. Failure modes
+## Delivery and lifecycle
 
-- `gh` failure → silent `Skip` per tick, one `watch-error` wake after the
-  streak threshold, streak reset on recovery.
-- Malformed cron message (bad JSON, missing repo/pr) → `Done` with the
-  reason: a watch that can never succeed removes itself instead of retrying
-  forever.
-- State file unwritable → alerts may repeat (duplicate wake), never lost, and
-  every wake carries a warning naming the directory. If the probe is failing
-  *and* state cannot persist, the streak can never accumulate, so that case
-  reports on the first tick instead of waiting for a threshold it will never
-  reach.
-- **Coalescing costs at least one extra tick**, because a window cannot open
-  and fire within the same tick — `elapsed` is zero at the moment it opens. On
-  a 60-second cron that is at least 60 seconds of added latency. Set
-  `coalesce_secs: 0` in the cron message when latency matters more than being
-  woken once.
-- `pending` never draining (a check wedged in queued, a phantom pending row) →
-  the window fires at the `coalesce_max_secs` wall instead, which is measured
-  from the first anomaly and independent of `pending`. A new anomaly arriving
-  after that starts a fresh window, so under a permanently stuck `pending`
-  count the worst case is one wake per hard-cap interval — delayed, never
-  dropped.
-- Session tab closed → the delivery path rehydrates the slot from history;
-  if the session's history was permanently deleted, delivery degrades to a
-  bell notification.
+Script cron execution maps `Skip` to no delivery, `Report` to a result while
+keeping the job, and `Done` to a result whose successful delivery removes the
+job. The script-cron branch in `slack.gateway._init_cron` delivers a result to
+the originating dashboard slot, queues it if that slot is busy, and rehydrates
+a closed slot from history when possible. If no slot is available, it sends a
+notification instead. This makes the arming session the normal wake target
+without claiming that headless delivery can start a session.
+
+The bundled script is a source asset, not a gateway import. `cron_script.resolve_script_path`
+requires a registered script file under the configured cron directory, so the
+babysit skill's watch recipe copies the bundled `pr_watch.py` there before
+registering it. The cron gateway revalidates and scans the current script body
+at fire time, then executes it through the script sandbox.
+
+## Non-goals
+
+The PR watch does not parse comment bodies or decide whether a review finding
+is valid. It reports a change and leaves judgment, source inspection, and any
+reply to the reactivated babysit session. It also watches one pull request per
+cron job. `monitor_start` remains the appropriate mechanism when each cycle
+requires the agent to make progress or when the watched subject is not a pull
+request.

--- a/docs/system-specs/features/claude-code-provider.md
+++ b/docs/system-specs/features/claude-code-provider.md
@@ -1,44 +1,55 @@
-# Standalone provider — removed
+# Claude Code provider — dormant ACP seam
 
-> **This provider no longer exists in KiroCrew.** The public fork drives a single
-> backend — `kiro-cli` over the Agent Client Protocol (`agent.provider` is fixed
-> to `acp`). The removed standalone provider, the removed Bedrock provider, the
-> removed agent-renderer / mirror modules, their config fields, and the dashboard
-> provider selector were all removed during de-Amazoning. There is no provider to
-> choose.
+## Public provider boundary
 
-## What remains (the dormant ACP seam)
+`AgentConfig.provider` admits only the ACP provider, and
+`KiroCrewConfig.create_provider_factory()` constructs `AcpProvider`. The public
+build still selects between its Kiro and KAS ACP harnesses through
+`agent.acp_backend`: `acp_backends.BASELINE_SELECTABLE_BACKENDS` contains those
+harnesses, while omitting the Claude backend. `DefaultProviderRegistry` adds no
+extra selectable backend.
 
-`acp/client.py` keeps an inert protocol seam (`ACP_BACKEND_CLAUDE` / the
-`_is_claude` branch) so an internal companion package can re-register an
-alternate `claude-agent-acp` backend without forking the client. The public core
-never selects it: `_resolve_kiro_bin` is the only backend the provider factory
-wires, and the dashboard exposes no provider choice. **Do not re-add the
-registration glue or a provider selector** — see the repo-root `CLAUDE.md`.
+`acp_backends.resolve_selected_backend()` normalizes an unregistered
+`agent.acp_backend` value to the Kiro harness. This boundary is load-bearing:
+`AcpProvider` rejects unknown harnesses, so normalization prevents a persisted
+or hand-edited value from becoming a startup failure. `TestConfigThreading.test_unselectable_values_degrade_to_the_default`
+exercises that path.
 
-The seam's binary-resolution details (`_resolve_claude_acp_bin`, the per-session
-`settings.local.json` permission routing, `CLAUDE_CONFIG_DIR` isolation) are
-documented in [`acp-client.md`](../modules/acp-client.md) for the companion that
-re-enables it — they are not user-facing in the public build.
+## Dormant Claude seam
 
-The host facts this backend needs that Kiro does not — its agent format, its
-own transcript store, its own credential command, its native permission engine —
-are tabulated beside kiro-cli and KAS in
-[`agent-host-contract.md`](agent-host-contract.md).
+`acp.client.AcpClient._is_claude` recognizes `ACP_BACKEND_CLAUDE`, and
+`AcpClient._spawn` retains its adapter-resolution branch through
+`_resolve_claude_acp_bin`. The public factory cannot select that branch because
+its backend is absent from the selectable registry. An edition companion makes
+the branch reachable only by registering both its provider and the Claude
+backend with `acp_backends.register_selectable_backend`; the registration
+function documents why either registration alone leaves the harness unreachable.
+
+The public client accepts companion-supplied Claude settings behavior without
+owning it. In the Claude branch, `_spawn` calls an optional
+`_write_claude_local_settings` hook and forwards `CLAUDE_CONFIG_DIR` from
+`extra_env` (`test_spawn_forwards_claude_config_dir_from_extra_env`).
+`AcpClient._reset_state` removes the per-work-directory local settings file for
+a Claude client. This is load-bearing because no caller retries teardown, so a
+session-scoped elevated permission setting must not outlive its client.
 
 ## Model registry
 
-`model_registry.json` (loaded by `model_registry.py`, mirrored to
-`website/src/model_registry.json` and guarded by `test/test_model_registry_parity.py`)
-remains the single source of truth for model names and context windows. Its
-per-entry `providers` map keys models under the canonical `claude_code` namespace
-— that is just the canonical key form (the public ACP model-id shape, e.g.
-`global.anthropic.claude-opus-4-8[1m]`); it is not a selectable provider.
+`src/kiro_crew/model_registry.json` is the shared model data source for
+`model_registry.py` and `website/src/model_registry.json`.
+`test_frontend_registry_matches_python_source` compares their parsed JSON, and
+`website/src/providers/modelRegistry.ts` imports the frontend copy. The
+per-entry `claude_code` provider IDs are registry mappings for the dormant
+adapter, not values accepted by `AgentConfig.provider`.
 
-Canonical keys include `fable-5-1m` (leads the JSON but is **not** default —
-Opus 4.8 `opus-4.8-1m` remains the sole `"default": true` entry), and
-`available_models()` (`model_registry.py`) is default-first-ordered, so a
-non-default entry sitting ahead of Opus in the file cannot change the
-`auto`-path pick. Each entry's `aliases` also include the bare, prefix-stripped
-provider-id spelling (e.g. `claude-fable-5`) so `from_provider_id` folds bare
-ids onto the canonical key.
+`model_registry._build_indices` indexes canonical keys, provider IDs, and
+aliases. `from_provider_id` uses that index to recover a canonical key from an
+advertised adapter ID. `TestModelRegistry.test_bare_advertised_ids_fold_to_canonical_key`
+pins the bare-ID case.
+
+`model_registry.available_models` and `display_list` sort default entries first
+rather than trusting JSON object order. This is load-bearing because the adapter
+uses the resulting allowlist when an automatic selection omits an explicit
+model. `TestModelRegistry.test_fable_5_not_default` and
+`TestModelRegistry.test_available_models_is_default_first` pin the default and
+ordering behavior.

--- a/docs/system-specs/features/code-approvers.md
+++ b/docs/system-specs/features/code-approvers.md
@@ -1,36 +1,23 @@
-# CodeApprovers Tier Routing
+# Code Ownership and AI Review Overrides
 
-## Overview
+## Ownership declaration
 
-Tier-based pull-request reviewer routing via `CODE_APPROVERS.yaml` in both KiroCrew and KiroCrewWebsite packages. Automatically assigns reviewers based on file paths changed, with a drift validator test that fails the build if patterns don't match actual files.
+`.github/CODEOWNERS` assigns every repository path to `@kirodotdev/kirocrew-team` through a single wildcard rule. GitHub uses this file to request reviews; it does not itself establish an approval count or enforce branch protection. Do not infer a tier, a required number of reviewers, or a designated-maintainer requirement from this repository file. The wildcard ownership rule in `.github/CODEOWNERS` enforces the declaration, while GitHub branch protection remains the enforcement point for any required approval policy.
 
-## Tiers
+## AI review override authorization
 
-| Tier | Approval Required | Scope |
-|------|-------------------|-------|
-| T1 | 1 random core-team member | Small fixes, non-critical paths |
-| T2 | 2 random core-team members | Security, harness, config, prompts, overlapping PRs |
-| T3 | Two designated maintainers required | Frozen memory modules |
+`ai-review-human-override.yml` records a human decision for an AI-review lane only when the commenter has `admin`, `maintain`, or `write` collaborator permission. The `Validate and record the decision` step resolves the current PR head and accepts the supplied SHA only when it is a prefix of that head; it also requires a non-empty, bounded reason. `test_handler_requires_write_permission_fresh_sha_and_reason` pins these authorization and freshness checks.
 
-## Drift Validator
+The workflow writes a `github-actions[bot]` marker that names the lane and full PR head before it re-runs a reviewer. This ordering is load-bearing: `Resolve human override` in `claude-review.yml` and `codex-review.yml` consumes only bot-authored markers for the current head, so an untrusted PR comment or a decision for an earlier push cannot make an AI-review gate pass. `test_fable_consumes_only_a_bot_authored_sha_scoped_record` and `test_gpt_has_clear_verdict_banner_and_human_override` enforce that consumer contract.
 
-`test_code_approvers.py` validates that file path patterns in `CODE_APPROVERS.yaml` match actual files in the repo. Build fails if patterns drift from reality (e.g., renamed files not updated in approvers config).
+## Fork review approval state
 
-## Code Reviewer Built-in App
+`pr-readiness.yml` treats a fork review workflow with GitHub's `action_required` conclusion as awaiting maintainer approval and publishes an action-required readiness state. This condition remains distinct from a review failure so contributors cannot clear an approval wait by changing the pull request. The `Evaluate readiness` step maintains that distinction.
 
-The Code Reviewer is now a built-in app (`src/kiro_crew/apps/builtins/code_reviewer/`) with a full Python backend. It is disabled by default (`defaultEnabled: false`) and can be enabled via the App Store or config.
+## Related code
 
-Key capabilities:
-- **Workspace browsing** — `POST /api/browse` with input-validation controls (path containment, sensitive-path blocklist, capped results)
-- **Git revert** — `POST /api/repos/{ws}/{pkg}/revert` with non-destructive multi-commit revert, conflict detection (409), rollback to original HEAD
-- **Git reset** — `POST /api/repos/{ws}/{pkg}/reset` with mode selection (soft/mixed/hard), pushed-boundary warning
-- **AI review SSE** — `POST /api/ai-review/complete` broadcasts `ai-review.completed` event with fail-closed redaction
-- **Fix engine** — `_spawn_fix` supports `target_sha` for amending fixes into specific commits via `git --fixup` + `--autosquash`; broadcasts `commit.amended` SSE event
-
-All endpoints follow audit + input-validation patterns (SHA regex, SEL audit on success and error paths).
-
-## Key Files
-
-- `CODE_APPROVERS.yaml` (both packages)
-- `test/test_code_approvers.py` — drift validator
-- `src/kiro_crew/apps/builtins/code_reviewer/` — built-in app backend
+- `.github/CODEOWNERS` — repository-wide ownership declaration
+- `.github/workflows/ai-review-human-override.yml` — authorization, SHA freshness, and trusted override record
+- `.github/workflows/claude-review.yml` and `.github/workflows/codex-review.yml` — trusted-record consumers
+- `.github/workflows/pr-readiness.yml` — fork approval-wait handling
+- `test/test_ai_review_workflows.py` — regression coverage for override authorization and trusted consumption

--- a/docs/system-specs/features/inline-action-buttons.md
+++ b/docs/system-specs/features/inline-action-buttons.md
@@ -1,254 +1,40 @@
 # Inline Action Buttons
 
-## Problem
+## Scope
 
-Agents can send Block Kit messages with arbitrary buttons via `send_message`, but every button click currently goes through the OPTIONS handler which:
+`action::` is an inline-action value protocol inside legacy Slack OPTIONS controls. It is not a general Block Kit routing protocol: `kiro_crew.slack.interactions.dispatch` calls `_handle_options` only for action IDs with `OPTIONS_ACTION_PREFIX`, which `kiro_crew.slack.format` defines for OPTIONS choices. Other action IDs reach the tool-approval fallback when the interaction supplies a channel and message. `test_unknown_action_id_falls_through_to_tool_approval` locks that fallback.
 
-1. Deletes the original message
-2. Posts the button's `value` as a **visible user message** in the thread
-3. Starts a **new session** with that text
+The dispatcher first requires `is_allowed_user(user_id)`. OPTIONS interactions also pass `channel_inbound_permitted("slack")` before their handler runs. These gates are load-bearing because the action value becomes agent-visible context and a routed turn.
 
-This means structured payloads (JSON, metadata) pollute the chat, and the originating session loses context. Adding new button behaviors requires KiroCrew code changes.
+## Button routing
 
-## Goal
+An OPTIONS choice whose `value` starts with `action::` enters the action branch of `kiro_crew.slack.interactions._handle_options`. The remainder of `value` is an opaque payload; the handler does not parse or require JSON. It derives the visible label from `action["text"]["text"]`, falling back to the selected overflow option's text.
 
-Allow agents to define arbitrary Block Kit buttons whose clicks route back to the **originating session** as invisible context, with no KiroCrew code changes per button type.
+`_route_action_to_session` performs the shared delivery:
 
-## Design
+1. It redacts exfiltration URLs and credentials from the label, then attempts to replace matching elements in the source message with a context label.
+2. It posts the redacted label as a visible reply in the source thread. A failed post aborts routing, so an agent turn never runs without its visible Slack message. `test_post_message_failure_aborts` locks this ordering.
+3. It redacts and bounds the payload according to `_ACTION_PAYLOAD_CAP`, records the Slack access event, and builds an `Action button clicked` context entry.
+4. It calls `kiro_crew.slack.handler.handle_message` with the source message's `thread_ts`, the new reply timestamp, the visible label, and `action_context`.
 
-### Button value protocol
+`ContextBuilder.build_message` appends a non-empty `action_context` before the actual message text. The payload is therefore delivered as context rather than displayed verbatim in the thread; `test_redaction_applied_to_payload` covers payload redaction.
 
-Buttons use a prefix convention in their `value` field to control routing:
+The source-message update is best-effort. `_route_action_to_session` logs and continues when `update_message` fails, so a successful route does not guarantee that the original button has been replaced visually.
 
-| Prefix | Behavior |
-|---|---|
-| `action::{payload}` | Route payload to originating session as context injection |
-| _(no prefix)_ | Current behavior — visible message, new session |
+## Clicked-message rendering
 
-The `action::` prefix is chosen because it's unlikely to collide with natural language button values, and the `::` delimiter is unambiguous.
+`_mark_button_clicked` walks every `actions` block. For each block containing the supplied action ID, it removes every matching element, inserts a `context` block containing `✓ {label}` immediately before that actions block, and omits the actions block when no elements remain. It preserves blocks without a matching element. `TestMarkButtonClicked` covers replacement, unchanged input when no match exists, and removal of an empty actions block.
 
-### Example button
+The identifier match is the load-bearing link between Slack's interaction payload and the rendered message. Reused action IDs in separate actions blocks produce a context label for each matching block.
 
-```json
-{
-  "type": "button",
-  "text": {"type": "plain_text", "text": "📝 Draft reply"},
-  "action_id": "options_choice_0",
-  "value": "action::{\"intent\": \"draft_reply\", \"email_id\": \"AAMk...\", \"from\": \"jbarr\"}"
-}
-```
+## Extended elements
 
-### Clicked-button visual state
+`_handle_options` contains a direct-handler branch for an `action_id` beginning with `action::`. It parses the suffix as a JSON object, obtains a selection through `_extract_selected_value`, adds `selected_value`, derives a label from `placeholder.text` and the selected display text, and routes it through `_route_action_to_session`. `_extract_selected_value` handles `selected_option`, date, time, and datetime fields; malformed JSON or a non-object payload stops this branch without routing.
 
-When a button is clicked, it must remain visible as a non-interactive "done" indicator. Slack Block Kit doesn't support disabled buttons, so we use this approach:
+This branch is not reachable through the normal Slack dispatcher: `dispatch` forwards only `OPTIONS_ACTION_PREFIX` action IDs to `_handle_options`, while an `action::` action ID falls through to `_handle_tool_approval`. `test_extended_element_happy_path`, `test_malformed_json_in_action_id_no_crash`, and `test_non_dict_json_in_action_id_no_crash` exercise `_handle_options` directly, not the dispatcher.
 
-- The `actions` block containing the clicked button is split into:
-  1. A `context` block with mrkdwn text `✓ {button label}` (renders as small gray text)
-  2. A new `actions` block with the remaining (unclicked) buttons
-- If all buttons in an actions block have been clicked, only context blocks remain
+An element with an `OPTIONS_ACTION_PREFIX` action ID can enter the existing value branch when its selected value starts with `action::`, but that selected value is the opaque payload. It does not activate the direct-handler branch or merge a base JSON object with `selected_value`. Agents must not rely on `action::` in an extended element's `action_id` as an available Slack protocol.
 
-This preserves full visual context — with 5 emails × 4 buttons each, the user always sees which actions they've taken and which remain.
+## Tests
 
-### Routing flow
-
-1. User clicks button → Slack sends interaction payload to Socket Mode handler
-2. `interactions.py::_handle_options` checks if `value.startswith("action::")`
-3. **If action button:**
-   - Extract payload: `value[len("action::"):]`
-   - Extract display text from `action["text"]["text"]`
-   - Replace the clicked button with a `✓ {label}` context block (see above)
-   - Update the Slack message via `update_message` with the modified blocks
-   - Post the display text as a visible user message for conversational continuity
-   - Inject the structured payload as a context entry:
-     ```
-     --- CONTEXT ENTRY BEGIN ---
-     [Action button clicked: {"intent": "draft_reply", "email_id": "AAMk...", "from": "jbarr"}]
-     --- CONTEXT ENTRY END ---
-     ```
-   - Route to the **existing session** (same `thread_ts`) via `handle_message`
-4. **If no prefix:** current behavior unchanged (delete message, post value, new session)
-
-### What the agent sees
-
-A normal message turn with:
-- **Visible text:** The button's display text (e.g., "📝 Draft reply")
-- **Context entry:** The full structured payload
-
-The agent parses the JSON from the context entry and dispatches on `intent` or any other field. No KiroCrew code changes needed per button type — the agent's prompt defines the behavior.
-
-### What the user sees
-
-- The button they clicked becomes a static "✓ Draft reply" label (small gray text)
-- All other buttons on the same message remain clickable
-- A short message appears in the thread: "📝 Draft reply"
-- The agent responds in the same thread
-
-No JSON or structured payload visible in chat.
-
-## Files changed
-
-### `src/kiro_crew/slack/interactions.py`
-
-Modify `_handle_options`:
-- Check `value` for `action::` prefix (buttons), then `action_id` (extended elements)
-- For buttons: extract payload from `value` (existing behavior)
-- For extended elements: extract base payload from `action_id`, extract user selection via `_extract_selected_value(action)`, merge as `selected_value`
-- Derive display label: buttons use `text.text`, extended elements use `placeholder.text` + selected display text
-- Rest of flow shared: transform blocks, update message, post display text, inject context, route to session
-- If no prefix on either field: current behavior (unchanged)
-
-Add helper `_extract_selected_value(action) -> tuple[str, str]`:
-- Returns `(raw_value, display_text)` by checking fields in order:
-  `selected_option` → `selected_date` → `selected_time` → `selected_date_time`
-- For `selected_option`: raw = `.value`, display = `.text.text`
-- For date/time: raw = display = the date/time string
-
-Add helper `_mark_button_clicked(blocks, clicked_action_id, label) -> list`:
-- Walk blocks looking for `actions` blocks
-- When the clicked `action_id` is found in an actions block's elements:
-  - Remove the clicked element from elements
-  - Insert a `context` block (with `✓ {label}`) immediately before the actions block
-  - If no elements remain, drop the now-empty actions block
-- Return the updated block list (works for any element type, not just buttons)
-
-### `src/kiro_crew/slack/handler.py`
-
-Add optional `action_context` parameter to `handle_message`:
-- When provided, prepend as a context entry in the message sent to the agent
-
-### `src/kiro_crew/context.py`
-
-Add `action_context` parameter to `ContextBuilder.build_message`:
-- When provided, append as a `--- CONTEXT ENTRY ---` block
-
-## Extended interactive elements
-
-### Supported elements
-
-Beyond buttons, the `action::` protocol extends to other Block Kit interactive elements that fire `block_actions` events:
-
-| Element | Slack payload field | Example use case |
-|---|---|---|
-| Static select menu | `selected_option.value` | Priority picker, category selector |
-| Date picker | `selected_date` (YYYY-MM-DD) | Snooze until, deadline |
-| Time picker | `selected_time` (HH:mm) | Reminder time |
-| Datetime picker | `selected_date_time` (unix epoch) | Schedule send |
-| Overflow menu | `selected_option.value` | Compact action menu |
-| Radio buttons | `selected_option.value` | Single-choice selection |
-
-Not supported (different interaction model):
-- Multi-select menus / checkboxes (array payloads — add later if needed)
-- Plain text input (requires `dispatch_action` or modals)
-- Modals / views
-
-### Routing protocol
-
-The `action_id` carries the routing prefix and base payload. The user's selection is extracted from the element-specific field and merged in:
-
-```
-action_id: "action::{\"intent\": \"snooze\", \"email_id\": \"AAMk...\"}"
-```
-
-When the user picks a date, the handler:
-1. Parses the base payload from `action_id[len("action::"):]`
-2. Extracts the user's selection from the element-specific field
-3. Merges them: `{"intent": "snooze", "email_id": "AAMk...", "selected_value": "2026-04-15"}`
-4. Injects the merged payload as the context entry
-
-The `selected_value` key is normalized — regardless of whether Slack sends `selected_date`, `selected_time`, `selected_option.value`, etc., the context entry always uses `selected_value`.
-
-### Example: date picker
-
-Agent sends:
-```json
-{
-  "type": "datepicker",
-  "action_id": "action::{\"intent\": \"snooze\", \"email_id\": \"AAMk...\"}",
-  "placeholder": {"type": "plain_text", "text": "Snooze until..."}
-}
-```
-
-User picks 2026-04-15. The agent sees:
-```
---- CONTEXT ENTRY BEGIN ---
-[Action element selected: {"intent": "snooze", "email_id": "AAMk...", "selected_value": "2026-04-15"}]
---- CONTEXT ENTRY END ---
-```
-
-### Example: static select
-
-Agent sends:
-```json
-{
-  "type": "static_select",
-  "action_id": "action::{\"intent\": \"set_priority\", \"task_id\": \"T-1234\"}",
-  "placeholder": {"type": "plain_text", "text": "Set priority"},
-  "options": [
-    {"text": {"type": "plain_text", "text": "🔴 High"}, "value": "high"},
-    {"text": {"type": "plain_text", "text": "🟡 Medium"}, "value": "medium"},
-    {"text": {"type": "plain_text", "text": "🟢 Low"}, "value": "low"}
-  ]
-}
-```
-
-User picks "🔴 High". The agent sees:
-```
---- CONTEXT ENTRY BEGIN ---
-[Action element selected: {"intent": "set_priority", "task_id": "T-1234", "selected_value": "high"}]
---- CONTEXT ENTRY END ---
-```
-
-### Visual feedback for non-button elements
-
-Non-button elements use the same `_mark_button_clicked` approach, adapted per element type:
-
-| Element | ✓ label format |
-|---|---|
-| Date picker | `✓ Snooze until: 2026-04-15` |
-| Time picker | `✓ Remind at: 14:30` |
-| Static select | `✓ Priority: 🔴 High` |
-| Overflow / radio | `✓ {selected option text}` |
-
-The label is composed from the element's `placeholder.text` (or a fallback) + the selected display text.
-
-### Key difference from buttons
-
-Buttons carry the full payload in `value`. Extended elements carry the base payload in `action_id` and the user's selection in an element-specific field. This is because:
-- `action_id` is the only field common to all interactive elements
-- `value` is button-specific; other elements use `selected_date`, `selected_option`, etc.
-- The `action_id` has a 255-char limit in Slack, which is sufficient for typical JSON payloads
-
-### `action_id` length validation
-
-`send_message` validates that every `action_id` in the outgoing blocks is ≤ 255 characters. If any `action_id` exceeds the limit, the request is rejected immediately with a clear error (HTTP 400) listing the offending element. This catches oversized payloads before they reach Slack, giving the agent actionable feedback to shorten or use short-ID indirection.
-
-### Implementation
-
-Modify `_handle_options` to:
-1. Check `action_id` (not just `value`) for `action::` prefix
-2. Extract base payload from `action_id`
-3. Extract user selection via priority chain: `selected_option.value` → `selected_date` → `selected_time` → `selected_date_time`
-4. Merge `{"selected_value": extracted}` into base payload
-5. Derive display label from element type + selection text
-6. Rest of flow identical: update message, post display text, inject context, route to session
-
-Buttons use `value` exclusively for the `action::` prefix — no `action_id` fallback. Extended elements use `action_id` exclusively. This keeps routing unambiguous: each element type has exactly one field to check.
-
-## Not in scope
-
-- Custom `action_id` routing beyond the `action::` prefix convention (buttons use `options_choice_` prefix; extended elements use `action::` in `action_id`)
-- Multi-click tracking / state management
-- Dashboard button support (Slack-only for now)
-- Button-specific agent selection (uses thread's current agent)
-- Multi-select menus / checkboxes (array payloads)
-- Plain text input / modals
-
-## Testing
-
-- Unit test: `_mark_button_clicked` correctly transforms blocks for buttons and non-button elements
-- Unit test: `_extract_selected_value` returns correct value/display for each element type
-- Unit test: `_handle_options` with `action::` prefix in `value` (button) routes to existing session
-- Unit test: `_handle_options` with `action::` prefix in `action_id` (extended element) merges `selected_value` and routes
-- Unit test: `_handle_options` without prefix on either field preserves current behavior
-- Manual: send Block Kit message with action buttons, click several, verify ✓ labels persist
-- Manual: send message with date picker, select date, verify merged payload in context
+`test/test_action_interactions.py` covers the direct action-handler path, payload redaction, audit logging, and the block-transforming helpers. `test/test_slack_interactions_coverage.py::TestDispatchPayloadParsing::test_unknown_action_id_falls_through_to_tool_approval` covers the dispatch boundary that excludes arbitrary action IDs.

--- a/docs/system-specs/features/model-fallback.md
+++ b/docs/system-specs/features/model-fallback.md
@@ -1,131 +1,128 @@
-# Model Fallback (throttle-exhaustion)
+# Model fallback
 
-When the active model stays throttled past the same-model transient-retry budget,
-the turn is retried on a fallback model instead of failing — visibly, never
-silently. kiro-cli has no fallback mechanism; this feature is entirely
-Kiro Crew-side, built on the substitute `set_model` path.
+`agent.fallback_model` controls an optional retry after an active model exhausts
+its transient-error budget before activity begins. The implementation is
+Kiro Crew-side: `llm_helpers.advance_fallback_candidate` changes the model through
+the substitute `set_model` seam, and `test/test_llm_helpers.py` pins that a
+successful swap is observable before it is recorded.
 
-## Config
+## Configuration
 
-`agent.fallback_model` (`AgentConfig`, `config/loader.py`) — a SINGLE value with
-three shapes. Coercion (`coerce_fallback_model`) normalizes registry
-keys/aliases to acp ids and matches `"auto"` case-insensitively:
+`AgentConfig.fallback_model` is normalized by
+`config/loader.py:coerce_fallback_model`. `llm_helpers.configured_fallback_chain`
+is the shared derivation used by the fallback callers:
 
-- **`"auto"` (the default)** — defer to the backend's availability-aware
-  routing when the active model stays throttled. Team-decided default: the
-  backend knows live availability and every account serves *some* model, so
-  auto is the one fallback that works regardless of subscription plan or
-  partition.
-- **a concrete model id** — tried first, with `"auto"` as the final
-  fallthrough (walk order `(id, "auto")`, derived in
-  `configured_fallback_chain` — the one shared derivation).
-- **`""`** — fallback explicitly disabled: every surface behaves byte-for-byte
-  as before the feature existed (regression-pinned; this is the rollback
-  story).
+- The automatic-routing sentinel is the field default; its configured value
+  produces a chain containing that sentinel.
+- A concrete model value produces a chain that tries the configured value before
+  the automatic-routing sentinel.
+- An empty value produces an empty chain, so the fallback branch remains inert
+  and the existing terminal error path handles the failure.
 
-Editable via `kirocrew config set agent.fallback_model <id|auto|''>`, the
-config PATCH API (str type, model-id grammar, `_validate_role_model` — the same
-entitlement validation as the role-model pins, so `""`/`"auto"` always allow),
-and Settings → Chat → Rate-limit fallback (single-select dropdown fed by the
-advertised-model list — no free text, so a typo'd id cannot exist).
+`TestFallbackModelLoad` in `test/test_config_loader.py` and
+`TestCoerceFallbackModel` in `test/test_role_models.py` pin the default,
+normalization, concrete-value ordering, and empty-value opt-out. The dashboard
+PATCH schema in `dashboard/handlers/core.py` applies the model-id grammar and
+`_validate_role_model`; that validator allows the automatic and empty values,
+rejects a known unusable concrete value, and permits a concrete value when no
+advertised-model set is available.
 
-## Trigger and walk
+## Trigger and candidate walk
 
-The trigger is the exhaustion of the SAME transient budget that governs today's
-retries (`TRANSIENT_RETRIES`, classifier `acp_error_is_transient`) with no output
-streamed — exactly where the error used to surface. The chain walk is ONE shared
-body, `llm_helpers.advance_fallback_candidate`, used by all three surfaces so
-skip rules and marker semantics cannot diverge:
+The fallback path is eligible only after the normal transient retry budget is
+spent on a transient error with no qualifying prior activity. Each surface
+tracks that condition in its own stream loop: `llm_helpers.stream_and_collect`
+requires no result text or tool activity, `dashboard/chat_runner.py` requires
+no emitted or thought activity, and `subagent._stream_with_transient_retry`
+requires no activity. Post-activity recovery does not enter the model-fallback
+walk.
 
-- seeds the primary from a surviving sticky marker first (a session already on a
-  fallback whose true primary only the marker remembers), the active model second;
-- walks the derived chain in order, skipping the primary, unadvertised ids
-  (fail-open when the advertised list is unknown, matching `model_is_unusable`),
-  and the currently-active failing candidate. `"auto"` is a legitimate candidate
-  filtered by the same advertised check: a partition that does not serve it
-  skips it rather than sending a no-op swap;
-- applies the first candidate whose substitute `set_model` lands (the path that
-  never puts an unserved model on the wire; its own `resolve_usable_model`
-  sends `"auto"` only when advertised), publishes the sticky marker, and
-  logs `model fallback: X -> Y (reason=throttle-exhaustion, surface=...)`.
+`llm_helpers.advance_fallback_candidate` owns candidate selection for all three
+paths. It preserves the original primary from an existing provider marker when
+available, otherwise from the active model. It then skips the primary, the
+currently active model, and candidates absent from a known advertised-model
+set. An unavailable advertised set does not reject a candidate; this is
+load-bearing because entitlement cannot be determined without that set.
 
-Each candidate gets `FALLBACK_CANDIDATE_ATTEMPTS` (2: initial + one ~2s retry) —
-deliberately not a fresh full budget, because throttle events are frequently
-cell-scoped and model-agnostic. The budget lives in one place: the in-walk
-surfaces consume it via `FallbackState.should_retry_active`, and the dashboard's
-counter rewind derives from the same constant
-(`fallback_rewound_transient_budget()`). A non-transient error mid-chain
-propagates immediately. Chain exhaustion surfaces the original error class with
-the chain's story attached (`FALLBACK_STORY_ATTR`, built by
-`FallbackState.exhaustion_story`); the unattended surfaces append it to their
-terminal error text via `append_fallback_story` — the cron failure alert, the
-sub-agent `info.error`, and the heartbeat failure log — so an unattended failure
-names the whole walk, not just the last candidate's error. The story is
-redacted and capped centrally in `fallback_story_of` (`_FALLBACK_STORY_CAP`):
-walked ids originate in config (LLM-reachable via MCP, advertised check fails
-open), and consumers like the heartbeat log apply no redaction of their own.
+The helper calls the substitute `set_model` path and verifies that the serving
+model changed before it records the candidate, publishes `TURN_FALLBACK_ATTR`,
+or logs the swap. This witness prevents a non-raising no-op model selection from
+being announced as a fallback. `TestSetModelWitness`,
+`TestAdvanceFallbackCandidateAutoPrimary`, and `TestFallbackState` in
+`test/test_llm_helpers.py` cover no-op handling, marker-seeded primary
+selection, advertised-model filtering, and chain progress.
+
+`FallbackState.should_retry_active` owns the per-candidate retry allowance, and
+`fallback_rewound_transient_budget` derives the dashboard counter from the same
+allowance. The pinning tests in `test/test_llm_helpers.py` and
+`TestRunChatModelFallback` in `test/test_dashboard_chat.py` prevent the three
+surfaces from granting different candidate budgets.
+
+When no candidate can advance, `FallbackState.exhaustion_story` describes the
+candidates actually tried. `stream_and_collect` and the sub-agent attach that
+story to the terminal exception for their delivery paths; the dashboard retains
+its slot-local walked candidates to render its terminal error. `fallback_story_of`
+redacts and bounds the attached story centrally, and `append_fallback_story`
+uses it for cron alerts, sub-agent errors, and heartbeat failure logs. Central
+handling is load-bearing because fallback model values are configuration input
+and each error surface must receive the same safe text.
 
 ## Surfaces
 
-- **`stream_and_collect`** (Case 2.75; cron and heartbeat pass the chain via
-  `fallback_models=configured_fallback_chain()`): walks in-place and re-prompts.
-  Delivered results are prefixed with a redacted warning line
-  (`annotate_model_fallback`, one body in `llm_helpers` next to
-  `TURN_FALLBACK_ATTR`, used by the cron/heartbeat delivery and the sub-agent
-  completion path).
-- **Dashboard** (`chat_runner`): the pre-token exhaustion branch swaps, appends a
-  persisted notice card ("⚠️ X is throttled — running on Y until X recovers."),
-  and re-queues the same message on the same live session
-  (`SYNTHETIC_RECOVERY_KIND`). The per-candidate budget rides the existing
-  transient counter, rewound to `fallback_rewound_transient_budget()` (derived
-  from the same `FALLBACK_CANDIDATE_ATTEMPTS` constant = one in-branch retry).
-  Nested turns (`_prompt_depth > 0`) get no fallback. Chain exhaustion falls
-  through to the unchanged terminal branch with the story prepended.
-- **Sub-agents** (`subagent._stream_with_transient_retry`): same walk on the
-  zero-activity arm; the delivered result carries the warning prefix.
+- `llm_helpers.stream_and_collect` accepts a caller-supplied fallback chain.
+  The Slack gateway passes `configured_fallback_chain()` for its cron and
+  heartbeat work, then `annotate_model_fallback` prefixes a delivered result
+  while the provider marker remains active.
+- `dashboard/chat_runner.py` swaps through `_fallback_swap_for_turn` after its
+  pre-activity transient branch, persists a notice, and requeues the same
+  message as a synthetic recovery item. Its fallback condition excludes nested
+  prompts. On exhaustion it renders the slot-local walk in the terminal error.
+- `subagent._stream_with_transient_retry` follows the zero-activity branch,
+  uses the shared candidate helper, and applies `annotate_model_fallback` to
+  the completed result.
 
-## Sticky state and restore
+`annotate_model_fallback` redacts model values before rendering and leaves the
+marker in place. That persistence is load-bearing: subsequent successful turns
+on the fallback remain visibly identified until restoration succeeds.
 
-A swap is sticky for the session. The marker `TURN_FALLBACK_ATTR`
-(`(primary, candidate)` on the provider) drives the unattended restore:
-`probe_fallback_restore` runs at the next `stream_and_collect` entry and tries
-one `set_model(primary)` — quiet on success (log only; recovery is the expected
-state), staying on the fallback on transient failure, and dropping a stale
-marker without touching the model when the session moved on by other means.
+## Sticky restore
 
-The dashboard's slot probe (`_probe_fallback_restore_for_slot_locked`) wraps the
-same `probe_fallback_restore` body with slot-held state (`_active_fallback_model`,
-`_fallback_primary_model`) and one extra rule: **an explicit user pick is never
-overridden.** Picks are detected by a generation counter
-(`slot._model_pick_gen`) bumped ONLY by the explicit set-model surfaces
-(single-slot pick, bulk switch, provider-switch clear) and rolled back when a
-pick is refused (`AcpModelUnavailable`) — never by the automatic provider
-backfill, which writes the served model into an unpinned slot's `slot.model` and
-must not read as a pick. On restore, a backfill-polluted `slot.model` is healed
-back to the activation snapshot (`_fallback_slot_model`), because `slot.model`
-is re-sent as a pin on resume.
+A successful swap is sticky on the provider through `TURN_FALLBACK_ATTR`.
+`probe_fallback_restore` makes one start-of-turn attempt to restore the primary
+for unattended callers. It keeps the fallback on a transient restore failure;
+if the session no longer serves the recorded fallback, it clears stale state
+without selecting a model.
 
-## Visibility (mandatory, not configurable)
+The dashboard adapter,
+`chat_runner._probe_fallback_restore_for_slot_locked`, applies the same probe to
+slot-held state. It snapshots `slot.model` and `_model_pick_gen` when fallback
+activates. Explicit single-slot and bulk model picks, plus a provider switch,
+increment the generation; a rejected single-slot pick restores its prior
+value. A changed generation makes the fallback record stale, so restore cannot
+override an explicit user choice. When automatic provider backfill changes
+`slot.model` without changing the generation, the restore hook reinstates the
+activation snapshot before clearing fallback state. This prevents an automatic
+fallback selection from becoming a persistent user pin.
 
-Every swap is announced: notice card (dashboard), warning-prefixed result
-(cron/heartbeat/sub-agent), and a warning log for swap and restore. Model ids
-originate in config (LLM-reachable via MCP), so every rendered occurrence passes
-`redact_exfiltration_urls` + `redact_credentials`. `meta.turn_stats.model`
-records the model that actually served the turn (both `set_model` paths sync
-`_model`/`_resolved_model_id`, which `read_turn_model` reads).
+`TestRunChatModelFallback` and `TestSlotProbeWrapsSharedRestoreBody` in
+`test/test_dashboard_chat.py`, together with the restore tests in
+`test/test_llm_helpers.py`, pin the stale-record, explicit-pick, and backfill
+invariants.
 
 ## Non-goals
 
-- Post-token / mid-stream model swap (the one-shot CONTINUE recovery is untouched).
-- Per-crew / per-cron / per-role chains (v1 is global).
+- Swapping models after activity has begun; the existing continuation recovery
+  handles that path.
+- Per-crew, per-cron, or per-role fallback chains.
 - A dedicated per-turn model field on the ACP wire.
 - kiro-cli changes.
 
 ## Tests
 
-`test/test_llm_helpers.py` (candidate selection, Case 2.75 matrix, restore
-probe, marker-seeded primary), `test/test_dashboard_chat.py`
-(`TestRunChatModelFallback`), `test/test_subagent_turn_resilience.py`,
-`test/test_cron_gateway_integration.py` (`TestThrottleFallbackCronWiring`),
-`test/test_role_models.py` / `test/test_config_loader.py` (coercion + load),
-`test/test_dashboard_handlers_core_coverage.py` (fallback-model PATCH validation).
+`test/test_llm_helpers.py` covers chain derivation, candidate selection, retry
+state, story handling, and unattended restore. `test/test_dashboard_chat.py`
+covers dashboard fallback and slot restore. `test/test_subagent_turn_resilience.py`
+and `test/test_cron_gateway_integration.py` cover sub-agent and gateway wiring.
+`test/test_config_loader.py`, `test/test_role_models.py`, and
+`test/test_dashboard_handlers_core_coverage.py` cover configuration loading and
+PATCH validation.

--- a/docs/system-specs/features/session-work-ledger.md
+++ b/docs/system-specs/features/session-work-ledger.md
@@ -1,186 +1,70 @@
 # Session Work Ledger
 
-Status: implemented (this PR)
-Owners: gateway core (`session_ledger.py`), MCP tools (`mcp_tools/ledger.py`)
+Owners: `kiro_crew.session_ledger`, `kiro_crew.mcp_tools.ledger`, and the dashboard ledger routes
 
-## 1. Problem
+## 1. Purpose
 
-Long-horizon loops — `monitor_start` babysit loops, goal loops, any session that
-wakes dozens of times — carry their working state in the context window. Every
-cycle appends a full turn to the same session, so "what am I doing, what have I
-tried, where are my artifacts" survives only as prior transcript turns. When the
-context fills, compaction summarizes generically and the agent loses exactly the
-state it needs to keep going: approaches already rejected, the branch it was on,
-the reason a phase was entered.
+`kiro_crew.session_ledger` provides durable, per-session work state for long-running work. The state record holds a goal, phase, resumable next step, rejected approaches, artifact pointers, and a bounded event history. This separates resumable state from transcript context; `mcp_tools.ledger.schemas()` describes the record as authoritative over prior-cycle memory.
 
-Compaction itself is out of scope: it is performed by the agent harness (the
-ACP/kiro-cli layer), not by this codebase, so the fix cannot be "compact
-better". The fix is to stop using the context window as the authoritative store
-for loop state.
+## 2. Storage, identity, and lifecycle
 
-The pattern already exists in this repo — three times, hand-rolled per app:
-
-- Issue Radar's crew ledger (`apps/builtins/issue_radar/backend/crew_store.py`):
-  work items with `phase` / `next` / `tried[]`, an append-only content-addressed
-  event log, and the rule that a phase never moves without a logged event.
-- Ops Mission Control's knowledge ledger
-  (`apps/builtins/ops_mission_control/backend/ledger.py`): append-only JSONL,
-  content-addressed ids, locked read-modify-write.
-- The heartbeat/cron surfaces re-derive state per cycle from files.
-
-Each app that needs durable work state re-invents the primitive. Sessions that
-are not one of those apps get nothing.
-
-## 2. Solution overview
-
-A generic, per-session **work ledger** on disk:
-
-- One directory per session under the data home, created lazily on first write,
-  deleted when the session's history is permanently deleted.
-- A mutable **state record** (goal, phase, next intent, tried/rejected
-  approaches, artifact pointers) plus an append-only **event log**.
-- Two core MCP tools, `session_ledger_read` and `session_ledger_record`, with
-  session-resolved identity: a session can only ever touch its own ledger.
-- Auto-nudge integration: when a monitor loop fires on a session that has a
-  ledger, the nudge body carries a compact snapshot of the state record, so each
-  cycle starts from the ledger instead of from transcript memory.
-
-The context window becomes a cache; the ledger is the authority. A loop cycle
-needs the snapshot plus its check instructions — its cost no longer grows with
-the number of cycles that came before it.
-
-## 3. On-disk layout and lifecycle
+Each recorded ledger lives below `<data_home>/ledger/` in a directory containing:
 
 ```
-<data_home>/ledger/<store-name>/
-    slot_key        # breadcrumb: the exact ledger key this dir belongs to
-    state.json      # the whole record, replaced atomically on every write
-    .lock           # cross-process mutex inode (never replaced by writes)
+slot_key   # original ledger key breadcrumb
+state.json # complete state record
+.lock      # dedicated cross-process lock inode
 ```
 
-- **Identity is the exact key.** The ledger key is the session key with only
-  the dashboard prefixes stripped (one dashboard session is legitimately
-  spelled both `dashboard_chat-X` and `chat-X`, and both must reach one
-  ledger); nothing else is rewritten. `<store-name>` is a readable charset
-  fold of that key plus a sha256 prefix over the FULL key — the fold shapes
-  only legibility, the digest carries identity, so two distinct
-  colon-structured channel keys can never share a directory (a lossy charset
-  fold as the identity would let one session read and overwrite another's
-  state). Path safety mirrors `subagent_persistence._agent_dir`: hostile keys
-  refused, resolved path required to stay inside the ledger root.
-- **Not `/tmp`, not the scratch dir.** Scratch (`KIROCREW_SCRATCH`) is keyed to
-  process liveness and swept hourly once the owner process group dies; a ledger
-  must survive gateway restarts for as long as its session exists.
-- **Tab close keeps the ledger.** Closing a dashboard tab
-  (`api_chat_slot_delete`) deliberately preserves resumable session state, and
-  the ledger is part of that state.
-- **History deletion reaps the ledger.** Both permanent-delete endpoints
-  (`DELETE /api/sessions/{key}` and the bulk `DELETE /api/sessions`) funnel
-  through `_remove_slot_for_history_key`; the ledger purge runs at the END of
-  that funnel — after the slot's turn is cancelled and its session destroyed —
-  so an in-flight write from the dying turn cannot land after the purge. A
-  write racing in from another process can at worst recreate an orphan
-  directory that the next delete sweeps; ledger content is disposable
-  intermediate state, so that residue is accepted rather than buying a
-  tombstone protocol for data nothing reconstructs from.
+`session_ledger.record()` creates the directory and writes `state.json` atomically. `session_ledger._locked()` keeps the lock file separate from the replaced state file, so replacing state cannot let concurrent writers lock different inodes.
 
-## 4. Data model
+`session_ledger.ledger_key()` removes only dashboard namespace and prefix spellings before storage. `session_ledger._store_name()` combines a readable fold with a digest of that exact key; `test_distinct_channel_keys_never_share_a_ledger` guards against the lossy-fold collision that would otherwise let one channel session overwrite another. `session_ledger.ledger_dir()` rejects hostile raw keys and requires the resolved directory to remain below the ledger root, preventing traversal through a folded name.
 
-`state.json` is ONE document — the mutable state record carrying a bounded
-event tail — replaced atomically (`atomic_write`: temp file + rename) on every
-write. Schema-versioned; unknown fields preserved, defaults coerced forward on
-read; a malformed or oversized file is treated as absent, never fatal.
+Closing a dashboard tab preserves the ledger. Permanent history deletion calls `_remove_slot_for_history_key()` in `dashboard.handlers.sessions`; it cancels matching turns and destroys their sessions before calling `session_ledger.purge()` and `purge_matching()`. That ordering prevents a dying in-process turn from writing after the normal purge. `session_ledger.purge()` accepts that a cross-process race can recreate disposable orphan state; the next deletion sweep removes it.
 
-| Field | Type | Meaning |
-|---|---|---|
-| `schema` | int | record version, currently 1 |
-| `goal` | str | the binding objective of the workstream |
-| `phase` | str | current phase; free-form but see write discipline |
-| `next` | str | the resumable intent — a concrete next step, not a status word |
-| `tried` | list | `{approach, rejected_because, at}` — appended, never rewritten |
-| `artifacts` | dict | string-to-string pointers: worktree, branch, pr, paths |
-| `events` | list | bounded tail of `{ts, kind, text}` progress lines, oldest aged out |
-| `created_at` / `last_progress_at` / `finished_at` | str | ISO timestamps |
+## 3. State record and bounded writes
 
-### Write discipline (carried over from the crew ledger)
+`session_ledger._empty_state()` defines the state fields:
 
-- A `phase` change **requires** an event (`event` + a recognized `event_kind`)
-  in the same call. Because state and event land in the same atomic write,
-  the invariant is crash-atomic by construction: no failure between "phase
-  moved" and "event logged" can exist.
-- Every field is clamped at write time and the event tail is bounded, so the
-  document cannot grow without limit and every read is O(record), never
-  O(history).
-- `last_progress_at` advances on every accepted record call; `finished_at` is
-  set when `phase` enters a terminal value (`done`, `abandoned`).
-- Fields omitted from a record call keep their stored values: partial updates
-  are the norm and never a way to erase state.
-- Writes hold a per-ledger cross-process file lock with a **bounded** acquire:
-  a wedged holder costs one refused write (surfaced as a retryable error),
-  never a worker thread parked forever. Reads are lock-free — the atomic
-  replace means a reader sees the old or the new document, never a torn one,
-  and state + events always come from one transaction.
+| Field | Meaning |
+|---|---|
+| `schema` | stored schema marker |
+| `goal` | binding objective |
+| `phase` | current free-form work phase |
+| `next` | concrete resumable intent |
+| `tried` | rejected approaches with their reason and timestamp |
+| `artifacts` | string pointers to work artifacts |
+| `events` | recent classified progress entries |
+| timestamps | creation, latest progress, and terminal-completion time |
 
-## 5. MCP tools
+`session_ledger._coerce_state()` supplies defaults for malformed known fields and preserves unknown fields for forward compatibility. `session_ledger._read_state_unlocked()` treats unreadable, malformed, undecodable, or oversized state as empty rather than failing a turn. `test_read_state_malformed_oversized_or_undecodable_reads_empty` pins that behavior.
 
-Registered as a core domain module (`mcp_tools/ledger.py`, listed in
-`DOMAIN_MODULES`), following the `learn.py` template: `schemas()` + `HANDLERS`,
-handlers reach the gateway over the loopback HTTP API with the session-resolved
-identity header. There is no slot-key argument — the backend resolves the
-calling session and refuses requests that carry no session identity, exactly
-like the Issue Radar crew routes (raw HTTP gets 403).
+`session_ledger.record()` applies partial updates. Omitted fields retain their stored value; artifact updates merge with the stored map; a supplied rejected approach appends to `tried`; and a nonblank event appends to `events`. `test_record_roundtrip_and_partial_update`, `test_artifacts_merge_and_clamp`, `test_tried_appends_and_caps`, and `test_events_tail_bounded` pin the retention and aging rules. The bounds keep a resumed session from accumulating unbounded durable context.
 
-- `session_ledger_read` — no arguments. Returns the state record plus the tail
-  of the event log. The tool description tells the agent this is its own
-  session's durable work state.
-- `session_ledger_record` — `goal?`, `phase?`, `next?`, `tried_approach?` +
-  `tried_rejected_because?`, `artifacts?` (string map, merged), `event?` +
-  `event_kind?`. Enforces the phase/event rule server-side.
+Every accepted record advances `last_progress_at`. Changing `phase` requires a nonblank event and a recognized event kind. `session_ledger.record()` writes the phase and its event in one atomic state document, so a crash cannot expose a phase move without its classified reason; `test_phase_and_event_land_in_one_document` enforces this load-bearing audit trail. A phase in `session_ledger.TERMINAL_PHASES` stamps `finished_at`; a later non-terminal phase clears it, as guarded by `test_terminal_phase_sets_finished_at_and_reopening_clears_it`.
 
-Subagent, cron, and channel sessions may call the tools; each writes the ledger
-of its own session key. The primitive is deliberately session-scoped — there is
-no cross-session read, which keeps the authorization story trivial.
+`session_ledger._serialize_bounded()` evicts oldest history before an accepted state file can exceed the reader ceiling. `test_writer_guarantees_the_read_ceiling_for_legitimate_records` ensures a valid record remains readable, and `test_oversized_unknown_fields_are_dropped_not_self_corrupting` ensures oversized forward-compatible fields do not destroy known state.
 
-## 6. Auto-nudge snapshot injection
+Writes use the bounded exclusive lock in `session_ledger._locked()`. Contention raises `OSError` rather than allowing an unserialized write or indefinitely blocking a worker; `test_record_fails_closed_on_held_lock` enforces this. Reads are lock-free because `atomic_write` exposes either the previous or complete replacement document, so the state and event tail come from one transaction.
 
-`compose_nudge_body` (`dashboard/handlers/autonudge.py`) is the single
-composer used by all three fire callbacks (dashboard slot, Slack thread,
-Discord DM). When the loop's session has a ledger with a non-empty,
-non-terminal state record, the rendered body is prefixed with a bounded
-`[work ledger]` block — goal, phase, next, the last few tried entries,
-artifacts — capped in size so a runaway ledger cannot flood the turn. The
-ledger read runs in a worker thread: a slow or wedged filesystem costs one
-loop's snapshot, never the gateway event loop.
+## 4. MCP surface and authorization
 
-No MCP schema or directive plumbing changes: the snapshot is derived
-server-side at fire time from the session key the loop already carries. Loops
-on sessions without a ledger render exactly as before. Cron and heartbeat
-composers are intentionally untouched — heartbeat is stateless-per-cycle by
-design, and cron sessions can call `session_ledger_read` themselves.
+`mcp_tools.__init__.DOMAIN_MODULES` registers `mcp_tools.ledger`. `session_ledger_read` has no arguments and returns the calling session's state and recent event tail. `session_ledger_record` accepts only optional state fields; `validation.SESSION_LEDGER_RECORD_SCHEMA` validates their types and lengths, while `session_ledger.record()` enforces the conditional phase/event rule.
 
-## 7. Non-goals
+`mcp_tools.ledger._strict_session_key()` obtains a gateway-authored session identity before either tool calls the loopback routes. This is load-bearing because the lenient resolver can walk a subagent process tree to its parent; rejecting an unverified identity prevents a subagent from reading or overwriting the parent's ledger. `test_mcp_tools_refuse_without_strict_identity` and `test_mcp_tools_pass_the_verified_key_to_transport` enforce that boundary.
 
-- **Compaction.** Owned by the agent harness (ACP/kiro-cli); this feature
-  reduces what compaction can lose, it does not change how compaction works.
-- **Turn-internal durability / operation log.** Journaling tool calls with
-  stable operation ids so an interrupted turn can resume without re-executing
-  side effects is a separate, finer-grained track. This ledger records state
-  *between* wakes, not execution *within* a turn.
-- **Multi-writer arbitration / fenced leases.** One gateway process owns a
-  session's turns; concurrent cross-process writes to the same ledger are
-  serialized by the file lock. There is no takeover semantic to protect, so
-  version-fenced execution tokens would be complexity without a customer.
-- **UI.** No dashboard surface in this iteration; the ledger is agent-facing.
+`dashboard.handlers.session_ledger._resolve_ledger_key()` derives storage identity from the recognized `X-Session-Key`, never the request body. The routes reject missing or unrecognized identities and restricted session modes, so a request can read or write only its own durable ledger. `api_session_ledger_record()` sends bounded-lock failures back as retryable service errors and validates that artifact maps contain only strings. `test_route_refuses_unrecognized_session`, `test_route_refuses_restricted_session`, and `test_route_rejects_non_string_artifacts` cover those boundaries.
 
-## 8. Failure modes
+## 5. Auto-nudge injection
 
-- Ledger read/parse failure, or a state file past the size ceiling → treated
-  as absent; tools report empty state; nudge injection skips the block. Never
-  blocks the loop or the turn.
-- Lock contention → the acquire is a bounded poll; on expiry the record call
-  fails closed with a retryable error. Nudge-time reads are lock-free and
-  never wait on a writer.
-- Session deleted while a loop still points at it → purge wins; subsequent
-  reads see an empty ledger. A cross-process write racing the purge can
-  recreate an orphan directory, which the next delete sweeps — accepted for
-  disposable state (§3).
+`dashboard.handlers.autonudge.compose_nudge_body()` renders the normal nudge body, then reads `render_snapshot()` in a worker thread. A nonempty, non-terminal ledger snapshot prefixes the nudge; an absent ledger, terminal phase, or snapshot exception leaves the nudge body unchanged. `test_compose_nudge_body_prefixes_snapshot`, `test_compose_nudge_body_unchanged_without_ledger`, and `test_compose_nudge_body_survives_snapshot_failure` enforce those outcomes.
+
+`session_ledger.render_snapshot()` includes current goal, phase, next step, recent rejected approaches, and artifact pointers, and applies its own rendering bounds. It omits terminal records because completed work provides no next-cycle steering; `test_snapshot_empty_without_ledger_or_when_terminal` and `test_snapshot_contains_state_and_is_capped` guard this behavior.
+
+Every `_fire_*_nudge` adapter in `slack.gateway` calls `compose_nudge_body()`, including the messaging and dashboard transports. `test_gateway_fire_callbacks_use_the_composer` enumerates adapters rather than pinning their count, so a new transport cannot silently bypass the ledger snapshot.
+
+## 6. Failure behavior and scope
+
+A read failure yields an empty ledger. A write lock failure is retryable. Permanent deletion removes matching ledger directories, while the documented cross-process race may leave only disposable orphan state for the next sweep. Snapshot failures are best-effort and never prevent the nudge from firing.
+
+The ledger does not journal individual tool operations, arbitrate execution ownership with leases, or add a dashboard UI. It records state between wakes; the MCP tools and nudge composer are its public surfaces.

--- a/docs/system-specs/features/turn-complete-chime.md
+++ b/docs/system-specs/features/turn-complete-chime.md
@@ -1,28 +1,26 @@
 # Turn-Complete Chime
 
-When the agent finishes a turn, the dashboard plays a notification sound.
+When the dashboard receives an eligible `chat_done` WebSocket event, it dispatches a frontend turn-sound event. `useNotificationSound()` turns that event into audio only when the current sound settings and browser audio state permit playback.
 
 ## Policy
 
-Every real turn completion chimes — active chat or background, focused window or not. A turn completion (`chat_done` WS event) plays a sound when:
+`notificationEvent.ts:shouldChimeOnTurnDone()` accepts a slot-bearing event while `reconnecting` is false. `notificationEvent.test.ts` pins both exclusions: slot-less events and events received while the reconnect catch-up flag is set. These gates are load-bearing because they keep malformed events and reconnect replay from creating extra sound requests.
 
-- the event carries a `slot` (slot-less events have no real turn behind them), and
-- the client is not in reconnect catch-up replay (`reconnectingRef`, same suppression as `markSlotUnread`) — stale completions replayed on reconnect must not chime-storm; the unread badges already cover them.
-
-Users who want silence set the "Agent replies" category to Silent (or use the main enable toggle).
-
-The decision is the pure function `shouldChimeOnTurnDone()` in `website/src/hooks/notificationEvent.ts`, unit-tested in `website/src/test/notificationEvent.test.ts`.
+The policy does not inspect the active slot, document focus, or tab visibility. It also does not inspect a completion outcome: every slot-bearing `chat_done` event that passes the reconnect gate requests the turn sound, including a terminal event emitted by a stop or cancellation path.
 
 ## Wiring
 
-Sound-only path. No Redux notification, no toast, no badge, no feed entry:
+- The backend emits `chat_done` with a `slot` from terminal chat paths, including `chat_runner.py`, `chat_orchestrator.py`, and `chat_handlers.py`.
+- `useWebSocket.ts` passes the event slot and `reconnectingRef.current` to `shouldChimeOnTurnDone()`. When it returns true, the handler calls `notificationEvent.ts:dispatchMcNotification(TURN_DONE_KIND)`.
+- `dispatchMcNotification()` emits `MC_NOTIFICATION_EVENT` with the frontend-only `turn` kind and contains listener failures so a sound listener cannot interrupt WebSocket handling.
+- `App.tsx` mounts `useNotificationSound()` application-wide. Its listener resolves the `turn` category through `useNotificationSound.ts:presetForKind()`: an explicit `turn` preset wins, otherwise the `all` preset supplies the fallback. `notificationEvent.test.ts` and `useNotificationSound.test.ts` pin the category and fallback behavior.
+- `useNotificationSound()` suppresses playback when sounds are disabled, volume is silent, or the selected preset is Silent. It also coalesces closely spaced audible notification events; `useNotificationSound.test.ts` pins that cooldown behavior. This prevents completion bursts from stacking audio.
+- `ThemeExperienceLayer.tsx` also observes `MC_NOTIFICATION_EVENT`. An enabled, consented theme with a `notification` audio trigger can play its manifest sound for the same turn event.
+- `NotificationsPanel.tsx` exposes the localized **Agent replies** row for the `turn` category, including preset overrides and Silent. Its main sound toggle and volume control apply to this category.
 
-- `useWebSocket.ts` `chat_done` handler dispatches the window event `MC_NOTIFICATION_EVENT` with `kind: TURN_DONE_KIND` (`'turn'`) when the policy passes.
-- `useNotificationSound.ts` (already mounted app-wide) resolves the preset via the `turn` category. `'turn'` is a member of `SOUND_CATEGORIES`; with no per-category override it falls back to the `all` default (chime). Its existing 300 ms rate-limit dedupes bursts (e.g. several sessions finishing together).
-- Settings: Notifications panel row "Agent replies" — per-category preset override incl. Silent, same chrome as other categories. The main enable toggle and volume slider apply.
+The chime branch does not add a notification-feed record or create a native OS notification. The surrounding `chat_done` handler still performs ordinary completion work, including marking a background slot unread; that badge behavior is separate from the sound event.
 
 ## Non-goals
 
-- Native OS banner for turn completion (feed/banner behavior is owned by the notification bus; this feature is a sound cue only).
-- Backend involvement: the `turn` kind is synthesized in the frontend and never appears in the notifications feed or `~/.kiro/crew` state.
-- Attention gating (hidden tab / unfocused window / background-slot heuristics): the chime is an unconditional audible cue for any finished session; per-user silence lives in the sound settings, not in focus heuristics.
+- A dedicated backend notification kind or persisted turn-notification record. The backend supplies `chat_done`; `notificationEvent.ts` synthesizes `TURN_DONE_KIND` in the frontend, and `useNotificationSound.ts` documents it as sound-only rather than a feed kind.
+- Focus or visibility gating. The policy intentionally requests the sound event for active and background slots alike; users control audible playback through sound settings, while the listener's cooldown limits bursts.

--- a/docs/system-specs/features/turn-stats-footer.md
+++ b/docs/system-specs/features/turn-stats-footer.md
@@ -1,78 +1,54 @@
-# Per-Turn Stats Footer (Elapsed Time + Credits) — Design Document
+# Per-Turn Stats Footer (Elapsed Time + Credits)
 
 ## Overview
 
-kiro-cli natively prints an end-of-turn line with elapsed time and credits used; the dashboard chat previously showed neither. This feature attaches per-turn stats (`elapsed_ms`, `credits`, `cost_usd`) to the final assistant message of each completed turn and renders them as an always-visible muted footer line under that message — parity with the CLI.
+The dashboard persists per-turn measurement metadata on an assistant message and renders it as a muted footer when that message is the completed turn's final assistant message. `chat_runner._attach_turn_stats` keeps the metadata on the message before persistence, so the `chat_done` refresh can restore the same footer after reconnects.
 
 ## Data flow
 
 ```
-kiro-cli meteringUsage (unit=="credit")           claude_code result payload
-        │ (acp/_dispatch.py accumulates)                  │ (duration_ms, cost_usd)
-        ▼                                                 ▼
-TurnUsage on EVENT_COMPLETE  ──►  chat_runner captures _turn_elapsed_ms /
-                                  _turn_credits / _turn_cost_usd
-                                          │
-                                          ▼
-                     _attach_turn_stats(slot, …)  →  meta["turn_stats"] on the
-                     last assistant message (before _save_slot_to_history)
-                                          │
-                                          ▼
-                     chat_done WS → frontend refreshSlot re-fetch → meta arrives
-                                          │
-                                          ▼
-                     AssistantMessage renders the stats line (showFooter only)
+ACP metadata / provider usage
+        │
+        ▼
+TurnUsage on EVENT_COMPLETE
+        │
+        ▼
+chat_runner captures elapsed, credits, cost, and model
+        │
+        ▼
+_attach_turn_stats(slot, ...) → meta["turn_stats"] on a current-turn assistant message
+        │
+        ▼
+chat_done → refreshSlot → persisted metadata
+        │
+        ▼
+AssistantMessage renders the footer when its presentation gates permit it
 ```
 
 ## Backend (`src/kiro_crew/dashboard/chat_runner.py`)
 
-- **Turn start stamp**: `_turn_t0 = time.monotonic()` is recorded immediately before the event-stream loop of each turn.
-- **Capture at `EVENT_COMPLETE`**: `_turn_elapsed_ms` prefers the provider-reported `TurnUsage.duration_ms` (claude_code fills it; kiro/acp reports 0) and falls back to local wall clock. `_turn_credits` is kiro-cli's per-turn `meteringUsage` sum; `_turn_cost_usd` is claude_code's API-reported cost; `_turn_model` is `read_turn_model(client)` (see Model attribution).
-- **`_attach_turn_stats(slot, elapsed_ms, credits, cost_usd, turn_boundary)`**: mirrors `_flush_file_changes` — walks `slot.messages[turn_boundary:]` backwards and sets `meta["turn_stats"]` on the last assistant message. `turn_boundary` is `len(slot.messages)` captured at turn start, restricting the scan to messages appended during THIS turn — an error/refusal-only turn (no assistant message) therefore attaches nothing rather than overwriting the previous turn's stats. Runs in the `not _retrying_empty` post-turn block, *before* `_flush_file_changes` and `_save_slot_to_history`, so the meta both persists and reaches live tabs via the existing `chat_done` → `refreshSlot` re-fetch (no new WS event).
+`_run_chat` captures a monotonic start time and message boundary at turn start. On `EVENT_COMPLETE`, it prefers `TurnUsage.duration_ms` when present and otherwise measures elapsed time locally; it reads credits and cost from `TurnUsage` and calls `read_turn_model(client)`. ACP credit telemetry is accumulated from `meteringUsage` entries whose unit is `credit` by `acp.client.AcpClient._track_metadata`; `acp._dispatch.parse_metadata` applies the same unit filter for the shared dispatch path.
 
-### Meta contract
+`_attach_turn_stats(slot, elapsed_ms, credits, cost_usd, turn_boundary, model)` writes `meta["turn_stats"]` on the last assistant message appended at or after `turn_boundary`. `TestAttachTurnStats.test_error_only_turn_does_not_overwrite_previous_turn` and `test_boundary_scopes_to_current_turn_assistant` enforce this boundary: without it, an error-only turn could overwrite the prior turn's measurement. The helper does not fabricate a message, and it returns without a positive elapsed measurement. The post-turn persistence block skips the helper for `_retrying_empty` turns.
 
-```json
-"turn_stats": { "elapsed_ms": 84210, "credits": 2.5, "cost_usd": 0.0231, "model": "claude-sonnet-4.6" }
-```
-
-| Field | Presence | Meaning |
-|-------|----------|---------|
-| `elapsed_ms` | always (> 0) | Turn wall clock (provider duration preferred) |
-| `credits` | only when > 0 (rounded to 4 dp) | kiro per-turn credit spend |
-| `cost_usd` | only when > 0 (rounded to 6 dp) | claude_code API cost |
-| `model` | only when non-empty | What served the turn: a resolved id, or the bare `auto` |
+The helper preserves pre-existing `meta`, always records a positive `elapsed_ms`, and omits non-positive credits, cost, and empty model values. `TestAttachTurnStats.test_credits_rounded` pins credit precision; `test_preserves_existing_meta`, `test_zero_credits_key_omitted`, `test_zero_cost_key_omitted`, and `test_model_omitted_when_unattributable` pin the remaining contract.
 
 ### Model attribution
 
-`read_turn_model` (`dashboard/handlers/usage.py`) answers "what served this turn" in three states, and the distinction between the last two is the point:
+`dashboard.handlers.usage.read_turn_model` returns a concrete resolved model identifier when one is available, the `auto` sentinel for an Auto request without a resolved identifier, or an empty string when neither is known. `TestReadTurnModel` enforces the precedence and the unattributable case. The sentinel distinguishes an explicit Auto selection from absent attribution; callers that need a concrete identifier for pricing or context-window lookup use `read_effective_model` instead.
 
-| State | Value | When |
-|-------|-------|------|
-| Resolved | e.g. `global.anthropic.claude-opus-4-8[1m]` | A concrete id reached the provider chain (`_resolved_model_id`, else `_model`) |
-| Auto | `auto` | The session is on Auto and the backend disclosed no id for the turn |
-| Unattributable | `""` (key omitted) | No model information at all |
+## Frontend
 
-Auto is reported as the bare sentinel rather than collapsed into the empty state because a blank footer is indistinguishable from a turn with no measurement, which reads as a broken footer rather than as "the backend chose". It is never presented as a model id.
+`website/src/pages/ChatPage.tsx` passes `m.meta.turn_stats` to `AssistantMessage` only when `ChatConfig.showTurnStats` is true. `ChatSettings.loadChatConfig` defaults and repairs that persisted setting as enabled under `mc-chat-config`; `ChatPanel` does not currently expose a control for it. `website/src/app-sdk/messageRenderers.tsx` separately forwards `turn_stats` without consulting `ChatConfig`.
 
-Auto's per-turn choice is not on the ACP wire — the `_kiro.dev/metadata` frame carries `contextUsagePercentage` and `meteringUsage` only, and `currentModelId` is session-scoped (`session/new` / `session/load`), which `set_model("auto")` then overwrites with the sentinel. So `auto` is the whole of what can be said truthfully; disclosing which model Auto picked requires the backend to report it per turn.
+`website/src/pages/chat/AssistantMessage.tsx` renders the footer only when the message is not streaming, `showFooter` is true, and `turnStats.elapsed_ms` is positive. `ChatPage` computes `showFooter` for the last assistant message before a user message or, at the end of the transcript, after the slot is no longer running. Together with the backend boundary, these gates prevent an in-progress or earlier assistant segment from presenting the completed-turn footer.
 
-`read_effective_model` remains the reader for pricing and context-window lookups, where the sentinel is not a usable key.
-
-Edge cases: no attach when `elapsed_ms <= 0` (turn never reached `EVENT_COMPLETE`); no synthetic message is fabricated and no earlier turn is touched when a turn produced no assistant message (error-only turns — enforced by `turn_boundary`). Empty-response re-queue turns skip attachment entirely (the whole post-turn block is skipped).
-
-## Frontend (`website/src/pages/chat/AssistantMessage.tsx`)
-
-- New `turnStats?: TurnStats` prop, passed from `ChatPage.tsx` via `m.meta.turn_stats` only when the persisted `ChatConfig.showTurnStats` setting is enabled.
-- **User control**: Chat Settings includes a `Show elapsed time and credits` switch. It defaults to enabled for existing/new users, persists in `mc-chat-config`, and hides only the presentation — collection and persistence continue so re-enabling restores stats on existing messages.
-- Rendered only on messages where `showFooter` is true (the last assistant message of each completed turn) and never while streaming — so exactly one stats line per turn.
-- Always visible (unlike the hover-revealed action footer): 11px muted mono line with a clock icon, e.g. `⏱ 1m 24s · 2.50 credits`. `cost_usd` renders as `· $0.02` only when credits are absent (providers bill in one or the other).
-- **Model chip**: `model` leads the line when present, trimmed by `fmtTurnModel` (drops region/vendor routing prefixes) for width; the untrimmed id stays in the footer tooltip. The `auto` sentinel passes through the trimmer verbatim and renders as `auto`.
-- Formatting: `fmtTurnElapsed` — `3.5s` under 10 s, `42s` under a minute, `2m 34s` beyond; `fmtCredits` — 2 decimals under 10, 1 above.
-- Messages persisted before this feature simply lack the meta and render nothing.
+The footer is visible rather than hover-revealed, uses muted tabular numerals, and places a clock beside elapsed time. Only the optional model label uses the monospace face; `messageFooterFont.test.tsx` protects the footer-level font-setting contract. It displays credits when positive and otherwise displays positive dollar cost; elapsed time always follows the billed value. `fmtTurnModel` trims known routing prefixes for the inline label while the title retains the untrimmed model identifier. `fmtTurnElapsed`, `fmtCredits`, and their formatter tests in `AssistantMessage.test.tsx` pin the display rules. Missing `turn_stats`, `showFooter=false`, and streaming messages render no stats footer.
 
 ## Tests
 
-- `test/test_turn_stats.py` — attach/omit semantics, last-assistant targeting, rounding, meta coexistence with `file_changes`, and the binding that keeps the footer on the auto-aware model reader.
-- `test/test_usage.py` (`TestReadTurnModel`) — the three attribution states.
-- `website/src/test/AssistantMessage.test.tsx` (`turn stats footer` suite) — render variants (credits / cost / elapsed-only / model / `auto`), hidden while streaming / `showFooter=false` / missing meta, formatter contracts.
+- `test/test_turn_stats.py` (`TestAttachTurnStats`) covers attachment, omission, rounding, current-turn targeting, model attribution, and meta coexistence.
+- `test/test_usage.py` (`TestReadTurnModel`) covers resolved, Auto, and unattributable model states.
+- `website/src/test/AssistantMessage.test.tsx` (`turn stats footer`) covers rendering, ordering, model display, suppression gates, and formatters.
+- `website/src/test/ChatSettings.test.tsx` covers the persisted `showTurnStats` default and validation.
+- `website/src/test/messageFooterFont.test.tsx` verifies that the footer follows the configured font family.

--- a/docs/system-specs/features/voice-streaming.md
+++ b/docs/system-specs/features/voice-streaming.md
@@ -1,230 +1,123 @@
-# Voice Streaming — Design Document
+# Voice Streaming
 
 ## Overview
 
-Real-time text-to-speech for dashboard chat responses. Two providers: **Piper**
-(local, offline, the default — no AWS needed) and **Amazon Polly** (cloud). For
-Polly, voice playback starts as soon as the first sentence finishes streaming —
-no waiting for the full response. Piper produces a single local clip delivered
-whole. Sending a new message interrupts playback immediately.
+Dashboard text-to-speech has two providers: local Piper and Amazon Polly.
+`voice_reply.DEFAULT_PROVIDER` selects Piper unless configuration selects a valid
+provider. `chat_voice.api_voice_synthesize()` sends Piper output as one WAV
+chunk and streams Polly sentence chunks as MP3; the browser queues either form
+for sequential playback.
 
-## Architecture
+## Components
 
-```
-Polly:  chat_chunk (WS) → sentence detection (frontend) → POST /api/voice/synthesize
-    → Polly TTS (per sentence) → voice_chunk (WS) → Audio playback (browser)
-Piper:  POST /api/voice/synthesize → synthesize_speech() one WAV
-    → single voice_chunk + voice_complete (WS) → Audio playback (browser)
-```
+| Component | Code | Responsibility |
+|---|---|---|
+| Dashboard routes | `dashboard.routes.sessions.register()` | Registers the synthesis, configuration, and Polly voice-catalogue endpoints. |
+| Voice endpoints | `dashboard.chat_voice.api_voice_config()`, `api_voice_synthesize()`, and `api_voice_voices()` | Read and persist configuration, synthesize dashboard speech, and return the Polly catalogue. |
+| Provider implementation | `voice_reply.synthesize_speech()`, `streaming_voice_reply()`, and `stitch_mp3s()` | Redacts text, selects a provider, creates audio, and joins completed Polly chunks. |
+| Streaming playback | `website/src/hooks/useWebSocket.ts` | Detects completed sentences, serializes synthesis requests, queues audio, and handles interruption. |
+| Settings | `website/src/pages/settings/VoicePanel.tsx` | Updates auto-speak, provider, Polly, and Piper settings; fetches the Polly catalogue only while Polly is selected. |
+| Slack reply | `slack.handler.handle_message()` and `_safe_voice_reply()` | Starts a background provider-aware voice reply when thread, global, or voice-input settings allow it. |
 
-### Components
+## Dashboard auto-speak
 
-| Component | File | Role |
-|-----------|------|------|
-| Sentence detector | `website/src/hooks/useWebSocket.ts` | Watches streaming chunks for sentence boundaries |
-| Playback queue | `website/src/hooks/useWebSocket.ts` | Queues and plays audio chunks sequentially |
-| Synthesize endpoint | `src/kiro_crew/dashboard/chat_voice.py` | `POST /api/voice/synthesize` — Polly: splits text into sentences + broadcasts chunks; Piper: `_synthesize_nonstreaming()` emits one clip (re-exported via `chat.py`) |
-| Voice config endpoint | `src/kiro_crew/dashboard/chat_voice.py` | `GET/PUT /api/voice/config` — read/update voice settings incl. `provider` + `piper_*` (re-exported via `chat.py`) |
-| TTS synthesis | `src/kiro_crew/voice_reply.py` | `synthesize_speech()` provider dispatcher (Polly `aws polly` / local `piper`), `streaming_voice_reply()` (Polly-only), `validate_length_scale()`, `stitch_mp3s()` |
-| Settings UI | `website/src/pages/settings/VoicePanel.tsx` | Provider selector + auto-speak toggle; Polly fields (voice/engine/speed/profile/region) or Piper fields (model/binary/speed) |
+`useWebSocket` buffers `chat_chunk` text and, after it updates the Redux
+streaming message, scans the active slot for completed sentence boundaries. It
+submits only text beyond `voiceProgressRef.spokenLen` through
+`enqueueVoiceSynthesis()`. The progress record is keyed by slot and message
+identity: this prevents an old segment or a background slot from replaying text
+or resetting the active response.
 
-## Streaming Auto-Speak Flow
+`flushVoiceTail()` handles the remaining eligible text at `chat_segment` and
+`chat_done`. It marks the message consumed even when the tail does not meet the
+speech floor, so a later completion event cannot retry it. The floor and
+boundary rule are implemented in `useWebSocket.ts`; they are not duplicated
+here.
 
-1. User sends a message; `voiceProgressRef` clears its prior message identity
-2. Backend streams `chat_chunk` events via WebSocket
-3. Frontend accumulates text in a `streaming` message in Redux
-4. On each chunk, regex scans for sentence boundaries (`[.!?]` followed by whitespace)
-5. New complete sentences (≥10 chars) are sent to `POST /api/voice/synthesize`
-6. Backend calls Polly per sentence, broadcasts `voice_chunk` (base64 MP3) via WS
-7. Frontend decodes chunks into blob URLs, queues them, plays sequentially
-8. On `chat_segment` or `chat_done`, any remaining unspoken tail text is synthesized before finalization
-9. `voice_complete` event carries the stitched full MP3 for replay
+`enqueueVoiceSynthesis()` appends each request to `synthChainRef`. This keeps
+requests in source order even if a provider finishes them out of order, which is
+load-bearing because the playback queue cannot reconstruct the intended
+sentence order after receiving audio.
 
-## Interrupt Mechanism
+For Polly, `api_voice_synthesize()` iterates
+`voice_reply.streaming_voice_reply()`, broadcasts each `voice_chunk`, then
+uses `stitch_mp3s()` to broadcast `voice_complete`. For Piper,
+`_synthesize_nonstreaming()` broadcasts one WAV `voice_chunk` and one
+`voice_complete`. `useWebSocket` decodes `voice_chunk` audio into blob URLs and
+plays the queue one item at a time. `voice_complete` also updates the Redux
+`voiceAudio` field; `UseWebSocketCoverage.test.tsx` covers that state update.
 
-Sending a new message while voice is playing triggers an interrupt:
+## Interruption
 
-1. `ChatPage.tsx` dispatches a `voice-stop` DOM event on send
-2. `useWebSocket` listens for `voice-stop` and calls `stopVoice()`
-3. `stopVoice()` pauses the active `Audio` element, clears the queue, and sets `voiceMutedRef = true`
-4. Incoming `voice_chunk` events from the old response are dropped while muted
-5. `chat_done` for the old response skips remaining-text synthesis when muted
-6. When a new response message identity is observed, `voiceMutedRef` resets to `false`
+`ChatPage` dispatches `voice-stop` when it sends a message, and its Speak
+handler dispatches the same event while audio is playing. `useWebSocket` maps
+the event to `stopVoice()`, which pauses the active audio element, revokes
+queued blob URLs, clears the queue, and sets `voiceMutedRef`.
 
-The DOM event pattern avoids prop drilling between `ChatPage` (where send lives) and `useWebSocket` (where audio state lives, called from `App.tsx`).
+While muted, `voice_chunk` frames are discarded and the `chat_segment`/
+`chat_done` tail paths do not synthesize more text. `voiceProgressFor()` clears
+the muted state only when it sees a different message identity. This identity
+boundary is load-bearing: it prevents late audio from an interrupted response
+from being played as though it belonged to the next response.
 
-## Voice Configuration
+## Configuration and API
 
-Stored in `~/.kiro/crew/config.json` under `voice_reply`:
+Configuration is stored under `voice_reply` in the Crew configuration file.
+`slack.handler.load_voice_reply_config()` loads the live `_VoiceConfig`, and
+`api_voice_config()` merges a partial update back into that section rather than
+replacing it. The merge preserves voice settings owned by other channels.
 
-| Setting | Default | Range |
-|---------|---------|-------|
-| `provider` | piper | `piper` (local) or `polly` (AWS). An unrecognized value falls back to `voice_reply.DEFAULT_PROVIDER`, which is `piper`: the fallback has to be the local one, because reaching for a paid AWS service is not a choice a typo may make on the operator's behalf |
-| `voice_id` | Ruth | Any Polly voice ID (Polly only) |
-| `engine` | generative | generative, neural, long-form, standard (Polly only) |
-| `rate` | 100% | 50%–200% (Polly only) |
-| `pitch` | +0% | -20% to +20% (Polly only) |
-| `enabled` | true | Primary voice switch; gates Slack voice replies. Independent of `auto_speak` |
-| `auto_speak` | false | Dashboard auto-speak: speak each assistant reply automatically. Independent of `enabled` — the manual 🔊 Speak button works regardless of either flag |
-| `aws_profile` | _(empty)_ | AWS CLI profile name for Polly calls. Empty = use default credentials |
-| `region` | _(empty)_ | AWS region for Polly. Empty = use CLI default |
-| `piper_model` | _(empty)_ | Path to a Piper `.onnx` voice model. Required for Piper |
-| `piper_binary` | _(empty)_ | Path to the `piper` executable. Empty = auto-detect on PATH / `~/piper-venv/bin/piper` |
-| `piper_model_config` | _(empty)_ | Optional `.onnx.json` config (auto-detected next to the model if empty) |
-| `piper_length_scale` | 1.0 | Piper speed (lower = faster); coerced finite/positive by `validate_length_scale()` |
+| Setting | Meaning |
+|---|---|
+| `provider` | Validated by `voice_reply.synthesis_settings()` and `slack.handler.load_voice_reply_config()`; invalid values fall back to `voice_reply.DEFAULT_PROVIDER`. |
+| `enabled` | Enables global Slack voice replies. |
+| `auto_speak` | Enables dashboard auto-speak; `api_voice_config()` exposes it as `autoSpeak`. |
+| `voice_id`, `engine`, `rate`, `pitch` | Polly synthesis settings, also usable as request overrides for the dashboard synthesis endpoint. |
+| `aws_profile`, `region` | Passed to the AWS CLI by the Polly provider. |
+| `piper_binary`, `piper_model`, `piper_model_config`, `piper_length_scale` | Piper executable, model, optional model configuration, and validated speed setting. `validate_length_scale()` rejects invalid or non-positive values. |
 
-### AWS Authentication
+`dashboard.routes.sessions.register()` registers:
 
-Voice synthesis calls `aws polly synthesize-speech` via the AWS CLI. Credentials
-are resolved in standard AWS CLI order (env vars, default profile, instance role,
-etc.). To use a specific profile, set `aws_profile` in the config:
+* `GET` and `PUT /api/voice/config`
+* `POST /api/voice/synthesize`
+* `GET /api/voice/voices`
 
-```json
-{
-  "voice_reply": {
-    "enabled": true,
-    "aws_profile": "my-profile",
-    "region": "us-east-1"
-  }
-}
-```
+`api_voice_voices()` caches a successful Polly catalogue in process, sorts it by
+language code and name, and does not cache the empty result produced when the
+AWS CLI is unavailable. It checks that Polly is the active provider and that
+`aws_consent.refuse_and_log()` grants consent before it invokes
+`aws polly describe-voices`. Those gates keep a direct API request from
+silently using ambient AWS credentials for a provider the operator did not
+select or authorize.
 
-### Polly needs a recorded consent, not just credentials
+## Provider safety
 
-Polly is a paid service, so `_synthesize_polly` calls
-`aws_consent.refuse_and_log(SERVICE_POLLY, profile, region)` before it spends
-anything, and returns `None` when that refuses. The check is local and makes no
-AWS call of its own, because this path runs unattended (a Slack thread reply, an
-auto-reply to a voice memo, a scheduled job) and there is nobody present to
-prompt. `None` is the function's established "no audio" answer, so every caller
-already degrades to a text-only reply.
+`voice_reply.synthesize_speech()` redacts credentials and suspicious URLs before
+provider selection. `text_to_ssml()` and `strip_markdown()` then produce
+speakable text. `strip_markdown()` replaces fenced code, diff blocks, widgets,
+tables, path-like inline code, and links with spoken placeholders or labels and
+removes option markers, emoji, formatting markers, and diff hunk headers. The
+thresholds and pattern details remain in `voice_reply.strip_markdown()`.
 
-The grant is per profile, per region and per resolved account, and it lives in
-`aws_service_consent.json` under the data home rather than in `config.json`
-because it is an authorization: that file is on the read and write keystone floor,
-so the agent can neither read it nor grant itself permission to spend. An empty
-`aws_profile` is not "no account", it is the CLI's own credential chain, so the
-consent record pins whichever account that resolves to and the log names it.
+`_synthesize_polly()` calls `aws_consent.refuse_and_log()` before resolving or
+spawning the AWS CLI. It returns no audio when consent is absent, which lets its
+callers retain their text response rather than spending through an unattended
+path.
 
-### Sandbox requirement
+`_synthesize_polly()` and `_synthesize_piper()` run their commands through
+`wrap_argv_async(..., _prepare=wrap_argv)` and catch
+`SandboxUnavailableError` separately from provider failures. They log the
+sandbox error kind and its own message. The distinction is load-bearing because
+only the sandbox layer can distinguish a missing backend from transient
+pressure or an existing outer sandbox, and therefore provides the applicable
+remedy.
 
-Both synthesis paths spawn a subprocess (`aws polly synthesize-speech` /
-`piper`), and both route it through `sandbox.wrap_argv(mode="standard")` because
-the argv carries LLM-derived text. `wrap_argv` **fail-closes** where the host
-offers no OS sandbox backend — every Windows host, and Linux without user
-namespaces — so on those hosts synthesis returns `None` until the operator sets
-`agent.sandbox_allow_unsandboxed_exec` in `config.json`.
+## Slack voice replies
 
-That refusal arrives as the typed `SandboxUnavailableError` and is caught ahead
-of the generic handler in both `_synthesize_polly` and `_synthesize_piper`. The
-generic handler logs "Polly synthesis error" / "piper synthesis error" with a
-stack trace, which misreads as an AWS-credential or piper-model fault and sends
-the operator to the wrong place.
-
-Both handlers log `exc.kind` plus **`str(exc)`** — the remedy prose the sandbox
-layer selected — and never compose their own remedy text. Only `kind ==
-"no_backend"` names the `agent.sandbox_allow_unsandboxed_exec` opt-in;
-`"transient"` means momentary resource pressure where the caller must *not*
-advise disabling the sandbox, and `"foreign_sandbox"` means this host's sandbox
-works and the fix is a kiro-cli setting. A hardcoded remedy would give the wrong
-instruction for two of the three kinds.
-
-### API
-
-- `GET /api/voice/config` — returns current settings + `autoSpeak` flag (mirrors `auto_speak`, not `enabled`)
-- `PUT /api/voice/config` — update settings (partial patch), persists to config.json
-- `POST /api/voice/synthesize` — `{ slot, text, voice?, engine?, rate?, pitch? }`
-- `GET /api/voice/voices` — list available Polly voices via `aws polly
-  describe-voices` (respects `aws_profile`/`region`), cached in-process for 1
-  hour. Each entry: `{ id, name, language, languageCode, gender, engines }`,
-  sorted by `languageCode` then `name`. If the `aws` CLI is not resolvable on
-  the gateway's PATH (it is optional — the default Piper provider doesn't
-  need it), the endpoint returns `{ "voices": [] }` with a 200 instead of
-  erroring; the empty result is not cached, so the list recovers once `aws`
-  becomes available
-
-## Content Filtering for Speech
-
-`strip_markdown()` in `voice_reply.py` transforms response text into natural
-speakable content. Non-speakable elements are replaced with brief spoken
-placeholders so listeners know content exists without hearing raw syntax.
-
-| Content Type | Handling |
-|-------------|----------|
-| Fenced code blocks | Replaced with "(code block)" |
-| Diff blocks | Replaced with "(diff block)" |
-| `<mcwidget>` blocks | Replaced with "(widget)" |
-| Residual HTML/XML tags | Stripped (after Slack-link handling) |
-| Markdown tables | Replaced with "(table with N rows)" |
-| Long inline code (>30 chars or paths) | Replaced with "(file path)" |
-| Short inline code (≤30 chars, no `/`) | Kept as spoken text |
-| Bare URLs | Replaced with "(link)" |
-| Slack URLs `<url\|label>` | Kept label only |
-| Markdown links `[label](url)` | Kept label only |
-| `[OPTIONS: ...]` lines | Stripped silently |
-| Unicode emoji | Stripped silently |
-| Slack shortcodes (`:emoji:`) | Stripped silently |
-| Bold/italic/strikethrough markers | Stripped (text kept) |
-| Diff hunk headers (`@@`) | Stripped |
-
-## Segment Handling (Tool Call Boundaries)
-
-When the assistant calls a tool mid-response, the backend emits a `chat_segment`
-event that finalizes the current streaming message and starts a new one.
-
-The frontend keys `voiceProgressRef` by `{slot, messageId}`. Before
-`chat_segment` finalizes the current streaming message, it synthesizes any
-unspoken tail of at least 10 characters and marks that message consumed. The
-next segment receives a new message identity and therefore starts at offset 0.
-This also prevents a background slot's segment event from resetting speech
-progress for the active slot.
-
-## Synthesize Serialization
-
-Synthesize calls are chained via a promise (`synthChainRef`) to prevent
-out-of-order audio. Each `voiceSynthesize` call waits for the previous one to
-complete before firing. This guarantees `voice_chunk` events arrive in sentence
-order regardless of per-sentence Polly synthesis time. The chain resets on new
-user messages.
-
-## WebSocket Events
-
-| Event | Direction | Payload |
-|-------|-----------|---------|
-| `voice_chunk` | server → client | `{ slot, index, sentence, audio }` (base64 MP3) |
-| `voice_complete` | server → client | `{ slot, audio, chunks }` (stitched MP3) |
-
-## Slack Voice Reply
-
-Separate from dashboard streaming. Uses `!voice` commands in Slack threads:
-
-- `!voice on/off` — toggle voice replies per thread
-- `!voice <name>` — switch Polly voice (e.g., `!voice Matthew`)
-- `!voice engine <type>` — change engine
-- `!voice speed <percent>` — adjust speed
-- `!voice pitch <percent>` — adjust pitch
-
-Handler integration in `src/kiro_crew/slack/handler.py` with fire-and-forget
-async pipeline: markdown strip → SSML → Polly → Slack file upload.
-
-## Frontend State
-
-| Ref | Type | Purpose |
-|-----|------|---------|
-| `voiceQueueRef` | `string[]` | Blob URLs queued for playback |
-| `voicePlayingRef` | `boolean` | True while an Audio element is playing |
-| `activeAudioRef` | `HTMLAudioElement` | Currently playing audio (for pause on interrupt) |
-| `autoSpeakRef` | `boolean` | Cached auto-speak preference from server |
-| `voiceProgressRef` | `{ slot, messageId, spokenLen }` | Message-scoped character offset already sent to TTS |
-| `voiceMutedRef` | `boolean` | Suppresses incoming voice chunks after interrupt |
-| `synthChainRef` | `Promise` | Serializes synthesize calls to prevent out-of-order audio |
-
-Redux state in `chatSlice`:
-- `voicePlaying: boolean` — drives UI indicators
-- `voiceAudio: string | null` — base64 stitched MP3 for replay via the Speak button
-
-## Manual Replay
-
-The Speak button appears on hover over assistant messages ≥50 chars.
-Clicking it calls `api.voiceSynthesize(slot, content)` which streams the
-full message through the same pipeline. This works independently of auto-speak.
+`slack.handler` accepts `!voice` thread commands for enabling and disabling a
+thread, toggling global replies, and choosing a voice, engine, speed, or pitch.
+`handle_message()` starts `_safe_voice_reply()` as a background task when a
+thread or global setting enables replies, or when voice-input reply settings
+allow a transcribed voice message to receive audio. `_safe_voice_reply()` calls
+the provider-aware `voice_reply.voice_reply()` path, so Slack replies follow
+the selected provider rather than assuming Polly.

--- a/docs/system-specs/features/workflow-chat-cards.md
+++ b/docs/system-specs/features/workflow-chat-cards.md
@@ -1,83 +1,34 @@
 # Workflow Chat Cards
 
-## Problem
+## Behavior
 
-A dynamic workflow launched from chat (`workflow_run`) surfaces poorly at both
-ends of its lifecycle:
+Workflow launches and completions render as durable inline cards in chat. `ChatPage.tsx` renders them for the primary chat surface, and `transcriptRenderers.tsx::createTranscriptRenderers` registers the same cards for SDK transcript hosts. `TurnBlock.tsx` keeps those items outside collapsed tool and reasoning groups so a launch or completion remains available in either collapse mode.
 
-- **Launch:** the `workflow_run` tool call renders as a generic tool pill and is
-  folded into the collapsed "N tool calls" group — no persistent, scannable,
-  clickable anchor to the run's live state.
-- **Completion:** the injected completion event (see
-  `dashboard/workflow_inject.py`) dumps the entire result JSON inline as a wall
-  of text.
+### Launch card
 
-## Goal
+`website/src/pages/chat/WorkflowRunCard.tsx` renders a launch card only for a `tool` message whose persisted `meta.output` yields a run ID through `extractWorkflowRunId`; `isWorkflowRunTool` enforces the role check. The output contract originates in `src/kiro_crew/mcp_tools/workflows.py::workflow_run`, which returns a successful-launch message for definition, intent, and source launches.
 
-Give both lifecycle ends a persistent, clickable inline card in the chat flow
-that shows run state and opens the Workflows side panel — **render-only**, with
-no backend or persistence changes and no change to the agent-facing message
-content.
+The card reads the live entry from `chat.workflowRuns`. `website/src/hooks/useWebSocket.ts` folds workflow event frames into that slice and reconciles it with the workflow-runs API; `WorkflowRunCard` also uses `useRunSnapshot` when its live entry is not running. This makes the card useful both while a run is active and after an event frame was missed or the live entry has gone away.
 
-## Design
+The card sanitizes display text, switches to its own slot before opening the Workflows panel when rendered from a background pane, and dispatches `openActivityToTab('workflows')`. A finished run exposes the save-workflow flow; `WorkflowRunCard` requires a snapshot source before the library-promotion action is enabled.
 
-Frontend-only. Both cards are special-cased in `ChatPage.tsx` `renderMessage`
-and exempted from folding in `TurnBlock.tsx`; neither adds Redux/backend state.
+### Completion card
 
-### Components
+`src/kiro_crew/dashboard/workflow_inject.py::_summarize` creates the completion header, and `inject_workflow_result` appends it as an `assistant` message to the originating slot, broadcasts it to the live chat, and persists the same message for replay. The broadcast includes a workflow-result kind, while the durable message is an assistant row; the renderer therefore detects the persisted content rather than relying on an event kind.
 
-| Component | Renders for | Live source |
-|---|---|---|
-| `website/src/pages/chat/WorkflowRunCard.tsx` | a `workflow_run` tool message | `chat.workflowRuns[run_id]` (folded from `workflow_run_event` WS frames) — status / phase / last-log |
-| `website/src/pages/chat/WorkflowCompletionCard.tsx` | the injected `[Workflow completion event]` assistant message | header parsed from content; full result folded behind a "Show result" toggle |
+`website/src/pages/chat/WorkflowCompletionCard.tsx::parseWorkflowCompletion` parses the backend header and separates the display body. It removes the trailing agent-facing workflow-tool hint only from the rendered body; it does not mutate the message. The card sanitizes the workflow title, renders the body with `MarkdownRenderer`, starts with the completion body collapsed, and opens the Workflows panel through `openActivityToTab('workflows')`.
 
-Both open the Workflows side panel on click via
-`dispatch(openActivityToTab('workflows'))` (the same Redux path `/side` and
-approvals use, bridged into the `usePanelTabs` tab model by ChatPage). Header
-fields pass through `sanitizeLlmOutput`; the completion body renders through
-`MarkdownRenderer` (sanitized rehype pipeline).
+### Rendering invariants
 
-### Detection contract (content-based)
+**Parse-gated completion detection prevents data loss.** `isWorkflowCompletionMessage` accepts only an assistant message that `parseWorkflowCompletion` successfully parses. `ChatPage.tsx` and `transcriptRenderers.tsx` use that predicate before selecting `WorkflowCompletionCard`; an unparseable header therefore falls through to ordinary markdown instead of selecting a card that returns no content. `WorkflowCompletionCard.test.tsx` pins this fallback.
 
-Detection keys off message **content**, not the WS `kind` — the injected
-completion is persisted as a plain `assistant` message and the `kind` is dropped
-on persist, so content-matching is what survives a history reload. This creates
-a cross-layer contract with two backend strings:
+**Launch detection has the same fallback.** `WorkflowRunCard.tsx::extractWorkflowRunId` returns no ID when persisted tool output does not match the launch contract. `ChatPage.tsx` then renders the generic `ToolCallLine`, and `transcriptRenderers.tsx` does the same inside its launch renderer. This preserves the normal tool row while output is absent, malformed, or from another tool.
 
-| Frontend matcher | Backend source | Pinned by |
-|---|---|---|
-| `WF_RUN_ID_RE` = `` /Started workflow run `(wf_[A-Za-z0-9_]+)`/ `` | `mcp_core.py` `workflow_run` handler (both `source` and `intent` paths) | frontend unit test |
-| `WF_COMPLETION_RE` = ``/^\[Workflow completion event\]\nWorkflow `([^`]+)` \((wf_…)\) → \*\*([a-z]+)\*\*/`` | `workflow_inject.py` `_summarize` header | `test/test_workflows_inject.py::test_summary_header_format_is_pinned_for_frontend` |
-
-**Invariant — graceful degradation, never data loss.** Detection must be gated
-on a *successful parse*, not a loose prefix. `isWorkflowCompletionMessage`
-returns true only when `parseWorkflowCompletion` succeeds; otherwise the message
-falls through to normal markdown rendering (the pre-feature behavior). This
-prevents a card that renders `null` from swallowing a completion whose header
-doesn't parse (e.g. an unusual workflow name). The launch card likewise falls
-through to the generic `ToolCallLine` on a regex miss.
-
-Known follow-ups (tracked, not in this feature): (1) persist a structured
-marker (`meta.workflow_run_id` / a completion `kind`) so the frontend keys off
-data instead of prose, removing both regexes; (2) carry the `run_id` through
-panel-open so the panel focuses that specific run (mirroring
-`openActivityToTool`'s `focusToolCallId`).
-
-### TurnBlock fold exemption
-
-`TurnBlock.tsx` treats both cards as always-visible inline items (via
-`isWorkflowRunItem` / `isWorkflowCompletionItem`, added to `isVisibleInline`),
-so they are never folded into the collapsible tool-call / reasoning panes in
-either collapse mode, and the launch card does not inflate the "N tool calls"
-count.
+**Cards remain visible independently of turn folding.** `TurnBlock.tsx::isWorkflowRunItem` removes launch cards from the collapsed tool set, and `isWorkflowCompletionItem` includes completion cards in `isVisibleInline`. Without those classifications, the only chat anchor for a workflow lifecycle event can be hidden behind a turn disclosure.
 
 ## Tests
 
-- `website/src/test/WorkflowRunCard.test.tsx` — detection helpers, live status
-  render, intent fallback, click-opens-panel.
-- `website/src/test/WorkflowCompletionCard.test.tsx` — parse/detection incl. the
-  parse-gated fallback (prefix-but-unparseable is not detected) and newline-in-
-  name tolerance, compact render, collapsed-by-default, expand toggle,
-  click-opens-panel.
-- `test/test_workflows_inject.py::test_summary_header_format_is_pinned_for_frontend`
-  — pins the completion-header format the frontend depends on.
+- `website/src/test/WorkflowRunCard.test.tsx` covers launch detection, live-state and intent fallback rendering, panel opening, slot retargeting, and saving a finished workflow.
+- `website/src/test/WorkflowCompletionCard.test.tsx` covers parsing, parse-gated fallback, rendering disclosure, panel opening, and completion-body containment.
+- `website/src/test/transcriptRenderersRenderCov80.test.tsx` verifies that the shared transcript registry selects both cards and wraps their rows.
+- `test/test_workflows_inject.py::test_summary_header_format_is_pinned_for_frontend` pins the header emitted by `_summarize` for the completion parser.


### PR DESCRIPTION
Third batch of the spec audit. #6584 covered the 36 shipped product docs, #6643 covered 8 module specs, #6826 covered 5 feature specs plus `persistent-agent-channels.md`. This finishes `docs/system-specs/features/` — the remaining 14.

**Two of these are safety-relevant and are the part worth reading closely.** Both documented a protection the code does not provide.

## `aws-control.md` — promised a confirmation gate that is not there

The spec claimed all billable resources and access-granting shares require human confirmation. In fact:

| Operation | Confirmation |
|---|---|
| drive bootstrap | API-level preview-plus-confirm (`routes.py` `_handle_drive_bootstrap`, `confirm` is the only such parameter in the route set) |
| object / folder deletion | dashboard confirmation strip (`DrivePage.tsx`), **not** an API gate |
| upload, profile registration, library push, share creation, backup | **none** |

It also claimed every share can be revoked. `forget_share` removes only the local ledger entry; the presigned URL stays valid until expiry, and nothing rotates a credential or deletes the object. The rendered IAM policy is likewise never applied — `_handle_iam_policy` is a guarded GET.

The spec now states the guards that do exist (owner gating, restricted-session refusal, SEL audit on denied/error/success/refused, live identity and service consent, publish governance) and stops promising the one that does not. It also arrived carrying `Status: draft` with Problem / Product-shape sections, so it was a design document, not a spec.

## `code-approvers.md` — documented a mechanism that does not exist

It described a `CODE_APPROVERS.yaml` tier-routing system: T1/T2/T3 approval quotas, a designated-maintainer gate for "frozen memory modules", and a drift-validator test failing the build on pattern drift. None of it is in the repository — the only occurrence of that filename is `AGENTS.md:74`, listing it as an artifact that must never be re-added. The built-in app it documented ("Code Reviewer", with browse/revert/reset/SSE/fix-engine endpoints) is not what ships either; the tracked app is Code Review Sage.

For a document about who may approve what, asserting approval gates that do not exist is the worst available failure. It now describes the wildcard `.github/CODEOWNERS` declaration and the AI-review override authorization that are real, and explicitly declines to imply an approval quota, since branch protection rather than this file is the enforcement point.

## `inline-action-buttons.md` — taught agents a protocol that does not route

It presented `action::` as a general Block Kit routing protocol. `dispatch` forwards only `OPTIONS_ACTION_PREFIX` (`options_choice_`) action IDs to `_handle_options`, and `_ACTION_PREFIX` is `action::` — the two are mutually exclusive, so an arbitrary `action::` action ID reaches the tool-approval fallback instead. The extended-element branch exists but is exercised only by tests calling the handler directly. Now documented as what it is: a value protocol inside legacy OPTIONS controls.

## The other eleven

Mostly convention violations under `docs/system-specs/README.md`: proposal narration and future tense instead of present-tense current behavior, and constants copied out of the code rather than naming the test that pins them. `claude-code-provider.md` is the only file that grew.

The change is net −1210 lines. The shrink is proposal text and copied constants, not content: `inline-action-buttons.md` 254→40 and `aws-control.md` 319→152 are the two design documents above.

## Verification

Three passes, and every pass caught something the previous one missed — recorded because the pattern is the point.

**Pass 2 (adversarial, targeting the corrections themselves) fixed three defects.** The `aws-control` rewrite had overstated the danger: it read only the route layer, concluded object and folder deletion were unconfirmed, and missed the dashboard confirmation strips. That is the same over-correction failure as the earlier batches, in the opposite direction — an alarming claim that is false rather than a reassuring one. `app-sdk-durable-jobs-and-view-state.md` had dropped a real cancellation invariant (a worker thread survives cancellation of the awaiting coroutine, so a disconnect yields no cancelable or reattachable job) while removing proposal text. `claude-code-provider.md` cited `test_acp_client_shutdown_reset`, which does not exist — the one file that grew invented a citation.

**Pass 3 (two local review lanes against the extracted CI contracts) disagreed with each other,** which was the most useful result. The Opus lane reported all 145 cited identifiers resolving and no findings; the GPT lane found five that do not resolve: a relative test path with no anchor, three renamed classes in `aws-control.md` (`TestDriveDiscovery`/`TestDriveCreation`/`TestPrefixDelete` → `TestFindDrive`/`TestCreateDrive`/`TestDeletePrefix`), two non-existent classes in `model-fallback.md`, a private-name drift in `turn-stats-footer.md` (`_parse_metadata` → `parse_metadata`), and a renamed registrar in `voice-streaming.md` (`register_session_routes()` → `register()`). All five verified against the tree and repointed at the class or function that actually owns each claim.

Since the lanes contradicted each other, the citations were then checked **mechanically** instead of by reading: **195 distinct class, function and path references across the 14 specs now resolve to a definition in the tree.** That also caught four `module.function` citations written without `.py`, now normalized. Citations are the whole point of the convention — a reader is meant to verify a claim rather than trust prose — so a stale one silently removes that ability while still looking authoritative.

One Opus caveat was checked and is not a defect: the `agent-interrupt-controller` "floor, not a timeout" invariant survives the shrink, reworded as convergence floor versus hard cap with both reasons and their pinning tests intact. Restoring it would have duplicated existing text.

Gates: `docs_lint.py --test`, `docs-lint.sh`, `check_brand_name.py`, `check_changelog_history.py`, `check_focus_cue.py`, `scrub-lint.sh --no-history`, `check_harness_parity.py`, `git diff --check` — all exit 0.

<!-- no-visual-delta -->
**Why no screenshot:** documentation only, no rendered surface changes.

no linked issue: continuation of the documentation-vs-code audit.
