### PR TITLE
chore(config): remove confirmed dead code in the config and validation surface

### DIFF
--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2562,21 +2562,12 @@ SELECT_CREW_SCHEMA = ToolSchema(
     ],
 )
 
-# ── Tool Schemas (Slack Reactions) ──
+# ── Slack reaction field patterns ──
 
 # Slack emoji names: alphanumeric, underscores, hyphens, and plus signs
 _EMOJI_NAME_RE = re.compile(r"^[a-zA-Z0-9+\-][a-zA-Z0-9_+\-]{0,98}[a-zA-Z0-9]$|^[a-zA-Z0-9+]$")
 # Slack message timestamp: digits.digits
 _SLACK_TS_RE = re.compile(r"^\d+\.\d+$")
-
-ADD_REACTION_SCHEMA = ToolSchema(
-    tool_name="add_reaction",
-    fields=[
-        FieldSpec("channel", str, required=True, max_len=CHANNEL_MAX_LEN, pattern=CHANNEL_ID_RE),
-        FieldSpec("timestamp", str, required=True, max_len=30, pattern=_SLACK_TS_RE),
-        FieldSpec("reaction", str, required=True, max_len=100, pattern=_EMOJI_NAME_RE),
-    ],
-)
 
 LOCAL_KNOWLEDGE_SEARCH_SCHEMA = ToolSchema(
     tool_name="local_knowledge_search",


### PR DESCRIPTION
Dead-code audit of the config / validation surface: `src/kiro_crew/config/` (21 files, incl. `loader.py` at 9675 lines), `validation.py`, `env.py`, `constants.py`, `portability.py`, `project_scope.py`, `frontmatter.py`, `doc_parser.py`, `effort.py`, `model_registry.py`, `preflight.py`, `_bootstrap.py`, `_ssl_compat.py`, `_sqlite_compat.py`, `flock_compat.py`, `subprocess_utf8.py` — about 19k lines.

One symbol confirmed dead and deleted. Six more are confirmed dead but are validation artifacts, so they are listed below for a decision rather than removed here. Seven are test-only and deferred.

## Deleted

### `ADD_REACTION_SCHEMA` — `src/kiro_crew/validation.py:2572-2579`

A `ToolSchema` for an MCP tool that does not exist.

- **No enforcement reachability.** There is no `add_reaction` MCP tool: `src/kiro_crew/mcp_tools/` has zero matches for "reaction". The matching names elsewhere are Slack/Discord *client* methods (`slack/client.py:391`, `discord/client.py:844`).
- **Neither registered nor called.** Nine `*_SCHEMA` objects sit outside the `MCP_*_SCHEMAS` registries. The other eight are each consumed by a direct `validate_tool_args(...)` at their handler — `SPAWN_CONTINUE_SCHEMA` → `mcp_tools/spawn.py:763`, `HOOK_CREATE_SCHEMA` → `dashboard/handlers/hooks.py:191`, `FILE_READ_SCHEMA` → `dashboard/handlers/files.py:1809`, `SELECT_CREW_SCHEMA` → `mcp_tools/control.py:640`. This one has no registry entry and no call site.
- **Not a validation gap.** The only reaction surface that exists is the `slack_reactions` handler at `dashboard/handlers/messaging.py:2536-2556`. It validates all three fields with the same shape predicates (`CHANNEL_ID_RE`, `^\d+\.\d+$`, `_EMOJI_NAME_RE`) **plus** an `is_tracked_channel` authorization gate the schema lacked.
- **Nothing orphaned.** `_EMOJI_NAME_RE` stays live at `messaging.py:2555`, `_SLACK_TS_RE` at `mcp_tools/messaging.py:605`, and `CHANNEL_MAX_LEN` at 12 sites across `cron.py`, `cli_commands.py`, `dashboard/handlers/cron.py` and three other schemas.
- **Age.** Introduced `2026-06-02` in the fork-init commit `64e47961a`, well outside the 30-day new-code gate.

The comment header above the two surviving regexes read "Tool Schemas" and would no longer be true, so it is retitled to what it now heads.

### One observable effect, and it is a correction

`security_posture._tool_schema_items()` (`security_posture.py:1751-1758`) walks the registries **and then reflects** over `dir(validation)` for uppercase `*_SCHEMA` names with a non-empty `tool_name`. `ADD_REACTION_SCHEMA` satisfied that second pass, so the security posture report has been listing a validated tool named `add_reaction` that never existed.

Measured: **98 posture items before, 97 after**, with `('add_reaction', 'ADD_REACTION_SCHEMA')` the only entry removed. No test pins that count — `test_security_posture.py` asserts `count == len(items)`, derived at runtime.

This is worth recording as an audit lesson: that reflection is a **pattern** match on the name, not a literal occurrence of it, so no name-based scanner — vulture, AST, tokenize, or grep — can see it. Every `*_SCHEMA` in `validation.py` has one reflective consumer that never shows up in a reference count. Future audits of this file should decide on enforcement reachability, not on reference count.

## Needs a decision — confirmed dead, but validation artifacts

Under the rule that a dead validator is itself a defect and should be wired rather than deleted, these are not touched here. For each I checked whether the deadness is actually a defect, and in every case it is not; my recommendation is delete, but that is your call.

| Symbol | Line | Why its deadness is not a gap |
|---|---|---|
| `ALLOWED_SCHEDULE_KINDS` | `validation.py:90` | No boundary supplies a raw schedule `kind`. `cron_add` / `cron_update` take `every` / `cron_expr` / `at` / `at_time` / `delay`; `CronSchedule.kind` is derived internally and then read back from our own `jobs.json` (`cron.py:1060`). The sibling allowlists `ALLOWED_LESSON_SCOPES` (`:1059`) and `ALLOWED_HOOK_EVENTS` (`:2332`, `:2347`) are wired via `allowed=` because a matching input field exists. This one never had one. |
| `JIRA_ISSUE_KEY_RE` | `validation.py:206` | Superseded by a divergent live copy. Enforcement is `_JIRA_KEY_RE` at `source_providers.py:506`, applied at `:530`. The two disagree: live is `[A-Z][A-Z0-9]{0,9}-\d+` (Jira's real 10-char project cap, no underscore), this one is `[A-Z][A-Z0-9_]+-\d+` (unbounded, allows `_`). The live copy is commented as pinned to the frontend's `JIRA_KEY_RE` in `pullRequestLinks.ts` so the two parsers agree. |
| `JIRA_PROJECT_KEY_RE` | `validation.py:202` | Project key is not an input. `_jira_ref` derives it by `key.rsplit("-", 1)` from the already-validated issue key (`source_providers.py:534`). |
| `JIRA_SITE_ID_RE` | `validation.py:204` | Guards a concept that does not exist — no Jira `site_id` or cloud-id anywhere in `src/`. The only `site_id` in the tree is `deploy/handlers.py` (S3 deploy slot, unrelated, validated by its own `_safe_site_id:523`). |
| `JIRA_SITE_URL_RE` | `validation.py:208` | Wiring it would regress. The pattern is `^https://…\.atlassian\.net/?$`, Cloud only. Live host authorization is the operator `dashboard.jira_hosts` allowlist (`loader.py:3586`, `_coerce_jira_hosts:6067`) plus `parse_source_url` (https-only, no userinfo, exact parsed-host match), and `_jira_ref`'s docstring documents deliberate Data Center / self-hosted support behind a context path. Enforcing this regex would break every self-hosted tenant. |
| `shared_kiro_settings_writable` | `config/paths.py:241-261` | Zero references repo-wide, but its sole commit is `3701948c1 feat(browser): move browsing from MCP proxy to CLI (#3233)` dated `2026-08-13` — 17 days old, inside the 30-day gate. A capability probe shipped with no caller. Deferred on age, not on doubt. |

## Deferred — test-only references

Zero production callers but live test references, so removal means rewriting those tests. That is a separate change.

| Symbol | Line | Test refs | Note |
|---|---|---|---|
| `validate_api_body` | `validation.py:3099` | 12 | Largest test surface in the group. |
| `is_toolbox_install` | `env.py:578` | 6 + 2 docs | Also on a documented surface: `docs/request-for-change/version-compliance-framework.md:18` states outright that it "now has zero callers", and `:66` tables it as "No enforcement action taken". The test references are `monkeypatch.setattr` / `patch` no-ops. |
| `ensure_node` | `env.py:547` | 6 | |
| `window_source` | `model_registry.py:471` | 5 | |
| `reset_degraded_observations` | `config/loader.py:956` | 4 | Test-fixture reset helper. |
| `validate_kiro_agent_references` | `config/loader.py:9660` | 3 | Validator, so the adjudication rule applies too. |
| `_FALLBACK_PROVIDER_ID` | `model_registry.py:56` | 1 | |

## Pre-existing gap observed, deliberately not touched

`slack_reactions` (`dashboard/handlers/messaging.py:2536-2556`) bounds neither `channel` nor `ts` by length: `CHANNEL_ID_RE` is `^[CDGW][A-Z0-9]+$` and the inline ts check is `^\d+\.\d+$`, both unbounded, where the deleted schema declared `max_len=20` and `max_len=30`. The schema was unreachable, so it never enforced those caps either — the property is pre-existing and unchanged by this PR. `messaging.py` is outside this change's file scope, so it is reported rather than fixed.

## How the candidates were generated

Four independent passes, then a confirmation protocol on the intersection.

| Pass | Method | Findings |
|---|---|---|
| 1 | `vulture --min-confidence 60` on the scope files alone | 399 — structurally invalid, since callers outside the scope files are invisible and every cross-module function reads as dead. Discarded. |
| 1b | `vulture` on `src/ test/ scripts/`, filtered to scope | 23 — 19 of them dataclass config fields |
| 2 | AST: defined names minus `Name(Load)` / `Attribute.attr` / `keyword.arg` / import names, across 3054 `.py` files | 11 — 3 are implicit Python hooks |
| 3 | tokenize: real `NAME` tokens only, docstrings and comments excluded | 243 — union list, over-broad |
| 4 | One-pass reference counter over 7472 files across 19 text extensions, own definition span excluded, refs bucketed prod / test / docs / web | 14 with no production reference |

Three-way intersection gave 7 zero-reference symbols; pass 4 isolated the 7 test-only ones separately.

### Config keys — the group's headline false-positive source, all rejected

All 19 loader dataclass fields vulture flagged are read by string dispatch or materialized from `config.json`. Spot-verified:

- `skills.lazy_load` → `getattr(_cfg.skills, "lazy_load", False)` at `context.py:2271` and `:2770`, plus `docs/configuration.md:383` and `docs/troubleshooting.md:178`. Invisible to every name-based scanner.
- `FieldSpec.custom_validator` / `.item_max_len` / `.item_pattern` → honored by `validate_tool_args` at `validation.py:427`, `:392`, `:396`; 8–12 call sites each.
- `SupersededDefault.new_default_display` → `superseded_defaults.py:132`, `:188`.
- `poolable_servers`, `read_buffer_limit_bytes`, `response_spill_threshold_bytes`, `embed_model_url/_path/_id`, `embedding_threads`, `embed_timeout_secs`, `embed_content_budget`, `episodic_dedup_threshold`, `doc_ingest_hosts`, `sso_login_flags`, `telegram_account` → all carry production references.

Platform shims (`_ssl_compat.py`, `_sqlite_compat.py`, `flock_compat.py`, `subprocess_utf8.py`, `portability.py`) are report-only by policy; no zero-reference symbol was found in any of them, so there is nothing to report.

`config/__init__.py:40 __getattr__` and `:54 __dir__` were flagged by two passes. Both are PEP 562 module hooks invoked implicitly by the interpreter, backing the documented lazy seam that avoids a `config.__init__` ↔ `config.loader` import cycle. Excluded by rule, not by search.

## Verification

- `flake8` clean, `isort --check` clean.
- `black --check` reports `validation.py` would reformat, and reproduces identically on unmodified `origin/main` (local Python 3.12 against a `py315` target). Inherited, not caused by this change.
- Targeted: 276 passed across the 11 validation / reaction / config-schema suites.
- Broad, `-k "validation or schema or reaction or tool_args"`: **1988 passed, 2 skipped, 0 failed**.
- Post-deletion import check: `ADD_REACTION_SCHEMA` absent; `_EMOJI_NAME_RE`, `_SLACK_TS_RE`, `CHANNEL_MAX_LEN` all present; `MCP_CORE_SCHEMAS` at 63 entries.
- Two local reviewers ran against the commit before push. They split on the `security_posture` reflection: `gpt-5.6-sol` flagged it, `claude-opus-4.8` asserted the derivation was registry-only. Resolved by reading the function and measuring the 98 → 97 delta — `gpt-5.6-sol` was right, and the commit message and this description were corrected accordingly. `gpt-5.6-sol`'s second point, that the handler-equivalence claim overstated the length bounds, was also correct and is now stated accurately above.

One commit, one file, 10 lines removed and 1 changed, sitting on `origin/main` at `6388dde48`.
