### PR TITLE
fix(dashboard): hold the reading position when a message is appended

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -469,18 +469,26 @@ export function useVirtualChat<T>(
   const heightAnchorPendingRef = useRef<{ key: string; top: number } | null>(null)
 
   /**
-   * ONE compensation routine, TWO triggers, ONE capture point.
+   * ONE compensation routine, THREE triggers, ONE capture point.
    *
    *   TRIGGER 1 — prepend (load-older history): every index shifts up, so
    *     pre-existing rows move down by the inserted height.
    *   TRIGGER 2 — upward window shift (scroll recompute / top-sentinel
    *     expansion): rows mount above the viewport, and they are re-measured
    *     from the flat estimate, so the content above the reader changes height.
+   *   TRIGGER 3 — tail append (a new message arrives while the reader is
+   *     scrolled up): nothing is inserted above them, but the growth re-syncs
+   *     the offset tree, and every row that has never been measured is
+   *     re-priced from the running MEAN of the measured ones — so the height
+   *     credited above the reader changes anyway and the transcript slides
+   *     (measured in the harness: a row at screen offset 0 landed at 500).
    *
-   * Both are "content above the reader grew"; the correction is identical, so
-   * they share this slot and the single consumer below.
+   * All three are "the height above the reader grew"; the correction is
+   * identical, so they share this slot and the single consumer below. A parallel
+   * path would fight this one for `scrollTop`, which is why append folds in here
+   * rather than getting an anchor slot of its own.
    *
-   * The capture is in the RENDER phase (getSnapshotBeforeUpdate idiom) for BOTH.
+   * The capture is in the RENDER phase (getSnapshotBeforeUpdate idiom) for ALL.
    * That point is canonical rather than merely convenient: a post-commit read
    * cannot recover a pre-shift position — the row has already moved and the
    * delta reads zero — while a pre-shift capture is valid for the window shift
@@ -505,6 +513,11 @@ export function useVirtualChat<T>(
   const shiftAnchorRef = useRef<{ key: string; top: number } | null>(null)
   const shiftStageRef = useRef<'awaiting-rebase' | 'rebased' | 'ready' | null>(null)
   const prependCountRef = useRef(0)
+  /** Set by part 1 in the commit it schedules a re-base in, cleared by part 2 in
+   *  that same commit. Part 2 now also watches `itemCount` (for trigger 3), so
+   *  it shares a commit with part 1 and would otherwise consume a prepend anchor
+   *  before the re-base kept its row mounted — see part 2. */
+  const rebaseScheduledRef = useRef(false)
   /** Previous render's identity. `items` is held because `itemsRef` has already
    *  advanced by the time the capture runs, while the mounted nodes still carry
    *  the PREVIOUS commit's indices. */
@@ -545,6 +558,14 @@ export function useVirtualChat<T>(
       anchorCapturedThisRender = true
     }
   }
+  // TRIGGER 3's predicate, read BEFORE the mirror below advances: the count grew
+  // while index 0 kept its key, which is a TAIL append (a front insert renames
+  // index 0 and is trigger 1's; a slot switch changes the session).
+  const tailAppended =
+    itemCount > prependPrev.count &&
+    prependPrev.session === sessionId &&
+    prependPrev.firstKey !== null &&
+    prependFirstKey === prependPrev.firstKey
   prependPrevRef.current = { session: sessionId, count: itemCount, firstKey: prependFirstKey, items }
 
   // Window range for what is currently mounted. Initial state is the TAIL of
@@ -572,6 +593,31 @@ export function useVirtualChat<T>(
       : null
     if (shiftAnchor) {
       shiftAnchorRef.current = shiftAnchor
+      shiftStageRef.current = 'ready'
+      anchorCapturedThisRender = true
+    }
+  }
+  // TRIGGER 3 capture. Same slot, same stage as trigger 2: an append needs the
+  // correction only, never a re-base — existing indices do not move, so the
+  // anchor row is already mounted. Keyed on the window start having stayed put,
+  // which is what separates this from trigger 2 (an upward shift) and keeps the
+  // two from double-capturing in one render.
+  //
+  // This capture is what makes the correction possible at all: the DOM read here
+  // is the PREVIOUS commit's geometry, so it records where the reader's row was
+  // BEFORE the re-pricing lands. The offset tree is re-synced later in this same
+  // render (see the `offsetIndex` memo), and after that commit the row has
+  // already moved — a post-commit read would measure zero drift.
+  if (!anchorCapturedThisRender && tailAppended && windowRange.start === windowRangeRef.current.start && !stickRef.current) {
+    const appendEl = scrollerRef.current
+    const appendAnchor = appendEl
+      ? captureTopAnchorFrom(appendEl, elIndexRef.current.entries(), (idx) => {
+          const it = items[idx]
+          return it ? getKey(it, idx) : null
+        })
+      : null
+    if (appendAnchor) {
+      shiftAnchorRef.current = appendAnchor
       shiftStageRef.current = 'ready'
     }
   }
