### PR TITLE
fix(channels): gate a channel turn on the shutdown state before it opens

### DIFF
--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -76,6 +76,7 @@ from kiro_crew.messaging.upload_gate import live_dashboard_slot, uploads_restric
 from kiro_crew.safety_override import describe_grant_lifetime, safety_override
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.session_map import ConversationOwnershipConflict
 from kiro_crew.stats import Stats
 
@@ -621,6 +622,7 @@ class DiscordDispatcher:
                 ),
                 audit_session_key=session_key,
                 audit_agent=agent or "kirocrew",
+                closing_gate=lambda: self.sessions.begin_turn(session_key),
             )
             accumulated = await driver.run(full_message)
 
@@ -691,6 +693,16 @@ class DiscordDispatcher:
                 )
             except Exception:
                 logger.debug("Discord: success audit failed", exc_info=True)
+        except SessionClosingError:
+            # Shutdown began between the claim and the dispatch, so no turn ever
+            # opened. Caught ahead of the generic handler so a restart is not
+            # charged to the circuit breaker via `record_failure`, which is not
+            # true of a session that never misbehaved. The `finally` still
+            # finalizes the renderer and releases the lease.
+            logger.info(
+                "Discord: aborting dispatch for %s — gateway is shutting down",
+                session_key,
+            )
         except Exception:
             logger.exception("Discord transport_dispatch: error handling message")
             if _acquired:

--- a/src/kiro_crew/messaging/dispatch.py
+++ b/src/kiro_crew/messaging/dispatch.py
@@ -47,6 +47,12 @@ from kiro_crew.messaging.renderer import SilentRenderer
 from kiro_crew.security import redact, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
+# Imported from the leaf that DEFINES it rather than through kiro_crew.session:
+# this module deliberately types ``sessions`` as ``Any`` to stay off the session
+# package's import graph, and session_allocation imports nothing from messaging,
+# so this direction cannot cycle.
+from kiro_crew.session_allocation import SessionClosingError
+
 logger = logging.getLogger(__name__)
 
 
@@ -630,6 +636,7 @@ async def drive_turn(turn: ChannelTurn, *, sessions: Any, ctx_builder: Any) -> N
             directive_consumer=turn.directive_consumer,
             audit_session_key=session_key,
             audit_agent=turn.agent or "kirocrew",
+            closing_gate=lambda: sessions.begin_turn(session_key),
         )
         accumulated = await driver.run(full_message)
 
@@ -707,6 +714,22 @@ async def drive_turn(turn: ChannelTurn, *, sessions: Any, ctx_builder: Any) -> N
             )
         except Exception:
             logger.debug("%s: success audit failed", turn.channel_type, exc_info=True)
+    except SessionClosingError:
+        # The gateway began shutting down between the claim and the dispatch, so
+        # this turn never opened. Terminal for the message, but NOT a fault of
+        # the session — which is why it is caught ahead of the generic handler
+        # below and deliberately skips `record_failure`: charging a restart to
+        # the circuit breaker would count toward tripping a reset on a session
+        # that never misbehaved, and `logger.exception` would file a routine
+        # shutdown as an error with a full traceback.
+        #
+        # The `finally` still runs, so the renderer is finalized (the user gets
+        # this channel's notice rather than silence) and the lease is released.
+        logger.info(
+            "%s: aborting dispatch for %s — gateway is shutting down",
+            turn.channel_type,
+            session_key,
+        )
     except Exception:
         logger.exception("%s transport_dispatch: error handling message", turn.channel_type)
         if _acquired:

--- a/src/kiro_crew/messaging/driver.py
+++ b/src/kiro_crew/messaging/driver.py
@@ -318,6 +318,7 @@ class TurnDriver:
         directive_consumer: DirectiveConsumer | None = None,
         audit_session_key: str = "",
         audit_agent: str = "kirocrew",
+        closing_gate: Callable[[], None] | None = None,
     ) -> None:
         self.provider = provider
         self.renderer = renderer
@@ -347,6 +348,14 @@ class TurnDriver:
         # Terminal stop reason of the last run() — read by the dispatcher's
         # post-turn bookkeeping (e.g. COMPACTION_FAILED -> session reset).
         self.last_stop_reason: str = ""
+        # Synchronous pre-registration shutdown gate, supplied by the dispatcher
+        # as a zero-arg closure over its SessionManager and session key. It lives
+        # HERE rather than at each call site because the only placement that is
+        # actually atomic is the one immediately before the provider stream opens,
+        # and `run()` owns that line. Raising from it aborts the turn before any
+        # prompt is registered. A driver built without one keeps the old ungated
+        # behaviour, so a stand-in predating the parameter still works.
+        self.closing_gate = closing_gate
 
     async def run(self, message: str) -> str:
         """Drive one turn; return the accumulated channel-safe assistant text."""
@@ -418,6 +427,25 @@ class TurnDriver:
                 )
 
         await self.renderer.on_turn_start()
