### PR TITLE
chore(mcp): remove confirmed dead code in the top-level MCP and misc surface

### DIFF
--- a/src/kiro_crew/frontend.py
+++ b/src/kiro_crew/frontend.py
@@ -28,11 +28,6 @@ from kiro_crew.executors import subprocess_executor
 
 logger = logging.getLogger(__name__)
 
-# The frontend is in-tree at ``<repo-root>/website``; there is no remote to
-# clone. ``KIROCREW_WEBSITE_REPO`` is retained only so existing tooling/docs
-# referencing the public mirror keep a stable name to point at.
-_DEFAULT_REPO_URL = "https://github.com/kirodotdev/KiroCrew"
-_REPO_URL = os.environ.get("KIROCREW_WEBSITE_REPO") or _DEFAULT_REPO_URL
 # In-tree frontend directory name (under the repo root). The legacy sibling
 # clone directory name is kept only for last-resort dist resolution.
 _DIR_NAME = "website"

--- a/src/kiro_crew/llm_helpers.py
+++ b/src/kiro_crew/llm_helpers.py
@@ -896,10 +896,6 @@ class ToolApprovalPolicy(Enum):
     HOOK_BASED = "hook_based"
 
 
-# Callback type for custom tool approval logic
-OnPermissionCallback = Callable[[LLMEvent], Awaitable[bool]]
-
-
 # ── Stream and Collect ──
 
 

--- a/src/kiro_crew/stats.py
+++ b/src/kiro_crew/stats.py
@@ -80,27 +80,9 @@ class Stats:
     def inc_tool_auto_approved(self) -> None:
         self.inc("tool_auto_approved")
 
-    def inc_input_tokens(self, n: int) -> None:
-        self.inc("input_tokens", n)
-
-    def inc_output_tokens(self, n: int) -> None:
-        self.inc("output_tokens", n)
-
-    def inc_cache_creation_tokens(self, n: int) -> None:
-        self.inc("cache_creation_tokens", n)
-
-    def inc_cache_read_tokens(self, n: int) -> None:
-        self.inc("cache_read_tokens", n)
-
     def inc_cost_usd(self, amount: float) -> None:
         with self._mu:
             self._cost_usd += amount
-
-    def inc_turns(self, n: int) -> None:
-        self.inc("total_turns", n)
-
-    def inc_duration_ms(self, n: int) -> None:
-        self.inc("total_duration_ms", n)
 
     def get_cost_usd(self) -> float:
         with self._mu:


### PR DESCRIPTION
Eight symbols, 27 lines, three files. No behaviour change, no test altered.

This is one slice of a wider dead-code sweep, scoped to the top-level MCP modules, the bootstrap/model/publish modules, the trust surface, and the misc utility modules — 83 files, 47,596 lines.

## Deleted

### `stats.py` — six orphaned mutators (18 lines)

`inc_input_tokens`, `inc_output_tokens`, `inc_cache_creation_tokens`, `inc_cache_read_tokens`, `inc_turns`, `inc_duration_ms`.

