### PR TITLE
fix(mcp-gateway): honor the first adopted drift check

### DIFF
--- a/src/kiro_crew/mcp_gateway/manager.py
+++ b/src/kiro_crew/mcp_gateway/manager.py
@@ -892,7 +892,13 @@ class GatewayManager:
         was fetching anyway.
         """
         now = time.monotonic()
-        if now - self._last_drift_check < _DRIFT_RECHECK_INTERVAL_SECS:
+        # Zero means "never checked".  Treating it as a real monotonic stamp
+        # suppresses every first check on a host with less uptime than the
+        # interval (notably freshly provisioned macOS CI runners).
+        if (
+            self._last_drift_check > 0.0
+            and now - self._last_drift_check < _DRIFT_RECHECK_INTERVAL_SECS
+        ):
             return False
         self._last_drift_check = now
         missing = self._adoption_drift(pong)

--- a/test/test_mcp_gateway_adopted_daemon_repair.py
+++ b/test/test_mcp_gateway_adopted_daemon_repair.py
@@ -399,6 +399,11 @@ class TestAdoptedDriftRecheck:
         refuses to yield -- and then never ask again for the life of the
         process. One assessment per interval is what keeps the repair available.
         """
+        # A fresh macOS hosted runner can have less uptime than the five-minute
+        # interval.  Zero is the manager's "never checked" sentinel, not a real
+        # monotonic timestamp, so the first assessment must not depend on host
+        # uptime.
+        monkeypatch.setattr(mgr.time, "monotonic", lambda: 60.0)
         manager = _manager(tmp_path, {"KIROCREW_MCP_TARGET_CORE": "run core"})
         asked = AsyncMock(return_value=mgr._ADOPT)
         monkeypatch.setattr(manager, "_repair_or_adopt", asked)


### PR DESCRIPTION
## Summary
- treat `_last_drift_check == 0` as the existing "never checked" sentinel
- keep the five-minute rate limit only after an actual adopted-daemon drift assessment
- make the regression deterministic by pinning monotonic time below the interval

## Root cause
Freshly provisioned macOS runners can have less than five minutes of uptime. The code subtracted the zero sentinel from `time.monotonic()` and treated that small result as a recent check, so the first drift assessment was skipped. The dependent replacement/watchdog assertions then failed even though no assessment ran.

## Determinism evidence
- with monotonic time fixed at 60 seconds, the pre-fix test fails deterministically at `the first call assesses`
- after the fix, all 13 `TestAdoptedDriftRecheck` tests pass with RuntimeWarning and PytestUnraisable warnings promoted to errors
- no sleeps, retries, timeout changes, tolerance changes, or warning filters were added

## Validation
- targeted strict drift-recheck class: 13 passed
- flake8 and isort checks passed
- repository baseline-aware Black gate passed
- `git diff --check` passed

## Overlap audit
- all open PRs were scanned, including all 247 files in #6307; none touches the manager or this regression test
- the final rebase incorporated #6949, #6953, #6948, #6958, and #6954; none overlaps these paths

This is the independent owner fix for the macOS gateway failures first observed on #6962; #6962 remains unchanged.