### PR TITLE
fix(packaging): ship the Apple-Silicon ffmpeg uncompressed so macOS notarizes

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -338,6 +338,11 @@ same way). Key details:
   weights are deliberately excluded from the installer: the user selects a
   model and clicks **Download now**, with no package manager or separate
   dependency step. Intel macOS is the unsupported recognizer exception.
+  Every bundled executable ships **uncompressed** — the Apple notary service
+  decompresses archive members and rejects an unsigned executable found inside
+  one, which fails the whole macOS release (see
+  [stt-streaming](../system-specs/features/stt-streaming.md) for how the runtime
+  then authenticates a decoder whose bytes signing rewrote).
 - **Dashboard bundled** — the SPA is staged into
   `lib/python3.12/site-packages/kiro_crew/static/dist/` inside the bundle.
 - **Pruned** — `__pycache__`, test dirs, and unused stdlib (tkinter, idlelib,

--- a/docs/system-specs/features/stt-streaming.md
+++ b/docs/system-specs/features/stt-streaming.md
@@ -30,6 +30,21 @@ dependency metadata or an ambient PATH copy satisfying the check. Source
 environments use the fixed system-decoder search instead, because a project venv
 is agent-writable executable storage.
 
+That executable ships **uncompressed** inside the macOS bundle, and must keep
+doing so: the Apple notary service decompresses archive members and scans what is
+inside them, so a decoder sealed as a compressed payload is rejected as an
+unsigned nested executable and fails the entire macOS release. Shipping it plain
+means the app signer rewrites its Mach-O signature, so its released bytes cannot
+match the pinned upstream digest. The runtime therefore accepts the macOS decoder
+on **either** cryptographic anchor: the pinned upstream digest (a local or
+unsigned build, and the pre-signing release gate above) or a valid Developer ID
+signature from the release team, evaluated by `codesign` against the exact
+private snapshot staged for execution. Neither anchor is a path or a
+filesystem-permission claim, and a payload satisfying neither is refused.
+`packaging/signing/generate-manifest.py` additionally fails the sign when any
+compressed member of the bundle contains a Mach-O, so this class of defect
+surfaces at sign time rather than as an opaque notarization `Invalid`.
+
 Legacy provider values and the loader behavior for persisted values are in
 [Legacy provider values](#legacy-provider-values).
 

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -129,46 +129,26 @@ is_macos_intel_backend() {
   }
 }
 
-# Keep the Apple-Silicon decoder byte-for-byte identical to the pinned upstream
-# wheel after packaging. electron-builder signs every Mach-O it finds, which
-# replaces the upstream linker/ad-hoc signature and necessarily changes both
-# size and SHA-256 after our pre-sign gate. The upstream arm64 executable already
-# carries the ad-hoc LC_CODE_SIGNATURE Apple Silicon requires. Store those exact
-# signed bytes as inert gzip data; runtime expands them beneath its agent-denied
-# runtime root, makes the private snapshot non-writable, verifies the ORIGINAL
-# wheel digest, and keeps its descriptor open through spawn. The app signer never
-# sees a Mach-O to rewrite, while the user still receives the complete offline
-# decoder payload.
-seal_macos_ffmpeg_payload() {
-  local python="$1" want_arch="$2"
-  [ "$OS" = "darwin" ] || return 0
-  is_macos_intel_backend "$want_arch" && return 0
-  "$python" -s -c '
-import gzip
-import os
-import shutil
-import sys
-from pathlib import Path
-
-binaries = (
-    Path(sys.prefix)
-    / "lib"
-    / "python3.12"
-    / "site-packages"
-    / "imageio_ffmpeg"
-    / "binaries"
-)
-source = binaries / "ffmpeg-macos-aarch64-v7.1"
-target = source.with_name(source.name + ".gz")
-staged = target.with_name(target.name + ".tmp")
-with source.open("rb") as incoming, staged.open("xb") as outgoing:
-    with gzip.GzipFile(filename="", fileobj=outgoing, mode="wb", mtime=0) as encoded:
-        shutil.copyfileobj(incoming, encoded, length=1 << 20)
-os.chmod(staged, 0o444)
-os.replace(staged, target)
-source.unlink()
-'
-}
+# NOTE ON THE APPLE-SILICON DECODER -- do NOT re-introduce a compressed payload.
+#
+# The arm64 imageio-ffmpeg executable ships as a PLAIN Mach-O under
+# Contents/Resources, exactly like its x86_64 sibling, so the app signer signs it
+# with Developer ID + hardened runtime + secure timestamp along with every other
+# nested binary (packaging/signing/generate-manifest.py enumerates it).
+#
+# #6746 instead stored it as inert gzip data, to keep the bytes byte-identical to
+# the pinned upstream wheel across signing. The Apple notary service DECOMPRESSES
+# archive members and scans what is inside them, so that made notarization fail
+# closed on the whole release (submission 3dbd3c7d, three `error` issues on
+# .../binaries/ffmpeg-macos-aarch64-v7.1.gz/ffmpeg-macos-aarch64-v7.1: not signed
+# with a valid Developer ID certificate / no secure timestamp / hardened runtime
+# not enabled). The x86_64 copy of the same wheel, shipped raw in the same
+# submission, drew no issue at all -- that is the working shape.
+#
+# The runtime consequence is handled in kiro_crew.transcribe: the packaged decoder
+# is accepted either at the pinned upstream digest (local builds and the build gate
+# below, which run BEFORE signing) or on a valid Developer ID signature from our
+# team (the released app, whose bytes signing necessarily rewrote).
 
 # Prove that the installed native wheel, audio decoder, and their transitive
 # libraries can actually run from the pruned bundle. A successful pip resolution
@@ -495,7 +475,6 @@ LAUNCH
     rm -rf lib/python3.12/test lib/python3.12/idlelib lib/python3.12/tkinter \
            lib/python3.12/turtledemo lib/python3.12/ensurepip lib/python3.12/lib2to3 2>/dev/null || true )
 
