### PR TITLE
feat(aws-control): library removal + a ledger reconcile direction

### DIFF
--- a/docs/system-specs/features/aws-control.md
+++ b/docs/system-specs/features/aws-control.md
@@ -118,6 +118,88 @@ layer after the route's S3-consent and publish-governance checks. It refuses
 credential-bearing artifact content; `test_aws_control_app.py::TestLibraryScan.test_credential_bearing_artifact_is_refused`
 pins that egress boundary.
 
+`library.library_remove` deletes the whole `artifacts/<slug>/` prefix and then
+forgets the slug's ledger record. The order is load-bearing rather than
+transactional: a local file and a remote bucket cannot be committed as one, and
+objects-then-record leaves at worst a record the bucket does not back, which
+`library.reconcile` repairs. The reverse order would leave objects that no
+surface lists. Removal writes delete markers on the versioned bucket, so it
+empties the listing rather than reaching billing-zero; a version purge remains
+outstanding, as it does for the Drive's own deletes.
+
+`library.reconcile` is the direction that makes the ledger's "display state, not
+truth" claim hold: it drops records the bucket does not back and never invents a
+record for a cloud copy it finds, because version and push time live in that
+copy's sidecar. It prunes only what the bucket has had a chance to disprove — a
+record stamped at or after the listing it is judged against is left alone, since
+that listing predates the record — so a push completing mid-render does not lose
+its record. `routes._handle_library_list` reconciles before joining local
+artifacts, and reports whether the bucket was actually read — a failed, absent,
+or unconsented read leaves the rows rendering as an unverified ledger claim
+rather than as an authoritative empty. It reads the prefix through
+`storage.list_library_folders`, which is unredacted and completely paginated
+because a reconcile reasons about absence; the paged, redacted display listing
+cannot answer that question. `library._update_ledger` is the ledger's only
+writer, so push, removal, and reconcile cannot drop each other's records.
+
+`routes._library_lock` serializes the three Library operations on one drive —
+push, removal, and the reconcile read. Each is a network round trip followed by a
+ledger write, and interleaving two of them corrupts state neither half can
+detect: a push completing between the reconcile's listing and its prune, or a
+push racing a removal of the same slug past the delete sweep. The ledger's file
+lock cannot serve this — it covers a sub-second read plus rename by design.
+
+The two mutations wait on that lock unbounded — they are user-initiated actions
+that may legitimately queue — but the render path waits only
+`_LIBRARY_RECONCILE_LOCK_WAIT_SECS` and then reports `reconciled: false`. A push
+holds the lock across an upload allowed up to 600s, and a page render must not
+hang for that; skipping loses nothing durable because the reconcile is
+self-correcting, so the next render performs it. Errors on this path already
+degrade rather than failing, and slowness degrades the same way.
+
+Because that lock makes a caller WAIT, all three operations re-run their
+authorization inside it via `routes._reauthorize_in_lock` — app enabled, then live
+identity still resolving to the requested account, then S3 consent, then the drive
+bucket re-resolved and compared, plus publish governance for the push. This is the
+same re-check `_handle_drive_upload` runs after its spool and for the same reason:
+the wait sits between the checks that authorized the call and the call itself. The
+bucket is included because tag discovery can return a different bucket while the
+identity is unchanged, and this module keeps no bucket-name cache precisely
+because that identity must not be stale. The reconcile read is included because a
+listing is still a call into a paid service; on the read path a failed re-check
+degrades to "not reconciled" rather than an error, so the local half still
+renders, and so does a ledger that cannot be written — the rows are renderable,
+they are merely unverified. The degraded identity denial is SEL-audited even
+though the route does not fail on it: a permission decision reaches SEL whether or
+not it becomes an error response.
+
+`library_remove` CONFIRMS the prefix is gone before touching the ledger.
+`delete_prefix` deliberately degrades on an unreadable listing page — it stops the
+walk and reports the count so far, so it can under-delete — and forgetting a record
+on that would drop a copy still in the bucket while reporting the removal as done.
+A slug still present raises instead, leaving the record intact.
+
+The lock is per-process, so a second gateway sharing the data home is still a
+racer. `library._recorded_at_or_after` is that cross-process guard, one rule
+asked by both operations: reconcile will not prune, and removal will not forget,
+a record written at or after the remote observation each is acting on. Both
+cutoffs are read BEFORE their observation begins, never after — a cutoff that
+postdates its own observation protects nothing, because a record written in the
+gap compares as older than it. Reading early only widens the set of records left
+alone, and a record left behind whose objects were really removed is merely
+stale, which the next render repairs.
+
+Soundness also depends on `pushedAt` being stamped when the record is WRITTEN —
+inside the ledger lock, after the uploads have succeeded — not when the push
+began; a pre-upload stamp would read older than a listing that ran during a slow
+upload. The metadata sidecar keeps its own pre-upload stamp, which is what remote
+metadata should say about when the push started.
+
+Cloud copies with no local artifact row are reported to the caller as
+`remoteOnly` rather than being hidden: `list_pushable` walks the local store, so
+a copy pushed from another machine has no row to carry it and would otherwise be
+unreachable from the console that must be able to remove it.
+
 `costs.fetch_month_costs` calls Cost Explorer for the requested linked account
 and groups results by service. `routes._handle_costs` serves a fresh local cache
 without a new consent check; a stale cache is returned with its stale state when
@@ -145,12 +227,17 @@ resources itself.
 profiles, reconnect guidance, drive status/list/download, costs, library,
 backup status, share metadata, and rendered IAM policy. Its mutations are
 profile registration; drive bootstrap, upload, delete, folder create/delete,
-and share; share-ledger removal; library push; backup run, nightly toggle, and
-staged restore.
+and share; share-ledger removal; library push and library removal; backup run,
+nightly toggle, and staged restore.
 
 Drive bootstrap is the only API-level preview-plus-confirm flow. Upload, profile
-registration, library push, share creation, and backup mutations have no
-separate confirmation request; the dashboard separately confirms object and
-folder deletion. Every mutation is owner-gated, restricted-session refused, and
+registration, library push, library removal, share creation, and backup
+mutations have no separate confirmation request; the dashboard separately
+confirms object and folder deletion. Library removal is API-level only in this
+change — it has no dashboard caller yet, so no UI confirm exists for it; the
+companion frontend is expected to gate it the way object and folder deletion are
+gated. Every mutation is owner-gated, restricted-session refused, and
 SEL-audited. Account-targeted AWS operations additionally enforce live identity
-and service consent, and egress paths enforce publish governance.
+and service consent, and egress paths enforce publish governance. Library removal
+is deliberately outside that egress set: it sends no bytes out, so a profile that
+denies publishing can still empty a bucket it is paying for.

