### PR TITLE
fix(frontend): restore node_modules when npm ci is refused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,12 @@ pyrightconfig.json
 # worktree node_modules is often a SYMLINK to a sibling checkout's, and a slash
 # matches a directory only.
 node_modules
+# A dependency tree stashed mid-install by the node_modules transaction (this
+# module's `.kirocrew-frontend-backup`, or the Dev Fleet sync runner's
+# `.kirocrew-sync-backup`). Left behind only when a run was killed or its cleanup
+# failed, and an untracked leftover makes the checkout read as dirty, which
+# fail-closes Dev Fleet's "Prune merged".
+node_modules.kirocrew-*-backup
 frontend/package-lock.json
 frontend/dist/
 tui/dist/
@@ -66,6 +72,8 @@ src/kiro_crew/static/dist
 # fail-closes Dev Fleet's "Prune merged".
 src/kiro_crew/static/.dist.staging.*
 src/kiro_crew/static/.dist.previous.*
+# Lock serializing one node_modules install transaction (node_modules_tx).
+src/kiro_crew/static/.node-modules.install.*
 
 # Build-time provenance stamp (scripts/stamp-distribution.sh). Generated per
 # packaging path; a committed copy would mislabel every other build's beacon.

--- a/src/kiro_crew/frontend.py
+++ b/src/kiro_crew/frontend.py
@@ -23,7 +23,7 @@ import tempfile
 from pathlib import Path
 from typing import Callable, Iterator, Optional
 
-from kiro_crew import platform_compat
+from kiro_crew import node_modules_tx, platform_compat
 from kiro_crew.executors import subprocess_executor
 
 logger = logging.getLogger(__name__)
@@ -295,6 +295,73 @@ def _staging_lock(static_parent: Path) -> Iterator[None]:
             yield
 
 
