### PR TITLE
fix(config): apply the Windows config DACL whenever the caller has offloaded

### DIFF
--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -107,13 +107,21 @@ def _write_all(fd: int, data: bytes, path: Path) -> None:
         view = view[written:]
 
 
-def _on_event_loop() -> bool:
+def on_event_loop() -> bool:
     """Whether this thread is currently running an asyncio event loop.
 
     Mirrors the probe guarding ``CronService``'s store lock: a worker started by
     ``asyncio.to_thread`` or ``run_in_executor`` has no running loop of its own,
     so a caller that offloads its write keeps the retry while the loop thread
     itself never sleeps.
+
+    Public because it decides more than this module's own retries.
+    ``config/loader.py``'s ``write_config_atomically`` asks it before applying the
+    Windows owner-only DACL, whose cost on a network-homed data home is bounded
+    only by SMB. Both uses turn on the same property: the answer is about the
+    CALLING THREAD, so it holds no matter how many synchronous helpers sit between
+    a coroutine and the call, and a caller earns the stronger behavior by
+    offloading rather than by declaring anything.
     """
     try:
         asyncio.get_running_loop()
@@ -159,7 +167,7 @@ def replace_with_retry(src: Path | str, dst: Path | str) -> None:
         except PermissionError:
             if not platform_compat.IS_WINDOWS:
                 raise
