### PR TITLE
docs(comments): retire the stale icacls-subprocess rationale on the two lockdown-ok sites

### DIFF
--- a/scripts/check_lockdown_before_publish.py
+++ b/scripts/check_lockdown_before_publish.py
@@ -47,8 +47,9 @@ Deliberately NOT violations (continued):
   is mandatory, and there are three legitimate kinds: a load-time re-assert; a
   file that holds no data; or a call site where a REVIEWED decision says the
   helper must not be used here at all -- ``workflows/store.py::save`` runs on
-  the event loop and ``restrict_to_owner`` spawns ``icacls``, so #5228 settled
-  it on POSIX ``chmod`` with a ``_redact``-ed payload.
+  the event loop, where ``restrict_to_owner``'s Windows DACL write costs an
+  unbounded SMB round-trip on a network-homed data home, so #5228 settled it on
+  POSIX ``chmod`` with a ``_redact``-ed payload.
 
   The marker and ``KNOWN_UNCONVERTED`` are not interchangeable, and picking the
   wrong one misreports the site. ``KNOWN_UNCONVERTED`` means "this SHOULD be
@@ -184,7 +185,7 @@ SUPPRESS_RE = re.compile(r"#\s*lockdown-ok\s*:\s*(?P<reason>\S.*)$")
 KNOWN_UNCONVERTED: dict[str, tuple[str, str]] = {
     # Empty: #5493 converted denied_commands; this PR converts write_pod_config
     # and snapshot._do_merge, and annotates sel._append_lines_locked lockdown-ok
-    # (same event-loop / icacls reason as #5228). Shrink-only: do not re-add a
+    # (same event-loop reason as #5228). Shrink-only: do not re-add a
     # converted site.
 }
 

--- a/src/kiro_crew/platform/policy_distribution.py
+++ b/src/kiro_crew/platform/policy_distribution.py
@@ -1182,9 +1182,9 @@ def _ensure_cache_dir() -> Optional[Path]:
 
     Created and tightened at most once per process.  The tighten is what matters and
     it matters at CREATION: re-applying it on every write costs a ``chmod`` on POSIX
