### PR TITLE
fix(apps): serialize the builtin config sync against both config writers

### DIFF
--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -1596,11 +1596,32 @@ async def handle_enable_app(request: web.Request) -> web.Response:
         origin = info.get("origin", "")
         if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
             try:
-                # to_thread: the sync helper does a file-locked read-modify-write
-                # of config.json and, on Windows, applies the owner-only lockdown
-                # (a possible SMB round-trip on a network-homed data home) —
-                # neither may run on the event loop.
-                await asyncio.to_thread(_sync_builtin_config, name, enabled=True)
+                # ``run_config_write``, not a bare ``to_thread``: the helper is a
+                # read-modify-write of the SAME ``config.json`` the legacy dashboard
+                # writers (agents endpoint, updates.py, security.py, messaging.py,
+                # mcp.py, core.py STT) mutate while holding ONLY the loop-side
+                # ``_get_config_lock``. ``update_config_locked`` inside the helper
+                # takes only the sidecar advisory flock, which excludes nothing that
+                # family respects -- so a settings PUT landing mid-write commits from
+                # a snapshot taken before it and silently reverts this app's enabled
+                # flag, or loses the user's settings. ``run_config_write`` is the one
+                # entry point that holds BOTH generations, and it still hands the
+                # blocking work (the flock wait, and on Windows the owner-only
+                # lockdown's possible SMB round-trip) to a worker, so the loop never
+                # stalls -- the property the previous ``to_thread`` was there for.
+                #
+                # Lock order is app_lifecycle_lock -> config lock, matching
+                # ``handle_app_uninstall`` above, which already nests them that way
+                # for the same reason. Verified across the tree: 14 functions take
+                # ``app_lifecycle_lock`` and none of them is reachable from inside a
+                # config-lock block, so the reverse order does not exist.
+                #
+                # Call-time import for the layering reason documented at the
+                # ``_get_config_lock`` import above: ``apps`` sits below
+                # ``dashboard`` and must not depend on it at load time.
+                from kiro_crew.dashboard.chat_utils import run_config_write
+
+                await run_config_write(_sync_builtin_config, name, enabled=True)
             except OSError as exc:
                 logger.warning("Failed to sync config.json for %s: %s", name, exc)
                 resp.setdefault("warnings", []).append(
@@ -1692,11 +1713,32 @@ async def handle_disable_app(request: web.Request) -> web.Response:
         origin = info.get("origin", "")
         if origin == "builtin" and name in _BUILTIN_SERVICE_APPS:
             try:
-                # to_thread: the sync helper does a file-locked read-modify-write
-                # of config.json and, on Windows, applies the owner-only lockdown
-                # (a possible SMB round-trip on a network-homed data home) —
-                # neither may run on the event loop.
-                await asyncio.to_thread(_sync_builtin_config, name, enabled=False)
+                # ``run_config_write``, not a bare ``to_thread``: the helper is a
+                # read-modify-write of the SAME ``config.json`` the legacy dashboard
+                # writers (agents endpoint, updates.py, security.py, messaging.py,
+                # mcp.py, core.py STT) mutate while holding ONLY the loop-side
+                # ``_get_config_lock``. ``update_config_locked`` inside the helper
+                # takes only the sidecar advisory flock, which excludes nothing that
+                # family respects -- so a settings PUT landing mid-write commits from
+                # a snapshot taken before it and silently reverts this app's enabled
+                # flag, or loses the user's settings. ``run_config_write`` is the one
+                # entry point that holds BOTH generations, and it still hands the
+                # blocking work (the flock wait, and on Windows the owner-only
+                # lockdown's possible SMB round-trip) to a worker, so the loop never
+                # stalls -- the property the previous ``to_thread`` was there for.
+                #
+                # Lock order is app_lifecycle_lock -> config lock, matching
+                # ``handle_app_uninstall`` above, which already nests them that way
+                # for the same reason. Verified across the tree: 14 functions take
+                # ``app_lifecycle_lock`` and none of them is reachable from inside a
+                # config-lock block, so the reverse order does not exist.
+                #
+                # Call-time import for the layering reason documented at the
+                # ``_get_config_lock`` import above: ``apps`` sits below
+                # ``dashboard`` and must not depend on it at load time.
+                from kiro_crew.dashboard.chat_utils import run_config_write
+
+                await run_config_write(_sync_builtin_config, name, enabled=False)
             except OSError as exc:
                 logger.warning("Failed to sync config.json for %s: %s", name, exc)
                 warnings.append(_redact_warning(f"config sync failed: {exc}"))

--- a/test/test_builtin_app_lifecycle.py
+++ b/test/test_builtin_app_lifecycle.py
@@ -8,10 +8,12 @@ on any specific bundled service (the former ``secretary`` builtin was removed).
 """
 from __future__ import annotations
 
+import ast
 import inspect
 import json
 import os
 import re
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -22,6 +24,7 @@ from kiro_crew.apps.routes import (
     _notify_builtin_service,
     _sync_builtin_config,
     handle_disable_app,
+    handle_enable_app,
 )
 
 # Synthetic builtin used to drive the generic machinery.
@@ -174,16 +177,23 @@ class TestSyncBuiltinConfig:
 
     def test_async_call_sites_offload_off_the_event_loop(self):
         """The helper does file I/O and, on Windows, spawns icacls via
-        restrict_to_owner — its async callers must route it through
-        asyncio.to_thread (no-blocking-call-on-event-loop). Any bare
-        direct call (statement, assignment, or nested argument) is a
-        violation; the to_thread form never matches because there the name is
-        followed by a comma, not a call paren."""
+        restrict_to_owner — its async callers must never run it on the loop
+        (no-blocking-call-on-event-loop). Any bare direct call (statement,
+        assignment, or nested argument) is a violation; a dispatched form never
+        matches because there the name is followed by a comma, not a call paren.
+
+        The dispatcher is now ``run_config_write`` rather than a bare
+        ``asyncio.to_thread``. It still hands the blocking work to a worker — so
+        this property is unchanged — and additionally holds the loop-side config
+        lock, which a bare offload does not. See
+        ``TestBuiltinConfigSyncHoldsBothConfigLocks`` for that half, and
+        ``TestBuiltinConfigDispatchRatchet`` for the guard against regressing to
+        the one-lock dispatch."""
         src = inspect.getsource(routes)
         assert not re.findall(
             r"(?<!def )_sync_builtin_config\(", src
         ), "found a bare on-loop _sync_builtin_config call"
-        assert src.count("asyncio.to_thread(_sync_builtin_config, name") == 2
+        assert src.count("run_config_write(_sync_builtin_config, name") == 2
 
 
 # ── _notify_builtin_service ──
@@ -331,3 +341,197 @@ class TestNotifyBuiltinServiceEdgeCases:
         request = type("R", (), {"app": {"state": state}})()
         result = await _notify_builtin_service(request, _TEST_BUILTIN)
         assert "restart returned" in result
+
+
+class TestBuiltinConfigSyncHoldsBothConfigLocks:
+    """The builtin enable/disable config sync must exclude the LEGACY writers too.
+
+    ``_sync_builtin_config`` is a read-modify-write of the same ``config.json``
+    that the legacy dashboard handlers mutate while holding only the loop-side
+    ``_get_config_lock``. Offloading it with a bare ``asyncio.to_thread`` holds
+    just the sidecar advisory flock, which excludes nothing that family respects:
+    a settings PUT landing mid-write commits from a snapshot taken before it and
+    silently reverts the enabled flag this handler just persisted.
+
+    Probing the lock from INSIDE the worker is what makes this a behavioural test
+    rather than a shape assertion -- it fails on the real defect, not on the
+    spelling of the dispatch.
+    """
+
+    @staticmethod
+    def _request(name, state=None):
+        request = AsyncMock()
+        request.match_info = {"name": name}
+        request.app = {"state": state} if state is not None else {}
+        return request
+
+    @staticmethod
+    def _probe():
+        """Record loop-lock state and thread identity from inside the worker."""
+        seen = {}
+
+        def _spy(name, *, enabled):
+            from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+            seen["locked"] = _get_config_lock().locked()
+            seen["thread"] = threading.current_thread()
+            return None
+
+        return seen, _spy
+
+    @pytest.mark.asyncio
+    async def test_disable_holds_the_loop_side_lock_across_the_write(
+        self, tmp_path, register_test_builtin
+    ):
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({_TEST_CFG_KEY: {"enabled": True}}))
+        seen, spy = self._probe()
+
+        restart_fn = AsyncMock(return_value="ok")
+        state = type("S", (), {_TEST_RESTART_ATTR: restart_fn})()
+
+        with (
+            patch("kiro_crew.apps.routes.get_app", return_value={
+                "name": _TEST_BUILTIN, "origin": "builtin", "resources": "gateway",
+                "lifecycle": "locked", "enabled": True, "manifest": {},
+            }),
+            patch("kiro_crew.apps.routes.disable_app") as mock_disable,
+            patch("kiro_crew.apps.routes.stop_app_backend"),
+            patch("kiro_crew.apps.routes.deregister_app"),
+            patch("kiro_crew.apps.routes.config_path", return_value=cfg),
+            patch("kiro_crew.apps.routes.sel"),
+            patch("kiro_crew.apps.routes._sync_builtin_config", spy),
+        ):
+            mock_disable.return_value = type("R", (), {
+                "ok": True,
+                "to_dict": lambda self: {"ok": True, "name": _TEST_BUILTIN, "message": "d"},
+            })()
+            resp = await handle_disable_app(self._request(_TEST_BUILTIN, state))
+
+        assert json.loads(resp.body)["ok"] is True
+        assert seen, "the config sync never ran"
+        # Red-before with a bare `asyncio.to_thread`: False == True.
+        assert seen["locked"] is True, (
+            "config.json was rewritten without the loop-side lock, so a legacy "
+            "dashboard writer could interleave and revert it"
+        )
+        assert seen["thread"] is not threading.current_thread(), (
+            "the blocking write must stay off the event loop"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enable_holds_the_loop_side_lock_across_the_write(
+        self, tmp_path, register_test_builtin
+    ):
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({_TEST_CFG_KEY: {"enabled": False}}))
+        seen, spy = self._probe()
+
+        restart_fn = AsyncMock(return_value="ok")
+        state = type("S", (), {_TEST_RESTART_ATTR: restart_fn})()
+
+        with (
+            # `resources` deliberately not "gateway": the config sync is gated on
+            # origin/builtin alone, so skipping the registration branch keeps this
+            # test on the lock property instead of the whole enable pipeline.
+            patch("kiro_crew.apps.routes.get_app", return_value={
+                "name": _TEST_BUILTIN, "origin": "builtin", "resources": "",
+                "lifecycle": "locked", "enabled": False, "manifest": {},
+            }),
+            patch("kiro_crew.apps.routes.enable_app") as mock_enable,
+            patch("kiro_crew.apps.routes.on_app_enable", AsyncMock(return_value=None)),
+            patch("kiro_crew.apps.routes.config_path", return_value=cfg),
+            patch("kiro_crew.apps.routes.sel"),
+            patch("kiro_crew.apps.routes._sync_builtin_config", spy),
+        ):
+            mock_enable.return_value = type("R", (), {
+                "ok": True,
+                "to_dict": lambda self: {"ok": True, "name": _TEST_BUILTIN, "message": "e"},
+            })()
+            resp = await handle_enable_app(self._request(_TEST_BUILTIN, state))
+
+        assert json.loads(resp.body)["ok"] is True
+        assert seen, "the config sync never ran"
+        assert seen["locked"] is True
+        assert seen["thread"] is not threading.current_thread()
+
+    @pytest.mark.asyncio
+    async def test_the_loop_side_lock_is_released_afterwards(
+        self, tmp_path, register_test_builtin
+    ):
+        """Holding it is only correct if the handler also gives it back."""
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({_TEST_CFG_KEY: {"enabled": True}}))
+        restart_fn = AsyncMock(return_value="ok")
+        state = type("S", (), {_TEST_RESTART_ATTR: restart_fn})()
+
+        with (
+            patch("kiro_crew.apps.routes.get_app", return_value={
+                "name": _TEST_BUILTIN, "origin": "builtin", "resources": "gateway",
+                "lifecycle": "locked", "enabled": True, "manifest": {},
+            }),
+            patch("kiro_crew.apps.routes.disable_app") as mock_disable,
+            patch("kiro_crew.apps.routes.stop_app_backend"),
+            patch("kiro_crew.apps.routes.deregister_app"),
+            patch("kiro_crew.apps.routes.config_path", return_value=cfg),
+            patch("kiro_crew.apps.routes.sel"),
+        ):
+            mock_disable.return_value = type("R", (), {
+                "ok": True,
+                "to_dict": lambda self: {"ok": True, "name": _TEST_BUILTIN, "message": "d"},
+            })()
+            await handle_disable_app(self._request(_TEST_BUILTIN, state))
+
+        assert not _get_config_lock().locked()
+        assert json.loads(cfg.read_text(encoding="utf-8"))[_TEST_CFG_KEY]["enabled"] is False
+
+
+class TestBuiltinConfigDispatchRatchet:
+    """Static guard so the dispatch cannot quietly regress to a bare offload.
+
+    The behavioural tests above prove the lock is held today. This proves nobody
+    can reintroduce the one-lock dispatch without the failure naming the site.
+    """
+
+    @staticmethod
+    def _offending_sites():
+        source = Path(inspect.getsourcefile(routes)).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        bad = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "attr", None) or getattr(func, "id", None)
+            if name != "to_thread" or not node.args:
+                continue
+            target = node.args[0]
+            if getattr(target, "id", None) == "_sync_builtin_config":
+                bad.append(node.lineno)
+        return bad
+
+    def test_sync_builtin_config_is_never_dispatched_with_a_bare_to_thread(self):
+        sites = self._offending_sites()
+        assert not sites, (
+            "_sync_builtin_config offloaded with a bare asyncio.to_thread at line(s) "
+            + ", ".join(str(n) for n in sites)
+            + " — it rewrites config.json and must go through run_config_write, "
+            "which holds the loop-side lock as well as the flock"
+        )
+
+    def test_the_ratchet_can_actually_fail(self):
+        """A scan that stopped matching would pass vacuously; prove it still bites."""
+        tree = ast.parse(
+            "import asyncio\n"
+            "async def f():\n"
+            "    await asyncio.to_thread(_sync_builtin_config, 'x', enabled=True)\n"
+        )
+        found = [
+            n.lineno for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and (getattr(n.func, "attr", None) or getattr(n.func, "id", None)) == "to_thread"
+            and n.args and getattr(n.args[0], "id", None) == "_sync_builtin_config"
+        ]
+        assert found == [3]