@@ -1469,6 +1515,7 @@ export function useVirtualChat<T>(
       return
     }
     shiftStageRef.current = 'rebased'
+    rebaseScheduledRef.current = true
     setWindowRange((r) => ({
       start: Math.min(itemCount, r.start + inserted),
       end: Math.min(itemCount, r.end + inserted),
@@ -1476,7 +1523,7 @@ export function useVirtualChat<T>(
   }, [itemCount])
 
   /**
-   * Part 2 — the single consumer for BOTH triggers: re-read the anchor row in
+   * Part 2 — the single consumer for ALL THREE triggers: re-read the anchor row in
    * the shifted DOM and move scrollTop by however far it travelled, which holds
    * the user's place whatever mix of inserted rows and re-estimated heights
    * caused the shift.
@@ -1499,6 +1546,13 @@ export function useVirtualChat<T>(
    * window's own decision, and recomputing it here would fight the scroll.
    */
   useLayoutEffect(() => {
+    // Part 1 just scheduled the re-base in THIS commit (both effects watch
+    // itemCount). Its anchor row may not be mounted yet, so stand down once and
+    // leave the slot intact for the re-based commit that follows.
+    if (rebaseScheduledRef.current) {
+      rebaseScheduledRef.current = false
+      return
+    }
     const stage = shiftStageRef.current
     if (stage !== 'rebased' && stage !== 'ready') return
     shiftStageRef.current = null
@@ -1518,7 +1572,11 @@ export function useVirtualChat<T>(
     // cannot be forgotten here (see writeScrollTop).
     if (Math.abs(delta) > 0.5) writeScrollTop(el, el.scrollTop + delta, 'auto', 'pin')
     if (stage === 'rebased') recomputeWindow()
-  }, [windowRange, scrollerRef, writeScrollTop, recomputeWindow])
+    // `itemCount` is an invalidation key, not a value this body reads: TRIGGER 3
+    // captures in a render that changes no windowRange, so without it the
+    // correction would wait for an unrelated window commit and be applied to
+    // geometry that had already drifted.
+  }, [windowRange, itemCount, scrollerRef, writeScrollTop, recomputeWindow])
 
   // Same correction for a HEIGHT-SYNC commit (spacer repricing), keyed on the
   // owner's announced version. See heightAnchorPendingRef for why this cannot

--- a/website/src/test/useVirtualChat.prependAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.prependAnchor.test.tsx
@@ -7,6 +7,10 @@
  * re-bases the window so it stays mounted, then corrects scrollTop by how far
  * that row actually travelled.
  *
+ * A tail APPEND lands on the same path (issue #4352): it inserts nothing above
+ * the reader, but it re-syncs the offset tree, which re-prices every unmeasured
+ * row from the running mean and so changes the height credited above them.
+ *
  * jsdom has no layout, so this installs the same deterministic layout engine the
  * integration suite uses: getBoundingClientRect walks the scroller's children
  * summing heights minus scrollTop. That makes the jump reproducible — the rows
@@ -189,6 +193,33 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     return { el, view, scrollerRef, readScrollTop: () => scrollTop }
   }
 
+  /** Mounts 30 rows and leaves the reader PINNED to the bottom — the primary
+   *  reading mode, where an append must follow the new message down rather than
+   *  hold the old position. `scrollHeight` is derived from the live children
+   *  here (not the fixed constant) so growing the transcript really does move
+   *  the bottom, which is what the follow pin is asserted against. */
+  function mountAtBottom() {
+    const scrollerRef: RefObject<HTMLDivElement | null> = { current: null }
+    let scrollTop = 0
+    const view = rtlRender(<Harness items={mkItems(30)} scrollerRef={scrollerRef} />)
+    const el = scrollerRef.current!
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true, get: () => scrollTop, set: (v: number) => { scrollTop = v },
+    })
+    Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => CLIENT })
+    Object.defineProperty(el, 'scrollHeight', {
+      configurable: true,
+      get: () => Array.from(el.children).reduce((h, c) => {
+        const node = c as HTMLElement
+        if (node.getAttribute('data-index') !== null) return h + REAL_H
+        return h + (parseFloat(node.style?.height || '0') || 0)
+      }, 0),
+    })
+    installFakeLayout(el, CLIENT)
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+    return { el, view, scrollerRef, readScrollTop: () => scrollTop }
+  }
+
   it('holds the reading position when older history is prepended', () => {
     const { el, view, scrollerRef, readScrollTop } = mountScrolledUp()
 
@@ -241,34 +272,84 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     expect(readScrollTop()).toBeGreaterThan(beforeTop)
   })
 
