### PR TITLE
fix(issue-radar): replace findings on a new investigation run instead of merging

### DIFF
--- a/docs/system-specs/modules/issue-radar.md
+++ b/docs/system-specs/modules/issue-radar.md
@@ -252,6 +252,23 @@ findings object (the UI's clear path); there is deliberately no per-field clear.
 `provider`/`host`/`kind` are always sent explicitly — the record is keyed on them,
 and defaulting them records a GitLab item into a same-slug GitHub repo's ledger.
 
+Per-key merging is the contract WITHIN one run and the wrong one ACROSS runs. A
+re-run ("Start over", or any path that opens a replacement session) recording a
+`verdict` and `summary` but no `root_cause` would inherit the previous run's
+`root_cause`, leaving the record — the only copy — holding a verdict assembled
+from two investigations with nothing marking which parts came from which. The
+store therefore owns the run boundary, because only there is it atomic with the
+write: the record remembers the session its findings were written under
+(`findings_slot_key`), and the FIRST findings write under a different session
+REPLACES rather than merges, while later writes from that same session keep
+merging. The prior verdict survives until a new one exists and never blends with
+it — which is why the replacement is not done by clearing at session open
+(`agentSession.ts` says so at the save site): the record is the only copy, so an
+abandoned re-run would lose the prior verdict permanently. A boundary needs BOTH
+sessions known and different; an unknown owner (findings recorded for an item
+with no session linked) or a cleared link falls back to merging, which is the
+non-destructive reading.
+
 **In the MCP tool**, every finding string and label goes through the platform
 redaction shim (`platform.redact_via_context` → exfil URLs + credentials) before the
 PUT: findings are LLM prose about an untrusted issue body, they are stored verbatim,

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/store.py
@@ -1809,6 +1809,11 @@ def _merge_findings(existing: Any, raw: Any) -> dict[str, Any] | None:
     There is deliberately NO per-field clear: an empty string means "leave this
     alone", which is what makes a partial patch safe for an LLM writer. Clear
     everything with an explicit null and re-write what should remain.
+
+    All of the above is the contract for writes WITHIN one investigation run.
+    Across a run boundary it is the wrong contract, and
+    :func:`write_investigation` decides that question before calling here — see
+    :func:`_findings_run_key`.
     """
     if raw is None:
         return None
@@ -1828,6 +1833,26 @@ def _merge_findings(existing: Any, raw: Any) -> dict[str, Any] | None:
     return _normalize_findings(combined)
 
 
+def _findings_run_key(existing: dict[str, Any]) -> str | None:
+    """Which run's session the STORED findings were written under, or None when
+    that is not known.
+
+    ``findings_slot_key`` is stamped by :func:`write_investigation` on every
+    write, so a record written by this build always answers for itself. A record
+    written BEFORE the field existed carries findings but no stamp, and the
+    honest backfill is the record's own ``slot_key``: those findings were
+    written by whatever session the record pointed at at the time. That reading
+    keeps a mid-run partial update on an upgraded record merging exactly as it
+    did before, and still moves the boundary when the slot later changes,
+    because this is read from the PRE-patch record — before a new ``slot_key``
+    overwrites the old one.
+    """
+    raw = existing.get("findings_slot_key") if "findings_slot_key" in existing else existing.get("slot_key")
+    if not isinstance(raw, str):
+        return None
+    return raw.strip() or None
+
+
 def write_investigation(
     owner: str, repo: str, number: int, patch: dict[str, Any], *,
     root: Path | None = None, kind: str = "issue",
@@ -1840,7 +1865,30 @@ def write_investigation(
     ``findings`` (merged per key by :func:`_merge_findings`, so a patch carrying
     only ``verdict`` keeps the stored ``root_cause``/``summary``/labels; an
     explicit ``None`` clears them). A partial patch (even ``{}``, which just bumps
-    the open stamp) is valid. Returns the stored record."""
+    the open stamp) is valid. Returns the stored record.
+
+    Per-key merging is right WITHIN one investigation run and wrong ACROSS runs:
+    a re-run (Issue Radar's "Start over", or any path that opens a replacement
+    session) that records a ``verdict`` and ``summary`` but no ``root_cause``
+    would inherit the PREVIOUS run's ``root_cause``, leaving the record — the
+    only copy — holding a verdict assembled from two investigations with nothing
+    marking which parts came from which.
+
+    So the run boundary is owned HERE rather than by callers, because only here
+    is it atomic with the write. The record remembers the session its findings
+    were written under (``findings_slot_key``), and the FIRST findings write
+    under a different session REPLACES rather than merges; later writes from that
+    same session merge as before. The previous verdict therefore survives right
+    up until a new one exists and never blends with it — which is why the clear
+    is not done when the replacement session opens (the record is the only copy,
+    so an abandoned re-run would lose the prior verdict permanently).
+
+    A boundary is only crossed when BOTH sessions are known and differ. An
+    unknown owner (findings recorded through the MCP tool for an item with no
+    session linked) falls back to merging: the store cannot tell those findings
+    from ones the about-to-be-linked session just wrote, and merging is the
+    non-destructive reading. Clearing the link (``slot_key: ""``) is not a new
+    run either."""
     number = int(number)
     now = _now_iso()
     lock_path = investigation_path(owner, repo, number, root, kind=kind).with_suffix(".lock")
@@ -1848,6 +1896,10 @@ def write_investigation(
     with open(lock_path, "w") as fd:
         with platform_compat.file_lock(fd.fileno(), exclusive=True):
             existing = read_investigation(owner, repo, number, root, kind=kind) or {}
+            # Read the findings' owning session from the PRE-patch record: the
+            # patch below may replace slot_key, and the comparison needs the old
+            # one.
+            findings_run_key = _findings_run_key(existing)
 
             record: dict[str, Any] = {
                 "owner": owner,
@@ -1859,6 +1911,9 @@ def write_investigation(
                 "started_at": existing.get("started_at") or now,
                 "last_opened_at": now,
                 "findings": existing.get("findings"),
+                # Only meaningful while findings are stored; re-stamped below
+                # whenever they change.
+                "findings_slot_key": findings_run_key if existing.get("findings") else None,
             }
 
             if "slot_key" in patch and isinstance(patch["slot_key"], str):
@@ -1870,9 +1925,41 @@ def write_investigation(
                 if st in _INVESTIGATION_STATUSES:
                     record["status"] = st
             if "findings" in patch:
-                record["findings"] = _merge_findings(
-                    existing.get("findings"), patch.get("findings")
+                # Runs AFTER slot_key is applied: a patch may carry both, and the
+                # session it names is the run this write belongs to.
+                raw = patch.get("findings")
+                # None (the explicit clear), a non-dict, and a dict with nothing
+                # in it all normalize to None — so this is "the patch carries a
+                # real verdict", which is the only thing that may cross a run
+                # boundary.
+                fresh = _normalize_findings(raw)
+                crossed_runs = bool(
+                    findings_run_key
+                    and record["slot_key"]
+                    and findings_run_key != record["slot_key"]
                 )
+                if fresh is not None:
+                    if crossed_runs:
+                        # First findings of a new run: REPLACE. Nothing from the
+                        # previous run survives into the new verdict.
+                        record["findings"] = fresh
+                    else:
+                        record["findings"] = _merge_findings(existing.get("findings"), raw)
+                    # A real verdict was written, so the current session owns it.
+                    # The merge above always keeps `fresh`, so this is never a
+                    # stamp on an empty findings object.
+                    record["findings_slot_key"] = record["slot_key"]
+                elif raw is None:
+                    # The explicit clear. No findings, so no owning run.
+                    record["findings"] = None
+                    record["findings_slot_key"] = None
+                # else: nothing to write — an empty dict, a whitespace-only value,
+                # or a malformed one. Findings AND their owning run are both left
+                # exactly as the pre-patch record had them. Advancing the stamp
+                # here would silently re-home the PREVIOUS run's findings onto the
+                # new session, so the next real write would merge into them
+                # instead of replacing them — the very blend this boundary
+                # exists to stop, reachable through a no-op.
 
             atomic_write(
                 investigation_path(owner, repo, number, root, kind=kind),

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_investigation.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_investigation.py
@@ -7,11 +7,17 @@ fields, ``started_at`` is stamped once, ``last_opened_at`` bumps every write);
 ``status`` is constrained; ``findings`` is normalized (trimmed strings,
 de-duplicated label list, all-empty collapses to None). Records live under the
 repo cache dir, so a disconnect's ``rmtree`` removes them too.
+
+``TestInvestigationRunBoundary`` covers the one place merging is NOT the
+contract: across an investigation run boundary, where a re-run's findings
+REPLACE the previous run's rather than blending with them.
 """