--- a/src/kiro_crew/apps/builtins/aws_control/backend/library.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/library.py
@@ -1,14 +1,24 @@
 """Library — cloud copies of artifacts on the drive's ``artifacts/`` prefix.
 
-Push-shaped in this PR: an artifact's current version is uploaded as
-``artifacts/<slug>/v<N>`` plus a ``meta.json`` sidecar, and a local sync
-ledger records what was pushed when. Artifact versions map onto both the
-version-named keys AND the bucket's object versioning, so history survives
-even a same-key overwrite. Pull stays a download (share/presign or Drive
-download) — merging a cloud copy back into the local store is future work.
+An artifact's current version is uploaded as ``artifacts/<slug>/v<N>`` plus a
+``meta.json`` sidecar, and a local sync ledger records what was pushed when.
+Artifact versions map onto both the version-named keys AND the bucket's object
+versioning, so history survives even a same-key overwrite. Pull stays a
+download (share/presign or Drive download) — merging a cloud copy back into the
+local store is future work.
 
 The ledger (``<app data dir>/library.json``) is display state, not truth:
 truth is the bucket listing; the ledger only makes "synced · 2h ago" cheap.
+That is a claim the code has to keep, so two rules hold it up:
+
+* :func:`_update_ledger` is the ONLY writer. Push, removal and reconcile all
+  edit the file through it, because two independent writers of one JSON
+  document is how a later whole-file write drops an earlier record.
+* :func:`reconcile` lets the bucket CORRECT the ledger. Without it a stale
+  record is believed indefinitely, and the surface ends up accommodating the
+  divergence instead of resolving it. It prunes only what the bucket has had a
+  chance to disprove: a record stamped at or after the listing it is judged
+  against is left alone, because that listing predates the record.
 
 CALLER CONTRACT: same as storage.py — handlers hold the consent gate; sync
 functions, call via ``asyncio.to_thread``.
@@ -21,17 +31,36 @@ import json
 import logging
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Collection
 
 from kiro_crew.apps.builtins.aws_control.backend import storage
 from kiro_crew.apps.manager import app_data_dir
-from kiro_crew.artifacts import get_default_store
+from kiro_crew.artifacts import ArtifactValidationError, _validate_slug, get_default_store
 from kiro_crew.atomic_write import atomic_write
+from kiro_crew.deploy.engine import AWSError
 from kiro_crew.platform_compat import file_lock
 
 logger = logging.getLogger(__name__)
 
 APP_NAME = "aws-control"
+
+
+def valid_slug(slug: str) -> bool:
+    """Whether ``slug`` has a shape the artifact store could have produced.
+
+    Checked against the store's OWN validator rather than a second copy of the
+    pattern: removal turns the slug into an object prefix, and a local copy that
+    drifted from ``artifacts._SLUG_RE`` would let a caller address a prefix the
+    store can never have written. Shape only, never existence -- a cloud copy
+    whose local artifact was deleted is precisely the thing that must stay
+    removable.
+    """
+    try:
+        _validate_slug(slug)
+    except ArtifactValidationError:
+        return False
+    return True
+
 
 #: Artifact kind → pushed file extension (content is text for all of these).
 _KIND_EXT = {
@@ -61,6 +90,88 @@ def _write_ledger(ledger: dict[str, Any]) -> None:
     path = _ledger_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write(path, json.dumps(ledger, indent=1))
+
+
+def _update_ledger(account: str, mutate: Callable[[dict[str, Any]], bool]) -> bool:
+    """The ONE writer of ``library.json``. Returns whether the file was written.
+
+    Every mutation — a push recording a copy, a removal forgetting one, a
+    reconcile pruning what the bucket does not back — goes through here, so
+    there is exactly one place that reads, edits and rewrites this file. Two
+    independent writers of one JSON document is how a later atomic write drops
+    an earlier record: each would rewrite the WHOLE ledger from its own stale
+    snapshot.
+
+    ``mutate`` receives THIS account's slug map (always a dict — a corrupted
+    scalar entry is reset first, the same tolerance :func:`read_ledger` shows)
+    and returns whether it changed anything. The file is rewritten only when it
+    did, so a reconcile that finds nothing stale costs no disk write on a
+    surface that renders on every page load.
+
+    The lock is held for a read plus an atomic rename and nothing else. Callers
+    that also touch S3 do that OUTSIDE this block on purpose:
+    :func:`platform_compat.file_lock` documents every in-tree critical section
+    as sub-second, and its Windows path FAILS CLOSED once a bounded ceiling
+    passes — so holding it across a multi-round network delete would turn a
+    concurrent push into a 500.
+    """
+    lock_path = _ledger_path().with_suffix(".lock")
+    _ledger_path().parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as fd:
+        with file_lock(fd.fileno(), exclusive=True, required=True):
+            ledger = read_ledger()
+            slugs = ledger.get(account)
+            if not isinstance(slugs, dict):
+                slugs = {}
+            ledger[account] = slugs
+            if not mutate(slugs):
+                return False
+            _write_ledger(ledger)
+            return True
+
+
+def _recorded_at_or_after(entry: Any, moment: dt.datetime) -> bool:
+    """Whether ``entry``'s ledger record was written at or after ``moment``.
+
+    ONE rule, two callers, because both ask the same question of a remote
+    observation: "could what I saw have covered this record?" :func:`reconcile`
+    asks it of the listing it prunes against, and :func:`library_remove` of the
+    delete sweep it is about to forget a record for. A record written after the
+    observation is one the observation could not have seen, so neither may act on
+    it. Two copies of a rule this subtle would drift.
+
+    ``pushedAt`` is stamped when the record is WRITTEN (inside the ledger lock,
+    after the upload has already succeeded), not when the push began -- that is
+    what makes this comparison sound. A pre-upload stamp would read older than an
+    observation that ran during a slow upload, and the record it names would be
+    acted on despite being newer than the observation.
+
+    ``moment`` is floored to the second the ledger records at: ``pushedAt`` is
+    written with ``timespec="seconds"``, so a record written at 12:00:00.9 stores
+    "12:00:00" and an unfloored 12:00:00.1 comparison would read it as older.
+    Flooring plus ``>=`` absorbs exactly that truncation, at the cost of
+    protecting a record written in the observation's own second -- one round's
+    delay, in the safe direction for both callers.
+
+    An unstamped or unparseable record answers False, i.e. it stays actionable.
+    Every record this module writes carries ``pushedAt``, so one without it is
+    not a concurrent write -- and protecting it would make a corrupted record
+    permanently unrepairable, which is the opposite of what reconcile is for.
+    """
+    if not isinstance(entry, dict):
+        return False
+    raw = entry.get("pushedAt")
+    if not isinstance(raw, str):
+        return False
+    try:
+        stamp = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return False
+    if stamp.tzinfo is None:
+        # A naive stamp is this machine's own UTC clock (the writer below is
+        # tz-aware UTC); read it as UTC rather than crashing on the comparison.
+        stamp = stamp.replace(tzinfo=dt.timezone.utc)
+    return stamp >= moment.astimezone(dt.timezone.utc).replace(microsecond=0)
 
 
 def list_pushable(account: str) -> list[dict[str, Any]]:
@@ -186,22 +297,183 @@ def push_artifact(
             account=account,
         )
 
-    # Locked read-modify-write: two concurrent pushes of different slugs
-    # would otherwise each rewrite the whole ledger from a stale snapshot,
-    # and the later atomic write would silently drop the earlier record.
-    lock_path = _ledger_path().with_suffix(".lock")
-    _ledger_path().parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as fd:
-        with file_lock(fd.fileno(), exclusive=True, required=True):
-            ledger = read_ledger()
-            entry = {
-                "version": artifact.version,
-                "kind": artifact.kind,
-                "pushedAt": meta["pushedAt"],
-            }
-            bucket_entry = ledger.setdefault(account, {})
-            if not isinstance(bucket_entry, dict):
-                bucket_entry = ledger[account] = {}
-            bucket_entry[slug] = entry
-            _write_ledger(ledger)
+    # Through the single ledger writer: two concurrent pushes of different
+    # slugs would otherwise each rewrite the whole ledger from a stale
+    # snapshot, and the later atomic write would silently drop the earlier
+    # record. Removal and reconcile write through the same helper.
+    entry = {
+        "version": artifact.version,
+        "kind": artifact.kind,
+    }
+
+    def _record(slugs: dict[str, Any]) -> bool:
+        # Stamped HERE -- inside the ledger lock, after both uploads have
+        # succeeded -- and deliberately not reused from the metadata sidecar,
+        # which is stamped before the upload starts. `pushedAt` is what
+        # _recorded_at_or_after compares a remote observation against, so it has
+        # to mean "when this record came into existence". With the sidecar's
+        # pre-upload stamp, a listing that ran DURING a slow upload would
+        # postdate the stamp while predating the record, and a reconcile on that
+        # listing would delete a record whose objects are in the bucket. The
+        # sidecar keeps its own stamp: it describes when the push began, which is
+        # the right thing for remote metadata to say.
+        entry["pushedAt"] = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+        slugs[slug] = entry
+        return True
+
+    _update_ledger(account, _record)
     return entry | {"slug": slug, "account": account}
+
+
+def reconcile(
+    account: str, remote_slugs: Collection[str], *, observed_at: dt.datetime
+) -> list[str]:
+    """Correct the ledger from the bucket. Returns the slugs it forgot.
+
+    This is the direction that was missing, and every symptom the removal
+    action kept producing came from its absence. The ledger is LOCAL and the
+    bucket is REMOTE, the two can disagree, and only one of them is truth — so
+    a record the bucket does not back is dropped rather than believed. A stale
+    record is not cosmetic: it made the console refuse the very push that would
+    have restored a cloud copy deleted somewhere else.
+
+    Only that direction is safe to automate. A slug present in the bucket but
+    absent from the ledger cannot be reconstructed here — version and push time
+    live in its ``meta.json``, one GET per slug — so it is reported to the
+    caller instead (see ``routes._handle_library_list``), never invented.
+
+    ``remote_slugs`` MUST be a COMPLETE listing of this account's library
+    prefix, which is what :func:`storage.list_library_folders` guarantees and
+    what the paged display listing does not. This function concludes ABSENCE
+    from it, and absence from a partial listing would delete live records.
+
+    ``observed_at`` is when that listing was taken, and it is REQUIRED because
+    the listing is a snapshot: a push completing after it — objects uploaded,
+    record written — is absent from ``remote_slugs`` while the bucket does back
+    it, and pruning on the stale snapshot would delete a live record. So a
+    record written at or after the snapshot is never pruned; the bucket has not
+    had a chance to disprove it yet (see :func:`_recorded_at_or_after`).
+    Under-pruning is the safe direction, and it self-corrects: the next render's
+    snapshot postdates the record.
+
+    Callers hold ``routes._library_lock`` across listing and prune, which closes
+    the same window structurally IN THIS PROCESS. The cutoff is what still holds
+    when that is not enough — a second gateway on the same machine shares this
+    ledger and this bucket, and an in-process lock does not reach it.
+    """
+    present = set(remote_slugs)
+    forgotten: list[str] = []
+
+    def _prune(slugs: dict[str, Any]) -> bool:
+        stale = [
+            slug
+            for slug, entry in slugs.items()
+            if slug not in present and not _recorded_at_or_after(entry, observed_at)
+        ]
+        for slug in stale:
+            del slugs[slug]
+        forgotten.extend(stale)
+        return bool(stale)
+
+    if _update_ledger(account, _prune):
+        logger.info(
+            "aws-control library: forgot %d ledger record(s) the bucket does not back",
+            len(forgotten),
+        )
+    return forgotten
+
+
+def library_remove(
+    profile: str, region: str, bucket: str, account: str, slug: str
+) -> dict[str, Any]:
+    """Remove one artifact's cloud copy AND its ledger record, together.
+
+    "Together" is an ORDER, not a transaction: a local file and a remote bucket
+    cannot be committed as one, and pretending otherwise is what produced three
+    rounds of the same defect. So the order is chosen for which divergence a
+    crash between the two halves can leave:
+
+    * objects first, record second — the worst case is "the ledger claims a
+      copy the bucket does not have", which is exactly the state
+      :func:`reconcile` repairs on the next listing;
+    * the reverse would leave an untracked cloud copy — objects nothing points
+      at, in a bucket the user pays for, invisible to the surface that would
+      remove them.
+
+    That is why the two halves of this fix are one change: the removal is only
+    safe to order this way because the reconcile direction exists.
+
+    The record is forgotten CONDITIONALLY. A second gateway sharing this ledger
+    can push this slug after the delete sweep has finished looking, and its
+    record names objects that really are in the bucket -- so a record written at
+    or after the sweep survives and ``forgotten`` reports False. The same rule
+    reconcile applies to its listing (:func:`_recorded_at_or_after`), asked of
+    the sweep instead. ``routes._library_lock`` already prevents the in-process
+    version of this race; this is the half that holds across processes.
+
+    The whole ``<slug>/`` prefix goes, not just the version the ledger recorded.
+    An artifact pushed at v1 and again at v2 has TWO content keys plus the
+    sidecar, and deleting only the recorded version would leave a paid object
+    behind that no surface lists. ``storage.delete_prefix`` anchors on the
+    trailing slash (so a sibling slug sharing a name-prefix is not swept in),
+    pages the batch API, and fails rather than reporting a partial delete as
+    done.
+
+    The bucket is versioned, so each delete writes a delete MARKER: the listing
+    empties and a presigned share stops resolving, while prior versions remain
+    until the version-aware purge the spec still calls out. "Removed" here means
+    removed from the drive, not billing-zero — the same meaning the Drive's own
+    file and folder deletes carry.
+    """
+    if not valid_slug(slug):
+        # The slug becomes an object PREFIX below. An empty or '/'-shaped value
+        # would widen that prefix to the whole section, so the shape is checked
+        # here as well as at the route -- a blast radius is not a display
+        # concern to be validated only on the way in.
+        raise ValueError(f"{slug!r} is not an artifact slug")
+    # Taken BEFORE the delete, never after -- the same rule the reconcile path
+    # states for its listing cutoff, and for the same reason: a cutoff that
+    # POSTDATES the observation it describes protects nothing. `delete_prefix`
+    # stops looking at its final listing, so an upload landing after that survives
+    # the sweep; if the cutoff were read once delete_prefix returned, a record
+    # written in that gap would compare as OLDER than the cutoff and be forgotten
+    # while its objects sat in the bucket. Reading it early only widens the set of
+    # records left alone, and a record left behind whose objects really were
+    # deleted is merely stale -- which reconcile repairs on the next render.
+    swept_at = dt.datetime.now(dt.timezone.utc)
+    objects = storage.delete_prefix(profile, region, bucket, "library", slug, account=account)
+    # delete_prefix does NOT guarantee the prefix is empty when it returns: a
+    # garbled listing page makes it stop the walk and report the count so far,
+    # deliberately, so a bad page can only under-delete. That is the right choice
+    # there and the wrong thing to forget a record on -- the ledger would drop a
+    # copy that is still in the bucket and the response would call it removed. So
+    # the absence is CONFIRMED, before the ledger is touched, and a slug still
+    # present raises rather than reporting a removal that did not happen.
+    if slug in set(storage.list_library_folders(profile, region, bucket, account=account)):
+        raise AWSError(
+            f"objects under {slug} are still present after the delete; refusing to "
+            "report the copy as removed or to forget its record"
+        )
+
+    def _forget(slugs: dict[str, Any]) -> bool:
+        # CONDITIONAL, not an unconditional pop. A second gateway pushing this
+        # same slug after the sweep finished writes a record whose objects are
+        # really in the bucket; popping it would leave objects with no record and
+        # report a removal that did not fully happen. Such a record survives, and
+        # `forgotten` says so, which is the honest answer -- the objects then
+        # surface as `remoteOnly` on the next render and stay removable.
+        if _recorded_at_or_after(slugs.get(slug), swept_at):
+            return False
+        return slugs.pop(slug, None) is not None
+
+    forgotten = _update_ledger(account, _forget)
+    return {
+        "slug": slug,
+        "account": account,
+        "objects": objects,
+        # Whether a RECORD was dropped, told apart from whether objects were.
+        # A copy pushed from another machine has objects and no local record;
+        # reporting one number for both would make the console unable to say
+        # which of the two it just emptied.
+        "forgotten": forgotten,
+    }

--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -13,7 +13,7 @@ READS
 ``GET /drive/{account}/list``                  one listing page (?section&path&token)
 ``GET /drive/{account}/download``              short-lived download URL (?section&key)
 ``GET /costs/{account}``                       cached bill (?refresh=1 re-queries CE)
-``GET /library/{account}``                     local artifacts + push state
+``GET /library/{account}``                     local artifacts + reconciled push state
 ``GET /backup/{account}``                      backup state + remote archive listing
 ``GET /shares``                                live share ledger (?account=)
 ``GET /iam-policy``                            drive-tier policy JSON (local render)
@@ -27,6 +27,7 @@ MUTATIONS (also restricted-session refused + SEL-audited)
 ``POST /drive/{account}/share``                mint a presigned share + ledger entry
 ``POST /shares/{id}/forget``                   drop a ledger entry (link lives to expiry)
 ``POST /library/{account}/push``               push one artifact to the cloud library
+``POST /library/{account}/remove``             delete a cloud copy + forget its record
 ``POST /backup/{account}/run``                 run a backup (snapshot | sessions)
 ``POST /backup/{account}/nightly``             toggle the nightly snapshot
 ``POST /backup/{account}/restore``             download an archive to the staging dir
@@ -54,6 +55,7 @@ GUARDS, in order, and why each exists:
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import logging
 import os
 import shutil
@@ -106,7 +108,33 @@ Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 #: be stale; the identity of the bucket we write to cannot.
 #: Serializes drive creation (see _handle_drive_bootstrap). LoopBoundLock so
 #: the module global never binds an import-time loop (#4800).
+#: How long the RENDER path waits for the Library lock before giving up on the
+#: reconcile. The lock is also held across a push, whose upload allows up to 600s,
+#: so waiting on it unbounded would let one large push hang every Library page
+#: render for the length of that upload. Errors on this path already degrade to
+#: `reconciled: false`; slowness has to degrade the same way or the degradation is
+#: only half real. Skipping costs nothing durable -- the reconcile is
+#: self-correcting, so the next render does it.
+_LIBRARY_RECONCILE_LOCK_WAIT_SECS = 5.0
+
 _bootstrap_lock = LoopBoundLock()
+
+#: Serializes the Library's own operations on one drive: a push, a removal, and
+#: the reconcile that repairs the ledger. Each is a network round trip followed
+#: by a ledger write, and interleaving two of them corrupts state that neither
+#: half can detect on its own -- a push completing between the reconcile's
+#: listing and its prune has its fresh record deleted, and a push racing a
+#: removal of the same slug can leave one uploaded object behind the delete
+#: sweep. The ledger's own file lock cannot serialize these: it deliberately
+#: covers a sub-second read plus rename, and stretching it across S3 would make
+#: a concurrent caller fail closed on Windows.
+#:
+#: Coarse on purpose -- one lock, not one per slug. This is an owner-only
+#: surface where a human clicks buttons, so the contention is theoretical, and a
+#: per-slug map would need eviction to stay bounded. LoopBoundLock for the same
+#: reason ``_bootstrap_lock`` uses it: a module global must not bind an
+#: import-time loop (#4800).
+_library_lock = LoopBoundLock()
 
 #: The provider name this app's egress paths answer to under the shared
 #: publish-governance gate (``capabilities.publish`` ∩ ``destinations:<id>``).
@@ -934,10 +962,248 @@ async def _handle_costs(request: web.Request) -> web.Response:
 # --------------------------------------------------------------------------
 
 
+async def _reauthorize_in_lock(
+    request: web.Request,
+    operation: str,
+    account: str,
+    profile: str,
+    region: str,
+    bucket: str,
+    *,
+    publish: bool,
+) -> web.Response | None:
+    """Re-run the authorization a queued caller may have outlived.
+
+    ``_library_lock`` makes a Library operation WAIT, and the wait sits between
+    the checks ``_require_drive`` ran and the AWS call they authorized. In that
+    gap the app can be disabled, the profile can be repointed at another account,
+    consent can be withdrawn, publish governance can start denying, or the drive
+    tags can move to a different bucket -- and the call would then run on an
+    authorization that no longer holds.
+
+    Exactly the gap ``_handle_drive_upload`` already re-checks after its spool,
+    and in the same order and for the same reason: app, then IDENTITY, then
+    consent. Consent is asked ABOUT a profile and region, so verifying it against
+    a stale pair proves nothing about where the bytes are going -- the identity
+    has to be re-resolved first, and must still be the triple the request was
+    authorized for.
+
+    The BUCKET is re-resolved too, which the identity check does not cover: tag
+    discovery can return a different bucket while the identity is unchanged. This
+    module keeps no bucket-name cache precisely because "numbers can be stale; the
+    identity of the bucket we write to cannot" (see the module's cache comment),
+    and a queued caller holding a name resolved before the wait is the same
+    staleness that comment forbids.
+
+    ``publish`` adds the egress gate, for the push. Removal and the reconcile read
+    send nothing out, so they do not consult that gate here any more than they do
+    on the way in.
+    """
+    if not await asyncio.to_thread(is_app_enabled, APP_NAME):
+        _audit(operation, request.path, "denied", error="app_disabled")
+        return _forbidden("aws-control is disabled", "app_disabled")
+    recheck = await _account_target(request)
+    if isinstance(recheck, web.Response):
+        # A permission DECISION, and it must reach SEL from HERE rather than
+        # relying on the caller. The two mutations return this response and
+        # `_mutating` records their outcome, but the reconcile READ converts it
+        # into a degraded 200 -- so without an audit at the point of decision the
+        # denial disappears entirely on that path.
+        _audit(operation, request.path, "denied", error="account_unavailable")
+        return recheck
+    if recheck != (account, profile, region):
+        _audit(operation, request.path, "denied", error="account_mismatch")
+        return _conflict(
+            "this connection changed while the request was queued; nothing was written",
+            "account_mismatch",
+        )
+    denied = await _consent(aws_consent.SERVICE_S3, profile, region)
+    if denied:
+        return denied
+    try:
+        current = await _drive_bucket(account, profile, region)
+    except AWSError as exc:
+        return _aws_failed(exc)
+    if current != bucket:
+        _audit(operation, request.path, "denied", error="drive_changed")
+        return _conflict(
+            "this account's drive changed while the request was queued; nothing was written",
+            "drive_changed",
+        )
+    if publish:
+        return await _publish_gate(request, operation)
+    return None
+
+
+async def _reconciled_remote_slugs(request: web.Request) -> tuple[set[str] | None, str]:
+    """Read the account's cloud library and reconcile the ledger against it.
+
+    Returns the slugs the bucket holds, or ``(None, reason)`` when it could not
+    be read. A NON-FATAL variant of the drive preamble: the Library list must
+    keep rendering local artifacts for an account that is disconnected, has not
+    confirmed S3, or has no drive yet -- the same shape
+    ``_handle_backup_status`` uses for its remote half. Every failure comes back
+    as a reason rather than as a response, and the caller reports it instead of
+    implying an answer.
+
+    The listing and the prune run under ``_library_lock`` as ONE step. They are
+    a read of remote state followed by a decision about local state, and a push
+    completing between them would have its fresh record pruned on a snapshot
+    taken before it existed -- the bucket backs that record, so deleting it
+    breaks reconcile's own rule that it only drops what the bucket has
+    disproven. ``observed_at`` is passed through as a second, cross-process
+    guard; see :func:`library.reconcile`.
+    """
+    target = await _account_target(request)
+    if isinstance(target, web.Response):
+        # A permission DECISION, even though this route degrades instead of
+        # failing: the profile became unavailable or now names another account,
+        # and _guarded's own rule is that such a decision reaches SEL. Degrading
+        # quietly would drop the one event an incident review asks about.
+        _audit("library_list", request.path, "denied", error="account_unavailable")
+        return None, "no working connection for this account"
+    account, profile, region = target
+    if await _consent(aws_consent.SERVICE_S3, profile, region) is not None:
+        return None, "S3 is not confirmed for the account in use"
+    try:
+        bucket = await _drive_bucket(account, profile, region)
+    except AWSError as exc:
+        return None, _safe_error(exc)
+    if not bucket:
+        return None, "this account has no drive yet"
+    # Taken BEFORE the listing, never after: the cutoff must not postdate the
+    # snapshot it describes. Reading it early only widens the set of records the
+    # prune leaves alone, which is the safe direction.
+    observed_at = dt.datetime.now(dt.timezone.utc)
+    try:
+        # BOUNDED wait, unlike the two mutations, which are user-initiated actions
+        # that may legitimately queue. This is a page render: a push holding the
+        # lock through a 600s upload must not hang it. Giving up here loses
+        # nothing durable -- the reconcile is self-correcting, so the next render
+        # performs it -- and it is reported rather than silently skipped.
+        await asyncio.wait_for(_library_lock.acquire(), timeout=_LIBRARY_RECONCILE_LOCK_WAIT_SECS)
+    except asyncio.TimeoutError:
+        return None, "another library operation is in progress; the bucket was not re-read"
+    try:
+        # The lock is a WAIT, so the consent and identity resolved above may have
+        # expired while queued -- and a listing is still a call into a paid
+        # service, which this app never makes on a withdrawn grant. Same re-check
+        # the two mutations run; failure degrades to "not reconciled" rather than
+        # to an error, because this route's local half must still render.
+        if (
+            await _reauthorize_in_lock(
+                request, "library_list", account, profile, region, bucket, publish=False
+            )
+            is not None
+        ):
+            return None, "authorization changed while this request was queued"
+        try:
+            # list_library_folders, NOT the paged display listing: this answer is
+            # compared against ledger KEYS and reasoned about as absence, so it
+            # must be unredacted and complete. See its docstring.
+            folders = await asyncio.to_thread(
+                storage_mod.list_library_folders,
+                profile,
+                region,
+                bucket,
+                account=account,
+            )
+        except AWSError as exc:
+            return None, _safe_error(exc)
+        slugs = {f for f in folders if library_mod.valid_slug(f)}
+        try:
+            await asyncio.to_thread(library_mod.reconcile, account, slugs, observed_at=observed_at)
+        except OSError as exc:
+            # The reconcile WRITES, and this route is best-effort by contract. An
+            # unwritable ledger directory, or a lock this platform refuses to
+            # take, must not turn a page render into a 500: the rows are still
+            # renderable, they are just unverified. Reported as a reason rather
+            # than swallowed, so the payload does not claim a reconcile happened.
+            logger.warning("aws-control library reconcile could not write: %s", exc)
+            return None, "the local sync ledger could not be updated"
+    finally:
+        _library_lock.release()
+    return slugs, ""
+
+
 async def _handle_library_list(request: web.Request) -> web.Response:
+    """Local artifacts + push state, with the ledger reconciled first.
+
+    The reconcile is BEST-EFFORT and its outcome is REPORTED, never implied.
+    ``reconciled`` says whether the bucket was actually read; when it is false
+    the rows are the ledger's unverified claim and ``remoteError`` says why. A
+    caller that cannot tell "no cloud copy" from "cloud state unknown" is how a
+    destructive control gets offered for an item nothing is known about, so the
+    distinction is in the payload rather than left to be inferred from an empty
+    list.
+
+    This GET writes local state, which is deliberate and narrow: reconcile only
+    ever DELETES a claim the bucket has already disproven. It touches no object,
+    removes no data, and takes nothing from the request -- the bucket listing is
+    its only input, so a caller cannot steer it. Doing it here is the point: the
+    stale record's whole symptom (a push refused because the ledger insists the
+    copy is already there) is only observable on the render that reads it.
+    """
     account = request.match_info.get("account", "")
+    remote, reason = await _reconciled_remote_slugs(request)
+    payload: dict[str, Any] = {"reconciled": remote is not None}
+    if remote is None:
+        payload["remoteError"] = reason
     rows = await asyncio.to_thread(library_mod.list_pushable, account)
-    return web.json_response({"artifacts": rows})
+    if remote is not None:
+        # Cloud copies with no local artifact row: pushed from another machine,
+        # or the local artifact has since been deleted. list_pushable walks the
+        # LOCAL store, so these have no row to carry them and would otherwise be
+        # unreachable from the console -- the exact "filled it, cannot empty it"
+        # gap. Slugs only; a version would cost one GET per copy on a render.
+        local = {str(row.get("slug", "")) for row in rows}
+        payload["remoteOnly"] = sorted(remote - local)
+    return web.json_response({"artifacts": rows, **payload})
+
+
+async def _handle_library_remove(request: web.Request) -> web.Response:
+    """Delete one artifact's cloud copy and forget its ledger record.
+
+    No publish gate: that gate governs bytes LEAVING the box (a push, a
+    presigned link), and this route sends nothing out. It is a mutation, so it
+    carries the restricted-session refusal and the SEL audit every mutation
+    does. Single-call like the Drive's own file and folder deletes -- the
+    two-call confirm is for creating a BILLABLE resource, and the dashboard
+    confirms deletions itself.
+    """
+    ctx = await _require_drive(request)
+    if isinstance(ctx, web.Response):
+        return ctx
+    account, profile, region, bucket = ctx
+    body = await _body(request)
+    slug = str(body.get("slug", ""))
+    # An artifact slug, not a free-form key: the slug becomes an object prefix,
+    # and the validator refuses the empty and '/'-bearing values that would
+    # widen that prefix beyond one artifact. library_remove re-checks it, so the
+    # blast radius does not depend on this route being the only caller.
+    if not library_mod.valid_slug(slug):
+        return _bad_request("slug must be an artifact slug", "invalid_slug")
+    try:
+        # Under _library_lock, for the mirror of the push case: the delete sweep
+        # and the ledger write are two steps, and a push of the same slug
+        # interleaving can land an object after the sweep has finished looking.
+        async with _library_lock:
+            # A queued delete can outlive its own authorization the same way a
+            # queued push can; a delete under withdrawn consent is still an
+            # unauthorized call into the account.
+            denied = await _reauthorize_in_lock(
+                request, "library_remove", account, profile, region, bucket, publish=False
+            )
+            if denied:
+                return denied
+            result = await asyncio.to_thread(
+                library_mod.library_remove, profile, region, bucket, account, slug
+            )
+    except ValueError as exc:
+        return _bad_request(_safe_error(exc), "invalid_slug")
+    except AWSError as exc:
+        return _aws_failed(exc)
+    return web.json_response({"removed": True, **result})
 
 
 async def _handle_library_push(request: web.Request) -> web.Response:
@@ -957,9 +1223,21 @@ async def _handle_library_push(request: web.Request) -> web.Response:
     from kiro_crew.artifacts import ArtifactNotFoundError
 
     try:
-        record = await asyncio.to_thread(
-            library_mod.push_artifact, profile, region, bucket, account, slug
-        )
+        # Under _library_lock: the upload and the ledger write are two steps, and
+        # a removal of the same slug interleaving between them can sweep one of
+        # the two uploaded objects and then forget a record this push is about to
+        # rewrite. See the lock's own comment.
+        async with _library_lock:
+            # The lock is a WAIT, so the authorization above may have expired
+            # while queued. Re-run it before a byte moves.
+            denied = await _reauthorize_in_lock(
+                request, "library_push", account, profile, region, bucket, publish=True
+            )
+            if denied:
+                return denied
+            record = await asyncio.to_thread(
+                library_mod.push_artifact, profile, region, bucket, account, slug
+            )
     except ArtifactNotFoundError:
         return _not_found("unknown artifact", "unknown_artifact")
     except ValueError as exc:
@@ -1123,6 +1401,10 @@ def register_routes(app: web.Application) -> None:
     r.add_post(
         f"{_BASE}/library/{{account}}/push",
         _guarded(_mutating("library_push")(_handle_library_push)),
+    )
+    r.add_post(
+        f"{_BASE}/library/{{account}}/remove",
+        _guarded(_mutating("library_remove")(_handle_library_remove)),
     )
     r.add_post(
         f"{_BASE}/backup/{{account}}/run",

--- a/src/kiro_crew/apps/builtins/aws_control/backend/storage.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/storage.py
@@ -342,6 +342,69 @@ def list_section(
     }
 
 
+def list_library_folders(profile: str, region: str, bucket: str, *, account: str) -> list[str]:
+    """Every immediate folder name directly under ``artifacts/`` — RAW, unredacted.
+
+    Singular rather than section-parameterized, unlike its object-I/O siblings.
+    The Library is the only section with a local ledger to reconcile, so a
+    ``section`` argument here would have exactly one reachable value; the prefix
+    is anchored from ``SECTION_PREFIXES`` inside, which keeps the rule that a raw
+    prefix never comes from a caller.
+
+    Deliberately NOT :func:`list_section`. That one is a DISPLAY read: it runs
+    every name through the egress redactors, which is right for a name rendered
+    in the dashboard and wrong for an IDENTITY read. The Library reconcile
+    compares these names against ledger KEYS, and a redacted name matches no
+    key — so a reconcile fed the display listing could read a cloud copy that
+    is present as absent, and drop a live ledger entry on that reading.
+
+    Also deliberately without a page token. Omitting ``--max-items`` lets the
+    CLI auto-paginate and applies ``--query`` to the MERGED result (the same
+    property :func:`usage` relies on), so the answer is either the COMPLETE
+    set of folders or a raised error — never a first page a caller could
+    mistake for the whole prefix. Callers here reason about ABSENCE, and
+    absence from a partial listing is not absence.
+
+    For the same reason an unreadable response RAISES instead of degrading to
+    an empty list, unlike :func:`usage`: empty means "nothing in the cloud",
+    and a caller acting on that would discard every record it holds.
+    """
+    prefix = SECTION_PREFIXES["library"]
+    out = _checked(
+        [
+            "s3api",
+            "list-objects-v2",
+            "--bucket",
+            bucket,
+            "--prefix",
+            prefix,
+            "--delimiter",
+            "/",
+            "--expected-bucket-owner",
+            account,
+            "--output",
+            "json",
+            "--query",
+            "CommonPrefixes[].Prefix",
+        ],
+        profile,
+        action="s3:ListBucket",
+        timeout=60,
+    )
+    try:
+        rows = json.loads(out or "[]") or []
+    except json.JSONDecodeError:
+        raise AWSError(
+            "the folder listing returned a response that could not be read as JSON; "
+            "refusing to report the section as empty"
+        ) from None
+    return [
+        row[len(prefix) :].rstrip("/")
+        for row in rows
+        if isinstance(row, str) and row.startswith(prefix) and row[len(prefix) :].strip("/")
+    ]
+
+
 #: Ceiling for a single owner-pinned transfer. ``put-object`` is one request and
 #: S3 rejects a body over 5 GiB; ``s3 cp`` would have split it into a multipart
 #: upload, but no ``aws s3`` command accepts ``--expected-bucket-owner``, so a

--- a/test/test_aws_control_app.py
+++ b/test/test_aws_control_app.py
@@ -65,6 +65,7 @@ P0_ROUTES: tuple[tuple[str, str], ...] = (
     ("POST", "/drive/{account}/share"),
     ("POST", "/shares/{id}/forget"),
     ("POST", "/library/{account}/push"),
+    ("POST", "/library/{account}/remove"),
     ("POST", "/backup/{account}/run"),
     ("POST", "/backup/{account}/nightly"),
     ("POST", "/backup/{account}/restore"),

--- a/test/test_aws_control_library.py
+++ b/test/test_aws_control_library.py
@@ -3,21 +3,27 @@
 ``test_aws_control_app.py::TestLibraryScan`` already pins the two push
 REFUSALS (credential-bearing content, beacon URL). This file covers the
 lines those cases leave cold: the ledger read/write shape guards, the
-redacting ``list_pushable`` display path, the unpushable-kind refusal, and
-the full happy-path push through the locked ledger write.
+redacting ``list_pushable`` display path, the unpushable-kind refusal, the
+full happy-path push through the single ledger writer, and the removal side --
+``_update_ledger``'s single-writer discipline, ``valid_slug``'s blast-radius
+guard, ``reconcile``'s bucket-corrects-the-ledger direction, and
+``library_remove``'s ordering.
 
 Comments explain WHY each case matters, matching the sibling file's style.
 """
 
 from __future__ import annotations
 