-  it('does not compensate when items are APPENDED, only prepended', () => {
+  it('holds the reading position when a message is APPENDED at the tail', () => {
     const { el, view, scrollerRef, readScrollTop } = mountScrolledUp()
 
     const before = topVisible(el)
     expect(before).not.toBeNull()
     const beforeTop = readScrollTop()
 
-    // Growth alone must not trigger it. Index 0 is unchanged, so nothing was
-    // inserted above the reader and a scroll correction here would be the bug.
+    // Nothing is inserted ABOVE the reader here, which is why this case looks
+    // like it should need no correction. It does: growing the list re-syncs the
+    // offset tree, and every row that has never been measured is re-priced from
+    // the running mean of the measured ones — so the height credited above the
+    // reader changes and the transcript slides under them anyway (the row went
+    // from screen offset 0 to 500 before this trigger existed).
     act(() => {
       view.rerender(
         <Harness items={[...mkItems(30), ...mkItems(10, 'z')]} scrollerRef={scrollerRef} />,
       )
     })
 
-    expect(readScrollTop()).toBe(beforeTop)
-    // Row position is NOT asserted: an append drifts it identically on an
-    // unmodified hook (verified), so that drift is not this path's to fix.
-    expect(screenTopOf(el, before!.key)).not.toBeNull()
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+    // Held the same way the prepend trigger holds it: by moving the viewport
+    // down over the re-priced content, not by touching the estimator.
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
   })
 
-  // ---- Reader-row immobility: ONE invariant, both compensation triggers ----
+  it('holds the reading position when a SINGLE streaming message is appended', () => {
+    const { el, view, scrollerRef } = mountScrolledUp()
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+
+    // The shape a streaming agent actually produces: one row at a time.
+    act(() => {
+      view.rerender(
+        <Harness items={[...mkItems(30), { id: 'z0' }]} scrollerRef={scrollerRef} />,
+      )
+    })
+
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  it('still follows an append to the bottom while the reader is PINNED', () => {
+    const { el, view, scrollerRef, readScrollTop } = mountAtBottom()
+
+    const beforeTop = readScrollTop()
+
+    // Stick is armed, so the append trigger must stand down: following the new
+    // message is the primary reading mode, and holding position here would be
+    // the regression.
+    act(() => {
+      view.rerender(
+        <Harness items={[...mkItems(30), { id: 'z0' }]} scrollerRef={scrollerRef} />,
+      )
+    })
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+    // Followed down and landed exactly on the new bottom...
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+    expect(readScrollTop()).toBe(el.scrollHeight - CLIENT)
+    // ...so the appended message is what the reader is looking at.
+    const appended = screenTopOf(el, 'z0')
+    expect(appended).not.toBeNull()
+    expect(appended!).toBeGreaterThanOrEqual(0)
+    expect(appended!).toBeLessThan(CLIENT)
+  })
+
+  // ---- Reader-row immobility: ONE invariant, every compensation trigger ----
   //
-  // A prepend and an upward window shift are two ways the content above the
-  // reader grows. The user-visible contract is identical for both: the row
-  // being read does not move. These cases pin that contract per TRIGGER,
-  // independent of which internal slot carries the anchor, so collapsing the
-  // capture paths cannot silently drop one of them.
+  // A prepend, an upward window shift and a tail append are three ways the
+  // height credited above the reader grows. The user-visible contract is
+  // identical for all of them: the row being read does not move. These cases
+  // pin that contract per TRIGGER, independent of which internal slot carries
+  // the anchor, so collapsing the capture paths cannot silently drop one of
+  // them.
 
   it('INVARIANT holds the reader row across the PREPEND trigger', () => {
     const { el, view, scrollerRef } = mountScrolledUp()


### PR DESCRIPTION
<!-- no-visual-delta -->

Fixes #4352

## What

While you are scrolled up reading earlier messages, a new message arriving at the bottom moved the row you were reading down the screen. In the virtualizer's own harness a row sitting at screen offset `0` was at offset `500` after an append.

## Root cause (re-confirmed against `origin/main` @ `d7b7d65c3`)

The issue's hypothesis is correct, and the exact trigger turned out to be observable:

- `HeightIndex.heightAt` (`website/src/hooks/virtualizer/HeightIndex.ts:141`) prices any row that has never been measured as `this.cache.averageHeight(this.estimate)`.
- `HeightCache.averageHeight` (`website/src/hooks/virtualizer/HeightCache.ts:151`) is `Math.min(this.measuredSum / n, MAX_MEAN_PX)` — a running mean over **measured** rows only.
- Growing the list re-syncs the offset tree during render (`useVirtualChat.ts`, the `offsetIndex` memo calls `heightIndex.sync(itemCount)`), and that rebuild re-reads every row's height.

So an append re-prices every unmeasured row, **including the ones above the viewport**. Instrumented in the harness: the top spacer went from `2000px` to `2500px` across the append commit while `scrollTop` stayed at `2200`, moving row `m27` from screen offset `0` to `500`. Nothing was inserted above the reader; the height credited to them changed.

The estimator is deliberately **not** touched. Its own comments (`HeightCache.ts:14`, `:46`) record that a frozen mean and a flat estimate were both measured in a real browser and were worse (peak `scrollHeight` correction `~51,500px` → `~387,000px`).

## The fix

The append folds in as a **third trigger of the anchor path #6645 already unified** (prepend + upward window shift), not a new path — a parallel path would fight the existing one for `scrollTop`.

- **TRIGGER 3 capture** — render phase, same slot, same `'ready'` stage as the window-shift trigger. Keyed on the count growing while index 0 keeps its key (a tail append) and the window start staying put (which is what separates it from trigger 2). The render-phase DOM read is load-bearing: it records where the reader's row was *before* the re-pricing commits, because a post-commit read measures zero drift.
- An append needs the correction **only**, never a re-base — existing indices do not move, so the anchor row is already mounted.
- `stickRef` still gates it. A reader pinned to the bottom follows the new message down exactly as before; only a scrolled-up reader holds position.

Two supporting details:

- Part 2 (the single consumer) now also watches `itemCount`. A trigger-3 capture happens in a render that changes no `windowRange`, so without it the correction would wait for an unrelated later window commit and be applied to geometry that had already drifted.
- That shared commit means part 2 would consume a **prepend** anchor before part 1 had re-based the window to keep its row mounted. Part 1 now marks the commit it schedules a re-base in, and part 2 stands down once, leaving the slot intact for the re-based commit.

## Proof — red before, green after

The issue named the exact repro: the append case in `useVirtualChat.prependAnchor.test.tsx` carried a comment saying out loud that row position was **not** asserted because "an append drifts it identically on an unmodified hook (verified)". That comment is now an assertion.

On unmodified `main`, with the new assertions and the hook change reverted:

```
FAIL  holds the reading position when a message is APPENDED at the tail
      AssertionError: expected 500 to be less than or equal to 1

FAIL  holds the reading position when a SINGLE streaming message is appended
      AssertionError: expected 500 to be less than or equal to 1
```

`500` is the drift the issue reported. With the fix, all 7 cases in the file pass.

Three cases changed/added:

| case | pins |
| --- | --- |
| `holds the reading position when a message is APPENDED at the tail` | replaces `does not compensate when items are APPENDED, only prepended`, whose `expect(readScrollTop()).toBe(beforeTop)` asserted the bug. The row-position assertion supersedes it — holding the row *is* the contract, and it is held by moving the viewport. |
| `holds the reading position when a SINGLE streaming message is appended` | the shape a streaming agent actually produces — one row at a time. |
| `still follows an append to the bottom while the reader is PINNED` | the primary reading mode. Asserts `scrollTop` lands exactly on the new bottom and the appended row is on screen, so a mis-gated `stickRef` fails here rather than in production. |

## Verification

- The full virtualizer family is green with no assertion weakened anywhere: `useVirtualChat.anchorRestore`, `heightSyncAnchor`, `integration`, `layoutShrink`, `observerBackfill`, `postStreamLurch`, `prependAnchor`, `railCollapse`, `spacerLurch`, `viewportResize`, `test`, `UseVirtualChatCoverage`, `HeightCache`, `HeightCache.multiInstance` — **153 tests, 14 files, 0 failures**.
- Full website suite: **26,342 passed / 1,666 files**. The single failure is `src/i18n/productName.test.ts`, which fails identically on pristine `d7b7d65c3` with this diff stashed (two i18n catalog strings hardcode the product name) — inherited, not from this change.
- `tsc -b` clean, `eslint` clean on both touched files.

## Screenshots

No static visual delta — this is a scroll-position fix; the rendered markup is identical and the difference is where the viewport sits across a commit. The drift and its correction are pinned by the assertions above (`500px` → `≤1px`).
