### PR TITLE
fix(macos): enter the bound agent workspace by fchdir, not /dev/fd

### DIFF
--- a/src/kiro_crew/_spawn_exec_shim.py
+++ b/src/kiro_crew/_spawn_exec_shim.py
@@ -49,6 +49,7 @@ except ImportError:  # pragma: no cover - Windows has no POSIX rlimits
 
 _RLIMIT_FLAG = "--rlimits="
 _OOM_BIAS_FLAG = "--oom-bias"
+_CHDIR_FD_FLAG = "--chdir-fd="
 _ARGV_SEPARATOR = "--"
 # Shell convention for "command found but could not be executed", so a caller
 # that only sees the exit status can still tell an exec failure from the
@@ -141,6 +142,34 @@ def _bias_oom_score() -> None:
         pass
 
 
+def _enter_bound_directory(fd: int) -> bool:
+    """``fchdir`` into an inherited directory descriptor, then close it.
+
+    The caller verified that directory's IDENTITY, not its name, so entering it
+    by descriptor is the whole point: a pathname re-resolved here could have been
+    retargeted since the check. Handing the spawn ``cwd="/dev/fd/<n>"`` instead
+    only works on Linux, where those entries are symlinks to the target; macOS
+    refuses ``chdir()`` on them outright -- reported as ``EACCES`` on one host and
+    ``ENOTDIR`` on macOS 26, so the errno is not the thing to key on.
+
+    The descriptor is closed once this process stands in the directory, so the
+    command and its descendants do not inherit a handle that outlives the check.
+
+    Returns False rather than exec'ing from the inherited cwd: a silent fallback
+    would run the command in a workspace nobody authorized.
+    """
+    try:
+        os.fchdir(fd)
+    except OSError as exc:
+        sys.stderr.write(f"spawn shim: cannot enter bound directory fd {fd}: {exc.strerror}\n")
+        return False
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    return True
+
+
 def main(argv: list[str] | None = None) -> int:
     """Parse the shim's own options, then ``exec`` the command after ``--``.
 
@@ -150,12 +179,25 @@ def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     spec = ""
     want_oom_bias = False
+    chdir_fd: int | None = None
     while args and args[0] != _ARGV_SEPARATOR:
         item = args.pop(0)
         if item.startswith(_RLIMIT_FLAG):
             spec = item[len(_RLIMIT_FLAG) :]
         elif item == _OOM_BIAS_FLAG:
             want_oom_bias = True
+        elif item.startswith(_CHDIR_FD_FLAG):
+            raw_fd = item[len(_CHDIR_FD_FLAG) :]
+            try:
+                chdir_fd = int(raw_fd)
+            except ValueError:
+                chdir_fd = -1
+            if chdir_fd < 0:
+                # Fail closed for the same reason an unknown option does: the
+                # caller asked for one exact directory, and running in whatever
+                # cwd was inherited would substitute a different one silently.
+                sys.stderr.write(f"spawn shim: bad {_CHDIR_FD_FLAG}{raw_fd!r}\n")
+                return _EXEC_FAILED
         else:
             # Fail closed. A stray token here means the caller and this shim
             # disagree about the argv contract, and guessing which side the
@@ -178,6 +220,11 @@ def main(argv: list[str] | None = None) -> int:
         encoded = [os.fsencode(item) for item in args]
     except (UnicodeEncodeError, ValueError):
         sys.stderr.write("spawn shim: command argv is not encodable\n")
+        return _EXEC_FAILED
+
+    # Ahead of the limits, like every other allocating step: the failure path
+    # here writes to stderr, and a tight RLIMIT_AS must not be what breaks it.
+    if chdir_fd is not None and not _enter_bound_directory(chdir_fd):
         return _EXEC_FAILED
 
     _apply_rlimits(pairs)

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -137,12 +137,14 @@ from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
 from kiro_crew.resource_status import inject_xdist_auto_cap
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_SESSION_HOST,
+    BoundWorkspaceMismatch,
     apply_windows_resource_ceiling,
     assert_voice_runtime_outside_agent_workspace,
     bind_voice_safe_agent_workspace_async,
     cgroup_scope_argv,
     create_subprocess_limited,
     release_bound_agent_workspace,
+    resolve_bound_session_workspace,
     scrub_agent_subprocess_env,
     wrap_argv,
     wrap_argv_async,
@@ -2737,9 +2739,32 @@ class AcpClient:
         if descriptor is not None:
             await release_bound_agent_workspace(descriptor)
 
-    def _session_work_dir(self) -> str:
-        """Return the ACP cwd backed by the process's bound directory identity."""
-        return self._spawn_work_dir
+    async def _session_work_dir(self) -> str:
+        """Return the ACP cwd backed by the process's bound directory identity.
+
+        Unbound -- every platform but macOS, where nothing binds -- this is the
+        spawn's own pathname and there is nothing to re-check.
+
+        Bound, the descriptor is re-verified and the peer receives the DESCRIPTOR's
+        own name. The rule itself is ``sandbox.resolve_bound_session_workspace``,
+        shared with ``AcpRuntime._session_work_dir`` so the two halves of this
+        boundary cannot drift; only the error type is this front end's. Fails the
+        session rather than falling back to the bind-time spelling; see the runtime's
+        method for the residual limit a string cannot close.
+        """
+        if self._bound_workspace_fd is None:
+            return self._spawn_work_dir
+        try:
+            return await resolve_bound_session_workspace(
+                self._bound_workspace_fd, self._spawn_work_dir
+            )
+        except BoundWorkspaceMismatch as exc:
+            raise AcpError(
+                "A delegated macOS Kiro process is bound to one exact workspace; "
+                "respawn it bound to the requested workspace"
+            ) from exc
+        except OSError as exc:
+            raise AcpError("Cannot verify the macOS session workspace binding") from exc
 
     async def _cleanup_failed_live_spawn(self) -> None:
         """Kill a failed live child and always release its workspace binding."""
@@ -2992,37 +3017,27 @@ class AcpClient:
                 await bind_voice_safe_agent_workspace_async(self._work_dir)
             )
         try:
-            if self._bound_workspace_fd is not None:
-                self._process = await create_subprocess_limited(
-                    *argv,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=self._spawn_work_dir,
-                    limit=_STDOUT_BUFFER_LIMIT,
-                    env=env,
-                    start_new_session=platform_compat.IS_POSIX,
-                    creationflags=0,
-                    pass_fds=(self._bound_workspace_fd,),
-                    profile=RLIMIT_PROFILE_SESSION_HOST,
-                )
-            else:
-                self._process = await create_subprocess_limited(
-                    *argv,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=self._spawn_work_dir,
-                    limit=_STDOUT_BUFFER_LIMIT,
-                    env=env,
-                    start_new_session=platform_compat.IS_POSIX,
-                    creationflags=(
-                        platform_compat.CREATE_NEW_PROCESS_GROUP
-                        | platform_compat._SUBPROCESS_NO_WINDOW
-                        | platform_compat.CREATE_SUSPENDED
-                    ),
-                    profile=RLIMIT_PROFILE_SESSION_HOST,
-                )
+            self._process = await create_subprocess_limited(
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._spawn_work_dir,
+                limit=_STDOUT_BUFFER_LIMIT,
+                env=env,
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=(
+                    platform_compat.CREATE_NEW_PROCESS_GROUP
+                    | platform_compat._SUBPROCESS_NO_WINDOW
+                    | platform_compat.CREATE_SUSPENDED
+                ),
+                # None off macOS, where nothing binds. When set, the child enters
+                # the workspace through this verified descriptor instead of
+                # resolving ``cwd``'s pathname, which a same-UID symlink retarget
+                # could aim elsewhere in between.
+                chdir_fd=self._bound_workspace_fd,
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+            )
         except BaseException:
             await self._discard_bound_workspace()
             self._discard_sandbox_cleanup()
