### PR TITLE
chore(computer-use): remove confirmed dead code in the computer-use and voice surface

### DIFF
--- a/src/kiro_crew/computer_use/overlay.py
+++ b/src/kiro_crew/computer_use/overlay.py
@@ -40,7 +40,7 @@ import json
 import logging
 import sys
 import threading
-from typing import Any, Sequence
+from typing import Any
 
 from kiro_crew import platform_compat
 from kiro_crew.computer_use.cursor_motion import MotionPlan, plan_motion
@@ -423,11 +423,6 @@ def _move_command(plan: MotionPlan) -> "dict[str, Any]":
         OVERLAY_KEY_POINTS: [[point[0], point[1]] for point in plan.points],
         OVERLAY_KEY_MS: plan.duration_ms,
     }
-
-
-def points_payload(points: Sequence[tuple[float, float]]) -> "list[list[float]]":
-    """Wire form for an arbitrary point sequence (used by tests and diagnostics)."""
-    return [[float(x), float(y)] for x, y in points]
 
 
 # ── Process-wide shared supervisor ──

--- a/src/kiro_crew/computer_use/tools.py
+++ b/src/kiro_crew/computer_use/tools.py
@@ -274,11 +274,6 @@ _SECURE_TARGET_TOOLS: frozenset[str] = frozenset(
         TOOL_SCROLL,
     }
 )
