### PR TITLE
feat(desktop): add opt-in GPU-disable (KIROCREW_DISABLE_GPU / --disable-gpu) for VM/RDP/headless hosts

### DIFF
--- a/website/electron/disable-gpu.js
+++ b/website/electron/disable-gpu.js
@@ -1,0 +1,117 @@
+"use strict";
+//
+// Opt-in disabling of Chromium hardware acceleration for the desktop shell.
+//
+// The problem this solves: on hosts with no usable GPU — a VMware/VirtualBox
+// guest, a Windows RDP session (SESSIONNAME=RDP-Tcp#*), an X11-forwarded or
+// headless Linux box — Chromium's GPU process cannot create a rendering
+// context and aborts. Electron then reports the window as
+// `render-process-gone` with `reason: "launched-failed"` (exitCode 18 on
+// Windows), and `renderer-recovery.js` reloads it three times before giving
+// up. The backend Gateway is fine and still listening on :5476; only the
+// Electron renderer is dead, so the whole app looks broken on an otherwise
+// healthy machine. Observed live in `chromium.log`:
+//
+//     ContextResult::kFatalFailure: Failed to create shared context for virtualization.
+//     GetGpuDriverOverlayInfo: Failed to retrieve video device
+//
+// The Chromium-level fix is `--disable-gpu` (plus `--disable-gpu-compositing`
+// and `--disable-software-rasterizer`, which together stop the GPU process
+// from spawning at all — see electron/electron#28164). But a switch the user
+// has to remember to pass is a switch that is never set on the launch that
+// actually crashed, and — critically — the app's single-instance handoff drops
+// argv from a second launch, so `KiroCrew.exe --disable-gpu` does nothing once
+// an instance already holds the lock. So the decision is made HERE, before the
+// app is ready, from durable inputs (an env var, or argv on the winning
+// instance), and applied through the same `appendSwitch` seam `main.js`
+// already exposes to `native-logging.js`.
+//
+// This is deliberately OFF by default: a normal desktop with a real GPU should
+// keep hardware acceleration. It is opt-in via `KIROCREW_DISABLE_GPU`
+// (mirroring the existing `KIROCREW_*` env conventions: KIROCREW_HOME,
+// KIROCREW_PORT, KIROCREW_DEBUG) or the `--disable-gpu` command-line flag.
+//
+// Pure logic + injected dependencies: Electron main is not exercised by the
+// unit test runner, so the decision has to be testable without a live `app`
+// (same pattern as native-logging.js / renderer-recovery.js / perf-metrics.js).
+//
+
+/** Truthy env values, matching how the rest of the shell reads KIROCREW_* flags. */
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+
+/**
+ * Whether GPU acceleration should be disabled for this launch.
+ *
+ * Inputs, in order of intent (any one is enough):
+ *   1. `KIROCREW_DISABLE_GPU` env set to a truthy value (1/true/yes/on).
+ *   2. `--disable-gpu` present in argv.
+ *
+ * @param {object} deps
+ * @param {NodeJS.ProcessEnv} [deps.env]   Defaults to process.env at call time.
+ * @param {string[]}          [deps.argv]  Defaults to process.argv at call time.
+ * @returns {boolean}
+ */
+function shouldDisableGpu({ env = process.env, argv = process.argv } = {}) {
+  const raw = env && env.KIROCREW_DISABLE_GPU;
+  if (typeof raw === "string" && TRUTHY.has(raw.trim().toLowerCase())) return true;
+  if (Array.isArray(argv) && argv.includes("--disable-gpu")) return true;
+  return false;
+}
+
+/**
+ * The Chromium switches that fully stop the GPU process from spawning.
+ *
+ * Returned as data (not applied inline) so a test can assert the exact switch
+ * names: these are Chromium's spelling, and a typo fails silently (an unknown
+ * switch is ignored). `--disable-gpu` alone is not enough on modern Chromium —
+ * the GPU process still spawns for rasterization — so the compositing and
+ * software-rasterizer switches accompany it (electron/electron#28164).
+ *
+ * @returns {string[]}
+ */
+function gpuDisableSwitches() {
+  return [
+    "disable-gpu",
+    "disable-gpu-compositing",
+    "disable-software-rasterizer",
+  ];
+}
+
+/**
+ * Apply the GPU-disable switches if the launch opted in. Never throws.
+ *
+ * Must run BEFORE the app is ready: Chromium reads these switches during
+ * initialization, so appending them later is accepted and then ignored — the
+ * same timing constraint as the native-logging switches.
+ *
+ * @param {object} deps
+ * @param {(name: string, value?: string) => void} deps.appendSwitch
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string[]}          [deps.argv]
+ * @param {(msg: string) => void} [deps.log]
+ * @returns {{disabled: boolean, switches: string[]}}
+ */
+function initGpuPolicy({ appendSwitch, env, argv, log = () => {} } = {}) {
+  const disabled = shouldDisableGpu({ env, argv });
+  const applied = [];
+  if (!disabled) return { disabled: false, switches: applied };
+
+  for (const name of gpuDisableSwitches()) {
+    try {
+      appendSwitch(name);
+      applied.push(name);
+    } catch (e) {
+      // One rejected switch must not cost us the others, nor the boot.
+      log(`gpu-disable switch --${name} failed: ${e && e.message}`);
+    }
+  }
+  log(`gpu acceleration DISABLED for this launch: switches=${applied.join(",") || "none"}`);
+  return { disabled: true, switches: applied };
+}
+
+module.exports = {
+  shouldDisableGpu,
+  gpuDisableSwitches,
+  initGpuPolicy,
+  TRUTHY,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -142,6 +142,7 @@ const { seedRenamedStore } = require("./store-rename");
 const { isLocalGatewayEnabled, setLocalGatewayEnabled, classifyStartFailure } = require("./local-gateway");
 
 const { initNativeLogging } = require("./native-logging");
+const { initGpuPolicy } = require("./disable-gpu");
 
 // Carry settings across the npm `name` rename, by writing the new store's file
 // BEFORE electron-store opens it. Order is load-bearing: construction writes the
@@ -310,6 +311,22 @@ if (!app.requestSingleInstanceLock()) {
     appendSwitch: (name, value) => app.commandLine.appendSwitch(name, value),
     startCrashReporter: (opts) => crashReporter.start(opts),
     fs,
+    log: (m) => glog(m),
+  });
+
+  // Opt-in GPU-disable, applied through the SAME pre-app-ready appendSwitch
+  // seam as native logging above (Chromium reads switches during init, so a
+  // later append is ignored). OFF by default; enabled by KIROCREW_DISABLE_GPU
+  // or the --disable-gpu flag. This is the supported fix for hosts with no
+  // usable GPU — VM guests, Windows RDP sessions, headless/X11-forwarded Linux
+  // — where the renderer otherwise dies with launch-failed / exitCode 18 and
+  // renderer-recovery.js loops. Reading it here (not from forwarded argv on a
+  // second launch, which the single-instance lock drops) is what makes it take
+  // effect on the launch that actually renders.
+  initGpuPolicy({
+    appendSwitch: (name) => app.commandLine.appendSwitch(name),
+    env: process.env,
+    argv: process.argv,
     log: (m) => glog(m),
   });
 

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -167,6 +167,7 @@
       "gateway-recovery.js",
       "renderer-recovery.js",
       "native-logging.js",
