### PR TITLE
fix(cloud): find session-manager-plugin under a GUI-launched minimal PATH

### DIFF
--- a/src/kiro_crew/cloud/ssm.py
+++ b/src/kiro_crew/cloud/ssm.py
@@ -30,7 +30,7 @@ from typing import Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.cloud import aws
-from kiro_crew.deploy.engine import resolve_aws_bin
+from kiro_crew.deploy.engine import aws_spawn_env, resolve_aws_bin, resolve_aws_tool_bin
 
 logger = logging.getLogger(__name__)
 
@@ -192,8 +192,18 @@ def build_port_forward_argv(
 
 
 def session_manager_plugin_installed() -> bool:
-    """True when the local AWS Session Manager plugin is available."""
-    return shutil.which(_SESSION_MANAGER_PLUGIN) is not None
+    """True when the local AWS Session Manager plugin is available.
+
+    Resolved through the deploy engine's shared resolver, not a bare
+    ``shutil.which``: the plugin's own installers target ``/usr/local/bin`` (and
+    the Homebrew cask the brew prefix), neither of which is on the minimal
+    launchd ``PATH`` a Finder/Dock-launched gateway inherits — so the bare probe
+    reported "not installed" for a plugin that was installed, and
+    :func:`require_session_manager_plugin` refused every SSM tunnel before one
+    was attempted (#5392). Same resolution the ``start-session`` argv head
+    already uses, so probe and spawn can no longer disagree (#4770, #5360).
+    """
+    return shutil.which(resolve_aws_tool_bin(_SESSION_MANAGER_PLUGIN)) is not None
 
 
 def session_manager_plugin_install_hint() -> str:
@@ -323,6 +333,14 @@ def open_port_forward(
     caller drains the pipes (they block on ``wait()``), so PIPE would deadlock
     the tunnel once the OS pipe buffer fills. Tunnel liveness is verified via
     :func:`wait_for_local_port`, not by parsing plugin output.
+
+    The child gets :func:`~kiro_crew.deploy.engine.aws_spawn_env` rather than a
+    bare inherited env: the ``aws`` head is resolved absolutely, but the CLI then
+    looks ``session-manager-plugin`` up by name on its OWN ``PATH``, which under a
+    GUI-launched gateway is the minimal launchd one (#5392). The resolved head is
+    handed over so the widening is withheld when it is a bare name — a bare name
+    means provenance REFUSED the candidate in those dirs, and widening would put
+    it back within ``execvp``'s reach.
     """
     # Streaming child — bypasses the run_aws chokepoint, so carry the same
     # human-action guard here (opening a tunnel to the box is a sensitive,
@@ -334,7 +352,11 @@ def open_port_forward(
         "opening SSM port-forward %s: local %d -> remote %d", instance_id, local_port, remote_port
     )
     return subprocess.Popen(  # noqa: S603 — fixed argv, no shell
-        argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True
+        argv,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        env=aws_spawn_env(argv[0]),
     )
 
 

--- a/src/kiro_crew/deploy/engine.py
+++ b/src/kiro_crew/deploy/engine.py
@@ -91,26 +91,30 @@ def random_bucket_name() -> str:
 # neither Homebrew nor the official-pkg symlink dir — so a bare ``"aws"`` fails
 # ``execvp`` inside ``sandbox-exec`` with "No such file or directory", which is
 # exactly why the Artifact Deploy "Verify" step failed for Homebrew users until
-# the gateway was relaunched from a shell that carried the full PATH.
+# the gateway was relaunched from a shell that carried the full PATH. The SSM
+# session-manager-plugin installs into these same dirs, so it is resolved and
+# spawn-searched through them too (#5392).
 _AWS_BIN_DIRS = (
     "/opt/homebrew/bin",  # Apple Silicon Homebrew
     "/usr/local/bin",     # Intel Homebrew + official AWS CLI v2 pkg symlink
 )
 
 
-def resolve_aws_bin() -> str:
-    """Resolve ``aws`` to an absolute path, falling back to the bare name.
+def resolve_aws_tool_bin(name: str) -> str:
+    """Resolve an AWS-tooling binary to an absolute path, or the bare ``name``.
 
     Searches the inherited ``PATH`` first, then the well-known install dirs in
-    :data:`_AWS_BIN_DIRS`, so the desktop-app gateway resolves the CLI no matter
+    :data:`_AWS_BIN_DIRS`, so the desktop-app gateway resolves the tool no matter
     how it was launched (Finder/Dock give a minimal PATH; a terminal launch does
-    not). Falling back to the bare ``"aws"`` preserves the prior behaviour — and
-    its "not found" error — when the CLI genuinely is not installed anywhere.
+    not). Falling back to the bare ``name`` preserves the prior behaviour — and
+    its "not found" error — when the tool genuinely is not installed anywhere.
 
-    Public: this is the repo's single ``aws``-CLI resolution chokepoint, reused
-    by every sibling spawn site (``cloud.aws``, ``cloud.ssm``, ``voice_reply``,
-    ``dashboard.chat_voice``, the artifact-deploy skill scripts) so each one
-    survives a GUI-launched gateway's minimal PATH the same way (#4770).
+    Public and generic over ``name`` because ``aws`` is not the only AWS binary
+    the gateway has to find in those dirs: ``session-manager-plugin`` installs
+    into exactly the same ones (AWS's macOS ``.pkg`` symlinks it into
+    ``/usr/local/bin``, the Homebrew cask into the brew prefix), and its probe hit
+    the identical minimal-PATH gap (#5392). Both callers therefore share this one
+    body rather than each re-deriving the dirs and the provenance rule.
 
     A hit found only through the fallback dirs (i.e. NOT reachable via the
     inherited ``PATH``, which the pre-existing bare-argv behaviour already
@@ -123,21 +127,90 @@ def resolve_aws_bin() -> str:
     failure mode.
     """
     env_path = os.environ.get("PATH", "")
-    found = shutil.which("aws", path=env_path) if env_path else None
+    found = shutil.which(name, path=env_path) if env_path else None
     if found:
         # Same trust class as the pre-existing behaviour: execvp against the
         # inherited PATH already executed exactly this binary.
         return found
     fallback = os.pathsep.join(p for p in _AWS_BIN_DIRS if p)
-    found = shutil.which("aws", path=fallback) if fallback else None
+    found = shutil.which(name, path=fallback) if fallback else None
     if found:
         from kiro_crew.github_runner import validate_provider_executable
 
         try:
             return validate_provider_executable(found)
         except ValueError:
-            logger.warning("refusing aws CLI at %s: failed provenance validation", found)
-    return "aws"
+            logger.warning("refusing %s at %s: failed provenance validation", name, found)
+    return name
+
+
+def resolve_aws_bin() -> str:
+    """Resolve ``aws`` to an absolute path, falling back to the bare name.
+
+    Public: this is the repo's single ``aws``-CLI resolution chokepoint, reused
+    by every sibling spawn site (``cloud.aws``, ``cloud.ssm``, ``voice_reply``,
+    ``dashboard.chat_voice``, the artifact-deploy skill scripts) so each one
+    survives a GUI-launched gateway's minimal PATH the same way (#4770). See
+    :func:`resolve_aws_tool_bin` for the search order and the provenance rule.
+    """
+    return resolve_aws_tool_bin("aws")
+
+
+def aws_spawn_env(aws_bin: str) -> dict[str, str]:
+    """This process's env with :data:`_AWS_BIN_DIRS` APPENDED to ``PATH``.
+
+    ``aws_bin`` is the argv head the caller is about to spawn — the return value of
+    :func:`resolve_aws_bin` for that same spawn. It is required, not optional: see
+    the fail-closed rule below, which cannot be enforced without it.
+
+    Resolving our own argv head absolutely is not sufficient for ``aws ssm
+    start-session``: the CLI locates ``session-manager-plugin`` itself, by name,
+    against the CHILD's inherited ``PATH`` at exec time. A GUI-launched gateway
+    hands the child the minimal launchd ``PATH``, so the tunnel dies inside a
+    correctly-resolved ``aws`` — the resolver cannot reach that lookup, only the
+    child's environment can (#5392). Passing this as ``env=`` is therefore the
+    other half of the same fix, not a duplicate of it.
+
+    APPENDED, never prepended: the inherited ``PATH`` keeps first claim on every
+    name, so this can only make a previously-unresolvable lookup succeed and can
+    never re-point one the child already resolved. That is the whole trust
+    argument for widening a credential-bearing child's ``PATH`` at all, and it is
+    also why this is not :func:`kiro_crew.env.augmented_path`, which PREPENDS a
+    broader set (``~/.local/bin``, npm/mise/volta shims) — the right search space
+    for finding an MCP launcher, too wide and wrongly-ordered ahead of ``/usr/bin``
+    for a child holding AWS credentials and a live tunnel to the user's box.
+
+    **A non-absolute ``aws_bin`` returns the env UNWIDENED.** This is the one case
+    where "can only make an unresolvable lookup succeed" is not a safety argument
+    but the hazard itself: :func:`resolve_aws_tool_bin` falls back to the bare name
+    precisely when it found a candidate in these dirs and
+    ``validate_provider_executable`` REFUSED it, and that refusal is enforced only
+    by the bare name failing ``execvp`` against a ``PATH`` those dirs are absent
+    from. Widening the child's ``PATH`` would put the refused binary back on it and
+    hand it AWS credentials — converting a fail-closed rejection into an execution.
+    So the widening is offered only to a head that was already resolved
+    absolutely, where ``execvp`` performs no ``PATH`` search at all and the dirs
+    can affect nothing but the CLI's own onward lookups.
+
+    Dirs already on ``PATH`` are not repeated, so a terminal-launched gateway
+    (whose ``PATH`` carries them) gets a byte-identical env and the fix is inert
+    outside the minimal-PATH case it exists for.
+
+    Unlike the resolvers above this touches no filesystem — it is a dict copy and
+    a string join over ``os.environ`` — so it is safe to call directly on the
+    gateway event loop, where a PATH scan would not be.
+    """
+    env = dict(os.environ)
+    if not os.path.isabs(aws_bin):
+        # Unresolved head: the bare name IS the provenance refusal. Leave PATH
+        # alone so it keeps failing execvp, as it did before this env existed.
+        return env
+    current = env.get("PATH", "")
+    have = {p for p in current.split(os.pathsep) if p}
+    extra = [d for d in _AWS_BIN_DIRS if d and d not in have]
+    if extra:
+        env["PATH"] = os.pathsep.join(([current] if current else []) + extra)
+    return env
 
 
 def _aws(args: list[str], profile: str) -> list[str]:

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -66,6 +66,7 @@ from kiro_crew.cloud import ssm as cloud_ssm
 # be framed by this desktop app on whatever KIROCREW_PORT it runs on (no
 # hardcoded port, no wildcard). See server._extra_frame_ancestors.
 from kiro_crew.config.loader import DASHBOARD_PORT as _LOCAL_DASHBOARD_PORT
+from kiro_crew.deploy.engine import aws_spawn_env
 from kiro_crew.instances.constants import (
     DEFAULT_CONNECT_TIMEOUT_SECS as _DEFAULT_CONNECT_TIMEOUT_SECS,
 )
@@ -504,6 +505,17 @@ class _SshTunnel:
                 # CREATE_NEW_PROCESS_GROUP is what makes the tree taskkill /T-reapable.
                 start_new_session=(ssm and platform_compat.IS_POSIX),
                 creationflags=(platform_compat.CREATE_NEW_PROCESS_GROUP if ssm else 0),
+                # SSM only: the argv head is resolved absolutely, but the aws CLI
+                # then looks session-manager-plugin up BY NAME on this child's own
+                # PATH, which a GUI-launched gateway hands down as the minimal
+                # launchd one — so the tunnel dies inside a correctly-resolved aws
+                # unless the child's env carries the install dirs (#5392). argv[0]
+                # is handed over so the widening is withheld for a bare head: that
+                # bare name IS a provenance refusal, and widening would put the
+                # refused binary back within execvp's reach. None means inherit,
+                # which is what the ssh transport wants: its binary lives in the
+                # system bin dir and needs no widening.
+                env=(aws_spawn_env(argv[0]) if ssm else None),
             )
         except OSError as e:
             self.status.state = TunnelState.ERROR
@@ -1403,8 +1415,17 @@ class SshTunnelManager:
 
             # SSM needs the local session-manager-plugin; fail with an actionable
             # message rather than letting the child exit with a cryptic error.
+            #
+            # Probed in a worker thread: the probe resolves the plugin through the
+            # deploy engine's shared resolver (#5392), which scans PATH, then the
+            # well-known install dirs, then routes a fallback-dir hit through
+            # executable-provenance validation — filesystem work that must not run
+            # on the gateway event loop, where a stalled network mount would freeze
+            # every request and heartbeat. Same reason _build_argv is offloaded
+            # below, and the same thing the dashboard's own cloud handler does with
+            # this exact call.
             if params.method == "ssm":
-                if not cloud_ssm.session_manager_plugin_installed():
+                if not await asyncio.to_thread(cloud_ssm.session_manager_plugin_installed):
                     return self._error_status(inst, cloud_ssm.session_manager_plugin_install_hint())
 
             # Reclaim our own forwarder if a prior gateway hard-kill leaked it

--- a/test/test_cloud_ssm.py
+++ b/test/test_cloud_ssm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -78,6 +79,148 @@ class TestOpenPortForward:
         assert captured["stdout"] == subprocess.DEVNULL
         assert captured["stderr"] == subprocess.DEVNULL
         assert captured["start_new_session"] is True
+
+    def test_child_env_can_find_the_session_manager_plugin(self, monkeypatch, tmp_path):
+        """The child needs its OWN widened PATH, not just a resolved argv head.
+
+        Resolving ``aws`` absolutely does not help the CLI find
+        ``session-manager-plugin``: it looks that up by name against the child's
+        inherited PATH at start-session time, which under a GUI-launched gateway
+        is the minimal launchd one — so the tunnel died inside a correctly
+        resolved ``aws`` (#5392).
+        """
+        from kiro_crew.deploy import engine
+
+        captured: dict = {}
+
+        def fake_popen(argv, **kwargs):
+            captured.update(kwargs, argv=argv)
+            return object()
+
+        # tmp_path stand-ins for the inherited minimal PATH and the plugin's real
+        # install dir: a host literal would flake and is unrunnable on Windows.
+        # `aws` sits on the inherited PATH so the head resolves absolutely (a PATH
+        # hit needs no provenance check) and the widening is therefore offered.
+        # Windows resolves executables by PATHEXT, not the exec bit, so the planted
+        # file has to differ there or the head would fall back to the bare name and
+        # the widening would (correctly) be withheld.
+        inherited = tmp_path / "sysbin"
+        inherited.mkdir()
+        if os.name == "nt":
+            fake_aws = inherited / "aws.cmd"
+            fake_aws.write_text("@echo off\n")
+            monkeypatch.setenv("PATHEXT", ".cmd")
+        else:
+            fake_aws = inherited / "aws"
+            fake_aws.write_text("#!/bin/sh\n")
+            fake_aws.chmod(0o755)
+        install_dir = tmp_path / "install"
+        monkeypatch.setenv("PATH", str(inherited))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(install_dir),))
+        monkeypatch.setattr(ssm, "require_session_manager_plugin", lambda: None)
+        monkeypatch.setattr(ssm.subprocess, "Popen", fake_popen)
+
+        ssm.open_port_forward("i-0abc", 5476, 5599, "dev", "us-east-1")
+
+        assert captured["argv"][0] == str(fake_aws)  # absolute head
+        child_path = captured["env"]["PATH"].split(os.pathsep)
+        assert str(install_dir) in child_path  # the plugin's install dir
+        assert child_path.index(str(inherited)) < child_path.index(str(install_dir))
+
+    @pytest.mark.skipif(os.name == "nt", reason="provenance branch is dead on Windows")
+    def test_refused_aws_binary_is_not_put_back_on_the_child_path(self, monkeypatch, tmp_path):
+        """A provenance-REFUSED aws must not become reachable again via the env.
+
+        The resolver falls back to the bare name exactly when it found a candidate
+        in the install dirs and ``validate_provider_executable`` refused it, and
+        that refusal is enforced ONLY by the bare name failing execvp against a
+        PATH those dirs are absent from. Widening the child's PATH would put the
+        refused binary back in execvp's reach and hand it AWS credentials — a
+        fail-closed rejection silently turned into an execution.
+        """
+        from kiro_crew import github_runner
+        from kiro_crew.deploy import engine
+
+        captured: dict = {}
+
+        def fake_popen(argv, **kwargs):
+            captured.update(kwargs, argv=argv)
+            return object()
+
+        inherited = tmp_path / "sysbin"  # deliberately contains no aws
+        inherited.mkdir()
+        install_dir = tmp_path / "install"
+        install_dir.mkdir()
+        planted = install_dir / "aws"
+        planted.write_text("#!/bin/sh\n")
+        planted.chmod(0o755)
+        monkeypatch.setenv("PATH", str(inherited))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(install_dir),))
+
+        def _refuse(_candidate):
+            raise ValueError("planted shim")
+
+        monkeypatch.setattr(github_runner, "validate_provider_executable", _refuse)
+        monkeypatch.setattr(ssm, "require_session_manager_plugin", lambda: None)
+        monkeypatch.setattr(ssm.subprocess, "Popen", fake_popen)
+
+        ssm.open_port_forward("i-0abc", 5476, 5599, "dev", "us-east-1")
+
+        assert captured["argv"][0] == "aws"  # refused -> bare name
+        # The dir holding the refused binary must NOT be on the child's PATH.
+        assert str(install_dir) not in captured["env"]["PATH"].split(os.pathsep)
+        assert captured["env"]["PATH"] == str(inherited)
+
+
+class TestSessionManagerPluginProbe:
+    """#5392: the probe must agree with what the spawn actually does.
+
+    Reported against a shipped desktop build: the plugin was installed at
+    /usr/local/bin/session-manager-plugin and worked in a shell, but the
+    launchd-launched gateway inherits /usr/bin:/bin:/usr/sbin:/sbin, so a bare
+    shutil.which() missed it and every SSM tunnel was refused by the
+    prerequisite gate before one was attempted. A symlink into the minimal PATH
+    is not a workaround on macOS — those dirs are all SIP-restricted.
+    """
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="provenance validation needs POSIX uid semantics; the fallback "
+        "dir branch is dead on Windows by design",
+    )
+    def test_probe_finds_plugin_in_install_dir_under_minimal_path(self, monkeypatch, tmp_path):
+        from kiro_crew.deploy import engine
+
+        plugin = tmp_path / "session-manager-plugin"
+        plugin.write_text("#!/bin/sh\n")
+        plugin.chmod(0o755)
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        # A PATH that cannot see the plugin, standing in hermetically for the
+        # minimal launchd one (a literal /usr/bin would flake on a host that has
+        # the real plugin installed there).
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+
+        from kiro_crew import github_runner
+
+        monkeypatch.setattr(github_runner, "validate_provider_executable", lambda c: c)
+
+        assert ssm.session_manager_plugin_installed() is True
+
+    def test_probe_false_when_the_plugin_is_absent_everywhere(self, monkeypatch, tmp_path):
+        """Genuinely missing still reports missing — the actionable install hint
+        must not be traded away for the false-negative fix."""
+        from kiro_crew.deploy import engine
+
+        empty_bin = tmp_path / "emptybin"
+        empty_bin.mkdir()
+        monkeypatch.setenv("PATH", str(empty_bin))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", ())
+
+        assert ssm.session_manager_plugin_installed() is False
+        with pytest.raises(aws.AWSError):
+            ssm.require_session_manager_plugin()
 
     def test_open_port_forward_refused_under_agent_session(self, monkeypatch):
         # The streaming tunnel bypasses run_aws, so it carries its own