-  seal_macos_ffmpeg_payload "$out/bin/python3.12" "$want_arch"
   if ! is_macos_intel_backend "$want_arch"; then
     local_voice_runtime_gate "$out/bin/python3.12"
   fi

--- a/packaging/signing/generate-manifest.py
+++ b/packaging/signing/generate-manifest.py
@@ -32,13 +32,18 @@ INPUT_KEY, OUTPUT_KEY) and prints the final manifest JSON to stdout. A summary
 line is printed to stderr for build logs.
 """
 
+import bz2
 import glob
+import gzip
 import json
+import lzma
 import os
 import plistlib
 import re
 import struct
 import sys
+import tarfile
+import zipfile
 
 # Fallback identifier prefix when the app bundle's own CFBundleIdentifier
 # cannot be read (never expected for a real electron-builder output).
@@ -70,12 +75,8 @@ _THIN_MAGICS = {0xFEEDFACE, 0xFEEDFACF, 0xCEFAEDFE, 0xCFFAEDFE}
 _FAT_MAGIC, _FAT_CIGAM = 0xCAFEBABE, 0xBEBAFECA
 
 
-def is_macho(path: str) -> bool:
-    try:
-        with open(path, "rb") as fh:
-            head = fh.read(8)
-    except OSError:
-        return False
+def is_macho_head(head: bytes) -> bool:
+    """Mach-O detection from the first 8 bytes of a stream."""
     if len(head) < 8:
         return False
     (magic,) = struct.unpack(">I", head[:4])
@@ -88,6 +89,15 @@ def is_macho(path: str) -> bool:
         (nfat,) = struct.unpack("<I", head[4:8])
         return 0 < nfat < 30
     return False
+
+
+def is_macho(path: str) -> bool:
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(8)
+    except OSError:
+        return False
+    return is_macho_head(head)
 
 
 def read_bundle_identifier(bundle_path: str) -> "str | None":
@@ -205,6 +215,79 @@ def validate_layout(machos: "list[str]") -> "list[str]":
                         "Contents/Frameworks or add explicit bundle handling."
                     )
                     break
+    return errors
+
+
+def find_archived_machos(app_path: str) -> "list[str]":
+    """Fail-closed tripwire for a Mach-O hidden inside a compressed member.
+
+    collect_all_machos() reads magic bytes, so a Mach-O stored compressed is
+    invisible to it and to the pre-sign strip -- nothing signs it. The Apple
+    notary service, however, DECOMPRESSES archive members and scans what is
+    inside them, so such a payload fails the whole notarization with
+    "The binary is not signed with a valid Developer ID certificate",
+    "The signature does not include a secure timestamp" and "The executable does
+    not have the hardened runtime enabled" against a path of the form
+    `<archive>/<member>`. That is exactly how #6746 broke the release lane
+    (submission 3dbd3c7d): the Apple-Silicon imageio-ffmpeg executable was
+    gzip-sealed to survive signing byte-for-byte, and Apple looked inside.
+
+    Catch it HERE -- at sign time, with a bisectable trail -- instead of ~30
+    minutes later as an opaque notarization Invalid. Only stdlib-openable
+    containers are inspected, and only their first 8 bytes are read.
+    """
+    errors: "list[str]" = []
+
+    def report(archive_rel: str, member: str) -> None:
+        errors.append(
+            f"Mach-O inside a compressed member: {archive_rel} -> {member}\n"
+            "    Nothing signs a binary stored compressed, and the Apple notary "
+            "service decompresses archive members and rejects the submission "
+            "over it. Ship the executable UNCOMPRESSED so it is signed with the "
+            "other nested binaries (see kiro_crew.transcribe for how the runtime "
+            "authenticates a payload whose bytes signing rewrote)."
+        )
+
+    for root, _dirs, files in os.walk(app_path):
+        for name in files:
+            full = os.path.join(root, name)
+            if os.path.islink(full):
+                continue
+            rel = os.path.relpath(full, app_path)
+            lower = name.lower()
+            try:
+                if tarfile.is_tarfile(full):
+                    with tarfile.open(full) as archive:
+                        for member in archive:
+                            if not member.isfile():
+                                continue
+                            stream = archive.extractfile(member)
+                            if stream is not None and is_macho_head(stream.read(8)):
+                                report(rel, member.name)
+                elif zipfile.is_zipfile(full):
+                    with zipfile.ZipFile(full) as archive:
+                        for info in archive.infolist():
+                            if info.is_dir():
+                                continue
+                            with archive.open(info) as stream:
+                                if is_macho_head(stream.read(8)):
+                                    report(rel, info.filename)
+                elif lower.endswith(".gz"):
+                    with gzip.open(full, "rb") as stream:
+                        if is_macho_head(stream.read(8)):
+                            report(rel, name[: -len(".gz")])
+                elif lower.endswith(".bz2"):
+                    with bz2.open(full, "rb") as stream:
+                        if is_macho_head(stream.read(8)):
+                            report(rel, name[: -len(".bz2")])
+                elif lower.endswith((".xz", ".lzma")):
+                    with lzma.open(full, "rb") as stream:
+                        if is_macho_head(stream.read(8)):
+                            report(rel, name.rsplit(".", 1)[0])
+            except Exception:
+                # An unreadable or malformed container is not evidence of a
+                # hidden Mach-O; the notary reads what it can and so do we.
+                continue
     return errors
 
 
@@ -357,6 +440,7 @@ def main() -> int:
 
     machos = collect_all_machos(app_path)
     layout_errors = validate_layout(machos)
+    layout_errors.extend(find_archived_machos(app_path))
     if layout_errors:
         print("ERROR: bundle layout not understood by this generator:", file=sys.stderr)
         for err in layout_errors:

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import asyncio
 import errno
-import gzip
 import hashlib
 import logging
 import os
@@ -44,7 +43,6 @@ import sys
 import tempfile
 import threading
 import wave
-import zlib
 from typing import TYPE_CHECKING, Any, Iterator
 
 from kiro_crew import aws_consent, platform_compat, stt
@@ -127,9 +125,9 @@ _FFMPEG_CANDIDATE_DIRS = _ffmpeg_candidate_dirs()
 # matrix installs. The filename selects the platform artifact; size makes a
 # truncated payload fail cheaply; SHA-256 is the trust anchor. Desktop build
 # staging is intentionally writable, so path placement or a removable `.git`
-# marker cannot establish provenance. Only these exact upstream bytes may run.
+# marker cannot establish provenance. These are the bytes the WHEEL publishes.
 _PACKAGED_FFMPEG_ARTIFACTS: dict[str, tuple[int, str]] = {
-    "ffmpeg-macos-aarch64-v7.1.gz": (
+    "ffmpeg-macos-aarch64-v7.1": (
         49_368_728,
         "6d175a4743ca50256e89a8cdd731100f9cee33bd79aeea46894d209410dc6617",
     ),
@@ -146,6 +144,72 @@ _PACKAGED_FFMPEG_ARTIFACTS: dict[str, tuple[int, str]] = {
         "2ce797a0f88d7f067180338fb227f7b1928ea727bd9a4d7a1d022f7c52af71a3",
     ),
 }
+
+# Artifacts the macOS app signer REWRITES on its way into a release, so the
+# upstream digest above cannot be the only anchor. Signing replaces the wheel's
+# ad-hoc LC_CODE_SIGNATURE with a Developer ID one (plus hardened runtime and a
+# secure timestamp), which changes both size and SHA-256, and it is not optional:
+# Apple notarization rejects the whole submission over an unsigned nested
+# executable -- including one hidden inside a compressed member, which the notary
+# service decompresses and scans (submission 3dbd3c7d). A digest that could
+# survive signing does not exist, because it is not known until after the signing
+# service has run.
+#
+# So these artifacts are authenticated by EITHER anchor, both cryptographic:
+#   - the pinned upstream digest -- a local/unsigned build, and the desktop build
+#     gate, which executes the decoder BEFORE the bundle is signed; or
+#   - a valid Developer ID signature from our own team on the exact bytes staged
+#     for execution, which is what a released app carries.
+# Neither anchor is a path or a filesystem-permission claim.
+_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS: frozenset[str] = frozenset({"ffmpeg-macos-aarch64-v7.1"})
+
+# Upper bound on a signer-rewritten payload, whose exact size is unknowable in
+# source. Signing appends a code-signature superblob to a ~50 MB executable, so
+# this is a safety ceiling that keeps the copy below bounded, not a pin.
+_MAX_SIGNED_FFMPEG_BYTES = 192 * 1024 * 1024
+
+# Apple team identifier of the Developer ID certificate that signs Kiro Crew
+# releases (see packaging/signing/manifest-template.json). `anchor apple generic`
+# ties the chain to Apple's root, so only a certificate Apple issued to THIS team
+# satisfies the requirement -- a self-signed or ad-hoc replacement does not.
+_MACOS_SIGNING_TEAM_ID = "94KV3E626L"
+_MACOS_FFMPEG_REQUIREMENT = (
+    f"anchor apple generic and certificate leaf[subject.OU] = {_MACOS_SIGNING_TEAM_ID}"
+)
+
+
+def _macos_developer_id_authentic(path: str) -> bool:
+    """True when *path* carries an intact Developer ID signature from our team.
+
+    /usr/bin/codesign is the only supported authenticity oracle for a signed
+    Mach-O: it validates the code-directory hashes over the file's own bytes AND
+    evaluates the certificate chain, so a tampered or foreign-signed payload
+    fails. The absolute path is deliberate -- an ambient `codesign` on PATH must
+    never be able to answer this question.
+    """
+    if not platform_compat.IS_MACOS:
+        return False
+    try:
+        result = subprocess.run(
+            [
+                "/usr/bin/codesign",
+                "--verify",
+                "--strict",
+                # A leading "=" marks the argument as requirement SOURCE TEXT;
+                # without it codesign reads it as a path to a requirement file.
+                "-R",
+                f"={_MACOS_FFMPEG_REQUIREMENT}",
+                "--",
+                path,
+            ],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
 
 
 def _trusted_site_package_roots() -> tuple[str, ...]:
@@ -250,26 +314,13 @@ def _write_all(descriptor: int, chunk: bytes) -> None:
         view = view[written:]
 
 
-def _ffmpeg_payload_chunks(descriptor: int, *, compressed: bool) -> Iterator[bytes]:
-    """Yield original executable bytes from a raw or gzip package resource."""
-    if not compressed:
-        while True:
-            chunk = os.read(descriptor, 1 << 20)
-            if not chunk:
-                return
-            yield chunk
-
-    # Apple Silicon stores the already ad-hoc-signed upstream executable as
-    # inert gzip data so app signing cannot replace its Mach-O signature and
-    # invalidate the pinned digest. Duplicate the descriptor because GzipFile
-    # owns its file object.
-    with os.fdopen(os.dup(descriptor), "rb") as encoded:
-        with gzip.GzipFile(fileobj=encoded, mode="rb") as payload:
-            while True:
-                chunk = payload.read(1 << 20)
-                if not chunk:
-                    return
-                yield chunk
+def _ffmpeg_payload_chunks(descriptor: int) -> Iterator[bytes]:
+    """Yield the executable bytes of a package resource."""
+    while True:
+        chunk = os.read(descriptor, 1 << 20)
+        if not chunk:
+            return
+        yield chunk
 
 
 def _remove_named_snapshot(path: str) -> None:
@@ -422,7 +473,7 @@ def _authenticated_ffmpeg(
     expected_size: int,
     expected_sha256: str,
     *,
-    compressed: bool = False,
+    signature_anchored: bool = False,
 ) -> _AuthenticatedFfmpeg | None:
     """Copy/hash exact bytes and keep an immutable execution identity open.
 
