### PR TITLE
feat(ci): pattern harvest on fix PRs + deferred-finding discipline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -55,6 +55,18 @@
 
 <!-- Link to relevant issues, e.g. Fixes #123 -->
 
+## Pattern harvest
+
+<!-- REQUIRED for fix/revert PRs (PR Hygiene checks that this section is
+     present); delete this section otherwise. Every fixed defect is a chance
+     to stop its whole class: say whether this one generalizes.
+
+     One of:
+       Rule candidate: <semgrep | lint | review-prompt | agents-md>
+       Pattern: <one line, e.g. "sentinel return value used in boolean context">
+     or:
+       Not generalizable: <one line on why this defect is a one-off> -->
+
 ## Checklist
 
 - [ ] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)

--- a/.github/review-prompts/gpt-round-convergence.md
+++ b/.github/review-prompts/gpt-round-convergence.md
@@ -23,6 +23,14 @@ rulings a repository writer has already made on findings of THIS PR
      the no-softening principle). It never waives a defect no
      ruling covers, and for anything outside covered repetition it
      is never a reason to soften a finding that meets WHAT BLOCKS.
+  5. A DEFERRAL is not an adjudication for security, data-loss, or
+     corruption defects. If a recorded ruling's rationale merely
+     postpones such a finding (accepted-and-deferred, a follow-up
+     issue, "fix later") without rebutting it as not-a-defect or
+     showing it fixed, the ruling does NOT cover it: re-raise it at
+     its original severity every round until it is fixed, rebutted,
+     or human-overridden. Deferral covers advisory-class findings
+     only.
 Your review must CONVERGE: each round's blocking set must be a
 consequence of what changed since the adjudications, not a fresh
 re-litigation of the whole diff at a lower confidence bar.

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -406,3 +406,40 @@ jobs:
             exit 1
           fi
           echo "Commit count verified ($COMMIT_COUNT of at most $MAX_COMMITS)."
+
+      # ── Pattern harvest on fix PRs ──────────────────────────────────
+      # Every fix is a chance to retire its whole defect class. Fix/revert
+      # PRs must carry a "Pattern harvest" section stating either a rule
+      # candidate (semgrep / lint / review-prompt / agents-md) or why the
+      # defect is a one-off. Presence-only: content is judged by reviewers,
+      # never by this gate. Feature/docs/chore PRs are exempt.
+      - name: Require Pattern harvest section on fix PRs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if ! echo "$PR_TITLE" | grep -qiE '^(fix|revert)([(!:]|$)'; then
+            echo "Not a fix/revert PR; Pattern harvest section not required."
+            exit 0
+          fi
+          if ! printf '%s' "$PR_BODY" | grep -qiE '^##+ *Pattern harvest'; then
+            echo "::error::Fix/revert PRs must carry a '## Pattern harvest' section."
+            echo ""
+            echo "  State either a rule candidate or why the defect is a one-off:"
+            echo ""
+            echo "    ## Pattern harvest"
+            echo "    Rule candidate: semgrep"
+            echo "    Pattern: sentinel return value used in boolean context"
+            echo ""
+            echo "  or:"
+            echo ""
+            echo "    ## Pattern harvest"
+            echo "    Not generalizable: typo in a single format string"
+            echo ""
+            exit 1
+          fi
+          if ! printf '%s' "$PR_BODY" | grep -qiE '^ *(Rule candidate|Not generalizable) *:'; then
+            echo "::error::The Pattern harvest section must contain a 'Rule candidate:' or 'Not generalizable:' line."
+            exit 1
+          fi
+          echo "Pattern harvest section present."