+    "disable-gpu.js",
     "pierre-perf-log.js",
       "pyspy-dump.js",
       "perf-metrics.js",

--- a/website/electron/test/disable-gpu.test.js
+++ b/website/electron/test/disable-gpu.test.js
@@ -1,0 +1,93 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  shouldDisableGpu,
+  gpuDisableSwitches,
+  initGpuPolicy,
+} = require("../disable-gpu.js");
+
+test("shouldDisableGpu: off by default (no env, no flag)", () => {
+  assert.equal(shouldDisableGpu({ env: {}, argv: ["node", "main.js"] }), false);
+});
+
+test("shouldDisableGpu: truthy KIROCREW_DISABLE_GPU values enable it", () => {
+  for (const v of ["1", "true", "TRUE", "yes", "on", " On "]) {
+    assert.equal(
+      shouldDisableGpu({ env: { KIROCREW_DISABLE_GPU: v }, argv: [] }),
+      true,
+      `expected ${JSON.stringify(v)} to enable`
+    );
+  }
+});
+
+test("shouldDisableGpu: falsey/garbage env values do NOT enable it", () => {
+  for (const v of ["0", "false", "no", "off", "", "maybe"]) {
+    assert.equal(
+      shouldDisableGpu({ env: { KIROCREW_DISABLE_GPU: v }, argv: [] }),
+      false,
+      `expected ${JSON.stringify(v)} to stay disabled`
+    );
+  }
+});
+
+test("shouldDisableGpu: --disable-gpu argv flag enables it", () => {
+  assert.equal(
+    shouldDisableGpu({ env: {}, argv: ["node", "main.js", "--disable-gpu"] }),
+    true
+  );
+});
+
+test("gpuDisableSwitches: exact Chromium switch names, no leading dashes", () => {
+  assert.deepEqual(gpuDisableSwitches(), [
+    "disable-gpu",
+    "disable-gpu-compositing",
+    "disable-software-rasterizer",
+  ]);
+});
+
+test("initGpuPolicy: no-op and appends nothing when opted out", () => {
+  const seen = [];
+  const res = initGpuPolicy({
+    appendSwitch: (n) => seen.push(n),
+    env: {},
+    argv: [],
+  });
+  assert.equal(res.disabled, false);
+  assert.deepEqual(seen, []);
+});
+
+test("initGpuPolicy: appends all switches when opted in", () => {
+  const seen = [];
+  const res = initGpuPolicy({
+    appendSwitch: (n) => seen.push(n),
+    env: { KIROCREW_DISABLE_GPU: "1" },
+    argv: [],
+  });
+  assert.equal(res.disabled, true);
+  assert.deepEqual(seen, [
+    "disable-gpu",
+    "disable-gpu-compositing",
+    "disable-software-rasterizer",
+  ]);
+  assert.deepEqual(res.switches, seen);
+});
+
+test("initGpuPolicy: a throwing appendSwitch does not abort the rest", () => {
+  const seen = [];
+  const res = initGpuPolicy({
+    appendSwitch: (n) => {
+      if (n === "disable-gpu-compositing") throw new Error("boom");
+      seen.push(n);
+    },
+    env: { KIROCREW_DISABLE_GPU: "true" },
+    argv: [],
+  });
+  assert.equal(res.disabled, true);
+  // The middle switch threw; the other two still applied.
+  assert.deepEqual(seen, ["disable-gpu", "disable-software-rasterizer"]);
+});
+
+


