### PR TITLE
fix(dashboard): merge-on-write for app-owned entries in agent-config PUT

### DIFF
--- a/.github/coverage-baselines/backend.txt
+++ b/.github/coverage-baselines/backend.txt
@@ -51,7 +51,6 @@ src/kiro_crew/computer_use/cli.py 68.8   # 130/189
 src/kiro_crew/computer_use/macos_skylight.py 54.8   # 142/259
 src/kiro_crew/conpty.py 27.9   # 12/43
 src/kiro_crew/dashboard/_types.py 0.0   # 0/3
-src/kiro_crew/dashboard/handlers/agents.py 77.4   # 579/748
 src/kiro_crew/dashboard/handlers/cron.py 70.9   # 400/564
 src/kiro_crew/dashboard/handlers/portability.py 17.0   # 15/88
 src/kiro_crew/dashboard/handlers/prompts.py 64.5   # 260/403

--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -136,8 +136,113 @@ scrubs the app's entries out of the legacy shared file for every ENABLED app on
 every gateway start. Scrubbing only on deregister meant an already-enabled app
 kept leaking until the user happened to disable it.
 
+**The dashboard's whole-config PUT merges rather than replaces, for exactly this
+reason.** `PUT /api/agent/config` persists a whole-file snapshot the client read
+earlier, so an app registration landing between that read and the PUT used to be
+silently clobbered — the app's tools stopped resolving with nothing logged. The
+handler now takes bridges' own flock, re-reads the on-disk spec under it, and
+applies one rule: **preservation requires positive evidence of app or host
+ownership.** An absent `mcpServers` entry is kept only when its owner can be
+named — a host-managed server, or one of the exact `<app>:<server>` names an
+installed app's manifest DECLARES (`_register_mcp_servers` builds every key it
+writes from `manifest.mcpServers`, so the declared set names precisely what an
+app can own). Ownership is matched by exact name, never by namespace prefix: with
+`demo` installed, a client entry named `demo:custom` that the app never declared
+is the client's and is deletable. If that source cannot be read the PUT is
+REFUSED (500, `code: app_ownership_unreadable`) rather than guessed — preserving
+every namespaced entry would make entries undeletable, and treating the declared
+set as empty would clobber live bridges over a possibly-transient fault.
+Everything else is the client's and is deleted.
+
+**"Host-managed" means the entries the rebuild RE-ADDS, not every name in the
+managed map** — the preservation is justified by that re-add, so it reaches
+exactly as far. The handler therefore asks the emitter
+(`agent.emission_eligible_mcp_servers`, the one predicate both spec writers also
+consult) rather than testing membership itself. Two managed entries are NOT
+re-added and stay deletable: `kirocrew-dashboard` carries `opt_in`, an assignable
+set that `build_agent_config` never emits and that a refresh keeps current without
+ever re-granting, so preserving it left the grant unrevocable through the only
+surface that can revoke it; and `kirocrew-computer` carries a `spec_gate` that both
+writers `pop` while it is shut, so preserving it resurrected the backend the gate
+exists to keep unspawned — and the next rebuild removed it again, the two surfaces
+disagreeing about one config. A gate that raises counts as shut, matching the
+emitter's own fail-closed reading.
+
+The direction is load-bearing. The inverse test — keep anything no mcp.json scope
+declares — reads as equivalent but made a server the user added *through this same
+editor* permanently undeletable, because it lives only in the installed spec and
+the spec is not a scope, so every retry re-read it and put it back. Requiring
+evidence costs a bridge nothing, since a bridge is always identifiable. The scope
+census plays no part in the decision: an earlier cut subtracted every
+scope-declared name ahead of the ownership test as **precedence**, but against
+exact manifest names that could only ever remove a name that IS provably owned, so
+a user who also declared `demo:notes` in their own mcp.json had every stale PUT
+delete app `demo`'s live bridge. Proven ownership outranks a declaration, and a
+declared name with no proven owner is deleted by the general rule anyway.
+
+| Case | Outcome |
+|---|---|
+| scope-declared name that an installed, ENABLED app also declares by exact name, absent | **preserved** — proven ownership outranks the declaration |
+| scope-declared name with no proven app or host owner, absent | **deleted** — the general rule; the declaration adds nothing |
+| direct entry the user added here, absent | **deleted** — the ordinary lifecycle works |
+| `<app>:<server>` of an installed, ENABLED app that declares it, absent | **preserved** — remove it through the app lifecycle, not this editor |
+| `<app>:<name>` the app never declared, absent | **deleted** — squatting a namespace confers nothing |
+| `<app>:<server>` of a DISABLED app, absent | **deleted** — the disable lifecycle owns bridge removal, so a failed removal must be cleanable here |
+| `<app>:<server>` whose app dir or `installed.json` is absent | **deleted** — not installed |
+| host-managed server the rebuild always emits (`kirocrew-cron`, `kirocrew-core`, edition extras), absent | **preserved** — the rebuild re-adds it anyway, so removing it here never stuck |
+| host-managed server flagged `opt_in` (`kirocrew-dashboard`), absent | **deleted** — an assignable grant no rebuild re-adds (a refresh keeps an existing one current but never re-grants), so revocation must stick here |
+| host-managed server whose `spec_gate` is CLOSED (`kirocrew-computer` off or unsupported), absent | **deleted** — both spec writers `pop` it, so the rebuild would not re-add it and preserving it resurrects the backend the gate withholds |
+| `installed.json` present but corrupt | **refused** (500, `app_ownership_unreadable`) |
+| `installed.json` present but non-regular (broken symlink, directory, unstattable) | **refused** (500, `app_ownership_unreadable`) |
+| apps root present but not a directory | **refused** (500, `app_ownership_unreadable`) |
+| apps-root child listable but unstattable (e.g. a symlink loop) | **refused** (500, `app_ownership_unreadable`) |
+| app manifest unreadable | **refused** (500, `app_ownership_unreadable`) |
+| apps directory unenumerable | **refused** (500, `app_ownership_unreadable`) |
+
+Ownership therefore requires **installed AND enabled AND declared**. Enablement is
+read through `manager.app_enabled_state`, whose tri-state exists for exactly this
+kind of caller — its docstring separates "not installed" from "unreadable" because
+collapsing them is the wrong answer for a caller deciding whether to *delete*.
+`is_app_enabled` and `list_apps` are both unusable here: each turns an unreadable
+record into a plain "no", which silently narrows ownership and deletes that app's
+bridges.
+
+A record with no `enabled` field counts as **enabled**, matching the manager's own
+parse (`InstalledApp.from_dict` reads `bool(data.get("enabled", True))`) so a legacy
+record is treated here exactly as the rest of the tree treats it.
+
+**Absence is proven by `lstat` raising `FileNotFoundError`, nothing weaker.**
+`Path.is_file()` / `Path.is_dir()` answer False for a malformed path as readily as
+for a missing one, so screening on them alone read a broken symlink or a
+directory-where-a-file-belongs as "not installed" and made that app's live bridges
+deletable. The shape screen lives at the handler's call site
+(`_require_present_shape`), so `manager.app_enabled_state` keeps the contract its
+other callers rely on. The apps-root ENUMERATION obeys the same rule: each child is
+stat'ed explicitly instead of filtered through `is_dir()`, which routes its fault
+through pathlib's `_ignore_error` and returns a plain False for ENOENT, ENOTDIR,
+EBADF and ELOOP — so a child that is a symlink loop looked like a regular file and
+was skipped, deleting the bridges of the app under that name.
+
+The complete row-by-row table, including which test pins each row, is the docstring
+of `dashboard/handlers/agents.py::_app_declared_server_names`.
+
+Scoped to `mcpServers`: all three bridges writers of this file touch that key and
+nothing else, so every other key still replaces wholesale. The merge runs *ahead
+of* the governance filter, so a preserved entry's `autoApprove` is governed like
+any other. An unreadable spec preserves nothing and lets the snapshot land, which
+keeps this endpoint the repair path for a corrupt spec.
+
+The flock spans the merge read **and** the spec write, so neither an app
+registration nor a deregistration can interleave. That matters asymmetrically:
+the deregistration direction never self-healed, because
+`reconcile_enabled_app_resources` only re-registers ENABLED apps, so a bridge
+resurrected from a disabled or uninstalled app would have persisted indefinitely.
+Lock order is unchanged (transaction → config → bridge-file); the widened hold is
+the innermost one.
+
 Writer: `apps/bridges.py::_apply_agent_mcp_policy`, `_mcp_json_path`,
-`_scrub_legacy_shared_mcp`.
+`_scrub_legacy_shared_mcp`;
+`dashboard/handlers/agents.py::_merge_unowned_servers` for the PUT side.
 
 ## 2. Auto-approve is intersected with the governance ceiling
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -752,6 +752,88 @@ def _computer_use_spec_gate() -> bool:
         return False
 
 
+def _mcp_spec_gate_open(name: str, spec: dict) -> bool:
+    """Whether *spec*'s ``spec_gate`` permits emission RIGHT NOW (absent = open).
+
+    The single place a gate is called. A gate that raises is reported CLOSED, for
+    the same fail-closed reason the computer-use gate itself is: emitting the
+    entry is what makes kiro-cli spawn the backend, and a keystone we could not
+    read is not evidence that the capability is on.
+    """
+    gate = spec.get("spec_gate")
+    if gate is None:
+        return True
+    try:
+        return bool(gate())
+    except Exception:
+        logger.debug("spec gate for %s raised; treating as closed", name, exc_info=True)
+        return False
+
+
+def _mcp_server_emission_eligible(
+    name: str, spec: object, *, gated_off: "frozenset[str] | None" = None
+) -> bool:
+    """Whether a FRESH spec build would EMIT this MCP server entry.
+
+    THE single definition of "the rebuild re-adds this", and it has exactly two
+    disqualifiers, both owned by the entry's own spec:
+
+    * ``opt_in`` — an assignable set, never auto-emitted. ``build_agent_config``
+      skips it outright and ``_refresh_dynamic_fields`` keeps an EXISTING grant
+      current without ever re-introducing one, so nothing re-adds a grant the
+      user removed.
+    * a CLOSED ``spec_gate`` — both writers ``pop`` the entry while the gate is
+      shut, so the rebuild actively withholds it rather than merely skipping it.
+
+    Both spec writers consult this, and so does the dashboard PUT's merge-on-write
+    host set (``handlers/agents.py::_app_or_host_owned``). That co-tenancy is the
+    whole point of the helper rather than a convenience: the merge preserves an
+    absent managed entry *because* a rebuild would re-add it, so if the two ever
+    disagreed the merge would resurrect entries the rebuild withholds — an
+    ``opt_in`` grant the user revoked through the only surface that can revoke it,
+    or a gate-closed server whose backend the gate exists to keep unspawned.
+
+    *gated_off* is a caller's ONE-PER-REBUILD gate snapshot
+    (:func:`_gated_off_servers`); passing it keeps a rebuild's emit path and its
+    withhold audit agreeing on one reading, which is why that snapshot exists.
+    Omitted (the merge's case, which audits nothing), the gate is read live.
+
+    A spec that is not a mapping at all is reported ELIGIBLE. Only the host can
+    produce that shape — the managed map is a module constant and the extras come
+    from an edition adapter — the name is host-owned either way, and this keeps
+    the merge's pre-existing verdict for it instead of raising ``AttributeError``
+    out of a commit unit contracted to leave its targets byte-identical.
+    """
+    if not isinstance(spec, dict):
+        return True
+    if spec.get("opt_in"):
+        return False
+    if gated_off is not None:
+        return name not in gated_off
+    return _mcp_spec_gate_open(name, spec)
+
+
+def emission_eligible_mcp_servers() -> frozenset[str]:
+    """Every MCP server name a fresh spec build would emit right now.
+
+    Managed servers and the edition's extras under ONE predicate — extras get no
+    exemption, so an extra that ever carries ``opt_in`` or a gate is withheld
+    here for the same reason a managed one is. Today they carry neither, so this
+    is every extra plus the always-emitted managed entries.
+
+    Exported (no leading underscore) because ``handlers/agents.py``'s
+    merge-on-write is a legitimate out-of-module consumer: it must preserve
+    exactly the set a rebuild would re-add, and computing that itself is what let
+    the two drift. Read live rather than cached — a keystone flip between two PUTs
+    must change the answer.
+    """
+    return frozenset(
+        name
+        for name, spec in (*_MANAGED_MCP_SERVERS.items(), *_extra_mcp_servers().items())
+        if _mcp_server_emission_eligible(name, spec)
+    )
+
+
 def _gated_off_servers() -> frozenset[str]:
     """Managed servers whose ``spec_gate`` is CLOSED right now.
 
@@ -763,20 +845,12 @@ def _gated_off_servers() -> frozenset[str]:
     record is read during incident response, against the config it describes.
 
     A gate that raises is treated as closed, for the same fail-closed reason the
-    computer-use gate itself is.
+    computer-use gate itself is — see :func:`_mcp_spec_gate_open`, which is where
+    that call now lives so the merge-on-write host set reads the gate the same way.
     """
