### PR TITLE
chore(cron): remove confirmed dead code in the cron and task surface

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -75,9 +75,6 @@ _REARM_BACKOFF_MAX_SHIFT = 16  # clamp the 2**shift exponent
 # to cancel the pending fire again if they are still actively conversing.
 _OVERDUE_REARM_SECS = 10
 
-# Sentinel file per loop: creating it halts the loop on next cycle.
-STOP_SENTINEL = "STOP"
-
 # Persisted source category for a deliberate ``autonudge_stop`` directive.
 # The caller's free-form explanation is intentionally not stored: it is
 # model-authored text and the watchdog only needs the deterministic source.

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -27,7 +27,6 @@ from kiro_crew.subagent import compute_max_subagents
 from kiro_crew.task_executor import (
     build_task_prompt,
     execute_single_task,
-    run_tests,
 )
 from kiro_crew.task_executor import self_review as self_review_fn
 
@@ -1820,13 +1819,6 @@ class TaskRunner:
             if run.last_task_time > now - _STALL_TIMEOUT:
                 stall_notified = False
                 self._stall_cancelled_ids.discard(run.task_id)
-
-    # ── Test Verification ──
-
-    async def _run_tests(self) -> tuple[bool, str]:
-        if not self._test_cmd:
-            return True, "no test command configured"
-        return await run_tests(self._test_cmd, self._work_dir)
 
     # ── Runs Persistence ──
 

--- a/test/test_taskrunner_coverage.py
+++ b/test/test_taskrunner_coverage.py
@@ -1177,27 +1177,6 @@ class TestWatchdogLoop:
         assert any("stalled task" in call.args[0] for call in notify.await_args_list)
 
 