### PR DESCRIPTION
## Problem / Motivation

On hosts with no usable GPU — VMware/VirtualBox guests, Windows RDP sessions (`SESSIONNAME=RDP-Tcp#*`), and headless or X11-forwarded Linux — Chromium's GPU process cannot create a rendering context and aborts. The user observes a desktop app that never opens: every window (dashboard, Mochi pet) dies immediately and `renderer-recovery.js` gives up after three reloads.

Observed live in `chromium.log` on a VMware guest over RDP:

```
ContextResult::kFatalFailure: Failed to create shared context for virtualization.
GetGpuDriverOverlayInfo: Failed to retrieve video device
```

and in `gateway-launch.log`:

```
renderer died (reason=launch-failed, exitCode=18) - reloading dashboard (attempt 1/3)
renderer died 4x within 60000ms - giving up to avoid a reload loop
```

There is currently **no** way for a user to disable hardware acceleration to work around this: the shell never calls `app.disableHardwareAcceleration()`, sets no GPU switch, and passing `--disable-gpu` to `KiroCrew.exe` has no effect because the single-instance lock drops a second launch's argv.

## Why it matters

The backend Gateway is healthy and listening on :5476 the whole time — only the Electron renderer is dead — so the app looks completely broken on an otherwise working machine. This hits everyone running the desktop app inside a VM or over RDP (a common enterprise/remote-dev setup), leaving the desktop shell unusable with no supported workaround. Giving these users an opt-in switch turns a hard failure into a one-line fix.

