### PR TITLE
feat(connections): add the premint endpoint

### DIFF
--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -5,19 +5,23 @@ approval URL: ~7.5s per card. `kiro_crew.connections.warm` serves the whole gall
 process, and every rule below answers an observed failure.
 
 **Placement.** All warm code is in `src/kiro_crew/connections/warm.py`; the dashboard handler
-adds only endpoint wiring and a function-local `expire_dead_mints` import on the status path,
-keeping the mint engine off the gateway's boot path.
+adds only endpoint wiring and function-local engine imports -- `expire_dead_mints` on the status
+path, `mintable_providers` plus `warm_mint_all` on the premint path -- keeping the mint engine
+off the gateway's boot path.
 
-**Scope boundary: the TABLE, the SPECS and the PROCESS LIFECYCLE have landed; the ENDPOINT
-WIRING has not.** Shipped now: the shared row shape (`shared`/`generation`/`activation`), the
+**Scope boundary: the TABLE, the SPECS, the PROCESS LIFECYCLE and the ENDPOINT WIRING have
+landed.** Shipped: the shared row shape (`shared`/`generation`/`activation`), the
 liveness registry those stamps are read against, `expire_dead_mints()` on the status path, the
 spec side -- the registry-derived universe, the plan and its servability test, the tool-alias key
 shape, the spec files the plan writes, and the filesystem-drift guard covering their synchronous
-helpers -- and the lifecycle: spawn/respawn, activation, park-or-kill, the reaper, and
-`warm_mint_all`, which is what gives the spec planner a caller. Still deferred: the dashboard
-endpoint that premints a gallery, so `warm_mint_all` itself has NO CALLER yet and no request
-path reaches any of this. That is the last seam, and it is deliberately thin -- the endpoint adds
-a handler, not a rule.
+helpers -- the lifecycle: spawn/respawn, activation, park-or-kill, the reaper, and
+`warm_mint_all`, which is what gives the spec planner a caller; and the request path,
+`POST /api/connections/premint`, which the Connections page fires once on mount. The endpoint
+adds a handler, not a rule: it scans the mintable candidates off the loop, hands that same list
+to `warm_mint_all` so the slugs it reports and the rows the engine claims come from ONE registry
+read, and answers without awaiting the activation -- warming costs seconds, and the card's
+verdict is its own mint state rather than this list. Still deferred: proactive refresh, which
+attaches to the reaper in its own slice.
 
 ## Measured facts
 

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -98,9 +98,10 @@ where a stat is unbounded -- so they are synchronous, and a coroutine reaches th
 ``asyncio.to_thread``. Enforced by a fixed-point drift guard in
 ``test/test_connections_warm.py``, not merely described here.
 
-SEAM left open: :func:`warm_mint_all` has NO CALLER yet. The dashboard endpoint that
-premints a whole gallery is its own slice, so nothing here is reachable from a request
-today. Proactive refresh attaches in :func:`_warm_mint_reaper` when slice N3 lands.
+REQUEST PATH: :func:`warm_mint_all` is driven by ``POST /api/connections/premint``, which the
+Connections page fires once on mount. The endpoint scans the candidates and hands them over,
+so the slugs it reports and the rows the engine claims come from one registry read. Proactive
+refresh attaches in :func:`_warm_mint_reaper` when slice N3 lands.
 """
 
 from __future__ import annotations
@@ -1481,7 +1482,9 @@ async def warm_mint_all(providers: list[Provider] | None = None) -> list[str]:
     lock holder computes, so a claim the activation did not cover is released rather than
     left minting forever.
 
-    NO CALLER YET: the premint endpoint that drives this lands in its own slice.
+    ``POST /api/connections/premint`` passes the candidates it scanned, so an explicit
+    ``providers`` is the ordinary call shape; ``None`` re-scans for a caller that has no
+    list of its own.
     """
     candidates = (
         await asyncio.to_thread(mintable_providers) if providers is None else list(providers)

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -92,6 +92,7 @@ from kiro_crew.dashboard.handlers.connections import (  # noqa: E402, F401
     api_connections_cancel,
     api_connections_mint,
     api_connections_mint_state,
+    api_connections_premint,
     api_connections_status,
     api_mcp_oauth_relay,
 )

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from dataclasses import dataclass
 from urllib.parse import parse_qs, urlsplit
 
 from aiohttp import web
 
+from kiro_crew import hooks
 from kiro_crew.connections import get_provider
 from kiro_crew.connections.registry import Provider
 from kiro_crew.dashboard.handlers.mcp import _is_valid_mcp_name
 from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
 
 _MAX_RETURN_ADDRESS_BYTES = 8192
 _MAX_REQUEST_TARGET_BYTES = 6144
@@ -257,6 +261,16 @@ async def api_mcp_oauth_relay(request: web.Request) -> web.Response:
 # Fire-and-forget mint tasks, held so the loop cannot collect one mid-flight.
 _mint_tasks: set[asyncio.Task] = set()
 
+# The same keepalive for the premint activation, kept separate so a page open cannot
+# be mistaken for a card-initiated mint when either set is inspected.
+_premint_tasks: set[asyncio.Task] = set()
+
+#: SEL read-id for the grant observation the premint endpoint acts on. Distinct from
+#: the mint engine's and the status module's ids so the trail says which surface
+#: looked; registered in ``hooks._AUDIT_ONLY_READ_IDS``, which fail-closes on an
+#: unregistered id and would record nothing.
+_GRANT_PRESENCE_READ_ID = "connections_premint.oauth_grant_presence"
+
 
 def _requested_provider(slug: str) -> Provider | None:
     """The registry provider ``slug`` names, or None."""
@@ -456,3 +470,91 @@ async def api_connections_cancel(request: web.Request) -> web.Response:
         )
     )
     return web.json_response({"ok": True, "slug": slug, "dropped": dropped})
