### PR TITLE
chore(apps): remove confirmed dead code in the smaller builtin apps

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/subquestion_queue.py
+++ b/src/kiro_crew/apps/builtins/auto_research/subquestion_queue.py
@@ -142,15 +142,6 @@ def pending_count(queue: dict) -> int:
     return len(queue.get("pending", []))
 
 
-def analyzed_count(queue: dict) -> int:
-    return len(queue.get("analyzed", []))
-
-
-def is_known(queue: dict, text: str) -> bool:
-    """True if ``text`` (normalized) is already pending or analyzed."""
-    return _norm(text) in _known_keys(queue)
-
-
 def normalize(text: str) -> str:
     """Public dedup-key normalizer (lowercased, whitespace-collapsed, stripped).
 

--- a/src/kiro_crew/apps/builtins/crew_companion/appearances.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/appearances.py
@@ -198,7 +198,7 @@ class AppearanceStore:
                 # The built-in ghost's art is bundled with the frontend, so the
                 # renderer already has it and needs no content here.
                 "animations": {},
-                "colorMap": self._colour_maps.get(DEFAULT_PACK) or {},
+                "colorMap": self.colour_map(DEFAULT_PACK),
             }
 
         pack_dir = self._root / ident
@@ -276,7 +276,7 @@ class AppearanceStore:
             "randomNames": random_names,
             "categories": categories,
             "sprite": sprite,
-            "colorMap": self._colour_maps.get(ident) or {},
+            "colorMap": self.colour_map(ident),
         }
         # The ORIGINAL sheet, when the pack kept one for re-editing. It is not
         # an animation slot, so it never appears in `animations` — and reading
@@ -307,6 +307,12 @@ class AppearanceStore:
         return (self._root / ident).is_dir()
 
     def colour_map(self, pack_id: str) -> dict[str, str]:
+        """A pack's recolouring, as a COPY.
+
+        Callers put this straight into a response payload, so handing out the
+        stored dict would alias the store's own state to whatever the caller
+        does next.
+        """
         ident = _safe_id(pack_id)
         return dict(self._colour_maps.get(ident or "", {}))
 

--- a/src/kiro_crew/apps/builtins/crew_companion/reminders.py
+++ b/src/kiro_crew/apps/builtins/crew_companion/reminders.py
@@ -143,10 +143,6 @@ BREAK_NUDGES: tuple[tuple[str, tuple[str, ...]], ...] = (
 #: panel — this caps the PROMPT, never the exercise.
 MAX_BREATHE_PROMPTS_PER_DAY = 2
 
-#: Break-interval choices offered as one-tap presets. The panel and the dashboard
-#: page render this same list, so the two surfaces cannot drift.
-BREAK_PRESETS = (30, 45, 60, 90)
-
 #: Bounds for a custom interval. Below 5 the companion would be a pest; above 8h
 #: it would never fire in a working day.
 BREAK_MIN_MINS = 5

--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -481,7 +481,7 @@ def _file_kind(p: Path) -> str:
     return "other"
 
 
-def _entry_meta(p: Path, *, with_size: bool = True) -> dict:
+def _entry_meta(p: Path) -> dict:
     try:
         st = p.stat()  # follow symlinks -- consistent with _file_kind()
     except OSError:
@@ -499,7 +499,7 @@ def _entry_meta(p: Path, *, with_size: bool = True) -> dict:
         "type": kind,
         "mtime": int(st.st_mtime),
     }
-    if with_size and kind == "file":
+    if kind == "file":
         info["size"] = st.st_size
     elif kind == "dir":
         info["size"] = 0
@@ -522,7 +522,6 @@ def _list_dir(p: Path, depth: int = 1, ignore: bool = True) -> tuple[list[dict],
     # makes the containment legible to CodeQL py/path-injection). Descent into
     # subdirs is already gated by the _is_within check in walk().
     p = _contain_in_allowed_roots(p, operation="tree_list")
-    out: list[dict] = []
     count = [0]
 
     def walk(d: Path, rem: int) -> list[dict]:

--- a/src/kiro_crew/apps/builtins/papyrus/backend/store.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/store.py
@@ -70,8 +70,15 @@ MAX_PROJECT_FILES = 4000
 #: cannot balloon the gateway's memory.
 MAX_FILE_BYTES = 8 * 1024 * 1024
 
-#: Suffixes never offered as editable text (LaTeX build artifacts + binaries).
-#: Filtering them here as well as in the UI keeps the two from drifting.
+#: Suffixes that mark a LaTeX build artifact rather than paper source.
+#:
+#: Read only by ``is_artifact``. ``list_files`` does NOT filter on it, so the
+#: tree the API returns still carries artifacts and the UI is what drops them
+#: (``website/src/apps/papyrus/lib.ts``). The two lists have already drifted:
+#: the UI also lists ``.pdf`` and spells ``.synctex.gz`` as one suffix, where
+#: this set has ``.synctex`` and ``.gz`` separately -- so this one would also
+#: hide any plain ``.gz``. Reconcile them before wiring either side to the
+#: other.
 ARTIFACT_SUFFIXES = frozenset(
     {
         ".aux", ".bbl", ".blg", ".fdb_latexmk", ".fls", ".log", ".out",

--- a/src/kiro_crew/apps/builtins/workflows/server.py
+++ b/src/kiro_crew/apps/builtins/workflows/server.py
@@ -175,17 +175,6 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(data)
 
-    def _read_body(self) -> dict:
-        length = int(self.headers.get("Content-Length", 0) or 0)
-        if length <= 0:
-            return {}
-        raw = self.rfile.read(length)
-        try:
-            obj = json.loads(raw)
-            return obj if isinstance(obj, dict) else {}
-        except json.JSONDecodeError:
-            return {}
-
     def _authorized(self, method: str, raw_body: bytes) -> bool:
         """Verify the gateway's X-KiroCrew-Proxy HMAC before dispatch (CWE-306).
 