--- a/test/test_cloud_ssm_cov80.py
+++ b/test/test_cloud_ssm_cov80.py
@@ -225,10 +225,19 @@ class TestPluginPrerequisite:
         monkeypatch.setattr(ssm, "session_manager_plugin_installed", lambda: True)
         assert ssm.require_session_manager_plugin() is None
 
-    def test_installed_probe_uses_path_lookup(self, monkeypatch) -> None:
-        monkeypatch.setattr(ssm.shutil, "which", lambda name: None)
+    def test_installed_probe_goes_through_the_shared_resolver(self, monkeypatch) -> None:
+        """#5392: the probe resolves through the deploy engine's shared resolver,
+        so it searches the well-known install dirs too.
+
+        A bare PATH lookup reported "not installed" for a plugin that WAS
+        installed (AWS's .pkg symlinks it into /usr/local/bin, absent from the
+        minimal launchd PATH a GUI-launched gateway inherits), which refused every
+        SSM tunnel at the prerequisite gate. Hence the ``path=`` kwarg below: the
+        resolver searches an explicit dir list, not just the inherited PATH.
+        """
+        monkeypatch.setattr(ssm.shutil, "which", lambda name, path=None: None)
         assert ssm.session_manager_plugin_installed() is False
-        monkeypatch.setattr(ssm.shutil, "which", lambda name: _stub_bin(name))
+        monkeypatch.setattr(ssm.shutil, "which", lambda name, path=None: _stub_bin(name))
         assert ssm.session_manager_plugin_installed() is True
 
 