+import datetime as dt
 import json
+import time
 from types import SimpleNamespace as NS
 from unittest import mock
 
 import pytest
 
 from kiro_crew.apps.builtins.aws_control.backend import library
+from kiro_crew.deploy.engine import AWSError
 
 ACCOUNT = "123456789012"
 
@@ -252,3 +258,394 @@ class TestPushArtifact:
         persisted = library.read_ledger()[ACCOUNT]
         assert isinstance(persisted, dict)
         assert persisted["doc"]["version"] == 1
+
+    def test_the_ledger_stamp_is_taken_after_the_uploads_not_before(self, tmp_path, monkeypatch):
+        # The stamp is what _recorded_at_or_after compares a remote observation
+        # against, so it has to mean "when this record came into existence". With
+        # the metadata sidecar's PRE-upload stamp, a listing that ran during a
+        # slow upload would postdate the stamp while predating the record, and a
+        # reconcile on that listing would delete a record whose objects landed.
+        _ledger_at(monkeypatch, tmp_path)
+        art = NS(
+            slug="doc",
+            name="n",
+            kind="text",
+            version=1,
+            description="",
+            tags=[],
+            content="plain body",
+        )
+        marks: dict[str, dt.datetime] = {}
+
+        def _slow_upload(*_a, **_kw):
+            # Sleep FIRST, then mark: the mark has to land in a LATER second than
+            # the sidecar's pre-upload stamp, or second-flooring makes the two
+            # indistinguishable and this test stops discriminating between them.
+            # A listing taken at the mark is AFTER the push began and BEFORE the
+            # record exists -- the window the pre-upload stamp got wrong.
+            time.sleep(1.1)
+            marks.setdefault("mid_upload", dt.datetime.now(dt.timezone.utc))
+
+        with (
+            mock.patch.object(library, "get_default_store") as store,
+            mock.patch.object(library.storage, "put_file", side_effect=_slow_upload),
+        ):
+            store.return_value.get.return_value = art
+            entry = library.push_artifact("p", "us-west-2", "b", ACCOUNT, "doc")
+
+        stamped = dt.datetime.fromisoformat(entry["pushedAt"])
+        # The record's own stamp postdates the mid-upload instant, so a reconcile
+        # on a listing taken then leaves it alone.
+        assert stamped >= marks["mid_upload"].replace(microsecond=0)
+        assert library.reconcile(ACCOUNT, set(), observed_at=marks["mid_upload"]) == []
+        assert "doc" in library.read_ledger()[ACCOUNT]
+
+
+# --------------------------------------------------------------------------
+# _update_ledger — the ONE writer. Push, removal and reconcile all edit the
+# file through it, which is what stops two writers of one JSON document from
+# dropping each other's records.
+# --------------------------------------------------------------------------
+class TestUpdateLedger:
+    def test_a_mutation_that_changed_nothing_writes_no_file(self, tmp_path, monkeypatch):
+        # The Library list reconciles on EVERY page render. A reconcile that
+        # finds nothing stale must cost no disk write, or an idle console
+        # rewrites this file forever.
+        path = _ledger_at(monkeypatch, tmp_path)
+        assert library._update_ledger(ACCOUNT, lambda slugs: False) is False
+        assert not path.exists()
+
+    def test_a_corrupted_account_entry_is_reset_before_the_callback_runs(
+        self, tmp_path, monkeypatch
+    ):
+        # The callback is promised a dict. A scalar per-account entry (hand-edited
+        # or half-written) must be reset first, not handed through as a str the
+        # callback would raise on.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(json.dumps({ACCOUNT: "corrupt"}), encoding="utf-8")
+        seen: list[object] = []
+
+        def _mutate(slugs):
+            # A COPY: the same dict is mutated below, so keeping the reference
+            # would assert against the post-mutation state, not what was handed in.
+            seen.append(dict(slugs))
+            slugs["fresh"] = {"version": 1}
+            return True
+
+        assert library._update_ledger(ACCOUNT, _mutate) is True
+        assert seen == [{}]
+        assert library.read_ledger()[ACCOUNT] == {"fresh": {"version": 1}}
+
+    def test_other_accounts_are_carried_through_untouched(self, tmp_path, monkeypatch):
+        # The write rewrites the WHOLE document, so a mutation scoped to one
+        # account must not drop a sibling account's records -- the exact loss the
+        # single-writer rule exists to prevent.
+        path = _ledger_at(monkeypatch, tmp_path)
+        other = "999988887777"
+        path.write_text(
+            json.dumps({other: {"kept": {"version": 7}}, ACCOUNT: {"gone": {"version": 1}}}),
+            encoding="utf-8",
+        )
+        library._update_ledger(ACCOUNT, lambda slugs: bool(slugs.pop("gone", None)))
+        ledger = library.read_ledger()
+        assert ledger[other] == {"kept": {"version": 7}}
+        assert ledger[ACCOUNT] == {}
+
+
+# --------------------------------------------------------------------------
+# valid_slug — the slug becomes an object PREFIX in library_remove, so the
+# shape is checked against the artifact store's own validator.
+# --------------------------------------------------------------------------
+class TestValidSlug:
+    def test_accepts_a_store_shaped_slug(self):
+        assert library.valid_slug("my-artifact-2")
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",  # would widen the delete prefix to the whole section
+            "/",  # ditto
+            "..",  # traversal shape
+            "a/b",  # a key, not a slug: reaches below one artifact
+            "Upper",  # the store lowercases; an uppercase key is not ours
+            "trailing-",  # the store never emits a trailing hyphen
+        ],
+    )
+    def test_refuses_anything_the_store_could_not_have_written(self, bad):
+        assert not library.valid_slug(bad)
+
+
+# --------------------------------------------------------------------------
+# reconcile — the direction that was missing. The bucket corrects the ledger;
+# a record the bucket does not back is dropped rather than believed.
+# --------------------------------------------------------------------------
+#: A listing taken "now". Records stamped before it are judged against it; a
+#: record stamped at or after it was written too late for that listing to have
+#: seen, so it is off limits.
+NOW = dt.datetime(2026, 8, 30, 12, 0, 0, tzinfo=dt.timezone.utc)
+BEFORE = "2026-08-30T11:59:00+00:00"
+AFTER = "2026-08-30T12:00:30+00:00"
+
+
+class TestReconcile:
+    def test_drops_records_the_bucket_does_not_back(self, tmp_path, monkeypatch):
+        # The symptom this repairs: a stale record made the console refuse the
+        # very push that would have restored a cloud copy deleted elsewhere.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(
+            json.dumps(
+                {
+                    ACCOUNT: {
+                        "still-there": {"version": 1, "pushedAt": BEFORE},
+                        "deleted-elsewhere": {"version": 2, "pushedAt": BEFORE},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        forgotten = library.reconcile(ACCOUNT, {"still-there"}, observed_at=NOW)
+        assert forgotten == ["deleted-elsewhere"]
+        assert library.read_ledger()[ACCOUNT] == {"still-there": {"version": 1, "pushedAt": BEFORE}}
+
+    def test_a_record_written_after_the_listing_is_not_pruned(self, tmp_path, monkeypatch):
+        # THE race both GPT and Design flagged. The listing is a snapshot; a push
+        # that completes after it -- objects uploaded, record written -- is absent
+        # from the snapshot while the bucket DOES back it. Pruning on the stale
+        # set would delete a live record, breaking reconcile's own rule that it
+        # only drops what the bucket has disproven.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(
+            json.dumps({ACCOUNT: {"pushed-mid-render": {"version": 1, "pushedAt": AFTER}}}),
+            encoding="utf-8",
+        )
+        assert library.reconcile(ACCOUNT, set(), observed_at=NOW) == []
+        assert "pushed-mid-render" in library.read_ledger()[ACCOUNT]
+
+    def test_a_record_stamped_in_the_listings_own_second_is_not_pruned(self, tmp_path, monkeypatch):
+        # pushedAt is written with timespec="seconds", so a push at 12:00:00.9
+        # stores "12:00:00". Judged against an unfloored 12:00:00.1 cutoff it
+        # would look older than the snapshot and be pruned; flooring plus >=
+        # absorbs exactly that truncation.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(
+            json.dumps(
+                {ACCOUNT: {"same-second": {"version": 1, "pushedAt": "2026-08-30T12:00:00+00:00"}}}
+            ),
+            encoding="utf-8",
+        )
+        mid_second = NOW.replace(microsecond=100000)
+        assert library.reconcile(ACCOUNT, set(), observed_at=mid_second) == []
+        assert "same-second" in library.read_ledger()[ACCOUNT]
+
+    @pytest.mark.parametrize("stamp", [None, "not-a-timestamp", 12345])
+    def test_an_undatable_record_stays_prunable(self, stamp, tmp_path, monkeypatch):
+        # Every record this module writes carries a parseable pushedAt, so one
+        # without it is not a push racing the listing. Protecting it would make a
+        # corrupted record permanently unrepairable, which is the opposite of
+        # what reconcile is for.
+        path = _ledger_at(monkeypatch, tmp_path)
+        entry: dict = {"version": 1}
+        if stamp is not None:
+            entry["pushedAt"] = stamp
+        path.write_text(json.dumps({ACCOUNT: {"undatable": entry}}), encoding="utf-8")
+        assert library.reconcile(ACCOUNT, set(), observed_at=NOW) == ["undatable"]
+
+    def test_a_naive_stamp_is_read_as_utc_rather_than_crashing(self, tmp_path, monkeypatch):
+        # A tz-naive stamp (hand-edited, or an older writer) must not raise on
+        # the aware/naive comparison. Read as this machine's UTC, an AFTER stamp
+        # is still protected.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(
+            json.dumps({ACCOUNT: {"naive": {"version": 1, "pushedAt": "2026-08-30T12:00:30"}}}),
+            encoding="utf-8",
+        )
+        assert library.reconcile(ACCOUNT, set(), observed_at=NOW) == []
+
+    def test_a_cloud_copy_with_no_record_is_not_invented(self, tmp_path, monkeypatch):
+        # Version and push time live in the copy's meta.json, one GET per slug.
+        # Reconcile reports the gap to its caller instead of fabricating a
+        # record it cannot know.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(json.dumps({ACCOUNT: {}}), encoding="utf-8")
+        assert library.reconcile(ACCOUNT, {"pushed-from-another-machine"}, observed_at=NOW) == []
+        assert library.read_ledger()[ACCOUNT] == {}
+
+    def test_an_agreeing_ledger_is_left_alone_and_unwritten(self, tmp_path, monkeypatch):
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(json.dumps({ACCOUNT: {"a": {"version": 1}}}), encoding="utf-8")
+        before = path.read_text(encoding="utf-8")
+        assert library.reconcile(ACCOUNT, {"a"}, observed_at=NOW) == []
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_another_accounts_records_are_not_pruned(self, tmp_path, monkeypatch):
+        # The listing is ONE account's bucket. Pruning on it must never reach a
+        # second account's records, which no part of this observation covers.
+        path = _ledger_at(monkeypatch, tmp_path)
+        other = "999988887777"
+        path.write_text(
+            json.dumps({other: {"theirs": {"version": 1}}, ACCOUNT: {"ours": {"version": 1}}}),
+            encoding="utf-8",
+        )
+        assert library.reconcile(ACCOUNT, set(), observed_at=NOW) == ["ours"]
+        assert library.read_ledger()[other] == {"theirs": {"version": 1}}
+
+    def test_a_freshly_pushed_record_survives_a_reconcile_on_a_stale_listing(
+        self, tmp_path, monkeypatch
+    ):
+        # End to end on the real writers rather than a hand-built ledger: take
+        # the snapshot, push (which stamps pushedAt = now), then reconcile on the
+        # snapshot that predates it. The record must survive.
+        _ledger_at(monkeypatch, tmp_path)
+        art = NS(
+            slug="doc",
+            name="n",
+            kind="text",
+            version=1,
+            description="",
+            tags=[],
+            content="plain body",
+        )
+        observed_at = dt.datetime.now(dt.timezone.utc)
+        with (
+            mock.patch.object(library, "get_default_store") as store,
+            mock.patch.object(library.storage, "put_file"),
+        ):
+            store.return_value.get.return_value = art
+            library.push_artifact("p", "us-west-2", "b", ACCOUNT, "doc")
+        assert library.reconcile(ACCOUNT, set(), observed_at=observed_at) == []
+        assert "doc" in library.read_ledger()[ACCOUNT]
+
+
+# --------------------------------------------------------------------------
+# library_remove — objects and record removed together, in the order whose
+# only reachable divergence is the one reconcile repairs.
+# --------------------------------------------------------------------------
+class TestLibraryRemove:
+    def test_removes_the_whole_slug_prefix_and_forgets_the_record(self, tmp_path, monkeypatch):
+        # The whole `<slug>/` prefix, not the recorded version: a slug pushed at
+        # v1 and again at v2 has two content keys plus the sidecar, and deleting
+        # only the recorded one leaves a paid object no surface lists.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(
+            json.dumps({ACCOUNT: {"doc": {"version": 2}, "other": {"version": 1}}}),
+            encoding="utf-8",
+        )
+        with (
+            mock.patch.object(library.storage, "delete_prefix", return_value=3) as rm,
+            mock.patch.object(library.storage, "list_library_folders", return_value=["other"]),
+        ):
+            result = library.library_remove("p", "us-west-2", "bucket", ACCOUNT, "doc")
+
+        assert rm.call_args.args == ("p", "us-west-2", "bucket", "library", "doc")
+        assert rm.call_args.kwargs == {"account": ACCOUNT}
+        assert result == {
+            "slug": "doc",
+            "account": ACCOUNT,
+            "objects": 3,
+            "forgotten": True,
+        }
+        # The record is gone and the sibling slug is untouched.
+        assert library.read_ledger()[ACCOUNT] == {"other": {"version": 1}}
+
+    def test_a_prefix_still_present_after_the_delete_raises_and_keeps_the_record(
+        self, tmp_path, monkeypatch
+    ):
+        # delete_prefix DELIBERATELY degrades on a garbled listing page: it stops
+        # the walk and returns the count so far, so it can under-delete. Forgetting
+        # the record on that would drop a copy still in the bucket and call the
+        # removal done, so the absence is confirmed first -- and confirmed BEFORE
+        # the ledger is touched, so a failed check cannot forget anything.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(json.dumps({ACCOUNT: {"doc": {"version": 2}}}), encoding="utf-8")
+        with (
+            mock.patch.object(library.storage, "delete_prefix", return_value=1),
+            mock.patch.object(library.storage, "list_library_folders", return_value=["doc"]),
+        ):
+            with pytest.raises(AWSError, match="still present after the delete"):
+                library.library_remove("p", "us-west-2", "bucket", ACCOUNT, "doc")
+        # Record intact: the copy is still there, so the ledger is still right.
+        assert library.read_ledger()[ACCOUNT]["doc"]["version"] == 2
+
+    def test_objects_are_deleted_before_the_record_is_forgotten(self, tmp_path, monkeypatch):
+        # ORDER is the whole design: if the ledger were cleared first, a failing
+        # delete would leave an UNTRACKED cloud copy -- objects nothing points
+        # at, invisible to the surface that would remove them. Failing this way
+        # round leaves only "the ledger claims a copy the bucket lacks", which
+        # reconcile repairs on the next listing.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text(json.dumps({ACCOUNT: {"doc": {"version": 1}}}), encoding="utf-8")
+        with mock.patch.object(
+            library.storage, "delete_prefix", side_effect=AWSError("access denied")
+        ):
+            with pytest.raises(AWSError):
+                library.library_remove("p", "us-west-2", "bucket", ACCOUNT, "doc")
+        # Still recorded: nothing was forgotten on the strength of a delete that
+        # did not happen.
+        assert library.read_ledger()[ACCOUNT] == {"doc": {"version": 1}}
+
+    def test_an_untracked_cloud_copy_is_removable_and_reported_as_such(self, tmp_path, monkeypatch):
+        # A copy pushed from another machine has objects and no local record.
+        # It must still be removable -- that is the "empty what it fills" case --
+        # and `forgotten` tells the caller no record was involved.
+        _ledger_at(monkeypatch, tmp_path)
+        with (
+            mock.patch.object(library.storage, "delete_prefix", return_value=2),
+            mock.patch.object(library.storage, "list_library_folders", return_value=[]),
+        ):
+            result = library.library_remove("p", "us-west-2", "bucket", ACCOUNT, "elsewhere")
+        assert result["objects"] == 2
+        assert result["forgotten"] is False
+
+    def test_a_record_written_after_the_sweep_is_not_forgotten(self, tmp_path, monkeypatch):
+        # The cross-process race GPT found: a second gateway pushes this slug
+        # after the delete sweep has stopped looking, so its record names objects
+        # that really are in the bucket. Popping it would leave objects with no
+        # record and report a removal that did not fully happen.
+        path = _ledger_at(monkeypatch, tmp_path)
+
+        def _sweep(*_a, **_kw):
+            # Stands in for the other gateway's push landing past the sweep's
+            # final listing. The record is written, and only THEN does the sweep
+            # return -- which is what discriminates the cutoff's direction: read
+            # before the delete the record is protected, read after the delete
+            # returns it compares as older than the cutoff and is forgotten.
+            path.write_text(
+                json.dumps(
+                    {
+                        ACCOUNT: {
+                            "doc": {
+                                "version": 9,
+                                "pushedAt": dt.datetime.now(dt.timezone.utc).isoformat(
+                                    timespec="seconds"
+                                ),
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            time.sleep(1.1)
+            return 1
+
+        with (
+            mock.patch.object(library.storage, "delete_prefix", side_effect=_sweep),
+            mock.patch.object(library.storage, "list_library_folders", return_value=[]),
+        ):
+            result = library.library_remove("p", "us-west-2", "bucket", ACCOUNT, "doc")
+        # The newer record survives, and the report says no record was dropped
+        # rather than claiming a clean removal.
+        assert result["forgotten"] is False
+        assert library.read_ledger()[ACCOUNT]["doc"]["version"] == 9
+
+    @pytest.mark.parametrize("bad", ["", "/", "..", "a/b"])
+    def test_a_slug_that_would_widen_the_prefix_is_refused_before_any_delete(
+        self, bad, tmp_path, monkeypatch
+    ):
+        # The blast-radius guard, checked HERE and not only at the route: an
+        # empty or '/'-bearing value would turn the delete prefix into the whole
+        # artifacts/ section.
+        _ledger_at(monkeypatch, tmp_path)
+        with mock.patch.object(library.storage, "delete_prefix") as rm:
+            with pytest.raises(ValueError, match="not an artifact slug"):
+                library.library_remove("p", "us-west-2", "bucket", ACCOUNT, bad)
+        rm.assert_not_called()

--- a/test/test_aws_control_routes.py
+++ b/test/test_aws_control_routes.py
@@ -22,6 +22,7 @@ module-private there and the two files must not edit each other.
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import json
 from types import SimpleNamespace
 from unittest import mock
@@ -1158,19 +1159,416 @@ class TestCostsEndpoint:
 
 
 class TestLibrary:
-    def test_library_list_returns_pushable_rows(self):
+    def test_library_list_renders_rows_when_the_bucket_cannot_be_read(self):
+        # The load-bearing degradation: no working connection means the ledger's
+        # claim is UNVERIFIED, so the rows still render but `reconciled` is false
+        # and the reason is stated. A caller that could not tell this apart from
+        # "nothing in the cloud" is how a delete control gets offered for an item
+        # nothing is known about.
         handlers = _registered()
         rows = [{"slug": "x", "name": "X"}]
         with (
             mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(
+                routes_mod.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=None),
+            ),
             mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=rows),
+            mock.patch.object(routes_mod.library_mod, "reconcile") as reconcile,
         ):
             resp = asyncio.run(
                 handlers[("GET", "/library/{account}")](  # type: ignore[operator]
                     _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
                 )
             )
-        assert _payload(resp) == {"artifacts": rows}
+        body = _payload(resp)
+        assert body["artifacts"] == rows
+        assert body["reconciled"] is False
+        assert body["remoteError"]
+        # Nothing was concluded about absence, so nothing was pruned.
+        reconcile.assert_not_called()
+        # And no remoteOnly key: an empty list would read as "no untracked
+        # copies", which was never established.
+        assert "remoteOnly" not in body
+
+    def test_library_list_reconciles_the_ledger_and_reports_untracked_copies(self):
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        rows = [{"slug": "local-one", "name": "L"}]
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(
+                routes_mod.storage_mod,
+                "list_library_folders",
+                return_value=["local-one", "pushed-elsewhere"],
+            ),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=rows),
+            mock.patch.object(routes_mod.library_mod, "reconcile", return_value=["stale"]) as rec,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        body = _payload(resp)
+        assert body["reconciled"] is True
+        assert "remoteError" not in body
+        # The bucket listing is what corrects the ledger, and it is the SERVER's
+        # own read -- never a set handed in by the caller.
+        assert rec.call_args.args[0] == ACCOUNT
+        assert rec.call_args.args[1] == {"local-one", "pushed-elsewhere"}
+        # The snapshot's own time travels with it: reconcile refuses to prune a
+        # record written after the listing, and cannot do that without knowing
+        # when the listing was taken.
+        assert isinstance(rec.call_args.kwargs["observed_at"], dt.datetime)
+        # A cloud copy with no local artifact row has nothing to carry it in
+        # `artifacts`; without this it would be unreachable from the console.
+        assert body["remoteOnly"] == ["pushed-elsewhere"]
+
+    def test_library_list_ignores_a_folder_that_is_not_a_slug(self):
+        # A prefix written by another tool ("my uploads/") is not a slug the
+        # store could have produced, so it cannot answer for a ledger key. It is
+        # dropped before reconcile rather than counted as a cloud copy.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(
+                routes_mod.storage_mod,
+                "list_library_folders",
+                return_value=["good-slug", "my uploads", "Not_A_Slug"],
+            ),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod.library_mod, "reconcile", return_value=[]) as rec,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        assert rec.call_args.args[1] == {"good-slug"}
+        assert _payload(resp)["remoteOnly"] == ["good-slug"]
+
+    def test_library_list_skips_reconcile_when_the_listing_fails(self):
+        # An AWS failure is not evidence of an empty bucket. The reason is
+        # reported and the ledger is left exactly as it was.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(
+                routes_mod.storage_mod,
+                "list_library_folders",
+                side_effect=AWSError("list denied"),
+            ),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod.library_mod, "reconcile") as rec,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        body = _payload(resp)
+        assert body["reconciled"] is False and "list denied" in body["remoteError"]
+        rec.assert_not_called()
+
+    def test_library_list_skips_reconcile_when_the_account_has_no_drive(self):
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            mock.patch.object(routes_mod.storage_mod, "find_drive", return_value=""),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod.library_mod, "reconcile") as rec,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        # Still 200 with rows: the Library list is a LOCAL view first, and an
+        # account with no drive yet must not blank the page.
+        assert resp.status == 200
+        assert _payload(resp)["reconciled"] is False
+        rec.assert_not_called()
+
+    def test_the_listing_and_the_prune_run_under_one_lock(self):
+        # The window GPT and Design both flagged: a push completing between the
+        # reconcile's listing and its prune has its fresh record deleted on a
+        # snapshot taken before it existed. The lock is what makes the two a
+        # single step, so the listing must observe it HELD -- asserting on the
+        # lock rather than on a sleep, which would only prove timing.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        seen: dict[str, bool] = {}
+
+        def _list_folders(*_a, **_kw):
+            seen["locked_during_listing"] = routes_mod._library_lock.locked()
+            return ["a"]
+
+        def _reconcile(*_a, **_kw):
+            seen["locked_during_prune"] = routes_mod._library_lock.locked()
+            return []
+
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(
+                routes_mod.storage_mod, "list_library_folders", side_effect=_list_folders
+            ),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod.library_mod, "reconcile", side_effect=_reconcile),
+        ):
+            asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        assert seen == {"locked_during_listing": True, "locked_during_prune": True}
+        # And released afterwards, or the next render would deadlock behind it.
+        assert not routes_mod._library_lock.locked()
+
+    def test_library_list_skips_reconcile_when_consent_is_withdrawn_while_queued(self):
+        # The lock makes the reconcile read WAIT too, and a listing is still a
+        # call into a paid service -- so it re-checks inside the lock like the two
+        # mutations. Failure degrades to "not reconciled" rather than erroring:
+        # this route's local half must keep rendering.
+        handlers = _registered()
+        calls = {"n": 0}
+
+        async def _consent_then_deny(*_a, **_kw):
+            calls["n"] += 1
+            return calls["n"] <= 1
+
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(
+                routes_mod.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("prof", "us-west-2")),
+            ),
+            mock.patch.object(
+                routes_mod.aws_consent,
+                "probe_identity",
+                AsyncMock(return_value=aws_consent.Identity(ok=True, account=ACCOUNT)),
+            ),
+            mock.patch.object(
+                routes_mod.aws_consent, "refuse_and_log", AsyncMock(side_effect=_consent_then_deny)
+            ),
+            _drive_found(),
+            mock.patch.object(routes_mod.storage_mod, "list_library_folders") as lister,
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod.library_mod, "reconcile") as rec,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        body = _payload(resp)
+        assert resp.status == 200
+        assert body["reconciled"] is False and body["remoteError"]
+        # No AWS call and no prune on a grant that no longer holds.
+        lister.assert_not_called()
+        rec.assert_not_called()
+
+    def test_library_list_skips_reconcile_when_the_drive_changes_while_queued(self):
+        # Identity unchanged is NOT enough: tag discovery can return a different
+        # bucket while the profile still names the same account, and this module
+        # keeps no bucket-name cache precisely because that identity must not be
+        # stale. A queued caller holding a pre-wait name is that staleness.
+        handlers = _registered()
+        seen = {"n": 0}
+
+        def _drive_then_move(*_a, **_kw):
+            seen["n"] += 1
+            return "kirocrew-drive-abc" if seen["n"] <= 1 else "kirocrew-drive-def"
+
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(
+                routes_mod.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("prof", "us-west-2")),
+            ),
+            mock.patch.object(
+                routes_mod.aws_consent,
+                "probe_identity",
+                AsyncMock(return_value=aws_consent.Identity(ok=True, account=ACCOUNT)),
+            ),
+            _consent_ok(),
+            mock.patch.object(routes_mod.storage_mod, "find_drive", side_effect=_drive_then_move),
+            mock.patch.object(routes_mod.storage_mod, "list_library_folders") as lister,
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod.library_mod, "reconcile") as rec,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        assert resp.status == 200
+        assert _payload(resp)["reconciled"] is False
+        lister.assert_not_called()
+        rec.assert_not_called()
+
+    def test_library_list_survives_an_unwritable_ledger(self):
+        # The reconcile WRITES, and this route is best-effort by contract. An
+        # unwritable ledger dir must not turn a page render into a 500 -- the rows
+        # are still renderable, they are just unverified.
+        handlers = _registered()
+        rows = [{"slug": "x", "name": "X"}]
+        p1, p2, p3 = _enabled_owner_env()
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(routes_mod.storage_mod, "list_library_folders", return_value=["x"]),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=rows),
+            mock.patch.object(
+                routes_mod.library_mod,
+                "reconcile",
+                side_effect=OSError("read-only file system"),
+            ),
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        body = _payload(resp)
+        assert resp.status == 200
+        assert body["artifacts"] == rows
+        # Reported, not swallowed: the payload must not claim a reconcile happened.
+        assert body["reconciled"] is False and body["remoteError"]
+
+    def test_library_list_audits_an_identity_denial_it_degrades_past(self):
+        # _guarded's own rule: a permission DECISION reaches SEL. This route
+        # degrades instead of failing, so without an explicit audit the decision
+        # would go unrecorded -- the one event an incident review asks about.
+        handlers = _registered()
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(
+                routes_mod.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=None),
+            ),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod, "_audit") as audit,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        assert resp.status == 200
+        assert _payload(resp)["reconciled"] is False
+        denials = [c for c in audit.call_args_list if "denied" in c.args]
+        assert denials, "the degraded identity denial was not audited"
+
+    def test_library_list_audits_a_queued_identity_denial_it_degrades_past(self):
+        # The SECOND site of the same class: the pre-lock denial was audited last
+        # round, this one fires inside _reauthorize_in_lock. On the read path that
+        # response becomes a degraded 200, so the decision has to be recorded at
+        # the point it is made or it vanishes on this path entirely.
+        handlers = _registered()
+        calls = {"n": 0}
+
+        async def _resolve_then_lose(*_a, **_kw):
+            calls["n"] += 1
+            return ("prof", "us-west-2") if calls["n"] <= 1 else None
+
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(
+                routes_mod.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(side_effect=_resolve_then_lose),
+            ),
+            mock.patch.object(
+                routes_mod.aws_consent,
+                "probe_identity",
+                AsyncMock(return_value=aws_consent.Identity(ok=True, account=ACCOUNT)),
+            ),
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(routes_mod.storage_mod, "list_library_folders") as lister,
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=[]),
+            mock.patch.object(routes_mod, "_audit") as audit,
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        assert resp.status == 200
+        assert _payload(resp)["reconciled"] is False
+        lister.assert_not_called()
+        denials = [c for c in audit.call_args_list if "denied" in c.args]
+        assert denials, "the queued identity denial was not audited"
+
+    def test_library_list_gives_up_the_reconcile_rather_than_waiting_on_a_slow_mutation(self):
+        # The lock is also held across a push, whose upload allows up to 600s. An
+        # unbounded wait here would hang every Library page render for that long.
+        # Errors on this path already degrade to reconciled:false; slowness has to
+        # degrade the same way, or the degradation is only half real.
+        handlers = _registered()
+        rows = [{"slug": "x", "name": "X"}]
+        p1, p2, p3 = _enabled_owner_env()
+
+        async def _run():
+            # Hold the lock the way a slow push would, then render.
+            await routes_mod._library_lock.acquire()
+            try:
+                return await handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            finally:
+                routes_mod._library_lock.release()
+
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(routes_mod, "_LIBRARY_RECONCILE_LOCK_WAIT_SECS", 0.05),
+            mock.patch.object(routes_mod.storage_mod, "list_library_folders") as lister,
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=rows),
+            mock.patch.object(routes_mod.library_mod, "reconcile") as rec,
+        ):
+            resp = asyncio.run(_run())
+        body = _payload(resp)
+        # The rows still render; only the re-read was skipped, and it says so.
+        assert resp.status == 200 and body["artifacts"] == rows
+        assert body["reconciled"] is False and body["remoteError"]
+        lister.assert_not_called()
+        rec.assert_not_called()
+        # Released, so the next render is not stuck behind this one.
+        assert not routes_mod._library_lock.locked()
 
     def _push(self, *, side_effect=None, record=None):
         handlers = _registered()
