### PR TITLE
fix(test): stop kill_and_reap's group-kill skip from reading host process state

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -478,6 +478,45 @@ def _isolate_sandbox_mount_source_roots(_sandbox_mount_source_root, monkeypatch)
 
 
 @pytest.fixture(autouse=True)
+def _pin_kill_and_reap_group_probe(monkeypatch):
+    """Stop ``kill_and_reap``'s group-kill skip from reading host process state.
+
+    ``platform_compat.kill_and_reap()`` skips the process-GROUP kill when the
+    child shares the gateway's own group (spawned without
+    ``start_new_session``, so it leads no tree of its own). That decision is a
+    live ``os.getpgid()`` probe -- and almost every test of this path hands it a
+    SYNTHETIC pid (4242 is the shared convention) with the tree kill mocked. The
+    probe then resolves that fake pid against the runner's REAL process table:
+    when some genuine process happens to own it AND sits in the pytest run's own
+    process group, the skip fires, no tree kill is recorded, and the assertion
+    fails. Under xdist the runner spawns plenty of low-pid children in exactly
+    that group, which is why this flaked in batches -- four tests across three
+    files in one run -- and passed on re-run.
+
+    The pin is the child-leads-its-own-group answer, i.e. tree kill attempted,
+    which is what every one of those tests is written to assert. It is safe as a
+    floor because the skip is an optimisation, not a safety guard: it exists so
+    a routine timeout does not trip :func:`kill_process_tree`'s broadcast
+    refusal on every same-group child. That refusal is the actual protection and
+    is untouched here, so even a real same-group child reached through this
+    fixture is refused a group signal and falls through to the pid-scoped kill.
+    Pinning the shared ``_OWN_PGID`` instead WOULD disarm that refusal, which is
+    why the seam is this one function.
+
+    A test that wants the skip patches ``_shares_own_process_group`` itself -- a
+    later patch wins and reverts independently (see
+    ``TestKillAndReap::test_skips_the_group_kill_for_a_same_group_child``).
+    Tolerant of a partial checkout, and STRICT on the attribute: a silent miss
+    on a rename would quietly restore the flake this exists to remove.
+    """
+    try:
+        platform_compat = importlib.import_module("kiro_crew.platform_compat")
+    except Exception:  # pragma: no cover - a partial checkout must not break collection
+        return
+    monkeypatch.setattr(platform_compat, "_shares_own_process_group", lambda _pid: False)
+
+
+@pytest.fixture(autouse=True)
 def _no_credential_env_residue():
     """Restore the credential env vars a test may have had INJECTED into it.
 

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -3133,6 +3133,33 @@ async def kill_process_tree_async(pid: int, sig: int = SIGTERM) -> bool:
 REAP_TIMEOUT_SECS: float = 10
 
 
+def _shares_own_process_group(pid: int) -> bool:
+    """True when *pid* runs in the gateway's OWN process group.
+
+    Such a child was spawned without ``start_new_session``, so it has no tree
+    of its own to signal — see :func:`kill_and_reap`, whose group kill this
+    gates. Fail-closed (``False``) on every probe failure: the pid may be gone
+    or unreadable, and the tree kill it guards is itself best-effort and
+    protected by :func:`kill_process_tree`'s own broadcast/self-group guard.
+
+    This is a named seam on purpose. The probe reads the LIVE process table,
+    so a test handing :func:`kill_and_reap` a synthetic pid was at the mercy
+    of whichever real process happened to own that pid: when it landed inside
+    the runner's own group the skip fired and the expected tree kill never
+    happened. The rootdir ``conftest`` pins this one function instead of the
+    shared ``_OWN_PGID`` — pinning that would also disarm
+    :func:`kill_process_tree`'s self-group refusal, the guard that keeps a
+    test from broadcasting a signal to the whole pytest run.
+    """
+
+    if not IS_POSIX:
+        return False
+    try:
+        return os.getpgid(pid) == _OWN_PGID
+    except Exception:
+        return False
+
+
 async def kill_and_reap(proc: asyncio.subprocess.Process, *, timeout: float | None = None) -> None:
     """Kill *proc* AND its descendants, then wait for it under a bound.
 