--- a/test/test_deploy_web_engine.py
+++ b/test/test_deploy_web_engine.py
@@ -152,6 +152,158 @@ def test_aws_bin_prefers_path_then_falls_back_to_bare_name(monkeypatch):
     assert engine._aws(["s3", "ls"], "")[0] == "aws"
 
 
+# --- #5392: the same minimal-PATH gap for session-manager-plugin -------------
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="the fallback install dirs are macOS path literals and provenance "
+    "validation needs POSIX uid semantics; the fallback branch is dead on "
+    "Windows by design",
+)
+def test_aws_tool_bin_resolves_session_manager_plugin_from_extra_dirs(monkeypatch, tmp_path):
+    """The plugin installs into the SAME dirs as the CLI, so the same resolver
+    must find it: AWS's macOS .pkg symlinks it into /usr/local/bin, which a
+    Finder-launched gateway's minimal PATH does not contain (#5392)."""
+    fake_plugin = tmp_path / "session-manager-plugin"
+    fake_plugin.write_text("#!/bin/sh\n")
+    fake_plugin.chmod(0o755)
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+
+    from kiro_crew import github_runner
+
+    validated = []
+
+    def _passthrough(candidate):
+        validated.append(candidate)
+        return candidate
+
+    monkeypatch.setattr(github_runner, "validate_provider_executable", _passthrough)
+
+    assert engine.resolve_aws_tool_bin("session-manager-plugin") == str(fake_plugin)
+    # The fallback hit is routed through provenance exactly like the CLI's is —
+    # these dirs are user-writable, and the plugin is executed by a child that
+    # holds AWS credentials and a live tunnel.
+    assert validated == [str(fake_plugin)]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fallback branch is dead on Windows")
+def test_aws_tool_bin_refused_provenance_falls_back_to_that_tool_s_name(monkeypatch, tmp_path):
+    """The bare-name fallback is the REQUESTED tool, not a hardcoded "aws".
+
+    Pins the generalization: returning "aws" here would make a refused plugin
+    shim silently spawn the CLI under the plugin's name.
+    """
+    fake_plugin = tmp_path / "session-manager-plugin"
+    fake_plugin.write_text("#!/bin/sh\n")
+    fake_plugin.chmod(0o755)
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(tmp_path),))
+
+    from kiro_crew import github_runner
+
+    def _refuse(candidate):
+        raise ValueError("planted shim")
+
+    monkeypatch.setattr(github_runner, "validate_provider_executable", _refuse)
+
+    assert engine.resolve_aws_tool_bin("session-manager-plugin") == "session-manager-plugin"
+
+
+def test_aws_spawn_env_appends_install_dirs_after_inherited_path(monkeypatch, tmp_path):
+    """APPEND, never prepend: the inherited PATH keeps first claim on every name.
+
+    This is the whole trust argument for widening a credential-bearing child's
+    PATH — it can only make a previously-unresolvable lookup succeed, never
+    re-point one the child already resolved.
+
+    Dirs are tmp_path stand-ins for the real ``/opt/homebrew/bin`` and
+    ``/usr/local/bin``, per this file's existing convention: a host path literal
+    both flakes on hosts that really have the tool there and is unrunnable on
+    Windows.
+    """
+    system, extra_system = tmp_path / "sysbin", tmp_path / "sysbin2"
+    brew, pkg = tmp_path / "brew", tmp_path / "pkg"
+    monkeypatch.setenv("PATH", os.pathsep.join([str(system), str(extra_system)]))
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(brew), str(pkg)))
+
+    parts = engine.aws_spawn_env(str(pkg / "aws"))["PATH"].split(os.pathsep)
+
+    assert parts == [str(system), str(extra_system), str(brew), str(pkg)]
+
+
+def test_aws_spawn_env_refuses_to_widen_for_a_bare_argv_head(monkeypatch, tmp_path):
+    """A bare head means provenance REFUSED a candidate in these dirs.
+
+    That refusal is enforced ONLY by the bare name failing ``execvp`` against a
+    PATH the dirs are absent from. Widening would put the refused binary back on
+    the child's PATH and hand it AWS credentials — turning a fail-closed rejection
+    into an execution. The env therefore comes back untouched.
+    """
+    system, brew, pkg = tmp_path / "sysbin", tmp_path / "brew", tmp_path / "pkg"
+    inherited = str(system)
+    monkeypatch.setenv("PATH", inherited)
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(brew), str(pkg)))
+
+    env = engine.aws_spawn_env("aws")  # what resolve_aws_bin returns on refusal
+
+    assert env["PATH"] == inherited
+    assert str(pkg) not in env["PATH"]
+    # A relative head is the same hazard: execvp would still search PATH.
+    assert engine.aws_spawn_env("bin/aws")["PATH"] == inherited
+
+
+def test_aws_spawn_env_is_inert_when_dirs_are_already_on_path(monkeypatch, tmp_path):
+    """A terminal-launched gateway already carries the dirs: same env, no dupes.
+
+    Keeps the fix scoped to the minimal-PATH case it exists for instead of
+    reshuffling a PATH that already worked.
+    """
+    brew, pkg = tmp_path / "brew", tmp_path / "pkg"
+    inherited = os.pathsep.join([str(tmp_path / "sysbin"), str(brew), str(pkg)])
+    monkeypatch.setenv("PATH", inherited)
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(brew), str(pkg)))
+
+    assert engine.aws_spawn_env(str(pkg / "aws"))["PATH"] == inherited
+
+
+def test_aws_spawn_env_with_empty_inherited_path_has_no_leading_separator(monkeypatch, tmp_path):
+    """An empty PATH must not produce a leading separator — that reads as "."
+    (the child's cwd) to the exec lookup, which would be a search-path hole."""
+    brew, pkg = tmp_path / "brew", tmp_path / "pkg"
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(brew), str(pkg)))
+
+    path = engine.aws_spawn_env(str(pkg / "aws"))["PATH"]
+
+    assert path == os.pathsep.join([str(brew), str(pkg)])
+    assert not path.startswith(os.pathsep)
+
+
+def test_aws_spawn_env_preserves_the_rest_of_the_environment(monkeypatch, tmp_path):
+    """Only PATH changes. Passing env= to a spawn REPLACES the child's whole
+    environment, so dropping anything here would break credential resolution
+    (the CLI needs HOME/AWS_* to find ~/.aws and the active profile)."""
+    system, pkg = tmp_path / "sysbin", tmp_path / "pkg"
+    monkeypatch.setenv("PATH", str(system))
+    monkeypatch.setenv("AWS_PROFILE", "kauai")
+    monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(pkg),))
+
+    env = engine.aws_spawn_env(str(pkg / "aws"))
+
+    assert env["AWS_PROFILE"] == "kauai"
+    assert env["PATH"] == os.pathsep.join([str(system), str(pkg)])
+    # Everything except PATH is carried through untouched.
+    assert {k: v for k, v in env.items() if k != "PATH"} == {
+        k: v for k, v in os.environ.items() if k != "PATH"
+    }
+
+
 def test_random_bucket_name_format():
     name = engine.random_bucket_name()
     assert name.startswith("kirocrew-web-")

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -5040,6 +5040,59 @@ class TestSsmTunnelProcessGroup:
         assert seen["start_new_session"] is False
         assert seen["creationflags"] == 0
 