@@ -433,6 +484,12 @@ def _authenticated_ffmpeg(
     spawn. Windows instead holds a ``CreateFileW`` handle
     that denies both write and delete sharing until ``CreateProcess`` has opened
     the image. In every case the bytes hashed are the bytes staged for execution.
+
+    ``signature_anchored`` marks an artifact the macOS app signer rewrites (see
+    ``_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS``): the upstream digest still authenticates
+    an unsigned build, and a Developer ID signature from our own team authenticates
+    the released one. One of the two must hold; a payload that satisfies neither is
+    refused exactly as before.
     """
     source = -1
     snapshot_writer = -1
@@ -447,11 +504,16 @@ def _authenticated_ffmpeg(
         opened = os.fstat(source)
         if not stat.S_ISREG(opened.st_mode):
             return None
-        if compressed:
-            if opened.st_size <= 0:
+        if signature_anchored:
+            # The signed size is unknowable in source, so bound the copy by the
+            # file's own length under a safety ceiling instead of by the pin.
+            if opened.st_size <= 0 or opened.st_size > _MAX_SIGNED_FFMPEG_BYTES:
                 return None
+            size_limit = opened.st_size
         elif opened.st_size != expected_size:
             return None
+        else:
+            size_limit = expected_size
 
         seal_snapshot = False
         if not platform_compat.IS_WINDOWS:
@@ -459,17 +521,21 @@ def _authenticated_ffmpeg(
 
         digest = hashlib.sha256()
         total = 0
-        for chunk in _ffmpeg_payload_chunks(source, compressed=compressed):
+        for chunk in _ffmpeg_payload_chunks(source):
             total += len(chunk)
-            if total > expected_size:
+            if total > size_limit:
                 return None
             digest.update(chunk)
             if snapshot_writer >= 0:
                 _write_all(snapshot_writer, chunk)
-        if total != expected_size or digest.hexdigest() != expected_sha256:
+        source_digest = digest.hexdigest()
+        upstream_bytes = total == expected_size and source_digest == expected_sha256
+        if not upstream_bytes and not signature_anchored:
             return None
 
         if platform_compat.IS_WINDOWS:
+            # Windows artifacts are never signer-rewritten, so reaching here means
+            # the pinned digest matched.
             result = _AuthenticatedFfmpeg(candidate, source, candidate)
             source = -1  # ownership transferred to result
             return result
@@ -483,7 +549,9 @@ def _authenticated_ffmpeg(
             os.chmod(os.path.dirname(snapshot_path), 0o500)
 
         # Authenticate the descriptor that will actually be inherited, after
-        # the last writer owned by this process has closed.
+        # the last writer owned by this process has closed. Compared against the
+        # digest of what was READ, so the snapshot is proven identical to the
+        # verified source whether the anchor was the pin or the signature.
         snapshot_digest = hashlib.sha256()
         snapshot_total = 0
         while True:
@@ -492,13 +560,17 @@ def _authenticated_ffmpeg(
                 break
             snapshot_total += len(chunk)
             snapshot_digest.update(chunk)
-        if snapshot_total != expected_size or snapshot_digest.hexdigest() != expected_sha256:
+        if snapshot_total != total or snapshot_digest.hexdigest() != source_digest:
             return None
         os.lseek(snapshot, 0, os.SEEK_SET)
         if snapshot_path is None:
             execution_path = f"/proc/self/fd/{snapshot}"
         else:
             execution_path = snapshot_path
+        # Bytes that are not the pinned upstream payload are only executed when
+        # macOS itself vouches for their signature, on the snapshot about to run.
+        if not upstream_bytes and not _macos_developer_id_authentic(execution_path):
+            return None
         result = _AuthenticatedFfmpeg(
             candidate,
             snapshot,
@@ -508,7 +580,7 @@ def _authenticated_ffmpeg(
         snapshot = -1  # ownership transferred to result
         snapshot_path = None  # ownership transferred to result
         return result
-    except (EOFError, OSError, zlib.error):
+    except OSError:
         return None
     finally:
         if source >= 0:
@@ -548,14 +620,13 @@ def _open_packaged_ffmpeg_resource() -> _AuthenticatedFfmpeg | None:
                 or not os.path.isfile(candidate)
             ):
                 continue
-            compressed = filename.endswith(".gz")
-            if (
-                not compressed
-                and not platform_compat.IS_WINDOWS
-                and not os.access(candidate, os.X_OK)
-            ):
+            if not platform_compat.IS_WINDOWS and not os.access(candidate, os.X_OK):
                 continue
-            authenticated = _authenticated_ffmpeg(candidate, *artifact, compressed=compressed)
+            authenticated = _authenticated_ffmpeg(
+                candidate,
+                *artifact,
+                signature_anchored=filename in _SIGNER_REWRITTEN_FFMPEG_ARTIFACTS,
+            )
             if authenticated is not None:
                 candidates.append(authenticated)
     if len(candidates) == 1:

--- a/test/test_signing_manifest_archived_machos.py
+++ b/test/test_signing_manifest_archived_machos.py
@@ -1,0 +1,103 @@
+"""The sign-time tripwire for a Mach-O hidden inside a compressed member.
+
+`collect_all_machos` reads magic bytes, so an executable stored compressed is
+invisible to it AND to the pre-sign ad-hoc signature strip -- nothing signs it.
+The Apple notary service, however, decompresses archive members and scans what
+is inside, so such a payload fails the WHOLE submission ~30 minutes later with
+an opaque `Invalid`. That is how #6746 broke the macOS release lane (Apple
+submission 3dbd3c7d, three `error` issues against
+`.../binaries/ffmpeg-macos-aarch64-v7.1.gz/ffmpeg-macos-aarch64-v7.1`).
+
+These tests pin the tripwire that turns that into a sign-time failure with a
+bisectable trail.
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import pathlib
+import struct
+import tarfile
+import zipfile
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+GENERATOR = REPO_ROOT / "packaging" / "signing" / "generate-manifest.py"
+
+# Thin arm64 Mach-O magic (MH_MAGIC_64) plus a plausible cputype word.
+MACHO_HEAD = struct.pack(">I", 0xFEEDFACF) + struct.pack(">I", 0x0100000C)
+
+
+@pytest.fixture(scope="module")
+def generator():
+    spec = importlib.util.spec_from_file_location("generate_manifest", GENERATOR)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bundle(tmp_path: pathlib.Path) -> pathlib.Path:
+    binaries = tmp_path / "KiroCrew.app" / "Contents" / "Resources" / "binaries"
+    binaries.mkdir(parents=True)
+    return binaries
+
+
+def test_a_clean_bundle_reports_nothing(generator, tmp_path):
+    binaries = _bundle(tmp_path)
+    # A plain Mach-O is the SHIPPING shape: enumerated and signed elsewhere, so
+    # this tripwire must stay silent about it.
+    (binaries / "ffmpeg-macos-aarch64-v7.1").write_bytes(MACHO_HEAD + b"\x00" * 64)
+    (binaries / "notes.txt.gz").write_bytes(gzip.compress(b"just text", mtime=0))
+
+    assert generator.find_archived_machos(str(tmp_path / "KiroCrew.app")) == []
+
+
+def test_gzip_sealed_macho_is_reported(generator, tmp_path):
+    """The exact #6746 shape."""
+    binaries = _bundle(tmp_path)
+    (binaries / "ffmpeg-macos-aarch64-v7.1.gz").write_bytes(
+        gzip.compress(MACHO_HEAD + b"\x00" * 64, mtime=0)
+    )
+
+    errors = generator.find_archived_machos(str(tmp_path / "KiroCrew.app"))
+
+    assert len(errors) == 1
+    assert "ffmpeg-macos-aarch64-v7.1.gz" in errors[0]
+    assert "Mach-O inside a compressed member" in errors[0]
+    # The message must say what to DO, not just that something is wrong.
+    assert "UNCOMPRESSED" in errors[0]
+
+
+def test_zip_and_tar_members_are_inspected_too(generator, tmp_path):
+    binaries = _bundle(tmp_path)
+    payload = binaries / "payload"
+    payload.write_bytes(MACHO_HEAD + b"\x00" * 64)
+    with zipfile.ZipFile(binaries / "sealed.zip", "w") as archive:
+        archive.write(payload, arcname="inner-binary")
+    with tarfile.open(binaries / "sealed.tar.gz", "w:gz") as archive:
+        archive.add(payload, arcname="tarred-binary")
+    payload.unlink()
+
+    reported = " ".join(generator.find_archived_machos(str(tmp_path / "KiroCrew.app")))
+
+    assert "inner-binary" in reported
+    assert "tarred-binary" in reported
+
+
+def test_unreadable_container_is_not_treated_as_a_finding(generator, tmp_path):
+    """A malformed container is not evidence of a hidden binary, and must not
+    fail a sign that would otherwise notarize."""
+    binaries = _bundle(tmp_path)
+    (binaries / "truncated.gz").write_bytes(b"\x1f\x8b\x08truncated-garbage")
+
+    assert generator.find_archived_machos(str(tmp_path / "KiroCrew.app")) == []
+
+
+def test_the_generator_wires_the_tripwire_into_its_fail_closed_path(generator):
+    """`main` must merge these errors with the layout errors it already aborts
+    on -- a check nothing calls is not a check."""
+    source = GENERATOR.read_text(encoding="utf-8")
+    assert "layout_errors.extend(find_archived_machos(app_path))" in source

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1197,6 +1197,16 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # this audit through the generic helper, so each caller remains independently
         # reviewed and a future caller fails the gate until it is classified.
         "transcribe.py::_create_ffmpeg_subprocess",
