### PR TITLE
fix(dashboard): claim the Tab on branches that rewrite a field mid-composition

### DIFF
--- a/website/src/apps/file-explorer/PathBar.tsx
+++ b/website/src/apps/file-explorer/PathBar.tsx
@@ -64,11 +64,14 @@ export default function PathBar({ rootPath, gitInfo, onChangeRoot, onNavigate }:
     if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) { setOpen(true); return }
     if (open && e.key === 'ArrowDown') { e.preventDefault(); setActiveIdx((i) => suggestions.length === 0 ? -1 : (i + 1) % suggestions.length) }
     else if (open && e.key === 'ArrowUp') { e.preventDefault(); setActiveIdx((i) => suggestions.length === 0 ? -1 : (i - 1 + suggestions.length) % suggestions.length) }
-    // Only the Enter branches are claimed — arrow/Tab navigation stays untouched.
+    // The Enter and Tab branches are claimed — arrow navigation stays untouched
+    // because it neither consumes the key nor rewrites the draft.
     else if (open && e.key === 'Enter') { if (!ime.claimEnter(e)) return; if (activeIdx >= 0 && suggestions[activeIdx]) accept(suggestions[activeIdx]); else commit() }
     else if (!open && e.key === 'Enter') { if (ime.claimEnter(e)) commit() }
     else if (e.key === 'Escape') { setDraft(rootPath); setEditing(false); setOpen(false) }
-    else if (e.key === 'Tab' && open && suggestions.length > 0) { e.preventDefault(); setDraft(suggestions[activeIdx >= 0 ? activeIdx : 0].path) }
+    // Tab accepts the highlighted suggestion INTO the draft, so an IME using Tab
+    // to cycle its candidate list would replace the text mid-composition.
+    else if (e.key === 'Tab' && open && suggestions.length > 0) { if (!ime.claimKey(e)) return; e.preventDefault(); setDraft(suggestions[activeIdx >= 0 ? activeIdx : 0].path) }
   }
 
   const segs = parentChain(rootPath)