+        # Lease-dispatch race gate, placed HERE because this is the only line at
+        # which it is actually atomic. The dispatcher claimed the session long
+        # before this, and everything since -- the context build, and the
+        # `on_turn_start` platform round-trip immediately above -- is awaited. A
+        # gate at the call site therefore still leaves that round-trip open: a
+        # restart landing in it sets `_closing` and takes `close_all`'s drain
+        # snapshot while no turn is registered, and the prompt below then opens
+        # BEHIND that snapshot, where teardown kills it mid-turn holding its
+        # native lock and the user gets an empty response instead of a notice.
+        #
+        # Synchronous, with no await between this call and the `async for` below.
+        # `provider.stream(...)` registers the turn before its own first await
+        # (AcpClient.stream_events clears _turn_done up front), so the gate and
+        # the registration form one span ordered against `_closing`. This is the
+        # same shape the dashboard runner and the native Slack handler use, and
+        # the reason the gate is one line here rather than four at the call
+        # sites. Raises SessionClosingError, which each dispatcher catches.
+        if self.closing_gate is not None:
+            self.closing_gate()
         async for event in self.provider.stream(message):
             kind = event.kind
             if kind == EVENT_TEXT_CHUNK:

--- a/src/kiro_crew/slack/transport_dispatch.py
+++ b/src/kiro_crew/slack/transport_dispatch.py
@@ -17,6 +17,7 @@ unaffected (they don't go through events.py Slack dispatch).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 import time
@@ -37,6 +38,7 @@ from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn
 from kiro_crew.messaging.link import canonical_key
 from kiro_crew.platform import current_context
 from kiro_crew.sel import sel
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.slack.handler import (
     _get_default_agent,
     _hydrate_conv_flags,
@@ -611,6 +613,7 @@ async def handle_message_transport(
             ),
             audit_session_key=session_key,
             audit_agent=_agent or "kirocrew",
+            closing_gate=lambda: sessions.begin_turn(session_key),
         )
         # The thread's owner as of the moment the turn starts producing output.
         # A dashboard link landing during the run moves the conversation to a
@@ -847,6 +850,16 @@ async def handle_message_transport(
                 exc_info=True,
             )
 
+    except SessionClosingError:
+        # Shutdown began between the claim and the dispatch, so no turn opened.
+        # Mirrors the native handler's own gate: clear the thread status and
+        # return quietly. Deliberately NOT the generic branch below -- a restart
+        # is not a session fault (record_failure counts toward tripping the
+        # circuit breaker on a session that never misbehaved), is not a failed
+        # message, and does not warrant an error posted into the thread.
+        logger.info("Aborting Slack dispatch for %s — gateway is shutting down", session_key)
+        with contextlib.suppress(Exception):
+            await slack.set_thread_status(channel, reply_ts, "")
     except Exception:
         logger.exception("transport_dispatch: error handling message")
         Stats().inc_message_failed()

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -72,6 +72,7 @@ from kiro_crew.messaging.upload_gate import uploads_restricted
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import redact, redact_local_paths
 from kiro_crew.sel import sel
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.stats import Stats
 from kiro_crew.telegram.attachments import process_telegram_attachments
 from kiro_crew.telegram.commands import (
@@ -808,6 +809,7 @@ class TelegramDispatcher:
                 ),
                 audit_session_key=session_key,
                 audit_agent=agent or "kirocrew",
+                closing_gate=lambda: self.sessions.begin_turn(session_key),
             )
             accumulated = await driver.run(full_message)
 
@@ -899,6 +901,18 @@ class TelegramDispatcher:
                 )
             except Exception:
                 logger.debug("Telegram: success audit failed", exc_info=True)
+        except SessionClosingError:
+            # Shutdown began between the claim and the dispatch, so no turn ever
+            # opened. Caught ahead of the generic handler so a restart is not
+            # charged to the circuit breaker via `record_failure` nor counted as
+            # a failed message — neither is true of a session that never
+            # misbehaved. `failure_reason` is left as it was, so the `finally`
+            # finalizes the placeholder with this channel's usual notice instead
+            # of leaving a perma-"🤔 …".
+            logger.info(
+                "Telegram: aborting dispatch for %s — gateway is shutting down",
+                session_key,
+            )
         except Exception as exc:
             logger.exception("Telegram transport_dispatch: error handling message")
             # Permanent, user-actionable failures (e.g. model entitlement)

--- a/test/test_channel_session_trust_parity.py
+++ b/test/test_channel_session_trust_parity.py
@@ -47,6 +47,7 @@ from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, AcpEve
 from kiro_crew.hooks import TOOL_DENY
 from kiro_crew.messaging.renderer import Renderer, TransportCapabilities
 from kiro_crew.safety_override import safety_override
+from kiro_crew.session_allocation import SessionClosingError
 
 # ── Channel-neutral doubles ───────────────────────────────────────────────────
 
@@ -136,6 +137,12 @@ class _Sessions:
         # is_new=False deliberately: it keeps the turn off the dashboard-surfacing
         # and set_channel paths, neither of which this suite is about.
         return self._p, False, False
