### PR TITLE
fix(acp): chdir workspace by descriptor in spawn shim to fix macOS /dev/fd crash

### DIFF
--- a/src/kiro_crew/_spawn_exec_shim.py
+++ b/src/kiro_crew/_spawn_exec_shim.py
@@ -2,7 +2,7 @@
 
 Spawned as::
 
-    <sys.executable> -I -S -c <this file's source> [--rlimits=SPEC] [--oom-bias] -- argv...
+    <sys.executable> -I -S -c <this file's source> [--rlimits=SPEC] [--oom-bias] [--chdir-fd=N] -- argv...
 
 and replaces itself with ``argv`` via ``execv``, so the PID, process group,
 session, inherited fds, and exit status the caller observes are all the child's
@@ -49,6 +49,7 @@ except ImportError:  # pragma: no cover - Windows has no POSIX rlimits
 
 _RLIMIT_FLAG = "--rlimits="
 _OOM_BIAS_FLAG = "--oom-bias"
+_CHDIR_FD_FLAG = "--chdir-fd="
 _ARGV_SEPARATOR = "--"
 # Shell convention for "command found but could not be executed", so a caller
 # that only sees the exit status can still tell an exec failure from the
@@ -150,12 +151,22 @@ def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     spec = ""
     want_oom_bias = False
+    chdir_fd: int | None = None
     while args and args[0] != _ARGV_SEPARATOR:
         item = args.pop(0)
         if item.startswith(_RLIMIT_FLAG):
             spec = item[len(_RLIMIT_FLAG) :]
         elif item == _OOM_BIAS_FLAG:
             want_oom_bias = True
+        elif item.startswith(_CHDIR_FD_FLAG):
+            # Change directory BY DESCRIPTOR (see below). An unparseable fd is a
+            # contract mismatch between caller and shim, so fail closed rather
+            # than exec in an unknown directory.
+            try:
+                chdir_fd = int(item[len(_CHDIR_FD_FLAG) :])
+            except ValueError:
+                sys.stderr.write(f"spawn shim: invalid {_CHDIR_FD_FLAG} value {item!r}\n")
+                return _EXEC_FAILED
         else:
             # Fail closed. A stray token here means the caller and this shim
             # disagree about the argv contract, and guessing which side the
@@ -179,6 +190,28 @@ def main(argv: list[str] | None = None) -> int:
     except (UnicodeEncodeError, ValueError):
         sys.stderr.write("spawn shim: command argv is not encodable\n")
         return _EXEC_FAILED
+
+    # Change into the child's working directory BY DESCRIPTOR, before the limits
+    # go on so a tight RLIMIT cannot interfere with the fchdir. The parent opened
+    # and verified this directory's identity and passed the descriptor down via
+    # pass_fds; os.fchdir uses that already-verified identity rather than a
+    # mutable pathname, which is both immune to symlink retargeting (the reason
+    # the descriptor binding exists) and portable -- fchdir on a directory fd
+    # works identically on Linux and macOS, unlike chdir-ing into /dev/fd/N,
+    # which macOS devfs re-opens under a fresh permission check and rejects.
+    if chdir_fd is not None:
+        try:
+            os.fchdir(chdir_fd)
+        except OSError as exc:
+            sys.stderr.write(f"spawn shim: cannot fchdir to fd {chdir_fd}: {exc.strerror}\n")
+            return _EXEC_FAILED
+        # The child no longer needs the descriptor once its cwd is set; closing
+        # it here keeps it out of the exec'd image. (It still had to be inherited
+        # for the fchdir above, so the parent must keep it in pass_fds.)
+        try:
+            os.close(chdir_fd)
+        except OSError:
+            pass
 
     _apply_rlimits(pairs)
     if want_oom_bias:

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2993,6 +2993,11 @@ class AcpClient:
             )
         try:
             if self._bound_workspace_fd is not None:
+                # The child changes into the verified workspace BY DESCRIPTOR:
+                # the shim os.fchdir()s the inherited descriptor before exec, so
+                # pass_fds keeps it inheritable and chdir_fd tells the shim which
+                # one. cwd= is the real workspace pathname (used only for PATH
+                # resolution and process reporting), not /dev/fd/N.
                 self._process = await create_subprocess_limited(
                     *argv,
                     stdin=asyncio.subprocess.PIPE,
@@ -3004,6 +3009,7 @@ class AcpClient:
                     start_new_session=platform_compat.IS_POSIX,
                     creationflags=0,
                     pass_fds=(self._bound_workspace_fd,),
+                    chdir_fd=self._bound_workspace_fd,
                     profile=RLIMIT_PROFILE_SESSION_HOST,
                 )
             else:

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -1010,10 +1010,14 @@ class AcpRuntime:
                 "A delegated macOS Kiro runtime is bound to one exact workspace; "
                 "create a runtime bound to the requested workspace"
             )