-# Tools that synthesize KEYSTROKES. Both are element-targeted, and both are refused
-# outright without an index (see 3b in ``_dispatch``) — including
-# ``computer_press_key``, because ``press_key('tab')`` can MOVE focus onto a
-# password box and the next keystroke would land there.
-_KEYBOARD_TOOLS: frozenset[str] = frozenset({TOOL_TYPE_TEXT, TOOL_PRESS_KEY})
 
 
 def dispatch_tool(

--- a/src/kiro_crew/computer_use/types.py
+++ b/src/kiro_crew/computer_use/types.py
@@ -334,37 +334,7 @@ OBS_SUPPRESSED_NOTE = (
     "Screenshot suppressed: your organization's security policy does not permit "
     "screen capture. The accessibility tree above is the full available detail."
 )
-OBS_VALUES_SUPPRESSED_NOTE = (
-    "Element values suppressed: your organization's security policy does not "
-    "permit reading field contents."
-)
-OBS_TITLES_SUPPRESSED_NOTE = (
-    "Window titles suppressed: your organization's security policy does not "
-    "permit reading window titles."
-)
-OBS_TREE_SUPPRESSED_NOTE = (
-    "Accessibility tree suppressed: your organization's security policy does not "
-    "permit reading window contents."
-)
-OBS_PATHS_SUPPRESSED_NOTE = (
-    "Filesystem paths in this result were replaced: your organization's security "
-    "policy does not permit disclosing file paths."
-)
 GOVERNED_VALUE_PLACEHOLDER = "<redacted:policy>"
-GOVERNED_PATH_PLACEHOLDER = "<redacted:path>"
-
-# Absolute-path shapes scrubbed when the ``file_paths`` channel is denied.
-# Deliberately broad and deliberately NOT a completeness claim: an accessibility
-# tree leaked real volume names, document paths and bundle ids in live probes, and
-# a relative path or a path split across two AX attributes is not matched. The
-# honest framing (documented in computer-use.md): denying ``file_paths`` reduces
-# disclosure, it does not prove absence — a fleet that needs a bound should also
-# narrow ``apps``. Covers POSIX absolute paths, ``~``-relative paths, and Windows
-# drive/UNC paths.
-PATH_SCRUB_PATTERNS: tuple[str, ...] = (
-    r"(?:[A-Za-z]:[\\/]|\\\\)[^\s\"'<>|]*",
-    r"~?/[A-Za-z0-9._~\-][^\s\"'<>|]*",
-)
 
 # ── Keystone primary-enable state file ──
 # NOT config.json: a primary enable for full desktop observation plus input
@@ -442,7 +412,6 @@ MAX_SCREENSHOT_MAX_PX = 2000
 SCREENSHOT_DIR_NAME = "kirocrew-computer-shots"
 SCREENSHOT_FILE_PREFIX = "shot-"
 SCREENSHOT_FILE_SUFFIX = ".jpeg"
-SCREENSHOT_MIME = "image/jpeg"
 # Ring-trim: the dir is a cache, not an archive. Bounded so a long session
 # cannot fill the temp volume.
 SCREENSHOT_KEEP = 200
@@ -632,17 +601,12 @@ REFUSAL_DISABLED = (
     "computer use is disabled. Enable it in the KiroCrew dashboard under "
     "Settings -> Computer Use; it cannot be enabled by an agent."
 )
-REFUSAL_UNATTENDED = (
-    "computer use is not available to unattended sessions ({session}). It runs "
-    "only in an interactive session where a human can see the approval prompt."
-)
 REFUSAL_DENIED_APP = "'{app}' is a blocked target for computer use ({reason})."
 REFUSAL_SECURE_TARGET = (
     "refusing to send input to a secure (password) field: element {index} of "
     "'{app}' has subrole {subrole}."
 )
 REFUSAL_TEXT_SENSITIVE = "refusing to type this text into '{app}': {reason}"
-REFUSAL_GOVERNANCE = "computer use is not permitted by the active security policy: {reason}"
 
 # ── Refusals ──
 # The real-pointer path, refused when an IN-PROCESS caller passed


### PR DESCRIPTION
Dead-code audit of the **computer-use / voice / connectors** group (≈36k lines: `computer_use/`, `browser/`, `stt/`, `apple_speech/`, `connections/`, `providers/`, `mcp_computer.py`, `transcribe.py`, `voice_reply.py`, `imaging.py`, `qr.py`). One commit, 47 deletions, no behaviour change, no refactor, no reformatting.

## Candidate generation

Three independent scanners; only the intersection was carried forward.

| Pass | Findings |
|---|---|
| vulture `--min-confidence 60` | 149 — dominated by TypedDict/dataclass fields and Protocol/base-class stubs, excluded by design |
| AST (defined names minus Load/Attribute/keyword names) | 622 raw — too weak alone, any in-file `self.x` marks a symbol alive |
| tokenize (real NAME tokens only, repo-wide occurrence count == 1) | 40 — excludes docstring/comment substring collisions |
| **Confirmed after the full protocol** | **11** |

Each survivor then went through: repo-wide search across `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1` including `tests/`, `docs/`, `system-specs/`, `builtin_skills/`, `.github/`, baselines and `pyproject.toml` entry points (never truncated through `head`); a bare-string / value-dispatch sweep; a reverse-direction reachability proof; a public-surface check (`__all__`, docs, SKILL.md); the 30-day new-code gate; and a cross-platform reachability proof for every Windows-only and macOS-only candidate.

## Deleted (11 symbols)

### `computer_use/types.py` — observation-ceiling and refusal residue (9)

Root fact: `gate.permitted_observation_channels()` returns `frozenset(ALL_OBSERVATION_CHANNELS)` unconditionally and `gate.apply_observation_ceiling()` is `return dict(payload)` (`gate.py:164-187`) — no branch on platform, edition, config, session or policy, and neither consults the real `GovernanceCeiling` model in `platform/governance.py`. The layer was already a pass-through at the commit that introduced the package (verified with `git show d6d8a0da4:.../gate.py`), and the removal is documented in `docs/system-specs/modules/computer-use.md:606-607`, `:2433-2437` and `governance.md:2504-2510`. These constants are residue of a documented non-feature, not an unfinished control.

| Symbol | Evidence |
|---|---|
| `OBS_VALUES_SUPPRESSED_NOTE` | Zero refs; literal `"Element values suppressed"` only at its own def. The `element_values` deny path (`tools.py:1039`) drops detail via `GOVERNED_VALUE_PLACEHOLDER` and `tools.py:1029-1032` states explicitly that ceiling notes are *deliberately not* appended. |
| `OBS_TITLES_SUPPRESSED_NOTE` | Zero refs; `OBS_WINDOW_TITLES` is never membership-tested, only declared into the pass-through gate (`tools.py:1260`). |
| `OBS_TREE_SUPPRESSED_NOTE` | Zero refs; `OBS_A11Y_TREE` never membership-tested (`tools.py:1258` only). |
| `OBS_PATHS_SUPPRESSED_NOTE` | Zero refs; `OBS_FILE_PATHS` has no consumer at all beyond its def and the channel tuple. |
| `GOVERNED_PATH_PLACEHOLDER` | Zero refs; literal `"<redacted:path>"` appears nowhere else. Live sibling `GOVERNED_VALUE_PLACEHOLDER` is consumed at `tools.py:1071` — **kept**. |
| `PATH_SCRUB_PATTERNS` | Zero refs; sole intended consumer `_scrub_paths` **does not exist in the tree**. No inlined duplicate of either regex. |
| `SCREENSHOT_MIME` | Zero refs. No image bytes cross a wire from this path: tool results are text-only, only the file path is relayed; the live-view frame uses `screencast.FRAME_FORMAT` and the browser hardcodes the data-URL prefix (`useComputerUseFrame.ts:65`). The four spool siblings are all alive — kept. |
| `REFUSAL_UNATTENDED` | Zero refs. The unattended rule is removed, stated in five source comments plus `governance.md:1230-1233` ("Neither exists."). Not in `error-code-baseline.json`, no i18n catalog entry, no prose-enumerating test. |
| `REFUSAL_GOVERNANCE` | Zero refs. Unreachable by construction: `require_computer_use` is `return None` on every path (`gate.py:88`), so its one caller's `if denial:` branch can never be entered — a property `test_computer_use_gate.py:286` pins. |

### `computer_use/overlay.py` (1)

**`points_payload`** — zero refs. Its docstring claimed "used by tests and diagnostics"; that is false, there were zero test refs and zero diagnostic callers at the parent commit. Superseded by the inline comprehension in `_move_command` (`overlay.py:423`), which is the actual wire path. Not in `overlay.py.__all__`. Removing it left `Sequence` unused, so that import went too (no other use remains in the file).

### `computer_use/tools.py` (1)

**`_KEYBOARD_TOOLS`** — zero refs, a dead duplicate. Superseded by `_ELEMENT_REQUIRED_TOOLS` (`tools.py:244-251`), a strict superset whose own comment says so ("keyboard tools included"). The live "keyboard tool refused without an index, so a keystroke cannot land on a password box" control is carried by `_ELEMENT_REQUIRED_TOOLS` plus `_SECURE_TARGET_TOOLS` (`tools.py:268`, used at `:715`) — both contain `TOOL_TYPE_TEXT` and `TOOL_PRESS_KEY`, both active. **No guard is weakened.** (One blank line was restored under the removed block to satisfy E302; that is the single `+` line in the diff.)

Post-deletion: zero residual references for all 11 across every scanned file type.

## Deferred (13)

**30-day new-code gate (10).** All from `f4e31653b` (#4530, 10d) and `14775e490` (#3260, 13d):
- `_SMOOTHING_NONE` (`capture_windows.py:98`) — dead on evidence *including on Windows*: its consumer `GdipSetSmoothingMode` is not bound in the FFI table (`capture_windows.py:264-265`), and the dynamic `getattr(lib, symbol)` loop iterates that same table.
- `ACTION_COLLAPSE` (`windows_driver.py:243`) — local alias only; `WINDOWS_ACTION_COLLAPSE` is alive and the value `"collapse"` still reaches the driver by string via `SUPPORTED_ACTIONS`.
- `registry_slugs` (`connections/tool_aliases.py:183`) — dead on evidence (13d); every real consumer calls `get_all_registry_providers()` directly.
- 7 × Win32 FFI enum mirrors (`windows_ffi.py`): `TreeScope_Element`, `TreeScope_Descendants`, `ExpandCollapseState_PartiallyExpanded`, `ScrollAmount_SmallDecrement`, `DPI_AWARENESS_CONTEXT_{UNAWARE,SYSTEM_AWARE,PER_MONITOR_AWARE}`. Held for a second reason too: each is one member of a faithful mirror of a documented UIA/Win32 enum whose other members are load-bearing, and deleting a middle ordinal makes the block read as a mistranscription — the exact failure the `UIA_IsPasswordPropertyId` comment (`windows_ffi.py:151-157`) documents at length.

**Test-referenced with no production caller — refactor, not deletion (3):** `exposed_server_keys` (`tool_aliases.py:270`, superseded by a direct `_parse_tool_refs` call at `:321`), `unsupported_snapshot` (`backend.py:525`, its stated consumer never materialized), `char_keystroke` (`keymap.py:391`, its per-character path was deliberately rejected for Unicode key events at `macos_driver.py:495-499`).

## Rejected as alive — worth recording

- **`DriftVerdict.prior_state_loaded` / `_recorded_at` / `_discarded`** (`connections/l0_drift.py:58-60`) — `DriftVerdict` is a **TypedDict**, so the field names *are* the runtime dict keys, written literally at `l0_drift.py:158-160` and asserted in `test_connections_l0_probe.py`. The scanners saw one identifier occurrence because the values flow through `StateLoad` while the keys are string literals. This is the expected false-positive class for serialized shapes.
- **`_packaged_ffmpeg_version_probe`** (`transcribe.py:586`) — imported at build time by `packaging/build-desktop.sh:184` and pinned by `website/electron/test/packaging.test.js:342-343`.
- **26 further vulture findings** across `alias_record.py`, `mint.py`, `ownership.py`, `status.py`, `command_bus.py`, `enable_state.py`, `stt/engine.py`, `voice_reply.py`, `transcribe.py`, `qr.py`, `imaging.py`, `mcp_computer.py`, `backend.py` — all have production callers, mostly in `dashboard/handlers/connections.py`, `dashboard/handlers/messaging.py`, `agent.py`, or a CLI verb (`run_mcp_server` is the `kirocrew mcp-computer` verb at `cli.py:2675`).

## Needs a decision (not in this diff)

1. **`PAYLOAD_SCREENSHOT_META` (`gate.py:54`, in `__all__`) — a real correctness finding rather than dead code.** `gate.py:50-53` says these payload keys are named constants "because `tools` and `render` both build and destructure these dicts, and a typo would silently drop a field rather than fail" — yet `tools.py:1123-1125` builds all three keys with bare string literals. Worse, the three keys are **write-only**: `_render_snapshot`'s rebuild (`tools.py:1132-1145`) reads back only window-title/elements/screenshot and takes width and height from `snap`, never from `shaped`. A typo is silently harmless today and silently lossy the day the ceiling stops being a pass-through. Fix is either to wire `tools.py:1123-1125` through the constant, or to delete the constant *and* the three write-only keys together.
2. **`is_mutating_action` (`gate.py:155`, in `__all__`, named in `governance.md:2441`) — retained-by-design accessor.** The spec is accurate and does not claim a consumer: "it currently has no caller in the package: it is retained as the accessor an edition would use." The "one live consumer" is `hooks`, which reads the SSOT table directly (`hooks.py:1409`). Not an inlined duplicate — the predicates genuinely differ, since `end_turn` is `CU_CLASS_CONTROL`, making `is_mutating_action("end_turn")` `False` while hooks' predicate is `True`. Deleting it would require changing a spec paragraph in the same commit.
3. **Stale comments naming a function that does not exist.** `tools.py:1014-1037` describes an active file-path scrub via `_scrub_paths` (absent from the tree) and claims `permitted_observation_channels` "returns the empty set on an error" — it cannot, there is no `try`/`except` and the return is unconditional. Pre-existing drift on main; left untouched because this PR makes no prose or behaviour changes.
4. **`expire_dead_mints` (`connections/warm.py:106`) — half-wired, documented deferral.** The withdrawal half is wired (`dashboard/handlers/connections.py:411`) but the loop skips every row without `entry.get("shared")`, and nothing in the repo ever writes `shared: True` — the only occurrence is the TypedDict field declaration (`mint.py:113`). `warm.py:19-21` and `docs/architecture/design-notes/connections-warm-table.md` both say this is deferred to slice N2b. Not deletable: it answers correctly the moment N2b starts filling the table.
5. **`BrowserCommandBus.is_registered` (`browser/command_bus.py:189`) — half-wired read accessor.** The write half `_register_locked` is called from `drain` (`:350`) and `complete` (`:403`); the public query half has zero production readers. The endpoint that logically wants it re-derives liveness inline (`submit` → `_panel_alive_locked`, `:232`), and `dashboard/handlers/messaging.py:2963-2965`'s docstring claims that check *is* the registration when it is actually the private predicate. No unregister counterpart exists at all — deregistration is TTL-only (`:81`).

Also noted, no action here: `find_brew` (`transcribe.py:758`) has zero production callers while the one site that resolves `brew` uses bare `shutil.which("brew")` (`cloud/ssm.py:231`) with no fixed-prefix fallback — exactly the GUI-launched-gateway failure `_BREW_CANDIDATE_PATHS` exists to prevent. A hardened resolver that was never adopted; keep it.

## Verification

- `flake8`, `isort --check`, `black --check` clean on all three touched files.
- Affected-scope pytest: **681 passed** (`test_computer_use_gate.py`, `test_computer_use_overlay.py`, `test_mcp_computer.py`, `test_computer_use_snapshot.py`, `test_computer_use_backend.py`, `test_computer_use_api.py`, `test_computer_use_capture.py`, `test_computer_use_unsupported.py`, `test_computer_use_registration.py`). No test was deleted or adjusted — nothing referenced any deleted symbol.
- Two local adversarial review lanes on the diff before push, both **no findings**: one on collateral damage (residual refs, value-dispatch reachability, guard weakening, import/whitespace, doc drift), one on the security angle (whether the observation gate is genuinely unconditional, whether any edition/CPP/policy seam reaches the deleted constants, whether any baseline or i18n catalog enumerates the two refusal strings, and whether deleting the strings erases the only evidence a control is missing — position: no, the authoritative record lives in the retained spec and the retained reintroduction seam).