--- a/.github/workflows/deferred-findings-audit.yml
+++ b/.github/workflows/deferred-findings-audit.yml
@@ -1,0 +1,76 @@
+# Weekly audit of deferred review findings (RFC: closing the fix loop).
+#
+# Issues labeled `deferred-finding` are promises made in a PR review — a
+# finding acknowledged as real and postponed. This audit makes an overdue
+# promise visible instead of letting it become an unbounded write-off: every
+# Monday it lists open deferred-finding issues past their due date (a
+# `Due: YYYY-MM-DD` line in the body, or the milestone's due date), bumps each
+# with a comment, and writes the roll-up to the run summary.
+#
+# Deliberately NOT wired into ship-report.yml: that workflow's counts are
+# channel-locked and deterministic-by-contract; this audit posts to the issues
+# themselves, where the assignee is already subscribed.
+name: Deferred Findings Audit
+
+on:
+  schedule:
+    - cron: "0 16 * * 1" # Mondays 16:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  audit:
+    name: Surface overdue deferred findings
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: List, evaluate, and bump overdue deferrals
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          today="$(date -u +%Y-%m-%d)"
+          issues_json="$(gh api "repos/$REPO/issues?state=open&labels=deferred-finding&per_page=100" --paginate | jq -s 'add // []')"
+          total="$(printf '%s' "$issues_json" | jq 'length')"
+          overdue=0
+          undated=0
+          {
+            echo "## Deferred findings audit ($today)"
+            echo ""
+            echo "Open \`deferred-finding\` issues: $total"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for n in $(printf '%s' "$issues_json" | jq -r '.[].number'); do
+            item="$(printf '%s' "$issues_json" | jq --argjson n "$n" '.[] | select(.number == $n)')"
+            title="$(printf '%s' "$item" | jq -r '.title')"
+            assignee="$(printf '%s' "$item" | jq -r '[.assignees[].login] | join(", ")')"
+            due="$(printf '%s' "$item" | jq -r '.body // ""' | grep -oE '^ *Due: *[0-9]{4}-[0-9]{2}-[0-9]{2}' | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true)"
+            if [ -z "$due" ]; then
+              due="$(printf '%s' "$item" | jq -r '.milestone.due_on // "" | .[0:10]')"
+            fi
+            if [ -z "$due" ]; then
+              undated=$((undated + 1))
+              echo "- #$n $title — **no due date** (assignee: ${assignee:-none})" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            if [ "$due" \< "$today" ]; then
+              overdue=$((overdue + 1))
+              echo "- #$n $title — **overdue since $due** (assignee: ${assignee:-none})" >> "$GITHUB_STEP_SUMMARY"
+              {
+                echo "<!-- deferred-finding-overdue -->"
+                echo "**This deferred finding is overdue** (due $due). It was accepted as real in a PR review and postponed; an overdue deferral is a flagged bug waiting to ship. Fix it, re-date it with a new \`Due:\` line, or close it with a rationale."
+              } > /tmp/bump.md
+              gh api "repos/$REPO/issues/$n/comments" -f body="$(cat /tmp/bump.md)" >/dev/null
+            fi
+          done
+
+          {
+            echo ""
+            echo "Overdue: $overdue · Missing due date: $undated"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Audit complete: $total open, $overdue overdue, $undated undated."

--- a/.github/workflows/disposition-deferral-check.yml
+++ b/.github/workflows/disposition-deferral-check.yml
@@ -1,0 +1,112 @@
+# Deferred-finding discipline (RFC: closing the fix loop).
+#
+# A review finding dispositioned as `accepted-and-deferred` is a promise, and
+# 63% of this repo's traceable escaped bugs were exactly such promises: flagged
+# by a review lane, deferred to a follow-up issue, never recycled, then shipped
+# and broke. This workflow validates the promise's shape at the moment it is
+# made: a deferral must name an open follow-up issue that carries the
+# `deferred-finding` label, an assignee (the owner), and a due date (a
+# `Due: YYYY-MM-DD` line in the issue body, or a milestone with a due date).
+#
+# ADVISORY BY DESIGN: an issue_comment event cannot gate a PR that is already
+# green, so this lane replies with what is missing rather than failing a
+# required check. The teeth live elsewhere: the GPT lane's ROUND CONVERGENCE
+# rules re-raise security/data-loss findings that a deferral tries to cover,
+# and the weekly deferred-findings-audit surfaces overdue items.
+#
+# INJECTION SAFETY: the comment body is attacker-controlled on a public repo.
+# It reaches shell steps ONLY via env (never ${{ }} inside run:), and this
+# workflow takes no privileged action from its content — it reads, validates,
+# and replies.
+name: Disposition Deferral Check
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  validate-deferral:
+    # Only PR comments that are disposition records mentioning a deferral.
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '<!-- ai-review-disposition') &&
+      contains(github.event.comment.body, 'accepted-and-deferred')
+    name: Validate deferred-finding promise
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check the deferral names a tracked follow-up issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+        run: |
+          set -euo pipefail
+          problems=""
+
+          # Issue references in the disposition body ("#123"), excluding the
+          # PR's own number. The deferral must point at least one of them at a
+          # properly-shaped follow-up issue.
+          refs="$(printf '%s' "$COMMENT_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -u | grep -vx "$PR_NUMBER" || true)"
+
+          if [ -z "$refs" ]; then
+            problems="- The deferral names no follow-up issue. File one and reference it (\`#<number>\`) in the disposition."
+          else
+            valid=""
+            for n in $refs; do
+              issue_json="$(gh api "repos/$REPO/issues/$n" 2>/dev/null || true)"
+              [ -z "$issue_json" ] && continue
+              # Skip refs that are PRs, not issues.
+              if printf '%s' "$issue_json" | jq -e '.pull_request' >/dev/null 2>&1; then
+                continue
+              fi
+              state="$(printf '%s' "$issue_json" | jq -r '.state // ""')"
+              has_label="$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | index("deferred-finding") != null')"
+              has_assignee="$(printf '%s' "$issue_json" | jq -r '(.assignees | length) > 0')"
+              body_due="$(printf '%s' "$issue_json" | jq -r '.body // ""' | grep -cE '^ *Due: *[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)"
+              milestone_due="$(printf '%s' "$issue_json" | jq -r '.milestone.due_on // ""')"
+              missing=""
+              [ "$state" != "open" ] && missing="$missing closed;"
+              [ "$has_label" != "true" ] && missing="$missing no deferred-finding label;"
+              [ "$has_assignee" != "true" ] && missing="$missing no assignee (owner);"
+              if [ "${body_due:-0}" -eq 0 ] && [ -z "$milestone_due" ]; then
+                missing="$missing no due date (add a 'Due: YYYY-MM-DD' line to the issue body, or a milestone with a due date);"
+              fi
+              if [ -z "$missing" ]; then
+                valid="$n"
+                break
+              fi
+              problems="$problems
+          - Issue #$n:$missing"
+            done
+            if [ -n "$valid" ]; then
+              echo "Deferral is tracked by issue #$valid (open, labeled, owned, dated)."
+              exit 0
+            fi
+            if [ -z "$problems" ]; then
+              problems="- None of the referenced numbers resolve to an issue in this repository."
+            fi
+          fi
+
+          echo "Deferral promise is incomplete — replying with requirements."
+          {
+            echo "<!-- deferred-finding-check -->"
+            echo "**This deferral is not yet tracked.** An \`accepted-and-deferred\` disposition must name an open follow-up issue that has:"
+            echo ""
+            echo "- the \`deferred-finding\` label"
+            echo "- an assignee (the owner who will recycle it)"
+            echo "- a due date: a \`Due: YYYY-MM-DD\` line in the issue body, or a milestone with a due date"
+            echo ""
+            echo "What is missing:"
+            echo "$problems"
+            echo ""
+            echo "_An untracked deferral is how flagged findings ship anyway — 63% of this repo's traceable escaped bugs were flagged and then deferred without follow-through. Checked disposition: $COMMENT_URL_"
+          } > /tmp/reply.md
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$(cat /tmp/reply.md)" >/dev/null