@@ -1241,6 +1639,197 @@ class TestLibrary:
     def test_push_surfaces_an_aws_error(self):
         resp = self._push(side_effect=AWSError("put denied"))
         assert resp.status == 502
+
+    def _remove(self, *, body=None, side_effect=None, result=None, publish_reason=""):
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        req = _request("POST", f"/library/{ACCOUNT}/remove", match_info={"account": ACCOUNT})
+        req.json = AsyncMock(return_value={"slug": "art-1"} if body is None else body)  # type: ignore[method-assign]
+        remove = mock.patch.object(
+            routes_mod.library_mod,
+            "library_remove",
+            side_effect=side_effect,
+            return_value=(
+                result
+                if result is not None
+                else {"slug": "art-1", "account": ACCOUNT, "objects": 2, "forgotten": True}
+            ),
+        )
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(routes_mod, "publish_denied_reason", return_value=publish_reason),
+            remove as removed,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/library/{account}/remove")](req)  # type: ignore[operator]
+            )
+        return resp, removed
+
+    def test_remove_deletes_the_cloud_copy_and_reports_both_halves(self):
+        resp, removed = self._remove()
+        assert resp.status == 200
+        body = _payload(resp)
+        assert body["removed"] is True
+        # Objects AND record, told apart: a copy pushed from another machine has
+        # objects with no local record, and one number for both would hide which
+        # of the two was emptied.
+        assert body["objects"] == 2 and body["forgotten"] is True
+        assert removed.call_args.args == (
+            "prof",
+            "us-west-2",
+            "kirocrew-drive-abc",
+            ACCOUNT,
+            "art-1",
+        )
+
+    def test_remove_is_not_gated_by_the_publish_gate(self):
+        # Publish governance decides whether BYTES MAY LEAVE the box. A removal
+        # sends nothing out, so a profile that forbids publishing must still be
+        # able to empty a bucket it is paying for -- otherwise denying publish
+        # traps whatever was pushed before it was denied.
+        resp, removed = self._remove(publish_reason="capability denied")
+        assert resp.status == 200
+        removed.assert_called_once()
+
+    def test_remove_requires_a_slug(self):
+        resp, removed = self._remove(body={})
+        assert resp.status == 400
+        assert _payload(resp)["code"] == "invalid_slug"
+        removed.assert_not_called()
+
+    def test_remove_refuses_a_slug_that_would_widen_the_delete_prefix(self):
+        # "a/b" is a KEY, not a slug: it would address a prefix below one
+        # artifact. The empty and '/'-shaped values are the same class of
+        # widening, and none of them reach the storage layer.
+        for bad in ("", "/", "..", "a/b", "Upper"):
+            resp, removed = self._remove(body={"slug": bad})
+            assert resp.status == 400, bad
+            assert _payload(resp)["code"] == "invalid_slug"
+            removed.assert_not_called()
+
+    def test_remove_maps_a_rejected_slug_from_the_engine_to_400(self):
+        # library_remove re-checks the shape itself, so the route reports that
+        # refusal as a bad request rather than a 500.
+        resp, _removed = self._remove(side_effect=ValueError("'x/y' is not an artifact slug"))
+        assert resp.status == 400
+        assert _payload(resp)["code"] == "invalid_slug"
+
+    def test_remove_surfaces_an_aws_error(self):
+        # A failed delete must NOT report success: the objects are still there,
+        # and the ledger still says so, which reconcile will confirm.
+        resp, _removed = self._remove(side_effect=AWSError("delete denied"))
+        assert resp.status == 502
+
+    def test_push_and_remove_both_hold_the_library_lock(self):
+        # Both are a network round trip followed by a ledger write, and the two
+        # interleaving on one slug can leave an object behind the delete sweep or
+        # forget a record the other is about to write. One lock covers push,
+        # remove, and the reconcile read.
+        held: dict[str, bool] = {}
+
+        def _record_push(*_a, **_kw):
+            held["push"] = routes_mod._library_lock.locked()
+            return {"slug": "art-1"}
+
+        def _record_remove(*_a, **_kw):
+            held["remove"] = routes_mod._library_lock.locked()
+            return {"slug": "art-1", "account": ACCOUNT, "objects": 1, "forgotten": True}
+
+        self._push(side_effect=_record_push)
+        self._remove(side_effect=_record_remove)
+        assert held == {"push": True, "remove": True}
+        assert not routes_mod._library_lock.locked()
+
+    def _queued_then_revoked(self, path: str, *, revoke: str):
+        """Run push/remove with authorization that FAILS on the second check.
+
+        The lock makes a caller wait, and the wait sits between the checks
+        _require_drive ran and the AWS call they authorized. These fakes pass the
+        first time and fail the second, standing in for the policy changing while
+        the caller was queued.
+        """
+        handlers = _registered()
+        calls = {"consent": 0, "identity": 0, "publish": 0}
+
+        async def _consent_then_deny(*_a, **_kw):
+            calls["consent"] += 1
+            return not (revoke == "consent" and calls["consent"] > 1)
+
+        async def _identity_then_move(*_a, **_kw):
+            calls["identity"] += 1
+            if revoke == "identity" and calls["identity"] > 1:
+                return aws_consent.Identity(ok=True, account="999988887777")
+            return aws_consent.Identity(ok=True, account=ACCOUNT)
+
+        def _publish_then_deny(*_a, **_kw):
+            calls["publish"] += 1
+            return "capability denied" if (revoke == "publish" and calls["publish"] > 1) else ""
+
+        req = _request("POST", f"{path}", match_info={"account": ACCOUNT})
+        req.json = AsyncMock(return_value={"slug": "art-1"})  # type: ignore[method-assign]
+        route = "/library/{account}/push" if path.endswith("push") else "/library/{account}/remove"
+        target = "push_artifact" if path.endswith("push") else "library_remove"
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(
+                routes_mod.accounts_mod,
+                "resolve_account_profile",
+                AsyncMock(return_value=("prof", "us-west-2")),
+            ),
+            mock.patch.object(
+                routes_mod.aws_consent, "probe_identity", AsyncMock(side_effect=_identity_then_move)
+            ),
+            mock.patch.object(
+                routes_mod.aws_consent, "refuse_and_log", AsyncMock(side_effect=_consent_then_deny)
+            ),
+            _drive_found(),
+            mock.patch.object(routes_mod, "publish_denied_reason", side_effect=_publish_then_deny),
+            mock.patch.object(routes_mod.library_mod, target) as engine,
+        ):
+            resp = asyncio.run(handlers[("POST", route)](req))  # type: ignore[operator]
+        return resp, engine
+
+    def test_push_refuses_when_consent_is_withdrawn_while_queued(self):
+        # The gap the lock introduced: a queued push must not upload on an
+        # authorization it has outlived. Same re-check drive_upload runs after its
+        # spool, for the same reason.
+        resp, engine = self._queued_then_revoked(f"/library/{ACCOUNT}/push", revoke="consent")
+        assert resp.status == 409
+        assert _payload(resp)["code"] == "aws_consent_required"
+        engine.assert_not_called()
+
+    def test_push_refuses_when_the_profile_moves_account_while_queued(self):
+        # A profile repointed A -> B while queued: the upload would still write
+        # into the bucket resolved for A, so it is refused rather than run.
+        resp, engine = self._queued_then_revoked(f"/library/{ACCOUNT}/push", revoke="identity")
+        assert resp.status == 409
+        engine.assert_not_called()
+
+    def test_push_refuses_when_publish_governance_starts_denying_while_queued(self):
+        resp, engine = self._queued_then_revoked(f"/library/{ACCOUNT}/push", revoke="publish")
+        assert resp.status == 403
+        assert _payload(resp)["code"] == "publish_denied"
+        engine.assert_not_called()
+
+    def test_remove_refuses_when_consent_is_withdrawn_while_queued(self):
+        # A queued DELETE can outlive its authorization too, and a delete under
+        # withdrawn consent is still an unauthorized call into the account.
+        resp, engine = self._queued_then_revoked(f"/library/{ACCOUNT}/remove", revoke="consent")
+        assert resp.status == 409
+        assert _payload(resp)["code"] == "aws_consent_required"
+        engine.assert_not_called()
+
+    def test_remove_does_not_consult_the_publish_gate_even_in_the_lock(self):
+        # Removal sends nothing out, so the egress gate does not apply on the way
+        # in OR on the re-check -- a profile denied publishing must still be able
+        # to empty a bucket it pays for.
+        resp, engine = self._queued_then_revoked(f"/library/{ACCOUNT}/remove", revoke="publish")
+        assert resp.status == 200
+        engine.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_aws_control_storage.py
+++ b/test/test_aws_control_storage.py
@@ -377,6 +377,68 @@ class TestListSection:
 # ---------------------------------------------------------------------------
 
 
