### PR TITLE
fix(mcp-gateway): give unnamed co-tenants their own snapshot namespace

### DIFF
--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -910,11 +910,14 @@ parent's tree. `mcp_core.py` offers two resolvers:
 - `_resolve_session_key()` (lenient, still walks ancestors) is only for read-only
   and telemetry callers where misattribution is harmless.
 
-An unresolved key is not automatically a refusal. `mcp_computer.py` forwards an
-empty key and lets the call proceed, because neither strict source exists for a
+An unresolved key is not automatically a refusal. `mcp_computer.py` forwards a
+namespace-only key (`unresolved:<shim pid>`, plus the gateway's per-connection
+nonce when there is one) and lets the call proceed, because neither strict source
+exists for a
 GUI-launched kiro-cli on macOS, so gating on identity would make the feature
 unusable on its only supported platform. What is lost there is audit
-*attribution*, not a control: the trail records an empty key, which is honest,
+*attribution*, not a control: the trail records a key the prefix marks as
+unresolved, which is honest,
 where the lenient walk would have recorded a forgeable one.
 
 **2. State belongs in the gateway.** The tool should be a thin forwarder: resolve

--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -190,7 +190,8 @@ control. `test_mcp_computer.py::test_the_shim_carries_no_identity_refusal_at_all
 guards the absence, because a behavioural test alone passes just as well with a
 refusal that happens to be unreachable.
 
-**An unresolved key becomes `unresolved:<shim pid>`, never the empty string** — and
+**An unresolved key becomes `unresolved:<shim pid>[#<connection nonce>]`, never the
+empty string** — and
 that is a correctness fix, not cosmetics. `SnapshotIndex` namespaces entries by
 `(session_key, window_key)`, so an empty key collapsed EVERY unresolved session onto
 one `("", window)` slot. Since unresolved is the normal case on macOS, two concurrent
@@ -201,13 +202,31 @@ per session, so the shim's own pid separates the namespaces exactly as far as th
 sessions are genuinely separate — in the 1:1 shim topology. On a POOLED backend one
 process serves many sessions, so the pid separates only what the injected caller
 block does not already name: co-tenants gatewayd CAN name get real per-session keys,
-and the residual — two or more co-tenants it cannot name sharing one
-`unresolved:<pid>` namespace — is tracked as #5322. Read at call time rather than
+and the ones it cannot are separated by the **per-connection nonce** gatewayd injects
+alongside the caller block (`_meta."kirocrew.tenant".nonce`, #5322). The nonce is
+gateway-minted and stripped on every inbound frame like the caller block, so a stub
+cannot choose to share a peer's namespace; it carries no session key, so
+`CallerContext.from_meta` still finds no identity and nothing is laundered into
+attribution. Both halves are read at call time rather than
 captured at import, so a forked child cannot inherit its parent's string and
 re-alias with it.
 
+Absent nonce is the normal 1:1 case (no gateway, or a backend that never advertised
+the caller extension), and the key stays `unresolved:<pid>` — correct there, because
+one process is one session. It is ALSO what a pre-nonce gatewayd produces: `manager.py`
+adopts whatever healthy daemon already holds the socket, so a daemon that outlived a
+package upgrade keeps serving and injects nothing, and the backend cannot tell that
+apart from the 1:1 case (absence of both blocks is ambiguous by construction). That
+window is why `kirocrew-computer` stays in `_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD`
+rather than being reclassified shareable here — the classification is a config WRITE
+via `seed.py`, so it must not promise a separation the serving daemon may not
+implement. A stub that reconnects gets a fresh nonce and therefore a
+fresh namespace: its earlier snapshots become unreachable, which surfaces as "call
+`computer_get_state` first" rather than as an action against a stale tree.
+
 The prefix is deliberate: this is a namespace separator, not attribution, and an audit
-reader must not mistake a pid for a resolved identity. And it is a namespacing fix
+reader must not mistake a pid — or a nonce — for a resolved identity. And it is a
+namespacing fix
 specifically **because** the alternative — refusing an empty key — is the line that
 made the feature unusable on macOS; the security posture is unchanged, only the cache
 key is.

--- a/docs/system-specs/modules/mcp-shareability.md
+++ b/docs/system-specs/modules/mcp-shareability.md
@@ -43,7 +43,7 @@ The bulk stub action consults whichever of the two the global sharing switch mak
 
 ## Session-bound by construction, which is not the same as "ours"
 
-The `disqualified` reason `first_party_session_scoped` names a server that resolves the calling session from its own PROCESS — an env var, a pid walk — so one backend can only ever serve one session correctly. It is decided by which servers actually consume the injected caller block, not by matching a name against Kiro Crew's managed set: keying it on authorship once disqualified `kirocrew-core` — which advertised the extension and consumed the block from the start — for a property only its unadopted siblings had. All four managed servers now advertise and consume the block (`kirocrew-core` from the start, `kirocrew-cron` since #4622's fix, `kirocrew-computer` and `kirocrew-dashboard` since #4659). Advertising is necessary but not sufficient for the shareable classification: `kirocrew-computer` stays session-bound deliberately, because a caller the gateway cannot name proceeds under `unresolved:<pid>` and unnamed co-tenants on a pooled backend would share that one snapshot namespace (#5322) — see `_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD` in `mcp_discovery.py`. The classification stays per-server because the next managed server starts unadopted, exactly as these did.
+The `disqualified` reason `first_party_session_scoped` names a server that resolves the calling session from its own PROCESS — an env var, a pid walk — so one backend can only ever serve one session correctly. It is decided by which servers actually consume the injected caller block, not by matching a name against Kiro Crew's managed set: keying it on authorship once disqualified `kirocrew-core` — which advertised the extension and consumed the block from the start — for a property only its unadopted siblings had. All four managed servers now advertise and consume the block (`kirocrew-core` from the start, `kirocrew-cron` since #4622's fix, `kirocrew-computer` and `kirocrew-dashboard` since #4659). Advertising is necessary but not sufficient for the shareable classification: `kirocrew-computer` stays session-bound deliberately, because a caller the gateway cannot name proceeds under `unresolved:<pid>` — #5322 gave each CONNECTION its own namespace there, but this classification is what `seed.py` turns into a config write and an ADOPTED pre-nonce daemon injects no nonce, so promotion waits on a negotiated guarantee rather than on the nonce alone. See `_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD` in `mcp_discovery.py`. The classification stays per-server because the next managed server starts unadopted, exactly as these did.
 
 `mcp_discovery.managed_server_is_session_bound` answers from a module-level set, `_MANAGED_SERVERS_CALLER_AWARE`, and deliberately imports nothing: the assessment must answer WITHOUT a handshake (the probe cannot spawn on every host — Windows, macOS >= 26 — and has not run at all before the first probe cycle), and it is consulted on every render, so importing a server module to read its `ADVERTISE_CALLER_IDENTITY` would execute package code from an editable checkout on a path the sandbox never confines. `test/test_mcp_managed_caller_identity.py::test_the_classification_reads_no_module_at_import_time` pins that refusal.
 
@@ -184,7 +184,7 @@ That split is also the export contract. The telemetry layer requires low-cardina
 | `observed_hazard` | refuted | Ledger entry; detail is the hazard code. **One of only two durable grounds for refusing to share, because it happened rather than being inferred.** |
 | `not_stdio` | disqualified | No stdio pipe — out of scope, not unsafe. **The other durable ground, and the only remaining `disqualified` code.** |
 | `handshake_not_reproducible` | note | Pre-flight saw a divergent replayed surface (capabilities, protocol version, `serverInfo` shape, or the tool list). Reported and gates nothing: see below. |
-| `session_bound_by_construction` | disqualified | A managed server that resolves its caller from its own process rather than the injected caller block -- or that consumes the block yet is deliberately withheld from the shareable classification. Kept gating because `mcp_cron._check_cron_job_ownership` treats a falsy session key as *allow*, so a pooled backend reading EMPTY skips the ownership check rather than merely losing a feature -- and no routing-shaped hazard code would ever record it. Current producer: `kirocrew-computer` (advertises, but unnamed co-tenants share one `unresolved:<pid>` snapshot namespace, #5322). |
+| `session_bound_by_construction` | disqualified | A managed server that resolves its caller from its own process rather than the injected caller block -- or that consumes the block yet is deliberately withheld from the shareable classification. Kept gating because `mcp_cron._check_cron_job_ownership` treats a falsy session key as *allow*, so a pooled backend reading EMPTY skips the ownership check rather than merely losing a feature -- and no routing-shaped hazard code would ever record it. Current producer: `kirocrew-computer` (advertises; #5322 gave its unnamed co-tenants per-connection namespaces on a current gateway, but an adopted pre-nonce daemon injects none). |
 | `rotating_secret_env` | note | Declares an env name excluded from the pool key. Detail is the name. Not emitted for a name in `mcp_gateway.pool_identity_env`, which IS in the pool key. |
 | `degrades_when_shared` | note | `logging`; detail is `logging_level`. |
 | `not_probed` | unknown | No handshake was observed. |
@@ -242,10 +242,11 @@ failure, and it is the one case the retreat cannot backstop: both hazard codes
 describe frames that could not be routed, so serving the wrong session's data
 produces no record. The producers have narrowed as managed servers adopted the
 caller block (#4622, #4659); today the code has one deliberate producer --
-`kirocrew-computer`, which advertises and consumes the block but whose UNNAMED
-co-tenants would share one `unresolved:<pid>` snapshot namespace on a pooled
-backend (#5322) -- and it remains the conservative default for the next managed
-server, which starts unadopted exactly as the others did.
+`kirocrew-computer`, which advertises and consumes the block, and whose UNNAMED
+co-tenants #5322 separated per CONNECTION on a current gateway but not on a
+pre-nonce daemon `manager.py` adopted across an upgrade -- and it remains the
+conservative default for the next managed server, which starts unadopted exactly
+as the others did.
 
 `*.listChanged` is deliberately absent from all of the above: those notifications
 are global broadcasts (`backend._GLOBAL_BROADCAST_NOTIFICATIONS`) and are safe to

--- a/src/kiro_crew/mcp_caller.py
+++ b/src/kiro_crew/mcp_caller.py
@@ -73,6 +73,7 @@ any future KiroCrew-owned MCP server must go through this module.
 from __future__ import annotations
 
 import os
+import secrets
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from types import MappingProxyType
@@ -94,6 +95,33 @@ CALLER_CAPABILITY_KEY = "kirocrew.caller-identity"
 #: change in a non-additive way. Additive changes (new optional fields) do
 #: NOT bump this version — consumers MUST ignore unknown fields.
 CALLER_SCHEMA_VERSION = 1
+
+#: Namespaced key placed inside ``params._meta`` carrying a per-CONNECTION
+#: nonce, on every forwarded request — including the ones the gateway cannot
+#: attach an identity to.
+#:
+#: This is deliberately NOT part of the caller block, and the distinction is the
+#: whole point: the caller block is an IDENTITY (who is calling, used for
+#: routing callbacks and for authorization), while this is only a SEPARATOR (two
+#: calls carrying different nonces came from different stub connections). A
+#: backend that needs distinct per-tenant state for callers the gateway could
+#: not name must key that state on the nonce; it must never present the nonce as
+#: attribution, and no identity resolver reads it.
+#:
+#: Why a nonce is needed at all: a backend serving an unnamed caller falls back
+#: to a per-PROCESS namespace, which separates sessions exactly as far as the
+#: 1:1 shim topology makes them separate processes. On a POOLED backend one
+#: process serves N connections, so that fallback collapses every unnamed
+#: co-tenant onto one namespace (#5322).
+TENANT_META_KEY = "kirocrew.tenant"
+
+#: Schema version of the tenant block. Same additive rule as the caller block.
+TENANT_SCHEMA_VERSION = 1
+
+#: Bytes of entropy in a minted nonce. It is a namespace separator, not a
+#: capability, so this only has to make an accidental collision impossible;
+#: 64 bits does that for any number of connections a gateway will ever hold.
+_TENANT_NONCE_BYTES = 8
 
 #: Process-lifetime cache of a RESOLVED ``from_env()`` identity. The env var
 #: and ancestor pidfile chain are immutable once present, so the walk need run
@@ -308,6 +336,54 @@ def build_caller_meta(ctx: CallerContext) -> dict[str, Any]:
     }
 
 
+def new_tenant_nonce() -> str:
+    """Mint a fresh per-connection nonce.
+
+    Minted by the GATEWAY, never derived from anything the stub sends. A stub
+    supplies its own ``stub_uuid`` on the Register frame, so deriving the nonce
+    from that value would let one stub choose to land in another unnamed
+    co-tenant's namespace — re-creating #5322's collision deliberately instead of
+    by accident.
+    """
+    return secrets.token_hex(_TENANT_NONCE_BYTES)
+
+
+def build_tenant_meta(nonce: str) -> dict[str, Any]:
+    """Build the ``_meta`` block carrying a per-connection *nonce*.
+
+    Separate from :func:`build_caller_meta` so the two can be injected
+    independently: a connection the gateway cannot name has a nonce but NO
+    identity, which is exactly the case that needs the separator.
+    """
+    return {
+        TENANT_META_KEY: {
+            "schemaVersion": TENANT_SCHEMA_VERSION,
+            "nonce": nonce,
+        }
+    }
+
+
+def tenant_nonce_from_meta(meta: Any) -> str:
+    """Parse the per-connection nonce out of ``params._meta``, or ``""``.
+
+    Returns ``""`` for every malformed shape rather than raising: a missing or
+    unparseable nonce must degrade to the backend's own per-process fallback,
+    not fail the call.
+    """
+    if not isinstance(meta, dict):
+        return ""
+    block = meta.get(TENANT_META_KEY)
+    if not isinstance(block, dict):
+        return ""
+    schema_v = block.get("schemaVersion")
+    if not isinstance(schema_v, int) or schema_v < 1:
+        return ""
+    nonce = block.get("nonce")
+    if not isinstance(nonce, str):
+        return ""
+    return nonce
+
+
 # --- Per-call current caller (stdio-loop dispatch state) --------------------
 #
 # ``run_mcp_stdio_loop`` dispatches at most ONE tool call at a time (a single
@@ -354,3 +430,37 @@ def current_caller() -> "CallerContext | None":
     resolution paths.
     """
     return _CURRENT_CALLER.get()
+
+
+# Held in its own slot rather than on ``CallerContext`` because the case it
+# exists for is precisely the one where there IS no ``CallerContext``: a
+# connection the gateway could not name. Folding it into the identity object
+# would have forced a context with an empty ``session_key`` into existence, and
+# every ``if caller is not None`` in the tree reads that as "identity known".
+_CURRENT_TENANT_NONCE: ContextVar[str] = ContextVar(
+    "kirocrew_current_tenant_nonce", default=""
+)
+
+
+def set_current_tenant_nonce(nonce: str) -> None:
+    """Install (or clear, with ``""``) the current call's per-connection nonce.
+
+    ONLY the stdio dispatch loop may call this, mirroring
+    :func:`set_current_caller`.
+    """
+    _CURRENT_TENANT_NONCE.set(nonce)
+
+
+def current_tenant_nonce() -> str:
+    """The gateway-injected per-connection nonce for the tool call in flight.
+
+    ``""`` when the gateway did not inject one (non-pooled topology, legacy
+    gateway, or a backend that never advertised the caller extension). A backend
+    that keys per-tenant state on this MUST keep working when it is empty — the
+    1:1 topology, where the backend's own pid already separates sessions.
+
+    NOT an identity: it names a connection, not a session, and nothing about it
+    is attributable to a principal. Never write it into an audit record as the
+    caller.
+    """
+    return _CURRENT_TENANT_NONCE.get()

--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -111,6 +111,7 @@ from kiro_crew.computer_use.types import (
     TOOL_TYPE_TEXT,
 )
 from kiro_crew.loopback_http import loopback_urlopen
+from kiro_crew.mcp_caller import current_tenant_nonce
 from kiro_crew.mcp_core import (
     _http_error_body,
     _internal_secret,
@@ -166,33 +167,56 @@ ERR_GATEWAY_UNREACHABLE = (
 # per session, so in the 1:1 shim topology the pid separates the namespaces exactly
 # as far as the sessions are actually separate — and it does so without reinstating
 # the unattended-surface refusal that was removed by product decision. On a POOLED
-# backend one process serves many sessions, so the pid separates only what the
+# backend one process serves many sessions, so the pid alone separates only what the
 # injected caller block does not already name: co-tenants gatewayd can name get real
-# per-session keys, and the residual — unnamed co-tenants sharing one
-# ``unresolved:<pid>`` namespace — is tracked as #5322. It is
+# per-session keys, and the unnamed ones USED to collapse onto one
+# ``unresolved:<pid>`` namespace (#5322). They no longer do — gatewayd injects a
+# per-CONNECTION nonce on every forwarded call, which is appended here, so two
+# unnamed co-tenants of one pooled process hold separate namespaces. It is
 # deliberately NOT presented as trustworthy attribution: the prefix names it as
-# unresolved so an audit reader cannot mistake a pid for a session identity.
+# unresolved so an audit reader cannot mistake a pid (or a nonce) for a session
+# identity.
 UNRESOLVED_SESSION_PREFIX = "unresolved:"
+
+#: Separates the process half from the connection half of an unresolved key.
+#: Not ``:``, which already separates the prefix from the pid — a distinct
+#: character keeps the two halves legible in an audit line.
+UNRESOLVED_TENANT_SEPARATOR = "#"
 
 
 def _unresolved_session_key() -> str:
-    """A per-PROCESS session identity for a session we could not name.
+    """A per-CONNECTION session identity for a session we could not name.
 
-    ``unresolved:<pid>`` of THIS shim process. kiro-cli spawns one shim per session,
-    so the pid separates two unresolved sessions exactly as far as they really are
-    separate — which is what keeps ``SnapshotIndex``'s ``(session_key, window_key)``
-    namespace from aliasing them onto one entry and letting one session's action
-    resolve against another's element indices.
+    ``unresolved:<pid>`` of THIS shim process, plus ``#<nonce>`` of the calling
+    CONNECTION when the gateway supplied one. Together they separate two
+    unresolved sessions exactly as far as they really are separate, in both
+    topologies:
 
-    Read at CALL time rather than captured at import: a ``fork``ed child would
-    otherwise inherit the parent's string and re-alias with it, which is the exact
-    failure this is here to prevent.
+    * 1:1 shim (no gateway, no nonce) — kiro-cli spawns one shim per session, so
+      the pid is already the separator and the key is unchanged.
+    * Pooled backend — one process serves N connections, so the pid separates
+      nothing; the gateway-minted per-connection nonce does (#5322).
+
+    Without the nonce half, two unnamed co-tenants of a pooled backend shared one
+    key, which is what let ``SnapshotIndex``'s ``(session_key, window_key)``
+    namespace alias them onto one entry and let one session's action resolve
+    against another's element indices — while each session's own fingerprint
+    check still passed, because both trees describe the same window.
+
+    Both halves are read at CALL time rather than captured at import: a ``fork``ed
+    child would otherwise inherit the parent's pid string and re-alias with it,
+    and the nonce belongs to the call in flight, not to the process.
 
     Never presented as trustworthy attribution — the prefix says so. This is a
     namespace separator, not an authenticated identity; a genuine identity still
-    comes only from the two sources ``_resolve_session_key_strict`` accepts.
+    comes only from the two sources ``_resolve_session_key_strict`` accepts, and
+    the nonce is not one of them (it names a connection, not a principal).
     """
-    return f"{UNRESOLVED_SESSION_PREFIX}{os.getpid()}"
+    key = f"{UNRESOLVED_SESSION_PREFIX}{os.getpid()}"
+    nonce = current_tenant_nonce()
+    if nonce:
+        return f"{key}{UNRESOLVED_TENANT_SEPARATOR}{nonce}"
+    return key
 
 
 def _list_tools() -> list[dict[str, Any]]:

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -2075,11 +2075,11 @@ def run_mcp_core_server() -> None:
         _call_tool,
         # Pooled-operation opt-in: kirocrew-core consumes the per-call
         # ``kirocrew.caller`` identity (see _resolve_session_key*), so it is
-        # safe to share one backend across sessions. kirocrew-cron advertises
-        # too, for the same reason. The two managed servers that do not --
-        # kirocrew-computer and kirocrew-dashboard -- are pooled all the same
-        # (nothing declines to pool an unadvertised backend; see
-        # ``rewriter.UNPOOLABLE_SERVERS``), so what they lack is the injected
-        # block, not co-tenancy.
+        # safe to share one backend across sessions. All four managed servers
+        # advertise today -- kirocrew-cron since #4622, kirocrew-computer and
+        # kirocrew-dashboard since #4659 -- and what advertising buys is the
+        # injected block, not co-tenancy: a backend that does NOT advertise is
+        # pooled all the same (nothing declines to pool one; see
+        # ``rewriter.UNPOOLABLE_SERVERS``) and simply never receives an identity.
         advertise_caller_identity=ADVERTISE_CALLER_IDENTITY,
     )

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -976,16 +976,28 @@ _MANAGED_SERVERS_CALLER_AWARE: frozenset[str] = frozenset(
 #: not-session-bound classification but not sufficient. ``kirocrew-computer``
 #: consumes the injected caller block (its pooled attribution is correct for
 #: every caller the gateway can name), but a caller the gateway CANNOT name
-#: proceeds under ``unresolved:<pid>`` by product decision — and on a pooled
-#: backend that pid is the shared process, so two unnamed co-tenants collapse
-#: onto one ``SnapshotIndex`` namespace and can act on each other's element
-#: indices (#5322). Unnamed is the NORMAL case on macOS, the only platform
-#: with a computer-use driver, so recommending co-tenancy would recommend the
-#: collision. Contrast ``kirocrew-dashboard``, which refuses an unidentified
-#: caller and is therefore safe to classify shareable. Remove this exception
-#: when #5322 gives unnamed callers isolated namespaces;
-#: ``test_mcp_managed_caller_identity.py`` pins it so it cannot silently
-#: persist or silently widen.
+#: proceeds under ``unresolved:<pid>`` by product decision — and unnamed is the
+#: NORMAL case on macOS, the only platform with a computer-use driver.
+#:
+#: #5322 gave those unnamed callers a per-CONNECTION nonce, so on a CURRENT
+#: gateway they no longer collapse onto one ``SnapshotIndex`` namespace. The
+#: entry stays because that is not the whole precondition. This set feeds
+#: ``managed_server_is_session_bound``, which feeds the shareability verdict,
+#: which ``mcp_gateway/seed.py`` turns into a CONFIG WRITE (``recommend_share``
+#: -> ``apply_seed``): promoting a name here can switch sharing ON for an
+#: operator who never chose it. And the daemon that would then serve those
+#: shared frames is not necessarily the one this code shipped with —
+#: ``mcp_gateway/manager.py`` ADOPTS whatever healthy daemon already holds the
+#: socket, so a gatewayd that outlived a package upgrade keeps running and
+#: injects no nonce (which is exactly why ``REGISTERED_CAPABILITIES`` exists).
+#: Promotion therefore has to wait until a nonce-blind gateway cannot serve a
+#: POOLED computer backend at all — negotiated, not assumed. Tracked as the
+#: #5322 follow-up.
+#:
+#: Contrast ``kirocrew-dashboard``, which refuses an unidentified caller and is
+#: therefore safe to classify shareable regardless of the daemon's generation.
+#: ``test_mcp_managed_caller_identity.py`` pins this so the entry can neither
+#: silently persist past its reason nor silently widen.
 _MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD: frozenset[str] = frozenset(
     {"kirocrew-computer"}
 )

--- a/src/kiro_crew/mcp_gateway/app_call.py
+++ b/src/kiro_crew/mcp_gateway/app_call.py
@@ -45,7 +45,7 @@ import uuid
 from typing import Any, Optional
 
 from kiro_crew.mcp_apps_render import load_spool
-from kiro_crew.mcp_caller import CallerContext
+from kiro_crew.mcp_caller import CallerContext, new_tenant_nonce
 from kiro_crew.mcp_gateway.apps import AUDIENCE_APP, visibility_allows
 from kiro_crew.sel import SecurityEventLog
 from kiro_crew.validation import ValidationError, validate_mcp_tool_arguments
@@ -95,7 +95,12 @@ async def _roundtrip(
     stub_uuid = f"__app_call__{uuid.uuid4().hex[:12]}"
     inbox = await backend.attach_stub(stub_uuid)
     try:
-        await backend.forward_from_stub(stub_uuid, frame, caller=caller)
+        # Own nonce per round-trip: this ephemeral stub is a distinct connection
+        # from every real one, so an unnamed app-call must not land in a chat
+        # session's per-tenant namespace on a pooled backend (#5322).
+        await backend.forward_from_stub(
+            stub_uuid, frame, caller=caller, tenant_nonce=new_tenant_nonce()
+        )
         deadline = time.monotonic() + timeout
         while True:
             remaining = deadline - time.monotonic()

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -32,8 +32,10 @@ from kiro_crew.executors import image_executor, maintenance_executor
 from kiro_crew.mcp_caller import (
     CALLER_CAPABILITY_KEY,
     CALLER_META_KEY,
+    TENANT_META_KEY,
     CallerContext,
     build_caller_meta,
+    build_tenant_meta,
 )
 from kiro_crew.mcp_gateway import hazards
 from kiro_crew.mcp_gateway.apps import (
@@ -296,20 +298,32 @@ class _PendingRequest:
 
 def _strip_caller_meta(msg: dict[str, Any]) -> dict[str, Any]:
     """Return a shallow copy of ``msg`` with any stub-supplied
-    ``params._meta.kirocrew.caller`` unconditionally removed.
+    ``params._meta.kirocrew.caller`` / ``params._meta.kirocrew.tenant``
+    unconditionally removed.
 
     The gateway is the trust boundary: stubs are untrusted clients and must
     never be able to forge their caller identity by pre-populating
     ``_meta.kirocrew.caller`` in the request. This function is called on
     EVERY forwarded request regardless of method so a malicious stub cannot
     sneak a forged caller block through non-tools/call methods.
+
+    BOTH gateway-owned blocks are stripped here, in ONE place, deliberately: the
+    tenant nonce decides which namespace an unnamed co-tenant's per-tenant state
+    lands in, so a stub allowed to supply its own could choose to land in a
+    PEER's namespace — the same collision #5322 fixed, only chosen instead of
+    accidental. Giving the nonce its own strip function would have added a second
+    site that every future forward path has to remember; both call sites of this
+    one (``forward_from_stub`` and ``_handle_initialize``) already exist.
     """
     out = dict(msg)
     params = out.get("params")
     if not isinstance(params, dict):
         return out
     meta_raw = params.get("_meta")
-    if not isinstance(meta_raw, dict) or CALLER_META_KEY not in meta_raw:
+    if not isinstance(meta_raw, dict):
+        return out
+    forged = [key for key in (CALLER_META_KEY, TENANT_META_KEY) if key in meta_raw]
+    if not forged:
         return out
     # The caller block is a FLAT ``params._meta[CALLER_META_KEY]`` key
     # ("kirocrew.caller") — exactly the shape build_caller_meta writes and
@@ -321,7 +335,8 @@ def _strip_caller_meta(msg: dict[str, Any]) -> dict[str, Any]:
     # request closes that regardless of whether injection happens.)
     params = dict(params)
     meta = dict(meta_raw)
-    del meta[CALLER_META_KEY]
+    for key in forged:
+        del meta[key]
     if meta:
         params["_meta"] = meta
     else:
@@ -497,6 +512,44 @@ def _inject_caller_meta(msg: dict[str, Any], caller: CallerContext) -> dict[str,
     meta = dict(meta_raw) if isinstance(meta_raw, dict) else {}
     # Inject the authoritative caller block from the gateway.
     meta.update(build_caller_meta(caller))
+    params["_meta"] = meta
+    out["params"] = params
+    return out
+
+
+def _inject_tenant_meta(msg: dict[str, Any], nonce: str) -> dict[str, Any]:
+    """Return a shallow copy of ``msg`` with ``params._meta.kirocrew.tenant``
+    set to this connection's *nonce*.
+
+    Injected on every request FORWARDED FROM A STUB by an advertising backend,
+    including the ones with no caller — that is the case it exists for. A backend
+    serving a caller the gateway cannot name falls back to a per-PROCESS
+    namespace, which on a pooled backend is one namespace for every unnamed
+    co-tenant (#5322); the nonce splits it per connection.
+
+    Deliberately NOT on the gateway's own synthesized lease frames
+    (``resources/subscribe`` / ``resources/unsubscribe`` replays): those carry the
+    caller because a subscription is held per caller, and no backend keys
+    subscription state by tenant. A backend that ever needs to would have to have
+    the nonce threaded into the lease bookkeeping, which is why this says
+    forwarded-from-a-stub rather than "always".
+
+    It is NOT an identity and must not be read as one: the block carries no
+    session key, so :meth:`CallerContext.from_meta` still finds nothing to parse
+    and every identity resolver keeps returning empty for an unnamed caller.
+
+    Copy discipline mirrors :func:`_inject_caller_meta`; assumes any stub-supplied
+    block was already removed by :func:`_strip_caller_meta`.
+    """
+    out = dict(msg)
+    params = out.get("params")
+    if isinstance(params, dict):
+        params = dict(params)
+    else:
+        params = {}
+    meta_raw = params.get("_meta")
+    meta = dict(meta_raw) if isinstance(meta_raw, dict) else {}
+    meta.update(build_tenant_meta(nonce))
     params["_meta"] = meta
     out["params"] = params
     return out
@@ -1135,6 +1188,7 @@ class Backend:
         msg: dict[str, Any],
         *,
         caller: Optional[CallerContext] = None,
+        tenant_nonce: str = "",
     ) -> None:
         """Forward one JSON-RPC message from ``stub_uuid`` to the backend.
 
@@ -1151,6 +1205,13 @@ class Backend:
            advertised the capability at initialize time. The block is
            built via :func:`kiro_crew.mcp_caller.build_caller_meta` so
            gateway + backend share exactly one wire format.
+
+        ``tenant_nonce`` is this CONNECTION's namespace separator, injected
+        alongside (3) and independently of it: a caller the gateway cannot name
+        gets no identity block but still gets a nonce, which is what keeps two
+        unnamed co-tenants of one pooled backend out of each other's per-tenant
+        state (#5322). Empty means "no separator available" and leaves the
+        backend on its own per-process fallback.
         """
         if not self.is_alive:
             raise BackendGone(self._dead_reason or "backend is not alive")
@@ -1255,6 +1316,8 @@ class Backend:
             msg = _strip_caller_meta(msg)
             if self.supports_caller_identity and caller is not None:
                 msg = _inject_caller_meta(msg, caller)
+            if self.supports_caller_identity and tenant_nonce:
+                msg = _inject_tenant_meta(msg, tenant_nonce)
 
         self.touch()
         try:

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -57,6 +57,7 @@ from kiro_crew.executors import (
 )
 from kiro_crew.mcp_caller import CallerContext
 from kiro_crew.mcp_caller import _parent_pid as _ppid_fn
+from kiro_crew.mcp_caller import new_tenant_nonce
 from kiro_crew.mcp_gateway import credwatch, hazards, socketsec, transport
 from kiro_crew.mcp_gateway.apps import sweep_spool as apps_sweep_spool
 from kiro_crew.mcp_gateway.backend import Backend, BackendGone, spawn_backend
@@ -1577,7 +1578,14 @@ class _StubConn:
     unreadable /proc) and never counts as a mismatch.
     """
 
-    __slots__ = ("stub_uuid", "ancestor_pids", "pool_label", "caller", "pid_start_ids")
+    __slots__ = (
+        "stub_uuid",
+        "ancestor_pids",
+        "pool_label",
+        "caller",
+        "pid_start_ids",
+        "tenant_nonce",
+    )
 
     def __init__(
         self,
@@ -1586,12 +1594,20 @@ class _StubConn:
         pool_label: str,
         caller: Optional[CallerContext],
         pid_start_ids: Optional[dict[int, Optional[str]]] = None,
+        tenant_nonce: str = "",
     ) -> None:
         self.stub_uuid = stub_uuid
         self.ancestor_pids = ancestor_pids
         self.pool_label = pool_label
         self.caller = caller
         self.pid_start_ids = pid_start_ids if pid_start_ids is not None else {}
+        # Namespace separator for a connection whose session the gateway cannot
+        # name, forwarded to the backend on every request (#5322). GATEWAY-minted
+        # and never derived from the Register frame: ``stub_uuid`` arrives from
+        # the stub, so a nonce derived from it would let one stub choose to share
+        # an unnamed peer's per-tenant namespace. Independent of ``caller``,
+        # which may be retargeted by a later claim-push while this stays put.
+        self.tenant_nonce = tenant_nonce
 
 
 #: Live stub connections indexed by every ancestor PID of the kiro-cli
@@ -2523,7 +2539,14 @@ async def _handle_connection(
         logger.exception("pid start-id snapshot failed for stub %s", stub_uuid)
         pid_start_ids = {}
 
-    conn = _StubConn(stub_uuid, indexed_pids, pool_key.human_readable(), caller, pid_start_ids)
+    conn = _StubConn(
+        stub_uuid,
+        indexed_pids,
+        pool_key.human_readable(),
+        caller,
+        pid_start_ids,
+        new_tenant_nonce(),
+    )
     _conn_index_add(conn)
 
     # Register this connection for the keepalive probe. Scoped to the handler's
@@ -2940,7 +2963,9 @@ async def _handle_connection(
                 captured_init = dict(msg)
 
             try:
-                await backend.forward_from_stub(stub_uuid, msg, caller=caller)
+                await backend.forward_from_stub(
+                    stub_uuid, msg, caller=caller, tenant_nonce=conn.tenant_nonce
+                )
             except BackendGone as exc:
                 # Transparent respawn: a shared backend dying must NOT brick
                 # this stub's transport (which would make kiro-cli mark the

--- a/src/kiro_crew/mcp_gateway/shareability.py
+++ b/src/kiro_crew/mcp_gateway/shareability.py
@@ -342,9 +342,11 @@ def assess(
     #    to fall back on. The set of producers has narrowed as managed servers
     #    adopted the caller block (#4622, #4659), but the branch keeps two jobs:
     #    ``kirocrew-computer`` advertises yet stays session-bound deliberately
-    #    (its UNNAMED co-tenants would share one ``unresolved:<pid>`` snapshot
-    #    namespace, #5322), and the conservative default for a future managed
-    #    server missing from ``_MANAGED_SERVERS_CALLER_AWARE`` (pinned by
+    #    (#5322 gave its UNNAMED co-tenants per-connection namespaces on a current
+    #    gateway, but an ADOPTED pre-nonce daemon injects none — see
+    #    ``_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD``), and the conservative
+    #    default for a future managed server missing from
+    #    ``_MANAGED_SERVERS_CALLER_AWARE`` (pinned by
     #    ``test_a_managed_server_missing_from_the_aware_set_reads_as_session_bound``)
     #    must land HERE, as a disqualifier, rather than in the shareable set.
     #

--- a/src/kiro_crew/mcp_shared.py
+++ b/src/kiro_crew/mcp_shared.py
@@ -28,6 +28,8 @@ from kiro_crew.mcp_caller import (
     CallerContext,
     caller_identity_capability,
     set_current_caller,
+    set_current_tenant_nonce,
+    tenant_nonce_from_meta,
 )
 from kiro_crew.sel import sel
 from kiro_crew.validation import (
@@ -869,6 +871,7 @@ def _run_stdio_dispatch_loop(
         tool_args: dict,
         cancel_evt: threading.Event,
         caller_ctx: "CallerContext | None" = None,
+        tenant_nonce: str = "",
     ) -> None:
         """Worker thread: run tool, store result unless cancelled."""
         global _thread_cancel_event
@@ -878,6 +881,11 @@ def _run_stdio_dispatch_loop(
         # a module slot: dispatch is strictly sequential (one worker at a
         # time, joined before the next dispatch).
         set_current_caller(caller_ctx)
+        # And the connection's namespace separator, which is present even when
+        # the caller is not: a tool that keys per-tenant state for a caller the
+        # gateway could not name reads it instead of a process-global fallback
+        # (#5322). Cleared in the same places as the caller.
+        set_current_tenant_nonce(tenant_nonce)
         try:
             result_text = call_tool_fn(tool_name, tool_args)
         except ToolCancelled:
@@ -892,6 +900,7 @@ def _run_stdio_dispatch_loop(
             )
             _thread_cancel_event = None
             set_current_caller(None)
+            set_current_tenant_nonce("")
             _result_ready.set()
             return
         except Exception as exc:
@@ -902,6 +911,7 @@ def _run_stdio_dispatch_loop(
         finally:
             _thread_cancel_event = None
             set_current_caller(None)
+            set_current_tenant_nonce("")
         # Audit decision is made atomically with the cancellation check, under
         # the same lock that guards response delivery: exactly ONE audit event
         # per request (a failed+late-cancel race must not emit two).
@@ -1117,6 +1127,11 @@ def _run_stdio_dispatch_loop(
             # on every forwarded call, so a block present here is
             # gateway-authored. None in the non-pooled stdio topology.
             _caller_ctx = CallerContext.from_meta(params.get("_meta"))
+            # The connection's namespace separator. Parsed separately because it
+            # arrives WITHOUT an identity for a caller the gateway could not
+            # name — the case it exists for (#5322) — so it cannot be folded
+            # into ``_caller_ctx``, which is None exactly then.
+            _tenant_nonce = tenant_nonce_from_meta(params.get("_meta"))
             # A queued request may have been cancelled while waiting -- emit
             # no response (per MCP spec) but audit the cancellation.
             if req_id is not None and str(req_id) in _cancelled_ids:
@@ -1160,6 +1175,7 @@ def _run_stdio_dispatch_loop(
                 # an Error response and the failure is SEL-audited with the
                 # caller identity (an escaped exception would kill the loop).
                 set_current_caller(_caller_ctx)
+                set_current_tenant_nonce(_tenant_nonce)
                 try:
                     result_text = call_tool_fn(tool_name, tool_args)
                 except Exception as exc:
@@ -1172,6 +1188,7 @@ def _run_stdio_dispatch_loop(
                     )
                 finally:
                     set_current_caller(None)
+                    set_current_tenant_nonce("")
                 respond(req_id, build_tool_response(result_text))
             else:
                 # Dispatch tool in worker thread so we can receive cancel notifications
@@ -1186,7 +1203,14 @@ def _run_stdio_dispatch_loop(
                 _result_box.clear()
                 _worker_thread = threading.Thread(
                     target=_run_tool,
-                    args=(req_id, tool_name, tool_args, _cancel_event, _caller_ctx),
+                    args=(
+                        req_id,
+                        tool_name,
+                        tool_args,
+                        _cancel_event,
+                        _caller_ctx,
+                        _tenant_nonce,
+                    ),
                     daemon=True,
                 )
                 _worker_thread.start()

--- a/test/fake_pool_mcp_server.py
+++ b/test/fake_pool_mcp_server.py
@@ -20,6 +20,11 @@ advertised, so a recorder that stayed silent would observe nothing and read as a
 broken gateway. Without the argument the handshake is byte-for-byte what the
 launch-counting tests already assert against.
 
+An OPTIONAL third path argument records the per-CONNECTION ``nonce`` the same way,
+which is the separate question of whether each connection got its OWN namespace --
+the one that matters for a caller gatewayd cannot name, where there is no identity
+to tell co-tenants apart by (#5322). Either path alone turns advertising on.
+
 Stdlib only, and launched as ``sys.executable <this file> <log>`` -- never
 through a shell and never via ``-c`` -- so no quoting or backslash assumption
 travels onto Windows.
@@ -41,6 +46,13 @@ def main() -> int:
     # nothing and read as "injection is broken". Default off so the pooling tests
     # that only count launches keep the exact handshake they assert against.
     caller_log = sys.argv[2] if len(sys.argv) > 2 else ""
+    # Optional third argument: a path to record the per-CONNECTION nonce each
+    # tools/call arrived with, one line per call. Separate from ``caller_log`` so
+    # the tests that assert on identities keep their exact line format: the nonce
+    # is a namespace separator, present even when the identity is not, and the
+    # question it answers ("did gatewayd give each connection its own?") is a
+    # different one.
+    tenant_log = sys.argv[3] if len(sys.argv) > 3 else ""
 
     # One line per process launch. Opened in append mode and closed
     # immediately: a backend that lingers must not hold the handle that the
@@ -58,15 +70,20 @@ def main() -> int:
         except json.JSONDecodeError:
             continue
         method = msg.get("method")
-        if method == "tools/call" and caller_log:
+        if method == "tools/call" and (caller_log or tenant_log):
             params = msg.get("params") or {}
             meta = params.get("_meta") or {}
             block = meta.get("kirocrew.caller") or {}
+            tenant = meta.get("kirocrew.tenant") or {}
             # The empty string is a meaningful observation -- it is what a
             # backend sees when nothing injected -- so record it rather than
             # skipping the line.
-            with open(caller_log, "a", encoding="utf-8") as fh:
-                fh.write(f"{block.get('sessionKey', '')}\n")
+            if caller_log:
+                with open(caller_log, "a", encoding="utf-8") as fh:
+                    fh.write(f"{block.get('sessionKey', '')}\n")
+            if tenant_log:
+                with open(tenant_log, "a", encoding="utf-8") as fh:
+                    fh.write(f"{tenant.get('nonce', '')}\n")
             sys.stdout.write(
                 json.dumps({"jsonrpc": "2.0", "id": msg.get("id"), "result": {}}) + "\n"
             )
@@ -76,7 +93,7 @@ def main() -> int:
             continue
         params = msg.get("params") or {}
         capabilities: dict = {"tools": {}}
-        if caller_log:
+        if caller_log or tenant_log:
             capabilities["experimental"] = {"kirocrew.caller-identity": {"schemaVersion": 1}}
         reply = {
             "jsonrpc": "2.0",

--- a/test/test_mcp_caller.py
+++ b/test/test_mcp_caller.py
@@ -11,8 +11,19 @@ from __future__ import annotations
 import os
 from unittest import mock
 
+import pytest
+
 import kiro_crew.mcp_caller
-from kiro_crew.mcp_caller import CallerContext
+from kiro_crew.mcp_caller import (
+    _TENANT_NONCE_BYTES,
+    TENANT_META_KEY,
+    TENANT_SCHEMA_VERSION,
+    CallerContext,
+    build_caller_meta,
+    build_tenant_meta,
+    new_tenant_nonce,
+    tenant_nonce_from_meta,
+)
 
 
 def test_from_env_uses_host_pid_env_before_walk(tmp_path, monkeypatch) -> None:
@@ -55,3 +66,74 @@ def test_from_env_host_pid_missing_file_falls_back_to_walk(tmp_path, monkeypatch
         with mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path):
             ctx = CallerContext.from_env()
     assert ctx.session_key == "walk-session-111"
+
+
+# --- Per-connection tenant nonce (#5322) ------------------------------------
+#
+# The nonce exists for the case the caller block cannot serve: a connection the
+# gateway cannot NAME. It is a namespace separator, so what these pin is that it
+# stays one -- parsed leniently, never promoted to an identity, and never derived
+# from anything a stub supplies.
+
+
+def test_a_tenant_block_carries_the_nonce_and_nothing_else() -> None:
+    meta = build_tenant_meta("n0nce")
+    assert meta[TENANT_META_KEY]["nonce"] == "n0nce"
+    assert meta[TENANT_META_KEY]["schemaVersion"] == TENANT_SCHEMA_VERSION
+    assert tenant_nonce_from_meta(meta) == "n0nce"
+
+
+def test_a_tenant_block_is_not_an_identity() -> None:
+    """The separation the whole design rests on.
+
+    If ``from_meta`` accepted a tenant block, an unnamed caller would reach every
+    consumer of a session key -- cron ownership, callback routing, audit --
+    carrying a value that names no principal while looking resolved.
+    """
+    assert CallerContext.from_meta(build_tenant_meta("n0nce")) is None
+
+
+def test_a_caller_block_carries_no_nonce() -> None:
+    """And the converse: the two blocks are independent, so a named caller's
+    frame does not smuggle a separator the fallback would then append."""
+    assert tenant_nonce_from_meta(build_caller_meta(CallerContext(session_key="s"))) == ""
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        None,
+        "not a dict",
+        {},
+        {TENANT_META_KEY: "not a dict"},
+        {TENANT_META_KEY: {}},
+        {TENANT_META_KEY: {"nonce": "n"}},  # no schemaVersion
+        {TENANT_META_KEY: {"schemaVersion": "1", "nonce": "n"}},  # not an int
+        {TENANT_META_KEY: {"schemaVersion": 0, "nonce": "n"}},  # below v1
+        {TENANT_META_KEY: {"schemaVersion": 1}},  # no nonce
+        {TENANT_META_KEY: {"schemaVersion": 1, "nonce": 7}},  # not a string
+    ],
+)
+def test_a_malformed_tenant_block_reads_as_absent(meta) -> None:
+    """Every bad shape degrades to "no separator", never to an exception.
+
+    The consumer's fallback (its own process) is correct in the 1:1 topology, so
+    an unparseable block must land there rather than failing the tool call.
+    """
+    assert tenant_nonce_from_meta(meta) == ""
+
+
+def test_an_unknown_schema_version_is_read_additively() -> None:
+    """Same forward-compatibility rule as the caller block: a v2 gateway talking
+    to a v1 backend must still get its nonce across."""
+    assert tenant_nonce_from_meta(
+        {TENANT_META_KEY: {"schemaVersion": 99, "nonce": "n0nce", "future": 1}}
+    ) == "n0nce"
+
+
+def test_each_minted_nonce_is_distinct_and_unguessable() -> None:
+    """Two connections must never collide, and one stub must not be able to
+    predict a peer's namespace from its own."""
+    minted = {new_tenant_nonce() for _ in range(100)}
+    assert len(minted) == 100
+    assert all(len(n) == _TENANT_NONCE_BYTES * 2 for n in minted)

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -78,6 +78,11 @@ from kiro_crew.computer_use.types import (
     TOOL_TYPE_TEXT,
     AppRef,
 )
+from kiro_crew.mcp_caller import (
+    CallerContext,
+    set_current_caller,
+    set_current_tenant_nonce,
+)
 from kiro_crew.testing.fake_computer_use import (
     FAKE_CREDENTIAL_FIXTURE,
     FAKE_FILES_APP,
@@ -2032,7 +2037,26 @@ class TestUnresolvedSessionsAreNamespaced:
     spawns one shim process per session, so the shim's own pid separates the
     namespaces precisely as far as the sessions are genuinely separate, and nothing is
     refused. The security posture is unchanged; only the cache key is.
+
+    #5322 is the POOLED half of the same aliasing. "One shim process per session" is
+    the 1:1 topology's premise, and a pooled backend breaks it: one process serves N
+    connections, so the pid separates nothing and every unnamed co-tenant collapsed
+    back onto a single ``unresolved:<pid>`` key. The pid is now joined by the
+    gateway-minted per-CONNECTION nonce, which separates them again — still a
+    separator, still not attribution, and still nothing refused.
     """
+
+    @pytest.fixture(autouse=True)
+    def _no_ambient_nonce(self):
+        """No injected nonce unless a test installs one.
+
+        The nonce lives in a ``ContextVar`` the dispatch loop sets and clears, so a
+        test leaving one installed would silently rewrite every later test's
+        expected key.
+        """
+        set_current_tenant_nonce("")
+        yield
+        set_current_tenant_nonce("")
 
     def test_two_unresolved_sessions_do_not_share_a_snapshot_slot(self):
         """The bug, at the layer it actually lived in."""
@@ -2065,6 +2089,99 @@ class TestUnresolvedSessionsAreNamespaced:
     def test_the_placeholder_is_per_process(self):
         key = mcp_computer._unresolved_session_key()
         assert key == f"{mcp_computer.UNRESOLVED_SESSION_PREFIX}{os.getpid()}"
+
+    def test_two_unnamed_co_tenants_of_ONE_process_do_not_share_a_slot(self, monkeypatch):
+        """#5322, at the layer it lives in — one pid, two connections.
+
+        Both co-tenants run in the SAME shim process, so ``os.getpid()`` is pinned to
+        one value here deliberately: that is the whole premise the pooled topology
+        breaks. Without the nonce half both keys are the same string and the second
+        snapshot answers the first session's lookup — the wrong-target action the
+        fingerprint check cannot catch, because both trees describe the same window.
+        """
+        from kiro_crew.computer_use.index import SnapshotIndex
+        from kiro_crew.computer_use.types import ElementRec, Snapshot
+
+        monkeypatch.setattr(os, "getpid", lambda: 5150)
+        app = AppRef(name="Notes", pid=1, window_id=7)
+
+        def snap(title: str) -> Snapshot:
+            return Snapshot(
+                app=app,
+                elements=(ElementRec(index=0, role="AXButton", title=title),),
+                captured_at=100.0,
+            )
+
+        keys: list[str] = []
+        for nonce in ("aaaa1111", "bbbb2222"):
+            set_current_tenant_nonce(nonce)
+            keys.append(mcp_computer._unresolved_session_key())
+
+        assert keys[0] != keys[1], "one pid, two connections: the keys must differ"
+
+        index = SnapshotIndex()
+        index.put(snap("A"), session_key=keys[0])
+        index.put(snap("B"), session_key=keys[1])
+        for key, expected in zip(keys, ("A", "B")):
+            got = index.get(app.window_key, session_key=key, now=100.0)
+            assert got is not None and got.elements[0].title == expected, key
+
+    def test_the_nonce_half_is_read_at_CALL_time_too(self, monkeypatch):
+        """One process serves many connections in sequence as well as concurrently.
+
+        A nonce captured once per process would namespace by process again, which is
+        the bug. Each call reads the connection the call arrived on.
+        """
+        monkeypatch.setattr(os, "getpid", lambda: 5150)
+        set_current_tenant_nonce("first")
+        assert mcp_computer._unresolved_session_key() == "unresolved:5150#first"
+        set_current_tenant_nonce("second")
+        assert mcp_computer._unresolved_session_key() == "unresolved:5150#second"
+
+    def test_the_nonce_never_becomes_an_IDENTITY(self, monkeypatch):
+        """A separator must not be promoted to attribution.
+
+        The nonce names a connection, not a principal. If the strict resolver ever
+        read it, an unnamed caller would arrive at every consumer of a session key —
+        cron ownership, callback routing, audit — carrying a key that names nobody
+        while LOOKING resolved. So with a nonce installed and no identity source,
+        strict resolution must still come back empty, and the shim must still take
+        the unresolved path.
+        """
+        monkeypatch.delenv("KIROCREW_SESSION_KEY", raising=False)
+        monkeypatch.delenv("KIROCREW_HOST_PID", raising=False)
+        set_current_caller(None)
+        set_current_tenant_nonce("cafebabe")
+
+        assert mcp_computer._resolve_session_key_strict() == ""
+        assert mcp_computer._unresolved_session_key().startswith(
+            mcp_computer.UNRESOLVED_SESSION_PREFIX
+        )
+
+    def test_a_named_co_tenant_is_unaffected_by_the_nonce(self, monkeypatch):
+        """The nonce is the fallback's business only.
+
+        A caller the gateway CAN name already has a per-session key; appending a
+        connection nonce to it would split one session's own namespace across a
+        reconnect for no reason.
+        """
+        set_current_caller(CallerContext(session_key="dashboard:main"))
+        set_current_tenant_nonce("cafebabe")
+        try:
+            assert mcp_computer._resolve_session_key_strict() == "dashboard:main"
+        finally:
+            set_current_caller(None)
+
+    def test_the_key_survives_an_HTTP_header(self):
+        """The key is sent as ``X-Session-Key``, so the separator must be encodable.
+
+        ``_session_key_header_error`` is the shim's own pre-flight; a key it rejects
+        never reaches the gateway at all.
+        """
+        set_current_tenant_nonce("cafebabe")
+        assert (
+            mcp_computer._session_key_header_error(mcp_computer._unresolved_session_key()) is None
+        )
 
     def test_it_is_read_at_CALL_time_not_captured_at_import(self, monkeypatch):
         """A ``fork``ed child must not inherit the parent's string.

--- a/test/test_mcp_gateway_backend_coverage.py
+++ b/test/test_mcp_gateway_backend_coverage.py
@@ -38,7 +38,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kiro_crew.mcp_caller import CALLER_META_KEY, CallerContext
+from kiro_crew.mcp_caller import (
+    CALLER_META_KEY,
+    TENANT_META_KEY,
+    CallerContext,
+    tenant_nonce_from_meta,
+)
 from kiro_crew.mcp_gateway import backend as backend_mod
 from kiro_crew.mcp_gateway.backend import (
     HEARTBEAT_PING_ID,
@@ -49,6 +54,7 @@ from kiro_crew.mcp_gateway.backend import (
     BackendGone,
     _inject_caller_meta,
     _inject_client_extensions,
+    _inject_tenant_meta,
     _is_heartbeat_id,
     _mcp_apps_enabled,
     _PendingRequest,
@@ -217,6 +223,66 @@ class TestFrameHelpers:
         assert out["params"]["_meta"]["progressToken"] == 7
         assert out["params"]["name"] == "t"
         assert "_meta" in msg["params"] and CALLER_META_KEY not in msg["params"]["_meta"]
+
+    def test_strip_caller_meta_also_removes_a_forged_TENANT_block(self) -> None:
+        """The nonce decides which namespace an unnamed co-tenant lands in.
+
+        A stub allowed to supply its own would pick a PEER's namespace — #5322's
+        collision chosen instead of accidental — so the nonce is stripped on the
+        same trust boundary as the identity, by the same function, on every
+        forwarded frame.
+        """
+        msg: dict[str, Any] = {
+            "method": "tools/call",
+            "params": {
+                "_meta": {
+                    TENANT_META_KEY: {"schemaVersion": 1, "nonce": "peer-nonce"},
+                    "progressToken": "pt",
+                }
+            },
+        }
+        out = _strip_caller_meta(msg)
+        assert TENANT_META_KEY not in out["params"]["_meta"]
+        assert out["params"]["_meta"]["progressToken"] == "pt"
+        assert TENANT_META_KEY in msg["params"]["_meta"]
+
+    def test_strip_caller_meta_removes_BOTH_blocks_at_once(self) -> None:
+        """One forged block must not shield the other."""
+        msg: dict[str, Any] = {
+            "method": "tools/call",
+            "params": {
+                "_meta": {
+                    CALLER_META_KEY: {"sessionKey": "forged"},
+                    TENANT_META_KEY: {"schemaVersion": 1, "nonce": "forged"},
+                }
+            },
+        }
+        out = _strip_caller_meta(msg)
+        assert "_meta" not in out["params"]
+
+    def test_inject_tenant_meta_carries_the_nonce_without_an_identity(self) -> None:
+        """The shape an UNNAMED co-tenant receives.
+
+        A nonce block and no caller block: the separator arrives, the identity does
+        not, and ``CallerContext.from_meta`` must still find nothing — otherwise a
+        connection name would be laundered into a session identity.
+        """
+        out = _inject_tenant_meta({"method": "tools/call"}, "n0nce")
+        meta = out["params"]["_meta"]
+        assert meta[TENANT_META_KEY]["nonce"] == "n0nce"
+        assert CALLER_META_KEY not in meta
+        assert CallerContext.from_meta(meta) is None
+        assert tenant_nonce_from_meta(meta) == "n0nce"
+
+    def test_inject_tenant_meta_preserves_other_meta(self) -> None:
+        msg: dict[str, Any] = {
+            "method": "tools/call",
+            "params": {"_meta": {"progressToken": 7}, "name": "t"},
+        }
+        out = _inject_tenant_meta(msg, "n0nce")
+        assert out["params"]["_meta"]["progressToken"] == 7
+        assert out["params"]["name"] == "t"
+        assert TENANT_META_KEY not in msg["params"]["_meta"]
 
     def test_is_heartbeat_id_accepts_int_and_string(self) -> None:
         assert _is_heartbeat_id(HEARTBEAT_PING_ID)

--- a/test/test_mcp_gateway_claim.py
+++ b/test/test_mcp_gateway_claim.py
@@ -139,6 +139,11 @@ class _FakeBackend:
 
     def __init__(self) -> None:
         self.callers: list[Any] = []
+        # Per-connection nonces the handler forwarded, in order. Recorded rather
+        # than swallowed so this double keeps ANSWERING the identity question it
+        # exists for: a nonce is what tells two co-tenants apart when the caller
+        # is None.
+        self.nonces: list[str] = []
         self.forwarded = asyncio.Event()
         self._pending_requests: dict = {}
 
@@ -154,8 +159,11 @@ class _FakeBackend:
     async def recycle_if_idle(self) -> bool:
         return False
 
-    async def forward_from_stub(self, _uuid: str, _msg: dict, caller: Any = None) -> None:
+    async def forward_from_stub(
+        self, _uuid: str, _msg: dict, caller: Any = None, tenant_nonce: str = ""
+    ) -> None:
         self.callers.append(caller)
+        self.nonces.append(tenant_nonce)
         self.forwarded.set()
 
 
@@ -242,6 +250,13 @@ async def test_claim_retargets_live_connection(monkeypatch: pytest.MonkeyPatch) 
     assert len(fb.callers) == 2
     assert fb.callers[1] is not None
     assert fb.callers[1].session_key == "dashboard:chat-CP-1"
+    # The nonce names the CONNECTION, not the session, so a claim that retargets
+    # the identity must leave it alone. If it moved with the identity, a backend
+    # keying per-tenant state on it would lose that state the moment its session
+    # was named — and the pre-claim frames would be attributed to a namespace no
+    # later frame can reach.
+    assert len(fb.nonces) == 2
+    assert fb.nonces[0] and fb.nonces[0] == fb.nonces[1]
     events = _claim_events(sel)
     assert len(events) == 1 and events[0]["outcome"] == "allowed"
     assert events[0]["caller"] == "dashboard:chat-CP-1"

--- a/test/test_mcp_gateway_exclusive_backend.py
+++ b/test/test_mcp_gateway_exclusive_backend.py
@@ -397,7 +397,9 @@ class _HandlerBackend:
     async def recycle_if_idle(self) -> bool:
         return False
 
-    async def forward_from_stub(self, _uuid: str, _msg: dict, caller: Any = None) -> None:
+    async def forward_from_stub(
+        self, _uuid: str, _msg: dict, caller: Any = None, tenant_nonce: str = ""
+    ) -> None:
         pass
 
 

--- a/test/test_mcp_gateway_pool_integ.py
+++ b/test/test_mcp_gateway_pool_integ.py
@@ -307,6 +307,102 @@ async def test_two_stubs_on_one_backend_are_told_apart(tmp_path: Path, short_soc
 
 
 @pytest.mark.asyncio
+async def test_two_UNNAMED_stubs_on_one_backend_get_distinct_namespaces(
+    tmp_path: Path, short_sock_dir
+) -> None:
+    """#5322: co-tenants gatewayd cannot NAME must still be separable.
+
+    The sibling test above proves a named co-tenant arrives carrying its own
+    identity. This is the case that has no identity to arrive with: a stub whose
+    session gatewayd cannot resolve forwards ``caller=None``, so nothing in the
+    frame distinguishes two such stubs. The backend then falls back to its own
+    process for a namespace -- correct in the 1:1 shim topology, and worthless on a
+    POOLED backend where that process is shared, which is how two unnamed
+    co-tenants came to share one ``unresolved:<pid>`` snapshot namespace and could
+    resolve element indices against each other's trees.
+
+    So this drives two identity-less stubs onto one pooled backend and reads back
+    the per-connection nonce each call carried. Distinct, non-empty values are the
+    whole fix: they are what the backend keys per-tenant state on when there is no
+    identity.
+
+    The nonce is asserted, not the (absent) identity: on a host where the peer
+    walk happens to find a pidfile for the test process's ancestry a stub could
+    legitimately be named, and that would not weaken this claim -- the nonce is
+    injected for every connection either way.
+    """
+    endpoint_root = short_sock_dir
+    sock = endpoint_root / "gw.sock"
+    work_dir = tmp_path / "ws"
+    work_dir.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    launch_log = tmp_path / "launches.txt"
+    caller_log = tmp_path / "callers.txt"
+    tenant_log = tmp_path / "tenants.txt"
+
+    def _resolver(_key: object) -> tuple[str, list[str], dict[str, str], str]:
+        return (
+            sys.executable,
+            [str(_FAKE_SERVER), str(launch_log), str(caller_log), str(tenant_log)],
+            {},
+            str(work_dir),
+        )
+
+    stop = asyncio.Event()
+    daemon = asyncio.create_task(
+        gw.run_gatewayd(
+            socket_path=sock,
+            max_backends=8,
+            idle_timeout_secs=300,
+            stop_event=stop,
+            target_resolver=_resolver,
+            prewarm_count=0,
+        )
+    )
+    procs: list[asyncio.subprocess.Process] = []
+    try:
+        for _ in range(100):
+            if transport.endpoint_exists(sock):
+                break
+            await asyncio.sleep(0.05)
+        assert transport.endpoint_exists(sock), "gatewayd never bound its endpoint"
+
+        for i in range(2):
+            proc = await _spawn_stub(
+                socket_path=sock, server="fake", agent="probe",
+                work_dir=work_dir, home=home, session_key="",
+            )
+            procs.append(proc)
+            reply = await _drive_initialize(proc, req_id=i + 1)
+            assert "result" in reply, f"unnamed stub {i} got no initialize result: {reply}"
+            reply = await _drive_tool_call(proc, req_id=100 + i)
+            assert "result" in reply, f"unnamed stub {i} got no tools/call result: {reply}"
+
+        assert _launch_count(launch_log) == 1, (
+            "the two stubs did not share a backend, so this run says nothing "
+            "about separating unnamed co-tenants"
+        )
+
+        nonces = _observed_callers(tenant_log)
+        assert len(nonces) == 2, f"expected one nonce per call, got {nonces!r}"
+        assert all(nonces), (
+            f"a call reached the shared backend with no nonce: {nonces!r}. With no "
+            "identity and no nonce the backend has nothing left but its own pid, "
+            "which is the SHARED process -- both co-tenants land in one namespace."
+        )
+        assert nonces[0] != nonces[1], (
+            f"both unnamed co-tenants got the same nonce {nonces[0]!r}. One "
+            "namespace for two sessions is exactly #5322: each one's own "
+            "fingerprint check still passes, so a wrong-target action is silent."
+        )
+    finally:
+        await _reap(procs)
+        stop.set()
+        await asyncio.wait_for(daemon, timeout=30)
+
+
+@pytest.mark.asyncio
 async def test_real_stubs_sharing_a_key_share_one_backend(tmp_path: Path, short_sock_dir) -> None:
     """THE pooling assertion: 3 real stub processes -> exactly 1 MCP server.
 

--- a/test/test_mcp_gateway_recaller.py
+++ b/test/test_mcp_gateway_recaller.py
@@ -103,7 +103,9 @@ class _FakeBackend:
     async def recycle_if_idle(self) -> bool:
         return False
 
-    async def forward_from_stub(self, _uuid: str, _msg: dict, caller: Any = None) -> None:
+    async def forward_from_stub(
+        self, _uuid: str, _msg: dict, caller: Any = None, tenant_nonce: str = ""
+    ) -> None:
         self.callers.append(caller)
 
 

--- a/test/test_mcp_managed_caller_identity.py
+++ b/test/test_mcp_managed_caller_identity.py
@@ -79,9 +79,9 @@ def test_session_bound_follows_advertising_modulo_the_withheld_set(name: str, mo
     Advertising is necessary for the shareable classification but not
     sufficient: ``_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD`` names servers
     whose pooled attribution is correct for every caller the gateway can name
-    but whose UNNAMED co-tenants would collide (#5322), so they are kept
-    session-bound deliberately. Every other server must follow the inverse
-    rule exactly.
+    but whose UNNAMED co-tenants are not provably separated on every gateway
+    generation, so they are kept session-bound deliberately. Every other server
+    must follow the inverse rule exactly.
     """
     module_name = _MANAGED_SERVER_TOOL_MODULES[name]
     advertised = _advertised_by_serve_entry(module_name, _SERVE_ENTRY[name], monkeypatch)
@@ -95,8 +95,8 @@ def test_session_bound_follows_advertising_modulo_the_withheld_set(name: str, mo
 def test_the_withheld_set_is_a_real_exception_not_a_stale_one(monkeypatch) -> None:
     """Each withheld name must be managed, actually advertise, and not also
     be claimed caller-aware — otherwise the exception is stale (the server
-    stopped advertising, or #5322 landed and the name was promoted without
-    deleting it here) or self-contradictory.
+    stopped advertising, or the hazard behind it was fixed and the name was
+    promoted without deleting it here) or self-contradictory.
     """
     withheld = mcp_discovery._MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD
     assert withheld <= set(_MANAGED_SERVER_TOOL_MODULES)
@@ -119,11 +119,12 @@ def test_the_concrete_verdicts_are_spelled_out() -> None:
     safely namespace an unidentified caller, so none is session-bound.
     ``kirocrew-computer`` also advertises and consumes the block (#4659 — its
     pooled attribution is correct for every caller the gateway can name), but
-    it stays session-bound DELIBERATELY: an unnamed caller proceeds under
-    ``unresolved:<pid>``, which on a pooled backend is one shared namespace for
-    every unnamed co-tenant (#5322) — and unnamed is the normal case on macOS,
-    the only platform with a driver. It flips when #5322 gives unnamed callers
-    isolated namespaces.
+    it stays session-bound DELIBERATELY, and #5322 did not change that on its
+    own: the per-connection nonce removes the namespace collision on a CURRENT
+    gateway, while this classification is what ``seed.py`` turns into a config
+    write, and the daemon serving those shared frames may be a pre-nonce one
+    ``manager.py`` adopted across an upgrade. Promotion waits on a negotiated
+    guarantee that a nonce-blind gateway cannot serve a pooled computer backend.
     """
     assert managed_server_is_session_bound("kirocrew-core") is False
     assert managed_server_is_session_bound("kirocrew-cron") is False

--- a/test/test_mcp_shared.py
+++ b/test/test_mcp_shared.py
@@ -808,6 +808,15 @@ def _tools_call_with_caller(req_id, tool_name: str, session_key: str) -> dict:
     return msg
 
 
+def _tools_call_with_tenant(req_id, tool_name: str, nonce: str) -> dict:
+    """A forwarded call as an UNNAMED co-tenant receives it: nonce, no identity."""
+    from kiro_crew.mcp_caller import build_tenant_meta
+
+    msg = _tools_call(req_id, tool_name)
+    msg["params"]["_meta"] = build_tenant_meta(nonce)
+    return msg
+
+
 class TestStdioLoopCallerIdentity:
     def setup_method(self):
         mcp_shared._use_content_length = False
@@ -858,6 +867,56 @@ class TestStdioLoopCallerIdentity:
             assert harness.wait_for(lambda: len(harness.responses) >= 1)
             assert seen == ["dashboard:chat-3"]
             assert mcp_caller.current_caller() is None  # cleared after dispatch
+        finally:
+            harness.close()
+
+    def test_tool_sees_the_tenant_nonce_WITHOUT_an_identity(self, monkeypatch):
+        """#5322: the separator arrives even when the identity does not.
+
+        This is the frame an unnamed co-tenant of a pooled backend receives. The
+        nonce must reach the tool (it is what per-tenant state is keyed on when
+        there is nothing else), the caller must stay None (a connection name is not
+        an identity), and both must be cleared afterwards so the next dispatch on
+        this thread cannot inherit them.
+        """
+        from kiro_crew import mcp_caller
+
+        seen: list = []
+
+        def call_tool(name, args):
+            seen.append((mcp_caller.current_caller(), mcp_caller.current_tenant_nonce()))
+            return "ok"
+
+        harness = _LoopHarness(monkeypatch, call_tool)
+        try:
+            harness.send(_tools_call_with_tenant(12, "echo", "n0nce-a"))
+            assert harness.wait_for(lambda: len(harness.responses) >= 1)
+            assert seen == [(None, "n0nce-a")]
+            assert mcp_caller.current_tenant_nonce() == ""  # cleared after dispatch
+        finally:
+            harness.close()
+
+    def test_a_call_with_no_tenant_block_sees_an_empty_nonce(self, monkeypatch):
+        """The 1:1 topology, where no gateway injects anything.
+
+        An empty nonce is the signal to keep using the backend's own per-process
+        fallback, so it must not be a stale value from a previous call.
+        """
+        from kiro_crew import mcp_caller
+
+        seen: list = []
+
+        def call_tool(name, args):
+            seen.append(mcp_caller.current_tenant_nonce())
+            return "ok"
+
+        harness = _LoopHarness(monkeypatch, call_tool)
+        try:
+            harness.send(_tools_call_with_tenant(13, "echo", "n0nce-a"))
+            assert harness.wait_for(lambda: len(harness.responses) >= 1)
+            harness.send(_tools_call(14, "echo"))
+            assert harness.wait_for(lambda: len(harness.responses) >= 2)
+            assert seen == ["n0nce-a", ""]
         finally:
             harness.close()
 


### PR DESCRIPTION
## What is the problem?

On a POOLED computer-use backend, two or more sessions the gateway cannot NAME shared one snapshot namespace and could act on each other's element indices.

`mcp_gateway/backend.py:forward_from_stub` injects a caller block only when gatewayd can name the calling stub; a co-tenant it cannot name reaches the backend with no identity at all. `kirocrew-computer` deliberately proceeds for an unidentified caller (refusing was removed by product decision, and unnamed is the NORMAL case on macOS -- the only platform with a driver) under a per-PROCESS namespace, `unresolved:<shim pid>`. That premise holds for the 1:1 shim topology, where kiro-cli spawns one shim per session. A pooled backend breaks it: one process serves N connections, so the pid separates nothing and every unnamed co-tenant landed on the single `unresolved:<pid>` key.

`SnapshotIndex` namespaces its entries by `(session_key, window_key)`, so those co-tenants observing the same window overwrote each other's cached element indices.

## Why this issue matters to the user

The failure is a wrong-target desktop action with nothing reporting it -- the exact outcome element addressing exists to prevent.

Session A snapshots a window and is shown indices. Session B then snapshots the same window after the UI moved, and B's tree REPLACES A's under the shared key. A's next `computer_click` resolves index 7 against B's tree and clicks a different control. A's own `verify_fingerprint` still passes, because both trees describe the same window and `role|subrole|title` at that index matches. Nothing refuses, nothing warns, and no hazard-ledger entry is produced either: both hazard codes are routing-shaped (a frame that could not be routed), and here every frame routed perfectly -- to a namespace that was not exclusively its own.

## How our fix solves it

Chain from the symptom back to the cause:

- **Symptom**: one session's snapshot answers another's index lookup.
- **Because**: both sessions present the same `session_key` to `SnapshotIndex`.
- **Because**: with no identity in the frame, the backend has nothing to distinguish them by except its own pid.
- **Because**: gatewayd injects nothing at all for a caller it cannot name -- so the frame carries no per-connection information either.

The fix is at that last link: gatewayd already knows which CONNECTION a frame arrived on, even when it cannot name the session behind it. It now says so.

- **`mcp_caller.py`** -- a second, separate `_meta` block, `kirocrew.tenant` = `{schemaVersion, nonce}`, with `build_tenant_meta` / `tenant_nonce_from_meta` / `new_tenant_nonce`, plus a `ContextVar` accessor pair mirroring the caller slot. Deliberately NOT a field on the caller block: the caller block is an IDENTITY (who is calling, used for routing and authorization) and this is only a SEPARATOR (two calls with different nonces came from different connections). Folding it in would have forced a `CallerContext` with an empty `session_key` into existence, and every `if caller is not None` in the tree reads that as "identity known".
- **`mcp_gateway/gatewayd.py`** -- mints one nonce per accepted Register (`secrets.token_hex(8)`) onto `_StubConn` and passes it on every forwarded frame. Gateway-minted, never derived from the stub-supplied `stub_uuid`: a nonce a stub could choose would let it land in an unnamed peer's namespace on purpose, which is this same collision, selected rather than stumbled into.
- **`mcp_gateway/backend.py`** -- `forward_from_stub(..., tenant_nonce=...)` injects the block for an advertising backend independently of whether a caller was injected, which is the whole point. `_strip_caller_meta` now removes BOTH gateway-owned blocks, in the one place both existing call sites (`forward_from_stub` and the `initialize` early return) already call -- rather than a second strip function every future forward path would have to remember.
- **`mcp_gateway/app_call.py`** -- a dashboard-originated app call mints its OWN nonce per round-trip. This changes real behavior rather than riding along: that ephemeral stub is a distinct connection, so an unnamed app-initiated call must not be handed a chat session's per-tenant namespace on a pooled backend.
- **`mcp_shared.py`** -- the stdio dispatch loop parses the nonce next to the caller block and installs/clears it on all three paths (worker thread, its cancelled early return, and the Windows synchronous branch).
- **`mcp_computer.py`** -- `_unresolved_session_key()` returns `unresolved:<pid>#<nonce>` when a nonce is present and the unchanged `unresolved:<pid>` when it is not. Both halves are read at CALL time, so a forked child cannot inherit a parent's string and re-alias with it.

What is deliberately NOT claimed: the nonce is not attribution. The `unresolved:` prefix still marks the key as unresolved so an audit reader cannot mistake a pid -- or a nonce -- for a session identity, and `_resolve_session_key_strict` still returns empty for an unnamed caller. A separator promoted to an identity would reach cron ownership, callback routing and audit carrying a value that names no principal while looking resolved.

**What this PR deliberately does NOT do**: promote `kirocrew-computer` out of `_MANAGED_SERVERS_ADVERTISING_BUT_WITHHELD`. The first revision did, on the strength of that set's own comment ("Remove this exception when #5322..."). The GPT lane was right to block it: `manager.py` ADOPTS whatever healthy daemon already holds the socket, so a gatewayd that outlived a package upgrade keeps serving and injects no nonce -- and the backend cannot detect that, because for an unnamed caller the absence of both blocks is ambiguous between "1:1, no gateway" and "legacy pooled gateway". The classification is also not advisory: `seed.py` turns `recommend_share` into a config WRITE, so promoting the name can switch sharing ON for an operator who never chose it. The promotion, and the negotiation that has to precede it, are #7032. The set's comment now names that precondition instead of pointing at this issue.

## What tests we did

Targeted files only (the full suite is CI's job). All green, and both directions of the fix are mutation-verified.

- **The bug, at the layer it lives in** -- `test_two_unnamed_co_tenants_of_ONE_process_do_not_share_a_slot` pins `os.getpid()` to one value (the pooled premise), derives two keys under two nonces, and drives a real `SnapshotIndex` to show each session gets its own tree back. MUTATION: with the nonce half disabled, this and `test_the_nonce_half_is_read_at_CALL_time_too` both fail.
- **End-to-end through gatewayd** -- `test_two_UNNAMED_stubs_on_one_backend_get_distinct_namespaces` spawns two real identity-less stub processes onto one pooled backend and reads back what the shared backend was actually handed. MUTATION: with injection disabled the assertion fires with `['', '']` -- the backend left with nothing but its shared pid. The fake pooled server gained an optional third log path so this records nonces without changing the line format the existing identity test asserts on.
- **The trust boundary** -- a stub-forged `kirocrew.tenant` block is stripped; one forged block does not shield the other; a nonce-only block yields `CallerContext.from_meta() is None`.
- **Not an identity** -- with a nonce installed and no identity source, `_resolve_session_key_strict()` still returns `""`; a NAMED caller's key is unaffected by a nonce; the composed key survives the `X-Session-Key` latin-1 header pre-flight.
- **Wire format** -- 11 malformed-block shapes all degrade to "no separator" rather than raising, an unknown `schemaVersion` is read additively, and 100 minted nonces are distinct.
- **Dispatch loop** -- a tool sees `(caller=None, nonce="n0nce-a")` for an unnamed co-tenant, both are cleared after dispatch, and a following call with no tenant block sees `""` rather than the previous call's value.
- **Nonce names the connection, not the session** -- a claim-push that retargets a connection's identity leaves its nonce unchanged.
- Files run: `test_mcp_computer.py`, `test_mcp_caller.py`, `test_mcp_shared.py`, `test_mcp_gateway_backend_coverage.py`, `test_mcp_gateway_pool_integ.py`, `test_mcp_gateway_claim.py`, `test_mcp_gateway_exclusive_backend.py`, `test_mcp_gateway_recaller.py`, `test_mcp_managed_caller_identity.py`, `test_mcp_pool_identity_computer_dashboard.py`, `test_mcp_discovery.py`, `test_mcp_shareability.py`, `test_mcp_shareability_frontend_parity.py`, `test_computer_use_snapshot.py`, `test_mcp_apps_call_endpoint.py`, `test_mcp_apps_e2e.py`, `test_mcp_gateway_apps_spool.py`, `test_mcp_cron_caller_identity.py`, `test_mcp_gatewayd_coverage.py`, `test_gatewayd_more_coverage.py`, `test_gatewayd_diag.py`, `test_stop_kill_cancel.py`. `isort`, `flake8`, `mypy` and the baselined `black` gate clean on every touched file.

Three test doubles (`test_mcp_gateway_claim.py`, `test_mcp_gateway_exclusive_backend.py`, `test_mcp_gateway_recaller.py`) had drifted from the real `forward_from_stub` signature and were updated; the claim double now RECORDS the nonce rather than swallowing it, so it keeps answering the question it exists for.

## Any other suggestions on the work

Three things a reviewer should weigh, stated rather than buried:

1. **A reconnect retires a namespace.** A stub that reconnects gets a fresh nonce, so its earlier snapshots become unreachable. This is the safe direction -- a "call `computer_get_state` first" refusal, never an action against a stale tree -- and the alternative (deriving the nonce from a reconnect-stable value like the SO_PEERCRED peer pid) trades that for a pid-recycle aliasing window in the exact class being fixed here.
2. **Retired namespaces are unreachable but resident**, bounded by `MAX_INDEXED_APPS` (8) per namespace with a 90s TTL. This is pre-existing rather than introduced: `SnapshotIndex` has no cross-session sweep, so every retired session key already leaves entries that only a same-key read would TTL-drop. This fix adds "unnamed stub reconnect" as one more trigger. I deliberately did NOT add an expired-entry sweep to `put()` -- it would make a correctness-critical cache clock-sensitive on its write path, which is a change worth making on its own merits and its own review, not folded in here.
3. **The lease-replay frames do not carry a nonce.** `resources/subscribe` / `unsubscribe` replays that gatewayd synthesizes carry the caller (a subscription is held per caller) but not the nonce, because no backend keys subscription state by tenant and threading it there would mean carrying it through the lease bookkeeping for no consumer. Documented at `_inject_tenant_meta` so the next person reads a decision rather than an omission.

Closes #5322
Follow-up: #7032