+import json
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 from kiro_crew.apps.builtins.issue_radar.backend import store
 
@@ -184,6 +190,183 @@ class TestInvestigationStore(unittest.TestCase):
         self.assertTrue(store.investigation_path("o", "r", 7, self.tmp).is_file())
         store.remove_connected_repo("o", "r", root=self.tmp)
         self.assertIsNone(store.read_investigation("o", "r", 7, self.tmp))
+
+
+class TestInvestigationRunBoundary(unittest.TestCase):
+    """A re-run's findings REPLACE the previous run's; same-run writes merge.
+
+    Per-key merging is right within one run (the MCP tool's contract is "a
+    partial update is fine") and wrong across runs: a replacement session that
+    records a verdict but no root_cause would otherwise inherit the previous
+    run's, leaving the record — the only copy — holding a verdict assembled from
+    two investigations. The store owns the boundary because only there is it
+    atomic with the write; the session the findings were written under
+    (``findings_slot_key``) is what marks it.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        # Registered at creation, not in tearDown: an interrupt between the
+        # allocation and the end of setUp would skip tearDown and leave the
+        # directory behind.
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def _stored(self) -> dict:
+        """The record as it is on disk. ``read_investigation`` returns
+        ``dict | None``, and every caller here has just written the record, so
+        this asserts it exists and hands back a plain dict."""
+        rec = store.read_investigation("o", "r", 7, self.tmp) or {}
+        self.assertTrue(rec, "the record must exist on disk")
+        return rec
+
+    def _run_one(self):
+        """Investigate: the SPA links the session, then the agent records."""
+        store.write_investigation(
+            "o", "r", 7, {"slot_key": "chat-1-100", "status": "investigating"}, root=self.tmp
+        )
+        return store.write_investigation(
+            "o", "r", 7,
+            {
+                "status": "resolved",
+                "findings": {
+                    "verdict": "bug",
+                    "root_cause": "run one's cause",
+                    "summary": "run one's summary",
+                    "suggested_labels": ["area: apps"],
+                },
+            },
+            root=self.tmp,
+        )
+
+    def test_rerun_findings_replace_rather_than_blend(self):
+        self._run_one()
+
+        # Start over: a replacement session is linked (deliberately WITHOUT
+        # clearing findings — the record is the only copy).
+        store.write_investigation(
+            "o", "r", 7, {"slot_key": "chat-2-200", "status": "investigating"}, root=self.tmp
+        )
+        self.assertEqual(
+            self._stored()["findings"]["root_cause"],
+            "run one's cause",
+            "the prior verdict must survive until a new one exists",
+        )
+
+        # The new run's first record omits root_cause and labels.
+        rec = store.write_investigation(
+            "o", "r", 7,
+            {"status": "resolved", "findings": {"verdict": "question", "summary": "run two"}},
+            root=self.tmp,
+        )
+        self.assertIsNone(rec["findings"]["root_cause"], "inherited from the previous run")
+        self.assertEqual(rec["findings"]["suggested_labels"], [], "inherited from the previous run")
+        self.assertEqual(rec["findings"]["verdict"], "question")
+        self.assertEqual(rec["findings"]["summary"], "run two")
+        self.assertEqual(rec["findings_slot_key"], "chat-2-200")
+
+    def test_same_run_partial_updates_still_merge(self):
+        self._run_one()
+        rec = store.write_investigation(
+            "o", "r", 7, {"findings": {"verdict": "confirmed bug"}}, root=self.tmp
+        )
+        self.assertEqual(rec["findings"]["verdict"], "confirmed bug")
+        self.assertEqual(rec["findings"]["root_cause"], "run one's cause")
+        self.assertEqual(rec["findings"]["summary"], "run one's summary")
+
+    def test_second_record_of_the_new_run_merges_again(self):
+        self._run_one()
+        store.write_investigation("o", "r", 7, {"slot_key": "chat-2-200"}, root=self.tmp)
+        store.write_investigation(
+            "o", "r", 7, {"findings": {"verdict": "question", "summary": "run two"}}, root=self.tmp
+        )
+        rec = store.write_investigation(
+            "o", "r", 7, {"findings": {"root_cause": "run two's cause"}}, root=self.tmp
+        )
+        self.assertEqual(rec["findings"]["root_cause"], "run two's cause")
+        self.assertEqual(rec["findings"]["summary"], "run two", "same run: merge, not replace")
+
+    def test_legacy_record_without_the_stamp_crosses_on_the_next_slot(self):
+        # Records written before findings_slot_key existed carry findings but no
+        # stamp. The backfill is the record's own slot_key, so a mid-run partial
+        # update still merges...
+        path = store.investigation_path("o", "r", 7, self.tmp)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "owner": "o", "repo": "r", "number": 7,
+                "slot_key": "chat-1-100", "folder_id": None, "status": "resolved",
+                "started_at": "2020-01-01T00:00:00.000000Z",
+                "last_opened_at": "2020-01-01T00:00:00.000000Z",
+                "findings": {
+                    "verdict": "bug", "root_cause": "legacy cause",
+                    "suggested_labels": [], "next_action": None, "summary": "legacy",
+                },
+            }),
+            encoding="utf-8",
+        )
+        merged = store.write_investigation(
+            "o", "r", 7, {"findings": {"verdict": "still bug"}}, root=self.tmp
+        )
+        self.assertEqual(merged["findings"]["root_cause"], "legacy cause")
+
+        # ...and a replacement session still moves the boundary.
+        store.write_investigation("o", "r", 7, {"slot_key": "chat-2-200"}, root=self.tmp)
+        rec = store.write_investigation(
+            "o", "r", 7, {"findings": {"verdict": "question"}}, root=self.tmp
+        )
+        self.assertIsNone(rec["findings"]["root_cause"])
+
+    def test_empty_and_malformed_patches_never_cross_the_boundary(self):
+        # An empty dict is a no-op and garbage is rejected upstream: neither is a
+        # new verdict, so neither may destroy the old one just because the slot
+        # changed...
+        self._run_one()
+        store.write_investigation("o", "r", 7, {"slot_key": "chat-2-200"}, root=self.tmp)
+        patch: dict[str, Any]
+        for patch in ({"findings": {}}, {"findings": "not a dict"}, {"findings": {"summary": "  "}}):
+            rec = store.write_investigation("o", "r", 7, patch, root=self.tmp)
+            self.assertEqual(
+                rec["findings"]["root_cause"], "run one's cause", f"wiped by {patch!r}"
+            )
+            # ...and neither may ADVANCE the stamp either. Re-homing the previous
+            # run's findings onto the new session would make the next real write
+            # merge into them instead of replacing them, arming the blend through
+            # a no-op.
+            self.assertEqual(rec["findings_slot_key"], "chat-1-100", f"re-homed by {patch!r}")
+
+        # The new run's real first record still replaces, after all three no-ops.
+        rec = store.write_investigation(
+            "o", "r", 7, {"findings": {"verdict": "question", "summary": "run two"}}, root=self.tmp
+        )
+        self.assertIsNone(rec["findings"]["root_cause"], "a no-op re-armed the blend")
+        self.assertEqual(rec["findings_slot_key"], "chat-2-200")
+
+    def test_unknown_owner_and_cleared_link_fall_back_to_merging(self):
+        # Findings recorded through the MCP tool for an item with no session
+        # linked have no owning run. The store cannot tell them from ones the
+        # about-to-be-linked session just wrote, so it merges.
+        store.write_investigation(
+            "o", "r", 7, {"findings": {"root_cause": "unowned cause"}}, root=self.tmp
+        )
+        self.assertIsNone(self._stored().get("findings_slot_key"))
+        store.write_investigation("o", "r", 7, {"slot_key": "chat-1-100"}, root=self.tmp)
+        rec = store.write_investigation(
+            "o", "r", 7, {"findings": {"verdict": "bug"}}, root=self.tmp
+        )
+        self.assertEqual(rec["findings"]["root_cause"], "unowned cause")
+
+        # Unlinking is not a new run either.
+        store.write_investigation("o", "r", 7, {"slot_key": ""}, root=self.tmp)
+        rec = store.write_investigation(
+            "o", "r", 7, {"findings": {"summary": "s"}}, root=self.tmp
+        )
+        self.assertEqual(rec["findings"]["root_cause"], "unowned cause")
+
+    def test_clearing_findings_drops_the_stamp(self):
+        self._run_one()
+        rec = store.write_investigation("o", "r", 7, {"findings": None}, root=self.tmp)
+        self.assertIsNone(rec["findings"])
+        self.assertIsNone(rec["findings_slot_key"])
 
 
 if __name__ == "__main__":

--- a/website/src/apps/issue-radar/api.ts
+++ b/website/src/apps/issue-radar/api.ts
@@ -789,6 +789,12 @@ export interface InvestigationRecord {
   started_at: string
   last_opened_at: string
   findings: InvestigationFindings | null
+  /** Which session's run the stored `findings` were written under. Server-owned
+   * (it is not part of `InvestigationPatch`): the store stamps it on every write
+   * and uses it to REPLACE rather than merge the first findings of a new run, so
+   * a re-run's verdict never blends with the previous one's. Null when no
+   * findings are stored. */
+  findings_slot_key?: string | null
 }
 
 /** Which sequence a number belongs to. Only load-bearing on GitLab, where issues


### PR DESCRIPTION
## What is the problem?

Re-running an Issue Radar investigation produces a verdict assembled from two
different investigations.

When a replacement session is opened for an item that already has a record
("Start over", or any path that opens a replacement session), the new run's
first `record_investigation` is MERGED into the stored findings per key. So a new
run that records a `verdict` and `summary` but no `root_cause` inherits the
PREVIOUS run's `root_cause`. The record is the only copy, and nothing on it marks
which half came from which run.

Per-key merging is correct for the case it was written for -- the
`issue_radar_record_investigation` MCP tool's contract is "a partial update is
fine", so a second write carrying only a `verdict` must not destroy an earlier
`root_cause`. It is simply the wrong contract across a run boundary.

## Why this issue matters to the user

The card's verdict is what a human acts on, and a blended one is wrong in the
most expensive way: it reads as a single coherent conclusion. A re-run started
precisely because the first conclusion looked wrong can leave that wrong
`root_cause` attached to the new verdict, with no way to tell from the card that
it is stale.

The obvious client-side fix does not work, which is why this is store-side.
Sending `findings: null` when the replacement session opens was tried on #6260
and reverted: the clear lands BEFORE the new run has produced anything, and since
the record is the only copy, an abandoned or failed Start over loses the prior
verdict permanently. That makes the accidental path more destructive even as the
guard makes it less likely.

## How our fix solves it

Symptom: a new run's verdict carries the old run's fields.
Cause: `findings` merge per key with no notion of which run wrote them.
Fix: give the store that notion, and let it own the boundary -- it is the only
place where "a new run started" and "the findings changed" can be atomic.

- The record now remembers the session its findings were written under
  (`findings_slot_key`), stamped on every write.
- The FIRST findings write under a DIFFERENT session REPLACES the stored
  findings; later writes from that same session merge exactly as before. The
  prior verdict survives right up until a new one exists, and never blends with
  it.
- The run boundary was already observable: the SPA links the replacement session
  by writing a new `slot_key`, and the agent's own record carries no `slot_key`,
  so the last-written slot identifies the run.

Two deliberate non-crossings, both in the non-destructive direction:

- A boundary needs BOTH sessions known and different. Findings with no owning
  session (recorded through the MCP tool for an item with no session linked)
  merge, because the store cannot distinguish them from findings the
  about-to-be-linked session just wrote. Unlinking (`slot_key: ""`) is not a new
  run either.
- An empty, whitespace-only, or malformed `findings` value is a no-op even across
  a boundary. It is not a new verdict, so it must not destroy the old one.

Records written before the field existed carry findings but no stamp; the
backfill is the record's own `slot_key`, read from the pre-patch record. A
mid-run partial update on an upgraded record therefore merges exactly as it did
before, and a later slot change still moves the boundary.

## What tests we did

New `TestInvestigationRunBoundary` in
`src/kiro_crew/apps/builtins/issue_radar/tests/test_investigation.py` (7 cases),
mutation-verified against this branch's base:

- `test_rerun_findings_replace_rather_than_blend` fails on base with exactly the
  reported defect -- `AssertionError: "run one's cause" is not None : inherited
  from the previous run` -- and passes with the fix. It also pins that the prior
  verdict is still readable after the replacement session is linked and before
  the new run records.
- `test_legacy_record_without_the_stamp_crosses_on_the_next_slot` fails on base
  (`'legacy cause' is not None`); covers the upgrade path in both directions.
- `test_clearing_findings_drops_the_stamp` is red on base (new field).
- Four preservation cases pass on base AND with the fix, which is what shows the
  merge contract is unchanged where it was right: same-run partial updates, the
  second record of a new run, empty/malformed patches across a boundary, and the
  unknown-owner / cleared-link fallbacks.

Gates: 22/22 in the changed test file; 217 passed across
`test_investigation.py` + `test_azure.py` + `test_gitlab.py` (the other files
that exercise this write); flake8 + isort clean on both touched Python files;
mypy clean for `store.py`; `tsc --noEmit` and eslint clean for the touched
frontend type. Per this host's constraint the full suites were not run locally --
CI owns them.

## Any other suggestions on the work

- **Retaining the superseded verdict** (`previous_findings` or a small history)
  is left out on purpose. The issue raises it as worth deciding; it is a schema
  and UI decision rather than part of stopping the blend, and the fix above
  already keeps the old verdict readable until a new one replaces it.
- **The adjacent half from the issue's comment thread is NOT in this PR**:
  `write_investigation` still accepts a concluded record being reset to
  `investigating` by any caller, so the "finished work is not silently redone"
  invariant lives only in the SPA's `openSession` (#6260). A restart-shaped store
  operation would give this fix a more explicit trigger than "the slot changed"
  and would let the store validate the intent. Worth its own issue rather than
  widening this diff; the mechanism here is independent of it and works today.
- The spec (`docs/system-specs/modules/issue-radar.md`) moves with the code, and
  `agentSession.ts`'s existing comment at the save site already points here.

Closes #6327
