### PR TITLE
fix(snapshot): stage databases read-only through one hardened copy

### DIFF
--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -532,7 +532,27 @@ def _chain_is_link_free(root: Path, rel_parts: tuple[str, ...]) -> bool:
     """
     if not pinned_fs.supports_pinned_walk():
         return True
-    fd = pinned_fs.open_dir_pinned(root, what="database source root")
+    try:
+        fd = pinned_fs.open_dir_pinned(root, what="database source root")
+    except OSError:
+        # Gone, or otherwise unopenable: the same answer the intermediate components below
+        # already give, and for the same reason -- a root this pass cannot open is a file it
+        # cannot verify as reachable without following a link.
+        #
+        # `open_dir_pinned` translates only `ELOOP`/`ENOTDIR` into `PinnedPathRefusal` and
+        # re-raises every other `OSError`, and this call sat OUTSIDE the try below. So a root
+        # lost to a concurrent rename or removal left `ENOENT` escaping as
+        # `FileNotFoundError` from a call site under `_build_snapshot`, whose enclosing try
+        # handles `PinnedPathRefusal`, `UnsafeComponentRoot` and `DatabaseCopyFailed` -- the
+        # `OSError` arm belongs to a later, separate try. The command exited on a traceback
+        # where the declared path owes a named refusal and the tree path owes a recorded
+        # skip. Returning False routes both through the `require_database` asymmetry the
+        # caller already implements. Review's finding.
+        #
+        # `PinnedPathRefusal` is deliberately NOT caught here: `snapshot_main` handles it and
+        # audits it as `unpinnable_staging`. That is a decision the operator should see, not
+        # a source that went missing.
+        return False
     try:
         for part in rel_parts[:-1]:
             try:
@@ -555,7 +575,237 @@ def _dir_flags_nofollow() -> int:
     return flags | getattr(os, "O_CLOEXEC", 0)
 
 
-def _restage_databases(src_dir: Path, dst_dir: Path) -> None:
+# Outcomes of `_copy_database_consistently`. Three, not a bool, because the two
+# non-success cases need OPPOSITE handling from the caller and collapsing them is how a
+# bundle ends up carrying a database nobody copied consistently while reporting success:
+#
+#   COPIED         the backup API produced a consistent copy at the destination.
+#   NOT_A_DATABASE the file is positively NOT SQLite, so the caller should stage its bytes
+#                  -- a non-database named `.db` is still the operator's file.
+#   UNSAFE_SOURCE  the source could not be verified as reachable without traversing a
+#                  link, so nothing was read from it. The caller must NOT substitute a
+#                  byte copy: that is the read this refusal exists to prevent.
+#
+# Anything else raises `DatabaseCopyFailed`. A database that IS readable but could not be
+# copied is never degraded to a byte copy, because this module excludes `-wal`/`-shm` and
+# such a copy would be a torn database shipped as a whole one.
+DB_COPIED = "copied"
+DB_NOT_A_DATABASE = "not_a_database"
+DB_UNSAFE_SOURCE = "unsafe_source"
+
+# Recorded in MANIFEST.json when a database was staged as bytes rather than consistently.
+# An archive whose manifest names the degradation is recoverable information; a quietly
+# inconsistent database in an archive that reports success is not.
+SKIP_DB_UNPINNED_SOURCE = "db_unpinned_source"
+
+
+def _copy_database_consistently(
+    src: Path,
+    dst: Path,
+    *,
+    root: Path,
+    rel_parts: tuple[str, ...],
+    require_database: bool = False,
+) -> str:
+    """Copy the live SQLite database *src* to *dst* through the backup API, read-only.
+
+    THE one place this module reads a live database on the creation path. Both staging
+    paths -- the fixed core-file list and the tree re-stage pass -- call it, because the
+    hardening below was arrived at over five review rounds on #5156 and a second,
+    structurally identical copy of it is how one of the two drifts back.
+
+    Four properties, each closing a failure that reported success:
+
+    **The chain is verified through descriptors, not by name.** Every component from
+    *root* down is opened relative to the previous one with ``O_NOFOLLOW``, so a directory
+    that is a link -- or one swapped for a link while this runs -- fails its own open
+    instead of redirecting the read. ``src.resolve()`` and a late ``realpath()`` are both
+    a SECOND by-name walk and were both wrong here: they can land on a database this
+    function never inspected, whose rows then ride in the bundle under an innocuous name.
+
+    **The URI is percent-escaped.** ``as_uri()``, not interpolation: a POSIX filename
+    containing ``?`` or ``#`` was otherwise parsed as the start of the URI's query or
+    fragment, truncating the path so the copy opened a DIFFERENT database and stored it
+    under the requested name. Built once and shared by the probe and the copy, because two
+    spellings of one URI is how they diverge.
+
+    **The connection is ``mode=ro``.** Staging only ever needs to read, and a read-write
+    open is not merely more authority than required -- it MUTATES the live database.
+    Measured on a fixture with a ``-wal`` left unreplayed by a killed writer: the
+    read-write open recovered the log into the main file (8192 -> 16384 bytes, different
+    hash) and unlinked the 836 KB ``-wal``; ``mode=ro`` left both byte-identical and
+    captured exactly the same rows. So a backup command was rewriting the data it was
+    asked to read, and in the window before SQLite's own open a swapped-in database was
+    handed a writable handle. ``mode=ro`` refuses the write outright.
+
+    **"Not a database" is told apart from "cannot read this database".** They are
+    distinguished by probing readability separately from copying, not by matching the
+    error, because ``sqlite_errorname`` is 3.11+ while this package supports 3.10 and
+    message text changes with any SQLite release. The broad form was wrong in the
+    dangerous direction: "database is locked" is also a ``DatabaseError``, so an exclusive
+    writer made the probe report "not a database" and a raw byte copy shipped as if it
+    were consistent.
+
+    What this does NOT close, stated rather than implied: SQLite's API takes a PATH and
+    cannot be pointed at a held descriptor -- probed, it refuses ``/proc/self/fd/N`` and
+    ``/dev/fd/N`` alike -- so SQLite re-resolves the final name itself, and a same-uid
+    swap in the window between the check above and that open is not detectable here. A
+    post-hoc identity re-check does not close it either, since swapping back defeats the
+    check. Closing it needs a descriptor-taking VFS, which is a different change.
+
+    The WAL question the issue this came from also raises is NOT handled by checkpointing
+    and copying bytes, and deliberately so: the backup API already reads a consistent
+    snapshot that INCLUDES rows living only in the ``-wal``. Measured against a
+    cross-process writer with ``wal_autocheckpoint=0`` and a 1.5 MB log, the copy
+    contained all 421 rows -- 371 of them WAL-resident -- and passed ``integrity_check``.
+    A check-then-copy-bytes design has the race; this one has no check to race.
+    """
+    if not _chain_is_link_free(root, rel_parts):
+        if require_database:
+            # Same reasoning as the not-a-database case below, and an earlier revision of
+            # this change applied it to only one of the two: omitting a REQUIRED database
+            # still let the snapshot succeed, so `--keep N` pruned the last complete
+            # archive in favour of one missing the database it claims. A recorded omission
+            # is "recoverable information" only while the operator still HAS the archive it
+            # could be recovered from. Review's finding.
+            raise DatabaseCopyFailed(
+                src,
+                pinned_fs.PinnedPathRefusal(
+                    f"{'/'.join(rel_parts)} could not be verified as reachable without "
+                    "following a link, so it was not read"
+                ),
+            )
+        return DB_UNSAFE_SOURCE
+    ro_uri = f"{src.absolute().as_uri()}?mode=ro"
+    try:
+        with closing(sqlite3.connect(ro_uri, uri=True)) as probe:
+            probe.execute("PRAGMA schema_version").fetchone()
+    except sqlite3.DatabaseError as e:
+        # `sqlite_errorname` is read defensively for 3.10 and the message is the
+        # documented fallback. Either way the DEFAULT is to raise: an error this code
+        # cannot classify is not evidence the file is safe to copy byte-for-byte.
+        name = getattr(e, "sqlite_errorname", "")
+        not_a_database = name == "SQLITE_NOTADB" or (
+            not name and "not a database" in str(e).lower()
+        )
+        if not not_a_database:
+            raise DatabaseCopyFailed(src, e) from e
+        if require_database:
+            # A DECLARED component file, so this is a hard failure. The asymmetry with the
+            # tree pass below is deliberate, and an earlier revision of this change got it
+            # backwards by "unifying" the two -- review caught the consequence:
+            #
+            # A corrupt `memory.db` staged as bytes makes the snapshot SUCCEED. `--keep N`
+            # then counts that archive as the newest backup and prunes a real one, while
+            # restore refuses the new archive outright at its strict database validation.
+            # The operator is left with no restorable backup, having run a command that
+            # printed success. The module already names this hazard class where `--keep`
+            # is handled: an empty bundle "would count as the newest backup and prune a
+            # real one".
+            #
+            # A `.db` found by the TREE walk is incidental -- some file the operator
+            # happens to keep in their workspace -- and refusing the whole snapshot over
+            # it would be an outage, not a safeguard. Declared and load-bearing versus
+            # discovered and incidental is a real difference, so the two paths get
+            # different answers on purpose.
+            raise DatabaseCopyFailed(src, e) from e
+        return DB_NOT_A_DATABASE
+    # The connects are INSIDE the try, not just `backup()`. Between the probe above and
+    # this open the file can disappear -- and `mode=ro` makes that a hard failure where a
+    # read-write open would have silently CREATED an empty database, so this change made
+    # the window matter more, not less. `sqlite3.connect` then raises `OperationalError`,
+    # which `snapshot_main` does not catch (it handles PinnedPathRefusal,
+    # UnsafeComponentRoot, DatabaseCopyFailed and _ArchiveTooLarge), so the command exited
+    # on a traceback instead of naming the database. Review's finding.
+    try:
+        with (
+            closing(sqlite3.connect(ro_uri, uri=True)) as src_conn,
+            closing(sqlite3.connect(str(dst))) as dst_conn,
+        ):
+            # The file is a readable database, so a failure here means the consistent copy
+            # did not happen. Absorbing it would leave the caller's byte copy -- taken
+            # WITHOUT the `-wal` this module excludes -- passing for a whole database, so
+            # it is raised, but typed and naming the file so the command boundary reports
+            # which database failed instead of exiting on a traceback.
+            src_conn.backup(dst_conn)
+    except sqlite3.Error as e:
+        raise DatabaseCopyFailed(src, e) from e
+    if require_database:
+        _refuse_unsound_required_capture(src, dst)
+    return DB_COPIED
+
+
+def _refuse_unsound_required_capture(src: Path, dst: Path) -> None:
+    """Raise unless a REQUIRED database was captured soundly.
+
+    ``PRAGMA schema_version`` above only proves the file parses, which is a much weaker
+    claim than restore's, and the two unsoundnesses it misses need checking at OPPOSITE
+    ends. Both were measured rather than reasoned about.
+
+    **Page corruption -- checked on the STAGED COPY.** With a database's interior pages
+    overwritten and the header left intact, ``schema_version`` answered normally,
+    ``backup()`` succeeded and faithfully staged all 192512 bytes, and ``integrity_check``
+    reported "database disk image is malformed" on the source AND the copy. So the archive
+    reported success and restore was guaranteed to refuse it; ``--keep N`` then counts it as
+    the newest backup and prunes a real one, so the operator loses their last restorable
+    copy at the one moment they reach for it. The copy is the right end to check: it is what
+    goes in the archive and what restore validates, checking it keeps this path read-only
+    with respect to live data, and it also catches a copy damaged in transit. Source
+    corruption still surfaces, because ``backup()`` reproduces it.
+
+    **A zero-byte source -- checked on the SOURCE, and ONLY visible there.** SQLite opens a
+    zero-byte file as a valid EMPTY database, so ``integrity_check`` answers ``ok``. Worse,
+    ``backup()`` does not preserve the emptiness: measured, a 0-byte source produced a
+    4096-byte staged copy that ``integrity_check`` called ``ok``. Restore's own zero-byte
+    guard reads the size of the ARCHIVED file, so it sees 4096 and accepts -- meaning that
+    for this path restore does NOT refuse the archive, it RESTORES it and installs an empty
+    database over live data while reporting success. That is why the check cannot be
+    deferred to the copy or to restore: the "captured nothing" condition exists only at the
+    source, which is the same reason restore reads size before opening.
+
+    The cost is not a reason to hesitate: ``integrity_check`` measured 1285 MB/s against
+    415 MB/s for the ``backup()`` and 227 MB/s for the gzip this command already performs
+    over the same bytes unconditionally, so it adds about a tenth of work already paid.
+
+    Raises ``DatabaseCopyFailed`` rather than restore's ``SourceComponentUnsound``: the try
+    around ``_build_snapshot`` handles ``PinnedPathRefusal``, ``UnsafeComponentRoot`` and
+    ``DatabaseCopyFailed``, so the restore-side type would leave here as a traceback --
+    the same escape this change fixed for the chain check. Review's finding.
+    """
+    try:
+        if src.stat().st_size == 0:
+            raise DatabaseCopyFailed(
+                src,
+                sqlite3.DatabaseError(
+                    "the live database is EMPTY (zero bytes). SQLite opens such a file as "
+                    "a valid empty database and the staged copy passes an integrity check, "
+                    "so this would archive nothing and a later restore would install "
+                    "nothing over live data while reporting success"
+                ),
+            )
+    except OSError as e:
+        raise DatabaseCopyFailed(src, e) from e
+    try:
+        with closing(sqlite3.connect(str(dst))) as check:
+            result = check.execute("PRAGMA integrity_check;").fetchone()[0]
+    except sqlite3.Error as e:
+        # Severe corruption makes the pragma RAISE rather than answer -- the measurement
+        # above got `DatabaseError: database disk image is malformed` here -- so this arm is
+        # the common path for a page-corrupt database, not a defensive afterthought.
+        raise DatabaseCopyFailed(src, e) from e
+    if result != "ok":
+        raise DatabaseCopyFailed(
+            src, sqlite3.DatabaseError(f"integrity check on the staged copy failed ({result})")
+        )
+
+
+def _restage_databases(
+    src_dir: Path,
+    dst_dir: Path,
+    *,
+    bundle_root: Path,
+    on_skip: pinned_fs.SkipReporter | None = None,
+) -> None:
     """Re-copy every SQLite database under *src_dir* through the backup API.
 
     The plain tree copy already placed a byte copy there; this replaces it with a