+
+    def begin_turn(self, key: str) -> None:
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns = getattr(self, "begin_turns", 0) + 1
+        if getattr(self, "closing", False):
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key: str, channel_id: str) -> None:
         return None

--- a/test/test_command_surface_fixes.py
+++ b/test/test_command_surface_fixes.py
@@ -35,6 +35,7 @@ from kiro_crew.hooks import HookResult
 from kiro_crew.messaging import dispatch as D
 from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.telegram import commands as tcmd
 
 # ── 1. An unrecognized ``!command`` (and the prose that must not trip it) ───
@@ -343,6 +344,12 @@ class _PipelineSessions:
     async def get_or_create(self, key: str, agent: str = "", channel_id: str = "") -> Any:
         self.created.append(key)
         return object(), False, False
+
+    def begin_turn(self, key: str) -> None:
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns = getattr(self, "begin_turns", 0) + 1
+        if getattr(self, "closing", False):
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key: str, channel_id: str) -> None:
         return None

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -70,6 +70,7 @@ from kiro_crew.messaging.queue_receipt import receipt_text as _receipt_text
 from kiro_crew.messaging.split import split_markdown_safe
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session import _opt_out_key
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.session_map import ConversationOwnershipConflict
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
@@ -332,6 +333,10 @@ class FakeSessions:
         self.last_model: Any = None
         self.last_provider: Any = None
         self.raise_on_get = raise_on_get
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
         self._busy = False
         self._has = True
         self.queued: list = []
@@ -367,6 +372,12 @@ class FakeSessions:
         # rather than merely handing on something.
         self.last_provider = FakeProvider()
         return self.last_provider, True, False
+
+    def begin_turn(self, key: str) -> None:
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key: str, channel: str) -> None:
         return None
@@ -2178,6 +2189,42 @@ class TestDispatcher:
         await d.handle_message(self._msg("hello world"))
         assert "Answer: hello world" in (cli.final_text() or "")
         assert sess.successes and sess.released
+        # Pins that the pre-dispatch closing gate is consulted on the normal
+        # path, so it cannot be dropped or renamed into a no-op unnoticed.
+        assert sess.begin_turns == 1
+
+    @pytest.mark.asyncio
+    async def test_a_shutdown_between_the_claim_and_the_dispatch_never_opens_the_turn(
+        self,
+    ) -> None:
+        """The lease-dispatch race gate.
+
+        ``get_or_create`` guards the CLAIM, but the turn only opens at
+        ``driver.run``, and the context build between them is wide enough for a
+        gateway restart to land in. Opening a turn then registers it behind the
+        drain snapshot ``close_all`` has already taken, so it is killed
+        mid-flight holding its native lock and reaches the user as an empty
+        response instead of this channel's notice.
+        """
+        d, cli, sess = _dispatcher({"u1"})
+        # get_or_create deliberately ignores `closing`, so the CLAIM still
+        # succeeds here. That is the race being pinned: a refused claim was
+        # always handled, an accepted claim whose DISPATCH loses was not.
+        sess.closing = True
+
+        await d.handle_message(self._msg("hello world"))
+
+        assert "Answer: hello world" not in (
+            cli.final_text() or ""
+        ), "the turn must not open behind close_all's drain snapshot"
+        assert sess.begin_turns == 1
+        # A restart is neither a success nor a session fault: charging it to the
+        # circuit breaker would count toward resetting a session that never
+        # misbehaved.
+        assert not sess.successes
+        assert not sess.failures
+        # Refused is not leaked -- the session-keyed semaphore still comes back.
+        assert sess.released
 
     @pytest.mark.asyncio
     async def test_cold_start_failure_releases_nothing_but_closes_renderer(

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -20,6 +20,7 @@ from kiro_crew.messaging import session_resume as session_resume_core
 from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session import _opt_out_key
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.session_map import ConversationOwnershipConflict
 
 
@@ -114,6 +115,10 @@ class _Sessions:
 
     def __init__(self) -> None:
         self.mirror_links: dict[str, ChannelLink] = {}
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
         self.flushed: list[dict] = []
         self.flush_error: Exception | None = None
         self.origin_links: dict[str, ChannelLink] = {}
@@ -220,6 +225,16 @@ class _Sessions:
         self.last_key = key
         self.last_agent = kwargs.get("agent")
         return self.provider, getattr(self, "is_new_result", False), True
+
+    def begin_turn(self, key: str) -> None:
+        """The real manager's synchronous pre-dispatch closing gate.
+
+        ``closing`` mirrors SessionManager._closing so this refuses the dispatch
+        the way the real gate does once close_all has run.
+        """
+        self.begin_turns = getattr(self, "begin_turns", 0) + 1
+        if getattr(self, "closing", False):
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key: str, channel: str) -> None:
         self.set_channel_calls = getattr(self, "set_channel_calls", [])