@@ -3417,7 +3432,7 @@ class AcpClient:
         the internal companion, not the public core.
         """
         new_params: dict = {
-            "cwd": self._session_work_dir(),
+            "cwd": await self._session_work_dir(),
             # kiro-cli loads servers from --agent; claude-agent-acp must be
             # told here -- it does not read kirocrew.mcp.json on its own. The
             # Default hook returns [] (kiro-cli path unchanged); an internal
@@ -3540,7 +3555,7 @@ class AcpClient:
                 try:
                     load_params: dict = {
                         "sessionId": resume_sid,
-                        "cwd": self._session_work_dir(),
+                        "cwd": await self._session_work_dir(),
                         # kiro-cli gets its servers via --agent; the claude
                         # backend must receive them here (it does not read
                         # kirocrew.mcp.json itself). Default [] leaves kiro-cli

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -99,12 +99,13 @@ from kiro_crew.metrics.events import (
 from kiro_crew.resource_status import inject_xdist_auto_cap
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_SESSION_HOST,
+    BoundWorkspaceMismatch,
     assert_voice_runtime_outside_agent_workspace,
     bind_voice_safe_agent_workspace_async,
-    bound_agent_workspace_matches,
     cgroup_scope_argv,
     create_subprocess_limited,
     release_bound_agent_workspace,
+    resolve_bound_session_workspace,
     scrub_agent_subprocess_env,
     wrap_argv,
     wrap_argv_async,
@@ -995,25 +996,34 @@ class AcpRuntime:
         if self._bound_workspace_fd is None:
             return cwd if cwd else self._work_dir
         requested = cwd if cwd else self._work_dir
+        # The shared rule lives in sandbox.resolve_bound_session_workspace; only the
+        # error mapping is this front end's. What the peer receives is the BOUND
+        # DESCRIPTOR's own name, not the caller's spelling -- that one is what a
+        # symlink swap controls, and it can name a descendant this check never
+        # covered.
+        #
+        # What no string here can do is bind the PEER's own resolution.
+        # ``session/new`` carries a cwd STRING that a separate process re-resolves
+        # after this returns, so a same-UID rename of the canonical directory in that
+        # window remains open; that is a property of the protocol boundary, not of the
+        # spelling. ``/dev/fd/<n>`` is not the alternative: the binding is darwin-only
+        # (see bind_voice_safe_agent_workspace, which returns no descriptor off
+        # macOS), and macOS cannot resolve those entries at all -- the very bug this
+        # change exists to fix, i.e. that spelling never delivered a working session
+        # cwd, let alone a safer one. The agent PROCESS's own cwd is pinned by
+        # descriptor at spawn (create_subprocess_limited's chdir_fd), which is the
+        # part that does not go through a name.
         try:
-            matches = await asyncio.to_thread(
-                bound_agent_workspace_matches,
-                self._bound_workspace_fd,
-                requested,
-            )
+            return await resolve_bound_session_workspace(self._bound_workspace_fd, requested)
+        except BoundWorkspaceMismatch as exc:
+            raise AcpWorkspaceBindingError(
+                "A delegated macOS Kiro runtime is bound to one exact workspace; "
+                "create a runtime bound to the requested workspace"
+            ) from exc
         except OSError as exc:
             raise AcpWorkspaceBindingError(
                 "Cannot verify the requested macOS session workspace"
             ) from exc
-        if not matches:
-            raise AcpWorkspaceBindingError(
-                "A delegated macOS Kiro runtime is bound to one exact workspace; "
-                "create a runtime bound to the requested workspace"
-            )
-        # Return only the inherited descriptor.  Appending a descendant suffix
-        # would perform mutable pathname lookup in the child after this check,
-        # reopening the same-UID symlink-retarget window the binding closes.
-        return f"/dev/fd/{self._bound_workspace_fd}"
 
     async def _to_thread_guarding_sandbox(
         self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any
@@ -1263,43 +1273,34 @@ class AcpRuntime:
                 await bind_voice_safe_agent_workspace_async(self._work_dir)
             )
         try:
-            if self._bound_workspace_fd is not None:
-                self._process = await create_subprocess_limited(
-                    *argv,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=self._spawn_work_dir,
-                    limit=_STDOUT_BUFFER_LIMIT,
-                    start_new_session=platform_compat.IS_POSIX,
-                    creationflags=0,
-                    pass_fds=(self._bound_workspace_fd,),
-                    env=env,
-                    profile=RLIMIT_PROFILE_SESSION_HOST,
-                )
-            else:
-                self._process = await create_subprocess_limited(
-                    *argv,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=self._spawn_work_dir,
-                    limit=_STDOUT_BUFFER_LIMIT,
-                    # POSIX: setsid so kill() can killpg the whole tree. Windows:
-                    # start_new_session is silently ignored; CREATE_NEW_PROCESS_GROUP
-                    # makes the child tree taskkill /T-reapable (see platform_compat
-                    # spawn-isolation note). CREATE_NO_WINDOW suppresses the console
-                    # window Windows would otherwise pop for this console child spawned
-                    # from the windowless gateway (0 on POSIX, so no effect there).
-                    start_new_session=platform_compat.IS_POSIX,
-                    creationflags=(
-                        platform_compat.CREATE_NEW_PROCESS_GROUP
-                        | platform_compat._SUBPROCESS_NO_WINDOW
-                        | platform_compat.CREATE_SUSPENDED
-                    ),
-                    env=env,
-                    profile=RLIMIT_PROFILE_SESSION_HOST,
-                )
+            self._process = await create_subprocess_limited(
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._spawn_work_dir,
+                limit=_STDOUT_BUFFER_LIMIT,
+                # POSIX: setsid so kill() can killpg the whole tree. Windows:
+                # start_new_session is silently ignored; CREATE_NEW_PROCESS_GROUP
+                # makes the child tree taskkill /T-reapable (see platform_compat
+                # spawn-isolation note). CREATE_NO_WINDOW suppresses the console
+                # window Windows would otherwise pop for this console child spawned
+                # from the windowless gateway (0 on POSIX, so no effect there).
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=(
+                    platform_compat.CREATE_NEW_PROCESS_GROUP
+                    | platform_compat._SUBPROCESS_NO_WINDOW
+                    | platform_compat.CREATE_SUSPENDED
+                ),
+                # None off macOS, where nothing binds. When set, the child enters
+                # the workspace through this verified descriptor instead of
+                # resolving ``cwd``'s pathname, which a same-UID symlink retarget
+                # could aim elsewhere in between; ``cwd`` stays the same directory
+                # by name so the spawn keeps reporting a real path.
+                chdir_fd=self._bound_workspace_fd,
+                env=env,
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+            )
         except BaseException:
             await self._discard_bound_workspace()
             self._discard_sandbox_cleanup()

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -451,9 +451,21 @@ def bind_voice_safe_agent_workspace(
 
     A pathname-only overlap check has an unavoidable check/use window: another
     sandboxed process can retarget a workspace symlink after ``stat`` and before
-    Kiro initializes its own sandbox. On macOS, open the workspace first, compare
-    directory ancestry entirely through descriptors, and make the child chdir via
-    that descriptor. The returned descriptor must stay open until the child exits.
+    Kiro initializes its own sandbox. On macOS, open the workspace first and
+    compare directory ancestry entirely through descriptors.
+
+    The descriptor is returned ALONGSIDE the pathname, never baked into it. The
+    child enters it with ``fchdir`` (see ``create_subprocess_limited``'s
+    ``chdir_fd``), so nothing re-resolves the name. Handing the spawn a
+    ``cwd="/dev/fd/<n>"`` pathname instead does not work: only Linux publishes
+    those entries as symlinks to the target, and on macOS -- the only platform
+    that binds here at all -- ``chdir()`` on one is refused (``EACCES`` on one
+    reporting host, ``ENOTDIR`` on macOS 26), which is every delegated spawn on a
+    packaged build.
+
+    The returned descriptor must stay open as long as the caller re-verifies the
+    binding through :func:`bound_agent_workspace_target`. The child's copy is
+    independent, so closing this one does not disturb a running agent.
 
     Other platforms keep their original pathname and do not inherit a descriptor.
     """