+class TestListLibraryFolders:
+    """The IDENTITY read behind the Library reconcile.
+
+    Distinct from list_section on three points a reconcile depends on, each
+    pinned here: unredacted names, a complete answer rather than a page, and a
+    RAISE rather than an empty list when the response cannot be read.
+    """
+
+    def test_returns_raw_folder_names_and_anchors_the_library_prefix(self):
+        # CommonPrefixes carry the full key prefix; the caller compares these
+        # against ledger keys, so the prefix and the trailing slash both have to
+        # come off. The prefix is anchored INSIDE (there is no section argument),
+        # so a caller cannot point this read at another section.
+        payload = json.dumps(["artifacts/alpha/", "artifacts/beta-two/"])
+        with mock.patch.object(storage, "_checked", return_value=payload) as checked:
+            folders = storage.list_library_folders(
+                "prof", "us-west-2", "bkt", account="111122223333"
+            )
+        assert folders == ["alpha", "beta-two"]
+        argv = checked.call_args.args[0]
+        # Delimiter + prefix make it a one-level listing, and the query pulls
+        # CommonPrefixes so the CLI's auto-pagination merges every page into it.
+        assert "--delimiter" in argv and argv[argv.index("--delimiter") + 1] == "/"
+        assert argv[argv.index("--prefix") + 1] == "artifacts/"
+        assert argv[argv.index("--query") + 1] == "CommonPrefixes[].Prefix"
+        # Owner-pinned like every other call: a bucket name that changed hands
+        # must not answer for this account.
+        assert argv[argv.index("--expected-bucket-owner") + 1] == "111122223333"
+        # NO --max-items: passing one turns the CLI to client-side pagination and
+        # this answer would become a first page the caller would read as the
+        # whole prefix.
+        assert "--max-items" not in argv
+
+    def test_an_empty_library_is_an_empty_list(self):
+        # No CommonPrefixes at all: --query renders null, which must read as "no
+        # folders" rather than raising.
+        with mock.patch.object(storage, "_checked", return_value="null"):
+            assert (
+                storage.list_library_folders("prof", "us-west-2", "bkt", account="111122223333")
+                == []
+            )
+
+    def test_foreign_and_bare_prefix_rows_are_dropped(self):
+        # A row outside the prefix (another section leaking into the response)
+        # and the prefix placeholder itself carry no folder name; neither may
+        # become an empty-string "folder" the caller then reasons about.
+        payload = json.dumps(["drive/other/", "artifacts/", "artifacts//", "artifacts/real/"])
+        with mock.patch.object(storage, "_checked", return_value=payload):
+            assert storage.list_library_folders(
+                "prof", "us-west-2", "bkt", account="111122223333"
+            ) == ["real"]
+
+    def test_unreadable_response_raises_instead_of_reading_as_empty(self):
+        # THE case this function exists for. An empty answer means "nothing in
+        # the cloud", and the reconcile acts on that by dropping every record it
+        # holds -- so a garbled response must fail loudly, the opposite of
+        # usage()'s deliberate degrade-to-empty.
+        with mock.patch.object(storage, "_checked", return_value="{not json"):
+            with pytest.raises(AWSError, match="could not be read as JSON"):
+                storage.list_library_folders("prof", "us-west-2", "bkt", account="111122223333")
+
+
 class TestObjectIO:
     def test_put_file_is_owner_pinned_and_section_scoped(self, tmp_path):
         # s3api put-object, NOT `s3 cp`: no `aws s3` command accepts