--- a/test/test_feishu_dispatch.py
+++ b/test/test_feishu_dispatch.py
@@ -15,6 +15,7 @@ from kiro_crew.messaging.link import (
     CHAT_TYPE_FORUM,
     build_dm_session_key,
 )
+from kiro_crew.session_allocation import SessionClosingError
 
 # ------------------------------------------------------------------
 # Fakes
@@ -80,12 +81,22 @@ class FakeSessions:
         self.channels: list = []
         self.last_agent = None
         self._max_gen: dict[str, int] = {}
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
 
     async def get_or_create(self, key, *, agent, channel_id):
         self.last_agent = agent
         if self._raise is not None:
             raise self._raise
         return self._p, self._is_new, False
+
+    def begin_turn(self, key):
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, cid) -> None:
         self.channels.append((key, cid))

--- a/test/test_imessage_dispatch.py
+++ b/test/test_imessage_dispatch.py
@@ -8,6 +8,7 @@ import pytest
 
 from kiro_crew.imessage.client import IMessageInbound
 from kiro_crew.imessage.transport_dispatch import IMessageDispatcher
+from kiro_crew.session_allocation import SessionClosingError
 
 HANDLE = "+15551234567"
 
@@ -52,6 +53,10 @@ class FakeProvider:
 class FakeSessions:
     def __init__(self) -> None:
         self.busy: set[str] = set()
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
         self.providers: dict[str, Any] = {}
         self.sessions: set[str] = set()
         self.acquired: list[str] = []
@@ -73,6 +78,12 @@ class FakeSessions:
             return False
         self.acquired.append(key)
         return True
+
+    def begin_turn(self, key: str) -> None:
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     def release(self, key: str) -> None:
         self.released.append(key)

--- a/test/test_messaging_dispatch.py
+++ b/test/test_messaging_dispatch.py
@@ -9,27 +9,39 @@ finalization itself fails.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 from kiro_crew.messaging import dispatch as D
 from kiro_crew.messaging.dispatch import ChannelTurn, drive_turn
 from kiro_crew.messaging.renderer import SilentRenderer
+from kiro_crew.session_allocation import SessionClosingError
 
 
 class _Sessions:
     """Minimal stand-in that counts the calls this contract is about."""
 
-    def __init__(self, raise_on_acquire: bool = False):
+    def __init__(self, raise_on_acquire: bool = False, closing: bool = False):
         self.released = 0
         self.successes = 0
         self.failures = 0
         self.resets = 0
         self._raise_on_acquire = raise_on_acquire
+        #: Mirrors SessionManager._closing. When set, begin_turn refuses the
+        #: dispatch exactly as the real gate does once close_all has run.
+        self.closing = closing
+        self.begin_turns = 0
 
     async def get_or_create(self, key, agent=None, channel_id=None):
         if self._raise_on_acquire:
             raise RuntimeError("cold start failed")
         return object(), False, False
+
+    def begin_turn(self, key):
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, channel_id):
         pass
@@ -75,9 +87,15 @@ class _Driver:
     last_stop_reason = ""
 
     def __init__(self, *a, **kw):
-        pass
+        # Mirrors the real TurnDriver: the shutdown gate is supplied at
+        # construction and invoked by run(), immediately before the provider
+        # stream would open. A stand-in that swallowed it would let these tests
+        # pass while the gate was wired nowhere.
+        self._closing_gate = kw.get("closing_gate")
 
     async def run(self, message):
+        if self._closing_gate is not None:
+            self._closing_gate()
         return "the reply"
 
 
@@ -181,6 +199,122 @@ def test_the_happy_path_releases_exactly_once(monkeypatch) -> None:
     assert renderer.closed == 1
     assert sessions.released == 1
     assert sessions.successes == 1
