### PR TITLE
test(i18n): govern hooked carriers in the memo-i18n subscription ratchet

### DIFF
--- a/website/src/test/MemoI18nSubscriptionRatchet.test.ts
+++ b/website/src/test/MemoI18nSubscriptionRatchet.test.ts
@@ -42,7 +42,7 @@
  *    `LanguageProvider` documents why the value must stay identity-fresh.
  *    Forcing `useLanguageGeneration()` onto such a consumer would be redundant.
  *
- * ## Why the trigger follows imports, and only through hook-free modules
+ * ## Why the trigger follows imports, and how far it travels
  *
  * Language dependence is transitive. `utils/timeAgo.ts` imports the seam and
  * re-exports its output as a plain function, so a memo boundary that renders
@@ -51,27 +51,63 @@
  * see. That is the same "added one innocent import at a time" route the
  * direct-import branch closed, one module further out (#5922).
  *
- * So a module counts as a LANGUAGE WRAPPER when it contains no React hook call
- * AND it either imports the seam directly or imports another wrapper. The
- * hook-free half is the load-bearing one, and it is a statement about who CAN
- * fix the staleness:
+ * So a module counts as a LANGUAGE WRAPPER when it carries the seam's output
+ * onward with nothing in its own file requiring a subscription for it: it
+ * imports the seam directly or imports another wrapper, AND it is not already
+ * governed. "Governed" is a statement about who CAN fix the staleness, and two
+ * shapes satisfy it:
  *
  *  - A hook-free module cannot subscribe to anything. It is a plain function
  *    (or a hookless presentational component) reading the active language at
  *    call time, so the only site where a subscription can exist is the memo
- *    boundary that calls it. Flagging that caller points at the one fix.
- *  - A module that already calls hooks owns its own freshness: it can add
- *    `useLanguageGeneration()` itself, and if it has a memo boundary the two
- *    branches above already require it. Propagating the trigger to ITS callers
- *    would red a parent for a child's omission and nudge the fix into the wrong
- *    file, so the trigger stops at the first hooked module.
+ *    boundary that calls it. Flagging that caller points at the one fix. Such a
+ *    module is never governed, so it always carries onward.
+ *  - A module that calls hooks CAN subscribe. When it does, or when it has a
+ *    memo boundary of its own -- which the two branches above already require a
+ *    subscription for -- the walk stops there: that file is fresh on a switch
+ *    and its callers re-render through it.
  *
- * The wrapper set is therefore a CLOSURE over hook-free modules, not a fixed
- * depth: a hook-free wrapper of a wrapper cannot subscribe either, so capping
- * the walk at one hop would recreate the same blind spot one module further out
- * and contradict the rule's own premise. The closure is what makes it
- * self-consistent, and it costs one loop -- measured at 31 modules reached in 2
- * rounds, with zero offenders.
+ * What that leaves is a hooked module with NO memo boundary and NO subscription,
+ * which is #6111: branch 1 does not see it (no `i18nT(`), branch 2 skips it (no
+ * boundary), and excluding it from the wrapper set left its memoized callers
+ * with nothing to satisfy either. A custom hook of that shape returns
+ * language-dependent output straight into `memo(() => useSomething(t))`, and the
+ * subtree keeps the previous catalog with nothing red. So it carries onward too.
+ *
+ * Requiring the subscription IN such a module was the other candidate, and it is
+ * wrong for this tree. The four hook-exporting instances measured are a
+ * type-and-localStorage importer, two prompt builders whose resolved language is
+ * a functional payload handed to a model at click time, and one whose collated
+ * list is captured into state by a user gesture -- a `useLanguageGeneration()`
+ * call fixes nothing in any of them, and in the last the value would still be
+ * stale after the extra render. Propagating instead asks nothing of them and
+ * lands the obligation on the memo boundary that actually renders, where the
+ * staleness is observable. Either fix satisfies it: the boundary subscribes, or
+ * the hooked module does and drops out of the set.
+ *
+ * That trade -- a parent flagged for a child's omission -- is the one #6093
+ * declined, narrowed here to the case where NOBODY on the path subscribed. One
+ * subscription anywhere along the chain stops the walk.
+ *
+ * The wrapper set is therefore a CLOSURE, not a fixed depth: a carrier of a
+ * carrier is not governed either, so capping the walk at one hop would recreate
+ * the same blind spot one module further out and contradict the rule's own
+ * premise. It costs one loop -- measured at 243 of 1262 modules, 89 of which
+ * import the seam directly, with zero offenders and the SAME ten triggered memo
+ * files as before the hooked tier existed, so the extension arms the guard
+ * without moving today's tree.
+ *
+ * The set stays bounded for a reason worth stating: a subscribing module is
+ * excluded, and #5543 converted the rendering tree to subscribe, so what
+ * accumulates is non-rendering plumbing that memo boundaries rarely import.
+ *
+ * Accepted residue: the import edge is module-granular, not binding-granular, so
+ * a module joins the set for importing ANY binding from a wrapper -- including a
+ * type, or an unrelated helper the wrapper happens to export next to a
+ * language-dependent one (`apps/issue-radar/context.tsx` enters on localStorage
+ * helpers from `lib/format.ts`, and ten more enter behind it). The base rule
+ * already accepts this: the regex is a trigger for a per-file audit, so a red
+ * names a path to READ, not a proof that every hop on it is language-dependent.
  *
  * A direct `i18next.language` read is the small sibling of the same gap (e.g.
  * `components/commandPalette/providers/recentsProvider.ts`): the file reads the