### PR DESCRIPTION
## What is the problem?

The account console's Drive can copy an artifact into the cloud but cannot
remove it again. The Library folder is add-only: it lists what is under the
bucket's `artifacts/` prefix, offers a per-item add advertised by count, and its
only exit is a hint pointing at the CLI.

A removal action was built and then withdrawn during #6780, deliberately. It
produced three consecutive blocking review findings and they were all one defect
wearing different clothes: removing the objects left the local push ledger
asserting the copy was still there; a failed lookup was indistinguishable from
"no copy", so a destructive control could appear for an item nothing was known
about; and a stale ledger entry disabled the very push that would have restored
a cloud copy deleted elsewhere.

The root cause is that the push ledger is **local**, the bucket is **remote**,
the two can disagree, and the UI trusted the ledger. There was no operation that
owned both sides of a change and no reconciliation between them.

## Why this issue matters to the user

Storage in this bucket costs the user money, and the console is the only place
most users will ever see it. "You can put things here, ask a terminal to take
them out" is not a complete feature, and the picker actively encourages bulk
filling. The divergence also had a visible cost: the push button had to stop
disabling on `upToDate` so a cloud copy deleted out of band could be restored --
an accommodation of the disagreement rather than a fix for it.

## How our fix solves it

Two backend pieces, and they only work as one change.