+    @pytest.mark.asyncio
+    async def test_ssm_child_gets_plugin_search_path_and_ssh_inherits(self, monkeypatch, tmp_path):
+        """The SSM child needs a PATH that can find session-manager-plugin.
+
+        The argv head is resolved absolutely, but the aws CLI then looks the
+        plugin up BY NAME on this child's own PATH — under a GUI-launched gateway
+        the minimal launchd one — so the tunnel died inside a correctly resolved
+        ``aws`` (#5392). SSH keeps ``env=None`` (inherit): its binary lives in
+        the system bin dir and widening a tunnel child's PATH without a reason to
+        is the opposite of what this fix argues for.
+        """
+        import kiro_crew.instances.ssh_tunnel_manager as mod
+        from kiro_crew.deploy import engine
+
+        seen = {}
+
+        async def fake_exec(*argv, **kw):
+            seen.update(kw)
+            raise OSError("stop here — we only care about the spawn kwargs")
+
+        # tmp_path stand-ins: a host path literal would flake and is unrunnable
+        # on Windows, which this class deliberately also exercises. `aws` sits on
+        # the inherited PATH so the head resolves absolutely (a PATH hit needs no
+        # provenance check), which is what makes the widening applicable. Windows
+        # resolves executables by PATHEXT rather than the exec bit, so the planted
+        # file differs there — otherwise the head falls back to the bare name and
+        # the widening is (correctly) withheld.
+        inherited = tmp_path / "sysbin"
+        inherited.mkdir()
+        if os.name == "nt":
+            fake_aws = inherited / "aws.cmd"
+            fake_aws.write_text("@echo off\n")
+            monkeypatch.setenv("PATHEXT", ".cmd")
+        else:
+            fake_aws = inherited / "aws"
+            fake_aws.write_text("#!/bin/sh\n")
+            fake_aws.chmod(0o755)
+        install_dir = tmp_path / "install"
+        monkeypatch.setenv("PATH", str(inherited))
+        monkeypatch.setattr(engine, "_AWS_BIN_DIRS", (str(install_dir),))
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(mod.platform_compat, "IS_POSIX", True)
+
+        await self._tunnel("ssm").start()
+        child_path = seen["env"]["PATH"].split(os.pathsep)
+        assert str(install_dir) in child_path
+        # Appended: the inherited PATH still wins every name it can resolve.
+        assert child_path.index(str(inherited)) < child_path.index(str(install_dir))
+
+        seen.clear()
+        await self._tunnel("ssh").start()
+        assert seen["env"] is None
+
     def test_teardown_routes_through_the_platform_shim(self, monkeypatch):
         """Not raw os.killpg — that leaves the plugin alive on Windows."""
         import kiro_crew.instances.ssh_tunnel_manager as mod