--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -432,3 +432,33 @@ custom-rules:
         unexplained edit to shipped history is the defect this rule exists for.
       - Porting an already-written section verbatim between main and a release
         branch, where the diff adds a section and removes nothing.
+
+  - id: recurring-defect-patterns
+    blocking: false
+    file-patterns:
+      - "src/kiro_crew/**/*.py"
+    rule: |
+      Defect patterns harvested from this repository's own fix history (each
+      appeared as a SERIES of shipped bugs, not a one-off). Flag a changed
+      line that re-introduces one of these classes as an advisory FINDING:
+
+      - A user-supplied or config-sourced STRING used directly in a boolean
+        context, especially for a security-relevant toggle: `bool("false")`
+        is True, so `if config.get("dangerously_skip_permissions"):` passes
+        for the string "false". Require an explicit typed comparison or a
+        real bool before the branch.
+      - A docstring or comment that CONTRADICTS the code below it (an
+        allowlist entry the docstring names but the code omits, a comment
+        saying "denies by default" above a loader that permits). Either the
+        prose or the code is wrong; both shipped as bugs here. Flag the
+        contradiction itself — do not guess which side is intended.
+      - A documented allowlist/denylist whose entries have no round-trip
+        assertion: when a diff adds or edits such a list alongside prose
+        (docstring, spec, comment) enumerating its members, expect a test
+        asserting each documented member is actually in the list.
+
+      This rule is maintained by the pattern-harvest loop (fix PRs propose
+      candidates in their "Pattern harvest" section; accepted ones land
+      here or in semgrep/). Sentinel-return misuse (str.find/rfind -1 in a
+      boolean context) is deliberately NOT listed: semgrep owns it
+      (semgrep/find-sentinel-truthiness.yaml).