-    and, on Windows, an ``icacls`` SUBPROCESS — which, with a 304 being the common
-    poll outcome, would be a process spawn per refresh interval to re-assert a DACL
-    that has not changed.
+    and, on Windows, a DACL write — which, with a 304 being the common poll outcome,
+    would be filesystem work per refresh interval (and an unbounded SMB round-trip on
+    a network-homed data home) to re-assert a DACL that has not changed.
     """
     global _cache_dir_ready
     directory = cache_dir()

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -1150,14 +1150,19 @@ class SecurityEventLog:
             written = os.fstat(f.fileno())
         # Ensure permissions are correct even if file pre-existed with
         # wrong mode (e.g. created by an older version). POSIX repair only,
-        # deliberately NOT ``platform_compat.restrict_to_owner``: that helper
-        # spawns ``icacls`` on Windows (a blocking subprocess), and this
-        # append path can run inline on a caller's thread that may be the
-        # asyncio event loop — the ``critical=True`` audit-or-deny write, and
-        # the fallback taken when the writer thread cannot start (see
-        # ``_may_rotate``) — where a blocking call freezes every gateway task.
+        # deliberately still NOT ``platform_compat.restrict_to_owner``: on POSIX
+        # that helper IS this exact call, so a swap would add only the Windows
+        # owner-only DACL — and this append path can run inline on a caller's
+        # thread that may be the asyncio event loop (the ``critical=True``
+        # audit-or-deny write, and the fallback taken when the writer thread
+        # cannot start, see ``_may_rotate``), where a DACL write to a UNC or
+        # mapped-drive path costs an unbounded SMB round-trip. Adopting the
+        # helper here therefore means first deciding what a non-local volume
+        # gets, the way ``write_config_atomically`` gates its own lockdown on
+        # ``windows_acl.volume_is_local``; until that is settled the log keeps
+        # whatever DACL it inherits on Windows. Tracked in #6359.
         try:
-            os.chmod(self._path, 0o600)  # lockdown-ok: #5228 -- icacls would block the event loop
+            os.chmod(self._path, 0o600)  # lockdown-ok: #5228 -- unbounded SMB round-trip on the loop
         except OSError:
             logger.warning("Failed to enforce 0o600 permissions on SEL audit log %s", self._path, exc_info=True)
         self._live_seen = (written.st_dev, written.st_ino, written.st_size)

--- a/src/kiro_crew/workflows/store.py
+++ b/src/kiro_crew/workflows/store.py
@@ -137,15 +137,16 @@ class WorkflowRunStore:
             tmp.write_text(payload, encoding="utf-8")
             os.replace(tmp, path)  # atomic on POSIX
             try:
-                # POSIX tightening only, deliberately NOT
-                # ``platform_compat.restrict_to_owner``: that helper spawns
-                # ``icacls`` on Windows (a blocking subprocess), and ``save``
-                # runs on the event loop via the registry's persist hooks,
-                # where a blocking call freezes every gateway task. The
+                # POSIX tightening only, deliberately still NOT
+                # ``platform_compat.restrict_to_owner``: on POSIX that helper IS
+                # this exact call, so a swap would add only the Windows
+                # owner-only DACL — and ``save`` runs on the event loop via the
+                # registry's persist hooks, where a DACL write to a UNC or
+                # mapped-drive path costs an unbounded SMB round-trip. The
                 # payload is already passed through ``_redact`` above, so
                 # what a wider Windows DACL could expose is the redacted
-                # run record, not credentials.
-                os.chmod(path, 0o600)  # lockdown-ok: #5228 -- icacls would block the event loop
+                # run record, not credentials. Tracked in #6359.
+                os.chmod(path, 0o600)  # lockdown-ok: #5228 -- unbounded SMB round-trip on the loop
             except OSError:
                 pass
         except Exception:  # noqa: BLE001 - persistence must never break a run


### PR DESCRIPTION
Refs #6359 -- this retires the stale comments left behind by that issue's ALREADY-MERGED half (#6530). It deliberately does not close #6359: the chmod failure-policy decision is that issue's remaining half, it carries @CrysisDeu's `claimed` label, and this PR leaves that residue to its claimant.

## 1. What is the problem?

PR #5266 replaced the Windows owner-only lockdown's `icacls` subprocess with an in-process `advapi32` call, and #6530 then swept the rationale comments across `src/` that still asserted the dead constraint. Both stopped short of the two `os.chmod(0o600)` sites, because #6359 groups their comments with the still-open question of whether those sites should adopt `restrict_to_owner` at all.

That leaves four present-tense claims that a subprocess is spawned, each of them load-bearing rationale:

- `src/kiro_crew/sel.py` -- the block above the SEL audit-log lockdown, plus the reason on its `# lockdown-ok: #5228` marker.
- `src/kiro_crew/workflows/store.py` -- the same shape, plus its marker. This one makes the claim WRAPPED across two lines ("that helper spawns" / "``icacls`` on Windows"), so no line-based pattern in the #6359 thread ever caught it.
- `src/kiro_crew/platform/policy_distribution.py` -- `_ensure_cache_dir`'s docstring: "on Windows, an ``icacls`` SUBPROCESS ... would be a process spawn per refresh interval". Same class, and also missed by every pattern in the thread (the words are not contiguous and the case differs).
- `scripts/check_lockdown_before_publish.py` (2 sites) -- the checker that GOVERNS these exact two markers documents them with the same dead reason. `scripts/` is outside the issue's `src/`-scoped grep, which is why it survived the sweep.

## 2. Why this matters to the user

Nothing observable breaks, which is precisely why this gets fixed now rather than never. Each comment explains why a call site made an architectural choice, so the next reader to touch the SEL audit log or the workflow store re-derives a constraint that no longer exists: they believe the lockdown costs a 313 ms process spawn when it now costs 0.24 ms in-process, and they keep or add offloads and skips for a reason that has been removed. The checker's copy matters most, because it is the document a contributor consults when deciding whether a new site may carry a `lockdown-ok` marker at all.

## 3. How the fix solves it

Comment and docstring text only, no behaviour change. The chain from symptom to cause:

- **Symptom:** the comments claim `restrict_to_owner` spawns `icacls` and would block the event loop.
- **Cause:** #5266 removed that subprocess. `platform_compat._apply_owner_only_dacl` now builds the descriptor through `advapi32`, and its docstring records the measurement (313 ms per call as a subprocess, 0.24 ms in-process) and states that offloading "remains good practice" but "is no longer mandatory".
- **The reason that is still true, and the one now stated:** a DACL write to a UNC or mapped-drive path costs an unbounded SMB round-trip, so a caller running inline on the event loop still cannot apply it unconditionally. This is not invented here. It is what `restrict_to_owner`'s own docstring instructs such a caller to do ("must ask `windows_acl.volume_is_local` FIRST and skip the lockdown itself"), it is the precedent `config/loader.py`'s `write_config_atomically` already follows, and it is the vocabulary #6530 established at the sites it rewrote.
- Both blocks keep every clause that is still accurate -- SEL's `critical=True` audit-or-deny path and its writer-thread-start fallback, the store's already-`_redact`-ed payload -- and both now name #6359 as where the pending decision lives.

Both `# lockdown-ok: #5228` markers are KEPT, with corrected reasons. They are not discharged: the swap is still pending, and removing them would tell the gate a decision has been made that has not been.

## 4. What tests we did

- **Behaviour-neutrality, proved rather than asserted.** A `tokenize` comparison of each file against its base version, dropping `COMMENT` tokens, reports **zero** differing tokens in `sel.py` and `workflows/store.py` (both edits are pure `#` comments, so even the string stream is untouched) and **exactly one** differing `STRING` token in each of the other two files -- the edited docstring. No non-comment token differs anywhere in the diff.
- `python3 scripts/check_lockdown_before_publish.py` (full `src/kiro_crew` scan): **passed** -- the gate this PR edits still passes on the tree it governs.
- `pytest test/test_lockdown_before_publish.py`: **77 passed**, including `TestTheRealTree::test_src_has_no_unclassified_violation` and `test_every_known_unconverted_entry_still_violates`, which run the edited checker over the real tree.
- `pytest test/test_governance_distribution.py -k 'cache_dir or cache'`: **137 passed** (covers the module whose docstring changed).
- `flake8` and `isort --check-only` on all four files: clean. Baseline-aware black gate (`scripts/check_black_formatting.py`, 4 files in scope): passed.
- Both grep variants from the #6359 thread -- the pattern as shipped and the backtick-optional correction -- plus an uppercase `SUBPROCESS` variant now return **zero** hits across `src/` and `scripts/`.
- No new test is added: there is no behaviour to pin, and a test asserting on comment prose would be a ratchet on wording rather than on a contract.
- Not run: the full suite, deliberately. CI owns that.

## 5. Any other suggestions on the work

- **Scope discipline.** Neither `os.chmod` call is modified, no labels or assignees on #6359 were touched, and no part of the `volume_is_local` question is answered here. #6353 is answering that same question for `config.json` on the same helper, and it should be answered once for all three callers rather than three times.
- **One correction worth recording for whoever takes the remaining half.** #6359 frames the blocker as a fail-loud-vs-warn-and-continue decision, and the code does not support that framing: `restrict_to_owner`'s POSIX branch IS `os.chmod(path, 0o600)`; its Windows branch translates every failure to `OSError` on purpose, commented "every caller's handler is written against the POSIX chmod's OSError"; `current_user_sid()` returns `None` rather than raising; and both sites already catch `OSError`. A straight swap therefore keeps warn-and-continue on both platforms and changes no audit-or-deny semantics. The genuinely open question is the non-local-volume one these comments now state. Full evidence in https://github.com/kirodotdev/KiroCrew/issues/6359#issuecomment-5469318307.
- For the merger: this uses "Refs", not "Closes", on purpose. Merging it must not close #6359.