@@ -3167,11 +3194,9 @@ async def kill_and_reap(proc: asyncio.subprocess.Process, *, timeout: float | No
     """
 
     async def _cleanup() -> None:
-        same_group = False
-        if IS_POSIX:
-            with contextlib.suppress(Exception):
-                same_group = os.getpgid(proc.pid) == _OWN_PGID
-        if not same_group:
+        # Bare-name lookup so a test can pin the probe (see
+        # ``_shares_own_process_group``) without reaching into ``os``.
+        if not _shares_own_process_group(proc.pid):
             # Bare-name lookup resolves through this module's namespace at
             # call time, so tests patching ``kiro_crew.platform_compat.
             # kill_process_tree_async`` still intercept the tree kill.

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -31,6 +31,13 @@ import pytest
 
 from kiro_crew import platform_compat as pc
 
+#: The REAL same-group probe, bound at module import so this file can test it.
+#: The rootdir conftest pins ``pc._shares_own_process_group`` for every test
+#: (see ``_pin_kill_and_reap_group_probe``), and that pin lands after this
+#: import -- so reaching for the module attribute inside a test would exercise
+#: the stub instead of the function.
+_real_shares_own_process_group = pc._shares_own_process_group
+
 
 def _fake_windows_bins(monkeypatch):
     """Resolve Windows system binaries while ``IS_WINDOWS`` is faked on POSIX.
@@ -4131,6 +4138,64 @@ class TestKillAndReap:
         tree.assert_awaited_once()
         assert tree.await_args.args == (4242, pc.SIGKILL)
         proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_the_group_kill_for_a_same_group_child(self) -> None:
+        """A child sharing OUR group leads no tree, so the group signal is
+        skipped and the pid-scoped kill covers it -- otherwise every routine
+        timeout would trip ``kill_process_tree``'s broadcast refusal.
+
+        Also the escape hatch for the rootdir conftest's autouse pin of this
+        probe: a test that wants the skip patches the seam itself and wins.
+        """
+        from unittest import mock
+
+        proc = self._proc()
+        with (
+            mock.patch.object(pc, "_shares_own_process_group", lambda _pid: True),
+            mock.patch.object(pc, "kill_process_tree_async", mock.AsyncMock()) as tree,
+        ):
+            await pc.kill_and_reap(proc)
+        tree.assert_not_awaited()
+        proc.kill.assert_called_once()
+        proc.communicate.assert_awaited_once()
+
+    @pytest.mark.skipif(not pc.IS_POSIX, reason="POSIX only")
+    def test_group_probe_reports_our_own_group(self) -> None:
+        """Our own pid is in our own group by construction."""
+        assert _real_shares_own_process_group(os.getpid()) is True
+
+    @pytest.mark.skipif(not pc.IS_POSIX, reason="POSIX only")
+    def test_group_probe_fails_closed_for_an_unreadable_pid(self, monkeypatch) -> None:
+        """Fail-closed, so a vanished or unreadable pid still gets its tree
+        signalled rather than silently skipping the kill."""
+        monkeypatch.setattr(
+            pc.os,
+            "getpgid",
+            lambda _pid: (_ for _ in ()).throw(ProcessLookupError()),
+        )
+        assert _real_shares_own_process_group(4242) is False
+
+    def test_group_probe_is_posix_only(self, monkeypatch) -> None:
+        """Windows has no process groups to compare, so nothing is ever skipped
+        there -- and the probe must not reach a missing ``os.getpgid``.
+
+        This case runs on EVERY platform on purpose -- the non-POSIX branch is
+        what it covers -- so the tripwire is installed with ``raising=False``:
+        ``os.getpgid`` is Unix-only, and a strict ``setattr`` raises
+        ``AttributeError`` during the test's own arrangement on Windows, which
+        is where the assertion matters most. With ``raising=False`` the sentinel
+        is created where the attribute is absent, never called (that is the
+        assertion), and removed at teardown.
+        """
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(
+            pc.os,
+            "getpgid",
+            lambda _pid: (_ for _ in ()).throw(AssertionError("probed on Windows")),
+            raising=False,
+        )
+        assert _real_shares_own_process_group(os.getpid()) is False
 
     @pytest.mark.asyncio
     async def test_reaps_via_communicate_never_wait(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

Four backend tests failed together in one run and passed on re-run:

```
FAILED test/test_source_providers.py::test_run_json_kills_process_tree_when_stdout_exceeds_limit
  - assert [] == [(4242, <Signals.SIGKILL: 9>)]
FAILED test/test_source_providers.py::test_terminate_process_reaps_via_communicate_not_wait
FAILED test/test_update_provider.py::TestCancellationKillsUpdaterChild::test_kill_and_reap_kills_the_whole_tree
  - Expected mock to have been awaited once. Awaited 0 times.
FAILED src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers.py::TestRunGhTimeoutReapsChild::test_timeout_reaps_child_via_communicate_not_wait
  - Lists differ: [] != [(4242, <Signals.SIGKILL: 9>)]
```

Each asserts that `platform_compat.kill_and_reap()` SIGKILLs the child's whole
process group. Each hands it a **synthetic pid** (4242, the shared convention in
this suite) with the tree kill mocked.

But `kill_and_reap` decided whether to send the group signal by asking the **live
process table**: it skips the group kill when `os.getpgid(pid)` matches the
gateway's own pgid, because a child spawned without `start_new_session` leads no
tree of its own and would otherwise trip `kill_process_tree`'s broadcast refusal
on every routine timeout.

So the assertion was at the mercy of whichever real process happened to own pid
4242. When that pid belonged to a live process **inside the pytest run's own
process group** — and under xdist the runner spawns plenty of low-pid children in
exactly that group — the skip fired, no tree kill was recorded, and every one of
those tests failed at once. That batch shape (four tests, three files, one run,
green on re-run) is the fingerprint.

## Why it matters

A flake that fires in batches across three files reads as a real regression in
process cleanup, so it costs a triage pass every time it lands, and it teaches
the habit of re-running red CI instead of reading it. The same synthetic-pid
assertion also sits in two sites that had not flaked yet — `TestKillAndReap` in
`test/test_platform_compat.py` and `TestReapInstallTree` in
`test/test_mcp_resolve_once.py` — so the blast radius grows with every new test
of this path.

## What changed (motivation → approach → change)

**Symptom** — four tree-kill assertions fail together, green on re-run.
**Root cause** — the same-group probe inside `kill_and_reap._cleanup()` reads the
host process table, so a fake pid resolves against whatever really owns it.

The probe becomes a named seam, `_shares_own_process_group()`, and the rootdir
`conftest.py` pins it for the whole suite to the child-leads-its-own-group answer
— i.e. *attempt* the tree kill — which is what every affected test is written to
assert. Same class of floor as that conftest's existing pins (the XDG home, the
sandbox mount-source roots, the /proc pin scan): a test seam that reads host
state and that each test had to remember to stub.

Behaviour is preserved on every production path. Non-POSIX returns `False`,
matching the old `IS_POSIX`-gated `same_group = False`; a probe exception returns
`False`, matching the old `contextlib.suppress(Exception)` leaving `same_group`
false. Both mean *signal the tree*, exactly as before.

**Why pin this function and not `_OWN_PGID`.** The skip is an optimisation, not
a safety guard. The guard is `kill_process_tree`'s own broadcast/self-pgid
refusal, which this change does not touch: a **real** same-group child reached
through the fixture is still refused a group signal and still falls through to
the pid-scoped kill. Pinning the shared `_OWN_PGID` instead would have disarmed
that refusal — the thing standing between a test double and a signal broadcast
to the whole pytest run.

## Tests

- `TestKillAndReap::test_skips_the_group_kill_for_a_same_group_child` — the skip path had **no test at all** before this PR. Locks in that a same-group child gets no group signal and is still covered by the pid-scoped kill, and doubles as the documented escape hatch from the autouse pin (a test that wants the skip patches the seam itself and wins).
- `TestKillAndReap::test_group_probe_reports_our_own_group` — the probe answers `True` for our own pid.
- `TestKillAndReap::test_group_probe_fails_closed_for_an_unreadable_pid` — a `ProcessLookupError` yields `False`, so a vanished pid still gets its tree signalled.
- `TestKillAndReap::test_group_probe_is_posix_only` — on Windows the probe never reaches `os.getpgid`.

The real probe is bound at module import (`_real_shares_own_process_group`),
before the autouse pin replaces the module attribute — otherwise these three
would exercise the stub.

## Manual verification

The flake was reproduced deterministically rather than argued from the traceback.
A throwaway pytest plugin forced the probe's `os.getpgid` to return `_OWN_PGID`
— simulating a real process owning pid 4242 inside the runner's group:

- **On this base, without the fixture:** all four reported tests fail, with the exact assertions from the report.
- **With the fixture:** all four pass, as do the two latent sites.

Full backend suite run twice under `-n 8`, once on this branch and once on clean
`origin/main`: **97 failures on each side**, all pre-existing host-isolation
artifacts of running outside CI (real-home pinning, `AF_UNIX path too long`,
worker-budget counts that assume CI's core count). The sets differ by one flake
in each direction — a `/tmp/x` ordering artifact in
`test_deploy_round3_fixes.py` on this side (passes in isolation on both) and a
slot-cap timing test on the base side — and neither is touched by this change.
A later diff-scoped `run_scoped_tests.py --surface backend` run (escalated to the
full suite, correctly, because `conftest.py` is a broad-impact change) produced a
failure set that is a **strict subset** of that clean-`main` baseline: zero
branch-only failures.

## Screenshots / video

N/A — backend and test-harness only, no user-visible surface.

## Related Issues

no linked issue: the flake was reported directly from a CI run, not filed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the reasoning lives in the docstrings of the new seam and the new fixture, which is where a future reader of this code path looks
- [x] No secrets, credentials, or internal references in the diff
