### PR TITLE
fix(session-directive): make an identity-gate drop diagnosable, accept both qualified tool-name spellings

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4903,6 +4903,14 @@ async def _run_chat(
     # (event.tool_name + event.mcp_server_name), never from the title. This is
     # the ONLY map the session-directive gate below trusts.
     _pending_dir_tool: dict[str, str] = {}
+    # Identity OBSERVED on each tool_call frame, for the NOT-APPLIED
+    # diagnostic only. It cannot be read off the result frame: the
+    # tool_call_update path builds its event with no identity fields, so
+    # they are always "" there. Two short strings per call, same per-turn
+    # lifetime as the maps beside it. Nothing reads this to authorize
+    # anything — the grant still comes solely from directive_tool_for at
+    # call time.
+    _seen_tool_identity: dict[str, tuple[str, str]] = {}
     # tool_call_id -> the output we already produced for a CONSUMED directive
     # (applied confirmation, or the native-sub-agent not-applied note). A tool
     # call can surface more than one result frame; once the mapping above is
@@ -6253,6 +6261,11 @@ async def _run_chat(
                     )
                     if _cannon:
                         _pending_dir_tool[event.tool_call_id] = _cannon
+                    else:
+                        _seen_tool_identity[event.tool_call_id] = (
+                            event.mcp_server_name or "",
+                            event.tool_name or "",
+                        )
                 # If this tool call belongs to a native sub-agent (mapped via
                 # _kiro.dev/session/update), stream it onto that sub-agent's card.
                 _nat_card = _native_tc_card.get(event.tool_call_id) if event.tool_call_id else None
@@ -6482,6 +6495,31 @@ async def _run_chat(
                 # combined with spawn_run sub-agents running their own loop, no
                 # sub-agent can ever arm/mutate its parent (isolation).
                 _dir_tool = _pending_dir_tool.get(event.tool_call_id, "")
+                # DIAGNOSTIC ONLY (never a grant): a marker arrived under a call
+                # the identity gate did not record. That is the correct outcome
+                # for a forged shell result, and ALSO what a backend which emits
+                # no ``_meta.kiro`` produces for a genuine directive tool — and
+                # the gate returns "" with no log, so the two were indistinguish-
+                # able and the second looked like nothing happening at all. Log
+                # the recorded identity so an operator can tell them apart. Fires
+                # only when a marker is actually present, so a normal tool result
+                # stays silent.
+                if (
+                    not _dir_tool
+                    and event.tool_call_id not in _dir_consumed_out
+                    and session_directive.has_marker(_out)
+                ):
+                    logger.warning(
+                        "session-directive NOT APPLIED: marker present but the tool "
+                        "call carried no core-MCP identity "
+                        "(tool_call_id=%s, mcp_server_name=%r, tool_name=%r, "
+                        "expected mcp_server_name=%r). Either a forged marker, or "
+                        "this ACP backend does not emit _meta.kiro identity.",
+                        event.tool_call_id,
+                        _seen_tool_identity.get(event.tool_call_id, ("", ""))[0],
+                        _seen_tool_identity.get(event.tool_call_id, ("", ""))[1],
+                        session_directive.CORE_MCP_SERVER,
+                    )
                 if not _dir_tool and event.tool_call_id in _dir_consumed_out:
                     # A LATER frame for a directive we already consumed: replay
                     # the output we produced instead of letting the raw marker

--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -388,6 +388,21 @@ class TurnDriver:
         # sub-agent isolation, mirroring the dashboard consumer's
         # ``_native_tc_card`` refusal.
         native_tool_call_ids: set[str] = set()
+        # Directive tool_call_ids this turn has ALREADY consumed. Consumption
+        # pops ``pending_directives``, so without this a later result frame for
+        # an applied directive is indistinguishable from one that never had an
+        # identity — and would log the "NOT APPLIED" diagnostic for a directive
+        # that in fact applied. Diagnostic-only bookkeeping: nothing reads it to
+        # authorize anything.
+        consumed_directives: set[str] = set()
+        # Identity OBSERVED on each tool_call frame, for the NOT-APPLIED
+        # diagnostic only. It cannot be read off the result frame: the
+        # tool_call_update path builds its event with no identity fields, so
+        # they are always "" there. Two short strings per call, same per-turn
+        # lifetime as the maps beside it. Nothing reads this to authorize
+        # anything — the grant still comes solely from directive_tool_for at
+        # call time.
+        seen_tool_identity: dict[str, tuple[str, str]] = {}
         # Purpose text from each tool_call, keyed by its tool_call_id, so a
         # permission request can be paired with the purpose of the tool IT asks
         # about. The permission payload carries the title but no purpose, and the
@@ -500,6 +515,11 @@ class TurnDriver:
                     )
                     if canonical:
                         pending_directives[event.tool_call_id] = canonical
+                    else:
+                        seen_tool_identity[event.tool_call_id] = (
+                            getattr(event, "mcp_server_name", "") or "",
+                            getattr(event, "tool_name", "") or "",
+                        )
             elif kind == EVENT_SUBAGENT_ACTIVITY:
                 # Native sub-agent lifecycle marker. Its only role in this
                 # driver is the isolation gate above: remember which
@@ -518,7 +538,13 @@ class TurnDriver:
                 # ignored. Without a consumer this event stays inert,
                 # preserving the pre-consumer behavior exactly.
                 if self.directive_consumer is not None:
-                    await self._consume_directive(event, pending_directives, native_tool_call_ids)
+                    await self._consume_directive(
+                        event,
+                        pending_directives,
+                        native_tool_call_ids,
+                        consumed_directives,
+                        seen_tool_identity,
+                    )
             elif kind == EVENT_PERMISSION_REQUEST:
                 # Untrusted sender: no tool runs, full stop. This precedes even
                 # the PreToolUse gate's auto_approve branch and the
@@ -704,7 +730,12 @@ class TurnDriver:
         return accumulated
 
     async def _consume_directive(
-        self, event: Any, pending: dict[str, str], native_tool_call_ids: set[str]
+        self,
+        event: Any,
+        pending: dict[str, str],
+        native_tool_call_ids: set[str],
+        consumed: set[str] | None = None,
+        seen_identity: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         """Decode one directive-tool result and apply it via the consumer.
 
@@ -719,6 +750,27 @@ class TurnDriver:
         consumer = self.directive_consumer
         tool = pending.get(event.tool_call_id or "", "")
         if consumer is None or not tool:
+            # DIAGNOSTIC ONLY (never a grant) — mirrors the dashboard consumer.
+            # A marker with no recorded identity is the right outcome for a
+            # forged result AND what a backend emitting no ``_meta.kiro``
+            # produces for a real directive; the gate is silent, so log enough
+            # to tell those apart.
+            if (
+                consumer is not None
+                and (event.tool_call_id or "") not in (consumed or ())
+                and session_directive.has_marker(event.tool_output)
+            ):
+                logger.warning(
+                    "session-directive NOT APPLIED: marker present but the tool "
+                    "call carried no core-MCP identity "
+                    "(tool_call_id=%s, mcp_server_name=%r, tool_name=%r, "
+                    "expected mcp_server_name=%r). Either a forged marker, or "
+                    "this ACP backend does not emit _meta.kiro identity.",
+                    event.tool_call_id,
+                    (seen_identity or {}).get(event.tool_call_id or "", ("", ""))[0],
+                    (seen_identity or {}).get(event.tool_call_id or "", ("", ""))[1],
+                    session_directive.CORE_MCP_SERVER,
+                )
             return
         if event.tool_call_id in native_tool_call_ids:
             # Sub-agent ISOLATION: a native child's tool calls surface as flat
@@ -728,6 +780,8 @@ class TurnDriver:
             # (terminal for this call) and audit the refusal so the denial is
             # never a silent drop, mirroring the dashboard consumer.
             pending.pop(event.tool_call_id, None)
+            if consumed is not None and event.tool_call_id:
+                consumed.add(event.tool_call_id)
             sel().log_api_access(
                 caller="turn_driver",
                 operation="session_directive",
@@ -754,6 +808,8 @@ class TurnDriver:
                     # delivery limit): nothing was applied and the result text
                     # already told the model so. Terminal for this call.
                     pending.pop(event.tool_call_id, None)
+                    if consumed is not None and event.tool_call_id:
+                        consumed.add(event.tool_call_id)
                     logger.info(
                         "session-directive REFUSED for %r (tool_call_id=%s): "
                         "payload over the %d-char delivery limit; nothing applied",
@@ -775,6 +831,8 @@ class TurnDriver:
                     )
             return
         pending.pop(event.tool_call_id, None)
+        if consumed is not None and event.tool_call_id:
+            consumed.add(event.tool_call_id)
         try:
             await consumer(tool, args)
         except Exception:

--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -44,6 +44,7 @@ directive tool and is ignored.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 # The stateless, session-bound tools. ``ask_question`` joins
@@ -103,6 +104,12 @@ MAX_DIRECTIVE_CHARS = 3800
 # no payload and grants no effect, so a model emitting the literal bytes can only
 # change how a log line reads, never what gets applied.
 _REFUSAL_SENTINEL = "[[KIROCREW_SESSION_DIRECTIVE_REFUSED]]"
+# A server-qualified canonical tool name separates server from tool with a RUN
+# of underscores, and the run length is transport-specific ("___" from kiro-cli,
+# "__" in the canonical MCP prefix form). Matching the run rather than one
+# spelling is what lets :func:`match_tool` accept both without widening to a
+# bare suffix match. Mirrors ``channel._MCP_SEPARATOR_RE``.
+_MCP_SEPARATOR_RE = re.compile(r"_{2,}")
 
 
 def encode(kind: str, args: dict[str, Any], human: str) -> str:
@@ -128,6 +135,19 @@ def encode(kind: str, args: dict[str, Any], human: str) -> str:
             f"nothing was applied.\n{_REFUSAL_SENTINEL}"
         )
     return out
+
+
+def has_marker(text: str | None) -> bool:
+    """True iff *text* carries the directive marker sentinel.
+
+    Used ONLY for diagnostics — never to authorize anything. A marker is
+    model-visible text, so its presence proves nothing about provenance; what it
+    does tell an operator is that a directive was EXPECTED here, which is the
+    signal that made an identity-gate drop invisible (the gate returns ``""``
+    with no log, so a backend that omits ``_meta.kiro`` produced silence rather
+    than a diagnosis).
+    """
+    return bool(text) and _SENTINEL in (text or "")
 
 
 def is_refusal(text: str | None) -> bool:
@@ -170,18 +190,27 @@ def match_tool(raw: str) -> str:
 
     ``raw`` MUST be the trusted ``_meta.kiro.toolName`` (NOT the LLM-authored
     title). For an MCP tool that name is the bare tool name (``"monitor_start"``);
-    some transports server-qualify it as ``"<server>___<name>"``. Accept exact
-    membership plus that single ``___`` split — nothing wider, so a crafted
-    string cannot smuggle a directive name in as a path/namespace tail.
+    some transports server-qualify it, and the separator is NOT one fixed
+    spelling: kiro-cli reports ``"<server>___<name>"`` while the canonical MCP
+    prefix form is ``"mcp__<server>__<name>"``. Split on the LAST run of two or
+    more underscores so BOTH qualified forms resolve — the same normalization
+    ``channel._blocked_tool_named`` already applies for the same reason, which
+    this deliberately mirrors rather than re-inventing.
+
+    Still nothing wider than that: the separator must be a run of >= 2
+    underscores, so a crafted path/namespace tail (``"a/b/monitor_start"``,
+    ``"do_monitor_start"``) cannot smuggle a directive name in. The tool half
+    never authenticates the SERVER either way — :func:`directive_tool_for`
+    checks ``mcp_server_name`` independently, and that is the check a
+    third-party server fails.
     """
     if not raw:
         return ""
     if raw in DIRECTIVE_TOOLS:
         return raw
-    if "___" in raw:
-        tail = raw.rsplit("___", 1)[-1]
-        if tail in DIRECTIVE_TOOLS:
-            return tail
+    parts = _MCP_SEPARATOR_RE.split(raw)
+    if len(parts) > 1 and parts[-1] in DIRECTIVE_TOOLS:
+        return parts[-1]
     return ""
 
 

--- a/test/test_driver_session_directives.py
+++ b/test/test_driver_session_directives.py
@@ -628,3 +628,99 @@ class TestBuildDirectiveConsumer:
         assert isinstance(state, _ChannelDirectiveState)
         assert state.sessions is sessions
         assert state._slots == {} and state.channel_transports == {}
+
+
+class TestSilentDropIsDiagnosable:
+    """The identity gate refuses correctly but used to refuse SILENTLY, so an
+    ACP backend that emits no ``_meta.kiro`` was indistinguishable from nothing
+    happening. The refusal must stay a refusal AND leave a log line naming the
+    identity it saw. Diagnostic only: no test here may show an effect applying.
+    """
+
+    def test_missing_backend_identity_logs_what_it_saw(self, caplog):
+        """The KAS-shaped case: a genuine directive tool whose frame carries no
+        ``_meta.kiro`` at all. Nothing applies (unchanged), and the operator can
+        now see WHY instead of an empty log."""
+        spy = _SpyConsumer()
+        with caplog.at_level("WARNING"):
+            _run(
+                [
+                    AcpEvent(
+                        kind=EVENT_TOOL_CALL,
+                        tool_call_id="tc-kas",
+                        title="monitor_start",
+                        tool_name="",
+                        mcp_server_name="",
+                    ),
+                    _result(_directive("monitor_start"), tcid="tc-kas"),
+                    AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+                ],
+                spy,
+            )
+        assert spy.applied == []
+        assert "session-directive NOT APPLIED" in caplog.text
+        assert session_directive.CORE_MCP_SERVER in caplog.text
+
+    def test_forged_shell_marker_also_logs_and_still_does_not_apply(self, caplog):
+        spy = _SpyConsumer()
+        with caplog.at_level("WARNING"):
+            _run(
+                [
+                    AcpEvent(
+                        kind=EVENT_TOOL_CALL,
+                        tool_call_id="tc-sh",
+                        title="monitor_start",
+                        tool_name="execute_bash",
+                        mcp_server_name="",
+                        is_shell=True,
+                    ),
+                    _result(_directive("monitor_start"), tcid="tc-sh"),
+                    AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+                ],
+                spy,
+            )
+        assert spy.applied == []
+        assert "session-directive NOT APPLIED" in caplog.text
+        assert "execute_bash" in caplog.text
+
+    def test_ordinary_tool_result_stays_silent(self, caplog):
+        """No marker, no log — the diagnostic must not fire on every tool call."""
+        spy = _SpyConsumer()
+        with caplog.at_level("WARNING"):
+            _run(
+                [
+                    AcpEvent(
+                        kind=EVENT_TOOL_CALL,
+                        tool_call_id="tc-plain",
+                        title="ls",
+                        tool_name="execute_bash",
+                        mcp_server_name="",
+                        is_shell=True,
+                    ),
+                    _result("a.txt  b.txt", tcid="tc-plain"),
+                    AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+                ],
+                spy,
+            )
+        assert spy.applied == []
+        assert "session-directive NOT APPLIED" not in caplog.text
+
+    def test_an_applied_directive_does_not_log_not_applied(self, caplog):
+        """SINGLE-CONSUME pops the pending entry, so a SECOND result frame for a
+        directive that DID apply reaches the same branch. It must not be
+        reported as not-applied — that false alarm is what the consumed-id set
+        exists to prevent."""
+        spy = _SpyConsumer()
+        payload = _directive("monitor_start")
+        with caplog.at_level("WARNING"):
+            _run(
+                [
+                    _core_call(tcid="tc-ok"),
+                    _result(payload, tcid="tc-ok"),
+                    _result(payload, tcid="tc-ok"),
+                    AcpEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+                ],
+                spy,
+            )
+        assert [k for k, _ in spy.applied] == ["monitor_start"]
+        assert "session-directive NOT APPLIED" not in caplog.text

--- a/test/test_session_directive.py
+++ b/test/test_session_directive.py
@@ -133,10 +133,22 @@ def test_forgery_gate_malformed_json():
     [
         ("monitor_start", "monitor_start"),
         ("kirocrew-core___monitor_start", "monitor_start"),
-        # Tightened surface (#755 security fix): only exact membership and a
-        # single ``___`` server-qualifier split are accepted. Any other
-        # separator no longer tail-matches, so a crafted title/path cannot
-        # smuggle a directive name in as a namespace tail.
+        # The separator is a RUN of underscores and its length is transport-
+        # specific, so the canonical MCP prefix form must resolve too. Before
+        # this, ``mcp__<server>__<tool>`` fell through and the directive was
+        # dropped on any transport using that spelling — the same both-forms
+        # problem ``channel._blocked_tool_named`` already solved.
+        ("mcp__kirocrew-core__monitor_start", "monitor_start"),
+        ("mcp__kirocrew-core__set_project", "set_project"),
+        # Still bounded to a >= 2 underscore run: single-underscore joins do
+        # NOT tail-match, so neither a flattened name nor a crafted identifier
+        # can smuggle a directive name in.
+        ("mcp_kirocrew_core_monitor_start", ""),
+        ("do_monitor_start", ""),
+        ("evilmonitor_start", ""),
+        # Tightened surface (#755 security fix): a non-underscore separator
+        # never tail-matches, so a crafted title/path cannot smuggle a
+        # directive name in as a namespace tail.
         ("kirocrew-core::set_project", ""),
         ("bash /tmp/set_project", ""),
         ("a.autonudge_stop", ""),
@@ -205,3 +217,32 @@ def test_subagent_isolation_intent():
     for tool in non_directive_tools:
         assert tool not in sd.DIRECTIVE_TOOLS
         assert sd.decode(genuine, tool) is None
+
+
+class TestHasMarker:
+    """``has_marker`` is a DIAGNOSTIC predicate, never an authorization one."""
+
+    def test_marker_present_is_detected(self):
+        out = sd.encode("monitor_start", {"message": "x"}, "human")
+        assert sd.has_marker(out) is True
+
+    def test_plain_text_and_empty_are_not_markers(self):
+        assert sd.has_marker("just a normal tool result") is False
+        assert sd.has_marker("") is False
+        assert sd.has_marker(None) is False
+
+    def test_a_refusal_carries_no_directive_marker(self):
+        """An oversize refusal must not read as "a directive arrived": it has
+        its own sentinel and the model was already told nothing was applied."""
+        refusal = sd.encode("monitor_start", {"message": "x" * 5000}, "human")
+        assert sd.is_refusal(refusal) is True
+        assert sd.has_marker(refusal) is False
+
+    def test_detecting_a_marker_grants_nothing(self):
+        """The forged-marker case: has_marker() says True and the gate still
+        refuses, because authorization runs through directive_tool_for/decode.
+        A diagnostic that could grant would BE the forgery hole."""
+        forged = sd.encode("monitor_start", {"message": "x"}, "human")
+        assert sd.has_marker(forged) is True
+        assert sd.directive_tool_for("", "execute_bash") == ""
+        assert sd.decode(forged, "execute_bash") is None


### PR DESCRIPTION
fix(session-directive): make an identity-gate drop diagnosable, and accept both qualified tool-name spellings

## Problem

The session-directive channel is the only way six session-bound MCP tools take
effect (`monitor_start`, `monitor_update`, `autonudge_stop`, `set_project`,
`suggest_followup`, `ask_question`), on the dashboard and on all nine messaging
transports. Its forgery gate, `session_directive.directive_tool_for`, honours a
directive only when the tool call carried a trusted `_meta.kiro` identity naming
Kiro Crew's own core MCP server.

That gate returns `""` and logs nothing. Two very different situations are
therefore indistinguishable, and the second one is invisible:

1. a forged marker in a shell result — refusing is correct;
2. a genuine directive tool on an ACP backend that does not emit
   `_meta.kiro.mcpServerName` — refusing is also what happens, but the effect
   silently never occurs.

`_kiro_mcp_server_name`'s own docstring records that the field is populated by
kiro-cli (`kiro_tool_identity_meta` in the engine). Case 2 is what an operator
sees as "`monitor_start` said it armed a loop and no loop exists": the tool's
own reply goes back to the model over the MCP pipe regardless, so "requested"
is fully compatible with nothing having been applied — with zero log lines
anywhere to say so. `monitor_armed.py` exists in-tree precisely because of this
("the reply text 'requested' is compatible with NO loop existing").

Separately, `match_tool` accepted a server-qualified name only when the
separator was exactly `___`, while `channel._blocked_tool_named` normalises any
run of 2+ underscores because BOTH spellings occur — `kirocrew-core___<tool>`
and the canonical MCP prefix form `mcp__kirocrew-core__<tool>`. Under the second
spelling a genuine directive was dropped on the same silent path.

## What changed

No gate is loosened, and no new authorization path is introduced.

- `match_tool` splits on the last run of 2+ underscores instead of `___` only,
  so both qualified spellings resolve. Still bounded to an underscore run:
  `mcp_kirocrew_core_monitor_start`, `do_monitor_start` and `a/b/monitor_start`
  do not match. The tool half never authenticated the server anyway —
  `directive_tool_for` checks `mcp_server_name` independently, and that is the
  check a third-party server fails.
- New `session_directive.has_marker`, a diagnostics-only predicate.
- Both consumers (`dashboard/chat_runner` and `messaging/driver.TurnDriver`) now
  log a warning when a marker arrives under a call the gate did not record,
  naming the identity that was actually observed and the one that was required.
  It fires only when a marker is present, so ordinary tool calls stay silent.
- The observed identity is captured at `EVENT_TOOL_CALL`. It cannot be read at
  result time: the `tool_call_update` path builds its event with no identity
  fields, so logging them there would print two empty strings.
- The driver tracks which directive ids it already consumed. Consumption pops
  the pending map, so a second result frame for a directive that DID apply
  reaches the same branch and would otherwise be reported as not-applied.

## Tests

`test/test_session_directive.py`
- `test_match_tool` gains both `mcp__kirocrew-core__*` forms, plus the negative
  cases that keep the surface bounded (`mcp_kirocrew_core_monitor_start`,
  `do_monitor_start`, `evilmonitor_start`).
- `TestHasMarker`: marker detected, plain text and empty are not, an oversize
  refusal does not read as a directive, and — the important one —
  `test_detecting_a_marker_grants_nothing` pins that `has_marker` is true for a
  forged marker while `directive_tool_for` / `decode` still refuse it.

`test/test_driver_session_directives.py::TestSilentDropIsDiagnosable`
- a backend emitting no `_meta.kiro`: nothing applies (unchanged) and the log
  now names what was seen;
- a forged shell marker: nothing applies and it is logged as `execute_bash`;
- an ordinary tool result: no log, so the diagnostic is not per-call noise;
- a directive that DID apply: its second result frame must not log
  "NOT APPLIED".

Every existing forgery test is unmodified and still passes, including
`test_forged_shell_result_is_not_applied`,
`test_non_core_mcp_server_directive_is_not_applied`, and the
`TestForgedMarkersIgnored` / `TestNativeSubAgentIsolation` suites.

## Manual verification

- Mutation-checked all three behaviours, each reverted in isolation with the
  named test re-run: `match_tool` back to `___`-only, the driver warning
  downgraded to debug, and the consumed-id record removed. All three were
  caught (the pinning test failed), then restored. A regression test that has
  not been seen to fail proves nothing.
- 237 tests green across the directive, identity, transport, applier, per-tool
  and channel suites.
- isort, flake8, mypy clean on the touched modules. The black gate passes;
  `session_directive.py` is a pre-existing baseline entry and its one
  unformatted line is untouched.

## Scope

This makes the existing failure legible and fixes one real name-matching gap.
It does NOT remove the provider dependency itself — a directive still needs the
backend to emit `_meta.kiro`. Doing that needs a provider-neutral delivery path
and is deliberately left to a follow-up, because it is an architectural change
with its own threat model rather than a bug fix.

## Screenshots

N/A — no user-visible surface changes; the new signal is a gateway log line.

## Rebase

Rebased onto current `main` (231 commits) at head `70fed9261`. Zero conflicts; the
diff is byte-identical (+275/-13, 5 files). Gates re-run on the new base: 74
`test_session_directive` + `test_driver_session_directives` tests, flake8, isort,
mypy all clean.
