### PR TITLE
fix(website): bind app art failures to url generations

### DIFF
--- a/website/src/pages/AppDetailPage.tsx
+++ b/website/src/pages/AppDetailPage.tsx
@@ -156,6 +156,36 @@ interface AppManifest {
   minKiroCrewVersion?: string
 }
 
+type ScreenshotFailureState = {
+  screensKey: string
+  fallbacksKey: string
+  primary: ReadonlySet<number>
+  fallback: ReadonlySet<number>
+}
+
+const NO_SCREENSHOT_FAILURES: ReadonlySet<number> = new Set()
+
+function recordScreenshotFailure(
+  previous: ScreenshotFailureState,
+  screensKey: string,
+  fallbacksKey: string,
+  index: number,
+  tier: 'primary' | 'fallback',
+): ScreenshotFailureState {
+  // A failure belongs to the generation that rendered the image. The URL lists
+  // are re-armed during render (below), so a handler still holding an older
+  // generation's keys is by definition superseded: drop it rather than let it
+  // resurrect a set the current generation already cleared.
+  if (previous.screensKey !== screensKey || previous.fallbacksKey !== fallbacksKey) {
+    return previous
+  }
+  const primary = new Set<number>(previous.primary)
+  const fallback = new Set<number>(previous.fallback)
+  if (tier === 'primary') primary.add(index)
+  else fallback.add(index)
+  return { screensKey, fallbacksKey, primary, fallback }
+}
+
 // Exported for tests: the per-index latch guards (self-match, '' placeholder
 // skip) are not all reachable through the page once the call site gates the
 // fallback list on a registry-supplied primary.