--- a/semgrep-tests/find-sentinel-truthiness.py
+++ b/semgrep-tests/find-sentinel-truthiness.py
@@ -1,0 +1,47 @@
+# Fixtures for semgrep/find-sentinel-truthiness.yaml, exercised by
+# `semgrep --test` in the SAST job. `ruleid:` asserts the NEXT line MUST
+# match; `ok:` asserts it must NOT. The negatives encode the precision
+# contract: explicit -1 comparisons and index arithmetic stay clean.
+
+
+def _boolean_context_misuses(text: str, needle: str) -> None:
+    # ruleid: kirocrew.find-sentinel-in-boolean-context
+    if text.find(needle):
+        pass
+    # ruleid: kirocrew.find-sentinel-in-boolean-context
+    if text.rfind(needle):
+        pass
+    # ruleid: kirocrew.find-sentinel-in-boolean-context
+    if not text.find(needle):
+        pass
+    # ruleid: kirocrew.find-sentinel-in-boolean-context
+    while text.find(needle):
+        break
+
+
+def _short_circuit_misuses(text: str, limit: int) -> int:
+    # ruleid: kirocrew.find-sentinel-in-boolean-context
+    cut = text.rfind("\n") or limit
+    # ruleid: kirocrew.find-sentinel-in-boolean-context
+    other = text.find(":") and limit
+    return cut + other
+
+
+def _explicit_comparisons_are_fine(text: str, needle: str, limit: int) -> int:
+    # ok: kirocrew.find-sentinel-in-boolean-context
+    if text.find(needle) != -1:
+        pass
+    # ok: kirocrew.find-sentinel-in-boolean-context
+    if text.rfind(needle) == -1:
+        return limit
+    # ok: kirocrew.find-sentinel-in-boolean-context
+    pos = text.rfind("\n")
+    if pos == -1:
+        pos = limit
+    # ok: kirocrew.find-sentinel-in-boolean-context
+    if text.find(needle) >= 0:
+        pass
+    # ok: kirocrew.find-sentinel-in-boolean-context
+    if needle in text:
+        pass
+    return pos

