### PR TITLE
fix(mcp): let a rebuild re-derive the command it computed, for agent-only servers

### DIFF
--- a/docs/architecture/design-notes/mcp-entry-provenance.md
+++ b/docs/architecture/design-notes/mcp-entry-provenance.md
@@ -121,9 +121,67 @@ Concretely:
 - **The dashboard's own store stays unmarked entirely.** The store is ours by
   definition; the marker only ever appears in files we do not own.
 - **The emitted agent spec is stripped of the marker.** kiro-cli never sees it;
-  the spec is rendered output, not an owned file.
+  the spec is rendered output, not an owned file. (It does carry a separate
+  field-provenance key — see the next section — because that spec is also read
+  back as an input.)
 - **Connections sync is the only writer that stamps**, and only for names the
   store manages.
+
+## Field provenance in the rendered spec (a second, separate key)
+
+The section above is about ENTRY authorship in files we do not own. There is a
+second question, in the one file this note calls pure output: **which FIELDS of a
+rendered entry did the rebuild compute?**
+
+`rebuild_agent_config` reads its own previous output back as a merge source, so
+that a field the user set and Kiro Crew never models survives a rebuild. One field
+in that output is not the user's — the resolved absolute `command`. Reading a
+computed value back as if it were authored is what makes it permanent:
+`_resolve_command` accepts an absolute existing executable without a PATH search,
+so no later change to how commands resolve can rebind one that was stored once
+(#4955).
+
+    "x-kirocrew-derived": { "from": "npx", "emitted": "/abs/npx" }
+
+Both halves are load-bearing. `from` is what the next rebuild re-derives from, which
+is also why the source stays IN the file: a server whose only persisted home is the
+agent spec would otherwise lose the field entirely. `emitted` is the ownership proof
+— a field is restored only while it still holds exactly what we wrote, so a hand
+edit is left alone. That is this note's reclamation rule at field granularity, and
+it must hold across REPEATED rebuilds: recording a value we merely passed through
+would make our own record read as proof on the next pass, which is how an unearned
+claim becomes an overwrite.
+
+Deliberately a second key rather than a field inside `x-kirocrew`. The two records
+answer different questions about different files, and the marker's invariant is
+that it appears only in files we do not own — folding this in would put the marker
+into the very file that exclusion is about, and expose it to `without_marker`,
+which the shared-entry copy path applies. Both keys rely on the same `x-`
+namespace argument.
+
+### Scope: only a server with no other home
+
+The record applies **only to a server no other config source declares**. For a
+scope-owned server the record and the live declaration can disagree, and choosing
+between them correctly means selecting a per-field source AFTER resolution — the
+merge picks a winner by which command resolves, then adopts that winner's
+`args`/`env` as a unit. Any pre-resolution guess is wrong in one of two directions:
+scanning per field mixes sources, and taking the first owning scope picks a source
+the merge would not have chosen. That is a merge-precedence question, not a
+provenance one, and it belongs with the ownership work in #6171.
+
+The ownership test is deliberately conservative and compares by ALIAS, not raw key:
+a scope keys entries by its own raw name while the config's slash-containing keys
+were rewritten to aliases, so a raw-key probe would miss the owner of an aliased
+entry and wrongly read it as having no other home. Over-matching only declines to
+apply the record, which is today's behaviour; under-matching would let the record
+shadow a live declaration.
+
+`env.PATH` is the rebuild's other computed field and needs no record here. For a
+server with no other home the declaration IS the stored value, so narrowing it is
+an edit the ownership guard reads as the user's, and the next emit expands what
+they wrote. `env.PATH` becomes irrevocable only when the declaration lives in a
+different file from the expansion — the scope-owned case above.
 
 ## What this is not
 

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -72,7 +72,14 @@ from kiro_crew.env import (
     spec_path_key,
 )
 from kiro_crew.mcp_cleanup import purge_deleted_proxy_from_config
-from kiro_crew.mcp_provenance import without_marker
+from kiro_crew.mcp_provenance import (
+    DERIVED_KEY,
+    command_is_ours,
+    record_derived,
+    recorded_source,
+    source_view,
+    without_marker,
+)
 from kiro_crew.mcp_utils import kiro_oauth_wire_entry, mcp_server_alias
 from kiro_crew.platform import current_context
 from kiro_crew.platform import redact_via_context as redact
@@ -2352,10 +2359,20 @@ def _norm_mcp_spec(spec: Any) -> Any:
     collapse onto the canonical alias. An empty ``env``/``args`` is a launch
     no-op for kiro-cli (missing == empty), so this is also the cleaner spec to
     persist.
+
+    :data:`~kiro_crew.mcp_provenance.DERIVED_KEY` is excluded for the same reason,
+    and it is load-bearing: the record is our bookkeeping about which field this
+    rebuild computed, not part of how the server launches, so an entry carrying one
+    and an otherwise-identical re-merged copy without one ARE the same server.
+    Comparing it would make them differ and mint the ever-growing suffix this
+    function exists to prevent -- and it would do so asymmetrically, since only the
+    population with no other config source is ever recorded.
     """
     if not isinstance(spec, dict):
         return spec
-    return {k: v for k, v in spec.items() if not (k in ("env", "args") and not v)}
+    return {
+        k: v for k, v in spec.items() if k != DERIVED_KEY and not (k in ("env", "args") and not v)
+    }
 
 
 def _alias_family_base(key: str) -> str:
@@ -3622,9 +3639,106 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         if isinstance(_s, dict):
             _store_by_alias.setdefault(mcp_server_alias(_n), []).append(_s)
     _cfg_servers: dict[str, Any] = config.get("mcpServers", {})
+    # One spelling of the scope chain, in priority order, for BOTH consumers below:
+    # the live-value probe that keeps a rebuild-authored field re-derivable, and the
+    # resolution candidate list. The probe's correctness is "this is the value the
+    # chain would have resolved", so two separate spellings could drift apart.
+    _scopes: tuple[tuple[str, dict], ...] = (
+        ("kirocrew", kirocrew_mcp),
+        ("kiro-global", shared_mcp),
+        ("provider-global", extra_shared_mcp),
+    )
     for name, spec in _cfg_servers.items():
         if not isinstance(spec, dict):
             continue
+        # This file is BOTH this function's output and, here, one of its inputs: the
+        # entry is read back so a field the user set and we never model survives. One
+        # field below is ours, not the user's -- the resolved absolute ``command`` --
+        # and reading our own computed value back as if it were authored is what made
+        # it permanent: ``_resolve_command`` takes an absolute path without searching,
+        # so no later change to how commands resolve could rebind one stored once.
+        #
+        # The record applies ONLY to a server no other source declares -- the one
+        # whose sole persisted home is this file, and which therefore has nothing to
+        # lose a conflict to. For a scope-owned server, choosing between the record
+        # and the live declaration correctly means selecting a per-field source AFTER
+        # resolution (the merge picks a winner by which command resolves, then adopts
+        # that winner's args/env as a unit), which is a merge-precedence change rather
+        # than a provenance one; it is tracked separately. Excluding that population
+        # leaves it behaving exactly as it does today.
+        #
+        # The test is deliberately CONSERVATIVE, and compares by alias rather than by
+        # raw key. A scope keys entries by their own raw name while ``name`` here is
+        # the config's, whose slash-containing spellings an earlier pass rewrote to
+        # aliases (see the ``_store_by_alias`` note above), so a raw-key probe would
+        # miss the owner of an aliased entry and wrongly read it as having no other
+        # home. Over-matching only declines to apply the record -- today's behavior,
+        # and safe. Under-matching would let the record shadow a live declaration.
+        #
+        # A scope owns the COMMAND only when it actually supplies one. A dict alone is
+        # not enough: a same-named URL-only entry, or an empty one, declares nothing
+        # about ``command``, so treating it as a competing source would strip the
+        # record off an agent-only stdio server and strand its stale path forever.
+        # A non-dict value supplies nothing either, and the candidate chain below
+        # skips it for the same reason (``isinstance(alt, dict)``).
+        #
+        # This stays a yes/no ownership question -- does any other source declare a
+        # command? -- and never a choice BETWEEN two declared values. Choosing would
+        # need the after-resolution ordering this PR is scoped out of.
+        _alias_here = mcp_server_alias(name)
+        _scope_owned = any(
+            any(
+                mcp_server_alias(k) == _alias_here
+                and isinstance(v, dict)
+                and isinstance(v.get("command"), str)
+                and v["command"]
+                for k, v in _scope.items()
+            )
+            for _label, _scope in _scopes
+        )
+        # Captured BEFORE the view rewrites anything: what the entry carried on the
+        # way in, and the record's own pair. Together they decide what may be
+        # recorded on the way out -- see the emit site below.
+        _owned_in = command_is_ours(spec) if not _scope_owned else False
+        _pre_cmd = spec.get("command")
+        _pair = recorded_source(spec)
+        # PRESERVED, never stripped. A scope-owned server's record is not acted on --
+        # no restoration, see above -- but destroying it would be a decision in its
+        # own right, and the wrong one: a scope command that does not resolve, or a
+        # scope entry that later goes away, would leave the server agent-only again
+        # with its only re-derivation source deleted, so a relocated binary could
+        # never rebind. Keeping it inert costs nothing, because the ownership guard
+        # re-checks the emitted value before anything is ever restored from it, so a
+        # record that has gone stale in the meantime is simply not used.
+        #
+        # Deciding this by which candidate WINS resolution would be the other way to
+        # rule out a non-resolving scope command, and that is the after-resolution
+        # per-field source selection this change is deliberately scoped out of; it
+        # belongs with the agent-config ownership work. Preserving is the part that
+        # needs no ordering at all.
+        _keep_record: tuple[str, str] | None = _pair if _scope_owned else None
+        if not _scope_owned:
+            _viewed = source_view(spec)
+            if not _owned_in or _pair is None:
+                # Nothing of ours to restore; the view only strips the key.
+                spec = _viewed
+            elif _resolve_command(_pair[0], _viewed.get("env"))[0]:
+                # The source still resolves, so re-derive from it: that is the whole
+                # point, and it is what rebinds a moved binary.
+                spec = _viewed
+            else:
+                # It does NOT resolve, and for this population the emitted config is
+                # the entry's only copy -- so re-deriving would drop the server from
+                # the map, the file would be rewritten without it, and the next
+                # rebuild would have nothing to read. A stale-but-working command
+                # beats a deleted server, so keep what we emitted.
+                #
+                # The record is re-recorded VERBATIM below rather than refreshed from
+                # the value we kept: re-deriving must stay possible once whatever
+                # broke the source clears, and recording the emitted path as its own
+                # source would retire the record's only useful fact.
+                _keep_record = _pair
+                spec = {k: v for k, v in spec.items() if k != DERIVED_KEY}
         # Remote Streamable HTTP servers — preserved as-is except for the OAuth
         # hints, which are renamed to the fields kiro-cli actually deserializes.
         # This is the one boundary where the internal spelling (``scopes`` /
@@ -3687,11 +3801,7 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         # Build candidate specs in priority order: the merged winner first,
         # then the same server from each source as a resolution fallback.
         candidates: list[tuple[str, dict]] = [("winner", spec)]
-        for label, src in (
-            ("kirocrew", kirocrew_mcp),
-            ("kiro-global", shared_mcp),
-            ("provider-global", extra_shared_mcp),
-        ):
+        for label, src in _scopes:
             alt = src.get(name)
             if isinstance(alt, dict) and alt is not spec:
                 candidates.append((label, alt))
@@ -3739,7 +3849,31 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             spec_env = merged.get("env")
             if isinstance(spec_env, dict):
                 merged["env"] = emit_env(spec_env)
-            valid_servers[name] = merged
+            # Record only for a server with no other source, and only a field this
+            # pass may honestly claim: one the record already proved ours on the way
+            # in, or one whose emitted value DIFFERS from what the entry carried, so
+            # we computed it.
+            #
+            # The excluded case is a value we merely passed through -- a hand edit,
+            # or an already-absolute declaration nothing was derived from. It survives
+            # this rebuild either way, but a record written over it would read as
+            # proof on the NEXT pass, which is how a claim we never earned turns into
+            # a value we overwrite. Unrecorded means it stays the user's.
+            #
+            # Read from the candidate that WON: on a fallback the command came from
+            # ``chosen``, so recording ``spec``'s would name a source this entry was
+            # not derived from. ``None`` records "the source carried no such field".
+            _derived: tuple[str, str] | None = _keep_record
+            if _keep_record is None and not _scope_owned and (_owned_in or resolved != _pre_cmd):
+                _cmd_source = chosen.get("command")
+                # Non-empty by construction -- ``resolved`` is truthy, and it came
+                # from resolving THIS candidate's command -- but assert it in the
+                # type rather than in a comment: a record whose source is blank is
+                # unreadable on the way back, so writing one would silently disable
+                # the fix instead of failing here.
+                if isinstance(_cmd_source, str) and _cmd_source:
+                    _derived = (_cmd_source, resolved)
+            valid_servers[name] = record_derived(merged, _derived)
         elif not had_any_command:
             # No candidate defined a command at all — distinct from a command
             # that was defined but couldn't be resolved.

--- a/src/kiro_crew/mcp_provenance.py
+++ b/src/kiro_crew/mcp_provenance.py
@@ -62,6 +62,180 @@ MARKER_KEY = "x-kirocrew"
 # second reserved key.
 _MANAGED_FIELD = "managed"
 
+# A SECOND reserved key, deliberately not a field inside :data:`MARKER_KEY`.
+#
+# The two records answer different questions about different files. The marker
+# says "we authored this ENTRY in a file we do not own", and its invariant is
+# that it appears only in such files -- the rendered agent spec stays unmarked,
+# so a reader of a shared file cannot mistake output for authorship. This record
+# says "we COMPUTED these FIELDS of this rendered entry, and here is what they
+# were derived from", and it belongs only in the rendered agent spec, which is
+# the one file that is simultaneously our output and an input to our next
+# rebuild. Folding it into the marker object would put the marker into the very
+# file whose exclusion is the marker's invariant, and would expose it to
+# :func:`without_marker`, which the shared-entry copy path applies.
+#
+# The ``x-`` namespace argument for :data:`MARKER_KEY` covers this key too: a
+# kiro-cli field can never contain a hyphen, and unknown keys are dropped at
+# deserialization rather than rejected.
+DERIVED_KEY = "x-kirocrew-derived"
+
+# Inside the record: what the field was derived FROM, and what we EMITTED. The
+# second is the ownership proof -- see :func:`source_view`.
+_FROM_FIELD = "from"
+_EMITTED_FIELD = "emitted"
+
+# The record describes the ONE field the rebuild computes from a source value and
+# therefore must not re-consume as if the user had written it: the resolved absolute
+# ``command``. It is stored FLAT -- the two keys above sit directly under
+# :data:`DERIVED_KEY` -- rather than nested under a field name. There is one field,
+# and the reader already fails open, so a later second field can widen the shape
+# without a migration; nesting now would be structure for a variant that does not
+# exist.
+#
+# The rebuild's other computed field is the expanded ``env.PATH``, and for the
+# servers this record serves -- ones no other source declares -- it needs no record:
+# the declaration IS the stored value, so a user narrowing it edits the field
+# directly, the ownership guard reads that as theirs, and the next emit expands what
+# they wrote. ``env.PATH`` becomes irrevocable only when the declaration lives in a
+# DIFFERENT file from the expansion, which is the scope-owned case this record
+# deliberately excludes.
+_COMMAND: Final = "command"
+
+
+def _command_record(entry: object) -> dict[str, str] | None:
+    """The readable command record on ``entry``, or None.
+
+    Fails open in the direction of TODAY's behavior: anything other than the exact
+    shape reads as "no record", so the caller keeps consuming the stored value
+    exactly as it did before this key existed. That is what makes a config written
+    by an older build, or one whose record a user mangled, degrade to the previous
+    behavior rather than to a dropped server.
+    """
+    if not isinstance(entry, dict):
+        return None
+    record = entry.get(DERIVED_KEY)
+    if not isinstance(record, dict):
+        return None
+    src = record.get(_FROM_FIELD)
+    emitted = record.get(_EMITTED_FIELD)
+    # BOTH must be non-empty strings. ``emitted`` is the ownership proof, so a
+    # record without it cannot establish anything. ``from`` is what a restore writes
+    # back, and a blank or absent one would make the restore DELETE or empty the
+    # command -- which drops the server on the next resolution. That is the opposite
+    # of this reader's contract: an unreadable record must degrade to the behavior
+    # that predates the key, never to a lost server. There is no "the source carried
+    # no such field" case to represent, because a record is only ever written for a
+    # command that resolved, and the candidate it resolved from carried one.
+    if not (isinstance(src, str) and src) or not (isinstance(emitted, str) and emitted):
+        return None
+    return {_FROM_FIELD: src, _EMITTED_FIELD: emitted}
+
+
+def record_derived(entry: dict[str, Any], command_source: tuple[str, str] | None) -> dict[str, Any]:
+    """Copy of ``entry`` recording what its ``command`` was derived FROM.
+
+    ``command_source`` is ``(source, emitted)``: the value the rebuild resolved
+    from, and the value it wrote. Pass ``None`` to record nothing, which is how a
+    caller declines to claim a field it did not author.
+
+    Both halves are load-bearing and both must be non-empty: the source is what a
+    later rebuild re-derives from, and the emitted value is the only proof that the
+    field on disk is still ours. A record written with either one blank is not
+    readable back (see :func:`_command_record`), so it degrades to pre-record
+    behavior rather than to a restore that empties the command.
+
+    Both halves are load-bearing. The source is what a later rebuild re-derives
+    from; the emitted value is the only proof that the field on disk is still ours.
+
+    Keeping the source IN the entry is what makes the record safe for a server whose
+    only persisted home is this file. Dropping the computed field on readback
+    instead would be correct for a server that also lives in a scope config and
+    destructive for one that does not.
+    """
+    out = {k: v for k, v in entry.items() if k != DERIVED_KEY}
+    if command_source is None:
+        return out
+    out[DERIVED_KEY] = {
+        _FROM_FIELD: command_source[0],
+        _EMITTED_FIELD: command_source[1],
+    }
+    return out
+
+
+def recorded_source(entry: object) -> tuple[str, str] | None:
+    """The readable ``(source, emitted)`` pair on ``entry``, or None.
+
+    For a caller that decides NOT to act on the record this pass but must not lose
+    it: re-recording the pair verbatim keeps the original source available, so a
+    later rebuild can still re-derive once whatever blocked it clears. Recording the
+    currently-emitted value as its own source instead would quietly retire the
+    record's only useful fact.
+    """
+    record = _command_record(entry)
+    if record is None:
+        return None
+    src = record[_FROM_FIELD]
+    emitted = record[_EMITTED_FIELD]
+    assert isinstance(src, str) and isinstance(emitted, str)  # _command_record checks
+    return (src, emitted)
+
+
+def command_is_ours(entry: object) -> bool:
+    """True when the stored ``command`` is still exactly what we recorded emitting.
+
+    The caller needs this BEFORE :func:`source_view` rewrites anything, to decide
+    what it may record on the way out. A field that was not ours on the way in and
+    that the caller did not compute must not be recorded, or the next rebuild reads
+    our claim as proof and overwrites the user's value -- the reclamation hazard
+    this module's entry-level marker documents, one pass later.
+    """
+    record = _command_record(entry)
+    if record is None or not isinstance(entry, dict):
+        return False
+    return entry.get(_COMMAND) == record[_EMITTED_FIELD]
+
+
+def source_view(entry: object) -> dict[str, Any]:
+    """Copy of ``entry`` with a ``command`` STILL ours restored to its source value.
+
+    This is what a rebuild must read instead of its own previous output. Without it,
+    a field the rebuild computed reads back as the user's and can never be
+    re-derived, so a moved binary or a changed setting cannot take effect.
+
+    **Only valid for an entry no other config source declares.** The caller must not
+    apply this to a server that also lives in a scope config: the record holds what
+    the PREVIOUS rebuild derived from, and because the entry is the caller's first
+    resolution candidate, restoring it would pre-empt a live declaration edited
+    since. Choosing between the two correctly means selecting a per-field source
+    AFTER resolution -- the merge decides a winner by which command resolves and
+    adopts that winner's ``args``/``env`` as a unit -- which is a merge precedence
+    question, not a provenance one. The caller therefore restricts this to the entry
+    that has no other source to lose to.
+
+    The field is restored only while the stored value is byte-identical to what we
+    recorded emitting. Anything else means someone edited it since -- the user by
+    hand, or another writer -- and an edited field is theirs, so it is left exactly
+    as it is. This is the entry-level marker's reclamation rule at field
+    granularity, and it is why the record carries the emitted value as well as the
+    source: without that proof, restoring would silently revert hand edits.
+
+    The record itself is removed from the returned copy: it describes the emitted
+    entry, and the next emit writes a fresh one.
+    """
+    if not isinstance(entry, dict):
+        return {}
+    out = {k: v for k, v in entry.items() if k != DERIVED_KEY}
+    if not command_is_ours(entry):
+        return out
+    record = _command_record(entry)
+    assert record is not None  # command_is_ours implies a readable record
+    # A readable record's source is a non-empty string by construction, so the
+    # restore can only ever REPLACE the command -- never delete or empty it, which
+    # would drop the server on the next resolution.
+    out[_COMMAND] = record[_FROM_FIELD]
+    return out
+
 
 def is_marked(entry: object) -> bool:
     """True when ``entry`` carries our authorship marker.

--- a/test/mcp_merge_helpers.py
+++ b/test/mcp_merge_helpers.py
@@ -1,0 +1,98 @@
+"""Shared fixtures for tests that drive ``install_agent``'s MCP merge.
+
+Extracted from ``test_agent`` so a second test module can drive the same rebuild
+without importing a test module. The repo's convention is a dedicated
+``*_helpers.py`` imported by bare name (see ``spawn_test_helpers``,
+``chat_test_helpers``); no ``test_*`` module imports another, and a
+``from test.test_agent import ...`` form does not resolve under CI's rootdir at
+all -- ``test`` is not an importable package there.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+from kiro_crew.agent import install_agent
+
+
+def bundled_defaults(tmp_path: Path) -> Path:
+    """Write a minimal bundled defaults.json and return its parent dir."""
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    defaults = {
+        "model": "claude-default",
+        "tools": ["ReadFile"],
+        "allowedTools": ["ReadFile"],
+        "mcpServers": {},
+        "toolsSettings": {"execute_bash": {"deniedCommands": ["rm -rf /"]}},
+        "hooks": {"preToolUse": "audit"},
+    }
+    (cfg_dir / "defaults.json").write_text(json.dumps(defaults))
+    (cfg_dir / "prompt.md").write_text("system prompt")
+    return cfg_dir
+
+
+DEFAULT_MANAGED_MCPS = {
+    "kirocrew-cron": {"command": "/usr/bin/kirocrew", "args": ["mcp-cron"]},
+    "kirocrew-core": {"command": "/usr/bin/kirocrew", "args": ["mcp-core"]},
+}
+
+
+def run_install_mcp_merge(
+    tmp_path: Path,
+    cfg_dir: Path,
+    *,
+    cc_servers: dict,
+    kiro_servers: dict,
+    kirocrew_servers: dict | None = None,
+    which_side_effect=lambda c, **kw: c,
+) -> dict:
+    """Run install_agent with CC-global and Kiro-global mcp.json seeded and a
+    customizable shutil.which. Returns the parsed kirocrew.json config."""
+    kiro_dir = tmp_path / "kiro_agents"
+    kiro_dir.mkdir(exist_ok=True)
+    prompt = cfg_dir / "prompt.md"
+    mc_config = tmp_path / "empty_mc_config.json"
+    if not mc_config.exists():
+        mc_config.write_text(json.dumps({"agent": {"kiro_hooks_autoimport": False}}))
+    kiro_mcp = tmp_path / "fake_kiro_mcp.json"
+    cc_mcp = tmp_path / "fake_cc_mcp.json"
+    kiro_mcp.write_text(json.dumps({"mcpServers": kiro_servers}))
+    cc_mcp.write_text(json.dumps({"mcpServers": cc_servers}))
+    if kirocrew_servers is not None:
+        kc_home = tmp_path / "kirocrew_home"
+        kc_home.mkdir(parents=True, exist_ok=True)
+        (kc_home / "mcp.json").write_text(json.dumps({"mcpServers": kirocrew_servers}))
+
+    _user_home = tmp_path / "kirocrew_home"
+    patches = [
+        patch.multiple(
+            "kiro_crew.agent",
+            KIRO_AGENTS_DIR=kiro_dir,
+            _BUNDLED_CFG_DIR=cfg_dir,
+            _KIROCREW_BIN="/usr/bin/kirocrew",
+            _MANAGED_MCP_SERVERS=DEFAULT_MANAGED_MCPS,
+            _KIRO_MCP_JSON=kiro_mcp,
+            _CC_MCP_JSON=cc_mcp,
+        ),
+        patch("kiro_crew.agent._user_dir", lambda: _user_home),
+        patch("kiro_crew.agent._prompt_path", return_value=prompt),
+        patch("kiro_crew.agent._shipped_defaults", return_value=cfg_dir / "defaults.json"),
+        patch("kiro_crew.agent._project_dir", return_value=None),
+        patch("kiro_crew.agent._aim_skill_paths", return_value=[]),
+        patch("kiro_crew.agent.shutil.which", side_effect=which_side_effect),
+        patch("kiro_crew.agent._mc_config_path", return_value=mc_config),
+        # A companion contributes the Claude Code scope via the CPP seam — the
+        # core no longer reads ~/.claude.json directly at rebuild time (OSS is
+        # Kiro-only). Point the seam at cc_mcp so these merge-priority tests
+        # exercise the seam-routed provider-global merge.
+        patch("kiro_crew.agent._extra_mcp_scope_globals", return_value=[cc_mcp]),
+    ]
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        path = install_agent()
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -12,35 +12,19 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+# Shared with ``test_mcp_rebuild_reconsumption`` via a dedicated helpers module --
+# the repo's convention, since a test module is not importable from another one.
+# Re-exported under the original private names so the call sites below are unchanged.
+from mcp_merge_helpers import DEFAULT_MANAGED_MCPS as _DEFAULT_MANAGED_MCPS
+from mcp_merge_helpers import bundled_defaults as _bundled_defaults
+from mcp_merge_helpers import run_install_mcp_merge as _run_install_mcp_merge
 from windows_sim import replace_sharing_violation
 
 from conftest import requires_symlinks
 from kiro_crew import agent_state
 from kiro_crew import atomic_write as aw
 from kiro_crew.agent import install_agent, migrate_agent_specs
-
-
-def _bundled_defaults(tmp_path: Path) -> Path:
-    """Write a minimal bundled defaults.json and return its parent dir."""
-    cfg_dir = tmp_path / "config"
-    cfg_dir.mkdir()
-    defaults = {
-        "model": "claude-default",
-        "tools": ["ReadFile"],
-        "allowedTools": ["ReadFile"],
-        "mcpServers": {},
-        "toolsSettings": {"execute_bash": {"deniedCommands": ["rm -rf /"]}},
-        "hooks": {"preToolUse": "audit"},
-    }
-    (cfg_dir / "defaults.json").write_text(json.dumps(defaults))
-    (cfg_dir / "prompt.md").write_text("system prompt")
-    return cfg_dir
-
-
-_DEFAULT_MANAGED_MCPS = {
-    "kirocrew-cron": {"command": "/usr/bin/kirocrew", "args": ["mcp-cron"]},
-    "kirocrew-core": {"command": "/usr/bin/kirocrew", "args": ["mcp-core"]},
-}
 
 
 def _run_install(tmp_path: Path, cfg_dir: Path, managed_mcps: dict | None = None, **kwargs) -> Path:  # type: ignore[return]
@@ -4398,63 +4382,6 @@ def _make_exec(tmp_path: Path, name: str) -> str:
     p.write_text("#!/bin/sh\n")
     p.chmod(0o755)
     return str(p)
-
-
-def _run_install_mcp_merge(
-    tmp_path: Path,
-    cfg_dir: Path,
-    *,
-    cc_servers: dict,
-    kiro_servers: dict,
-    kirocrew_servers: dict | None = None,
-    which_side_effect=lambda c, **kw: c,
-) -> dict:
-    """Run install_agent with CC-global and Kiro-global mcp.json seeded and a
-    customizable shutil.which. Returns the parsed kirocrew.json config."""
-    kiro_dir = tmp_path / "kiro_agents"
-    kiro_dir.mkdir(exist_ok=True)
-    prompt = cfg_dir / "prompt.md"
-    mc_config = tmp_path / "empty_mc_config.json"
-    if not mc_config.exists():
-        mc_config.write_text(json.dumps({"agent": {"kiro_hooks_autoimport": False}}))
-    kiro_mcp = tmp_path / "fake_kiro_mcp.json"
-    cc_mcp = tmp_path / "fake_cc_mcp.json"
-    kiro_mcp.write_text(json.dumps({"mcpServers": kiro_servers}))
-    cc_mcp.write_text(json.dumps({"mcpServers": cc_servers}))
-    if kirocrew_servers is not None:
-        kc_home = tmp_path / "kirocrew_home"
-        kc_home.mkdir(parents=True, exist_ok=True)
-        (kc_home / "mcp.json").write_text(json.dumps({"mcpServers": kirocrew_servers}))
-
-    _user_home = tmp_path / "kirocrew_home"
-    patches = [
-        patch.multiple(
-            "kiro_crew.agent",
-            KIRO_AGENTS_DIR=kiro_dir,
-            _BUNDLED_CFG_DIR=cfg_dir,
-            _KIROCREW_BIN="/usr/bin/kirocrew",
-            _MANAGED_MCP_SERVERS=_DEFAULT_MANAGED_MCPS,
-            _KIRO_MCP_JSON=kiro_mcp,
-            _CC_MCP_JSON=cc_mcp,
-        ),
-        patch("kiro_crew.agent._user_dir", lambda: _user_home),
-        patch("kiro_crew.agent._prompt_path", return_value=prompt),
-        patch("kiro_crew.agent._shipped_defaults", return_value=cfg_dir / "defaults.json"),
-        patch("kiro_crew.agent._project_dir", return_value=None),
-        patch("kiro_crew.agent._aim_skill_paths", return_value=[]),
-        patch("kiro_crew.agent.shutil.which", side_effect=which_side_effect),
-        patch("kiro_crew.agent._mc_config_path", return_value=mc_config),
-        # A companion contributes the Claude Code scope via the CPP seam — the
-        # core no longer reads ~/.claude.json directly at rebuild time (OSS is
-        # Kiro-only). Point the seam at cc_mcp so these merge-priority tests
-        # exercise the seam-routed provider-global merge.
-        patch("kiro_crew.agent._extra_mcp_scope_globals", return_value=[cc_mcp]),
-    ]
-    with ExitStack() as stack:
-        for p in patches:
-            stack.enter_context(p)
-        path = install_agent()
-    return json.loads(path.read_text(encoding="utf-8"))
 
 
 class TestSpecEnvPathIsExpandedOnEmit:

--- a/test/test_mcp_field_provenance.py
+++ b/test/test_mcp_field_provenance.py
@@ -1,0 +1,176 @@
+"""The command-derivation record: what the rebuild computed, and from what.
+
+The agent spec is both this rebuild's output and an input to its next run, so the
+resolved absolute ``command`` in it must not read back as one the user wrote. These
+tests pin the record's shape, the ownership guard that keeps it from reverting a
+hand edit, and the restore that lets a computed value be derived again.
+
+The record applies only to a server no other config source declares. The
+end-to-end consequences of that boundary live in
+``test_mcp_rebuild_reconsumption.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.mcp_provenance import (
+    DERIVED_KEY,
+    MARKER_KEY,
+    command_is_ours,
+    record_derived,
+    source_view,
+)
+
+
+def _rec(source: str | None, emitted: str) -> dict:
+    return {DERIVED_KEY: {"from": source, "emitted": emitted}}
+
+
+class TestRecordShape:
+    """What gets written, and what declining looks like."""
+
+    def test_a_recorded_source_round_trips(self) -> None:
+        entry = record_derived({"command": "/abs/npx"}, ("npx", "/abs/npx"))
+        assert entry[DERIVED_KEY] == {"from": "npx", "emitted": "/abs/npx"}
+        # The computed value stays in the entry -- the record describes it, it does
+        # not replace it. kiro-cli reads ``command``, not the record.
+        assert entry["command"] == "/abs/npx"
+
+    def test_none_writes_no_record(self) -> None:
+        """How a caller declines to claim a field it did not author."""
+        assert DERIVED_KEY not in record_derived({"command": "/abs/npx"}, None)
+
+    def test_recording_replaces_a_previous_record(self) -> None:
+        """Each emission describes itself; a stale record must not accumulate."""
+        first = record_derived({"command": "/a"}, ("one", "/a"))
+        second = record_derived(first, ("two", "/b"))
+        assert second[DERIVED_KEY] == {"from": "two", "emitted": "/b"}
+
+    def test_the_record_is_not_the_authorship_marker(self) -> None:
+        """Two keys, two questions. The marker's invariant excludes this file."""
+        assert DERIVED_KEY != MARKER_KEY
+        assert MARKER_KEY not in record_derived({"command": "/a"}, ("npx", "/a"))
+
+
+class TestSourceViewRestores:
+    """Reading back through the view yields the source, not the emission."""
+
+    def test_a_computed_command_is_restored(self) -> None:
+        emitted = record_derived({"command": "/abs/npx"}, ("npx", "/abs/npx"))
+        assert source_view(emitted)["command"] == "npx"
+
+    def test_the_record_is_stripped_from_the_view(self) -> None:
+        emitted = record_derived({"command": "/a"}, ("npx", "/a"))
+        assert DERIVED_KEY not in source_view(emitted)
+
+    def test_a_user_field_is_untouched(self) -> None:
+        """The record covers our field only; everything else survives verbatim."""
+        emitted = record_derived(
+            {"command": "/abs/npx", "args": ["--x"], "env": {"TOKEN": "t"}, "disabled": True},
+            ("npx", "/abs/npx"),
+        )
+        view = source_view(emitted)
+        assert view["args"] == ["--x"]
+        assert view["env"] == {"TOKEN": "t"}
+        assert view["disabled"] is True
+
+
+class TestOwnershipGuard:
+    """The field is ours only while it still holds what we emitted.
+
+    Without this the restore would revert hand edits, which is worse than the bug it
+    fixes. Same rule the entry-level marker applies, at field granularity.
+    """
+
+    def test_an_edited_command_is_left_alone(self) -> None:
+        entry = {"command": "/user/choice"}
+        entry.update(_rec("npx", "/abs/npx"))
+        assert source_view(entry)["command"] == "/user/choice"
+
+    def test_a_removed_field_is_not_reinstated(self) -> None:
+        """The user deleting a field we wrote is an edit like any other."""
+        entry: dict = {}
+        entry.update(_rec("npx", "/abs/npx"))
+        assert "command" not in source_view(entry)
+
+    def test_command_is_ours_judges_the_same_way(self) -> None:
+        ours = record_derived({"command": "/abs/npx"}, ("npx", "/abs/npx"))
+        assert command_is_ours(ours) is True
+        edited = {"command": "/user/choice"}
+        edited.update(_rec("npx", "/abs/npx"))
+        assert command_is_ours(edited) is False
+
+    def test_command_is_ours_needs_a_record(self) -> None:
+        assert command_is_ours({"command": "/abs/npx"}) is False
+        assert command_is_ours("nope") is False
+
+
+class TestARestoreNeverRemovesTheCommand:
+    """The reader's contract is fail-open, so it must never cost a server.
+
+    A restore that deletes or empties the command leaves nothing to resolve, and the
+    rebuild then drops the server from the emitted config. So a record whose source
+    is blank or absent is not "a record meaning remove" -- it is unreadable, and an
+    unreadable record degrades to the behaviour that predates the key.
+    """
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            {"emitted": "/abs/npx"},  # no ``from`` at all
+            {"from": None, "emitted": "/abs/npx"},
+            {"from": "", "emitted": "/abs/npx"},
+            {"from": "npx", "emitted": ""},  # no usable ownership proof either
+        ],
+    )
+    def test_a_blank_or_absent_source_is_unreadable(self, field: dict) -> None:
+        entry = {"command": "/abs/npx", DERIVED_KEY: field}
+        view = source_view(entry)
+        assert view["command"] == "/abs/npx"
+        assert command_is_ours(entry) is False
+
+    def test_a_readable_record_always_yields_a_command(self) -> None:
+        emitted = record_derived({"command": "/abs/npx"}, ("npx", "/abs/npx"))
+        assert source_view(emitted)["command"]
+
+
+class TestFailsOpenToPreviousBehaviour:
+    """No readable record means "consume the stored value", exactly as before.
+
+    A config written by an older build carries no record, and a user can mangle one.
+    Neither may cost the user a server, so every unreadable shape degrades to the
+    behaviour that predates the record rather than to a removed field.
+    """
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            None,
+            True,
+            "command",
+            [],
+            {},
+            None,
+            7,
+            "npx",
+            # No ``emitted``: nothing proves the field is ours, so it is not touched.
+            {"from": "npx"},
+            {"from": "npx", "emitted": 7},
+            {"from": ["npx"], "emitted": "/abs/npx"},
+            # The old multi-field shape: unreadable now, and must not crash.
+            # Earlier nested shapes: unreadable now, and must not crash.
+            {"fields": {"command": {"from": "npx", "emitted": "/abs/npx"}}},
+            {"command": {"from": "npx", "emitted": "/abs/npx"}},
+        ],
+    )
+    def test_an_unreadable_record_leaves_the_stored_value(self, record: object) -> None:
+        view = source_view({"command": "/abs/npx", DERIVED_KEY: record})
+        assert view["command"] == "/abs/npx"
+        assert DERIVED_KEY not in view
+
+    def test_an_entry_with_no_record_passes_through(self) -> None:
+        assert source_view({"command": "/abs/npx"}) == {"command": "/abs/npx"}
+
+    def test_a_non_dict_entry_is_tolerated(self) -> None:
+        assert source_view("nope") == {}