## What changed (motivation → approach → change)

- **Symptom:** renderer `launch-failed` / exitCode 18, reload loop, blank app.
- **Root cause:** Chromium's GPU process cannot create a context on a virtualized/RDP graphics stack and fatally fails instead of falling back to software.
- **Approach:** the Chromium-level fix is `--disable-gpu` (plus `--disable-gpu-compositing` and `--disable-software-rasterizer`, which together stop the GPU process from spawning at all — see electron/electron#28164). It must be applied **before app-ready** (Chromium reads switches during init) and must survive the single-instance handoff (a rejected second launch's argv is dropped, so the winning process must decide from durable inputs). I considered a plain CLI flag alone and rejected it for that handoff reason; an env var is present in the winning process regardless of which launch won.
- **Change:** a new `disable-gpu.js` module (pure logic + injected deps, mirroring `native-logging.js`) that decides from `KIROCREW_DISABLE_GPU` (truthy: `1`/`true`/`yes`/`on`, matching the existing `KIROCREW_*` env conventions) or the `--disable-gpu` flag, and applies the three switches through the same `appendSwitch` seam `main.js` already exposes to `initNativeLogging`. It is **OFF by default**, so a normal desktop with a real GPU keeps hardware acceleration. `disable-gpu.js` is added to `package.json` `build.files` so it ships in the packaged app (enforced by the build-config-schema contract test).

Files:
- `website/electron/disable-gpu.js` (new)
- `website/electron/test/disable-gpu.test.js` (new)
- `website/electron/main.js` (require + `initGpuPolicy(...)` right after `initNativeLogging(...)`)
- `website/electron/package.json` (`disable-gpu.js` → `build.files`)

## Tests

Added `website/electron/test/disable-gpu.test.js` (`node:test`, 8 cases) locking in:
- OFF by default (no env, no flag).
- Truthy `KIROCREW_DISABLE_GPU` values (`1`/`true`/`TRUE`/`yes`/`on`/` On `) enable it; falsey/garbage (`0`/`false`/`no`/`off`/``/`maybe`) do not.
- `--disable-gpu` argv flag enables it.
- `gpuDisableSwitches()` returns the exact Chromium switch names (guards against a silent typo).
- `initGpuPolicy` appends nothing when opted out, all three switches when opted in, and a throwing `appendSwitch` on one switch does not abort the others.

Results:
```
cd website/electron && npm install
node --test test/disable-gpu.test.js          # tests 8 / pass 8 / fail 0
node --test test/build-config-schema.test.js  # tests 2 / pass 2 / fail 0 (build.files contract)
npm test                                      # full electron suite: fail 0
```

## Manual verification

On a VMware guest accessed over RDP (the reproducing environment), `set KIROCREW_DISABLE_GPU=1` before launch: the renderer no longer dies with `launch-failed`/exitCode 18, the reload loop stops, and the dashboard window renders via software. With the variable unset, behavior is unchanged (hardware acceleration retained).

## Screenshots / video

N/A — no user-visible UI change. This toggles a Chromium launch switch; it adds no panel, component, layout, or theme.

## Related Issues

N/A — filed directly as a fix for the VM/RDP renderer `launch-failed` crash; happy to link a tracking issue if the team prefers one.

## Checklist

- [x] At most two commits (one here), with a Conventional Commits title (`feat: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, opt-in env var documented inline in `disable-gpu.js`
- [x] No secrets, credentials, or internal references in the diff