+        # The macOS authenticity oracle for the bundled ffmpeg: spawns the
+        # absolute /usr/bin/codesign (never PATH) with constant flags and a
+        # requirement string built from a module-level team-ID constant. The
+        # only variable argument is the path of the process-private snapshot
+        # (`/proc/self/fd/N`-style descriptor or the 0o500 snapshot dir this
+        # module itself just wrote and digest-verified) — no agent influence
+        # over command, args, cwd, or env. It cannot route through
+        # sandboxed_spawn_argv: codesign must read the system trust store and
+        # evaluate the Apple certificate chain, which the OS sandbox denies.
+        "transcribe.py::_macos_developer_id_authentic",
         "transcribe.py::_pcm_via_ffmpeg",
         "transcribe.py::_transcribe_aws",
         # The build probe executes the same authenticated image with the single

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -10,7 +10,6 @@ whisper.cpp decodes one.
 from __future__ import annotations
 
 import asyncio
-import gzip
 import importlib.machinery
 import importlib.util
 import os
@@ -1221,27 +1220,28 @@ class TestBundledFfmpeg:
 
     @staticmethod
     def _fake_package(
-        monkeypatch, tmp_path, *, create_binary: bool = True, compressed: bool = False
+        monkeypatch, tmp_path, *, create_binary: bool = True, signer_rewritten: bool = False
     ):
         package_dir = tmp_path / "imageio_ffmpeg"
         binaries = package_dir / "binaries"
         binaries.mkdir(parents=True)
