### PR TITLE
chore(apps): remove confirmed dead code in code_review_sage, dev_fleet and mochi

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -6901,21 +6901,6 @@ def _dropin_content(worktree: Path, kcbin: Path) -> str:
     )
 
 
-def _restore_dropin(dropin: Path, prior: str | None) -> bool:
-    """Restore the drop-in to its pre-cutover state after a failed cutover:
-    rewrite *prior* content, or delete the file when there was none. Returns
-    ``True`` when the on-disk state was restored; best-effort, returning
-    ``False`` on any OSError so the caller can report ``rolled_back: false``."""
-    try:
-        if prior is None:
-            dropin.unlink(missing_ok=True)
-        else:
-            gateway_service.atomic_write_text(dropin, prior)
-        return True
-    except OSError:
-        return False
-
-
 async def _find_worktree_by_path(path: str) -> tuple[dict | None, str | None]:
     """Resolve a discovered worktree by filesystem path.
 

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -2209,26 +2209,48 @@ def test_foreground_backend_is_none_off_posix(monkeypatch):
 # --------------------------------------------------------------------------
 # drop-in rollback + path selector
 # --------------------------------------------------------------------------
-def test_restore_dropin_deletes_when_there_was_none(tmp_path):
+def _systemd_backend(dropin: Path) -> gateway_service.SystemdBackend:
+    """A SystemdBackend whose drop-in path is *dropin*.
+
+    ``rollback`` touches only the injected drop-in path and the module-level
+    ``atomic_write_text``, so the remaining seams stay inert stubs.
+    """
+    return gateway_service.SystemdBackend(
+        AsyncMock(return_value=(0, "", "")),
+        lambda: "kirocrew.service",
+        platform="linux",
+        which=lambda _name: "/usr/bin/systemctl",
+        dropin_path=lambda: dropin,
+        dropin_content=lambda _wt, _kcbin: "",
+    )
+
+
+def test_service_rollback_deletes_the_dropin_when_there_was_none(tmp_path):
+    """No prior drop-in -> the file staged over it is removed, not left behind."""
     dropin = tmp_path / "make-live.conf"
     dropin.write_text("[Service]\n", encoding="utf-8", newline="\n")
-    assert mod._restore_dropin(dropin, None) is True
+    assert _systemd_backend(dropin).rollback(None) is True
     assert not dropin.exists()
 
 
-def test_restore_dropin_rewrites_prior_content(tmp_path):
+def test_service_rollback_rewrites_prior_content(tmp_path):
+    """A prior drop-in -> its exact content is restored over the staged one."""
     dropin = tmp_path / "make-live.conf"
     dropin.write_text("new\n", encoding="utf-8", newline="\n")
-    assert mod._restore_dropin(dropin, "prior\n") is True
+    assert _systemd_backend(dropin).rollback("prior\n") is True
     assert dropin.read_text(encoding="utf-8") == "prior\n"
 
 
-def test_restore_dropin_reports_failure(monkeypatch, tmp_path):
+def test_service_rollback_reports_failure(monkeypatch, tmp_path):
+    """A failed restore returns False so the caller can report
+    ``rolled_back: false`` rather than claiming a rollback that did not land."""
+
     def _boom(path, content):
         raise OSError("read-only fs")
 
     monkeypatch.setattr(gateway_service, "atomic_write_text", _boom)
-    assert mod._restore_dropin(tmp_path / "make-live.conf", "prior") is False
+    backend = _systemd_backend(tmp_path / "make-live.conf")
+    assert backend.rollback("prior") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Dead-code audit of the three builtin apps in group C — `code_review_sage`, `dev_fleet`, `mochi` — 49 production files, 41 753 lines. **One symbol deleted (13 lines of code), plus its three unit tests re-pointed at the live replacement rather than dropped.**

The yield is low for a scope-wide reason, not for lack of dead-looking code: **`mochi`'s entire git history begins `ac7576c0d` "feat(apps): add Mochi desktop companion as a builtin app (#1258)", 2026-08-04.** Every mochi candidate is 26 days old and fails the 30-day new-code gate regardless of reachability. `code_review_sage` (2026-07-16) and `dev_fleet` (2026-07-20) clear the gate, and only they could contribute.

Nothing in `code_review_sage` or `mochi` is touched by this diff.

## Deleted

### `_restore_dropin` — `dev_fleet/server.py:6904-6916` (13 lines)

An orphaned duplicate of `SystemdBackend.rollback`.

| Check | Evidence |
|---|---|
| Zero production callers | Whole-repo search across `*.py *.ts *.tsx *.js *.md *.json *.yml *.yaml *.toml *.sh *.ps1`, plus dynamic forms (`getattr`/`setattr`/`hasattr`, string `monkeypatch.setattr`, `importlib`, `__all__`, entry_points) and quoted-annotation forms. Only the `def` and 3 dedicated tests. |
| Supersession proven, not assumed | `git show 2205475de` (#1434) deletes **both** former call sites (`- rolled_back = _restore_dropin(dropin, prior_content)` ×2). |
| Replacement demonstrably in use | `SystemdBackend.rollback` (`gateway_service.py:332-341`) is called live at `server.py:7486` inside `_unwind_sync`. |
| Not on any public surface | Absent from dev_fleet's `app.json`, `app-registry.json`, every `SKILL.md`/SOP under `dev_fleet/skills/`, `docs/`, `docs/system-specs/`, `config-baseline.json`, `error-code-baseline.json`, `website/src/apps/`. |
| 30-day gate | Introduced 2026-07-22 `42db54fa2` (#120), orphaned 2026-08-04 `2205475de` — 39 days. Passes. |

`dev_fleet` is a destructive-operations surface, so the governing rule here is that an apparently-dead safeguard is report-only **unless** the replacement is proven in use. That bar is met by the live call site above, which is why this one is a deletion rather than a report.

The replacement's try/except body is behaviourally identical (absent prior deletes the drop-in; a prior value is rewritten; `OSError` returns `False` so the caller reports `rolled_back: false`), but not textually identical: it sources the drop-in from `self._dropin_path()` rather than taking it as an argument, and calls `atomic_write_text` unqualified from its own module namespace.

### The three companion tests are re-pointed, not deleted

An earlier revision of this branch deleted `test_restore_dropin_{deletes_when_there_was_none,rewrites_prior_content,reports_failure}` on the assumption that the make-live tests still covered the same ground. **They do not** — both drive the `live_target` *pointer* surface, not the systemd *drop-in*:

- `test_make_live_rolls_back_pointer_on_restart_failure` (`test_dev_fleet_app.py:4414`) asserts the pointer file `live_target.json` is removed (`:4431`) — a different mechanism.
- `test_cancel_reports_a_failed_rollback` (`:4954`) stages through `_stage_a_cutover`'s `unit_status="no_user_unit"` (`:4693`), so `can_restart` is false and `svc.rollback` is never reached; the failure it asserts comes from a patched `live_target.restore`.

No test in the suite called `SystemdBackend.rollback` directly at all. Deleting the three would have left the rewrite-prior and `OSError` semantics of a destructive filesystem path asserted **nowhere**. They now drive the live backend through a stub-injected drop-in path.

Each was revert-verified: mutating the corresponding branch of `rollback` fails exactly the test that covers it and only that test.

| Mutation applied to `SystemdBackend.rollback` | Result |
|---|---|
| `prior is None` no longer unlinks | `test_service_rollback_deletes_the_dropin_when_there_was_none` → 1 failed |
| prior content no longer rewritten | `test_service_rollback_rewrites_prior_content` → 1 failed |
| `except OSError` returns `True` | `test_service_rollback_reports_failure` → 1 failed |

Verified on parsed pass/fail counts rather than pytest's exit code, since `rc=2` is *interrupted/internal*, not a test failure — trusting the exit code alone is how a vacuous guard passes verification.

## Method — four independent scans

The repo carries `from __future__ import annotations`, so annotations are runtime **strings** and invisible to every NAME-token scanner. A prior round in this series nearly deleted a live `Protocol` for exactly this reason, so an annotation-aware pass is mandatory here, not optional.

| Pass | Result |
|---|---|
| vulture `--min-confidence 60` | 47 raw findings |
| naive AST (defined names − `Load`-ed names) | intersected |
| tokenize (real NAME tokens only, def-line discounted) | intersected |
| **annotation-aware AST** — re-`ast.parse` every string annotation (`AnnAssign`, `arg.annotation`, `returns`, `cast()`) | intersected |
| Production candidates | **37** |

The fourth pass earned its place twice: it kept `IO` (`gateway_service.py:76`, used only as `stdout: "IO[str] | int"`) out of the candidate set, and it proved the *absence* of quoted-annotation references for `QueuePollerCallbacks` and `PlannerNotes`.

Then per symbol: whole-repo search (no `head` truncation), bare-string dispatch search, reverse-direction reachability, 30-day gate, test-only check, half-wired-pair check, guard/validator exemption, and companion-test premise check.

**Verdicts: 1 DELETE · 14 ALIVE · 11 DEFER · 16 NEEDS-ADJUDICATION.** Unscanned files: 0.

## ALIVE — false positives worth recording

| Symbol | Why alive |
|---|---|
| `get_due_watch_items`, `get_unnotified_watch_items`, `on_agent_spawn_start`, `on_agent_spawn_end`, `on_budget_exhausted` (`mochi/hooks.py`) | `getattr` string dispatch from `queue_poller.py` (444, 511, 652/682, 660/668/690/700, 479). `QueuePoller.__init__` takes `callbacks: Any` and duck-types. |
| `on_shutdown` (`mochi/hooks.py:1148`) | Manifest dispatch — `mochi/app.json:69` `"on_shutdown": "hooks:on_shutdown"` → `LifecycleDispatcher._get_hook` (`lifecycle.py:165, 199`). 121 repo hits disambiguated; the rest are aiohttp `app.on_shutdown` and other apps' hooks. |
| `skipped_tips`, `watching_last_status`, `user_pattern` (`mochi/queue_file.py`) | Named by string in shipped skills (`mochi-plan/SKILL.md:188,189,211,251-253,264`, `mochi-tips/SKILL.md:11`, `mochi-replan/SKILL.md:36`). |
| `ALL_MOODS` (`mochi/pet_state_manager.py:49`) | Python leg of a 3-surface contract with `agents/context/prompt.md:23,25` and the TS sprite slots. The 15 frontend hits are an **independent** TS const (`appearanceTypes.ts:23`); the lists deliberately differ (Python adds `"neutral"`). |
| `redirect_request` + `fp`/`newurl` (`code_review_sage/sage_lib/review_driver.py:79`) | **Safety-critical.** Override of `urllib.request.HTTPRedirectHandler.redirect_request` — the caller is the stdlib. Returning `None` is urllib's documented redirect refusal; it stops `X-Internal-Secret` being replayed to whatever `Location` names. `fp`/`newurl` are required ABI parameters. 8 sibling instances repo-wide. |
| `sub_box` (`dev_fleet/skills/feature-demo-recording/references/record_template.py:176`) | Skill template API — `SKILL.md:163` tells the agent to copy the file and adapt the beat blocks. Reference scripts are run standalone, never imported. |
| `IO` (`dev_fleet/gateway_service.py:76`), `tb` (`references/_pathcheck.py:210`) | String annotation; `__exit__`'s third required parameter. |

## DEFER — evidence clean, blocked by a rule

| Symbol | Blocking rule |
|---|---|
| `execute_next` (`mochi/queue_poller.py:305`) | 30-day gate. Strongest post-gate candidate — unreachable by *port boundary*: `mcp_server.py:520-522` states the MCP server is a separate process and cannot poke the poller. Must be paired with the `Awaitable` import edit at `:55`. |
| `appearance` (`mochi/soul_loader.py:138`) | 30-day gate. Cleanest of all — zero `.appearance` attribute accesses in any `*.py`; the 230 name hits are i18n keys, the unrelated `activeAppearance` settings key, and prose. |
| `search_archive` (`mochi/watchlist_file.py:656`) | 30-day gate. Orphans the `:653` section header and the sole `cmp_to_key` import. |
| `_locked_write` (`mochi/queue_poller.py:575`) | Locking write path — exempt. Verified there is **no** unlocked bypass (every `write_queue_atomic` sits inside `queue_mutation`), so its deadness is redundancy, not a missing lock. |
| `get_watched_paths`, `pending_count` | Test-only; deletion trades a public accessor for private-attribute test coupling. `pending_count` carries the buffer-cap oracle `assert gate.pending_count == MAX_BUFFER_SIZE`. |
| `set_config_soul` (`mochi/soul_loader.py:101`) | Deliberate retained capability per `get()`'s docstring. |
| `ALL_STATES`, `ALL_EVENTS`, `BUILTIN_PACKS` | 30-day gate + drift (below). |
| duplicated `return out` (`references/narrate.py:333`) | Real unreachable-code defect, but last touched 2026-08-21 (#4785) — 9 days. Merge residue; belongs with that PR's author. |

## NEEDS-ADJUDICATION — reported, nothing deleted

Nothing below is cruft. In each case the **deadness is itself the defect**, so a silent sweep would cement a bug.

**Half-wired lifecycles (release half never wired)**

- `clear_plan_spawn_lock` (`queue_poller.py:264`) — acquire wired (364, 549); docstring names "WS chat_done" as caller but `hooks.py:582` calls only `notify_agent_done`. Plan lock releases by lazy timeout alone.
- `on_user_chat_success` (`:271`) — `_plan_fail_count` is incremented (384) and gates planning (344), but the reset never fires, so "user chat proves the gateway is reachable" recovery never happens.
- `end_first_launch_grace` (`:260`) — acquire wired at `hooks.py:420`; weaker case, `tick()` auto-releases.
- **`start_walking`** (`pet_state_manager.py:114`) — pair `finish_walking` **is** wired behind `POST /walk-done`, but **there is no `/walk-start` route**, so the pet can never enter `walking`: `_walk_started_at` stays 0 ⇒ `finish_walking` always takes the deferred branch. The module docstring's headline walking-buffer behaviour is unreachable, and `routes.py:392`'s claim that `walk_start` "belongs to the walk routes" is false. Deleting the symbol alone is the one option that must not be taken — it leaves a wired route driving a gutted mechanism.
- **`on_milestone`** (`stats_service.py:236`) — the only registration seam for ~38 lines of milestone machinery; `hooks.py:211` constructs `StatsService` and never registers. `app.json:18` advertises "milestones celebrated exactly once". In-repo precedent (`routes.py:1040-1049`): unwired stats recorders were **wired**, not deleted.
- **`add_pin`** (`pinned_files_service.py:223`) — the live path is MCP `_tool_pin_file` (`mcp_server.py:586`), which writes `pinned-files.json` directly and **under-validates**: it replicates `is_sensitive_path` and the dup check but not `os.path.isabs`, not the `MAX_PINS` cap (this is the file's only `MAX_PINS` reader), not the `pinned:files-changed` broadcast, not `_start_watcher`. Siblings `remove_pin`/`get_pins`/`mark_seen` are all wired. Born dead alongside its own replacement in the same PR #1258.
- `spawn_failures` (`watchlist_service.py:153`) — writer wired, reader unread.

**Dead guards / validators**

- **`is_legal_transition`** (`pet_state_machine.py:97`) — `_handle_pet_event` (`routes.py:410-444`) gates only on *vocabulary* membership, never legality from the current state. `POST /pet-event {"event":"task_complete"}` while `offline` returns `200 {"ok":true,"state":"offline"}`: accepted-and-silently-dropped is indistinguishable from applied, exactly the failure the route docstring claims to prevent.
- `legal_events` (`:101`) — `GET /pet-state` publishes current state with no statement of what may legally follow, so renderers duplicate `_CHAT_EVENTS` client-side.
- `is_degraded` (`watchlist_service.py:157`) — drift, not dead: its condition is duplicated inline at 5 call sites. Fix is to route callers to the property.
- **`on_power_event`** (`hooks.py:509`) — exactly 1 repo hit. No route relays power events; sibling `_shell_idle_secs()` (`:897`) is likewise a `return 0` stub annotated "provided by the Electron shell over a route (C track)". Its own docstring: "without it the 'pause when away' behavior is silently absent." Mochi's pause-when-away is unwired.
- `find_overdue_items` (`watchlist_file.py:751`) — 1 hit; sibling query helpers are wired, and `mochi-replan/SKILL.md:14` references overdue handling.

**Stale / drifted contracts**

- `QueuePollerCallbacks` (`queue_poller.py:188`) — stale *and* unenforced: `__init__` takes `callbacks: Any`, `hooks._PollerCallbacks` does not inherit it, and it declares 6 members while the poller reads 11 (all 5 ALIVE hooks above are missing from it).
- `PlannerNotes` (`queue_file.py:66`) — the only Python declaration of the live `planner_notes` contract, but the MCP schema types it as bare `{"type":"object"}` so it validates nothing, and it is already drifted: `mochi-plan/SKILL.md:37,59` and `prompt.md:111,114` use `user_rhythm`/`silent_until`, neither declared. Two names for one idea (`user_rhythm` in prose, `user_pattern` in the template).
- `ALL_STATES`/`ALL_EVENTS` drift — `appearance_store.py:61-75` hand-maintains `REQUIRED_STATES`/`OPTIONAL_STATES` mirroring the same vocabulary, and **its own docstring narrates a past drift where pack art silently vanished**. Nothing asserts the subset relation. `_CHAT_EVENTS` (`routes.py:396-407`) is a hand-written subset with no `_CHAT_EVENTS <= set(ALL_EVENTS)` guard. `ALL_EVENTS` also contains `"voice_error"`, which no `TRANSITIONS` entry maps and `test_table_shape` cannot see.
- `BUILTIN_PACKS` drift — `soul_loader.py:56-75` keys `BUILTIN_PERSONAS`/`BUILTIN_PET_NAMES` off hand-written `'kiro-ghost'`/`'default-mochi'` literals. **Adding a third built-in pack ships it with no persona and no default pet name.**
- `ALL_MOODS` unguarded — the `mood` MCP schema carries no enum (`mcp_server.py:163,180,221`) and `hooks.py:146,724` pass agent-authored free text into `set_mood`, so an off-vocabulary mood is accepted, stored, and rendered as a missing sprite with no error.
- `max_starting`/`worker_factory` (`code_review_sage/sage_lib/review_pool.py:411-413`) — ctor params "accepted-and-ignored for back-compat" by their own comment; no caller passes either, all 22 instantiations keyword-only. Narrowing a public ctor named in `docs/architecture/resource-protection.md:447` and 3 module specs is a policy call, not cruft removal.
- **`design_discussion`** (`code_review_sage/sage_lib/adapters.py:58`) — advertised by string in `app.json:17`, `README.md:5`, `website/src/i18n/locales/en.json:808`, `learn-from-sage/SKILL.md:42`; serialized by `to_dict()` into the pipeline payload, but the single producer hard-codes `design_discussion=[]` (`:431`) and nothing reads it back. Either populate it or drop the claim from all four surfaces in one change — do not remove the field while the marketing string stands.

## Local verification

| Gate | Result |
|---|---|
| Residual `_restore_dropin` references, all file types | 0 |
| `flake8` | clean |
| `isort --check` | clean |
| `git diff --check` (whitespace/EOL) | clean |
| `pytest test_dev_fleet_server_coverage.py test_dev_fleet_app.py` | **665 passed** (+3 vs base), 1 skipped |
| `black --check` | 2 files would reformat — **reproduced identically on unmodified `origin/main`**, version-mismatch red, pre-existing |
| `test_trusted_bin_pins_the_resolved_target_not_the_symlink` | fails — **reproduced identically on unmodified `origin/main`**, scratch-path environmental |

Two local AI review lanes ran against the diff before push and both produced findings that were fixed rather than argued with:

- **gpt-5.6-sol (Medium)** falsified the original "no coverage is lost" claim — the cited survivor tests assert the pointer surface, not the drop-in. This is why the three tests are now re-pointed rather than deleted.
- **claude-opus-4.8 (Medium ×2)** caught `server.py:7501` as a citation pointing at a *comment* in a different try block rather than the live call at `:7486`, and "byte-equivalent logic" as false where only the behaviour is equivalent. Both corrected in the commit message.

## Not for this PR

`chore(apps):` and the three-app subject follow the audit series' naming; only `dev_fleet` is modified. Say the word if you would rather the subject read `chore(dev_fleet):` and I will narrow it.