--- a/test/test_mcp_rebuild_reconsumption.py
+++ b/test/test_mcp_rebuild_reconsumption.py
@@ -1,0 +1,379 @@
+"""#4955: a rebuild must not consume its own previous output.
+
+The agent spec is this rebuild's output AND one of its inputs. The resolved
+absolute ``command`` in it is computed, not authored, so reading it back as the
+user's makes it permanent: ``_resolve_command`` accepts an absolute existing
+executable with no PATH search, so a command resolved once can never be rebound.
+
+These run the REAL rebuild repeatedly against one on-disk config, which is the
+only way the readback participates at all. The helper is reused from
+``test_agent``: seeding each rebuild identically by hand is what made this defect
+invisible.
+
+The record applies only to a server no other config source declares -- the one
+whose sole persisted home is this file. ``TestScopeOwnedIsExcluded`` pins that
+boundary, so narrowing it later is a visible change rather than a silent one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from mcp_merge_helpers import bundled_defaults as _bundled_defaults
+from mcp_merge_helpers import run_install_mcp_merge as _run_install_mcp_merge
+
+from kiro_crew.mcp_provenance import DERIVED_KEY
+
+
+def _emitted(tmp_path: Path, cfg_dir: Path, kiro_servers: dict, **kw) -> dict:
+    return _run_install_mcp_merge(
+        tmp_path, cfg_dir, cc_servers={}, kiro_servers=kiro_servers, **kw
+    )["mcpServers"]
+
+
+def _make_agent_only(tmp_path: Path, name: str, command: str) -> None:
+    """Turn an emitted entry into an agent-only one: bare command, no scope entry.
+
+    This is the shape ``kiro-cli mcp add --agent kirocrew`` and a hand-edit both
+    produce -- a server whose only persisted home is the generated spec.
+    """
+    spec_path = tmp_path / "kiro_agents" / "kirocrew.json"
+    cfg = json.loads(spec_path.read_text())
+    cfg["mcpServers"][name] = {"command": command}
+    spec_path.write_text(json.dumps(cfg))
+
+
+class TestAnAgentOnlyCommandIsReDerived:
+    """The fix: a computed command is re-resolved rather than pinned."""
+
+    def test_a_relocated_binary_is_re_resolved(self, tmp_path: Path, monkeypatch) -> None:
+        """A stored absolute path must not pin a command whose location moved.
+
+        ``_resolve_command`` accepts an absolute existing executable without a PATH
+        search, so an emitted path still on disk short-circuits every later
+        resolution. Re-deriving from the recorded source is what lets a changed
+        search path rebind it.
+        """
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        old = tmp_path / "old" / "srv"
+        new = tmp_path / "new" / "srv"
+        for p in (old, new):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("#!/bin/sh\n")
+            p.chmod(0o755)
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "s", "srv")
+
+        first = _emitted(
+            tmp_path, cfg_dir, {}, which_side_effect=lambda c, **kw: str(old) if c == "srv" else c
+        )
+        assert first["s"]["command"] == str(old)
+        assert first["s"][DERIVED_KEY]["from"] == "srv"
+
+        second = _emitted(
+            tmp_path, cfg_dir, {}, which_side_effect=lambda c, **kw: str(new) if c == "srv" else c
+        )
+        assert second["s"]["command"] == str(new), (
+            "the stored absolute path short-circuited resolution, so the command "
+            "could not be rebound"
+        )
+
+    def test_re_derivation_is_stable_across_repeated_rebuilds(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Nothing accumulates and nothing drifts when the source has not changed."""
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        binary = tmp_path / "bin" / "srv"
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "s", "srv")
+        which = lambda c, **kw: str(binary) if c == "srv" else c  # noqa: E731
+        seen = [_emitted(tmp_path, cfg_dir, {}, which_side_effect=which)["s"] for _ in range(3)]
+        assert all(e["command"] == str(binary) for e in seen)
+        assert all(e[DERIVED_KEY] == seen[0][DERIVED_KEY] for e in seen)
+
+    def test_an_unresolvable_source_never_deletes_the_server(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Re-derivation must never cost the entry its only copy.
+
+        If the recorded source stops resolving while the emitted path still works --
+        a shim removed from PATH, its target still on disk -- restoring the source
+        would resolve to nothing, the server would be dropped from the emitted map,
+        and the file would be rewritten without it. For this population that file is
+        the only copy, so the next rebuild would have nothing to read. A
+        stale-but-working command beats a deleted server.
+        """
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        target = tmp_path / "target" / "srv"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "s", "srv")
+        first = _emitted(
+            tmp_path,
+            cfg_dir,
+            {},
+            which_side_effect=lambda c, **kw: str(target) if c == "srv" else c,
+        )
+        assert first["s"]["command"] == str(target)
+
+        # "srv" no longer resolves; the emitted absolute path still exists.
+        second = _emitted(tmp_path, cfg_dir, {}, which_side_effect=lambda c, **kw: None)
+        assert "s" in second, "the server was dropped, and this file was its only copy"
+        assert second["s"]["command"] == str(target)
+        # The record must survive VERBATIM, so a later PATH fix can still rebind it.
+        assert second["s"][DERIVED_KEY] == {
+            "from": "srv",
+            "emitted": str(target),
+        }
+
+    @pytest.mark.parametrize(
+        "scope_entry",
+        [
+            None,  # malformed: supplies nothing
+            {},  # empty: declares no command
+            {"url": "https://example.invalid"},  # remote: declares no command
+            {"command": ""},  # blank: not a usable command
+        ],
+        ids=["null", "empty", "url-only", "blank-command"],
+    )
+    def test_a_scope_entry_without_a_command_does_not_own_one(
+        self, tmp_path: Path, monkeypatch, scope_entry: object
+    ) -> None:
+        """Ownership of the COMMAND needs a scope that actually declares one.
+
+        A same-named entry that declares no command is not a competing source, so
+        treating it as one would strip the record off an agent-only stdio server and
+        strand its stale path -- the defect this fixes, reintroduced sideways.
+        """
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        old = tmp_path / "old" / "srv"
+        new = tmp_path / "new" / "srv"
+        for p in (old, new):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("#!/bin/sh\n")
+            p.chmod(0o755)
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "s", "srv")
+        scope = {"s": scope_entry}
+        first = _emitted(
+            tmp_path,
+            cfg_dir,
+            scope,
+            which_side_effect=lambda c, **kw: str(old) if c == "srv" else c,
+        )
+        assert DERIVED_KEY in first["s"], "the record was stripped by a non-command scope entry"
+
+        second = _emitted(
+            tmp_path,
+            cfg_dir,
+            scope,
+            which_side_effect=lambda c, **kw: str(new) if c == "srv" else c,
+        )
+        assert second["s"]["command"] == str(new)
+
+    def test_a_non_resolving_scope_command_does_not_destroy_the_record(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A scope-owned server's record is inert, not deleted.
+
+        The record is not acted on while another source declares a command. But
+        destroying it is its own decision, and the wrong one: if that scope command
+        never resolves, or the entry later goes away, the server is agent-only again
+        with its only re-derivation source gone, and a relocated binary can never
+        rebind.
+        """
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        old = tmp_path / "old" / "srv"
+        new = tmp_path / "new" / "srv"
+        for p in (old, new):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("#!/bin/sh\n")
+            p.chmod(0o755)
+        which = lambda c, **kw: str(old) if c == "srv" else None  # noqa: E731
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "s", "srv")
+        first = _emitted(tmp_path, cfg_dir, {}, which_side_effect=which)
+        assert first["s"][DERIVED_KEY] == {"from": "srv", "emitted": str(old)}
+
+        # A same-named scope command appears and never resolves.
+        with_scope = _emitted(
+            tmp_path, cfg_dir, {"s": {"command": "nonexistent-binary"}}, which_side_effect=which
+        )
+        assert (
+            DERIVED_KEY in with_scope["s"]
+        ), "a non-resolving scope command destroyed the only re-derivation source"
+        assert with_scope["s"][DERIVED_KEY] == {"from": "srv", "emitted": str(old)}
+
+        # The scope entry goes away and the binary has moved: rebinding must work.
+        back = _emitted(
+            tmp_path,
+            cfg_dir,
+            {},
+            which_side_effect=lambda c, **kw: str(new) if c == "srv" else None,
+        )
+        assert back["s"]["command"] == str(new)
+
+    def test_a_recovered_source_rebinds_after_being_retained(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Retaining the record is what makes the pause recoverable."""
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        old = tmp_path / "old" / "srv"
+        new = tmp_path / "new" / "srv"
+        for p in (old, new):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("#!/bin/sh\n")
+            p.chmod(0o755)
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "s", "srv")
+        _emitted(
+            tmp_path, cfg_dir, {}, which_side_effect=lambda c, **kw: str(old) if c == "srv" else c
+        )
+        _emitted(tmp_path, cfg_dir, {}, which_side_effect=lambda c, **kw: None)  # source broken
+        back = _emitted(
+            tmp_path, cfg_dir, {}, which_side_effect=lambda c, **kw: str(new) if c == "srv" else c
+        )
+        assert back["s"]["command"] == str(new), (
+            "the retained record did not survive the unresolvable pass, so the "
+            "command could not be rebound once the source came back"
+        )
+
+
+class TestUserEditsAreNotOverwritten:
+    """Provenance must protect a hand edit, not undo it."""
+
+    def test_a_hand_edited_command_is_left_alone(self, tmp_path: Path, monkeypatch) -> None:
+        """If the stored value is no longer ours, the user owns it.
+
+        Same rule the entry-level marker applies: an entry we cannot prove we wrote
+        is never rewritten. At field level the proof is that the stored value is
+        still exactly what we emitted.
+        """
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        found = tmp_path / "found" / "srv"
+        chosen = tmp_path / "chosen" / "srv"
+        for p in (found, chosen):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("#!/bin/sh\n")
+            p.chmod(0o755)
+        which = lambda c, **kw: str(found) if c == "srv" else c  # noqa: E731
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "s", "srv")
+        _emitted(tmp_path, cfg_dir, {}, which_side_effect=which)
+
+        spec_path = tmp_path / "kiro_agents" / "kirocrew.json"
+        cfg = json.loads(spec_path.read_text())
+        cfg["mcpServers"]["s"]["command"] = str(chosen)
+        spec_path.write_text(json.dumps(cfg))
+
+        # Twice: surviving one rebuild is not enough. If the emit recorded the edit
+        # as ours, the SECOND pass would read our own record as proof and re-derive
+        # over it.
+        for pass_no in (1, 2):
+            out = _emitted(tmp_path, cfg_dir, {}, which_side_effect=which)
+            assert out["s"]["command"] == str(
+                chosen
+            ), f"the hand edit was reclaimed on pass {pass_no}"
+
+
+class TestTheRecordIsNotPartOfSpecIdentity:
+    """The record must never make two copies of one server look like two servers.
+
+    ``_normalize_mcp_server_keys`` collapses family members whose NORMALIZED specs
+    match, and mints an ever-growing ``-2``/``-3`` suffix when they do not. Only the
+    population with no other config source is ever recorded, so comparing the record
+    would make a recorded entry differ from an otherwise-identical re-merged copy --
+    asymmetrically, and on every rebuild.
+    """
+
+    def test_the_record_is_excluded_from_the_dedup_comparison(self) -> None:
+        from kiro_crew.agent import _norm_mcp_spec
+
+        plain = {"command": "/abs/srv", "args": ["--x"]}
+        recorded = dict(plain)
+        recorded[DERIVED_KEY] = {"from": "srv", "emitted": "/abs/srv"}
+        assert _norm_mcp_spec(recorded) == _norm_mcp_spec(plain)
+
+    def test_a_real_difference_still_differs(self) -> None:
+        """The exclusion must not flatten specs that genuinely disagree."""
+        from kiro_crew.agent import _norm_mcp_spec
+
+        a = {"command": "/abs/one", DERIVED_KEY: {"from": "srv", "emitted": "/abs/one"}}
+        b = {"command": "/abs/two"}
+        assert _norm_mcp_spec(a) != _norm_mcp_spec(b)
+
+
+class TestScopeOwnedIsExcluded:
+    """The boundary this PR deliberately does not cross.
+
+    For a server another source declares, choosing between the record and the live
+    declaration correctly means selecting a per-field source AFTER resolution: the
+    merge picks a winner by which command resolves, then adopts that winner's
+    args/env as a unit. That is a merge-precedence change, not a provenance one, so
+    such a server gets no record and behaves exactly as it does today.
+    """
+
+    def test_a_scope_owned_server_gets_no_record(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        out = _emitted(tmp_path, cfg_dir, {"s": {"command": "/opt/s"}})
+        assert DERIVED_KEY not in out["s"]
+
+    def test_an_alias_keyed_scope_entry_still_counts_as_owned(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A scope keys by its own raw name; the config key was alias-normalized.
+
+        Matching by ALIAS is not merely conservative here, it is what the merge does:
+        a scope entry is copied into the config under its raw key and then normalized,
+        so a slash-keyed scope server and an alias-keyed config server become ONE
+        entry and the scope's command genuinely supplies the emitted one. Measured,
+        not assumed -- the assertion below is the evidence. A raw-key ownership probe
+        would miss that owner and let the record shadow a live declaration, which is
+        why an alias collision counts as owning even when it names a server the
+        author thought was separate.
+        """
+        monkeypatch.setenv("PATH", "/usr/bin")
+        cfg_dir = _bundled_defaults(tmp_path)
+        scope_bin = tmp_path / "scope" / "srv"
+        scope_bin.parent.mkdir(parents=True, exist_ok=True)
+        scope_bin.write_text("#!/bin/sh\n")
+        scope_bin.chmod(0o755)
+
+        _emitted(tmp_path, cfg_dir, {})
+        _make_agent_only(tmp_path, "vendor-srv", "gone-binary")
+        out = _emitted(
+            tmp_path,
+            cfg_dir,
+            {"vendor/srv": {"command": str(scope_bin)}},
+            which_side_effect=lambda c, **kw: None if c == "gone-binary" else c,
+        )
+        assert out["vendor-srv"]["command"] == str(scope_bin), (
+            "the colliding scope entry did not supply the command, so alias matching "
+            "would be over-broad -- revisit the ownership test"
+        )
+        assert DERIVED_KEY not in out["vendor-srv"], (
+            "an alias-colliding scope entry that supplies the command must read as "
+            "owning it, or the record would shadow a live declaration"
+        )


### PR DESCRIPTION
## What is the problem?

`rebuild_agent_config` writes the agent spec AND reads its own previous output back
as one of its merge sources, so that a field the user set and Kiro Crew never models
survives a rebuild. The resolved absolute `command` in that output is not the
user's, and nothing marks it as ours -- so a computed value is indistinguishable
from a typed one and gets re-consumed instead of re-derived.

`_resolve_command` accepts an absolute existing executable directly, with no PATH
search, so a command resolved once can never be rebound: not by a relocated binary,
and not by any later change to how commands resolve.

The property is already documented in-tree, as a reason to withhold something from
the emitted value: `_resolve_command`'s own docstring notes that the contributed MCP
directories are deliberately kept out of the emitted PATH because "an emitted PATH
is persisted and read back as an authored entry, so a contributed directory written
there could never be removed again". That is a point workaround for one field; this
is the general defect behind it.

## Why this issue matters to the user

Any setting that influences resolution becomes irrevocable after one rebuild, and it
blocks work: an attempt to add a user-extensible MCP binary search path was
withdrawn because both emitting and not emitting the search path left something
persisted that clearing the setting could not remove.

What the user sees is a server still pointing at a path that no longer makes sense,
with no way to correct it -- editing the source has no effect, because the rebuild
prefers what it wrote last time.

## How our fix solves it -- chain from symptom to root cause

1. **A computed field cannot be re-derived** because the rebuild reads it back as if
   the user had written it.
2. **Nothing distinguishes the two**, so the rebuild cannot treat its own output
   differently from its input.
3. **So record it.** The emitted entry names the field the rebuild computed, what it
   was derived FROM, and what was emitted:

       "x-kirocrew-derived": { "from": "npx", "emitted": "/abs/npx" }

4. **The source stays in the file on purpose.** A server whose only persisted home is
   the agent spec has no other copy, so dropping a computed field on readback would
   be correct for a server that also lives in a scope config and destructive for one
   that does not.
5. **The emitted value is the ownership proof.** A field is restored only while it
   still holds exactly what we wrote; anything else means someone edited it since,
   and an edited field is theirs. This has to hold across REPEATED rebuilds, not just
   the next one: recording a value we merely passed through would make our own record
   read as proof on the following pass, which is how an unearned claim becomes an
   overwrite. A test asserts across two consecutive rebuilds.
6. **Unreadable records fail open.** A config written by an older build carries no
   record, and a user can mangle one; every shape other than the exact one degrades
   to the behaviour that predates the key rather than to a removed field.

Deliberately a SECOND key rather than a field inside `x-kirocrew`. The marker answers
"did we author this entry in a file we do not own", and its invariant is that it
appears only in such files; folding this in would put the marker into the one file
that exclusion is about, and expose it to `without_marker`, which the shared-entry
copy path applies. Both rest on the same `x-` namespace argument -- a kiro-cli field
can never contain a hyphen, and unknown keys are dropped at deserialization.

### What this deliberately does NOT cover, and why

The record applies **only to a server no other config source declares** -- the one
whose sole persisted home is this file. A scope-owned server gets no record and
behaves exactly as it does today.

That boundary is not caution, it is where provenance stops being sufficient. For a
scope-owned server the record and the live declaration can disagree, and choosing
between them correctly means selecting a per-field source AFTER resolution: the merge
picks a winner by which command resolves, then adopts that winner's `args`/`env` as a
unit. Every pre-resolution guess is wrong in one of two directions, and earlier
revisions of this branch shipped both -- scanning per field mixes sources (command
from one scope, PATH from another, which the merge never does), and taking the first
owning scope picks a source the merge would not have chosen. Resolving aliases fixes
the lookup but not the ordering.

Correcting that changes how the merge picks per-field sources, which is the
agent-config ownership question in #6171, not a provenance one. `TestScopeOwnedIsExcluded`
pins the boundary so narrowing it later is a visible change rather than a silent one.
The full analysis is in [this comment](https://github.com/kirodotdev/KiroCrew/pull/7027#issuecomment-5470052554).

`env.PATH` is the rebuild's other computed field and needs no record for this
population: where there is no other home the declaration IS the stored value, so
narrowing it is an edit the ownership guard reads as the user's and the next emit
expands what they wrote. It becomes irrevocable only when the declaration lives in a
different file from the expansion -- the scope-owned case above.

The trailer is therefore `Refs`, not `Closes`: the issue's core claim holds for
scope-owned servers still.

## What tests we did

Targeted only -- the full suite is CI's job.

- `test/test_mcp_field_provenance.py`: record shape, restore semantics, the ownership
  guard (an edited command and a deleted field are both left alone), `command_is_ours`,
  and twelve unreadable-record shapes that must fail open.
- `test/test_mcp_rebuild_reconsumption.py`: runs the REAL rebuild repeatedly against
  one on-disk config, which is the only way the readback participates. Covers a
  relocated binary being re-resolved, stability across three rebuilds, a hand edit
  surviving two consecutive passes, and both halves of the excluded boundary --
  including an alias-keyed scope entry, since a raw-key ownership probe would miss
  its owner and wrongly treat it as having no other home.
- **Mutation-verified against the fix itself**: with the `source_view` call disabled,
  the relocated-binary test fails with "the stored absolute path short-circuited
  resolution, so the command could not be rebound", and the stability test fails too.
  Restored, both pass, and the probe left no residue.
- No fallout: `test_mcp_provenance.py` and `test_agent.py` MCP/merge/env/tool subsets
  both pass (54 in the agent subset).
- black, flake8, isort and mypy clean on every touched file.

## Any other suggestions on the work

- **This branch went through four revisions before this one**, and seven legitimate
  review findings, all in a single surface: deciding whether a field in the generated
  spec is ours and which source owns it now. Every fix was real, but the pattern was
  the signal -- the reduction above removes the question for this PR instead of
  answering it a fifth time.
- **The ownership proof is a value comparison**, exactly as strong as the entry-level
  marker and no stronger: a writer who can edit the agent spec can forge a record.
  That grants nothing new -- the same writer can set `command` directly, and the
  record only ever yields a value they could have written there -- but it is why this
  stays a declaration of authorship rather than a security boundary.
- **The population is closed on purpose.** the record is stored FLAT for the one field
  it describes rather than keyed by field name, so a second computed field has to be
  added deliberately, with its own test and its own restore semantics. The reader
  fails open, so widening the shape later needs no migration.

Refs #4955
