### PR TITLE
fix(pod): prove the health responder is this pod before reporting it up

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -224,8 +224,20 @@ Relies on `kiro_crew.pod` subpackage (optional import — degrades gracefully if
 
 - `runtime.active_names(cfg)` — systemctl list (blocking, offloaded via `run_in_executor`)
 - `runtime.derive_port(cfg, name)` — cksum-based port derivation (blocking, offloaded)
-- `runtime.health(port, timeout)` — HTTP probe (blocking, offloaded)
-- `runtime.mint_token(cfg, name, ttl)` — token minting (blocking, offloaded)
+- `runtime.health(cfg, name, port, timeout)` — identity-gated HTTP probe (blocking,
+  offloaded). Takes the pod's NAME, not just its port, because a derived port is
+  routinely held by another pod or by the live gateway: `port_owner` requires the
+  process a `127.0.0.1` connect reaches to be this pod's own `MainPID`, and a
+  responder that is provably somebody else's returns `HEALTH_FOREIGN` (`-2`)
+  instead of its HTTP status. The fleet row treats that as unhealthy, since the
+  frontend's `health >= 200` test already excludes a negative value. There is
+  deliberately no bare-port variant to call — see `instances/run_marker`, which
+  states the rule ("no caller can mistake reachability for identity")
+- `runtime.mint_token(cfg, name, ttl)` — credential minting (blocking, offloaded).
+  Requires POSITIVE ownership proof and refuses when ownership is merely
+  unprovable, unlike `health`, which keeps its reading: this call sends the pod's
+  own `.local_secret`, so failing open would hand a credential to whatever
+  answered
 - `runtime.recent_journal(cfg, name, n)` — journalctl tail (blocking, offloaded)
 - `provision.has_venv(path)` / `provision.has_dist(path)` — filesystem checks (offloaded)
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -3078,8 +3078,15 @@ async def _build_fleet() -> dict:
                     port = await loop.run_in_executor(
                         subprocess_executor(), rt.derive_port, cfg, name
                     )
+                    # Identity-gated: ``rt.health`` takes the pod NAME as well as
+                    # the port because a derived port can be held by another pod
+                    # or by the live gateway, and a bare port probe would report
+                    # that squatter's 200 as this worktree's health — the row
+                    # would show a healthy dot for a pod that never bound its
+                    # port. A foreign responder comes back as
+                    # ``rt.HEALTH_FOREIGN`` and renders as unhealthy.
                     health = await loop.run_in_executor(
-                        subprocess_executor(), rt.health, port, 2
+                        subprocess_executor(), rt.health, cfg, name, port, 2
                     )
             except Exception:  # noqa: BLE001
                 pass

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -105,8 +105,14 @@ green). Flags:
 1. **up** — `kirocrew pod up <wt> --json`. If already active, reuses it (and
    won't stop it on exit). Boots the worktree's own gateway with `--no-crons`,
    blank-seed DB, isolated HOME.
-2. **health** — polls `base_url/api/health` until 200/401/403 (≤45s). On timeout
-   it dumps logs to `boot-fail.log` and aborts.
+2. **health** — polls `kirocrew pod status <wt> --json` until its `health` is
+   200/401/403 (≤60s). Deliberately not a bare `curl base_url/api/health`: a
+   derived port is routinely held by another pod or by the live gateway, every
+   gateway answers that path identically, so a 200 there proves only that
+   *something* is listening. `pod status` reports the pod's OWN health and returns
+   `-2` when the responder is provably somebody else's, which this phase reports
+   as a port conflict naming `PORT=`. On timeout it dumps logs to `boot-fail.log`
+   and aborts.
 3. **auth** — proves auth: `/api/sessions` → 200 with token, 403 without.
    Token comes from `kirocrew pod up --json` output (no manual minting needed).
 4. **API tests** — runs the fixed command `python -m pytest -q` with cwd=the

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -281,18 +281,60 @@ if [ "$PORT" = "5476" ] || [ "$PORT" = "7777" ]; then
 fi
 
 # ---------------------------------------------------------------- health --
-log "waiting for health on $BASE_URL ..."
+# Identity-gated, deliberately NOT a bare probe of base_url. A pod's port is
+# derived from its name across 199 slots and can be pinned by hand, so it is
+# routinely held by another pod or by the live gateway -- and every Kiro Crew
+# gateway answers /api/health with the same body, so a 200 from that port proves
+# only that SOMETHING is there. `pod status --json` reports the pod's OWN health:
+# the HTTP code when the process a 127.0.0.1 connect reaches is this pod's own
+# gateway, 0 when nothing answers, and -2 when the responder is provably somebody
+# else's. Curling base_url here would accept a stranger's 200 and hand every
+# later phase -- auth, API tests, Playwright, the artifacts -- a pod this run
+# never booted.
+log "waiting for health on $NAME ($BASE_URL) ..."
 HEALTHY=0
-for i in $(seq 1 45); do
-  CODE=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/api/health" 2>/dev/null || echo "000")
-  if [ "$CODE" = "200" ] || [ "$CODE" = "401" ] || [ "$CODE" = "403" ]; then
-    HEALTHY=1; break
-  fi
+FOREIGN=0
+# Overridable so a slow host can wait longer, and so the phase is drivable in a
+# test without sitting out the real deadline. Validated as 1-6 plain decimal
+# digits BEFORE any arithmetic, and read with an explicit 10# base, because a
+# plain typo in this env var otherwise breaks the run three different ways:
+#   abc    -> inside $(( )) bash reads it as a variable NAME; under `set -u`
+#             that is "abc: unbound variable" and the run dies (exit 127).
+#   08     -> a leading zero means octal, and 08 is not valid octal:
+#             "value too great for base", the run dies (exit 1).
+#   1e24   -> no error at all: the deadline lands centuries out and the poll
+#             never gives up. For an unattended harness a silent hang is worse
+#             than a crash, which is what the 6-digit cap (~11 days) closes.
+# All three die or hang BEFORE any verdict or the summary is printed, so the
+# value is normalized here rather than trusted at the point of use.
+HEALTH_TIMEOUT="${POD_E2E_HEALTH_TIMEOUT:-60}"
+case "$HEALTH_TIMEOUT" in
+  ''|*[!0-9]*) HEALTH_TIMEOUT="" ;;
+esac
+if [ -z "$HEALTH_TIMEOUT" ] || [ "${#HEALTH_TIMEOUT}" -gt 6 ]; then
+  echo "pod-e2e: ignoring POD_E2E_HEALTH_TIMEOUT='${POD_E2E_HEALTH_TIMEOUT:-}' (want 1-6 decimal digits of seconds); using 60" >&2
+  HEALTH_TIMEOUT=60
+fi
+HEALTH_DEADLINE=$(( $(date +%s) + 10#$HEALTH_TIMEOUT ))
+while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
+  CODE=$("$KIROCREW_CLI" pod status "$NAME" --json 2>/dev/null \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin).get("health",0))' 2>/dev/null \
+    || echo 0)
+  case "$CODE" in
+    200|401|403) HEALTHY=1; break ;;
+    # Keep polling: a predecessor may still be releasing the port. Remembered so
+    # the timeout names the conflict instead of blaming the worktree build.
+    -2)          FOREIGN=1 ;;
+  esac
   sleep 1
 done
 if [ "$HEALTHY" -eq 0 ]; then
   "$KIROCREW_CLI" pod logs "$NAME" -n 50 > "$ARTIFACT_DIR/boot-fail.log" 2>&1 || true
-  fail "health — pod never became healthy (45s timeout, see boot-fail.log)"
+  if [ "$FOREIGN" -eq 1 ]; then
+    fail "health — :$PORT is held by another process, not this pod's gateway; pin a free PORT= for $NAME (see boot-fail.log)"
+  else
+    fail "health — pod never became healthy (${HEALTH_TIMEOUT}s timeout, see boot-fail.log)"
+  fi
 fi
 
 # ---------------------------------------------------------------- auth ----

--- a/src/kiro_crew/pod/README.md
+++ b/src/kiro_crew/pod/README.md
@@ -93,6 +93,16 @@ stop-drain-verify path `down` uses, with liveness re-checked per name).
 `PORT=` is pinned in `~/.kiro/crew/pods/<name>.env`. `pod up` refuses if a derived
 port ever resolves to the live port.
 
+199 slots means a **collision between two pod names is ordinary**, and a pinned
+`PORT=` can land on one deliberately. Whoever binds first wins; the loser's gateway
+exits "address already in use" and its unit crash-loops behind `Restart=on-failure`.
+So reachability on the derived port is never evidence that THIS pod is up: `health`
+and the credential mint both require the process a `127.0.0.1` connect reaches to be
+the pod's own `MainPID` (`port_owner`), and `pod status` / `pod ls` print
+`foreign (port held by another instance)` when it is not. `pod up` names the
+conflict and points at `PORT=` rather than blaming the worktree build. Give a
+colliding pod its own `PORT=` to clear it.
+
 ## Configuration (`PodConfig`, all `KIROCREW_POD_*`-overridable)
 
 | env | default | meaning |