@@ -176,16 +212,36 @@ export function resolveSpecifier(fromRel: string, spec: string, known: Set<strin
 }
 
 /**
- * Modules that carry the seam's language-dependent output and cannot subscribe
- * on their own: no hook call, and either a direct `i18n/format` import or an
- * import of another such module. Closed to a fixpoint, because a hook-free
- * wrapper of a wrapper cannot subscribe either -- see the header for why the
- * walk stops at the first hooked module rather than at a fixed depth.
+ * Whether a module that CALLS hooks still carries the seam's output onward.
+ *
+ * True only when nothing in the file governs that output: no memo boundary (the
+ * two branches above would already require the subscription here) and no
+ * subscription of either accepted shape (a subscribing module recomputes on a
+ * switch, so its callers are fresh through it). Hook-free modules never reach
+ * this test -- they can never subscribe, so they always carry onward.
+ */
+export function carriesSeamOutputOnward(src: string): boolean {
+  const { boundaries, subscriptions, languageContextReads } = scanFile(src)
+  return boundaries === 0 && subscriptions + languageContextReads === 0
+}
+
+/**
+ * Modules that carry the seam's language-dependent output to their callers with
+ * nothing in their own file required to keep it fresh: a direct `i18n/format`
+ * import or an import of another such module, in a file that is either hook-free
+ * (cannot subscribe) or hooked-but-ungoverned (no memo boundary, no
+ * subscription -- #6111). Closed to a fixpoint, because a carrier of a carrier
+ * is not governed either -- see the header for why the walk stops at a
+ * subscription or a memo boundary rather than at a fixed depth.
  */
 export function languageWrapperModules(sources: Map<string, string>): Set<string> {
   const known = new Set(sources.keys())
   const code = new Map([...sources].map(([rel, src]) => [rel, stripComments(src)]))
-  const candidates = [...code].filter(([rel, src]) => rel !== LANGUAGE_SEAM && !HOOK_CALL.test(src))
+  const candidates = [...sources]
+    .filter(([rel, src]) =>
+      rel !== LANGUAGE_SEAM && (!HOOK_CALL.test(code.get(rel)!) || carriesSeamOutputOnward(src)),
+    )
+    .map(([rel]) => [rel, code.get(rel)!] as [string, string])
   const wrappers = new Set(candidates.filter(([, src]) => FORMAT_IMPORT.test(src)).map(([rel]) => rel))
   for (;;) {
     const grew = candidates.filter(([rel, src]) =>
@@ -259,8 +315,10 @@ describe('memo() + i18nT() subscription ratchet', () => {
       if (EXEMPT.has(rel)) continue
       const { boundaries, subscriptions, importsFormat, readsI18nextLanguage, languageContextReads } = scanFile(src)
       if (boundaries === 0) continue
-      // One hop out: a wrapper's output is the seam's output, and the wrapper
-      // cannot subscribe on its own, so this boundary owns the freshness.
+      // A wrapper's output is the seam's output, and no file along the way is
+      // required to keep it fresh -- hook-free ones cannot subscribe, hooked
+      // ones with no boundary and no subscription are governed by nothing -- so
+      // this boundary owns the freshness.
       const viaWrappers = importedSpecifiers(src)
         .map(spec => resolveSpecifier(rel, spec, known))
         .filter((dep): dep is string => dep !== null && wrappers.has(dep))
@@ -284,9 +342,11 @@ describe('memo() + i18nT() subscription ratchet', () => {
       offenders,
       'src/i18n/format.ts formatters read the active language at call time, so a memoized component ' +
       'rendering their output goes stale after a language switch exactly like an i18nT() one -- whether ' +
-      'it calls them directly, through a hook-free wrapper module one import hop away, or reads ' +
+      'it calls them directly, through a chain of carrier modules that no branch requires to subscribe ' +
+      '(hook-free helpers, or hooks with no memo boundary and no subscription), or reads ' +
       'i18next.language itself. Each such memo() boundary must call useLanguageGeneration() or consume ' +
-      'the useLanguage() context (which re-renders through memo), or be exempted here with a reason.',
+      'the useLanguage() context (which re-renders through memo); alternatively the named carrier can ' +
+      'subscribe, which drops it and everything behind it out of the set. Or exempt it here with a reason.',
     ).toEqual([])
   })
 
@@ -411,11 +471,44 @@ describe('wrapper closure and import resolution', () => {
     expect([...wrappers]).toEqual(['utils/timeAgo.ts'])
   })
 
-  it('does not treat a hooked seam importer as a wrapper: it can subscribe itself', () => {
+  it('treats an ungoverned hooked seam importer as a wrapper: nothing else can be flagged', () => {
+    // #6111: hooks but no memo boundary and no subscription, so neither branch
+    // sees it and its memoized callers had nothing to satisfy.
     const wrappers = languageWrapperModules(new Map([
-      ['components/Row.tsx', `import { fmtDate } from '../i18n/format'\nexport const Row = () => { const [x] = useState(0); return fmtDate(x) }`],
+      ['hooks/useStamp.ts', `import { fmtDate } from '../i18n/format'\nexport const useStamp = (t) => { const [x] = useState(t); return fmtDate(x) }`],
+    ]))
+    expect([...wrappers]).toEqual(['hooks/useStamp.ts'])
+  })
+
+  it('does not treat a SUBSCRIBED hooked seam importer as a wrapper: it is fresh on a switch', () => {
+    const wrappers = languageWrapperModules(new Map([
+      ['hooks/useStamp.ts', `import { fmtDate } from '../i18n/format'\nexport const useStamp = (t) => { useLanguageGeneration(); return fmtDate(t) }`],
     ]))
     expect([...wrappers]).toEqual([])
+  })
+
+  it('does not treat a language-context consumer as a wrapper either', () => {
+    const wrappers = languageWrapperModules(new Map([
+      ['hooks/useStamp.ts', `import { fmtDate } from '../i18n/format'\nexport const useStamp = (t) => { const { language } = useLanguage(); return fmtDate(t) }`],
+    ]))
+    expect([...wrappers]).toEqual([])
+  })
+
+  it('does not treat a hooked seam importer WITH a memo boundary as a wrapper: branch 2 owns it', () => {
+    // The boundary is where the staleness shows, and the two branches above
+    // already require the subscription in this very file -- so propagating to
+    // its callers would flag a second file for one defect.
+    const wrappers = languageWrapperModules(new Map([
+      ['components/Row.tsx', `import { fmtDate } from '../i18n/format'\nexport default memo(function Row({ d }) { const [x] = useState(d); return fmtDate(x) })`],
+    ]))
+    expect([...wrappers]).toEqual([])
+  })
+
+  it('carriesSeamOutputOnward is false as soon as the file governs its own output', () => {
+    expect(carriesSeamOutputOnward(`export const useStamp = (t) => { const [x] = useState(t); return x }`)).toBe(true)
+    expect(carriesSeamOutputOnward(`export const useStamp = () => { useLanguageGeneration() }`)).toBe(false)
+    expect(carriesSeamOutputOnward(`export const useStamp = () => { const { language } = useLanguage() }`)).toBe(false)
+    expect(carriesSeamOutputOnward(`export default memo(function Row() { return null })`)).toBe(false)
   })
 
   it('never treats the seam itself as a wrapper, and needs a real seam import', () => {
@@ -427,19 +520,45 @@ describe('wrapper closure and import resolution', () => {
     expect([...wrappers]).toEqual([])
   })
 
-  it('closes over hook-free wrappers of wrappers, and stops at the first hooked module', () => {
+  it('closes over carriers of carriers, through hook-free and ungoverned hooked modules alike', () => {
     const wrappers = languageWrapperModules(new Map([
       ['utils/timeAgo.ts', `import { fmtRelative } from '../i18n/format'\nexport const timeAgo = (t) => fmtRelative(t)`],
       ['utils/stamp.ts', `import { timeAgo } from './timeAgo'\nexport const stamp = (t) => timeAgo(t)`],
       ['utils/label.ts', `import { stamp } from '@/utils/stamp'\nexport const label = (t) => stamp(t)`],
       ['hooks/useStamp.ts', `import { label } from '../utils/label'\nexport const useStamp = (t) => { const [v] = useState(label(t)); return v }`],
-      ['components/Far.tsx', `import { useStamp } from '../hooks/useStamp'\nexport const Far = () => useStamp(1)`],
+      ['hooks/useFresh.ts', `import { useStamp } from './useStamp'\nexport const useFresh = (t) => { useLanguageGeneration(); return useStamp(t) }`],
+      ['components/Far.tsx', `import { useFresh } from '../hooks/useFresh'\nexport const Far = () => useFresh(1)`],
     ]))
-    // Three hops of hook-free modules, reached through both spellings.
-    expect([...wrappers].sort()).toEqual(['utils/label.ts', 'utils/stamp.ts', 'utils/timeAgo.ts'])
-    // The hooked module owns its own freshness, so the walk does not continue past it.
-    expect(wrappers.has('hooks/useStamp.ts')).toBe(false)
+    // Three hop-free hops reached through both spellings, then one hooked module
+    // that no branch governs (#6111).
+    expect([...wrappers].sort()).toEqual([
+      'hooks/useStamp.ts', 'utils/label.ts', 'utils/stamp.ts', 'utils/timeAgo.ts',
+    ])
+    // The walk stops at the subscription, so what is downstream of it is fresh
+    // and nothing there is flagged.
+    expect(wrappers.has('hooks/useFresh.ts')).toBe(false)
     expect(wrappers.has('components/Far.tsx')).toBe(false)
+  })
+
+  it('the #6111 shape: a memoized caller of an ungoverned hooked hook is the offender', () => {
+    const sources = new Map([
+      ['utils/timeAgo.ts', `import { fmtRelative } from '../i18n/format'\nexport const timeAgo = (t) => fmtRelative(t)`],
+      ['hooks/useStamp.ts', `import { timeAgo } from '../utils/timeAgo'\nexport const useStamp = (t) => { const [v] = useState(t); return timeAgo(v) }`],
+      ['components/Row.tsx', `import { useStamp } from '@/hooks/useStamp'\nexport default memo(({ t }) => <a>{useStamp(t)}</a>)`],
+    ])
+    const wrappers = languageWrapperModules(sources)
+    expect(wrappers.has('hooks/useStamp.ts')).toBe(true)
+    const row = sources.get('components/Row.tsx')!
+    const r = scanFile(row)
+    // Neither narrower branch sees the boundary: no i18nT(, no seam import.
+    expect(r.usesI18nT).toBe(false)
+    expect(r.importsFormat).toBe(false)
+    expect(r.boundaries).toBe(1)
+    expect(r.subscriptions + r.languageContextReads).toBe(0)
+    const via = importedSpecifiers(row)
+      .map(spec => resolveSpecifier('components/Row.tsx', spec, new Set(sources.keys())))
+      .filter(dep => dep !== null && wrappers.has(dep))
+    expect(via).toEqual(['hooks/useStamp.ts'])
   })
 
   it('the defect shape is a memo boundary whose only language input is a wrapper', () => {
@@ -470,6 +589,22 @@ describe('wrapper closure and import resolution', () => {
     expect(wrappers.size).toBeGreaterThan(0)
     for (const rel of ['utils/timeAgo.ts', 'utils/formatCost.ts', 'utils/scheduleCadence.ts', 'apps/issue-radar/lib/format.ts']) {
       expect(wrappers.has(rel), `expected wrapper: ${rel}`).toBe(true)
+    }
+  })
+
+  it('the live tree still has HOOKED carriers, so the #6111 tier is not a no-op', () => {
+    // Pinned as a population rather than by name: the tier is measured at 207 of
+    // 243 and every member is one edit (a subscription, a memo boundary) away
+    // from leaving, so naming files here would red on unrelated refactors. A
+    // count of zero, though, means the hooked tier stopped matching anything and
+    // #6111 is open again.
+    const sources = sourceMap()
+    const hooked = [...languageWrapperModules(sources)]
+      .filter(rel => HOOK_CALL.test(stripComments(sources.get(rel)!)))
+    expect(hooked.length).toBeGreaterThan(0)
+    // Each one is ungoverned by construction -- that is the whole predicate.
+    for (const rel of hooked) {
+      expect(carriesSeamOutputOnward(sources.get(rel)!), `governed but carried: ${rel}`).toBe(true)
     }
   })
 })


### PR DESCRIPTION
## 1. What is the problem?

`website/src/test/MemoI18nSubscriptionRatchet.test.ts` propagates its
language-dependent trigger through WRAPPER modules -- files that carry
`src/i18n/format.ts` output onward -- and its walk stopped at the first module
that calls a React hook. The stated reason was that a hooked module can
subscribe itself, and "if it has a memo boundary the two branches above already
require it".

That qualifier is where the hole is. A module that calls hooks but has NO memo
boundary, and reaches the seam only through a wrapper, matched nothing:

- branch 1 needs a literal `i18nT(` in the file,
- branch 2 needs a `memo()` boundary in the file,
- and it was excluded from the wrapper set because it calls a hook.

So nothing required it to subscribe, and because it was not a wrapper, nothing
required its callers to either. Found by the Design review lane on #6093 using
that PR's own test fixture as the counterexample.

## 2. Why this issue matters to the user

A custom hook of that shape returns language-dependent output straight into a
memoized caller (`memo(() => useSomething(t))`). `React.memo` compares props,
and formatter output is not a prop, so after switching the dashboard language
that subtree keeps rendering the PREVIOUS catalog -- dates, numbers, lists and
collation in the old language -- until its props next move. That is the same
defect #5545 and #5922 closed at other seams; this is the last uncovered route
to it, and until now it could be reintroduced by one innocent-looking import
with no test going red.

Measured on the current tree, 7 modules sit in the ungoverned shape (4 of them
export a custom hook). None is a confirmed live staleness bug, so this is a
guard gap, not a user-visible defect today.

## 3. How our fix solves it

Cause -> mechanism -> consequence: hooked modules were excluded from the wrapper
set -> a hooked wrapper-consumer with no memo boundary was checked by no branch
-> its memoized callers stayed stale after a language switch, undetected.

The fix removes the exclusion and replaces it with the property the exclusion
was standing in for. A module carries the seam's output onward when it imports
the seam or another carrier AND nothing in its own file governs that output:

- hook-free -- it can never subscribe, so the memo boundary that calls it owns
  the freshness (unchanged behaviour), or
- hooked with no memo boundary and no subscription -- the #6111 shape.

The walk stops at a module that subscribes (`useLanguageGeneration()` or
`useLanguage()`) or that has a memo boundary of its own, because the two
existing branches already require the subscription in that very file. One
subscription anywhere along the chain therefore ends the propagation, which
narrows the trade-off #6093 declined ("flags a parent for a child's omission")
to the case where NOBODY on the path subscribed. Either fix satisfies a red:
the boundary subscribes, or the named carrier does and drops itself plus
everything behind it out of the set.

The alternative -- requiring the subscription IN the hooked module -- was
rejected on evidence. The four hook-exporting instances are a type-and-
localStorage importer, two prompt builders whose resolved language is a
functional payload handed to a model at click time, and one whose collated list
is captured into state by a user gesture. A `useLanguageGeneration()` call fixes
nothing in any of them, and in the last the value would still be stale after the
extra render. That is the "red the wrong file" failure mode the hook-free rule
exists to avoid, and it would have needed a four-entry exemption list encoding a
judgment nobody can re-verify mechanically.

Kept out of scope deliberately: the import edge stays module-granular rather
than binding-granular, and `import type` edges still count -- the file already
states that position for the direct-seam regex, and reversing it is a separate
decision. The header records the resulting residue with a concrete example.

## 4. What tests we did

Test-only change; one file touched.

- Targeted run: `vitest run src/test/MemoI18nSubscriptionRatchet.test.ts` --
  29 passed (24 before). Both live-tree branches stay at zero offenders.
- Mutation-verified: disabling the new predicate (back to hook-free only) reds
  exactly the 4 new #6111 tests and leaves all 25 pre-existing tests green, so
  the additions have teeth and the extension is additive rather than a rewrite
  of existing semantics.
- New fixtures: an ungoverned hooked seam importer becomes a carrier; a
  subscribed one and a `useLanguage()` consumer do not; a hooked importer WITH a
  memo boundary does not (branch 2 owns it); the closure walks hook-free and
  hooked carriers alike and stops at the subscription; the end-to-end #6111
  shape (memoized caller of an ungoverned hooked hook) is the offender; and a
  live-tree pin asserts the hooked tier is non-empty so a regex tightened later
  cannot turn it into a silent no-op.
- Measurements taken against the live tree before choosing the design: carriers
  36 -> 243 of 1262 modules, 89 of them direct seam importers, and the set of
  TRIGGERED memo files is byte-identical before and after (the same 10 files).
  The extension arms the guard without moving today's tree.
- `eslint` clean on the touched file, `tsc -b` clean, and the i18n gate run with
  a base ref (`I18N_BASE_REF=<merge-base> npm run i18n:check`) exits 0.
- Full suites deliberately not run locally; CI covers them.

## 5. Any other suggestions on the work

- The remaining gap, stated in the header rather than silently left open: a
  hooked module with no memo boundary that RENDERS the output itself (rather
  than exporting it) is still only reachable by flagging its memoized ancestor.
  Three such files exist today, all reached through non-language bindings
  (font-size constants, `sanitize`), so pinning them would red the wrong file.
- The real precision ceiling is the module-granular import edge. Making it
  binding-granular would need to know which of a wrapper's exports actually
  derive from the seam -- intra-module dataflow, not a regex -- and it is what
  keeps the carrier set at 243 instead of a much smaller number. Worth its own
  issue if the eventual reds prove noisy.
- The set stays bounded for a reason worth keeping in mind when reading the
  number: a subscribing module is excluded, and #5543 converted the rendering
  tree to subscribe, so what accumulates is non-rendering plumbing that memo
  boundaries rarely import.

Closes #6111