+    # Pins that the gate is actually consulted on the normal path, so it cannot
+    # be dropped or renamed into a no-op without a test noticing.
+    assert sessions.begin_turns == 1
+
+
+def test_every_turn_open_site_is_gated_on_the_shutdown_state() -> None:
+    """Ratchet: the shutdown gate is wired at every site AND placed atomically.
+
+    Two halves, because either alone is satisfiable while the race stays open.
+
+    A gate at the CALL SITE is not enough, which is what the first version of
+    this change got wrong: ``TurnDriver.run`` awaits ``renderer.on_turn_start()``
+    -- a platform round-trip -- before opening the provider stream, so a restart
+    landing there still let the prompt register behind ``close_all``'s drain
+    snapshot. The only atomic placement is inside ``run()``, immediately before
+    the stream, so the gate lives there and each dispatcher passes it in.
+
+    So: every ``TurnDriver(...)`` construction must pass ``closing_gate``, and in
+    the driver the gate call must be the nearest preceding statement to the
+    provider stream, comments only in between. Any other statement fails -- an
+    await there is exactly the race this closes.
+    """
+    src = Path(D.__file__).resolve().parent.parent
+
+    # Half 1 -- every construction wires a gate.
+    unwired: list[str] = []
+    sites = 0
+    for path in sorted(src.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if "TurnDriver(" not in text:
+            continue
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            if "TurnDriver(" not in line or line.lstrip().startswith("#"):
+                continue
+            sites += 1
+            # Scan the construction's argument list to its closing paren.
+            probe, wired = idx, False
+            while probe < len(lines) and probe < idx + 40:
+                if "closing_gate" in lines[probe]:
+                    wired = True
+                    break
+                if lines[probe].strip() == ")":
+                    break
+                probe += 1
+            if not wired:
+                unwired.append(f"{path.relative_to(src)}:{idx + 1}")
+    assert not unwired, "TurnDriver built without a shutdown gate:\n" + "\n".join(unwired)
+    assert sites >= 4, f"expected the known TurnDriver sites, found {sites}"
+
+    # Half 2 -- the gate is atomic with the stream the driver opens.
+    driver_lines = (src / "messaging" / "driver.py").read_text(encoding="utf-8").splitlines()
+    opens = [i for i, ln in enumerate(driver_lines) if "self.provider.stream(" in ln]
+    assert opens, "could not find the provider stream in the driver"
+    for idx in opens:
+        probe = idx - 1
+        while probe >= 0 and (
+            not driver_lines[probe].strip() or driver_lines[probe].lstrip().startswith("#")
+        ):
+            probe -= 1
+        assert "closing_gate" in driver_lines[probe], (
+            f"messaging/driver.py:{idx + 1} opens a turn without the gate "
+            f"immediately before it; found: {driver_lines[probe].strip()!r}"
+        )
+
+
+def test_a_shutdown_between_the_claim_and_the_dispatch_never_opens_the_turn(
+    monkeypatch,
+) -> None:
+    """The lease-dispatch race gate.
+
+    ``get_or_create`` guards the CLAIM, but the turn only opens at
+    ``driver.run``, and everything between them awaits: ``set_channel``, the
+    origin/mirror bind's thread hop, ``publish_turn_identity``, and the whole
+    context build. A restart landing in that span used to leave this pipeline
+    opening a turn that ``close_all`` had already taken its drain snapshot
+    without -- killed mid-flight holding its native lock, which reaches the user
+    as an empty response. The dashboard runner and the Slack handler each carry
+    this gate already; every channel on the shared pipeline had no equivalent.
+    """
+    ran: list[str] = []
+
+    class _RecordingDriver(_Driver):
+        async def run(self, message):
+            # Gate first, then record -- the real driver runs the gate
+            # immediately BEFORE the provider stream opens, so a refused turn
+            # must never reach the recording below.
+            if self._closing_gate is not None:
+                self._closing_gate()
+            ran.append(message)
+            return "the reply"
+
+    _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(D, "TurnDriver", _RecordingDriver)
+    sessions = _Sessions()
+    renderer = _Renderer()
+    # The fake's get_or_create deliberately does NOT consult ``closing``, so the
+    # claim still succeeds here. That is the race being pinned: a refused CLAIM
+    # was already handled, an accepted claim whose DISPATCH races the shutdown
+    # was not.
+    sessions.closing = True
+
+    asyncio.run(drive_turn(_turn(renderer), sessions=sessions, ctx_builder=_CtxBuilder()))
+
+    assert ran == [], "the turn must not open behind close_all's drain snapshot"
+    assert sessions.begin_turns == 1
+    # Refused is not leaked: the renderer is still finalized (so the user gets
+    # this channel's notice rather than a hanging placeholder) and the
+    # session-keyed semaphore is still given back.
+    assert renderer.closed == 1
+    assert sessions.released == 1
+    # A restart is not a session fault. Charging it to the circuit breaker via
+    # record_failure would count toward tripping a reset on a session that never
+    # misbehaved, and it is not a success either.
+    assert sessions.failures == 0
+    assert sessions.successes == 0
 
 
 def test_a_compaction_failed_terminal_resets_the_session(monkeypatch) -> None:

--- a/test/test_teams_dispatch.py
+++ b/test/test_teams_dispatch.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, AcpEvent
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.teams.client import TeamsInbound
 from kiro_crew.teams.transport_dispatch import TeamsDispatcher
 
@@ -61,6 +62,10 @@ class FakeSessions:
         self.channels: list = []
         self.last_agent = None
         self._busy = False
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
         # Mid-turn queue + dashboard-mirror surface the dispatcher now uses.
         self.queues: dict[str, list] = {}
         self.cleared: list = []
@@ -110,6 +115,12 @@ class FakeSessions:
         if self._raise is not None:
             raise self._raise
         return self._p, self._is_new, False
+
+    def begin_turn(self, key):
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, cid) -> None:
         self.channels.append((key, cid))

--- a/test/test_teams_dispatch_cov80.py
+++ b/test/test_teams_dispatch_cov80.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import pytest
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, AcpEvent
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.teams.client import TeamsInbound
 from kiro_crew.teams.transport_dispatch import TeamsDispatcher
 
@@ -137,6 +138,12 @@ class _Sessions:
 
     async def get_or_create(self, key, *, agent, channel_id):
         return self._p, True, False
