### PR TITLE
perf(chat): bound the recurring refreshSlot history fetch to the view's own count

### DIFF
--- a/website/src/store/chatSlice.boundedRefetchShrink.test.ts
+++ b/website/src/store/chatSlice.boundedRefetchShrink.test.ts
@@ -182,6 +182,53 @@ describe('a bounded refetch must not shrink what is already loaded', () => {
     expect(limitsFor('coldwarm')).toEqual([WARM])
   })
 
+  /** `olderHeadAbovePage` is the ONE cut all three reducers share, so the identity rule
+   *  lives there. A bare `findIndex` cut at the FIRST row carrying the page-oldest id,
+   *  and `meta.mid` is caller-supplied (minted only when absent), so a repeated id cut
+   *  at the wrong occurrence. These two pin both directions of that rule on the warm
+   *  path, which reaches the cut without the thunk-side strict check in front of it. */
+  it('keeps the cache whole when the page-oldest id names two rows', async () => {
+    const dup = 'mid-repeated'
+    HISTORY = makeHistory(true).map((r, i) =>
+      i === 0 || i === 60 ? { ...r, meta: { mid: dup } } : r,
+    )
+    const store = makeStore()
+    store.dispatch(setActiveSlot('other'))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'bg', messages: HISTORY.slice(0, 140), hasMore: false,
+      bounded: false, total: TOTAL, running: false,
+    }))
+
+    await store.dispatch(warmSlotCache('bg'))
+
+    // The ambiguous id declines the cut, and declining must not lose rows: the
+    // reducer keeps the longer prior array instead of trusting a wrong boundary.
+    const cache = store.getState().chat.slotMessages.bg
+    const kept = new Set(cache.map(m => m.content))
+    const dropped = HISTORY.slice(0, 140).filter(m => !kept.has(m.content)).map(m => m.content)
+    expect(dropped).toEqual([])
+  })
+
+  it('still cuts on an id whose rows carry no ts', async () => {
+    // Declining inside the shared cut costs the KEPT HEAD, not a round trip, so the
+    // rule only requires that the two rows do not contradict each other. Demanding a
+    // `ts` here would drop scrollback for legacy rows that have none.
+    HISTORY = makeHistory(true).map(({ ts: _ts, ...rest }) => rest as never)
+    const store = makeStore()
+    store.dispatch(setActiveSlot('other'))
+    store.dispatch(hydrateSlotMessages({
+      slot: 'bg', messages: HISTORY.slice(0, 140), hasMore: false,
+      bounded: false, total: TOTAL, running: false,
+    }))
+
+    await store.dispatch(warmSlotCache('bg'))
+
+    const cache = store.getState().chat.slotMessages.bg
+    const kept = new Set(cache.map(m => m.content))
+    const dropped = HISTORY.slice(0, 140).filter(m => !kept.has(m.content)).map(m => m.content)
+    expect(dropped).toEqual([])
+  })
+
   it('leaves the cursor consistent with what is loaded', async () => {
     const store = makeStore()
     store.dispatch(setActiveSlot('active'))

--- a/website/src/store/chatSlice.refreshSlotBound.test.ts
+++ b/website/src/store/chatSlice.refreshSlotBound.test.ts
@@ -1,0 +1,787 @@
+/** `refreshSlot` must bound its fetch WITHOUT shrinking the open transcript.
+ *
+ *  The recurring refresh (WS reconnect, `chat_done`, a variant switch) used to
+ *  pass no `limit` at all, so every one of them pulled the whole chained history
+ *  — a cost that grows with the transcript and is paid again at the end of every
+ *  turn (#4690). A FIXED bound is not available to it: unlike a pane warm, this
+ *  thunk REPLACES `messages` in place, so a 50-row page would delete scrollback
+ *  the user had paged back through.
+ *
+ *  The bound is therefore COUNT-MATCHED — at least as many rows as the view
+ *  already holds — and these tests assert the `limit` argument that reaches
+ *  `api.chatSlotDetail`, not merely the resulting state: the argument is the fix,
+ *  and a state assertion alone would still pass if the bound were dropped.
+ *
+ *  The `warmSlotCache` half of #4690 was already bounded by #3240 and is not
+ *  touched here; `chatSlice.warmSlotCacheBound.test.ts` owns it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+
+const TOTAL = 300
+/** The slot-detail handler's own clamp (`min(int(limit), 500)`), mirrored so a
+ *  request above it comes back SHORT here exactly as it would in production. */
+const SERVER_CLAMP = 500
+
+type Row = { role: string; content: string; cls: string; ts: string; meta?: { mid: string } }
+
+const rows = (n: number, from = 0): Row[] =>
+  Array.from({ length: n }, (_, i) => ({
+    role: (from + i) % 2 === 0 ? 'user' : 'assistant',
+    content: `m${from + i}`,
+    cls: 'msg',
+    ts: new Date(Date.UTC(2026, 0, 1, 0, 0, from + i)).toISOString(),
+    meta: { mid: `mid-${from + i}` },
+  }))
+
+let HISTORY: Row[] = rows(TOTAL)
+let RUNNING = false
+/** Fired once, inside the next `chatSlotDetail` call. */
+let DURING_FETCH: (() => void) | null = null
+
+vi.mock('../api/client', () => ({
+  api: {
+    /** Mirrors the handler: the corpus is collapsed to one row per displayed
+     *  message BEFORE `total` and the slice, the slice is the most-recent-N, and
+     *  `limit` is clamped to 500. */
+    chatSlotDetail: vi.fn((_slot: string, limit?: number, before?: number) => {
+      // Lets a test land a concurrent store write INSIDE the thunk's await, which is
+      // the only way to reproduce a `loadOlderMessages` resolving mid-refresh.
+      if (DURING_FETCH) {
+        const fire = DURING_FETCH
+        DURING_FETCH = null
+        fire()
+      }
+      const corpus = [...HISTORY]
+      const total = corpus.length
+      const end = before !== undefined ? Math.max(0, Math.min(before, total)) : total
+      const eff = limit === undefined ? undefined : Math.min(limit, SERVER_CLAMP)
+      const start = eff === undefined ? 0 : Math.max(0, end - eff)
+      return Promise.resolve({
+        key: _slot,
+        messages: corpus.slice(start, end),
+        has_more: start > 0,
+        next_before: start,
+        total,
+        running: RUNNING,
+        queue: [],
+      })
+    }),
+  },
+}))
+
+import chatReducer, {
+  PANE_HYDRATE_LIMIT,
+  REFRESH_LIMIT_CEILING,
+  refreshSlot,
+  replaceMessages,
+} from './chatSlice'
+import { api } from '../api/client'
+
+const SLOT = 'slot-1'
+
+function makeStore(extra: Record<string, unknown> = {}) {
+  const base = chatReducer(undefined, { type: '@@INIT' })
+  return configureStore({
+    reducer: { chat: chatReducer },
+    preloadedState: { chat: { ...base, activeSlot: SLOT, ...extra } },
+    middleware: (getDefault) => getDefault({ serializableCheck: false, immutableCheck: false }),
+  })
+}
+
+/** A view that has paged back to the newest `held` rows of `TOTAL`. */
+function pagedBack(held: number) {
+  const oldest = TOTAL - held
+  return makeStore({
+    messages: HISTORY.slice(oldest),
+    slotHasMore: oldest > 0,
+    slotOldestIndex: oldest > 0 ? oldest : 0,
+    slotCursorKey: SLOT,
+  })
+}
+
+/** Every `limit` argument the thunk sent, in order. */
+const limits = () =>
+  (api.chatSlotDetail as unknown as { mock: { calls: unknown[][] } }).mock.calls.map(c => c[1])
+
+describe('refreshSlot count-matched bound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    HISTORY = rows(TOTAL)
+    RUNNING = false
+    DURING_FETCH = null
+  })
+
+  it('bounds the recurring refresh instead of pulling the whole transcript', async () => {
+    const store = pagedBack(120)
+    await store.dispatch(refreshSlot(SLOT) as never)
+    // The defect signal: a `limit` is present at all, and it is not the corpus.
+    expect(limits()).toEqual([120])
+    expect(120).toBeLessThan(TOTAL)
+  })
+
+  it('asks for at least PANE_HYDRATE_LIMIT on a slot holding only a few rows', async () => {
+    HISTORY = rows(6)
+    const store = makeStore({ messages: HISTORY.slice(0, 3), slotHasMore: false })
+    await store.dispatch(refreshSlot(SLOT) as never)
+    expect(limits()).toEqual([PANE_HYDRATE_LIMIT])
+    // The floor is a floor, not a cap: it can only ask for MORE than the view
+    // holds, so it can never be the thing that truncates.
+    expect(PANE_HYDRATE_LIMIT).toBeGreaterThan(3)
+    expect(store.getState().chat.messages).toHaveLength(6)
+  })
+
+  it('refreshes a paged-back view at ITS count, never at the floor', async () => {
+    const held = 180
+    const store = pagedBack(held)
+    await store.dispatch(refreshSlot(SLOT) as never)
+    expect(limits()).toEqual([held])
+    expect(limits()).not.toEqual([PANE_HYDRATE_LIMIT])
+    // History the user paged in survives the in-place replacement.
+    const after = store.getState().chat.messages
+    expect(after).toHaveLength(held)
+    expect(after[0].content).toBe(`m${TOTAL - held}`)
+    expect(after.at(-1)?.content).toBe(`m${TOTAL - 1}`)
+  })
+
+  it('leaves hasMore and the older cursor exactly where the paged-back view had them', async () => {
+    const held = 180
+    const store = pagedBack(held)
+    const before = store.getState().chat
+    await store.dispatch(refreshSlot(SLOT) as never)
+    const after = store.getState().chat
+    // A wrong `hasMore` either hides the "load older" affordance or spins on a
+    // cursor that never advances, so both fields are pinned, not just the flag.
+    expect({ hasMore: after.slotHasMore, oldest: after.slotOldestIndex })
+      .toEqual({ hasMore: before.slotHasMore, oldest: before.slotOldestIndex })
+    expect(after.slotHasMore).toBe(true)
+  })
+
+  it('reports no older page once the count-matched refresh covers the corpus', async () => {
+    const store = pagedBack(TOTAL)
+    await store.dispatch(refreshSlot(SLOT) as never)
+    const after = store.getState().chat
+    expect({ limit: limits()[0], hasMore: after.slotHasMore, oldest: after.slotOldestIndex })
+      .toEqual({ limit: TOTAL, hasMore: false, oldest: 0 })
+  })
+
+  it('stays unbounded above the handler ceiling rather than come back short', async () => {
+    // The handler clamps `limit` to 500, so a count-matched request above it
+    // would be answered with 500 rows — a shrink of the very view it matched.
+    HISTORY = rows(REFRESH_LIMIT_CEILING + 120)
+    const store = makeStore({
+      messages: HISTORY.slice(),
+      slotHasMore: false,
+      slotCursorKey: SLOT,
+    })
+    await store.dispatch(refreshSlot(SLOT) as never)
+    expect(limits()).toEqual([undefined])
+    expect(store.getState().chat.messages).toHaveLength(REFRESH_LIMIT_CEILING + 120)
+    expect(REFRESH_LIMIT_CEILING).toBe(SERVER_CLAMP)
+  })
+
+  it('stays unbounded when the view holds nothing to count-match against', async () => {
+    // A refresh on an empty view (reconnect after clearMessages, a refresh
+    // racing slot activation) is the client's only read of that transcript.
+    const store = makeStore({ messages: [] })
+    await store.dispatch(refreshSlot(SLOT) as never)
+    expect(limits()).toEqual([undefined])
+    expect(store.getState().chat.messages).toHaveLength(TOTAL)
+  })
+
+  it('count-matches a STREAMING view too, since the handler collapses before it slices', async () => {
+    RUNNING = true
+    const held = 140
+    const store = pagedBack(held)
+    await store.dispatch(refreshSlot(SLOT) as never)
+    expect(limits()).toEqual([held])
+    expect(store.getState().chat.messages).toHaveLength(held)
+  })
+
+  // The window a count-matched limit returns SLIDES when the server grew while
+  // this client was away -- which is exactly the reconnect this refresh exists to
+  // recover from. Matching the COUNT preserves the row count, not the row
+  // identities, so the reducer has to keep the head that falls out.
+  describe('a slid window must not drop the head', () => {
+    it('keeps the loaded oldest rows when the server gained messages during the gap', async () => {
+      const held = 180
+      const store = pagedBack(held)
+      const oldestBefore = store.getState().chat.messages[0].content
+      // Five messages landed while the socket was down.
+      HISTORY = [...HISTORY, ...rows(5, TOTAL)]
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      const after = store.getState().chat.messages
+      // The page began 5 rows NEWER than the view's oldest row, so a wholesale
+      // assignment would have deleted those 5.
+      expect(after[0].content).toBe(oldestBefore)
+      expect(after.map(m => m.content)).toContain(`m${TOTAL + 4}`)
+      expect(after).toHaveLength(held + 5)
+    })
+
+    it('shifts the older cursor by the head it kept, so "load older" is not a dead click', async () => {
+      const held = 180
+      const store = pagedBack(held)
+      const oldestIndexBefore = store.getState().chat.slotOldestIndex
+      HISTORY = [...HISTORY, ...rows(5, TOTAL)]
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      const after = store.getState().chat
+      // The page's own cursor was 125 (305 - 180); the 5 kept rows sit below it,
+      // so the cursor must come back down to where the view actually starts.
+      expect({ hasMore: after.slotHasMore, oldest: after.slotOldestIndex })
+        .toEqual({ hasMore: true, oldest: oldestIndexBefore })
+    })
+
+    it('reports no older page when the kept head proves the window is complete', async () => {
+      // The view holds the whole corpus, then 5 rows land. The page covers the
+      // newest `held`, the head covers the rest — together, everything.
+      const store = pagedBack(TOTAL)
+      HISTORY = [...HISTORY, ...rows(5, TOTAL)]
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      const after = store.getState().chat
+      expect(after.messages).toHaveLength(TOTAL + 5)
+      expect({ hasMore: after.slotHasMore, oldest: after.slotOldestIndex })
+        .toEqual({ hasMore: false, oldest: 0 })
+    })
+
+    it('refetches unbounded when the gap slid the page CLEAR of the view', async () => {
+      // The server gained more rows than the view holds, so the most-recent-N page
+      // and the view are fully disjoint: the page carries no row the reducer can
+      // cut at, and a wholesale assignment would drop the entire loaded window.
+      const held = 180
+      const store = pagedBack(held)
+      const oldestBefore = store.getState().chat.messages[0].content
+      HISTORY = [...HISTORY, ...rows(held + 20, TOTAL)]
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // First the count-matched request, then the unbounded retry.
+      expect(limits()).toEqual([held, undefined])
+      const after = store.getState().chat
+      expect(after.messages).toHaveLength(TOTAL + held + 20)
+      expect(after.messages[0].content).toBe('m0')
+      // Nothing the view held was dropped, and no hole was spliced into it.
+      expect(after.messages.map(m => m.content)).toContain(oldestBefore)
+      expect(after.slotHasMore).toBe(false)
+    })
+
+    it('does not bound at all when the view carries no server row identity', async () => {
+      // `olderHeadAbovePage` cuts on `meta.mid` only (two rows can share a `ts`, so a
+      // ts match can cut at the wrong row) and declines without one. A view of rows
+      // carrying none has a server span of zero, so there is no count to match and
+      // the bound is skipped outright — one fetch, not a bounded one thrown away.
+      HISTORY = rows(TOTAL).map(({ meta: _meta, ...rest }) => rest) as typeof HISTORY
+      const store = pagedBack(180)
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([undefined])
+      expect(store.getState().chat.messages).toHaveLength(TOTAL)
+    })
+
+    it('does NOT retry when the page already reaches the start of history', async () => {
+      // The floor asks for 50 against a 30-row transcript, so the page IS the whole
+      // history and `hasMore` is false. Nothing can sit above it, so no anchor is
+      // needed and a retry would be a wasted round trip.
+      HISTORY = rows(30)
+      const store = makeStore({ messages: HISTORY.slice(), slotHasMore: false })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([PANE_HYDRATE_LIMIT])
+      expect(store.getState().chat.messages).toHaveLength(30)
+    })
+  })
+
+  // The limit reaches a handler that applies it to SERVER rows, so the count has to
+  // be the view's server span. `state.messages` also carries client-only rows, and
+  // counting those over-requests: the page then starts BELOW the view's oldest row,
+  // which is benign in itself but must not be mistaken for a slid window.
+  describe('the count is the view\'s SERVER-row span', () => {
+    /** A paged-back view with `extra` client-only rows interleaved — the shape any
+     *  session with reasoning, an approval card or a queued bubble is in. */
+    function withClientRows(held: number, extra: number) {
+      const server = HISTORY.slice(TOTAL - held)
+      const clientOnly = Array.from({ length: extra }, (_, i) => ({
+        role: 'thinking', content: `reasoning ${i}`, cls: 'msg',
+        ts: new Date(Date.UTC(2026, 0, 1, 0, 0, TOTAL - held + i)).toISOString(),
+      }))
+      return makeStore({
+        messages: [...server.slice(0, 1), ...clientOnly, ...server.slice(1)],
+        slotHasMore: true,
+        slotOldestIndex: TOTAL - held,
+        slotCursorKey: SLOT,
+      })
+    }
+
+    it('does not count client-only rows toward the limit', async () => {
+      const store = withClientRows(180, 12)
+      expect(store.getState().chat.messages).toHaveLength(192)
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // 180, the server span — not 192, the array length.
+      expect(limits()).toEqual([180])
+    })
+
+    it('makes ONE request for a window holding reasoning, not a bounded one plus an unbounded retry', async () => {
+      // The regression this pins: an inflated count drags the page below the view's
+      // oldest row, the anchor check misses, and the thunk falls back to the
+      // whole-transcript pull the bound exists to prevent — on every turn end of any
+      // session carrying a reasoning block.
+      const store = withClientRows(180, 12)
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // No unbounded call in the list at all, and exactly one request total.
+      expect(limits()).not.toContain(undefined)
+      expect(api.chatSlotDetail).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps an id-less legacy prefix that sits below the oldest identified row', async () => {
+      // MIXED history: the view holds durable rows carrying no `meta.mid` (written
+      // before the backend stamped them) BELOW rows that do. `serverRows[0]` is then
+      // the oldest IDENTIFIED row, not the view's oldest durable row, so the page can
+      // legitimately begin above the legacy prefix. What preserves the prefix is the
+      // head-keep: the page's oldest row IS in the view, so `olderHeadAbovePage` cuts
+      // at it and everything above — the legacy rows included — is kept.
+      const legacy = rows(20).map(({ meta: _meta, ...rest }) => rest) as typeof HISTORY
+      const identified = rows(180, 20)
+      HISTORY = [...legacy, ...identified]
+      const store = makeStore({
+        messages: [...legacy, ...identified],
+        slotHasMore: false,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // Bounded to the 180 IDENTIFIED rows — the legacy rows are not counted.
+      expect(limits()).toEqual([180])
+      const after = store.getState().chat
+      // Nothing was dropped: all 20 legacy rows plus all 180 identified ones.
+      expect(after.messages).toHaveLength(200)
+      expect(after.messages[0].content).toBe('m0')
+      expect(after.messages[19].content).toBe('m19')
+      expect(after.messages.at(-1)?.content).toBe('m199')
+      // The kept head saturates the page's cursor, so nothing older is advertised.
+      expect({ hasMore: after.slotHasMore, oldest: after.slotOldestIndex })
+        .toEqual({ hasMore: false, oldest: 0 })
+    })
+
+    it('retries unbounded when a mixed-history page slides clear of the identified rows', async () => {
+      // The same mixed shape, but the server also gained more rows than the view's
+      // identified span — so the page overlaps neither the legacy prefix nor the
+      // identified rows, and only the unbounded refetch can preserve the window.
+      const legacy = rows(20).map(({ meta: _meta, ...rest }) => rest) as typeof HISTORY
+      const identified = rows(180, 20)
+      HISTORY = [...legacy, ...identified]
+      const store = makeStore({
+        messages: [...legacy, ...identified],
+        slotHasMore: false,
+        slotCursorKey: SLOT,
+      })
+      HISTORY = [...HISTORY, ...rows(200, 200)]
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([180, undefined])
+      const after = store.getState().chat
+      expect(after.messages).toHaveLength(400)
+      expect(after.messages[0].content).toBe('m0')
+    })
+
+    it('refuses a DUPLICATE anchor id rather than cutting at the wrong occurrence', async () => {
+      // `meta.mid` on an inbound message is caller-supplied, so a client can post the
+      // same id twice. A membership test (`Set.has` / `Array.some`) then answers
+      // "SOME row carries this id" and the page reads as spanning the view while the
+      // matching occurrence is a NEWER row -- the reducer cuts there and deletes the
+      // history above it. The anchor must name exactly ONE row on each side.
+      const dup = 'mid-shared'
+      const held = 180
+      const oldest = TOTAL - held
+      // The view's OLDEST row and a much newer row share an id.
+      const viewRows = HISTORY.slice(oldest).map((r, i) =>
+        i === 0 || i === held - 20 ? { ...r, meta: { mid: dup } } : r,
+      )
+      HISTORY = HISTORY.map((r, i) =>
+        i === oldest || i === oldest + held - 20 ? { ...r, meta: { mid: dup } } : r,
+      )
+      const store = makeStore({
+        messages: viewRows,
+        slotHasMore: true,
+        slotOldestIndex: oldest,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // Declined the ambiguous anchor and refetched unbounded instead of trusting it.
+      expect(limits()).toEqual([held, undefined])
+      const after = store.getState().chat
+      expect(after.messages).toHaveLength(TOTAL)
+      expect(after.messages[0].content).toBe('m0')
+    })
+
+    it('refuses an anchor whose two rows disagree on ts, even when the id is unique', async () => {
+      // Unique on both sides is not sufficient: two DIFFERENT rows can carry the same
+      // caller-supplied id once each. The ts agreement is what makes the id a
+      // reference to one row rather than a coincidence.
+      const held = 180
+      const oldest = TOTAL - held
+      const viewRows = HISTORY.slice(oldest).map((r, i) =>
+        i === 0 ? { ...r, ts: '2020-01-01T00:00:00Z' } : r,
+      )
+      const store = makeStore({
+        messages: viewRows,
+        slotHasMore: true,
+        slotOldestIndex: oldest,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([held, undefined])
+      expect(store.getState().chat.messages).toHaveLength(TOTAL)
+    })
+
+    it('does NOT retry when the floor over-requests into a SUPERSET of the view', async () => {
+      // A near-empty view against a long transcript: the floor asks for 50 where the
+      // view holds 3, so the page begins below the view's oldest row. Its oldest row
+      // is therefore absent from the view — but the page SPANS the view, and a
+      // superset cannot lose anything, so a retry would be a wasted round trip.
+      const store = makeStore({
+        messages: HISTORY.slice(TOTAL - 3),
+        slotHasMore: true,
+        slotOldestIndex: TOTAL - 3,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([PANE_HYDRATE_LIMIT])
+      const after = store.getState().chat
+      expect(after.messages).toHaveLength(PANE_HYDRATE_LIMIT)
+      expect(after.slotHasMore).toBe(true)
+    })
+  })
+
+  // `olderHeadAbovePage` is shared by switchSlot.fulfilled, refreshSlot.fulfilled and
+  // warmSlotCache.fulfilled, so the anchor invariant lives THERE rather than at each
+  // caller. These pin the two directions of the shared cut through the refresh path.
+  describe('the shared cut refuses an ambiguous anchor', () => {
+    it('drops no history when the page-oldest id names two rows in the view', async () => {
+      // A bare findIndex cut at the FIRST row carrying the id, which for a
+      // caller-repeated `mid` is an OLDER row than the one meant -- so the head was
+      // measured to the wrong place and the rows between were lost.
+      const dup = 'mid-repeated'
+      const held = 180
+      const oldest = TOTAL - held
+      // The page's oldest row's id also appears much later in the view.
+      HISTORY = HISTORY.map((r, i) =>
+        i === oldest || i === oldest + 40 ? { ...r, meta: { mid: dup } } : r,
+      )
+      const store = makeStore({
+        messages: HISTORY.slice(oldest),
+        slotHasMore: true,
+        slotOldestIndex: oldest,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // Declined at the thunk, so the reducer never sees a page it cannot cut.
+      expect(limits()).toEqual([held, undefined])
+      const after = store.getState().chat
+      expect(after.messages).toHaveLength(TOTAL)
+      expect(after.messages[0].content).toBe('m0')
+    })
+
+    it('refetches unbounded when no row carries a ts, losing nothing', async () => {
+      // The thunk asks for the STRICT form, so a corpus with no `ts` anywhere cannot
+      // anchor and it refetches unbounded. That is the safe direction here -- the cost
+      // is one round trip. The reducer's own cut uses the lenient form for the opposite
+      // reason, pinned in chatSlice.boundedRefetchShrink.test.ts.
+      const held = 180
+      const oldest = TOTAL - held
+      const stripTs = (r: Row) => {
+        const { ts: _ts, ...rest } = r
+        return rest as Row
+      }
+      HISTORY = HISTORY.map(stripTs)
+      const store = makeStore({
+        messages: HISTORY.slice(oldest).map(stripTs),
+        slotHasMore: true,
+        slotOldestIndex: oldest,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([held, undefined])
+      const after = store.getState().chat
+      expect(after.messages).toHaveLength(TOTAL)
+      expect(after.messages[0].content).toBe('m0')
+    })
+  })
+
+  /** The FLOOR over-request meeting durable rows that carry no id.
+   *
+   *  At `want === held` the page cannot strand a durable row -- the span check only
+   *  passes when a page of exactly `held` rows holds all `held` identified ones,
+   *  leaving no room for an unidentified row to be its oldest. The floor breaks that
+   *  arithmetic: it asks for MORE than the view's identified span, so the extra rows
+   *  come from older history, and with legacy rows there the page's oldest row is one
+   *  the `mid`-keyed cut cannot anchor. The reducer then keeps no head while the view
+   *  holds rows above the page -- rows in no page and no head.
+   *
+   *  These pin the floor's decline. The count-matched cases above stay bounded. */
+  describe('the floor meeting durable rows that carry no id', () => {
+    /** `total` rows where only the newest `identified` carry a `meta.mid`. */
+    const legacyTail = (total: number, identified: number): Row[] =>
+      rows(total).map((r, i) => {
+        if (i >= total - identified) return r
+        const { meta: _meta, ...rest } = r
+        return rest as Row
+      })
+
+    it('refreshes unbounded when the floor would reach past the identified rows', async () => {
+      // 20 identified rows, so the floor asks for 50 -- a page holding all 20 AND 30
+      // older legacy rows. The span check passes on the oldest identified row while the
+      // page's OWN oldest row carries no id, so the cut keeps nothing and a 300-row
+      // transcript would collapse to the 50-row page.
+      const identified = 20
+      expect(identified).toBeLessThan(PANE_HYDRATE_LIMIT)
+      HISTORY = legacyTail(TOTAL, identified)
+      const store = makeStore({
+        messages: HISTORY.slice(),
+        slotHasMore: false,
+        slotOldestIndex: 0,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([undefined])
+      const after = store.getState().chat.messages
+      expect(after).toHaveLength(TOTAL)
+      expect(after[0].content).toBe('m0')
+      expect(after.at(-1)?.content).toBe(`m${TOTAL - 1}`)
+    })
+
+    it('declines on a single unidentified durable row, not just a large legacy block', async () => {
+      // The floor cannot retain ONE unanchorable row any more than hundreds, so a
+      // threshold would leave exactly that row droppable. The view here is the newest
+      // 20 identified rows plus the one legacy row directly below them.
+      const identified = 20
+      HISTORY = legacyTail(TOTAL, identified)
+      const oldest = TOTAL - identified - 1
+      const store = makeStore({
+        messages: HISTORY.slice(oldest),
+        slotHasMore: true,
+        slotOldestIndex: oldest,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([undefined])
+      expect(store.getState().chat.messages).toHaveLength(TOTAL)
+    })
+
+    it('still bounds when the floor is not in play, whatever the identities are', async () => {
+      // `held >= PANE_HYDRATE_LIMIT`, so `want === held` and the arithmetic that makes
+      // the count-matched request safe applies -- legacy rows do not disable it.
+      const identified = 180
+      HISTORY = legacyTail(TOTAL, identified)
+      const store = makeStore({
+        messages: HISTORY.slice(),
+        slotHasMore: false,
+        slotOldestIndex: 0,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([identified])
+      expect(store.getState().chat.messages).toHaveLength(TOTAL)
+    })
+
+    it('still bounds a view whose only id-less rows are client-only', async () => {
+      // `thinking` / `queued` carry no `mid` either and are the common case -- if they
+      // tripped the guard, #4690 would be unfixed in every live session. Not durable,
+      // so they do not count. Held below the floor to put the floor genuinely in play.
+      const held = 20
+      const oldest = TOTAL - held
+      const store = makeStore({
+        messages: [
+          ...HISTORY.slice(oldest),
+          { role: 'thinking', content: 'thinking...', cls: 'msg' } as unknown as Row,
+          { role: 'queued', content: 'next up', cls: 'msg' } as unknown as Row,
+        ],
+        slotHasMore: true,
+        slotOldestIndex: oldest,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([PANE_HYDRATE_LIMIT])
+    })
+  })
+
+  /** A client-only row that happens to carry a `mid`.
+   *
+   *  `permission` cards are not persisted, so the handler's disk slice never contains
+   *  one -- but they can still arrive carrying a `meta.mid`. Counting one inflates
+   *  `held`, and the damage is not the over-request: it makes `want === held` true
+   *  while the DURABLE span is smaller, which bypasses the floor guard whose argument
+   *  is that a page of exactly `held` rows has no room to hide an unidentified row.
+   *  With legacy rows present that is the scrollback loss again, reached through the
+   *  count rather than the floor. */
+  describe('client-only rows carrying an id', () => {
+    it('does not count a permission card toward the bound', async () => {
+      const held = 120
+      const oldest = TOTAL - held
+      const store = makeStore({
+        messages: [
+          ...HISTORY.slice(oldest),
+          // Not persisted, but stamped.
+          {
+            role: 'permission',
+            content: 'allow?',
+            cls: 'msg',
+            meta: { mid: 'mid-perm-1' },
+          } as unknown as Row,
+        ],
+        slotHasMore: true,
+        slotOldestIndex: oldest,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // 120, not 121: the card is not a row the disk slice can return.
+      expect(limits()).toEqual([held])
+    })
+
+    it('does not let stamped permission cards inflate held past the floor guard', async () => {
+      // 20 durable identified rows plus 30 stamped permission cards. Counting the
+      // cards makes held 50, so `want === held` and the floor guard is skipped --
+      // while the real durable span is 20 and the page of 50 reaches back into the
+      // legacy rows, whose oldest the `mid`-keyed cut cannot anchor.
+      const identified = 20
+      const legacy = TOTAL - identified
+      HISTORY = rows(TOTAL).map((r, i) => {
+        if (i >= legacy) return r
+        const { meta: _meta, ...rest } = r
+        return rest as Row
+      })
+      const cards = Array.from({ length: 30 }, (_, i) => ({
+        role: 'permission',
+        content: `allow ${i}?`,
+        cls: 'msg',
+        meta: { mid: `mid-perm-${i}` },
+      })) as unknown as Row[]
+      const store = makeStore({
+        messages: [...HISTORY.slice(), ...cards],
+        slotHasMore: false,
+        slotOldestIndex: 0,
+        slotCursorKey: SLOT,
+      })
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // held is 20, so the floor genuinely over-requests and the guard fires.
+      expect(limits()).toEqual([undefined])
+      const after = store.getState().chat.messages
+      expect(after.filter(m => m.role !== 'permission')).toHaveLength(TOTAL)
+    })
+  })
+
+  /** The view can change DURING the fetch.
+   *
+   *  `view` is read before the await so the limit can be sized from it, but
+   *  `loadOlderMessages` can resolve inside that await. The rows it prepends are
+   *  precisely the scrollback a wrong decision strands, and they can also turn an
+   *  anchor that was unique in the old view into an AMBIGUOUS one. So the page is
+   *  judged against the view as it is when the page arrives, not against the snapshot
+   *  the limit came from. */
+  describe('a view that changed while the fetch was in flight', () => {
+    it('keeps rows that load-earlier prepended during the await', async () => {
+      const held = 120
+      const oldest = TOTAL - held
+      const store = pagedBack(held)
+      // Mid-fetch, "load earlier" lands: the view grows to the whole corpus.
+      DURING_FETCH = () => {
+        store.dispatch(replaceMessages(HISTORY.slice()))
+      }
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      const after = store.getState().chat.messages
+      // The page covers only the newest 120, so accepting it against the GROWN view
+      // would drop the rows that just arrived.
+      expect(after).toHaveLength(TOTAL)
+      expect(after[0].content).toBe('m0')
+      expect(after.at(-1)?.content).toBe(`m${TOTAL - 1}`)
+      expect(oldest).toBeGreaterThan(0)
+    })
+
+    it('refetches unbounded when the arriving rows make the anchor ambiguous', async () => {
+      // The page's own oldest row is the anchor. If the rows landing mid-fetch carry a
+      // second copy of that id, the anchor no longer names one row and the cut cannot
+      // be trusted -- judged on the OLD view it still looks unique.
+      const held = 120
+      const oldest = TOTAL - held
+      const dup = HISTORY[oldest].meta?.mid
+      const store = pagedBack(held)
+      DURING_FETCH = () => {
+        const grown = HISTORY.slice().map((r, i) =>
+          i === oldest - 30 ? { ...r, meta: { mid: dup as string } } : r,
+        )
+        store.dispatch(replaceMessages(grown))
+      }
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([held, undefined])
+      expect(store.getState().chat.messages).toHaveLength(TOTAL)
+    })
+
+    it('still bounds normally when nothing lands during the await', async () => {
+      // The re-read must not become a blanket decline: an undisturbed refresh keeps
+      // the single bounded request, which is the whole point of #4690.
+      const held = 120
+      const store = pagedBack(held)
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      expect(limits()).toEqual([held])
+      expect(store.getState().chat.messages).toHaveLength(held)
+    })
+
+    it('fetches nothing more when the slot switched during the await', async () => {
+      const store = pagedBack(120)
+      DURING_FETCH = () => {
+        store.dispatch({ type: 'chat/setActiveSlot', payload: 'other-slot' })
+      }
+
+      await store.dispatch(refreshSlot(SLOT) as never)
+
+      // One bounded request went out before the switch; nothing is retried after it.
+      expect(limits()).toEqual([120])
+    })
+  })
+
+  it('still fetches nothing for a slot that is no longer active', async () => {
+    const store = makeStore({ activeSlot: 'other', messages: HISTORY.slice() })
+    await store.dispatch(refreshSlot(SLOT) as never)
+    expect(api.chatSlotDetail).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1386,6 +1386,60 @@ function writeSlotPage(
   state.slotPaneHasMore[k] = hasMore
 }
 
+/** Occurrences of each usable `meta.mid` in a row list.
+ *
+ *  `meta` on an inbound message is CALLER-supplied and an id is minted only when
+ *  one is ABSENT, so a client can post the same `mid` twice and an id is NOT a
+ *  unique key. Counting is what lets a caller tell "this id names the row I mean"
+ *  from "this id names SOME row" -- the distinction a membership test cannot make.
+ */
+function midOccurrences(rows: Array<{ meta?: Record<string, unknown> }>): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const row of rows) {
+    const mid = row.meta?.mid
+    if (typeof mid === 'string' && mid.length > 0) counts.set(mid, (counts.get(mid) ?? 0) + 1)
+  }
+  return counts
+}
+
+/** Does this id name exactly ONE row on each side, and are those two rows the same row?
+ *
+ *  The one identity rule every bounded-page comparison in this file runs on. An id
+ *  that names two rows is a predicate, not a reference: acting on it cuts or
+ *  substitutes at whichever occurrence happened to be found first.
+ *
+ *  `requireTs` exists because DECLINING costs different things at the two call
+ *  sites, and the safe default is therefore different:
+ *
+ *    - `refreshSlot`'s pre-fulfil check pays ONE ROUND TRIP for a decline (it
+ *      refetches unbounded), so it can afford the strict form and passes
+ *      `requireTs: true`: both rows must carry a `ts` and it must match. That is
+ *      what rules out two genuinely different rows sharing a caller-supplied id.
+ *    - `olderHeadAbovePage` pays the KEPT HEAD for a decline -- the scrollback it
+ *      exists to protect. Demanding a `ts` there would drop the head for legacy
+ *      rows that carry none, turning a guard into the very data loss it guards
+ *      against. So the default only requires that the two rows do not CONTRADICT
+ *      each other: a missing `ts` on either side is not evidence of a mismatch.
+ */
+function idAnchorsOneRow(
+  id: unknown,
+  view: Array<{ ts?: string; meta?: Record<string, unknown> }>,
+  page: Array<{ ts?: string; meta?: Record<string, unknown> }>,
+  viewCounts: Map<string, number>,
+  pageCounts: Map<string, number>,
+  opts?: { requireTs?: boolean },
+): boolean {
+  if (typeof id !== 'string' || id.length === 0) return false
+  if (viewCounts.get(id) !== 1 || pageCounts.get(id) !== 1) return false
+  const inView = view.find(m => m.meta?.mid === id)
+  const inPage = page.find(m => m.meta?.mid === id)
+  if (!inView || !inPage) return false
+  const bothTimestamped = typeof inView.ts === 'string' && inView.ts.length > 0
+    && typeof inPage.ts === 'string' && inPage.ts.length > 0
+  if (opts?.requireTs && !bothTimestamped) return false
+  return bothTimestamped ? inView.ts === inPage.ts : true
+}
+
 /** The prior rows that sit ABOVE a bounded page's first row, plus the index the
  *  cut fell at (-1 when there is none).
  *
@@ -1395,29 +1449,64 @@ function writeSlotPage(
  *  paths diverged: `warmSlotCache` kept the head while `switchSlot` discarded
  *  it, collapsing a paged-in window to the newest page on switch-away-and-back.
  *
- *  Identity is `meta.mid` ONLY. Two rows can share a `ts`, so a ts match can cut
- *  at the wrong row and drop one; no mid means decline (an empty head), never
- *  guess. Callers hold `thinking` rows out: reasoning is broadcast-only, carries
- *  no identity, and is re-placed by `mergePreservedThinking` afterwards.
+ *  Identity is `meta.mid`, and it must name exactly ONE row on each side --
+ *  `idAnchorsOneRow`, the same invariant `refreshSlot` and the slot-detail
+ *  handler's overlay run on. A bare `findIndex` cut at the FIRST row carrying the
+ *  id, and `meta.mid` is caller-supplied (an id is minted only when absent), so a
+ *  client posting one twice made the cut land on the wrong occurrence and drop the
+ *  history above it. An ambiguous id therefore declines exactly like a missing one:
+ *  `cutIdx -1`, empty head, which every caller already handles.
+ *
+ *  No mid means decline (an empty head), never guess. Callers hold `thinking` rows
+ *  out: reasoning is broadcast-only, carries no identity, and is re-placed by
+ *  `mergePreservedThinking` afterwards.
  */
 function olderHeadAbovePage(
   prior: ChatMessage[],
   page: ChatMessage[],
 ): { cutIdx: number; olderHead: ChatMessage[] } {
   const pageOldestMid = page[0]?.meta?.mid
-  const cutIdx = typeof pageOldestMid === 'string' && pageOldestMid
+  const anchored = idAnchorsOneRow(
+    pageOldestMid, prior, page, midOccurrences(prior), midOccurrences(page),
+  )
+  const cutIdx = anchored
     ? prior.findIndex(m => m.meta?.mid === pageOldestMid)
     : -1
   return { cutIdx, olderHead: cutIdx > 0 ? prior.slice(0, cutIdx) : [] }
 }
 
+/** Roles the server never writes to history. `permission` is in the backend's own
+ *  `_TRANSIENT_ROLES`; `queued`/`streaming`/`thinking` exist only in this client.
+ *  `error`/`mcp_oauth` are deliberately absent -- those ARE persisted.
+ *
+ *  One set, because two consumers ask the same question for opposite reasons and a
+ *  second copy would let them drift: `serverRowCount` counts durable rows to shift
+ *  a paging OFFSET, and `hasUnidentifiedDurableRow` looks for a durable row the
+ *  bound cannot see. A role missing from one copy would silently mis-shift a cursor
+ *  in the first and silently drop scrollback in the second. */
+const CLIENT_ONLY_ROLES: ReadonlySet<string> = new Set(['queued', 'streaming', 'thinking', 'permission'])
+
+/** Does this row survive in the server's transcript? */
+function isDurableRow(m: ChatMessage): boolean {
+  return !CLIENT_ONLY_ROLES.has(m.role)
+}
+
 /** How many rows of a kept older head came from SERVER history, for shifting the
  *  paging cursor. The cursor is a row OFFSET, so client-only rows must not count
- *  toward it. `thinking` is already held out by the caller. `permission` is in the
- *  backend's `_TRANSIENT_ROLES` and is never persisted, so it holds no offset --
- *  unlike `error`/`mcp_oauth`, which ARE written to history and must keep counting. */
+ *  toward it. Callers already strip `thinking`, so including it in the shared set
+ *  costs nothing here and keeps one definition of durable. */
 function serverRowCount(rows: ChatMessage[]): number {
-  return rows.filter(m => m.role !== 'queued' && m.role !== 'streaming' && m.role !== 'permission').length
+  return rows.filter(isDurableRow).length
+}
+
+/** Is there a row the server PERSISTS but that carries no `meta.mid`?
+ *
+ *  Such a row is invisible to a `mid`-counted bound and unreachable to a
+ *  `mid`-keyed cut: it cannot be counted into the limit, and it cannot be anchored
+ *  into a kept head. It is nonetheless on screen. Legacy history written before
+ *  `mid` existed is the real case. */
+function hasUnidentifiedDurableRow(rows: ChatMessage[]): boolean {
+  return rows.some(m => isDurableRow(m) && !(typeof m.meta?.mid === 'string' && m.meta.mid.length > 0))
 }
 
 /** The `(hasMore, cursor)` pair to install after keeping an older head above a
@@ -1477,10 +1566,12 @@ function retainServerTotal(state: ChatState, key: string, total: number | undefi
 
 async function fetchSlotDetail(key: string, limit?: number) {
   // A limit takes the handler's most-recent-N slice. `undefined` keeps the
-  // unbounded shape, which two callers still need: refreshSlot replaces the
-  // active transcript in place (a bound would shrink history the user already
-  // paged in), and a STREAMING warm/switch fetch (deliberate, though the handler
-  // collapses before slicing). Omit the arg when unbounded to keep the one-arg shape.
+  // unbounded shape, which a STREAMING warm/switch fetch still takes
+  // (deliberate, though the handler collapses before slicing). refreshSlot
+  // replaces the active transcript in place, so it cannot take a FIXED bound
+  // (that would shrink history the user already paged in) — it passes a
+  // COUNT-MATCHED one instead, see REFRESH_LIMIT_CEILING. Omit the arg when
+  // unbounded to keep the one-arg shape.
   const d = await (limit === undefined ? api.chatSlotDetail(key) : api.chatSlotDetail(key, limit))
   type QueueItem = string | { content: string; id: string }
   return { key, nextBefore: d.next_before || 0, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }), context: d.context_pct != null ? { pct: d.context_pct, used: d.context_used_tokens ?? undefined, window: d.context_window_tokens ?? undefined } : undefined }
@@ -2210,12 +2301,131 @@ function mergePreservedClientTs<M extends { role: string; content: string; ts?: 
   )
 }
 
+/** Upper bound on the count-matched `refreshSlot` limit, matching the ceiling
+ *  the slot-detail handler clamps `limit` to. A request above it comes back
+ *  SHORT of what was asked for, which for an in-place replacement means the
+ *  view SHRINKS — so a transcript paged back past this keeps the unbounded
+ *  shape rather than truncate. */
+export const REFRESH_LIMIT_CEILING = 500
+
 export const refreshSlot = createAsyncThunk(
   'chat/refreshSlot',
   async (key: string, { getState }) => {
     const state = (getState() as { chat: ChatState }).chat
     if (state.activeSlot !== key) return null
-    return fetchSlotDetail(key)
+    // COUNT-MATCHED bound, not a fixed one. The recurring refresh (reconnect,
+    // chat_done, variant switch) no longer pulls the whole chained transcript
+    // every time — but because it REPLACES `messages` wholesale, a fixed
+    // bound would delete scrollback the user paged in. Asking for at least as
+    // many rows as the view already HOLDS is bounded and cannot shrink it, since
+    // the handler's slice is the most-recent-N. PANE_HYDRATE_LIMIT is the FLOOR
+    // (a floor cannot truncate) so a near-empty slot still asks for a sensible
+    // page instead of one row.
+    //
+    // An EMPTY view is the one case that stays unbounded: there is no count to
+    // match, so any number here would be the fixed bound this design rejects,
+    // and this refresh is then the client's only read of a transcript it holds
+    // nothing of (a reconnect after `clearMessages`, a refresh racing slot
+    // activation). Bounding it would install a window nothing asked for.
+    // Only rows the SERVER transcript carries can be counted against a limit the
+    // HANDLER applies to server rows. `state.messages` also holds client-only rows
+    // -- a `thinking` block, a `permission` card, a `queued` bubble -- and counting
+    // those inflates the request past the view's own span, which drags the page
+    // BELOW the view's oldest row. `meta.mid` is the server's own per-row stamp,
+    // the same server-row notion `serverRowCount` and the reducer's
+    // `priorServerRows` are built on.
+    const view = state.messages
+    /* `isDurableRow` is load-bearing here, not decoration. A client-only row can
+     * carry a `mid` too, and counting one inflates `held` -- which does not merely
+     * over-request, it makes `want === held` hold when the DURABLE span is smaller,
+     * silently bypassing the floor guard below whose whole argument is that at
+     * `want === held` a page of `held` rows cannot hide an unidentified row. The
+     * limit reaches a handler that slices DISK, and disk has no client-only rows, so
+     * only durable ones may be counted against it. */
+    const serverRows = view.filter(
+      m => isDurableRow(m) && typeof m.meta?.mid === 'string' && m.meta.mid.length > 0,
+    )
+    const held = serverRows.length
+    const want = Math.max(held, PANE_HYDRATE_LIMIT)
+    /* The FLOOR is the one over-request, and mixed history is where it bites.
+     *
+     * At `want === held` the page cannot strand a durable row: `spansView` only
+     * passes when all `held` identified rows are INSIDE a page of exactly `held`
+     * rows, which leaves no room for an unidentified row to be the page's oldest --
+     * and `overlapsView` already requires the page's oldest row to anchor. So the
+     * count-matched request is safe whatever the identities are.
+     *
+     * `want > held` breaks that arithmetic. With few identified rows the floor pulls
+     * a page of 50 that holds all of them (so `spansView` passes) plus older
+     * UNIDENTIFIED rows -- and the page's oldest row is then one the `mid`-keyed cut
+     * cannot anchor, so the reducer keeps no head while the view holds rows above it.
+     * They would be in no page and no head, which is the scrollback loss this bound
+     * exists to avoid. Legacy rows written before the backend stamped `mid` are the
+     * real case.
+     *
+     * So the floor declines on a window it cannot fully identify. Modern transcripts
+     * -- every live session, which is the recurring cost #4690 is about -- keep the
+     * bound, because their rows all carry a `mid`. */
+    const floorOverRequests = want > held
+    const bounded =
+      held > 0 &&
+      want <= REFRESH_LIMIT_CEILING &&
+      !(floorOverRequests && hasUnidentifiedDurableRow(view))
+    if (!bounded) return fetchSlotDetail(key)
+    const page = await fetchSlotDetail(key, want)
+    /* Is this page safe to hand a reducer that REPLACES the transcript with it?
+     * It is, on any one of three counts -- and each is a different relationship
+     * between the page's range and the view's, not a restatement:
+     *
+     *   1. the page reaches the START of history (`!hasMore`), so it covers the
+     *      view whatever the identities are;
+     *   2. the page CONTAINS the view's oldest row, so it spans everything the
+     *      view holds -- the floor's over-request lands here, and a superset can
+     *      lose nothing;
+     *   3. the page's own oldest row is IN the view, so the ranges overlap and
+     *      `olderHeadAbovePage` can cut a head to keep above it.
+     *
+     * None of the three: the server gained at least `held` rows during the gap, so
+     * page and view are FULLY DISJOINT and the reducer -- correctly declining to
+     * guess a cut it has no identity for -- would drop every loaded row. Refetch
+     * unbounded there. One extra round trip in exactly the case a slice cannot be
+     * stitched, which keeps the alternative off the table: splicing a disjoint
+     * page onto the view publishes a transcript with a silent hole in it.
+     */
+    /* Counts, not membership. A `Set.has` / `Array.some` answers "SOME row carries
+     * this id", and a caller-repeated `meta.mid` makes that true while pointing at
+     * a DIFFERENT occurrence than the one meant -- so the page reads as safe and
+     * the reducer then cuts at the wrong row and drops visible history. Both tests
+     * below therefore go through the one anchor invariant. */
+    /* Validate against the view as it is NOW, not the snapshot the limit was sized
+     * from. `view` was read before the await, and `loadOlderMessages` can resolve
+     * inside it: the rows it prepends are exactly the scrollback a wrong decision
+     * strands, and they can also make an anchor that was unique in the old view
+     * AMBIGUOUS in the new one. Judging a page against a view that no longer exists
+     * is how it gets accepted and then cut wrong.
+     *
+     * The limit itself is not re-derived -- the request is already in flight and a
+     * page that is now too small simply fails the checks below and refetches
+     * unbounded, which is the safe direction. Re-reading is only about the DECISION.
+     *
+     * A slot switch during the await makes the whole answer moot, so it declines the
+     * same way the pre-fetch check does. */
+    const after = (getState() as { chat: ChatState }).chat
+    if (after.activeSlot !== key) return null
+    const viewNow = after.messages
+    const serverRowsNow = viewNow.filter(
+      m => isDurableRow(m) && typeof m.meta?.mid === 'string' && m.meta.mid.length > 0,
+    )
+    const viewCounts = midOccurrences(viewNow)
+    const pageCounts = midOccurrences(page.messages)
+    const anchors = (id: unknown): boolean =>
+      idAnchorsOneRow(id, viewNow, page.messages, viewCounts, pageCounts, { requireTs: true })
+    /* `serverRowsNow` can be empty even though the pre-fetch `held` was positive --
+     * a `clearMessages` landing in the await empties the view -- so the oldest-row
+     * anchor is guarded rather than indexed blind. */
+    const spansView = serverRowsNow.length > 0 && anchors(serverRowsNow[0].meta?.mid)
+    const overlapsView = anchors(page.messages[0]?.meta?.mid)
+    return !page.hasMore || spansView || overlapsView ? page : fetchSlotDetail(key)
   },
 )
 
@@ -5032,7 +5242,32 @@ const chatSlice = createSlice({
           const s = v == null ? '' : String(v)
           return transcriptTsMs(s) ?? 0
         }
-        const merged = [...messages.filter(m => m.role !== 'permission'), ...statePerms.values()]
+        /* This page is now COUNT-MATCHED (see refreshSlot), not the whole
+         * transcript, so the window it returns can SLIDE: when the server gained
+         * rows while this client was away -- which is precisely the reconnect this
+         * refresh exists to recover from -- the most-recent-N slice begins NEWER
+         * than the transcript's own oldest loaded row, and assigning it wholesale
+         * would delete that scrollback. Matching the count keeps the row COUNT, not
+         * the row IDENTITIES.
+         *
+         * So keep any prior head sitting above the page's first row, through the
+         * one shared cut `switchSlot`/`warmSlotCache` use, so a third reducer
+         * cannot re-derive it and diverge (:1360). `thinking` is held out (no
+         * identity, broadcast-only) and re-placed by `mergePreservedThinking`
+         * below; `permission` is held out because `statePerms` re-injects the
+         * client's own copies with their resolved flags, and keeping them here too
+         * would seat each card twice. Identity is `meta.mid` only, so an
+         * unidentified page declines the cut rather than guessing -- the same
+         * boundary the two existing head-keeping reducers already stand on.
+         */
+        const priorServerRows = state.messages.filter(m => m.role !== 'thinking' && m.role !== 'permission')
+        const { olderHead } = olderHeadAbovePage(priorServerRows, messages)
+        /* The cursor is a row OFFSET, so a kept head shifts it down by its own
+         * server-row count. Both boundary cases (head proves completeness / the two
+         * counts disagree) are owned by `pagingCursorAfterKeptHead`, not clamped. */
+        const keptCursor = pagingCursorAfterKeptHead(
+          hasMore, nextBefore, serverRowCount(olderHead))
+        const merged = [...olderHead, ...messages.filter(m => m.role !== 'permission'), ...statePerms.values()]
         const mergedWithPastes = mergePreservedPastes(state.messages, merged)
         // Only sort if permissions were re-injected (they need positional merge).
         // Backend messages arrive in order; sorting with mixed ts formats reorders them.
@@ -5044,11 +5279,21 @@ const chatSlice = createSlice({
         // Coverage from the PURE fetched page (`messages`): `sorted` carries
         // re-injected preserved permission cards, which must not vouch for
         // history the snapshot never covered.
-        state.messages = mergePreservedThinking(state.messages, mergePreservedClientTs(state.messages, sorted), messages)
+        /* `windowComplete` defaults to TRUE, which was accurate while this fetch was
+         * unbounded and is a claim a count-matched page cannot make. It gates the
+         * `ambiguous()` skip, so an over-claim lets a text-anchored block seat on a
+         * duplicate answer inside the window while its real anchor sits above it.
+         * Same value as the `reinsertThinkingOrphans` call below and as
+         * `switchSlot.fulfilled` -- the retained head is part of the loaded window,
+         * so raw `hasMore` would park reasoning whose anchor is already on screen. */
+        state.messages = mergePreservedThinking(state.messages, mergePreservedClientTs(state.messages, sorted), messages, !keptCursor.hasMore)
         // A refresh rebuilds `messages` wholesale, so parked reasoning has to be re-seated
         // here too — otherwise it stays invisible until the next slot switch.
         const parkedOnRefresh = (state.thinkingOrphans ??= {})
-        const seatedOnRefresh = reinsertThinkingOrphans(state.messages, parkedOnRefresh[safeKey(key)] ?? [], !hasMore)
+        // `windowComplete` describes the LOADED window, not the fetch: `messages`
+        // now carries the retained head, so a raw `hasMore` would park reasoning
+        // whose anchor is already on screen.
+        const seatedOnRefresh = reinsertThinkingOrphans(state.messages, parkedOnRefresh[safeKey(key)] ?? [], !keptCursor.hasMore)
         state.messages = seatedOnRefresh.list
         parkedOnRefresh[safeKey(key)] = seatedOnRefresh.remaining
         // Re-hydrate queued bubbles through the SAME shared path as
@@ -5061,7 +5306,7 @@ const chatSlice = createSlice({
         state.slotRunning = running
         state.slotStopping = action.payload.stopping ?? false
         state.pendingTurnSlot = null
-        setPagingCursor(state, hasMore, nextBefore)
+        setPagingCursor(state, keptCursor.hasMore, keptCursor.nextBefore)
         seedContextUsage(state, key, action.payload.context)
       })
       .addCase(warmSlotCache.fulfilled, (state, action) => {


### PR DESCRIPTION
## Problem / Motivation

`refreshSlot` called `fetchSlotDetail(key)` with **no `limit`**, so every recurring
refresh pulled the **whole chained transcript**. It fires on a WS reconnect, on every
`chat_done`, and on a variant switch — so the cost grows with the transcript and is
paid again at the end of each turn. A user with a long session re-downloads their
entire history on every reply.

**The `warmSlotCache` half of #4690 is already fixed** — merged commit `8c751bda1`
(#3240) bounds it to `PANE_HYDRATE_LIMIT`. This PR closes the remaining half and
leaves the warm path untouched.

## Why it matters

The refresh is *recurring*, not one-shot, so this is the transcript-length tax on
every turn end and every reconnect: a multi-thousand-row session pays it repeatedly
for rows already on screen. It gets worse the longer a session is used, which is the
opposite of what the user experiences elsewhere in the chat.

## What changed (motivation → approach → change)

### 1. The client bound (the fix #4690 asks for)

A **fixed** bound is not available to this thunk. Unlike a pane warm, `refreshSlot`
**replaces `messages` in place**, so a `PANE_HYDRATE_LIMIT` page would delete
scrollback the user had paged back through — exactly what the `fetchSlotDetail`
comment was guarding against. So the bound is **count-matched**, against the view's
**server-row span**:

```ts
const view = state.messages
const serverRows = view.filter(m => typeof m.meta?.mid === 'string' && m.meta.mid.length > 0)
const held = serverRows.length
const want = Math.max(held, PANE_HYDRATE_LIMIT)
const bounded = held > 0 && want <= REFRESH_LIMIT_CEILING
```

The handler's slice is the most-recent-N, so a request of that size is bounded (it no
longer grows with the transcript) while never returning fewer rows than are on screen.

The count is the **server-row span**, not `messages.length`: the array also carries
client-only rows (a `thinking` block, a `permission` card, a `queued` bubble) that the
server transcript does not, and counting those over-requests past the view's own span.
`meta.mid` is the server's per-row stamp — the same notion `serverRowCount` and the
reducer's `priorServerRows` are built on. `PANE_HYDRATE_LIMIT` is the **floor**, not a
cap; a floor cannot truncate.

Two carve-outs, both to avoid trading a perf win for a truncation:

- **Above `REFRESH_LIMIT_CEILING` (500).** The handler clamps `limit` to 500
  (`min(int(limit_raw or "200"), 500)`), so a count-matched request above it comes back
  *short* of what it matched. A view paged back past 500 rows keeps the unbounded shape.
- **A view with a server span of zero.** No count to match, and that refresh is the
  client's only read of a transcript the client holds nothing of.

### 2. The sliding window (matching the count is not matching the rows)

Matching the count preserves the row **count**, not the row **identities**. When the
server gained rows while this client was away — precisely the reconnect this refresh
recovers from — the most-recent-N slice begins *newer* than the view's oldest loaded
row. So the page is checked before it is fulfilled, and is safe on any one of three
counts, each a different relationship between its range and the view's:

1. it reaches the **start of history** (`!hasMore`), so it covers the view whatever the
   identities are;
2. it **contains the view's oldest row**, so it spans everything the view holds — where
   the floor's over-request lands, and a superset can lose nothing;
3. its own **oldest row is in the view**, so the ranges overlap and
   `olderHeadAbovePage` can cut a head to keep above it.

On none of the three, page and view are **fully disjoint** and the fetch is retried
unbounded. I deliberately did *not* reuse `warmSlotCache`'s disjoint-and-behind branch
(`[...prior, ...pageTail]`): that is right for a per-slot cache but wrong for the active
transcript, where it would publish rows 120–299 followed by 320–499 with 300–319
silently missing.

For the overlapping case, `refreshSlot.fulfilled` keeps that head through the same three
shared helpers `switchSlot`/`warmSlotCache` already use — `olderHeadAbovePage`,
`serverRowCount`, `pagingCursorAfterKeptHead`. That cut exists precisely so a reducer
consuming a `fetchSlotDetail` page does not re-derive it; re-deriving is how the first
two diverged. The kept head also shifts the older cursor (so "load earlier" is not a
dead click), and `windowComplete` for both reasoning helpers now describes the *loaded
window* rather than the fetch — it defaulted to `true`, a claim a bounded page cannot
make.

### 3. The server-side gap this exposes — filed, not fixed here

Bounding this fetch moves it onto the **other branch** of the slot-detail handler, and
the two branches do not agree about which store decides a row's **content**:

| Branch | Reads | Authority for content |
|---|---|---|
| unbounded | `older + list(slot.messages)` | the in-memory **window** |
| bounded | chained **disk** history | **disk** |

That disagreement is pre-existing on `main` and already reachable through the
pane-hydrate and warm-cache paths. This PR does not introduce it; by bounding the
recurring refresh it makes it **more frequent**.

An earlier revision of this PR carried a server-side reconciliation for it. It drew four
blocking findings in one span across four rounds, and the last three each came out of the
previous round's fix — matching rows after the fact always has a case where the match is
wrong. On the fourth, the reviewing lane recommended removing the mechanism rather than
refining it, and that is what happened: `chat_handlers.py` is byte-identical to `main` on
this branch.

The gap, all four findings, the round-by-round table, and two directions that remove the
ambiguity by construction are in
[#7526](https://github.com/kirodotdev/KiroCrew/issues/7526). The eleven tests written
across those rounds are preserved in commit `c9979c43dff6c8699735802b64d946a913433fed`
for whoever picks it up.

## Tests

**Frontend** — `website/src/store/chatSlice.refreshSlotBound.test.ts`, 20 tests. They
assert **the `limit` argument reaching `api.chatSlotDetail`**, not merely the resulting
state: the argument is the fix, and a state-only assertion would still pass with the
bound removed. The mock mirrors the handler — collapse before slice, most-recent-N, and
the 500 clamp.

*The bound itself:* a recurring refresh sends a `limit` and it is not the corpus size; a
3-row slot asks for `PANE_HYDRATE_LIMIT`; a view paged back to 180 refreshes at **180,
not 50**; `hasMore` **and** `slotOldestIndex` are unchanged for a paged-back view; a
refresh covering the corpus reports `hasMore: false`; a view above the ceiling stays
unbounded; a zero-server-span view stays unbounded; a **streaming** view is
count-matched and loses no rows; a non-active slot fetches nothing.

*A slid window must not drop the head:* the server gaining 5 rows keeps the loaded oldest
rows; the kept head shifts the older cursor; a head proving completeness reports
`hasMore: false`; a gap sliding the page **clear** of the view retries unbounded; a view
with no server identity is not bounded at all; a page already at the start of history
does **not** retry; an id-less **legacy prefix** below the oldest identified row survives
(all 200 rows, `{hasMore: false, oldest: 0}`); a mixed-history page sliding clear retries
unbounded with all 400 rows retained.

*The count is the view's server-row span:* client-only rows are not counted (a 192-row
view holding 12 reasoning rows requests **180**); a window holding reasoning makes
**one** request, not a bounded one plus an unbounded retry; the floor over-requesting
into a **superset** does not retry.

**Red-before:** 7 of the 20 frontend tests fail on the base commit, and the three
head-keeping cases fail with the count-matched bound in place but their own guard
reverted, so each guard is pinned independently rather than by the bound alone.

Also re-ran the neighbouring suites: the `chatSlice` family (8 files, 528 tests) —
including `chatSlice.boundedRefetchShrink.test.ts` and `chatSlice.warmSlotCacheBound.test.ts`,
which pin the anti-shrink contract this PR operates inside — and, to confirm this branch
leaves the server untouched, the three `slot_detail` backend suites against `main`'s own
handler (23 tests, all passing). **No existing assertion was edited or deleted.**

## Manual verification

N/A — unit coverage sufficient. The change is exercised directly: the `limit` argument on
an HTTP call plus the reducer's merge of its response. It has no rendered surface to drive
that the tests do not already cover.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** store-only change — no component, layout, theme, or user-visible
string is touched, so a before/after would be identical pixels.

## Related Issues

Fixes #4690

