### PR TITLE
fix(dashboard): one owner for the JSON-object body guard, plus a first sweep tranche

### DIFF
--- a/.github/coverage-baselines/backend.txt
+++ b/.github/coverage-baselines/backend.txt
@@ -51,7 +51,6 @@ src/kiro_crew/computer_use/cli.py 68.8   # 130/189
 src/kiro_crew/computer_use/macos_skylight.py 54.8   # 142/259
 src/kiro_crew/conpty.py 27.9   # 12/43
 src/kiro_crew/dashboard/_types.py 0.0   # 0/3
-src/kiro_crew/dashboard/handlers/agents.py 77.4   # 579/748
 src/kiro_crew/dashboard/handlers/cron.py 70.9   # 400/564
 src/kiro_crew/dashboard/handlers/portability.py 17.0   # 15/88
 src/kiro_crew/dashboard/handlers/prompts.py 64.5   # 260/403

--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1241,
+    "missing_code": 1228,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1438,
+  "_compliant": 1435,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -61,7 +61,7 @@
       "missing_code": 9
     },
     "dashboard/handlers/agents.py": {
-      "missing_code": 58
+      "missing_code": 52
     },
     "dashboard/handlers/artifacts.py": {
       "dynamic_status": 2
@@ -109,7 +109,7 @@
     },
     "dashboard/handlers/memory.py": {
       "dynamic_status": 1,
-      "missing_code": 31
+      "missing_code": 24
     },
     "dashboard/handlers/messaging.py": {
       "dynamic_status": 6,

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -74,39 +74,101 @@ _MAX_BODY_BYTES = 64 * 1024
 
 
 async def read_bounded_json(
-    request: web.Request, max_bytes: int = _MAX_BODY_BYTES
+    request: web.Request,
+    max_bytes: int | None = _MAX_BODY_BYTES,
+    *,
+    allow_absent: bool = False,
 ) -> tuple[dict[str, Any] | None, web.Response | None]:
     """Read and parse a JSON *object* request body, capped at *max_bytes*.
 
     Returns ``(body, None)`` on success, or ``(None, error_response)`` when the
-    caller should return early. The cap is enforced BEFORE decoding: a
-    Content-Length precheck rejects an oversized declared body, and the stream
-    is then read incrementally so a chunked body (which carries no
-    Content-Length) cannot buffer past ``max_bytes + one chunk`` on the
-    event-loop thread. Consolidates the previously-duplicated block in
-    ``messaging.api_notification_agent_push`` and
-    ``notifications_push.api_push_notification`` so the cap and the 413/400
-    contract stay identical across both (issue #490).
+    caller should return early. This owns the parse-and-shape guard for the
+    endpoints routed through it: ``await request.json()`` happily returns a
+    list, string, or number for a body that is valid JSON but not an object, and
+    a handler that then calls ``.get()`` on the result turns a client mistake
+    into a 500 (issue #5587).
+
+    NOT yet the dashboard's only such guard. Four siblings survive and diverge:
+    ``handlers_channel._json_object`` (same ``invalid_json``/``body_not_object``
+    codes, but raises ``HTTPBadRequest`` instead of returning the response),
+    ``handlers/hooks.py::_json_object`` (``default_empty=True`` collapses a
+    MALFORMED body to defaults -- the defect this issue fixed in
+    ``api_memory_promote``), ``handlers/session_storage.py::_json_body``
+    (deliberately different: an empty body is legitimate there, and it
+    documents why), and ``handlers/artifacts.py::_read_json_body`` (raises
+    ``ArtifactValidationError``, carries its own cap). Folding or narrowing each
+    is tracked on issue #5587 alongside the remaining handler sweep -- claiming
+    one owner before that is done would be a claim the tree does not support.
+
+    The cap is enforced BEFORE decoding: a Content-Length precheck rejects an
+    oversized declared body, and the stream is then read incrementally so a
+    chunked body (which carries no Content-Length) cannot buffer past
+    ``max_bytes + one chunk`` on the event-loop thread. That bound is the point
+    of the helper for the strict-internal notification routes (issue #490).
+
+    ``max_bytes=None`` reads the body whole with no pre-decode ceiling, for the
+    endpoints that have no principled byte limit today (a knowledge bundle
+    import has no defensible maximum size). It is deliberately explicit rather
+    than the default: an endpoint opting out of the cap should say so at the
+    call site, and giving one of those endpoints a real ceiling later is then a
+    one-argument change here instead of a re-plumb.
+
+    Which one a converting caller wants is a real choice, not a default to
+    inherit: take the cap when the body is a fixed set of control fields (an
+    identifier, a flag, a number), and ``None`` only when the body legitimately
+    carries user content of unbounded size (file contents, an export, a fetched
+    document). Note that switching a site TO the cap also moves it off
+    ``request.json()`` onto the streaming read, so that handler's unit tests
+    must feed ``content``/``content_length`` rather than mocking ``json``.
+
+    *allow_absent* treats a request with no readable body as an empty object,
+    for endpoints whose fields all have defaults. A body that is *present but
+    malformed* is still a 400 -- "the client sent nothing" and "the client sent
+    garbage" are different facts, and only the first one can be defaulted.
+
+    Decoding matches ``request.json()`` on both paths -- ``decode(charset or
+    utf-8)`` then ``loads`` -- so the two differ only in whether the read is
+    bounded, and the declared ``charset=`` is honoured either way. The uncapped
+    path calls ``request.json()`` itself rather than reimplementing it, which is
+    what makes converting a ``try: await request.json()`` site a drop-in: no
+    handler and no test harness sees a different read.
+
+    The catch is narrowed to the three client-input failures -- ``ValueError``
+    (which covers ``json.JSONDecodeError`` and ``UnicodeDecodeError``),
+    ``LookupError`` (an unknown ``charset=`` codec), and ``RecursionError`` (a
+    deeply nested document blowing the parser's stack). Transport failures (a
+    disconnect mid-body, a read timeout) deliberately propagate: they are not a
+    client JSON mistake and keep their 500 status class.
     """
-    if request.content_length and request.content_length > max_bytes:
-        return None, web.json_response(
-            {"error": "payload too large", "code": "payload_too_large"}, status=413
-        )
-    chunks: list[bytes] = []
-    received = 0
-    async for chunk in request.content.iter_chunked(8192):
-        received += len(chunk)
-        if received > max_bytes:
+    if allow_absent and not request.can_read_body:
+        return {}, None
+    if max_bytes is None:
+        try:
+            body = await request.json()
+        except (LookupError, RecursionError, ValueError):
+            return None, web.json_response(
+                {"error": "invalid JSON", "code": "invalid_json"}, status=400
+            )
+    else:
+        if request.content_length and request.content_length > max_bytes:
             return None, web.json_response(
                 {"error": "payload too large", "code": "payload_too_large"}, status=413
             )
-        chunks.append(chunk)
-    try:
-        body = json.loads(b"".join(chunks))
-    except Exception:
-        return None, web.json_response(
-            {"error": "invalid JSON body", "code": "invalid_json"}, status=400
-        )
+        chunks: list[bytes] = []
+        received = 0
+        async for chunk in request.content.iter_chunked(8192):
+            received += len(chunk)
+            if received > max_bytes:
+                return None, web.json_response(
+                    {"error": "payload too large", "code": "payload_too_large"}, status=413
+                )
+            chunks.append(chunk)
+        try:
+            body = json.loads(b"".join(chunks).decode(request.charset or "utf-8"))
+        except (LookupError, RecursionError, ValueError):
+            return None, web.json_response(
+                {"error": "invalid JSON", "code": "invalid_json"}, status=400
+            )
     if not isinstance(body, dict):
         return None, web.json_response(
             {"error": "body must be a JSON object", "code": "body_not_object"}, status=400

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -63,6 +63,7 @@ from kiro_crew.dashboard.handlers._shared import (
     agent_skill_keys,
     agent_skill_views,
     apply_skill_mapping,
+    read_bounded_json,
 )
 from kiro_crew.dashboard.handlers.discover import _redact_external
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
@@ -308,10 +309,10 @@ async def api_agent_config(request: web.Request) -> web.Response:
         denied = await _require_owner(request, "agent_config.write")
         if denied is not None:
             return denied
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+        body, body_err = await read_bounded_json(request, max_bytes=None)
+        if body_err is not None:
+            return body_err
+        assert body is not None  # read_bounded_json returns (dict, None) on success
         config = body.get("config")
         if not isinstance(config, dict):
             return web.json_response({"error": "config must be an object"}, status=400)
@@ -520,10 +521,10 @@ async def api_default_agent(request: web.Request) -> web.Response:
         denied = await _require_owner(request, "default_agent.write")
         if denied is not None:
             return denied
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+        body, body_err = await read_bounded_json(request, max_bytes=None)
+        if body_err is not None:
+            return body_err
+        assert body is not None  # read_bounded_json returns (dict, None) on success
         name = body.get("agent", "")
         # Reject non-strings before any use: a JSON list/object here would make
         # the membership check below raise (unhashable) into a 500, and a
@@ -713,10 +714,10 @@ async def api_capability_mcp_install(request: web.Request) -> web.Response:
     denied = await _require_owner(request, "capability_mcp_install")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     server_id = body.get("server_id", "").strip()
     if not server_id:
         return web.json_response({"error": "server_id required"}, status=400)
@@ -749,10 +750,10 @@ async def api_capability_mcp_uninstall(request: web.Request) -> web.Response:
     denied = await _require_owner(request, "capability_mcp_uninstall")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     server_id = body.get("server_id", "").strip()
     if not server_id:
         return web.json_response({"error": "server_id required"}, status=400)
@@ -801,10 +802,10 @@ async def api_capability_skills_install(request: web.Request) -> web.Response:
     denied = await _require_owner(request, "capability_skills_install")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     package = body.get("package", "").strip()
     if not package:
         return web.json_response({"error": "package required"}, status=400)
@@ -831,10 +832,10 @@ async def api_capability_skills_uninstall(request: web.Request) -> web.Response:
     denied = await _require_owner(request, "capability_skills_uninstall")
     if denied is not None:
         return denied
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     package = body.get("package", "").strip()
     if not package:
         return web.json_response({"error": "package required"}, status=400)

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -13,7 +13,6 @@ import uuid
 import zipfile
 from datetime import datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Any
 
 from aiohttp import web
 
@@ -21,6 +20,7 @@ from kiro_crew._sqlite_compat import sqlite3
 from kiro_crew.artifacts import get_default_store
 from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
 from kiro_crew.dashboard import part_stream
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.handlers.files import (
     _ZIP_CONTAINER_EXTS,
     _content_matches_ext,
@@ -155,52 +155,6 @@ def _store(request: web.Request):
 
 def _pipeline(request: web.Request):
     return request.app.get("knowledge_pipeline")
-
-
-async def _json_object_body(
-    request: web.Request, *, allow_absent: bool = False
-) -> tuple[dict[str, Any] | None, web.Response | None]:
-    """Parse the request body as a JSON **object**, or produce the 400 to return.
-
-    ``await request.json()`` happily returns a list, string, or number for a
-    body that is valid JSON but not an object, and every caller in this module
-    then calls ``.get()`` on the result -- which raises and turns a client
-    mistake into a 500. One owner for the parse-and-shape guard keeps the
-    module's ``request.json()`` call sites on a single contract instead of
-    bespoke per-handler guards.
-
-    Returns ``(body, None)`` on success, or ``(None, error_response)`` when
-    the caller should return early. *allow_absent* treats a request without a
-    readable body as an empty object, for endpoints whose fields all have
-    defaults.
-
-    Deliberately separate from ``_shared.read_bounded_json``, which shares the
-    ``invalid_json``/``body_not_object`` codes: switching these nine sites onto
-    it would mean choosing a byte cap per endpoint (its ``max_bytes`` must be
-    a number, and knowledge bundles have no principled ceiling today), would
-    change the ``"invalid JSON"`` message text existing tests and callers pin,
-    and it has no *allow_absent*. Consolidating the two helpers is deferred
-    scope, not a disagreement about the contract.
-    """
-    if allow_absent and not request.can_read_body:
-        return {}, None
-    try:
-        parsed = await request.json()
-    except (LookupError, RecursionError, ValueError):
-        # json.JSONDecodeError and UnicodeDecodeError are ValueError
-        # subclasses; LookupError is an unknown charset= codec in the
-        # client's Content-Type header; RecursionError is a deeply nested
-        # JSON document blowing the parser's stack. All are client mistakes.
-        # Transport failures (disconnect mid-body, read timeout) deliberately
-        # propagate: they are not a client JSON mistake and keep their 500
-        # status class.
-        return None, web.json_response(
-            {"error": "invalid JSON", "code": "invalid_json"}, status=400)
-    if not isinstance(parsed, dict):
-        return None, web.json_response(
-            {"error": "body must be a JSON object", "code": "body_not_object"},
-            status=400)
-    return parsed, None
 
 
 def _create_embedder(app):
@@ -540,10 +494,10 @@ async def update_item(request: web.Request) -> web.Response:
     item_id = request.match_info["id"]
     if not store.get_item(item_id):
         return web.json_response({"error": "not found"}, status=404)
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     allowed = {"tags", "item_type", "status", "title", "summary", "namespace"}
     fields = {k: v for k, v in body.items() if k in allowed}
     if not fields:
@@ -873,10 +827,10 @@ async def pick_folder(request: web.Request) -> web.Response:
 async def add_source(request: web.Request) -> web.Response:
     """POST /api/knowledge/sources -- add a remote source."""
     store = _store(request)
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name = body.get("name", "")
     source_type = body.get("source_type", "")
     uri = body.get("uri", "")
@@ -1222,10 +1176,10 @@ async def rename_source(request: web.Request) -> web.Response:
     source_id = request.match_info["id"]
     if not store.db.execute("SELECT 1 FROM sources WHERE id = ?", (source_id,)).fetchone():
         return web.json_response({"error": "not found"}, status=404)
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     name = body.get("name")
     if not isinstance(name, str):
         return web.json_response({"error": "name must be a string"}, status=400)
@@ -1350,10 +1304,10 @@ async def retry_file(request: web.Request) -> web.Response:
     """POST /api/knowledge/sources/{id}/files/retry -- reset file to pending."""
     store = _store(request)
     source_id = request.match_info["id"]
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     file_path = body.get("file_path", "")
     if not file_path:
         return web.json_response({"error": "file_path required"}, status=400)
@@ -1372,10 +1326,10 @@ async def skip_file(request: web.Request) -> web.Response:
     """POST /api/knowledge/sources/{id}/files/skip -- mark file as skipped."""
     store = _store(request)
     source_id = request.match_info["id"]
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     file_path = body.get("file_path", "")
     if not file_path:
         return web.json_response({"error": "file_path required"}, status=400)
@@ -1400,10 +1354,10 @@ async def ingest_text(request: web.Request) -> web.Response:
     pipeline = _pipeline(request)
     if not pipeline:
         return web.json_response({"error": "pipeline not configured"}, status=503)
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     text = body.get("text", "")
     if not text:
         return web.json_response({"error": "no text provided"}, status=400)
@@ -1658,10 +1612,10 @@ async def export_all(request: web.Request) -> web.Response:
 
 async def import_bundle(request: web.Request) -> web.Response:
     """POST /api/knowledge/import -- accept .knowledge JSON bundle."""
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     shape_error = _validate_knowledge_bundle(body)
     if shape_error is not None:
         _sel_log("import", outcome="rejected", reason=shape_error)
@@ -1804,10 +1758,10 @@ async def batch_embed_items(request: web.Request) -> web.Response:
     if not await embedder.is_available_async():
         return web.json_response({"error": "Embedding model not available"}, status=503)
 
-    body, body_err = await _json_object_body(request, allow_absent=True)
+    body, body_err = await read_bounded_json(request, max_bytes=None, allow_absent=True)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     rebuild = body.get("rebuild", False)
     force = body.get("force", False)
 
@@ -1978,10 +1932,10 @@ async def add_agent_document_route(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "pipeline not configured",
              "code": "pipeline_unavailable"}, status=503)
-    body, body_err = await _json_object_body(request)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
     if body_err is not None:
         return body_err
-    assert body is not None  # _json_object_body returns (dict, None) on success
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     result = await add_agent_document(
         pipeline,
         title=str(body.get("title") or ""),

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -51,7 +51,7 @@ from kiro_crew.sandbox import (
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
-from ._shared import _get_memory, _is_restricted_session, _redact_memory_field
+from ._shared import _get_memory, _is_restricted_session, _redact_memory_field, read_bounded_json
 from .cron import _recognize_session
 
 logger = logging.getLogger(__name__)
@@ -84,10 +84,10 @@ async def api_memory_preferences(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     mem = _get_memory(state)
     if request.method == "PUT":
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+        body, body_err = await read_bounded_json(request, max_bytes=None)
+        if body_err is not None:
+            return body_err
+        assert body is not None  # read_bounded_json returns (dict, None) on success
         content = body.get("content", "")
         # Offloaded to a worker thread: write_preferences does synchronous
         # atomic file I/O plus an FTS index update, and this handler runs on
@@ -110,10 +110,10 @@ async def api_memory_projects(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     mem = _get_memory(state)
     if request.method == "PUT":
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+        body, body_err = await read_bounded_json(request, max_bytes=None)
+        if body_err is not None:
+            return body_err
+        assert body is not None  # read_bounded_json returns (dict, None) on success
         content = body.get("content", "")
         # Offloaded for the same reason as api_memory_preferences above.
         async with _projects_write_lock:
@@ -127,10 +127,10 @@ async def api_memory_history(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     mem = _get_memory(state)
     if request.method == "PUT":
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+        body, body_err = await read_bounded_json(request, max_bytes=None)
+        if body_err is not None:
+            return body_err
+        assert body is not None  # read_bounded_json returns (dict, None) on success
         content = body.get("content", "")
         # Write to today's history file. Offloaded like the two handlers
         # above (synchronous file I/O on the event loop stalls every other
@@ -150,10 +150,10 @@ async def api_memory_settings(request: web.Request) -> web.Response:
     """GET/PUT /api/memory/settings — memory consolidation config."""
     cfg = KiroCrewConfig.load()
     if request.method == "PUT":
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+        body, body_err = await read_bounded_json(request, max_bytes=None)
+        if body_err is not None:
+            return body_err
+        assert body is not None  # read_bounded_json returns (dict, None) on success
         # Read existing config, update memory section only
         # Validated BEFORE the transaction: none of it reads the config, and a
         # 400 should not have taken the lock or occupied a worker.
@@ -337,10 +337,10 @@ async def api_memory_semantic_write(request: web.Request) -> web.Response:
         )
         return web.json_response({"error": "Memory writes are not allowed in this session mode."}, status=403)
     store = await _get_vector_store_async(request.app["state"])
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     key = body.get("key", "")
     value = body.get("value")
     confidence = float(body.get("confidence", 1.0)) if isinstance(body.get("confidence"), (int, float)) else 1.0
@@ -688,20 +688,10 @@ async def api_memory_embedding_model(request: web.Request) -> web.Response:
             {"error": "not available in this session", "code": "restricted_session"},
             status=403,
         )
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response(
-            {"error": "invalid JSON", "code": "invalid_json"}, status=400
-        )
-    if not isinstance(body, dict):
-        # `[]`, `"str"` and `5` are all VALID JSON, so request.json() returns them
-        # happily and only the .get() below would fail — with an AttributeError
-        # outside the try above, i.e. a 500 for what is really malformed client
-        # input. Reject them on the same 400 contract as unparseable bytes.
-        return web.json_response(
-            {"error": "invalid JSON", "code": "invalid_json"}, status=400
-        )
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
 
     raw = str(body.get("path", "") or "").strip()
     validate_only = bool(body.get("validate_only"))
@@ -1276,10 +1266,10 @@ async def api_memory_import(request: web.Request) -> web.Response:
         )
         return web.json_response({"error": "Memory writes are not allowed in this session mode."}, status=403)
     store = await _get_vector_store_async(request.app["state"])
-    try:
-        data = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    data, data_err = await read_bounded_json(request, max_bytes=None)
+    if data_err is not None:
+        return data_err
+    assert data is not None  # read_bounded_json returns (dict, None) on success
     # import_memory embeds each imported entry via blocking in-process model
     # inference (unbounded — one per entry); offload so a large import can't
     # stall the gateway event loop.
@@ -1325,10 +1315,10 @@ async def api_memory_consolidate(request: web.Request) -> web.Response:
         return web.json_response({"error": "Memory writes are not allowed in this session mode."}, status=403)
     if not state.consolidator:
         return web.json_response({"error": "consolidator not available"}, status=503)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     key = body.get("key", "").strip()
     if not key:
         return web.json_response({"error": "session key required"}, status=400)
@@ -1411,10 +1401,15 @@ async def api_memory_observability(request: web.Request) -> web.Response:
 async def api_memory_promote(request: web.Request) -> web.Response:
     """POST /api/memory/promote — promote repeated episodic patterns to semantic facts."""
     store = await _get_vector_store_async(request.app["state"])
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
+    # allow_absent: every field below has a default, so a bodyless POST is
+    # legitimate. A body that is present but malformed is still a 400 -- the
+    # previous `except Exception: body = {}` answered 200-with-defaults to a
+    # client typo, which silently ran a different promotion than the caller
+    # asked for.
+    body, body_err = await read_bounded_json(request, max_bytes=None, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     try:
         min_count = int(body.get("min_count", 5))
         min_sim = float(body.get("min_sim", 0.75))

--- a/test/test_embedding_model_apply.py
+++ b/test/test_embedding_model_apply.py
@@ -408,17 +408,30 @@ class TestNonObjectJsonBody:
             mem.api_memory_embedding_model(self._request(payload))
         )
         assert resp.status == 400, f"{payload!r} must be a 400, not a crash"
-        assert b"invalid_json" in resp.body
+        # The shared guard separates "unparseable" from "parsed, wrong shape";
+        # this handler used to answer invalid_json for both.
+        assert b"body_not_object" in resp.body
 
-    def test_the_guard_is_an_isinstance_check_on_dict(self) -> None:
-        """Guard against a refactor that only special-cases lists."""
+    def test_the_guard_runs_before_the_first_field_read(self) -> None:
+        """Guard against a refactor that only special-cases lists.
+
+        The check itself lives in ``_shared.read_bounded_json`` now (issue
+        #5587), so this pins the two properties that made the inline version
+        correct: the handler consults the guard BEFORE its first ``.get()``,
+        and the guard is a general ``isinstance(body, dict)`` test rather than a
+        list-only special case. The parametrized cases above prove the
+        generality behaviorally; this catches a refactor that reorders or drops
+        the call while the parametrized cases still pass for another reason.
+        """
         import inspect
 
+        from kiro_crew.dashboard.handlers._shared import read_bounded_json
         from kiro_crew.dashboard.handlers.memory import api_memory_embedding_model
 
         src = inspect.getsource(api_memory_embedding_model)
-        assert "isinstance(body, dict)" in src
-        assert src.index("isinstance(body, dict)") < src.index('body.get("path"')
+        assert "read_bounded_json(" in src
+        assert src.index("read_bounded_json(") < src.index('body.get("path"')
+        assert "isinstance(body, dict)" in inspect.getsource(read_bounded_json)
 
 
 class TestApplyIsAudited:

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -76,6 +76,7 @@ def _make_request(
     query: dict[str, str] | None = None,
     match_info: dict[str, str] | None = None,
     session_key: str = "",
+    body_present: bool | None = None,
 ) -> Any:
     req = MagicMock()
     req.app = {"state": state}
@@ -83,8 +84,16 @@ def _make_request(
     req.query = query or {}
     req.match_info = match_info or {}
     req.headers = {"X-Session-Key": session_key} if session_key else {}
+    # ``can_read_body`` is what ``_shared.read_bounded_json`` consults for its
+    # allow_absent endpoints. It defaults to "a body was supplied", which makes
+    # ``json_body=None`` an ABSENT body -- the common case for the GET tests.
+    # Pass ``body_present=True`` alongside ``json_body=None`` for the other
+    # meaning: a body that is present and whose content is the JSON literal
+    # ``null``, which is a non-object and must be refused, not defaulted.
+    req.can_read_body = json_body is not None if body_present is None else body_present
     if isinstance(json_body, _BadJSON):
         req.json = AsyncMock(side_effect=ValueError("not json"))
+        req.can_read_body = True
     else:
         req.json = AsyncMock(return_value=json_body)
     return req
@@ -167,7 +176,7 @@ class TestPreferencesProjectsHistory:
         req = _make_request(state, method="PUT", json_body=_BadJSON())
         resp = await mem_mod.api_memory_preferences(req)
         assert resp.status == 400
-        assert _body(resp) == {"error": "invalid JSON"}
+        assert _body(resp) == {"error": "invalid JSON", "code": "invalid_json"}
         mem.write_preferences.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1079,12 +1088,40 @@ class TestContextPreviewAndObservability:
 
 class TestPromote:
     @pytest.mark.asyncio
-    async def test_invalid_json_body_uses_defaults(self) -> None:
+    async def test_absent_body_uses_defaults(self) -> None:
+        # Every field has a default, so a bodyless POST is legitimate and must
+        # still run the default promotion -- that is what allow_absent buys.
+        store = _store(promote_episodic_patterns=MagicMock(return_value=2))
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="POST")
+        assert _body(await mem_mod.api_memory_promote(req)) == {"ok": True, "promoted": 2}
+        store.promote_episodic_patterns.assert_called_once_with(5, 0.75)
+
+    @pytest.mark.asyncio
+    async def test_malformed_body_is_400_not_silent_defaults(self) -> None:
+        # A body that is PRESENT but unparseable is a client mistake, not an
+        # absent body: answering 200-with-defaults ran a different promotion
+        # than the caller asked for and told them nothing (issue #5587).
         store = _store(promote_episodic_patterns=MagicMock(return_value=2))
         state = _make_state(vector_store=store)
         req = _make_request(state, method="POST", json_body=_BadJSON())
-        assert _body(await mem_mod.api_memory_promote(req)) == {"ok": True, "promoted": 2}
-        store.promote_episodic_patterns.assert_called_once_with(5, 0.75)
+        resp = await mem_mod.api_memory_promote(req)
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_json"
+        store.promote_episodic_patterns.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_object_body_is_400(self) -> None:
+        # `[]` / `"str"` / `5` are valid JSON but not objects; the .get() calls
+        # below would raise AttributeError into a 500 without the shape guard.
+        store = _store(promote_episodic_patterns=MagicMock(return_value=2))
+        state = _make_state(vector_store=store)
+        for payload in ([], "str", 5):
+            req = _make_request(state, method="POST", json_body=payload)
+            resp = await mem_mod.api_memory_promote(req)
+            assert resp.status == 400, payload
+            assert _body(resp)["code"] == "body_not_object", payload
+        store.promote_episodic_patterns.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_explicit_thresholds_are_forwarded(self) -> None:
@@ -1215,7 +1252,9 @@ class TestEmbeddingModelEndpoint:
             req = _make_request(state, method="POST", json_body=payload)
             resp = await mem_mod.api_memory_embedding_model(req)
             assert resp.status == 400
-            assert _body(resp)["code"] == "invalid_json"
+            # The shared guard distinguishes "unparseable" from "parsed, wrong
+            # shape"; this handler used to answer invalid_json for both.
+            assert _body(resp)["code"] == "body_not_object"
 
     @pytest.mark.asyncio
     async def test_validation_error_is_400_with_code(self) -> None:
@@ -2122,3 +2161,55 @@ class TestConfigWritesRunOffTheEventLoop:
         assert json.loads(cfg.read_text(encoding="utf-8")) == {"memory": []}, (
             "the malformed section was rewritten"
         )
+
+
+class TestNonObjectBodiesAcrossConvertedHandlers:
+    """Every converted handler answers 400, never 5xx, on a non-object body.
+
+    ``[]`` / ``"s"`` / ``5`` / ``true`` / ``null`` are all VALID JSON, so
+    ``request.json()`` returns them and the ``.get()`` each handler performs
+    next raised ``AttributeError`` from OUTSIDE the parse ``try`` -- a 500 for
+    what is really malformed client input (issue #5587). Enumerated rather than
+    written one test per handler so a handler that loses the guard fails by
+    construction; the agents.py half of the same invariant lives in
+    ``test_json_object_body_guard.py``.
+    """
+
+    _HANDLERS = [
+        ("api_memory_preferences", "PUT"),
+        ("api_memory_projects", "PUT"),
+        ("api_memory_history", "PUT"),
+        ("api_memory_settings", "PUT"),
+        ("api_memory_semantic_write", "PUT"),
+        ("api_memory_import", "POST"),
+        ("api_memory_consolidate", "POST"),
+        ("api_memory_promote", "POST"),
+        ("api_memory_embedding_model", "POST"),
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [[], "a string", 5, 1.5, True, None], ids=repr)
+    @pytest.mark.parametrize("handler_name,method", _HANDLERS, ids=str)
+    async def test_non_object_body_is_400_not_500(
+        self, handler_name: str, method: str, payload: Any
+    ) -> None:
+        state = _make_state(
+            vector_store=_store(),
+            memory=MagicMock(),
+            consolidator=MagicMock(),
+        )
+        req = _make_request(
+            state,
+            method=method,
+            json_body=payload,
+            session_key="dashboard:ui",
+            # A body IS present in every row -- including the ``null`` one,
+            # which must be refused as a non-object rather than read as an
+            # absent body by the allow_absent endpoints.
+            body_present=True,
+        )
+        handler = getattr(mem_mod, handler_name)
+        with patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()):
+            resp = await handler(req)
+        assert resp.status == 400, f"{handler_name} on {payload!r}: expected 400"
+        assert _body(resp)["code"] == "body_not_object", handler_name

--- a/test/test_json_object_body_guard.py
+++ b/test/test_json_object_body_guard.py
@@ -1,0 +1,335 @@
+"""Every handler routed through the shared body guard answers 400, never 5xx.
+
+``[]``, ``"s"``, ``5``, ``true`` and ``null`` are all VALID JSON, so
+``await request.json()`` returns them happily -- and the ``.get()`` that every
+one of these handlers performs next then raises ``AttributeError`` from OUTSIDE
+the ``try`` that wrapped the parse. The result was a 500 for what is really
+malformed client input (issue #5587).
+
+This is enumerate-the-invariant coverage rather than one test per handler: the
+table below is the list of handlers converted to
+``_shared.read_bounded_json``, and it is the ratchet for the remaining sweep --
+a handler converted in a later tranche gets a row here, and a row that stops
+answering ``body_not_object`` fails by construction.
+
+A later tranche must record its cap decision in ``_CAP_REGISTER`` below, which is
+checked against the code: a converted call site that is not registered fails, and
+a declared cap that disagrees with what the handler passes fails. Prose could not
+stop ``max_bytes=None`` being copied along with a row; the register can.
+
+Handlers are called directly with a minimal request stand-in. Going through the
+router would drag in the owner-identity middleware and a real config load for
+every row, and neither is the subject: the guard runs on the parsed body,
+after those gates.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import json
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.dashboard.handlers import _shared as shared
+from kiro_crew.dashboard.handlers import agents as agents_mod
+
+# Marked per-test rather than module-wide: the cap-register tests below are
+# synchronous, and a module-wide asyncio mark warns on every one of them.
+
+#: Valid JSON documents that are not objects. ``None`` is the JSON literal
+#: ``null``, which is distinct from an absent body.
+_NON_OBJECTS = ([], "a string", 5, 1.5, True, None)
+
+
+class _Req:
+    """The parts of ``web.Request`` the guard and these handlers read."""
+
+    def __init__(self, payload, method: str = "POST"):
+        self._payload = payload
+        self.method = method
+        self.headers: dict[str, str] = {}
+        self.match_info: dict[str, str] = {}
+        self.query: dict[str, str] = {}
+        self.can_read_body = True
+        self.charset = None
+        self.app = {"state": None}
+
+    async def json(self):
+        return self._payload
+
+
+#: ``(handler, method)`` for each agents.py handler in this tranche. Every one
+#: sits behind ``_require_owner``, neutralised by the fixture below.
+_AGENTS_HANDLERS = [
+    (agents_mod.api_agent_config, "PUT"),
+    (agents_mod.api_default_agent, "PUT"),
+    (agents_mod.api_capability_mcp_install, "POST"),
+    (agents_mod.api_capability_mcp_uninstall, "POST"),
+    (agents_mod.api_capability_skills_install, "POST"),
+    (agents_mod.api_capability_skills_uninstall, "POST"),
+]
+
+
+@pytest.fixture
+def _owner_allowed(monkeypatch):
+    """Let the owner gate through so the body guard is what runs.
+
+    The gate is a separate invariant with its own coverage in
+    ``test_agents_endpoints_owner_auth.py``; leaving it armed here would answer
+    403 to every row and the guard would never be reached.
+    """
+
+    async def _allow(_request, _operation):
+        return None
+
+    monkeypatch.setattr(agents_mod, "_require_owner", _allow)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "handler,method", _AGENTS_HANDLERS, ids=lambda v: getattr(v, "__name__", v)
+)
+@pytest.mark.parametrize("payload", _NON_OBJECTS, ids=repr)
+async def test_non_object_body_is_400_not_500(handler, method, payload, _owner_allowed):
+    resp = await handler(_Req(payload, method=method))
+    assert resp.status == 400, f"{handler.__name__} on {payload!r}: expected 400"
+    assert json.loads(resp.text)["code"] == "body_not_object"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "handler,method", _AGENTS_HANDLERS, ids=lambda v: getattr(v, "__name__", v)
+)
+async def test_unparseable_body_is_400_with_invalid_json(handler, method, _owner_allowed):
+    """The other half of the contract: bad bytes stay ``invalid_json``.
+
+    Without this, a guard that answered ``body_not_object`` for everything
+    would satisfy the test above while losing the distinction clients switch on.
+    """
+
+    class _BadReq(_Req):
+        async def json(self):
+            raise ValueError("not json")
+
+    resp = await handler(_BadReq(None, method=method))
+    assert resp.status == 400
+    assert json.loads(resp.text)["code"] == "invalid_json"
+
+
+# ── The cap register ──────────────────────────────────────────────────────────
+#
+# ``read_bounded_json``'s byte cap is its original safety property: it bounds a
+# body BEFORE decoding on a network-reachable surface. ``max_bytes=None`` opts
+# out of it, and the docstring says that choice "is a real choice, not a default
+# to inherit" -- but prose cannot stop the sweep copying ``None`` along with a
+# row. So every call site's decision is RECORDED here and checked against the
+# code: a conversion that is not registered fails, and a registered cap that
+# disagrees with what the handler actually passes fails. An unexamined
+# ``max_bytes=None`` therefore cannot land silently.
+
+_UNBOUNDED_USER_CONTENT = (
+    "body carries user content with no defensible maximum size (a file's "
+    "contents, an export, a fetched document, a bundle)"
+)
+_CONTROL_FIELDS_CAP_PENDING = (
+    "body is a fixed set of control fields and SHOULD take the default cap; "
+    "left uncapped only to keep this tranche behaviour-preserving, because "
+    "capping moves the site off request.json() onto the streaming read and "
+    "every unit test mocking json for it must be refed. Cap it in the sweep."
+)
+_BOUNDED_BY_DEFAULT = "small fixed-shape payload on a strict-internal route"
+_BOUNDED_EXPLICIT = "explicit per-route cap, larger than the shared default"
+
+_CAP_REASONS = {
+    _UNBOUNDED_USER_CONTENT,
+    _CONTROL_FIELDS_CAP_PENDING,
+    _BOUNDED_BY_DEFAULT,
+    _BOUNDED_EXPLICIT,
+}
+
+#: ``module::handler`` -> (declared cap, why). Declared cap is ``"None"`` for an
+#: opt-out, ``"<default>"`` for the shared 64 KB ceiling, or the literal
+#: expression passed for a per-route cap.
+_CAP_REGISTER: dict[str, tuple[str, str]] = {
+    # Pre-existing capped sites -- the bounded read's live consumers.
+    "chat_pins.py::api_chat_pins_create": ("<default>", _BOUNDED_BY_DEFAULT),
+    "handlers/feedback.py::api_feedback_submit": ("<default>", _BOUNDED_BY_DEFAULT),
+    "handlers/messaging.py::api_notification_agent_push": (
+        "<default>",
+        _BOUNDED_BY_DEFAULT,
+    ),
+    "handlers/notifications_push.py::api_push_notification": (
+        "<default>",
+        _BOUNDED_BY_DEFAULT,
+    ),
+    "handlers/messaging.py::api_teams_activity": (
+        "TEAMS_MAX_ACTIVITY_BYTES",
+        _BOUNDED_EXPLICIT,
+    ),
+    # agents.py tranche.
+    "handlers/agents.py::api_agent_config": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/agents.py::api_default_agent": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/agents.py::api_capability_mcp_install": (
+        "None",
+        _CONTROL_FIELDS_CAP_PENDING,
+    ),
+    "handlers/agents.py::api_capability_mcp_uninstall": (
+        "None",
+        _CONTROL_FIELDS_CAP_PENDING,
+    ),
+    "handlers/agents.py::api_capability_skills_install": (
+        "None",
+        _CONTROL_FIELDS_CAP_PENDING,
+    ),
+    "handlers/agents.py::api_capability_skills_uninstall": (
+        "None",
+        _CONTROL_FIELDS_CAP_PENDING,
+    ),
+    # memory.py tranche.
+    "handlers/memory.py::api_memory_preferences": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/memory.py::api_memory_projects": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/memory.py::api_memory_history": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/memory.py::api_memory_import": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/memory.py::api_memory_semantic_write": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/memory.py::api_memory_settings": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/memory.py::api_memory_consolidate": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/memory.py::api_memory_promote": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/memory.py::api_memory_embedding_model": (
+        "None",
+        _CONTROL_FIELDS_CAP_PENDING,
+    ),
+    # knowledge.py -- the 9 sites that moved off the deleted duplicate helper.
+    "handlers/knowledge.py::update_item": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/knowledge.py::add_source": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/knowledge.py::rename_source": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/knowledge.py::retry_file": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/knowledge.py::skip_file": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/knowledge.py::ingest_text": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/knowledge.py::import_bundle": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/knowledge.py::batch_embed_items": ("None", _CONTROL_FIELDS_CAP_PENDING),
+    "handlers/knowledge.py::add_agent_document_route": (
+        "None",
+        _UNBOUNDED_USER_CONTENT,
+    ),
+}
+
+_DASHBOARD_DIR = Path(shared.__file__).resolve().parent.parent
+
+#: How many rows currently ship uncapped while their body is a fixed set of
+#: control fields -- i.e. endpoints whose register entry says they SHOULD take
+#: the default cap, deferred only to keep this tranche behaviour-preserving.
+#:
+#: This number is a RATCHET, in the same shape as the repo's error-code and
+#: coverage baselines: it may SHRINK as a later tranche applies those caps, and
+#: it may never grow. Recording the decision (above) is what stops an unexamined
+#: ``max_bytes=None`` from landing; this is what stops the recorded debt from
+#: quietly becoming permanent, because otherwise the sweep could finish with
+#: every one of these endpoints still unbounded and nothing would fail. The
+#: 64 KB bound is the helper's original safety property (issue #490), so
+#: "recorded" is not the same as "handled".
+_CAP_PENDING_CEILING = 13
+
+
+@functools.lru_cache(maxsize=1)
+def _call_sites() -> dict[str, str]:
+    """``module::handler`` -> the ``max_bytes`` expression actually passed."""
+    found: dict[str, str] = {}
+    for path in sorted(_DASHBOARD_DIR.rglob("*.py")):
+        src = path.read_text(encoding="utf-8")
+        if "read_bounded_json(" not in src:
+            continue
+        tree = ast.parse(src)
+        funcs = [
+            n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "read_bounded_json"
+            ):
+                continue
+            owner = None
+            for fn in funcs:
+                if fn.lineno <= node.lineno <= (fn.end_lineno or fn.lineno):
+                    if owner is None or fn.lineno > owner.lineno:
+                        owner = fn
+            kw = {k.arg: ast.unparse(k.value) for k in node.keywords}
+            rel = path.relative_to(_DASHBOARD_DIR).as_posix()
+            found[f"{rel}::{getattr(owner, 'name', '?')}"] = kw.get("max_bytes", "<default>")
+    return found
+
+
+class TestCapRegister:
+    def test_the_register_is_not_vacuous(self) -> None:
+        # A refactor that moved or renamed the helper would otherwise empty the
+        # scan and make every assertion below pass by finding nothing.
+        assert len(_call_sites()) >= 25
+
+    def test_every_call_site_records_a_cap_decision(self) -> None:
+        unregistered = sorted(set(_call_sites()) - set(_CAP_REGISTER))
+        assert not unregistered, (
+            "these read_bounded_json call sites record no cap decision -- add a "
+            "row with a reason rather than inheriting max_bytes=None: "
+            f"{unregistered}"
+        )
+
+    def test_no_register_row_outlives_its_call_site(self) -> None:
+        stale = sorted(set(_CAP_REGISTER) - set(_call_sites()))
+        assert not stale, f"register rows with no matching call site: {stale}"
+
+    def test_declared_cap_matches_the_code(self) -> None:
+        mismatches = {
+            key: (declared, actual)
+            for key, (declared, _why) in _CAP_REGISTER.items()
+            if (actual := _call_sites().get(key)) is not None and actual != declared
+        }
+        assert not mismatches, f"declared cap disagrees with the code: {mismatches}"
+
+    def test_every_reason_is_one_of_the_documented_ones(self) -> None:
+        bad = {k: why for k, (_c, why) in _CAP_REGISTER.items() if why not in _CAP_REASONS}
+        assert not bad, f"rows citing an undocumented reason: {sorted(bad)}"
+
+    def test_the_bounded_read_still_has_live_consumers(self) -> None:
+        # The point of the register: if the sweep converts everything to None,
+        # the cap becomes an opt-in nobody exercises. This fails when the last
+        # bounded consumer disappears.
+        bounded = [k for k, v in _call_sites().items() if v != "None"]
+        assert len(bounded) >= 5, f"only {len(bounded)} bounded call site(s) left"
+
+    def test_the_pending_cap_debt_only_shrinks(self) -> None:
+        """The deferred caps are a ratchet, not a permanent state.
+
+        Recording a cap decision stops an unexamined ``max_bytes=None`` from
+        landing, but on its own it would let the sweep finish with every
+        control-field endpoint still unbounded -- the decision would be written
+        down and never acted on. So the count is pinned: a later tranche that
+        applies a cap must lower ``_CAP_PENDING_CEILING`` with it, and one that
+        adds a new deferral fails here instead of growing the debt silently.
+        """
+        pending = sorted(
+            key for key, (_cap, why) in _CAP_REGISTER.items() if why == _CONTROL_FIELDS_CAP_PENDING
+        )
+        assert len(pending) <= _CAP_PENDING_CEILING, (
+            f"{len(pending)} endpoints now defer their cap, over the ceiling of "
+            f"{_CAP_PENDING_CEILING}. Apply the cap instead of deferring another "
+            f"one: {pending}"
+        )
+        assert len(pending) == _CAP_PENDING_CEILING, (
+            f"only {len(pending)} endpoints still defer their cap, below the "
+            f"ceiling of {_CAP_PENDING_CEILING} -- lower _CAP_PENDING_CEILING to "
+            f"{len(pending)} so the ratchet keeps tightening"
+        )
+
+    def test_every_deferred_cap_is_actually_uncapped(self) -> None:
+        # A row claiming a DEFERRED cap while the code already caps it would
+        # inflate the ceiling and make the ratchet unfalsifiable.
+        sites = _call_sites()
+        wrong = {
+            key: sites.get(key)
+            for key, (_cap, why) in _CAP_REGISTER.items()
+            if why == _CONTROL_FIELDS_CAP_PENDING and sites.get(key) != "None"
+        }
+        assert not wrong, f"rows deferring a cap that the code already applies: {wrong}"

--- a/test/test_knowledge_handlers_coverage.py
+++ b/test/test_knowledge_handlers_coverage.py
@@ -734,8 +734,8 @@ class TestImportBundle:
     @pytest.mark.parametrize("payload", [[1, 2, 3], "just a string", 42])
     async def test_non_object_json_is_400_not_500(self, store, payload):
         # request.json() happily parses a bare array/string/number/null. The
-        # shared _json_object_body guard answers the non-object case for all
-        # nine request.json() sites in this module, so it fires before the
+        # shared read_bounded_json guard answers the non-object case for all
+        # nine JSON-body sites in this module, so it fires before the
         # bundle-shape validator and owns this code.
         async with _client(_make_app(store)) as client:
             resp = await client.post("/api/knowledge/import", json=payload)
@@ -1971,31 +1971,9 @@ class TestJsonObjectBodyGuard:
             assert resp.status == 400
             assert (await resp.json())["code"] == "invalid_json"
 
-    @pytest.mark.asyncio
-    async def test_recursion_error_is_400_not_500(self):
-        # A deeply nested document blows the JSON parser's recursion budget:
-        # request.json() raises RecursionError (not a ValueError), which must
-        # also read as a client mistake. The raise threshold varies by Python
-        # version and platform (~1k on 3.10, ~10k on 3.12, lower on
-        # small-stack Windows), so a real payload either misses the threshold
-        # or gambles with the worker's C stack -- pin the contract at the
-        # helper boundary like the transport-error test below.
-        request = MagicMock()
-        request.json = AsyncMock(side_effect=RecursionError())
-        body, err = await kh._json_object_body(request)
-        assert body is None
-        assert err is not None
-        assert err.status == 400
-        assert json.loads(err.text)["code"] == "invalid_json"
-
-    @pytest.mark.asyncio
-    async def test_transport_errors_propagate_not_400(self):
-        # A disconnect mid-body is not a client JSON mistake: the narrowed
-        # ValueError catch must let transport failures keep their 500 class.
-        request = MagicMock()
-        request.json = AsyncMock(side_effect=ConnectionResetError())
-        with pytest.raises(ConnectionResetError):
-            await kh._json_object_body(request)
+    # The RecursionError and transport-error boundaries moved with the guard:
+    # they are properties of ``_shared.read_bounded_json``, not of this module,
+    # and are pinned in ``test_read_bounded_json.py`` (TestDecodeContract).
 
     @pytest.mark.asyncio
     async def test_file_state_object_body_still_works(self, store):

--- a/test/test_read_bounded_json.py
+++ b/test/test_read_bounded_json.py
@@ -1,16 +1,29 @@
-"""Unit tests for the shared ``read_bounded_json`` body-cap helper (issue #490).
+"""Unit tests for the shared ``read_bounded_json`` body guard.
 
-The two 64 KB body-capped notification endpoints
-(``messaging.api_notification_agent_push`` and
-``notifications_push.api_push_notification``) previously each inlined a
+It owns the parse-and-shape contract for the endpoints routed through it
+(issue #5587), and the 64 KB pre-decode byte cap the two notification
+endpoints need (issue #490). It is not yet the dashboard's only such guard --
+four siblings survive and are tracked on #5587; the helper's docstring names
+them.
+
+The cap half: ``messaging.api_notification_agent_push`` and
+``notifications_push.api_push_notification`` previously each inlined a
 byte-identical Content-Length precheck + incremental read + 413/400 block, with
 the cap as a function-local. Extracting the helper means the cap and the
-413/400 contract live in exactly one place and cannot drift. These tests pin
-that contract directly against the helper.
+413/400 contract live in exactly one place and cannot drift.
+
+The shape half: ``await request.json()`` returns a list, string, or number for a
+body that is valid JSON but not an object, and a handler that then calls
+``.get()`` on it turns a client mistake into a 500. ``knowledge`` used to carry
+a second helper for this with a different cap, message, absent-body rule, and
+exception breadth; these tests pin the one surviving contract.
 """
+
+import json
 
 import pytest
 
+from kiro_crew.dashboard.handlers import _shared as shared
 from kiro_crew.dashboard.handlers._shared import _MAX_BODY_BYTES, read_bounded_json
 
 
@@ -26,9 +39,37 @@ class _FakeContent:
 
 
 class _FakeRequest:
-    def __init__(self, data: bytes, content_length: int | None = None):
+    def __init__(
+        self,
+        data: bytes,
+        content_length: int | None = None,
+        *,
+        charset: str | None = None,
+        can_read_body: bool = True,
+        read_error: BaseException | None = None,
+    ):
         self.content = _FakeContent(data)
         self.content_length = content_length
+        self.charset = charset
+        self.can_read_body = can_read_body
+        self._data = data
+        self._read_error = read_error
+
+    async def json(self):
+        """Stand in for ``request.json()`` -- the uncapped (max_bytes=None) path.
+
+        Mirrors aiohttp: ``read()`` then ``decode(charset or utf-8)`` then
+        ``loads``, so an unknown codec raises LookupError here exactly as it
+        would in production.
+        """
+        if self._read_error is not None:
+            raise self._read_error
+        return json.loads(self._data.decode(self.charset or "utf-8"))
+
+
+def _code(resp) -> str:
+    """The machine-readable ``code`` from an error response body."""
+    return json.loads(resp.text or "")["code"]
 
 
 class TestReadBoundedJson:
@@ -75,6 +116,7 @@ class TestReadBoundedJson:
         body, err = await read_bounded_json(_FakeRequest(b"{not json", content_length=9))
         assert body is None
         assert err is not None and err.status == 400
+        assert _code(err) == "invalid_json"
 
     @pytest.mark.asyncio
     async def test_non_object_body_returns_400(self):
@@ -82,3 +124,155 @@ class TestReadBoundedJson:
         body, err = await read_bounded_json(_FakeRequest(raw, content_length=len(raw)))
         assert body is None
         assert err is not None and err.status == 400
+        assert _code(err) == "body_not_object"
+
+    @pytest.mark.asyncio
+    async def test_oversize_carries_payload_too_large_code(self):
+        body, err = await read_bounded_json(
+            _FakeRequest(b"{}", content_length=_MAX_BODY_BYTES + 1)
+        )
+        assert body is None
+        assert err is not None and _code(err) == "payload_too_large"
+
+
+class TestUncappedReads:
+    """``max_bytes=None`` -- the endpoints with no principled byte ceiling."""
+
+    @pytest.mark.asyncio
+    async def test_body_far_over_the_default_cap_is_accepted(self):
+        # A knowledge bundle import has no defensible maximum size, so opting
+        # out of the cap must actually lift it -- not merely raise it.
+        raw = b'{"pad": "' + b"a" * (_MAX_BODY_BYTES * 2) + b'"}'
+        body, err = await read_bounded_json(
+            _FakeRequest(raw, content_length=len(raw)), max_bytes=None
+        )
+        assert err is None
+        assert body is not None and len(body["pad"]) == _MAX_BODY_BYTES * 2
+
+    @pytest.mark.asyncio
+    async def test_shape_guard_still_applies_without_a_cap(self):
+        # Dropping the cap must not drop the reason the helper exists.
+        raw = b'"just a string"'
+        body, err = await read_bounded_json(
+            _FakeRequest(raw, content_length=len(raw)), max_bytes=None
+        )
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _code(err) == "body_not_object"
+
+
+class TestAllowAbsent:
+    @pytest.mark.asyncio
+    async def test_absent_body_becomes_empty_object(self):
+        body, err = await read_bounded_json(
+            _FakeRequest(b"", can_read_body=False), allow_absent=True
+        )
+        assert err is None
+        assert body == {}
+
+    @pytest.mark.asyncio
+    async def test_absent_body_is_400_without_the_opt_in(self):
+        # Defaulting an absent body is per-endpoint, not the global rule.
+        body, err = await read_bounded_json(_FakeRequest(b"", can_read_body=False))
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _code(err) == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_present_but_malformed_body_is_still_400(self):
+        # "sent nothing" and "sent garbage" are different facts: only the first
+        # one can be defaulted. Answering 200-with-defaults to a client typo
+        # runs a different operation than the caller asked for, silently.
+        body, err = await read_bounded_json(
+            _FakeRequest(b"{not json", content_length=9), allow_absent=True
+        )
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _code(err) == "invalid_json"
+
+
+class TestDecodeContract:
+    """Both paths decode like ``request.json()``: decode(charset) then loads.
+
+    Every case runs against the capped path AND the uncapped one: the two must
+    differ only in whether the read is bounded, or the helper has two contracts
+    wearing one name.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_bytes", [_MAX_BODY_BYTES, None])
+    async def test_declared_charset_is_honoured(self, max_bytes):
+        raw = '{"name": "caf\u00e9"}'.encode("latin-1")
+        body, err = await read_bounded_json(
+            _FakeRequest(raw, content_length=len(raw), charset="latin-1"),
+            max_bytes=max_bytes,
+        )
+        assert err is None
+        assert body == {"name": "caf\u00e9"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_bytes", [_MAX_BODY_BYTES, None])
+    async def test_unknown_charset_is_400_not_500(self, max_bytes):
+        # charset= names a codec Python does not have: bytes.decode raises
+        # LookupError, which is not a ValueError and would otherwise escape the
+        # guard as a 500 for what is really a malformed client header.
+        raw = b'{"name": "x"}'
+        body, err = await read_bounded_json(
+            _FakeRequest(raw, content_length=len(raw), charset="not-a-codec"),
+            max_bytes=max_bytes,
+        )
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _code(err) == "invalid_json"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_bytes", [_MAX_BODY_BYTES, None])
+    async def test_undecodable_bytes_are_400_not_500(self, max_bytes):
+        raw = b'{"name": "\xff\xfe"}'
+        body, err = await read_bounded_json(
+            _FakeRequest(raw, content_length=len(raw)), max_bytes=max_bytes
+        )
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _code(err) == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_recursion_error_is_400_not_500(self, monkeypatch):
+        # A deeply nested document blows the JSON parser's stack: json.loads
+        # raises RecursionError, which is not a ValueError and would otherwise
+        # escape the guard as a 500. The raise depth is version- and
+        # platform-dependent (~1k on 3.10, ~10k on 3.12, lower on small-stack
+        # Windows), so inject at the parse boundary rather than gambling with
+        # the test worker's C stack on a real payload.
+        class _ParserStackOverflow:
+            @staticmethod
+            def loads(_text):
+                raise RecursionError()
+
+        # Swap only the helper module's ``json`` reference -- patching
+        # ``json.loads`` itself would also break this test's own decoding.
+        monkeypatch.setattr(shared, "json", _ParserStackOverflow)
+        raw = b'{"a": 1}'
+        body, err = await read_bounded_json(_FakeRequest(raw, content_length=len(raw)))
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _code(err) == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_recursion_error_from_request_json_is_400_not_500(self):
+        # Same contract on the uncapped path, where the parse happens inside
+        # request.json() and the helper never sees json.loads at all.
+        request = _FakeRequest(b'{"a": 1}', read_error=RecursionError())
+        body, err = await read_bounded_json(request, max_bytes=None)
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _code(err) == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_transport_error_propagates_instead_of_becoming_400(self):
+        # A disconnect mid-body is not a client JSON mistake; reporting it as
+        # 400 invalid_json tells the client its payload was wrong when it was
+        # not, and hides the disconnect from the 500 class that owns it.
+        request = _FakeRequest(b"{}", read_error=ConnectionResetError())
+        with pytest.raises(ConnectionResetError):
+            await read_bounded_json(request, max_bytes=None)

--- a/test/test_teams_webhook_hardening.py
+++ b/test/test_teams_webhook_hardening.py
@@ -85,6 +85,10 @@ class _FakeRequest(dict):
         self.headers = headers or {}
         self.content = _FakeContent(body)
         self.content_length = len(body) if content_length is None else content_length
+        # ``read_bounded_json`` decodes with ``request.charset or "utf-8"``, the
+        # same way ``request.json()`` does. A real ``web.Request`` always
+        # exposes it (None when the Content-Type declares no charset).
+        self.charset: str | None = None
         self.app = app if app is not None else {"allowed_origins": {"http://localhost:5476"}}
 
 


### PR DESCRIPTION
## Problem / Motivation

Two problems, in dependency order (both from the First Principles review of #5575).

**One job, competing owners.** The dashboard carried two helpers with the SAME
`(body, err)` return contract that parse a JSON
*object* request body and hand back either `(body, None)` or `(None, 400)`.
They shared the `invalid_json` / `body_not_object` codes and the return
contract, and disagreed on everything else:

| | `_shared.read_bounded_json` (5 sites) | `knowledge._json_object_body` (9 sites) |
|---|---|---|
| byte cap | required, 64 KB default | none |
| absent body | not supported | `allow_absent` -> `{}` |
| message text | `invalid JSON body` | `invalid JSON` |
| exceptions | `except Exception` (swallowed transport errors) | narrowed, transport errors propagate |

**~85 handlers 500 on a valid request body.** `[]`, `"s"`, `5`, `true` and
`null` are all valid JSON, so `await request.json()` returns them happily -- and
the `.get()` every one of these handlers performs next raises `AttributeError`
from OUTSIDE the `try` that wrapped the parse. A static scan of the dashboard
finds 218 `await request.json()` sites, 79 of them guarded by a bare
`except Exception -> "invalid JSON"` with no dict check.

## Why it matters

A client that posts a top-level array to `/api/memory/preferences` or
`/api/capability/mcp/install` gets a 500. That is wrong in three ways: it tells
the client the server broke when the client's payload was malformed, it is
unactionable (no `code` to switch on), and it lands in the logs as a server
fault, so the real signal -- clients sending the wrong shape -- is invisible.

The two-helper split is what made this expensive to fix at scale. Sweeping ~85
sites while two spellings exist bakes the second one in ~85 times, which is why
#5587 sequenced consolidation first and why the triage pass held the whole issue
in `needs-investigation`.

## What changed (motivation -> approach -> change)

**Item 1 -- consolidate.** `_shared.read_bounded_json` survives as the single
owner; `knowledge._json_object_body` is deleted and its 9 call sites move over.
The issue named three decisions that had to be settled to do this, and the
triage comment asked for each explicitly:

- **The cap for unbounded-body endpoints.** `max_bytes` becomes
  `int | None`; `None` means no pre-decode ceiling. The knowledge sites pass
  `max_bytes=None`, which preserves today's behaviour exactly -- this refactor
  introduces no new 413 on `import_bundle`. Picking a real ceiling for bundle
  import is a product decision with a failure mode on both sides, and it is now
  a one-argument change at one call site instead of a re-plumb. The opt-out is
  deliberately explicit at each call site rather than a second wrapper helper:
  a wrapper would have recreated the two-spelling problem this PR removes.
- **Which exception contract wins.** The narrow one:
  `(LookupError, RecursionError, ValueError)`. Transport failures (a disconnect
  mid-body, a read timeout) propagate and keep their 500 class -- reporting a
  disconnect as `400 invalid_json` tells the client its payload was wrong when
  it was not, and hides the disconnect from the class that owns it. This
  *tightens* the 5 pre-existing capped sites, which previously swallowed
  `Exception`.
- **The single message text.** `invalid JSON`, which is what 187 responses in
  the tree already say against 25 for `invalid JSON body`. The eventual sweep
  therefore changes no prose at all, and per this repo's own error-code
  doctrine the prose is advisory -- the `code` is the contract.

Decoding now matches `request.json()` on both paths (`decode(charset or utf-8)`
then `loads`), so the two differ only in whether the read is bounded and the
declared `charset=` is honoured either way. The uncapped path calls
`request.json()` itself rather than reimplementing it as read-plus-decode: that
is what makes converting a `try: await request.json()` site a genuine drop-in,
with no handler and no existing test harness seeing a different read. An earlier
revision did reimplement it and broke 18 unrelated MagicMock-based tests, which
would have been ~85 harness rewrites during the sweep.

**What this does NOT claim.** It does not make `read_bounded_json` the
dashboard's only body guard. Four siblings survive in the same tree, and the
helper's docstring now names each with its divergence:
`handlers_channel._json_object` (emits the identical `invalid_json` /
`body_not_object` codes but raises `HTTPBadRequest` instead of returning the
response), `handlers/hooks.py::_json_object` (`default_empty=True` collapses a
MALFORMED body to defaults -- the exact defect this PR fixes in
`api_memory_promote`, and its own docstring claims otherwise),
`handlers/session_storage.py::_json_body` (deliberately different and
documented: an empty body is legitimate there), and
`handlers/artifacts.py::_read_json_body` (raises `ArtifactValidationError`,
carries its own cap). Folding or narrowing each is part of the #5587 worklist,
recorded in a comment there -- the PR's own sequencing argument ("sweeping while
two spellings exist bakes the second one in") applies to them too, so the sweep
must not finish while four contracts still diverge.

**Item 2 -- a first tranche, not the sweep.** 14 handlers, chosen by one rule:
*every site that 500s today*. That is all 9 JSON-body sites in `memory.py`
(8 handlers) plus the 6 in `agents.py` with no dict check at all. Sites that
already hand-roll a correct check are behaviour-correct today, and folding them
in would rewrite a third prose spelling (`body must be an object`) for no
behavioural gain -- they ride with the sweep. **The remaining ~65 sites across
~21 files are follow-up work and this PR does not claim them** (hence `Refs`,
not `Closes`).

Two deliberate contract changes inside the tranche, both narrowing a case that
was silently wrong:

- `POST /api/memory/promote` used `except Exception: body = {}`, so a malformed
  body ran the *default* promotion and returned 200. It now answers 400. A
  genuinely bodyless POST still gets the defaults, via `allow_absent=True` --
  "sent nothing" and "sent garbage" are different facts and only the first can
  be defaulted.
- `POST /api/memory/embedding/model` answered `invalid_json` for a non-object
  body; it now answers `body_not_object`, the code the rest of the repo uses for
  that case.

`error-code-baseline.json` is regenerated: `missing_code` 1262 -> 1249
(`agents.py` 58 -> 52, `memory.py` 31 -> 24), matching the 13 code-less error
responses the conversion removed.

## Tests

- `test_read_bounded_json.py` becomes the contract's home: the cap tests it
  already had, plus `TestUncappedReads` (a body 128 KB over the default cap is
  accepted; the shape guard still applies without a cap), `TestAllowAbsent`
  (absent -> `{}`; absent without the opt-in -> 400; **present but malformed ->
  still 400**), and `TestDecodeContract` -- charset honoured, unknown charset
  400, undecodable bytes 400, RecursionError 400, transport error propagates.
  The decode cases are parametrized over `max_bytes=[64 KB, None]`, so the two
  read paths are proven to answer identically rather than assumed to.
- `test_json_object_body_guard.py` (new) enumerates the 6 converted `agents.py`
  handlers x 6 non-object payloads and asserts 400 `body_not_object`, plus the
  other half of the contract (bad bytes stay `invalid_json`, so a guard that
  answered `body_not_object` for everything could not pass). It is written as the
  ratchet for the rest of the sweep: a later tranche adds rows.
- `TestNonObjectBodiesAcrossConvertedHandlers` does the same for the 9
  `memory.py` handlers.
- The two knowledge boundary tests that called `_json_object_body` directly are
  retired, not deleted-and-forgotten: their subject moved to `_shared`, and a
  comment at the old site points at the module that now owns them.
- `test_embedding_model_apply.py`'s structural test asserted
  `"isinstance(body, dict)" in inspect.getsource(handler)`. Its stated intent --
  "guard against a refactor that only special-cases lists" -- still holds, so it
  is re-expressed against the new structure: the handler consults the guard
  before its first `.get()`, and the guard is a general dict check.

- `_CAP_REGISTER` in `test_json_object_body_guard.py` records every
  `read_bounded_json` call site's cap decision with a reason drawn from a
  documented set, and four tests check the register against an AST scan of the
  tree: an unregistered conversion fails, a declared cap that disagrees with what
  the handler passes fails, an undocumented reason fails, and a row that outlives
  its call site fails. A fifth asserts the bounded read still has at least 5 live
  consumers, so the sweep cannot quietly turn the cap into an opt-in nobody
  exercises.

**Mutation-verified.** 12 mutants, each caught by the test that claims it:
`allow_absent` early-return removed; `LookupError` dropped from the catch; catch
widened back to `Exception`; `max_bytes=None` falling back to the cap; shape
guard removed; charset ignored on the capped path; `promote` losing
`allow_absent`; `promote` tolerating a malformed body again; plus the four register mutants
(dropped row, mis-declared cap, undocumented reason, stale row).

**Red on base.** Reverting `agents.py` to `main` turns all 42 cases in the new
module red with `AttributeError: 'list' object has no attribute 'get'`; reverting
`memory.py` turns all 54 memory cases red the same way. That is the reported 500,
reproduced mechanically.

929 targeted tests pass across the 17 affected modules (the helper, the tranche,
the 5 pre-existing capped call sites, the knowledge suites, and the error-code
contract gate). isort, flake8, black gate and mypy clean on every touched file;
mypy's 2 remaining errors are pre-existing in `transcribe.py`, untouched here.

## Manual verification

N/A -- no user-visible surface changes. The behaviour is HTTP status and response
body on malformed input, which the tests assert directly at the handler and
helper boundaries, including the two intentional contract narrowings.

## Other suggestions

- The remaining ~65 unshaped sites are a per-file conversion -- mechanical in
  the edit, NOT in the cap decision, which `_CAP_REGISTER` now forces each one
  to state and checks against the code. Worth
  doing per-file with the new module as the ratchet. `messaging.py` (10),
  `chat_handlers.py` (12), `taskrunner.py` (11), `chat_tags.py` (6) and
  `chat_folders.py` (5) are the largest clusters; `cron.py` hand-rolls the
  isinstance check twice and can drop it.
- `import_bundle` still has no byte ceiling. That is unchanged by this PR and
  deliberately so, but it remains an open memory-pressure surface and now needs
  only a number.
- The prose is still English generated in Python. `read_bounded_json` being the
  single producer for these three responses makes it the natural place to start
  the Track B work `test_error_code_contract.py` describes.

Refs #5587