--- a/website/src/apps/md-notebook/BlockEditor.tsx
+++ b/website/src/apps/md-notebook/BlockEditor.tsx
@@ -118,9 +118,15 @@ export function BlockEditor({
           // Tab nests a list item, Shift+Tab lifts it out. On anything that is
           // not a list item Tab keeps its native job of moving focus, so the
           // keyboard can still leave the editor.
+          //
+          // Claim BEFORE the rewrite: IMEs use Tab to cycle the candidate list,
+          // and on WebKit the keydown that commits a candidate arrives after
+          // `compositionend` with `isComposing` already false — so an unclaimed
+          // Tab would re-indent the block and replace the composing text.
           const ta = e.currentTarget
           const next = shiftListItem(text, ta.selectionStart, e.shiftKey)
           if (!next) return
+          if (!ime.claimKey(e)) return
           e.preventDefault()
           rewrite(ta, next.text, next.pos)
         } else if (e.key === 'Enter' && !e.shiftKey && onSplit) {

--- a/website/src/apps/md-notebook/MdNotebookPage.tsx
+++ b/website/src/apps/md-notebook/MdNotebookPage.tsx
@@ -6,6 +6,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIsMobile } from '../../hooks/useIsMobile'
+import { useImeGuard } from '../../hooks/useImeGuard'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import type { CSSProperties } from 'react'
@@ -193,6 +194,9 @@ export default function MdNotebookPage() {
   )
   const [panelOpen, setPanelOpen] = useState(() => loadPref<boolean>(LS.panelOpen, true))
   const isMobile = useIsMobile()
+  // Composition state for the raw-markdown textarea, whose Tab re-indents a list
+  // item by rewriting the whole value — see the keydown handler below.
+  const ime = useImeGuard()
   // The panel is a fixed 260px `flexShrink: 0` column, so at 390px it left the
   // editor 130px. `panelOpen` already exists but is a stored DESKTOP preference,
   // so it arrives open on a phone. While narrow the panel is a drawer that starts
@@ -2462,11 +2466,18 @@ export default function MdNotebookPage() {
               spellCheck={false}
               aria-label={i18nT('apps.mdNotebook.header.view_raw')}
               onChange={e => edit(e.target.value)}
+              {...ime.bindComposition<HTMLTextAreaElement>()}
               onKeyDown={e => {
                 if (e.key !== 'Tab') return
                 const ta = e.currentTarget
                 const next = shiftListItem(content, ta.selectionStart, e.shiftKey)
                 if (!next) return
+                // Claim BEFORE the rewrite: IMEs use Tab to cycle the candidate
+                // list, and on WebKit the keydown that commits a candidate
+                // arrives after `compositionend` with `isComposing` already
+                // false — so an unclaimed Tab would re-indent the list item and
+                // overwrite the text still being composed.
+                if (!ime.claimKey(e)) return
                 e.preventDefault()
                 ta.value = next.text
                 ta.setSelectionRange(next.pos, next.pos)

--- a/website/src/apps/mochi/src/renderer/ChatPanel.tsx
+++ b/website/src/apps/mochi/src/renderer/ChatPanel.tsx
@@ -1526,6 +1526,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onToggleWatch, watchPanelV
                 if (e.key === 'ArrowDown') { e.preventDefault(); setCmdIdx(i => (i + 1) % filtered.length); return }
                 if (e.key === 'ArrowUp') { e.preventDefault(); setCmdIdx(i => (i - 1 + filtered.length) % filtered.length); return }
                 if (e.key === 'Tab') {
+                  // Tab accepts the highlighted command INTO the composer, so an
+                  // IME cycling its candidate list with Tab must not rewrite the
+                  // draft mid-composition. Claimed like the Enter branch below.
+                  if (!ime.claimKey(e)) return
                   e.preventDefault(); setInput(filtered[cmdIdx].cmd); setCmdIdx(0); return
                 }
                 // While the picker is open Enter belongs to it, so the key is claimed

--- a/website/src/test/ImeEnterClaimRatchet.test.ts
+++ b/website/src/test/ImeEnterClaimRatchet.test.ts
@@ -240,9 +240,10 @@ function scanUnguardedEnterBlurCommits(lines: string[]): number[] {
  * it declines, so a claim past the move (or a sibling branch's claim beyond
  * it) does not clear this one. A Tab branch that acts through STATE
  * (accepting a suggestion, indenting a list item) has no focus call to
- * anchor on and is out of this rule's scope by design: fail open rather
- * than mis-flag, consistent with the rest of this file. A `.focus(` further
- * than the window is likewise not this structure.
+ * anchor on and is out of THIS rule's scope by design: fail open rather
+ * than mis-flag, consistent with the rest of this file. The rule below
+ * covers that shape, anchored on the act instead of the move. A `.focus(`
+ * further than the window is likewise not this structure.
  */
 const TAB_BRANCH = /key === 'Tab'|key !== 'Tab'/
 const FOCUS_MOVE = /\.focus\(/
@@ -310,6 +311,118 @@ function scanHandSpelledSyntheticClaims(lines: string[]): number[] {
   const hits: number[] = []
   codeLines(lines).forEach((line, i) => {
     if (HAND_SPELLED_SYNTHETIC_CLAIM.test(line)) hits.push(i + 1)
+  })
+  return hits
+}
+
+/**
+ * A Tab branch that takes the key from the browser and then ACTS ON THE FIELD,
+ * with no composition signal anywhere.
+ *
+ * The state-setter twin of the rule above, for the half of the boundary-Tab
+ * shape a focus anchor structurally cannot see. Four sites carried it: a path
+ * bar accepting the highlighted suggestion into the draft, two markdown
+ * editors re-indenting a list item by rewriting the whole textarea value, and
+ * a composer accepting slash-command autocomplete. The hazard is the one the
+ * focus rule pins — IMEs use Tab to cycle the candidate list, and on WebKit
+ * the keydown that commits a candidate arrives after `compositionend` with
+ * `isComposing` already false — but the damage lands in the field's own text
+ * instead of in the focus ring, which is the worse half: the composing draft
+ * is replaced, so the user loses what they were typing rather than where they
+ * were.
+ *
+ * The anchor is `preventDefault()` FOLLOWED BY AN ACT, inside the branch and
+ * with no focus move in it — the two anchors partition the shape between them
+ * rather than double-reporting it. Consuming the key on its own is
+ * deliberately NOT enough: a surface that swallows Tab to hold still
+ * (`useListKeyboardNav`'s empty-list branch, whose host composer carries its
+ * own guard) writes nothing an IME could corrupt, and flagging it would buy a
+ * noisy rule an exemption list to quiet it. What makes an unclaimed Tab a
+ * corruption is the act that follows the consumption, so that is what puts a
+ * branch in scope.
+ *
+ * The claim clears the branch from either position that actually guards the
+ * code path: on the branch before the consumption it owns, or as a
+ * decline-and-return ABOVE the branch at no deeper nesting — an early
+ * `if (!latch.claimKey(e)) return` covering every branch below it, which is
+ * how `useListKeyboardNav` guards its own choose dispatch. A claim nested
+ * inside a SIBLING branch is not on this branch's path and does not count,
+ * the same asymmetry the rule above states. Indentation is the nesting proxy,
+ * as it is for the element-bracketing rules below; unrecognized formatting
+ * fails open.
+ */
+const TAB_CONSUME = /\.preventDefault\(/
+/** A decline-and-return, in both spellings the tree uses. */
+const TAB_DECLINE = /!\s*[\w.!?]*\bclaimKey\(/
+/** Where a keydown handler opens — the ceiling for the decline search. */
+const KEY_HANDLER = /\bonKeyDown\b|\bonKey\b|['"]keydown['"]/
+/** Consuming the key and leaving the branch is plumbing, not an act. */
+const BRANCH_PLUMBING =
+  /^[{}();,\s]*$|^[\w.?!]*\.(?:preventDefault|stopPropagation|stopImmediatePropagation)\(\)[\s;)}]*$|^return(?:\s+(?:true|false))?[\s;)}]*$/
+const HANDLER_WINDOW = 60
+
+/** The branch's own lines, to the first dedent that closes it (this tree's formatting). */
+function tabBranchSpan(code: string[], i: number): string[] {
+  const indent = code[i].search(/\S/)
+  const out = [code[i]]
+  for (let j = i + 1; j < code.length && j <= i + TRAP_WINDOW; j++) {
+    if (code[j].trim() === '') continue
+    if (code[j].search(/\S/) <= indent && /^\s*[})]/.test(code[j])) break
+    out.push(code[j])
+  }
+  return out
+}
+
+/** True when the branch does something after consuming the key. */
+function actsAfterConsuming(branch: string[], at: number): boolean {
+  // The one-line spelling puts the act on the consume line itself:
+  // `{ e.preventDefault(); setDraft(suggestion) }`.
+  const consume = branch[at]
+  const tail = consume
+    .slice(consume.search(TAB_CONSUME))
+    .replace(/^\.preventDefault\(\)\s*;?/, '')
+  return [tail, ...branch.slice(at + 1)].some(
+    l => l.trim() !== '' && !BRANCH_PLUMBING.test(l.trim()),
+  )
+}
+
+/** True when an early decline-and-return above the branch covers its path. */
+function declinedAbove(code: string[], i: number): boolean {
+  const indent = code[i].search(/\S/)
+  for (let j = i - 1; j >= 0 && i - j <= HANDLER_WINDOW; j--) {
+    const line = code[j]
+    if (line.trim() === '') continue
+    // Above the handler's own opening there is no shared path left to guard.
+    if (KEY_HANDLER.test(line)) return false
+    // Deeper than this branch means it sits inside a sibling one.
+    if (line.search(/\S/) > indent) continue
+    if (!TAB_DECLINE.test(line)) continue
+    // The decline has to RETURN — on its own line, or the two-line spelling.
+    if (/\breturn\b/.test(line)) return true
+    for (let k = j + 1; k <= j + 2 && k < code.length; k++) {
+      if (/\breturn\b/.test(code[k])) return true
+    }
+  }
+  return false
+}
+
+function scanUnguardedTabStateWrites(lines: string[]): number[] {
+  const code = lines.map(l => {
+    const t = l.trim()
+    return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') ? '' : l
+  })
+  const hits: number[] = []
+  code.forEach((line, i) => {
+    if (!TAB_BRANCH.test(line)) return
+    const branch = tabBranchSpan(code, i)
+    // A branch that re-aims focus is the rule above's shape, not this one.
+    if (branch.some(l => FOCUS_MOVE.test(l))) return
+    const at = branch.findIndex(l => TAB_CONSUME.test(l))
+    if (at === -1) return
+    if (!actsAfterConsuming(branch, at)) return
+    if (branch.slice(0, at + 1).some(l => TAB_CLAIM.test(l))) return
+    if (declinedAbove(code, i)) return
+    hits.push(i + 1)
   })
   return hits
 }
@@ -403,6 +516,26 @@ describe('IME Enter claim ratchet', () => {
     // document/window listeners, `.claimSyntheticKey(e)` (or
     // `useImeGuard().claimKey(e)`) for React handlers — the claim runs BEFORE
     // the preventDefault() and focus move.
+    expect(offenders).toEqual([])
+  })
+
+  it('never rewrites the field on a Tab the branch did not claim', () => {
+    // The other half of the boundary-Tab shape: the rule above anchors on a
+    // focus move, so the four branches that acted through STATE instead were
+    // invisible to every rule in this file — a path bar accepting a suggestion
+    // into the draft, two markdown editors re-indenting a list item, a
+    // composer accepting slash-command autocomplete. Each replaced the text an
+    // IME was still composing, and each sat one line away from the guard its
+    // own Enter branch already used.
+    const offenders: string[] = []
+    for (const rel of sourceFiles()) {
+      if (rel === 'hooks/useImeGuard.ts') continue
+      const lines = readFileSync(join(SRC, rel), 'utf8').split('\n')
+      for (const n of scanUnguardedTabStateWrites(lines)) offenders.push(`${rel}:${n}`)
+    }
+    // An entry here acts on a Tab it never checked. Claim the key first
+    // (`if (!ime.claimKey(e)) return`) and keep the composition tracked with
+    // the `bindComposition` spread the claim reads.
     expect(offenders).toEqual([])
   })
 
@@ -792,7 +925,7 @@ describe('ratchet rule fixtures', () => {
       }}`))).toHaveLength(0)
     // Scoped to a FOCUS MOVE: a Tab branch that acts through state (accepting
     // a suggestion, indenting a list item) has no focus call to anchor on and
-    // is out of scope by design — fail open rather than mis-flag.
+    // is out of THIS rule's scope — the state-write rule below owns it.
     expect(scanUnguardedTabFocusTraps(jsx(`
       onKeyDown={e => {
         if (e.key === 'Tab' && open && suggestions.length > 0) { e.preventDefault(); setDraft(suggestions[0].path) }
@@ -844,5 +977,125 @@ describe('ratchet rule fixtures', () => {
     expect(scanHandSpelledSyntheticClaims(jsx(
       '  // sites used to spell claimKey(e.nativeEvent) plus a caller-side stop',
     ))).toHaveLength(0)
+  })
+
+  it('flags a Tab branch that acts on the field without claiming the key', () => {
+    // The one-line accept-the-suggestion shape the path bar carried: consume
+    // the key, replace the draft, no composition signal anywhere.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Tab' && open && suggestions.length > 0) { e.preventDefault(); setDraft(suggestions[0].path) }
+      }}`))).toHaveLength(1)
+    // Its sanctioned form: the claim runs before the consumption it owns.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Tab' && open && suggestions.length > 0) { if (!ime.claimKey(e)) return; e.preventDefault(); setDraft(suggestions[0].path) }
+      }}`))).toHaveLength(0)
+    // The guard-clause spelling both markdown editors used: the early
+    // `!== 'Tab'` return scopes the rest of the handler, and the rewrite sits
+    // several lines below its own bail-outs.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      onKeyDown={e => {
+        if (e.key !== 'Tab') return
+        const ta = e.currentTarget
+        const next = shiftListItem(content, ta.selectionStart, e.shiftKey)
+        if (!next) return
+        e.preventDefault()
+        ta.value = next.text
+        edit(next.text)
+      }}`))).toHaveLength(1)
+    expect(scanUnguardedTabStateWrites(jsx(`
+      onKeyDown={e => {
+        if (e.key !== 'Tab') return
+        const ta = e.currentTarget
+        const next = shiftListItem(content, ta.selectionStart, e.shiftKey)
+        if (!next) return
+        if (!ime.claimKey(e)) return
+        e.preventDefault()
+        ta.value = next.text
+        edit(next.text)
+      }}`))).toHaveLength(0)
+    // A claim that runs AFTER the consumption does not guard it: by then the
+    // browser has already been told the site owns the key.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Tab') {
+          e.preventDefault()
+          if (!ime.claimKey(e)) return
+          setInput(filtered[cmdIdx].cmd)
+        }
+      }}`))).toHaveLength(1)
+    // Consuming the key to hold a surface STILL is not an act: the empty-list
+    // branch swallows Tab so the picker stays put and writes nothing an IME
+    // could corrupt. Flagging it would need an exemption list to quiet it.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        if (n === 0) {
+          if (e.key === 'Enter' || e.key === 'Tab') {
+            if (releaseKeysWhenEmpty) {
+              onClose()
+              return
+            }
+            e.preventDefault()
+            e.stopPropagation()
+          }
+          return
+        }
+      }`))).toHaveLength(0)
+    // An early decline-and-return at no deeper nesting covers every branch
+    // below it — the shape `useListKeyboardNav` guards its choose dispatch
+    // with, in both the one-line and the wrapped spelling.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        if ((e.key === 'Enter' || e.key === 'Tab') && !latch.claimKey(e)) {
+          return
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          onChoose(selected)
+        } else if (e.key === 'Tab') {
+          e.preventDefault()
+          onChoose(selected)
+        }
+      }`))).toHaveLength(0)
+    // …but a claim nested inside a SIBLING branch is not on this branch's
+    // path, so it does not clear it (the asymmetry the focus rule states).
+    expect(scanUnguardedTabStateWrites(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          if (!latch.claimKey(e)) return
+          e.preventDefault()
+          onClose()
+          return
+        }
+        if (e.key === 'Tab') {
+          e.preventDefault()
+          onChoose(selected)
+        }
+      }`))).toHaveLength(1)
+    // A decline that never returns is not a guard: the branch runs on anyway.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      const onKey = (e: KeyboardEvent) => {
+        const declined = !latch.claimKey(e)
+        if (e.key === 'Tab') {
+          e.preventDefault()
+          onChoose(selected)
+        }
+      }`))).toHaveLength(1)
+    // A branch that never takes the key from the browser is a different
+    // structure: nothing was re-aimed, so there is nothing to have claimed.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Tab') setHint(null)
+      }}`))).toHaveLength(0)
+    // A claim mentioned only in a comment does not launder the site.
+    expect(scanUnguardedTabStateWrites(jsx(`
+      onKeyDown={e => {
+        if (e.key === 'Tab') {
+          // ime.claimKey( is handled upstream, honestly
+          e.preventDefault()
+          setInput(filtered[cmdIdx].cmd)
+        }
+      }}`))).toHaveLength(1)
   })
 })

--- a/website/src/test/ImeEnterGuardSites.test.tsx
+++ b/website/src/test/ImeEnterGuardSites.test.tsx
@@ -44,12 +44,21 @@ vi.mock('../api/client', async (importOriginal) => {
   }
 })
 
+vi.mock('../apps/file-explorer/api', () => ({
+  fileExplorerApi: {
+    complete: vi.fn().mockResolvedValue({
+      entries: [{ name: 'src', path: '/home/user/src', type: 'dir', size: 0, mtime: 0 }],
+    }),
+  },
+}))
+
 import { api } from '../api/client'
 import TagManagerList from '../components/TagManagerList'
 import ProjectPicker from '../components/ProjectPicker'
 import SearchBar from '../components/SearchBar'
 import BroadcastBar from '../apps/meetings/components/BroadcastBar'
 import { BlockEditor } from '../apps/md-notebook/BlockEditor'
+import PathBar from '../apps/file-explorer/PathBar'
 
 /** Arm the hook's post-composition latch: the WebKit commit-Enter window. */
 function armLatch(el: Element) {
@@ -374,5 +383,83 @@ describe('md-notebook BlockEditor — rule 3 textarea: claim before the Enter→
     const { ta, onCommit } = renderEditor()
     fireEvent.keyDown(ta, { key: 'Enter', ctrlKey: true })
     expect(onCommit).toHaveBeenCalledWith('草稿')
+  })
+
+  // The Tab branch of the same textarea, and the OTHER half of the
+  // boundary-Tab shape: it re-indents the list item by rewriting the whole
+  // value, so an IME cycling its candidate list with Tab replaced the text
+  // still being composed. No focus move to anchor on, which is why the source
+  // ratchet needed a second, act-anchored rule to see it.
+  function renderListEditor() {
+    const onCommit = vi.fn()
+    render(<BlockEditor initial="- item" onCommit={onCommit} onCancel={vi.fn()} />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    return { ta, onCommit }
+  }
+
+  it('does NOT re-indent the list item on the committing Tab in the post-composition window', () => {
+    const { ta } = renderListEditor()
+    armLatch(ta)
+    const defaultNotPrevented = fireEvent.keyDown(ta, { key: 'Tab' })
+    expect(ta.value).toBe('- item')
+    // The decline consumes the key: in this window the browser would otherwise
+    // move focus out of the editor, abandoning the composition.
+    expect(defaultNotPrevented).toBe(false)
+  })
+
+  it('leaves a mid-composition Tab to the IME (native flag set)', () => {
+    const { ta } = renderListEditor()
+    fireEvent.compositionStart(ta)
+    const defaultNotPrevented = fireEvent.keyDown(ta, { key: 'Tab', isComposing: true })
+    expect(ta.value).toBe('- item')
+    expect(defaultNotPrevented).toBe(true)
+  })
+
+  it('re-indents the list item on a plain Tab (positive control)', () => {
+    const { ta } = renderListEditor()
+    fireEvent.keyDown(ta, { key: 'Tab' })
+    expect(ta.value).toBe('\t- item')
+  })
+})
+
+describe('file-explorer PathBar — Tab accepts a suggestion INTO the draft', () => {
+  // The path bar recorded its Tab as a deliberate exemption ("arrow/Tab
+  // navigation stays untouched"), which held only while Tab did nothing to the
+  // text. It accepts the highlighted suggestion into the draft, so with the
+  // latch armed the accept overwrote the composing path.
+  async function openEditor() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <PathBar rootPath="/home/user" gitInfo={null} onChangeRoot={vi.fn()} onNavigate={vi.fn()} />
+      </QueryClientProvider>,
+    )
+    fireEvent.click(screen.getByTitle('Click to edit path'))
+    const input = screen.getByPlaceholderText('/path/to/folder') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '/home/user/s' } })
+    // The suggestion query is debounced, so the row is what proves it arrived.
+    await waitFor(() => expect(screen.getByText('/home/user/src')).toBeInTheDocument())
+    return input
+  }
+
+  it('does NOT replace the draft on the committing Tab in the post-composition window', async () => {
+    const input = await openEditor()
+    armLatch(input)
+    const defaultNotPrevented = fireEvent.keyDown(input, { key: 'Tab' })
+    expect(input.value).toBe('/home/user/s')
+    expect(defaultNotPrevented).toBe(false)
+  })
+
+  it('accepts the highlighted suggestion on a plain Tab (positive control)', async () => {
+    const input = await openEditor()
+    fireEvent.keyDown(input, { key: 'Tab' })
+    expect(input.value).toBe('/home/user/src')
+  })
+
+  it('keeps arrow-key list navigation working while the latch is armed', async () => {
+    const input = await openEditor()
+    armLatch(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(screen.getByRole('option')).toHaveAttribute('aria-selected', 'true')
   })
 })


### PR DESCRIPTION
## What is the problem?

The boundary-Tab ratchet added for #5475 anchors on a `.focus(` call inside the
Tab branch, which is what a focus trap or a close-and-return branch does. Four
Tab branches act with NO composition signal at all and through STATE instead of
a focus move, so no rule in `ImeEnterClaimRatchet.test.ts` could see them:

1. `website/src/apps/file-explorer/PathBar.tsx` - Tab accepts the highlighted
   suggestion into the draft (`setDraft`). The file recorded the choice as
   deliberate ("Only the Enter branches are claimed - arrow/Tab navigation stays
   untouched"), which held only while Tab did nothing to the text.
2. `website/src/apps/md-notebook/MdNotebookPage.tsx` - Tab in the raw-markdown
   textarea re-indents a list item by rewriting the whole value. This file had
   no IME guard at all.
3. `website/src/apps/mochi/src/renderer/ChatPanel.tsx` - Tab accepts
   slash-command autocomplete, one line from the Enter branch that already
   claims.
4. `website/src/apps/md-notebook/BlockEditor.tsx` - the same list-item re-indent
   in the block editor. This one was NOT named in the issue; the new ratchet
   rule found it.

## Why this issue matters to the user

IMEs use Tab to cycle the candidate list, and on WebKit the keydown that commits
a candidate arrives after `compositionend` with `KeyboardEvent.isComposing`
already false. So for a CJK/Japanese/Korean operator, a Tab meant for the
candidate list reached these branches and they acted on it: the path being typed
was replaced by a suggestion, or the list item was re-indented and the composing
text overwritten. This is the worse half of the shape the focus rule pins - the
damage lands in the field's own text, so the user loses what they were typing
rather than only where they were.

## How our fix solves it

Symptom: a candidate-cycling Tab rewrites the field. Cause: the branch consumes
the key and acts on it without ever consulting a composition signal. Root cause
for the whole class: nothing in the tree could detect the shape, because every
rule in the ratchet keys on a signal the offender must already have NAMED, and
the one rule that needs no prior signal anchors on a focus move these branches
do not have.

- Each of the four branches now claims first: `if (!ime.claimKey(e)) return`
  before the `preventDefault()` and the write. `claimKey` owns both halves of a
  decline (always `stopPropagation`, `preventDefault` only in the
  post-composition window), so a call site cannot get one half right and the
  other wrong.
- `MdNotebookPage`'s raw textarea also gained the `ime.bindComposition()` spread,
  because the claim reads the instance latch and without the tracking it would
  fall back to the native flag - the exact flag that is false in the WebKit
  commit window.
- A second ratchet rule, `never rewrites the field on a Tab the branch did not
  claim`, is anchored on `preventDefault()` FOLLOWED BY AN ACT with no focus move
  in the branch. The two anchors partition the shape rather than double-reporting
  it. Consuming the key on its own is deliberately not enough: a surface that
  swallows Tab to hold still (`useListKeyboardNav`'s empty-list branch, whose
  host composer carries its own guard) writes nothing an IME could corrupt, and
  flagging it would have bought a noisy rule an exemption list to quiet it. That
  is what keeps the rule absolute, consistent with this file's no-allowlist
  stance. The claim clears a branch from either position that actually guards the
  path: on the branch before the consumption, or as an early
  decline-and-return above it at no deeper nesting (how `useListKeyboardNav`
  guards its own choose dispatch); a claim nested in a SIBLING branch does not
  count.

The issue also raised widening the existing rule as an option. That was rejected:
its focus anchor is load-bearing for the fail-open direction it was hand-tuned
for, and widening it to "any Tab branch with an action" is what would have needed
the exemption channel.

## What tests we did

- `src/test/ImeEnterClaimRatchet.test.ts` (targeted run, 20 passed): the new tree
  scan plus 10 fixture cases pinning the predicate - the one-line accept shape,
  the guard-clause spelling both markdown editors use, a claim that runs AFTER
  the consumption (still flagged), the swallow-to-hold-still branch (out of
  scope), the early decline-and-return (clears), a sibling-nested claim (does
  not clear), a decline that never returns, a branch that never consumes, and a
  claim mentioned only in a comment.
- Mutation-verified: with the four site fixes reverted and the rule in place, the
  new test fails naming exactly
  `PathBar.tsx:71`, `BlockEditor.tsx:117`, `MdNotebookPage.tsx:2466`,
  `ChatPanel.tsx:1528` - and the other 19 tests in the file stay green.
- `src/test/ImeEnterGuardSites.test.tsx` (targeted run, 28 passed): behaviour for
  two of the sites - BlockEditor's Tab does not re-indent in the
  post-composition window and does not consume mid-composition, PathBar's Tab
  does not replace the draft, both with plain-Tab positive controls, plus arrow
  navigation still working with the latch armed. Mutation-verified: reverting the
  two claims reds 3 of these.
- `tsc -b` clean. eslint on the six touched files: 0 errors, and the warning
  count is byte-identical to base (49/49), so the repo's `--max-warnings` ratchet
  is untouched. `i18n-check` and `check-i18n-strings` both pass.
- Full suites were left to CI by design on this host.

## Any other suggestions on the work

- The new rule's nesting proxy is indentation, like the element-bracketing rules
  below it; unrecognized formatting fails open, which is the right direction for
  a rule whose job is to catch a copied shape.
- Same-line granularity is inherited from the sibling rule: a claim written after
  the `preventDefault()` on the SAME line would read as guarding it. Both rules
  share that limitation, and the multi-line spelling is what the tree uses.
- The two remaining `useListKeyboardNav` Tab paths are now the only unclaimed
  consumers left in the tree, both deliberate and both explained in place. If a
  third deliberate swallow ever appears, that is the point to revisit whether an
  explicit exemption marker beats the act anchor.

Closes #5534