-        filename = (
-            "ffmpeg-test.gz"
-            if compressed
-            else ("ffmpeg-test.exe" if _pc.IS_WINDOWS else "ffmpeg-test")
-        )
+        filename = "ffmpeg-test.exe" if _pc.IS_WINDOWS else "ffmpeg-test"
         binary = binaries / filename
         payload = b"bundled decoder"
         if create_binary:
-            binary.write_bytes(gzip.compress(payload, mtime=0) if compressed else payload)
-            binary.chmod(0o444 if compressed else 0o755)
+            binary.write_bytes(payload)
+            binary.chmod(0o755)
 
         monkeypatch.setattr(transcribe, "_trusted_site_package_roots", lambda: (str(tmp_path),))
         monkeypatch.setattr(
             transcribe,
             "_PACKAGED_FFMPEG_ARTIFACTS",
             {filename: (len(payload), transcribe.hashlib.sha256(payload).hexdigest())},
+        )
+        monkeypatch.setattr(
+            transcribe,
+            "_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS",
+            frozenset({filename} if signer_rewritten else ()),
         )
         monkeypatch.setattr(transcribe.platform_compat, "is_bundled_interpreter", lambda: True)
         return binary
@@ -1299,60 +1299,120 @@ class TestBundledFfmpeg:
 
         assert transcribe._bundled_ffmpeg() is None
 