Their sole caller was the `chat_runner.py` block deleted in 61cb3048 (#1082). That PR also added `test_chat_runner_no_longer_builds_the_dead_stats_object`, which asserts the wiring stays gone — so a quiet revival is blocked by CI, not just by convention. Zero references repo-wide across every file type; no computed-name dispatch (`f"inc_{key}"`) exists; the three `getattr(stats, ...)` sites in the repo target unrelated `Stats` classes in other modules.

The counter keys in `_init_counters` are deliberately **not** touched, so `snapshot()` still returns the full dict and the `/api/system` response shape (`dashboard/handlers_system.py`:193) is unchanged. `test_stats.py`'s snapshot-key pin still holds.

### `llm_helpers.py` — `OnPermissionCallback` (3 lines)

A type alias whose only occurrence repo-wide was its own definition. The identical type `Callable[[LLMEvent], Awaitable[bool]]` is already inlined at both live call sites (:1432 and :1899), so no behaviour and no signature changes.

### `frontend.py` — `_REPO_URL` + `_DEFAULT_REPO_URL` (5 lines)

Dead as a pair: `_DEFAULT_REPO_URL`'s only consumer was `_REPO_URL`, which nothing consumed. The `.github/workflows/publish-docker.yml` grep hit is `SOURCE_REPO_URL`, an unrelated Docker build ARG — a suffix collision.

The comment above them is removed with them because it was false: it claimed `KIROCREW_WEBSITE_REPO` was "retained only so existing tooling/docs referencing the public mirror keep a stable name to point at", but that variable has zero references anywhere in the repo, website, docs, workflows or installers. A caller setting it today already gets a no-op.

## Verification

Per symbol: whole-repo search across `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1` plus `tests/`, `docs/`, `docs/system-specs/`, `builtin_skills/`, `.github/`, `config-baseline.json`, `error-code-baseline.json`, `install.sh`, `Makefile`, `pyproject.toml` — never truncated through `head`; bare-string search for string dispatch; `getattr`/`setattr`/`globals()`/`importlib`/`__all__` sweep; reverse-direction reachability proof; public-surface check; 30-day introduction gate (all eight last touched 2026-07-16, 45 days).

`flake8` clean on all three files — `os` remains used in `frontend.py`, `Callable`/`Awaitable` in `llm_helpers.py`. `isort` clean. 468 tests pass across the affected scope, 0 failures. (`black --check` flags `frontend.py` at lines 282/366, far from this diff; it reproduces identically on unmodified `origin/main` and is a local black/target-version mismatch, not this change.)

### A scanner defect worth recording

`vulture` is near-useless scoped to a file subset — it flags every symbol imported from outside the scope, so it reported `parse_widgets`, `GatewayLock`, `LessonStore`, `SleepInhibitor` and `prune_pycache` as unused. More importantly, this codebase uses `from __future__ import annotations`, which makes **every annotation a string at runtime**; quoted forward references like `store: "_ReconcilableStore"` never become NAME tokens, so tokenize- and vulture-based scanning is *structurally blind* to annotation-only references. That produced a false positive (`_ReconcilableStore`, which is live) and was only caught by adding an annotation-aware AST pass that re-parses string annotations. Any future audit of this repo needs that pass or it will propose deleting live Protocols.

## Reviewer finding, addressed

A local GPT-5.6 review lane raised one Medium: deleting `OnPermissionCallback` removes the only *named* form of the callback contract, breaking a hypothetical `from kiro_crew.llm_helpers import OnPermissionCallback`.

Not acting on it, on these grounds: `llm_helpers.py` declares no `__all__`, the name appears in no `docs/`, `docs/system-specs/` or `SKILL.md` file, it is not a declared export in `pyproject.toml`, and it has zero importers in-repo. Under Python's conventions every non-underscore module-level name is "externally importable", so that alone would make any internal helper undeletable. KiroCrew ships as an application rather than a published library, so there is no semver contract on `kiro_crew.llm_helpers` internals. Happy to restore it as a deprecated alias if a maintainer disagrees.

A local Opus-4.8 lane reviewed the same commit for behaviour change, env-var regression, vacuous tests and partial-deletion hazard.

## Deferred — not in this PR

- **`_create_embedding`** (`embeddings.py`:1529) — genuinely orphaned by efadac8b2, superseded by `_submit_infer`, but that commit is 2026-08-12, **18 days**: inside the 30-day gate. Eligible 2026-09-12; deleting it must also fix the dangling `:meth:` cross-ref at :1485.
- **`DM_FILE_NAME`** (`members.py`:56) — real leftover (`"dm.json"` is never used to build a path; live layout is `trust/member-bindings/<slug>.json`), but introduced **3 days ago** in a231501af (#6210) alongside its own replacement. Dead on arrival within one PR; belongs back with that PR rather than an unrelated chore branch.
- **`RemoteListing`** (`publish_provider.py`:152) — `website/src/types/index.ts`:1176-1204 mirrors its six fields and cites it 4× as the authoritative base contract. Also an *unenforced* contract: nothing constructs it, the wire shape is a plain dict, and the browse handler passes the provider dict straight through. Design debt, not dead code.
- Tests-only references (rule: refactor, not deletion): `sso_status_async`, `unregister_channel`, `accepts_priority`, `DERIVED_SLUG_RE`, `list_entries`, `_reset_signature_replay`, `_reset_auth_throttle`.

## Live — scanner false positives, do not re-propose

- **`_ReconcilableStore`** (`embeddings.py`:61) — a `typing.Protocol` annotating two functions in quoted form (:973, :1055), both with production callers in `cli_server.py`, `slack/gateway.py` and `dashboard/handlers/memory.py`, documented at `docs/system-specs/modules/memory-skills-hooks.md`:413. It is the only written statement of a contract on a destructive path (`clear_when_unknown=True` clears stored vectors).
- **`_HANDLER_SURFACE`** (`mcp_core.py`:82) — live as a *fuse*. Holds 8 objects consumed via late-bound `mcp_core.<name>` lookup from seven `mcp_tools/*.py` modules and rebound by ~60 `patch("kiro_crew.mcp_core.X")` sites. The tuple is the only in-file use of those imports, so deleting it makes them F401-visible and arms a cascade where a routine unused-import sweep breaks every handler with `AttributeError`. Named as a contract in `docs/architecture/mcp.md`:681.

## Needs a maintainer decision

1. **`stats.py` cost trio.** `inc_cost_usd` (:95), `get_cost_usd` (:105) and the backing field `self._cost_usd` (:56) are *all three* dead, and `get_cost_usd` never had a caller in repo history. Because `_cost_usd` is not in the `_c` dict it never reached `snapshot()` or the API, so there is no exposure to lose. Left in place because a matched pair with both halves dead is design incompleteness rather than cruft — 9 lines if you want it gone as one unwired-feature removal.
2. **Six now-writerless counter keys.** After this PR, `input_tokens`, `output_tokens`, `cache_creation_tokens`, `cache_read_tokens`, `total_turns`, `total_duration_ms` have no writer and no reader, yet still ship in `/api/system`. Nothing in `website/src` reads them (the Usage tab sources the separate provider-usage API). Removing them changes the response shape and breaks `test_snapshot_keys`, so it is a separate decision.
3. **Vault secrets are never redacted from logs** — found while auditing the trust surface, unrelated to this diff and untouched by it. `cli._setup_cli_logging` (`cli.py`:1015) is the only production caller of `install_log_redaction` and passes `[]`, so `_secret_pattern` is always `None`: only Bearer tokens are scrubbed, and only for `_LONG_LIVED_COMMANDS` (`cli.py`:1014). Meanwhile `security_posture.py`:1577 allowlists the module out of the egress drift-guard describing it as "strips vault secrets and Bearer tokens from log output" — a governance surface asserting a control that is half-live. The module docstring admits it as "a follow-up PR". Worth its own ticket.
4. **Three orphaned lifecycle halves on the trust surface** (reported, not touched — a dead guard is a defect, not cruft):
   - `skill_trust.grant_project_trust` has **no expiry sweep**: entries persist `granted_at` only, no TTL, no reaper. The 512-entry ceiling *refuses* the 513th grant (`TrustStoreFull`) instead of evicting the stalest, so a store full of abandoned grants blocks new legitimate consent until a human revokes manually.
   - `safety_override.renew` (unscoped) has **zero production callers** (20 test refs); all real renewal goes through `renew_scoped`. The global YOLO grant therefore has no sliding extension in practice while the code reads as though it does.
   - `name_grant.pin_human_approval` has **no unpin**: release is implicit via a 512-entry LRU and identity-mismatch rebind, with no operator-facing revoke.

## Files not exhaustively hand-confirmed

All 83 scope files were parsed by the AST/tokenize/annotation passes and all 71 declared top-level modules exist. What was not hand-audited for string-dispatch-only symbols is the deep-semantic layer of the ten largest files, which hold 44% of the scope in 12% of the files: `onboarding_import.py` (5089), `kiro_prerequisite.py` (3034), `llm_helpers.py` (2351), `embeddings.py` (2183), `mcp_core.py` (2085), `name_grant.py` (1405), `publish_sync.py` (1369), `mcp_dashboard.py` (1212), `mcp_shared.py` (1201), `tips.py` (1170). `name_grant.py`, `skill_trust.py`, `safety_override.py`, `trust_patterns.py`, `zip_vet.py` and `pinned_fs.py` also warrant a dedicated half-wired-guard pass.