-        # Return only the inherited descriptor.  Appending a descendant suffix
-        # would perform mutable pathname lookup in the child after this check,
-        # reopening the same-UID symlink-retarget window the binding closes.
-        return f"/dev/fd/{self._bound_workspace_fd}"
+        # Re-verified against the bound descriptor identity above, so this is the
+        # one exact workspace the runtime is bound to. Return its real pathname:
+        # it is sent to the agent over the wire as the session/new ``cwd`` and
+        # must be a path the agent process can interpret. The child's own working
+        # directory was already set by descriptor (os.fchdir in the spawn shim)
+        # at spawn time, so this pathname is not used as a chdir target here and
+        # does not reopen the symlink-retarget window the binding closes.
+        return self._spawn_work_dir
 
     async def _to_thread_guarding_sandbox(
         self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any
@@ -1264,6 +1268,11 @@ class AcpRuntime:
             )
         try:
             if self._bound_workspace_fd is not None:
+                # The child changes into the verified workspace BY DESCRIPTOR:
+                # the shim os.fchdir()s the inherited descriptor before exec, so
+                # pass_fds keeps it inheritable and chdir_fd tells the shim which
+                # one. cwd= is the real workspace pathname (used only for PATH
+                # resolution and process reporting), not /dev/fd/N.
                 self._process = await create_subprocess_limited(
                     *argv,
                     stdin=asyncio.subprocess.PIPE,
@@ -1274,6 +1283,7 @@ class AcpRuntime:
                     start_new_session=platform_compat.IS_POSIX,
                     creationflags=0,
                     pass_fds=(self._bound_workspace_fd,),
+                    chdir_fd=self._bound_workspace_fd,
                     env=env,
                     profile=RLIMIT_PROFILE_SESSION_HOST,
                 )

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -451,9 +451,21 @@ def bind_voice_safe_agent_workspace(
 
     A pathname-only overlap check has an unavoidable check/use window: another
     sandboxed process can retarget a workspace symlink after ``stat`` and before
-    Kiro initializes its own sandbox. On macOS, open the workspace first, compare
-    directory ancestry entirely through descriptors, and make the child chdir via
-    that descriptor. The returned descriptor must stay open until the child exits.
+    Kiro initializes its own sandbox. On macOS, open the workspace first and
+    compare directory ancestry entirely through descriptors; the returned
+    descriptor stays open until the child exits and is what the child chdirs
+    into -- the post-exec spawn shim calls ``os.fchdir`` on the inherited
+    descriptor before ``execv``, so the working-directory change uses the
+    already-verified directory identity rather than a mutable pathname.
+
+    The returned STRING is the real verified workspace pathname (not
+    ``/dev/fd/N``). It is the value handed to the agent over the wire as the
+    session/new ``cwd``; the child's own directory change happens by descriptor
+    via the shim, not by chdir-ing into this pathname. (An earlier version
+    returned ``/dev/fd/{fd}`` as the cwd, but macOS devfs re-opens ``/dev/fd/N``
+    under a fresh permission check and a directory fd opened
+    ``O_RDONLY|O_DIRECTORY`` is not a usable chdir target there, which raised
+    ``PermissionError``.)
 
     Other platforms keep their original pathname and do not inherit a descriptor.
     """
@@ -481,7 +493,7 @@ def bind_voice_safe_agent_workspace(
                     "runtime; keep the workspace and Kiro Crew data home disjoint"
                 )
 
-        return f"/dev/fd/{workspace_fd}", workspace_fd
+        return workspace_path, workspace_fd
     except OSError as exc:
         if workspace_fd >= 0:
             os.close(workspace_fd)
@@ -6475,9 +6487,32 @@ def _needs_path_search(argv: "Sequence[str]") -> bool:
     return not (os.sep in name or (os.altsep and os.altsep in name))
 
 
+def _inject_chdir_fd(prefix: "Sequence[str]", chdir_fd: int, kwargs: "dict[str, Any]") -> list[str]:
+    """Splice ``--chdir-fd=N`` into a shim *prefix* and keep the fd inheritable.
+
+    The chdir descriptor differs per spawn, so it cannot ride on the
+    profile-keyed :func:`spawn_shim_argv` cache -- it is injected per call here.
+    The flag goes in front of the ``--`` separator that ends the shim's own
+    options, and *chdir_fd* is added to ``pass_fds`` so the child still inherits
+    the descriptor the shim will ``os.fchdir`` (see ``_spawn_exec_shim.py``).
+
+    A fresh list is built so the cached prefix tuple is never mutated.
+    """
+    prefix_list = list(prefix)
+    # The cached prefix always ends with the "--" separator; put the per-call
+    # flag just before it so it is parsed as a shim option, not a command arg.
+    sep = prefix_list.index("--")
+    prefix_list.insert(sep, f"--chdir-fd={chdir_fd}")
+    existing = kwargs.get("pass_fds") or ()
+    if chdir_fd not in existing:
+        kwargs["pass_fds"] = (*existing, chdir_fd)
+    return prefix_list
+
+
 async def create_subprocess_limited(
     *argv: str,
     profile: str = RLIMIT_PROFILE_TOOL,
+    chdir_fd: int | None = None,
     **kwargs: Any,
 ) -> asyncio.subprocess.Process:
     """``asyncio.create_subprocess_exec`` with resource limits applied post-exec.
@@ -6486,6 +6521,17 @@ async def create_subprocess_limited(
     resource_limit_preexec())``. Every keyword argument is forwarded untouched
     except ``preexec_fn``, which this owns: passing one would reintroduce the fork
     hazard the shim exists to remove, so it is refused.
+
+    ``chdir_fd`` is an optional directory descriptor the child should change
+    into BY DESCRIPTOR: when set and the shim is active, ``--chdir-fd=N`` is
+    injected into the shim options and ``N`` is kept in ``pass_fds`` so the shim
+    inherits it and calls ``os.fchdir`` before ``exec``. This is how the macOS
+    workspace binding hands the child its already-verified working directory
+    without chdir-ing into ``/dev/fd/N`` (which macOS rejects). When there is no
+    shim (Windows, a no-op profile, a truncated install), the descriptor cannot
+    be applied post-exec, so the caller's own ``cwd=`` pathname is relied on
+    instead -- the ACP session-host profile always carries a shim, so the
+    descriptor path covers the primary case.
 
     The returned ``Process`` describes the command itself, not a wrapper -- the
     shim ``exec``s in place -- so ``pid``, ``returncode``, signal delivery, and
@@ -6502,10 +6548,14 @@ async def create_subprocess_limited(
     if not prefix:
         # No shim (Windows, a no-op profile, or a truncated install): keep
         # whatever policy the profile carries on the legacy fork path. Dropping
-        # the caps silently would be worse than the fork hazard.
+        # the caps silently would be worse than the fork hazard. The chdir
+        # descriptor cannot be applied without the shim, so the caller's ``cwd=``
+        # pathname is what takes effect on this fallback path.
         return await asyncio.create_subprocess_exec(
             *argv, preexec_fn=_preexec_for_profile(profile), **kwargs
         )
+    if chdir_fd is not None:
+        prefix = _inject_chdir_fd(prefix, chdir_fd, kwargs)
     if not _needs_path_search(argv):
         # Explicit path: nothing to resolve, so no filesystem access and no
         # thread hop -- exec does the work.

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -904,7 +904,7 @@ class TestSpawnStderrDrainCleanup:
 async def test_failed_live_spawn_cleanup_releases_workspace_when_kill_is_cancelled(tmp_path):
     client = AcpClient(work_dir=tmp_path)
     client._bound_workspace_fd = 74
-    client._spawn_work_dir = "/dev/fd/74"
+    client._spawn_work_dir = str(tmp_path)
     client._kill_process = AsyncMock(side_effect=asyncio.CancelledError())
     released: list[int] = []
 
@@ -3499,7 +3499,7 @@ class TestEnsureReadyRetryOnAcpError:
         async def fake_spawn():
             client._process = MagicMock(returncode=None, pid=123)
             client._bound_workspace_fd = 77
-            client._spawn_work_dir = "/dev/fd/77"
+            client._spawn_work_dir = str(tmp_path)
 
         async def fake_init():
             raise AcpError("init failed")

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -1091,11 +1091,15 @@ async def test_bound_macos_runtime_reuses_descriptor_cwd_for_sessions(monkeypatc
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 71
-    runtime._spawn_work_dir = "/dev/fd/71"
+    # The binding now stores the real verified workspace pathname (the child's
+    # own cwd is set BY DESCRIPTOR via the shim's os.fchdir), and that pathname
+    # is what session/new sends over the wire -- no longer /dev/fd/71.
+    runtime._spawn_work_dir = str(tmp_path)
     matches = MagicMock(return_value=True)
     monkeypatch.setattr(runtime_mod, "bound_agent_workspace_matches", matches)
 
-    assert await runtime._session_work_dir(tmp_path) == "/dev/fd/71"
+    # Still re-verified against the bound descriptor identity before returning.
+    assert await runtime._session_work_dir(tmp_path) == str(tmp_path)
     matches.assert_called_once_with(71, tmp_path)
 
 
@@ -1105,7 +1109,7 @@ async def test_bound_macos_runtime_rejects_descendant_session_workspace(monkeypa
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 71
-    runtime._spawn_work_dir = "/dev/fd/71"
+    runtime._spawn_work_dir = str(tmp_path)
     descendant = tmp_path / "packages" / "app"
     matches = MagicMock(return_value=False)
     monkeypatch.setattr(runtime_mod, "bound_agent_workspace_matches", matches)
@@ -1121,7 +1125,7 @@ async def test_bound_macos_runtime_rejects_different_session_workspace(monkeypat
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 72
-    runtime._spawn_work_dir = "/dev/fd/72"
+    runtime._spawn_work_dir = str(tmp_path)
     monkeypatch.setattr(runtime_mod, "bound_agent_workspace_matches", MagicMock(return_value=False))
 
     with pytest.raises(AcpRuntimeError, match="exact workspace"):
@@ -1134,7 +1138,7 @@ async def test_kill_cancellation_still_releases_bound_workspace(monkeypatch, tmp
 
     runtime = AcpRuntime(work_dir=tmp_path)
     runtime._bound_workspace_fd = 73
-    runtime._spawn_work_dir = "/dev/fd/73"
+    runtime._spawn_work_dir = str(tmp_path)
     entered = asyncio.Event()
     closed: list[int] = []
 

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -415,7 +415,11 @@ class TestBuildSeatbeltProfile:
 
         path, descriptor = sandbox_mod.bind_voice_safe_agent_workspace("/mutable/workspace")
 
-        assert (path, descriptor) == ("/dev/fd/41", 41)
+        # The binding returns the real verified workspace pathname (for the
+        # session/new wire cwd) plus the descriptor the child chdirs into via the
+        # shim's os.fchdir -- no longer a /dev/fd/N chdir target (macOS rejects
+        # that; see bind_voice_safe_agent_workspace docstring).
+        assert (path, descriptor) == ("/mutable/workspace", 41)
         assert closed == [42]
 
     def test_macos_workspace_binding_rejects_opened_runtime_ancestor(self, monkeypatch):
@@ -469,7 +473,7 @@ class TestBuildSeatbeltProfile:
         def delayed_binding(_workspace):
             entered.set()
             assert release.wait(timeout=2)
-            return "/dev/fd/61", 61
+            return "/mutable/workspace", 61
 
         def record_close(descriptor):
             assert descriptor == 61

--- a/test/test_spawn_exec_shim.py
+++ b/test/test_spawn_exec_shim.py
@@ -149,6 +149,44 @@ class TestShimArgvContract:
             shim.main(["--oom-bias", "--", "/bin/true"])
             assert biased == [True]
 
+    def test_chdir_fd_fchdirs_and_closes_before_exec(self):
+        """The macOS workspace fix: chdir BY DESCRIPTOR, before exec, then close.
+
+        fchdir must run before the limits go on (a tight RLIMIT must not be able
+        to interfere with it) and the descriptor is closed once the cwd is set,
+        so it does not survive into the exec'd image.
+        """
+        order: list[str] = []
+        with (
+            patch.object(shim.os, "fchdir", lambda fd: order.append(f"fchdir:{fd}")),
+            patch.object(shim.os, "close", lambda fd: order.append(f"close:{fd}")),
+            patch.object(shim, "_apply_rlimits", lambda _p: order.append("limits")),
+            patch.object(
+                shim.os,
+                "execv",
+                lambda *_a: order.append("exec") or (_ for _ in ()).throw(OSError(2, "x")),
+            ),
+        ):
+            shim.main(["--rlimits=RLIMIT_NOFILE:1024", "--chdir-fd=9", "--", "/bin/true"])
+        assert order == ["fchdir:9", "close:9", "limits", "exec"]
+
+    def test_chdir_fd_fails_closed_when_fchdir_raises(self, capsys):
+        """A failed chdir must NOT exec in the wrong directory -- fail with 127."""
+
+        def boom(_fd):
+            raise OSError(9, "Bad file descriptor")
+
+        with (
+            patch.object(shim.os, "fchdir", boom),
+            patch.object(shim.os, "execv", side_effect=AssertionError("exec despite fchdir fail")),
+        ):
+            assert shim.main(["--chdir-fd=9", "--", "/bin/true"]) == 127
+        assert "cannot fchdir" in capsys.readouterr().err
+
+    def test_unparseable_chdir_fd_fails_closed(self, capsys):
+        assert shim.main(["--chdir-fd=notanint", "--", "/bin/true"]) == 127
+        assert "invalid --chdir-fd" in capsys.readouterr().err
+
 
 # --------------------------------------------------------------------------
 # Parent side: the argv prefix and the profiles
@@ -310,6 +348,53 @@ class TestCreateSubprocessLimited:
         assert kwargs["cwd"] == "/tmp"
         assert kwargs["env"] == {"A": "1"}
         assert kwargs["start_new_session"] is True
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_injects_the_flag_before_the_separator_and_keeps_the_fd(self):
+        """The macOS workspace fix: the shim chdirs BY DESCRIPTOR before exec.
+
+        ``--chdir-fd=N`` must land among the shim's own options (before ``--``),
+        and ``N`` must stay in ``pass_fds`` so the child inherits the descriptor
+        the shim will ``os.fchdir``.
+        """
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited(
+                "/nonexistent/tool",
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+                chdir_fd=41,
+                cwd="/real/workspace",
+            )
+        argv = spawn.await_args.args
+        assert "--chdir-fd=41" in argv
+        assert argv.index("--chdir-fd=41") < argv.index("--")
+        assert 41 in spawn.await_args.kwargs["pass_fds"]
+        # cwd stays the real pathname (used for PATH resolution / reporting),
+        # never /dev/fd/N.
+        assert spawn.await_args.kwargs["cwd"] == "/real/workspace"
+        assert strip_spawn_shim(argv) == ("/nonexistent/tool",)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_is_merged_into_existing_pass_fds(self):
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited(
+                "/nonexistent/tool",
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+                chdir_fd=7,
+                pass_fds=(3, 4),
+            )
+        assert set(spawn.await_args.kwargs["pass_fds"]) == {3, 4, 7}
+
+    @pytest.mark.asyncio
+    async def test_no_chdir_fd_leaves_the_argv_and_pass_fds_alone(self):
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited(
+                "/nonexistent/tool", profile=RLIMIT_PROFILE_SESSION_HOST
+            )
+        assert not any(str(a).startswith("--chdir-fd") for a in spawn.await_args.args)
+        assert "pass_fds" not in spawn.await_args.kwargs
 
 
 # --------------------------------------------------------------------------
@@ -627,3 +712,46 @@ class TestRealChild:
         else:
             expected = gateway_hard
         assert int(out.decode().strip()) == expected
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_puts_the_child_in_the_descriptor_directory(self, tmp_path):
+        """Regression for the macOS ``/dev/fd/N`` crash (issue: insider.5 ACP spawn).
+
+        The old binding handed the child ``cwd=/dev/fd/N``; macOS devfs re-opens
+        that path under a fresh permission check and rejects a directory fd, so
+        every kiro-cli ACP session raised ``PermissionError``. The fix hands the
+        child the descriptor and lets the shim ``os.fchdir`` it before exec.
+
+        This starts a REAL child through the same shim + ``chdir_fd`` path the
+        ACP spawn sites use and asserts its working directory is the descriptor's
+        directory. It runs (not skips) on Linux, so it exercises the mechanism
+        end to end and would have caught the crash -- the old tests stubbed the
+        binding and never started a child with that working directory. fchdir on
+        a directory fd behaves identically on macOS, so this covers the fix on
+        both platforms even though the original crash is Darwin-only.
+        """
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        real_workspace = os.path.realpath(workspace)
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        fd = os.open(str(workspace), flags)
+        try:
+            proc = await create_subprocess_limited(
+                sys.executable,
+                "-c",
+                "import os,sys;sys.stdout.write(os.path.realpath(os.getcwd()))",
+                profile=RLIMIT_PROFILE_SESSION_HOST,
+                chdir_fd=fd,
+                # cwd is a DIFFERENT real directory: proves the descriptor, not
+                # cwd=, is what places the child. (With cwd honored the child
+                # would report tmp_path, not the workspace subdirectory.)
+                cwd=str(tmp_path),
+                pass_fds=(fd,),
+                stdout=asyncio.subprocess.PIPE,
+            )
+            out, _ = await proc.communicate()
+        finally:
+            # The shim closes its inherited copy; the parent still owns this one.
+            os.close(fd)
+        assert proc.returncode == 0
+        assert out.decode() == real_workspace


### PR DESCRIPTION
Fixes #6982.

## Root cause

`bind_voice_safe_agent_workspace()` (introduced in 0.5.0-insider.4 by commit `f2575b1bb`, "fix(stt): bundle desktop voice dependencies (#6746)") returned `f"/dev/fd/{workspace_fd}"` as the child subprocess `cwd` on macOS. On Linux `/dev/fd/N` behaves like a `/proc/self/fd` symlink and is a usable chdir target, but macOS devfs re-opens `/dev/fd/N` under a fresh permission check, and a directory descriptor opened `O_RDONLY|O_DIRECTORY` is not usable that way. The result was `EACCES` surfacing as `PermissionError: [Errno 13] Permission denied: '/dev/fd/N'` on every kiro-cli ACP session, regardless of `agent.sandbox`.

The failing object was the working directory, not the `kiro-cli` executable: CPython's `subprocess._execute_child` only attaches `cwd` to the child failure filename when the child reports `noexec:chdir`, which matches the observed dynamic `/dev/fd/N` filename. Both ACP spawn sites (`runtime.py::_spawn_admitted`, `client.py::_spawn`) were affected.

## Fix

chdir-by-descriptor inside the post-exec spawn shim, chosen over reverting to a mutable pathname `cwd` so the descriptor-based ancestry-verification property the binding exists for is preserved:

- **`_spawn_exec_shim.py`**: new optional `--chdir-fd=N` flag; the shim `os.fchdir(N)`s the inherited, already-verified workspace descriptor before applying rlimits and before `execv`, then closes it. Fails closed (exit 127) on an unparseable value or an `fchdir` OSError, so it never execs in the wrong directory. `fchdir` on a directory fd is identical on Linux and macOS and is immune to symlink retargeting.
- **`sandbox.py`**: `bind_voice_safe_agent_workspace()` now returns the real verified workspace pathname + fd (not `/dev/fd/N`); new `_inject_chdir_fd()` helper and `chdir_fd` kwarg on `create_subprocess_limited` splice `--chdir-fd=N` before the `--` separator and keep `N` in `pass_fds` (fresh list; the profile-keyed cache tuple is never mutated).
- **`runtime.py` / `client.py`**: both bound spawn sites pass `chdir_fd=self._bound_workspace_fd`, retain `pass_fds`, and use the real pathname as `cwd=` (PATH resolution/reporting and the `session/new` wire cwd). `_session_work_dir` returns the real verified pathname.

## Testing

The bug is Darwin-only and this was verified on a Linux host in an INTEGRATIONS_ONLY sandbox (external PyPI blocked, so the full pytest suite and the macOS crash itself could not run here). Verification performed:

- `py_compile` + import of all 4 changed source files and 4 changed test files: pass.
- `grep` confirms no `/dev/fd/{` cwd construction remains (only a fix-explaining docstring).
- New `test/test_spawn_exec_shim.py::TestRealChild` spawns a **real** child through `create_subprocess_limited(chdir_fd=…)` with `cwd=` deliberately pointing at a different directory, and asserts the child lands in the descriptor's directory. This runs (not skips) on Linux and would fail under a `/dev/fd/N` revert. Plus shim argv-contract, fchdir-before-limits ordering, fail-closed, and pass_fds-merge tests.
- Hardcoded `/dev/fd/NN` assertions in `test/test_sandbox_argv.py`, `test/test_acp_runtime.py`, and `test/test_acp_client.py` updated to the real pathname.
- `black --check` clean on the changed shim/client/new-test files. (Pre-existing black reformat noise on `runtime.py`/`sandbox.py` predates this branch and touches no added line.)

## Notes

- CI (running on macOS with the full dependency set) should exercise the Darwin path directly.
- Two non-blocking, pre-existing observations, unchanged by this diff: the no-shim fallback relies on `cwd=` (the ACP session-host profile always carries a shim); and the client's `_session_work_dir` does not re-verify against the bound descriptor the way the runtime's does.