### PR TITLE
fix(sandbox): stop spawning agents with a /dev/fd cwd on macOS (ENOTDIR)

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -416,6 +416,9 @@ def assert_voice_runtime_outside_agent_workspace(workspace: str | os.PathLike[st
         ) from exc
 
 
+_MAXPATHLEN = 1024
+
+
 def _open_directory_descriptor(path: str | os.PathLike[str], *, dir_fd: int | None = None) -> int:
     """Open a directory identity without making its descriptor inheritable."""
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
@@ -444,6 +447,27 @@ def _directory_ancestor_identities(descriptor: int) -> tuple[tuple[int, int], ..
         os.close(current)
 
 
+def _descriptor_directory_path(descriptor: int) -> str:
+    """Resolve a verified directory descriptor back to a pathname.
+
+    ``/dev/fd/N`` cannot be used as a spawn ``cwd`` on macOS when N is a
+    *directory* descriptor. Unlike Linux's ``/proc/self/fd/N`` -- a magic symlink
+    that resolves to the directory itself -- a ``/dev/fd`` entry is served by
+    fdescfs, which reopens the underlying vnode as a file rather than exposing it
+    as something traversable. ``chdir()`` on it fails with ``ENOTDIR``, so a child
+    spawned with that ``cwd`` dies before ``exec`` with
+    ``NotADirectoryError: [Errno 20] Not a directory: '/dev/fd/N'``.
+
+    ``F_GETPATH`` asks the kernel for the pathname of the descriptor whose
+    identity was just verified, so the value handed to the child still derives
+    from the checked vnode rather than from the caller's original string.
+    """
+    import fcntl  # POSIX-only, and this helper is reached on darwin alone.
+
+    resolved = fcntl.fcntl(descriptor, fcntl.F_GETPATH, bytes(_MAXPATHLEN))
+    return os.fsdecode(resolved.split(b"\0", 1)[0])
+
+
 def bind_voice_safe_agent_workspace(
     workspace: str | os.PathLike[str],
 ) -> tuple[str, int | None]:
@@ -451,9 +475,10 @@ def bind_voice_safe_agent_workspace(
 
     A pathname-only overlap check has an unavoidable check/use window: another
     sandboxed process can retarget a workspace symlink after ``stat`` and before
-    Kiro initializes its own sandbox. On macOS, open the workspace first, compare
-    directory ancestry entirely through descriptors, and make the child chdir via
-    that descriptor. The returned descriptor must stay open until the child exits.
+    Kiro initializes its own sandbox. On macOS, open the workspace first and
+    compare directory ancestry entirely through descriptors, then resolve that
+    verified descriptor back to the pathname the child chdirs into. The returned
+    descriptor must stay open until the child exits.
 
     Other platforms keep their original pathname and do not inherit a descriptor.
     """
@@ -481,7 +506,19 @@ def bind_voice_safe_agent_workspace(
                     "runtime; keep the workspace and Kiro Crew data home disjoint"
                 )
 
-        return f"/dev/fd/{workspace_fd}", workspace_fd
+        spawn_path = _descriptor_directory_path(workspace_fd)
+        # F_GETPATH yields a pathname, and a pathname can be retargeted between
+        # this resolution and the child's chdir(). Confirm it still names the
+        # vnode whose ancestry was just cleared and fail closed if it does not,
+        # so the narrowed window cannot widen back into the check/use gap this
+        # descriptor-based verification exists to remove.
+        spawn_identity = os.stat(spawn_path)
+        if (spawn_identity.st_dev, spawn_identity.st_ino) != workspace_id:
+            raise RuntimeError(
+                "macOS agent workspace changed identity while binding; refusing "
+                "to spawn into a directory that is no longer the verified one"
+            )
+        return spawn_path, workspace_fd
     except OSError as exc:
         if workspace_fd >= 0:
             os.close(workspace_fd)

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -412,11 +412,108 @@ class TestBuildSeatbeltProfile:
         )
         closed: list[int] = []
         monkeypatch.setattr(sandbox_mod.os, "close", closed.append)
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_descriptor_directory_path",
+            lambda descriptor: "/mutable/workspace",
+        )
+
+        def fake_stat(path):
+            assert path == "/mutable/workspace"
+            result = MagicMock()
+            result.st_dev = 7
+            result.st_ino = 101
+            return result
+
+        monkeypatch.setattr(sandbox_mod.os, "stat", fake_stat)
 
         path, descriptor = sandbox_mod.bind_voice_safe_agent_workspace("/mutable/workspace")
 
-        assert (path, descriptor) == ("/dev/fd/41", 41)
+        # The child receives a real, traversable pathname -- never "/dev/fd/N",
+        # which cannot be chdir'd into on macOS (see the ENOTDIR regression test
+        # below) -- while the verified descriptor is still handed back to keep
+        # the workspace pinned for the child's lifetime.
+        assert (path, descriptor) == ("/mutable/workspace", 41)
         assert closed == [42]
+
+    def test_macos_workspace_binding_rejects_identity_change_after_resolution(
+        self, monkeypatch
+    ):
+        """F_GETPATH returns a pathname, so re-verify it still names the vnode."""
+        monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_voice_runtime_sandbox_paths",
+            lambda: (),
+        )
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_open_directory_descriptor",
+            lambda path, **_kwargs: 71,
+        )
+
+        def fake_fstat(descriptor):
+            result = MagicMock()
+            result.st_dev = 9
+            result.st_ino = 404
+            return result
+
+        monkeypatch.setattr(sandbox_mod.os, "fstat", fake_fstat)
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_directory_ancestor_identities",
+            lambda descriptor: ((9, 404), (9, 1)),
+        )
+        monkeypatch.setattr(
+            sandbox_mod,
+            "_descriptor_directory_path",
+            lambda descriptor: "/mutable/workspace",
+        )
+
+        def swapped_stat(path):
+            result = MagicMock()
+            result.st_dev = 9
+            result.st_ino = 999  # retargeted between resolution and use
+            return result
+
+        monkeypatch.setattr(sandbox_mod.os, "stat", swapped_stat)
+        closed: list[int] = []
+        monkeypatch.setattr(sandbox_mod.os, "close", closed.append)
+
+        with pytest.raises(RuntimeError, match="no longer the verified one"):
+            sandbox_mod.bind_voice_safe_agent_workspace("/mutable/workspace")
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS /dev/fd semantics")
+    def test_bound_workspace_path_is_actually_spawnable(self, tmp_path):
+        """End-to-end guard for the ENOTDIR regression this binding once shipped.
+
+        Every other test in this class mocks ``_open_directory_descriptor``,
+        ``os.fstat`` and ``os.close``, so none of them ever performs a real
+        ``chdir()``. That is precisely how a ``cwd`` of ``/dev/fd/N`` -- which
+        macOS rejects with ``ENOTDIR`` for a directory descriptor -- passed CI
+        while failing every real spawn. This test does the real thing: bind a
+        real directory, then spawn a real process into the returned path.
+        """
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        path, descriptor = sandbox_mod.bind_voice_safe_agent_workspace(str(workspace))
+        try:
+            assert not path.startswith("/dev/fd/")
+            completed = subprocess.run(
+                [sys.executable, "-c", "import os; print(os.getcwd())"],
+                cwd=path,
+                pass_fds=(descriptor,) if descriptor is not None else (),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert os.path.realpath(completed.stdout.strip()) == os.path.realpath(
+                str(workspace)
+            )
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
 
     def test_macos_workspace_binding_rejects_opened_runtime_ancestor(self, monkeypatch):
         monkeypatch.setattr(sandbox_mod.sys, "platform", "darwin")


### PR DESCRIPTION
## Problem / Motivation

Spawning a kiro-backend agent on macOS fails before `exec`:

```
NotADirectoryError: [Errno 20] Not a directory: '/dev/fd/22'
```

The descriptor number changes on every spawn (I observed 20, 22, 31, 32, 43), so it reads as an intermittent, environment-specific glitch. It is neither intermittent nor environmental.

What the user actually sees is the downstream damage in `gateway.log` — three unrelated-looking failures that all bottom out in the same traceback through `create_subprocess_limited()`:

```
WARNING kiro_crew.session: Failed to create background session
WARNING kiro_crew.dashboard.chat_nav: Link summary resolution failed: NotADirectoryError
ERROR   kiro_crew.dashboard.chat_runner: Dashboard chat error in slot chat-NN
```

## Why it matters

`bind_voice_safe_agent_workspace()` takes its macOS branch under `sys.platform == "darwin"`, and `ACP_BACKENDS_INTERNAL_SANDBOX` is `{ACP_BACKEND_KIRO}` — the default backend. Every macOS spawn that goes through the bound-workspace path therefore hits this, so agent startup, background sessions, dashboard chat, and link-summary resolution all fail on a stock macOS install.

The error text actively misleads triage in two ways. It names a `/dev/fd` path, which points investigators at file-descriptor exhaustion, and the varying number reinforces that reading. I went down exactly that path myself and posted a wrong root-cause attribution on kirodotdev/Kiro#10625 before finding the real cause, and have since retracted it. Anyone else debugging this will likely lose the same time.

## What changed (motivation → approach → change)

**Symptom → root cause.** The returned cwd is `/dev/fd/<fd>`:

```python
if sys.platform != "darwin":
    return workspace_path, None
...
return f"/dev/fd/{workspace_fd}", workspace_fd
```

That is a Linux idiom. `/proc/self/fd/N` is a magic symlink that resolves to the directory, so `chdir()` through it works. macOS has no equivalent: a `/dev/fd` entry is served by fdescfs, which reopens the underlying vnode **as a file** rather than exposing it as traversable. `chdir()` on a directory descriptor's `/dev/fd/N` returns `ENOTDIR`.

The message names the cwd rather than the executable because of the `"noexec:chdir"` branch in CPython's `subprocess._execute_child`:

```python
if err_msg == "noexec:chdir":
    err_msg = ""
    # The error must be from chdir(cwd).
    err_filename = cwd
```

So `'/dev/fd/22'` was the cwd being passed *in*, not a descriptor the runtime ran out of. Reproducible in four lines with no KiroCrew involved:

```python
import os, subprocess
fd = os.open("/tmp", os.O_RDONLY)
subprocess.run(["/bin/pwd"], cwd=f"/dev/fd/{fd}", pass_fds=(fd,))
# NotADirectoryError: [Errno 20] Not a directory: '/dev/fd/3'
```

**Approach.** The function's purpose is to close a check/use window: verify the workspace through descriptors so a symlink swap between `stat` and use cannot redirect the agent. The fix must keep that property, not trade it away for a working `cwd`.

I considered `fchdir()` in the child, which would be strictly stronger. `create_subprocess_limited()` deliberately refuses `preexec_fn` to avoid the fork hazard, and threading an fchdir through `spawn_shim_argv` is a much larger change than this defect warrants. Happy to take that route instead if you'd prefer it.

**Change.** Resolve the already-identity-verified descriptor back to a real pathname with `fcntl` `F_GETPATH`, so the value handed to the child still derives from the checked vnode rather than from the caller's original string. Because `F_GETPATH` yields a *pathname*, which can be retargeted between resolution and the child's `chdir()`, the resolved path is re-verified against the descriptor's `(st_dev, st_ino)` and the bind fails closed on mismatch — the narrowed window cannot widen back into the gap this function exists to remove.

## Tests

The existing test asserted the broken value while mocking away everything that could have caught it:

```python
monkeypatch.setattr(sandbox_mod, "_open_directory_descriptor", ...)
monkeypatch.setattr(sandbox_mod.os, "fstat", fake_fstat)
monkeypatch.setattr(sandbox_mod.os, "close", closed.append)
...
assert (path, descriptor) == ("/dev/fd/41", 41)
```

No real `chdir()` ever ran, which is how a `cwd` that cannot work on macOS shipped green.

- `test_macos_workspace_binding_uses_opened_ancestor_identities` — updated. Locks in that the child receives a traversable pathname rather than `/dev/fd/N`, while still asserting the verified descriptor is returned for the caller to hold open.
- `test_bound_workspace_path_is_actually_spawnable` — **new**, unmocked, macOS-gated. Binds a real directory and spawns a real process into the returned `cwd`, asserting it lands in the right place. This is the test that would have caught the bug: verified it fails on `main` (`'/dev/fd/16'`) and passes with the fix.
- `test_macos_workspace_binding_rejects_identity_change_after_resolution` — **new**. Locks in the fail-closed re-check when the resolved path no longer names the verified vnode.

Results:
- `test/test_sandbox_argv.py` — 161 passed, 5 skipped.
- all `test/test_sandbox*.py` + `test/test_acp*.py` — 2136 passed, 57 skipped.
- `flake8` clean on both changed files. `black --check` leaves `sandbox.py` unchanged and touches none of the added test lines (the file has pre-existing black drift on `main`, unrelated to this diff).

Three failures in that suite are **pre-existing on `main`** and unrelated — confirmed by stashing this diff and re-running:
- `test_acp_client.py::TestResolveKiroBinEnvOverride::test_spawn_passes_installed_path_through_exact_wrappers`
- `test_acp_runtime.py::test_runtime_spawn_passes_installed_path_through_exact_wrappers`
- `test_acp_spawn_offload.py` — two `TemporaryDirectory` cleanup failures

The first two are worth a look on their own: both assert `'pass_fds' not in kwargs`, which is only true off macOS, so they fail on any macOS checkout. Together with the fully-mocked binding test, that is consistent with this spawn path not being exercised on macOS in CI — the reason a broken `cwd` went unnoticed.

## Manual verification

Unit coverage alone would not prove the real spawn path works on a live install, so I also verified against the packaged app (KiroCrew 0.5.0-insider.5, macOS 26.6.2 build 25G83, arm64):

1. Reproduced the original failure directly on the app's bundled interpreter (`backend-dist/kirocrew-backend-arm64/bin/python3.12`), getting `NotADirectoryError: [Errno 20] Not a directory: '/dev/fd/3'`.
2. Loaded the patched `kiro_crew.sandbox` through that same interpreter, called `bind_voice_safe_agent_workspace()` on a real directory, confirmed the returned path is not `/dev/fd/...`, then spawned a real subprocess with it as `cwd` and confirmed `os.getcwd()` in the child matched the bound workspace.

## Related Issues

No existing KiroCrew issue that I could find. Related only as a correction: I initially misattributed this error to the extension-host descriptor leak in kirodotdev/Kiro#10625 and have retracted that comment, since the two are unrelated.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`) — one commit, `fix(sandbox): ...`
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing behavior or documented interface changes; the rationale is captured in the docstring and inline comments
- [x] No secrets, credentials, or internal references in the diff
