### PR TITLE
chore(dashboard): remove confirmed dead code in the frontend app and utility surface

### DIFF
--- a/website/src/types/index.ts
+++ b/website/src/types/index.ts
@@ -1057,15 +1057,6 @@ export interface NotificationChannel {
   settings: { muted?: boolean; priority?: string }
 }
 
-export interface SecretaryItem {
-  id: string; channel: string; channel_name: string
-  thread_ts: string | null; message: string
-  sender_id: string; sender_name: string
-  thread_context: { sender: string; text: string }[]
-  classification: string; draft: string; confidence: string
-  status: string; created_at: number; context_summary?: string
-}
-
 export interface PendingApproval {
   tool: string
   tool_input: string

--- a/website/src/utils/artifactPopout.ts
+++ b/website/src/utils/artifactPopout.ts
@@ -4,7 +4,6 @@ import {
   pruneStale,
   HEARTBEAT_MS,
   STALE_MS,
-  NAV_CLAIM_MS,
   type PopoutMap,
   type PopoutMsg,
   type NavIntent,
@@ -25,7 +24,7 @@ import {
 
 export const ARTIFACT_POPOUT_CHANNEL = 'kirocrew-artifact-popout'
 
-export { HEARTBEAT_MS, STALE_MS, NAV_CLAIM_MS, applyMessage, pruneStale }
+export { HEARTBEAT_MS, STALE_MS, applyMessage, pruneStale }
 export type { PopoutMap, PopoutMsg, NavIntent }
 
 /**

--- a/website/src/utils/chatDrafts.ts
+++ b/website/src/utils/chatDrafts.ts
@@ -80,8 +80,6 @@ export function mergeRecoveredDraft(keep: string | null | undefined, payload: st
   return mergeIntoDraft(existing, payload)
 }
 
-export type Drafts = Record<string, string>
-
 const isNonEmptyString = (v: unknown): string | null => (typeof v === 'string' && v ? v : null)
 
 const store = createSlotDraftStore<string>({

--- a/website/src/utils/chatFileDrafts.ts
+++ b/website/src/utils/chatFileDrafts.ts
@@ -12,8 +12,6 @@ import { createSlotDraftStore } from './slotDraftStore'
 
 export const FILE_DRAFTS_KEY = 'mc-chat-file-drafts'
 
-export type FileDrafts = Record<string, string[]>
-
 /** Coerce to a non-empty string[] (dropping non-string members), or null. The
  *  returned copy isolates the store from caller mutations and vice versa. */
 const sanitizePaths = (v: unknown): string[] | null => {

--- a/website/src/utils/chatPasteDrafts.ts
+++ b/website/src/utils/chatPasteDrafts.ts
@@ -37,8 +37,6 @@ export const PASTE_DRAFT_MAX_ENTRIES = DRAFT_MAX_ENTRIES
 /** Discard blocks not touched within this window (shared with text drafts). */
 export const PASTE_DRAFT_TTL_MS = DRAFT_TTL_MS
 
-export type PasteDrafts = Record<string, PasteBlock[]>
-
 /** A value is a valid PasteBlock iff it carries all four fields with the right
  *  primitive types. Anything else is corruption and is dropped. */
 function isPasteBlock(v: unknown): v is PasteBlock {

--- a/website/src/utils/commentDrafts.ts
+++ b/website/src/utils/commentDrafts.ts
@@ -12,8 +12,6 @@ export const COMMENT_DRAFTS_KEY = 'mc-comment-drafts'
 /** Cap stored files to prevent unbounded growth from long-term reviewers. */
 export const COMMENT_DRAFT_MAX_FILES = 20
 
-export type CommentDrafts = Record<string, InlineComment[]>
-
 /** Accept only non-empty arrays of comments carrying the required string keys;
  *  return a deep copy isolating the store from caller mutations, or null to
  *  drop. The per-comment spread is a full copy ONLY because every InlineComment


### PR DESCRIPTION
Dead-code audit of the frontend `apps` / `utils` / `lib` / `api` surface — `website/src/{apps,utils,lib,api,app-sdk,types,pierre,kirocrew-ui}`, 689 files / 156,223 lines. Six symbols deleted, 19 lines. Five deletions are type-only; the sixth removes one unused runtime re-export.

The interesting result is not the deletion count. It is that of 52 candidates both analyzers agreed on, **46 were false positives**, and the confirmation protocol is what separated them. The four blind spots below are worth reading before the next scan of this repo, because each one produced a wrong answer here.

## Deleted

| symbol | file | evidence |
|---|---|---|
| `Drafts` | `website/src/utils/chatDrafts.ts:83` | 22 whole-repo word hits, 21 outside the definition, **none an identifier reference** — i18n prose (8), README/`app.json`/`ImpactSection.tsx` prose (3), a JSON description string, two comments, and `folderTree.test.ts` using the string literal `'Drafts'` as a folder name. The module has 8 importers, none taking the alias. Last touched 2026-07-13 (48 days). |
| `FileDrafts` | `website/src/utils/chatFileDrafts.ts:15` | 1 whole-repo hit — the definition. Sole importer `ChatPage.tsx:203` takes `loadFileDrafts`/`saveFileDrafts`/`setFileDraft`; `test/chatFileDrafts.test.ts` imports the functions, not the type. 2026-07-13. |
| `PasteDrafts` | `website/src/utils/chatPasteDrafts.ts:40` | 1 whole-repo hit — the definition. `ChatPage.tsx:204` imports load/save/set only. 2026-07-13. |
| `CommentDrafts` | `website/src/utils/commentDrafts.ts:15` | 1 whole-repo hit — the definition. `MarkdownPanel.tsx:25` takes `loadCommentDrafts`/`saveCommentDrafts`/`setCommentsForFile`; `grep -w` does not conflate those with the type. 2026-07-18. |
| `SecretaryItem` | `website/src/types/index.ts:1060-1067` | 1 whole-repo hit — the definition. Zero intra-file use: it sat between `NotificationChannel` and `PendingApproval` and there is no `Secretary*` family. Backend subsystem **removed** — no `secretary.py`, no `/api/secretary` route, no `secretary_new_item` emitter, and explicit comments at `src/kiro_crew/dashboard/state.py:4924` ("Secretary subsystem removed; kept as permanent None") and `src/kiro_crew/slack/gateway.py:1610` ("Secretary runtime service removed"). No Python producer for the field shape. 2026-06-02 (89 days). |
| `NAV_CLAIM_MS` | `website/src/utils/artifactPopout.ts:7,28` | Re-export of a `popoutController.ts` constant. 14 whole-repo hits: 3 in `popoutController.ts` (definition, doc, use at :476), 9 in `popoutNavForwarding.test.ts` — all importing from `popoutController` directly at :4, never through this module — and 2 here. Zero consumers of the re-export. It is the only member of that block with no sibling re-export, so no cross-file convention breaks. 2026-07-13. |

The four record aliases were unused because `createSlotDraftStore<T>` already carries the record shape; consumers spell it inline (`Record<string, string>` at `ChatPage.tsx:1074`).

## Why 46 of 52 agreed candidates were false positives

The repo configures neither knip nor ts-prune, so both were run via `npx` — no dependency or `tsconfig` change is committed. `noUnusedLocals`/`noUnusedParameters` are already on in `tsconfig.app.json`, so `tsc -b` already catches unused locals and parameters; unused *exports* are the only surface left for these tools.

**1. knip's "Unused exports" means "no cross-module importer", not "unreferenced".** A symbol with a live caller in its own file is reported. This alone accounted for 10 of 10 rejections in the `utils/`+`lib/` wave — including three live security controls: `sanitizeExfiltrationUrls` (live via `sanitizeLlmOutput:151`, ~18 importing modules, functionally tested at `CollapsibleMessage.test.tsx:65-71`) and `CSS_VALUE_ALLOWED_RE`/`CSS_DANGEROUS_FUNC_RE` (live via `sanitizeCssValue:44-45`, 6 production call sites, revert-sensitive proof at `WidgetFrame.test.tsx:181-199`). Any `validate|sanitize|escape|redact|check|allow|deny`-named symbol needs an in-file caller check before it enters a candidate list.

**2. ts-prune does not credit bare-directory import specifiers.** A symbol imported as `from '../types'` (resolving through `types/index.ts`) is reported unused; the same symbol imported as `from '../types/index'` is credited. Reproduced in an isolated fixture. Every consumer here uses the directory form, so ts-prune's false-positive rate on `website/src/types/index.ts` is effectively 100% — it reported `ChatMessage` (558 real references), `Artifact` (245), `ChatFolder` (144), `CronJob` (90), `ToolActivity` (33) and `StatusData` (27) as unused. The same bug explains the whole `kirocrew-ui/index.ts` cluster (18 findings; consumed as `import * as kirocrewUi from '../kirocrew-ui'` in `app-sdk/shared-modules.ts`, which also makes it public app-SDK surface) and `pierre/index.tsx` (17 bare-directory importers).

**3. Both tools miss inline `import('../types').X` type queries.** `api/client.ts` uses that form 12 times, and it is the *sole* reference for four `types/index.ts` candidates both tools flagged: `DiscoverSkillsResponse` (:2576), `McpDiscoverResponse` (:2591), `McpDiscoverInstallResult` (:2597), `McpCustomSpecResponse` (:2603). A literal `grep -w` does catch this form, which is why grep — not the analyzers — is the authority for that file.

**4. My own first measurement excluded the defining directory.** Grepping with `-v '^./website/src/types/'` filters out the only file that can reference a leaf payload type, and it made 10 of 11 `types/` candidates look dead when each is a field of an externally-live wrapper: `BlockType` (of `ContentBlock`), `SessionStorageBucket` (`SessionStorageReport`), `TodoTask` (`TodoList`), `PullRequestCommit` (`PullRequestSource`), the four `Issue*` types (`IssueSource`), `IntentNextStep`, `SummaryGenerateState`.

One more for whoever scans `src/apps/` next: `vite.config.ts:469-482` `appWindowEntries()` globs every `src/apps/<app>/<name>.html` into `rollupOptions.input` — mochi contributes 5 entries, crew-companion 3. A detector rooted only at `index.html`/`main.tsx` treats those eight `main.tsx` files as unreachable and reports both whole app trees dead. knip also never loaded `vite.config.ts`, which is why `TAILWIND_RUNTIME_SRC`/`MERMAID_RUNTIME_SRC` looked dead while being consumed at `vite.config.ts:20,125-126`.

## Needs a decision from a human — 5 items where deadness is the defect

These are worth more than the deletions. None is touched by this PR.

**1. `clearSnapshots` is unwired and snapshots can grow without bound.** `website/src/apps/code-review-sage/lib/persist.ts:170`. `writeSnapshot` and `readSnapshot` are both live (`context.tsx:217,290,309,318,428,454,501,517`, `PrSourcePanel.tsx:42,54`); the clear half has no caller. Eviction is lazy and per-key — `readSnapshot` drops an entry only when that same key is read back past `MAX_AGE_MS` (`persist.ts:148-151`) — and there is no sweep. Two key families are unbounded in cardinality (`report:${runId}`, `pr-source:${url}`), so once a run is evicted server-side or a PR is merged its key is never read again and its entry never expires. Each survivor may be up to 256 KB against a 5 MB origin-wide budget the rest of the dashboard shares, a risk the file's own comment at :36-39 names. **Wire it, don't delete it.**

**2. `isLiveEdge` has a non-equivalent inline duplicate on a correctness path.** `website/src/apps/issue-radar/lib/deps.ts:424`. `GraphView.tsx:513` reimplements it as `liveEdges.filter((e) => nodes.get(e.blocker)?.state !== 'done')`, and the two **disagree**: for an edge whose blocker is absent from the `nodes` map, `isLiveEdge` returns `false` (drops it) while the inline form evaluates `undefined !== 'done'` → `true` (keeps it, and `componentOf` then pulls the dangling id into the component). Which dependency edges are still constraints versus history is a correctness question. Point `GraphView.tsx:513` at `isLiveEdge` and settle the dangling-blocker case deliberately.

**3. `subscribeErrors` — push channel built, pull channel shipped.** `website/src/utils/errorReport.ts:273`. The publisher is live (`recordError` imported by `ErrorBoundary.tsx:5`, `MessageErrorBoundary.tsx:4`, `api/client.ts:33`, `instanceFailureReport.ts:25`, and `errorReport.ts:246-248` iterates `_listeners`), but nothing subscribes; `_listeners` (:202) is only populated by `subscribeErrors` and only cleared by the test reset (:282). Deleting the subscribe function alone leaves the notify loop and the reset's `clear()` as dead weight, so the real choice is unwinding all four sites (~10 lines, journal becomes pull-only) or wiring a subscriber.

**4. Mochi appearance-pack manifest enum checks exist only in dead TS.** `validateManifestStructure` (`website/src/apps/mochi/src/shared/appearanceTypes.ts:232`) is the only implementation anywhere of the `meta.type ∈ {built-in, custom}` and `meta.format ∈ {svg, lottie, sprite}` checks and of the non-empty-string check on required meta fields; the server-side gate (`src/kiro_crew/apps/builtins/mochi/appearance_store.py`, `import_bundle()`) enforces none of them. This is defence-in-depth, not a vulnerability: `import_bundle` does validate flat entry names, an extension allowlist, a 32 MB cap, required states, and validates before staging; and both consumer surfaces are script-safe (SVG reaches `<img src="data:image/svg+xml,…">` where no script or scripted `foreignObject` runs; Lottie goes through `JSON.parse` in try/catch plus `stripExpressions()`, with `unsafe-eval` absent from the CSP). Impact is contained because `animationResolver.formatFromFilename()` derives the render format from the file extension rather than `meta.format`, so a bogus value surfaces as wrong gallery metadata. Either port the enum checks into `import_bundle` or record the gap deliberately. Note `isValidSvg` is only `content.toLowerCase().includes('<svg')` and would not have blocked anything hostile even if wired.

**5. `getContrastingTextColor` is a superseded accessibility helper.** `website/src/utils/sessionColors.ts:31`, 89 days old so the gate does not hold it. It uses the legacy YIQ formula with a hard `>128` threshold while the live palette machinery in the same file computes contrast with APCA (`apcaLc`, `contrastRampL`, `LC_DARK`/`LC_LIGHT`, :142-155) against the actual theme background. Its `if (!rgb) return '#ffffff'` fallback silently assumes a dark background, which is wrong under a light theme — an argument for removing it rather than leaving it as a trap. Held only because a silent-failure accessibility decision should not be swept without a human saying so.

Contract drift found along the way, lower stakes: `getSoul` (`apps/mochi/api.ts:164`) is an abandoned client over a live, tested route (`routes.py:971`) while `src/mochiApi.ts:33` lists it under "Deliberately ABSENT" — one of the two is wrong; `GetWatchlistParams` declares 7 fields where the live MCP schema has one (`mcp_server.py:277-296`); `UpdateWatchlistResult` is duplicated at `api.ts:71` and *that* copy is what consumers import; `UpdateWatchlistParams` is missing `remove?`, which both `routes.py` and `api.ts:145` support; `PetEvent` (`mochi/src/shared/types.ts:17`) is unused while `panel/panelBridge.ts:150` re-declares the union independently; `SelfUpdateResponse` (`apps/design-tweak/types.ts:155`) describes an endpoint that exists on neither side; spec-builder's `SettingsResponse` disagrees with the inline type its own caller uses at `api.ts:312` over a live route. Also `MERMAID_RUNTIME_PATH` has no cross-language parity guard while `TAILWIND_RUNTIME_PATH` does (`test/test_publish_sync.py:662-671`), and `publish_sync.py:135` hardcodes the build-emit path that `vendorPaths.ts:14-16` warns about in prose with nothing enforcing it.

Three `__*ForTests` seams are missing-coverage gaps rather than surplus code, so the fix is a test: `__resetSessionRefDraftsForTests` (`utils/chatSessionRefDrafts.ts:34`, module has no test file while both siblings with the same seam are exercised), `__resetStaleOwnerHandlerForTests` (`api/staleOwnerSignal.ts:34`, the test cannot live in `staleOwnerSession.test.ts` because importing `api/client` installs the handler), and `artifactPopout.ts`'s three seams (`artifactPopout.test.ts:11-14` states the BroadcastChannel wiring is "intentionally not exercised here").

## Pre-existing drift found, deliberately not fixed here

`docs/system-specs/modules/slack-gateway.md:577-586` still documents `secretary.py`, `_init_secretary()`, and the three `secretary_*` WebSocket events as live. That section is byte-identical on `origin/main` and `secretary.py` does not exist there either, so this predates this PR rather than being created by it, and the file is outside this group's scope (a Python-side spec). Deleting the TS type does not make the doc more wrong. Worth a follow-up.

## Deferred by the 30-day gate

Every remaining `src/apps/` candidate. These trees all landed 2026-08-01..2026-08-23, so the gate is the dominant blocker for this group rather than an occasional one: 2026-09-03 for the mochi set (`ac7576c0d`, 2026-08-04 — 27 symbols including all 10 of `watchlistTypes.ts`), 2026-09-06 for crew-companion (`d54272dce`), 2026-09-07 for `SessionRefDrafts` and its test seam, plus `KIND_LABEL`, `clearSnapshots`, `loadJob`, `SelfUpdateResponse`, `isLiveEdge`, `SettingsResponse`, `DESKTOP_APP_REQUIRED_LABEL`, `PanelToggleChord`, `__resetStaleOwnerHandlerForTests`, `subscribeErrors`, and the `hljs` default export.

Two of those have a second independent reason to hold: `BG_AGENT_NAME`'s *value* `'mochi-bg'` is live in Python (`hooks.py:98,116`, `agent_policy.py:50`, `agents/mochi-bg.json`, `app.json:75`), and `AGENT_SPAWN_TIMEOUT_MS` is named by name in two Python comments (`watchlist_service.py:68`, `queue_poller.py:66`) as the origin of the ported timeout — cross-surface parity anchors with no test guarding the pair. The `hljs` default export needs a paired edit rather than a deletion: `eslint.config.js:41` is an ERROR-level `no-restricted-imports` rule whose remedy text prescribes `import hljs from '<relative>/utils/hljs'`, so removing the export makes the rule's own instruction uncompilable.

`src/app-sdk/` (13 files) is report-only by scope rule — it is the public API third-party apps compile against, so zero in-repo references does not imply dead. `src/apps/` was only audited at the symbols the two analyzers surfaced; apps with no candidate in either output were not independently swept. Given how comprehensively the gate blocks this group, the productive next pass is after 2026-09-07 rather than a wider sweep now.

## Verification

`tsc -b` exit 0 and eslint 0 errors (658 pre-existing warnings), both re-run after rebasing onto current `origin/main`. 203 tests across 15 files pass: the four drafts stores, `slotDraftStore`, `folderTree`, `ChatPageDrafts`, and the whole popout family (`artifactPopout`, `terminalPopout`, `chatPopout`, `popoutNavForwarding`, `ArtifactPopoutFrameCov80`, `ArtifactDetailPage.popoutNav`, `terminalPopoutCov80`, `SessionActionsMenu.popout`). Node 24 is required locally — vitest passes `--no-experimental-webstorage`, which node 20 rejects.

All five diff-scoped gates were run with their base refs exported, since without them each degrades to full-tree report mode and exits 0 vacuously: `I18N_BASE_REF` → `i18n:check` and `lint:i18n` both exit 0 (476 untranslated strings against a 1015 baseline); `BRAND_BASE_REF`, `CHANGELOG_BASE_REF` (7 shipped sections intact), `FOCUS_CUE_BASE_REF`, `HARNESS_BASE_REF` → all exit 0.

Two adversarial review lanes ran locally on the commit before push. `claude-opus-4.8`: no findings, and it independently judged the single-member `NAV_CLAIM_MS` removal correct rather than a broken three-file convention. `gpt-5.6-sol`: one Medium (the pre-existing `slack-gateway.md` drift above) and two Low commit-message overstatements — that "every importer takes only load/save/set" (several take merge helpers and constants; corrected to "no importer references the deleted aliases") and that there is "no behaviour change" (the `NAV_CLAIM_MS` drop does change the module's runtime export surface; corrected to name that explicitly). Both wording corrections are in the commit message.
