### PR TITLE
test(session-pool): close rearmed managers

### DIFF
--- a/test/test_session_pool.py
+++ b/test/test_session_pool.py
@@ -1019,6 +1019,7 @@ class TestReloadProviderFactoryRefillsPool:
         old_provider.shutdown.assert_awaited_once()
         # Pool started was reset and start_pool ran (non-blocking task created)
         assert mgr._pool_started is True  # re-set by start_pool
+        await mgr.close_all()
 
     @pytest.mark.asyncio
     async def test_reload_cancels_old_health_task(self):
@@ -1041,6 +1042,7 @@ class TestReloadProviderFactoryRefillsPool:
             await mgr.reload_provider_factory()
 
         fake_task.cancel.assert_called_once()
+        await mgr.close_all()
 
 
 # ---------------------------------------------------------------------------
@@ -1122,6 +1124,7 @@ class TestRefreshDefaultsSparesLiveSessions:
 
         stale_pooled.shutdown.assert_awaited()
         assert mgr._warm_pool.empty()
+        await mgr.close_all()
 
     @pytest.mark.asyncio
     async def test_pool_is_restarted_after_the_drain(self):
@@ -1149,6 +1152,7 @@ class TestRefreshDefaultsSparesLiveSessions:
 
         stale_task.cancel.assert_called_once()
         assert mgr._pool_started is True, "start_pool never re-armed after the drain"
+        await mgr.close_all()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- close SessionManager instances in the four pool tests that re-arm manager-owned background health tasks
- use the existing `close_all()` lifecycle contract after assertions
- prevent `_pool_health_loop was never awaited` warnings from being emitted during later GC or neighboring tests

## Determinism evidence
- before the fix, strict RuntimeWarning/PytestUnraisable handling makes the refresh-defaults reproducer fail, with tracemalloc pointing to the health-task creation site
- the reload-provider reproducer can pass its assertions and still exit non-zero because two unawaited pool-health warnings are emitted during teardown
- no retries, sleeps, timeout increases, tolerance changes, or warning filters were added

## Validation
- `test/test_session_pool.py` with RuntimeWarning and PytestUnraisable warnings promoted to errors: 76 passed, 2 Windows-only skips
- flake8, official Black baseline gate, and `git diff --check` passed

## Overlap audit
- all open PRs were checked; none modifies `session_pool.py` or `test_session_pool.py`
- the SessionManager refactor on main does not replace the test-owned lifecycle obligation fixed here