--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -53,25 +53,41 @@ def _die(msg: str) -> NoReturn:
 
 
 def _wait_healthy(cfg: PodConfig, name: str, port: int, tries: int = 45) -> int:
-    """Poll until the pod serves (200/401/403), or bail fast if the unit died.
+    """Poll until the pod itself serves (200/401/403), or bail fast on failure.
 
     Returns the HTTP code on success, or a negative sentinel on early failure:
       -1 = the unit's gateway crashed / is crash-looping (a broken worktree build
            — the thing under test won't boot, so there's nothing to wait for). The
            caller surfaces the gateway's own journal as the cause.
+      ``rt.HEALTH_FOREIGN`` = the port answers, but another process owns it, so
+           this pod's gateway cannot have bound it.
     A pod IS the worktree's gateway, so a dead gateway is a real, expected signal —
     we just want it fast and clearly attributed, not a silent 45s timeout.
+
+    A foreign responder does NOT end the wait on sight. The pod may still be
+    starting, and its own gateway may be moments from winning the port back after
+    a predecessor releases it, so the loop keeps its existing exit conditions.
+    What the flag changes is the ATTRIBUTION: a port already held by somebody else
+    is the reason this pod's gateway is crash-looping, so it is reported ahead of
+    the generic crash verdict, which would otherwise send the operator to read a
+    journal that only says "address already in use".
     """
+    saw_foreign = False
     for _ in range(tries):
-        code = rt.health(port)
+        code = rt.health(cfg, name, port)
         if code in (200, 401, 403):
             return code
+        if code == rt.HEALTH_FOREIGN:
+            saw_foreign = True
         state, restarts = rt.unit_state(cfg, name)
         # failed = exited non-zero and not restarting; restarts>0 = crash-looping.
         if state == "failed" or restarts > 0:
-            return -1
+            return rt.HEALTH_FOREIGN if saw_foreign else -1
         time.sleep(1)
-    return rt.health(port)
+    final = rt.health(cfg, name, port)
+    if final in (200, 401, 403):
+        return final
+    return rt.HEALTH_FOREIGN if (saw_foreign or final == rt.HEALTH_FOREIGN) else final
 
 
 def _resolve_or_die(cfg: PodConfig, name: str) -> Path:
@@ -185,6 +201,27 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
             tail = rt.recent_journal(cfg, name, 30)
             print(tail, file=sys.stderr)
             rt.stop_pod(cfg, name)
+            if code == rt.HEALTH_FOREIGN:
+                # Reported ahead of the crash verdict: the port being taken is
+                # WHY this gateway could not boot, and it is fixed by choosing a
+                # port rather than by debugging the worktree. Without this the
+                # operator reads a journal that only says "address already in
+                # use" — or, before the identity check existed, was told the pod
+                # was up and drove somebody else's instance.
+                _audit(
+                    "pod.up",
+                    "failure",
+                    f"name={name} port={port}",
+                    error="derived port held by another process",
+                )
+                _die(
+                    f"{name}: :{port} is already held by another process (another pod, "
+                    f"or the live gateway), so this pod's gateway could not bind it — "
+                    f"the responder on that port is not this pod.\n"
+                    f"  Which pods hold which ports: kirocrew pod ls\n"
+                    f"  Give this pod its own port:  add PORT=<free port> to "
+                    f"{cfg.env_file(name)}, then `kirocrew pod up {name}` again."
+                )
             if code == -1:
                 _die(
                     f"{name}: the worktree's gateway failed to start (see journal above). "
@@ -195,13 +232,45 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
                 f"(see journal above; check the worktree's gateway start path)."
             )
 
+    # The pod is already booted and healthy by here, so the credential is the
+    # LAST step, not the point of the command. That asymmetry decides how the two
+    # refusals are handled:
+    #
+    # * FOREIGN is positive knowledge that the port is somebody else's, so there
+    #   is nothing truthful left to print — die.
+    # * UNPROVEN is not knowledge. On a POSIX host with no lsof there is no way to
+    #   prove ownership at all, and dying here would boot the pod and then fail
+    #   the command that booted it, turning a hardened credential path into a
+    #   `pod up` that never succeeds on that host class. So report what IS known
+    #   (the pod, its port, its base_url), withhold only the credential, and say
+    #   how to get it. The secret still never goes on the wire — the guard lives
+    #   in `mint_token`, which raised before dialling anything.
+    token = ""
+    unproven = ""
     try:
         token = rt.mint_token(cfg, name, args.ttl)
+    except rt.PodOwnershipUnproven as exc:
+        unproven = str(exc)
+        _audit(
+            "pod.token",
+            "denied",
+            f"name={name} port={port}",
+            error="ownership unprovable; credential withheld",
+        )
     except rt.PodError as exc:
         _audit("pod.token", "failure", f"name={name} port={port}", error="mint failed")
         _die(str(exc))
-    _audit("pod.token", "allowed", f"name={name} port={port} ttl={args.ttl}")
+    if token:
+        _audit("pod.token", "allowed", f"name={name} port={port} ttl={args.ttl}")
     base = f"http://127.0.0.1:{port}"
+    if unproven:
+        # The reason goes to stderr on BOTH paths rather than into the payload. The
+        # empty ``token`` is already the machine-readable signal -- it is what
+        # pod-e2e tests, and it is unambiguous because every other mint failure
+        # exits instead of returning -- so a payload field would add schema surface
+        # that is committed forever for no consumer. stderr reaches a subprocess
+        # caller and a human equally.
+        print(f"pod: {unproven}", file=sys.stderr)
     if args.json:
         print(
             json.dumps(
@@ -218,8 +287,11 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
     else:
         print(f"pod '{name}' is up (full stack: API + frontend on one port)")
         print(f"  base_url : {base}")
-        print(f"  token    : {token}")
-        print(f"  open     : {base}/?token={token}")
+        if token:
+            print(f"  token    : {token}")
+            print(f"  open     : {base}/?token={token}")
+        else:
+            print("  token    : (withheld — ownership of the port could not be proven)")
         print(f"  stop     : kirocrew pod down {name}")
 
 
@@ -277,6 +349,18 @@ def _down(cfg: PodConfig, args: argparse.Namespace) -> None:
         print(f"pod '{name}' was not running (nothing to stop)")
 
 
+def _health_label(code: int) -> str:
+    """Human rendering of a :func:`rt.health` verdict.
+
+    The JSON stays numeric (three callers parse ``pod ls --json``), but a bare
+    ``-2`` on a terminal tells the operator nothing, and "another instance owns
+    this port" is precisely the thing they need to read.
+    """
+    if code == rt.HEALTH_FOREIGN:
+        return "foreign (port held by another instance)"
+    return str(code)
+
+
 def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
     names = sorted(rt.active_names(cfg))
     # Teardown belongs to `pod down` on BOTH platforms, so a pod that went away
@@ -289,7 +373,7 @@ def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
         rows: list[dict[str, object]] = []
         for n in names:
             p = rt.derive_port(cfg, n)
-            rows.append({"name": n, "port": p, "health": rt.health(p)})
+            rows.append({"name": n, "port": p, "health": rt.health(cfg, n, p)})
         print(json.dumps(rows))
         return
     # Any fail-closed probe underneath surfaces as PodError, which the dispatch
@@ -299,7 +383,7 @@ def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
         print(f"{'POD':<28} {'PORT':<7} HEALTH")
         for n in names:
             p = rt.derive_port(cfg, n)
-            print(f"{n:<28} {p:<7} {rt.health(p)}")
+            print(f"{n:<28} {p:<7} {_health_label(rt.health(cfg, n, p))}")
     else:
         print("no pods running")
     _print_orphans(cfg, orphans)
@@ -584,7 +668,7 @@ def _status(cfg: PodConfig, args: argparse.Namespace) -> None:
     name = rt.validate_name(args.name)
     port = rt.derive_port(cfg, name)
     up = rt.is_active(cfg, name)
-    code = rt.health(port) if up else 0
+    code = rt.health(cfg, name, port) if up else 0
     if args.json:
         print(
             json.dumps(
@@ -592,7 +676,7 @@ def _status(cfg: PodConfig, args: argparse.Namespace) -> None:
             )
         )
     else:
-        print(f"{name}: {'up' if up else 'down'}  port={port}  health={code}")
+        print(f"{name}: {'up' if up else 'down'}  port={port}  health={_health_label(code)}")
 
 
 def _token(cfg: PodConfig, args: argparse.Namespace) -> None:

--- a/src/kiro_crew/pod/launchd.py
+++ b/src/kiro_crew/pod/launchd.py
@@ -316,6 +316,36 @@ def is_active(cfg: PodConfig, name: str) -> bool:
     return _PID_RE.search(cp.stdout or "") is not None
 
 
+def main_pid(cfg: PodConfig, name: str) -> int | None:
+    """PID of this pod's own process, or ``None`` when it is not running.
+
+    The launchd counterpart of systemd's ``MainPID``, and the identity
+    ``runtime.port_owner`` compares a port's listener against. ``launchctl
+    print`` reports the live pid of a running agent; a loaded-but-dead agent
+    prints without one.
+
+    Fails the same way :func:`is_active` does, and for the same reason: a label
+    that is simply not loaded is a real answer (``None``), while an OPERATIONAL
+    failure proves nothing and raises. The distinction is load-bearing for the
+    caller — "asked, and this pod has no process" is what lets a listener be
+    attributed to someone else, whereas "could not ask" must stay undecided.
+    """
+    cp = _print(cfg, name)
+    if cp.returncode != 0:
+        if _service_absent(cp):
+            return None
+        raise LaunchdError(
+            f"launchctl print failed (rc={cp.returncode}) for "
+            f"{pod_label(cfg, name)}; cannot tell which process this pod is, "
+            f"refusing to guess: {(cp.stderr or cp.stdout or '').strip()}"
+        )
+    m = _PID_RE.search(cp.stdout or "")
+    if not m:
+        return None
+    pid = int(m.group(1))
+    return pid if pid > 0 else None
+
+
 def unit_state(cfg: PodConfig, name: str) -> tuple[str, int]:
     """``(state, restarts)`` shaped like the systemd backend's return.
 

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -10,6 +10,7 @@ layer. No state is held; each function reads what it needs from a
 from __future__ import annotations
 
 import contextlib