+
+    def begin_turn(self, key):
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns = getattr(self, "begin_turns", 0) + 1
+        if getattr(self, "closing", False):
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, cid) -> None:
         pass

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -35,6 +35,7 @@ from kiro_crew.messaging.renderer import (
 )
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.session import BACKGROUND_KEY, _opt_out_key
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.session_map import ConversationOwnershipConflict
 from kiro_crew.telegram.client import (
     TELEGRAM_CHUNK_LIMIT,
@@ -310,6 +311,10 @@ class FakeSessions:
         self.last_agent: Any = None
         self.last_model: Any = None
         self.raise_on_get = raise_on_get
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
         self._busy = False
         self._has = True
         self.queued: list = []
@@ -337,6 +342,12 @@ class FakeSessions:
         if self.raise_on_get:
             raise RuntimeError("cold-start failed")
         return FakeProvider(), True, False
+
+    def begin_turn(self, key: str) -> None:
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key: str, channel: str) -> None:
         return None
@@ -2649,6 +2660,46 @@ class TestDispatcher:
         asyncio.run(_go())
         assert cli.final_text() == "Answer: hello world"
         assert sess.successes == ["telegram:kirocrew:direct:7"]
+        assert sess.released == ["telegram:kirocrew:direct:7"]
+        # Pins that the pre-dispatch closing gate is consulted on the normal
+        # path, so it cannot be dropped or renamed into a no-op unnoticed.
+        assert sess.begin_turns == 1
+
+    def test_a_shutdown_between_the_claim_and_the_dispatch_never_opens_the_turn(self) -> None:
+        """The lease-dispatch race gate.
+
+        ``get_or_create`` guards the CLAIM, but the turn only opens at
+        ``driver.run``, and the context build between them is wide enough for a
+        gateway restart to land in. Opening a turn then registers it behind the
+        drain snapshot ``close_all`` has already taken, so it is killed
+        mid-flight holding its native lock and reaches the user as an empty
+        response instead of this channel's notice.
+        """
+        d, cli, sess = _dispatcher({7})
+        # get_or_create deliberately ignores `closing`, so the CLAIM still
+        # succeeds here. That is the race being pinned: a refused claim was
+        # always handled, an accepted claim whose DISPATCH loses was not.
+        sess.closing = True
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(
+                    channel_type="telegram", user_id="7", conversation_id="7", text="hello world"
+                )
+            )
+
+        asyncio.run(_go())
+
+        assert "Answer: hello world" not in (
+            cli.final_text() or ""
+        ), "the turn must not open behind close_all's drain snapshot"
+        assert sess.begin_turns == 1
+        # A restart is neither a success nor a session fault: charging it to the
+        # circuit breaker would count toward resetting a session that never
+        # misbehaved.
+        assert sess.successes == []
+        assert sess.failures == []
+        # Refused is not leaked -- the session-keyed semaphore still comes back.
         assert sess.released == ["telegram:kirocrew:direct:7"]
 
     def test_agent_resolves_to_kirocrew_when_unset(self) -> None:

--- a/test/test_webex_dispatch.py
+++ b/test/test_webex_dispatch.py
@@ -11,6 +11,7 @@ import pytest
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, AcpEvent
 from kiro_crew.messaging.link import ChannelLink
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.webex import cards
 from kiro_crew.webex import transport_dispatch as webex_dispatch
 from kiro_crew.webex.client import WebexInbound
@@ -97,12 +98,22 @@ class FakeSessions:
         self.mirror_links: dict = {}
         self.opt_out: dict = {}
         self.batched = 0
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
 
     async def get_or_create(self, key, *, agent, channel_id):
         self.last_agent = agent
         if self._raise is not None:
             raise self._raise
         return self._p, self._is_new, False
+
+    def begin_turn(self, key):
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, cid) -> None:
         self.channels.append((key, cid))

--- a/test/test_wecom_dispatch.py
+++ b/test/test_wecom_dispatch.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK, AcpEvent
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.wecom.client import WeComInbound
 from kiro_crew.wecom.commands import ConversationState, parse_command
 from kiro_crew.wecom.transport_dispatch import WeComDispatcher
@@ -81,6 +82,10 @@ class FakeSessions:
         self.mirror_links: dict = {}
         self.opted_out: dict = {}
         self.cleared_mirror: list = []
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
 
     @contextlib.contextmanager
     def batched_save(self):
@@ -118,6 +123,12 @@ class FakeSessions:
         if self._raise is not None:
             raise self._raise
         return self._p, self._is_new, False
+
+    def begin_turn(self, key):
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, cid) -> None:
         self.channels.append((key, cid))

--- a/test/test_weixin_dispatch.py
+++ b/test/test_weixin_dispatch.py
@@ -14,6 +14,7 @@ import pytest
 
 from kiro_crew.messaging.driver import APPROVAL_AUTO
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.weixin.client import ContextTokenStore, TypingTicketCache
 from kiro_crew.weixin.commands import parse_command
 from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
