### PR TITLE
fix: make a retried session_stop idempotent instead of escalating

### DIFF
--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -177,6 +177,51 @@ backwards, so they would be skipped permanently while the response read as
 "nothing new". A cursor exactly AT the end is not stale and still returns an empty
 window.
 
+## Stopping is safe to re-send
+
+The Stop button escalates: a second press while the first cancel is still pending
+hard-kills the turn, and the hard-kill path clears the slot's queue and its pending
+steers. That is right for a button, where the second press means a person watched
+the cooperative stop fail to take. It is wrong for an RPC, where a client that got
+no response inside its 30s request timeout re-sends the same request — so on the
+button's semantics a timeout retry would silently get the destructive variant of a
+verb the caller asked for once, and the queued work would be gone with nothing
+saying a retry rather than a decision caused it (issue #5074).
+
+`session_stop` therefore withholds the escalation for a call it cannot tell apart
+from a retry. `stop_retry.allow_escalation` records the first stop a caller makes
+against a target and answers `False` for any repeat inside `WINDOW_SECS` (120s);
+`stop_slot_turn` takes that as `escalate=False` and lets the repeat fall through to
+its existing "stop already in progress" no-op.
+
+Three properties are worth stating because each one is a way this could have gone
+wrong:
+
+- **Only the escalation is withheld, never the stop.** A repeat that finds the
+  target running again soft-stops it exactly as a first call would. The window
+  suppresses a kill, not a cancel.
+- **The window is anchored at the first stop and is not extended by the repeats it
+  absorbs.** So escalation is suppressed for at most one window: a client that
+  retries forever is absorbed, and after 120s a stop that STILL finds the target
+  winding down escalates — which is the case where escalating is the right answer.
+  A sliding window would put a hard kill out of reach of any caller polling faster
+  than the window.
+- **The key is (caller, target), not the target alone.** A retry comes from the
+  caller that made the original request; two different callers stopping one target
+  are two independent decisions, and keying on the target would suppress the second
+  caller's FIRST call — removing escalation from the RPC rather than making a retry
+  safe.
+
+The window is sized against what it has to outlast rather than picked: below the
+30s request timeout it would expire before the retry it exists to absorb. Nothing
+durable backs it, for `create_rate_limit`'s reason — a restart buys a caller one
+window, not a capability.
+
+The caller is told which of the two no-op facts it hit. `already_stopping`
+separates "was never running" from "its cancel is still in flight", because a
+de-duplicated retry reaches that reply routinely and rendering both as "nothing to
+stop" would tell the second caller the opposite of what happened.
+
 ## Configuration
 
 `agent.session_control` (bool, default **false**). Off makes all three tools

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -4627,8 +4627,10 @@ item, which you handle immediately.
 #:   under that target's own grants. The server-side gates bound WHICH target is
 #:   reachable; nothing bounds WHAT is sent.
 #: * ``session_stop`` — WITHHELD. Ends another session's in-flight turn and
-#:   DISCARDS its work (``stop_target``: "A first call cancels cooperatively;
-#:   calling again while that is pending escalates to a hard kill").
+#:   DISCARDS its work (``stop_target``: "A stop cancels cooperatively", and the
+#:   cancelled turn's work is gone either way — the retry de-duplication that
+#:   keeps a re-sent stop from ALSO discarding the queue does not make the verb
+#:   non-destructive).
 #:
 #: Every withheld verb stays MOUNTED (``@kirocrew-dashboard`` is still in
 #: ``tools``) — it just passes through ``hooks.on_tool_call`` like any ungranted

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2586,6 +2586,7 @@ async def stop_slot_turn(
     force: bool = False,
     source: str = "dashboard",
     cancel_key: str = "",
+    escalate: bool = True,
 ) -> dict[str, Any]:
     """Stop the slot's turn: cooperative cancel, hard kill on a second call.
 
@@ -2593,6 +2594,16 @@ async def stop_slot_turn(
     escalates to a hard kill, regardless of *force* — the caller's view of the
     stop state can lag the backend's, so the backend's own ``_stop_state`` is
     what decides.
+
+    *escalate* is how a caller says its second call may not be a second
+    DECISION. It defaults to True because that is true of the Stop button this
+    function was written for: a person pressing again has watched the cooperative
+    stop fail to take. It is not true of an RPC, where a client that timed out
+    re-sends the same request — so ``session_control.stop_target`` passes False
+    for a call it cannot distinguish from a retry, and the repeat falls through to
+    the no-op below instead of discarding the target's queue (issue #5074). It
+    withholds only the ESCALATION: a stop that finds the slot running still stops
+    it either way.
 
     Inserts a ``stop_event`` card into the slot transcript so whoever is
     watching the session sees the stop, and returns the JSON body the route
@@ -2614,7 +2625,12 @@ async def stop_slot_turn(
     # from the WS-echoed stop_state, which may lag behind the actual state on a
     # slow connection. The backend's own _stop_state is the authoritative
     # "already soft_pending" signal, so a second press always means "kill it".
-    if slot._stop_state == "soft_pending":
+    #
+    # Unless the caller told us this call may not be a second press at all
+    # (*escalate*): a re-sent RPC carries no new intent, and the caller is the
+    # only layer that can know whether its second call was a decision or a
+    # timeout retry. A withheld escalation falls into the no-op branch below.
+    if escalate and slot._stop_state == "soft_pending":
         slot._stop_state = "killing"
         # Survives turn teardown, which resets _stop_state to "idle". Without
         # it a cooperative ack from the first press could still land and label
@@ -2672,6 +2688,13 @@ async def stop_slot_turn(
             _info = "not running"
         else:
             _info = "stop already in progress"
+        _meta: dict[str, Any] = {"slot": name, "via": source, "reason": _info}
+        if not escalate and slot._stop_state == "soft_pending":
+            # The branch a de-duplicated retry lands on. Recorded so the audit
+            # shows an escalation was WITHHELD rather than never asked for --
+            # #5074's "no record that a retry rather than a decision caused it",
+            # read from the other side: the absorbed retry has to be visible too.
+            _meta["escalation_withheld"] = True
         sel().log_tool_invocation(
             session_key=_history_key_for(name),
             agent=getattr(slot, "agent", "") or "kirocrew",
@@ -2679,9 +2702,15 @@ async def stop_slot_turn(
             tool_name="dashboard_stop",
             tool_kind="command",
             outcome="noop",
-            metadata={"slot": name, "via": source, "reason": _info},
+            metadata=_meta,
         )
-        return {"ok": True, "info": _info}
+        # ``already_stopping`` separates the two facts this branch merges: a
+        # target that was never running has nothing to stop, while one whose
+        # cooperative cancel is still in flight IS stopping. Both answer
+        # ``info``, and a caller that renders them alike tells the second one the
+        # opposite of what happened — which the de-duplicated retry above now
+        # reaches routinely.
+        return {"ok": True, "info": _info, "already_stopping": bool(slot.running)}
 
     # First press: soft stop
     slot._stop_state = "soft_pending"

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -44,6 +44,7 @@ from kiro_crew.dashboard.chat_persistence import _TRANSIENT_ROLES as _PERSISTENC
 from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
 from kiro_crew.dashboard.create_rate_limit import SESSION_CREATE, allow_create
 from kiro_crew.dashboard.state import MAX_LIVE_SLOTS, MAX_SLOTS_PER_CREATOR, SlotOrigin
+from kiro_crew.dashboard.stop_retry import allow_escalation
 from kiro_crew.history import metadata_now_iso, transcript_stem
 from kiro_crew.security import redact, redact_and_truncate
 from kiro_crew.sel import sel
@@ -1128,11 +1129,22 @@ async def stop_target(
 ) -> dict[str, Any]:
     """Stop *target*'s in-flight turn, via the same path as the Stop button.
 
-    A first call cancels cooperatively; calling again while that is pending
-    escalates to a hard kill. The escalation is decided by the target's own stop
-    state, not by anything the caller can ask for -- which is why there is no
-    force flag: `stop_slot_turn` escalates on a second press regardless of one,
-    so advertising it would promise a hard kill a first call cannot deliver.
+    A stop cancels cooperatively. The button escalates to a hard kill when a
+    second press lands while the first is still pending; this verb deliberately
+    does not do that for a repeat it cannot tell apart from a RETRY, because a
+    client that got no response inside its request timeout re-sends the same
+    request, and the kill path discards the target's queue and pending steers. So
+    within ``stop_retry.WINDOW_SECS`` of this caller's first stop of this target, a
+    repeat returns the existing "stop already in progress" no-op instead. A stop
+    arriving after that window still escalates, so a genuine second decision keeps
+    the capability — only a blind retry cannot reach it (issue #5074).
+
+    Withholding the escalation never costs the caller the stop it asked for: a
+    repeat that finds the target running again soft-stops it as a first call would.
+
+    Still no force flag: escalation is decided by the target's own stop state and
+    the window above, never by anything the caller can ask for, so advertising one
+    would promise a hard kill a first call cannot deliver.
     """
     # Prewarmed BEFORE `authorize_target`, and that ordering is load-bearing.
     # `stop_slot_turn`'s IDLE branch logs to the SEL with no await before it, so on
@@ -1172,18 +1184,35 @@ async def stop_target(
         target=target,
         operation="stop",
     )
+    # Both calls below are SYNCHRONOUS, which is what lets them sit here at all:
+    # the rule the comment above states is that nothing may SUSPEND between the
+    # gate and the act, and neither of these does.
+    #
+    # `caller_slot_key` repeats the slot walk `authorize_target` just did rather
+    # than changing what that function returns for all three verbs. The walk is
+    # bounded by `MAX_LIVE_SLOTS` and touches no filesystem, and with no
+    # suspension between them the two resolutions cannot disagree — a rebind
+    # landing in that window is impossible, not merely unlikely.
+    caller_key = caller_slot_key(state, caller_session_key)
+    may_escalate = allow_escalation(caller_key, slot.key)
     # Deferred: ``chat_handlers`` imports ``dashboard.chat`` transitively, which
     # reaches back into the gateway at import time — a module-scope import here
     # closes that cycle through ``handlers.session_control`` -> ``server``.
     from kiro_crew.dashboard.chat_handlers import stop_slot_turn
 
-    result = await stop_slot_turn(state, slot, source="session_control")
+    result = await stop_slot_turn(state, slot, source="session_control", escalate=may_escalate)
     _audit(
         caller_session_key=caller_session_key,
         operation="stop",
         slot_key=slot.key,
         outcome="allowed",
-        detail={"result": result.get("info", "stopping")},
+        detail={
+            "result": result.get("info", "stopping"),
+            # Recorded on the ALLOWED line, not only inside `stop_slot_turn`'s
+            # own audit: this is the layer that made the retry judgement, so the
+            # session-control trail has to show it was made.
+            "escalation_withheld": not may_escalate,
+        },
     )
     return {"ok": True, "target": slot.key, **result}
 

--- a/src/kiro_crew/dashboard/stop_retry.py
+++ b/src/kiro_crew/dashboard/stop_retry.py
@@ -1,0 +1,99 @@
+"""Retry de-duplication for the ``session_stop`` RPC's escalation.
+
+``stop_slot_turn`` hard-kills when a second stop arrives while the first is still
+pending, and that is right for the Stop BUTTON it was written for: a person
+pressing again has watched the cooperative stop fail to take, so the second press
+is a decision. It is wrong for an RPC. A client that does not get a response
+inside its request timeout re-sends, and a retry is not a second decision -- it is
+the same request again. The kill path clears the target's ``_queue`` and
+``_pending_steers``, so on that path a caller whose first request merely timed out
+silently gets the destructive variant of a verb it asked for once (issue #5074).
+
+This module holds the one fact that tells the two apart: whether this caller has
+already asked to stop this target recently. ``stop_target`` consults it and
+withholds escalation for a repeat, which lands the call on the existing
+"stop already in progress" no-op instead of a kill. Nothing else changes -- a stop
+that finds the target running still stops it, so withholding escalation never
+costs the caller the stop it asked for.
+
+**The window is anchored at the caller's FIRST stop of a target and is not
+extended by the repeats it absorbs.** That bounds how long escalation is
+suppressed: a client that retries forever is absorbed for one window, after which
+a stop that still finds the target pending escalates as before. A sliding window
+would instead put escalation out of reach of any client polling faster than the
+window, trading one silent failure for another.
+
+:data:`WINDOW_SECS` is sized against the thing it has to outlast. ``mcp_core._post``
+times out at 30s, so the retry this exists to absorb cannot arrive sooner than
+that; a window at or under the request timeout would expire before its own retry
+and fix nothing. 120s leaves room for that timeout plus the caller's own turn.
+Nothing is lost at the far end either, because the only call the window can delay
+is one that finds the target STILL winding down two minutes after a cooperative
+stop -- which is exactly the case where escalating is the right answer.
+
+Keyed per (caller, target): a retry comes from the caller that made the original
+request. Two different callers stopping one target are two independent decisions,
+and widening the key to the target alone would suppress the second caller's FIRST
+call -- removing escalation from the RPC altogether rather than making a retry
+safe.
+
+Follows ``create_rate_limit``'s in-memory shape, and for the same reason it gives:
+a guard measured in minutes needs no durable state, because a restart buys a
+caller one window rather than a clean slate. It differs in sweeping on every call
+instead of on an interval -- stop is a low-frequency verb and the map is bounded by
+the pairs of live slots that stopped each other inside the window, so there is no
+burst for an interval guard to amortize.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+#: How long after a caller's first stop of a target a repeat is read as a retry
+#: rather than as an escalation. See the module docstring for the sizing.
+WINDOW_SECS = 120.0
+
+_lock = threading.Lock()
+
+#: (caller slot key, target slot key) -> monotonic time of the FIRST stop in the
+#: current window. Deliberately not refreshed by later stops; see the docstring.
+_windows: dict[tuple[str, str], float] = {}
+
+
+def allow_escalation(caller_key: str, target_key: str, *, now: float | None = None) -> bool:
+    """Record a stop of *target_key* by *caller_key*; say whether it may escalate.
+
+    ``False`` means this caller already stopped this target inside
+    :data:`WINDOW_SECS`, so the call cannot be told apart from a retry of that
+    request and must not be read as "escalate".
+
+    Recording and deciding are one operation under one lock, so two concurrent
+    stops cannot both observe an empty window and both escalate.
+
+    Fails CLOSED (no escalation) on an unattributable pair: an empty key cannot be
+    matched against a first call, so a hard kill would be granted to precisely the
+    caller whose retries cannot be recognized. Withholding costs only the kill --
+    the cooperative stop still lands -- so the safe direction is the one that
+    cannot discard a queue. Every caller reaching here has already resolved its
+    identity strictly, so this refuses nothing legitimate.
+    """
+    if not caller_key or not target_key:
+        return False
+    if now is None:
+        now = time.monotonic()
+    cutoff = now - WINDOW_SECS
+    key = (caller_key, target_key)
+    with _lock:
+        for stale in [k for k, first in _windows.items() if first <= cutoff]:
+            del _windows[stale]
+        if key in _windows:
+            return False
+        _windows[key] = now
+        return True
+
+
+def reset_for_tests() -> None:
+    """Clear every window. Test-only: module state would otherwise leak across tests."""
+    with _lock:
+        _windows.clear()

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -256,8 +256,10 @@ def _tool_definitions() -> list[dict[str, Any]]:
                 "Stop another session's in-flight turn — the same thing as pressing Stop "
                 "in that tab. Use it when a peer session is working on something you now "
                 "know is wrong or already done, and letting it finish would waste the run "
-                "or make a conflicting change. The first call cancels cooperatively; "
-                "calling again while that is still pending escalates to a hard kill. "
+                "or make a conflicting change. The stop is cooperative and safe to "
+                "re-send: a repeat within two minutes reports that the earlier stop is "
+                "still in progress instead of escalating to a hard kill, so retrying a "
+                "call that timed out cannot discard the target's queued messages. "
                 "A stop card appears in the "
                 "target's transcript so the person reading it sees what happened. Stopping "
                 "discards the turn's work, so read the session first when you are not sure "
@@ -884,8 +886,14 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         target = resp.get("target", args["target"])
         info = resp.get("info")
         if info:
-            # The target was not running (or a stop was already in flight) — say
-            # so rather than implying a turn was cancelled.
+            # Two different facts share this reply and must not read alike. A
+            # target that was never running has nothing to stop; one whose
+            # cooperative cancel is still in flight IS stopping, and after #5074 a
+            # re-sent stop lands there routinely — telling that caller "nothing to
+            # stop" would report the opposite of what happened and invite it to
+            # act as though the target were still free-running.
+            if resp.get("already_stopping"):
+                return f"\u2139\ufe0f `{target}`: {info} — the earlier stop still stands."
             return f"\u2139\ufe0f `{target}`: {info} — nothing to stop."
         return f"\U0001f6d1 Stop sent to `{target}`. Its transcript now shows the stop card."
 

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1413,6 +1413,52 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
         # `_get` takes the key positionally, matching its signature.
         assert get.call_args.args[1] == self.VERIFIED
 
+    def test_a_re_sent_stop_is_not_reported_as_nothing_to_stop(self):
+        """A de-duplicated retry (#5074) lands on the no-op reply routinely.
+
+        Its earlier cooperative stop IS still in flight, so rendering it the way a
+        never-running target is rendered would tell the caller the opposite of what
+        happened — and invite it to act as though the target were free-running.
+
+        Mutation guard: ignoring `already_stopping` restores "nothing to stop".
+        """
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+            ),
+            patch(
+                "kiro_crew.mcp_dashboard._post",
+                return_value={
+                    "ok": True,
+                    "target": "peer",
+                    "info": "stop already in progress",
+                    "already_stopping": True,
+                },
+            ),
+        ):
+            out = _call_tool_inner("session_stop", {"target": "peer"})
+        assert "stop already in progress" in out
+        assert "nothing to stop" not in out
+        assert "the earlier stop still stands" in out
+
+    def test_a_target_that_was_never_running_still_says_nothing_to_stop(self):
+        with (
+            patch(
+                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+            ),
+            patch(
+                "kiro_crew.mcp_dashboard._post",
+                return_value={
+                    "ok": True,
+                    "target": "peer",
+                    "info": "not running",
+                    "already_stopping": False,
+                },
+            ),
+        ):
+            out = _call_tool_inner("session_stop", {"target": "peer"})
+        assert "nothing to stop" in out
+
     def test_an_empty_window_still_hands_back_the_cursor(self):
         """A poll loop's commonest answer is empty, and it must not lose its place.
 

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -23,6 +23,7 @@ from chat_test_helpers import _make_state
 from kiro_crew.config import loader
 from kiro_crew.dashboard import chat_delivery as cd
 from kiro_crew.dashboard import session_control as sc
+from kiro_crew.dashboard import stop_retry
 from kiro_crew.dashboard.chat_utils import slot_history_key
 from kiro_crew.dashboard.handlers import session_control as handlers_sc
 
@@ -38,6 +39,18 @@ _REAL_ENABLED = sc.session_control_enabled
 def _enabled(monkeypatch):
     """Default every test to the shipped state (enabled) without reading config."""
     monkeypatch.setattr(sc, "session_control_enabled", lambda: True)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_stop_windows():
+    """The stop-retry window is process-wide module state.
+
+    Left behind, one test's stop makes a later test's FIRST stop read as a repeat
+    — so escalation would be withheld from a test that never retried anything.
+    """
+    stop_retry.reset_for_tests()
+    yield
+    stop_retry.reset_for_tests()
 
 
 def _slot(state, name: str, **kwargs):
@@ -1350,7 +1363,7 @@ def test_nothing_suspends_between_the_stop_gate_and_the_stop(tmp_path, monkeypat
         order.append("authorize")
         return real_authorize(*a, **kw)
 
-    async def _fake_stop(_state, slot, *, source):
+    async def _fake_stop(_state, slot, *, source, escalate=True):
         order.append("stop")
         return {"ok": True}
 
@@ -1404,7 +1417,7 @@ def test_the_config_warm_is_the_last_suspension_before_the_stop_gate(tmp_path, m
         order.append("warm")
         return True
 
-    async def _fake_stop(_state, slot, *, source):
+    async def _fake_stop(_state, slot, *, source, escalate=True):
         order.append("stop")
         return {"ok": True}
 
@@ -1466,7 +1479,7 @@ def test_stop_constructs_the_sel_off_loop_before_stopping(tmp_path, monkeypatch)
 
     monkeypatch.setattr(sc, "sel", _sel)
 
-    async def _fake_stop(_state, slot, *, source):
+    async def _fake_stop(_state, slot, *, source, escalate=True):
         return {"ok": True}
 
     monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.stop_slot_turn", _fake_stop)
@@ -1491,9 +1504,10 @@ def test_stop_goes_through_the_same_path_as_the_stop_button(tmp_path, monkeypatc
 
     seen: dict[str, object] = {}
 
-    async def _fake_stop(_state, slot, *, source):
+    async def _fake_stop(_state, slot, *, source, escalate=True):
         seen["slot"] = slot.key
         seen["source"] = source
+        seen["escalate"] = escalate
         return {"ok": True}
 
     monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.stop_slot_turn", _fake_stop)
@@ -1502,8 +1516,10 @@ def test_stop_goes_through_the_same_path_as_the_stop_button(tmp_path, monkeypatc
 
     assert out["target"] == "chat-2"
     # No `force`: `stop_slot_turn` escalates on a second press regardless of one,
-    # so the tool does not advertise a flag a first call cannot honour.
-    assert seen == {"slot": "chat-2", "source": "session_control"}
+    # so the tool does not advertise a flag a first call cannot honour. A FIRST
+    # stop still carries `escalate=True` — the retry guard withholds it only for a
+    # repeat, so the button's semantics are unchanged for a call that is not one.
+    assert seen == {"slot": "chat-2", "source": "session_control", "escalate": True}
 
 
 def test_stop_is_refused_for_a_session_out_of_bounds(tmp_path):
@@ -1512,6 +1528,255 @@ def test_stop_is_refused_for_a_session_out_of_bounds(tmp_path):
     _slot(state, "chat-hidden", memory_mode="incognito")
     with pytest.raises(sc.SessionControlError):
         asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-hidden"))
+
+
+# ── session_stop is safe to re-send (#5074) ──────────────────────────────────
+
+
+def _stoppable(state, slot):
+    """A target with a live turn and unconsumed work behind it.
+
+    Both lists are what the hard-kill path clears, so they are the evidence a
+    retry read as an escalation would destroy. ``stop_turn`` answers "cancelled"
+    rather than "idle" so the soft stop stays PENDING — the state a retry arrives
+    into, and the only state from which escalation is reachable at all.
+    """
+    _busy(slot)
+    slot._queue.append({"id": "q1", "content": "the next thing"})
+    slot._pending_steers.append("steer-1")
+    slot._steer_delivery_ids["steer-1"] = "delivery-1"
+    state.sessions.stop_turn = AsyncMock(return_value="cancelled")
+    return slot
+
+
+def test_a_retried_stop_keeps_the_queue_instead_of_escalating(tmp_path, monkeypatch):
+    """The defect: a timeout retry is read as a second press and discards work.
+
+    `stop_slot_turn` hard-kills on any second stop while the first is still
+    pending, and the kill clears `_queue` and `_pending_steers`. An MCP client
+    that got no response inside `_post`'s 30s timeout re-sends the same request,
+    so a caller that asked once silently got the destructive variant — the
+    exposure is worst for the unattended agent this verb exists for, which
+    retries without anyone deciding anything.
+
+    Mutation guard: dropping `escalate=` from `stop_target`'s call, or the
+    `escalate and` guard in `stop_slot_turn`, empties both lists here and leaves
+    `_stop_state` at "killing".
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _stoppable(state, _peer_target(state, "chat-2", caller))
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.sel", lambda: MagicMock())
+
+    first = asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+    assert target._stop_state == "soft_pending", "fixture must leave a stop pending"
+
+    second = asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+
+    assert first.get("info") is None, "the first stop is the real cooperative one"
+    assert second["info"] == "stop already in progress"
+    assert target._stop_state == "soft_pending", "the retry escalated to a hard kill"
+    assert [q["id"] for q in target._queue] == ["q1"], "the retry discarded queued work"
+    assert target._pending_steers == ["steer-1"], "the retry discarded a pending steer"
+    assert target._steer_delivery_ids == {"steer-1": "delivery-1"}
+
+
+def test_a_repeat_still_stops_a_target_that_started_running_again(tmp_path, monkeypatch):
+    """Withholding the escalation must not withhold the STOP.
+
+    The retry guard suppresses a kill, not a cancel. A repeat that arrives after
+    the first stop has settled and the target has picked up its next turn is a
+    plain first stop as far as that turn is concerned, and has to cancel it.
+
+    Mutation guard: short-circuiting `stop_target` on a repeat — returning the
+    first call's answer without calling `stop_slot_turn` — leaves this second turn
+    running.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _stoppable(state, _peer_target(state, "chat-2", caller))
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.sel", lambda: MagicMock())
+
+    asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+    # The first stop lands and the target drains its queue into a new turn.
+    target._stop_state = "idle"
+    target._stop_event_id = None
+
+    out = asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+
+    assert out.get("info") is None, "a repeat against a fresh turn is a real stop"
+    assert target._stop_state == "soft_pending"
+    assert state.sessions.stop_turn.await_count == 2
+
+
+def test_a_stop_after_the_window_still_escalates(tmp_path, monkeypatch):
+    """Escalation is delayed, not removed.
+
+    A stop that STILL finds the target winding down once the window has closed is
+    the case escalating was written for, and the capability has to survive: the
+    alternative contract (never escalate from the RPC) was rejected because it
+    takes the hard kill away from the agent surface entirely.
+
+    Mutation guard: withholding escalation unconditionally leaves `_stop_state` at
+    "soft_pending" and the queue intact.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _stoppable(state, _peer_target(state, "chat-2", caller))
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.sel", lambda: MagicMock())
+
+    asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+    # The window closes, so the next stop is a decision rather than a retry.
+    monkeypatch.setattr(stop_retry, "WINDOW_SECS", 0.0)
+
+    asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+
+    assert target._stop_state == "killing"
+    assert list(target._queue) == [], "an escalation discards the queue, by design"
+
+
+def test_a_withheld_escalation_is_recorded(tmp_path, monkeypatch):
+    """#5074 read from the other side: the absorbed retry must be visible too.
+
+    The issue's complaint is that queued messages went "with no record that a
+    retry rather than a decision caused it". Suppressing the kill silently would
+    leave the same gap inverted — an audit in which a de-duplicated retry is
+    indistinguishable from a stop nobody made.
+
+    Mutation guard: dropping the metadata key.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _stoppable(state, _peer_target(state, "chat-2", caller))
+    logged: list[dict] = []
+    fake_sel = MagicMock()
+    fake_sel.log_tool_invocation = lambda **kw: logged.append(kw)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.sel", lambda: fake_sel)
+
+    asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+    asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+
+    noop = [row for row in logged if row.get("outcome") == "noop"]
+    assert noop, f"the retry did not reach the no-op branch: {[r.get('outcome') for r in logged]}"
+    assert noop[-1]["metadata"].get("escalation_withheld") is True
+
+
+def test_the_stop_button_still_escalates_on_a_second_press(tmp_path, monkeypatch):
+    """The button's contract is unchanged, and that is the point of the default.
+
+    A person pressing Stop again has watched the cooperative stop fail to take, so
+    the second press IS a decision. Only the RPC, which cannot tell a decision
+    from a re-sent request, gives that up.
+
+    Mutation guard: defaulting `escalate` to False in `stop_slot_turn` breaks this
+    without touching the session-control tests above.
+    """
+    from kiro_crew.dashboard.chat_handlers import stop_slot_turn
+
+    state = _make_state(tmp_path)
+    slot = _stoppable(state, _slot(state, "chat-1"))
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.sel", lambda: MagicMock())
+
+    asyncio.run(stop_slot_turn(state, slot))
+    assert slot._stop_state == "soft_pending"
+
+    asyncio.run(stop_slot_turn(state, slot))
+
+    assert slot._stop_state == "killing"
+    assert list(slot._queue) == []
+
+
+def test_the_no_op_reply_says_which_of_its_two_facts_it_hit(tmp_path, monkeypatch):
+    """`info` alone merges "was never running" with "its cancel is in flight".
+
+    The de-duplicated retry lands on the second one routinely now, and a caller
+    that renders both alike tells that caller the opposite of what happened.
+
+    Mutation guard: hardcoding `already_stopping` either way collapses the two.
+    """
+    from kiro_crew.dashboard.chat_handlers import stop_slot_turn
+
+    state = _make_state(tmp_path)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.sel", lambda: MagicMock())
+
+    stopping = _stoppable(state, _slot(state, "chat-1"))
+    asyncio.run(stop_slot_turn(state, stopping))
+    still_stopping = asyncio.run(stop_slot_turn(state, stopping, escalate=False))
+    assert still_stopping == {
+        "ok": True,
+        "info": "stop already in progress",
+        "already_stopping": True,
+    }
+
+    idle = _slot(state, "chat-2")
+    assert asyncio.run(stop_slot_turn(state, idle)) == {
+        "ok": True,
+        "info": "not running",
+        "already_stopping": False,
+    }
+
+
+def test_the_window_is_anchored_at_the_first_stop_not_slid_by_repeats():
+    """Escalation is suppressed for ONE window, not for as long as retries arrive.
+
+    A sliding window would put a hard kill out of reach of any caller polling
+    faster than the window — trading a silent queue loss for a capability that can
+    never be reached again.
+
+    Mutation guard: refreshing the stored timestamp on a repeat makes the third
+    call read as a repeat as well.
+    """
+    first_at = 100.0
+    assert stop_retry.allow_escalation("chat-1", "chat-2", now=first_at) is True
+    assert stop_retry.allow_escalation("chat-1", "chat-2", now=first_at + 80.0) is False
+    assert (
+        stop_retry.allow_escalation("chat-1", "chat-2", now=first_at + stop_retry.WINDOW_SECS)
+        is True
+    )
+
+
+def test_the_window_outlasts_the_request_timeout_it_absorbs():
+    """A window at or under `_post`'s 30s timeout expires before its own retry.
+
+    The retry this exists to absorb cannot be sent until the first request has
+    timed out, so the window is sized against that number rather than picked.
+    """
+    assert stop_retry.WINDOW_SECS > 30.0
+
+
+def test_the_window_is_keyed_per_caller_and_target():
+    """A different caller's FIRST stop is its own decision, not somebody's retry.
+
+    Keying on the target alone would suppress that call — removing escalation from
+    the RPC rather than making a retry safe.
+    """
+    assert stop_retry.allow_escalation("chat-1", "chat-2", now=100.0) is True
+    assert stop_retry.allow_escalation("chat-9", "chat-2", now=100.0) is True
+    assert stop_retry.allow_escalation("chat-1", "chat-3", now=100.0) is True
+    assert stop_retry.allow_escalation("chat-1", "chat-2", now=100.0) is False
+
+
+def test_an_unattributable_stop_cannot_escalate():
+    """Fails closed: an empty key cannot be matched against a first call.
+
+    Granting the kill there would hand the destructive variant to exactly the
+    caller whose retries cannot be recognized. Withholding costs only the
+    escalation — the cooperative stop still lands.
+    """
+    assert stop_retry.allow_escalation("", "chat-2", now=100.0) is False
+    assert stop_retry.allow_escalation("chat-1", "", now=100.0) is False
+
+
+def test_expired_windows_are_swept_rather_than_accumulated():
+    """The map must not grow for the gateway's lifetime.
+
+    Mutation guard: dropping the sweep keeps both keys, so a long-lived gateway
+    holds one entry per pair of slots that ever stopped each other.
+    """
+    stop_retry.allow_escalation("chat-1", "chat-2", now=100.0)
+    stop_retry.allow_escalation("chat-3", "chat-4", now=100.0)
+    stop_retry.allow_escalation("chat-5", "chat-6", now=100.0 + stop_retry.WINDOW_SECS + 1.0)
+    assert list(stop_retry._windows) == [("chat-5", "chat-6")]
 
 
 # ── session_send ──


### PR DESCRIPTION
## What is the problem?

`session_stop` inherited the Stop button's escalation. `stop_slot_turn` hard-kills
whenever a second stop arrives while the first cooperative cancel is still
pending, and the hard-kill path clears the target slot's `_queue` alongside its
`_pending_steers`.

That is correct for a button. A person pressing Stop again has watched the
cooperative stop fail to take, so the second press is a decision. It is wrong for
an RPC: `mcp_core._post` times out at 30s, and a client that gets no response
re-sends the same request. A retry carries no new intent, but on this surface the
second call was read as "escalate", so a caller whose first request merely timed
out silently got the destructive variant of a verb it asked for once.

## Why this issue matters to the user

The two outcomes are not distinguishable from the caller's side. A cooperative
stop leaves the target's queue intact; the escalated kill does not. So queued
messages and unconsumed steers could disappear from a session the caller meant to
stop once, with nothing in the audit trail saying a retry rather than a decision
caused it.

The exposure is worst for exactly the caller this verb exists for. An unattended
agent retries on its own, without a person deciding anything, and the goal
conductor's own skill drives `session_stop` on peer sessions it is coordinating,
which are the sessions most likely to have work queued behind the running turn.

## How our fix solves it

The symptom is a lost queue. The queue is cleared by the hard-kill branch. That
branch fires on `_stop_state == "soft_pending"` alone, which is a proxy for "a
second press happened", and the proxy is what breaks: on an RPC a second call is
not necessarily a second press. So the fix restores the missing distinction rather
than removing the kill.

- **`stop_slot_turn` takes `escalate` (default `True`).** The default keeps the
  button's contract exactly as it was; only a caller that knows its second call
  might not be a decision passes `False`, and the repeat then falls through to the
  no-op branch that already existed for "already stopping".
- **`dashboard/stop_retry.py` is the one fact needed to decide that.** It records
  the first stop a caller makes against a target and answers `False` for any
  repeat inside `WINDOW_SECS`. `stop_target` passes that straight through as
  `escalate`.
- **The window is sized against `_post`'s 30s timeout, not picked.** The retry it
  exists to absorb cannot be sent until the first request has timed out, so a
  window at or under 30s would expire before its own retry and fix nothing. 120s
  leaves room for that timeout plus the caller's own turn.

Three properties keep this from trading one silent failure for another:

- **Only the escalation is withheld, never the stop.** A repeat that finds the
  target running again soft-stops it exactly as a first call would. There is a
  test for this specifically, because short-circuiting the repeat inside
  `stop_target` (the obvious implementation) would silently stop stopping.
- **The window is anchored at the first stop and is not extended by the repeats it
  absorbs.** Escalation is therefore suppressed for at most one window: a stop
  that STILL finds the target winding down two minutes after a cooperative cancel
  escalates as before, which is the case escalating was written for. A sliding
  window would instead put the hard kill out of reach of any caller polling faster
  than the window.
- **The key is (caller, target).** A retry comes from the caller that made the
  original request. Keying on the target alone would suppress a *different*
  caller's first call, which removes escalation from the RPC rather than making a
  retry safe.

Two smaller pieces close the reporting half of the same defect:

- The withheld escalation is recorded (`escalation_withheld` in the SEL's `noop`
  line and on session-control's own `allowed` line) so an absorbed retry is
  visible instead of looking like a stop nobody made.
- The no-op reply carries `already_stopping`, and the MCP layer renders it. `info`
  alone merged "was never running" with "its cancel is still in flight"; the
  de-duplicated retry reaches the second one routinely, and telling that caller
  "nothing to stop" reported the opposite of what happened.

This adopts option 1 from the issue (idempotent first-call window). Option 3
(never escalate from the RPC) was not taken because it removes the hard kill from
the agent surface entirely; option 2 (echo the pending state back) adds a
wire-protocol field to reach the same place a window reaches with none.

## What tests we did

Targeted suites, all green: `test_session_control.py`,
`test_mcp_dashboard_folders.py`, `test_stop_handler_idempotent.py`,
`test_stop_addresses_linked_session.py`, `test_session_control_boundaries.py`,
`test_mcp_dashboard_registration.py`, `test_conductor_agent.py`,
`test_chat_slot_interrupt.py`, `test_steer_requeue.py`,
`test_create_rate_limit.py` - 375 passed. `isort` and `flake8` clean on the
touched files; the repo's baselined black gate passes on this diff's scope. `mypy`
reports two errors, both in `src/kiro_crew/transcribe.py`, which this diff does
not touch - reproduced identically on a pristine `main` checkout.

Every new test was mutation-verified red against the behaviour it pins:

| Mutation | Red |
|---|---|
| drop the `escalate and` guard (i.e. restore today's behaviour) | `test_a_retried_stop_keeps_the_queue_instead_of_escalating`, `test_a_withheld_escalation_is_recorded`, `test_the_no_op_reply_says_which_of_its_two_facts_it_hit` |
| default `escalate` to `False` (i.e. break the button) | `test_the_stop_button_still_escalates_on_a_second_press` |
| refresh the stored timestamp on a repeat (sliding window) | `test_the_window_is_anchored_at_the_first_stop_not_slid_by_repeats` |
| drop the sweep | `test_expired_windows_are_swept_rather_than_accumulated`, plus both window-expiry tests |

The end-to-end tests drive the real `stop_slot_turn` against a real `_ChatSlot`
with a populated `_queue` and `_pending_steers`, so what they assert is the actual
data the kill path would have discarded rather than a call-argument stand-in.

## Any other suggestions on the work

- `stop_target` resolves the caller's slot key a second time (`authorize_target`
  already did it internally) rather than changing what that function returns for
  all three verbs. It is a bounded in-memory walk with no suspension between the
  two resolutions, so they cannot disagree, but if a fourth verb ever needs the
  caller key, returning it from `authorize_target` is the tidier shape.
- `already_stopping` is additive on `POST /api/chat/slots/{slot}/stop` too. The
  dashboard does not read it today; a future Stop button could use it to say
  "still stopping" instead of leaving the press looking ignored.
- There is no unfixed sibling. `api_chat_slot_interrupt` has no escalation branch
  at all - its `_stop_state != "idle"` guard returns the no-op - so `stop_slot_turn`
  was the only place the escalate-on-any-second-call proxy lived. (An earlier
  revision of this description claimed otherwise; that was wrong and is corrected
  here.)

Closes #5074
