### PR TITLE
chore(apps): remove confirmed dead code in issue_radar and auto_improvement

### DIFF
--- a/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/github_client.py
@@ -122,13 +122,6 @@ def _gh_bin() -> str:
         raise GhSetupError(str(exc), reason="not_installed") from exc
 
 
-def _gh_env() -> dict[str, str]:
-    """A minimal environment for ``gh``: the platform's safe-key base plus gh's
-    own auth + network/TLS vars when set — NOT the gateway's full environment.
-    Owned by the shared runner so every gh surface stays in lockstep."""
-    return github_runner.gh_env()
-
-
 def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
     """Last few stderr lines, sanitized for display.
 

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -8,8 +8,8 @@ used — auth is entirely delegated to the user's own ``gh`` CLI session.
 Layout::
 
     <data_dir>/config.json                          # connected repos, no secrets
-    <data_dir>/repos/{owner}__{repo}/issues-cache.json  # last-fetched open issues
-    <data_dir>/repos/{owner}__{repo}/members-cache.json # repo members (derived)
+    <data_dir>/repos/{owner}/{repo}/issues-cache.json   # last-fetched open issues
+    <data_dir>/repos/{owner}/{repo}/members-cache.json  # repo members (derived)
 
 ``root`` is accepted on every function (mirroring code_review_sage's
 ``store.py``) so tests can point at a tmp dir instead of the real app data dir.
@@ -71,13 +71,6 @@ def _config_lock(root: Path | None = None):
     with open(lock_path, "w") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             yield
-
-
-def repo_slug_dir_name(owner: str, repo: str) -> str:
-    # Use nested directories (owner/repo) so repos whose names contain "__"
-    # don't collide.  This helper remains for migration/test use; repo_data_dir
-    # is the canonical path builder.
-    return f"{owner}/{repo}"
 
 
 # ── provider-scoped storage ─────────────────────────────────────────────────


### PR DESCRIPTION
Dead-code audit of the two largest builtin apps — `issue_radar` and `auto_improvement`, 76,436 lines of Python across 60 production files. Two symbols confirmed dead and deleted; everything else is reported below rather than removed.

## Scan method

| pass | mechanism | findings |
|---|---|---|
| 1 | `vulture --min-confidence 60` on the two app dirs | 48 |
| 2 | naive AST — defined names minus Load-ed names, reference universe = every `*.py` in the repo | — |
| 3 | tokenize — real NAME tokens only, so docstring/comment strings don't count as references | — |
| 4 | **annotation-aware AST** — re-`ast.parse` every string constant inside `AnnAssign`, `arg.annotation`, `returns`, `Subscript` slices, and `cast`/`TypeVar` args, counting names found inside | — |
| 2∩3∩4 | zero references anywhere | **9** |

Pass 4 is not optional in this repo. `from __future__ import annotations` makes every annotation a string at runtime, so `store: "_ReconcilableStore"` never becomes a NAME token and passes 1–3 cannot see it. A previous round nearly deleted a live Protocol for exactly this reason.

vulture over-reports here by ~5x, for two reasons worth recording: running it on a file subset marks any symbol whose importer sits outside the subset as unused, and it cannot see dataclass fields that travel as serialized dict keys or as frontend wire-type properties. Every one of the 48 was therefore re-confirmed repo-wide.

## Deleted (2 symbols, 11 deleted lines)

**`_gh_env()`** — `issue_radar/backend/github_client.py`:125–129

A wrapper whose whole body was `return github_runner.gh_env()`. #2407 ("extract shared hardened gh runner") moved env minimization *inside* the runner: `github_runner.run_gh` applies `env=gh_env(pin_host=…)` itself, and Issue Radar's sole gh spawn chokepoint `_gh_run` delegates there. All 13 `"gh"` argv paths in the app terminate at `_gh_run`, with no bypass — so removing the wrapper cannot weaken the credential-minimization control. Sole repo-wide word-boundary hit was its own `def`; the other textual hits are the *different* symbol `prevalidated_gh_env` and the unrelated test name `test_spawn_env_is_exactly_gh_env`. Not in `__all__`, no dynamic dispatch, no test. Introduced 2026-07-24 (#314, 37d), orphaned 2026-08-09 — superseded, not born dead.

**`repo_slug_dir_name()`** — `issue_radar/backend/store.py`:76–80

Superseded by `repo_data_dir` (:142), which builds the same nested `repos/{owner}/{repo}` and is used by ~20 call sites — none used this. Its own comment claimed it "remains for migration/test use", but no test and no migration code referenced it, and `store.py`:1740 records that nothing needs migrating. Single repo-wide hit; no quoted form, no dynamic dispatch, not on any public surface. Introduced 2026-07-24 (#314, 37d), never modified since.

**Paired prose fix.** The `store.py` module header documented the abandoned `repos/{owner}__{repo}` layout — already false against `repo_data_dir`, and the deleted helper's comment was the only thing explaining the `__` form away. Corrected to `repos/{owner}/{repo}` rather than left knowingly wrong. The section comment at :78 already said the nested form, so no other prose in the file still refers to the old layout.

Residual-reference check after deletion: `git grep -nw` for both names across `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1` returns exit 1. Neither appears in `website/src/`, `app.json`, `app-registry.json`, `config-baseline.json`, `error-code-baseline.json`, `docs/system-specs/`, `builtin_skills/`, or `.github/`. No import became unused (`github_runner` keeps 7 uses).

## Blocked by the 30-day new-code gate (10 items, ~250 lines)

Not deletable in a chore branch. Two were **born dead in the same PR as their own replacement** — those belong back with the original author, not in a cleanup commit.

| symbol | file:line | age | note |
|---|---|---|---|
| `USAGE_SUMS` | `pipeline_fold.py`:1244 | **1d** (#6672) | Born dead alongside its replacement — the fold sums the same 7 fields explicitly at :1421–1428. |
| `turns` row field | `pipeline_fold.py`:1272, write at :1429 | **1d** (#6672) | Write-only accumulator; `to_dict`:1291 deliberately emits `"turns": self.rows`. |
| `update_issue_comment` | `github_client.py`:3045–3092 | 24d | Test-only (5 sites). |
| `find_crew_claim` | `github_client.py`:3447–3495 | 24d | Test-only (~24 sites); deletion cascades to exclusive helpers `_CREW_CLAIM_MARKER_RE`, `_FIELD_RE`, `_ISO_Z_RE`, `_parse_crew_marker` (~105 lines total). |
| `create_pull_request` | `github_client.py`:2833–2897 | 24d | Test-only (6 sites); `pr_recipe.py` holds a separate parallel implementation. |
| `upsert_work_item` | `crew_store.py`:825–845 | 24d | Test-only (~45 sites). Production deliberately bypasses it via `_upsert_work_item_locked` — re-entering the crew file lock from the same thread self-deadlocks. |
| `compose_turn_prompt` | `crew_runtime.py`:375–395 | 24d | Test-only; the async twin is the production path and does **not** delegate to the sync form. `:496` is a signature-parity test pinning the pair. |
| `pin_attributes` | `spine/git_safety.py`:281 | 24d | Also public surface and a guard — see below. |
| `self_clone_src` | `spine/gate.py`:385 | 24d | Also half-wired; born in the same PR as the staging method that replaced it. |
| `if True:` block | `spine/driver.py`:1501 | 24d | Genuinely dead — a literal `True` cannot be a defensive re-check, it is refactor residue. Removal is a pure dedent of :1502–1519. Hold until 2026-09-05. |

## Deferred — test-only, no production caller (refactor, not deletion)

The five test-only `github_client`/`crew_store`/`crew_runtime` symbols above, plus `configured_clone` (`pr_watchers.py`:1497), `SpineDriver.preflight_result` (`driver.py`:232/:366) and `AgentResult.duration_s` (`agent_runner.py`:70 — 20 production write sites but reads only in tests; sibling `cost_usd` *is* consumed, so this is an asymmetric result-contract gap where deletion would touch 20 call sites for no gain).

## Alive — scanner false positives worth recording

`Candidate.evidence` (read at `routes.py`:672, declared in `FindingDetail.tsx`:34) · `Candidate.confidence` (carried into `candidates/<id>.json`, the stated operator-inspection artifact) · `BugReproducingTest.expected_on_base`/`expected_on_fix` (serialized through `routes.py`:676) · `Ruler.measurement_constants` (a `@runtime_checkable` Protocol member — uncalled by design) · `known_loci` (not a field: a keyword-only parameter, live caller `driver.py`:464) · `app_name` (a required positional in the `AppDisableHook` signature — `apps/teardown.py`:429 calls `await hook(app)`; removing it is a `TypeError` at app-disable time) · `fam` (an unused tuple-unpack slot inside `_host_is_blocked`, the SSRF/DNS-rebinding guard).

## Needs a maintainer decision (7 items)

Each of these is a design gap that *looks* like dead code. Per the audit's own rules, guards, validators and half-wired lifecycle pairs are reported, never deleted — their deadness is the defect.

1. **`broadcast`** — `auto_improvement/backend/sse.py`:38–64. A half-wired pair with **neither end connected**. The consumer half is served (`sse.stream` → `_handle_events` → `GET /api/apps/auto-improvement/events`, with a live test), but nothing calls `broadcast` and no frontend subscribes — `EventSource` under `website/src/apps/` hits only `auto-research`. Wire the producer, or drop both halves?
2. **`VALID_STATUSES`** — `spine/ledger.py`:58. A 10-status allowlist **no code validates against** (`Ledger.record` compares individual `STATUS_*` constants; the allowlist survives only as a type comment at :207), while being cross-surface public contract — `docs/system-specs/modules/auto-improvement-test-plan.md`:339 pins it as the i18n label-map key set and `AutoImprovementPage.tsx`:91 names it as the mirror. Unvalidated status writes are possible today; the fix is a check in `record`.
3. **`TTL_ACTIVE_PHASES`** — `crew_store.py`:101. Claim-TTL expiry is agent/protocol-enforced in `crew_ledger_spec.md`:87–88 and `crew_brief.md`:291/323/331, and the frontend keeps an explicit mirror (`issue-radar/api.ts`:983) consumed only by its own test. Both code halves are dead while the markdown contract is live.
4. **`is_skipped`** — `crew_store.py`:1171–1174. **A guard predicate never wired.** `GET /crew` builds `skipped_numbers` from `read_skips` directly. The `issue_radar_crew_read` contract tells the agent to check an issue against `skipped_numbers` before investigating — this is the server-side enforcement point for that rule, currently delegated to agent judgement.
5. **`pin_attributes`** — `spine/git_safety.py`:281. Superseded by the fail-closed `require_pinned` (8 helpers call it), but it *is* the security pin, and it is named in `auto-improvement-test-plan.md`:370/372. **Separate drift found:** D-123 claims "all 8 helpers … call the shared `pin_attributes`", which the code contradicts.
6. **`RepoKey.is_default_host`** — `provider.py`:89–93. Zero refs, but its consumer **inlines the identical predicate** (`store.py`:137 `if provider == "github" and host == "github.com"`). Zero refs + an inline duplicate on the same semantic path is drift, not dead code. Sibling `is_github` *is* wired.
7. **`configured_clone`** — `pr_watchers.py`:1497. Same shape at larger scale: **9 inline duplicates** of the same read across `commit.py`, `routes.py`, `runner.py`, `profile.py`.

Half-wired pairs also noted: `Candidate.fix_diff` (in the documented §1.3 contract, zero assignments anywhere — the real fix travels on `Proposal.diff`), `CalibrationParams.drift_reanchor_cycles` and `.heldout` (both constructed twice, never read; the latter named in `README.md`:60 and `skills/metric-design/SKILL.md`:31).

## Verification

- `isort --check`, `flake8` — clean.
- `black --check` — `store.py` reformats, and **reproduces identically on unmodified `origin/main`** (py3.12 parsing py3.14-targeted code). Environmental.
- `pytest src/kiro_crew/apps/builtins/issue_radar/tests` — **929 passed**.
- `pytest test/test_issue_radar_*.py` (19 files) — 3 failed / 1328 passed, **identical totals on unmodified `origin/main`**. The two `test_issue_radar_gh_bin.py` reds are environmental (no root-owned `gh`); the one `test_issue_radar_crew_runtime.py` red is a cross-test trust-state flake that names a *different* test on each run and passes in isolation both with and without this diff.
- `auto_improvement` is unmodified, so its suites are outside the affected range.
- Two local reviewer lanes on the diff before push (`gpt-5.6-sol` on reachability and the security control, `claude-opus-4.8` on public surface and contract drift) — both **SAFE-TO-PUSH**, one Low note that the corrected header omits the non-GitHub provider subtree, which store.py's own "provider-scoped storage" section at :78 already documents.
- File-overlap gate: 237 open PRs scanned; only #5654 touches `store.py`, at hunks @@19/@@29/@@1401/@@1479 — no overlap with :8–12 or :76–80.

## Unscanned

None. All 60 production `*.py` files in both apps were parsed by passes 2–4, and all 48 vulture findings were re-confirmed repo-wide.

no linked issue: routine dead-code cleanup found by audit, not filed as an issue. The `#NNNN` references above are provenance for when each symbol was introduced or orphaned, not issues this PR closes.