### PR DESCRIPTION
## Problem / Motivation

Enabling or disabling a builtin gateway app writes `config.json` through `_sync_builtin_config`, and both call sites offloaded it with a bare `asyncio.to_thread`:

```python
await asyncio.to_thread(_sync_builtin_config, name, enabled=True)   # routes.py:1603
await asyncio.to_thread(_sync_builtin_config, name, enabled=False)  # routes.py:1699
```

That offload is correct about the event loop and wrong about **exclusion**. `_sync_builtin_config` performs a read-modify-write of the main `config.json` under `update_config_locked`, which takes only the **sidecar advisory flock**. `config.json` has two writer generations that do not exclude each other:

- `update_config_locked` takes the sidecar flock (CLI, boot refresh, other processes).
- The legacy dashboard writers — agents endpoint, `updates.py`, `security.py`, `messaging.py`, `mcp.py`, `core.py` STT — take the loop-side `_get_config_lock` asyncio lock **alone**.

Holding only the flock excludes nothing that second family respects. A settings PUT that lands between this handler's read and its write commits from a snapshot taken before it — silently reverting the `enabled` flag the user just toggled, or losing whatever settings they changed. `config/loader.py` states the rule directly: a caller running while the dashboard serves requests must **also** hold the in-process asyncio lock.