-    def test_gzip_payload_chunks_expand_original_bytes(self, tmp_path):
-        encoded = tmp_path / "ffmpeg.gz"
-        encoded.write_bytes(gzip.compress(b"bundled decoder", mtime=0))
-        descriptor = os.open(encoded, os.O_RDONLY)
+    def test_payload_chunks_yield_the_file_bytes(self, tmp_path):
+        raw = tmp_path / "ffmpeg"
+        raw.write_bytes(b"bundled decoder")
+        descriptor = os.open(raw, os.O_RDONLY)
         try:
-            assert (
-                b"".join(transcribe._ffmpeg_payload_chunks(descriptor, compressed=True))
-                == b"bundled decoder"
-            )
+            assert b"".join(transcribe._ffmpeg_payload_chunks(descriptor)) == b"bundled decoder"
         finally:
             os.close(descriptor)
 
-    def test_gzip_payload_chunks_reject_corruption(self, tmp_path):
-        encoded = tmp_path / "ffmpeg.gz"
-        encoded.write_bytes(b"not a gzip stream")
-        descriptor = os.open(encoded, os.O_RDONLY)
-        try:
-            with pytest.raises(OSError):
-                b"".join(transcribe._ffmpeg_payload_chunks(descriptor, compressed=True))
-        finally:
-            os.close(descriptor)
+    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="signer-rewritten payloads are macOS-only")
+    def test_signer_rewritten_payload_is_accepted_on_a_developer_id_signature(
+        self, monkeypatch, tmp_path
+    ):
+        """A released macOS decoder no longer matches the upstream digest, because
+        signing replaced its Mach-O signature. macOS vouching for the exact bytes
+        staged for execution is the second anchor."""
+        binary = self._fake_package(monkeypatch, tmp_path, signer_rewritten=True)
+        binary.write_bytes(b"bundled decoder + developer id signature")
+        binary.chmod(0o755)
+        verified: list[str] = []
 
-    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="gzip payload is Apple-Silicon-only")
-    def test_gzip_payload_is_expanded_then_authenticated(self, monkeypatch, tmp_path):
-        binary = self._fake_package(monkeypatch, tmp_path, compressed=True)
+        def authentic(path):
+            verified.append(path)
+            return True
+
+        monkeypatch.setattr(transcribe, "_macos_developer_id_authentic", authentic)
 
         opened = transcribe._open_packaged_ffmpeg_resource()
 
         assert opened is not None
         try:
             assert opened.source_path == str(binary)
-            assert not os.access(binary, os.X_OK)
-            assert os.read(opened.descriptor, 1024) == b"bundled decoder"
+            # The signature was checked on the snapshot, not on the bundle path.
+            assert verified == [opened.execution_path]
+            assert opened.execution_path != str(binary)
         finally:
             opened.close()
 
-    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="gzip payload is Apple-Silicon-only")
-    def test_corrupt_gzip_payload_is_rejected(self, monkeypatch, tmp_path):
-        binary = self._fake_package(monkeypatch, tmp_path, compressed=True)
-        binary.chmod(0o644)
-        binary.write_bytes(b"not a gzip stream")
+    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="signer-rewritten payloads are macOS-only")
+    def test_signer_rewritten_payload_without_a_valid_signature_is_refused(
+        self, monkeypatch, tmp_path
+    ):
+        binary = self._fake_package(monkeypatch, tmp_path, signer_rewritten=True)
+        binary.write_bytes(b"attacker decoder, ad-hoc signed")
+        binary.chmod(0o755)
+        monkeypatch.setattr(transcribe, "_macos_developer_id_authentic", lambda _path: False)
 
         assert transcribe._bundled_ffmpeg() is None
 
