### PR TITLE
test(md-notebook): shrink the batch-boundary fixture

### DIFF
--- a/test/test_md_notebook.py
+++ b/test/test_md_notebook.py
@@ -1625,7 +1625,7 @@ async def test_trash_does_not_overwrite_a_same_named_note(fixtures) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sync_refuses_rather_than_pushing_a_subset(fixtures) -> None:
+async def test_sync_refuses_rather_than_pushing_a_subset(fixtures, monkeypatch) -> None:
     """An explicit Sync must not commit only part of what the user asked for.
 
     `status()` reports a rename as TWO entries — old path deleted, new path added —
@@ -1634,6 +1634,11 @@ async def test_sync_refuses_rather_than_pushing_a_subset(fixtures) -> None:
     while the UI reports success. The autosave keeps the cap (it pushes nothing, and
     the next tick repairs a split), so it must still succeed here.
     """
+    # The production limit is an argv-safety bound, not part of this test's
+    # semantics.  Exercising all 500 paths makes a functional assertion depend
+    # on filesystem throughput under Windows CI load; a small injected limit
+    # still proves refusal and the complete two-batch autosave drain.
+    monkeypatch.setattr(git_ops, "MAX_STAGED_PATHS", 3)
     _mod, remote, _seed = fixtures
     async with signed_client(_mod) as client:
         vault = await _clone(client, remote)


### PR DESCRIPTION
## Problem / Motivation

`test_sync_refuses_rather_than_pushing_a_subset` creates and stages 501 real
files to cross the production batch limit. Under concurrent Windows CI I/O,
that functional test can spend the full 120-second product timeout in
`git add`, even though the behavior under test is the batch boundary rather
than the throughput of 500 filesystem writes.

## Why it matters

The load-sensitive fixture can fail an otherwise unrelated PR and restart the
full CI matrix. It also obscures real regressions because the failure is
reported as a product Git timeout rather than a test-load problem.

## What changed (motivation → approach → change)

The test now injects a batch limit of three with `monkeypatch`. It still drives
the real HTTP, repository, commit, and push boundaries and proves the complete
contract: manual Sync refuses an over-limit set without committing or pushing,
autosave drains the same set in two capped commits, and Sync succeeds once the
queue is empty. The production limit remains 500.

No retry, sleep, timeout increase, skip, tolerance, or weakened assertion was
added.

## Tests

- `py -3.12 -m pytest test/test_md_notebook.py::test_sync_refuses_rather_than_pushing_a_subset -n0 -q -W error::RuntimeWarning -W error::pytest.PytestUnraisableExceptionWarning`
- `py -3.12 scripts/check_black_formatting.py`
- `py -3.12 -m isort --check-only test/test_md_notebook.py`
- `py -3.12 -m flake8 test/test_md_notebook.py`
- `git diff --check origin/main...HEAD`

## Manual verification

N/A — this changes only the scale of a hermetic backend test fixture; the real
Git and HTTP integration path remains covered by that test.

## Related Issues

Observed in the Windows backend shard for #6918.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no product behavior changed)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The repository's existing contribution terms apply; no CLA wording is added by
this change.
