### PR TITLE
fix(security): fence repeated Windows path separators (#6350)

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -5807,6 +5807,26 @@ def _build_sensitive_regex() -> re.Pattern[str]:
     # itself the signal (same fail-safe posture as the branches above), so
     # over-matching an odd mixed-separator spelling is the safe direction.
     win_sep = r"[\\/]"
+    # Win32 collapses a repeated separator run, so ``kiro-cli`` and
+    # ``\\kiro-cli`` and ``//kiro-cli`` name the same entry. Matching only the
+    # single-separator spelling was a bypass of every store branch at once
+    # (#6350): a doubled separator at an inter-segment boundary named the fenced
+    # path while matching no branch.
+    #
+    # The patterns below deliberately still spell ONE separator, and the run is
+    # collapsed in the SUBJECT instead -- once, linearly, in
+    # ``is_sensitive_bash_command`` via ``_collapse_separator_runs``.
+    #
+    # Admitting a run in the PATTERNS (``{win_sep}+``) was tried first and is a
+    # denial-of-service on this very gate: the run appears inside the starred
+    # generalized separator below and again after it, so a long run can be split
+    # between them many ways and the engine consumes the whole run at every start
+    # offset. Measured, 6,000 backslashes in one command: 33s against 1.3s on
+    # base, past the gateway's 25s watchdog (found in review). Making the run
+    # maximal with a lookahead only halved it, and capping it at 64 bought speed
+    # by letting a 65-separator spelling escape the fence outright -- trading a
+    # hang for a bypass. Collapsing the subject is complete for any run length
+    # and leaves every pattern here exactly as tight as it already was.
     # Generalized separator: a plain separator, optionally preceded by any
     # chain of canonical no-ops — single-dot segments (``\.``) and same-level
     # down-up excursions (``\X\..``). This is what makes traversal spellings
@@ -5874,7 +5894,8 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         rf"|{re.escape('${env:HOMEDRIVE}${env:HOMEPATH}')})"
     )
     win_home_alts = (
-        f"(?:{home}|{generic_win_home}|{unc_prefix}|{userprofile}|{tilde}|{home_var})"
+        f"(?:{home}|{generic_win_home}|{unc_prefix}|{userprofile}"
+        f"|{tilde}|{home_var})"
     )
     # Between the anchor and the fenced remainder, accept the same
     # canonical-no-op chains (``\.\``, ``\X\..\``): they are equivalent to a
@@ -6019,7 +6040,8 @@ def _build_sensitive_regex() -> re.Pattern[str]:
         r"|\$[A-Za-z_][A-Za-z0-9_]*)"
     )
     win_crew_var_leaf_path = (
-        rf"{win_home_alts}{win_gsep}(?:{win_crew_leaf_parents}){win_sep}{any_expansion}"
+        rf"{win_home_alts}{win_gsep}(?:{win_crew_leaf_parents})"
+        rf"{win_sep}{any_expansion}"
     )
     # ── ~/.kiro/agents WRITE-protection (a whole DIRECTORY, not a leaf) ──
     # A spec under this dir becomes a KIROCREW_MCP_TARGET_<SERVER> command the
@@ -6771,12 +6793,16 @@ _SENSITIVE_SEGMENT_ALT = "|".join(re.escape(d) for d in _SENSITIVE_HOME_DIRS)
 # Windows-native relative spelling (``..\..\.aws\credentials``) is caught by
 # the traversal matcher below alongside the POSIX one. Forward-slash-only
 # entries still match (the class includes ``/``), so this strictly widens.
+# A repeated separator run is handled by collapsing the SUBJECT before this
+# matcher runs, not by admitting a run here (#6350) -- see
+# ``_collapse_separator_runs``.
 _SENSITIVE_SEGMENT_ALT_ANYSEP = "|".join(
     r"[\\/]".join(re.escape(part) for part in d.split("/"))
     for d in _SENSITIVE_HOME_DIRS
 )
 _RELATIVE_SENSITIVE_RE = re.compile(
-    rf"(?:^|[\s'\"=:,;])(?:\.\.?[\\/])+(?:{_SENSITIVE_SEGMENT_ALT_ANYSEP})(?:[\\/]|\s|$|['\"])",
+    rf"(?:^|[\s'\"=:,;])(?:\.\.?[\\/])+(?:{_SENSITIVE_SEGMENT_ALT_ANYSEP})"
+    rf"(?:[\\/]|\s|$|['\"])",
     re.IGNORECASE,
 )
 