-# ── Tests hook ──
-
-
-class TestRunTests:
-    @pytest.mark.asyncio
-    async def test_no_command_configured(self, tmp_path: Path) -> None:
-        ok, out = await _runner(tmp_path)._run_tests()
-        assert (ok, out) == (True, "no test command configured")
-
-    @pytest.mark.asyncio
-    async def test_delegates_to_run_tests(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        runner = _runner(tmp_path)
-        runner._test_cmd = ["pytest", "-q"]
-        fake = AsyncMock(return_value=(False, "1 failed"))
-        monkeypatch.setattr(tr, "run_tests", fake)
-        assert await runner._run_tests() == (False, "1 failed")
-        assert fake.await_args.args == (["pytest", "-q"], Path(tmp_path))
-
-
 # ── Registry persistence ──
 
 


### PR DESCRIPTION
Dead-code audit of the cron / task / workflow / eval group. Two symbols confirmed unreachable and deleted; 30 candidates rejected or deferred with reasons; five design gaps surfaced that are **not** dead code and are left untouched.

## Deleted (2 symbols, 32 lines)

### `STOP_SENTINEL` — `src/kiro_crew/autonudge.py`

Its own sole occurrence repo-wide. Searched `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1` plus `docs/`, `docs/system-specs/`, `builtin_skills/`, `skills/`, `config/*.md`, `config-baseline.json`, `error-code-baseline.json`, `.github/`, `Makefile`, `scripts/`, `pyproject.toml` — zero hits. No `__all__` in the module, no import-under-alias, no `getattr`, no module-attribute lookup on `autonudge`.

The kill switch it appears to name is **not** wired through it. The live mechanism is a caller-supplied `stop_sentinel_path` resolved by `resolve_stop_sentinel` (`autonudge_authz.py`:53-57) and stat'd directly in `_timer` (`autonudge.py`:1573-1575, `Path(loop.stop_sentinel_path).exists()`). The three real consumers each declare their own filename rather than importing this constant:

- `apps/builtins/issue_radar/backend/crew_runtime.py`:437 — `return d / "STOP"`
- `apps/builtins/spec_builder/backend/routes.py`:201 — `_STOP_FILE = "STOP"`
- `apps/builtins/auto_research/handlers.py`:1759 — inline `"STOP"`

30-day gate: introduced `849a03fff`, 2026-07-16 (45 days). The stop-sentinel test (`test_autonudge.py`:579-594) passes unchanged.

### `TaskRunner._run_tests` — `src/kiro_crew/taskrunner.py`

Three-line shim over `task_executor.run_tests` (live at `task_executor.py`:702). Its `if not self._test_cmd` guard is already subsumed by production's `if auto_test and test_cmd` at `task_executor.py`:701. No production caller, no subclass caller, no string dispatch, no method table, no docs mention.

The four apparent references at `test_taskrunner_v2_scenarios.py`:1751/1764/1984/1989 are a **local function of the same name** passed as `side_effect` when patching `kiro_crew.task_executor.run_tests` — not references to the deleted method. Verified by reading each site.

30-day gate: 2026-07-16 (45 days).

Companion removals:

- the `run_tests,` entry in the `from kiro_crew.task_executor import (...)` block at `taskrunner.py`:27-31 — sole consumer was the shim, would fail F401. This block is **not** the public re-export block, which begins at `:33` marked `# noqa: F401`; nothing imports `run_tests` from `kiro_crew.taskrunner`.
- `class TestRunTests` in `test/test_taskrunner_coverage.py` — both tests called `runner._run_tests()` directly, i.e. self-tests of the shim, never the production path.

Cascade checks: `self._test_cmd` stays live (set at `:284`, read in production at `:1169` where it is passed into `execute_single_task`). `_runner` (88 uses), `tr` (12), `AsyncMock`, `patch`, `Path` all still used in the test file. Zero residual references to either deleted symbol.

## Candidate generation

| pass | method | candidates in scope |
|---|---|---|
| 1 | vulture on scope files only | 217 — discarded, a file-subset scan cannot see cross-module callers |
| 2 | vulture whole repo (`src/kiro_crew` + `test`) | 7 |
| 3 | AST: defined names − Name(Load)/Attribute/str-constant refs, repo-wide | 1 real (34 were `ast.NodeVisitor` `visit_*` dispatch and `__post_init__`/`__repr__` dunders) |
| 4 | tokenize: real NAME tokens only, docstrings excluded | agreed with pass 3 |
| 5 | test-only references (zero production refs, ≥1 test ref) | 25 |
| 6 | half-wired lifecycle pairs, 19 verb pairs | 0 by heuristic; 3 found by manual inspection |

Triple-intersection = `STOP_SENTINEL`. Union = 32, all confirmed individually.

## Rejected as alive (5)

| symbol | why the scan was wrong |
|---|---|
| `ScriptContext` — `cron_script.py`:274 | Instantiated by the generated child launcher **inside a string literal**: `:654` imports it, `:665` does `ctx = ScriptContext(job=job)` in generated source. Invisible to any AST scan. Documented cron-script SDK. Deleting it breaks every script cron. |
| `append_heartbeat_task` — `heartbeat.py`:65 | Agent-facing API reachable by instruction, not by call. `config/prompt.md`:128 and `config/prompt-orchestrator.md`:263 both tell the model to call `kiro_crew.heartbeat.append_heartbeat_task(entry)` and forbid editing `HEARTBEAT.md` directly. |
| `ctx.send_slack` — `workflows/__init__.py`:181, `runner.py`:552 | Workflow `ctx` DSL, string-called by author scripts. Wired port at `runner.py`:312, gated by conformance D5, documented `workflows.md`:277, used by the shipped example `examples/workflows/03_scheduled_triage_native.py`:68. |
| `content_chars`, `result_bytes` — `events/kinds.py`:43, 83 | Dataclass schema fields, populated by `events/backfill.py`:283 and :385. |
| `use_24hour_time_format` — `cron.py`:765 | Attribute on the third-party `cron_descriptor.Options()` object. Not our symbol. |

## Deferred (25)

**Rule: documented public surface — report only.** `ack_job` / `unack_job` (`cron.py`:2735, 2767) are superseded by their `_async` siblings in every production caller, but both names appear in `learn-cron-dashboard.md`:65, in the `CronStoreBusy` docstring at `cron.py`:436-437, **and** in the `_CRON_WRITES` frozenset whose guard test asserts `callable(getattr(CronService, name))` — removal is a spec + guard edit, not a code deletion. Same rule holds `current_run` (`taskrunner.md`:172), `_persist_runs` (documented twice as a "synchronous compatibility/testing helper only"), `register_internal_read_path` (an edition CPP seam at `platform-context.md`:930 whose whole class is caller-free in OSS by design — `register_selectable_backend` and `register_embedding_backend` also have zero in-tree callers), `serialize_events` / `deserialize_events`, `score_locomo` / `score_longmemeval`, `compare_interleaved` / `sensitivity_check`, and `_open_in_pinned_parent`.

**Rule: inside the 30-day gate.** `_save_snapshot` (`hooks.py`:4147, 2026-08-06, 24d) — genuinely superseded, `fire()` now persists via `_persist_current()` → `_save()` under mutex. `is_evidence_only` and `recall_ceiling_note` (both 2026-08-12, 18d); `recall_ceiling_note` is a superseded inlined duplicate of `run.py`:213 `_ingest_warnings`, which emits the same sentence with injection attribution the property lacks.

**Rule: test-referenced with no production caller ⇒ refactor, not deletion.** Six pure pass-through shims in `taskrunner.py` whose delegates production calls directly — `_normalize_cross_group_deps`, `_build_task_prompt`, `_save_progress`, `_load_checkpoint`, `_build_resume_context` — plus `runs_dir` (`workflows/store.py`:96, whose six internal uses all go to `self._runs_dir`). Their tests assert the *delegate's* behaviour and reach it through the shim; several are shared fixture helpers seeding ~10 unrelated tests each. `_run_tests` is the one shim that escaped this rule: its only two tests tested the shim itself.

## Needs a maintainer decision — not touched

1. **`AutoNudgeService.stop()` has zero production callers.** Its docstring at `autonudge.py`:365 claims "`stop()` is reached from SYNCHRONOUS callers — the gateway's shutdown path and test…", but the gateway shutdown block at `slack/gateway.py`:8528-8532 stops `cron_svc` and `heartbeat_svc` only; `autonudge_svc` is absent. `stop()` cancels all timers and clears `_INSTANCE`, so without it nudge timers and the module singleton survive shutdown. A half-wired lifecycle whose deadness is the defect — looks like a one-line gateway fix.
2. **GATE B4 is green while the code path it names is unused.** The gate asserts workflow persistence is "JSON only — `serialize_events`/`deserialize_events`". Real write is `registry.py`:185 `to_store_json` → `store.py` `json.dumps`; real read is `registry.py`:234 `[WorkflowEvent.from_json(e) for e in obj.get("events", [])]`, which skips `deserialize_events`'s array-shape check **and** its per-event `validate_event` loop. Fully-orphaned pair plus a spec-vs-code disagreement.
3. **`WorkingMemory.files_changed` has no production writer.** `update_from_result` (`task_models.py`:81) is its only writer and has no callers, while the reader is live (`summary()` ← `taskrunner.py`:1222, `task_executor.py`:756) — so the prompt's "Files Changed" section is permanently empty in production. `test_taskrunner_v2_scenarios.py`:2545 records "In V2, `update_from_result` was removed": the call site was deleted, the writer was not. Either rewire it or delete the writer plus the field.
4. **`eval/bench/scorers.py` + `stats.py` are an unwired half-module,** not four dead functions. Neither is imported anywhere under `src/`; `bench/__init__.py` wires only `corpus`/`datasets`/`ingest`/`retrieval`/`run`, and `cli_bench.py`'s subparsers are `list`/`fetch`/`retrieval`/`compare` — the retrieval half only. But `bench/__init__.py`'s own docstring documents `.scorers`/`.stats` as the answer-metric half of the design, and `score_locomo` carries 307 lines of live logic (`normalize_answer`, `token_f1`, `multi_answer_f1`, `refusal_score`, `aggregate`). Authored-but-unwired; the remedy is a `bench score` subcommand, not deletion.
5. **`TaskRunner(auto_commit=…)` is a documented knob that does nothing.** `taskrunner.py`:272 assigns `self._auto_commit`; nothing ever reads it, and the parameter appears in `taskrunner.md`:146. Deleting only the attribute would leave the parameter silently ignored — the same defect, less visible; deleting the parameter is an API change.

## Two rotted tests found in passing

- `test/test_hooks_json_shared_file.py`:91 asserts in its docstring that "the async `fire()` path writes through `_save_snapshot`, not `_save`". False since `1f91027dc`. The test passes only because it calls `_save_snapshot` directly, so the real `fire()` → `_persist_current()` seam is uncovered.
- `test_taskrunner_v2_scenarios.py::TestScenarioCheckpointResumeWithGit` is **vacuous**: it patches `runner._load_checkpoint`, but `run()` calls the module-level `load_checkpoint(spec_path)` at `taskrunner.py`:970, so the patch never fires. Its `result.tasks[0].status == PASSED  # from checkpoint` assertion passes because the test's own `_mock_exec_steps` sets every PENDING task to PASSED. Checkpoint-resume-with-git has no real coverage.

## Verification

`flake8` clean · `isort --check` clean · 536 affected tests pass (`test_taskrunner_coverage` + `test_autonudge` 214; `test_taskrunner`, `test_taskrunner_v2_scenarios`, `test_plan_mode`, `test_scenarios_v2_logic`, `test_taskrunner_atomic_persistence`, `test_run_tests_reap` 322).

Two local reds are pre-existing on `origin/main` and reproduce on the unmodified tree (verified by `git stash`), so they are untouched: `black --check test/test_taskrunner_coverage.py` fails because the local Python 3.12 cannot AST-verify code targeting 3.14, and `test_autonudge.py::TestSentinelPathRepair::test_unnormalized_path_escaping_legacy_is_preserved` asserts `.kiro/crew` is absent from a `$HOME`-derived path, which does not hold where `$HOME` is `/local/home/...`.

Reviewed locally before push by two independently pinned reviewers (`gpt-5.6-sol`, `claude-opus-4.8`), each asked to falsify the safety claim across seven specific angles including the kill-switch question and the re-export-block question. Both returned no findings.

Behaviour unchanged. No reformatting, no refactoring, nothing outside the audited group.