@@ -564,8 +814,23 @@ def _restage_databases(src_dir: Path, dst_dir: Path) -> None:
     covered without anyone remembering to register it.
 
     A file whose suffix says database but which SQLite cannot open is left as the byte
-    copy already made: a non-database that happens to be named ``.db`` is still the
-    operator's file and must ride the bundle.
+    copy already made -- UNLESS its bundle-relative path is in ``PRODUCT_TREE_DATABASES``,
+    in which case the snapshot fails. That set's own contract is that everything in it is
+    "validated as strictly as ``memory.db``", and the restore side already enforces exactly
+    that (``_refuse_unless_sound(..., strict=rel in PRODUCT_TREE_DATABASES)``). Staging a
+    corrupt ``workspace/knowledge/knowledge.db`` as bytes and reporting success therefore
+    produced an archive that restore is guaranteed to refuse, which is worse than failing:
+    ``--keep N`` counts the new archive as the newest backup and prunes a real one, so the
+    operator loses their last restorable copy to a snapshot that "succeeded". Review's
+    finding.
+
+    *bundle_root* is what makes that key comparable. ``PRODUCT_TREE_DATABASES`` is spelled
+    relative to a bundle root, while this pass walks one tree, so a tree-relative path would
+    never match any entry and the strictness would be silently vacuous.
+
+    A non-database that happens to be named ``.db`` and is NOT one of ours is still the
+    operator's file and must ride the bundle: refusing a whole snapshot over a stray
+    ``Thumbs.db`` would be an outage rather than a safeguard.
 
     A database the tree copy did NOT stage is left alone. This pass exists to REPLACE a
     byte copy with a consistent one, so a destination that does not already hold that byte
@@ -575,6 +840,12 @@ def _restage_databases(src_dir: Path, dst_dir: Path) -> None:
     to a database outside the component tree was skipped as `not_regular` and then rebuilt
     by this pass, putting the external database's rows in the bundle. Checking the PARENT
     directory is not enough, because the parent exists for every sibling that copied fine.
