### PR TITLE
refactor(proc): give the /proc subtree walk one home above both callers

### DIFF
--- a/src/kiro_crew/mcp_gateway/pool.py
+++ b/src/kiro_crew/mcp_gateway/pool.py
@@ -55,6 +55,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping, Optional
 
+from kiro_crew import platform_compat
 from kiro_crew.mcp_gateway.breaker import CircuitBreaker
 
 if TYPE_CHECKING:
@@ -139,45 +140,6 @@ def _resolve_spill_threshold() -> int:
 RESPONSE_SPILL_THRESHOLD_BYTES: int = _resolve_spill_threshold()
 
 
-# Upper bound on processes walked when summing a backend's subtree RSS. A
-# pooled MCP backend's real tree is tiny (parent shim + a handful of workers);
-# the cap only guards against a pathological/looping /proc graph.
-_RSS_SUBTREE_MAX_PROCS = 256
-
-
-def _single_proc_rss_kb(pid: int) -> int:
-    """RSS (KiB) of a single ``pid`` from /proc/<pid>/status, or -1."""
-    try:
-        with open(f"/proc/{pid}/status", encoding="ascii") as fh:
-            for line in fh:
-                if line.startswith("VmRSS:"):
-                    return int(line.split()[1])
-    except (OSError, ValueError, IndexError):
-        pass
-    return -1
-
-
-def _proc_children(pid: int) -> list[int]:
-    """Direct child PIDs of ``pid`` via /proc/<pid>/task/<tid>/children.
-
-    Uses the kernel-provided children list (CONFIG_PROC_CHILDREN), so no
-    ``pgrep``/full-table scan. Returns ``[]`` if the file is unavailable.
-    """
-    kids: list[int] = []
-    task_dir = f"/proc/{pid}/task"
-    try:
-        tids = os.listdir(task_dir)
-    except OSError:
-        return kids
-    for tid in tids:
-        try:
-            with open(f"{task_dir}/{tid}/children", encoding="ascii") as fh:
-                kids.extend(int(tok) for tok in fh.read().split())
-        except (OSError, ValueError):
-            continue
-    return kids
-
-
 def _proc_rss_kb(pid: Optional[int]) -> int:
     """Resident set size (KiB) for ``pid`` **and all its descendants**.
 
@@ -186,31 +148,18 @@ def _proc_rss_kb(pid: Optional[int]) -> int:
     memory lives in a child process. Counting only ``pid``'s own ``VmRSS``
     under-reports the true footprint by ~30x, so we sum the whole subtree.
 
+    Delegates to :func:`platform_compat.proc_subtree_sample`, the one shared
+    ``/proc`` subtree walker — this module used to carry its own line-for-line
+    copy of that BFS plus its own copy of the process ceiling (#6096). ``rss``
+    is the only reading asked for, so the pool pays no ``/proc/<pid>/stat`` read
+    per process for a CPU figure it does not surface, and an unreadable root pid
+    still returns -1 without walking anything.
+
     Returns -1 if ``pid`` is falsy or its own status cannot be read; otherwise
     the summed KiB (descendants that vanish mid-walk are simply skipped, so the
     result degrades gracefully to parent-only when ``children`` is unreadable).
     """
-    if not pid:
-        return -1
-    own = _single_proc_rss_kb(pid)
-    if own < 0:
-        return -1
-    total = own
-    seen = {pid}
-    frontier = [pid]
-    while frontier and len(seen) < _RSS_SUBTREE_MAX_PROCS:
-        nxt: list[int] = []
-        for parent in frontier:
-            for child in _proc_children(parent):
-                if child in seen:
-                    continue
-                seen.add(child)
-                kb = _single_proc_rss_kb(child)
-                if kb > 0:
-                    total += kb
-                nxt.append(child)
-        frontier = nxt
-    return total
+    return platform_compat.proc_subtree_sample(pid, jiffies=False, counts=False).rss_kb
 
 
 # --- PoolKey ----------------------------------------------------------------

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -4474,6 +4474,203 @@ def proc_rss_bytes_for_pid(pid: int) -> int | None:
         return None
 
 