+
+
+async def api_connections_premint(request: web.Request) -> web.Response:
+    """POST /api/connections/premint — warm every mintable provider's URL in one activation.
+
+    The page fires this once on mount, ahead of any click, so that a Connect
+    serves a URL the warm table already holds instead of paying a cold spawn.
+    Takes no body: what is mintable is a fact about the user's registry and grant
+    state, never a caller's choice, and the bound on what may be spawned has to
+    stay on this side of the wire.
+
+    ``preminting`` names the providers warming was STARTED for, which is why the
+    response can precede any of them holding a URL. Warming one provider costs
+    seconds and the whole activation is a single shared process, so awaiting it
+    would stall the page's first paint for the sake of a report the card already
+    gets from its own mint feed. A slug reported here can still end up without a
+    URL -- the activation snapshot is the engine's to compute -- so the card's
+    verdict remains the mint state, not this list.
+    """
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    # Owner-gated for the same reason as the mint POST: warming spawns a kiro-cli
+    # process, so the caller has to be the owner rather than merely authenticated.
+    owner_denied = await require_owner_dashboard_request(request, "connections_premint")
+    if owner_denied is not None:
+        return owner_denied
+
+    # Function-local by DESIGN, not for a cycle: the handlers package is imported on
+    # the gateway boot path, and the warm engine imports the cold mint at module
+    # scope then adds the ACP runtime and the MCP inventory on top -- the heaviest
+    # half of Connections. test_the_handlers_package_does_not_import_the_warm_engine
+    # enforces it in a subprocess; hoisting this to module scope turns that red.
+    from kiro_crew.connections.warm import mintable_providers, warm_mint_all
+
+    # Off the loop: the scan reads the user's MCP config and stats kiro-cli's OAuth
+    # artifact directory, either of which can sit on a network mount where a stat is
+    # unbounded. warm.py routes the same call through a thread for this reason and
+    # pins it with a drift guard.
+    candidates = await asyncio.to_thread(mintable_providers)
+    slugs = [str(provider["slug"]) for provider in candidates]
+    if not slugs:
+        # Nothing to warm: an activation with an empty claim set would spawn a
+        # process, pay the fixed activation cost and hold nothing. Nothing was acted
+        # on either, so the scan owes no audit -- see below.
+        return web.json_response({"ok": True, "preminting": []})
+
+    # The credential-store observation this endpoint ACTS on: the scan above stats
+    # kiro-cli's OAuth artifacts per provider, and reaching this line means the answer
+    # is about to spawn a warm activation. ONE event for the whole sweep, matching
+    # ``connections.status``: a single scan pass yields N answers but exactly one act
+    # decision, so per-candidate events would over-count one observation, and the
+    # per-URL ``mcp_grant.grant_observed`` wrapper would additionally have to break the
+    # scan's synchronous shape that warm.py pins with a drift guard.
+    #
+    # Off the loop because the entry point marks its events critical, which drains the
+    # SEL queue synchronously -- the same reason the log_api_access calls here are
+    # threaded. Best-effort, NOT fail-closed: the artifacts are stat-ed and never
+    # opened, so no credential material crosses this boundary, and refusing to warm on
+    # an SEL outage would make every Connect pay a cold spawn instead. An unaudited
+    # boolean is the lesser failure, and it leaves a warning behind.
+    if not await asyncio.to_thread(
+        hooks.emit_internal_read_audit, _GRANT_PRESENCE_READ_ID, "success"
+    ):
+        logger.warning(
+            "grant-presence audit for the premint scan could not be recorded; "
+            "proceeding unaudited"
+        )
+
+    # The candidates are PASSED rather than re-derived inside the engine, so the
+    # claim set and this response come from one scan. Two independent scans can
+    # disagree -- a consent completing between them drops a provider -- and the
+    # response would then name a slug nothing ever claimed.
+    task = asyncio.create_task(warm_mint_all(candidates))
+    _premint_tasks.add(task)
+    task.add_done_callback(_premint_tasks.discard)
+
+    # Off the loop for the same reason as api_connections_mint: this handler can be
+    # the first state-changing request a fresh gateway serves, and the FIRST sel()
+    # of a process constructs the log.
+    await asyncio.to_thread(
+        lambda: sel().log_api_access(
+            caller="dashboard",
+            operation="connections_premint",
+            outcome="started",
+            resources=f"providers:{len(slugs)}",
+        )
+    )
+    return web.json_response({"ok": True, "preminting": slugs})

