### PR TITLE
test(mcp): model probe process streams exactly

### DIFF
--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -2533,7 +2533,11 @@ class TestProbeServerProcessCleanup:
         proc = AsyncMock()
         proc.returncode = None  # process still running
         proc.stdin = MagicMock()
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
         proc.stdin.close = MagicMock()
+        proc.stderr = MagicMock()
+        proc.stderr.read = AsyncMock(return_value=b"")
         proc.kill = MagicMock()
         if wait_side_effect:
             proc.wait = AsyncMock(side_effect=wait_side_effect)
@@ -2562,7 +2566,7 @@ class TestProbeServerProcessCleanup:
     async def test_fallback_kill_on_timeout(self) -> None:
         """When graceful shutdown times out, falls back to proc.kill()."""
         proc = self._make_mock_proc(
-            wait_side_effect=[asyncio.TimeoutError(), AsyncMock(return_value=0)()]
+            wait_side_effect=[asyncio.TimeoutError(), 0]
         )
         server = McpServerInfo(name="test", command="echo")
 
@@ -2769,6 +2773,8 @@ class TestProbeServerTimeout:
         mock_proc.stdin.close = MagicMock()
         mock_proc.stdout = AsyncMock()
         mock_proc.stdout.readline = AsyncMock(side_effect=[init_resp, asyncio.TimeoutError])
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read = AsyncMock(return_value=b"")
         mock_proc.returncode = None
         mock_proc.kill = MagicMock()
         mock_proc.wait = AsyncMock(return_value=0)
@@ -2793,14 +2799,15 @@ class TestProbeServerTimeout:
 
         mock_proc = AsyncMock()
         mock_proc.stdin = AsyncMock()
-        # `StreamWriter.write` is synchronous; only `drain()` is awaited. As an
-        # AsyncMock auto-child it returned a coroutine nobody awaits, surfacing later
-        # as an unraisable "never awaited" warning attributed to whichever test
-        # triggered the GC. The sibling test above already pins this.
+        # StreamWriter.write/close are synchronous while drain is async; stderr.read
+        # is async but returns bytes. Model each boundary explicitly so AsyncMock
+        # cannot invent a coroutine-returning bytes.decode() on the error path.
         mock_proc.stdin.write = MagicMock()
         mock_proc.stdin.close = MagicMock()
         mock_proc.stdout = AsyncMock()
         mock_proc.stdout.readline = AsyncMock(side_effect=asyncio.TimeoutError)
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read = AsyncMock(return_value=b"")
         mock_proc.returncode = None
         mock_proc.kill = MagicMock()
         mock_proc.wait = AsyncMock(return_value=0)


### PR DESCRIPTION
## Summary
- model subprocess stdin/stderr mocks with their real sync/async stream contracts
- return a process exit code directly from the mocked wait instead of nesting an unawaited coroutine
- prevent cleanup-path RuntimeWarning/PytestUnraisable warnings from drifting into unrelated tests

## Determinism evidence
- before the fix, the 7 cleanup/timeout targets fail under strict RuntimeWarning and PytestUnraisable handling
- after the fix, those 7 targets pass both serially and under xdist; the complete test file passes (191 passed, 9 skipped)
- no retries, sleeps, timeout increases, tolerance changes, or warning filters were added

## Validation
- `py -3.12 -m pytest test/test_mcp_discovery.py::TestProbeServerProcessCleanup test/test_mcp_discovery.py::TestProbeServerTimeout -W error::RuntimeWarning -W error::pytest.PytestUnraisableExceptionWarning -q` (7 passed)
- flake8, isort, baseline-aware Black, and diff-check passed

## Overlap audit
- the only open PR touching this test file is #2602; it changes the reserved-environment probe tests, not these stream mocks, and a merge-tree check is clean