@@ -481,7 +493,7 @@ def bind_voice_safe_agent_workspace(
                     "runtime; keep the workspace and Kiro Crew data home disjoint"
                 )
 
-        return f"/dev/fd/{workspace_fd}", workspace_fd
+        return workspace_path, workspace_fd
     except OSError as exc:
         if workspace_fd >= 0:
             os.close(workspace_fd)
@@ -558,7 +570,7 @@ async def bind_voice_safe_agent_workspace_async(
     raise cancellation
 
 
-def bound_agent_workspace_matches(descriptor: int, workspace: str | os.PathLike[str]) -> bool:
+def _bound_agent_workspace_matches(descriptor: int, workspace: str | os.PathLike[str]) -> bool:
     """Whether *workspace* currently names an already-bound directory identity.
 
     The caller uses the bound identity after this comparison, never the supplied
@@ -571,6 +583,72 @@ def bound_agent_workspace_matches(descriptor: int, workspace: str | os.PathLike[
         return (expected.st_dev, expected.st_ino) == (actual.st_dev, actual.st_ino)
     finally:
         os.close(candidate)
+
+
+def bound_agent_workspace_target(descriptor: int, workspace: str | os.PathLike[str]) -> str | None:
+    """The bound directory's OWN pathname, or None when *workspace* is not it.
+
+    The identity check and the name read are one call because a caller needs both
+    in the same worker hop, and because returning the caller's own pathname would
+    defeat the check: that string is exactly what a same-UID retarget controls,
+    and a peer handed it re-resolves it after this returns.
+
+    What comes back is the kernel's name for the descriptor that was verified
+    (``/proc/self/fd`` on Linux, ``F_GETPATH`` on macOS), so it carries no symlink
+    component left to swap and it cannot name a descendant the check never covered.
+
+    It does NOT make a peer's own resolution descriptor-bound, and nothing can: a
+    pathname handed to another process is re-resolved by that process, and macOS has
+    no descriptor-addressable path namespace to hand instead (``/dev/fd/<n>`` is
+    exactly what it cannot resolve). A same-UID rename of the canonical directory
+    between this call and that resolution therefore stays open. Callers that own the
+    child's cwd should pin it with ``create_subprocess_limited``'s ``chdir_fd``,
+    which does not go through a name at all; this is for the ACP ``session/new`` cwd,
+    where a string is the only thing the protocol carries.
+
+    Raises OSError when this platform exposes no way to ask, so the caller fails
+    closed instead of falling back to the mutable spelling.
+    """
+    if not _bound_agent_workspace_matches(descriptor, workspace):
+        return None
+    # Local import: hooks imports sandbox at call time, so a module-level
+    # dependency would be circular. `_fd_real_path` is private but already
+    # borrowed this way by apps/builtins/spec_builder/backend/routes.py; issue
+    # #6907 tracks promoting it to a shared home.
+    from kiro_crew.hooks import _fd_real_path
+
+    resolved = _fd_real_path(descriptor)
+    if resolved is None:
+        raise OSError(
+            errno.ENOSYS,
+            "cannot read a bound workspace descriptor's own path on this platform",
+        )
+    return resolved
+
+
+class BoundWorkspaceMismatch(Exception):
+    """A requested session workspace is not the bound directory identity."""
+
+
+async def resolve_bound_session_workspace(
+    descriptor: int, workspace: str | os.PathLike[str]
+) -> str:
+    """Off-loop verify-then-substitute for an ACP session cwd on a bound runtime.
+
+    Both ACP front ends enforce one rule -- prove the requested path still names the
+    bound identity, then hand the peer the DESCRIPTOR's own name instead of the
+    caller's spelling -- so the rule lives here once rather than in two places that
+    can drift apart. Each caller keeps only the mapping to its own error type:
+    :class:`BoundWorkspaceMismatch` when the path is not the bound identity, OSError
+    when the binding cannot be verified at all.
+
+    Off-loop because it opens a directory and reads a descriptor's name; on the loop
+    that is filesystem IO in front of every session start.
+    """
+    resolved = await asyncio.to_thread(bound_agent_workspace_target, descriptor, workspace)
+    if resolved is None:
+        raise BoundWorkspaceMismatch(os.fspath(workspace))
+    return resolved
 
 
 def _is_policy_cache_dir(path: str) -> bool:
@@ -6328,6 +6406,13 @@ _PROFILE_OOM_BIAS = {
     RLIMIT_PROFILE_NONE: False,
 }
 
+# The shim's own argv contract, mirrored here so a cached prefix can be extended
+# for one spawn. Kept as literals rather than imported from the shim module: the
+# shim is consumed as a source string captured at import time, never imported from
+# the (agent-writable) package directory at spawn time.
+_SHIM_ARGV_SEPARATOR = "--"
+_SHIM_CHDIR_FD_FLAG = "--chdir-fd="
+
 _SHIM_ARGV_CACHE: dict[str, tuple[str, ...]] = {}
 _SHIM_UNAVAILABLE_LOGGED = False
 
@@ -6410,10 +6495,36 @@ def spawn_shim_argv(profile: str = RLIMIT_PROFILE_TOOL) -> tuple[str, ...]:
         argv.append(f"--rlimits={spec}")
     if bias:
         argv.append("--oom-bias")
-    argv.append("--")
+    argv.append(_SHIM_ARGV_SEPARATOR)
     resolved = tuple(argv)
     _SHIM_ARGV_CACHE[key] = resolved
     return resolved
+
+
+def _shim_prefix_entering_fd(prefix: "tuple[str, ...]", descriptor: int) -> "tuple[str, ...]":
+    """Return *prefix* with ``--chdir-fd`` inserted ahead of its argv separator.
+
+    Copied rather than mutated: the prefix is cached per profile, while the
+    descriptor belongs to a single spawn.
+    """
+    if not prefix or prefix[-1] != _SHIM_ARGV_SEPARATOR:
+        raise RuntimeError("spawn shim prefix is missing its argv separator")
+    return prefix[:-1] + (f"{_SHIM_CHDIR_FD_FLAG}{descriptor}", _SHIM_ARGV_SEPARATOR)
+
+
+def _pass_fds_including(passed: Any, descriptor: int) -> "tuple[int, ...]":
+    """Return *passed* with *descriptor* inherited, leaving its order alone.
+
+    The shim can only ``fchdir`` a descriptor the child actually holds, and
+    ``pass_fds`` is what carries it there: it exempts the fd from
+    ``_close_open_fds`` and clears the ``O_CLOEXEC`` the binder opens with. Owned
+    here rather than left to each caller so the flag and the inheritance cannot
+    drift apart.
+    """
+    existing = tuple(passed or ())
+    if descriptor in existing:
+        return existing
+    return existing + (descriptor,)
 
 
 def _preexec_for_profile(profile: str) -> "Callable[[], None] | None":
@@ -6469,6 +6580,24 @@ def _resolve_spawn_target(
     return found
 
 
+def _absolutely_rooted_path(env: "Mapping[str, str] | None") -> "dict[str, str]":
+    """A copy of *env* whose ``PATH`` keeps only its absolute entries.
+
+    For resolving a command when the child's working directory is pinned by
+    descriptor: a relative entry (``''``, ``.``, ``tools``) is resolved against that
+    directory, which is the one place the pin says not to trust by name. Dropping
+    them can leave ``PATH`` empty, and that is the intended outcome -- the resolve
+    then raises ``FileNotFoundError`` exactly as an unresolvable command already
+    did, rather than silently searching somewhere else.
+    """
+    source = dict(env if env is not None else os.environ)
+    raw = source.get("PATH") or os.defpath
+    source["PATH"] = os.pathsep.join(
+        entry for entry in raw.split(os.pathsep) if entry and os.path.isabs(entry)
+    )
+    return source
+
+
 def _needs_path_search(argv: "Sequence[str]") -> bool:
     """Whether ``argv[0]`` is a bare name, i.e. whether resolution touches disk."""
     name = argv[0]
@@ -6478,6 +6607,7 @@ def _needs_path_search(argv: "Sequence[str]") -> bool:
 async def create_subprocess_limited(
     *argv: str,
     profile: str = RLIMIT_PROFILE_TOOL,
+    chdir_fd: int | None = None,
     **kwargs: Any,
 ) -> asyncio.subprocess.Process:
     """``asyncio.create_subprocess_exec`` with resource limits applied post-exec.
@@ -6490,6 +6620,26 @@ async def create_subprocess_limited(
     The returned ``Process`` describes the command itself, not a wrapper -- the
     shim ``exec``s in place -- so ``pid``, ``returncode``, signal delivery, and
     ``platform_compat.kill_process_tree`` all behave as they did before.
+
+    ``chdir_fd`` pins the child's working directory to a directory IDENTITY
+    rather than to a name: the descriptor is inherited, the shim ``fchdir``s into
+    it and closes it, and only then is the command exec'd. Callers pass it when a
+    pathname re-resolved in the child could be retargeted between the check and
+    the chdir. It is deliberately not spelled ``cwd="/dev/fd/<n>"`` -- that is a
+    Linux-only trick, and macOS refuses ``chdir()`` on those entries (``EACCES`` or
+    ``ENOTDIR`` depending on the OS version). It needs the shim, and is refused rather than quietly downgraded
+    to ``cwd``'s pathname when the shim is missing: entering a name nobody
+    re-verified would reopen the window the descriptor exists to close.
+
+    Setting it also DROPS ``cwd`` from the spawn, since ``Popen`` would otherwise
+    chdir that pathname in the fork child before the shim ever runs, and narrows
+    ``PATH`` to its ABSOLUTE entries -- for the search that resolves a bare command
+    name here AND for the child's own environment. ``execvpe`` resolved a relative
+    entry against the child's cwd, the directory this descriptor exists to distrust,
+    and resolving ``argv[0]`` is not the last lookup that happens: the wrapper this
+    spawns looks its own target up on ``PATH`` after the shim has entered that
+    directory. ``PATH=.:/usr/bin`` would otherwise exec a binary out of the agent's
+    own workspace, ahead of the sandbox meant to contain it.
     """
     if "preexec_fn" in kwargs:
         raise TypeError(
@@ -6500,12 +6650,53 @@ async def create_subprocess_limited(
         raise ValueError("create_subprocess_limited requires a command")
     prefix = spawn_shim_argv(profile)
     if not prefix:
+        if chdir_fd is not None:
+            raise RuntimeError(
+                "a descriptor-pinned working directory requires the post-exec "
+                "spawn shim; refusing to enter an unverified pathname instead"
+            )
         # No shim (Windows, a no-op profile, or a truncated install): keep
         # whatever policy the profile carries on the legacy fork path. Dropping
         # the caps silently would be worse than the fork hazard.
         return await asyncio.create_subprocess_exec(
             *argv, preexec_fn=_preexec_for_profile(profile), **kwargs
         )
+    search_cwd = kwargs.get("cwd")
+    search_env = kwargs.get("env")
+    if chdir_fd is not None:
+        prefix = _shim_prefix_entering_fd(prefix, chdir_fd)
+        kwargs["pass_fds"] = _pass_fds_including(kwargs.get("pass_fds"), chdir_fd)
+        # THE INVARIANT: while the cwd is pinned by descriptor, NO resolution of a
+        # program name -- not the one below, and not one the child performs later --
+        # may consult a relative PATH entry or the pinned directory. Three things
+        # enforce it together, and each was a hole on its own:
+        #
+        # (a) `cwd` leaves the spawn. ``Popen`` chdirs it in the fork child BEFORE it
+        #     execs the shim, so leaving it in place would resolve the very pathname
+        #     the descriptor exists to bypass -- and fail the spawn outright
+        #     (EACCES/ENOENT/ENOTDIR) if that name was removed or retargeted since the
+        #     bind, with the pinned descriptor never reached.
+        # (b) The search below gets no cwd and an absolute-only PATH. A bare name IS
+        #     the normal shape here -- the macOS sandbox wrapper hands back "env" as
+        #     argv[0] and the Linux cgroup wrapper hands back "systemd-run" -- so the
+        #     search cannot simply be refused, and `execvpe` resolved a relative entry
+        #     against the child's cwd, i.e. the pinned workspace.
+        # (c) The CHILD gets that same absolute-only PATH. Resolving argv[0] here is
+        #     not the last resolution that happens: `env` looks `sandbox-exec` up on
+        #     PATH itself, inside the child, after the shim has already entered the
+        #     workspace. Narrowing only (b) left `PATH=.:/usr/bin` exec'ing a
+        #     `sandbox-exec` the agent dropped in its own workspace -- ahead of the
+        #     sandbox that was supposed to contain it. One sanitized PATH, used for
+        #     both, is what makes the invariant hold rather than move down a level.
+        #
+        # Those two wrapper names are spelled in prose on purpose: test_spawn_audit
+        # matches its routed-through-the-sandbox tokens against this function's raw
+        # source, comments included, so writing either identifier here would make the
+        # spawn chokepoint read as if it routed on its own behalf.
+        kwargs.pop("cwd", None)
+        search_cwd = None
+        search_env = _absolutely_rooted_path(search_env)
+        kwargs["env"] = search_env
     if not _needs_path_search(argv):
         # Explicit path: nothing to resolve, so no filesystem access and no
         # thread hop -- exec does the work.
@@ -6514,9 +6705,7 @@ async def create_subprocess_limited(
         # A PATH search stats every entry, so it runs off the loop. One stalled
         # NFS/autofs entry would otherwise freeze the gateway -- and the search it
         # replaces used to happen in the child, never in this process.
-        resolved = await asyncio.to_thread(
-            _resolve_spawn_target, argv, kwargs.get("env"), kwargs.get("cwd")
-        )
+        resolved = await asyncio.to_thread(_resolve_spawn_target, argv, search_env, search_cwd)
     return await asyncio.create_subprocess_exec(
         *prefix, resolved, *argv[1:], preexec_fn=None, **kwargs
     )

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -901,6 +901,67 @@ class TestSpawnStderrDrainCleanup:
 
 
 @pytest.mark.asyncio
+async def test_unbound_client_session_cwd_is_the_spawn_pathname(tmp_path):
+    """Off macOS nothing binds, so there is no descriptor to re-verify."""
+    client = AcpClient(work_dir=tmp_path)
+
+    assert client._bound_workspace_fd is None
+    assert await client._session_work_dir() == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_bound_client_session_cwd_is_read_off_the_descriptor(tmp_path, monkeypatch):
+    """The sibling of AcpRuntime._session_work_dir: same rule, same reason.
+
+    session/new and session/load carry a cwd STRING the peer re-resolves, so the
+    bind-time spelling -- the one a symlink swap controls -- is re-verified and
+    replaced with the descriptor's own name before it is handed over.
+    """
+    client = AcpClient(work_dir=tmp_path)
+    client._bound_workspace_fd = 81
+    client._spawn_work_dir = str(tmp_path)
+    target = AsyncMock(return_value="/canonical/workspace")
+    monkeypatch.setattr(acp_client, "resolve_bound_session_workspace", target)
+
+    assert await client._session_work_dir() == "/canonical/workspace"
+    target.assert_awaited_once_with(81, str(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_bound_client_session_cwd_fails_rather_than_handing_over_the_spelling(
+    tmp_path, monkeypatch
+):
+    """A workspace that no longer names the bound identity is not a fallback."""
+    client = AcpClient(work_dir=tmp_path)
+    client._bound_workspace_fd = 82
+    client._spawn_work_dir = str(tmp_path)
+    monkeypatch.setattr(
+        acp_client,
+        "resolve_bound_session_workspace",
+        AsyncMock(side_effect=acp_client.BoundWorkspaceMismatch("not-bound")),
+    )
+
+    with pytest.raises(AcpError, match="exact workspace"):
+        await client._session_work_dir()
+
+
+@pytest.mark.asyncio
+async def test_bound_client_session_cwd_fails_when_the_name_cannot_be_read(tmp_path, monkeypatch):
+    """Fail closed, for the same reason bound_agent_workspace_target raises."""
+    client = AcpClient(work_dir=tmp_path)
+    client._bound_workspace_fd = 83
+    client._spawn_work_dir = str(tmp_path)
+    monkeypatch.setattr(
+        acp_client,
+        "resolve_bound_session_workspace",
+        AsyncMock(side_effect=OSError("no F_GETPATH here")),
+    )
+
+    with pytest.raises(AcpError, match="Cannot verify"):
+        await client._session_work_dir()
+
+
+@pytest.mark.asyncio
 async def test_failed_live_spawn_cleanup_releases_workspace_when_kill_is_cancelled(tmp_path):
     client = AcpClient(work_dir=tmp_path)
     client._bound_workspace_fd = 74

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -1086,17 +1086,26 @@ async def test_runtime_spawn_passes_installed_path_through_exact_wrappers(
 
 
 @pytest.mark.asyncio
-async def test_bound_macos_runtime_reuses_descriptor_cwd_for_sessions(monkeypatch, tmp_path):
+async def test_bound_macos_runtime_hands_sessions_the_verified_pathname(monkeypatch, tmp_path):
+    """The ACP peer resolves this name itself, so it must be a name it can resolve.
+
+    It is returned only after the descriptor proves it still names the bound
+    identity. The earlier "/dev/fd/<n>" spelling is not resolvable on macOS -- the
+    only platform that binds -- so it reached the peer as an unusable cwd.
+    """
     import kiro_crew.acp.runtime as runtime_mod
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 71
-    runtime._spawn_work_dir = "/dev/fd/71"
-    matches = MagicMock(return_value=True)
-    monkeypatch.setattr(runtime_mod, "bound_agent_workspace_matches", matches)
+    runtime._spawn_work_dir = str(tmp_path)
+    target = AsyncMock(return_value="/canonical/workspace")
+    monkeypatch.setattr(runtime_mod, "resolve_bound_session_workspace", target)
 
-    assert await runtime._session_work_dir(tmp_path) == "/dev/fd/71"
-    matches.assert_called_once_with(71, tmp_path)
+    # The DESCRIPTOR's own name, not the pathname the caller asked with: the peer
+    # re-resolves what it is handed, so the caller's spelling would leave the
+    # retarget window open.
+    assert await runtime._session_work_dir(tmp_path) == "/canonical/workspace"
+    target.assert_called_once_with(71, tmp_path)
 
 
 @pytest.mark.asyncio
@@ -1105,14 +1114,14 @@ async def test_bound_macos_runtime_rejects_descendant_session_workspace(monkeypa
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 71
-    runtime._spawn_work_dir = "/dev/fd/71"
+    runtime._spawn_work_dir = str(tmp_path)
     descendant = tmp_path / "packages" / "app"
-    matches = MagicMock(return_value=False)
-    monkeypatch.setattr(runtime_mod, "bound_agent_workspace_matches", matches)
+    target = AsyncMock(side_effect=runtime_mod.BoundWorkspaceMismatch(str(descendant)))
+    monkeypatch.setattr(runtime_mod, "resolve_bound_session_workspace", target)
 
     with pytest.raises(AcpRuntimeError, match="exact workspace"):
         await runtime._session_work_dir(descendant)
-    matches.assert_called_once_with(71, descendant)
+    target.assert_awaited_once_with(71, descendant)
 
 
 @pytest.mark.asyncio
@@ -1121,8 +1130,12 @@ async def test_bound_macos_runtime_rejects_different_session_workspace(monkeypat
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 72
-    runtime._spawn_work_dir = "/dev/fd/72"
-    monkeypatch.setattr(runtime_mod, "bound_agent_workspace_matches", MagicMock(return_value=False))
+    runtime._spawn_work_dir = str(tmp_path)
+    monkeypatch.setattr(
+        runtime_mod,
+        "resolve_bound_session_workspace",
+        AsyncMock(side_effect=runtime_mod.BoundWorkspaceMismatch("retargeted")),
+    )
 
     with pytest.raises(AcpRuntimeError, match="exact workspace"):
         await runtime._session_work_dir(tmp_path / "retargeted")
@@ -1134,7 +1147,7 @@ async def test_kill_cancellation_still_releases_bound_workspace(monkeypatch, tmp
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 73
-    runtime._spawn_work_dir = "/dev/fd/73"
+    runtime._spawn_work_dir = str(tmp_path)
     entered = asyncio.Event()
     closed: list[int] = []
 

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -415,8 +415,87 @@ class TestBuildSeatbeltProfile:
 
         path, descriptor = sandbox_mod.bind_voice_safe_agent_workspace("/mutable/workspace")
 
-        assert (path, descriptor) == ("/dev/fd/41", 41)
+        # The pathname comes back UNCHANGED, with the descriptor beside it. The
+        # earlier spelling returned "/dev/fd/41" as the spawn's cwd, which only
+        # Linux can chdir -- on macOS, the one platform that binds, every spawn
+        # died with EACCES. The descriptor now travels as create_subprocess_limited's
+        # ``chdir_fd`` and is entered with fchdir instead.
+        assert (path, descriptor) == ("/mutable/workspace", 41)
+        assert "/dev/fd" not in path
         assert closed == [42]
+
+    def test_bound_session_target_is_read_off_the_descriptor(self, monkeypatch, tmp_path):
+        """A peer that can only take a pathname gets the DESCRIPTOR's own name.
+
+        Handing back the caller's spelling would leave a same-UID retarget between
+        this check and the peer's own resolution, which is the window the binding
+        exists to close.
+        """
+        monkeypatch.setattr(
+            sandbox_mod, "_bound_agent_workspace_matches", lambda *_args: True
+        )
+        monkeypatch.setattr(
+            "kiro_crew.hooks._fd_real_path", lambda _fd: "/canonical/workspace"
+        )
+
+        assert (
+            sandbox_mod.bound_agent_workspace_target(41, "/mutable/workspace")
+            == "/canonical/workspace"
+        )
+
+    def test_bound_session_target_is_none_for_a_workspace_that_is_not_bound(self, monkeypatch):
+        monkeypatch.setattr(
+            sandbox_mod, "_bound_agent_workspace_matches", lambda *_args: False
+        )
+
+        assert sandbox_mod.bound_agent_workspace_target(41, "/other/workspace") is None
+
+    def test_bound_session_target_fails_closed_when_the_name_cannot_be_read(self, monkeypatch):
+        """No fallback to the mutable pathname: that is the string under attack."""
+        monkeypatch.setattr(
+            sandbox_mod, "_bound_agent_workspace_matches", lambda *_args: True
+        )
+        monkeypatch.setattr("kiro_crew.hooks._fd_real_path", lambda _fd: None)
+
+        with pytest.raises(OSError):
+            sandbox_mod.bound_agent_workspace_target(41, "/mutable/workspace")
+
+    @pytest.mark.asyncio
+    async def test_shared_session_resolver_substitutes_the_descriptor_name(self, monkeypatch):
+        """One rule for both ACP front ends, so the two halves cannot drift."""
+        monkeypatch.setattr(
+            sandbox_mod, "bound_agent_workspace_target", lambda *_args: "/canonical/workspace"
+        )
+
+        resolved = await sandbox_mod.resolve_bound_session_workspace(41, "/mutable/workspace")
+
+        assert resolved == "/canonical/workspace"
+
+    @pytest.mark.asyncio
+    async def test_shared_session_resolver_raises_on_a_workspace_that_is_not_bound(
+        self, monkeypatch
+    ):
+        """A distinct error, so each caller maps it to its own type without restating it."""
+        monkeypatch.setattr(sandbox_mod, "bound_agent_workspace_target", lambda *_args: None)
+
+        with pytest.raises(sandbox_mod.BoundWorkspaceMismatch):
+            await sandbox_mod.resolve_bound_session_workspace(41, "/other/workspace")
+
+    @pytest.mark.asyncio
+    async def test_shared_session_resolver_runs_off_the_event_loop(self, monkeypatch):
+        """It opens a directory and reads a descriptor's name on every session start."""
+        loop_thread = threading.get_ident()
+        ran_on: list[int] = []
+
+        def record(_descriptor, _workspace):
+            ran_on.append(threading.get_ident())
+            return "/canonical/workspace"
+
+        monkeypatch.setattr(sandbox_mod, "bound_agent_workspace_target", record)
+
+        await sandbox_mod.resolve_bound_session_workspace(41, "/mutable/workspace")
+
+        assert ran_on and ran_on[0] != loop_thread
 
     def test_macos_workspace_binding_rejects_opened_runtime_ancestor(self, monkeypatch):
         monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")

--- a/test/test_spawn_exec_shim.py
+++ b/test/test_spawn_exec_shim.py
@@ -138,6 +138,58 @@ class TestShimArgvContract:
             shim.main(["--rlimits=RLIMIT_NOFILE:1024", "--oom-bias", "--", "/bin/true"])
         assert order == ["limits", "oom", "exec"]
 
+    def test_a_malformed_chdir_fd_is_refused_rather_than_ignored(self, capsys):
+        # Ignoring it would exec in whatever cwd was inherited -- a directory the
+        # caller never authorized -- which is exactly what the pin exists to stop.
+        assert shim.main(["--chdir-fd=not-a-number", "--", "/bin/true"]) == 127
+        assert "bad --chdir-fd=" in capsys.readouterr().err
+        assert shim.main(["--chdir-fd=-1", "--", "/bin/true"]) == 127
+        assert "bad --chdir-fd=" in capsys.readouterr().err
+
+    def test_an_unenterable_chdir_fd_never_reaches_exec(self, capsys):
+        """Fail the spawn rather than run the command in the wrong directory."""
+        not_a_directory = os.open(os.devnull, os.O_RDONLY)
+        execs: list[tuple] = []
+        try:
+            with patch.object(shim.os, "execv", lambda *args: execs.append(args)):
+                rc = shim.main([f"--chdir-fd={not_a_directory}", "--", "/bin/true"])
+        finally:
+            os.close(not_a_directory)
+        assert rc == 127
+        assert execs == []
+        assert "cannot enter bound directory" in capsys.readouterr().err
+
+    def test_the_bound_directory_is_entered_before_the_limits(self):
+        """A tight RLIMIT_AS must not be able to break the fchdir's error path."""
+        order: list[str] = []
+        with (
+            patch.object(shim, "_enter_bound_directory", lambda _fd: order.append("chdir") or True),
+            patch.object(shim, "_apply_rlimits", lambda _p: order.append("limits")),
+            patch.object(
+                shim.os,
+                "execv",
+                lambda *_a: order.append("exec") or (_ for _ in ()).throw(OSError(2, "x")),
+            ),
+        ):
+            shim.main(["--rlimits=RLIMIT_NOFILE:1024", "--chdir-fd=9", "--", "/bin/true"])
+        assert order == ["chdir", "limits", "exec"]
+
+    def test_entering_a_bound_directory_closes_the_descriptor(self, tmp_path, monkeypatch):
+        """The command must not inherit a handle that outlives the parent's check."""
+        # monkeypatch.chdir, not a bare os.chdir with a manual restore: the cwd is
+        # process-wide state shared with every other test on this worker, and only
+        # the fixture guarantees it reverts when the assertion below fails.
+        monkeypatch.chdir(tmp_path)
+        descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+        closed: list[int] = []
+        try:
+            with patch.object(shim.os, "close", closed.append):
+                assert shim._enter_bound_directory(descriptor) is True
+            assert os.path.realpath(os.getcwd()) == os.path.realpath(str(tmp_path))
+            assert closed == [descriptor]
+        finally:
+            os.close(descriptor)
+
     def test_oom_bias_only_when_requested(self):
         biased: list[bool] = []
         with (
@@ -300,6 +352,123 @@ class TestCreateSubprocessLimited:
         assert spawn.await_args.args == ("/bin/true",)
 
     @pytest.mark.asyncio
+    async def test_chdir_fd_rides_the_shim_and_is_inherited_by_it(self):
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("/bin/true", cwd="/tmp", chdir_fd=9, pass_fds=(7,))
+        args = spawn.await_args.args
+        # Ahead of the separator, so the shim reads it as its own option.
+        assert args.index("--chdir-fd=9") < args.index("--")
+        assert strip_spawn_shim(args) == ("/bin/true",)
+        # The shim can only fchdir a descriptor the child actually holds, and
+        # pass_fds is what carries it past _close_open_fds.
+        assert spawn.await_args.kwargs["pass_fds"] == (7, 9)
+        # cwd is DROPPED from the spawn: Popen would chdir it in the fork child
+        # before the shim runs, resolving the very name the descriptor bypasses.
+        assert "cwd" not in spawn.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_never_resolves_a_command_inside_the_pinned_directory(self, tmp_path):
+        """A bare name is the NORMAL shape here, so the search is narrowed, not refused.
+
+        wrap_argv hands back "env" on macOS and cgroup_scope_argv hands back
+        "systemd-run", so a pinned spawn does search PATH. ``execvpe`` resolved a
+        relative entry against the child's cwd -- the pinned workspace -- so a planted
+        copy there must lose to the absolute entry.
+        """
+        planted = tmp_path / "tools"
+        planted.mkdir()
+        (planted / "mytool").write_text("#!/bin/sh\nexit 9\n")
+        (planted / "mytool").chmod(0o755)
+        real_dir = tmp_path / "real-bin"
+        real_dir.mkdir()
+        real = real_dir / "mytool"
+        real.write_text("#!/bin/sh\n")
+        real.chmod(0o755)
+
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited(
+                "mytool",
+                cwd=str(tmp_path),
+                chdir_fd=9,
+                env={"PATH": os.pathsep.join(["tools", "", ".", str(real_dir)])},
+            )
+        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
+        assert "cwd" not in spawn.await_args.kwargs
+        # The CHILD gets the same absolute-only PATH. Resolving argv[0] here is not
+        # the last lookup: the wrapper this spawns looks its own target up on PATH
+        # after the shim has entered the pinned workspace, so a relative entry left
+        # in the child's environment would exec out of that directory one level down.
+        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+
+    @pytest.mark.asyncio
+    async def test_an_unpinned_spawn_keeps_its_env_untouched(self):
+        """The PATH narrowing is scoped to a pinned spawn, environment included."""
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("/bin/true", env={"PATH": "tools:/usr/bin"})
+        assert spawn.await_args.kwargs["env"]["PATH"] == "tools:/usr/bin"
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_narrows_the_child_path_even_with_no_env_passed(self, monkeypatch):
+        """A caller that passes no env still must not hand the child a relative entry."""
+        monkeypatch.setenv("PATH", os.pathsep.join([".", "/usr/bin"]))
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("/bin/true", chdir_fd=9)
+        assert spawn.await_args.kwargs["env"]["PATH"] == "/usr/bin"
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_with_only_relative_path_entries_resolves_nothing(self, tmp_path):
+        """Dropping every entry is the intended fail-closed outcome, not a fallback."""
+        planted = tmp_path / "tools"
+        planted.mkdir()
+        (planted / "mytool").write_text("#!/bin/sh\n")
+        (planted / "mytool").chmod(0o755)
+        with patch("asyncio.create_subprocess_exec", AsyncMock()):
+            with pytest.raises(FileNotFoundError):
+                await create_subprocess_limited(
+                    "mytool", cwd=str(tmp_path), chdir_fd=9, env={"PATH": "tools:.:"}
+                )
+
+    @pytest.mark.asyncio
+    async def test_an_unpinned_spawn_still_resolves_a_relative_path_entry(self, tmp_path):
+        """The refusal is scoped to a pinned spawn; ordinary callers are unchanged."""
+        tools = tmp_path / "tools"
+        tools.mkdir()
+        tool = tools / "mytool"
+        tool.write_text("#!/bin/sh\n")
+        tool.chmod(0o755)
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("mytool", cwd=str(tmp_path), env={"PATH": "tools"})
+        assert strip_spawn_shim(spawn.await_args.args) == (str(tool),)
+        assert spawn.await_args.kwargs["cwd"] == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_is_refused_when_no_shim_can_carry_it(self):
+        """Downgrading to cwd's pathname would reopen the window the pin closes."""
+        with (
+            patch.object(sandbox, "_SPAWN_SHIM_CODE", ""),
+            patch("asyncio.create_subprocess_exec", AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="descriptor-pinned"):
+                await create_subprocess_limited("/bin/true", chdir_fd=9)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_does_not_leak_into_the_cached_profile_prefix(self):
+        """The prefix is cached per profile; a descriptor belongs to one spawn."""
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("/bin/true", chdir_fd=9)
+            first = spawn.await_args.args
+            await create_subprocess_limited("/bin/true")
+            second = spawn.await_args.args
+        assert "--chdir-fd=9" in first
+        assert not any(item.startswith("--chdir-fd=") for item in second)
+
+    @pytest.mark.asyncio
     async def test_forwards_every_other_keyword_untouched(self):
         spawn = AsyncMock()
         with patch("asyncio.create_subprocess_exec", spawn):
@@ -310,6 +479,123 @@ class TestCreateSubprocessLimited:
         assert kwargs["cwd"] == "/tmp"
         assert kwargs["env"] == {"A": "1"}
         assert kwargs["start_new_session"] is True
+
+
+# --------------------------------------------------------------------------
+# Descriptor-pinned working directory (macOS workspace binding)
+# --------------------------------------------------------------------------
+
+
+@posix_only
+class TestDescriptorPinnedWorkingDirectory:
+    """The child lands in the directory the parent VERIFIED, not in a name.
+
+    The regression this pins reached a packaged build: the verified descriptor was
+    handed to the spawn as ``cwd="/dev/fd/<n>"``. Linux publishes those entries as
+    symlinks to the target, so it happened to work there; macOS -- the only
+    platform that binds a workspace at all -- fails ``chdir()`` on them with
+    EACCES, so every agent spawn died with
+    ``PermissionError: [Errno 13] Permission denied: '/dev/fd/25'``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_child_enters_the_pinned_directory_even_after_a_retarget(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        decoy = tmp_path / "decoy"
+        decoy.mkdir()
+        name = tmp_path / "workspace"
+        name.symlink_to(real)
+
+        descriptor = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            # The same-UID retarget the binding exists to survive: it lands
+            # between the parent's check and the child's own resolution.
+            name.unlink()
+            name.symlink_to(decoy)
+            proc = await create_subprocess_limited(
+                sys.executable,
+                "-I",
+                "-S",
+                "-c",
+                "import os; print(os.getcwd())",
+                stdout=asyncio.subprocess.PIPE,
+                cwd=str(name),
+                chdir_fd=descriptor,
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+            )
+            stdout, _ = await proc.communicate()
+        finally:
+            os.close(descriptor)
+
+        assert proc.returncode == 0
+        assert stdout.decode().strip() == os.path.realpath(str(real))
+
+    @pytest.mark.asyncio
+    async def test_child_still_starts_when_the_name_is_gone_after_the_bind(self, tmp_path):
+        """The pinned descriptor must be the ONLY thing that decides the cwd.
+
+        Popen chdirs to ``cwd`` before exec'ing the shim, so a pathname that stopped
+        naming a directory after the bind used to fail the spawn outright -- the
+        descriptor was never reached.
+        """
+        real = tmp_path / "real"
+        real.mkdir()
+        name = tmp_path / "workspace"
+        name.symlink_to(real)
+
+        descriptor = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            # Not merely retargeted: gone. A pathname-based chdir has nothing left
+            # to resolve, while the descriptor still names the same directory.
+            name.unlink()
+            proc = await create_subprocess_limited(
+                sys.executable,
+                "-I",
+                "-S",
+                "-c",
+                "import os; print(os.getcwd())",
+                stdout=asyncio.subprocess.PIPE,
+                cwd=str(name),
+                chdir_fd=descriptor,
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+            )
+            stdout, _ = await proc.communicate()
+        finally:
+            os.close(descriptor)
+
+        assert proc.returncode == 0
+        assert stdout.decode().strip() == os.path.realpath(str(real))
+
+    @pytest.mark.asyncio
+    async def test_the_pinned_descriptor_is_not_inherited_by_the_command(self, tmp_path):
+        """The shim closes it once it stands in the directory."""
+        descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        probe = (
+            "import os\n"
+            "try:\n"
+            f"    os.fstat({descriptor})\n"
+            "except OSError:\n"
+            "    print('closed')\n"
+            "else:\n"
+            "    print('inherited')\n"
+        )
+        try:
+            proc = await create_subprocess_limited(
+                sys.executable,
+                "-I",
+                "-S",
+                "-c",
+                probe,
+                stdout=asyncio.subprocess.PIPE,
+                chdir_fd=descriptor,
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+            )
+            stdout, _ = await proc.communicate()
+        finally:
+            os.close(descriptor)
+
+        assert stdout.decode().strip() == "closed"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What broke

On a packaged macOS build off current `main`, **every** agent spawn fails. Any new chat message produces:

```
PermissionError: [Errno 13] Permission denied: '/dev/fd/25'
  ... acp/runtime.py:1267 in _spawn_admitted
  ... sandbox.py:6520 in create_subprocess_limited
  ... subprocess.py:1955 in _execute_child
```

`subprocess`'s child reports a failed `chdir(cwd)` under the *cwd's* own name (the `noexec:chdir` branch of `_execute_child`), so that path is the working directory the spawn was given — not the executable.

## Why

`bind_voice_safe_agent_workspace` (added in #6746) opened the macOS agent workspace, verified its ancestry by descriptor, and then handed the descriptor to the spawn **as a pathname**: `cwd="/dev/fd/<n>"`. Linux publishes `/dev/fd` as symlinks into `/proc/self/fd`, so `chdir()` there resolves to the target. macOS does not: `/dev/fd/<n>` is a devfs `fdesc` node, and `chdir()` on it fails. The binding is darwin-only, CI runs Linux and Windows, and the tests asserted the literal `"/dev/fd/41"` string with `sys.platform` monkeypatched — so nothing ever executed this on the one platform it runs on.

`transcribe.py` already documents the same macOS limitation for the exec side ("its Mach-O loader does not reliably execute an unlinked file through `/dev/fd`"), which is the same constraint arriving from the other direction.

Two spawn sites were affected (`AcpRuntime._spawn_admitted`, `AcpClient._spawn`), plus `AcpRuntime._session_work_dir`, which sent the same `/dev/fd/<n>` spelling to the ACP peer as its `session/new` cwd — so fixing only the spawn would have failed again one step later.

## The fix

Keep the binding — descriptor-based ancestry comparison is what closes the check/use window a pathname-only overlap check leaves open — and stop expressing it as a pathname. The descriptor now travels *beside* the path:

- **`_spawn_exec_shim.py`** takes `--chdir-fd=<n>`: it `fchdir`s into the inherited descriptor and closes it, then `exec`s the command. Nothing re-resolves the name, and the agent does not inherit a directory handle that outlives the check. A malformed or unenterable descriptor fails the spawn (127) rather than exec'ing in whatever cwd was inherited. It runs ahead of `setrlimit`, like every other allocating step, so a tight `RLIMIT_AS` cannot break its own error path.
- **`create_subprocess_limited`** grows `chdir_fd`, which inserts that flag into the shim prefix (copied, not mutated — the prefix is cached per profile) and adds the descriptor to `pass_fds`, which is what carries it past `_close_open_fds` and clears the `O_CLOEXEC` the binder opens with. When no shim can carry it, the call is **refused, not downgraded** to `cwd`'s pathname: entering a name nobody re-verified would reopen the window the pin exists to close.
  It also enforces one invariant while that cwd is pinned: **no resolution of a program name — not the one this function performs, and not one the child performs later — may consult a relative `PATH` entry or the pinned directory.** Three things enforce it, and each was a hole on its own:

  | Enforced by | Why it is needed |
  |---|---|
  | `cwd` leaves the spawn | `Popen` chdirs it in the fork child *before* exec'ing the shim, so a name removed or retargeted since the bind fails the spawn outright with the descriptor never reached |
  | the parent's `PATH` search gets no cwd and absolute entries only | `execvpe` resolved a relative entry against the child's cwd, and a bare `argv[0]` is the normal shape here (the macOS sandbox wrapper hands back `env`, the Linux cgroup wrapper `systemd-run`) |
  | the **child** gets that same absolute-only `PATH` | resolving `argv[0]` is not the last lookup: the wrapper looks its own target up on `PATH` inside the child, *after* the shim has entered the workspace |
- **`bind_voice_safe_agent_workspace`** returns the workspace pathname alongside the descriptor.
- **`AcpRuntime._session_work_dir`** hands the peer the **bound descriptor's own name**, read back off the descriptor by the new `sandbox.bound_agent_workspace_target()` (`/proc/self/fd` on Linux, `F_GETPATH` on macOS), and only after that same call proves the requested path still names the bound identity. It fails closed rather than falling back to the caller's spelling.

- **`sandbox.resolve_bound_session_workspace`** owns that verify-then-substitute rule once. Both `AcpRuntime._session_work_dir` and `AcpClient._session_work_dir` (now `async`) call it and keep only the mapping of its one `BoundWorkspaceMismatch` to their own error type, so the two halves of the boundary cannot drift — the duplication this PR briefly introduced is gone.

### Residual limit, stated rather than implied

`session/new` carries a cwd **string** that a separate process re-resolves, and macOS has no descriptor-addressable path namespace, so nothing put in that field can bind the peer's resolution. A same-UID **rename of the canonical directory** in the window between the check and the peer's resolution stays open, and that limit is written into the code comments rather than left implied. The `/dev/fd/<n>` spelling is not an alternative: the binding is darwin-only, and macOS cannot resolve those entries — so that spelling never delivered a working session cwd at all. Closing this for real needs the ACP `cwd` contract to take something other than a re-resolved pathname.
- Both spawn sites lose their duplicated bound/unbound branch — they differed only in `creationflags`, which is `0` on POSIX, and in a `pass_fds` the helper now owns.

## Tests

11 of the added/updated assertions **fail on `main` and pass here**, including:

- two end-to-end spawns that still land the child in the bound directory — one retargets the workspace symlink between the `open` and the spawn, one **deletes the name entirely** (`TypeError: Popen.__init__() got an unexpected keyword argument 'chdir_fd'` on main);
- a spawn proving `cwd` still resolves a bare command through a relative `PATH` entry even though it no longer reaches the child;
- `bound_agent_workspace_target` returning the descriptor's own name, returning `None` for a path that is not the bound identity, and raising rather than falling back when that name cannot be read;
- the same four states on `AcpClient._session_work_dir`: unbound pathname, bound descriptor-name substitution, not-bound-identity refusal, unreadable-name refusal;
- a binary planted inside the pinned workspace losing to an absolute `PATH` entry, the child's own `env["PATH"]` carrying no relative entry, a caller passing no `env` still getting the process `PATH` narrowed, and an **unpinned** spawn's `env` left untouched;
- the shared resolver's three states plus its off-loop hop;
- a spawn proving the pinned descriptor is closed before the command runs;
- shim contract tests for a malformed and an unenterable `--chdir-fd`, and for ordering against the limits;
- the binder returning a real pathname, with an explicit `"/dev/fd" not in path`.

The end-to-end tests run on Linux CI, which is what the previous, fully-monkeypatched coverage could not do.

## Verification

- `pytest test/test_spawn_exec_shim.py test/test_sandbox_argv.py test/test_acp_runtime.py test/test_acp_client.py test/test_spawn_preexec_guard.py test/test_acp_spawn_offload.py` — 1065 passed, 3 skipped.
- Full backend suite on the rebased commit: 70,706 passed; the 102 failures are pre-existing on this host and per-file identical to a run with the change stashed (`jq` version, `/local/home` uid, `AF_UNIX` path length, CPU-count budget).
- All 15 applicable profile gates exit 0: `black` gate, `isort`, `flake8`, `mypy src/kiro_crew/`, subprocess-encoding, brand, harness parity, loop-bound locks, testpaths coverage, changelog history, focus cue, docs lint, vendor manifest, scrub lint, lockdown.
- **`Gateway Tests (macOS)` is red on `main` itself**, not from this PR: the failures are all in `test/test_mcp_gateway_adopted_daemon_repair.py` (touched by #6931, merged five minutes before this branch point), disjoint from this diff, and main's own run `33302565811` (head `901ef092b`) reports the same job `completed/failure`.

## macOS execution, by two independent reporters

I have no Darwin host, so the mechanism was verified by others on this PR:

| | @warren830 | @milichev |
|---|---|---|
| host | macOS arm64, bundled 3.12.14 + system 3.14.5 | macOS 26.6.2 arm64, bundled 3.12.14 + system 3.14.7 |
| shipped failure reproduced | yes, `EACCES` on `cwd=/dev/fd/N` | yes, **`ENOTDIR`** on `/dev/fd/26` |
| `--chdir-fd` contract works | yes, lands in the correct cwd | yes, `fchdir` works where `chdir("/dev/fd/N")` does not |
| dropping `cwd` is required | proved by a third case: `fchdir` **+** `cwd=/dev/fd/N` still fails | hit the same trap independently |

Consequences folded into this revision: **the errno is not stable** (macOS 26 gives `ENOTDIR`, so the prose no longer asserts `EACCES`), dropping `cwd` now reads as a required enforcer rather than tidiness, and @milichev's independent band-aid missing `client.py:_spawn` — the same site First Principles caught — is why the rule is hoisted into one shared resolver.

Still not executed on Darwin: this branch's own diff. Both reporters have offered to build and exercise it, which is the merge gate the Design Review asked for.



no linked issue: this macOS regression from #6746 was reported directly by a user building the desktop app off main, and was not filed as an issue.