## Why it matters

The lost update is silent and bidirectional. Either the app comes back enabled after the user disabled it, or an unrelated settings write is reverted by an app toggle. Nothing errors, nothing is logged, and the UI reports success in both directions — the response is built from the handler's own result, not from a re-read of what actually landed on disk.

It is also reachable by ordinary use rather than by a race a user has to provoke: enabling an app and saving a setting are both routine dashboard actions, and the write window includes a filesystem lock wait plus, on Windows, an owner-only DACL application that can cost an unbounded SMB round-trip on a network-homed data home.

## What changed (motivation → approach → change)

**Symptom** → a config write that can be silently reverted. **Root cause** → the dispatch holds one of the two locks that guard `config.json`. **Change** → route both sites through the entry point that holds both.

`src/kiro_crew/apps/routes.py`:

```python
await run_config_write(_sync_builtin_config, name, enabled=True)
```

`dashboard.chat_utils.run_config_write` is the repository's existing helper for exactly this — no new lock and no new abstraction is introduced here. It acquires the loop-side `_get_config_lock`, then runs the sync in a worker thread, so the flock wait never blocks the loop. **The off-loop property the `to_thread` existed for is unchanged**; what is added is exclusion against the legacy family.

**Lock ordering was proven before the change, not assumed.** The new nesting is `app_lifecycle_lock` → config lock, which is already what `handle_app_uninstall` does in this same file (`routes.py:1348`) for the same reason. The reverse order was checked across the whole tree by walking every `with`/`async with` block: 14 functions acquire `app_lifecycle_lock`, and none of them is reachable from inside a `_get_config_lock` / `run_config_write` block. There is no inversion to deadlock against, and the only existing nesting anywhere in `src/kiro_crew` is the forward one.