-            if _on_event_loop():
+            if on_event_loop():
                 logger.debug(
                     "atomic rename contended at %s on the event loop; "
                     "re-raising instead of sleeping (offload the write to retry)",
@@ -215,7 +223,7 @@ def read_bytes_with_retry(path: Path | str) -> bytes:
         except PermissionError:
             if not platform_compat.IS_WINDOWS:
                 raise
-            if _on_event_loop():
+            if on_event_loop():
                 logger.debug(
                     "read contended at %s on the event loop; re-raising instead "
                     "of sleeping (offload the read to retry)",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -41,7 +41,7 @@ from kiro_crew import __version__, model_registry, platform_compat, windows_acl
 from kiro_crew.acp_backends import resolve_selected_backend
 
 # Leaf module (stdlib + platform_compat only) — no import cycle with config.
-from kiro_crew.atomic_write import atomic_write
+from kiro_crew.atomic_write import atomic_write, on_event_loop
 
 # Computer-use defaults/ceilings come from the feature's constants module rather
 # than being re-spelled here (AGENTS.md: no hardcoded values in business logic).
@@ -1046,6 +1046,17 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
     passing both to ``atomic_write``, which refuses ``restrict_to_owner=True``
     alongside a wider explicit ``mode``.
 
+    **On a network-homed data home the DACL turns on the CALLER, not the volume.**
+    The in-process lockdown costs 0.24 ms on a local volume but is bounded only by
+    SMB on a UNC or mapped-drive path, which a write running inline on the event
+    loop cannot afford. That is a fact about the calling thread, so it is asked as
+    one, via :func:`kiro_crew.atomic_write.on_event_loop`. A caller that has
+    offloaded this write -- ``dashboard/chat_utils.run_config_write``, any
+    ``asyncio.to_thread`` wrapper, and every CLI and startup path, which have no
+    loop at all -- blocks only its own thread and therefore gets the owner-only
+    DACL on **any** volume. Only a write still inline on the loop falls back to
+    classifying the volume and skipping when it is remote.
+
     **Symlinks are followed, not replaced.** ``os.replace`` renames over the link
     itself, turning a symlinked ``config.json`` into a regular file and orphaning
     its target — whereas the ``write_text`` this replaced followed the link and
@@ -1061,10 +1072,19 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
         pass
     # Decide the Windows lockdown HERE, before the stat and the mkdir below and
     # before anything atomic_write does -- every one of those is a round-trip on a
-    # network-homed data home, and this function runs inline on the event loop
-    # (async dashboard handlers reach it on every config write). A DACL write to a
-    # UNC or mapped-drive path is an unbounded SMB round-trip, so it has to be
-    # ruled out before the work starts rather than part way through.
+    # network-homed data home. A DACL write to a UNC or mapped-drive path is an
+    # unbounded SMB round-trip, so when it cannot be afforded it has to be ruled
+    # out before the work starts rather than part way through.
+    #
+    # But whether it can be afforded is a question about the CALLING THREAD, not
+    # about the volume. The volume was only ever a proxy: this function is
+    # synchronous and async dashboard handlers reach it inline, where an unbounded
+    # wait stalls the one loop the whole gateway shares. Off the loop there is
+    # nothing to stall -- a worker started by ``run_config_write`` /
+    # ``asyncio.to_thread``, a CLI invocation, a startup path all block only
+    # themselves -- so the same predicate ``atomic_write`` already gates its own
+    # unbounded-on-Windows step on decides here too, and a network-homed data home
+    # gets the DACL whenever its caller has offloaded the write.
     #
     # This sits just AFTER the symlink resolve rather than at the very top of the
     # function, and deliberately: a config symlinked into a dotfiles repo (which
@@ -1073,19 +1093,27 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
     # The resolve is two stats; the earliest CORRECT point is here.
     lock_down = platform_compat.IS_POSIX
     if not platform_compat.IS_POSIX:
-        try:
-            lock_down = windows_acl.volume_is_local(path)
-        except Exception:
-            # A descriptor API that cannot be loaded cannot tell us the volume is
-            # local, and the lockdown would have failed on this host anyway.
-            lock_down = False
-        if not lock_down:
-            logger.warning(
-                "config write: %s is on a non-local volume, so the owner-only "
-                "DACL was SKIPPED to avoid blocking the event loop on SMB; the "
-                "file may be readable by other local users",
-                path,
-            )
+        if not on_event_loop():
+            # Nothing to stall, so the volume does not decide -- and is not even
+            # classified, because its answer could only weaken the outcome.
+            lock_down = True
+        else:
+            try:
+                lock_down = windows_acl.volume_is_local(path)
+            except Exception:
+                # A descriptor API that cannot be loaded cannot tell us the volume
+                # is local, and the lockdown would have failed on this host anyway.
+                lock_down = False
+            if not lock_down:
+                logger.warning(
+                    "config write: %s is on a non-local volume and this write is "
+                    "running on the event loop, so the owner-only DACL was "
+                    "SKIPPED to avoid stalling the loop on SMB; the file may be "
+                    "readable by other local users. Offloading the write "
+                    "(dashboard/chat_utils.run_config_write) applies the DACL "
+                    "here too",
+                    path,
+                )
     try:
         mode = _stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
     except OSError:
@@ -1115,11 +1143,12 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
             restrict_on_error="warn",
         )
     else:
-        # Non-local volume: exactly the write this branch did before the lockdown
-        # was added, so a network-homed data home is no worse off than before and
-        # a local one is now protected. The residual is real and declared -- the
-        # file keeps its inherited ACL. Making this function's filesystem work
-        # async is the cause-level fix and is tracked separately (#6353).
+        # Reached only by a write still INLINE ON THE LOOP whose volume is not
+        # local: exactly the write this branch did before the lockdown was added,
+        # so such a data home is no worse off than before. The residual is real and
+        # declared -- the file keeps the ACL it inherits from its parent -- but it
+        # is now per CALLER rather than per platform: offloading a caller moves it
+        # to the branch above and it gets the DACL with no change needed here.
         atomic_write(path, payload, fsync=fsync, mode=mode)
 
 

--- a/test/test_config_rmw_preserves_settings.py
+++ b/test/test_config_rmw_preserves_settings.py
@@ -9,12 +9,44 @@ existing config raises, and a genuinely absent one still starts from ``{}``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
 
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import ConfigReadError, read_config_for_update
+
+
+def _inline_on_the_loop(fn, /, *args, **kwargs):
+    """Call *fn* from inside a running event loop, as an async handler does.
+
+    ``write_config_atomically`` is synchronous and several dashboard handlers
+    still reach it directly from a coroutine. That is the case its Windows volume
+    gate exists for, so a test about the gate has to actually be on a loop --
+    a plain test function is not, and would silently exercise the offloaded path
+    instead.
+    """
+
+    async def _main():
+        return fn(*args, **kwargs)
+
+    return asyncio.run(_main())
+
+
+def _offloaded(fn, /, *args, **kwargs):
+    """Call *fn* in a worker thread from a running loop.
+
+    The shape ``dashboard/chat_utils.run_config_write`` gives every config write
+    it owns: the loop stays free and the blocking work happens where a wait costs
+    nothing but the worker's own time.
+    """
+
+    async def _main():
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    return asyncio.run(_main())
+
 
 _REAL_SETTINGS = {
     "agent": {"approval_mode": "interactive", "max_subagents": 8},
@@ -325,8 +357,9 @@ class TestWriteConfigAtomically:
     def test_the_volume_is_classified_before_any_filesystem_work(self, tmp_path, monkeypatch):
         """Ordering IS the fix here, so it is asserted rather than the outcome alone.
 
-        This function runs inline on the event loop, and on Windows a DACL write to
-        a UNC or mapped-drive path is an unbounded SMB round-trip. A check placed
+        This case is a write running INLINE ON THE LOOP -- the one that cannot
+        afford the unbounded SMB round-trip a DACL write to a UNC or mapped-drive
+        path costs, and so the one the volume gate exists for. A check placed
         inside ``atomic_write`` -- where an earlier revision of this change put it
         -- is already too late: the ``stat`` and the ``parent.mkdir`` below, plus
         everything ``atomic_write`` does, each touch the target volume first, so the
@@ -336,6 +369,11 @@ class TestWriteConfigAtomically:
         config symlinked into a dotfiles repo can point at a different volume than
         the link, so classifying before resolving would classify the wrong volume.
         That is asserted too, rather than left implied.
+
+        The write is driven through :func:`_inline_on_the_loop` deliberately. A
+        plain test function has no running loop, which is now the OFFLOADED case
+        and skips the classification entirely -- so calling directly here would
+        assert nothing about the gate.
         """
         import kiro_crew.config.loader as loader
 
@@ -360,7 +398,9 @@ class TestWriteConfigAtomically:
         )
 
         path = tmp_path / "config.json"
-        loader.write_config_atomically(path, {"slack": {"bot_token": "xoxb-secret"}})
+        _inline_on_the_loop(
+            loader.write_config_atomically, path, {"slack": {"bot_token": "xoxb-secret"}}
+        )
 
         assert order[0] == "classify_volume", (
             "the volume must be classified before any filesystem work on it -- "
@@ -372,7 +412,7 @@ class TestWriteConfigAtomically:
 
     def test_a_local_volume_still_gets_the_lockdown(self, tmp_path, monkeypatch):
         # The other half: the gate must not become a blanket opt-out. On a local
-        # volume the write is protected exactly as it is without the gate.
+        # volume the on-loop write is protected exactly as it is without the gate.
         import kiro_crew.config.loader as loader
 
         locked: list[str] = []
@@ -381,7 +421,9 @@ class TestWriteConfigAtomically:
         monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: locked.append(str(p)))
 
         path = tmp_path / "config.json"
-        loader.write_config_atomically(path, {"slack": {"bot_token": "xoxb-secret"}})
+        _inline_on_the_loop(
+            loader.write_config_atomically, path, {"slack": {"bot_token": "xoxb-secret"}}
+        )
 
         assert len(locked) == 1, f"the lockdown must run on a local volume: {locked}"
         assert locked[0].endswith(".tmp"), "the DACL must land on the TEMP, before the content"
@@ -399,8 +441,109 @@ class TestWriteConfigAtomically:
         monkeypatch.setattr(loader.windows_acl, "volume_is_local", _boom)
 
         path = tmp_path / "config.json"
-        loader.write_config_atomically(path, {"auto_update": True})
+        _inline_on_the_loop(loader.write_config_atomically, path, {"auto_update": True})
         assert json.loads(path.read_text())["auto_update"] is True
+
+    def test_an_offloaded_write_gets_the_dacl_on_a_non_local_volume(self, tmp_path, monkeypatch):
+        """The fix. A network-homed data home is protected once the caller offloads.
+
+        The volume was never the thing that made the DACL unaffordable -- the
+        event loop was. A write handed to a worker thread (what
+        ``dashboard/chat_utils.run_config_write`` does for every config write it
+        owns) blocks nothing but that worker, so an unbounded SMB round-trip is
+        affordable and ``config.json`` gets the owner-only DACL even on a UNC or
+        mapped-drive path.
+
+        The volume must not even be classified here: its answer could only take
+        protection away, so asking would be both pointless and a round-trip.
+        """
+        import kiro_crew.config.loader as loader
+
+        locked: list[str] = []
+        classified: list[str] = []
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(
+            loader.windows_acl,
+            "volume_is_local",
+            lambda p: classified.append(str(p)) or False,  # a network-homed data home
+        )
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: locked.append(str(p)))
+
+        path = tmp_path / "config.json"
+        _offloaded(loader.write_config_atomically, path, {"slack": {"bot_token": "xoxb-secret"}})
+
+        assert len(locked) == 1, (
+            "an offloaded write blocks only its own worker, so the owner-only DACL "
+            f"must be applied regardless of the volume: {locked}"
+        )
+        assert locked[0].endswith(".tmp"), (
+            "the DACL must land on the TEMP file, before any content reaches it -- "
+            "otherwise the inline token exists in a readable file first"
+        )
+        assert not classified, (
+            "off the loop the volume must not be classified at all: its answer can "
+            f"only weaken the outcome, so asking is a wasted round-trip: {classified}"
+        )
+        assert json.loads(path.read_text())["slack"]["bot_token"] == "xoxb-secret"
+
+    def test_a_synchronous_caller_gets_the_dacl_on_a_non_local_volume(self, tmp_path, monkeypatch):
+        # The CLI and startup paths (cli_setup, cli_chat, KiroCrewConfig.save from
+        # boot) have no event loop at all, so they were skipping the DACL on a
+        # network-homed data home for a reason that never applied to them.
+        import kiro_crew.config.loader as loader
+
+        locked: list[str] = []
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(loader.windows_acl, "volume_is_local", lambda _p: False)
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", lambda p: locked.append(str(p)))
+
+        path = tmp_path / "config.json"
+        loader.write_config_atomically(path, {"slack": {"bot_token": "xoxb-secret"}})
+
+        assert len(locked) == 1, f"a caller with no loop has nothing to stall: {locked}"
+        assert locked[0].endswith(".tmp")
+
+    def test_an_offloaded_write_survives_a_lockdown_that_fails(self, tmp_path, monkeypatch):
+        # restrict_on_error="warn", not "raise": config.json must not become
+        # unwritable because a DACL could not be applied. Newly reachable on a
+        # non-local volume, so it is pinned there rather than assumed.
+        import kiro_crew.config.loader as loader
+
+        def _boom(_p):
+            raise OSError("the SMB share refused the descriptor write")
+
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(loader.windows_acl, "volume_is_local", lambda _p: False)
+        monkeypatch.setattr(platform_compat, "restrict_to_owner", _boom)
+
+        path = tmp_path / "config.json"
+        _offloaded(loader.write_config_atomically, path, {"auto_update": True})
+
+        assert json.loads(path.read_text())["auto_update"] is True, (
+            "a DACL that cannot be applied must warn and continue -- losing the "
+            "settings write would be strictly worse than an inherited ACL"
+        )
+
+    def test_the_predicate_answers_for_the_thread_that_actually_writes(self):
+        """The link the fix hangs on, asserted directly rather than inferred.
+
+        ``on_event_loop`` is asked from deep inside a synchronous call stack, so
+        what matters is that it reports on the CALLING THREAD: True in a coroutine,
+        False in the worker ``asyncio.to_thread`` hands the write to. If that ever
+        inverted, every case above would still pass while the real behaviour
+        flipped -- an on-loop write would take the SMB stall and an offloaded one
+        would skip the DACL it can afford.
+        """
+        from kiro_crew.atomic_write import on_event_loop
+
+        async def _both():
+            return on_event_loop(), await asyncio.to_thread(on_event_loop)
+
+        inline, offloaded = asyncio.run(_both())
+
+        assert inline is True, "a coroutine runs on the loop it must not stall"
+        assert offloaded is False, "asyncio.to_thread's worker has no loop of its own"
+        assert on_event_loop() is False, "a plain synchronous caller has no loop either"
 
     @pytest.mark.skipif(
         not platform_compat.IS_POSIX,


### PR DESCRIPTION
## Problem / Motivation

On Windows, `write_config_atomically` skips the owner-only DACL on any non-local
volume. A data home on a UNC path or a mapped network drive therefore leaves
`config.json` -- which can carry inline provider tokens and API keys -- on
whatever ACL it inherits from its parent directory, readable by other local
accounts on that machine.

The skip is deliberate. PR #5266 added the in-process DACL and, with it, this
gate: a descriptor write to a network path is an unbounded SMB round-trip, and
`write_config_atomically` is synchronous and reached inline from async dashboard
handlers on every config write. Stalling the gateway's single event loop on SMB
is worse than an inherited ACL, so the volume is classified first (before the
`stat`, the `mkdir` and anything `atomic_write` does) and the lockdown is skipped
when the volume is remote.

That is a gate rather than a cure, and #6353 asks for the cause-level fix.

## Why it matters

On a network-homed Windows data home this affects *every* config write, so
`config.json` never gets the owner-only DACL at all -- the file that holds
provider tokens stays as readable as its parent directory happens to be. It is
not a regression (before #5266 no DACL was applied on any volume), but it is a
declared gap rather than a fix.

Two populations were losing the DACL for a reason that never applied to them:
writes that had already been offloaded to a worker thread, and every CLI and
startup write, which has no event loop to protect in the first place.

## What changed (motivation -> approach -> change)

The volume was only ever a proxy for the real constraint. The gate's own
justification is "this must not stall the event loop" -- and whether that is a
risk is a question about the **calling thread**, not about the volume. Off the
loop there is nothing to stall: a worker started by `run_config_write` /
`asyncio.to_thread`, a CLI invocation and a startup path all block only
themselves.

`atomic_write` already owns that exact predicate and already gates its own
unbounded-on-Windows step on it -- `replace_with_retry`'s sharing-violation
retry sleeps only when there is no running loop, and its docstring states the
property this change depends on: it is a property of the calling thread, so it
holds no matter how many synchronous helpers sit between a coroutine and the
call. So `_on_event_loop` is promoted to a public `on_event_loop` and reused
rather than a second mechanism being invented.

The decision becomes:

- **Off the loop** -- apply the owner-only DACL on any volume, including a
  network-homed one. The volume is not even classified, because its answer could
  only take protection away.
- **On the loop** -- unchanged: classify the volume, skip when it is remote, and
  warn (the warning now also names the offload that avoids the skip).

Why this shape rather than the one the issue sketched: the issue proposed making
the config write async and then deleting the gate outright, and flagged the
API-shape choice (an `async` variant of `write_config_atomically` versus an
`asyncio.to_thread` wrapper at the handler boundary) as a maintainer call. That
call is already settled in the codebase -- `dashboard/chat_utils.run_config_write`
is documented as "the one async entry point" for config writes, offloads via
`asyncio.to_thread` under both config locks, and has 26 call sites. No new API
surface is needed. What the gate was missing was not an async variant but the
right question.

Deleting the gate is deliberately *not* done here: on-loop callers still exist,
and removing it while they do would put an unbounded SMB wait back on the loop --
the regression #5266 added the gate to prevent. Instead the residual becomes per
CALLER rather than per platform, and shrinks as remaining on-loop handlers are
offloaded, with no further change needed in this function.

This also stays clear of #4767 (a cross-process advisory lock on the same call
path): the change does not move where the write happens or alter any lock hold,
so the two do not need to be sequenced against each other.

## Tests

All in `test/test_config_rmw_preserves_settings.py`.

New:

- `test_an_offloaded_write_gets_the_dacl_on_a_non_local_volume` -- the fix. A
  write handed to a worker thread gets the owner-only DACL on a volume reported
  as non-local, the DACL lands on the temp file (before any content, so an inline
  token never exists in a readable file), and the volume is asserted *not* to be
  classified at all.
- `test_a_synchronous_caller_gets_the_dacl_on_a_non_local_volume` -- the CLI and
  startup population, which has no loop to protect.
- `test_an_offloaded_write_survives_a_lockdown_that_fails` -- pins
  `restrict_on_error="warn"` on the newly reachable path: a DACL that cannot be
  applied must not cost the settings write.
- `test_the_predicate_answers_for_the_thread_that_actually_writes` -- asserts
  `on_event_loop()` directly (True in a coroutine, False in `asyncio.to_thread`'s
  worker and in a plain sync call). If that inverted, every case above would
  still pass while the real behaviour flipped.

Updated -- three existing tests describe the ON-LOOP gate, so they now run their
scenario on a loop via a new `_inline_on_the_loop` helper. A plain test function
has no running loop, which is now the offloaded case; left as direct calls they
would have silently stopped testing the gate:
`test_the_volume_is_classified_before_any_filesystem_work` (the
classify-before-any-filesystem-work ordering, still asserted),
`test_a_local_volume_still_gets_the_lockdown`, and
`test_an_unloadable_descriptor_api_skips_rather_than_crashing`.

Mutation-verified: with the new branch forced off (base behaviour, volume always
decides), the two behaviour tests fail with their own messages and the other ten
in the class still pass.

Targeted runs, all green: `test_config_rmw_preserves_settings.py`,
`test_atomic_write_capabilities.py`, `test_atomic_write_retry.py`,
`test_atomic_write_migrated_sites.py`, `test_atomic_write_parent_link.py`,
`test_no_blocking_call_on_loop.py`, `test_windows_acl.py` -- 148 passed, 13
skipped. Plus flake8, isort, the black baseline gate, and the inclusive-language
scan on the added lines.

## Manual verification

**No Windows host was available, so the Windows-only path was not exercised end
to end.** Stating precisely what that does and does not leave verified:

- **Verified on Linux.** The decision logic, through the harness the #5266 tests
  already use: `platform_compat.IS_POSIX` patched False, with
  `windows_acl.volume_is_local` and `platform_compat.restrict_to_owner` stubbed
  to record calls. That covers which branch is taken, that the DACL is requested
  on the temp file rather than the final one, and that the volume is not
  classified off the loop.
- **Verified platform-independently.** The predicate itself is pure `asyncio`,
  with no platform component, and is asserted directly rather than inferred.
- **Not verified.** That a real `advapi32` descriptor write to a real UNC path
  completes in acceptable time inside a worker thread. The change only moves
  where that cost is paid; it does not make the cost bounded.
- **Not verified, and worth a reviewer's eye.** Worker-pool pressure:
  `asyncio.to_thread` uses the default bounded executor, so a DACL write hung on
  SMB occupies a pool slot. This is not a new exposure -- the file write to that
  same volume is already an unbounded round-trip on that same thread, so the slot
  is already held for the same reason -- but the added share of it is unmeasured
  here.

Reproducing on Windows would need a data home on a UNC path or mapped drive: a
config write from a dashboard handler that goes through `run_config_write` should
now produce an owner-only DACL on `config.json`, where previously it logged the
non-local-volume skip warning.

## Related Issues

Closes #6353

Follow-up to PR #5266 (which introduced the gate); part of the #4987 owner-only
sweep.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- the `write_config_atomically` and `on_event_loop` docstrings carry the new contract
- [x] No secrets, credentials, or internal references in the diff