@@ -5266,6 +5319,44 @@ class TestSsmTransportSelection:
         await mgr2.connect("ec2b")
         assert seen["timeout_secs"] == 45.0
         await mgr2.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_plugin_probe_runs_off_the_event_loop(self, tmp_path, monkeypatch):
+        """#5392: the prerequisite probe must not block the gateway event loop.
+
+        The probe resolves the plugin through the deploy engine's shared resolver
+        — PATH scan, then the well-known install dirs, then executable-provenance
+        validation — so a stalled network mount on any of those would freeze every
+        request and heartbeat. Pinned by the THREAD it actually runs on rather
+        than by source inspection, so an edit that drops the offload fails here
+        even if it keeps the wording.
+        """
+        import threading
+
+        from kiro_crew.instances.ssh_tunnel_manager import TunnelState
+
+        loop_thread = threading.get_ident()
+        ran_on: dict = {}
+
+        def _probe():
+            ran_on["thread"] = threading.get_ident()
+            return False  # short-circuit: no tunnel spawn, error status asserted
+
+        monkeypatch.setattr("kiro_crew.cloud.ssm.session_manager_plugin_installed", _probe)
+        reg, mgr = self._mgr(tmp_path)
+        reg.add(
+            name="EC2",
+            connection_method="ssm",
+            ssm_target="i-0123456789abcdef0",
+            instance_id="ec2",
+            remote_port=53514,
+        )
+
+        st = await mgr.connect("ec2")
+
+        assert st.state == TunnelState.ERROR
+        assert ran_on["thread"] != loop_thread
+        await mgr.shutdown()
 
     @pytest.mark.asyncio
     async def test_ssm_connect_fails_clean_without_plugin(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## 1. What is the problem?

Connecting a remote instance over SSM fails immediately on a desktop-app
gateway with `session-manager-plugin is not installed locally` -- while the
plugin *is* installed and works fine in a terminal.

A launchd/Electron-launched gateway inherits the minimal PATH
`/usr/bin:/bin:/usr/sbin:/sbin`. The plugin installs to `/usr/local/bin` (AWS's
`.pkg` symlink) or the Homebrew prefix, neither of which is on it. Two
independent surfaces broke on that:

* **The probe.** `cloud/ssm.py::session_manager_plugin_installed()` used a bare
  `shutil.which()`, so it returned `None` for an installed plugin. The
  prerequisite gate in `instances/ssh_tunnel_manager.py` then refused every SSM
  tunnel before one was attempted. The same bare probe also made
  `install_session_manager_plugin()` report "installer completed, but the binary
  was not found on PATH" after a *successful* install.
* **The child env.** Neither `start-session` spawn site passed an env, so the
  `aws` CLI -- whose argv head #5360 already resolves absolutely -- looked the
  plugin up **by name** against that same minimal PATH at exec time.

These are the residual surfaces the First Principles review of #5360 identified
and #4770 triage scoped out. Items 2 and 3 of #5392 (dev_fleet
`narrate.py`/`deps.py`, the cloud doctor probe) already landed in #5561; this
closes out the remaining item 1.