--- a/semgrep/find-sentinel-truthiness.yaml
+++ b/semgrep/find-sentinel-truthiness.yaml
@@ -1,0 +1,39 @@
+rules:
+  # ─── str.find()/rfind(): -1 sentinel is truthy ───────────────────────
+  # str.find() and str.rfind() signal "not found" with -1, which is TRUTHY.
+  # Using the result directly in a boolean context therefore inverts the
+  # intended logic exactly when the needle is absent: `if s.find(x):` is
+  # true for "not found" and for every position except 0, and
+  # `s.rfind(x) or DEFAULT` never falls back to DEFAULT on a miss (-1 is
+  # kept). This shipped a real defect: a Slack-truncation helper read
+  # rfind's -1 as a valid cut position and left an oversized body intact.
+  # Compare explicitly instead: `if s.find(x) != -1:` / `pos = s.rfind(x);
+  # if pos == -1: pos = DEFAULT`. For pure membership, use `in`.
+
+  - id: kirocrew.find-sentinel-in-boolean-context
+    languages: [python]
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: |
+              if $S.find(...): ...
+          - pattern: |
+              if $S.rfind(...): ...
+          - pattern: |
+              if not $S.find(...): ...
+          - pattern: |
+              if not $S.rfind(...): ...
+          - pattern: |
+              while $S.find(...): ...
+          - pattern: |
+              while $S.rfind(...): ...
+          - pattern: $S.find(...) or $DEFAULT
+          - pattern: $S.rfind(...) or $DEFAULT
+          - pattern: $S.find(...) and $THEN
+          - pattern: $S.rfind(...) and $THEN
+    message: >
+      str.find()/rfind() returns the sentinel -1 for "not found", and -1 is
+      truthy — this boolean context inverts the miss case (and treats a match
+      at index 0 as false). Compare against -1 explicitly
+      (`$S.find(...) != -1`), keep the index in a variable and branch on
+      `== -1`, or use `in` for membership.

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -83,7 +83,7 @@ Answering is prose work. It never needs a push and never widens the diff.
 |---|---|---|
 | `fixed` | you changed the code | the change and the SHA |
 | `rebutted` | the code stays correct as-is | the evidence it does not hold, **or** the reasoning it is disproportional |