-    def test_deflate_error_is_reported_as_an_invalid_payload(self, monkeypatch, tmp_path):
-        self._fake_package(monkeypatch, tmp_path, compressed=True)
+    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="signer-rewritten payloads are macOS-only")
+    def test_upstream_digest_still_authenticates_without_any_signature(self, monkeypatch, tmp_path):
+        """The desktop build gate runs BEFORE signing, so the pinned wheel bytes
+        must keep authenticating on their own."""
+        binary = self._fake_package(monkeypatch, tmp_path, signer_rewritten=True)
 
-        def broken_payload(*_args, **_kwargs):
-            raise transcribe.zlib.error("corrupt deflate block")
-            yield b""  # pragma: no cover - make this a generator
+        def _unexpected_codesign(_path):
+            raise AssertionError("codesign consulted for pinned upstream bytes")
 
-        monkeypatch.setattr(transcribe, "_ffmpeg_payload_chunks", broken_payload)
+        monkeypatch.setattr(transcribe, "_macos_developer_id_authentic", _unexpected_codesign)
+
+        assert transcribe._bundled_ffmpeg() == str(binary)
+
+    def test_non_signer_rewritten_artifact_never_consults_codesign(self, monkeypatch, tmp_path):
+        """Linux and Windows payloads stay digest-only: a mismatch is refused
+        outright, never escalated to a signature check."""
+        binary = self._fake_package(monkeypatch, tmp_path)
+        binary.write_bytes(b"changed decoder!!")
+
+        def _unexpected_codesign(_path):
+            raise AssertionError("codesign consulted for a digest-pinned artifact")
+
+        monkeypatch.setattr(transcribe, "_macos_developer_id_authentic", _unexpected_codesign)
 
         assert transcribe._bundled_ffmpeg() is None