**1. `library_remove(profile, region, bucket, account, slug)`** deletes the whole
`artifacts/<slug>/` prefix, then forgets the slug's ledger record. "Together" is
an ORDER, not a transaction -- a local file and a remote bucket cannot be
committed as one, so the order is chosen for which divergence a crash between the
halves can leave:

* objects first: the worst case is "the ledger claims a copy the bucket does not
  have", which piece 2 repairs on the next listing;
* the reverse would leave an untracked cloud copy -- objects nothing points at,
  in a bucket the user pays for, invisible to the surface that would remove them.

The whole prefix goes, not just the version the ledger recorded: a slug pushed at
v1 and again at v2 has two content keys plus the sidecar, and deleting only the
recorded one leaves a paid object no surface lists.

**2. `reconcile(account, remote_slugs, observed_at)`** lets the bucket correct the
ledger, which is what finally makes the ledger's own "display state, not truth"
docstring true. It drops records nothing backs -- the stale entry that refused the
restoring push -- and never invents a record for a cloud copy it finds, because
version and push time live in that copy's `meta.json`.

Chaining that back to the three findings:

* finding 1 (objects gone, ledger still asserting) is now a state the system
  repairs itself, and the removal is only safe to order this way *because* the
  reconcile direction exists;
* finding 2 (a failed lookup reading as "no copy") is answered by reporting the
  tri-state instead of implying it: `GET /library/{account}` returns
  `reconciled: true/false` plus `remoteError`, so an unreadable bucket renders as
  an unverified ledger claim rather than as an authoritative empty;