The import is call-time, matching the `_get_config_lock` import a few hundred lines above and for the same documented reason: `apps` sits below `dashboard` in the package tree, and no module in `src/kiro_crew/apps/` imports `kiro_crew.dashboard` at load time. This is layering, not a circular-import claim.

Deliberately unchanged: the error contract (`OSError` still degrades to a warning on the response, because the config write is not the point of the request), the restart notification, and `_sync_builtin_config` itself.

## Tests

`test/test_builtin_app_lifecycle.py`:

- `test_disable_holds_the_loop_side_lock_across_the_write` and `test_enable_holds_the_loop_side_lock_across_the_write` — **behavioural**, not shape. Each patches `_sync_builtin_config` with a probe that records `_get_config_lock().locked()` and its own thread identity **from inside the worker**, then drives the real handler. Both assert the lock is held *and* that the work is off the event loop, so a fix that took the lock by moving the write back onto the loop would fail too.
- `test_the_loop_side_lock_is_released_afterwards` — holding it is only correct if the handler gives it back; also asserts the flag actually landed on disk.
- `TestBuiltinConfigDispatchRatchet` — a static AST guard that fires only when the callable being offloaded is `_sync_builtin_config` itself, so ordinary `asyncio.to_thread` use elsewhere in the module stays legal. Its failure names the exact line numbers.
- `test_the_ratchet_can_actually_fail` — feeds the ratchet's own predicate the shape it exists to reject, so a scan that silently stopped matching cannot pass vacuously.