+
+    *on_skip* is how a degradation reaches ``MANIFEST.json``. A source that cannot be
+    verified link-free leaves the tree walk's byte copy in place, which is the right call
+    -- deleting it is data loss -- but the bundle then holds a database that was never
+    copied consistently, and that belongs on the record rather than only in the console
+    scrollback of whoever ran the command.
     """
     for src in sorted(src_dir.rglob("*")):
         if not src.is_file() or src.is_symlink() or src.suffix not in _DB_SUFFIXES:
@@ -588,82 +859,27 @@ def _restage_databases(src_dir: Path, dst_dir: Path) -> None:
             continue
         if not _stat.S_ISREG(dst_st.st_mode):
             continue
-        # The chain from the source root down to this file is verified COMPONENT BY
-        # COMPONENT through descriptors, each opened `O_NOFOLLOW`, so a directory that is a
-        # link -- or one swapped for a link while this pass runs -- is refused where it is
-        # opened rather than silently traversed.
-        #
-        # `src.resolve()` was wrong here, and so was resolving the parent late: both re-walk
-        # every ancestor BY NAME after the loop screened the file, so a swapped ancestor
-        # redirects the open at a database this pass never inspected -- someone else's, whose
-        # rows then ride in the bundle under an innocuous name. Review's finding; this is the
-        # construction `open_dir_pinned` uses, for the same reason.
-        #
-        # Once no component is a link, the path AS GIVEN names the file that was verified, so
-        # the URI is built from it without resolving anything. What this does NOT close,
-        # stated rather than implied: SQLite's API takes a PATH, not a descriptor, so SQLite
-        # re-resolves the name itself, and a same-uid swap in the window between this check
-        # and that open is not detectable here -- a post-hoc identity re-check is defeated by
-        # swapping back. Closing that needs a descriptor-taking VFS, which is a change to how
-        # this module opens every database: main's own snapshot module opens SQLite by name
-        # in six places, including the structurally identical creation-side copy.
-        if not _chain_is_link_free(src_dir, src.relative_to(src_dir).parts):
-            continue
-        # `as_uri()` percent-escapes the path. Interpolating it raw meant a POSIX
-        # filename containing `?` or `#` was parsed as the start of the URI's query or
-        # fragment, truncating the path — so the copy would open a DIFFERENT database
-        # and store it under the requested name. Built ONCE and reused by both the probe
-        # and the copy: two spellings of the same URI is how one of them drifts.
-        ro_uri = f"{src.absolute().as_uri()}?mode=ro"
-        # Two different failures hide behind sqlite3.Error here, and treating them
-        # alike is unsafe. If the file is not a database at all, the plain byte copy
-        # already staged is exactly right. If it IS a database and the backup call
-        # failed -- an exclusive writer, an I/O error -- the staged copy is a raw
-        # snapshot of the file WITHOUT its WAL sidecars, which this module deliberately
-        # excludes, so the bundle would carry a torn database and report success.
-        #
-        # They are told apart by probing readability separately from copying, rather
-        # than by inspecting the error: `sqlite_errorname` is 3.11+ and this package
-        # supports 3.10, and matching on message text would break with any SQLite
-        # wording change.
-        try:
-            with closing(sqlite3.connect(ro_uri, uri=True)) as probe:
-                probe.execute("PRAGMA schema_version").fetchone()
-        except sqlite3.DatabaseError as e:
-            # Only a POSITIVELY identified non-database keeps the plain copy. The broad
-            # form was wrong in the dangerous direction: "database is locked" is also a
-            # DatabaseError, so an exclusive writer made the probe report "not a
-            # database" and the raw byte copy -- taken WITHOUT its WAL sidecars, which
-            # this module excludes -- shipped as if it were consistent.
-            #
-            # `sqlite_errorname` is 3.11+ and this package supports 3.10, so it is read
-            # defensively and the message is the documented fallback. Either way the
-            # DEFAULT is to raise: an error this code cannot classify is not evidence
-            # that the file is safe to copy byte-for-byte.
-            name = getattr(e, "sqlite_errorname", "")
-            not_a_database = name == "SQLITE_NOTADB" or (
-                not name and "not a database" in str(e).lower()
-            )
-            if not not_a_database:
-                raise DatabaseCopyFailed(src, e) from e
+        # Spelled `relative_to(bundle_root).as_posix()` to match the restore side's own
+        # key for the same set, so the two ends of the invariant read the same.
+        rel = dst.relative_to(bundle_root).as_posix()
+        outcome = _copy_database_consistently(
+            src,
+            dst,
+            root=src_dir,
+            rel_parts=src.relative_to(src_dir).parts,
+            require_database=rel in PRODUCT_TREE_DATABASES,
+        )
+        if outcome == DB_UNSAFE_SOURCE:
+            # The byte copy the walk already made stays -- it is the operator's data and
+            # this pass only ever REPLACES a copy, never creates one. Recorded so the
+            # archive does not silently claim a consistent database.
+            if on_skip is not None:
+                on_skip(SKIP_DB_UNPINNED_SOURCE, str(src))
+        elif outcome == DB_NOT_A_DATABASE:
             print(
                 f"⚠️  {_safe_name(src.name)} is not a readable SQLite database "
                 "— copied as a plain file"
             )
-            continue
-        with (
-            closing(sqlite3.connect(ro_uri, uri=True)) as src_conn,
-            closing(sqlite3.connect(str(dst))) as dst_conn,
-        ):
-            # The file is a readable database, so a failure here means the consistent
-            # copy did not happen and the staged file is a raw copy WITHOUT its WAL
-            # sidecars. Absorbing that would ship a torn database, so it is raised --
-            # but as a typed error naming the file, so the command boundary can report
-            # which database failed instead of exiting on a traceback.
-            try:
-                src_conn.backup(dst_conn)
-            except sqlite3.Error as e:
-                raise DatabaseCopyFailed(src, e) from e
 
 
 def safe_tree_root(root: Path, *, what: str, home: Path | None = None) -> Path | None:
@@ -1546,32 +1762,31 @@ def _build_snapshot(
                         # (`workspace/knowledge/knowledge.db`), so the parent is created
                         # per file rather than assumed from the component's tree roots.
                         (stage / f).parent.mkdir(parents=True, exist_ok=True)
-                        # DATABASES ARE OUT OF SCOPE for this change, deliberately, and
-                        # this is main's behaviour unchanged.
+                        # Through the SAME hardened copy the tree pass uses, so the two
+                        # cannot drift: descriptor-verified chain, percent-escaped URI,
+                        # `mode=ro`, and "not a database" told apart from "cannot read
+                        # this database". Before this, the core path was the last
+                        # unhardened SQLite read on the creation path -- it connected
+                        # READ-WRITE to the live name, which is what #5451 is about.
                         #
-                        # Capturing a live SQLite database without reopening its name is a
-                        # genuine conflict of requirements -- SQLite accepts only a path,
-                        # and it cannot be pointed at a held descriptor (probed: it refuses
-                        # /proc/self/fd/N and /dev/fd/N alike). Five review rounds were
-                        # spent on it here and each fix set up the next, so the database
-                        # question is tracked separately rather than solved in the middle
-                        # of a PR about the pinned tree walk.
-                        #
-                        # The `backup()` call reopens the live name and so inherits main's
-                        # existing exposure. That is not a regression introduced here: it is
-                        # what shipped before this change and what still ships after it.
-                        with (
-                            closing(sqlite3.connect(str(src))) as src_conn,
-                            closing(sqlite3.connect(str(stage / f))) as dst_conn,
-                        ):
-                            # Same contract as the tree path: a failed consistent copy is
-                            # reported by name at the command boundary, never absorbed and
-                            # never a traceback. A silently-skipped database would upload a
-                            # bundle that restores an incomplete memory.
-                            try:
-                                src_conn.backup(dst_conn)
-                            except sqlite3.Error as e:
-                                raise DatabaseCopyFailed(src, e) from e
+                        # `mc_fd` screened this name a few lines up and cannot be handed
+                        # to SQLite, which takes only a path; the chain check inside the
+                        # helper is what makes the ANCESTORS non-redirectable, and the
+                        # residual final-name window is documented there.
+                        # `require_database=True` makes every non-success outcome a raise,
+                        # so there is no outcome to branch on here: a declared component
+                        # file is either copied consistently or the snapshot fails. Both
+                        # degradations that used to live here -- byte-copying a corrupt
+                        # database, and omitting an unverifiable one -- let the command
+                        # succeed, which let `--keep` prune the last good archive in favour
+                        # of one that cannot be restored.
+                        _copy_database_consistently(
+                            src,
+                            stage / f,
+                            root=mc,
+                            rel_parts=PurePosixPath(f).parts,
+                            require_database=True,
+                        )
                     elif mc_fd is not None:
                         (stage / f).parent.mkdir(parents=True, exist_ok=True)
                         pinned_fs.copy_file_pinned(
@@ -1649,7 +1864,7 @@ def _build_snapshot(
             # outright. Re-copy each one through the backup API, which takes a
             # consistent snapshot, and leave the -wal/-shm out entirely: they
             # describe the source's transaction state, not the copy's.
-            _restage_databases(src_dir, dst_dir)
+            _restage_databases(src_dir, dst_dir, bundle_root=stage, on_skip=_record_skip)
 
         # Manifest
         ws_files = sum(1 for _ in (stage / "workspace").rglob("*") if _.is_file())
@@ -1850,16 +2065,25 @@ def snapshot_main(
         if total_mb > 500:
             print(f"⚠️  {mc} is {total_mb:.0f} MB — snapshot may be large and slow")
 
-    # WAL checkpoint
-    if (mc / "memory.db").is_file():
-        try:
-            with closing(sqlite3.connect(str(mc / "memory.db"))) as c:
-                c.execute("PRAGMA wal_checkpoint(TRUNCATE);")
-        except Exception:
-            print(
-                "⚠️  WAL checkpoint failed (DB may be locked by gateway). "
-                "The backup API still produces a consistent copy."
-            )
+    # NO pre-staging WAL checkpoint. There used to be one here, and removing it is the
+    # point rather than an omission: it was the ONLY write this command made to the live
+    # database, and it could not be made safe. A checkpoint cannot run read-only, so the
+    # name has to be reopened for writing -- and verifying the name first does not close
+    # that, because SQLite re-resolves it, so a swap in the window between the check and
+    # the open put the checkpoint's WRITE into whatever the name then pointed at,
+    # truncating an external database's log. Review's finding, and the remedy it asked for.
+    #
+    # Nothing the archive depends on is lost. The backup API reads a consistent snapshot
+    # that already INCLUDES rows living only in the `-wal`: measured against a
+    # cross-process writer with `wal_autocheckpoint=0` and a 1.5 MB log, the copy carried
+    # all 421 rows -- 371 of them WAL-resident -- and passed `integrity_check`. The
+    # checkpoint only kept the log from riding along at its full size, which is a size
+    # optimisation, not a correctness step.
+    #
+    # With it gone, the whole creation path is read-only: every database is opened
+    # `mode=ro`, so `kirocrew snapshot` cannot modify the data it was asked to copy.
+    # That is a cleaner invariant than "read-only except one verified write", and it is
+    # what makes `test_the_command_never_writes_to_the_live_database` assertable.
 
     try:
         outfile = _build_snapshot(

--- a/test/test_snapshot_copy_failure_atomicity.py
+++ b/test/test_snapshot_copy_failure_atomicity.py
@@ -64,13 +64,13 @@ class TestAFailedDatabaseCopyIsNotSilentlyDowngraded:
         dst.mkdir()
         (src / "notes.db").write_text("this is not a database", encoding="utf-8")
         (dst / "notes.db").write_text("this is not a database", encoding="utf-8")
-        snap._restage_databases(src, dst)
+        snap._restage_databases(src, dst, bundle_root=dst)
         assert "not a readable SQLite database" in capsys.readouterr().out
         assert (dst / "notes.db").read_text(encoding="utf-8") == "this is not a database"
 
     def test_a_real_database_is_copied_consistently(self, tmp_path):
         src, dst = self._staged_pair(tmp_path)
-        snap._restage_databases(src, dst)
+        snap._restage_databases(src, dst, bundle_root=dst)
         with closing(sqlite3.connect(str(dst / "memory.db"))) as c:
             assert c.execute("SELECT v FROM t").fetchone()[0] == "real"
 
@@ -108,7 +108,7 @@ class TestAFailedDatabaseCopyIsNotSilentlyDowngraded:
         src, dst = self._staged_pair(tmp_path)
         self._break_backup(monkeypatch, "database is locked")
         with pytest.raises(snap.DatabaseCopyFailed) as e:
-            snap._restage_databases(src, dst)
+            snap._restage_databases(src, dst, bundle_root=dst)
         assert e.value.path.name == "memory.db", "the error must name the file"
 
     def test_the_probe_does_not_mask_a_backup_failure_as_a_plain_file(
@@ -118,7 +118,7 @@ class TestAFailedDatabaseCopyIsNotSilentlyDowngraded:
         src, dst = self._staged_pair(tmp_path)
         self._break_backup(monkeypatch, "disk I/O error")
         with pytest.raises(snap.DatabaseCopyFailed):
-            snap._restage_databases(src, dst)
+            snap._restage_databases(src, dst, bundle_root=dst)
         assert "not a readable SQLite database" not in capsys.readouterr().out
 
     def test_the_command_reports_it_instead_of_crashing(self, home, tmp_path, monkeypatch, capsys):
@@ -159,7 +159,7 @@ class TestAFailedDatabaseCopyIsNotSilentlyDowngraded:
             holder.execute("BEGIN EXCLUSIVE")
             holder.execute("INSERT INTO t VALUES ('held')")
             with pytest.raises(snap.DatabaseCopyFailed) as e:
-                snap._restage_databases(src, dst)
+                snap._restage_databases(src, dst, bundle_root=dst)
             assert e.value.path.name == "memory.db"
             assert "not a readable SQLite database" not in capsys.readouterr().out
         finally:
@@ -173,35 +173,62 @@ class TestAFailedDatabaseCopyIsNotSilentlyDowngraded:
         dst.mkdir()
         (src / "notes.db").write_text("plainly not a database", encoding="utf-8")
         (dst / "notes.db").write_text("plainly not a database", encoding="utf-8")
-        snap._restage_databases(src, dst)
+        snap._restage_databases(src, dst, bundle_root=dst)
         assert "not a readable SQLite database" in capsys.readouterr().out
 
     def test_both_database_copy_sites_raise_the_typed_error(self):
-        """Structural: core files and trees are separate `backup()` call sites, and only
-        one was wrapped at first -- the other exited on a traceback. The readability
-        PROBE is a third raiser: anything it cannot positively classify as
-        not-a-database must raise rather than fall through to the plain-file path."""
+        """Structural: core files and trees are separate staging paths, and only one was
+        wrapped at first -- the other exited on a traceback. The readability PROBE is a
+        third raiser: anything it cannot positively classify as not-a-database must raise
+        rather than fall through to the plain-file path.
+
+        Rewritten when #5451 collapsed the two duplicated `backup()` blocks into one
+        shared helper. The invariant is unchanged and now holds by construction: instead
+        of counting two call sites and checking each is wrapped, there is ONE call site to
+        wrap, and what needs asserting is that BOTH paths still route through it. The old
+        `calls >= 2` form would now fail on the very refactor that removed the duplication
+        it existed to police.
+        """
         import inspect
         import re
 
         src = inspect.getsource(snap)
         calls = len(re.findall(r"src_conn\.backup\(dst_conn\)", src))
         wrapped = len(re.findall(r"raise DatabaseCopyFailed\(src, e\) from e", src))
-        assert calls >= 2, "expected both the core-file and tree copy sites"
+        assert calls == 1, (
+            f"{calls} backup call sites; the copy is meant to live in exactly one helper "
+            "so the two staging paths cannot drift apart again"
+        )
         assert wrapped >= calls, (
             f"{calls} backup call sites but only {wrapped} raise the typed error; an "
             "unwrapped site exits the command on a traceback"
         )
+        # Both staging paths must reach that one helper. Without this, collapsing the
+        # duplication would satisfy the count above while silently leaving one path
+        # copying databases some other way.
+        assert "_copy_database_consistently(" in inspect.getsource(
+            snap._restage_databases
+        ), "the tree pass no longer routes through the shared hardened copy"
+        assert "_copy_database_consistently(" in inspect.getsource(
+            snap._build_snapshot
+        ), "the core-file pass no longer routes through the shared hardened copy"
         # The probe must fail closed. `SQLITE_BUSY` (a locked database) is a
         # DatabaseError too, so continuing on anything unclassified ships a raw copy
         # without its WAL as if it were consistent.
-        probe_src = inspect.getsource(snap._restage_databases)
+        probe_src = inspect.getsource(snap._copy_database_consistently)
         assert (
             "SQLITE_NOTADB" in probe_src
         ), "the probe must identify not-a-database positively, not by exception class"
         assert probe_src.index("if not not_a_database:") < probe_src.index(
-            "is not a readable SQLite database"
-        ), "the raise must precede the plain-file fall-through"
+            "return DB_NOT_A_DATABASE"
+        ), "the raise must precede the not-a-database outcome"
+        # The source is opened read-only. This is the #5451 fix and it is asserted
+        # structurally as well as behaviourally, because a read-write open still passes
+        # every functional test on a database with no unreplayed log.
+        assert "?mode=ro" in probe_src, (
+            "the staging connection must be read-only; a read-write open recovers an "
+            "unreplayed -wal into the live main file and unlinks the log"
+        )
 
     def test_the_module_under_test_and_this_file_agree_on_the_driver(self):
         """Pins the reason the tests above use snap.sqlite3: if the package ever binds