@@ -100,6 +101,10 @@ class FakeSessions:
     def __init__(self, provider=None, busy=False):
         self.provider = provider or FakeProvider()
         self._busy = busy
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
         self.released = 0
         self.successes = 0
         self.failures = 0
@@ -113,6 +118,12 @@ class FakeSessions:
 
     async def get_or_create(self, key, agent=None, channel_id=None):
         return self.provider, True, False
+
+    def begin_turn(self, key):
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, channel_id):
         self.channels[key] = channel_id

--- a/test/test_whatsapp_dispatch.py
+++ b/test/test_whatsapp_dispatch.py
@@ -15,6 +15,7 @@ from typing import Any
 from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.messaging.driver import APPROVAL_AUTO
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.whatsapp.commands import (
     COMPACT_AUTO_TEXT,
     COMPACT_BUSY_TEXT,
@@ -92,6 +93,10 @@ class FakeSessions:
         persisted_generations: dict[str, int] | None = None,
     ) -> None:
         self.provider = provider or FakeProvider()
+        # `closing` mirrors SessionManager._closing so begin_turn refuses the
+        # dispatch the way the real gate does after close_all.
+        self.closing = False
+        self.begin_turns = 0
         #: What ``max_generation`` reports per durable bucket, standing in for the
         #: session map on disk. Empty means a machine that has never run this
         #: channel, which is the only case an unseeded counter gets right.
@@ -131,6 +136,12 @@ class FakeSessions:
 
     async def get_or_create(self, key, agent=None, channel_id=None):
         return self.provider, True, False
+
+    def begin_turn(self, key: str) -> None:
+        """The real manager's synchronous pre-dispatch closing gate."""
+        self.begin_turns += 1
+        if self.closing:
+            raise SessionClosingError("SessionManager is closing")
 
     async def set_channel(self, key, channel_id):
         self.channels[key] = channel_id


### PR DESCRIPTION
## What is the problem?

Four dispatchers open a turn without any pre-dispatch shutdown gate, so a turn
can open *behind* the drain snapshot `close_all` has already taken. One of the
four is the Slack path a default install runs.

`close_all` sets `_closing` under the manager lock and only then takes its drain
snapshot, and that ordering is deliberate: it is what stops a new turn slipping
into the multi-second drain window. The dashboard runner and the *native* Slack
handler each honour it with a synchronous `sessions.begin_turn(session_key)`
immediately before their stream opens. None of the four `TurnDriver` dispatchers
did -- including `slack/transport_dispatch.py`, which `messaging.use_transport`
selects by default (`config/loader.py:7741`).

`get_or_create` does check `_closing`, but it guards the CLAIM, and the claim is
the START of the window rather than its end. Between the claim and the turn
actually opening at `driver.run`, the shared pipeline awaits `set_channel`, the
origin/mirror bind's thread hop, `publish_turn_identity`, and the entire context
build in `run_in_embed_pool`. A restart landing anywhere in that span leaves a
claimed session about to open a turn that the drain will never wait on.

## Why this issue matters to the user

A turn opened behind the drain snapshot is killed mid-flight holding its native
lock. The user does not get an error, and does not get the channel's usual
"please try again" notice either -- they get an empty response, on a message the
platform already showed as delivered. It is the same empty-response class the
`begin_turn` gate was introduced to prevent on the two surfaces that had it, so
every adopted channel plus default-configured Slack was carrying a defect those
two had already fixed.

## How our fix solves it

The gate lives in `TurnDriver.run()`, immediately before `provider.stream(...)`,
and each of the four channel dispatchers passes it in as `closing_gate` -- a
zero-arg closure over its own manager and session key. The dispatchers are
`messaging/dispatch.py` (covering Teams, Webex, WeCom, Weixin, WhatsApp, iMessage
and Feishu), `telegram/transport_dispatch.py`, `discord/transport_dispatch.py`,
and `slack/transport_dispatch.py`.

Placement is the substance of the change, and a gate at the CALL SITE is not
enough: `run()` awaits `renderer.on_turn_start()` -- a platform round-trip for the
typing indicator -- before it opens the stream, so a restart landing in that
round-trip would still let the prompt register behind the drain snapshot. Inside
`run()` there is no await between the gate and the `async for`.

What that does and does not buy, stated precisely because an earlier version of
this description overclaimed it. `AcpClient.stream_events` resolves the prompt
timeout BEFORE it clears `_turn_done`, and on the default path that resolution is
a config read off disk (`asyncio.to_thread`). So registration is not the first
thing that happens, and a residual window remains: a restart landing in that one
await still orphans the turn. That residual is NOT introduced here --
`AcpProvider.stream()` delegates straight to `stream_events`, so the dashboard
runner and the native Slack handler have carried the identical window since the
gate pattern was introduced. What this PR does is narrow the channel surfaces from
a window spanning the whole context build plus the `on_turn_start` round-trip down
to that same one await. The cause-level fix (register before resolving the
timeout, with a guard that re-sets `_turn_done` if the pre-prompt span fails,
closing it for all five surfaces at once) is captured as a follow-up rather than
folded in here, because it changes the turn lifecycle every surface depends on.
The stale comment in `chat_runner.py` asserting that `stream_events` clears
`_turn_done` before its first await is part of that follow-up; it is outside this
diff.