-    closed: set[str] = set()
-    for name, spec in _MANAGED_MCP_SERVERS.items():
-        gate = spec.get("spec_gate")
-        if gate is None:
-            continue
-        try:
-            if not gate():
-                closed.add(name)
-        except Exception:
-            logger.debug("spec gate for %s raised; treating as closed", name, exc_info=True)
-            closed.add(name)
-    return frozenset(closed)
+    return frozenset(
+        name for name, spec in _MANAGED_MCP_SERVERS.items() if not _mcp_spec_gate_open(name, spec)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2020,20 +2094,23 @@ def build_agent_config(*, gated_off: "frozenset[str] | None" = None) -> dict:
     if gated_off is None:
         gated_off = _gated_off_servers()
     for name, spec in _MANAGED_MCP_SERVERS.items():
-        if name in gated_off:
-            # The gate is the whole point of this branch: emitting the entry is
-            # what makes kiro-cli spawn the backend, so a closed gate must not
-            # emit one. ``pop`` as well as ``continue`` because the base here is
-            # shipped defaults merged with the user override file, and an entry
-            # arriving from there would otherwise slip past a platform gate that
-            # exists because the capability has no driver on this OS.
-            mcp.pop(name, None)
-            continue
-        # An opt-in server is an assignable set: it belongs to the agents whose
-        # own spec references it, so a freshly built default spec must not carry
-        # it. kiro-cli loads a server only when ``tools`` names it, and the
-        # shipped template names only the always-on ones.
-        if spec.get("opt_in"):
+        if not _mcp_server_emission_eligible(name, spec, gated_off=gated_off):
+            # NOT eligible, and the two reasons part company on one point: a
+            # closed gate must RETRACT the entry, an opt-in one is merely never
+            # introduced.
+            if name in gated_off:
+                # The gate is the whole point of this branch: emitting the entry is
+                # what makes kiro-cli spawn the backend, so a closed gate must not
+                # emit one. ``pop`` as well as ``continue`` because the base here is
+                # shipped defaults merged with the user override file, and an entry
+                # arriving from there would otherwise slip past a platform gate that
+                # exists because the capability has no driver on this OS.
+                mcp.pop(name, None)
+            # An opt-in server is an assignable set: it belongs to the agents whose
+            # own spec references it, so a freshly built default spec must not carry
+            # it. kiro-cli loads a server only when ``tools`` names it, and the
+            # shipped template names only the always-on ones. Left in place rather
+            # than popped: an entry already on disk is a grant the user made.
             continue
         if "invocation_fn" in spec:
             cmd, args = spec["invocation_fn"]()
@@ -2094,7 +2171,8 @@ def _refresh_dynamic_fields(config: dict, *, gated_off: "frozenset[str] | None" 
     if gated_off is None:
         gated_off = _gated_off_servers()
     for name, spec in _MANAGED_MCP_SERVERS.items():
-        if name in gated_off:
+        eligible = _mcp_server_emission_eligible(name, spec, gated_off=gated_off)
+        if not eligible and name in gated_off:
             # RETRACT, not merely skip: an earlier refresh wrote this entry while
             # the gate was open, and leaving it would mean turning the feature
             # off never reclaims the backend process turning it on started.
@@ -2117,8 +2195,12 @@ def _refresh_dynamic_fields(config: dict, *, gated_off: "frozenset[str] | None" 
         is_new = name not in mcp
         # An opt-in server is granted by the spec itself, so a refresh keeps an
         # entry the user put there current but never introduces one: adding it
-        # back would re-grant a set on every gateway start.
-        if is_new and spec.get("opt_in"):
+        # back would re-grant a set on every gateway start. Spelled through the
+        # shared eligibility predicate (the gate half is already spent above, so
+        # what remains of ineligibility here is exactly ``opt_in``) rather than
+        # re-reading the flag, so the rule cannot drift from the emitter's or the
+        # dashboard merge's reading of it.
+        if is_new and not eligible:
             continue
         if not is_new and spec.get("opt_in") and not isinstance(mcp.get(name), dict):
             # A hand-written entry that is not an object at all. Refreshing it

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import stat
 import subprocess
 import uuid
 from pathlib import Path
@@ -22,6 +23,7 @@ from kiro_crew.agent import (
     AGENT_FILENAME,
     _spec_path_is_safe,
     clear_model_pin,
+    emission_eligible_mcp_servers,
     get_shipped_tools,
     install_agent,
     kiro_agents_dir_path,
@@ -33,6 +35,14 @@ from kiro_crew.agent_discovery import (
     project_agent_names,
     spec_model,
     spec_str,
+)
+from kiro_crew.apps.bridges import _mcp_lock as _agent_file_lock
+from kiro_crew.apps.bridges import _registration_source
+from kiro_crew.apps.manager import (
+    INSTALLED_META_FILENAME,
+    app_dir,
+    app_enabled_state,
+    apps_dir,
 )
 from kiro_crew.config.loader import (
     ConfigReadError,
@@ -164,21 +174,426 @@ def _installed_agent_config() -> Path:
     return kiro_agents_dir_path() / AGENT_FILENAME
 
 
-def _write_installed_config_locked(path: Path, config: dict[str, Any]) -> None:
-    """Write the installed agent spec while holding bridges' file lock.
+def _merge_unowned_servers(config: dict[str, Any], installed_path: Path) -> tuple[str, ...]:
+    """Re-add ``mcpServers`` entries the submitting client does not own.
 
-    Runs in a worker thread (see :func:`_commit_agent_config`, dispatched
-    through ``_offload_config_write``), which is what makes taking a synchronous
-    flock here legal — on the event loop it would stall the gateway whenever app
-    registration held the lock.
+    MERGE-ON-WRITE (#6664). This PUT persists a whole-file snapshot the client
+    read earlier, and ``apps/bridges.py::_register_mcp_servers`` writes app MCP
+    bridges into that same file under its own flock. A registration landing
+    between the client's read and its PUT was therefore silently clobbered, and
+    the app's tools simply stopped resolving with nothing logged anywhere.
 
-    ``bridges._mcp_lock`` is imported lazily: ``apps.bridges`` imports back into
-    the dashboard handlers, so a module-level import is circular.
+    The rule, in one sentence: **preservation requires positive evidence of app
+    or host ownership.** An on-disk entry absent from the submission is kept only
+    when :func:`_app_or_host_owned` can name its owner by EXACT name; everything
+    else is the client's and is deleted, which is what keeps an ordinary entry the
+    user typed into this editor deletable -- including one parked under an
+    installed app's namespace. If that evidence cannot be read the PUT is refused
+    rather than guessed; see :func:`_app_or_host_owned`.
+
+    The inverse test -- "keep anything no mcp.json scope declares" -- reads as
+    equivalent and is not. A server added through this same editor lives ONLY in
+    the installed spec, which is not a scope, so it looked unowned and was
+    re-inserted on every attempt to remove it: not merely preserved against the
+    user's wishes, but permanently undeletable, because each retry re-read the
+    same entry. Requiring evidence costs an app bridge nothing, since a bridge is
+    always positively identifiable.
+
+    The census is NOT consulted, and the reason is worth naming because an
+    earlier cut did consult it: it subtracted every scope-declared name from the
+    candidates ahead of the ownership test, as precedence carried over from the
+    prefix-matching era. With ownership matched by exact manifest name that
+    subtraction could only ever remove a name that IS provably owned, so a user
+    who also declared ``demo:notes`` in their own mcp.json made every stale PUT
+    delete app ``demo``'s live bridge. Proven ownership therefore outranks a
+    declaration, and a name with no proven owner is deleted whether a scope
+    declares it or not -- which leaves the census unable to change any verdict.
+
+    Two consequences worth naming rather than discovering:
+
+    * A host-MANAGED server the rebuild RE-ADDS (``agent.emission_eligible_mcp_servers``)
+      is preserved. That is not a new restriction -- the rebuild re-adds those
+      entries unconditionally, so removing one through this editor never stuck.
+      The qualifier is load-bearing: a managed entry the rebuild would NOT emit
+      (an ``opt_in`` grant, or one whose ``spec_gate`` is shut) is deleted like
+      any other absent entry, because nothing re-adds it and preserving it made
+      the grant unrevocable and the gated backend resurrectable.
+    * An app bridge cannot be removed through this endpoint. That is the issue's
+      explicit intent; the app lifecycle (disable/uninstall, which calls
+      ``_deregister_mcp_servers``) is what removes it.
+
+    BEST-EFFORT ON AN UNREADABLE SPEC, deliberately. A corrupt installed spec has
+    no parseable entries to preserve, and this editor is the user's repair path
+    for exactly that state -- failing the PUT closed would leave a broken agent
+    with no way to fix it from the dashboard. So an unreadable spec preserves
+    nothing and the snapshot lands as it did pre-fix; enabled apps re-register
+    their servers on the next gateway start
+    (``reconcile_enabled_app_resources``), so the loss self-heals.
+
+    WHAT REMAINS, now that the caller holds bridges' flock across this read and
+    the spec write (see :func:`_commit_agent_config`). Every writer of this file
+    INSIDE the gateway takes that same flock -- ``_register_mcp_servers``,
+    ``_deregister_mcp_servers``, ``reregister_app_mcp_servers``, the agent
+    rebuild, and ``handlers/mcp.py``'s spec syncs -- so no app registration or
+    deregistration can interleave with this read any more, in either direction.
+    The earlier writeup here claimed a bounded, self-healing residual for that
+    window; that was wrong twice over, and both halves are now moot: the
+    deregistration direction was never self-healing (startup reconciliation only
+    re-registers ENABLED apps, so a resurrected bridge from a disabled or
+    uninstalled app persisted indefinitely), and the window itself is closed
+    rather than narrowed.
+
+    The residual that is real is a writer OUTSIDE this process that does not take
+    the flock -- kiro-cli writing the spec itself, or a user editing the file by
+    hand. Nothing in the gateway can serialize against those, and the same
+    exposure applies to every other writer here, so it is a property of the file
+    rather than of this change. Torn reads are not part of it: the in-process
+    writers all go through ``atomic_write``, so a reader sees the whole old file
+    or the whole new one.
+
+    Returns the names it preserved, for the caller to log.
     """
-    from kiro_crew.apps.bridges import _mcp_lock as _agent_file_lock
+    submitted = config.get("mcpServers")
+    if "mcpServers" in config and not isinstance(submitted, dict):
+        # A non-object ``mcpServers`` is a shape kiro-cli rejects outright.
+        # Merging into it would mean inventing a map the client never sent, so
+        # the submission is left exactly as-is and the existing verbatim-persist
+        # behaviour (and its rejection) is unchanged.
+        logger.warning(
+            "Skipping agent-config merge-on-write: submitted mcpServers is %s, not an object",
+            type(submitted).__name__,
+        )
+        return ()
+    submitted_servers: dict[str, Any] = submitted if isinstance(submitted, dict) else {}
+    try:
+        on_disk = json.loads(installed_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # Missing (a first-ever write) or corrupt: nothing recoverable to
+        # preserve. See BEST-EFFORT above.
+        return ()
+    if not isinstance(on_disk, dict):
+        return ()
+    existing = on_disk.get("mcpServers")
+    if not isinstance(existing, dict) or not existing:
+        return ()
+    absent = {name: spec for name, spec in existing.items() if name not in submitted_servers}
+    if not absent:
+        return ()
+    # POSITIVE EVIDENCE decides, and nothing overrides it. An earlier cut
+    # subtracted every scope-declared name from the candidates BEFORE ownership
+    # was tested, as a precedence rule inherited from the prefix-matching era.
+    # Once ownership became the EXACT manifest-declared set, that subtraction
+    # could only ever remove a name that IS provably owned -- a user who also
+    # declares ``demo:notes`` in their own mcp.json made every stale PUT delete
+    # app ``demo``'s live bridge. A name with no proven owner is deleted whether
+    # a scope declares it or not, so the census cannot change any verdict and is
+    # no longer consulted.
+    owned = _app_or_host_owned(absent)
+    preserved = {name: spec for name, spec in absent.items() if name in owned}
+    if not preserved:
+        return ()
+    # Submitted first so the client's own key order is stable and the preserved
+    # entries append; the two maps are disjoint by construction, so which side
+    # wins is not in question.
+    config["mcpServers"] = {**submitted_servers, **preserved}
+    return tuple(sorted(preserved))
 
-    with _agent_file_lock(target=path):
-        write_config_atomically(path, config)
+
+class AppOwnershipUnreadable(RuntimeError):
+    """The app-ownership source could not be read, so nothing may be decided.
+
+    Raised by :func:`_app_or_host_owned` and turned into a 500 with
+    ``code: app_ownership_unreadable`` by the PUT. Deliberately NOT a guess in
+    either direction -- see that function.
+    """
+
+
+def _require_present_shape(path: Path, *, expect: str, what: str) -> bool:
+    """Whether *path* is genuinely ABSENT; raise when it is present but malformed.
+
+    ``Path.is_file()`` and ``Path.is_dir()`` answer False for BOTH "nothing is
+    there" and "something is there but it is the wrong kind of thing" -- a broken
+    or looping symlink, a directory where a file belongs, a fifo, or a path whose
+    parent denies the stat. Reading that False as absence is the
+    cannot-read-becomes-not-owned defect one shape further out: a malformed
+    ``installed.json`` would classify its app as not installed, and its live
+    bridges would become deletable.
+
+    Absence is proven ONLY by ``lstat`` raising ``FileNotFoundError`` -- the link
+    itself, not its target, so a dangling symlink counts as present. Anything
+    else that is present but not *expect* raises
+    :class:`AppOwnershipUnreadable`. The follow-up ``stat`` is what makes a
+    symlink to a VALID file still acceptable: ``lstat`` would call it a link and
+    reject it, while ``stat`` resolves to the regular file it names.
+
+    Returns True when the path is genuinely absent, so the caller can take its
+    own not-installed branch.
+    """
+    try:
+        os.lstat(path)
+    except FileNotFoundError:
+        return True  # genuinely absent
+    except OSError as exc:
+        raise AppOwnershipUnreadable(f"{what} present but unstattable: {exc}") from exc
+    try:
+        st = os.stat(path)  # follows symlinks: a link to a valid target is fine
+    except OSError as exc:
+        # Dangling or looping symlink, or a permission fault on the target. The
+        # entry EXISTS, so this is unreadable rather than absent.
+        raise AppOwnershipUnreadable(f"{what} present but unresolvable: {exc}") from exc
+    ok = stat.S_ISDIR(st.st_mode) if expect == "dir" else stat.S_ISREG(st.st_mode)
+    if not ok:
+        raise AppOwnershipUnreadable(f"{what} present but not a {expect}")
+    return False
+
+
+def _app_declared_server_names() -> frozenset[str]:
+    """The exact ``<app>:<server>`` names installed, ENABLED apps DECLARE.
+
+    Ground truth, and it has to be exact. ``_register_mcp_servers`` builds every
+    key it writes as ``f"{app_name}:{server_name}"`` over
+    ``manifest.mcpServers.items()``, so the manifests' declared server lists name
+    precisely the entries an app can own -- nothing wider. A PREFIX test is not a
+    weaker version of this: with ``demo`` installed, a client entry named
+    ``demo:custom`` matches the prefix and becomes permanently undeletable.
+
+    Read through :func:`bridges._registration_source`, which resolves a shipped
+    builtin from its immutable package root rather than its mutable installed
+    snapshot, so installed metadata cannot borrow a builtin's name and claim
+    entries under it.
+
+    THE COMPLETE CLASSIFICATION TABLE for an entry ABSENT from the client's
+    submitted snapshot. Every reachable combination of name shape, install state,
+    enablement, declaration and manifest readability appears here, so the
+    classification of any absent entry is a table lookup rather than a judgement:
+
+    ===========================  ==========================  ==============================  =====================
+    Name shape                   App / metadata state        Verdict                         Pinned by
+    ===========================  ==========================  ==============================  =====================
+    host-managed, always-emitted  n/a (host, not an app)     PRESERVE                        test_host_managed_entry_is_preserved
+    host-managed, ``opt_in``     n/a (host, not an app)      DELETE                          test_an_opt_in_managed_server_omitted_from_the_snapshot_is_deleted
+    host-managed, gate CLOSED    n/a (host, not an app)      DELETE                          test_a_gate_closed_managed_server_omitted_from_the_snapshot_is_deleted
+    host-managed, gate OPEN      n/a (host, not an app)      PRESERVE                        test_a_gate_open_managed_server_is_still_preserved
+    host-managed, gate RAISES    n/a (host, not an app)      DELETE (gate reads closed)      test_a_managed_server_whose_gate_raises_is_deleted
+    edition extra                n/a (host, not an app)      PRESERVE                        test_an_edition_contributed_server_is_preserved
+    edition extra with ``:``     host-owned AND namespaced   PRESERVE (host outranks)        test_a_namespaced_edition_extra_is_preserved_by_host_ownership
+    host spec not a mapping      n/a (host-produced only)    PRESERVE (pre-fix verdict)      test_a_malformed_host_spec_does_not_fail_the_put
+    plain (no ``:``)             n/a -- no app can own it    DELETE                          test_direct_client_entry_deletes_on_a_sequential_add_then_remove
+    scope-declared, app-owned    enabled, declared           PRESERVE                        test_a_scope_declaration_does_not_defeat_proven_ownership
+    scope-declared, not owned    n/a -- no owner to name     DELETE                          test_a_scope_declared_name_with_no_proven_owner_is_deleted
+    ``<app>:<n>``                app dir absent entirely     DELETE                          test_a_namespaced_entry_of_an_uninstalled_app_is_deleted
+    ``<app>:<n>``                installed.json absent       DELETE                          test_absent_installed_metadata_is_still_skipped
+    ``<app>:<n>``                installed.json corrupt      FAIL ``app_ownership_unreadable``  test_corrupt_installed_metadata_fails_the_put_and_writes_nothing
+    ``<app>:<n>``                installed.json non-regular  FAIL ``app_ownership_unreadable``  test_installed_metadata_as_a_broken_symlink_fails_the_put, test_installed_metadata_as_a_directory_fails_the_put
+    ``<app>:<n>``                enabled=false (disabled)    DELETE                          test_disabled_app_bridge_is_deleted
+    ``<app>:<n>``                ``enabled`` field absent    treat as ENABLED, then declare  test_absent_enabled_field_counts_as_enabled
+    ``<app>:<n>``                enabled, manifest unreadable  FAIL ``app_ownership_unreadable``  test_unreadable_app_manifest_fails_the_put_and_writes_nothing
+    ``<app>:<n>``                enabled, NOT declared       DELETE                          test_client_entry_under_an_installed_apps_namespace_is_deleted
+    ``<app>:<n>``                enabled, declared           PRESERVE                        test_a_declared_app_server_is_still_preserved
+    any                          apps dir unreadable         FAIL ``app_ownership_unreadable``  test_unreadable_apps_directory_fails_the_put
+    any                          apps root not a directory   FAIL ``app_ownership_unreadable``  test_apps_root_as_a_regular_file_fails_the_put
+    any                          apps child unstattable      FAIL ``app_ownership_unreadable``  test_an_unstattable_apps_root_child_fails_the_put
+    ===========================  ==========================  ==============================  =====================
+
+    THE HOST ROWS ARE NOT ONE ROW, and collapsing them was a shipped defect. A
+    host-managed entry is preserved *because the rebuild re-adds it*, so the
+    justification only reaches the entries the rebuild actually emits. It does not
+    reach an ``opt_in`` server (``kirocrew-dashboard``: never auto-emitted, and a
+    refresh keeps an existing grant current without ever re-granting a removed
+    one), which preservation made undeletable through the only surface that can
+    revoke the grant; nor a server whose ``spec_gate`` is CLOSED
+    (``kirocrew-computer`` on an unsupported platform, or with computer use off),
+    which both spec writers ``pop`` — preserving it resurrects exactly the backend
+    the gate exists to keep unspawned, and the next rebuild removes it again. The
+    eligibility test is therefore the emitter's own
+    (``agent.emission_eligible_mcp_servers``), not a second copy here.
+
+    ABSENCE IS PROVEN BY ``lstat`` RAISING ``FileNotFoundError``, nothing weaker.
+    ``Path.is_file()`` and ``Path.is_dir()`` answer False for a malformed path as
+    readily as for a missing one, so screening on them alone read a broken
+    symlink, a directory-where-a-file-belongs, or an unstattable path as "not
+    installed" and made that app's live bridges deletable. Every present-but-wrong
+    shape raises instead -- see :func:`_require_present_shape`, which screens the
+    shape at the CALL SITE so ``manager.app_enabled_state`` keeps the contract its
+    other callers rely on. The ENUMERATION obeys the same rule: each child of the
+    apps root is stat'ed explicitly rather than filtered through ``is_dir()``,
+    because pathlib routes that fault through ``_ignore_error`` and hands back a
+    plain False for ENOENT, ENOTDIR, EBADF and ELOOP alike -- so a child that is a
+    symlink loop looked like a regular file and was skipped, deleting the bridges
+    of the app under that name. Only a resolved stat may exclude a child, and only
+    by proving it is not a directory.
+
+    Four justifications carry the rows that are not self-evident:
+
+    * A SCOPE DECLARATION DOES NOT OUTRANK PROVEN OWNERSHIP. An earlier cut
+      subtracted every scope-declared name from the candidates ahead of this test,
+      as precedence carried over from the prefix-matching era. Against EXACT
+      manifest names that subtraction could only ever remove a name that IS
+      provably owned: a user who also declares ``demo:notes`` in their own mcp.json
+      made every stale PUT delete app ``demo``'s live bridge. A declared name with
+      no proven owner is deleted anyway, by the general rule, so the census cannot
+      change a verdict and is not consulted.
+
+    * DISABLED ⇒ DELETE. The disable lifecycle owns bridge removal
+      (``_deregister_mcp_servers``), and a deregistration that FAILED during
+      disable leaves a stale entry behind. Startup reconciliation only
+      re-registers ENABLED apps, so it never revisits that entry: preserving it
+      would keep a disabled app's code launchable through the retained bridge
+      forever. Ownership therefore requires installed AND enabled.
+    * ABSENT ``enabled`` FIELD ⇒ ENABLED. This matches ``apps.manager``'s own
+      parse exactly -- ``InstalledApp.from_dict`` reads
+      ``bool(data.get("enabled", True))`` (manager.py:170) over a dataclass whose
+      default is ``enabled: bool = True`` (manager.py:114). A legacy record
+      written before the field existed is treated as enabled everywhere else in
+      the tree, and disagreeing here would delete the live bridges of an app the
+      rest of the system considers running.
+    * UNREADABLE ⇒ FAIL LOUD, never a guess. Preserving on an unreadable source
+      strands undeletable entries; deleting clobbers live bridges over a fault
+      that may be transient. The refusal is raised before any durable write.
+
+    Enablement comes from :func:`manager.app_enabled_state`, whose tri-state is
+    written for exactly this caller: its own docstring separates "not installed"
+    and "unreadable" *because* collapsing them is "the wrong [answer] for a
+    caller deciding whether to DELETE its files". ``True``/``False`` are definite
+    answers and ``None`` means the metadata could not be read. ``is_app_enabled``
+    and ``list_apps`` are both unusable here -- each collapses an unreadable
+    record into a plain "no", which silently narrows ownership and deletes that
+    app's bridges.
+    """
+    root = apps_dir()
+    if _require_present_shape(root, expect="dir", what="installed-apps directory"):
+        return frozenset()  # no apps directory at all: nothing is installed
+    try:
+        children = sorted(root.iterdir())
+    except OSError as exc:
+        raise AppOwnershipUnreadable(f"installed-apps directory unreadable: {exc}") from exc
+    entries: list[Path] = []
+    for child in children:
+        # ONE MORE SHAPE SCREEN, for the same reason as the two above. The filter
+        # here used to be ``p.is_dir()``, which routes its fault through pathlib's
+        # ``_ignore_error`` and returns a plain False for ENOENT, ENOTDIR, EBADF
+        # and ELOOP -- the same False a regular file gets. A child that is a
+        # symlink LOOP was therefore skipped as "not an app" and the absent bridges
+        # of the app under that name became deletable. Only a resolved stat may
+        # exclude a child, and only by PROVING it is not a directory.
+        try:
+            st = child.stat()  # follows symlinks, exactly as ``is_dir()`` did
+        except FileNotFoundError:
+            # Absence, and only absence, is a skip: an uninstall completing
+            # between the listing and this stat leaves precisely this state, and a
+            # DANGLING link lands here too -- unlike the metadata screen below,
+            # that is a definite answer rather than an unreadable one, because no
+            # app directory exists under the name at all.
+            continue
+        except OSError as exc:
+            raise AppOwnershipUnreadable(
+                f"installed-apps entry {child.name!r} present but unstattable: {exc}"
+            ) from exc
+        if stat.S_ISDIR(st.st_mode):
+            entries.append(child)
+    declared: set[str] = set()
+    for entry in entries:
+        # SHAPE before CONTENT. ``app_enabled_state`` reaches the metadata through
+        # ``Path.is_file()``, which answers False for a broken symlink, a
+        # directory, or any other non-regular file sitting at that path -- and its
+        # contract turns that False into "not installed", which here would make a
+        # live app's bridges deletable. Screening the shape first keeps that
+        # contract intact for its other callers while giving this one the
+        # present-but-malformed answer it needs.
+        if _require_present_shape(
+            app_dir(entry.name) / INSTALLED_META_FILENAME,
+            expect="file",
+            what=f"app {entry.name!r}: installed metadata",
+        ):
+            continue  # genuinely no installed.json: not an installed app
+        enabled = app_enabled_state(entry.name)
+        if enabled is None:
+            raise AppOwnershipUnreadable(
+                f"app {entry.name!r}: installed metadata present but unreadable"
+            )
+        if not enabled:
+            # Not installed, or installed and deliberately disabled. Both mean no
+            # ownership, so the conflation is harmless here: either way the entry
+            # is the client's and stays deletable.
+            continue
+        manifest, _app_root = _registration_source(entry.name)
+        if manifest is None:
+            # bridges returns None for a manifest it could not parse. That app's
+            # declared servers are UNKNOWN, not empty, and "empty" is what
+            # deletes its live bridges.
+            raise AppOwnershipUnreadable(f"app {entry.name!r}: manifest unreadable")
+        servers = manifest.mcpServers or {}
+        declared.update(f"{entry.name}:{server}" for server in servers)
+    return frozenset(declared)
+
+
+def _app_or_host_owned(names: dict[str, Any]) -> frozenset[str]:
+    """Which of *names* an APP or the HOST provably owns.
+
+    POSITIVE identification by EXACT NAME, and both halves of that matter. The
+    inverse test -- "preserve anything no mcp.json scope declares" -- made a
+    server the user typed into the raw editor permanently undeletable, because it
+    lives only in the installed spec and the spec is not a scope. A prefix test
+    over installed app ids reproduced the same defect for any name the client
+    parked under an app's namespace. Only an exact name an owner actually claims
+    is evidence.
+
+    Two sources, both narrow:
+
+    * HOST-managed, and only the entries a rebuild would actually RE-ADD:
+      ``agent.emission_eligible_mcp_servers()`` — the always-emitted managed
+      servers (cron/core) plus the edition's ``_extra_mcp_servers``. Preserving
+      one is justified BY that re-add, so the set has to be the emitter's, which
+      is why it is imported rather than recomputed here. The two managed entries
+      a rebuild does NOT re-add are excluded and stay deletable: an ``opt_in``
+      grant (``kirocrew-dashboard``) that no rebuild re-introduces, and a
+      server whose ``spec_gate`` is shut (``kirocrew-computer``), which both spec
+      writers actively ``pop``. Preserving those made a revocation impossible
+      through the only surface that can revoke it, and resurrected a backend the
+      gate exists to keep unspawned.
+    * APP-declared: the exact ``<app>:<server>`` set from installed manifests --
+      see :func:`_app_declared_server_names`.
+
+    ON A FAILED READ THIS RAISES rather than guessing, because both guesses are
+    wrong and each one is a defect this span has already shipped. Preserving
+    every namespaced entry makes entries permanently undeletable; treating the
+    declared set as empty deletes live app bridges over a fault that may be
+    transient -- the very clobber #6664 exists to fix. The PUT turns the raise
+    into a 500 the client can retry, and because this runs at step (0a) before
+    any durable write, all three targets stay byte-identical.
+
+    That branch IS reachable: manifests are separate files under the apps
+    directory, not covered by the installed-spec flock this unit holds, so a
+    corrupt ``app.json`` or an unreadable apps directory reaches it and persists
+    until repaired. It is reached whenever ANY candidate is namespaced, host-owned
+    or not: the refusal is per-PUT rather than per-entry, so an edition extra
+    whose name contains ``:`` is refused alongside a genuinely app-shaped one. That
+    is the fail-loud direction and it is retryable, so it stays as it is.
+    """
+    host = emission_eligible_mcp_servers()
+    owned = {name for name in names if name in host}
+    namespaced = {name for name in names if ":" in name}
+    if not namespaced:
+        # No candidate can be app-owned, so the manifests cannot change the
+        # answer and their readability is not this PUT's problem.
+        return frozenset(owned)
+    return frozenset(owned | (namespaced & _app_declared_server_names()))
+
+
+def _write_installed_config(path: Path, config: dict[str, Any]) -> None:
+    """Write the installed agent spec. The CALLER holds bridges' file lock.
+
+    The lock used to be taken here. It moved out to
+    :func:`_commit_agent_config`, which now holds it across the merge's on-disk
+    READ as well as this write -- reacquiring it here would deadlock, because
+    ``flock`` is per open file description and a second fd on the same file
+    blocks against the first from the same thread.
+
+    Still runs in a worker thread, which is what makes the caller's synchronous
+    flock legal -- on the event loop it would stall the gateway whenever app
+    registration held it.
+    """
+    write_config_atomically(path, config)
 
 
 def _commit_agent_config(
@@ -214,7 +629,12 @@ def _commit_agent_config(
     order, are:
 
     0. the governance filter raises — nothing durable, and the caller's 500 is
-       exact (it fails closed, so a raise withholds rather than grants);
+       exact (it fails closed, so a raise withholds rather than grants). The
+       merge-on-write step ahead of it (0a) adds one prefix of its own, and it is
+       the harmless end: it can raise :class:`AppOwnershipUnreadable` while
+       having mutated only the in-memory *config*, so the caller's 500 is exact
+       and all three targets are byte-identical (see
+       :func:`_app_or_host_owned` for why refusing beats guessing);
     1. the ``config.json`` read raises :class:`ConfigReadError` — nothing
        durable, and the caller's 500 is exact;
     2. the ``config.json`` write fails — nothing durable;
@@ -225,11 +645,17 @@ def _commit_agent_config(
        updated, the spec unchanged.
 
     Order inside the unit is chosen to make the *earliest* prefixes the *least*
-    harmful, and three steps are load-bearing rather than incidental:
+    harmful, and four steps are load-bearing rather than incidental:
 
-    * The governance filter is FIRST, and it is in here at all so that the grant
-      decision cannot be made against a ceiling that changes before the write
-      publishes it — see step (0). First because it persists nothing, so its own
+    * The merge (0a) precedes the governance filter, so the entries it re-adds
+      are governed like any other — see step (0a). It is in the unit at all for
+      the same reason as the read at (1): its on-disk read must be adjacent to
+      the write it feeds, or an app registration landing during the flock wait
+      is clobbered exactly as it was pre-fix.
+    * The governance filter is FIRST among the steps that decide what is
+      persisted, and it is in here at all so that the grant decision cannot be
+      made against a ceiling that changes before the write publishes it — see
+      step (0). Ahead of every write because it persists nothing, so its own
       fail-closed raise costs no partial write.
     * The read is FIRST among the writes' own inputs. It is the only
       fallible-by-decision I/O step, and running it here — immediately adjacent
@@ -269,9 +695,70 @@ def _commit_agent_config(
     #
     # Imported lazily: platform.governance is not a module-level dependency of
     # the dashboard handlers.
+    # ── THE BRIDGE-FILE LOCK SPANS THE WHOLE UNIT ─────────────────────────────
+    # Acquired here rather than at the spec write, because merge-on-write reads
+    # this same file and that read is only meaningful if no app writer can
+    # commit between it and the write it feeds. ``_deregister_mcp_servers``
+    # (app disable / uninstall / health demotion) read-modify-writes the spec
+    # under exactly this flock, so an unlocked read let a PUT resurrect a bridge
+    # that had just been removed -- and that direction does NOT self-heal,
+    # because ``reconcile_enabled_app_resources`` only re-registers ENABLED apps
+    # and skips the one whose bridge came back.
+    #
+    # LOCK ORDER IS UNCHANGED: transaction -> config -> bridge-file. The caller
+    # already holds the outer two before dispatching this unit, so widening the
+    # innermost hold adds no edge and inverts nothing. The cost is that app
+    # registration now waits on the ``config.json`` and bookkeeping writes too --
+    # the same accepted trade ``remove_provider_entry`` documents for holding the
+    # MCP lock across its unlinks, and the alternative (a second, later lock hold
+    # for just the spec write) is what reopens the window above.
+    #
+    # Taken once. ``_write_installed_config`` deliberately no longer locks: with
+    # ``flock`` being per open file description, a nested reacquisition from this
+    # same thread would block against this hold forever.
     from kiro_crew.platform.governance import sanitize_agent_config_governance
 
-    sanitize_agent_config_governance(config)
+    with _agent_file_lock(target=installed_path):
+        return _commit_agent_config_locked(
+            config=config,
+            name=name,
+            mc_cfg_path=mc_cfg_path,
+            removed_per_key=removed_per_key,
+            installed_path=installed_path,
+            sanitize=sanitize_agent_config_governance,
+        )
+
+
+def _commit_agent_config_locked(
+    *,
+    config: dict[str, Any],
+    name: str,
+    mc_cfg_path: Path,
+    removed_per_key: dict[str, list[str]],
+    installed_path: Path,
+    sanitize: Any,
+) -> bool:
+    """The commit unit's steps, with bridges' file lock already held.
+
+    Split out only so the lock acquisition reads as one statement; every
+    invariant documented on :func:`_commit_agent_config` applies here, and this
+    is never called from anywhere else.
+    """
+    # (0a) MERGE-ON-WRITE, immediately before the filter that governs the map it
+    # produces. Inside the unit for the same reason as (0) and (1): the on-disk
+    # read has to be adjacent to the write it feeds, or a bridge registration
+    # landing during the (unbounded, cross-process) flock wait is clobbered
+    # exactly as before the fix. BEFORE the filter, not after, so the entries it
+    # re-adds are governed too -- re-injecting them afterwards would hand an
+    # ``autoApprove`` on a preserved entry a path around step (0).
+    preserved = _merge_unowned_servers(config, installed_path)
+    if preserved:
+        logger.info(
+            "agent-config PUT: kept %d mcpServers entry/entries the client does not own: %s",
+            len(preserved),
+            ", ".join(preserved),
+        )
+    sanitize(config)
     # (1) The one fallible READ, and it precedes every write.
     #
     # Fail closed: writing back a {} baseline would drop every other setting
@@ -285,8 +772,8 @@ def _commit_agent_config(
     write_config_atomically(mc_cfg_path, mc_cfg)
     # (3) agent_model_state.json bookkeeping — after (2), before (4).
     changed = agent_state.lift_and_strip_bookkeeping(config, name)
-    # (4) the installed spec, under bridges' file lock.
-    _write_installed_config_locked(installed_path, config)
+    # (4) the installed spec, under the caller's bridge-file lock.
+    _write_installed_config(installed_path, config)
     return changed
 
 
@@ -399,9 +886,12 @@ async def api_agent_config(request: web.Request) -> web.Response:
             # api_mcp_server_detail, mcp_discover, api_capability_mcp_install),
             # and no config-lock or file-lock holder in the tree acquires the
             # transaction lock inside, so there is no ABBA cycle. The file lock is
-            # taken inside the worker thread (by _write_installed_config_locked,
-            # reached from _commit_agent_config) — a blocking flock on the event
-            # loop would freeze the gateway while app registration holds it.
+            # taken inside the worker thread (by ``_commit_agent_config``, which
+            # holds it across the whole unit so merge-on-write's on-disk READ and
+            # the spec write cannot be split by an app writer) — a blocking flock
+            # on the event loop would freeze the gateway while app registration
+            # holds it. Widening that innermost hold changes no ORDER: the outer
+            # two are already held before the unit is dispatched.
             # Nothing else in this branch takes a cross-process lock: governance +
             # SEL and agent_state take none, so running the filter inside the
             # worker adds no lock edge to the transaction → config → file order.
@@ -435,9 +925,11 @@ async def api_agent_config(request: web.Request) -> web.Response:
             )
 
             # Governance floor on the WHOLE-object write path: this handler
-            # persists the request's config verbatim, so a dashboard PUT could
-            # otherwise restore a ceiling-governed @denied grant or a governed
-            # server's autoApprove that the per-ref writers strip.
+            # persists the request's config as submitted (plus the ``mcpServers``
+            # entries merge-on-write re-adds, which the filter therefore also
+            # governs — see ``_commit_agent_config`` step (0a)), so a dashboard
+            # PUT could otherwise restore a ceiling-governed @denied grant or a
+            # governed server's autoApprove that the per-ref writers strip.
             #
             # NOT in phase 1. The filter used to run here, and that placed the
             # grant decision BEFORE both lock acquisitions: the transaction flock
@@ -485,6 +977,20 @@ async def api_agent_config(request: web.Request) -> web.Response:
                             mc_cfg_path=mc_cfg_path,
                             removed_per_key=removed_per_key,
                             installed_path=installed_path,
+                        )
+                    except AppOwnershipUnreadable:
+                        # Step (0a), ahead of every durable write, so all three
+                        # targets are byte-identical and this 500 is exact.
+                        # Refusing is the only honest answer: guessing preserved
+                        # would make entries undeletable, guessing deleted would
+                        # clobber live app bridges. The client can retry.
+                        logger.exception("Refusing agent-config PUT: app ownership unreadable")
+                        return web.json_response(
+                            {
+                                "error": "cannot determine app-owned MCP entries",
+                                "code": "app_ownership_unreadable",
+                            },
+                            status=500,
                         )
                     except ConfigReadError:
                         # The unit's FIRST step, so this 500 is exact: no write of

--- a/test/test_agent_config_merge_on_write.py
+++ b/test/test_agent_config_merge_on_write.py
@@ -1,0 +1,1142 @@
+"""Merge-on-write semantics for the agent-config PUT (#6664).
+
+``PUT /api/agent/config`` persists a whole-file snapshot the client read earlier,
+and ``apps/bridges.py::_register_mcp_servers`` writes app MCP bridges into that
+same file under its own flock. A registration landing between the client's read
+and its PUT was therefore silently clobbered.
+
+The rule under test: **preservation requires positive evidence of app or host
+ownership.** An on-disk ``mcpServers`` entry absent from the submission is kept
+only when its owner can be named -- a host-managed server, or one of the exact
+``<app>:<server>`` names an installed, ENABLED app's manifest declares; every
+other absent entry is the client's and is deleted. The ambiguity that makes the
+policy load-bearing is that a snapshot taken before an app registered its bridge
+is byte-identical to one where the user deliberately removed that entry, so
+ownership is the only disambiguator -- and an unclassifiable entry falls to
+DELETE, because preserving without evidence makes a directly-added entry
+permanently undeletable, while an ownership source that cannot be READ refuses
+the PUT rather than guessing in either direction.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from conftest import requires_symlinks
+from kiro_crew.dashboard.handlers import api_agent_config
+
+
+@pytest.fixture(autouse=True)
+def _owner_caller(monkeypatch):
+    """Run as the dashboard owner: the owner boundary on this endpoint has its
+    own enumerate-the-invariant coverage in test_agents_endpoints_owner_auth.py."""
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+        lambda request: True,
+    )
+
+
+@contextlib.asynccontextmanager
+async def _neutral_lock():
+    """Stand in for the transaction lock without touching the host's mcp.lock."""
+    yield
+
+
+async def _put(
+    tmp_path: Path,
+    *,
+    on_disk: dict | str,
+    submitted: dict,
+    scope_names: frozenset[str] = frozenset(),
+    unreadable_scope: bool = False,
+    apps: dict[str, tuple[str, ...]] | None = None,
+    apps_unreadable: bool = False,
+    installed_corrupt: bool = False,
+    installed_absent: bool = False,
+    enabled: bool | None = True,
+    installed_shape: str | None = None,
+    apps_root_is_file: bool = False,
+    apps_dir_unreadable: bool = False,
+    apps_child_unstattable: bool = False,
+    managed: tuple[str, ...] = (),
+    managed_specs: dict[str, dict] | None = None,
+    extra_managed: dict[str, dict] | None = None,
+    lock=_neutral_lock,
+    file_lock=None,
+    govern: bool = False,
+) -> tuple[web.Response, dict]:
+    """PUT *submitted* over an installed spec holding *on_disk*.
+
+    ``on_disk`` as a ``str`` is written verbatim, for the corrupt-spec case.
+    ``scope_names`` is what a readable mcp.json scope declares and
+    ``unreadable_scope`` reports the scope as unreadable instead; both are
+    injected at the census seam and BOTH must leave every verdict unchanged --
+    proven ownership decides, so re-introducing any scope-based exclusion ahead of
+    the ownership test trips the tests that set them. ``apps`` maps an INSTALLED
+    app name to the server names its manifest DECLARES, so ``{"demo": ("notes",)}``
+    makes ``demo:notes`` app-owned while ``demo:custom`` is not; ``apps_unreadable``
+    makes one manifest unreadable. ``managed`` are host-managed server names,
+    carrying no ``opt_in``/``spec_gate`` (the always-emitted shape);
+    ``managed_specs`` adds host-managed names with their REAL spec dicts, which is
+    how the opt-in and gated rows are exercised. ``extra_managed`` is what the
+    edition's ``_extra_mcp_servers`` contributes.
+    ``file_lock`` replaces bridges' flock, which is how the deregistration
+    interleaving is injected. ``govern=True`` leaves the real governance filter
+    in place instead of neutralizing it.
+    """
+    if apps is None:
+        apps = {"demo": ("notes",)}
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(
+        on_disk if isinstance(on_disk, str) else json.dumps(on_disk), encoding="utf-8"
+    )
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {"config": submitted}
+
+    request.json = mock_json
+
+    # Injected at spec_census, the seam any scope-derived rule would have to read
+    # through, so a re-introduced exclusion is caught wherever it is spelled.
+    def _census(project_dirs=()):
+        if unreadable_scope:
+            # The scope exists but could not be read: it declares nothing and is
+            # reported unreadable, so no name is proven client-declared.
+            return ({"kirocrew": {}}, ("kirocrew",))
+        return ({"kirocrew": {name: {"url": "scope"} for name in scope_names}}, ())
+
+    if file_lock is None:
+
+        @contextlib.contextmanager
+        def file_lock(*, exclusive: bool = True, target=None):  # noqa: ANN001
+            yield
+
+    # A real installed-apps tree, so enumeration walks directories the way the
+    # production helper does rather than consuming a pre-baked name list, and so
+    # the absent-vs-corrupt discrimination reads real files.
+    _apps_root = tmp_path / "apps"
+    if apps_root_is_file:
+        # The apps root PRESENT but not a directory: is_dir() answers False for
+        # this exactly as it does for genuine absence.
+        _apps_root.write_text("not a directory", encoding="utf-8")
+    else:
+        _apps_root.mkdir(exist_ok=True)
+    for _app in apps:
+        if apps_root_is_file:
+            break
+        _app_root = _apps_root / _app
+        _app_root.mkdir(exist_ok=True)
+        if installed_absent:
+            continue  # a directory under apps/ carrying no installed.json
+        _meta = _app_root / "installed.json"
+        if installed_shape == "broken_symlink":
+            # A DANGLING link: lstat succeeds (the link exists), stat raises.
+            _meta.symlink_to(_app_root / "no-such-target.json")
+            continue
+        if installed_shape == "directory":
+            _meta.mkdir()
+            continue
+        if installed_corrupt:
+            _body = "{ not json at all"
+        else:
+            _record: dict[str, object] = {"name": _app}
+            # Omitted entirely when ``enabled`` is None, so the REAL
+            # ``InstalledApp.from_dict`` default is what decides -- the absent-field
+            # row of the table is exercised rather than stubbed.
+            if enabled is not None:
+                _record["enabled"] = enabled
+            _body = json.dumps(_record)
+        _meta.write_text(_body, encoding="utf-8")
+
+    def _reg_source(app_name):  # noqa: ANN001 -- mirrors bridges._registration_source
+        root = _apps_root / app_name
+        if apps_unreadable:
+            # What bridges returns for a manifest it could not parse.
+            return None, root
+        return SimpleNamespace(mcpServers={s: {"command": s} for s in apps[app_name]}), root
+
+    _handler_apps_root: object = _apps_root
+    if apps_dir_unreadable:
+        # A REAL directory that stats as one but refuses enumeration. It has to be
+        # a genuine path, not a mock: the shape screen calls ``os.lstat``/``os.stat``
+        # on it, which a MagicMock cannot satisfy. Subclassing keeps every other
+        # path operation real and fails only the listing, so no chmod has to be
+        # restored before ``tmp_path`` cleanup.
+        class _UnlistableDir(type(_apps_root)):  # type: ignore[misc]
+            def iterdir(self):
+                raise OSError("permission denied")
+
+        _handler_apps_root = _UnlistableDir(_apps_root)
+    if apps_child_unstattable:
+        # A child the listing RETURNS but whose stat faults. ``ELOOP`` (a symlink
+        # loop) is the decisive errno rather than an arbitrary one: pathlib's
+        # ``_ignore_error`` swallows exactly ENOENT/ENOTDIR/EBADF/ELOOP, so those
+        # are the faults ``Path.is_dir()`` turns into a silent False -- an EACCES
+        # happens to propagate already, which is why it would not reproduce the
+        # defect. Subclassed rather than a real loop so the row runs on every
+        # platform (a real symlink needs privilege on Windows), and rather than a
+        # mock because the shape screen stats sibling paths in the same tree.
+        class _UnstattableChild(type(_apps_root)):  # type: ignore[misc]
+            def stat(self, *, follow_symlinks: bool = True):
+                raise OSError(errno.ELOOP, "symbolic link loop")
+
+        class _RootWithUnstattableChild(type(_apps_root)):  # type: ignore[misc]
+            def iterdir(self):
+                for child in super().iterdir():
+                    yield _UnstattableChild(child)
+
+        _handler_apps_root = _RootWithUnstattableChild(_apps_root)
+
+    _managed_map: dict[str, dict] = {n: {} for n in managed}
+    if managed_specs:
+        _managed_map.update(managed_specs)
+
+    patches = [
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.get_shipped_tools",
+            return_value={"tools": [], "allowedTools": []},
+        ),
+        # Patched at the AGENTS binding, not at bridges: the handler imports
+        # ``_mcp_lock as _agent_file_lock`` at module scope, so a patch on the
+        # source module would not reach the already-bound name.
+        patch("kiro_crew.dashboard.handlers.agents._agent_file_lock", file_lock),
+        # ``apps_dir`` is patched in BOTH modules on purpose: the handler binds it
+        # at module scope, while the real ``app_enabled_state`` resolves the
+        # metadata path through manager's own copy.
+        patch(
+            "kiro_crew.dashboard.handlers.agents.apps_dir",
+            return_value=_handler_apps_root,
+        ),
+        patch("kiro_crew.apps.manager.apps_dir", return_value=_apps_root),
+        patch("kiro_crew.dashboard.handlers.agents._registration_source", _reg_source),
+        patch("kiro_crew.agent._MANAGED_MCP_SERVERS", _managed_map),
+        patch("kiro_crew.agent._extra_mcp_servers", return_value=dict(extra_managed or {})),
+        patch("kiro_crew.dashboard.handlers.mcp._get_mcp_lock", lock),
+        patch("kiro_crew.connections.ownership.spec_census", _census),
+    ]
+    if not govern:
+        patches.append(
+            patch(
+                "kiro_crew.platform.governance.sanitize_agent_config_governance",
+                lambda config: None,
+            )
+        )
+
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        response = await api_agent_config(request)
+
+    written = json.loads(installed.read_text(encoding="utf-8"))
+    return response, written
+
+
+# ── (a) the concurrent register-vs-PUT race from the original finding ──────────
+
+
+@pytest.mark.asyncio
+async def test_app_bridge_registered_during_the_lock_wait_survives_the_put(tmp_path):
+    """The race the GPT round-6 finding reported, closed.
+
+    The transaction lock is a cross-process flock whose wait is unbounded, so an
+    app enable queued ahead of this PUT commits its ``mcpServers`` entry strictly
+    after the client's read and strictly before this PUT's write. Pre-fix the
+    snapshot was persisted as read and the bridge was gone, with no error and no
+    log line — the app's tools simply stopped resolving.
+
+    Modelled deterministically rather than by timing: the fake lock registers the
+    bridge as it is acquired, which is exactly that window.
+    """
+    installed = tmp_path / "kirocrew.json"
+
+    @contextlib.asynccontextmanager
+    async def _registering_lock():
+        # An app enable lands here: whole-file RMW of the installed spec, the
+        # shape apps/bridges.py::_register_mcp_servers performs under its flock.
+        data = json.loads(installed.read_text(encoding="utf-8"))
+        data.setdefault("mcpServers", {})["demo:notes"] = {"command": "notes-mcp"}
+        installed.write_text(json.dumps(data), encoding="utf-8")
+        yield
+
+    response, written = await _put(
+        tmp_path,
+        # The client read this — no app bridge in it yet.
+        on_disk={"name": "kirocrew", "mcpServers": {"weather": {"url": "w"}}},
+        submitted={"name": "kirocrew", "mcpServers": {"weather": {"url": "w"}}},
+        scope_names=frozenset({"weather"}),
+        lock=_registering_lock,
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"]["demo:notes"] == {"command": "notes-mcp"}, (
+        "an app bridge registered between the client's read and this PUT was "
+        "clobbered by the snapshot: the merge did not re-read on-disk state "
+        "inside the locked commit unit"
+    )
+    # The client's own entry still lands.
+    assert written["mcpServers"]["weather"] == {"url": "w"}
+
+
+@pytest.mark.asyncio
+async def test_app_deregistered_during_the_put_is_not_resurrected(tmp_path):
+    """FINDING 2: a bridge removed while the PUT runs must stay removed.
+
+    App disable / uninstall / health demotion calls ``_deregister_mcp_servers``,
+    which read-modify-writes the installed spec under bridges' OWN flock. Pre-fix
+    the merge read ran BEFORE that flock was taken, so a deregistration landing
+    between the read and the final locked write had its entry re-inserted -- and
+    unlike the registration direction this does NOT self-heal, because
+    ``reconcile_enabled_app_resources`` only re-registers ENABLED apps and skips
+    the disabled or uninstalled one whose bridge just came back.
+
+    Deterministic interleaving, no sleeps: the fake flock performs the
+    deregistration at ACQUISITION. Pre-fix the merge has already read the file by
+    then and the entry is preserved; with the read moved inside the same lock
+    hold, the read happens after and sees the entry gone.
+    """
+    installed = tmp_path / "kirocrew.json"
+
+    @contextlib.contextmanager
+    def _deregistering_lock(*, exclusive: bool = True, target=None):  # noqa: ANN001
+        # An app disable commits here: the same whole-file RMW
+        # apps/bridges.py::_deregister_mcp_servers performs under this flock.
+        data = json.loads(installed.read_text(encoding="utf-8"))
+        data.get("mcpServers", {}).pop("demo:notes", None)
+        installed.write_text(json.dumps(data), encoding="utf-8")
+        yield
+
+    response, written = await _put(
+        tmp_path,
+        # The client read this while the app was still enabled.
+        on_disk={
+            "name": "kirocrew",
+            "mcpServers": {"demo:notes": {"command": "notes-mcp"}, "weather": {"url": "w"}},
+        },
+        submitted={"name": "kirocrew", "mcpServers": {"weather": {"url": "w"}}},
+        scope_names=frozenset({"weather"}),
+        file_lock=_deregistering_lock,
+    )
+
+    assert response.status == 200
+    assert "demo:notes" not in written["mcpServers"], (
+        "the PUT resurrected a bridge that was deregistered while it ran: the "
+        "merge read must happen inside the same bridge-file lock hold as the "
+        "spec write, not before it"
+    )
+    assert written["mcpServers"]["weather"] == {"url": "w"}
+
+
+# ── (b) the ownership grid ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_direct_client_entry_deletes_on_a_sequential_add_then_remove(tmp_path):
+    """FINDING 1: a server the user typed into the raw editor must stay deletable.
+
+    The ordinary lifecycle, with no race at all: the user adds ``myserver``
+    through this same editor (so it exists ONLY in the installed spec -- no
+    mcp.json scope declares it), then in a later, race-free PUT removes it.
+
+    Pre-fix the preserve test was "no scope declares it", and the installed spec
+    is not a scope, so this entry was re-inserted on every deletion attempt --
+    permanently undeletable, breaking #6664's own requirement 2 for the most
+    ordinary kind of client entry. Preservation now requires POSITIVE evidence of
+    app or host ownership, which a direct entry has none of.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"myserver": {"command": "mine"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        scope_names=frozenset(),
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "a direct client-created entry was re-inserted on deletion: preservation "
+        "must require positive evidence of app/host ownership, not merely the "
+        "absence of a scope declaration"
+    )
+
+
+@pytest.mark.asyncio
+async def test_app_owned_entry_absent_from_the_snapshot_is_preserved(tmp_path):
+    """No scope declares an app bridge, so its absence carries no instruction."""
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        scope_names=frozenset(),
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"demo:notes": {"command": "notes-mcp"}}, (
+        "an app-owned entry absent from the submission was deleted; absence of an "
+        "entry the client never spoke for is not a deletion instruction"
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_owned_entry_absent_from_the_snapshot_is_deleted(tmp_path):
+    """A scope-declared entry is the client's own, so its absence IS a deletion.
+
+    The other half of the rule, and the one an over-broad fix breaks: preserving
+    every absent entry would make the editor unable to remove anything.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"weather": {"url": "w"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        scope_names=frozenset({"weather"}),
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "a client-owned entry the user removed was resurrected: merge-on-write "
+        "must preserve only entries the client does not own"
+    )
+
+
+@pytest.mark.asyncio
+async def test_entry_of_unknown_ownership_is_deleted(tmp_path):
+    """THE PINNED UNKNOWN-KEY POLICY: unclassifiable ⇒ client-owned ⇒ delete.
+
+    This is the INVERSE of the policy the first cut shipped, and the inversion is
+    the point. Preservation now requires positive evidence of app or host
+    ownership, so an entry with no such evidence -- including one whose census
+    source could not be read -- is treated as the client's and deleted when
+    absent from the submission.
+
+    The direction matters because the two errors are not the ones the first cut
+    weighed. Preserving without evidence does not merely risk keeping something
+    the user wanted gone: for a direct entry it makes deletion IMPOSSIBLE, since
+    every retry re-reads the same unowned-looking entry and re-inserts it. An
+    app bridge, by contrast, is positively identifiable, so requiring evidence
+    costs it nothing.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"weather": {"url": "w"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        unreadable_scope=True,
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "an entry with no evidence of app or host ownership was preserved; that "
+        "is what made direct client entries permanently undeletable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_scope_declaration_does_not_defeat_proven_ownership(tmp_path):
+    """ROUND 6: a scope declaration must not delete a bridge the app really owns.
+
+    The scope census used to subtract every declared name from the candidates
+    BEFORE ownership was tested, as a precedence rule inherited from the
+    prefix-matching era. Once ownership became the EXACT set of manifest-declared
+    names, that subtraction could only ever remove a name that IS provably owned:
+    app ``demo`` genuinely registers ``demo:notes``, so a user who also declares
+    ``demo:notes`` in their own mcp.json made every stale PUT delete the live
+    bridge -- the exact clobber #6664 exists to prevent, reachable through a
+    collision the user cannot see.
+
+    The census seam stays injected here on purpose: re-introducing any
+    scope-based exclusion ahead of the ownership test trips this test.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        scope_names=frozenset({"demo:notes"}),
+        apps={"demo": ("notes",)},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"demo:notes": {"command": "notes-mcp"}}, (
+        "a scope declaration deleted a bridge an installed, enabled app declares "
+        "by exact name; positive ownership outranks the declaration"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_scope_declared_name_with_no_proven_owner_is_deleted(tmp_path):
+    """The other half of the row: a declaration adds nothing to an unowned name.
+
+    ``demo:custom`` is squatting an installed app's namespace and the manifest
+    never declares it, so it has no proven owner and is deleted -- with or
+    without the user's own scope declaration. Pins that letting proven ownership
+    win did not turn a scope declaration into a preserve reason.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:custom": {"command": "mine"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        scope_names=frozenset({"demo:custom"}),
+        apps={"demo": ("notes",)},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "a scope-declared name with no app or host owner was preserved; only "
+        "positive ownership preserves anything"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_namespaced_entry_of_an_uninstalled_app_is_deleted(tmp_path):
+    """``foo:bar`` is only a bridge when ``foo`` is an INSTALLED app.
+
+    Otherwise the namespace test would let any hand-typed colon name become
+    undeletable -- the same defect as Finding 1, reachable through a different
+    spelling.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"nosuchapp:thing": {"command": "x"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}
+
+
+@pytest.mark.asyncio
+async def test_host_managed_entry_is_preserved(tmp_path):
+    """An ALWAYS-EMITTED host-managed server is positively owned, so it survives.
+
+    Not a new restriction, and the "always-emitted" qualifier is the whole of the
+    justification: a fresh rebuild re-adds ``kirocrew-core`` unconditionally, so
+    removing it through this editor never stuck. The two managed entries that are
+    NOT always emitted are covered by the three rows below, where preservation
+    would instead resurrect something the rebuild would leave out.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"kirocrew-core": {"command": "c"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        managed=("kirocrew-core",),
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"kirocrew-core": {"command": "c"}}
+
+
+@pytest.mark.asyncio
+async def test_an_opt_in_managed_server_omitted_from_the_snapshot_is_deleted(tmp_path):
+    """ROUND 7: an opt-in grant must be REVOCABLE through this editor.
+
+    ``kirocrew-dashboard`` carries ``opt_in``, which makes it an assignable set
+    rather than an always-on capability: ``build_agent_config`` never emits it and
+    ``_refresh_dynamic_fields`` keeps an EXISTING entry current without ever
+    re-introducing one. So the preserve rationale on the row above -- "the rebuild
+    re-adds it anyway, removing it here never stuck" -- is simply false for this
+    entry: nothing re-adds it. Preserving it made the grant UNDELETABLE through the
+    only surface that can revoke it, because each retry re-read the entry it had
+    just refused to drop.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"kirocrew-dashboard": {"command": "d"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        managed_specs={"kirocrew-dashboard": {"opt_in": True}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "an opt-in managed server was preserved: the grant cannot be revoked "
+        "through this editor, and no rebuild re-adds it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_gate_closed_managed_server_omitted_from_the_snapshot_is_deleted(tmp_path):
+    """ROUND 7: a CLOSED ``spec_gate`` means the rebuild would not re-add it.
+
+    ``kirocrew-computer``'s gate is consulted at emission time, and both spec
+    writers ``pop`` the entry while it is closed -- emitting it is what makes
+    kiro-cli spawn a backend for a capability that is off or has no driver on this
+    OS. Preserving such an entry here RESURRECTS exactly what the gate exists to
+    withhold, and the next rebuild would remove it again: the two surfaces
+    disagreed about the same config.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"kirocrew-computer": {"command": "u"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        managed_specs={"kirocrew-computer": {"spec_gate": lambda: False}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "a gate-closed managed server was preserved: the merge resurrected an "
+        "entry the rebuild withholds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_gate_open_managed_server_is_still_preserved(tmp_path):
+    """The overshoot guard for the two rows above: an OPEN gate still preserves.
+
+    Narrowing the host set to emission-eligible entries must not stop protecting
+    the ones a rebuild really does re-add -- an open gate emits, so deleting here
+    would be undone on the next rebuild and the two surfaces would disagree in the
+    other direction.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"kirocrew-computer": {"command": "u"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        managed_specs={"kirocrew-computer": {"spec_gate": lambda: True}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"kirocrew-computer": {"command": "u"}}
+
+
+@pytest.mark.asyncio
+async def test_a_managed_server_whose_gate_raises_is_deleted(tmp_path):
+    """A gate that RAISES is ineligible, mirroring ``_gated_off_servers`` exactly.
+
+    That function catches every exception and adds the name to the closed set, so
+    the emitter withholds the entry. Reading a raising gate as "eligible" here
+    would preserve an entry the rebuild pops -- the same resurrection as the
+    gate-closed row, reached through the fault path instead of the verdict.
+    """
+
+    def _explode() -> bool:
+        raise RuntimeError("keystone unreadable")
+
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"kirocrew-computer": {"command": "u"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        managed_specs={"kirocrew-computer": {"spec_gate": _explode}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "a raising spec gate was read as eligible: the merge preserves what the "
+        "emitter withholds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_edition_contributed_server_is_preserved(tmp_path):
+    """An edition extra is host-owned and always emitted, so it is preserved.
+
+    ``build_agent_config`` merges every ``_extra_mcp_servers`` entry with no gate
+    and no opt-in test, so the rebuild re-adds it unconditionally -- the same
+    justification as the always-emitted managed row. The eligibility predicate is
+    applied to these entries UNIFORMLY rather than special-cased, so an extra that
+    ever did carry ``opt_in`` or a closed gate would fall to DELETE with the
+    managed rows instead of silently keeping the old blanket preserve.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"internal-mcp": {"command": "i"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        extra_managed={"internal-mcp": {"command": "i", "args": []}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"internal-mcp": {"command": "i"}}
+
+
+@pytest.mark.asyncio
+async def test_a_namespaced_edition_extra_is_preserved_by_host_ownership(tmp_path):
+    """The one shape that is BOTH host-set and namespaced: host ownership decides.
+
+    An edition may contribute a name containing ``:``, which is the only way a
+    host-owned entry also looks app-owned (a managed name never contains one).
+    Host ownership is proven from the contributed map alone, so ``vendor:tools``
+    survives although the installed app ``demo`` declares nothing of the sort --
+    the union does not require both sources to agree, and the app-declared set
+    being empty for this name cannot veto it.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"vendor:tools": {"command": "v"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        extra_managed={"vendor:tools": {"command": "v", "args": []}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"vendor:tools": {"command": "v"}}
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_host_spec_does_not_fail_the_put(tmp_path):
+    """A non-object host spec keeps its pre-fix verdict instead of crashing the PUT.
+
+    Reading ``opt_in``/``spec_gate`` off the spec introduces a shape the old
+    keys-only union never touched, and the edition adapter behind
+    ``_extra_mcp_servers`` is the reachable producer of it. Only the HOST can
+    produce it at all, the name is host-owned either way, and this editor is the
+    user's repair path -- so it is treated as eligible, which is exactly what the
+    old code did, rather than raising ``AttributeError`` out of a commit unit whose
+    contract is that step (0a) leaves all three targets byte-identical.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"internal-mcp": {"command": "i"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        extra_managed={"internal-mcp": "not-a-mapping"},  # type: ignore[dict-item]
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"internal-mcp": {"command": "i"}}
+
+
+@pytest.mark.asyncio
+async def test_client_entry_under_an_installed_apps_namespace_is_deleted(tmp_path):
+    """ROUND 2: squatting an installed app's namespace must not confer ownership.
+
+    App ``demo`` is installed and declares only ``notes``. The client adds
+    ``demo:custom`` through this editor -- a name the app never registered -- and
+    later omits it. A prefix test (``name.split(":")[0] in installed``) read that
+    as app-owned and re-inserted it forever: F1's original defect, one branch
+    narrower. Ownership is now the EXACT ``<app>:<server>`` set the manifests
+    declare.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:custom": {"command": "mine"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "a client entry squatting an installed app's namespace was preserved: "
+        "prefix matching confers ownership the app never claimed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_declared_app_server_is_still_preserved(tmp_path):
+    """The overshoot guard: a name the app genuinely declares still survives.
+
+    Tightening ownership to exact names must not stop protecting real bridges --
+    that is the defect #6664 exists to fix.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"demo:notes": {"command": "notes-mcp"}}, (
+        "a server the app declares was deleted: the exact-name tightening "
+        "overshot and stopped protecting real bridges"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unreadable_app_manifest_fails_the_put_and_writes_nothing(tmp_path):
+    """An unreadable ownership source FAILS the PUT rather than guessing.
+
+    Both guesses are wrong, and each reintroduces one of the two defects this
+    span has already produced: preserving everything namespaced makes entries
+    permanently undeletable, and deleting everything namespaced clobbers live app
+    bridges under a fault that may be transient. So the PUT refuses.
+
+    The refusal is cheap and correct: step (0a) runs before every durable write,
+    so all three targets stay byte-identical and the client can simply retry.
+    """
+    installed = tmp_path / "kirocrew.json"
+    on_disk = {"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}}
+
+    response, written = await _put(
+        tmp_path,
+        on_disk=on_disk,
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        apps_unreadable=True,
+    )
+
+    assert response.status == 500
+    assert (
+        json.loads(response.text)["code"] == "app_ownership_unreadable"
+    ), "a non-2xx body must carry a machine-readable code (AGENTS.md)"
+    assert (
+        json.loads(installed.read_text(encoding="utf-8")) == on_disk
+    ), "the refused PUT still rewrote the agent spec"
+    assert written == on_disk
+
+
+@pytest.mark.asyncio
+async def test_corrupt_installed_metadata_fails_the_put_and_writes_nothing(tmp_path):
+    """ROUND 3: a malformed ``installed.json`` must refuse, not silently skip.
+
+    ``manager._read_installed`` returns None for BOTH a missing file and a parse
+    failure, so a bare ``is None: continue`` dropped a CORRUPT app out of the
+    ownership scan entirely -- its live bridges then classified as client-owned
+    and were deleted. Same asymmetric-failure class as the unreadable manifest,
+    one branch over: absence is a real "not installed" answer, corruption is
+    "cannot know".
+    """
+    installed = tmp_path / "kirocrew.json"
+    on_disk = {"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}}
+
+    response, written = await _put(
+        tmp_path,
+        on_disk=on_disk,
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        installed_corrupt=True,
+    )
+
+    assert response.status == 500
+    assert json.loads(response.text)["code"] == "app_ownership_unreadable", (
+        "corrupt installed metadata must refuse with the same machine-readable "
+        "code as an unreadable manifest"
+    )
+    assert (
+        json.loads(installed.read_text(encoding="utf-8")) == on_disk
+    ), "the refused PUT still rewrote the agent spec"
+    assert written == on_disk
+    assert "demo:notes" in written["mcpServers"], "the live bridge was deleted"
+
+
+@pytest.mark.asyncio
+async def test_absent_installed_metadata_is_still_skipped(tmp_path):
+    """The overshoot guard: no ``installed.json`` at all is a real answer.
+
+    A directory under ``apps/`` with no installed metadata is not an installed
+    app -- an ordinary uninstall race leaves exactly that. Skipping is correct,
+    and the refusal above must not widen into refusing this.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        installed_absent=True,
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "an app with no installed metadata was treated as installed; absence is "
+        "a real 'not installed' answer and its namespace confers no ownership"
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_app_bridge_is_deleted(tmp_path):
+    """ROUND 4: a DISABLED app's stale bridge must be cleanable, not protected.
+
+    A disabled app is still installed, so an installed-only ownership test keeps
+    its declared names app-owned. That protects the exact entry the disable
+    lifecycle was supposed to remove: when ``_deregister_mcp_servers`` FAILS
+    during disable the entry survives, and startup reconciliation only
+    re-registers ENABLED apps so it never revisits it. Every subsequent PUT would
+    then re-insert it, leaving a disabled app's code launchable through the
+    retained bridge forever. Ownership requires installed AND enabled.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        enabled=False,
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}, (
+        "a disabled app's stale bridge was preserved: the disable lifecycle owns "
+        "bridge removal, so a failed removal must be cleanable by the next PUT"
+    )
+
+
+@pytest.mark.asyncio
+async def test_absent_enabled_field_counts_as_enabled(tmp_path):
+    """A legacy record with no ``enabled`` field is ENABLED, matching the manager.
+
+    ``InstalledApp.from_dict`` reads ``bool(data.get("enabled", True))``
+    (manager.py:170) over a dataclass defaulting to ``enabled: bool = True``
+    (manager.py:114), so every other reader in the tree treats such a record as
+    running. Disagreeing here would delete the live bridges of an app the rest of
+    the system considers enabled.
+
+    The record is written WITHOUT the key and parsed by the real
+    ``app_enabled_state``, so this pins the manager's own default rather than a
+    stub's.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        enabled=None,
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"demo:notes": {"command": "notes-mcp"}}, (
+        "a record with no 'enabled' field was treated as disabled, deleting the "
+        "bridges of an app the manager considers enabled"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unreadable_apps_directory_fails_the_put(tmp_path):
+    """An unenumerable apps directory refuses rather than reading as 'no apps'.
+
+    Treating it as empty would classify every app bridge on the host as
+    client-owned and delete all of them in one PUT.
+    """
+    installed = tmp_path / "kirocrew.json"
+    on_disk = {"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}}
+
+    response, written = await _put(
+        tmp_path,
+        on_disk=on_disk,
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        apps_dir_unreadable=True,
+    )
+
+    assert response.status == 500
+    assert json.loads(response.text)["code"] == "app_ownership_unreadable"
+    assert json.loads(installed.read_text(encoding="utf-8")) == on_disk
+    assert written == on_disk
+
+
+async def _assert_refused_and_intact(tmp_path, **kwargs):
+    """PUT refuses with the ownership code and leaves the spec byte-identical."""
+    installed = tmp_path / "kirocrew.json"
+    on_disk = {"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}}
+
+    response, written = await _put(
+        tmp_path,
+        on_disk=on_disk,
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        **kwargs,
+    )
+
+    assert response.status == 500
+    assert json.loads(response.text)["code"] == "app_ownership_unreadable"
+    assert json.loads(installed.read_text(encoding="utf-8")) == on_disk
+    assert written == on_disk
+    assert "demo:notes" in written["mcpServers"], "the live bridge was deleted"
+
+
+@requires_symlinks
+@pytest.mark.asyncio
+async def test_installed_metadata_as_a_broken_symlink_fails_the_put(tmp_path):
+    """ROUND 5: a DANGLING installed.json symlink is unreadable, not absent.
+
+    ``Path.is_file()`` follows the link, finds nothing, and answers False -- the
+    same False it gives for genuine absence -- so the app read as not installed
+    and its live bridges became deletable. Absence is proven only by ``lstat``
+    raising ``FileNotFoundError``; the link itself exists, so this is the
+    cannot-read case and must refuse.
+    """
+    await _assert_refused_and_intact(tmp_path, installed_shape="broken_symlink")
+
+
+@pytest.mark.asyncio
+async def test_installed_metadata_as_a_directory_fails_the_put(tmp_path):
+    """A directory where ``installed.json`` belongs is present, so unreadable.
+
+    Needs no symlink privilege, which is why it carries the same row on every
+    platform the broken-symlink test may skip on.
+    """
+    await _assert_refused_and_intact(tmp_path, installed_shape="directory")
+
+
+@pytest.mark.asyncio
+async def test_apps_root_as_a_regular_file_fails_the_put(tmp_path):
+    """The apps root present but not a directory is unreadable, not empty.
+
+    Reading it as empty would classify every app bridge on the host as
+    client-owned and delete all of them in one PUT.
+    """
+    await _assert_refused_and_intact(tmp_path, apps_root_is_file=True)
+
+
+@pytest.mark.asyncio
+async def test_an_unstattable_apps_root_child_fails_the_put(tmp_path):
+    """ROUND 6: a child the listing returns but cannot stat is unreadable.
+
+    The enumeration screened its children with ``Path.is_dir()``, which routes
+    the fault through pathlib's ``_ignore_error`` and answers a plain False for
+    ENOENT, ENOTDIR, EBADF and ELOOP alike -- the same False it gives for a
+    regular file. So a child that is a symlink LOOP was skipped as "not an app",
+    and the absent bridge of the app living under that name was deleted: the
+    cannot-read-becomes-not-owned defect one level inside the shapes round 5's
+    screen already covers, and the same loop shape that screen refuses for
+    ``installed.json``. Only a resolved stat may exclude a child, and only by
+    PROVING it is not a directory.
+    """
+    await _assert_refused_and_intact(tmp_path, apps_child_unstattable=True)
+
+
+@pytest.mark.asyncio
+async def test_genuinely_absent_installed_metadata_still_skips(tmp_path):
+    """The overshoot guard: real absence stays a real "not installed" answer.
+
+    ``lstat`` raising ``FileNotFoundError`` is the ONLY proof of absence, and it
+    must keep taking the skip branch -- an ordinary uninstall race leaves exactly
+    this state, and refusing it would turn a routine PUT into a 500.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        apps={"demo": ("notes",)},
+        installed_absent=True,
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {}
+
+
+# ── (c) regressions: full replace still behaves for client-owned content ───────
+
+
+@pytest.mark.asyncio
+async def test_client_owned_entry_present_in_the_snapshot_is_updated(tmp_path):
+    """A submitted entry always wins — merge adds, it never shadows."""
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"weather": {"url": "old"}}},
+        submitted={"name": "kirocrew", "mcpServers": {"weather": {"url": "new"}}},
+        scope_names=frozenset({"weather"}),
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"weather": {"url": "new"}}
+
+
+@pytest.mark.asyncio
+async def test_app_owned_entry_present_in_the_snapshot_is_updated(tmp_path):
+    """Preservation must not shadow a submitted edit to the same name either."""
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "old"}}},
+        submitted={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "new"}}},
+        scope_names=frozenset(),
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"demo:notes": {"command": "new"}}, (
+        "a preserved on-disk entry overwrote the client's own edit to the same "
+        "name: the merge must yield to the submission where both carry a name"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_mcp_keys_are_still_replaced_wholesale(tmp_path):
+    """The merge is scoped to ``mcpServers``; every other key still replaces.
+
+    ``mcpServers`` is the whole app-owned surface in this file — all three
+    bridges writers of it touch that key and nothing else — so widening the merge
+    would preserve state no app owns.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "prompt": "old", "tools": ["a"], "mcpServers": {}},
+        submitted={"name": "kirocrew", "tools": ["b"]},
+        scope_names=frozenset(),
+    )
+
+    assert response.status == 200
+    assert written["tools"] == ["b"]
+    assert "prompt" not in written, "a non-mcpServers key survived the snapshot replace"
+
+
+@pytest.mark.asyncio
+async def test_unreadable_installed_spec_still_accepts_the_snapshot(tmp_path):
+    """A corrupt spec must stay repairable through this editor.
+
+    Best-effort by design: a corrupt file has no parseable entries to preserve,
+    and this endpoint is the user's repair path for exactly that state. Failing
+    closed would leave a broken agent with no way to fix it from the dashboard;
+    enabled apps re-register their servers on the next gateway start, so the loss
+    self-heals.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk="{ not json at all",
+        submitted={"name": "kirocrew", "mcpServers": {"weather": {"url": "w"}}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == {"weather": {"url": "w"}}
+
+
+@pytest.mark.asyncio
+async def test_non_object_mcp_servers_submission_is_left_untouched(tmp_path):
+    """A non-object ``mcpServers`` is a shape kiro-cli rejects outright.
+
+    Merging into it would mean inventing a map the client never sent, so the
+    submission is persisted as-is and its rejection is unchanged.
+    """
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "notes-mcp"}}},
+        submitted={"name": "kirocrew", "mcpServers": []},
+        scope_names=frozenset(),
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"] == []
+
+
+# ── the preserved entries are governed, not smuggled past the filter ──────────
+
+
+@pytest.mark.asyncio
+async def test_preserved_entries_go_through_the_governance_filter(tmp_path, monkeypatch):
+    """Merge runs BEFORE the governance filter, so what it re-adds is governed.
+
+    ``autoApprove`` is the one path that never reaches the permission gate, so an
+    entry re-injected AFTER step (0) would carry a ceiling-denied auto-approve
+    straight to disk — reopening the bypass that filter exists to close. Ordering
+    the merge ahead of the filter makes that unrepresentable.
+    """
+    import kiro_crew.platform.governance as gov
+
+    monkeypatch.setattr(gov, "may_skip_gate_now", lambda ref: ref != "@demo:notes")
+
+    response, written = await _put(
+        tmp_path,
+        on_disk={
+            "name": "kirocrew",
+            "mcpServers": {"demo:notes": {"command": "notes-mcp", "autoApprove": ["write"]}},
+        },
+        submitted={"name": "kirocrew", "mcpServers": {}},
+        scope_names=frozenset(),
+        govern=True,
+    )
+
+    assert response.status == 200
+    # Preserved at all — the merge ran.
+    assert "demo:notes" in written["mcpServers"]
+    # ...and governed, which only holds if it was merged before the filter.
+    assert "autoApprove" not in written["mcpServers"]["demo:notes"], (
+        "a preserved entry kept a ceiling-denied autoApprove: the merge ran "
+        "AFTER the governance filter, so what it re-added was never governed"
+    )

--- a/test/test_api_agent_config_put_succeeds.py
+++ b/test/test_api_agent_config_put_succeeds.py
@@ -371,7 +371,7 @@ async def test_agent_config_write_holds_the_mcp_transaction_lock(tmp_path):
             _recording_lock,
         ),
         patch(
-            "kiro_crew.apps.bridges._mcp_lock",
+            "kiro_crew.dashboard.handlers.agents._agent_file_lock",
             _recording_file_lock,
         ),
         patch(


### PR DESCRIPTION
## Problem / Motivation

The agent-config PUT handler (`api_agent_config` in `src/kiro_crew/dashboard/handlers/agents.py`) persists the client's whole-file snapshot. An app-bridge registration landing between the client's read and its PUT is silently clobbered: the app's MCP server vanishes from the spec even though nothing removed it. GPT review round 6 on #5899 found this; the maintainer decided (2026-08-28) to keep the snapshot contract there and ship merge-on-write as this follow-up — issue #6664.

## Why it matters

Any app that registers an MCP bridge while the user has the raw config editor open loses that bridge on the user's next save, with no error and no audit trail. The user sees an app that stopped working; the app sees its registration erased by a write it never participated in.

## What changed (motivation → approach → change)

Goal: preserve entries the client does not own across a PUT, while keeping the client fully able to delete what it does own.

Approach: an ownership rule at the write site, inside the existing commit unit. Under the transaction → config → bridge-file locks, the handler re-reads on-disk state and classifies every entry absent from the submitted snapshot:

- **App-owned** (exact `<app>:<server>` names from installed apps' manifest-declared server lists, resolved through `bridges._registration_source` so a shipped builtin resolves from its immutable package root — installed metadata cannot claim a builtin's namespace, and one app cannot claim another's) → preserved. Proven ownership is the only test: a name a client scope also declares is still preserved. (An earlier scope-declaration exclusion ran before ownership and could therefore only ever subtract provably-owned names — exactly the collision bug — so it is removed rather than reordered; a scope-declared name with no proven owner still deletes under the general rule.)
- **Host-managed, only while eligible for emission** — the eligibility rule lives once (`agent.emission_eligible_mcp_servers`) and both spec writers plus this merge consult it. Always-emitted managed servers and edition extras → preserved (the rebuild re-adds them, so deleting one never stuck). An `opt_in` server (assignable grant, never auto-emitted) or a gate-closed/gate-raising one → deleted: nothing re-adds those, so preserving them would make revocation impossible through this endpoint.
- **Everything else — including a client-created entry squatting under an installed app's namespace that the app did not declare** → client-owned, deleted exactly as before. Sequential add-then-delete behaves identically to the old contract.
- **Ownership source unreadable** (corrupt `app.json`, or an apps-root child that is listable but unstattable — `Path.is_dir()` silently swallows ELOOP/EBADF/ENOTDIR via pathlib's ignored-errno list, so enumeration stats each child explicitly and only `FileNotFoundError` proves absence): the PUT fails before any durable write with HTTP 500 and a machine-readable `code: app_ownership_unreadable`, leaving all three write targets byte-identical. Either silent guess is wrong — preserving makes entries undeletable, deleting clobbers live app bridges — so the handler refuses and the client retries after repair. `list_apps` is deliberately not used as the source: it swallows manifest parse errors, which would silently narrow ownership into bridge deletion.

The bridge-file lock is acquired before the merge read and held through the installed-spec write, so an app registration or deregistration cannot interleave with the merge in either direction. Preserved entries flow through the governance filter like everything else.

The five commit-unit invariants from #6166/#5899 are unchanged: exactly one shielded offload; transaction → config → bridge-file lock order (no ABBA cycle — bridge registration takes health→bridge only, MCP sync callers take the same forward order); `removed_per_key` diffed from the submitted pre-governance config; governance sanitize inside the commit unit; bookkeeping before spec write.

Two intended behavior changes a reviewer should see explicitly:
1. An app bridge can no longer be removed through this endpoint — the app lifecycle (disable/uninstall) removes it. This is the issue's stated intent.
2. Host-managed servers are preserved on merge for the reason above.

Residual, documented in `_merge_unowned_servers`: every in-gateway spec writer takes the bridge flock, so no in-process interleaving remains. What remains is a writer outside this process (kiro-cli writing the spec, a hand edit) — an exposure identical for every writer of the file and a property of the file rather than of this change.

Ownership is decided by the exact-manifest census alone; the scope-declaration pre-filter and the now-callerless `connections/ownership.py` accessor that served it are removed (that file is byte-identical to base and out of this diff). `docs/system-specs/modules/app-kit-platform.md` documents the new PUT semantics — including the ownership-outranks-declaration and unstattable-child rows — in the same commit.

## Tests

`test/test_agent_config_merge_on_write.py` (36 tests, all red-first against snapshot-replace or mutation-verified):

- the original finding's race: app bridge registered during the lock wait survives the PUT
- deterministic deregistration race: an app deregistered during the PUT is not resurrected (fake flock performs the deregistration at acquisition — no sleeps)
- ownership grid: app-owned absent → preserved; client-owned absent → deleted; unknown key → deleted; client entry under an installed app's namespace but undeclared by it → deleted; a declared app server → preserved; a scope declaration does not defeat proven ownership; a scope-declared name with no proven owner → deleted
- failure surfaces refuse rather than guess: unreadable apps directory → 500; apps-root child listable but unstattable (symlink loop) → 500 with all write targets untouched; broken-symlink or directory-shaped installed metadata → 500; genuinely absent metadata still skips (absence is proven only by `FileNotFoundError`)
- unreadable manifest → 500 with `code: app_ownership_unreadable` and all three targets byte-identical
- preserved entries pass through the governance filter
- regression guards: sequential full-replace flows for client-owned content unchanged; one shielded offload; the transaction lock held across the write

Mutation checks: each guard was verified to fail alone under a targeted mutation (snapshot-replace restored: 4 fail; preservation-set emptied: 1 fails; merge moved after governance: 1 fails; prefix matching restored: 1 fails; manifest error swallowed: 1 fails; scope exclusion restored: 1 fails; `is_dir()` child filter restored: 1 fails), with the handler restored byte-identical after each.

Full battery on the final commit: 14 suites, 1,142 passed / 6 skipped / 0 failed; black, subprocess-encoding, isort, flake8, mypy (1,176 files), brand gate all exit 0.

## Manual verification

N/A — unit coverage sufficient: the change is a locked read-merge-write inside one handler, and the 20-test matrix pins every classification branch, both races deterministically, and the failure path; no UI or external service is involved.

## Related Issues

Fixes #6664

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


## Known limitation (tracked in #7089)

This PR preserves app-owned servers that are **absent** from the submitted config. It deliberately does not rewrite app-owned entries that are **present** in a stale editor snapshot: an editor tab holding a snapshot from before an app was uninstalled or disabled writes that entry back on save. This is the editor-snapshot-wins contract kept in #5899 — the exposure is identical before and after this PR. Closing that axis (replace submitted app-owned rows from disk state, or optimistic concurrency on the PUT) is tracked in #7089.