+
+    def test_codesign_requirement_pins_the_release_team(self):
+        """Chained to Apple's root AND to our team, so an ad-hoc or self-signed
+        replacement cannot satisfy it."""
+        assert transcribe._MACOS_SIGNING_TEAM_ID == "94KV3E626L"
+        assert transcribe._MACOS_FFMPEG_REQUIREMENT == (
+            "anchor apple generic and certificate leaf[subject.OU] = 94KV3E626L"
+        )
+
+    def test_codesign_is_invoked_by_absolute_path_with_requirement_source_text(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(transcribe.platform_compat, "IS_MACOS", True)
+        recorded: list[list[str]] = []
+
+        class _Result:
+            returncode = 0
+
+        def fake_run(argv, **_kwargs):
+            recorded.append(argv)
+            return _Result()
+
+        monkeypatch.setattr(transcribe.subprocess, "run", fake_run)
+
+        assert transcribe._macos_developer_id_authentic(str(tmp_path / "ffmpeg")) is True
+        argv = recorded[0]
+        assert argv[0] == "/usr/bin/codesign"
+        assert "--strict" in argv
+        # A bare requirement string would be read as a FILE PATH by codesign.
+        assert argv[argv.index("-R") + 1].startswith("=anchor apple generic")
+
+    def test_codesign_absence_is_not_authenticity(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(transcribe.platform_compat, "IS_MACOS", True)
+
+        def missing_codesign(*_args, **_kwargs):
+            raise OSError("no such file")
+
+        monkeypatch.setattr(transcribe.subprocess, "run", missing_codesign)
+
+        assert transcribe._macos_developer_id_authentic(str(tmp_path / "ffmpeg")) is False
 
     def test_linux_memfd_explicitly_requests_executable_mode(self, monkeypatch):
         calls = []
@@ -1525,7 +1585,10 @@ class TestBundledFfmpeg:
 
     def test_release_artifact_pins_cover_every_supported_desktop(self):
         assert transcribe._PACKAGED_FFMPEG_ARTIFACTS == {
-            "ffmpeg-macos-aarch64-v7.1.gz": (
+            # NOT "...v7.1.gz": a compressed payload is decompressed and scanned
+            # by the Apple notary service, which rejects the unsigned executable
+            # inside it and fails the whole macOS release (#6746 regression).
+            "ffmpeg-macos-aarch64-v7.1": (
                 49_368_728,
                 "6d175a4743ca50256e89a8cdd731100f9cee33bd79aeea46894d209410dc6617",
             ),

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -341,8 +341,13 @@ describe("first-download installer design contract", () => {
     assert.match(buildScript, /from kiro_crew\.stt\.engine import probe/);
     assert.match(buildScript, /from kiro_crew\.transcribe import _packaged_ffmpeg_version_probe/);
     assert.match(buildScript, /if not _packaged_ffmpeg_version_probe\(\)/);
-    assert.match(buildScript, /source\.with_name\(source\.name \+ "\.gz"\)/);
-    assert.match(buildScript, /seal_macos_ffmpeg_payload "\$out\/bin\/python3\.12"/);
+    // The Apple-Silicon decoder must ship as a PLAIN Mach-O so the app signer
+    // signs it. Sealing it as a compressed payload (#6746) made Apple's notary
+    // service decompress the member, find an unsigned executable inside, and
+    // fail the whole macOS release.
+    assert.doesNotMatch(buildScript, /seal_macos_ffmpeg_payload/);
+    assert.doesNotMatch(buildScript, /source\.with_name\(source\.name \+ "\.gz"\)/);
+    assert.match(buildScript, /do NOT re-introduce a compressed payload/);
     assert.match(buildScript, /local_voice_runtime_gate "\$out\/bin\/python3\.12"/);
     assert.match(windowsBuilder, /local_voice_runtime_gate "\$out\/python\.exe"/);
 


### PR DESCRIPTION
## The failure

Release run [33295704858](https://github.com/kirodotdev/KiroCrew/actions/runs/33295704858) failed at **Sign + Notarize macOS / Notarize + staple (insider)**. Apple returned `Invalid` — submission `3dbd3c7d-ee1e-4f5c-bcd9-035aa15d2ae1`, `"statusSummary": "Archive contains critical validation errors"` — with **three `error` issues, all against a single path**:

```
signed.zip/KiroCrew.app/Contents/Resources/backend-dist/kirocrew-backend-arm64/lib/python3.12/site-packages/imageio_ffmpeg/binaries/ffmpeg-macos-aarch64-v7.1.gz/ffmpeg-macos-aarch64-v7.1
```

```
The binary is not signed with a valid Developer ID certificate.   (arm64)
The signature does not include a secure timestamp.                (arm64)
The executable does not have the hardened runtime enabled.        (arm64)
```

## Root cause

f2575b1bb (#6746) began bundling the desktop voice runtime, and to keep the Apple-Silicon `imageio-ffmpeg` executable **byte-identical to the pinned upstream wheel across app signing** it sealed that executable as inert gzip data (`seal_macos_ffmpeg_payload`). The reasoning was sound for our own signer — `generate-manifest.py` finds nested Mach-Os by reading magic bytes, so a gzipped one is invisible to it and is never rewritten.

**The Apple notary service decompresses archive members and scans what is inside them.** So the seal hid the Mach-O from our signer but not from Apple. The `<archive>/<member>` shape of the rejected path above is Apple reporting a file it decompressed itself.

The decisive evidence for the fix: the **x86_64 copy of the very same wheel** ships raw in `kirocrew-backend-x64` in that same bundle (`is_macos_intel_backend` made the seal arm64-only), is enumerated by `collect_entries()`, is signed by the signing service, and **drew no issue at all in that submission**. The working shape was already in the artifact next door.

## Why not just drop the dependency

`imageio-ffmpeg` is genuinely required at runtime, not a stray transitive dep: `transcribe.py` pins its executable per platform and uses it to decode the ogg/Opus and webm memos the default `local` STT provider receives, `local_voice_runtime_gate` executes it as a release gate, and the specs state desktop releases carry it so users never install system FFmpeg. Excluding it would regress the default dictation path on the most common Mac.

## The fix

**Ship it uncompressed** (`packaging/build-desktop.sh`): the arm64 executable is a plain Mach-O, so the signing service signs it with Developer ID + hardened runtime + secure timestamp along with every other nested binary. `seal_macos_ffmpeg_payload` is removed, with a load-bearing comment recording why it must not come back.

**Adapt the runtime anchor** (`src/kiro_crew/transcribe.py`): signing necessarily rewrites the Mach-O signature, so a released decoder can never match a digest pinned in source — and that digest is not knowable until after the signing service has run, so no pin could have survived. The macOS artifact is now authenticated by **either** cryptographic anchor:

- the **pinned upstream wheel digest** — unchanged values, because they always described the *raw* upstream bytes (the `.gz` entry hashed the decompressed stream). This is what an unsigned/local build and the pre-signing release gate see; and
- a valid **Developer ID signature from the release team** (`94KV3E626L`, chained to Apple's root via `anchor apple generic`), evaluated by `/usr/bin/codesign --verify --strict -R` against the **exact private snapshot staged for execution** — not the bundle path.

Neither anchor is a path or a filesystem-permission claim, and a payload satisfying neither is refused exactly as before. Linux and Windows artifacts stay **digest-only**: a mismatch there is refused outright, never escalated to a signature check (pinned by a test). The snapshot is additionally proven byte-identical to the verified source before it can run, as before.

## Guardrail

`generate-manifest.py` now **fails the sign** when any compressed member of the bundle contains a Mach-O (`find_archived_machos`, merged into the existing fail-closed `validate_layout` path). `collect_all_machos` reads magic bytes, so a compressed executable is invisible both to it and to the pre-sign ad-hoc strip — which is exactly why this defect reached Apple instead of the build log. This turns the class of regression into a sign-time failure with a bisectable trail instead of an opaque notarization `Invalid` ~30 minutes downstream. Only stdlib-openable containers are inspected (tar, zip, gz, bz2, xz), 8 bytes per member; a malformed container is not treated as a finding.

## Verification

The macOS signing path cannot be exercised off a Mac, so this is reviewed logic plus tests:

- `test/test_transcribe.py` — 33 bundled-decoder tests pass, including new cases for the signature anchor (accepted / refused / codesign consulted on the snapshot not the bundle path / requirement text passed as source text, since a bare string would be read as a *file path* by `codesign` / missing `codesign` is not authenticity) and for the pinned digest still authenticating with no signature at all (the pre-signing gate).
- `test/test_signing_manifest_archived_machos.py` (new, 5 tests) — including the exact gzip-sealed shape that failed, plus zip/tar members and the "a check nothing calls is not a check" wiring assertion.
- `website/electron/test/packaging.test.js` — 39 pass; the seal assertions are inverted to assert its **absence**.
- The 10 pre-existing `TestDoctor`/`TestDoctorStt` failures and the sandbox `userns` failure in this environment reproduce identically on a clean `origin/main` checkout (verified by stashing).

**Residual risk, stated plainly:** the first real proof is the next macOS release run reaching `Accepted`. macOS Intel is unchanged — its raw ffmpeg is still signed and still absent from the pin map, so it remains the documented legacy exception.