@@ -181,27 +211,50 @@ export function ScreenshotGallery({ screenshots, fallbacks }: { screenshots: str
   // #6886; the `screenshots` case pre-existed as a `.map` crash).
   const screenList: string[] = Array.isArray(screenshots) ? screenshots : []
   const fallbackList: string[] = Array.isArray(fallbacks) ? fallbacks : []
-  // Per-thumbnail failure latches, mirroring AppIcon's two-latch shape
-  // (#6804): a thumbnail whose primary errored swaps to ITS OWN fallback; one
+  // Per-thumbnail failure latches: a thumbnail whose primary errored swaps to
+  // ITS OWN fallback; one
   // whose fallback errored too is hidden — the pre-#6864 terminal state.
   // Per-index state, not one flag for the strip: one unreachable asset must
   // not blank its neighbours. `fallbacks` is optional so untouched callers
   // stay default-inert (the contract #6865 locked for AppIcon).
-  const [primaryFailed, setPrimaryFailed] = useState<ReadonlySet<number>>(new Set())
-  const [fallbackFailed, setFallbackFailed] = useState<ReadonlySet<number>>(new Set())
-  // Per-URL reset discipline (AppIcon's, list-shaped), keyed on the joined
-  // URLs rather than array identity because the caller builds these props
-  // inline, so identity changes every render. A changed primary list (theme
-  // flip, refetch) clears BOTH latch sets; a changed fallback list alone (an
-  // install completing under a mounted page) re-arms only the fallback
-  // latches. '\n' cannot appear in a URL, so the join is unambiguous.
   const screensKey = screenList.join('\n')
   const fallbacksKey = fallbackList.join('\n')
-  useEffect(() => {
-    setPrimaryFailed(new Set())
-    setFallbackFailed(new Set())
-  }, [screensKey])
-  useEffect(() => { setFallbackFailed(new Set()) }, [fallbacksKey])
+  // Re-arm the latches during render rather than in a passive effect. An image
+  // rendered for a new generation can fail BEFORE an effect would run, and the
+  // effect's reset would then erase that real failure and re-show the dead URL.
+  // Adjusting state while rendering re-arms before the new <img> is committed,
+  // and — unlike binding failures to the URL text alone — it clears on EVERY
+  // transition, so returning to an earlier list (theme flip back, refetch)
+  // retries instead of restoring a stale failure. A primary-list change re-arms
+  // both latch sets; a fallback-only change re-arms only the fallback latches.
+  const [failures, setFailures] = useState<ScreenshotFailureState>(() => ({
+    screensKey,
+    fallbacksKey,
+    primary: NO_SCREENSHOT_FAILURES,
+    fallback: NO_SCREENSHOT_FAILURES,
+  }))
+  if (failures.screensKey !== screensKey) {
+    setFailures({
+      screensKey,
+      fallbacksKey,
+      primary: NO_SCREENSHOT_FAILURES,
+      fallback: NO_SCREENSHOT_FAILURES,
+    })
+  } else if (failures.fallbacksKey !== fallbacksKey) {
+    setFailures({
+      screensKey,
+      fallbacksKey,
+      primary: failures.primary,
+      fallback: NO_SCREENSHOT_FAILURES,
+    })
+  }
+  const primaryFailed = failures.screensKey === screensKey
+    ? failures.primary
+    : NO_SCREENSHOT_FAILURES
+  const fallbackFailed = failures.screensKey === screensKey
+    && failures.fallbacksKey === fallbacksKey
+    ? failures.fallback
+    : NO_SCREENSHOT_FAILURES
 
   // ── screenshot magnification (issue #6162) ────────────────────────────────
   // This lightbox is the third full-viewport magnify overlay, bound by the same
@@ -363,8 +416,10 @@ export function ScreenshotGallery({ screenshots, fallbacks }: { screenshots: str
                   alt={i18nT('pages.appDetailPage.screenshot', { n: i + 1 })}
                   className="h-40 rounded-lg border border-border hover:border-accent/40 hover:shadow-md transition-all object-cover"
                   onError={() => {
-                    if (!primaryFailed.has(i)) setPrimaryFailed(prev => new Set(prev).add(i))
-                    else setFallbackFailed(prev => new Set(prev).add(i))
+                    const tier = primaryFailed.has(i) ? 'fallback' : 'primary'
+                    setFailures(previous => recordScreenshotFailure(
+                      previous, screensKey, fallbacksKey, i, tier,
+                    ))
                   }}
                 />
               </button>
@@ -457,26 +512,36 @@ export function ScreenshotGallery({ screenshots, fallbacks }: { screenshots: str
  */
 // Exported for tests (direct latch-discipline coverage).
 export function HeroBanner({ src, fallbackSrc, isDetail }: { src: string; fallbackSrc?: string; isDetail: boolean }) {
-  const [primaryFailed, setPrimaryFailed] = useState(false)
-  const [fallbackFailed, setFallbackFailed] = useState(false)
-  // A changed primary clears BOTH latches: a theme flip changes `src` without
-  // any prop the parent re-keys on, and an app update rewrites the local file
-  // in place, so a stale fallback latch would be a sticky failure.
-  useEffect(() => {
-    setPrimaryFailed(false)
-    setFallbackFailed(false)
-  }, [src])
-  // The same per-URL reset for the fallback latch alone: the fallback
-  // candidate moves independently of the primary (a theme flip where only the
-  // fallback pair has a dark variant, an install completing under a mounted
-  // page) and must never inherit a stale failure.
-  useEffect(() => { setFallbackFailed(false) }, [fallbackSrc])
   // Same-origin gate on the fallback, mirroring resolvedAt in the gallery:
   // the registry-only raw-row spread can deliver attacker-chosen fallback
   // keys, and an absolute URL honoured on error would leak the viewer's
   // address to a third-party host. installedArt only emits same-origin
   // routes, so real installed-app fallbacks always pass (GPT finding, #6886).
   const safeFallback = fallbackSrc && classifyManifestArt(fallbackSrc) === 'same-origin' ? fallbackSrc : ''
+  // Re-arm the latches during render rather than in a passive effect. The image
+  // for a new URL can fail BEFORE an effect would run, and the effect's reset
+  // would then erase that real failure and re-show the dead URL. Adjusting
+  // state while rendering re-arms before the new <img> is committed, and —
+  // unlike binding the failure to the URL text alone — it clears on EVERY
+  // transition, so a theme flip back to a previously failed URL retries instead
+  // of restoring a stale failure. A changed primary re-arms both latches; a
+  // fallback that moves on its own (an install completing under a mounted page)
+  // re-arms only the fallback latch.
+  const [latch, setLatch] = useState<{
+    src: string
+    fallback: string
+    primaryFailed: boolean
+    fallbackFailed: boolean
+  }>(() => ({ src, fallback: safeFallback, primaryFailed: false, fallbackFailed: false }))
+  if (latch.src !== src) {
+    setLatch({ src, fallback: safeFallback, primaryFailed: false, fallbackFailed: false })
+  } else if (latch.fallback !== safeFallback) {
+    setLatch({ src, fallback: safeFallback, primaryFailed: latch.primaryFailed, fallbackFailed: false })
+  }
+  const primaryFailed = latch.src === src && latch.primaryFailed
+  const fallbackFailed = latch.src === src
+    && latch.fallback === safeFallback
+    && latch.fallbackFailed
   const useFallback = primaryFailed && !!safeFallback && safeFallback !== src && !fallbackFailed
   if (!src || (primaryFailed && !useFallback)) return null
   return (
@@ -488,8 +553,14 @@ export function HeroBanner({ src, fallbackSrc, isDetail }: { src: string; fallba
         alt=""
         className="w-full h-full object-cover"
         onError={() => {
-          if (!primaryFailed) setPrimaryFailed(true)
-          else setFallbackFailed(true)
+          setLatch(previous => {
+            // Superseded generation: the current render already re-armed these
+            // tokens, so this error is about a URL no longer on screen.
+            if (previous.src !== src || previous.fallback !== safeFallback) return previous
+            return previous.primaryFailed
+              ? { ...previous, fallbackFailed: true }
+              : { ...previous, primaryFailed: true }
+          })
         }}
       />
     </div>

--- a/website/src/test/AppDetailArtLocalFallback.test.tsx
+++ b/website/src/test/AppDetailArtLocalFallback.test.tsx
@@ -17,6 +17,7 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useEffect } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const theme = { current: 'light' as 'light' | 'dark' }
@@ -57,6 +58,19 @@ function imgBySrc(src: string): HTMLImageElement | null {
 function heroBox(): HTMLElement | null {
   // The hero container is the page's only aspect-ratio box.
   return document.querySelector('.aspect-video, .aspect-\\[25\\/6\\]')
+}
+
+function ErrorImageInEarlierEffect({ src, enabled }: { src: string; enabled: boolean }) {
+  // This sibling is rendered before the image component, so React runs its
+  // passive effect first. It deterministically models another page effect
+  // observing a load error before later image bookkeeping effects.
+  useEffect(() => {
+    if (!enabled) return
+    const image = imgBySrc(src)
+    expect(image).not.toBeNull()
+    fireEvent.error(image!)
+  }, [enabled, src])
+  return null
 }
 
 function detailUi(name = 'demo-app') {
@@ -353,6 +367,40 @@ describe('AppDetailPage screenshots — per-thumbnail local fallback, index-alig
 })
 
 describe('ScreenshotGallery — component contract', () => {
+  it('keeps an error observed during a new screenshot generation', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <ErrorImageInEarlierEffect src={R_S1} enabled={false} />
+        <ScreenshotGallery screenshots={[R_S1]} />
+      </MemoryRouter>,
+    )
+
+    rerender(
+      <MemoryRouter>
+        <ErrorImageInEarlierEffect src={R_S2} enabled />
+        <ScreenshotGallery screenshots={[R_S2]} />
+      </MemoryRouter>,
+    )
+
+    expect(imgBySrc(R_S2)).toBeNull()
+  })
+
+  it('retries a previously failed list when the strip returns to it (A→B→A)', () => {
+    // A theme flip swaps the strip to the dark URLs and back. The failure the
+    // light generation recorded must not be restored on the way back: the asset
+    // may exist now (an install completing, a transient network error), and the
+    // pre-fix effect reset retried on every URL change.
+    const { rerender } = render(<MemoryRouter><ScreenshotGallery screenshots={[R_S1]} /></MemoryRouter>)
+    fireEvent.error(imgBySrc(R_S1)!)
+    expect(imgBySrc(R_S1)).toBeNull()
+
+    rerender(<MemoryRouter><ScreenshotGallery screenshots={[R_SD1]} /></MemoryRouter>)
+    expect(imgBySrc(R_SD1)).not.toBeNull()
+
+    rerender(<MemoryRouter><ScreenshotGallery screenshots={[R_S1]} /></MemoryRouter>)
+    expect(imgBySrc(R_S1)).not.toBeNull()
+  })
+
   it('stays default-inert with no fallbacks prop: error unmounts the thumbnail, no swap attempted', () => {
     render(<MemoryRouter><ScreenshotGallery screenshots={[R_S1, R_S2]} /></MemoryRouter>)
     fireEvent.error(imgBySrc(R_S1)!)
@@ -456,6 +504,40 @@ describe('ScreenshotGallery — component contract', () => {
 })
 
 describe('HeroBanner — component contract', () => {
+  it('keeps an error observed during a new hero generation', () => {
+    const { rerender } = render(
+      <>
+        <ErrorImageInEarlierEffect src={R_HERO} enabled={false} />
+        <HeroBanner src={R_HERO} fallbackSrc={LOCAL_HERO} isDetail={false} />
+      </>,
+    )
+
+    rerender(
+      <>
+        <ErrorImageInEarlierEffect src={R_HERO_DARK} enabled />
+        <HeroBanner src={R_HERO_DARK} isDetail={false} />
+      </>,
+    )
+
+    expect(imgBySrc(R_HERO_DARK)).toBeNull()
+    expect(heroBox()).toBeNull()
+  })
+
+  it('retries a previously failed hero when the page returns to it (A→B→A)', () => {
+    // Light hero fails → dark theme → back to light. The light failure belongs
+    // to the generation that recorded it and must not be restored, or the hero
+    // stays hidden without ever retrying.
+    const { rerender } = render(<HeroBanner src={R_HERO} isDetail={false} />)
+    fireEvent.error(imgBySrc(R_HERO)!)
+    expect(heroBox()).toBeNull()
+
+    rerender(<HeroBanner src={R_HERO_DARK} isDetail={false} />)
+    expect(imgBySrc(R_HERO_DARK)).not.toBeNull()
+
+    rerender(<HeroBanner src={R_HERO} isDetail={false} />)
+    expect(imgBySrc(R_HERO)).not.toBeNull()
+  })
+
   it('a fallback URL that changes independently re-arms the fallback latch alone', async () => {
     const NEXT = '/apps/demo-app/art/assets/hero-v2.png'
     const { rerender } = render(<HeroBanner src={R_HERO} fallbackSrc={LOCAL_HERO} isDetail={false} />)


### PR DESCRIPTION
## Summary
- re-arm the screenshot and hero failure latches *during render* instead of in a passive reset effect, so an image that fails before an effect would run keeps its real error instead of being re-shown at a dead URL
- because the re-arm happens on every URL transition, returning to an earlier generation (theme flip back, refetch) retries rather than restoring a stale failure
- a failure carries the generation that produced it, so a superseded `onError` is dropped instead of resurrecting a cleared set

## Determinism evidence
- the two effect-order regressions fail 2/2 against the unpatched production components
- the two `A→B→A` regressions (light art fails → dark theme → back to light) also fail 2/2 against the pre-fix components, and pass after
- state remains bounded to one current generation; no retries, sleeps, timeout changes, or weakened assertions were added

## Validation
- `AppDetailArtLocalFallback.test.tsx`: 27 passed
- all six `AppDetailPage*` test files: 96 passed
- `tsc -b`: passed

<!-- no-visual-delta -->
**Why no screenshot:** this is a state-sequencing fix inside two existing image-error latches. It introduces no new markup, styling, copy or layout — every rendered state (image shown, swapped to the local fallback, hidden) already existed and is pixel-identical. What changes is *which* of those pre-existing states is reached after a specific effect-order / theme-flip sequence, which a still frame cannot show; the four regression tests above assert it directly.

## Overlap audit
- #6646 changes the contributors UI in the same page file; merge-tree is clean and the behavior is disjoint
- #4085 changes spinner presentation in the same page file; this hunk auto-merges, while that PR remains conflicted elsewhere

This is the independent owner fix for the full-suite failure observed on #5248; #5248 itself is intentionally unchanged.