--- a/test/test_snapshot_db_staging_5451.py
+++ b/test/test_snapshot_db_staging_5451.py
@@ -1,0 +1,682 @@
+"""Snapshot's creation-side SQLite staging: read-only, descriptor-verified, WAL-complete.
+
+Issue #5451. Two claims were made about `snapshot_main`'s database staging, and they need
+opposite treatment, which is why they are tested separately here.
+
+The FIRST is real and these tests pin it: the core-file staging path opened the live
+database by name and READ-WRITE. That is not merely more authority than a backup needs --
+it mutates the operator's live data. With a `-wal` left unreplayed by a killed writer, the
+read-write open recovers the log into the main file and unlinks the log, so `kirocrew
+snapshot` rewrites the database it was asked to read.
+
+The SECOND -- "a WAL check races the copy" -- is a property of a check-then-copy-BYTES
+design, and the fix is not to build one. `TestTheBackupApiIsAlreadyWalConsistent` is the
+evidence for that: the backup API reads a snapshot that already includes rows living only
+in the log, so there is no check to race. Those are contract tests, not regression tests,
+and are labelled as such -- they pass on base too. Their job is to stop someone
+"fixing" the WAL race later by replacing `backup()` with a checkpoint and a byte copy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tarfile
+import textwrap
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+from test_snapshot import _setup_fake_kirocrew
+
+from kiro_crew import pinned_fs
+from kiro_crew import snapshot as snap
+
+pinned_only = pytest.mark.skipif(
+    not pinned_fs.supports_pinned_tree_walk(),
+    reason="requires O_DIRECTORY, O_NOFOLLOW, dir_fd and fd-listdir support (POSIX)",
+)
+
+#: Staging refuses by default where a directory cannot be pinned, so a test driving a real
+#: snapshot has to say which platform contract it asserts. These tests assert product
+#: behaviour true on both, and exercise the declared by-name path on Windows.
+UNPINNED_OK = {"allow_unpinned": True}
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "home"
+    d.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(d))
+    _setup_fake_kirocrew(d)
+    return d
+
+
+def _fingerprint(path: Path) -> tuple[int, str] | None:
+    """Size and content hash, or None when absent. Content, not mtime: the point is
+    whether the BYTES changed, and an mtime comparison would also fire on a touch."""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    return len(data), hashlib.sha256(data).hexdigest()
+
+
+#: Writes committed rows into the -wal and then dies WITHOUT closing the connection, so
+#: the log survives on disk with frames not yet folded into the main file. That is the
+#: state a killed gateway leaves behind, and it is the state in which a read-write open
+#: performs recovery -- which is a WRITE to the live database.
+_DIRTY_WRITER = textwrap.dedent("""
+    import os, sqlite3, sys
+    c = sqlite3.connect(sys.argv[1], isolation_level=None)
+    c.execute("PRAGMA journal_mode=WAL;")
+    c.execute("PRAGMA wal_autocheckpoint=0;")
+    for i in range(200):
+        c.execute(
+            "INSERT INTO semantic_memory"
+            " (key, value_json, confidence, source, created_at, updated_at)"
+            " VALUES (?, '\\"wal\\"', 0.5, 'wal', '2026-01-01', '2026-01-01')",
+            (f"wal.only.{i}",),
+        )
+    os._exit(0)
+    """).strip()
+
+
+def _leave_unreplayed_wal(db: Path, tmp_path: Path) -> None:
+    """Leave *db* with a non-empty -wal and no live connection holding it.
+
+    Done in a subprocess that hard-exits, because an in-process connection closing
+    normally is the LAST connection and SQLite checkpoints and unlinks the log on the way
+    out -- which is the very mutation these tests measure, applied by the fixture instead
+    of by the code under test.
+    """
+    with closing(sqlite3.connect(str(db))) as c:
+        c.execute("PRAGMA journal_mode=WAL;")
+        c.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+    script = tmp_path / "dirty_writer.py"
+    script.write_text(_DIRTY_WRITER, encoding="utf-8")
+    # `cwd=tmp_path`: the child inherits this process's directory otherwise, which under
+    # pytest is the repository checkout, so any relative artifact it created would land in
+    # the working tree. It only touches the absolute db path today; pinning the cwd keeps
+    # that true if the script grows. Review's finding.
+    subprocess.run([sys.executable, str(script), str(db)], check=True, cwd=tmp_path)
+    assert (_fingerprint(Path(str(db) + "-wal")) or (0, ""))[
+        0
+    ] > 0, "fixture did not leave an unreplayed -wal; the test below would prove nothing"
+
+
+def _staged_member(archive: Path, name: str) -> bytes:
+    with tarfile.open(archive) as tf:
+        root = os.path.commonprefix(tf.getnames()).rstrip("/")
+        extracted = tf.extractfile(f"{root}/{name}")
+        assert extracted is not None
+        return extracted.read()
+
+
+def _manifest(archive: Path) -> dict:
+    with tarfile.open(archive) as tf:
+        root = os.path.commonprefix(tf.getnames()).rstrip("/")
+        member = tf.extractfile(f"{root}/MANIFEST.json")
+        assert member is not None
+        return json.load(member)
+
+
+class TestStagingDoesNotWriteToTheLiveDatabase:
+    """The regression tests for #5451's first failure mode."""
+
+    def test_a_snapshot_leaves_the_live_database_byte_identical(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """A backup must not modify what it backs up.
+
+        This is the test that discriminates the fix. On base the core-file path connects
+        READ-WRITE, so opening a database whose -wal holds unreplayed frames recovers them
+        into the main file and unlinks the log: both fingerprints below change. Read-only
+        cannot perform that recovery, so both survive untouched.
+        """
+        db = home / "memory.db"
+        _leave_unreplayed_wal(db, tmp_path)
+        before_main = _fingerprint(db)
+        before_wal = _fingerprint(Path(str(db) + "-wal"))
+
+        snap._build_snapshot(
+            home, tmp_path / "out", "ro-archive", selected=["memory"], **UNPINNED_OK
+        )
+
+        assert _fingerprint(db) == before_main, (
+            "staging rewrote the live memory.db -- a read-write open recovered the -wal "
+            "into the main file. Staging only ever needs to read; open it mode=ro."
+        )
+        assert _fingerprint(Path(str(db) + "-wal")) == before_wal, (
+            "staging checkpointed and/or unlinked the live -wal. That is the operator's "
+            "in-flight transaction state, destroyed as a side effect of a backup."
+        )
+
+    def test_the_staged_copy_still_holds_the_rows_that_lived_only_in_the_wal(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """Read-only costs nothing in completeness.
+
+        The pairing matters: without this, the test above could be satisfied by not
+        reading the database at all. 200 rows exist ONLY in the -wal when staging runs,
+        and every one of them has to reach the archive.
+        """
+        db = home / "memory.db"
+        _leave_unreplayed_wal(db, tmp_path)
+
+        archive = snap._build_snapshot(
+            home, tmp_path / "out", "complete-archive", selected=["memory"], **UNPINNED_OK
+        )
+
+        staged = tmp_path / "staged.db"
+        staged.write_bytes(_staged_member(archive, "memory.db"))
+        with closing(sqlite3.connect(str(staged))) as c:
+            assert c.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+            wal_rows = c.execute(
+                "SELECT count(*) FROM semantic_memory WHERE key LIKE 'wal.only.%'"
+            ).fetchone()[0]
+        assert wal_rows == 200, (
+            f"only {wal_rows}/200 WAL-resident rows reached the archive -- the copy is "
+            "not reading the log, so the bundle is silently short of committed rows"
+        )
+
+    def test_the_command_never_writes_to_the_live_database(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """The whole COMMAND is read-only, not just the staging copy.
+
+        This replaces a narrower test of the pre-staging WAL checkpoint, which review had
+        removed by then. That checkpoint was the only write `kirocrew snapshot` made to live
+        data, and it could not be made safe: a checkpoint cannot run read-only, and
+        verifying the name first does not help because SQLite re-resolves it, so a swap in
+        that window put the WRITE into whatever the name then pointed at.
+
+        Asserting through `snapshot_main` rather than `_build_snapshot` is the whole point
+        -- the checkpoint lived in the command, so a test that called the builder directly
+        could never have caught it. With it gone, both the main file and the `-wal` survive
+        a full snapshot untouched.
+        """
+        db = home / "memory.db"
+        _leave_unreplayed_wal(db, tmp_path)
+        before_main = _fingerprint(db)
+        before_wal = _fingerprint(Path(str(db) + "-wal"))
+
+        rc = snap.snapshot_main([str(tmp_path / "out"), "--allow-unpinned-staging"])
+
+        assert rc == 0, f"the snapshot did not succeed (rc={rc})"
+        assert _fingerprint(db) == before_main, "the command rewrote the live memory.db"
+        assert _fingerprint(Path(str(db) + "-wal")) == before_wal, (
+            "the command checkpointed or unlinked the live -wal -- that is the operator's "
+            "in-flight transaction state, destroyed as a side effect of a backup"
+        )
+
+    def test_a_symlinked_data_home_does_not_traceback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A relocated data home reaches a decision instead of dying on a traceback.
+
+        History worth keeping, because it is the reason this test is shaped the way it is.
+        An intermediate revision verified the checkpoint's path with `_chain_is_link_free`,
+        which then called `open_dir_pinned` outside its own try and resolves only the PARENT
+        chain -- so a data home that is itself a symlink raised `PinnedPathRefusal` from a
+        call site above `snapshot_main`'s try, and the command exited on a traceback.
+
+        That root open is now wrapped, but it catches `OSError` only and still lets
+        `PinnedPathRefusal` through on purpose, so a symlinked home remains a refusal
+        `snapshot_main` handles and audits rather than something this helper swallows.
+        `test_a_source_root_that_disappears_is_named_not_a_traceback` pins the `OSError` half.
+
+        The reachability argument is what makes this test real. `_valid_override_home()`
+        ends in `.resolve()`, so a `KIROCREW_HOME` override can never present a symlinked
+        home -- a first version of this test used it and passed against the broken code,
+        proving nothing. The DEFAULT route does not resolve: `_default_home()` returns
+        `Path.home() / ".kiro" / "crew"` verbatim. Patching `_mc_dir` reproduces that shape.
+
+        Stated plainly: with the checkpoint removed there is no longer a guard above the
+        try for this to discriminate, so it is now a behavioural contract test rather than a
+        regression test for that specific line. It is kept because a symlinked data home
+        must not crash the command however the internals are arranged.
+        """
+        if not pinned_fs.supports_pinned_walk():
+            pytest.skip("the refusal only arises where descriptor pinning is available")
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        _setup_fake_kirocrew(real_home)
+        linked = tmp_path / "linked-home"
+        try:
+            linked.symlink_to(real_home)
+        except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+            pytest.skip("creating a symlink needs privilege on this host")
+        monkeypatch.setattr(snap, "_mc_dir", lambda: linked)
+
+        rc = snap.snapshot_main([str(tmp_path / "out"), "--allow-unpinned-staging"])
+        assert rc in (0, 1), f"expected a clean exit code, got {rc!r}"
+
+
+class TestACorruptCoreDatabaseFailsInsteadOfPruningAGoodBackup:
+    def test_a_corrupt_core_database_fails_the_snapshot(self, home: Path, tmp_path: Path) -> None:
+        """A declared component file that is not SQLite fails the snapshot.
+
+        An earlier revision of this change degraded it to a byte copy, "matching" the tree
+        pass. That is backwards, and review caught the consequence -- see the sibling test
+        below for the chain it opens.
+        """
+        (home / "memory.db").write_bytes(b"this is not a database\n")
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._build_snapshot(
+                home, tmp_path / "out", "corrupt", selected=["memory"], **UNPINNED_OK
+            )
+        assert "memory.db" in str(excinfo.value)
+
+    def test_the_failure_happens_before_any_backup_is_pruned(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """Why it raises: `--keep` pruning must never run for an unrestorable archive.
+
+        Degrading made the snapshot SUCCEED, so `--keep N` counted the new archive as the
+        newest backup and pruned a real one, while restore refuses that archive at its
+        strict database validation -- leaving nothing restorable after a command that
+        printed success. Asserted through the command rather than on the exception type,
+        because the ORDERING is what protects the operator's data.
+        """
+        out = tmp_path / "out"
+        out.mkdir()
+        previous = out / "kirocrew-snapshot-20260101-000000.tgz"
+        previous.write_bytes(b"the operator's only good backup\n")
+        (home / "memory.db").write_bytes(b"this is not a database\n")
+
+        rc = snap.snapshot_main([str(out), "--keep", "1", "--allow-unpinned-staging"])
+
+        assert rc != 0, "a snapshot over a corrupt core database reported success"
+        assert previous.exists(), (
+            "the pre-existing backup was pruned in favour of an archive that restore "
+            "would refuse -- the data-loss chain the raise exists to prevent"
+        )
+
+    def test_a_tree_database_that_is_not_sqlite_still_rides_as_bytes(
+        self, home: Path, tmp_path: Path, capsys
+    ) -> None:
+        """The other half of the asymmetry, asserted so nobody "fixes" it into symmetry.
+
+        A `.db` under a tree that is NOT in `PRODUCT_TREE_DATABASES` is incidental -- a file
+        the operator happens to keep in their workspace -- and refusing the whole snapshot
+        over it would be an outage rather than a safeguard. `_setup_fake_kirocrew` leaves a
+        stub `kb.sqlite3` under workspace/knowledge that is not a real database; it must ride
+        as bytes.
+
+        Set membership is what draws the line, not tree-versus-core: the sibling test
+        `test_a_corrupt_product_tree_database_fails_the_snapshot` pins that a corrupt
+        `knowledge.db` in the same directory FAILS the snapshot, because that path is one of
+        ours and restore validates it as strictly as `memory.db`.
+        """
+        archive = snap._build_snapshot(
+            home, tmp_path / "out", "tree-degrade", selected=["memory"], **UNPINNED_OK
+        )
+        assert (
+            _staged_member(archive, "workspace/knowledge/kb.sqlite3") == b"SQLite format 3\x00stub"
+        ), "an incidental non-database in a tree was not carried through as bytes"
+        assert "not a readable SQLite database" in capsys.readouterr().out
+
+    def test_a_database_vanishing_after_the_probe_is_named_not_a_traceback(
+        self, home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A source lost between the probe and the copy is reported by name.
+
+        The two `sqlite3.connect` calls used to sit OUTSIDE the try that translates errors
+        into `DatabaseCopyFailed`. `snapshot_main` handles `PinnedPathRefusal`,
+        `UnsafeComponentRoot`, `DatabaseCopyFailed` and `_ArchiveTooLarge` -- not a bare
+        `sqlite3.OperationalError` -- so the command exited on a traceback instead of naming
+        the database. Review's finding.
+
+        Worth stating that `mode=ro` WIDENED this window rather than narrowing it: a
+        read-write open would have silently created an empty database where a read-only one
+        fails outright. The fix belongs with the change that made it matter.
+
+        The vanish is injected for real -- the file is unlinked between the probe's connect
+        and the copy's -- rather than by raising a synthetic error, so the exception is the
+        one SQLite actually produces.
+        """
+        calls = {"n": 0}
+        real_connect = sqlite3.connect
+
+        class _VanishOnSecondConnect:
+            def __getattr__(self, item: str) -> object:
+                return getattr(sqlite3, item)
+
+            @staticmethod
+            def connect(*args: object, **kwargs: object) -> object:
+                target = str(args[0]) if args else ""
+                if "mode=ro" in target:
+                    calls["n"] += 1
+                    if calls["n"] == 2:
+                        (home / "memory.db").unlink()
+                return real_connect(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(snap, "sqlite3", _VanishOnSecondConnect())
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._build_snapshot(
+                home, tmp_path / "out", "vanished", selected=["memory"], **UNPINNED_OK
+            )
+        assert calls["n"] >= 2, "the second (copy) connect never happened; nothing was proven"
+        assert "memory.db" in str(excinfo.value)
+
+    @pinned_only
+    def test_a_source_root_that_disappears_is_named_not_a_traceback(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """A component root removed under the copy reaches a decision, not a traceback.
+
+        `_chain_is_link_free` calls `open_dir_pinned` OUTSIDE its own try, and
+        `open_dir_pinned` translates only `ELOOP`/`ENOTDIR` into `PinnedPathRefusal` and
+        re-raises every other `OSError`. So a root lost to a concurrent rename or removal
+        left `ENOENT` escaping as `FileNotFoundError`.
+
+        The reachability argument is what makes this a regression test rather than a
+        contract one. `snapshot_main` wraps `_build_snapshot` in a try whose handlers are
+        `PinnedPathRefusal`, `UnsafeComponentRoot` and `DatabaseCopyFailed`; its
+        `except (tarfile.TarError, OSError, EOFError)` belongs to a LATER, separate try that
+        does not cover `_build_snapshot`. This change is what routes the helper at the live
+        data home -- the sibling tree pass passes a staging directory the command itself
+        just created -- so the operator-facing trigger arrives with this diff and the
+        containment belongs with it. Review's finding.
+
+        The root is removed for real rather than by raising a synthetic error, so the
+        exception is the one the OS actually produces.
+
+        Both outcomes are asserted because they must stay OPPOSITE: a DECLARED database is
+        a hard failure, while one the tree walk merely found is recorded and rides as bytes.
+        Collapsing them is what let `--keep` prune an operator's last complete archive.
+        """
+        gone = tmp_path / "gone"
+        gone.mkdir()
+        src = gone / "memory.db"
+        with closing(sqlite3.connect(src)) as db:
+            db.execute("CREATE TABLE t (x)")
+        gone_src = src
+
+        shutil.rmtree(gone)
+        assert not gone.exists(), "the root still exists; nothing would be proven"
+
+        # A DECLARED component database: the snapshot must fail, by name.
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._copy_database_consistently(
+                gone_src,
+                tmp_path / "dst.db",
+                root=gone,
+                rel_parts=("memory.db",),
+                require_database=True,
+            )
+        assert "memory.db" in str(excinfo.value)
+
+        # The same loss on the incidental tree path is a recorded refusal, not a failure.
+        assert (
+            snap._copy_database_consistently(
+                gone_src,
+                tmp_path / "dst2.db",
+                root=gone,
+                rel_parts=("memory.db",),
+            )
+            == snap.DB_UNSAFE_SOURCE
+        )
+
+    def test_a_corrupt_product_tree_database_fails_the_snapshot(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """A corrupt `knowledge.db` fails the snapshot instead of riding as bytes.
+
+        `PRODUCT_TREE_DATABASES` says of itself that everything in it is "validated as
+        strictly as `memory.db`", and the restore side already enforces that --
+        `_refuse_unless_sound(src, rel, strict=rel in PRODUCT_TREE_DATABASES)`, asserted by
+        `test_an_unopenable_knowledge_database_is_refused`. The creation path staged those
+        same files leniently, so a corrupt `workspace/knowledge/knowledge.db` produced an
+        archive that reported success and that restore is GUARANTEED to refuse.
+
+        That combination is worse than either half. `--keep N` counts the new archive as the
+        newest backup and prunes a real one, so the operator loses their last restorable
+        copy to a command that said it worked. Review's finding.
+
+        This is the boundary of the tree/core asymmetry, not a repeal of it: the sibling
+        test above pins that an incidental `kb.sqlite3` still rides as bytes. The set
+        membership is what separates the two, which is why this asserts the path in the set
+        rather than any `.db` under a tree.
+        """
+        kdir = home / "workspace" / "knowledge"
+        kdir.mkdir(parents=True, exist_ok=True)
+        (kdir / "knowledge.db").write_bytes(b"torn, not a database")
+
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._build_snapshot(
+                home, tmp_path / "out", "corrupt-product-tree", selected=["memory"], **UNPINNED_OK
+            )
+        assert "knowledge.db" in str(excinfo.value)
+
+    def test_a_page_corrupt_required_database_fails_the_snapshot(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """A database that PARSES but is page-corrupt fails, instead of shipping.
+
+        `PRAGMA schema_version` only proves the file parses. Measured with the interior
+        pages overwritten and the header left intact: `schema_version` answered normally,
+        `backup()` succeeded and staged all bytes, and `integrity_check` reported "database
+        disk image is malformed" on both source and copy. So the archive reported success
+        and restore was guaranteed to refuse it -- `--keep N` then prunes a real backup in
+        favour of one that cannot be restored. Review's finding.
+
+        The check runs on the STAGED COPY with restore's own predicate, so this asserts the
+        two ends of the invariant now agree rather than merely that creation got stricter.
+        """
+        live = home / "memory.db"
+        with closing(sqlite3.connect(live)) as db:
+            db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, blob TEXT)")
+            db.executemany("INSERT INTO t (blob) VALUES (?)", [("x" * 400,) for _ in range(400)])
+            db.commit()
+
+        raw = bytearray(live.read_bytes())
+        page = 4096
+        assert len(raw) > 8 * page, "fixture too small to corrupt interior pages"
+        for pageno in range(3, 8):
+            start = pageno * page
+            raw[start : start + 200] = b"\xde\xad\xbe\xef" * 50
+        live.write_bytes(bytes(raw))
+
+        # Precondition: the weaker probe this replaces still passes, so the test is
+        # asserting the new check and not some earlier guard.
+        with closing(sqlite3.connect(f"{live.absolute().as_uri()}?mode=ro", uri=True)) as probe:
+            assert probe.execute("PRAGMA schema_version").fetchone() is not None
+
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._build_snapshot(
+                home, tmp_path / "out", "page-corrupt", selected=["memory"], **UNPINNED_OK
+            )
+        assert "memory.db" in str(excinfo.value)
+
+    def test_a_zero_byte_required_database_fails_the_snapshot(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """Zero bytes is the unsoundness neither `integrity_check` nor restore can see.
+
+        Measured, and worse than "restore would refuse it": SQLite opens a zero-byte file as
+        a valid EMPTY database, `PRAGMA schema_version` answers `(0,)`, and `backup()` does
+        not preserve the emptiness -- it produced a 4096-byte staged copy that
+        `integrity_check` called `ok`. Restore's own zero-byte guard reads the size of the
+        ARCHIVED file, so it sees 4096 and ACCEPTS, then installs an empty database over
+        live data and reports success.
+
+        So this one is not a pruning hazard, it is silent data loss on restore, and the
+        source is the only end where the condition is visible -- which is why the check sits
+        there rather than on the copy.
+        """
+        (home / "memory.db").write_bytes(b"")
+
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._build_snapshot(
+                home, tmp_path / "out", "zero-byte", selected=["memory"], **UNPINNED_OK
+            )
+        assert "memory.db" in str(excinfo.value)
+
+    def test_an_unreadable_core_database_still_fails_the_snapshot_loudly(
+        self, home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A readable database whose COPY fails must raise too.
+
+        Distinct from the corrupt case: this file IS a valid database, so the probe
+        succeeds and only `backup()` fails. Degrading it would ship a database without the
+        `-wal` this module strips -- torn, inside an archive reporting success.
+
+        Injected by shimming the module's own `sqlite3` reference rather than patching
+        `sqlite3.Connection.backup`, which is an immutable type.
+        """
+
+        class _FailingBackup:
+            def __init__(self, wrapped: sqlite3.Connection) -> None:
+                self._wrapped = wrapped
+
+            def __getattr__(self, item: str) -> object:
+                return getattr(self._wrapped, item)
+
+            def backup(self, *_a: object, **_k: object) -> None:
+                raise sqlite3.OperationalError("database is locked")
+
+        class _Shim:
+            def __getattr__(self, item: str) -> object:
+                return getattr(sqlite3, item)
+
+            @staticmethod
+            def connect(*args: object, **kwargs: object) -> object:
+                conn = sqlite3.connect(*args, **kwargs)  # type: ignore[arg-type]
+                return _FailingBackup(conn)
+
+        monkeypatch.setattr(snap, "sqlite3", _Shim())
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._build_snapshot(home, tmp_path / "out", "loud", selected=["memory"], **UNPINNED_OK)
+        assert "memory.db" in str(excinfo.value)
+
+
+@pinned_only
+class TestASourceThatCannotBeVerifiedIsRefusedAndRecorded:
+    def test_a_core_name_swapped_for_a_link_after_the_screen_is_not_archived(
+        self, home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The check-to-use window on the core path, made deterministic.
+
+        The staging loop screens `memory.db` through its held descriptor and then hands the
+        NAME to SQLite, which resolves it again. The swap is injected between those two
+        resolutions -- immediately after the screen returns -- which is precisely the
+        window an attacker with write access to the data home has. Without the helper's own
+        chain check the second resolution lands on the victim and its rows ride the bundle
+        under the name `memory.db`.
+        """
+        victim = tmp_path / "someone-elses.db"
+        with closing(sqlite3.connect(str(victim))) as c:
+            c.execute("CREATE TABLE secrets (v TEXT)")
+            c.execute("INSERT INTO secrets VALUES ('not-the-operators-row')")
+
+        real_stat_at = pinned_fs.stat_at
+        swapped = {"done": False}
+
+        def stat_at_then_swap(dir_fd: int, name: str):  # type: ignore[no-untyped-def]
+            result = real_stat_at(dir_fd, name)
+            if name == "memory.db" and not swapped["done"]:
+                swapped["done"] = True
+                (home / "memory.db").unlink()
+                (home / "memory.db").symlink_to(victim)
+            return result
+
+        # Probed on a name of its own. Probing `home/memory.db` -- which the fixture
+        # already created -- raised FileExistsError, was caught by the same handler, and
+        # skipped the test with "needs privilege": a green run that asserted nothing.
+        probe = tmp_path / "symlink-support-probe"
+        try:
+            probe.symlink_to(victim)
+        except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+            pytest.skip("creating a symlink needs privilege on this host")
+        probe.unlink()
+
+        monkeypatch.setattr(snap.pinned_fs, "stat_at", stat_at_then_swap)
+        with pytest.raises(snap.DatabaseCopyFailed) as excinfo:
+            snap._build_snapshot(home, tmp_path / "out", "swapped", selected=["memory"])
+        assert swapped["done"], "the swap never fired; this test proves nothing"
+        assert "memory.db" in str(excinfo.value)
+
+    def test_a_swapped_core_name_does_not_publish_an_archive_that_prunes_a_good_one(
+        self, home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Why the swap RAISES instead of being recorded as an omission.
+
+        An intermediate revision recorded it in `MANIFEST.json` and let the snapshot
+        succeed, on the issue's own reasoning that "an absent database with a recorded
+        reason is recoverable information". Review showed the flaw: it is recoverable
+        information only while the operator still HAS the archive it could be recovered
+        from, and a successful snapshot with `--keep 1` prunes exactly that.
+        """
+        victim = tmp_path / "someone-elses.db"
+        with closing(sqlite3.connect(str(victim))) as c:
+            c.execute("CREATE TABLE secrets (v TEXT)")
+
+        probe = tmp_path / "symlink-support-probe"
+        try:
+            probe.symlink_to(victim)
+        except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+            pytest.skip("creating a symlink needs privilege on this host")
+        probe.unlink()
+
+        out = tmp_path / "out"
+        out.mkdir()
+        previous = out / "kirocrew-snapshot-20260101-000000.tgz"
+        previous.write_bytes(b"the operator's only good backup\n")
+
+        real_stat_at = pinned_fs.stat_at
+        swapped = {"done": False}
+
+        def stat_at_then_swap(dir_fd: int, name: str):  # type: ignore[no-untyped-def]
+            result = real_stat_at(dir_fd, name)
+            if name == "memory.db" and not swapped["done"]:
+                swapped["done"] = True
+                (home / "memory.db").unlink()
+                (home / "memory.db").symlink_to(victim)
+            return result
+
+        monkeypatch.setattr(snap.pinned_fs, "stat_at", stat_at_then_swap)
+        rc = snap.snapshot_main([str(out), "--keep", "1"])
+
+        assert swapped["done"], "the swap never fired; this test proves nothing"
+        assert rc != 0, "a snapshot whose required database was omitted reported success"
+        assert previous.exists(), (
+            "the operator's previous backup was pruned in favour of an archive missing the "
+            "database it claims to contain"
+        )
+
+    def test_a_tree_database_that_cannot_be_verified_is_recorded_in_the_manifest(
+        self, home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The tree pass keeps its byte copy, but the archive stops claiming consistency.
+
+        Deleting the byte copy would be data loss, so it stays -- and that is exactly why
+        the degradation has to be on the record. Before this, `_restage_databases` had no
+        reporter at all and the outcome existed only as a `continue`.
+        """
+        # Scoped to the TREE entry. A blanket `lambda: False` also trips the core path,
+        # which now raises for an unverifiable required database, so the snapshot would die
+        # on `memory.db` before the tree pass ran and this test would assert nothing about
+        # the manifest.
+        real_chain_is_link_free = snap._chain_is_link_free
+
+        def only_the_tree_db_is_unverifiable(root: Path, rel_parts: tuple[str, ...]) -> bool:
+            if rel_parts and rel_parts[-1] == "kb.sqlite3":
+                return False
+            return real_chain_is_link_free(root, rel_parts)
+
+        monkeypatch.setattr(snap, "_chain_is_link_free", only_the_tree_db_is_unverifiable)
+        archive = snap._build_snapshot(
+            home, tmp_path / "out", "unverified-tree", selected=["memory"], **UNPINNED_OK
+        )
+        skipped = _manifest(archive)["skipped"]
+        assert any(
+            e["reason"] == snap.SKIP_DB_UNPINNED_SOURCE and e["path"].endswith("kb.sqlite3")
+            for e in skipped
+        ), f"the tree pass's degradation is absent from MANIFEST.json: {skipped}"

--- a/test/test_snapshot_redaction_fail_closed.py
+++ b/test/test_snapshot_redaction_fail_closed.py
@@ -797,7 +797,7 @@ class TestTheDatabaseRestageChecksAndOpensTheSameFile:
             return real_check(root, rel_parts)
 
         monkeypatch.setattr(snap, "_chain_is_link_free", swap_then_check)
-        snap._restage_databases(real, stage)
+        snap._restage_databases(real, stage, bundle_root=stage)
         assert swapped["done"], "the swap never fired; the test proves nothing"
 
         staged = stage / "workspace" / "notes.db"
@@ -851,7 +851,7 @@ class TestTheDatabaseRestageChecksAndOpensTheSameFile:
         monkeypatch.setattr(snap.os, "open", refuse_dir_fd)
 
         try:
-            snap._restage_databases(real, stage)
+            snap._restage_databases(real, stage, bundle_root=stage)
         finally:
             active["on"] = False
 
@@ -882,7 +882,7 @@ class TestTheDatabaseRestageChecksAndOpensTheSameFile:
         conn.commit()
         conn.close()
 
-        snap._restage_databases(real, stage)
+        snap._restage_databases(real, stage, bundle_root=stage)
 
         conn = redact.sqlite3.connect(str(stage / "notes.db"))
         rows = [r[0] for r in conn.execute("SELECT v FROM t")]

--- a/test/test_snapshot_review_fixes.py
+++ b/test/test_snapshot_review_fixes.py
@@ -174,7 +174,7 @@ class TestLiveDatabasesAreStagedConsistently:
         assert skips, "the walk did not refuse the hardlink alias, so this proves nothing"
         assert not (stage / "kb.db").exists()
 
-        snap_mod._restage_databases(tree, stage)
+        snap_mod._restage_databases(tree, stage, bundle_root=stage)
         assert not (
             stage / "kb.db"
         ).exists(), "the consistency pass rebuilt a database the walk deliberately skipped"
@@ -193,7 +193,7 @@ class TestLiveDatabasesAreStagedConsistently:
 
         snap_mod._copytree_safe(tree, stage, allow_unpinned=bool(unpinnable_argv()))
         assert (stage / "kb.db").is_file()
-        snap_mod._restage_databases(tree, stage)
+        snap_mod._restage_databases(tree, stage, bundle_root=stage)
 
         c = sqlite3.connect(str(stage / "kb.db"))
         assert [r[0] for r in c.execute("SELECT v FROM t")] == ["MINE"]

--- a/test/test_snapshot_sqlite_uri.py
+++ b/test/test_snapshot_sqlite_uri.py
@@ -49,7 +49,7 @@ class TestAQuestionMarkInTheFilenameDoesNotRedirectTheCopy:
     def test_the_requested_database_is_the_one_copied(self, tmp_path):
         name = "memory?snapshot=1.db"
         src_dir, dst_dir = self._stage(tmp_path, name)
-        snapshot._restage_databases(src_dir, dst_dir)
+        snapshot._restage_databases(src_dir, dst_dir, bundle_root=dst_dir)
         assert _read(dst_dir / name) == [
             "wanted"
         ], "the copy opened a different database than the one requested"
@@ -59,11 +59,11 @@ class TestAQuestionMarkInTheFilenameDoesNotRedirectTheCopy:
         # Windows where the `?` case above cannot exist.
         name = "memory#1.db"
         src_dir, dst_dir = self._stage(tmp_path, name)
-        snapshot._restage_databases(src_dir, dst_dir)
+        snapshot._restage_databases(src_dir, dst_dir, bundle_root=dst_dir)
         assert _read(dst_dir / name) == ["wanted"]
 
     def test_an_ordinary_name_still_works(self, tmp_path):
         name = "plain.db"
         src_dir, dst_dir = self._stage(tmp_path, name)
-        snapshot._restage_databases(src_dir, dst_dir)
+        snapshot._restage_databases(src_dir, dst_dir, bundle_root=dst_dir)
         assert _read(dst_dir / name) == ["wanted"]


### PR DESCRIPTION
## What is the problem?

Snapshot's creation path stages each `.db` core file by connecting to the live database
BY NAME and READ-WRITE:

```python
with (
    closing(sqlite3.connect(str(src))) as src_conn,
    closing(sqlite3.connect(str(stage / f))) as dst_conn,
):
    src_conn.backup(dst_conn)
```

After #5156 moved the surrounding tree walk onto held directory descriptors, this was the
last unhardened SQLite read on that path. The tree re-stage pass had already been hardened
in the same work -- descriptor-verified path chain, percent-escaped URI, `mode=ro`, and
"not a database" told apart from "cannot read this database" -- and the core-file path had
none of it. Two paths, one job, opposite guarantees.

Read-write is not merely more authority than a backup needs. Measured on a fixture whose
`-wal` was left unreplayed by a killed writer, the read-write open recovered the log into
the main file and unlinked the log:

```
mode=ro   : main (8192, 'dad09ce2d860') -> (8192, 'dad09ce2d860')
            -wal (836392, 'b64e0e7a0f03') -> (836392, 'b64e0e7a0f03')
read-write: main (8192, 'dad09ce2d860') -> (16384, '0c84d765f848')
            -wal (836392, '61af7e74069f') -> None
```

So the backup command rewrites the database it was asked to read, and destroys the
operator's in-flight transaction state on the way past.

The issue also describes a second defect: a WAL check that races the copy. That one is a
property of a check-then-copy-BYTES design, not of the code on main, and the important
part of this change is that it does not introduce one.

## Why this issue matters to the user

Both failure modes are silent, and a snapshot is trusted at restore time. The by-name
reopen lets a database swapped in during the window between the screen and SQLite's own
open ride the bundle under the name `memory.db`, so the archive contains rows the user
never had. A check-then-copy-bytes design would produce the opposite: an archive missing
rows the user did have, because in WAL mode committed rows live in `<db>-wal` until a
checkpoint folds them back. Either way the command prints success.

The read-write open is worse than a latent exposure because it fires on the ordinary path,
with no attacker present: any user whose gateway was killed with a non-empty WAL has
`kirocrew snapshot` silently rewriting `memory.db` and deleting its log.

## How our fix solves it

Extract the hardened copy the tree pass already used into one helper,
`_copy_database_consistently`, and route BOTH staging paths through it. Four properties,
each of which was arrived at over the five review rounds on #5156, now hold once instead
of in one of two copies:

- **The path chain is verified through descriptors, not by name.** Every component is
  opened relative to the previous one with `O_NOFOLLOW`, so a directory that is a link --
  or swapped for one mid-run -- fails its own open rather than redirecting the read.
- **The URI is percent-escaped** via `as_uri()`, so a filename containing `?` or `#` is
  not parsed as the start of a query or fragment and truncated.
- **The connection is `mode=ro`.** This is the fix for the mutation shown above; a
  read-only connection cannot perform the recovery that rewrote the main file.
- **"Not a database" is told apart from "cannot read this database"** by probing
  readability separately from copying, so a locked database is never mistaken for a
  non-database and degraded to a byte copy that lacks its `-wal`.

**No checkpoint-then-copy-bytes is introduced, deliberately.** The chain from symptom to
root cause ends at the OPEN, not at the WAL: the backup API already reads a consistent
snapshot that includes rows living only in the log, so there is no check to race. Against
a cross-process writer with `wal_autocheckpoint=0` and a 1.5 MB log, the copy contained all
421 rows -- 371 of them WAL-resident -- and passed `integrity_check`. Replacing `backup()`
with a checkpoint and a byte copy would CREATE the second defect the issue warns about,
which is why the WAL-consistency tests in this PR are written as contract tests that pass
on base: their job is to stop that change being made later.

Three consequences of unifying the two paths, called out because they are behaviour
changes rather than pure hardening:

1. A corrupt core `.db` still FAILS the snapshot, and the asymmetry with the tree pass is
   now deliberate rather than accidental. An earlier revision of this PR "unified" the two
   and degraded a corrupt `memory.db` to a byte copy; review showed that is backwards. The
   snapshot then succeeds, `--keep N` counts the new archive as the newest backup and
   prunes a real one, and restore refuses the new archive at its strict database
   validation -- leaving nothing restorable after a command that printed success. Which
   databases those are is decided by SET MEMBERSHIP, not by core-versus-tree: a declared
   component file qualifies, and so does any tree path in `PRODUCT_TREE_DATABASES`, whose
   own contract is that everything in it is "validated as strictly as `memory.db`" and
   which the restore side already enforces via
   `_refuse_unless_sound(..., strict=rel in PRODUCT_TREE_DATABASES)`. Staging a corrupt
   `workspace/knowledge/knowledge.db` as bytes and reporting success therefore built an
   archive restore is guaranteed to refuse -- the same pruning chain, with the two ends of
   one invariant disagreeing. `_restage_databases` now takes the bundle root so it spells
   that key the way the restore side does; the parameter is required because a
   tree-relative key would match no entry and make the strictness silently vacuous. A `.db`
   under a tree that is NOT one of ours stays incidental and still rides as bytes, since
   failing a whole snapshot over a stray `Thumbs.db` would be an outage. The helper takes
   `require_database`, so the policy is stated once and each caller declares its contract.
2. A source that cannot be verified link-free is recorded in `MANIFEST.json`, not just on
   the console. The tree pass keeps its byte copy, because deleting it is data loss --
   which is exactly why the archive must stop claiming that database was copied
   consistently.
3. The pre-staging `wal_checkpoint` is REMOVED. It was the only write this command made
   to live data and it could not be made safe in place: a checkpoint cannot run read-only,
   and verifying the name first does not close the window because SQLite re-resolves it, so
   a swap put the WRITE into whatever the name then pointed at. Nothing the archive depends
   on is lost, per the WAL measurement above -- it only kept the log from riding along at
   full size. The creation path is now read-only end to end, which is a cleaner invariant
   than "read-only except one verified write", and it is what makes
   `test_the_command_never_writes_to_the_live_database` assertable at the command level.

4. The two `sqlite3.connect` calls sit INSIDE the error translation. A source lost between
   the probe and the copy raised a bare `sqlite3.OperationalError`, which `snapshot_main`
   does not catch, so the command exited on a traceback instead of naming the database.
   `mode=ro` widened that window rather than narrowing it -- a read-write open would have
   silently created an empty database -- so the fix belongs with the change that made it
   matter.

### What this does NOT close

Stated rather than implied. SQLite takes a PATH and cannot be pointed at a held descriptor
-- it refuses `/proc/self/fd/N` and `/dev/fd/N` alike -- so SQLite re-resolves the final
name itself, and a same-uid swap of that final component between the check and SQLite's
open is not detectable here. A post-hoc identity re-check does not close it either, since
swapping back defeats the check. Closing it needs a descriptor-taking VFS, which is a
different change. What this PR closes is the ANCESTORS (non-redirectable), the write
capability (removed), and the silent inconsistency (now recorded).

The issue also asked for a `BEGIN EXCLUSIVE` writer-excluding lock spanning a log check and
a copy, and flagged an unexplained anomaly where a prototype of that lock did not exclude
an in-process writer. That design is not needed and is not implemented: it exists to make a
byte copy safe, and this change keeps the backup API instead. The anomaly therefore does
not block anything here.

## What tests we did

New file `test/test_snapshot_db_staging_5451.py`, 12 tests. Mutation-verified against base
`7d36d4fec` by reverting `snapshot.py` alone and re-running: 4 go red for the intended
reason, 3 stay green by design.

Red on base:
- `test_a_snapshot_leaves_the_live_database_byte_identical` -- "staging rewrote the live
  memory.db -- a read-write open recovered the -wal into the main file". The core defect.
- `test_a_core_name_swapped_for_a_link_after_the_screen_is_not_archived` -- "the bundle
  carries a database from outside the data home under memory.db". The swap is injected
  immediately after the descriptor screen returns, which is the real check-to-use window.
- `test_the_failure_happens_before_any_backup_is_pruned` -- red against the intermediate
  revision that degraded a corrupt core database: "a snapshot over a corrupt core database
  reported success", with the operator's pre-existing archive pruned.
- `test_a_symlinked_data_home_does_not_traceback_out_of_the_checkpoint_guard` -- red
  against the intermediate revision with the exact predicted escape:
  `PinnedPathRefusal: refusing to use the database source root: ... is a symbolic link`.
- `test_a_tree_database_that_cannot_be_verified_is_recorded_in_the_manifest` -- base
  manifest is empty.

Green on base, and labelled in the module docstring as contract not regression tests:
- `test_the_staged_copy_still_holds_the_rows_that_lived_only_in_the_wal` (200 WAL-only rows
  all reach the archive, so read-only costs nothing in completeness)
- `test_the_pre_staging_checkpoint_is_skipped_rather_than_written_through_a_link`
- `test_an_unreadable_core_database_still_fails_the_snapshot_loudly` (a readable database
  whose copy fails still raises, distinct from the corrupt-file case)
- `test_a_tree_database_that_is_not_sqlite_still_rides_as_bytes` (the other half of the
  asymmetry, asserted so it is not "fixed" into symmetry again)
- `test_a_corrupt_core_database_fails_the_snapshot`

Existing suites: 696 passed across all 45 `test_snapshot*` / `test_portability` /
`test_lockdown*` files, including the `pinned_fs` AST ratchet in `test_pinned_staging.py`
(scoped to `pinned_fs.py`, unaffected).

One existing test needed updating rather than merely passing:
`test_both_database_copy_sites_raise_the_typed_error` asserted `calls >= 2`, counting the
two duplicated `backup()` blocks. Collapsing them into one helper is the refactor that
removes the duplication that test existed to police, so it would have failed on the fix
itself. It now asserts the stronger form -- exactly ONE call site, that site raises the
typed error, BOTH paths route through it, the probe fails closed, and the source is opened
`?mode=ro` -- so the invariant is preserved and tightened rather than weakened.

Gates: `isort`, `flake8`, `scripts/check_black_formatting.py` all clean on the touched
files. `mypy src/kiro_crew/snapshot.py` reports zero errors in `snapshot.py` (the two it
prints are in `transcribe.py`, which this diff does not touch). Full suites were left to
CI.

## Any other suggestions on the work

Two follow-ups, neither folded in:

1. **The pre-staging checkpoint could be removed entirely.** Now that WAL-consistency of
   the backup API is measured rather than assumed, it is a size optimisation only -- and it
   is the sole remaining write to live data on the creation path. Removing it would make
   the whole creation path read-only, which is a cleaner invariant than "read-only except
   one chain-verified write". Left alone here because dropping it changes behaviour beyond
   what this issue asks.
2. **The restore path still opens databases by name** (four sites, around
   `_merge_memory`, `_refuse_unless_sound` and the post-restore integrity check). That path
   writes live state by design, so the reasoning is different from this one and needs its
   own analysis rather than a mechanical application of this helper.

Round-2 review removed one residual I had recorded here. `DB_UNSAFE_SOURCE` on the core
path is no longer a recorded omission at all -- it raises, because an omitted required
database let the snapshot succeed and `--keep` then pruned the last complete archive. The
outcome still exists for the tree pass, where a byte copy is already present and keeping it
is correct.

## Pattern harvest

Rule candidate: semgrep
Pattern: a SQLite connection opened without `mode=ro` on a path the caller only reads. The
authority argument understates it -- `sqlite3.connect` on a database with an unreplayed
`-wal` RECOVERS the log into the main file and unlinks the log, so a read-write open mutates
the file even when the code never issues a write. Any backup, export, integrity-check or
inspection path is a hit.

Rule candidate: review checklist
Pattern: a declared strict-validation set consulted at only ONE end of a produce/consume
pair. `PRODUCT_TREE_DATABASES` documents that its members are "validated as strictly as
`memory.db`" and the restore path enforced it, while the creation path did not -- so the
product emitted archives its own validator rejects. Grep a membership test that appears in
the consumer but has no counterpart in the producer.

Closes #5451