--- a/src/kiro_crew/dashboard/routes/agent_config.py
+++ b/src/kiro_crew/dashboard/routes/agent_config.py
@@ -78,6 +78,7 @@ def register(app: web.Application) -> None:
     app.router.add_post("/api/mcp/oauth/relay", handlers.api_mcp_oauth_relay)
     app.router.add_post("/api/connections/mint", handlers.api_connections_mint)
     app.router.add_get("/api/connections/mint", handlers.api_connections_mint_state)
+    app.router.add_post("/api/connections/premint", handlers.api_connections_premint)
     app.router.add_get("/api/connections/status", handlers.api_connections_status)
     app.router.add_post("/api/connections/cancel", handlers.api_connections_cancel)
     # REST-style MCP server registration (App Kit)

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -2990,6 +2990,23 @@ _AUDIT_ONLY_READ_IDS: dict[str, str] = {
     # ``status.reconcile_connected_since`` for why that boundary is
     # best-effort rather than fail-closed (stats only, no bytes returned).
     "connections_status.oauth_grant_presence": ".aws/sso/cache/<sha256(mcp_url)>.token.json",
+    # Class 2, same artifacts and same posture again: the premint endpoint
+    # (``dashboard.handlers.connections.api_connections_premint``) reaches the warm
+    # engine's candidate scan, which STATS the paired grant artifacts for every
+    # registry provider to decide which ones still need a URL minted.
+    #
+    # A separate id from the mint's and the status module's, so the trail names the
+    # surface that looked. ONE event per activation rather than one per candidate:
+    # the scan is a single pass whose N answers feed exactly one act decision (spawn
+    # the shared warm process, or do not), so per-candidate events would over-count
+    # one observation and, because this entry point marks its events critical, drain
+    # the queue N times for a single page mount. Audited only when the endpoint ACTS
+    # -- an empty candidate set returns early without spawning, persisting, or
+    # reporting any grant answer, so a page mounted against a fully-authorized
+    # gallery writes nothing. Best-effort rather than fail-closed for the same reason
+    # as the two entries above (stats only, no bytes returned); see
+    # ``api_connections_premint`` for why refusing would be the worse failure.
+    "connections_premint.oauth_grant_presence": ".aws/sso/cache/<sha256(mcp_url)>.token.json",
 }
 
 