+import http.client
 import json
 import os
 import re
@@ -31,7 +32,14 @@ except ImportError:  # pragma: no cover - Windows
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.loopback_http import loopback_urlopen
-from kiro_crew.platform_compat import IS_LINUX, IS_MACOS
+from kiro_crew.platform_compat import (
+    IS_LINUX,
+    IS_MACOS,
+    IS_POSIX,
+    find_port_listeners,
+    listening_pid_tool_available,
+    loopback_owner_pids,
+)
 from kiro_crew.pod import launchd
 from kiro_crew.pod import provision as prov
 from kiro_crew.pod import unit as unit_mod
@@ -423,6 +431,38 @@ def is_active(cfg: PodConfig, name: str) -> bool:
             raise PodError(str(exc)) from exc
     cp = systemctl("is-active", "--quiet", pod_unit(cfg, name))
     return cp.returncode == 0
+
+
+def main_pid(cfg: PodConfig, name: str) -> int | None:
+    """PID of the pod's OWN gateway process, or ``None`` when it is not running.
+
+    This is the pod's identity, and it is exact rather than approximate because
+    of how a pod boots: the unit is ``Type=simple`` running ``kirocrew pod _run
+    %i``, and :func:`_run` finishes with ``os.execve`` of the worktree's
+    ``kirocrew gateway``. The gateway therefore REPLACES the unit's main process
+    instead of being spawned beneath it, so ``MainPID`` names the very process
+    that binds the pod's port — no descendant walk, no cgroup scan.
+
+    Raises :class:`PodError` when the service manager could not be asked at all.
+    That is deliberately a different answer from ``None``: "asked, and this pod
+    has no process" is a fact a caller can act on (see :func:`port_owner`, where
+    it is what lets a listener be attributed to somebody else), while "could not
+    ask" must leave the question open. ``systemctl show`` prints ``MainPID=0``
+    for a dead or unknown unit and still exits 0, so an output with no
+    ``MainPID`` line at all is the honest signal that the query itself failed.
+    """
+    if IS_MACOS:
+        return launchd.main_pid(cfg, name)
+    cp = systemctl("show", pod_unit(cfg, name), "-p", "MainPID")
+    for ln in cp.stdout.splitlines():
+        if ln.startswith("MainPID="):
+            raw = ln.split("=", 1)[1].strip()
+            pid = int(raw) if raw.isdigit() else 0
+            return pid if pid > 0 else None
+    raise PodError(
+        f"could not read MainPID for pod {name!r} from systemctl "
+        f"(rc={cp.returncode}): {(cp.stderr or cp.stdout or '').strip()}"
+    )
 
 
 def unit_state(cfg: PodConfig, name: str) -> tuple[str, int]:
@@ -926,10 +966,122 @@ def install_backend(cfg: PodConfig) -> tuple[str, subprocess.CompletedProcess | 
     )
 
 