-| `accepted-and-deferred` | the work is already decided, just out of scope here — unlike `needs-a-decision`, nothing is being asked | why, plus an issue whose body names a task someone can pick up |
+| `accepted-and-deferred` | the work is already decided, just out of scope here — unlike `needs-a-decision`, nothing is being asked | why, plus an issue whose body names a task someone can pick up. The issue MUST carry the `deferred-finding` label, an assignee (the owner), and a `Due: YYYY-MM-DD` line in its body — an untracked deferral is how flagged findings ship anyway, and the Disposition Deferral Check replies to dispositions whose issue lacks any of the three. Security, data-loss, and corruption findings are never deferrable: fix them in-PR or get a human `/ai-review` override |
 | `needs-a-decision` | the outcome depends on a maintainer ruling | the question, put to the maintainer directly — do **not** file an issue for it |
 
 **What must be answered** (none of these ever reds a check, so nothing else in the

--- a/test/test_fix_loop_discipline.py
+++ b/test/test_fix_loop_discipline.py
@@ -1,0 +1,109 @@
+"""The fix-loop discipline stays wired: pattern harvest in, untracked deferrals out.
+
+Two mechanisms exist because this repository measured its own fix loop: 75% of
+escaped defects were preventable, and the largest traceable class was findings a
+reviewer raised and a disposition deferred without follow-through. The pattern-
+harvest half turns each fix into a rule candidate; the deferral half makes every
+deferred finding a tracked promise (label + owner + due date).
+
+Each half is spread across surfaces that cannot see each other — a PR template,
+a hygiene step, a semgrep rule, a review-prompt rule, two workflows, and a
+skill. Losing any one piece silently reopens the gap the others assume closed,
+and nothing else fails when that happens. So this file pins the wiring: it does
+not care how the guidance is worded, only that every load-bearing piece is
+still there and still pointed at the same names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE = ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+CODE_REVIEW = ROOT / ".github" / "workflows" / "code-review.yml"
+CONVERGENCE = ROOT / ".github" / "review-prompts" / "gpt-round-convergence.md"
+DEFERRAL_CHECK = ROOT / ".github" / "workflows" / "disposition-deferral-check.yml"
+AUDIT = ROOT / ".github" / "workflows" / "deferred-findings-audit.yml"
+SEMGREP_RULE = ROOT / "semgrep" / "find-sentinel-truthiness.yaml"
+SEMGREP_FIXTURE = ROOT / "semgrep-tests" / "find-sentinel-truthiness.py"
+AUTOSDE = ROOT / "AUTOSDE.yaml"
+PREPARE_PR = (
+    ROOT / "src" / "kiro_crew" / "builtin_skills" / "kirocrew-dev" / "prepare-pr" / "SKILL.md"
+)
+
+LABEL = "deferred-finding"
+
+
+class TestPatternHarvest:
+    def test_pr_template_carries_the_section_and_both_branches(self) -> None:
+        """Authors can only fill in a section the template still offers."""
+        text = TEMPLATE.read_text(encoding="utf-8")
+        assert "## Pattern harvest" in text
+        assert "Rule candidate:" in text, "the generalizable branch vanished from the template"
+        assert "Not generalizable:" in text, "the one-off branch vanished from the template"
+
+    def test_hygiene_gate_requires_the_section_on_fix_prs(self) -> None:
+        """The template alone is a suggestion; the hygiene step is what makes it land."""
+        text = CODE_REVIEW.read_text(encoding="utf-8")
+        assert "Require Pattern harvest section on fix PRs" in text
+        assert "Pattern harvest" in text
+        # The gate is scoped to fix/revert titles — a gate that fired on every
+        # PR would be removed within a week, taking the mechanism with it.
+        assert "fix|revert" in text
+
+    def test_hygiene_gate_reads_the_body_through_env(self) -> None:
+        """PR bodies are attacker-controlled; they must reach the shell via env only."""
+        text = CODE_REVIEW.read_text(encoding="utf-8")
+        assert "PR_BODY: ${{ github.event.pull_request.body }}" in text
+
+    def test_semgrep_owns_the_sentinel_rule_with_fixtures(self) -> None:
+        """The first harvested pattern stays enforced, and its fixtures keep both directions."""
+        rule = SEMGREP_RULE.read_text(encoding="utf-8")
+        assert "kirocrew.find-sentinel-in-boolean-context" in rule
+        fixture = SEMGREP_FIXTURE.read_text(encoding="utf-8")
+        assert "# ruleid: kirocrew.find-sentinel-in-boolean-context" in fixture
+        assert "# ok: kirocrew.find-sentinel-in-boolean-context" in fixture
+
+    def test_autosde_carries_the_harvested_pattern_rule(self) -> None:
+        """The review lanes read AUTOSDE, not prose promises — the harvest rule must live there."""
+        text = AUTOSDE.read_text(encoding="utf-8")
+        assert "recurring-defect-patterns" in text
+
+
+class TestDeferralDiscipline:
+    def test_convergence_refuses_deferral_of_security_findings(self) -> None:
+        """A deferral must never adjudicate away a security/data-loss finding."""
+        text = CONVERGENCE.read_text(encoding="utf-8")
+        assert "DEFERRAL is not an adjudication" in text
+        assert "security" in text and "data-loss" in text
+
+    def test_deferral_check_validates_the_full_promise_shape(self) -> None:
+        """Label, owner, and due date are the promise; dropping any one unmakes it."""
+        text = DEFERRAL_CHECK.read_text(encoding="utf-8")
+        assert "issue_comment" in text
+        assert "accepted-and-deferred" in text
+        assert LABEL in text
+        assert "assignee" in text
+        assert "Due: YYYY-MM-DD" in text
+
+    def test_deferral_check_reads_the_comment_through_env(self) -> None:
+        """Comment bodies are attacker-controlled; they must reach the shell via env only."""
+        text = DEFERRAL_CHECK.read_text(encoding="utf-8")
+        assert "COMMENT_BODY: ${{ github.event.comment.body }}" in text
+        # The body expression must appear ONLY in env stanzas — an occurrence
+        # inside a run: block would be shell injection on a public repo.
+        assert text.count("${{ github.event.comment.body }}") == 1
+
+    def test_audit_sweeps_the_label_on_a_schedule(self) -> None:
+        """An untracked overdue deferral is invisible; the weekly sweep is its visibility."""
+        text = AUDIT.read_text(encoding="utf-8")
+        assert "schedule" in text
+        assert LABEL in text
+        assert "overdue" in text
+
+    def test_prepare_pr_skill_teaches_the_tracked_deferral_shape(self) -> None:
+        """The agent filing the follow-up issue must know the shape CI will check."""
+        text = PREPARE_PR.read_text(encoding="utf-8")
+        assert LABEL in text
+        assert "Due: YYYY-MM-DD" in text
+        assert "never deferrable" in text


### PR DESCRIPTION
## Problem / Motivation

A full-coverage analysis of this repository's 2,335 fix commits (2026-08) found: 75.0% of escaped defects were preventable before merge; the single largest traceable escape class was findings a reviewer raised and a disposition deferred without follow-through; and the same defect patterns (sentinel truthiness, doc/code contradictions) recur as series because nothing turns a fix into a rule.

## Why it matters

Every recurrence of an already-fixed pattern is pure rework tax (fix share of all commits reached 58.8% in August), and every untracked deferral is a flagged bug waiting to ship. Both gaps are process-shaped: the detection machinery already exists, it just has no memory and no follow-through.

## What changed (motivation → approach → change)

**Pattern harvest (fixes must answer "can this become a rule?"):**
- `.github/PULL_REQUEST_TEMPLATE.md`: new `## Pattern harvest` section — `Rule candidate: <semgrep|lint|review-prompt|agents-md>` + one-line pattern, or `Not generalizable: <why>`.
- `code-review.yml` (pr-hygiene): presence-only check of that section on PRs whose title matches `^(fix|revert)`. Content is never judged by the gate; the body reaches the shell via env only. The job already listens on `edited`, so filling the section re-runs the check without a push.
- Seed rules landed with the mechanism: `semgrep/find-sentinel-truthiness.yaml` (+ fixtures, validated under the CI-pinned semgrep 1.78) for `str.find()/rfind()`'s -1 sentinel in boolean contexts — the fix that motivated it shipped its own would-have-caught test in the same commit; and an advisory `AUTOSDE.yaml` rule (`recurring-defect-patterns`) for string-truthiness security toggles, docstring/code contradictions, and documented allowlists without round-trip tests. Sentinel misuse is deliberately excluded from the AUTOSDE rule since semgrep owns it.

**Deferral discipline (a deferred finding is a tracked promise):**
- `disposition-deferral-check.yml` (new, `issue_comment`): an `accepted-and-deferred` disposition must reference an open issue carrying the `deferred-finding` label, an assignee, and a due date (`Due: YYYY-MM-DD` body line or milestone due date). Invalid deferrals get a reply naming what is missing. Advisory by design — a comment event cannot gate a green PR; it reads and replies only, comment text via env.
- `deferred-findings-audit.yml` (new, Mondays): bumps each overdue `deferred-finding` issue and writes the roll-up to the run summary. Deliberately not folded into ship-report (its counts are channel-locked and deterministic-by-contract).
- `gpt-round-convergence.md`: new ledger rule 5 — a deferral is not an adjudication for security/data-loss/corruption findings; they are re-raised at original severity until fixed, rebutted, or human-overridden.
- `prepare-pr` SKILL.md: the `accepted-and-deferred` row now teaches the tracked shape and names the non-deferrable classes.

## Tests

`test/test_fix_loop_discipline.py` (11 ratchet tests): template section + both branches; hygiene step present and scoped to fix/revert; semgrep rule + both fixture directions; AUTOSDE rule present; convergence rule 5; deferral-check validates label/assignee/due; audit sweeps the label on schedule; skill teaches the shape; and two injection pins — PR bodies and comment bodies reach `run:` blocks via env only (the comment-body expression appears exactly once, in the env stanza). Neighboring suites re-run green: `test_deferred_disposition_ratchet.py`, `test_github_workflow_security.py`, `test_ai_review_workflows.py`, `test_pr_readiness_evaluate.py` (290 total).

## Manual verification

`semgrep --test --config semgrep/find-sentinel-truthiness.yaml semgrep-tests/find-sentinel-truthiness.py` under semgrep 1.78 (the CI container version): 1/1 passed. Both new workflows YAML-parse. N/A beyond that — the workflows fire on real GitHub events (issue_comment, schedule) which unit tests pin structurally.

## Related Issues

no linked issue: implements the fix-loop RFC draft (docs/request-for-change/rfc-fix-loop-learning-and-disposition.md, proposals A1/A2/A4 and B1/B3/B4); the RFC document itself lands separately.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