--- a/test/test_subquestion_queue.py
+++ b/test/test_subquestion_queue.py
@@ -5,10 +5,8 @@ from pathlib import Path
 
 from kiro_crew.apps.builtins.auto_research.subquestion_queue import (
     QUEUE_FILENAME,
-    analyzed_count,
     dequeue_top_k,
     enqueue,
-    is_known,
     load_queue,
     mark_analyzed,
     new_queue,
@@ -112,18 +110,12 @@ class TestAnalyzedAndDedup:
         popped = dequeue_top_k(q, 1)
         assert popped == items
         mark_analyzed(q, popped)
-        assert analyzed_count(q) == 1
+        assert len(q["analyzed"]) == 1
         assert q["analyzed"][0]["status"] == "analyzed"
         # Re-generating the same sub-question must not be re-admitted.
         again = enqueue(q, [{"text": "Investigate ME"}])
         assert again == []
         assert pending_count(q) == 0
-
-    def test_is_known(self):
-        q = new_queue()
-        enqueue(q, [{"text": "Known one"}])
-        assert is_known(q, "  known   ONE ")
-        assert not is_known(q, "unseen")
 
 
 class TestPersistence:

--- a/website/src/apps/crew-companion/constants.ts
+++ b/website/src/apps/crew-companion/constants.ts
@@ -48,9 +48,9 @@ export const BREATHING_DONE_PATH = `${API_BASE}/breathing-done`
 export const POLL_MS = 10_000
 
 /**
- * Break-interval choices offered as one-tap presets. The panel renders this same
- * list, and `BREAK_PRESETS` in reminders.py holds the same values for the backend,
- * so the surfaces cannot drift.
+ * Break-interval choices offered as one-tap presets. They are a UI affordance,
+ * so the backend has no use for the list: what it enforces is the RANGE below,
+ * via `clamp_break_mins`.
  */
 export const BREAK_PRESETS = [30, 45, 60, 90]
 

--- a/website/src/apps/crew-companion/reminders.ts
+++ b/website/src/apps/crew-companion/reminders.ts
@@ -86,13 +86,6 @@ export function clampBreakMins(raw: string | number): number | null {
 }
 
 
-/**
- * Break-interval choices offered as one-tap presets. Both the panel and the
- * dashboard app page render this same list, so the two surfaces cannot drift.
- */
-
-/**
- * Break-interval presets, floor and ceiling — the panel's own controls and the
- * backend's clamp must agree, so the numbers live here rather than in the UI.
- */
-export const BREAK_PRESETS = [30, 45, 60, 90]
+// Re-exported so the panel can keep importing its reminder helpers and the
+// presets from one place; the values themselves live in ./constants.
+export { BREAK_PRESETS } from './constants'


### PR DESCRIPTION
## What

Removes seven confirmed-dead regions from the smaller builtin apps, and corrects the prose those removals falsify. Every response payload is unchanged; the one non-cosmetic change is named below.

This is the D group of the builtin-apps dead-code audit: `crew_companion`, `meetings`, `pptx_maker`, `papyrus`, `md_notebook`, `design_tweak`, `auto_research`, `aws_control`, `personal_shopper`, `file_explorer`, `design_critique`, `workflows`, `projects` — 98 files, 41,110 lines, 6,057 in-scope definitions.

<!-- no-visual-delta -->

**Why no screenshot:** the two frontend files change a doc comment and collapse a
duplicated `BREAK_PRESETS` constant into a re-export of the identical value, so no
rendered pixel moves — `Frontend5CcSections.cov80.test.tsx` (20/20) covers the
preset pills that consume it.

**No linked issue to close:** #7085 and #7086 are follow-ups this PR deliberately
does NOT fix — they are behavioural changes on security and cloud-spend paths that
need their own reviewed diffs. Nothing here should close on merge.

## Why the deletions cluster in three apps: the 30-day new-code gate

Ten of these apps are newer than 30 days, so their unreferenced symbols are not eligible for a cleanup branch — a symbol born dead last week belongs back with its author, not here.

| app | oldest file | age | eligible |
|---|---|---|---|
| `auto_research`, `file_explorer`, `workflows` | 2026-07-16 | 45d | yes |
| `design_critique`, `crew_companion` | 2026-08-01 | 29d | no |
| `papyrus`, `meetings`, `md_notebook`, `projects` | 2026-08-02 | 28d | no |
| `pptx_maker` | 2026-08-03 | 27d | no |
| `personal_shopper` | 2026-08-10 | 20d | no |
| `design_tweak` | 2026-08-16 | 14d | no |
| `aws_control` | 2026-08-26 | 4d | no |

2026-07-16 is the `KiroClaw` → `KiroCrew` rename (`849a03fff`, #2), the effective repo epoch. The `crew_companion` constant below is the one exception, deleted on the maintainer's explicit call.

## Deleted

### `auto_research/subquestion_queue.py`

**`analyzed_count`** — read-only accessor, born unconsumed. Whole-repo search: 3 sites, the definition plus 2 in `test/test_subquestion_queue.py`. The module's only production consumer is `auto_research/handlers.py` (`import subquestion_queue as _sq`), whose 11 `_sq.` call sites use 8 of the 10 public functions; the cycle gate at `handlers.py:2005` chose `pending_count` instead. No inline `len(queue["analyzed"])` duplicate exists, so this is unconsumed rather than drift, and `handlers.py` has been through 17 commits since the rename baseline without adopting it.

**`is_known`** — pre-check superseded by `enqueue`'s own documented internal dedup ("De-duplicates (case/whitespace-insensitive) against everything already in the queue AND within the batch"). Callers cannot need a pre-check because `enqueue` self-dedups and returns only what it admitted; the emergent-question path at `handlers.py:1958-1984` dedups via `normalize` plus its own `existing_norm` set. Of 17 repo-wide name hits only 4 are this symbol — the rest are a 2-arg `_is_known` local to `test_messaging_import_purity.py` and six unrelated `..._is_known...` test names.

`_norm` and `_known_keys` remain live (both called by `enqueue`).

### `workflows/server.py`

**`_Handler._read_body`** — orphaned by `5492a2cb9` ("fix(security): backend gateway hardening — 17 CSE findings (Batch 1)", #72), which removed the `body = self._read_body()` call from `do_POST` and replaced it with an inline read because `_authorized()` needs the raw bytes to verify the HMAC. The definition was left behind. No caller, no `_Handler` subclass, no string dispatch.

Compared dimension by dimension, the inline path is not weaker: identical Content-Length parse (`int(... or 0)`), identical `length <= 0` → `b""` handling, identical JSON dict-shape check and `JSONDecodeError` swallow, plus the HMAC verification the parser never did. Neither version bounds Content-Length, so no size bound is lost — the unbounded `rfile.read(length)` is pre-existing in both and untouched here.

`design_tweak/backend/server.py` and `pptx_maker/backend/routes.py` have their own independent `_read_body`; both are untouched and still called.

### `file_explorer/server.py`

**`_entry_meta(*, with_size=)`** — vestigial keyword-only parameter. Its three production call sites (`server.py:452, 553, 993`) and its two test call sites all use the default `True`, so `if with_size and kind == "file"` is always `if kind == "file"` and the `False` path is unreachable. Simplified accordingly.

**The `out: list[dict] = []` initializer in `_list_dir`** — dead store, unconditionally overwritten by `out = walk(p, depth)` with no read in between; the nested `walk()` builds its own `items` and never touches the outer name. `flake8`'s F841 misses it because `out` *is* read after the reassignment.

### `crew_companion` — the presets had three definitions and two false comments

**`BREAK_PRESETS` (`reminders.py`)** — zero Python references of any kind. Its comment named "the panel and the dashboard page" as the consumers that keep the surfaces from drifting, but both are frontend and both read a TS constant. The frontend one predates it by exactly six days (`dcfaafd2a` 2026-08-01 vs `d54272dce` 2026-08-07), so it was born unwired rather than superseded, and its neighbours show the intended split: the backend enforces the RANGE via `clamp_break_mins` and has no use for the preset LIST.

**`website/src/apps/crew-companion/reminders.ts`** carried a SECOND copy of the constant under two stale comments: one dangling block attached to nothing (carrying the same false "the two surfaces cannot drift" prose as the Python side), and one claiming the floor and ceiling live there too — they do not, line 10 imports them from `./constants`. Collapsed to a re-export so `PanelViews.tsx` keeps importing from `'./reminders'` while one definition remains. `constants.ts` imports nothing local, so there is no cycle, and `reminders.ts` has no internal use of the name, so the re-export creating no local binding is harmless.

**`constants.ts`** — dropped the reciprocal claim that `reminders.py` holds the backend mirror.

## Changed: `crew_companion` stops aliasing the colour store's internal dict

`pack_detail` built its `colorMap` payload from `self._colour_maps.get(...)` in both branches, putting the store's own mutable state into a response. `colour_map()` exists precisely to prevent that — it returns a copy and normalises the id — and had zero callers. Both reads now go through it.

`_safe_id` is idempotent on an already-normalised id and on `DEFAULT_PACK` (`"kiro-ghost"`), and `dict(get(k, {}))` matches `get(k) or {}` in the present, empty and absent cases, so the payload is byte-identical.

**Nothing observable changes.** `pack_detail`'s only callers are `routes.py:280`, which just serialises via `web.json_response`, and `pack_transfer.py:236`, whose `build_bundle` ignores `detail["colorMap"]` and rebuilds from `animations`/`categories`/`sprite`. Repo-wide there is no mutation of `detail["colorMap"]`. So the alias was a real footgun but not reachable today, and this closes it rather than fixing a live defect.

The two remaining `_colour_maps` reads are `bool(...)` truthiness checks with no aliasing risk and are left alone.

## Changed: `papyrus` artifact-filter comment — independent documentation fix

Not driven by any removal in this diff; called out separately for that reason.

`ARTIFACT_SUFFIXES`' comment claimed filtering happens "here as well as in the UI" so the two cannot drift. Neither half holds: `list_files` never applies the set (its only reader is `is_artifact`, which has no production caller), and the lists have **already drifted** — the UI carries `.pdf` and spells `.synctex.gz` as one suffix where this set has `.synctex` and `.gz` separately, which would also hide any plain `.gz`. The comment now states where filtering actually happens.

The set and `is_artifact` both stay: they are inside the 30-day gate, so nothing is removed here.

## Test changes are edits, not blanket deletions

Each premise was checked before touching it.

- `assert analyzed_count(q) == 1` → `assert len(q["analyzed"]) == 1`, the shape the next line already uses (`q["analyzed"][0]["status"]`). `test_mark_analyzed_then_blocks_reenqueue` still exercises the full `enqueue → dequeue_top_k → mark_analyzed → re-enqueue-blocked` path.
- `test_is_known` goes with its symbol. Its dedup coverage is redundant with the live path — `test_dedup_against_existing` and the re-enqueue assertions in the same class both exercise dedup through `enqueue` — so no real behaviour loses coverage.
- Two imports dropped.

## How the candidates were found

Four scanner passes, all required:

1. **vulture** `--min-confidence 60` → 77 findings, confirmed to over-report on a scoped subset: `is_owned_research_slot` is imported by `dashboard/session_directive_apply.py:51,411`, outside the scanned directories.
2. **naive AST** — defined names minus Load-context names.
3. **tokenize** — real NAME tokens only, excluding same-named strings in docstrings and comments.
4. **annotation-aware AST** — re-parses string constants in `AnnAssign` / `arg.annotation` / `returns` / `cast()` and counts the names inside as references.

Pass 4 was load-bearing, not defensive: vulture flagged `AsyncIterator` (`md_notebook/server.py:34`) at 90% confidence as an unused import, but it is used at line 211 inside the string annotation `"AsyncIterator[None]"`. Deleting it would have broken the module. `from __future__ import annotations` makes every annotation a string at runtime, so passes 1-3 are structurally blind to that whole class of reference.

Two of the deletions here were invisible to all four passes and were found only by reading the smaller apps directly: `_read_body` because name matching is repo-global and its live twins in `design_tweak`/`pptx_maker` masked the orphaned copy, and `with_size` because a vestigial *parameter* is not a definition at all.

## Verification

- Full backend suite: **75,251 passed**. The 114 failures are environmental and reproduce identically on pristine `origin/main` in a separate worktree — `AF_UNIX path too long`, `/local/home` owned by uid 65534, no Node ≥ 20, a jq version mismatch. The sampled `spec_builder` failure (`assert 'unsupported_platform' == 'write_failed'`) was checked specifically and is pre-existing.
- Scoped after the final rebase: 654 passed across `crew_companion/tests/`, `test_subquestion_queue.py`, `test_auto_research.py`, `test_papyrus_store.py`, `test_workflows_app.py`.
- Frontend: `tsc -b` clean, `Frontend5CcSections.cov80.test.tsx` 20/20, `eslint` 0 errors on `crew-companion/` and `papyrus/` (one pre-existing `react-hooks/exhaustive-deps` warning in `CrewCompanionPage.tsx`, untouched), `i18n:check` exit 0 with `I18N_BASE_REF`.
- `mypy src/kiro_crew/` clean, 1177 files. `isort` and `flake8` clean over all of `src/kiro_crew` and `test`.
- Diff-scoped gates run with their base refs so they enforce rather than report: `check_brand_name`, `check_harness_parity`, `check_changelog_history`, `check_focus_cue` — all pass. Plus `check_black_formatting`, `check_subprocess_encoding`, `check_lockdown_before_publish`, `check_loop_bound_locks`, `check_testpaths_coverage`, `verify_vendor_manifest`.
- Zero residual references to `analyzed_count`, `is_known`, `with_size`, `BREAK_PRESETS` (Python), or the workflows `_read_body` repo-wide.
- File-overlap gate: 282 open PRs scanned. Only PR#3013 touches a file of mine (`crew_companion/reminders.py`), and only its module docstring at lines 22-32 — no conflict.
- Two local reviewer lanes before push. `gpt-5.6-sol`: **No findings** after verifying every new comment line against the code and testing the byte-identity claim across all input classes. `claude-opus-4.8`: **no Critical/High/Medium**; its four Low findings on message precision are all folded in (the `_entry_meta` call-site count now separates production from test, the colour_map hunk is described as non-cosmetic rather than behavioural with its reachability spelled out, and the commit-count claim is now stated against the rename baseline).

## Not touched — 21 deferred symbols

Recorded in full with evidence, not silently dropped.

**30-day gate, otherwise deletable (1).** `UnsupportedPlatform` (`papyrus/backend/tectonic.py:234`) — genuinely dead, superseded by the documented `current_asset() -> None` degradation; all 25 other name hits are `code_review_sage`'s separate class. Eligible 2026-09-01.

**Test-only references, refactor not deletion (8).** `reset_provision_state`, `is_artifact` (papyrus); `reset_uv_cache` (pptx_maker); `shared_dictionary`, `write_agent_output`, `read_transcript` (meetings); `is_local_remote` (md_notebook); `PreferenceStore.close` (personal_shopper).

`read_transcript` is the best-evidenced of these — a one-line wrapper over the paged form production actually uses (`routes/meeting_lifecycle.py:183`), whose five test premises all survive a mechanical substitution already used by sibling tests in the same class. It is blocked by nothing but the gate at 20 days.

**Declared public surface, report only (6).** `_register_resources`, `_BITMAP_URI_TERMINATORS`, `missing_optional_deps` (pptx_maker); `register_calendar_provider`, `register_task_provider`, `MAX_CONCURRENT_MEETINGS` (meetings).

**Guard / validation / permission — deadness would be a defect, never a deletion (3).** `STATE_DIR_LEAF`, `_WINDOWS_CMDLINE_MAX` (aws_control); `is_user_owned` (pptx_maker).

Two trap notes for whoever picks these up: `test/test_meetings_routes.py:2014` carries `"write_agent_output"` as a **string** inside `TestNoStoreCallRunsOnTheEventLoop._BLOCKING_STORE_FNS`, so a name-based scanner reads it as live and deleting the function without editing that frozenset leaves it stale. And `is_local_remote`'s security concern is **disproved**, not deferred — it is a classifier, never a gate; all six network-reach controls are live and independently tested.

**Apps not scanned: none.** All 13 in-scope apps went through all four passes. `command_bar/`, `channels/`, `auto_triage_pipeline/` and `agent_worlds/` carry zero Python lines.

## Two defects deliberately left out — filed as issues

Both are behavioural changes on cloud-spend and security paths and need their own reviewed diffs; folding them into a dead-code sweep would bury real risk. Both reviewer lanes agreed with the split.

- #7085 — `design_tweak` proxy Content-Type allowlist is bypassed
- #7086 — `aws_control` nightly push is bounded at 600s, not the declared 3600s

1. **`design_tweak` proxy Content-Type allowlist is bypassed** (#7085)**.** `_safe_upstream_ctype` (`server.py:999`) selects a literal from a 30-entry allowlist whose comment names the CVE class it closes (`py/http-response-splitting`), and has zero callers. `_DevProxyHandler._relay_http` forwards the upstream `Content-Type` verbatim through `_header_value` only. Response splitting stays closed (CR/LF stripped at the sink); what is lost is forced `charset=utf-8` on text types and the collapse of exotic media types to `application/octet-stream` — on a body rendered at `127.0.0.1`, the dashboard's own cookie host. Two statements in the tree are false about this, and one is a **passing test** (`test_design_tweak_backend.py:1925`) asserting "The proxy path keeps its own selector." Born dead in `e6dfd22ee` (#1122) alongside the sink guard that replaced it.
2. **`aws_control` nightly push runs on a 600s bound, not the declared 3600s** (#7086)**.** `_PUSH_TIMEOUT_SECS = 3600` has one site, its definition. Both push paths call `storage.put_file` with no `timeout=`, taking its 600s default, and no `asyncio.wait_for` exists anywhere on the backup path. From `2d74cf533` (#5517). Fix by wiring it, not deleting it.