+# --- /proc process-subtree sampling ----------------------------------------
+#
+# ONE walk for the two callers that used to carry their own copy of it:
+# ``mcp_gateway.pool`` and ``subagent`` each had a line-for-line BFS over
+# ``/proc/<pid>/task/<tid>/children`` and its own ``256`` ceiling, so a fix to
+# either policy reached only one surface. :func:`proc_subtree_sample` is now the
+# single entry point for BOTH, and the helpers below are the per-process reads it
+# is built from -- module-private, because no caller outside this module wants a
+# single read on its own. Pure stdlib: on a host without ``/proc`` every access
+# raises ``OSError`` and each reading degrades to its own sentinel.
+#
+# NOT the only way this repository walks a process tree, and deliberately so.
+# ``session_pid._build_child_map`` sums a session's tree from a full ``/proc``
+# scan of every process's ``stat`` ``PPid`` field, precisely because the
+# ``children`` file this walk reads needs ``CONFIG_PROC_CHILDREN`` and is
+# documented as reliable only for frozen tasks -- for a live task it can return
+# an incomplete child set and silently drop a descendant subtree from the sum.
+# That trade is the right one there (an under-counted tree would make the RSS
+# watchdog no-op) and the wrong one here: these two callers sample per backend
+# and per live agent on a timer, where a whole-machine scan per sample is the
+# larger cost, and an under-count degrades a displayed number rather than
+# disabling a protection. Reconsidering the method for these two surfaces is a
+# behaviour change to figures users already read, not part of this
+# consolidation -- but it is now ONE place to reconsider instead of two.
+
+#: Upper bound on processes walked in one subtree sample. A real tree is tiny
+#: (a launcher plus a handful of workers); the cap only guards against a
+#: pathological or looping ``/proc`` graph.
+_SUBTREE_MAX_PROCS = 256
+
+
+def _proc_status_rss_kb(pid: int) -> int:
+    """RSS (KiB) of a single *pid* from ``/proc/<pid>/status``, or -1.
+
+    Reads ``VmRSS``, so the figure matches ``ps -o rss=`` for that one process.
+    Distinct from :func:`proc_rss_bytes_for_pid`, which reads ``statm`` pages and
+    has a Windows path: this one is the Linux subtree walk's per-process read and
+    keeps ``-1`` as its "unreadable" sentinel rather than ``None``.
+    """
+    try:
+        with open(f"/proc/{pid}/status", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        pass
+    return -1
+
+
+def _proc_children(pid: int) -> list[int]:
+    """Direct child PIDs of *pid* via ``/proc/<pid>/task/<tid>/children``.
+
+    Uses the kernel-provided children list (``CONFIG_PROC_CHILDREN``), so no
+    ``pgrep``/full-table scan. Returns ``[]`` if the file is unavailable.
+    """
+    kids: list[int] = []
+    task_dir = f"/proc/{pid}/task"
+    try:
+        tids = os.listdir(task_dir)
+    except OSError:
+        return kids
+    for tid in tids:
+        try:
+            with open(f"{task_dir}/{tid}/children", encoding="ascii") as fh:
+                kids.extend(int(tok) for tok in fh.read().split())
+        except (OSError, ValueError):
+            continue
+    return kids
+
+
+def _parse_cpu_jiffies(stat: bytes) -> int:
+    """Sum utime+stime (clock ticks) from raw ``/proc/<pid>/stat`` bytes.
+
+    Splits after the final ``)`` so a ``comm`` containing spaces/parens is
+    handled. utime/stime are fields 14/15 (1-indexed) → indices 11/12 of the
+    post-comm tokens. Returns 0 on any parse error.
+    """
+    try:
+        rparen = stat.rindex(b")")
+        fields = stat[rparen + 2 :].split()
+        return int(fields[11]) + int(fields[12])
+    except (ValueError, IndexError):
+        return 0
+
+
+def _proc_cpu_jiffies(pid: int) -> int:
+    """utime+stime (clock ticks) for a single pid, 0 on error."""
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            return _parse_cpu_jiffies(fh.read())
+    except OSError:
+        return 0
+
+
+class SubtreeSample(NamedTuple):
+    """Every reading one subtree walk can produce, from ONE frontier.
+
+    Each field keeps its own sentinel, because the readings are unmeasurable in
+    different ways and collapsing any of them into zero is a bug class in its own
+    right:
+
+    * ``rss_kb`` — summed KiB, or ``-1`` when the root pid's own status is
+      unreadable (it is gone, or the host has no ``/proc``).
+    * ``jiffies`` — summed utime+stime clock ticks; an unreadable pid contributes
+      0, since a *delta* of jiffies is what a caller consumes.
+    * ``procs`` / ``matched`` — how many processes the subtree carries, and how
+      many of their command lines contain one of the caller's ``needles``.
+      ``None`` means UNMEASURABLE, never zero: rendering "0 processes" for a live
+      tree would be a lie, so a surface renders ``None`` as an em dash instead.
+    """
+
+    rss_kb: int
+    jiffies: int
+    procs: Optional[int]
+    matched: Optional[int]
+
+
+def proc_subtree_sample(
+    pid: Optional[int],
+    *,
+    rss: bool = True,
+    jiffies: bool = True,
+    counts: bool = False,
+    needles: tuple[str, ...] = (),
+) -> SubtreeSample:
+    """Walk *pid*'s process subtree ONCE and return every requested reading.
+
+    A tracked process is frequently a thin launcher whose real memory lives in a
+    child, so every reading describes the whole subtree rather than the root pid
+    alone.
+
+    The point of one pass is not only the fewer ``/proc`` reads: separate readers
+    run at separate instants, so a process that exits between them is counted by
+    one and missed by another. Reading every metric off a single frontier is what
+    makes "the same set of processes" true of the *result* and not merely of the
+    walk rules.
+
+    ``rss`` / ``jiffies`` / ``counts`` let a caller skip the per-process reads it
+    does not want, so sharing this walk costs each caller what its own walk cost:
+    a CPU-only caller pays no ``status`` read, and an RSS-only caller pays no
+    ``stat`` read. A skipped reading comes back as its own sentinel. When nothing
+    remains to accumulate — RSS unreadable at the root, no jiffies, nothing
+    countable — the descendants are not walked at all.
+
+    ``counts`` is Linux-only (it matches command lines via
+    :func:`process_matches`) and yields ``(None, None)`` elsewhere.
+
+    Coverage caveat for a new caller: the walk reads
+    ``/proc/<pid>/task/<tid>/children``, which needs ``CONFIG_PROC_CHILDREN`` and
+    is documented as reliable only for frozen tasks, so a live tree can come back
+    short. That is acceptable for the periodic per-process figures the two
+    callers display; a reading that must not under-count (the RSS watchdog's
+    recycle decision) uses ``session_pid._build_child_map`` instead, which pays a
+    full ``/proc`` scan for completeness.
+
+    Blocking: reads a handful of ``/proc`` entries per process in the subtree, so
+    it belongs on an executor thread, never on the event loop.
+    """
+    if not pid:
+        return SubtreeSample(-1, 0, None, None)
+    # The counts share RSS's liveness probe: a root pid whose own status cannot
+    # be read has nothing to attribute, so there is nothing to count either.
+    own_rss = _proc_status_rss_kb(pid) if (rss or counts) else -1
+    countable = counts and IS_LINUX and own_rss >= 0
+    rss_total = own_rss if (rss and own_rss >= 0) else -1
+    total_jiffies = _proc_cpu_jiffies(pid) if jiffies else 0
+    procs = 1
+    matched = 1 if countable and process_matches(pid, needles) else 0
+    if rss_total < 0 and not jiffies and not countable:
+        # Nothing a descendant could add — do not pay for the walk.
+        return SubtreeSample(-1, total_jiffies, None, None)
+    seen = {pid}
+    frontier = [pid]
+    while frontier and len(seen) < _SUBTREE_MAX_PROCS:
+        nxt: list[int] = []
+        for parent in frontier:
+            for child in _proc_children(parent):
+                if child in seen:
+                    continue
+                seen.add(child)
+                if rss_total >= 0:
+                    kb = _proc_status_rss_kb(child)
+                    if kb > 0:
+                        rss_total += kb
+                if jiffies:
+                    total_jiffies += _proc_cpu_jiffies(child)
+                if countable:
+                    procs += 1
+                    if process_matches(child, needles):
+                        matched += 1
+                nxt.append(child)
+        frontier = nxt
+    if not countable:
+        return SubtreeSample(rss_total, total_jiffies, None, None)
+    return SubtreeSample(rss_total, total_jiffies, procs, matched)
+
+
 def proc_rss_tree_mb_for_pid(pid: int) -> float | None:
     """Sum RSS (MiB) of *pid* and its LINEAGE-VALIDATED Windows descendants.
 

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -18,7 +18,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Protocol
+from typing import TYPE_CHECKING, Any, Optional, Protocol
 
 from kiro_crew.acp.liveness import (
     VERDICT_DEAD,
@@ -716,165 +716,38 @@ def check_memory_available(min_gb: float = 4.0, path: str = "/proc/meminfo") -> 
     return (True, -1.0)
 
 
-# Process-subtree readers (relocated from the upstream mcp_gateway pool,
-# which is absent in this fork). Pure-stdlib /proc walkers: on non-Linux hosts
-# every /proc access raises OSError and these degrade to -1 / [] gracefully.
-# ONE ceiling for every reading. RSS, CPU and the two counts used to be three
-# walks carrying two copies of the same 256, which is how they could have
-# drifted apart.
-_SUBTREE_MAX_PROCS = 256
+# Process-subtree readings come from ONE shared walker,
+# :func:`platform_compat.proc_subtree_sample`. RSS, CPU and the two counts used
+# to be three walks here carrying two copies of one 256 ceiling, and a fourth
+# copy of the same walk lived in ``mcp_gateway.pool``; the walk now has a single
+# home above both callers (#6096), so a ceiling or a sentinel can no longer
+# drift between them.
 
 
-def _single_proc_rss_kb(pid: int) -> int:
-    """RSS (KiB) of a single ``pid`` from /proc/<pid>/status, or -1."""
-    try:
-        with open(f"/proc/{pid}/status", encoding="ascii") as fh:
-            for line in fh:
-                if line.startswith("VmRSS:"):
-                    return int(line.split()[1])
-    except (OSError, ValueError, IndexError):
-        pass
-    return -1
+def _proc_subtree_sample(pid: Optional[int]) -> platform_compat.SubtreeSample:
+    """One walk of *pid*'s subtree, carrying all four readings the sweep needs.
 
+    Thin adapter over :func:`platform_compat.proc_subtree_sample` that supplies
+    the needle this module counts by: ``STUB_MODULE``, the module path the
+    rewriter itself puts on the stub launch line. So ``sample.matched`` is the
+    stub count here, and the shared walker stays free of gateway vocabulary
+    while this module stays free of a second walk.
 
-def _proc_children(pid: int) -> list[int]:
-    """Direct child PIDs of ``pid`` via /proc/<pid>/task/<tid>/children.
-
-    Uses the kernel-provided children list (CONFIG_PROC_CHILDREN), so no
-    ``pgrep``/full-table scan. Returns ``[]`` if the file is unavailable.
-    """
-    kids: list[int] = []
-    task_dir = f"/proc/{pid}/task"
-    try:
-        tids = os.listdir(task_dir)
-    except OSError:
-        return kids
-    for tid in tids:
-        try:
-            with open(f"{task_dir}/{tid}/children", encoding="ascii") as fh:
-                kids.extend(int(tok) for tok in fh.read().split())
-        except (OSError, ValueError):
-            continue
-    return kids
-
-
-def _parse_cpu_jiffies(stat: bytes) -> int:
-    """Sum utime+stime (clock ticks) from raw ``/proc/<pid>/stat`` bytes.
-
-    Splits after the final ``)`` so a ``comm`` containing spaces/parens is
-    handled. utime/stime are fields 14/15 (1-indexed) → indices 11/12 of the
-    post-comm tokens. Returns 0 on any parse error.
-    """
-    try:
-        rparen = stat.rindex(b")")
-        fields = stat[rparen + 2 :].split()
-        return int(fields[11]) + int(fields[12])
-    except (ValueError, IndexError):
-        return 0
-
-
-def _proc_cpu_jiffies(pid: int) -> int:
-    """utime+stime (clock ticks) for a single pid, 0 on error."""
-    try:
-        with open(f"/proc/{pid}/stat", "rb") as fh:
-            return _parse_cpu_jiffies(fh.read())
-    except OSError:
-        return 0
-
-
-class _SubtreeSample(NamedTuple):
-    """Every subtree reading the cost sweep needs, from ONE walk.
-
-    Each field keeps the sentinel its own reader had, because the four readings
-    are unmeasurable in different ways and collapsing any of them into zero is
-    the bug class the count columns were added to fix:
-
-    * ``rss_kb`` — summed KiB, or ``-1`` when the root pid's own status is
-      unreadable (it is gone, or the host has no ``/proc``).
-    * ``jiffies`` — summed utime+stime clock ticks; an unreadable pid
-      contributes 0, since a *delta* of jiffies is what the caller consumes.
-    * ``procs`` / ``stubs`` — how many processes a runtime carries, and how many
-      of them are MCP stubs, matched on ``STUB_MODULE``, the module path the
-      rewriter itself puts on the stub launch line. ``None`` means UNMEASURABLE,
-      never zero. Rendering "0 processes" for a live runtime would be a lie; the
-      surface renders ``None`` as an em dash instead.
-    """
-
-    rss_kb: int
-    jiffies: int
-    procs: Optional[int]
-    stubs: Optional[int]
-
-
-def _proc_subtree_sample(
-    pid: Optional[int],
-    *,
-    rss: bool = True,
-    counts: bool = True,
-) -> _SubtreeSample:
-    """Walk ``pid``'s process subtree ONCE and return every reading from it.
-
-    A subagent's kiro-cli process is frequently a thin launcher whose real
-    memory lives in a child process, so all four readings describe the whole
-    subtree rather than the root pid alone.
-
-    The point of one pass is not only the ~3x fewer ``/proc`` reads: the three
-    readers this replaced ran at three different instants, so a process that
-    exited between them was counted by one and missed by another. Reading every
-    metric off a single frontier is what makes "the same set of processes" true
-    of the *result* and not merely of the walk rules.
-
-    ``rss`` / ``counts`` let a caller that only needs the CPU total skip those
-    per-process reads, so it costs what it cost before this walk was shared.
-    Skipped metrics come back as their own unmeasurable sentinel.
-
-    Blocking: reads a handful of ``/proc`` entries per process in the subtree,
-    so it belongs on an executor thread, never on the event loop (see
+    Blocking: reads a handful of ``/proc`` entries per process in the subtree, so
+    it belongs on an executor thread, never on the event loop (see
     ``_reaper_loop`` -> ``_sample_live_costs``).
     """
-    if not pid:
-        return _SubtreeSample(-1, 0, None, None)
-    # The counts share RSS's liveness probe: a root pid whose own status cannot
-    # be read has nothing to attribute, so there is nothing to count either.
-    own_rss = _single_proc_rss_kb(pid) if (rss or counts) else -1
-    countable = counts and platform_compat.IS_LINUX and own_rss >= 0
-    rss_total = own_rss if (rss and own_rss >= 0) else -1
-    needles = (STUB_MODULE,)
-    jiffies = _proc_cpu_jiffies(pid)
-    procs = 1
-    stubs = 1 if countable and platform_compat.process_matches(pid, needles) else 0
-    seen = {pid}
-    frontier = [pid]
-    while frontier and len(seen) < _SUBTREE_MAX_PROCS:
-        nxt: list[int] = []
-        for parent in frontier:
-            for child in _proc_children(parent):
-                if child in seen:
-                    continue
-                seen.add(child)
-                if rss_total >= 0:
-                    kb = _single_proc_rss_kb(child)
-                    if kb > 0:
-                        rss_total += kb
-                jiffies += _proc_cpu_jiffies(child)
-                if countable:
-                    procs += 1
-                    if platform_compat.process_matches(child, needles):
-                        stubs += 1
-                nxt.append(child)
-        frontier = nxt
-    if not countable:
-        return _SubtreeSample(rss_total, jiffies, None, None)
-    return _SubtreeSample(rss_total, jiffies, procs, stubs)
+    return platform_compat.proc_subtree_sample(pid, counts=True, needles=(STUB_MODULE,))
 
 
 def _subtree_cpu_jiffies(pid: int) -> int:
     """Sum utime+stime across ``pid`` and its descendants (clock ticks).
 
-    Thin wrapper over :func:`_proc_subtree_sample`, so the CPU subtree the
-    Sessions session rows read is the same subtree the task rows describe.
+    Asks the shared walker for the CPU reading alone, so the CPU subtree the
+    Sessions session rows read is the same subtree the task rows describe, and
+    the session rows pay no ``status`` read for an RSS figure they do not use.
     """
-    return _proc_subtree_sample(pid, rss=False, counts=False).jiffies
+    return platform_compat.proc_subtree_sample(pid, rss=False, counts=False).jiffies
 
 
 def _attributed_count(total: Optional[int], sharers: int, previous: Optional[int]) -> Optional[int]:
@@ -2117,7 +1990,7 @@ class SubagentManager:
                 if gb > info.peak_rss_gb:
                     info.peak_rss_gb = gb
             info.last_procs = _attributed_count(sample.procs, shared_n, info.last_procs)
-            info.last_stubs = _attributed_count(sample.stubs, shared_n, info.last_stubs)
+            info.last_stubs = _attributed_count(sample.matched, shared_n, info.last_stubs)
             jiffies = sample.jiffies
             if info._cpu_sample_ts > 0.0 and jiffies >= info._cpu_jiffies_prev and shared_n > 0:
                 dt = now - info._cpu_sample_ts

--- a/test/test_proc_subtree_sample.py
+++ b/test/test_proc_subtree_sample.py
@@ -1,0 +1,386 @@
+"""The ONE ``/proc`` subtree walker, and the two callers that read off it.
+
+``mcp_gateway.pool`` and ``subagent`` each used to carry a line-for-line copy of
+the same breadth-first walk over ``/proc/<pid>/task/<tid>/children``, each with
+its own ``256`` process ceiling (#6096). Two copies of a walk are two copies of
+its ceiling and two copies of its sentinels, which is the drift the earlier
+consolidation *inside* ``subagent`` (#3970) was itself about.
+
+So this module asserts three things:
+
+* the walker's own contract — the per-process reads, the summed readings, the
+  sentinel each reading falls back to, and the single ceiling;
+* that a caller pays only for the readings it asks for, because that is what
+  made sharing possible: the pool wants RSS and no CPU, the Sessions rows want
+  CPU and no RSS, and an RSS-only caller with an unreadable root must not walk
+  at all (the early return the pool's own copy had);
+* that neither caller has a second walk any more — by name, and behaviourally,
+  by installing ONE fake process tree at the shared module and watching both
+  callers traverse it.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew import subagent as sa
+from kiro_crew.mcp_gateway import pool as pool_mod
+from kiro_crew.mcp_gateway.backend import Backend
+from kiro_crew.mcp_gateway.pool import BackendPool, PoolKey
+
+#: 1 root + 3 children, two of which match the caller's needles.
+TREE = {10: [11, 12, 13], 11: [], 12: [], 13: []}
+RSS = {10: 1000, 11: 200, 12: 30, 13: 4}
+JIFFIES = {10: 100, 11: 50, 12: 25, 13: 10}
+MATCHING = {11, 12}
+
+
+def _fake_tree(*, needles: tuple[str, ...] = ()):
+    """Patch the shared per-process reads to describe :data:`TREE`."""
+    return (
+        patch.object(platform_compat, "IS_LINUX", True),
+        patch.object(platform_compat, "_proc_status_rss_kb", side_effect=lambda p: RSS.get(p, -1)),
+        patch.object(platform_compat, "_proc_cpu_jiffies", side_effect=lambda p: JIFFIES.get(p, 0)),
+        patch.object(platform_compat, "_proc_children", side_effect=lambda p: TREE.get(p, [])),
+        patch.object(
+            platform_compat,
+            "process_matches",
+            side_effect=lambda p, n: p in MATCHING and n == needles,
+        ),
+    )
+
+
+class _FakeTree:
+    """:func:`_fake_tree` as a context manager, since it patches five names."""
+
+    def __init__(self, *, needles: tuple[str, ...] = ()) -> None:
+        self._patches = _fake_tree(needles=needles)
+
+    def __enter__(self) -> None:
+        for p in self._patches:
+            p.start()
+
+    def __exit__(self, *exc: object) -> None:
+        for p in reversed(self._patches):
+            p.stop()
+
+
+# ── the per-process reads the walk is built from ───────────────────────────
+
+
+class TestPerProcessReads:
+    def test_status_rss_parses_vmrss(self) -> None:
+        with patch("builtins.open", mock_open(read_data="Name:\tx\nVmRSS:\t 2048 kB\n")):
+            assert platform_compat._proc_status_rss_kb(1234) == 2048
+
+    def test_status_rss_unreadable_is_minus_one(self) -> None:
+        with patch("builtins.open", side_effect=OSError):
+            assert platform_compat._proc_status_rss_kb(1234) == -1
+
+    def test_children_listing_unavailable(self) -> None:
+        with patch.object(os, "listdir", side_effect=OSError):
+            assert platform_compat._proc_children(1234) == []
+
+    def test_children_parsed_per_thread(self) -> None:
+        with (
+            patch.object(os, "listdir", return_value=["1234"]),
+            patch("builtins.open", mock_open(read_data="11 12 13")),
+        ):
+            assert platform_compat._proc_children(1234) == [11, 12, 13]
+
+    def test_children_garbage_skipped(self) -> None:
+        with (
+            patch.object(os, "listdir", return_value=["1234"]),
+            patch("builtins.open", mock_open(read_data="not-a-pid")),
+        ):
+            assert platform_compat._proc_children(1234) == []
+
+    def test_jiffies_parsed_past_a_comm_with_parens(self) -> None:
+        # comm with spaces + an embedded ')' — rindex must find the real close.
+        # post-comm tokens: state(0) ... utime(11)=120 stime(12)=60
+        stat = b"1234 (kiro cli (node)) S 2 3 4 5 6 7 8 9 10 11 120 60 0 0"
+        assert platform_compat._parse_cpu_jiffies(stat) == 180
+
+    @pytest.mark.parametrize("raw", [b"", b"no-parens-here", b"1 (x) S 1 2 3"])
+    def test_malformed_jiffies_are_zero(self, raw: bytes) -> None:
+        assert platform_compat._parse_cpu_jiffies(raw) == 0
+
+    def test_jiffies_unreadable_pid_is_zero(self) -> None:
+        with patch("builtins.open", side_effect=OSError):
+            assert platform_compat._proc_cpu_jiffies(1234) == 0
+
+    def test_jiffies_reads_stat(self) -> None:
+        with (
+            patch.object(platform_compat, "_parse_cpu_jiffies", return_value=77),
+            patch("builtins.open", mock_open(read_data=b"whatever")),
+        ):
+            assert platform_compat._proc_cpu_jiffies(1234) == 77
+
+
+# ── the walk ──────────────────────────────────────────────────────────────
+
+
+class TestSubtreeWalk:
+    def test_one_walk_carries_every_reading(self) -> None:
+        with _FakeTree(needles=("stub",)):
+            sample = platform_compat.proc_subtree_sample(10, counts=True, needles=("stub",))
+        assert sample.rss_kb == sum(RSS.values())
+        assert sample.jiffies == sum(JIFFIES.values())
+        assert (sample.procs, sample.matched) == (4, 2)
+
+    def test_each_process_is_visited_once(self) -> None:
+        seen: list[int] = []
+        with (
+            _FakeTree(),
+            patch.object(
+                platform_compat,
+                "_proc_children",
+                side_effect=lambda p: (seen.append(p), TREE.get(p, []))[1],
+            ),
+        ):
+            platform_compat.proc_subtree_sample(10, counts=True)
+        assert sorted(seen) == [10, 11, 12, 13]
+
+    def test_no_pid_is_unmeasurable_in_every_column(self) -> None:
+        assert platform_compat.proc_subtree_sample(None) == platform_compat.SubtreeSample(
+            -1, 0, None, None
+        )
+        assert platform_compat.proc_subtree_sample(0).rss_kb == -1
+
+    def test_rss_sums_descendants(self) -> None:
+        with _FakeTree():
+            assert platform_compat.proc_subtree_sample(10).rss_kb == sum(RSS.values())
+
+    def test_cycles_and_dead_children_do_not_break_the_sum(self) -> None:
+        with (
+            patch.object(platform_compat, "_proc_status_rss_kb", lambda p: 100 if p == 1 else -1),
+            patch.object(platform_compat, "_proc_children", lambda p: [1, 2] if p == 1 else []),
+        ):
+            assert platform_compat.proc_subtree_sample(1, jiffies=False).rss_kb == 100
+
+    def test_non_linux_loses_only_the_counts(self) -> None:
+        """Counts are ``None`` off Linux, but RSS and CPU keep their own
+        sentinels — the columns are unmeasurable in different ways."""
+        with _FakeTree(), patch.object(platform_compat, "IS_LINUX", False):
+            sample = platform_compat.proc_subtree_sample(10, counts=True)
+        assert (sample.procs, sample.matched) == (None, None)
+        assert sample.rss_kb == sum(RSS.values())
+        assert sample.jiffies == sum(JIFFIES.values())
+
+    def test_dead_root_keeps_the_cpu_walk(self) -> None:
+        """An unreadable root status means RSS and the counts have nothing to
+        attribute, but jiffies is consumed as a *delta*, so its walk stands."""
+        with _FakeTree(), patch.object(platform_compat, "_proc_status_rss_kb", return_value=-1):
+            sample = platform_compat.proc_subtree_sample(10, counts=True)
+        assert sample.rss_kb == -1
+        assert (sample.procs, sample.matched) == (None, None)
+        assert sample.jiffies == sum(JIFFIES.values())
+
+    def test_the_walk_is_bounded_by_one_ceiling(self) -> None:
+        with (
+            patch.object(platform_compat, "IS_LINUX", True),
+            patch.object(platform_compat, "_proc_status_rss_kb", return_value=1024),
+            patch.object(platform_compat, "_proc_cpu_jiffies", return_value=1),
+            patch.object(
+                platform_compat, "_proc_children", side_effect=lambda p: [p * 10, p * 10 + 1]
+            ),
+            patch.object(platform_compat, "process_matches", return_value=False),
+        ):
+            sample = platform_compat.proc_subtree_sample(2, counts=True)
+        assert sample.matched == 0
+        assert sample.procs is not None
+        assert sample.procs < platform_compat._SUBTREE_MAX_PROCS * 3
+        assert platform_compat._SUBTREE_MAX_PROCS > 0
+
+
+# ── a caller pays only for what it asks for ───────────────────────────────
+
+
+class TestSkippedReadingsCostNothing:
+    """Sharing one walk must not make either caller slower than its own copy.
+
+    The pool's copy read ``status`` and never ``stat``; the Sessions CPU reader
+    read ``stat`` and never ``status``. Both properties have to survive, or
+    consolidating would have bought one home at the price of per-process reads
+    nobody surfaces.
+    """
+
+    def test_an_rss_only_caller_reads_no_stat(self) -> None:
+        with (
+            _FakeTree(),
+            patch.object(
+                platform_compat,
+                "_proc_cpu_jiffies",
+                side_effect=AssertionError("CPU read on an RSS-only sample"),
+            ),
+        ):
+            sample = platform_compat.proc_subtree_sample(10, jiffies=False)
+        assert sample.rss_kb == sum(RSS.values())
+        assert sample.jiffies == 0
+
+    def test_a_cpu_only_caller_reads_no_status(self) -> None:
+        with (
+            _FakeTree(),
+            patch.object(
+                platform_compat,
+                "_proc_status_rss_kb",
+                side_effect=AssertionError("RSS read on a CPU-only sample"),
+            ),
+            patch.object(
+                platform_compat,
+                "process_matches",
+                side_effect=AssertionError("cmdline match on a CPU-only sample"),
+            ),
+        ):
+            sample = platform_compat.proc_subtree_sample(10, rss=False, counts=False)
+        assert sample.jiffies == sum(JIFFIES.values())
+        assert sample.rss_kb == -1
+
+    def test_nothing_measurable_means_no_walk_at_all(self) -> None:
+        """The early return the pool's own copy had: an RSS-only sample whose
+        root status is unreadable answers -1 without touching a ``children``
+        file, so a dead backend costs one read rather than a tree traversal."""
+        with (
+            _FakeTree(),
+            patch.object(platform_compat, "_proc_status_rss_kb", return_value=-1),
+            patch.object(
+                platform_compat,
+                "_proc_children",
+                side_effect=AssertionError("walked a subtree with nothing to accumulate"),
+            ),
+        ):
+            sample = platform_compat.proc_subtree_sample(10, jiffies=False)
+        assert sample == platform_compat.SubtreeSample(-1, 0, None, None)
+
+
+# ── one home: neither caller carries a second walk ────────────────────────
+
+
+class TestOneHome:
+    #: Names the two callers defined privately before #6096. A copy coming back
+    #: would restore one of them, so their absence is the ratchet.
+    RETIRED = (
+        "_RSS_SUBTREE_MAX_PROCS",
+        "_SUBTREE_MAX_PROCS",
+        "_single_proc_rss_kb",
+        "_proc_children",
+        "_proc_cpu_jiffies",
+        "_parse_cpu_jiffies",
+        "_SubtreeSample",
+    )
+
+    @pytest.mark.parametrize("name", RETIRED)
+    def test_the_pool_defines_no_walker_of_its_own(self, name: str) -> None:
+        assert not hasattr(pool_mod, name), f"mcp_gateway.pool re-grew {name}"
+
+    @pytest.mark.parametrize("name", RETIRED)
+    def test_subagent_defines_no_walker_of_its_own(self, name: str) -> None:
+        assert not hasattr(sa, name), f"subagent re-grew {name}"
+
+    def test_both_callers_traverse_the_same_fake_tree(self) -> None:
+        """The behavioural half of the ratchet: ONE fake installed on the shared
+        module is observed by both callers, which is only possible if neither
+        has a walk of its own left."""
+        with _FakeTree(needles=(sa.STUB_MODULE,)):
+            assert pool_mod._proc_rss_kb(10) == sum(RSS.values())
+            assert sa._subtree_cpu_jiffies(10) == sum(JIFFIES.values())
+            sample = sa._proc_subtree_sample(10)
+        assert sample.rss_kb == sum(RSS.values())
+        assert (sample.procs, sample.matched) == (4, 2)
+
+    def test_the_subagent_adapter_counts_by_the_stub_module_path(self) -> None:
+        """``matched`` is the stub count on the subagent side, so the needle it
+        passes must be the module path the rewriter puts on a stub launch line."""
+        seen: list[tuple[str, ...]] = []
+        with (
+            _FakeTree(),
+            patch.object(
+                platform_compat,
+                "process_matches",
+                side_effect=lambda p, n: bool(seen.append(n)) or p in MATCHING,
+            ),
+        ):
+            sa._proc_subtree_sample(10)
+        assert seen and all(n == (sa.STUB_MODULE,) for n in seen)
+
+
+# ── the pool caller ───────────────────────────────────────────────────────
+
+
+def _make_pool_key(server: str = "test-server", agent: str = "test-agent") -> PoolKey:
+    return PoolKey(
+        server_name=server,
+        agent_name=agent,
+        command_args_hash="abc123",
+        effective_env_hash="def456",
+        work_dir="/tmp/test",
+        binary_version="1.0",
+        os_uid=1000,
+        sandbox_mode="none",
+        autoapprove_set_hash="ghi789",
+        approval_mode="reads",
+        trust_all_tools=False,
+        config_snapshot_hash="jkl012",
+    )
+
+
+def _make_backend(pool_key: PoolKey, *, pid: int) -> Backend:
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = pid
+    proc.wait = AsyncMock(return_value=0)
+    now = time.monotonic()
+    return Backend(
+        pool_key=pool_key,
+        process=proc,
+        stdin=MagicMock(),
+        stdout=MagicMock(),
+        created_at=now,
+        last_used_at=now,
+    )
+
+
+class TestPoolReadsTheSharedWalk:
+    @pytest.mark.asyncio
+    async def test_backend_rss_is_the_whole_subtree(self) -> None:
+        """A pooled backend is often a thin launcher, so its row must report the
+        subtree total — the reason the pool summed a tree in the first place."""
+        pool = BackendPool(max_backends=4)
+        key = _make_pool_key()
+        await pool.add(key, _make_backend(key, pid=10))
+        with _FakeTree():
+            snap = await pool.metrics_snapshot_async()
+        assert [row["rss_kb"] for row in snap["backends"]] == [sum(RSS.values())]
+
+    @pytest.mark.asyncio
+    async def test_the_pool_pays_for_no_cpu_reading(self) -> None:
+        """The pool surfaces RSS only. Asking the shared walker for CPU too
+        would charge every pooled backend a ``/proc/<pid>/stat`` read per
+        process for a figure no row displays."""
+        pool = BackendPool(max_backends=4)
+        key = _make_pool_key()
+        await pool.add(key, _make_backend(key, pid=10))
+        with (
+            _FakeTree(),
+            patch.object(
+                platform_compat,
+                "_proc_cpu_jiffies",
+                side_effect=AssertionError("pool metrics read CPU jiffies"),
+            ),
+        ):
+            snap = await pool.metrics_snapshot_async()
+        assert snap["backends"][0]["rss_kb"] == sum(RSS.values())
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_backend_reports_minus_one(self) -> None:
+        pool = BackendPool(max_backends=4)
+        key = _make_pool_key()
+        await pool.add(key, _make_backend(key, pid=10))
+        with _FakeTree(), patch.object(platform_compat, "_proc_status_rss_kb", return_value=-1):
+            snap = await pool.metrics_snapshot_async()
+        assert snap["backends"][0]["rss_kb"] == -1

--- a/test/test_subagent_coverage.py
+++ b/test/test_subagent_coverage.py
@@ -17,7 +17,7 @@ import math
 import os
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -350,55 +350,6 @@ class TestCheckMemoryAvailable:
             assert sa.check_memory_available() == (True, -1.0)
 
 
-class TestProcRssReaders:
-    def test_single_proc_parses_vmrss(self) -> None:
-        with patch("builtins.open", mock_open(read_data="Name:\tx\nVmRSS:\t 2048 kB\n")):
-            assert sa._single_proc_rss_kb(1234) == 2048
-
-    def test_single_proc_missing_returns_minus_one(self) -> None:
-        with patch("builtins.open", side_effect=OSError):
-            assert sa._single_proc_rss_kb(1234) == -1
-
-    def test_children_listing_unavailable(self) -> None:
-        with patch.object(os, "listdir", side_effect=OSError):
-            assert sa._proc_children(1234) == []
-
-    def test_children_parsed_per_thread(self) -> None:
-        with (
-            patch.object(os, "listdir", return_value=["1234"]),
-            patch("builtins.open", mock_open(read_data="11 12 13")),
-        ):
-            assert sa._proc_children(1234) == [11, 12, 13]
-
-    def test_children_garbage_skipped(self) -> None:
-        with (
-            patch.object(os, "listdir", return_value=["1234"]),
-            patch("builtins.open", mock_open(read_data="not-a-pid")),
-        ):
-            assert sa._proc_children(1234) == []
-
-    def test_subtree_rss_falsy_pid(self) -> None:
-        assert sa._proc_subtree_sample(None, counts=False).rss_kb == -1
-        assert sa._proc_subtree_sample(0, counts=False).rss_kb == -1
-
-    def test_subtree_rss_unreadable_parent(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda _pid: -1)
-        assert sa._proc_subtree_sample(99, counts=False).rss_kb == -1
-
-    def test_subtree_rss_sums_descendants(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        tree = {1: [2, 3], 2: [4], 3: [], 4: []}
-        monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda pid: 100 * pid)
-        monkeypatch.setattr(sa, "_proc_children", lambda pid: tree.get(pid, []))
-        assert sa._proc_subtree_sample(1, counts=False).rss_kb == 100 + 200 + 300 + 400
-
-    def test_subtree_rss_ignores_cycles_and_dead_children(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(sa, "_single_proc_rss_kb", lambda pid: 100 if pid == 1 else -1)
-        monkeypatch.setattr(sa, "_proc_children", lambda pid: [1, 2] if pid == 1 else [])
-        assert sa._proc_subtree_sample(1, counts=False).rss_kb == 100
-
-
 class TestReadIntFile:
     def test_reads_integer(self, tmp_path: Path) -> None:
         path = tmp_path / "n"
@@ -562,36 +513,25 @@ class TestMacosAvailableMemory:
 
 
 class TestCpuJiffies:
-    def test_parses_utime_plus_stime(self) -> None:
-        fields = " ".join(str(i) for i in range(3, 30))
-        raw = f"42 (weird name (x)) S {fields}".encode("ascii")
-        # After the final ')' the tokens start at 'S'; utime/stime are indices 11/12.
-        tokens = raw[raw.rindex(b")") + 2 :].split()
-        expected = int(tokens[11]) + int(tokens[12])
-        assert sa._parse_cpu_jiffies(raw) == expected
+    """``_subtree_cpu_jiffies`` — the Sessions rows' CPU reading.
 
-    @pytest.mark.parametrize("raw", [b"", b"no-parens-here", b"1 (x) S 1 2 3"])
-    def test_malformed_returns_zero(self, raw: bytes) -> None:
-        assert sa._parse_cpu_jiffies(raw) == 0
-
-    def test_proc_cpu_jiffies_missing_pid(self) -> None:
-        with patch("builtins.open", side_effect=OSError):
-            assert sa._proc_cpu_jiffies(1234) == 0
-
-    def test_proc_cpu_jiffies_reads_stat(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sa, "_parse_cpu_jiffies", lambda _raw: 77)
-        with patch("builtins.open", mock_open(read_data=b"whatever")):
-            assert sa._proc_cpu_jiffies(1234) == 77
+    The per-process reads and the walk itself belong to
+    ``platform_compat.proc_subtree_sample`` and are pinned in
+    ``test_proc_subtree_sample.py``; what is subagent's own is that this wrapper
+    asks for the CPU column of that walk.
+    """
 
     def test_subtree_sums_descendants(self, monkeypatch: pytest.MonkeyPatch) -> None:
         tree = {1: [2], 2: [3], 3: []}
-        monkeypatch.setattr(sa, "_proc_cpu_jiffies", lambda pid: pid * 10)
-        monkeypatch.setattr(sa, "_proc_children", lambda pid: tree.get(pid, []))
+        monkeypatch.setattr(sa.platform_compat, "_proc_cpu_jiffies", lambda pid: pid * 10)
+        monkeypatch.setattr(sa.platform_compat, "_proc_children", lambda pid: tree.get(pid, []))
         assert sa._subtree_cpu_jiffies(1) == 10 + 20 + 30
 
     def test_subtree_skips_already_seen(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sa, "_proc_cpu_jiffies", lambda pid: 5)
-        monkeypatch.setattr(sa, "_proc_children", lambda pid: [1] if pid == 1 else [])
+        monkeypatch.setattr(sa.platform_compat, "_proc_cpu_jiffies", lambda pid: 5)
+        monkeypatch.setattr(
+            sa.platform_compat, "_proc_children", lambda pid: [1] if pid == 1 else []
+        )
         assert sa._subtree_cpu_jiffies(1) == 5
 
 
@@ -801,126 +741,6 @@ class TestLiveSharedCount:
             mgr._live_shared_count(777)  # type: ignore[call-arg]
 
 
-class TestProcSubtreeSample:
-    """``_proc_subtree_sample`` — the ONE walk every reading now comes off.
-
-    The three readers it replaced ran three independent walks at three different
-    instants, so a process that exited between them was counted by one and
-    missed by another. These pin both halves of the claim: the readings are the
-    same values the separate readers produced, and they cost one walk.
-
-    This class also absorbs what ``TestProcSubtreeCounts`` used to assert for the
-    #3953 count contract, and strengthens it: no-pid, non-Linux and dead-root are
-    now checked across all four columns at once rather than the two count columns
-    alone.
-    """
-
-    #: 1 runtime + 3 children; two of the children are MCP stubs.
-    TREE = {10: [11, 12, 13], 11: [], 12: [], 13: []}
-    RSS = {10: 1000, 11: 200, 12: 30, 13: 4}
-    JIFFIES = {10: 100, 11: 50, 12: 25, 13: 10}
-    STUBS = {11, 12}
-
-    @contextlib.contextmanager
-    def _fake_tree(self):
-        with (
-            patch.object(sa.platform_compat, "IS_LINUX", True),
-            patch.object(sa, "_single_proc_rss_kb", side_effect=lambda p: self.RSS.get(p, -1)),
-            patch.object(sa, "_proc_cpu_jiffies", side_effect=lambda p: self.JIFFIES.get(p, 0)),
-            patch.object(sa, "_proc_children", side_effect=lambda p: self.TREE.get(p, [])),
-            patch.object(
-                sa.platform_compat,
-                "process_matches",
-                side_effect=lambda p, needles: p in self.STUBS and needles == (sa.STUB_MODULE,),
-            ),
-        ):
-            yield
-
-    def test_one_sample_carries_all_four_readings(self) -> None:
-        with self._fake_tree():
-            sample = sa._proc_subtree_sample(10)
-        assert sample.rss_kb == sum(self.RSS.values())
-        assert sample.jiffies == sum(self.JIFFIES.values())
-        assert (sample.procs, sample.stubs) == (4, 2)
-
-    def test_the_readings_still_report_what_they_always_did(self) -> None:
-        """Value preservation: consolidating must not move a single number, or
-        the learned-cost store and ``compute_max_subagents`` would see a step.
-
-        The expected values are what the three separate readers produced for this
-        tree: summed RSS, summed jiffies, and the count pair from #3954.
-        """
-        with self._fake_tree():
-            sample = sa._proc_subtree_sample(10)
-            assert sample.rss_kb == sum(self.RSS.values())
-            assert (sample.procs, sample.stubs) == (4, 2)
-            assert sa._subtree_cpu_jiffies(10) == sum(self.JIFFIES.values())
-
-    def test_the_subtree_is_walked_once_not_once_per_metric(self) -> None:
-        seen: list[int] = []
-        with (
-            self._fake_tree(),
-            patch.object(
-                sa,
-                "_proc_children",
-                side_effect=lambda p: (seen.append(p), self.TREE.get(p, []))[1],
-            ),
-        ):
-            sa._proc_subtree_sample(10)
-        assert sorted(seen) == [10, 11, 12, 13], "each process's children read exactly once"
-
-    def test_no_pid_is_unmeasurable_in_every_column(self) -> None:
-        assert sa._proc_subtree_sample(None) == sa._SubtreeSample(-1, 0, None, None)
-
-    def test_non_linux_loses_only_the_counts(self) -> None:
-        """Counts are ``None`` off Linux, but RSS and CPU keep their own
-        sentinels — the columns are unmeasurable in different ways."""
-        with self._fake_tree(), patch.object(sa.platform_compat, "IS_LINUX", False):
-            sample = sa._proc_subtree_sample(10)
-        assert (sample.procs, sample.stubs) == (None, None)
-        assert sample.rss_kb == sum(self.RSS.values())
-        assert sample.jiffies == sum(self.JIFFIES.values())
-
-    def test_dead_root_keeps_the_cpu_walk(self) -> None:
-        """An unreadable root status means RSS and the counts have nothing to
-        attribute, but jiffies is consumed as a *delta*, so its walk stands."""
-        with self._fake_tree(), patch.object(sa, "_single_proc_rss_kb", return_value=-1):
-            sample = sa._proc_subtree_sample(10)
-        assert sample.rss_kb == -1
-        assert (sample.procs, sample.stubs) == (None, None)
-        assert sample.jiffies == sum(self.JIFFIES.values())
-
-    def test_a_skipped_metric_costs_no_reads(self) -> None:
-        """The one CPU-only caller must not pay for RSS and the counts, or
-        sharing the walk would have made the session rows slower."""
-        with (
-            self._fake_tree(),
-            patch.object(
-                sa,
-                "_single_proc_rss_kb",
-                side_effect=AssertionError("RSS read on a CPU-only sample"),
-            ),
-            patch.object(
-                sa.platform_compat,
-                "process_matches",
-                side_effect=AssertionError("stub match on a CPU-only sample"),
-            ),
-        ):
-            assert sa._subtree_cpu_jiffies(10) == sum(self.JIFFIES.values())
-
-    def test_the_walk_is_bounded_by_one_ceiling(self) -> None:
-        with (
-            patch.object(sa.platform_compat, "IS_LINUX", True),
-            patch.object(sa, "_single_proc_rss_kb", return_value=1024),
-            patch.object(sa, "_proc_cpu_jiffies", return_value=1),
-            patch.object(sa, "_proc_children", side_effect=lambda p: [p * 10, p * 10 + 1]),
-            patch.object(sa.platform_compat, "process_matches", return_value=False),
-        ):
-            sample = sa._proc_subtree_sample(2)
-        assert sample.stubs == 0
-        assert sample.procs is not None and sample.procs < sa._SUBTREE_MAX_PROCS * 3
-
-
 class TestAttributedCount:
     def test_unmeasured_keeps_the_last_good_reading(self) -> None:
         assert sa._attributed_count(None, 1, 7) == 7
@@ -946,7 +766,7 @@ class TestSampleLiveCounts:
     """The sweep must write procs/mcp on both the shared and exclusive paths."""
 
     def _patched(self, counts: tuple[int, int]):
-        sample = sa._SubtreeSample(1024 * 1024, 0, counts[0], counts[1])
+        sample = sa.platform_compat.SubtreeSample(1024 * 1024, 0, counts[0], counts[1])
         return (patch.object(sa, "_proc_subtree_sample", return_value=sample),)
 
     def test_shared_runtime_counts_are_split_per_sharer(self) -> None:
@@ -981,7 +801,9 @@ class TestSampleLiveCounts:
         info.last_procs, info.last_stubs = 7, 6
         mgr._agents["solo"] = info
         with patch.object(
-            sa, "_proc_subtree_sample", return_value=sa._SubtreeSample(-1, 0, None, None)
+            sa,
+            "_proc_subtree_sample",
+            return_value=sa.platform_compat.SubtreeSample(-1, 0, None, None),
         ):
             mgr._sample_live_costs()
         assert (info.last_procs, info.last_stubs) == (7, 6)
@@ -1002,7 +824,7 @@ class TestSampleLiveCounts:
 
         def _sample(pid, **kwargs):  # noqa: ANN001, ANN003 — test double
             walks.append(pid)
-            return sa._SubtreeSample(1024, 0, 4, 2)
+            return sa.platform_compat.SubtreeSample(1024, 0, 4, 2)
 
         with patch.object(sa, "_proc_subtree_sample", side_effect=_sample):
             mgr._sample_live_costs()
@@ -2301,6 +2123,3 @@ class TestPlatformConstants:
         back to 100 there."""
         assert isinstance(sa._CLK_TCK, int)
         assert sa._CLK_TCK > 0
-
-    def test_subtree_walk_caps_are_bounded(self) -> None:
-        assert sa._SUBTREE_MAX_PROCS > 0

--- a/test/test_subagent_sizing.py
+++ b/test/test_subagent_sizing.py
@@ -536,26 +536,13 @@ class TestQueuedIdentityRoundTrip:
         assert info.id == announced
 
 
-class TestCpuJiffiesParser:
-    """_parse_cpu_jiffies: utime+stime from raw /proc/<pid>/stat bytes."""
-
-    def test_parses_utime_stime(self) -> None:
-        from kiro_crew.subagent import _parse_cpu_jiffies
-
-        # comm with spaces + an embedded ')' — rindex must find the real close.
-        # post-comm tokens: state(0) ... utime(11)=120 stime(12)=60
-        stat = b"1234 (kiro cli (node)) S 2 3 4 5 6 7 8 9 10 11 120 60 0 0"
-        assert _parse_cpu_jiffies(stat) == 180
-
-    def test_malformed_returns_zero(self) -> None:
-        from kiro_crew.subagent import _parse_cpu_jiffies
-
-        assert _parse_cpu_jiffies(b"garbage") == 0
-        assert _parse_cpu_jiffies(b"") == 0
-
-
 class TestSubtreeCpuJiffies:
-    """_subtree_cpu_jiffies: sums pid + descendants."""
+    """_subtree_cpu_jiffies: sums pid + descendants.
+
+    The parser and the walk itself live in ``platform_compat`` and are pinned in
+    ``test_proc_subtree_sample.py``; this covers the wrapper the Sessions rows
+    call.
+    """
 
     def test_sums_tree(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
@@ -563,8 +550,12 @@ class TestSubtreeCpuJiffies:
         # tree: 1 -> [2, 3]; 2 -> [4]
         children = {1: [2, 3], 2: [4], 3: [], 4: []}
         jiffies = {1: 100, 2: 50, 3: 25, 4: 10}
-        monkeypatch.setattr(sub, "_proc_children", lambda pid: children.get(pid, []))
-        monkeypatch.setattr(sub, "_proc_cpu_jiffies", lambda pid: jiffies.get(pid, 0))
+        monkeypatch.setattr(
+            sub.platform_compat, "_proc_children", lambda pid: children.get(pid, [])
+        )
+        monkeypatch.setattr(
+            sub.platform_compat, "_proc_cpu_jiffies", lambda pid: jiffies.get(pid, 0)
+        )
         assert sub._subtree_cpu_jiffies(1) == 185
 
 
@@ -581,9 +572,9 @@ class TestSampleLiveCosts:
     @staticmethod
     def _sample(rss_kb: int = -1, jiffies: int = 0):
         """The one subtree reading the sweep takes per agent."""
-        from kiro_crew.subagent import _SubtreeSample
+        from kiro_crew.platform_compat import SubtreeSample
 
-        return _SubtreeSample(rss_kb, jiffies, None, None)
+        return SubtreeSample(rss_kb, jiffies, None, None)
 
     def test_rss_high_water(self, monkeypatch) -> None:
         import kiro_crew.subagent as sub
@@ -973,7 +964,7 @@ class TestLastSampleAndMemoryRows:
         monkeypatch.setattr(
             sub,
             "_proc_subtree_sample",
-            lambda pid, **kw: sub._SubtreeSample(next(rss_seq), 0, None, None),
+            lambda pid, **kw: sub.platform_compat.SubtreeSample(next(rss_seq), 0, None, None),
         )
         m._sample_live_costs()
         m._sample_live_costs()
@@ -993,7 +984,7 @@ class TestLastSampleAndMemoryRows:
         monkeypatch.setattr(
             sub,
             "_proc_subtree_sample",
-            lambda pid, **kw: sub._SubtreeSample(2 * 1024 * 1024, 0, None, None),
+            lambda pid, **kw: sub.platform_compat.SubtreeSample(2 * 1024 * 1024, 0, None, None),
         )
         m._sample_live_costs()
 


### PR DESCRIPTION
## 1. What is the problem?

`mcp_gateway/pool.py` and `subagent.py` each carried their own copy of the same
breadth-first walk over `/proc/<pid>/task/<tid>/children`, and each carried its
own `256`-process ceiling for it:

| | ceiling | per-process read | walk |
|---|---|---|---|
| `mcp_gateway/pool.py` | `_RSS_SUBTREE_MAX_PROCS = 256` | `_single_proc_rss_kb` | `_proc_rss_kb` |
| `subagent.py` | `_SUBTREE_MAX_PROCS = 256` | `_single_proc_rss_kb` | `_proc_subtree_sample` |

The two definitions were line-for-line siblings. #6087 collapsed three walkers
*inside* `subagent.py` for exactly this reason, and the comment that justified
keeping a copy there ("relocated from the upstream mcp_gateway pool, which is
absent in this fork") stopped being true once the pool existed in this fork.

## 2. Why this issue matters to the user

Nothing is visibly wrong today: the two walkers measure different pids for
different surfaces (the MCP pool's backend rows, and the Sessions task rows), so
no user sees a contradiction. What the duplication costs is that a fix to one is
not a fix to the other. Both copies decide how many processes to visit before
giving up, both decide what an unreadable pid contributes, and a change to either
policy silently applies to one surface and not the other, which is how "the RSS
column disagrees with the RSS column" arrives later as a bug with no obvious
cause.

## 3. How our fix solves it

The walk moves to `platform_compat` as `proc_subtree_sample`, above both callers,
and both now read off it. Three things decided the shape:

**Where it lives.** Not "pool imports subagent": `subagent.py` already imports
from `kiro_crew.mcp_gateway`, so the reverse edge closes a package cycle and
drags a ~7000-line module into every pool import. `platform_compat` is the
existing home of the cross-platform process family (`get_ppid`,
`process_matches`, `kill_process_tree`, `proc_rss_bytes_for_pid`), it imports
neither caller, and `mcp_gateway` already depends on it in six modules,
including `gatewayd.py`, which delegates its own RSS reading to
`platform_compat.proc_rss_bytes` with the comment "the one per-platform" reader.
This change follows that precedent rather than inventing a boundary.

**Each caller still pays only for what it reads.** Sharing a walk is only
correct if it does not make either caller slower than its own copy was. The
pool's copy read `status` and never `stat`; the Sessions CPU reader read `stat`
and never `status`. So `jiffies` became an opt-out alongside the existing `rss` /
`counts` switches, and the pool passes `jiffies=False`: no `/proc/<pid>/stat`
read per process for a CPU figure no pool row displays. The pool's early return
also had to survive (its copy answered `-1` for an unreadable root *without
walking*), so the shared walker skips the descendant walk whenever nothing is
left to accumulate.

**The shared walker knows nothing about MCP stubs.** Its count column is
`matched`: processes whose command line contains one of the caller's `needles`.
`subagent.py` keeps a thin adapter that supplies `STUB_MODULE`, the module path
the rewriter puts on a stub launch line, and reads `matched` as its stub count.
Gateway vocabulary stays out of `platform_compat`; the second walk stays out of
`subagent`.

No reading changes value: both ceilings were `256`, and every column keeps the
sentinel it had (`-1` unreadable RSS, `0` jiffies, `None` for an unmeasurable
count, never `0`).

Net -193 lines.

## 4. What tests we did

New `test/test_proc_subtree_sample.py` (41 tests) owns the shared walker's
contract and both callers:

- the per-process reads (`VmRSS` parse, per-thread `children` parse, a `comm`
  containing spaces and parens, and each read's failure sentinel);
- the walk: summed RSS, summed jiffies, the count pair, one visit per process,
  cycles and dead children, no-pid, non-Linux, dead root, and the single ceiling;
- **the cost switches**: an RSS-only sample reads no `stat`, a CPU-only sample
  reads no `status`, and a sample with nothing to accumulate reads no `children`
  at all (each asserted by making the forbidden read raise);
- **the one-home ratchet**: neither caller defines any of the seven retired
  private names, and one fake process tree installed on the shared module is
  observed by *both* callers, which is only possible if neither has a walk left;
- the pool caller: `metrics_snapshot_async` reports the subtree total, reports
  `-1` for an unreadable backend, and reads no CPU jiffies.

The walker's own unit tests moved out of `test_subagent_coverage.py` with the
code; what stayed there is what is subagent's own (the CPU wrapper, the
attribution split, the sweep). Retargeted tests still pass unchanged in
substance: only the patch target moved.

Mutation-verified (each mutation reddens the named test, reverted after):

| mutation | red test |
|---|---|
| pool stops passing `jiffies=False` | `test_the_pool_pays_for_no_cpu_reading` |
| delete the nothing-to-accumulate early return | `test_nothing_measurable_means_no_walk_at_all` |
| adapter passes `needles=()` | `test_the_subagent_adapter_counts_by_the_stub_module_path`, `test_both_callers_traverse_the_same_fake_tree` |

Targeted runs (never the full suite): `test_proc_subtree_sample.py`,
`test_subagent_coverage.py`, `test_subagent_sizing.py` gave 348 passed;
`test_platform_compat.py`, `test_platform_compat_coverage.py`,
`test_mcp_gateway_poolkey.py`, `test_mcp_gateway_bluegreen.py`,
`test_session_memory.py`, `test_dashboard_sessions_memory.py` gave 629 passed and
22 skipped. flake8, isort, mypy clean on all six touched files; the repo black
gate passes in scope.

## 5. Any other suggestions on the work

- **Deliberately out of scope: the other three readers of the `children`
  files.** #6096's discussion asks whether to cover all five. `acp/liveness.py`
  (`iter_descendants`), `acp/runtime.py`, and `acp/client.py`
  (`_direct_children`) walk the same kernel file, but they answer a different
  question (is this tree alive, which pids get signalled) with their own
  attribution rules, `proc_root` injection for tests, and no ceiling of this
  kind. Folding them in would be a behaviour change to the watchdog and the
  process-teardown path riding inside a dedup PR. The two RSS-subtree copies are
  what #6096 is titled for; the remaining three deserve their own issue if anyone
  wants them unified.
- **A fourth sibling sums a Linux tree by a deliberately different method, and
  this PR does not change it.** `session_pid._build_child_map` +
  `_rss_mb_from_tree` build a parent map from a full `/proc` scan of every
  process's `stat` `PPid` field, and that docstring records why: the
  `task/<tid>/children` file needs `CONFIG_PROC_CHILDREN` and is documented as
  reliable only for frozen tasks, so on a live tree it can return an incomplete
  child set and silently drop a descendant subtree from an RSS sum. That is the
  right trade there (an under-counted tree would make the RSS watchdog no-op) and
  the wrong one for these two callers, which sample per backend and per live
  agent on a timer, where a whole-machine scan per sample is the larger cost and
  an under-count degrades a displayed figure rather than disabling a protection.
  So the method is unchanged, and the reasoning now sits at
  `proc_subtree_sample`'s docstring and above the block, where a third caller
  will read it. Reconsidering the method for the pool and Sessions surfaces is a
  behaviour change to numbers users already read; it wants its own PR, and this
  change means there is one implementation to change rather than two.
- `proc_subtree_sample` and its `SubtreeSample` return type are the only public
  names; the five per-process reads are module-private, since nothing outside
  `platform_compat` wants a single read. A future third column (open fds, thread
  count) can join the one walk instead of opening a fourth.

Closes #6096