+@contextlib.contextmanager
+def _install_lock(static_parent: Path) -> Iterator[None]:
+    """Hold the cross-process lock for one ``node_modules`` transaction.
+
+    Serializes the whole reconcile-install-finish span in
+    :mod:`kiro_crew.node_modules_tx`, which reads leftovers as bare file
+    existence and so cannot tell a dead run's backup from a live one's. Three
+    in-tree callers can build the same checkout -- ``cli_server``'s sync build,
+    ``POST /api/update``, and the slack gateway -- and without this a second
+    builder's reconcile could rename the backup the first one is relying on into
+    the very slot its ``npm ci`` is emptying.
+
+    Distinct from :func:`_staging_lock` on purpose, not merely for scope: that
+    lock is an flock keyed per open-file-description, so re-entering it through a
+    second ``open()`` in the same process deadlocks against itself -- and the
+    install must be serialized while the build+stage that follows is separately
+    serialized against peers doing only the staging half.
+
+    Raises ``OSError`` if the lock cannot be taken. Callers on the event loop
+    MUST enter this from a worker thread: acquisition blocks for as long as a
+    peer's install runs, and ``platform_compat.file_lock`` deliberately refuses
+    to spin on the loop thread.
+    """
+    static_parent.mkdir(parents=True, exist_ok=True)
+    lock_path = static_parent / node_modules_tx.INSTALL_LOCK_NAME
+    with open(lock_path, "a+") as lock_fh:
+        # required=True for the same reason as the staging lock: a swallowed
+        # Windows acquisition failure would run the transaction unserialized,
+        # which is the exact race this exists to prevent.
+        with platform_compat.file_lock(
+            lock_fh.fileno(), exclusive=True, required=True
+        ):
+            yield
+
+
+def _reap_npm_tree(
+    proc: "subprocess.Popen[bytes]",
+    log: Callable[[str], None],
+    what: str,
+) -> None:
+    """SIGKILL a timed-out npm and everything it spawned, then reap it.
+
+    Enumerate BEFORE killing: the kill reparents survivors to init and erases the
+    PPID links that identify them. The group kill alone misses a descendant that
+    started its own session, and an escapee keeps writing after this function
+    returns — which is what makes a surviving writer able to corrupt the very
+    tree or bundle the caller is about to restore or stage.
+    """
+    descendants = platform_compat.process_descendants(proc.pid)
+    try:
+        platform_compat.kill_process_tree(proc.pid, platform_compat.SIGKILL)
+    except (ProcessLookupError, OSError, ValueError) as exc:
+        log(f"  ⚠️  Could not reap the timed-out frontend {what}: {exc}")
+    for child in descendants:
+        try:
+            platform_compat.kill_process_tree(child, platform_compat.SIGKILL)
+        except (ProcessLookupError, OSError, ValueError):
+            # Already reaped by the group kill, or no longer signalable.
+            continue
+    # Reap the direct child so it is not left a zombie. Bounded, so a survivor
+    # cannot hold a lock holder open indefinitely.
+    try:
+        proc.wait(timeout=_BUILD_KILL_GRACE)
+    except subprocess.TimeoutExpired:
+        log(f"  ⚠️  Frontend {what} did not die after SIGKILL")
+
+
 def _npm_build_and_stage_locked(
     website_dir: Path,
     proj_path: Path,
@@ -325,28 +392,7 @@ def _npm_build_and_stage_locked(
     try:
         proc.wait(timeout=_BUILD_TIMEOUT)
     except subprocess.TimeoutExpired:
-        # Enumerate BEFORE killing: the kill reparents survivors to init and
-        # erases the PPID links that identify them. The group kill alone misses
-        # a descendant that started its own session, and such an escapee keeps
-        # rewriting website/dist after this holder releases the staging lock —
-        # the mixed-bundle publication this lock exists to prevent.
-        descendants = platform_compat.process_descendants(proc.pid)
-        try:
-            platform_compat.kill_process_tree(proc.pid, platform_compat.SIGKILL)
-        except (ProcessLookupError, OSError, ValueError) as exc:
-            log(f"  ⚠️  Could not reap the timed-out frontend build: {exc}")
-        for child in descendants:
-            try:
-                platform_compat.kill_process_tree(child, platform_compat.SIGKILL)
-            except (ProcessLookupError, OSError, ValueError):
-                # Already reaped by the group kill, or no longer signalable.
-                continue
-        # Reap the direct child so it is not left a zombie. Bounded, so a
-        # survivor cannot hold the staging lock open indefinitely.
-        try:
-            proc.wait(timeout=_BUILD_KILL_GRACE)
-        except subprocess.TimeoutExpired:
-            log("  ⚠️  Frontend build did not die after SIGKILL")
+        _reap_npm_tree(proc, log, "build")
         log("  ⚠️  Frontend build timed out — dashboard may be stale")
         return False
     if proc.returncode != 0:
@@ -605,6 +651,13 @@ def build_frontend_sync(
     The edition seam is threaded through the build (see
     :func:`_edition_build_env`), so a downstream edition's rebuild recomposes THAT
     edition rather than staging a stock bundle over it.
+
+    The ``npm ci`` runs inside a :class:`~kiro_crew.node_modules_tx.
+    NodeModulesTransaction`: ``npm ci`` empties ``node_modules`` before it
+    installs, so a registry refusal used to leave the checkout with no dependency
+    tree at all and no way to rebuild one without the registry that just refused.
+    The tree is moved aside first, put back on any non-zero outcome, and the
+    backup dropped only on success.
     """
     website_dir = proj_path / _DIR_NAME
     if not website_dir.is_dir():
@@ -621,22 +674,68 @@ def build_frontend_sync(
         return
 
     log("  🔨 Building frontend (npm)…")
+    # `npm ci` EMPTIES node_modules before it installs; `npm install` updates it
+    # in place. Only the former needs the tree moved aside, and doing it for the
+    # latter would force a needless cold install of a tree npm was going to reuse.
+    empties_tree = (website_dir / "package-lock.json").is_file()
     install_args = (
         ["ci", "--no-audit", "--no-fund"]
-        if (website_dir / "package-lock.json").is_file()
+        if empties_tree
         else ["install", "--no-audit", "--no-fund"]
     )
-    try:
-        r = subprocess.run(
-            [npm, *install_args],
-            cwd=str(website_dir), capture_output=True, timeout=_INSTALL_TIMEOUT,
-        )
-    except subprocess.TimeoutExpired:
-        log("  ⚠️  Frontend npm install timed out — dashboard may be stale")
-        return
-    if r.returncode != 0:
-        log("  ⚠️  Frontend npm install failed — dashboard may be stale")
-        return
+    tx = node_modules_tx.NodeModulesTransaction(
+        website_dir / "node_modules", lambda msg: log(f"  {msg}")
+    )
+    static_parent = proj_path / "src" / "kiro_crew" / "static"
+    with contextlib.ExitStack() as install_lock:
+        # Scoped narrowly: a bare `except OSError` around the whole block would
+        # also swallow one raised by the install itself, which must propagate.
+        try:
+            install_lock.enter_context(_install_lock(static_parent))
+        except OSError as exc:
+            log(f"  ⚠️  Could not acquire the node_modules install lock: {exc}")
+            return
+        # Reconciled even for `npm install`: a leftover backup beside the tree
+        # means an earlier run died mid-install, so the tree on disk may be
+        # partial, and npm's incremental path trusts what it finds there. One
+        # rule for both commands, and the one that cannot lose the good copy.
+        if not tx.reconcile():
+            log("  ⚠️  Frontend dependency tree needs attention — dashboard may be stale")
+            return
+        if empties_tree and not tx.begin():
+            log("  ⚠️  Frontend npm install skipped — dashboard may be stale")
+            return
+        ok = False
+        try:
+            # Own process group, and the whole tree reaped on timeout, for the
+            # same reason the build below does it: `npm ci` spawns workers, and
+            # killing only npm leaves them writing into node_modules AFTER the
+            # restore renames the backup back over it — the two trees merge into
+            # a third that is neither. DEVNULL rather than captured pipes so the
+            # post-kill drain cannot block on a grandchild's inherited handle.
+            proc = subprocess.Popen(
+                [npm, *install_args],
+                cwd=str(website_dir),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            )
+            try:
+                proc.wait(timeout=_INSTALL_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                _reap_npm_tree(proc, log, "npm install")
+                log("  ⚠️  Frontend npm install timed out — dashboard may be stale")
+            else:
+                ok = proc.returncode == 0
+                if not ok:
+                    log("  ⚠️  Frontend npm install failed — dashboard may be stale")
+        finally:
+            # `ok` is pre-seeded False so an unexpected exception restores the
+            # tree rather than discarding it on the way out.
+            tx.finish(ok)
+        if not ok:
+            return
 
     # npm install does not touch website/dist, so only the build+stage pair
     # needs the lock.
@@ -662,6 +761,12 @@ async def build_frontend_async(
     Threads the edition seam like the sync helper — this is the path
     ``POST /api/update`` and the gateway auto-apply take, so an edition install
     must not silently rebuild as stock here either.
+
+    The ``npm ci`` runs inside the same
+    :class:`~kiro_crew.node_modules_tx.NodeModulesTransaction` as the sync
+    helper. This is the more important of the two: the auto-apply path runs
+    UNATTENDED, so nobody presses retry and nobody sees the failure until the
+    dashboard is already serving a stale bundle against new backend code.
     """
     proj_path = Path(proj)
     website_dir = proj_path / _DIR_NAME
@@ -683,30 +788,108 @@ async def build_frontend_async(
         _warn("Edition frontend sources not present -- keeping the shipped dashboard")
         return
 
+    # Same transaction as the sync path. The filesystem work runs on a worker
+    # thread: the renames are cheap metadata ops, but dropping a successful
+    # install's backup is an rmtree of a tree routinely hundreds of megabytes,
+    # and the event loop cannot sit through it. Messages are COLLECTED rather
+    # than pushed from the worker, because _warn reaches push_progress, which
+    # belongs to the loop thread.
+    empties_tree = (website_dir / "package-lock.json").is_file()
     install_args = (
         ["ci", "--no-audit", "--no-fund"]
-        if (website_dir / "package-lock.json").is_file()
+        if empties_tree
         else ["install", "--no-audit", "--no-fund"]
     )
-    npm_i = await asyncio.create_subprocess_exec(
-        npm, *install_args,
-        cwd=str(website_dir),
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
+    tx_messages: list[str] = []
+    tx = node_modules_tx.NodeModulesTransaction(
+        website_dir / "node_modules", tx_messages.append
     )
-    try:
-        await asyncio.wait_for(npm_i.wait(), timeout=_INSTALL_TIMEOUT)
-    except asyncio.TimeoutError:
+    loop = asyncio.get_running_loop()
+
+    def _drain() -> None:
+        for message in tx_messages:
+            _warn(message)
+        tx_messages.clear()
+
+    async def _off_loop(step: Callable[[], bool]) -> bool:
+        settled = await loop.run_in_executor(subprocess_executor(), step)
+        _drain()
+        return settled
+
+    install_lock = contextlib.ExitStack()
+
+    def _take_install_lock() -> bool:
         try:
-            npm_i.kill()
-        except ProcessLookupError:
-            pass
-        await npm_i.wait()
-        _warn("Frontend npm install timed out -- dashboard may be stale")
+            install_lock.enter_context(
+                _install_lock(proj_path / "src" / "kiro_crew" / "static")
+            )
+            return True
+        except OSError as exc:
+            tx_messages.append(f"could not acquire the node_modules install lock: {exc}")
+            return False
+
+    # Acquired on a worker thread: it blocks for as long as a peer's install
+    # runs, and file_lock refuses to spin on the loop thread.
+    if not await _off_loop(_take_install_lock):
         return
-    if npm_i.returncode != 0:
-        _warn("Frontend npm install failed -- dashboard may be stale")
-        return
+    try:
+        if not await _off_loop(tx.reconcile):
+            _warn("Frontend dependency tree needs attention -- dashboard may be stale")
+            return
+        if empties_tree and not await _off_loop(tx.begin):
+            _warn("Frontend npm install skipped -- dashboard may be stale")
+            return
+
+        ok = False
+        settled = False
+        try:
+            npm_i = await asyncio.create_subprocess_exec(
+                npm, *install_args,
+                cwd=str(website_dir),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                # Own session/group so kill_and_reap signals the whole TREE. Its
+                # group kill is SKIPPED for a child sharing our group, leaving
+                # `npm ci`'s workers alive to write into node_modules after the
+                # restore puts the backup back over it.
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            )
+            try:
+                await asyncio.wait_for(npm_i.wait(), timeout=_INSTALL_TIMEOUT)
+            except asyncio.TimeoutError:
+                await platform_compat.kill_and_reap(npm_i, timeout=_BUILD_KILL_GRACE)
+                _warn("Frontend npm install timed out -- dashboard may be stale")
+            except asyncio.CancelledError:
+                # A gateway shutdown cancels this task. The tree must NOT be put
+                # back while npm or a worker it spawned is still alive: an
+                # orphaned install keeps writing into node_modules after the
+                # rename, so the restored tree and the partial one merge into a
+                # third thing that is neither. Kill and reap the tree FIRST
+                # (kill_and_reap is internally shielded, so a repeat
+                # cancellation cannot abandon it), and settle through the
+                # executor like every other path — delivering CancelledError
+                # clears the task's cancel flag, so this await does run, and an
+                # inline settle would rmtree a multi-hundred-megabyte tree on the
+                # event loop during shutdown.
+                await platform_compat.kill_and_reap(npm_i, timeout=_BUILD_KILL_GRACE)
+                await _off_loop(lambda: tx.finish(False))
+                settled = True
+                raise
+            else:
+                ok = npm_i.returncode == 0
+                if not ok:
+                    _warn("Frontend npm install failed -- dashboard may be stale")
+        finally:
+            if not settled:
+                await _off_loop(lambda: tx.finish(ok))
+        if not ok:
+            return
+    finally:
+        # Closed inline, not through the executor: releasing is an unlock plus a
+        # close, both instant, and an awaited release would be skipped by the
+        # very cancellation that most needs the lock let go.
+        install_lock.close()
 
     # The build and the stage run under ONE lock holder, in a worker thread.
     # Vite empties website/dist, so a peer flow staging concurrently would copy

--- a/src/kiro_crew/node_modules_tx.py
+++ b/src/kiro_crew/node_modules_tx.py
@@ -1,0 +1,258 @@
+"""Move a ``node_modules`` tree aside for an install that empties it, then put it back.
+
+``npm ci`` deletes ``node_modules`` before it installs. When the registry then
+refuses the install -- an expired credential, or a curated mirror that blocks a
+version the lockfile pins -- the tree is already gone and nothing restores it.
+The checkout is left with a stale frontend bundle against new backend code, and
+the only way out needs the very registry that is unavailable.
+
+The move-aside/restore transaction that prevents that shipped first for Dev
+Fleet's Pull + Build, assembled as string literals inside a generated runner
+script. This module is that same transaction as real, importable, type-checked
+code, for the in-process ``npm ci`` callers in :mod:`kiro_crew.frontend` --
+reached from the CLI server, ``POST /api/update``, and the gateway's unattended
+auto-apply, where no operator is watching to press retry.
+
+**Stdlib-only, deliberately.** Nothing here imports ``kiro_crew``. The Dev Fleet
+runner is snapshotted to a temp dir and executed BY PATH so the revision being
+merged cannot change the code doing the merge, which is why it could not simply
+import the transaction from the package. Keeping this module free of package
+imports leaves that door open: a follow-up can snapshot it beside
+``npm_preflight.py`` and delete the runner's copy without weakening the snapshot
+contract.
+
+Crash safety is carried by :meth:`NodeModulesTransaction.reconcile`, not by the
+in-process ``finally``: a process killed mid-install cannot run its own restore,
+so the NEXT run reads the leftovers off disk and either recovers the backup or
+refuses to guess.
+
+**The caller MUST serialize.** Leftovers are read as bare file existence, which
+cannot tell a dead run's backup from a live one's, so a second builder reconciling
+concurrently would claim a backup the first is still relying on. Every method
+here assumes single-writer access to the tree for the whole
+reconcile-install-finish span; :data:`INSTALL_LOCK_NAME` is the lock file the
+in-tree callers agree on.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Callable
+
+#: Suffix appended to the tree's own name to address its stashed copy.
+#:
+#: Deliberately NOT the Dev Fleet sync runner's ``.kirocrew-sync-backup``. Sharing
+#: one name looks like the way to let both paths recognise each other's leftovers,
+#: and it would be -- but only under a lock both of them take. The runner takes
+#: none, so a shared name means this reconciler can claim a backup the runner's
+#: LIVE ``npm ci`` is still relying on, rename it into the slot that install is
+#: emptying, and merge the two trees into a third that is neither. A distinct name
+#: makes the two transactions invisible to each other, which is the only safe
+#: relationship available until one implementation serves both (#6739, then #6693's
+#: unification follow-up) and one lock covers both.
+#:
+#: The cost is bounded and strictly better than the status quo: a backup stranded
+#: by the runner is not recovered by this path, so a later Pull + Build meets its
+#: own both-exist refusal, which names both paths and is recoverable by hand. What
+#: it can no longer do is destroy a tree.
+BACKUP_SUFFIX = ".kirocrew-frontend-backup"
+
+#: Name of the lock file that serializes the reconcile-install-finish span. Held
+#: here as a NAME rather than a lock: taking it needs ``platform_compat``, and
+#: this module stays free of package imports so it can be snapshotted. Declared
+#: here anyway so every user of :data:`BACKUP_SUFFIX` agrees on one file instead
+#: of each inventing its own and serializing nothing.
+INSTALL_LOCK_NAME = ".node-modules.install.lock"
+
+
+def backup_for(tree: "str | os.PathLike[str]") -> Path:
+    """The path a stashed copy of *tree* is moved to."""
+    path = Path(tree)
+    return path.with_name(path.name + BACKUP_SUFFIX)
+
+
+def _confirm_gone(path: Path) -> bool:
+    """Delete *path* and report whether it is really gone.
+
+    ``shutil.rmtree(..., ignore_errors=True)`` alone is not safe here, though it
+    is the right default elsewhere: every deletion below decides what the next
+    rename does, so a partial removal that is silently ignored leaves a directory
+    in place, makes the following rename fail, and ends with a PARTIAL tree
+    restored over a good one. A refused build is recoverable; a half-restored
+    ``node_modules`` is not.
+
+    ``rmtree`` REFUSES a symbolic link ("Cannot call rmtree on a symbolic link")
+    and ``ignore_errors=True`` swallows that refusal -- which is how a symlinked
+    ``node_modules`` left an undeletable backup and wedged every later run as
+    ambiguous, escapable only by hand. So links are unlinked and only real trees
+    are handed to ``rmtree``.
+    """
+    if os.path.islink(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    else:
+        shutil.rmtree(path, ignore_errors=True)
+    # lexists, not exists: a DANGLING symlink is still something at this path,
+    # and reporting it as gone would let the caller rename onto an occupied slot.
+    return not os.path.lexists(path)
+
+
+class NodeModulesTransaction:
+    """Guard one dependency install against leaving *tree* deleted.
+
+    Lifecycle, in order: :meth:`reconcile` before anything is run, :meth:`begin`
+    immediately before the install, :meth:`finish` from a ``finally`` with the
+    install's outcome. :meth:`reconcile` and :meth:`begin` return ``False`` to
+    mean DO NOT RUN THE INSTALL -- running it anyway would destroy a tree this
+    object has just said it cannot put back.
+
+    Exposed as three calls rather than a context manager because the async caller
+    has to run each one on a worker thread. Renaming is cheap metadata work, but
+    dropping a successful run's backup is an ``rmtree`` of a tree that is
+    routinely hundreds of megabytes, and the event loop cannot afford to sit
+    through it. A context manager whose success is decided by a separate
+    argument would also read worse than an explicit ``finish(ok)``.
+
+    Every message goes to *log* as a plain sentence with no severity marker or
+    indentation: the two callers decorate differently (one prefixes warnings,
+    the other forwards to the update stream), and only they know which.
+    """
+
+    def __init__(
+        self,
+        tree: "str | os.PathLike[str]",
+        log: Callable[[str], None],
+    ) -> None:
+        self.tree = Path(tree)
+        self.backup = backup_for(self.tree)
+        self._log = log
+        self._stashed = False
+
+    def reconcile(self) -> bool:
+        """Settle leftovers from an earlier run. ``False`` means refuse to build.
+
+        Runs before any step, and owns BOTH leftover decisions. Deferring the
+        backup-only recovery to the install step would be a defect: a run killed
+        just after stashing leaves the tree absent and an intact backup
+        unclaimed, and a recovery gated on the install succeeding means a still
+        failing registry leaves the tree missing with the good copy sitting right
+        there. Both cases are knowable from disk with nothing applied, so both
+        are decided here.
+
+        Requires the caller to hold :data:`INSTALL_LOCK_NAME` for the whole
+        reconcile-install-finish span. Bare file existence cannot distinguish a
+        dead run's backup from a live one's, so claiming a backup without that
+        exclusion could rename the copy a concurrent install is relying on into
+        the slot that install is emptying.
+        """
+        # lexists, not isdir, for every presence gate. isdir FOLLOWS a symlink,
+        # so a DANGLING node_modules reads as absent -- and then the backup-only
+        # branch renames a directory onto that dangling link, fails ENOTDIR, and
+        # the tree is never recovered. lexists asks what these gates mean: is
+        # there anything at this path.
+        have_tree = os.path.lexists(self.tree)
+        have_backup = os.path.lexists(self.backup)
+        if have_tree and have_backup:
+            # Genuinely AMBIGUOUS, and no rule can be right:
+            #
+            #   * killed DURING the install -> the tree is the partial one npm
+            #     was writing and the backup is the last good copy.
+            #   * a backup that outlived a SUCCESSFUL install (its cleanup
+            #     failed) -> the tree is good and the backup is stale.
+            #
+            # Nothing on disk tells those apart, so either choice destroys the
+            # good copy in one of them. The only move that cannot lose data is to
+            # touch NEITHER and stop -- and to name both paths, because otherwise
+            # every later attempt refuses identically and the operator has to
+            # deduce that a directory needs removing.
+            self._log("a previous install left a dependency-tree backup beside the tree")
+            self._log(f"tree: {self.tree}")
+            self._log(f"backup: {self.backup}")
+            self._log("remove whichever of the two is not wanted, then build again")
+            return False
+        if have_backup:
+            self._log("restoring a dependency tree left stashed by an earlier run")
+            try:
+                os.rename(self.backup, self.tree)
+            except OSError as exc:
+                # The good copy is still there and the tree slot is still empty.
+                # Installing now would create a tree beside an unclaimed backup,
+                # which is the ambiguous state above -- permanent until someone
+                # deletes a directory by hand. Refusing keeps the recovery
+                # available for the next attempt.
+                self._log(f"could not restore the stashed dependency tree: {exc}")
+                self._log(f"backup: {self.backup}")
+                return False
+        return True
+
+    def begin(self) -> bool:
+        """Move the tree aside. ``False`` means refuse to run the install.
+
+        Call only for a command that EMPTIES the tree. ``npm ci`` does; ``npm
+        install`` updates in place, and moving the tree aside for it would force
+        a needless cold install and discard a tree npm was going to reuse.
+        """
+        if not os.path.lexists(self.tree):
+            # Nothing to protect: the install writes into an empty slot, so no
+            # backup is taken and finish() has nothing to put back.
+            return True
+        try:
+            # lexists above rather than isdir for the same reason as reconcile:
+            # with isdir a SYMLINKED node_modules would not be moved aside at
+            # all, leaving the install unprotected on exactly the layouts that
+            # most need it (a link into a shared store).
+            os.rename(self.tree, self.backup)
+        except OSError as exc:
+            self._log(f"could not move the dependency tree aside: {exc}")
+            self._log("skipping the install: npm would delete a tree that cannot be restored")
+            return False
+        self._stashed = True
+        return True
+
+    def finish(self, ok: bool) -> bool:
+        """Drop the backup when *ok*, else put the tree back. ``False`` on failure.
+
+        Safe to call unconditionally, including when :meth:`begin` took no
+        backup, and idempotent once it has settled.
+        """
+        # lexists: the backup is whatever os.rename moved here, so if the tree
+        # was a symlink the backup is one too. An isdir gate would skip this
+        # whole block for a DANGLING link -- the tree left moved aside, neither
+        # restored nor dropped, which is the data loss this exists to prevent.
+        if not self._stashed or not os.path.lexists(self.backup):
+            self._stashed = False
+            return True
+        if ok:
+            # A backup that will not delete on the SUCCESS path is not dangerous:
+            # the tree on disk is the new good one, and the next run's both-exist
+            # branch handles the leftover. Say so rather than failing an install
+            # that already worked.
+            if not _confirm_gone(self.backup):
+                self._log(
+                    f"note: a dependency-tree backup could not be removed and "
+                    f"was left at {self.backup}"
+                )
+            self._stashed = False
+            return True
+        if _confirm_gone(self.tree):
+            try:
+                os.rename(self.backup, self.tree)
+            except OSError as exc:
+                self._log(f"could not put the dependency tree back: {exc}")
+                self._log(f"backup: {self.backup}")
+                return False
+            self._log("restored the dependency tree after a failed install")
+            self._stashed = False
+            return True
+        # The rename would fail anyway, and forcing it is how a partial tree ends
+        # up installed over a good backup. Leave BOTH and name them: "the tree
+        # could not be put back" outranks whatever the install failed with,
+        # because it is the part the operator has to act on.
+        self._log("could not clear the partial dependency tree; both copies were left in place")
+        self._log(f"partial: {self.tree}")
+        self._log(f"backup: {self.backup}")
+        return False

--- a/test/test_frontend_dist_resolve.py
+++ b/test/test_frontend_dist_resolve.py
@@ -288,6 +288,10 @@ def test_resolver_produces_a_symlink_the_pwa_guard_accepts(fake_pkg, tmp_path, m
 def test_build_frontend_sync_spawns_resolved_npm_path(tmp_path, monkeypatch):
     """Regression: on Windows npm is ``npm.CMD``; CreateProcess cannot spawn the
     bare name "npm". build_frontend_sync must spawn the RESOLVED path.
+
+    Patches ``Popen``, which is the seam BOTH spawns go through: the install
+    moved onto it so a timed-out `npm ci` can have its whole worker tree reaped
+    before the node_modules transaction restores the stashed tree.
     """
     website = tmp_path / "website"
     website.mkdir()
@@ -299,14 +303,17 @@ def test_build_frontend_sync_spawns_resolved_npm_path(tmp_path, monkeypatch):
 
     calls: list[list[str]] = []
 
-    class _Result:
+    class _Proc:
         returncode = 0
 
-    def _fake_run(cmd, **kw):
-        calls.append(cmd)
-        return _Result()
+        def wait(self, timeout=None):
+            return 0
 
-    monkeypatch.setattr(frontend.subprocess, "run", _fake_run)
+    def _fake_popen(cmd, **kw):
+        calls.append(cmd)
+        return _Proc()
+
+    monkeypatch.setattr(frontend.subprocess, "Popen", _fake_popen)
     frontend.build_frontend_sync(tmp_path, log=lambda *a: None)
 
     assert calls, "no subprocess was spawned"

--- a/test/test_node_modules_tx.py
+++ b/test/test_node_modules_tx.py
@@ -1,0 +1,621 @@
+"""``npm ci`` must never leave a checkout with no ``node_modules`` (issue #6693).
+
+Two layers:
+
+* :class:`kiro_crew.node_modules_tx.NodeModulesTransaction` driven against real
+  ``tmp_path`` trees -- stash, restore, drop, the both-exist refusal, and the
+  symlink cases the suffix collision once wedged.
+* :func:`kiro_crew.frontend.build_frontend_sync` /
+  :func:`~kiro_crew.frontend.build_frontend_async` with a FAILING npm, asserting
+  the tree survives. These are the sites the issue names; the third (the
+  dashboard auto-apply) reaches the async one through ``_build_frontend``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_symlinks
+from kiro_crew import frontend, node_modules_tx, platform_compat
+
+#: The stashed copy's name for a ``website/node_modules``, derived from the
+#: module's own constant so a rename cannot leave these tests asserting a stale
+#: literal.
+BACKUP_NAME = "node_modules" + node_modules_tx.BACKUP_SUFFIX
+
+
+class _FakeProc:
+    """Stand-in for the install child: one ``wait``, then a return code."""
+
+    def __init__(self, returncode: int = 0, timeout: bool = False) -> None:
+        # Never signalled: every test that reaches the reap patches _reap_npm_tree.
+        self.pid = -4242
+        self.returncode = returncode
+        self._timeout = timeout
+        self.waits = 0
+
+    def wait(self, timeout=None):
+        self.waits += 1
+        if self._timeout and self.waits == 1:
+            raise frontend.subprocess.TimeoutExpired("npm", timeout or 0)
+        return self.returncode
+
+
+def _patch_install(monkeypatch, *, returncode=0, timeout=False, on_spawn=None, raises=None):
+    """Patch the install spawn seam. Returns (argv seen, spawn kwargs seen)."""
+    spawned: list[list[str]] = []
+    options: list[dict] = []
+
+    def _fake_popen(cmd, **kw):
+        spawned.append(cmd)
+        options.append(kw)
+        if on_spawn is not None:
+            on_spawn()
+        if raises is not None:
+            raise raises
+        return _FakeProc(returncode=returncode, timeout=timeout)
+
+    monkeypatch.setattr(frontend.subprocess, "Popen", _fake_popen)
+    return spawned, options
+
+
+def _tree(parent: Path, name: str = "node_modules", marker: str = "left") -> Path:
+    """A populated dependency tree, identifiable by the file inside it."""
+    tree = parent / name
+    (tree / "pkg").mkdir(parents=True)
+    (tree / "pkg" / "index.js").write_text(marker, encoding="utf-8")
+    return tree
+
+
+def _marker(tree: Path) -> str:
+    return (tree / "pkg" / "index.js").read_text(encoding="utf-8")
+
+
+# ── the transaction itself ─────────────────────────────────────────────────
+
+
+def test_backup_name_is_not_the_dev_fleet_runners(tmp_path):
+    """Sharing one backup name without a shared lock is the hazard, not the fix.
+
+    The runner takes no lock, so a shared name would let this reconciler claim a
+    backup the runner's LIVE ``npm ci`` still depends on and rename it into the
+    slot that install is emptying. A distinct name makes the two transactions
+    invisible to each other, which is the only safe relationship available until
+    one implementation and one lock serve both.
+    """
+    backup = node_modules_tx.backup_for(tmp_path / "node_modules")
+    assert backup.parent == tmp_path
+    assert node_modules_tx.BACKUP_SUFFIX != ".kirocrew-sync-backup"
+    assert backup.name == "node_modules" + node_modules_tx.BACKUP_SUFFIX
+
+
+def test_failed_install_puts_the_tree_back(tmp_path):
+    tree = _tree(tmp_path)
+    tx = node_modules_tx.NodeModulesTransaction(tree, lambda _m: None)
+
+    assert tx.reconcile() is True
+    assert tx.begin() is True
+    # This is what `npm ci` does before it installs, and where it used to stop.
+    assert not tree.exists()
+    assert node_modules_tx.backup_for(tree).is_dir()
+
+    assert tx.finish(False) is True
+    assert _marker(tree) == "left"
+    assert not node_modules_tx.backup_for(tree).exists()
+
+
+def test_successful_install_drops_the_backup(tmp_path):
+    tree = _tree(tmp_path)
+    tx = node_modules_tx.NodeModulesTransaction(tree, lambda _m: None)
+    tx.reconcile()
+    tx.begin()
+    # Stand in for npm writing a fresh tree into the empty slot.
+    fresh = _tree(tmp_path, marker="fresh")
+
+    assert tx.finish(True) is True
+    assert _marker(fresh) == "fresh"
+    assert not node_modules_tx.backup_for(tree).exists()
+
+
+def test_finish_is_idempotent_and_safe_without_a_stash(tmp_path):
+    """`finish` is called unconditionally from a ``finally``."""
+    tree = tmp_path / "node_modules"
+    tx = node_modules_tx.NodeModulesTransaction(tree, lambda _m: None)
+    assert tx.reconcile() is True
+    assert tx.begin() is True  # nothing to protect
+    assert not node_modules_tx.backup_for(tree).exists()
+    assert tx.finish(False) is True
+    assert tx.finish(True) is True
+
+    populated = _tree(tmp_path)
+    tx2 = node_modules_tx.NodeModulesTransaction(populated, lambda _m: None)
+    tx2.reconcile()
+    tx2.begin()
+    assert tx2.finish(False) is True
+    assert tx2.finish(False) is True  # settled; does not stash again
+    assert _marker(populated) == "left"
+
+
+def test_both_present_refuses_and_touches_neither(tmp_path):
+    """Killed-during-install and killed-during-cleanup are indistinguishable.
+
+    Either rule destroys the good copy in one of the two cases, so the only move
+    that cannot lose data is to touch NEITHER and stop.
+    """
+    tree = _tree(tmp_path, marker="maybe-partial")
+    backup = tmp_path / BACKUP_NAME
+    (backup / "pkg").mkdir(parents=True)
+    (backup / "pkg" / "index.js").write_text("maybe-good", encoding="utf-8")
+    messages: list[str] = []
+
+    tx = node_modules_tx.NodeModulesTransaction(tree, messages.append)
+    assert tx.reconcile() is False
+    # Both copies intact, byte for byte.
+    assert _marker(tree) == "maybe-partial"
+    assert _marker(backup) == "maybe-good"
+    # Both paths named: otherwise every later attempt refuses identically and the
+    # operator has to deduce that a directory needs removing.
+    assert any(str(tree) in m for m in messages)
+    assert any(str(backup) in m for m in messages)
+
+
+def test_backup_only_is_claimed_before_any_step_runs(tmp_path):
+    """A run killed just after stashing must not need the registry to recover.
+
+    Deferring this to the install step meant a still failing registry left the
+    tree missing with the good copy sitting right there.
+    """
+    tree = tmp_path / "node_modules"
+    backup = _tree(tmp_path, name=BACKUP_NAME, marker="rescued")
+
+    tx = node_modules_tx.NodeModulesTransaction(tree, lambda _m: None)
+    assert tx.reconcile() is True
+    assert _marker(tree) == "rescued"
+    assert not backup.exists()
+
+
+def test_restore_failure_leaves_both_and_reports_it(tmp_path, monkeypatch):
+    """A tree slot that will not clear must not be renamed onto.
+
+    Forcing the rename is how a partial tree ends up installed over a good
+    backup, so both are left and the caller is told.
+    """
+    tree = _tree(tmp_path)
+    messages: list[str] = []
+    tx = node_modules_tx.NodeModulesTransaction(tree, messages.append)
+    tx.reconcile()
+    tx.begin()
+    # npm got far enough to create a partial tree, and it cannot be removed.
+    partial = _tree(tmp_path, marker="partial")
+    monkeypatch.setattr(node_modules_tx.shutil, "rmtree", lambda *a, **k: None)
+
+    assert tx.finish(False) is False
+    assert _marker(partial) == "partial"
+    assert _marker(node_modules_tx.backup_for(tree)) == "left"
+    assert any("partial:" in m for m in messages)
+    assert any("backup:" in m for m in messages)
+
+
+def test_undeletable_backup_on_success_is_a_note_not_a_failure(tmp_path, monkeypatch):
+    """The tree on disk is the new good one; the next run reconciles the leftover."""
+    tree = _tree(tmp_path)
+    messages: list[str] = []
+    tx = node_modules_tx.NodeModulesTransaction(tree, messages.append)
+    tx.reconcile()
+    tx.begin()
+    _tree(tmp_path, marker="fresh")
+    monkeypatch.setattr(node_modules_tx.shutil, "rmtree", lambda *a, **k: None)
+
+    assert tx.finish(True) is True
+    assert any("could not be removed" in m for m in messages)
+
+
+def test_unstashable_tree_refuses_the_install(tmp_path, monkeypatch):
+    """If the tree cannot be moved aside, npm must not be allowed to delete it."""
+    tree = _tree(tmp_path)
+    messages: list[str] = []
+    tx = node_modules_tx.NodeModulesTransaction(tree, messages.append)
+
+    def _boom(*_a, **_k):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(node_modules_tx.os, "rename", _boom)
+    assert tx.begin() is False
+    assert not node_modules_tx.backup_for(tree).exists()
+    assert _marker(tree) == "left"
+    assert any("aside" in m for m in messages)
+
+
+@requires_symlinks
+def test_symlinked_tree_is_protected_and_restored(tmp_path):
+    """A link into a shared store is a layout that most needs the transaction.
+
+    An ``isdir`` presence gate would not move it aside at all, leaving the
+    install unprotected exactly there.
+    """
+    store = _tree(tmp_path, name="shared-store", marker="shared")
+    tree = tmp_path / "node_modules"
+    tree.symlink_to(store, target_is_directory=True)
+
+    tx = node_modules_tx.NodeModulesTransaction(tree, lambda _m: None)
+    assert tx.reconcile() is True
+    assert tx.begin() is True
+    assert not os.path.lexists(tree)
+    assert os.path.islink(node_modules_tx.backup_for(tree))
+
+    assert tx.finish(False) is True
+    assert os.path.islink(tree)
+    assert _marker(tree) == "shared"
+
+
+@requires_symlinks
+def test_symlinked_backup_is_unlinked_not_rmtreed(tmp_path):
+    """``rmtree`` REFUSES a symlink and ``ignore_errors`` swallows the refusal.
+
+    That is how a symlinked ``node_modules`` left an undeletable backup and
+    wedged every later run as ambiguous.
+    """
+    store = _tree(tmp_path, name="shared-store", marker="shared")
+    tree = tmp_path / "node_modules"
+    tree.symlink_to(store, target_is_directory=True)
+
+    tx = node_modules_tx.NodeModulesTransaction(tree, lambda _m: None)
+    tx.reconcile()
+    tx.begin()
+    _tree(tmp_path, marker="fresh")
+
+    assert tx.finish(True) is True
+    assert not os.path.lexists(node_modules_tx.backup_for(tree))
+    # The shared store the link pointed at is untouched.
+    assert _marker(store) == "shared"
+
+
+@requires_symlinks
+def test_dangling_tree_link_does_not_wedge_the_backup_recovery(tmp_path):
+    """``isdir`` reads a DANGLING link as absent, then renames onto it (ENOTDIR).
+
+    ``lexists`` asks what the gate means: is there anything at this path.
+    """
+    tree = tmp_path / "node_modules"
+    tree.symlink_to(tmp_path / "gone", target_is_directory=True)
+    _tree(tmp_path, name=BACKUP_NAME, marker="rescued")
+    messages: list[str] = []
+
+    # A dangling link IS something at that path, so this is the ambiguous case
+    # and must refuse rather than crash.
+    tx = node_modules_tx.NodeModulesTransaction(tree, messages.append)
+    assert tx.reconcile() is False
+    assert os.path.lexists(tree)
+    assert os.path.lexists(node_modules_tx.backup_for(tree))
+
+
+# ── the two frontend call sites ────────────────────────────────────────────
+
+
+def _checkout(tmp_path: Path) -> Path:
+    """A checkout whose website/ has a lockfile, so the build picks `npm ci`."""
+    website = tmp_path / "website"
+    website.mkdir()
+    (website / "package.json").write_text("{}", encoding="utf-8")
+    (website / "package-lock.json").write_text("{}", encoding="utf-8")
+    _tree(website, marker="installed")
+    return website
+
+
+def test_sync_build_restores_the_tree_when_npm_ci_fails(tmp_path, monkeypatch):
+    """The CLI-server path. Regression for issue #6693."""
+    website = _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+
+    def _at_spawn():
+        # Stand in for `npm ci`: the directory is already gone by the time npm
+        # decides the registry refused it.
+        assert not (website / "node_modules").exists()
+
+    spawned, _ = _patch_install(monkeypatch, returncode=1, on_spawn=_at_spawn)
+    messages: list[str] = []
+    frontend.build_frontend_sync(tmp_path, log=messages.append)
+
+    assert "ci" in spawned[0]
+    assert _marker(website / "node_modules") == "installed"
+    assert not (website / BACKUP_NAME).exists()
+    assert any("npm install failed" in m for m in messages)
+
+
+def test_sync_install_gets_its_own_process_group(tmp_path, monkeypatch):
+    """`npm ci` spawns workers, and killing only npm leaves them writing.
+
+    Without its own session the tree kill degrades to a pid-scoped kill, so a
+    worker outlives the restore and writes into the tree put back over it.
+    """
+    _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    _, options = _patch_install(monkeypatch, returncode=1)
+    frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+    assert options[0]["start_new_session"] is platform_compat.IS_POSIX
+    assert options[0]["creationflags"] == platform_compat.CREATE_NEW_PROCESS_GROUP
+
+
+def test_sync_build_reaps_the_install_tree_before_restoring(tmp_path, monkeypatch):
+    """The reap must happen while the tree is still moved aside."""
+    website = _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    reaped: list[tuple[str, bool]] = []
+
+    def _fake_reap(_proc, _log, what):
+        reaped.append((what, (website / "node_modules").exists()))
+
+    monkeypatch.setattr(frontend, "_reap_npm_tree", _fake_reap)
+    _patch_install(monkeypatch, timeout=True)
+    frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+    assert reaped == [("npm install", False)], "reaped after the restore, or not at all"
+    assert _marker(website / "node_modules") == "installed"
+    assert not (website / BACKUP_NAME).exists()
+
+
+def test_sync_build_restores_the_tree_when_npm_raises(tmp_path, monkeypatch):
+    """`ok` is pre-seeded False so an unexpected exception restores, not discards."""
+    website = _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    _patch_install(monkeypatch, raises=OSError(8, "Exec format error"))
+    with pytest.raises(OSError):
+        frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+    assert _marker(website / "node_modules") == "installed"
+    assert not (website / BACKUP_NAME).exists()
+
+
+def test_sync_build_refuses_when_a_leftover_backup_sits_beside_the_tree(tmp_path, monkeypatch):
+    """npm must not run at all: the tree on disk may be a partial one."""
+    website = _checkout(tmp_path)
+    _tree(website, name=BACKUP_NAME, marker="maybe-good")
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    spawned, _ = _patch_install(
+        monkeypatch, raises=AssertionError("npm must not be spawned when ambiguous")
+    )
+    messages: list[str] = []
+    frontend.build_frontend_sync(tmp_path, log=messages.append)
+
+    assert spawned == []
+    assert _marker(website / "node_modules") == "installed"
+    assert _marker(website / BACKUP_NAME) == "maybe-good"
+    assert any("needs attention" in m for m in messages)
+
+
+def test_sync_build_does_not_stash_for_npm_install(tmp_path, monkeypatch):
+    """`npm install` updates in place; stashing would force a cold install."""
+    website = tmp_path / "website"
+    website.mkdir()
+    (website / "package.json").write_text("{}", encoding="utf-8")
+    _tree(website, marker="installed")  # no package-lock.json
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    monkeypatch.setattr(frontend, "_npm_build_and_stage_locked", lambda *a, **k: True)
+    seen: list[bool] = []
+    spawned, _ = _patch_install(
+        monkeypatch, on_spawn=lambda: seen.append((website / "node_modules").exists())
+    )
+    frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+    assert "install" in spawned[0] and "ci" not in spawned[0]
+    assert seen == [True], "the tree was moved aside for an in-place install"
+    assert _marker(website / "node_modules") == "installed"
+
+
+@pytest.mark.asyncio
+async def test_async_build_restores_the_tree_when_npm_ci_fails(tmp_path, monkeypatch):
+    """The unattended path: POST /api/update and the gateway auto-apply."""
+    website = _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+
+    class _Proc:
+        returncode = 1
+
+        async def wait(self):
+            return 1
+
+    async def _fake_exec(_program, *args, **_kw):
+        assert not (website / "node_modules").exists()
+        assert "ci" in args
+        return _Proc()
+
+    monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _fake_exec)
+    events: list[tuple[str, str]] = []
+    await frontend.build_frontend_async(
+        str(tmp_path), push_progress=lambda k, m: events.append((k, m))
+    )
+
+    assert _marker(website / "node_modules") == "installed"
+    assert not node_modules_tx.backup_for(website / "node_modules").exists()
+    assert any("npm install failed" in m for _k, m in events)
+
+
+@pytest.mark.asyncio
+async def test_async_build_refuses_when_a_leftover_backup_sits_beside_the_tree(
+    tmp_path, monkeypatch
+):
+    website = _checkout(tmp_path)
+    _tree(website, name=BACKUP_NAME, marker="maybe-good")
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+
+    async def _fake_exec(*_a, **_k):
+        raise AssertionError("npm must not be spawned in the ambiguous state")
+
+    monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _fake_exec)
+    events: list[tuple[str, str]] = []
+    await frontend.build_frontend_async(
+        str(tmp_path), push_progress=lambda k, m: events.append((k, m))
+    )
+
+    assert _marker(website / "node_modules") == "installed"
+    assert _marker(website / BACKUP_NAME) == "maybe-good"
+    assert any("needs attention" in m for _k, m in events)
+
+
+@pytest.mark.asyncio
+async def test_async_build_recovers_a_stranded_backup_without_the_registry(tmp_path, monkeypatch):
+    """A run killed just after stashing recovers on the NEXT run, from disk."""
+    website = tmp_path / "website"
+    website.mkdir()
+    (website / "package.json").write_text("{}", encoding="utf-8")
+    (website / "package-lock.json").write_text("{}", encoding="utf-8")
+    _tree(website, name=BACKUP_NAME, marker="stranded")
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+
+    class _Proc:
+        returncode = 1
+
+        async def wait(self):
+            return 1
+
+    async def _fake_exec(*_a, **_k):
+        return _Proc()
+
+    monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _fake_exec)
+    await frontend.build_frontend_async(str(tmp_path))
+
+    # Recovered before the install, then put back when the install failed again.
+    assert _marker(website / "node_modules") == "stranded"
+
+
+def test_sync_build_holds_the_install_lock_while_npm_runs(tmp_path, monkeypatch):
+    """Reconcile reads bare file existence, so the span must be single-writer.
+
+    Without this a second builder's reconcile could rename the backup the first
+    is relying on into the slot its ``npm ci`` is emptying.
+    """
+    _checkout(tmp_path)
+    lock_path = tmp_path / "src" / "kiro_crew" / "static" / node_modules_tx.INSTALL_LOCK_NAME
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    monkeypatch.setattr(frontend, "_npm_build_and_stage_locked", lambda *a, **k: True)
+    free_to_take: list[bool] = []
+
+    def _probe():
+        # A separate open file description conflicts with the holder's even
+        # inside one process, so this is the peer builder's view of the lock.
+        with open(lock_path, "a+") as probe:
+            free_to_take.append(platform_compat.try_acquire_lock(probe.fileno(), exclusive=True))
+
+    _patch_install(monkeypatch, on_spawn=_probe)
+    frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+    assert free_to_take == [False], "the install ran without holding the lock"
+
+
+@pytest.mark.asyncio
+async def test_async_install_gets_its_own_process_group(tmp_path, monkeypatch):
+    """kill_and_reap SKIPS its group kill for a child sharing our own group.
+
+    Without its own session, `npm ci`'s workers survive the reap and write into
+    node_modules after the restore renames the backup back over it.
+    """
+    _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    options: list[dict] = []
+
+    class _Proc:
+        returncode = 1
+
+        async def wait(self):
+            return 1
+
+    async def _fake_exec(_program, *_args, **kw):
+        options.append(kw)
+        return _Proc()
+
+    monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _fake_exec)
+    await frontend.build_frontend_async(str(tmp_path))
+
+    assert options[0]["start_new_session"] is platform_compat.IS_POSIX
+    assert options[0]["creationflags"] == platform_compat.CREATE_NEW_PROCESS_GROUP
+
+
+@pytest.mark.asyncio
+async def test_async_build_kills_npm_before_restoring_on_cancellation(tmp_path, monkeypatch):
+    """A gateway shutdown must not put the tree back under a LIVE npm.
+
+    An orphaned install keeps writing into node_modules after the rename, so the
+    restored tree and the partial one merge into a third thing that is neither.
+    """
+    website = _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    running = asyncio.Event()
+
+    class _Hanging:
+        returncode = None
+
+        async def wait(self):
+            running.set()
+            await asyncio.sleep(3600)
+
+    proc = _Hanging()
+    reaped: list[object] = []
+    tree_at_reap: list[bool] = []
+
+    async def _fake_exec(*_a, **_k):
+        return proc
+
+    async def _fake_kill_and_reap(target, **_kw):
+        reaped.append(target)
+        # The tree is still moved aside at this point: the restore must come
+        # AFTER the reap, never before it.
+        tree_at_reap.append((website / "node_modules").exists())
+
+    monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr(frontend.platform_compat, "kill_and_reap", _fake_kill_and_reap)
+
+    task = asyncio.create_task(frontend.build_frontend_async(str(tmp_path)))
+    await running.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert reaped == [proc], "npm was not reaped on cancellation"
+    assert tree_at_reap == [False], "the tree was restored before npm was reaped"
+    # The restore still happened, so the next unattended wake is not wedged in
+    # the both-exist state.
+    assert _marker(website / "node_modules") == "installed"
+    assert not node_modules_tx.backup_for(website / "node_modules").exists()
+
+
+def test_async_transaction_filesystem_work_stays_off_the_event_loop(tmp_path, monkeypatch):
+    """Dropping a backup is an rmtree of a tree routinely hundreds of megabytes."""
+    _checkout(tmp_path)
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    monkeypatch.setattr(frontend, "_npm_build_and_stage_locked", lambda *a, **k: True)
+
+    class _Proc:
+        returncode = 0
+
+        async def wait(self):
+            return 0
+
+    async def _fake_exec(*_a, **_k):
+        return _Proc()
+
+    monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _fake_exec)
+    loop_thread = None
+    tx_threads: list[int] = []
+    real_rename = node_modules_tx.os.rename
+
+    def _watch_rename(src, dst):
+        tx_threads.append(threading.get_ident())
+        return real_rename(src, dst)
+
+    monkeypatch.setattr(node_modules_tx.os, "rename", _watch_rename)
+
+    async def _run():
+        nonlocal loop_thread
+        loop_thread = threading.get_ident()
+        await frontend.build_frontend_async(str(tmp_path))
+
+    asyncio.run(_run())
+
+    assert tx_threads, "the transaction never renamed anything"
+    assert loop_thread not in tx_threads


### PR DESCRIPTION
## What is the problem?

`npm ci` deletes `node_modules` before it installs. When the registry then
refuses the install -- an expired credential, or a curated mirror that blocks a
version the lockfile pins -- the tree is already gone and nothing puts it back.
The checkout is left with a stale frontend bundle against new backend code, and
the only way out needs the very registry that is unavailable.

PR #6541 made this a transaction for the one path a user presses, Dev Fleet's
Pull + Build. The three sibling sites named in #6693 still had the original
behaviour:

- `frontend.py` `build_frontend_sync` -- reached from the CLI server.
- `frontend.py` `build_frontend_async` -- reached from `POST /api/update`.
- The auto-apply path in `dashboard/handlers/updates.py`, which reaches the
  async one through `_build_frontend`.

`pod/provision.py` remains exempt: it skips when the tree is already populated.

## Why this issue matters to the user

The auto-apply path is the worst of the three and is arguably worse than the
button #6541 fixed, because it runs **unattended**. No operator is watching, so
nobody presses retry and nobody sees the failure until the dashboard is already
serving a stale bundle. A registry outage lasting minutes leaves a broken
frontend behind indefinitely.

## How our fix solves it

The symptom is a missing `node_modules`. The cause is that `npm ci`'s delete is
not paired with anything that can undo it, and the two `frontend.py` call sites
treated a failed install as nothing more than a line in the log -- `node_modules`
did not appear anywhere in that module.

New `src/kiro_crew/node_modules_tx.py` holds the transaction as real,
importable, type-checked code, and both `npm ci` invocations now run inside it:

- **Reconcile first.** Leftovers from an earlier run are settled before anything
  is spawned. A backup with no tree is claimed by rename, which needs no
  registry. A tree **and** a backup together refuse and name both paths, because
  killed-during-install and killed-during-cleanup are indistinguishable on disk
  and either rule destroys the good copy in one of the two cases.
- **Move aside, then install.** The tree is renamed out of the way, so npm
  installs into the empty directory it wanted anyway.
- **Settle.** On success the backup is dropped; on any non-zero outcome,
  including a timeout or an unexpected exception, the tree is put back. `ok` is
  pre-seeded `False` so an exception restores rather than discards. When the
  partial tree cannot be cleared, both copies are left and that is reported,
  rather than forcing a rename that installs a partial over a good backup.

A restore is only safe if nothing else is writing to the tree at the time, and
review found three ways that could happen. All three are fixed:

- **The span is serialized.** Bare file existence cannot tell a dead run's
  backup from a live one's, so a second builder's reconcile could rename the
  copy a running install depends on into the slot that install is emptying.
  A new `_install_lock()` (the repo's existing flock pattern) holds the whole
  reconcile/install/finish span; it is a separate lock file from
  `_staging_lock`, which is keyed per open-file-description and deadlocks when
  re-entered in-process. The name lives in `node_modules_tx.INSTALL_LOCK_NAME`
  so every user of the backup suffix agrees on one file, and `reconcile()`
  documents the requirement instead of assuming it. On the async path the lock
  is taken from a worker thread, because `file_lock` deliberately refuses to
  spin on the loop.
- **The whole install tree is torn down before a restore.** `npm ci` spawns
  workers, and signalling only npm leaves them writing into `node_modules` after
  the rename puts the backup back over it -- the same argument the build path
  already makes about vite. The enumerate-then-signal-tree block is now a shared
  `_reap_npm_tree()` helper; the sync install moved to `Popen` with
  `start_new_session` / `CREATE_NEW_PROCESS_GROUP` and DEVNULL stdio, and the
  async install got the same two flags, which is what makes `kill_and_reap`'s
  tree teardown apply rather than degrade to a pid-scoped signal.
- **Cancellation tears down first, then restores.** A gateway shutdown cancels
  the auto-update task; both the cancellation and timeout paths now go through
  `kill_and_reap` before the tree is put back, and the settle runs through the
  executor so a multi-hundred-megabyte `rmtree` never lands on the event loop.

Three smaller details worth calling out:

- Only `npm ci` gets the stash. `npm install` -- the no-lockfile fallback --
  updates in place, so moving the tree aside would force a needless cold install
  of a tree npm was going to reuse. Reconcile still runs for both, because a
  leftover backup means the tree on disk may be partial and npm's incremental
  path trusts what it finds.
- The backup suffix is `.kirocrew-frontend-backup`, deliberately **not** the
  runner's `.kirocrew-sync-backup`. Sharing one name looks like the way to let
  both paths recognise each other's leftovers, and it would be -- but only under
  a lock both of them take. The runner takes none, so a shared name lets this
  reconciler claim a backup the runner's live `npm ci` still depends on. A
  distinct name makes the two transactions invisible to each other, which is the
  only safe relationship available until one implementation and one lock serve
  both.
- Neither backup name was gitignored, so a leftover made the checkout read as
  dirty, which fail-closes Dev Fleet's "Prune merged" -- the same reason the
  staging lock is ignored. One pattern now covers both names.

The module imports nothing from `kiro_crew` on purpose. The Dev Fleet runner is
snapshotted to a temp dir and executed by path so the revision being merged
cannot change the code doing the merge, which is why it could not import the
transaction in the first place. Keeping this module package-import-free leaves
that door open.

## What tests we did

New `test/test_node_modules_tx.py`, 25 tests, all passing:

- The transaction against real `tmp_path` trees: stash and restore, drop on
  success, both-exist refusal touching neither copy, backup-only recovery,
  restore failure leaving both, undeletable backup on success as a note rather
  than a failure, unstashable tree refusing the install, and the symlink cases
  (`rmtree` refuses a link, and a dangling link is still something at that path).
- Both `frontend.py` entry points with a failing, timing-out and raising npm,
  asserting the tree survives; the ambiguous state spawning no npm at all; a
  stranded backup recovered without the registry; and `npm install` **not**
  stashed.
- `test_sync_build_holds_the_install_lock_while_npm_runs`: a peer's open file
  description cannot take the lock while the install runs.
- `test_sync_install_gets_its_own_process_group` and its async sibling, plus
  `test_sync_build_reaps_the_install_tree_before_restoring`, which asserts the
  tree is still moved aside at reap time so the ordering cannot invert.
- `test_async_build_kills_npm_before_restoring_on_cancellation`.
- `test_backup_name_is_not_the_dev_fleet_runners`.
- A thread-identity test pinning the async transaction's renames off the event
  loop.

`test_build_frontend_sync_spawns_resolved_npm_path` was retargeted at `Popen`,
because the install's spawn seam moved there. It is stronger now: it previously
saw only the install, since the build's `Popen` was unpatched and its
`FileNotFoundError` was swallowed as an `OSError`.

Mutation-verified at each round. With `frontend.py` reverted to `main`, 7 of the
8 original call-site tests fail; the eighth is `does_not_stash_for_npm_install`,
which guards against this change over-reaching and so passes on base by
construction. The lock and cancellation tests fail against the revision before
they were added, and the three process-group/reap tests fail against the
revision before those (the async one with exactly
`KeyError: 'start_new_session'`).

Gates on touched files: flake8 clean, isort clean, mypy clean, repo black gate
passed. 176 tests green across the new file plus
`test_frontend_dist_resolve.py`, `test_frontend_edition_build.py` and
`test_cli_server_more_coverage.py`. Full suites left to CI.

## Any other suggestions on the work

- **The sync runner still has its own copy.** #6693 asks for one implementation
  across all four call sites, and that is not reachable today: the runner is
  stdlib-only *by contract* because it is snapshotted and run by path, so it
  cannot import from the package. The honest end state is to snapshot this module
  beside `npm_preflight.py`, delete the runner's copy, and have the single
  implementation take the single lock -- at which point sharing one backup name
  becomes correct and desirable. That is a change to `dev_fleet/server.py`'s
  snapshot logic, which open #6739 is currently rewriting, so it is deliberately
  not in this PR's span. Worth a follow-up once #6739 lands.
- Until then the two transactions are deliberately isolated rather than
  cooperating: a backup stranded by the runner is not recovered by this path, so
  a later Pull + Build meets its own both-exist refusal, which names both paths
  and is fixable by hand. Strictly better than the status quo, where the tree is
  simply gone.
- `slack/gateway.py` also calls `build_frontend_async`; it inherits the fix
  without changes, which is why the transaction went at the invocation rather
  than at each caller.

Closes #6693
