### PR TITLE
fix(acp): report the environment the kiro-cli search actually used

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -31,7 +31,7 @@ import time
 from collections import deque
 from contextlib import aclosing
 from pathlib import Path
-from typing import Any, AsyncGenerator, AsyncIterator, Callable, Sequence, TypeVar
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, Mapping, Sequence, TypeVar
 
 from kiro_crew import agent_scratch, model_registry, platform_compat
 from kiro_crew.acp._dispatch import (
@@ -272,16 +272,27 @@ def _normalize_exe_casing(path: str | None) -> str | None:
         return path
 
 
-def _resolve_kiro_bin() -> str | None:
+def _resolve_kiro_bin(
+    *,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> str | None:
     """Resolve the user's installed Kiro CLI, to be launched in place.
 
     Returns the installed binary's own path. KiroCrew never copies the CLI and
     executes the copy: Kiro CLI 2.15+ dispatches subcommands by exec'ing a
     sibling executable resolved relative to its own path, which a copy into a
     private directory destroys.
+
+    *environ* and *home* exist so a caller that also needs to REPORT the search
+    can pin both to one reading of the environment. ``known_kiro_cli_dirs`` is a
+    pure function of ``(platform, home, environ)``, so passing the same mapping
+    here and to the diagnostic guarantees the directories named in a "not found"
+    message are the directories that were actually searched. Both default to the
+    live values, so every other caller is unchanged.
     """
 
-    executable = resolve_kiro_cli()
+    executable = resolve_kiro_cli(environ=environ, home=home)
     if not executable:
         return executable
     # Deferred to keep the low-level resolver import graph acyclic:
@@ -302,7 +313,11 @@ def _resolve_kiro_bin() -> str | None:
     return snapshot.launch_path
 
 
-async def _resolve_kiro_bin_for_spawn() -> str | None:
+async def _resolve_kiro_bin_for_spawn(
+    *,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> str | None:
     """Resolve the Kiro CLI path off the event loop.
 
     Plain ``to_thread`` — deliberately NOT shielded. The shield existed only to
@@ -317,7 +332,7 @@ async def _resolve_kiro_bin_for_spawn() -> str | None:
     ASYNCIO UNHANDLED record to crash.log for an ordinary tab close.
     """
 
-    return await asyncio.to_thread(_resolve_kiro_bin)
+    return await asyncio.to_thread(_resolve_kiro_bin, environ=environ, home=home)
 
 
 def _mise_which(tool: str) -> str | None:
@@ -2807,16 +2822,31 @@ class AcpClient:
                 )
             argv: list[str] = claude_argv
         else:
+            # Pin ONE reading of the environment for both the search and the
+            # message that reports it. The previous code resolved against the live
+            # ``os.environ`` and then, on failure, recomputed the directory set
+            # from a FRESH read -- so a PATH change landing in that window (a
+            # concurrent installer, a self-update, anything editing the gateway's
+            # environment) produced a "not found" message naming directories that
+            # were never searched, while omitting ones that were. #5048 already
+            # solved this for the Claude adapter by caching the search path WITH
+            # the resolution result; this is the same guarantee for the Kiro
+            # sibling, which it left recomputing.
+            spawn_environ = dict(os.environ)
+            spawn_home = Path.home()
             try:
-                kiro_bin = await _resolve_kiro_bin_for_spawn()
+                kiro_bin = await _resolve_kiro_bin_for_spawn(environ=spawn_environ, home=spawn_home)
             except _KiroExecutableTrustError as exc:
                 raise AcpError(str(exc)) from exc
             if not kiro_bin:
+                # Pure function of the arguments, so this reproduces exactly the
+                # set the resolution above walked. Still off-loop: it expands the
+                # inherited PATH.
                 searched_dirs = await asyncio.to_thread(
                     known_kiro_cli_dirs,
                     sys.platform,
-                    Path.home(),
-                    os.environ,
+                    spawn_home,
+                    spawn_environ,
                 )
                 raise AcpError(
                     f"{KIRO_CLI_BIN} not found "

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -1035,6 +1035,75 @@ class TestAcpClientBackendSelection:
         assert unsearched not in error
 
     @pytest.mark.asyncio
+    async def test_spawn_kiro_missing_bin_reports_the_environment_it_searched(
+        self, tmp_path, monkeypatch
+    ):
+        """The reported directories must come from the search's own environment.
+
+        The diagnostic used to recompute ``known_kiro_cli_dirs`` from a FRESH
+        read of ``os.environ`` after resolution had already failed. A PATH change
+        landing in that window -- a concurrent installer, a self-update, anything
+        editing the gateway's environment -- makes the message name directories
+        that were never searched and omit ones that were, which is the opposite
+        of what a "not found (searched ...)" line is for.
+
+        #5048 gave the Claude adapter this guarantee by caching the search path
+        with the resolution result (see
+        ``test_spawn_claude_missing_bin_reports_the_cached_search_path``); this
+        pins the same property for the Kiro sibling it left recomputing.
+        """
+        from kiro_crew.acp import client as client_mod
+
+        injected = str(tmp_path / "appeared-after-the-search")
+        resolver_env: dict[str, object] = {}
+        diagnostic_env: dict[str, object] = {}
+        real_dirs = client_mod.known_kiro_cli_dirs
+
+        def _resolve_then_change_path(*, environ=None, home=None):
+            resolver_env["mapping"] = environ
+            # A PATH mutation arriving while the resolve is in flight.
+            monkeypatch.setenv("PATH", injected + os.pathsep + os.environ.get("PATH", ""))
+            return None
+
+        def _spy_dirs(platform_name, home, environ, **kwargs):
+            diagnostic_env["mapping"] = environ
+            return real_dirs(platform_name, home, environ, **kwargs)
+
+        client = AcpClient(work_dir=tmp_path)
+        with (
+            patch(
+                "kiro_crew.acp.client._resolve_kiro_bin",
+                side_effect=_resolve_then_change_path,
+            ),
+            patch("kiro_crew.acp.client.known_kiro_cli_dirs", side_effect=_spy_dirs),
+        ):
+            with pytest.raises(AcpError, match="not found"):
+                await client._spawn()
+
+        assert injected in os.environ["PATH"], "the test never actually changed PATH"
+        # THE DEFECT: the directory set reported to the user must not be derived
+        # from an environment the search never saw. Red-before, where the
+        # diagnostic re-read the live os.environ, this is the late PATH entry.
+        assert injected not in diagnostic_env["mapping"].get("PATH", "")
+        # And the guarantee stated positively: one mapping drove both.
+        assert resolver_env.get("mapping") is not None, "resolver got no environment"
+        assert diagnostic_env["mapping"] is resolver_env["mapping"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_kiro_bin_defaults_keep_every_other_caller_unchanged(self, tmp_path):
+        """The new parameters are optional, so the four other call sites are intact.
+
+        ``_resolve_kiro_bin_for_spawn`` is also called from ``acp/runtime.py``,
+        ``handlers/agents.py`` and ``handlers/sessions.py``, none of which needs
+        the search set. Omitting the arguments must resolve exactly as before.
+        """
+        from kiro_crew.acp import client as client_mod
+
+        with patch("kiro_crew.acp.client.resolve_kiro_cli", return_value=None) as resolve:
+            assert await client_mod._resolve_kiro_bin_for_spawn() is None
+        resolve.assert_called_once_with(environ=None, home=None)
+
+    @pytest.mark.asyncio
     async def test_spawn_kiro_backend_unchanged(self, tmp_path):
         """Default (non-claude) backend still spawns `kiro-cli acp --agent <name>`."""
         client = AcpClient(work_dir=tmp_path)
@@ -10033,7 +10102,9 @@ class TestSpawnEnvScrub:
             captured["env"] = kwargs.get("env")
             raise _StopSpawn()
 
-        monkeypatch.setattr(acp_client, "_resolve_kiro_bin", lambda: "/fake/kiro")
+        # **_ absorbs the environ/home the spawn path now pins, so the search and
+        # the "not found" diagnostic cannot read different environments.
+        monkeypatch.setattr(acp_client, "_resolve_kiro_bin", lambda **_: "/fake/kiro")
         monkeypatch.setattr(
             acp_client,
             "wrap_argv",


### PR DESCRIPTION
## Problem / Motivation

When the ACP spawn path cannot find the Kiro CLI, it tells the user where it looked:

```
kiro-cli not found (searched 14 directories: ...)
```

That list was computed from the wrong environment. Resolution ran against the live `os.environ`; then, **after** it had already failed, the handler recomputed the directory set from a **fresh** read:

```python
kiro_bin = await _resolve_kiro_bin_for_spawn()          # searched os.environ as it was THEN
if not kiro_bin:
    searched_dirs = await asyncio.to_thread(
        known_kiro_cli_dirs, sys.platform, Path.home(), os.environ,   # re-read
    )
```

`known_kiro_cli_dirs` expands the inherited `PATH`, so any change to the gateway's environment landing between those two points changes the answer. The message then names directories that were never searched and omits ones that were — and the window is a filesystem walk plus a thread hop wide.

The failure is worst exactly when the message matters most. A user who is told "not found" is usually mid-install: they run the installer, the gateway's `PATH` gains the new directory, and the error now advertises that directory as searched-and-empty. The one diagnostic that exists to answer *"where should I look?"* answers it with a set that was never walked.

## Why it matters

This is the only signal the user gets. There is no fallback listing, no log line with the real set — `describe_search_path` output *is* the diagnostic, and a wrong one sends the user to check directories the resolver never opened while hiding the one it did.

It also silently contradicts a guarantee the repository already made. #5048 ("report actual directories on spawn failure") fixed precisely this class, and its commit message says it **cached the Claude adapter's search path with its resolution result**. That half is correct and is regression-tested (`test_spawn_claude_missing_bin_reports_the_cached_search_path` mutates `PATH` between two spawns and asserts the reported path does not move). The Kiro sibling in the same function was left recomputing, so the two adapters make different promises from adjacent lines.

## What changed (motivation → approach → change)

**Symptom** → a search-path diagnostic that can describe a search that never happened. **Root cause** → the environment is read twice, and only the second read reaches the user. **Change** → read it once.

`src/kiro_crew/acp/client.py`:

- `_resolve_kiro_bin` and `_resolve_kiro_bin_for_spawn` take optional `environ` / `home`, both defaulting to the live values and forwarded to the existing `resolve_kiro_cli(environ=..., home=...)` keywords. No resolver redesign and no caching layer is introduced.
- The spawn path pins one reading (`spawn_environ`, `spawn_home`) and passes it to **both** the resolver and the diagnostic.

`known_kiro_cli_dirs` is a pure function of `(platform, home, environ)`, so passing the same mapping to both makes the reported set exactly the set that was walked — the same guarantee #5048 gave the Claude adapter, reached the way this call site is shaped rather than by adding a second cache.

**Why optional parameters rather than returning a tuple like the Claude sibling.** `_resolve_kiro_bin_for_spawn` has four other callers — `acp/runtime.py` (×2), `handlers/agents.py`, `handlers/sessions.py` — none of which needs the search set. Changing the return type would churn four unrelated call sites in three modules for a diagnostic-only need. Defaulted keywords leave them byte-identical, and a test pins that.

The directory expansion stays off the event loop; only the mapping it reads changed.

**Scope boundary.** `acp/runtime.py:1048` and `:1053` raise `"{KIRO_CLI_BIN} not found in PATH"` with **no** directory list at all. That is a weaker message, not this defect — giving it one would be a new diagnostic rather than a fix, so it is deliberately left alone.

## Tests

`test/test_acp_client.py`:

- `test_spawn_kiro_missing_bin_reports_the_environment_it_searched` — the regression. It mutates `PATH` **from inside the resolver**, i.e. exactly in the window the old code re-read, then asserts the injected directory is absent from the environment the diagnostic used, that the diagnostic and the resolver received the **same mapping object**, and (as a self-check) that the test really did change `PATH`. Deliberately modelled on the Claude test above it, so the pair now reads as one property stated twice.
- `test_resolve_kiro_bin_defaults_keep_every_other_caller_unchanged` — calls `_resolve_kiro_bin_for_spawn()` with no arguments and asserts the resolver is invoked with `environ=None, home=None`, pinning that the four other call sites are unaffected by the new signature.

**Red-before**, with only the production change reverted:

```
assert 'F:\...\appeared-after-the-search' not in diagnostic_env["mapping"].get("PATH", "")
E   AssertionError
```

— the late `PATH` entry is present, because the diagnostic re-read `os.environ`. The second test fails on `resolve.assert_called_once_with(environ=None, home=None)`.

`test_client_spawn_scrubs_sensitive_env_on_default_auto` stubbed `_resolve_kiro_bin` with a zero-argument lambda; it now absorbs the keywords. That is a test double catching up with the signature, and it is the only stub in the suite that needed it.

**Green on this head:** `test/test_acp_client.py` — **516 passed, 29 skipped, 0 failed**.

**Gates green:** `mypy --platform linux` on the changed module, the baselined black gate (2 files in scope, no new offenders), isort, flake8. The full backend suite was not run locally; CI runs it authoritatively.

## Manual verification

N/A — unit coverage sufficient: the defect is which mapping two calls read, and the test observes both mappings directly and asserts they are the same object. Reproducing it by hand would mean racing a `PATH` edit against a resolver, which the test does deterministically by mutating from inside the resolver itself.

## Related Issues

No filed issue. The residual is the un-migrated half of #5048, whose commit message describes caching the search path with the resolution result for the Claude adapter; this applies the same guarantee to the Kiro adapter in the same function.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