--- a/test/test_connections_premint.py
+++ b/test/test_connections_premint.py
@@ -1,0 +1,327 @@
+"""Premint endpoint tests: the route, the report it makes, and what it must not wait for.
+
+``POST /api/connections/premint`` is the warm engine's only request-path caller. Its
+contract is narrow -- ``{"ok": true, "preminting": [<slug>, ...]}`` -- and the whole point
+is that the slugs are reported BEFORE any provider process exists, so the tests here pin
+the non-blocking property directly rather than trusting the handler's shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
+
+from kiro_crew.connections.registry import Provider
+from kiro_crew.dashboard.handlers import connections
+
+
+def _provider(slug: str) -> Provider:
+    return {  # type: ignore[typeddict-item]
+        "slug": slug,
+        "mcp_url": f"https://{slug}.example/mcp",
+        "l0_expectations": {"dcr": True},
+    }
+
+
+async def _client() -> TestClient:
+    app = web.Application()
+    app.router.add_post("/api/connections/premint", connections.api_connections_premint)
+    as_owner(app)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+@pytest.fixture
+def warm_engine(monkeypatch: pytest.MonkeyPatch):
+    """Stub the warm engine's two entry points. NEVER a real provider spawn.
+
+    Patched on the engine module, which is the namespace the handler's
+    function-local import resolves against -- patching a name on the handler
+    module would miss, and the real activation would spawn kiro-cli.
+    """
+    from kiro_crew.connections import warm
+
+    calls: dict[str, object] = {"warmed": None, "invocations": 0}
+    candidates: list[Provider] = [_provider("linear"), _provider("vercel")]
+
+    async def _warm_mint_all(providers: list[Provider] | None = None) -> list[str]:
+        calls["invocations"] = int(calls["invocations"]) + 1
+        calls["warmed"] = providers
+        return [str(provider["slug"]) for provider in providers or []]
+
+    monkeypatch.setattr(warm, "mintable_providers", lambda: list(candidates))
+    monkeypatch.setattr(warm, "warm_mint_all", _warm_mint_all)
+    calls["candidates"] = candidates
+    return calls
+
+
+async def _premint(client: TestClient) -> tuple[int, dict]:
+    resp = await client.post("/api/connections/premint")
+    return resp.status, await resp.json()
+
+
+# ── the wire contract ──
+
+
+@pytest.mark.asyncio
+async def test_premint_reports_every_mintable_provider(warm_engine):
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body == {"ok": True, "preminting": ["linear", "vercel"]}
+
+
+@pytest.mark.asyncio
+async def test_premint_drives_the_warm_engine_with_the_slugs_it_reported(warm_engine):
+    """The response and the claim set come from ONE registry scan, not two.
+
+    The handler passes the candidates it just scanned rather than letting the engine
+    re-scan: two independent scans can disagree (a consent completing between them
+    drops a provider), and the response would then name a slug nothing claimed.
+    """
+    client = await _client()
+    try:
+        _status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    # The task is fired, not awaited, so give the loop one pass to start it.
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 1
+    warmed = warm_engine["warmed"]
+    assert warmed is not None
+    assert [str(provider["slug"]) for provider in warmed] == body["preminting"]
+
+
+@pytest.mark.asyncio
+async def test_premint_with_no_eligible_provider_warms_nothing(
+    monkeypatch: pytest.MonkeyPatch, warm_engine
+):
+    """An empty candidate set must not activate a process to warm nothing."""
+    from kiro_crew.connections import warm
+
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [])
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body == {"ok": True, "preminting": []}
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 0
+
+
+@pytest.mark.asyncio
+async def test_premint_answers_before_the_activation_settles(
+    monkeypatch: pytest.MonkeyPatch, warm_engine
+):
+    """The page fires this on mount; an activation costs seconds, so it cannot be awaited.
+
+    A handler that awaited the engine would hang here for the whole test timeout
+    instead of answering, which is exactly the regression this pins.
+    """
+    from kiro_crew.connections import warm
+
+    released = asyncio.Event()
+    started = asyncio.Event()
+
+    async def _never_settles(providers: list[Provider] | None = None) -> list[str]:
+        started.set()
+        await released.wait()
+        return []
+
+    monkeypatch.setattr(warm, "warm_mint_all", _never_settles)
+    client = await _client()
+    try:
+        status, body = await asyncio.wait_for(_premint(client), timeout=5)
+        assert status == 200
+        assert body["preminting"] == ["linear", "vercel"]
+        # The engine really was entered -- the response overtook it rather than the
+        # handler having skipped the call altogether.
+        await asyncio.wait_for(started.wait(), timeout=5)
+    finally:
+        released.set()
+        await client.close()
+
+
+# ── the gate ──
+
+
+@pytest.mark.asyncio
+async def test_premint_is_owner_gated(warm_engine):
+    """Same gate as the sibling POSTs: warming spawns a kiro-cli process."""
+    client = await _client()
+    try:
+        resp = await client.post(
+            "/api/connections/premint", headers={"X-Test-User": "someone-else"}
+        )
+        assert resp.status in (401, 403)
+        body = await resp.json()
+    finally:
+        await client.close()
+    assert body.get("code")
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 0
+
+
+# ── the acted-on grant observation is SEL-audited ──
+
+
+def test_the_premint_read_id_is_registered_with_the_audit_gate():
+    """``emit_internal_read_audit`` fail-closes on an unregistered read_id, and the
+    audit tests below monkeypatch the hook, so only this un-mocked check can catch a
+    registration gap that silently disables the audit."""
+    from kiro_crew import hooks
+
+    assert connections._GRANT_PRESENCE_READ_ID in hooks._AUDIT_ONLY_READ_IDS
+
+
+@pytest.mark.asyncio
+async def test_premint_audits_the_grant_observation_it_acts_on(warm_engine, monkeypatch):
+    """The scan stats kiro-cli's OAuth artifacts and this handler SPAWNS on the answer.
+
+    One event per activation, not one per candidate: the scan is a single pass that
+    yields N candidates and exactly one act decision, so N events would over-count one
+    observation.
+    """
+    from kiro_crew import hooks
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        hooks,
+        "emit_internal_read_audit",
+        lambda read_id, outcome: (calls.append((read_id, outcome)), True)[1],
+    )
+
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body["preminting"] == ["linear", "vercel"]
+    assert calls == [(connections._GRANT_PRESENCE_READ_ID, "success")]
+
+
+@pytest.mark.asyncio
+async def test_premint_still_warms_when_the_audit_cannot_be_recorded(
+    warm_engine, monkeypatch, caplog
+):
+    """Best-effort, not fail-closed: the artifacts are stat-ed, never opened.
+
+    Denying here would turn an SEL outage into a page that pays a cold spawn on every
+    Connect, so an unaudited boolean is the lesser failure -- and it leaves a warning.
+    """
+    from kiro_crew import hooks
+
+    monkeypatch.setattr(hooks, "emit_internal_read_audit", lambda read_id, outcome: False)
+
+    client = await _client()
+    try:
+        with caplog.at_level(logging.WARNING, logger=connections.__name__):
+            status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body["preminting"] == ["linear", "vercel"]
+    # The activation is not gated on the trail.
+    await asyncio.sleep(0)
+    assert warm_engine["invocations"] == 1
+    assert any(
+        "proceeding unaudited" in record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    )
+
+
+@pytest.mark.asyncio
+async def test_premint_with_no_candidates_audits_nothing(warm_engine, monkeypatch):
+    """An empty scan is not an acted-on observation, so it owes no trail.
+
+    Same rule as ``connections.status``: the event records the observation a caller
+    ACTS on. Here the handler returns early -- no process is spawned, nothing is
+    persisted, and no grant answer reaches the user -- so a page mounted against a
+    fully-authorized gallery must not write an event on every poll.
+    """
+    from kiro_crew import hooks
+    from kiro_crew.connections import warm
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        hooks,
+        "emit_internal_read_audit",
+        lambda read_id, outcome: (calls.append((read_id, outcome)), True)[1],
+    )
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [])
+
+    client = await _client()
+    try:
+        status, body = await _premint(client)
+    finally:
+        await client.close()
+
+    assert status == 200
+    assert body == {"ok": True, "preminting": []}
+    assert calls == []
+
+
+# ── the route is reachable, not merely defined ──
+
+
+def test_the_premint_route_is_wired_into_the_dashboard():
+    """A handler the route table never registers is unreachable from the page."""
+    from kiro_crew.dashboard.routes import agent_config
+
+    app = web.Application()
+    agent_config.register(app)
+    wired = {
+        (route.method, route.resource.canonical)
+        for route in app.router.routes()
+        if route.resource is not None
+    }
+    assert ("POST", "/api/connections/premint") in wired
+
+
+# ── the boot path stays free of the engine ──
+
+
+def test_the_handlers_package_does_not_import_the_warm_engine():
+    """The gateway imports the handlers package at boot; the warm engine must not ride along.
+
+    The warm engine imports the cold mint at module scope and adds the ACP runtime and the
+    MCP inventory on top, so a module-scope import in the premint handler would put the
+    heaviest half of Connections on every gateway start. Run in a subprocess because this
+    test module reaches the engine directly, so an in-process ``sys.modules`` check would
+    always find it.
+    """
+    probe = (
+        "import sys; import kiro_crew.dashboard.handlers;"
+        " leaked = [m for m in ('kiro_crew.connections.warm', 'kiro_crew.connections.mint')"
+        " if m in sys.modules];"
+        " print('LEAKED:' + ','.join(leaked) if leaked else 'CLEAN')"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=180,
+    )
+    assert out.returncode == 0, out.stderr[-2000:]
+    assert out.stdout.strip().endswith("CLEAN"), out.stdout


### PR DESCRIPTION
## Problem / Motivation

The warm-mint engine (#6697) ships with `warm_mint_all` deliberately callerless: nothing in the product invokes it yet, so warm minting cannot actually happen. The Connections page draft already calls `POST /api/connections/premint` on page open (`connectionsPremint` in its `client.ts`), but that endpoint exists nowhere on the backend — the page-swap slice cannot work until it does.

## Why it matters

Without a caller, the engine merged in #6697 is dead weight and every Connect click still pays the full cold-mint wait (~7.5s measured on the reference branch). This endpoint is the piece that lets the page warm provider links ahead of clicks, which is the entire point of the warm-mint work.

## What changed (motivation → approach → change)

Goal: give `warm_mint_all` its first real caller with the exact contract the page expects, without blocking the HTTP response on provider spawns.

Approach: a thin owner-gated handler that scans provider candidates once, kicks off warm minting fire-and-forget, and answers immediately — the engine already owns claim fencing, absorption, and expiry (all landed in #6697), so the handler adds no lifecycle logic of its own.

Change:
- `api_connections_premint` in `src/kiro_crew/dashboard/handlers/connections.py` (+69): owner gate matching sibling `/api/connections/*` endpoints, one candidate scan off the event loop (`to_thread`), fire-and-forget `warm_mint_all(candidates)` with a module-level keepalive set (`_premint_tasks`) so the task cannot be garbage-collected mid-flight, SEL audit, immediate `{"ok": true, "preminting": [<slugs>]}` response.
- The warm/mint engine is imported function-locally so the handlers package never pays engine import cost at boot; a boot-path import-guard test pins that.
- Route registered in `src/kiro_crew/dashboard/routes/agent_config.py` alongside the other connections routes.
- `warm_mint_all`'s `providers` parameter is kept (not deleted): the handler needs the scanned candidate list for the response body anyway, and passes it through.
- `src/kiro_crew/connections/warm.py`: comment/docstring updates only (+7/−6) — the "no caller yet" seam notes now describe the request path. No runtime behavior change.
- Design note `docs/architecture/design-notes/connections-warm-table.md` updated to record that the endpoint wiring has landed.

Latency: the 7.5s→5.2s first-click improvement is not re-measured in this slice; it becomes end-to-end measurable once the page (W5) calls this endpoint. No performance claim is made for this diff on its own.

## Tests

`test/test_connections_premint.py` (7 tests, red-first against the missing handler):
- wire contract: 200 with `{ok, preminting}` shape matching the page draft's `connectionsPremint` call
- one-scan invariant: candidates scanned exactly once per request
- empty candidate set → `{"ok": true, "preminting": []}`
- non-blocking: response returns before warm activation settles (spawn layer stubbed — no real provider spawns)
- owner gate: unauthenticated caller rejected identically to sibling endpoints
- route wiring: endpoint reachable at `/api/connections/premint`
- boot-path import guard: importing the handlers package does not import the warm/mint engine

## Manual verification

N/A — unit coverage sufficient: the handler composes an existing gate, an existing scan, and the engine's own `warm_mint_all` (whose lifecycle behavior is covered by the 77 warm tests shipped in #6697); the new tests pin every seam this slice adds.

## Related Issues

no linked issue: this is a planned slice of the Connections warm-mint plan (first consumer of the engine from #6697); the per-provider spec-file family and `providers`-parameter questions deferred from #6697's review dispositions are decided here by this endpoint's contract.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