**Red-before**, with only the two production lines reverted and the tests in place:

- behavioural: `assert False is True` on both enable and disable — the loop-side lock is not held;
- ratchet: `assert not [1603, 1699]` — the two offending sites named;
- shape test: `assert 0 == 2`.

`test_async_call_sites_offload_off_the_event_loop` already existed and pinned the weaker `asyncio.to_thread` spelling. It is **updated rather than left passing by accident**: it now pins the stronger dispatcher, and its docstring says why the property it guards is unchanged.

**Green on this head:** `test_builtin_app_lifecycle.py`, `test_apps_routes_coverage.py`, `test_lifecycle_hooks.py`, `test_enable_deps_resolution.py`, `test_apps_instances_loop_offload.py` — **263 passed, 2 skipped, 0 failed**.

**Gates green:** `mypy --platform linux` on the changed module, the baselined black gate (2 files in scope, no new offenders), isort, flake8. The full backend suite was not run locally; CI runs it authoritatively.

## Manual verification

N/A — unit coverage sufficient: the defect is a lock-holding property, and the tests observe that property directly from inside the worker thread that performs the write, on both the enable and the disable path. A manual reproduction would require winning a race that the probe asserts deterministically.

## Related Issues

No filed issue. The residual was counted by the First Principles review on #4550, which fixed the same one-lock-only defect for the registry PUT in this module and explicitly left these two sites out of scope. This closes them as their own change rather than widening that PR.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