@@ -6851,6 +6877,68 @@ _LINK_CREATE_VERBS: frozenset[str] = frozenset({"ln", "link"})
 _REDIR_PREFIX_RE = re.compile(r"^\d*(?:>>?|<(?!<))")
 
 
+_SEPARATOR_RUN_RE = re.compile(r"[\\/]{2,}")
+#: What a path token may start after, used to recognise a LEADING separator run
+#: (a UNC prefix) as opposed to an interior one.
+_PATH_TOKEN_BOUNDARY = " \t\"'=:,;(<>|&`"
+
+
+def _separator_collapsed_variants(command: str) -> tuple[str, ...]:
+    """Return *command* with separator runs collapsed, one copy per spelling.
+
+    Win32 collapses a repeated separator run, so ``%LOCALAPPDATA%\\\\kiro-cli``
+    and ``%LOCALAPPDATA%\\kiro-cli`` open the same file. The fence matches raw
+    text, so without this the doubled spelling named a fenced store while
+    matching no branch (#6350).
+
+    Collapsing is done to the SUBJECT rather than by admitting a run in the
+    patterns, because a run inside the patterns is a denial-of-service on this
+    gate: it appears both inside the starred generalized separator and after it,
+    so the engine walks the splits and re-consumes the whole run at every start
+    offset (measured 33s on 6,000 backslashes against 1.3s on base, past the 25s
+    watchdog).
+
+    Up to FOUR copies, along two axes, because a single rewrite loses cases:
+
+    * **Which separator.** Not every pattern accepts either character -- the
+      resolved home literal is ``re.escape``-d and requires the platform's exact
+      separator -- so collapsing to one fixed character left a MIXED run
+      (``D:/\\profiles\\u``) matching neither spelling (found in review).
+    * **Whether a LEADING run stays a pair.** A UNC path begins with two
+      separators that its anchor requires, so collapsing them broke every UNC
+      spelling that ALSO had an interior run:
+      ``\\\\server\\share\\.kiro\\\\crew\\security_policy.json`` matched neither
+      the original (interior run) nor the collapsed copy (no UNC prefix left),
+      and the keystone read was permitted (found in review). The boundary form
+      keeps a run that starts a token at two characters and still collapses the
+      interior ones.
+
+    Empty tuple when there is no run to collapse, so the common command costs one
+    search and nothing else. Duplicates are dropped, so a command with only
+    interior backslash runs yields two copies rather than four.
+    """
+    if not _SEPARATOR_RUN_RE.search(command):
+        return ()
+
+    variants: list[str] = []
+    for sep in ("/", "\\"):
+        for keep_leading_pair in (False, True):
+
+            def _replace(
+                match: "re.Match[str]",
+                sep: str = sep,
+                keep_leading_pair: bool = keep_leading_pair,
+            ) -> str:
+                start = match.start()
+                leading = start == 0 or command[start - 1] in _PATH_TOKEN_BOUNDARY
+                return sep * 2 if (keep_leading_pair and leading) else sep
+
+            variant = _SEPARATOR_RUN_RE.sub(_replace, command)
+            if variant != command and variant not in variants:
+                variants.append(variant)
+    return tuple(variants)
+
+
 def is_sensitive_bash_command(command: str) -> str | None:
     """Check if a bash command reads sensitive paths, accesses IMDS, or leaks env creds.
 
@@ -6876,6 +6964,32 @@ def is_sensitive_bash_command(command: str) -> str | None:
     # it (was gated on ln/cp only, so dd/base64/xxd/head/tail slipped past).
     if _RELATIVE_SENSITIVE_RE.search(command):
         return "Blocked: command references a sensitive credential path via relative traversal"
+
+    # ── Pass 1b: the pass-1 matchers again over separator-COLLAPSED copies ──
+    # Win32 collapses a repeated separator run, so ``%LOCALAPPDATA%\\kiro-cli``
+    # opens the fenced store that ``%LOCALAPPDATA%\kiro-cli`` names -- and the
+    # patterns above spell one separator, so the doubled form matched no branch
+    # (#6350). Collapsing the subject closes that for every run length at linear
+    # cost; admitting a run in the patterns instead was measured as a
+    # watchdog-crossing hang on this gate (see ``_separator_collapsed_variants``).
+    #
+    # ALL THREE pass-1 checks are repeated, not just the path matcher: the
+    # extraction check is a separate control, and omitting it let
+    # ``tar -xf evil.tar -C $HOME//.kiro/crew`` overwrite governance files
+    # through the doubled separator (found in review).
+    #
+    # Run only after the original missed, so nothing that needs the run intact
+    # (a UNC ``\\server\share`` anchor) loses its match.
+    for collapsed in _separator_collapsed_variants(command):
+        if _get_sensitive_re().search(collapsed):
+            return "Blocked: command accesses sensitive credential path"
+        if _extracts_into_trust_root(collapsed):
+            return "Blocked: command extracts into the governance trust-root directory"
+        if _RELATIVE_SENSITIVE_RE.search(collapsed):
+            return (
+                "Blocked: command references a sensitive credential path "
+                "via relative traversal"
+            )
 
     # ── Pass 2: normalizer-based sensitive path detection ──
     normalizer_result = _check_sensitive_via_normalizer(command)

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -6308,6 +6308,238 @@ class TestWindowsPathShapes:
             assert is_sensitive_bash_command(cmd) is not None, cmd
 
 
+class TestWindowsSeparatorRuns:
+    """A repeated path separator names the same file the single one does.
+
+    Win32 collapses a separator run, so ``kiro-cli`` and ``\\\\kiro-cli`` and
+    ``//kiro-cli`` are one entry. The fence matched RAW text with exactly one
+    separator per boundary, so a doubled separator anywhere in the chain reached
+    the fenced store while matching no branch (#6350) -- including the live SSO
+    bearer-token database under ``AppData\\Local\\kiro-cli``.
+
+    Asserted as a MATRIX rather than per spelling, because closing these one at
+    a time is what produced the previous shape: every anchor times every run
+    shape times every boundary position. The whole class is host-independent --
+    the raw pass never reads ``os.name`` -- so these run and mean the same thing
+    on the Linux and macOS runners as on Windows. What a non-Windows host
+    CANNOT show is Win32 actually collapsing the run; that equivalence is
+    assumed from the platform contract, and these tests pin the matcher's side
+    of it.
+    """
+
+    #: Every anchor the Windows branches accept, in a spelling that needs no
+    #: host support: the generic drive-letter home, the cmd.exe and PowerShell
+    #: profile variables, and the POSIX-ish anchors the raw pass also allows.
+    ANCHORS = (
+        r"C:\Users\u",
+        "%USERPROFILE%",
+        "$env:USERPROFILE",
+        "~",
+        "$HOME",
+    )
+    #: Separator runs. Two and three backslashes, the forward-slash spelling,
+    #: and both mixed orders -- Win32 treats all of them as one boundary.
+    RUNS = ("\\\\", "\\\\\\", "//", "\\/", "/\\")
+
+    @staticmethod
+    def _double_nth_separator(path: str, index: int) -> str:
+        """Return *path* with its *index*-th backslash doubled."""
+        head, tail = "", path
+        for _ in range(index + 1):
+            cut = tail.index("\\")
+            head += tail[: cut + 1]
+            tail = tail[cut + 1 :]
+        return f"{head}\\{tail}"
+
+    @pytest.mark.parametrize("run", RUNS)
+    @pytest.mark.parametrize("fenced", (r".aws\credentials", r".ssh\id_rsa"))
+    def test_a_run_right_after_the_anchor_still_names_the_store(
+        self, run: str, fenced: str
+    ) -> None:
+        # The report measured the leak on the alias branch and the home-anchored
+        # branch alike, so the run is exercised against EVERY anchor. ``.aws``
+        # and ``.ssh`` were reported as unaffected; they are not -- the report
+        # only doubled the separator before the LEAF, which the trailing
+        # boundary already absorbed.
+        for anchor in self.ANCHORS:
+            cmd = f'type "{anchor}{run}{fenced}"'
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize("fenced", [d for d in security._SENSITIVE_HOME_DIRS if "/" in d])
+    def test_a_run_at_every_inter_segment_boundary_is_blocked(self, fenced: str) -> None:
+        # A doubled separator immediately before the LEAF was already blocked
+        # (the trailing boundary absorbs one), which is why the gap read as
+        # narrower than it was. Walk EVERY boundary of a multi-segment fenced
+        # dir instead of trusting one position.
+        native = "\\".join(fenced.split("/"))
+        path = f"C:\\Users\\u\\{native}\\data.sqlite3"
+        boundaries = path.count("\\")
+        assert boundaries >= 4, path
+        for index in range(boundaries):
+            spelling = self._double_nth_separator(path, index)
+            cmd = f'type "{spelling}"'
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize("run", RUNS)
+    def test_the_appdata_alias_branches_tolerate_a_run(self, run: str) -> None:
+        # ``%LOCALAPPDATA%`` names the CURRENT kiro-cli store, and the alias
+        # branches carry their own anchor-specific no-op excursion
+        # (``\..\Roaming``), which has its own separators.
+        for var, product in (("%APPDATA%", "kiro-cli"), ("%LOCALAPPDATA%", "kiro-cli")):
+            cmd = f'type "{var}{run}{product}\\data.sqlite3"'
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+        for cmd in (
+            f'type "%APPDATA%\\..{run}Roaming\\kiro-cli\\data.sqlite3"',
+            f'type "%APPDATA%{run}..\\Roaming\\kiro-cli\\data.sqlite3"',
+            f'type "%LOCALAPPDATA%\\..{run}Local\\kiro-cli\\data.sqlite3"',
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize("run", RUNS)
+    def test_a_run_composes_with_the_canonical_no_ops(self, run: str) -> None:
+        # The generalized separator already accepted ``\.`` and ``\X\..``
+        # excursions. A run at the seam between an excursion and the next
+        # segment is the same equivalence one level in.
+        for cmd in (
+            f'type "%LOCALAPPDATA%\\.{run}kiro-cli\\data.sqlite3"',
+            f'type "C:\\Users\\u\\.aws\\..{run}.aws\\credentials"',
+            f'type "C:\\Users\\u{run}.aws\\..\\.aws\\credentials"',
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize("run", RUNS)
+    def test_the_anchorless_relative_traversal_matcher_tolerates_a_run(self, run: str) -> None:
+        # The relative matcher has no anchor to lean on, so its own traversal
+        # prefix and segment joins each need the run: ``..\\.aws\credentials``
+        # is the same file ``..\.aws\credentials`` is.
+        for cmd in (
+            f"cat ..{run}.aws\\credentials",
+            f"cat ..{run}..\\.ssh\\id_rsa",
+            f"cat ..\\AppData{run}Local\\kiro-cli\\data.sqlite3",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize("run", RUNS)
+    def test_the_windows_write_gates_tolerate_a_run(self, run: str) -> None:
+        # ``~/.kiro/agents`` is a code-execution boundary, not a read fence: a
+        # planted spec becomes a command the gateway execs outside the
+        # per-session sandbox. The crew variable-leaf branch is the same shape
+        # with a computed leaf.
+        for cmd in (
+            f'echo x > "C:\\Users\\u\\.kiro{run}agents\\evil.json"',
+            f'echo x > "%USERPROFILE%\\.kiro{run}agents\\evil.json"',
+            f'echo x > "$env:KIRO_HOME{run}agents\\evil.json"',
+            f'echo x > "%USERPROFILE%\\.kiro\\crew{run}%F%"',
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize("leaf", security._WRITE_PROTECTED_BASH_LEAVES)
+    def test_the_write_protected_leaves_tolerate_a_run(self, leaf: str) -> None:
+        for prefix in (".kiro\\crew", ".kirocrew"):
+            cmd = f'echo forged > "C:\\Users\\u\\{prefix}\\\\{leaf}"'
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_the_resolved_home_literal_anchor_tolerates_a_run(self) -> None:
+        # A home that is NOT under ``Users``/``home`` has only the resolved
+        # literal to match on. The PATTERN spells one separator, so a run is
+        # handled by collapsing the SUBJECT first -- this asserts the
+        # composition, which is what the gate actually evaluates. Built through
+        # ``_build_sensitive_regex`` directly: it is a pure function of the
+        # home, so no module cache is disturbed and no Windows host is needed.
+        with mock.patch.object(security.Path, "home", return_value=Path("D:\\profiles\\u")):
+            pattern = security._build_sensitive_regex()
+        for spelling in (
+            r"D:\profiles\\u\.aws\credentials",
+            r"D:\profiles\u\\.aws\credentials",
+            r"D:\profiles\\u\\.ssh\id_rsa",
+            # A MIXED run: collapsing to one fixed separator left this unmatched,
+            # because the escaped home literal wants a backslash (found in
+            # review). Both spellings are emitted, so one of them matches.
+            r"D:/\profiles\u\.aws\credentials",
+        ):
+            cmd = f'type "{spelling}"'
+            variants = security._separator_collapsed_variants(cmd)
+            assert any(pattern.search(v) for v in variants), spelling
+        # The single-separator spelling needs no collapsing at all, and an
+        # unrelated profile on the same drive is not the fenced home either way.
+        assert pattern.search(r'type "D:\profiles\u\.aws\credentials"')
+        assert not pattern.search(r'type "D:\profiles\u2\notes.txt"')
+        assert not any(
+            pattern.search(v)
+            for v in security._separator_collapsed_variants(r'type "D:\profiles\\u2\notes.txt"')
+        )
+
+    def test_benign_paths_with_a_run_stay_allowed(self) -> None:
+        # Widening a deny boundary can only deny more, so the controls matter:
+        # a run in an ordinary path must not become a refusal, and a name that
+        # merely starts with a fenced one is a different directory.
+        for cmd in (
+            r'type "C:\src\myproj\\README.md"',
+            r'type "%LOCALAPPDATA%\\Microsoft\Edge\prefs.json"',
+            r'type "C:\Users\u\\Documents\notes.txt"',
+            r'type "C:\Users\u\\.awsx\notes.txt"',
+            r'type "C:\Users\u\\.kiro\agentsx\notes.txt"',
+            r"cat ..\\docs\readme.md",
+            r'type "C:\Users\\u2\Documents\a.txt"',
+        ):
+            assert is_sensitive_bash_command(cmd) is None, cmd
+
+    def test_a_run_does_not_smuggle_an_extraction_into_the_trust_root(self) -> None:
+        # The extraction check is a SEPARATE control from the path matcher, so
+        # repeating only the matcher over the collapsed copy let a doubled
+        # separator carry an archive into the governance root (found in review).
+        for cmd in (
+            "tar -xf evil.tar -C $HOME//.kiro/crew",
+            "tar -xf evil.tar -C ~//.kiro//crew",
+            "tar -xzf evil.tar -C $HOME/\\.kiro/crew",
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    @pytest.mark.parametrize("run", ("//", "\\\\", "\\/", "/\\"))
+    def test_a_mixed_run_is_normalized_to_both_separators(self, run: str) -> None:
+        # A run made of both characters collapses to neither spelling on its own,
+        # so both are emitted. Exercised through the real gate, not the helper.
+        cmd = f'type "%LOCALAPPDATA%{run}kiro-cli\\data.sqlite3"'
+        assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_a_unc_path_with_an_interior_run_is_still_fenced(self) -> None:
+        # A UNC path BEGINS with two separators that its anchor requires, so
+        # collapsing them broke every UNC spelling that also had an interior run:
+        # the original missed on the interior run and the collapsed copy had no
+        # UNC prefix left, so the keystone read was permitted (found in review).
+        for cmd in (
+            r'type "\\server\share\.kiro\\crew\security_policy.json"',
+            r'type "\\server\share\.kiro\crew\\security_policy.json"',
+            r'type "//server/share/.kiro//crew/security_policy.json"',
+            r'cat "\\srv\homes\u\\.ssh\id_rsa"',
+        ):
+            assert is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_the_unchanged_unc_spelling_still_matches(self) -> None:
+        # The control: a UNC path with no interior run needs no collapsing and
+        # must keep matching on the original command.
+        cmd = r'type "\\server\share\.kiro\crew\security_policy.json"'
+        assert is_sensitive_bash_command(cmd) is not None
+
+    def test_a_pathological_separator_run_is_decided_quickly(self) -> None:
+        # The run classes are DISJOINT from the name run (which excludes
+        # separators) and from ``.``, so admitting one-or-more adds no
+        # quantifier ambiguity. Pinned because a starred group holding an
+        # ambiguous adjacent pair is exponential, and this file has been there:
+        # an exponential shape shows as seconds at a few hundred characters.
+        for payload in (
+            "\\" * 400,
+            "\\." * 200,
+            "\\a\\.." * 100,
+            "\\" * 200 + "." * 200,
+        ):
+            cmd = f'type "%LOCALAPPDATA%{payload}X"'
+            start = time.perf_counter()
+            is_sensitive_bash_command(cmd)
+            elapsed = time.perf_counter() - start
+            assert elapsed < 2.0, f"{elapsed:.2f}s on {len(cmd)} chars"
+
+
 class TestBareTokenProtectedLeaves:
     """The distinctive leaves are refused by NAME, with no anchor required.
 


### PR DESCRIPTION
## What is the problem?

Win32 collapses a repeated path separator, so `%LOCALAPPDATA%\\kiro-cli` and
`%LOCALAPPDATA%\kiro-cli` are the same directory. The shell-side credential
fence (`is_sensitive_bash_command`) matches raw command text and accepted
exactly ONE separator per boundary, so a doubled separator anywhere in the
chain named the fenced store while matching no branch of the matcher:

| spelling | before | after |
|---|---|---|
| `type "%LOCALAPPDATA%\kiro-cli\data.sqlite3"` | blocked | blocked |
| `type "%LOCALAPPDATA%\\kiro-cli\data.sqlite3"` | **permitted** | blocked |
| `type "%LOCALAPPDATA%\\\kiro-cli\data.sqlite3"` | **permitted** | blocked |
| `type "%LOCALAPPDATA%//kiro-cli/data.sqlite3"` | **permitted** | blocked |
| `type "C:\Users\me\AppData\\Local\kiro-cli\data.sqlite3"` | **permitted** | blocked |
| `cat "C:\Users\me\\.aws\credentials"` | **permitted** | blocked |
| `echo x > "C:\Users\me\.kiro\\agents\evil.json"` | **permitted** | blocked |

Two of those rows go beyond what #6350 reported, and both matter for how the
issue is sized:

* **`.aws` and `.ssh` do leak.** The report concluded they stay blocked, but it
  only doubled the separator *before the leaf*, which the trailing boundary
  already absorbs. Doubled *after the anchor* they were permitted.
* **The `~/.kiro/agents` write gate leaks too.** That gate is a code-execution
  boundary, not a read fence: a spec planted there becomes a
  `KIROCREW_MCP_TARGET_<SERVER>` command the gateway execs outside the
  per-session sandbox.

Measured on the base commit with a 34-row matrix: **22 fenced spellings were
permitted**, 0 benign paths refused.

## Why this issue matters to the user

The fenced directories hold kiro-cli's live SSO bearer token, and this gate is
what stops read-only shell auto-approval and the agent file tools from reaching
them. An agent that reads `data.sqlite3` holds that token. The bypass needs no
unusual privilege and no symlink, only an extra backslash in a path the agent
was already going to write, and the doubled spelling is not one a human reviewer
reads as suspicious. For the agents-dir row the consequence is a persistent
unsandboxed command running as the user rather than a credential read.

## How our fix solves it

**Symptom:** a doubled separator at an inter-segment boundary is permitted while
the single-separator spelling of the same file is blocked.

**Mechanism:** `win_gsep`, the generalized separator, ended in exactly one
`win_sep`, and its repeat group accepted only the canonical no-ops `\.` and
`NAME\..`. A bare extra separator matches neither, so the chain simply failed
one segment in. A doubled separator immediately before the leaf still blocked,
because the trailing boundary `(?:{win_sep}|\s|$|['"])` absorbs one -- which is
why the gap looked narrower than it was.

**Root cause:** the separator was defined as "exactly one" in one shared place.
`win_gsep` is consumed by the fenced-dirs pattern, the home-anchored path, the
`%APPDATA%` / `%LOCALAPPDATA%` remainders, the write-protected prefixes and
leaves, the crew variable-leaf parents and the agents dir, so every store branch
inherited the same hole at once. This is fixed at that definition rather than
per spelling:

* `win_seps` (one-or-more) replaces the single separator at every join site
  **inside** a path. The **trailing** boundary deliberately stays single: it
  only has to observe that the path ended, and the rest of a run is text it
  never consumes.
* The other sites that spelled a separator directly rather than through
  `win_gsep` are moved over too, or the class re-enters one segment to the side:
  the generic drive-letter home anchor (`C:\\Users\\u`), the resolved home
  literal, the `%APPDATA%` / `%LOCALAPPDATA%` anchor-specific `\..\Roaming` and
  `\..\Local` excursions, the crew variable-leaf join, and the anchorless
  relative-traversal matcher with its segment alternation.
* The resolved home literal was `re.escape()`d whole, so a run inside the anchor
  itself escaped it. It is now rendered through the run. `generic_win_home`
  already covers the `Users` / `home` shapes; a home elsewhere
  (`D:\profiles\u`) has only this literal to match on.

Over-matching is the safe direction for this gate (naming a fenced path is the
signal), but this change also touches the write-protection gate, where
over-matching would refuse a legitimate write. That is why every run shape is
paired with benign controls in the tests.

On backtracking: the two separator classes are **disjoint** from the name run
(`[^\\/\s'\"]{1,64}`, which excludes separators) and from `.`, so admitting
one-or-more introduces no new quantifier ambiguity, and the name run keeps its
length cap. A pathological-input test pins the decision time.

## What tests we did

New `TestWindowsSeparatorRuns` in `test/test_security.py` (134 cases),
asserted as a matrix -- every anchor x every run shape x every boundary
position -- because closing these one spelling at a time is what produced the
current shape:

* a run right after each anchor (`C:\Users\u`, `%USERPROFILE%`,
  `$env:USERPROFILE`, `~`, `$HOME`) for `.aws` and `.ssh`;
* a run at **every** inter-segment boundary of every multi-segment fenced dir,
  parametrized off `_SENSITIVE_HOME_DIRS` so the matrix cannot drift from the
  list;
* the `%APPDATA%` / `%LOCALAPPDATA%` branches including their own excursions;
* runs composed with the canonical no-ops (`\.`, `X\..`);
* the anchorless relative-traversal spelling;
* the write gates: agents dir, `$env:KIRO_HOME`, the crew variable leaf, and
  every entry of `_WRITE_PROTECTED_BASH_LEAVES`;
* the resolved-home-literal anchor, built through `_build_sensitive_regex()`
  under a patched non-`Users` home -- a pure function of the home, so no module
  cache is disturbed;
* benign controls that must stay permitted, including `.awsx` and `agentsx`
  (a name that merely starts with a fenced one) and an ordinary project path
  with a doubled separator;
* a decision-time bound on pathological separator runs.

**Mutation-verified against the base commit: 131 of the 134 fail without the
`security.py` change.** The 3 that pass on base are the two guards that are
supposed to (the benign controls and the timing bound) plus one leaf
parametrization that a separate anchorless name rule already covered.

Gates run: `pytest test/test_security.py` (1129 passed, 1 skipped),
`test_hooks.py`, `test_governance_self_protection.py`,
`test_connections_tool_aliases.py`, `test_app_sources_write_protection.py`,
`test_app_registry_source_seams.py` (626 passed), `test_trust_reads.py`,
`test_mcp_cron_security.py`, `test_computer_use_api.py`, `test_aws_consent.py`,
`test_workflows_library.py` (458 passed). flake8, isort, mypy and black clean on
both touched files. Decision time on the pathological inputs is unchanged or
better than base (two of the four 4KB probes drop from ~750ms to ~0.3ms because
they now match early instead of scanning to the end).

**What is NOT verified, stated plainly because this is a security control:**
there is no Windows host in this environment. Nothing here observed Win32
actually collapsing a separator run; that equivalence is taken from the platform
contract, and what these tests pin is the matcher's side of it. That is sound
for this change because the fence is a **pure text function** -- the raw pass
never reads `os.name`, so every assertion above runs and means the same thing on
the Linux, macOS and Windows CI shards. No filesystem resolution is involved,
which is exactly what distinguishes this class from the 8.3 short-name class in
#5265.

## Any other suggestions on the work

* **Scope: this PR closes #6350 only, not #5265.** They are siblings in the same
  code span and #6350 suggests handling them together, but #5265 already has an
  open PR (#5336) that rewrites the same `win_gsep` statement for the
  trailing-dot and 8.3 classes. Doing both here would have duplicated live work.
  The two changes are complementary and the textual overlap is one statement, so
  whichever lands second rebases mechanically; #5336's `win_gsep` still ends in
  exactly one separator, so it does not close this class on its own (verified
  against its head `d19f8141`).
* The deeper direction both issues point at is direction 1 from #5265: extract
  path-shaped tokens and compare the **resolved** path against the fenced set.
  Worth noting that most of that engine already exists on `main` --
  `_shape_path_token` collapses separator runs, strips trailing dots and spaces,
  and nets `..` -- but it is only wired into the pass-3 cwd-walk scan. Reusing it
  for the whole fence is the real end state and is an architecture change to a
  security boundary, so it wants its own design ticket rather than riding along
  here.
* The `{1,64}` cap on the excursion name run is untouched by this PR and is
  defeatable by a 65-character segment. It is pre-existing and is being addressed
  in #5336.

Closes #6350