## 2. Why this issue matters to the user

SSM is the transport for connecting to a remote instance, so the feature is
fully unavailable on a shipped desktop build -- with an error message that
actively misleads, telling the user to install something they already installed.

There is no self-service fix. A symlink into the minimal PATH is a dead end on
macOS: `/usr/bin`, `/bin`, `/usr/sbin` and `/sbin` all carry the SIP
`restricted` flag, so even `sudo ln -s` fails with `Operation not permitted` --
there is no writable directory on the gateway's PATH. The only workaround is
`launchctl setenv PATH ...` plus a full quit-and-relaunch, which is global to
every launchd-launched app and does not survive a reboot.

Reported and reproduced on a shipped build (`0.4.0-insider.14`, macOS Apple
Silicon, plugin v1.2.835.0) in [#5392](https://github.com/kirodotdev/KiroCrew/issues/5392).

## 3. How our fix solves it

Symptom -> cause -> fix, for each half:

**Probe reports missing -> bare `shutil.which()` only searches the inherited
PATH -> route it through the shared resolver.**
`session_manager_plugin_installed()` now resolves via the deploy engine, so it
searches the well-known install dirs the plugin actually ships into. Probe and
spawn use the same resolution and can no longer disagree.

Resolution is generalized over the binary name (`resolve_aws_tool_bin`) instead
of duplicated, because the plugin lands in the same dirs as the CLI *and* needs
the same guard: a fallback-dir hit is routed through
`validate_provider_executable`, since those dirs are user-writable and the
binary is executed by a child holding AWS credentials and a live tunnel. The
bare-name fallback returns the **requested** tool, so a refused plugin shim
cannot silently spawn the CLI under the plugin's name. `resolve_aws_bin()` keeps
its exact public behaviour as a one-line delegate.

**Tunnel dies inside a correctly-resolved `aws` -> the CLI resolves the plugin
against the CHILD's PATH, which the resolver cannot reach -> give the child a
PATH that contains the install dirs.** Both `start-session` spawn sites
(`cloud/ssm.py::open_port_forward` and the supervised tunnel in
`instances/ssh_tunnel_manager.py`) now pass `env=aws_spawn_env()`. Fixing the
probe alone would have been worse than useless: the gate would pass and the
tunnel would then fail deeper, with a less actionable error.

Three deliberate constraints on that env, since widening a credential-bearing
child's PATH is the part worth arguing about:

* **Appended, never prepended.** The inherited PATH keeps first claim on every
  name, so this can only make a previously-unresolvable lookup succeed -- it can
  never re-point one the child already resolved.
* **Not `env.augmented_path`.** That existing helper prepends a broader set
  (`~/.local/bin`, npm/mise/volta shims) -- the right search space for finding
  an MCP launcher, too wide and wrongly ordered ahead of `/usr/bin` for this
  child. `aws_spawn_env` carries only the two dirs the repo already trusts for
  locating AWS tooling.
* **Inert when unnecessary.** Dirs already on PATH are not repeated, so a
  terminal-launched gateway gets a byte-identical env.

And one fail-closed rule, which review surfaced as a real hole in the first cut
of this PR (see the disposition comments below): `aws_spawn_env` **requires the
resolved argv head and refuses to widen when that head is not absolute.** A bare
head is exactly what `resolve_aws_tool_bin` returns when it found a candidate in
these dirs and `validate_provider_executable` REFUSED it -- and that refusal is
enforced only by the bare name failing `execvp` against a PATH those dirs are
absent from. Widening would have put the refused binary back in `execvp`'s reach
and handed it AWS credentials, converting a fail-closed rejection into an
execution. Note the "appended, never prepended" argument above does NOT cover
this case: the one lookup the widening newly made succeed was precisely the one
the refusal existed to keep failing. Making the head a required argument means a
future spawn site cannot get the unguarded behaviour by omission.

Because the probe now touches the filesystem, the tunnel manager's prerequisite
gate -- the only one of the four probe call sites that sits on the gateway event
loop -- offloads it with `asyncio.to_thread`. That matches what this file already
does for `_build_argv` twenty lines below, and what `handlers_cloud.py` already
does with this exact probe; a stalled network mount would otherwise freeze every
request and the heartbeat. `aws_spawn_env` itself touches no filesystem (a dict
copy and a string join over `os.environ`), so it stays safe to call on the loop.

Only `PATH` is altered. `env=` replaces the child's whole environment, so
dropping anything else would break credential resolution (the CLI needs
`HOME`/`AWS_*` to find `~/.aws`). The SSH transport keeps `env=None` (inherit):
its binary lives in the system bin dir, and widening a tunnel child's PATH with
no reason to is the opposite of what this change argues for.

## 4. What tests we did

Mechanism confirmed first, against this branch's source: the probe returns
`False` for a plugin present in an install dir under a minimal PATH, and neither
spawn site passed an env.

Nine new tests, **each mutation-verified red** against the pre-fix behaviour:

| Mutation applied | Test that caught it |
| --- | --- |
| probe back to bare `shutil.which` | `test_probe_finds_plugin_in_install_dir_under_minimal_path` |
| drop `env=` from `open_port_forward` | `test_child_env_can_find_the_session_manager_plugin` (KeyError: 'env') |
| supervised SSM spawn back to `env=None` | `test_ssm_child_gets_plugin_search_path_and_ssh_inherits` |
| prepend the dirs instead of appending | 3 tests, incl. both spawn-site ordering assertions |
| hardcode the fallback to `"aws"` | `test_aws_tool_bin_refused_provenance_falls_back_to_that_tool_s_name` |
| probe back on the event loop | `test_plugin_probe_runs_off_the_event_loop` (compares thread ids) |
| remove the non-absolute-head guard | `test_aws_spawn_env_refuses_to_widen_for_a_bare_argv_head` and `test_refused_aws_binary_is_not_put_back_on_the_child_path` |

The last two rows are the fixes for the two blocking review findings, and both are
pinned by behaviour rather than by source inspection: the offload test compares
the thread id the probe actually ran on, and the refused-binary test plants a real
executable in the install dir, has `validate_provider_executable` refuse it, and
asserts both that argv[0] came back bare and that the dir holding it is absent
from the child's PATH.

Also covered: the fallback hit goes through provenance validation; a refused
shim falls back to the bare name; a genuinely absent plugin still reports
missing and still raises the actionable install hint (the false-negative fix
does not trade away the true negative); an empty inherited PATH produces no
leading separator (which would read as the child's cwd); and everything except
`PATH` is carried through untouched.

One pre-existing test contradicted the change --
`test_installed_probe_uses_path_lookup` pinned the bare lookup with a
single-argument `which` stub. Rewritten to the new mechanism with the reason
recorded in its docstring, keeping its original true/false coverage.

Targeted suites run (per this machine's no-full-suite constraint; CI runs the
rest): `test_deploy_web_engine.py`, `test_cloud_ssm.py`,
`test_cloud_ssm_cov80.py` (98 passed), the `SsmTunnelProcessGroup` class,
`test_instances.py -k tunnel` (42 passed), plus every consumer of the changed
functions -- `test_tunnel_manager.py`, `test_ssh_tunnel_manager_cov80.py`,
`test_cloud_connect.py`, `test_cloud_login.py` (158 passed),
`test_cloud_cli.py`, `test_cloud_wizard.py`, `test_cloud_handlers.py`,
`test_spawn_audit.py` (105 passed, incl. the AST spawn-routing gate),
`test_cloud_aws.py`, `test_aws_consent.py`, `test_voice_reply.py`,
`test_video_skill_aws_resolution.py` (235 passed). flake8, isort and mypy clean
on all touched files; both black-dirty files were already in
`.github/black-baseline.txt` and the one baselined line this diff touches was
normalized to black style.

## 5. Any other suggestions on the work

* **Not verifiable locally.** The reproduction and the fix both target macOS
  under a launchd-minimal PATH; this branch was developed and tested on Linux,
  so the end-to-end "tunnel now connects" step rests on the reporter's
  reproduction plus the unit/mutation coverage above, not on a local run.
* **A stronger hardening deliberately left out.** Review offered "fail closed
  after provenance rejection" as an alternative to the non-absolute-head guard --
  i.e. have `resolve_aws_tool_bin` signal refusal instead of returning the bare
  name. That is defensible, but it changes the contract of a shared chokepoint
  (`cloud.aws`, `voice_reply`, `dashboard.chat_voice`, the artifact-deploy skill
  scripts) where the bare-name fallback is a deliberate #5360 decision to preserve
  the prior not-found error. It is a wider change needing its own review, and it is
  not required to close what this PR opened. Worth considering separately.
* **`_AWS_BIN_DIRS` is a fixed list of two dirs** and cannot be complete -- a
  plugin installed anywhere else stays invisible. That is unchanged by this PR
  and is the same tradeoff `resolve_aws_bin` has carried since #5360. Worth
  revisiting only if reports arrive from a third install location.
* **`run_aws` was deliberately not touched.** `start-session` is the only aws
  subcommand that spawns the plugin; the capture-only chokepoint
  (`send-command`, `describe-*`) has no child lookup to fix, so widening its env
  would be unjustified reach.
* One residue worth naming: `install_session_manager_plugin()`'s own install
  commands still use bare `sudo`/`installer`/`dpkg` argv heads. Those live in
  `/usr/bin` and so are on the minimal PATH -- correct today, but they are the
  same *class* of bare head this issue family keeps finding.

Closes #5392
