### PR TITLE
fix(md-notebook): reap git after timeout

### DIFF
--- a/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/git_ops.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from pathlib import Path, PureWindowsPath
 from typing import Any, Iterator, Optional
 
+from kiro_crew import platform_compat
+
 logger = logging.getLogger(__name__)
 
 # Identity used for commits the app makes on the user's behalf.
@@ -404,11 +406,17 @@ async def run_git(
         env=env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        start_new_session=platform_compat.IS_POSIX,
+        creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
     )
     try:
         out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except asyncio.TimeoutError:
-        proc.kill()
+        # Git may have spawned ssh, credential helpers or git-remote-* children
+        # that inherited its PIPE handles. Kill the whole isolated process tree
+        # and use the shared bounded reap, so cleanup cannot turn this timeout
+        # into an unbounded wait for a surviving helper's EOF.
+        await platform_compat.kill_and_reap(proc)
         raise GitError(f"git {args[0]} timed out after {timeout}s") from None
     stdout = out.decode("utf-8", "replace")
     stderr = err.decode("utf-8", "replace")

--- a/test/test_md_notebook_git_ops.py
+++ b/test/test_md_notebook_git_ops.py
@@ -1,0 +1,46 @@
+"""Lifecycle tests for the Notes git subprocess boundary."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.apps.builtins.md_notebook import git_ops
+
+
+@pytest.mark.asyncio
+async def test_run_git_tree_kills_and_reaps_after_a_timeout(monkeypatch) -> None:
+    """A timed-out Git tree is cleaned through the bounded shared primitive."""
+    communicate = MagicMock(return_value=_communicate_result())
+    proc = SimpleNamespace(communicate=communicate)
+    spawn = AsyncMock(return_value=proc)
+    reap = AsyncMock()
+    monkeypatch.setattr(git_ops.asyncio, "create_subprocess_exec", spawn)
+    monkeypatch.setattr(git_ops.platform_compat, "kill_and_reap", reap)
+    monkeypatch.setattr(git_ops, "_git_bin", lambda: "git")
+
+    async def _timeout(awaitable, timeout):
+        assert timeout == 7
+        # wait_for owns and cancels this first communicate coroutine on a real
+        # timeout. Close it here so the test injects that state without a clock.
+        awaitable.close()
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(git_ops.asyncio, "wait_for", _timeout)
+
+    with pytest.raises(git_ops.GitError, match="git status timed out after 7s"):
+        await git_ops.run_git(["status"], timeout=7)
+
+    reap.assert_awaited_once_with(proc)
+    assert communicate.call_count == 1
+    spawn_kwargs = spawn.await_args.kwargs
+    assert spawn_kwargs["start_new_session"] is git_ops.platform_compat.IS_POSIX
+    assert spawn_kwargs["creationflags"] == git_ops.platform_compat.CREATE_NEW_PROCESS_GROUP
+
+
+async def _communicate_result() -> tuple[bytes, bytes]:
+    """Coroutine closed by the deterministic wait_for timeout double."""
+    return b"", b""


### PR DESCRIPTION
## Summary

- start Notes git commands in an isolated process group on every platform
- on timeout, kill the whole Git/helper process tree and reap it through the repository's shared bounded cleanup primitive
- add deterministic coverage that pins both the cleanup delegation and the process-group spawn contract

## Why

The Windows backend shard emitted `PytestUnraisableExceptionWarning` from asyncio subprocess transports after `git add` timed out. The old path killed only Git and raised immediately, leaving the child and PIPE transports for event-loop teardown. A plain post-kill `communicate()` is also unsafe because an SSH or `git-remote-*` descendant can retain a PIPE and prevent EOF forever.

This uses the repository's established `platform_compat.kill_and_reap()` mechanism: the full isolated tree is killed, the direct child and PIPEs are reaped under the shared cleanup bound, and the original product timeout/error remains intact. There are no retries, sleeps, warning filters, or product-timeout increases.

## Test plan

- `py -3.12 -m pytest -q test/test_md_notebook_git_ops.py -W error::RuntimeWarning -W error::pytest.PytestUnraisableExceptionWarning` (1 passed)
- targeted isort, flake8, and diff checks
- `py -3.12 scripts/check_black_formatting.py`

## Scope

- 1 commit
- 2 files
- subprocess lifecycle cleanup plus focused deterministic regression coverage