* finding 3 (a stale entry disabling the push) is what reconcile deletes, so the
  up-to-date state can go back to meaning up to date.

**The listing reconcile judges records against is a snapshot**, so a push
completing after it -- objects uploaded, record written -- is absent from that set
while the bucket does back it. Pruning on the stale set would delete a live
record, which would break reconcile's own rule. Two guards, because they cover
different failures:

* `routes._library_lock` (a `LoopBoundLock`, same shape and rationale as the
  `_bootstrap_lock` already in that file) serializes the three Library operations
  on one drive -- push, removal, and the reconcile read. The listing and the prune
  become one step, and a push can no longer race a removal of the same slug past
  `delete_prefix`'s final sweep. Coarse on purpose: this is an owner-only surface
  where a human clicks buttons, and a per-slug map would need eviction to stay
  bounded.
* `observed_at` is the cross-process half, since that lock is per-process and a
  second gateway on the same machine shares this ledger and this bucket. A record
  stamped at or after the snapshot is never pruned. Under-pruning is the safe
  direction and self-corrects on the next render. The cutoff is floored to the
  second the ledger records at, because `pushedAt` is written with
  `timespec="seconds"`: without flooring, a push at 12:00:00.9 stores
  "12:00:00" and would read as older than a 12:00:00.1 cutoff.

Supporting changes:

* `_update_ledger` is now the ledger's **only** writer. The issue flagged this
  directly: `_write_ledger` had one caller, and removal must not become a second
  independent writer of the same document. Push, removal and reconcile all edit
  through it, so a later whole-file write cannot drop an earlier record. It holds
  the lock for a read plus an atomic rename and nothing more -- S3 stays outside
  it, because `platform_compat.file_lock` documents every in-tree critical
  section as sub-second and its Windows path fails closed past a bounded ceiling.
  That is also why the serialization above is an asyncio lock rather than a wider
  file lock.
* New `storage.list_section_folders` is the read reconcile consumes. It is
  deliberately **not** the display listing: `list_section` runs folder names
  through the egress redactors (right for a rendered name, wrong for an identity
  read compared against ledger keys) and is client-side paged, and a reconcile
  reasons about ABSENCE, so a first page or a redacted name would delete live
  records. Omitting `--max-items` lets the CLI auto-paginate with `--query`
  applied to the merged result, so the answer is the complete set or a raised
  error. An unreadable response raises rather than degrading to empty, unlike
  `usage()`: empty here means "nothing in the cloud", which a caller would act on
  by discarding every record it holds.
* Cloud copies with no local artifact row come back as `remoteOnly`.
  `list_pushable` walks the local store, so a copy pushed from another machine
  has no row to carry it and would otherwise stay unreachable from the console
  that must be able to empty it.
* `POST /library/{account}/remove` carries the owner gate, restricted-session
  refusal and SEL audit every mutation does, and deliberately **not** the publish
  gate: that gate governs bytes leaving the box, and a profile that denies
  publishing must still be able to empty a bucket it is paying for.

Two things this does NOT claim. The bucket is versioned, so each delete writes a
delete marker: the listing empties and a presigned share stops resolving, while
prior versions remain until the version-aware purge the spec already calls out --
the same meaning the Drive's own file and folder deletes carry. And the reconcile
runs on a GET, which writes local state; that is narrow on purpose -- it only ever
deletes a claim the bucket has already disproven, touches no object, and takes
nothing from the request, so a caller cannot steer it. Doing it there is the
point: the stale record's whole symptom is only observable on the render that
reads it.

No frontend in this PR, matching the issue's scope. #6780 is still open and
rewrites `DrivePage.tsx`; restoring the removal action behind the `localAnswered`
gate it established is the small follow-up this unblocks.

## What tests we did

Targeted runs only (full local suites are not run on this host); CI runs the full
suite on the merge ref.

* `test_aws_control_library.py`, `test_aws_control_storage.py`,
  `test_aws_control_routes.py`, `test_aws_control_app.py`,
  `test_aws_control_hooks.py`, `test_aws_control_backup.py` -- **340 passed**.
* New coverage: `_update_ledger`'s single-writer discipline (no write when
  nothing changed, corrupted per-account entry reset before the callback, a
  sibling account's records carried through untouched), `valid_slug`'s
  blast-radius rejections, `reconcile` (drops what the bucket does not back,
  never invents a record, leaves an agreeing ledger unwritten, never prunes
  another account, and the snapshot cases below), `library_remove` (whole prefix,
  ordering, untracked-copy case, refusals before any delete),
  `list_section_folders` (raw names, argv shape, no `--max-items`,
  raise-not-empty), and the route's reconcile reporting + removal endpoint.
* Snapshot-race coverage specifically: a record written after the listing is not
  pruned; a record stamped in the listing's own second is not pruned (the
  truncation margin); an undatable record stays prunable; a naive stamp does not
  crash the comparison; and an end-to-end case that runs the real `push_artifact`
  and then reconciles on a snapshot taken before it.
* The lock is asserted by observing it HELD during both the listing and the
  prune, and during push and removal -- on the lock itself, not on a sleep, which
  would only prove timing.
* Mutation-verified five guards, each reddening only the tests that claim it:
  making the listing degrade to empty instead of raising; inverting the removal
  order to record-then-objects (fails with the record forgotten after a failed
  delete); deleting the slug guard from `library_remove`; hardcoding
  `reconciled: true`; and removing the snapshot cutoff from `_prune`.
* `test_aws_control_app.py`'s P0 route contract was extended with the new POST,
  so it inherits the existing owner-gate and restricted-session ratchets.
* Gates on touched files: flake8 clean, isort clean, black clean (none of these
  files are in the baseline, so they must be), mypy clean on the three sources.
  No IAM change needed: `_drive_statements` already grants `s3:DeleteObject` on
  `artifacts/*` and `s3:ListBucket`.

## Any other suggestions on the work

* **The share ledger has the same unfixed shape, and it is now filed as #7015.**
  Shares can target the library section, so removing a cloud copy strands a share
  row asserting a link that 404s. Two corrections to how that reads: the gap
  predates this PR (`drive_delete` and `drive_folder_delete` strand rows
  identically today, so this adds a third door to a two-door gap), and `forget`
  is documented as dropping the record while the link lives to expiry -- so
  auto-pruning is a decision to discard the record of a minted URL, not tidying.
  That argues for marking the row rather than deleting it, which is a design
  question worth its own change. #7015 names all three routes and both candidate
  shapes.
* The version purge remains the honest gap. Removal empties the listing; the
  object versions behind the delete markers still bill until a version-aware
  purge exists, and that is true of the Drive's file and folder deletes too. It
  wants its own change, and the spec already names it.
* The remote-to-local reconcile direction is deliberately not automated. Filling
  in version and push time for an untracked copy costs one `meta.json` GET per
  slug, which is not a per-render cost; `remoteOnly` hands the caller the fact
  without paying for it.
* If a second surface ever calls `reconcile`, the two contracts on it are the
  things to preserve: `remote_slugs` must be a complete listing, and
  `observed_at` must not postdate it. Passing a paged listing or a late timestamp
  are both silent ways to delete live records.

Closes #6987