Each dispatcher also gains an explicit `except SessionClosingError` ahead of its
generic `except Exception`. Without it a shutdown would be charged to the session:
`record_failure` counts toward tripping the circuit breaker and resetting a
session that never misbehaved, `Stats().inc_message_failed()` books it as a failed
message, and `logger.exception` files a routine restart as an error with a full
traceback. The `finally` is untouched, so the renderer is still finalized and the
session-keyed semaphore is still released -- a refused turn must not become a
leaked one, because that semaphore is what every later message in the
conversation waits on. On the Slack transport path the handler mirrors the native
handler's own gate: clear the thread status and return quietly, rather than
posting an error into the thread.

A ratchet test pins both halves of the wiring, because either alone is satisfiable
while the race stays open: every `TurnDriver` construction in the tree must pass
`closing_gate`, and in the driver the gate call must be the nearest preceding
statement to `provider.stream(...)`, allowing only comments between them. Keeping
the gate in one place is also what removes the per-site hazard that this PR
already tripped over once -- the first version missed the Slack transport path
precisely because the native handler beside it already had a gate.

Two notes on what this deliberately does NOT do:

* It does not change the notice a channel user receives on a refusal. That is a
  product decision on the linked issue, not a code detail.
* It does not let a refused turn run. Draining accepted-but-unstarted messages
  was considered and rejected: it is not merely unbounded, it dismantles the
  `_closing`-before-snapshot ordering that this gate depends on.

Test stand-ins in fourteen test files gained the `begin_turn` their real
`SessionManager` counterpart already has -- the Slack and dashboard test fakes
already carried it, so this brings the channel fakes up to the same contract and
gives each the ability to simulate shutdown. The gate is deliberately a hard call
rather than a `getattr` lookup: a silent fallback would turn a missing safety gate
into a no-op, which is the failure this PR exists to remove, and would let a later
rename disable it everywhere with nothing going red.

## What tests we did

Three per-dispatcher tests plus the ratchet, all mutation-verified red on base.
With a gate commented out each per-dispatcher test fails on its behavioural
assertion rather than on a call count -- `assert ['hi'] == []` on the shared
pipeline, and "the turn must not open behind close_all's drain snapshot" on
Telegram and Discord -- so the mutation demonstrates the turn genuinely opening,
which is the defect itself. Ungating the Slack transport path makes the ratchet
name `slack/transport_dispatch.py:687` specifically.

Each test pins that the turn never opens, that the renderer is still finalized,
that the lease is still released, and that the refusal is recorded as neither a
success nor a failure. The three existing happy-path tests additionally gained a
`begin_turns == 1` assertion so the gate cannot be dropped or renamed into a
no-op unnoticed. The ratchet also asserts it still finds at least four sites, so
a refactor of the call shape cannot make it pass vacuously.

Targeted runs only, across the affected files: 1236 passed. flake8 and isort clean
on every changed file; mypy clean on the changed source files. The full suite is
left to CI.

Worth recording for review: Weixin and WhatsApp await `drive_turn` INLINE on their
long-poll loop and neonize event pump respectively, with no per-message task. Their
intake loop is therefore sensitive to how an exception propagates out of the
dispatcher, so it was checked specifically -- the refusal is caught inside
`drive_turn`, so neither loop is affected.

## Any other suggestions on the work

This closes a mirror defect found while investigating the linked issue; it does
not close that issue, hence `Refs` rather than `Closes`. The issue asks for
durable inbound persistence so an accepted-but-refused message is not lost, which
remains a maintainer decision.

Two findings from that investigation are recorded on the issue and may be useful
independently. The loss it describes is already legible on the nine messaging
channels -- `drive_turn`'s `finally` finalizes the renderer even when the claim
raises, so the user sees the channel's error text; the silent half is the
dashboard and the native Slack handler. And the platform-redelivery route that
looks like a cheap general fix reaches exactly one channel: only Webex defers its
ack until the handler completes. Teams fast-acks 200 immediately after spawning,
Slack acks its envelope before spawning, WeCom's and Feishu's dedup windows defend
against unrequested duplicates rather than offering a lever, and Weixin and
WhatsApp have no ack at all.

Scope, stated because the ratchet's name could imply more than it checks: the
same claim-then-ungated-stream shape exists on four NON-channel surfaces that
consume the same manager -- `dashboard/handlers/hooks.py`, the task runner,
`subagent.py`, and `channel.py`. I verified two directly (both do claim ->
`run_in_embed_pool` / prep -> `client.stream(...)` with no gate). They are out of
scope here and the `TurnDriver`-scoped ratchet deliberately does not claim to
cover them, so the "ungated fifth site" guarantee is a CHANNEL guarantee only.

Refs #2217