-def health(port: int, timeout: int = 3) -> int:
-    """HTTP status of the pod's /api/health, or 0 if unreachable.
+# --------------------------------------------------------------------------- #
+# Port ownership — WHO answers the pod's port, not merely whether anyone does.
+#
+# A pod's port is derived, not allocated: `base + (cksum(name) % 199) + 1` maps
+# every pod name into 199 slots, and `PORT=` in the per-pod env file can pin any
+# port by hand. So two pods colliding on one port is an ordinary event, and the
+# live gateway is reachable on the same loopback interface. Whoever binds first
+# wins; the loser's gateway exits "address already in use" and the unit
+# crash-loops behind it.
+#
+# A bare `GET /api/health` cannot tell those apart. `{"ok": true}` is the same
+# answer from any Kiro Crew gateway on the host, and its identity fields say
+# `app=kirocrew` plus a version — true of the squatter as well. Reading a 200 as
+# "this pod is up" therefore reports a crash-looping pod as healthy and points
+# the operator's browser at somebody else's instance.
+#
+# `instances/run_marker` states the rule this module was breaking: it
+# "deliberately does not offer a bare 'is something listening' helper, so no
+# caller can mistake reachability for identity". The pod probe is now held to it
+# — the reachability probe is private and every caller goes through `health`.
+# --------------------------------------------------------------------------- #
+#: Proven: the pod's own gateway process holds the port.
+OWNER_POD = "pod"
+#: Proven: something OTHER than this pod holds the port (another pod, the live
+#: gateway, an unrelated process).
+OWNER_FOREIGN = "foreign"
+#: Not decidable on this host — no listener-lookup tool, or the service manager
+#: could not be asked. Callers keep their pre-identity behaviour.
+OWNER_UNPROVEN = "unproven"
 
-    200 = open; 401/403 = serving but gated — all three mean "up".
+#: :func:`health` verdict for a port that answers but is NOT served by this pod.
+#: Negative like ``_wait_healthy``'s crash sentinel, so it can never collide with
+#: an HTTP status or with ``0`` (unreachable).
+HEALTH_FOREIGN = -2
+
+
+class PodOwnershipUnproven(PodError):
+    """Ownership could not be PROVEN either way, so a credential was withheld.
+
+    A distinct type because the two refusals want different handling. A
+    :data:`OWNER_FOREIGN` verdict is positive knowledge that the port belongs to
+    somebody else, and every caller should stop. "Could not prove it" is not that
+    — the pod may well be serving — so a caller whose main job is something other
+    than the credential (``pod up``, which has already booted the pod) can go on
+    and report what it does know, while still never putting the secret on the
+    wire. ``pod token`` has nothing else to do and still fails.
+    """
+
+
+def port_owner(cfg: PodConfig, name: str, port: int) -> str:
+    """Who holds *port*: :data:`OWNER_POD`, :data:`OWNER_FOREIGN`, or
+    :data:`OWNER_UNPROVEN`.
+
+    The proof is pid identity, the same shape ``port_resolution._gateway_owns_port``
+    uses for the live gateway: the process listening on the port must be the pod's
+    own (:func:`main_pid`). Three branches are worth naming.
+
+    **Ownership is scoped to the address the probe talked to.** A port NUMBER can
+    carry several LISTEN sockets on different local addresses, so "some process of
+    ours holds this port" is not the question -- the question is who a
+    ``127.0.0.1`` connect reaches. ``loopback_owner_pids`` answers exactly that,
+    mirroring the kernel's most-specific-bind dispatch. Taking every pid on the
+    port instead would let a pod bound to one specific local address vouch for a
+    foreign listener holding ``127.0.0.1`` on the same port -- the squatter would
+    be trusted BECAUSE the real pod exists elsewhere on that number. This scope
+    must stay in step with the address :func:`_probe_health` dials.
+
+    **A pod with no process, on a port somebody holds, is FOREIGN -- not
+    unproven.** This is the whole bug. A pod whose gateway lost the bind race has
+    no process at all, so there is no pid to match; if the answer were "cannot
+    tell" the squatter's 200 would still be reported as this pod's health, which
+    is exactly the state this function exists to name. A non-empty listener list
+    plus a pod that authoritatively has no pid IS proof the responder is someone
+    else.
+
+    **Undecidable stays undecidable.** No ``lsof``/``netstat``, a throwing
+    lookup, or a service manager that cannot be asked all return
+    :data:`OWNER_UNPROVEN`. Each caller then decides for itself: :func:`health`
+    keeps its pre-identity behaviour, because refusing would turn every pod on
+    such a host into a permanently unhealthy one -- a self-inflicted outage in
+    place of a misreport -- while :func:`mint_token`, which hands over a
+    credential, requires positive proof. That mirrors
+    ``cli_server._replacement_is_serving`` applying its listener check "only where
+    it can pass", and ``port_resolution._gateway_owns_port`` failing closed on the
+    path that sends the secret.
+    """
+    if not IS_POSIX or not listening_pid_tool_available():
+        return OWNER_UNPROVEN
+    try:
+        pids = set(loopback_owner_pids(find_port_listeners(port)))
+    except Exception:
+        return OWNER_UNPROVEN
+    if not pids:
+        # Something answered HTTP but no LISTEN socket covering loopback is
+        # visible. The two observations disagree, so claim nothing.
+        return OWNER_UNPROVEN
+    try:
+        ours = main_pid(cfg, name)
+    except Exception:
+        # Could not ask the service manager — see the docstring.
+        return OWNER_UNPROVEN
+    return OWNER_POD if ours is not None and ours in pids else OWNER_FOREIGN
+
+
+def _probe_health(port: int, timeout: int = 3) -> int:
+    """Raw HTTP status of ``/api/health`` on *port*, or 0 if unreachable.
+
+    Reachability ONLY — it says nothing about who answered, which is why it is
+    private. Callers want :func:`health`.
+
+    Every failure collapses to 0, ``http.client.HTTPException`` included: a
+    process holding the port that answers the TCP handshake without speaking
+    HTTP raises ``BadStatusLine``, which is neither ``OSError`` nor ``URLError``.
+    That case is not hypothetical here — a foreign listener on a derived port is
+    the reason this probe is being hardened — and it must read as "not serving"
+    rather than escaping as a traceback out of ``pod status``.
     """
     url = f"http://127.0.0.1:{port}/api/health"
     try:
@@ -940,8 +1092,28 @@ def health(port: int, timeout: int = 3) -> int:
             return resp.status
     except urllib.error.HTTPError as e:
         return e.code
-    except (urllib.error.URLError, OSError):
+    except (urllib.error.URLError, OSError, http.client.HTTPException):
         return 0
+
+
+def health(cfg: PodConfig, name: str, port: int, timeout: int = 3) -> int:
+    """HTTP status of **this pod's** ``/api/health``, or a non-positive verdict.
+
+    * 200 = open; 401/403 = serving but gated — all three mean this pod is up.
+    * 0 = nothing reachable on the port.
+    * :data:`HEALTH_FOREIGN` = the port answers, but the responder is provably
+      not this pod, so this pod is NOT up.
+
+    The ownership check runs only once something has answered, which keeps the
+    common case free: a stopped pod costs one refused connection and no process
+    lookup, exactly as before.
+    """
+    code = _probe_health(port, timeout)
+    if code == 0:
+        return 0
+    if port_owner(cfg, name, port) == OWNER_FOREIGN:
+        return HEALTH_FOREIGN
+    return code
 
 
 # --------------------------------------------------------------------------- #
@@ -958,6 +1130,30 @@ def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
             f"no .local_secret for pod {name!r} — is it running? ({secret_file})"
         ) from exc
     port = derive_port(cfg, name)
+    owner = port_owner(cfg, name, port)
+    if owner != OWNER_POD:
+        # Positive proof REQUIRED here, unlike `health`. This call sends the pod's
+        # own ``.local_secret`` and returns a dashboard credential for whatever
+        # answered, so the two ways of being wrong are not symmetrical: refusing a
+        # live pod costs an error message, while proceeding on an unproven port
+        # hands a different local user -- who can bind 127.0.0.1 but cannot read
+        # this 0600 secret -- a credential for this pod. That is the same reason
+        # ``port_resolution._gateway_owns_port`` fails closed on the path that
+        # sends the secret, including when the listener lookup is simply missing.
+        if owner == OWNER_FOREIGN:
+            raise PodError(
+                f"refusing to mint a credential for pod {name!r}: :{port} is held "
+                f"by another process, not this pod's gateway. `kirocrew pod status "
+                f"{name}` shows the same verdict; a credential minted here would "
+                f"belong to whatever owns that port."
+            )
+        raise PodOwnershipUnproven(
+            f"withholding a credential for pod {name!r}: could not prove which "
+            f"process holds :{port} (no lsof/netstat on this host, or the service "
+            f"manager could not be asked), and this call would put the pod's own "
+            f"secret on the wire to whatever answered. Install lsof so ownership "
+            f"can be proven, or pin a free PORT= in {cfg.env_file(name)}."
+        )
     url = f"http://127.0.0.1:{port}/api/token/local?ttl={urllib.parse.quote(str(ttl))}"
     req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
     try:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -6233,6 +6233,44 @@ async def _fleet_with(worktrees, **patches):
 
 
 @pytest.mark.asyncio
+async def test_fleet_pod_health_is_identity_gated_not_a_bare_port_probe():
+    """A squatter's 200 must not paint this worktree's row healthy.
+
+    A pod's port is derived from its name across 199 slots and can be pinned by
+    hand, so it is ordinarily held by another pod or by the live gateway; the row
+    therefore reads health from the identity-gated probe, which needs the pod NAME
+    as well as the port. Pinning the call shape here is what stops a future edit
+    reverting to a port-only probe -- the reported failure was a crash-looping pod
+    showing a healthy dot because somebody else answered its port.
+    """
+    seen: list[tuple] = []
+
+    def _health(cfg, name, port, timeout=3):
+        seen.append((name, port, timeout))
+        return mod.rt.HEALTH_FOREIGN
+
+    fake_cfg = SimpleNamespace()
+    with (
+        patch.object(mod.rt, "health", _health),
+        patch.object(mod.rt, "active_names", lambda cfg: {"repo-wt-x"}),
+        patch.object(mod.rt, "derive_port", lambda cfg, name: 7811),
+    ):
+        fleet = await _fleet_with(
+            [{"path": "/repo-wt-x", "branch": "feat/x", "is_main": False}],
+            _POD_AVAILABLE=True,
+            _POD_IMPORTED=True,
+            _load_cfg=lambda: fake_cfg,
+        )
+
+    row = {w["name"]: w for w in fleet["worktrees"]}["repo-wt-x"]
+    assert seen == [("repo-wt-x", 7811, 2)]
+    # Not a 2xx/401/403, so the frontend's `health >= 200` test renders this row
+    # as unhealthy rather than as an open pod.
+    assert row["health"] == mod.rt.HEALTH_FOREIGN
+    assert row["health"] < 200
+
+
+@pytest.mark.asyncio
 async def test_fleet_payload_marks_an_inferred_main_checkout():
     with patch.object(mod, "MAIN_REPO_INFERRED", True):
         fleet = await _fleet_with(

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -517,6 +517,215 @@ class TestWaitHealthyFailsFast:
         ):
             assert pod_cli._wait_healthy(cfg, "x", 7999, tries=3) == 403
 
+    def test_a_foreign_port_holder_outranks_the_generic_crash_verdict(self, cfg: PodConfig) -> None:
+        """A taken port is WHY the gateway crash-loops, so say that instead.
+
+        Both signals are present in this scenario -- the port answers from
+        somebody else AND the unit is restarting behind it -- and only one of them
+        tells the operator what to do about it.
+        """
+        with (
+            patch.object(rt, "health", return_value=rt.HEALTH_FOREIGN),
+            patch.object(rt, "unit_state", return_value=("activating", 1)),
+        ):
+            assert pod_cli._wait_healthy(cfg, "x", 7999, tries=45) == rt.HEALTH_FOREIGN
+
+    def test_a_foreign_holder_seen_mid_wait_is_remembered_at_the_deadline(
+        self, cfg: PodConfig
+    ) -> None:
+        """The verdict survives a later poll that merely fails to connect."""
+        codes = iter([rt.HEALTH_FOREIGN, 0, 0])
+
+        def _health(*a: object, **k: object) -> int:
+            return next(codes, 0)
+
+        with (
+            patch.object(rt, "health", _health),
+            patch.object(rt, "unit_state", return_value=("active", 0)),
+        ):
+            assert pod_cli._wait_healthy(cfg, "x", 7999, tries=2) == rt.HEALTH_FOREIGN
+
+    def test_a_pod_that_wins_its_port_back_still_reports_healthy(self, cfg: PodConfig) -> None:
+        """Seeing a squatter first must not condemn a pod that then comes up.
+
+        A predecessor releasing the port mid-wait is an ordinary sequence, so the
+        foreign observation is attribution for a FAILURE, never a verdict of its
+        own.
+        """
+        codes = iter([rt.HEALTH_FOREIGN, 200])
+
+        def _health(*a: object, **k: object) -> int:
+            return next(codes, 200)
+
+        with (
+            patch.object(rt, "health", _health),
+            patch.object(rt, "unit_state", return_value=("active", 0)),
+        ):
+            assert pod_cli._wait_healthy(cfg, "x", 7999, tries=5) == 200
+
+
+class TestPortOwner:
+    """Identity, not reachability: WHO holds the pod's derived port.
+
+    A derived port maps 199 slots across every pod name and can be pinned by
+    hand, so a collision with another pod or with the live gateway is ordinary.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _posix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pin the POSIX branch, for the same reason the module pins ``IS_MACOS``.
+
+        ``port_owner`` returns ``OWNER_UNPROVEN`` on a non-POSIX host before it
+        consults any of the helpers these tests patch, so on Windows the decision
+        cases FAILED (`'unproven' == 'pod'`) while the four that expect
+        ``OWNER_UNPROVEN`` passed VACUOUSLY -- they would have passed whatever the
+        logic did. Pinning it makes the branch under test explicit and asserts the
+        same contract on every platform. ``test_non_posix_is_unproven`` sets it
+        False itself, which still wins: this fixture runs first.
+        """
+        monkeypatch.setattr(rt, "IS_POSIX", True)
+
+    @staticmethod
+    def _listener(pid: int, address: str = "127.0.0.1", family: str = "4"):
+        return platform_compat.PortListener(pid=pid, address=address, family=family)
+
+    def test_the_pods_own_main_pid_holding_the_port_is_proof_it_is_ours(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(rt, "find_port_listeners", lambda port: [self._listener(4242)])
+        monkeypatch.setattr(rt, "main_pid", lambda c, n: 4242)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_POD
+
+    def test_a_wildcard_bind_by_the_pod_still_counts_as_ours(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """0.0.0.0 receives a 127.0.0.1 connect, so a wildcard pod owns the probe."""
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(
+            rt, "find_port_listeners", lambda port: [self._listener(4242, "0.0.0.0")]
+        )
+        monkeypatch.setattr(rt, "main_pid", lambda c, n: 4242)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_POD
+
+    def test_ownership_is_scoped_to_the_address_the_probe_reached(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pod existing elsewhere on the port must not vouch for a squatter.
+
+        A port NUMBER can carry several LISTEN sockets on different local
+        addresses. Here the pod holds one specific non-loopback address while a
+        foreign process holds 127.0.0.1 -- the address the probe dialled -- so the
+        foreign pid is the responder. Taking every pid on the port number instead
+        would find the pod's own and trust the squatter BECAUSE the real pod
+        exists.
+        """
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(
+            rt,
+            "find_port_listeners",
+            lambda port: [
+                self._listener(4242, "10.0.0.5"),  # the pod, on another address
+                self._listener(9999, "127.0.0.1"),  # the squatter, on the probed one
+            ],
+        )
+        monkeypatch.setattr(rt, "main_pid", lambda c, n: 4242)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_FOREIGN
+
+    def test_a_different_pid_holding_the_port_is_foreign(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(rt, "find_port_listeners", lambda port: [self._listener(9999)])
+        monkeypatch.setattr(rt, "main_pid", lambda c, n: 4242)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_FOREIGN
+
+    def test_a_pod_with_no_process_on_a_held_port_is_foreign_not_unproven(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reported bug, at its root.
+
+        A pod that lost the bind race has no process at all. If "no pid of ours"
+        read as undecidable, the squatter's 200 would still be reported as this
+        pod's health -- which is the whole defect. A held port plus a pod that
+        authoritatively has no pid IS proof the responder is someone else.
+        """
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(rt, "find_port_listeners", lambda port: [self._listener(9999)])
+        monkeypatch.setattr(rt, "main_pid", lambda c, n: None)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_FOREIGN
+
+    def test_no_listener_lookup_tool_is_unproven(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: False)
+        monkeypatch.setattr(
+            rt, "find_port_listeners", lambda port: pytest.fail("must not be reached")
+        )
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_UNPROVEN
+
+    def test_non_posix_is_unproven(self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(rt, "IS_POSIX", False)
+        monkeypatch.setattr(
+            rt, "listening_pid_tool_available", lambda: pytest.fail("must not be reached")
+        )
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_UNPROVEN
+
+    def test_an_unaskable_service_manager_is_unproven(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ "Could not ask" must never be rendered as "not ours"."""
+
+        def _boom(c: object, n: object) -> int:
+            raise rt.PodError("systemctl unavailable")
+
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(rt, "find_port_listeners", lambda port: [self._listener(9999)])
+        monkeypatch.setattr(rt, "main_pid", _boom)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_UNPROVEN
+
+    def test_a_throwing_listener_lookup_is_unproven(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(port: int) -> list:
+            raise OSError("lsof exploded")
+
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(rt, "find_port_listeners", _boom)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_UNPROVEN
+
+    def test_no_visible_listener_is_unproven(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HTTP answered but no LISTEN socket covering loopback is visible."""
+        monkeypatch.setattr(rt, "listening_pid_tool_available", lambda: True)
+        monkeypatch.setattr(rt, "find_port_listeners", lambda port: [])
+        monkeypatch.setattr(rt, "main_pid", lambda c, n: 4242)
+        assert rt.port_owner(cfg, "demo", 7999) == rt.OWNER_UNPROVEN
+
+
+class TestMainPid:
+    def test_reads_systemd_main_pid(self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(stdout="MainPID=4242\n"))
+        assert rt.main_pid(cfg, "demo") == 4242
+
+    def test_main_pid_zero_means_not_running(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """systemd prints MainPID=0 for a dead or unknown unit, and exits 0."""
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(stdout="MainPID=0\n"))
+        assert rt.main_pid(cfg, "demo") is None
+
+    def test_a_missing_main_pid_line_refuses_rather_than_guessing(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No MainPID key at all means the QUERY failed, not that the pod is dead."""
+        monkeypatch.setattr(
+            rt, "systemctl", lambda *a, **k: _cp(stdout="", returncode=1, stderr="boom")
+        )
+        with pytest.raises(rt.PodError):
+            rt.main_pid(cfg, "demo")
+
 
 class TestProvision:
     def test_detectors(self, tmp_path: Path) -> None:
@@ -1294,7 +1503,7 @@ class TestOrphanHomes:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
         c = self._plane(tmp_path, monkeypatch)
-        monkeypatch.setattr(rt, "health", lambda port, timeout=3: 200)
+        monkeypatch.setattr(rt, "health", lambda cfg, name, port, timeout=3: 200)
         pod_cli._ls(c, argparse.Namespace(json=False))
         out = capsys.readouterr().out
         assert "1 orphaned pod HOME(s)" in out
@@ -1305,7 +1514,7 @@ class TestOrphanHomes:
     ) -> None:
         """Three callers parse this array; orphans are human-output only."""
         c = self._plane(tmp_path, monkeypatch)
-        monkeypatch.setattr(rt, "health", lambda port, timeout=3: 200)
+        monkeypatch.setattr(rt, "health", lambda cfg, name, port, timeout=3: 200)
         pod_cli._ls(c, argparse.Namespace(json=True))
         assert [r["name"] for r in json.loads(capsys.readouterr().out)] == ["running"]
 
@@ -1315,7 +1524,7 @@ class TestOrphanHomes:
         """An orphan left 5 minutes ago and one left 3 weeks ago need different
         handling; the HOME's mtime is the signal the report was missing."""
         c = self._plane(tmp_path, monkeypatch)
-        monkeypatch.setattr(rt, "health", lambda port, timeout=3: 200)
+        monkeypatch.setattr(rt, "health", lambda cfg, name, port, timeout=3: 200)
         three_days = time.time() - 3 * 86400
         os.utime(c.pod_root / "orphan", (three_days, three_days))
         pod_cli._ls(c, argparse.Namespace(json=False))
@@ -1980,7 +2189,7 @@ class TestRuntimeHelpers:
         monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(stdout="garbage\n"))
         assert rt.unit_state(cfg, "x") == ("unknown", 0)
 
-    def test_health_codes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_health_codes(self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch) -> None:
         import urllib.error
 
         class _Resp:
@@ -1992,20 +2201,96 @@ class TestRuntimeHelpers:
             def __exit__(self, *a: object) -> bool:
                 return False
 
+        # Ownership is proven separately (see TestPortOwner); here the pod owns
+        # its port so health reports the raw code.
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
         monkeypatch.setattr(rt, "loopback_urlopen", lambda *a, **k: _Resp())
-        assert rt.health(7999) == 200
+        assert rt.health(cfg, "demo", 7999) == 200
 
         def _raise_http(*a: object, **k: object) -> None:
             raise urllib.error.HTTPError("u", 403, "f", {}, None)  # type: ignore[arg-type]
 
         monkeypatch.setattr(rt, "loopback_urlopen", _raise_http)
-        assert rt.health(7999) == 403
+        assert rt.health(cfg, "demo", 7999) == 403
 
         def _raise_url(*a: object, **k: object) -> None:
             raise urllib.error.URLError("down")
 
         monkeypatch.setattr(rt, "loopback_urlopen", _raise_url)
-        assert rt.health(7999) == 0
+        assert rt.health(cfg, "demo", 7999) == 0
+
+    def test_health_treats_a_non_http_listener_as_unreachable(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A process holding the port that does not speak HTTP is not "serving".
+
+        ``BadStatusLine`` is neither ``OSError`` nor ``URLError``, so without an
+        explicit catch it escapes as a traceback out of ``pod status`` — and a
+        foreign listener on a derived port is exactly when it happens.
+        """
+        import http.client
+
+        def _raise_bad_status(*a: object, **k: object) -> None:
+            raise http.client.BadStatusLine("garbage")
+
+        monkeypatch.setattr(rt, "loopback_urlopen", _raise_bad_status)
+        assert rt.health(cfg, "demo", 7999) == 0
+
+    def test_health_reports_a_foreign_responder_as_not_up(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bug: a 200 from somebody else's gateway must not read as up."""
+
+        class _Resp:
+            status = 200
+
+            def __enter__(self) -> "_Resp":
+                return self
+
+            def __exit__(self, *a: object) -> bool:
+                return False
+
+        monkeypatch.setattr(rt, "loopback_urlopen", lambda *a, **k: _Resp())
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_FOREIGN)
+        assert rt.health(cfg, "demo", 7999) == rt.HEALTH_FOREIGN
+
+    def test_health_keeps_the_code_when_ownership_is_unprovable(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No listener-lookup tool must not turn every pod into an unhealthy one."""
+
+        class _Resp:
+            status = 200
+
+            def __enter__(self) -> "_Resp":
+                return self
+
+            def __exit__(self, *a: object) -> bool:
+                return False
+
+        monkeypatch.setattr(rt, "loopback_urlopen", lambda *a, **k: _Resp())
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_UNPROVEN)
+        assert rt.health(cfg, "demo", 7999) == 200
+
+    def test_health_skips_the_ownership_check_when_nothing_answers(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stopped pod costs one refused connection and no process lookup."""
+        import urllib.error
+
+        def _raise_url(*a: object, **k: object) -> None:
+            raise urllib.error.URLError("down")
+
+        calls: list[object] = []
+
+        def _owner(*a: object, **k: object) -> str:
+            calls.append(a)
+            return rt.OWNER_FOREIGN
+
+        monkeypatch.setattr(rt, "loopback_urlopen", _raise_url)
+        monkeypatch.setattr(rt, "port_owner", _owner)
+        assert rt.health(cfg, "demo", 7999) == 0
+        assert calls == []
 
     def test_mint_token_reads_secret_and_posts(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2026,8 +2311,68 @@ class TestRuntimeHelpers:
             def read(self) -> bytes:
                 return b'{"token":"tok-xyz"}'
 
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
         monkeypatch.setattr(rt, "loopback_urlopen", lambda *a, **k: _Resp())
         assert rt.mint_token(c, "demo", "1h") == "tok-xyz"
+
+    def test_mint_token_refuses_a_foreign_port_holder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Never hand this pod's secret to whatever happens to answer.
+
+        Sharper than the health misreport: mint sends the pod's own
+        ``.local_secret`` and returns a dashboard token for the responder, so
+        against a squatter it prints a URL that drives the wrong instance.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        (home / ".local_secret").write_text("s3cret")
+
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_FOREIGN)
+        monkeypatch.setattr(
+            rt, "loopback_urlopen", lambda *a, **k: pytest.fail("must not dial a foreign listener")
+        )
+        with pytest.raises(rt.PodError, match="another process"):
+            rt.mint_token(c, "demo", "1h")
+
+    def test_mint_token_refuses_when_ownership_is_merely_unproven(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The credential path needs POSITIVE proof, unlike the health readout.
+
+        The two ways of being wrong are not symmetrical. Refusing a live pod costs
+        an error message; proceeding on an unproven port hands a different local
+        user -- who can bind 127.0.0.1 but cannot read this 0600 secret -- a
+        credential for this pod. ``_gateway_owns_port`` fails closed on the same
+        path for the same reason, including when the listener lookup is missing.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        (home / ".local_secret").write_text("s3cret")
+
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_UNPROVEN)
+        monkeypatch.setattr(
+            rt,
+            "loopback_urlopen",
+            lambda *a, **k: pytest.fail("must not dial an unproven listener"),
+        )
+        with pytest.raises(rt.PodOwnershipUnproven, match="could not prove"):
+            rt.mint_token(c, "demo", "1h")
+
+    def test_the_unprovable_refusal_is_a_distinguishable_type(self) -> None:
+        """`pod up` treats the two refusals differently, so they must be tellable.
+
+        FOREIGN is positive knowledge that the port is somebody else's; UNPROVEN is
+        the absence of knowledge. Both withhold the secret, but only the first
+        means there is nothing truthful left for `pod up` to print.
+        """
+        assert issubclass(rt.PodOwnershipUnproven, rt.PodError)
+        # A FOREIGN refusal must NOT be catchable as the unprovable one.
+        assert not issubclass(rt.PodError, rt.PodOwnershipUnproven)
 
     def test_mint_token_no_secret_raises(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2089,7 +2434,7 @@ class TestCliVerbs:
     ) -> None:
         monkeypatch.setattr(rt, "active_names", lambda c: {"alpha"})
         monkeypatch.setattr(rt, "derive_port", lambda c, n: 7811)
-        monkeypatch.setattr(rt, "health", lambda p: 403)
+        monkeypatch.setattr(rt, "health", lambda cfg, name, p: 403)
         pod_cli._ls(cfg, argparse.Namespace(json=False))
         assert "alpha" in capsys.readouterr().out
         pod_cli._ls(cfg, argparse.Namespace(json=True))
@@ -2099,7 +2444,7 @@ class TestCliVerbs:
     def test_status(self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
         monkeypatch.setattr(rt, "derive_port", lambda c, n: 7811)
         monkeypatch.setattr(rt, "is_active", lambda c, n: True)
-        monkeypatch.setattr(rt, "health", lambda p: 403)
+        monkeypatch.setattr(rt, "health", lambda cfg, name, p: 403)
         pod_cli._status(cfg, argparse.Namespace(name="alpha", json=True))
         out = capsys.readouterr().out
         assert '"status": "up"' in out and '"health": 403' in out
@@ -2184,6 +2529,63 @@ class TestUpVerb:
         assert '"port": 7811' in out and '"token": "tok-9"' in out
         # _up must pin the resolved checkout for the systemd boot.
         assert rt.read_env_file(c, "demo").get("CHECKOUT", "").endswith("wts/demo")
+
+    def test_up_still_succeeds_when_ownership_cannot_be_proven(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """An lsof-less host must not boot the pod and then fail the command.
+
+        The credential is the last step of `up`, not its point. Dying here would
+        make `pod up` impossible on a POSIX host with no listener-lookup tool,
+        where ownership can never be proven -- a self-inflicted outage in place of
+        a hardened credential path. The secret still never reaches the wire: the
+        guard is inside mint_token, which raised before dialling.
+        """
+        c = self._prep(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: 7811)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+
+        def _unprovable(cfg: object, n: object, ttl: object) -> str:
+            raise rt.PodOwnershipUnproven("could not prove which process holds :7811")
+
+        monkeypatch.setattr(rt, "mint_token", _unprovable)
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+        cap = capsys.readouterr()
+        out = cap.out
+        # Reports what it knows, withholds only the credential.
+        assert '"status": "up"' in out and '"port": 7811' in out
+        assert '"base_url": "http://127.0.0.1:7811"' in out
+        # The empty token IS the machine signal; the JSON shape gains no field for
+        # it, so the reason travels on stderr where a caller and a human both see
+        # it. A payload key with no consumer would be schema committed forever.
+        assert '"token": ""' in out
+        assert "token_withheld" not in out
+        assert "could not prove" in cap.err
+
+    def test_up_still_dies_on_a_foreign_port_holder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FOREIGN is positive knowledge, so there is nothing truthful left to print."""
+        c = self._prep(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: 7811)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+
+        def _foreign(cfg: object, n: object, ttl: object) -> str:
+            raise rt.PodError("held by another process")
+
+        monkeypatch.setattr(rt, "mint_token", _foreign)
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        with pytest.raises(SystemExit):
+            pod_cli._up(
+                c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+            )
 
     def test_up_refuses_live_port(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         c = self._prep(tmp_path, monkeypatch)
@@ -2332,6 +2734,9 @@ class TestReviewRound1Fixes:
             captured["url"] = req.full_url  # type: ignore[attr-defined]
             return _Resp()
 
+        # Mint now requires positive ownership proof; this test is about the URL
+        # it builds, so grant the proof rather than exercising the guard here.
+        monkeypatch.setattr(rt, "port_owner", lambda *a, **k: rt.OWNER_POD)
         monkeypatch.setattr(rt, "loopback_urlopen", _urlopen)
         rt.mint_token(c, "demo", "1 h")
         assert "ttl=1%20h" in captured["url"]

--- a/test/test_pod_e2e_harness_paths.py
+++ b/test/test_pod_e2e_harness_paths.py
@@ -248,3 +248,136 @@ def test_resolver_prefers_feat_over_another_branch_with_the_same_leaf(tmp_path):
 
 def test_resolver_reports_nothing_for_an_unknown_name(tmp_path):
     assert _resolve("nosuchpod", str(tmp_path), tmp=tmp_path) == ""
+
+
+# ---------------------------------------------------------------------------
+# Health phase: identity, not reachability.
+#
+# The phase used to bare-curl base_url/api/health and accept any 200/401/403. A
+# pod's port is derived from its name across 199 slots and can be pinned by hand,
+# so it is routinely held by another pod or by the live gateway, and every
+# gateway answers that path identically -- so the poll could hand every later
+# phase a pod this run never booted. It now reads the identity-gated verdict from
+# `pod status --json`. These drive the real fragment out of the shipped script.
+# ---------------------------------------------------------------------------
+HEALTH_FRAGMENT_START = (
+    "# ---------------------------------------------------------------- health --"
+)
+HEALTH_FRAGMENT_END = 'fail "health — pod never became healthy'
+
+
+def _health_snippet(stub_bin: str, timeout: str = "1") -> str:
+    """The shipped health fragment plus the minimum preamble it reads."""
+    body = _fragment(HEALTH_FRAGMENT_START, HEALTH_FRAGMENT_END) + '"\n  fi\nfi\n'
+    preamble = textwrap.dedent(f"""
+        set -uo pipefail
+        export POD_E2E_HEALTH_TIMEOUT='{timeout}'
+        KIROCREW_CLI="{stub_bin}"
+        NAME=demo
+        BASE_URL=http://127.0.0.1:7811
+        PORT=7811
+        # Under the supplied HOME (pytest's tmp_path), never `mktemp -d`: `_run`
+        # passes only HOME and PATH, so a bare mktemp would land in the host temp
+        # root and stay there after the test.
+        ARTIFACT_DIR="$HOME/artifacts"
+        mkdir -p "$ARTIFACT_DIR"
+        log() {{ :; }}
+        fail() {{ echo "FAIL:$1"; }}
+        """)
+    return preamble + body + '\necho "HEALTHY=$HEALTHY FOREIGN=$FOREIGN"\n'
+
+
+@pytest.fixture()
+def stub_cli(tmp_path: Path):
+    """A fake `kirocrew` whose `pod status --json` health value is injectable."""
+
+    def _make(health: str) -> str:
+        path = tmp_path / "kirocrew-stub"
+        path.write_text(
+            textwrap.dedent(f"""
+                #!/usr/bin/env bash
+                if [ "$1" = "pod" ] && [ "$2" = "status" ]; then
+                  printf '{{"name":"demo","status":"up","port":7811,"health":%s}}\\n' '{health}'
+                  exit 0
+                fi
+                exit 0
+                """).lstrip(),
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+        return str(path)
+
+    return _make
+
+
+def test_health_accepts_the_pods_own_serving_codes(stub_cli, tmp_path):
+    for code in ("200", "401", "403"):
+        res = _run(_health_snippet(stub_cli(code)), str(tmp_path))
+        assert res.returncode == 0, res.stdout + res.stderr
+        assert "HEALTHY=1" in res.stdout, f"code {code}: {res.stdout}"
+        assert "FAIL:" not in res.stdout, f"code {code} must not fail: {res.stdout}"
+
+
+def test_health_refuses_a_foreign_port_holder_and_names_the_conflict(stub_cli, tmp_path):
+    """-2 is a squatter, so the phase must NOT proceed, and must say why.
+
+    Blaming the worktree build here is what sent an operator to read a journal
+    that only says "address already in use"; the remedy is a free PORT=.
+    """
+    res = _run(_health_snippet(stub_cli("-2")), str(tmp_path))
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "HEALTHY=0 FOREIGN=1" in res.stdout, res.stdout
+    assert "FAIL:" in res.stdout, res.stdout
+    assert "held by another process" in res.stdout, res.stdout
+    assert "PORT=" in res.stdout, res.stdout
+
+
+def test_health_reports_a_plain_timeout_when_nothing_answers(stub_cli, tmp_path):
+    res = _run(_health_snippet(stub_cli("0")), str(tmp_path))
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "HEALTHY=0 FOREIGN=0" in res.stdout, res.stdout
+    assert "never became healthy" in res.stdout, res.stdout
+    assert "held by another process" not in res.stdout, res.stdout
+
+
+@pytest.mark.parametrize(
+    "bad,why",
+    [
+        ("abc", "read as a variable NAME inside $(( )); set -u kills the run"),
+        ("-5", "leading '-' is a non-digit, and a past deadline fakes a timeout"),
+        ("999999999999999999999999", "no error, but the deadline lands centuries out"),
+        ("6 0", "whitespace is not a digit"),
+    ],
+)
+def test_health_survives_every_bad_timeout_override(stub_cli, tmp_path, bad, why):
+    """A typo in one env var must cost a warning, never the run.
+
+    Each of these was verified to abort or hang the unvalidated form directly --
+    `abc` exits 127 with "unbound variable", and a 24-digit value does not error at
+    all but sets a deadline centuries out, so the poll never gives up. For an
+    unattended harness that silent hang is worse than the crashes. Validation
+    therefore happens once, before the value reaches arithmetic.
+    """
+    res = _run(_health_snippet(stub_cli("200"), timeout=bad), str(tmp_path))
+    assert res.returncode == 0, f"{why}: {res.stdout + res.stderr}"
+    # Fell back to the default and still reached a real verdict.
+    assert "HEALTHY=1" in res.stdout, f"{why}: {res.stdout}"
+    assert "ignoring POD_E2E_HEALTH_TIMEOUT" in res.stderr, f"{why}: {res.stderr}"
+    for boom in ("unbound variable", "value too great for base"):
+        assert boom not in res.stderr, f"{why}: {res.stderr}"
+
+
+@pytest.mark.parametrize("good", ["5", "08", "60", "999999"])
+def test_health_accepts_a_valid_timeout_override(stub_cli, tmp_path, good):
+    """The knob must still work -- validation that rejects everything is useless.
+
+    `08` is deliberately in the accepted set, not the rejected one: a leading zero
+    is a normal way to write a number, and it only broke because bash read it as
+    octal ("value too great for base", exit 1). The explicit `10#` base makes it
+    mean 8 seconds, so it is interpreted rather than refused.
+    """
+    res = _run(_health_snippet(stub_cli("200"), timeout=good), str(tmp_path))
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "HEALTHY=1" in res.stdout, res.stdout
+    assert "ignoring POD_E2E_HEALTH_TIMEOUT" not in res.stderr, res.stderr
+    assert "value too great for base" not in res.stderr, res.stderr


### PR DESCRIPTION
## What is the problem?

`kirocrew pod status` reports a crash-looping pod as up with `health=200`, and the Dev Fleet row paints it a healthy green dot.

A pod's port is derived, not allocated. `derive_port` returns `base + (cksum(name) % 199) + 1`, so every pod name lands in one of 199 slots, and `PORT=` in the per-pod env file can pin any port by hand. Two pods sharing a port is an ordinary event, and the live gateway answers on the same loopback interface. Whoever binds first wins; the loser's gateway exits "address already in use" and its unit crash-loops behind `Restart=on-failure`.

`pod/runtime.health()` probed `127.0.0.1:<derived port>/api/health` and returned the HTTP status, with 200/401/403 all meaning "up" -- and nothing in that exchange tied the responder to the pod being asked about. The endpoint cannot supply the tie either: `_liveness_payload` answers `{"ok": true}` plus `app=kirocrew` and a version for direct-local callers, which is equally true of the squatter.

`instances/run_marker` already states the rule this broke, in its own module docstring: it "deliberately does not offer a bare 'is something listening' helper, so no caller can mistake reachability for identity". The pod probe was that mistake.

## Why this issue matters to the user

Every pod workflow downstream of the probe inherits the wrong answer:

- `pod up` prints `pod '<name>' is up` with a `base_url` and credential for an instance that is not this pod. This is how it was noticed: PR-evidence capture on a machine running several pods drove somebody else's gateway while believing it was the worktree under test.
- `pod status` / `pod ls` report a health code the pod never produced, so the operator debugging a pod that will not boot is told it is fine.
- The Dev Fleet page shows a green "pod up" dot for a worktree whose gateway is crash-looping.
- The credential-mint path is worse than a misreport: it reads the pod's own `.local_secret` and sends it to whatever answers that port, then hands back a dashboard credential for the responder.

The failure is silent in the direction that costs the most -- evidence captured, or state edited, on an instance the operator never meant to touch.

## How our fix solves it

Symptom: a 200 read as this pod's health. Cause: the probe had no identity for the responder. Fix: give it one, and make it impossible to skip.

- **`port_owner(cfg, name, port)`** decides `OWNER_POD` / `OWNER_FOREIGN` / `OWNER_UNPROVEN`. The proof is the same shape `port_resolution._gateway_owns_port` uses for the live gateway: the process listening on the port must be the pod's own. It is exact rather than approximate because of how a pod boots -- the unit is `Type=simple` running `kirocrew pod _run %i`, and `_run` finishes with `os.execve` of the worktree's gateway, so `MainPID` names the very process that binds the port. No descendant walk, no cgroup scan.
- **`main_pid(cfg, name)`** reads that pid from systemd (`MainPID`) or launchd (the `pid =` line). It separates two answers the old code had no way to distinguish: `None` means "asked, and this pod has no process", while a query that could not be made raises. `systemctl show` prints `MainPID=0` for a dead unit and still exits 0, so output with no `MainPID` line at all is the honest signal that the query itself failed.
- **A pod with no process, on a port somebody holds, is `FOREIGN` -- not unproven.** This branch is the bug. A pod that lost the bind race has no pid to match; if that read as undecidable, the squatter's 200 would still be reported as this pod's health.
- **`health(cfg, name, port)`** returns the code only when ownership is not disproven, and `HEALTH_FOREIGN` (`-2`) when it is. The reachability probe is now private (`_probe_health`), so every caller goes through the identity gate and the run_marker rule cannot be broken again from this module.
- **Undecidable is handled per caller, and NOT uniformly "as before".** No `lsof`/`netstat`, a throwing lookup, or an unaskable service manager all return `OWNER_UNPROVEN`. `health` then keeps its pre-identity reading, mirroring `cli_server._replacement_is_serving`, which applies its listener check "only where it can pass" rather than reporting a false failure on hosts without the tooling -- refusing there would turn every pod on such a host into a permanently unhealthy one, a self-inflicted outage in place of a misreport. The credential path does NOT keep its old behaviour: `mint_token` raises `PodOwnershipUnproven` rather than putting the pod's secret on the wire to an unverified listener. `pod token` therefore fails on such a host, where it used to succeed. `pod up` does not fail: the credential is its last step, not its point, so it reports the pod, port and `base_url`, withholds only the token (`"token": ""`, with the reason on stderr and the JSON shape unchanged), and says how to get it -- dying there would boot a pod and then fail the command that booted it. Design Review asked for exactly this split and it is the shipped behaviour; First Principles then asked that the reason NOT become a payload field, since the empty `token` is already the machine signal and a key with no consumer is schema committed forever -- so it travels on stderr, which a subprocess caller and a human both see.
- **Callers.** `_wait_healthy` carries the verdict out; `_up` reports the taken port ahead of the generic crash verdict, because that is *why* the gateway could not boot and it is fixed by choosing a port rather than by debugging the worktree, and it names the env file to pin `PORT=` in. `pod status` / `pod ls` render `foreign (port held by another instance)` for humans. The mint path refuses rather than dialling a foreign listener. The Dev Fleet row passes the pod name through.
- **The pod-e2e harness had the same bare probe, so it is fixed here too.** `skills/pod-e2e/scripts/pod-e2e.sh` curled `base_url/api/health` and accepted any 200/401/403, which would have handed every later phase -- auth, API tests, Playwright, the artifacts -- a pod the run never booted. It now polls `kirocrew pod status --json` and accepts only that verdict; a `-2` does not end the poll on sight (a predecessor may still be releasing the port) but is remembered, so the timeout names the conflict and `PORT=` instead of blaming the worktree build. Its deadline moved from a fixed 45-iteration loop to a 60s budget, overridable via the new `POD_E2E_HEALTH_TIMEOUT`: each poll now spawns the CLI rather than curl, so an iteration count no longer implies a predictable wall clock. `SKILL.md` step 2 documented the old curl and moves with it. This was First Principles' Subtraction; the reason I first deferred it -- that a script had no verdict to consume -- was made false by this PR's own `pod status --json`.
- **Two smaller fixes in the same path.** `_probe_health` now catches `http.client.HTTPException`, so a process holding the port that answers the TCP handshake without speaking HTTP reads as unreachable instead of escaping as `BadStatusLine` out of `pod status` -- a foreign listener on a derived port is exactly when that happens, and `cli_server._probe_gateway_ready` documents the same case for its twin. And `pod status` keeps `status` sourced from the unit while `health` now reflects serving, because "the unit is loaded and restarting" and "this pod is serving" are different facts.

No frontend change is needed: `DevFleetPage`'s existing `w.health >= 200 && < 400 || 401 || 403` test already renders a negative sentinel as unhealthy, which is why `HEALTH_FOREIGN` was given a negative value rather than a new string state.

## What tests we did

Targeted only, always with an explicit worker cap (`-p no:randomly -n 4`) -- 310 passed across `test/test_pod.py`, `test/test_pod_launchd.py` and `test/test_pod_e2e_harness_paths.py`, plus 9 in the `test_dev_fleet_app.py` fleet-payload group. CI runs the full suite.

New coverage, all in the repo's existing harnesses:

- `TestPortOwner` -- own MainPID holding the port is proof; a different pid is foreign; **a pod with no process on a held port is foreign, not unproven**; no lookup tool, non-POSIX, a throwing lookup, an unaskable service manager, and no visible listener are each unproven.
- `TestMainPid` -- reads `MainPID`, treats `MainPID=0` as not running, and refuses rather than guessing when the `MainPID` line is absent.
- `health` -- a foreign responder reports `HEALTH_FOREIGN`; an unprovable host keeps its code; a non-HTTP listener reads as unreachable; a stopped pod skips the ownership check entirely (asserted by a probe that fails the test if called).
- `_wait_healthy` -- a foreign holder outranks the generic crash verdict, is remembered across a later failed connect, and does **not** condemn a pod that wins its port back mid-wait.
- The mint path -- refuses a foreign holder, and separately withholds on an unprovable one, each with the transport stubbed to fail the test if dialled; the unprovable refusal is a distinct `PodOwnershipUnproven` type, pinned so the two cannot be conflated.
- `pod up` -- still succeeds when ownership cannot be proven, reporting the pod, port and `base_url` with `"token": ""` on stdout, the reason on stderr, and no new payload key; still dies on a foreign holder.
- Dev Fleet -- the row's health comes from the identity-gated call, pinned by argument shape.
- pod-e2e -- three cases drive the REAL health fragment sliced out of the shipped script against a stub CLI: 200/401/403 proceed, `-2` refuses and names both the conflict and `PORT=`, `0` reports a plain timeout and must not claim a conflict.

Mutation-verified red on the un-fixed logic, six ways: making the no-pid branch return `UNPROVEN` reddens 2 ownership tests; widening ownership from the probed loopback address back to the whole port number reproduces GPT's reported vulnerability (`assert 'pod' == 'foreign'`); removing the gate from `health` reddens the foreign test (`assert 200 == -2`); reverting the Dev Fleet call to a port-only probe reddens its guard (`assert [] == [('repo-wt-x', 7811, 2)]`); accepting `-2` in the e2e poll, i.e. the pre-fix behaviour, reddens the foreign case (`assert 'HEALTHY=0 FOREIGN=1' in 'HEALTHY=1 FOREIGN=0'`); and making `pod up` die on an unprovable verdict reddens the degrade test with `SystemExit: 1`.

Gates: isort, flake8, and mypy clean on the touched modules (mypy's 2 remaining errors are in `src/kiro_crew/transcribe.py`, untouched here and pre-existing). The black baseline gate passes -- `runtime.py` and `test_pod.py` are not baselined and are black-clean; `cli.py`, `launchd.py`, `dev_fleet/server.py` and `test_dev_fleet_app.py` are baselined and carry no reformat churn.

Not tested against a real pod on purpose: exercising it for real means starting a gateway on a port the live plane may own, which is the failure this PR exists to prevent. The transitions are covered as unit behaviour instead.

## Any other suggestions on the work

- **Same defect class at a sibling.** `code_review_sage/sage_lib/review_driver.py` reads a local secret by port and probes it (`_probe(base, _local_secret(port))`). It deserves the same ownership check; left out here to keep this PR to the pod surface.
- **The Dev Fleet tooltip is now imprecise.** A foreign row says "pod is running but failing its health check", when the truth is that another instance owns the port. A distinct string needs new i18n keys, so it is deliberately a follow-up rather than scope creep into the frontend lanes.
- **`OWNER_UNPROVEN` is a real residual gap, not a solved case.** On a host without `lsof` the original misreport survives. Closing it needs an identity the gateway itself advertises (an instance id in the liveness payload), which is a probe-boundary change with its own fingerprinting question -- and it would depend on the pod's gateway revision, while a pod exists precisely to run arbitrary revisions. `MainPID` was chosen because it is revision-independent.
- **`derive_port`'s 199-slot space is the upstream cause.** This PR makes a collision legible instead of silent; it does not stop collisions happening. Allocating a free port at `up` time (and recording it) would, and is a separate change.

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.


