### PR TITLE
perf(skills): memoise the skills catalog behind GET /api/skills

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -916,6 +916,35 @@ help a user enable and interpret it. It does not enable the feature or trigger
 generation, and holds no runtime-written frontmatter, since a builtin skill is
 re-synced by `rmtree` + `copytree` on upgrade.
 
+**`GET /api/skills` coalesces concurrent readers onto one scan, and stores nothing.**
+The catalog assembly is filesystem-heavy (`os.walk` plus per-file frontmatter reads, package
+path globs, per-skill resolve/read, agent annotation), and the defect this addresses is that
+N simultaneous skill-menu opens each paid for their own scan. `_assemble_skills_catalog` in
+`dashboard/handlers/prompts.py` fixes that with single-flight coalescing: the first reader
+assembles, readers queued alongside it take those rows instead of scanning again. Measured
+against a counting assembler, 8-way concurrency goes from 0% to 87.5% redundant-scan
+elimination — eight opens cost one scan.
+
+**There is no stored result and no TTL, and that is what makes the invariant cheap.** The
+leader's rows are offered only while another reader for the same key is still inside
+`_assemble_skills_catalog`; when the last one leaves, they are dropped. So a read that is not
+part of a concurrent burst always scans current on-disk state, the base's recorded default
+("No result cache: the endpoint always reflects current on-disk state, so freshly
+created/installed skills appear immediately") is preserved, and **no mutation path anywhere
+owes the catalog an invalidation**.
+
+**The mechanism is one assembly lock per key** (`LoopBoundLock` values in a registry, the shape
+#4800 established) — fast path, lock, re-check under it, where the re-check is the join. Per key
+rather than global, so readers of different projects still scan in parallel as the base did; the
+registry entry is dropped with the waiter count, and a test pins the parallelism.
+`_assemble_skills_catalog`'s docstring is authoritative for the contract — which readers can be
+served older rows, and the bound — so it stays next to the code it constrains and is spelled once.
+
+**The `?agent=` filter is deliberately NOT part of the key.** It is applied downstream as a
+comprehension over the assembled rows, and an end-to-end test drives two agents through the
+real endpoint in both orders to keep that true rather than merely currently-true — a join that
+ever shared the FILTERED result would fail whichever agent asked second.
+
 **Loading:**
 1. **Always-on**: skills with `always: true` have full content injected every new session
 2. **On-demand**: skill summaries (name + description + dir path) in session context; LLM can `cat` the file when relevant

--- a/src/kiro_crew/dashboard/handlers/prompts.py
+++ b/src/kiro_crew/dashboard/handlers/prompts.py
@@ -28,6 +28,7 @@ from kiro_crew.hooks import (
     validate_file_path,
     verified_replace_file_nolink,
 )
+from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.platform_compat import is_link_or_junction
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.skill_trust import ReviewedProjectChanged as _ReviewedProjectChanged
@@ -1530,6 +1531,141 @@ async def _api_prompt_write(request: web.Request) -> web.Response:
 READONLY_SKILL_KEY_PREFIXES = ("kiro-user/", "kiro-workspace/")
 
 
+# Concurrent readers of the catalog share ONE scan. Nothing is stored and nothing
+# expires: the handoff below lives only while a reader is still queued for it.
+# Keyed on (loader, project), so two loaders cannot collide on one entry.
+_catalog_lock = threading.Lock()
+_catalog_waiters: dict[tuple[Any, str], int] = {}
+_catalog_handoff: dict[tuple[Any, str], list[dict[str, Any]]] = {}
+
+# One assembly lock PER KEY, so different projects still scan in parallel. Created
+# and dropped under _catalog_lock alongside the waiter count that bounds its life.
+_catalog_assembly_locks: dict[tuple[Any, str], LoopBoundLock] = {}
+
+
+async def _assemble_skills_catalog(skills: Any, project_dir: Path | None) -> list[dict[str, Any]]:
+    """Return the catalog for *project_dir*, sharing one scan across concurrent readers.
+
+    Shape: a fast path off the assembly lock, then the lock, then a re-check UNDER
+    it. The re-check is what coalesces -- readers queued behind the leader take the
+    rows it just finished instead of each scanning (0% -> 87.5% at 8-way, measured).
+
+    NOTHING is retained past the burst, so a read that is not concurrent with
+    another always scans current on-disk state. No generation or epoch check is
+    needed, but NOT because scans cannot overlap: cancelling a leader mid-scan
+    leaves its executor thread running (a started thread-pool task is not
+    cancellable) while a replacement leader starts its own, so two scans for one key
+    CAN overlap. What holds instead is that the handoff is published only after an
+    await returns, so a cancelled leader publishes nothing and its rows are
+    discarded; the offer is dropped when its last reader leaves.
+
+    The staleness this admits, stated exactly: any reader that shares a scan may be
+    served rows read before its own arrival -- a mid-assembly joiner, and equally a
+    reader arriving while the finished rows are still draining to their waiters. The
+    bound is one assembly for that key, since a reader never queues behind another
+    key's scan. There is NO read-after-write guarantee under a burst.
+
+    ONE assembly lock PER KEY, so readers of different projects still scan in
+    parallel exactly as the base did: this coalesces same-key readers without making
+    any reader wait on an unrelated catalog. That matters because assembly is not
+    reliably sub-second -- it can run seconds long on large skills x agents
+    catalogs -- so a shared lock would have handed a multi-project burst worse tail
+    latency than the base. A test pins the parallelism.
+
+    No work preservation when the leader disconnects: the assembly is awaited
+    inline, so cancelling the leader makes the next waiter start over. That buys the
+    removal of an in-flight task map and its cancellation bookkeeping.
+
+    The rows are returned as-is, not copied, so a caller that mutates an entry in
+    place must copy first.
+    """
+    key = (skills, str(project_dir) if project_dir is not None else "")
+    with _catalog_lock:
+        _catalog_waiters[key] = _catalog_waiters.get(key, 0) + 1
+        assembly_lock = _catalog_assembly_locks.get(key)
+        if assembly_lock is None:
+            assembly_lock = _catalog_assembly_locks[key] = LoopBoundLock()
+    try:
+        with _catalog_lock:
+            rows = _catalog_handoff.get(key)
+        if rows is not None:
+            return rows
+        async with assembly_lock:
+            # Re-check under the lock: the leader we queued behind may have just
+            # finished this catalog. This is the join.
+            with _catalog_lock:
+                rows = _catalog_handoff.get(key)
+            if rows is not None:
+                return rows
+            result = await _assemble_skills_catalog_uncached(skills, project_dir)
+            with _catalog_lock:
+                # Only offer the rows if someone else is queued; with no waiter
+                # there is nobody to hand them to.
+                if _catalog_waiters.get(key, 0) > 1:
+                    _catalog_handoff[key] = result
+            return result
+    finally:
+        with _catalog_lock:
+            remaining = _catalog_waiters.get(key, 1) - 1
+            if remaining > 0:
+                _catalog_waiters[key] = remaining
+            else:
+                _catalog_waiters.pop(key, None)
+                # Last reader out, so neither the offer nor this key's lock can
+                # outlive the burst that created them.
+                _catalog_handoff.pop(key, None)
+                _catalog_assembly_locks.pop(key, None)
+
+
+async def _assemble_skills_catalog_uncached(
+    skills: Any,
+    project_dir: Path | None,
+) -> list[dict[str, Any]]:
+    """Do the actual catalog assembly, with no sharing or reuse of any kind.
+
+    Called by :func:`_assemble_skills_catalog`, which awaits it inline while
+    holding the coalescing lock -- so a caller that disconnects mid-assembly
+    cancels it and the next waiter reassembles.
+
+    Runs the edition capability lookup async (on the loop, non-blocking), then
+    offloads ALL blocking filesystem work — kirocrew ``list_skills()`` (os.walk +
+    per-file frontmatter reads), package path globs, kiro per-skill resolve/read,
+    and the agent annotation — onto the dedicated DISCOVERY pool in one job. This
+    work would stall the event loop past the loop-stall watchdog (~25s) on large
+    skills×agents catalogs if run on-loop. Use the discovery pool (NOT
+    ``maintenance_executor``): this scan is browser-triggerable and can be
+    seconds-long, so the maintenance pool would let a few dashboard tabs occupy
+    the workers the orphan-reaper sweeps need to recover from a wedge (see
+    :mod:`kiro_crew.executors`).
+
+    PRESERVES THE BASE'S RECORDED DEFAULT. The base states, as a decision rather
+    than an omission: "No result cache: the endpoint always reflects current
+    on-disk state, so freshly created/installed skills appear immediately
+    (correctness over the latency a cache would add)." That still holds. Coalescing
+    stores no result and has no expiry: concurrent readers share ONE scan, and a
+    read that is not part of a concurrent burst always scans current on-disk state.
+
+    Sharing is what admits staleness rather than this function, and
+    :func:`_assemble_skills_catalog` is authoritative for that contract. The
+    consequence to respect here: do not build a mutation handler that returns this
+    catalog expecting the just-written skill.
+    """
+    mgr = _capability_manager()
+    try:
+        package_skills = await mgr.list_skills() if mgr.available() else []
+    except Exception:
+        # The capability manager is one of three skill sources; degrade to "no
+        # package skills" rather than 500 the whole /api/skills endpoint.
+        package_skills = []
+    return await asyncio.get_running_loop().run_in_executor(
+        discovery_executor(),
+        collect_skills_blocking,
+        skills,
+        package_skills,
+        project_dir,
+    )
+
+
 async def api_skills(request: web.Request) -> web.Response:
     """GET /api/skills — list skills from all known sources.
 
@@ -1575,32 +1711,7 @@ async def api_skills(request: web.Request) -> web.Response:
     # Strict: must match what SkillsLoader will resolve for THIS chat, or the
     # catalog advertises a skill whose $token expands to nothing.
     project_dir: Path | None = requesting_slot_project(state, session_key)
-    # Run the edition capability lookup async (on the loop, non-blocking), then offload ALL
-    # blocking filesystem work — kirocrew list_skills() (os.walk + per-file
-    # frontmatter reads), package path globs, kiro per-skill resolve/read, and the
-    # agent annotation — onto the dedicated DISCOVERY pool in one job. This work
-    # would stall the event loop past the loop-stall watchdog (~25s) on large
-    # skills×agents catalogs if run on-loop. Use the discovery pool
-    # (NOT maintenance_executor): this scan is browser-triggerable and can be
-    # seconds-long, so the maintenance pool would let a few dashboard tabs
-    # occupy the workers the orphan-reaper sweeps need to recover from a wedge
-    # (see kiro_crew.executors). No result cache: the endpoint always reflects
-    # current on-disk state, so freshly created/installed skills appear
-    # immediately (correctness over the latency a cache would add).
-    mgr = _capability_manager()
-    try:
-        package_skills = await mgr.list_skills() if mgr.available() else []
-    except Exception:
-        # The capability manager is one of three skill sources; degrade to "no
-        # package skills" rather than 500 the whole /api/skills endpoint.
-        package_skills = []
-    result = await asyncio.get_running_loop().run_in_executor(
-        discovery_executor(),
-        collect_skills_blocking,
-        skills,
-        package_skills,
-        project_dir,
-    )
+    result = await _assemble_skills_catalog(skills, project_dir)
     agent = request.query.get("agent") or None
     if agent:
         globs = await asyncio.get_running_loop().run_in_executor(

--- a/test/test_skills_catalog_cache.py
+++ b/test/test_skills_catalog_cache.py
@@ -1,0 +1,255 @@
+"""Behavioural tests for the ``GET /api/skills`` single-flight join.
+
+Covers:
+- concurrent readers coalesce onto ONE assembly (the measured fix: 0% -> 87.5%
+  redundant-scan elimination at 8-way)
+- NOTHING is retained past the burst, so a later read always rescans and the
+  base's recorded "no result cache" default still holds
+- a different loader is a different catalog and never joins
+- readers of different projects serialize on the one global assembly lock
+- no module owes the catalog an invalidation: no invalidator exists to call
+
+Every test stubs the two expensive collaborators (the edition capability manager
+and ``collect_skills_blocking``) and counts calls, so "shared one assembly" is
+asserted by the assembler NOT running rather than by a latency measurement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+# Reused rather than re-implemented: these are the same scaffolding helpers the
+# skills-browser suite builds its endpoint tests from. Imported instead of
+# copied, and the test lives HERE instead of being appended there, because that
+# module carries 155 lines of pre-existing black drift -- touching it would bury
+# this fix under unrelated reformatting.
+from test_skill_browser import _make_app, _write_skill  # type: ignore[import-not-found]
+
+from kiro_crew.dashboard.handlers import prompts
+
+
+@pytest.fixture(autouse=True)
+def clean_protocol_state():
+    """Each test starts and ends with no in-flight bookkeeping.
+
+    This is module state, so a leaked handoff or waiter count from a neighbour
+    could serve one test from another's rows -- which would make a broken join
+    look correct.
+    """
+    prompts._catalog_handoff.clear()
+    prompts._catalog_waiters.clear()
+    prompts._catalog_assembly_locks.clear()
+    yield
+    prompts._catalog_handoff.clear()
+    prompts._catalog_waiters.clear()
+    prompts._catalog_assembly_locks.clear()
+
+
+@pytest.fixture
+def stub_assembly(monkeypatch):
+    """Replace both expensive collaborators and count assembler invocations."""
+    calls = {"n": 0}
+
+    class _NoCapabilities:
+        def available(self) -> bool:
+            return False
+
+    def _collect(skills, package_skills, project_dir):
+        calls["n"] += 1
+        # Echo BOTH inputs the catalog varies by, so a key that omits either
+        # shows up as a wrong value rather than only as a wrong call count.
+        return [
+            {
+                "key": f"skill-for-{project_dir}",
+                "name": "s",
+                "description": "",
+                "loader": id(skills),
+            }
+        ]
+
+    monkeypatch.setattr(prompts, "_capability_manager", lambda: _NoCapabilities())
+    monkeypatch.setattr(prompts, "collect_skills_blocking", _collect)
+    return calls
+
+
+@pytest.fixture
+def loader():
+    """One SkillsLoader stand-in per test.
+
+    Reused across calls WITHIN a test on purpose: a gateway has a single loader,
+    so passing a fresh object per call would exercise the isolation gate instead
+    of the behaviour each test names.
+    """
+    return object()
+
+
+class TestSkillsCatalogSingleFlight:
+    """Concurrent readers must share one assembly.
+
+    This is the whole fix. Measured against a counting assembler, 8 simultaneous
+    reads produced 8 assemblies -- a 0% elimination rate precisely under the
+    contention the slow samples came from.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_misses_coalesce_into_one_assembly(self, stub_assembly, loader):
+        results = await asyncio.gather(
+            *[prompts._assemble_skills_catalog(loader, Path("/proj/a")) for _ in range(8)]
+        )
+        assert stub_assembly["n"] == 1, (
+            "each concurrent reader assembled its own catalog; without coalescing the "
+            "endpoint pays N scans exactly when it is contended"
+        )
+        assert all(r is results[0] for r in results), "joined readers got different objects"
+
+    @pytest.mark.asyncio
+    async def test_a_later_sequential_read_reassembles(self, stub_assembly, loader):
+        """Nothing survives the burst, so the recorded no-result-cache default holds.
+
+        This is the property that removes every invalidation obligation: a read
+        that is not part of a concurrent burst scans current on-disk state, so an
+        out-of-app edit can never be hidden and no mutator owes this code a call.
+        """
+        await prompts._assemble_skills_catalog(loader, Path("/proj/a"))
+        await prompts._assemble_skills_catalog(loader, Path("/proj/a"))
+        assert stub_assembly["n"] == 2, (
+            "a second, non-concurrent read was served from retained rows -- the join "
+            "is storing a result past its burst, which reintroduces staleness"
+        )
+        assert not prompts._catalog_handoff, "the handoff outlived its burst"
+        assert not prompts._catalog_waiters, "waiter bookkeeping leaked"
+
+    @pytest.mark.asyncio
+    async def test_different_keys_assemble_in_parallel(self, monkeypatch, loader):
+        """Two projects hold DIFFERENT assembly locks, so neither waits on the other.
+
+        Coalescing is per key: it must not turn unrelated catalogs into a queue.
+        Assembly is not reliably sub-second, so a shared lock would give a
+        multi-project burst worse tail latency than the base's parallel scans. If a
+        single global lock is ever reintroduced, this fails.
+        """
+        overlap = {"now": 0, "max": 0}
+
+        async def _assemble(skills, project_dir):
+            overlap["now"] += 1
+            overlap["max"] = max(overlap["max"], overlap["now"])
+            await asyncio.sleep(0)
+            overlap["now"] -= 1
+            return [{"name": str(project_dir)}]
+
+        monkeypatch.setattr(prompts, "_assemble_skills_catalog_uncached", _assemble)
+        await asyncio.gather(
+            prompts._assemble_skills_catalog(loader, Path("/proj/a")),
+            prompts._assemble_skills_catalog(loader, Path("/proj/b")),
+        )
+        assert overlap["max"] == 2, (
+            "two different projects did not assemble concurrently, so they are "
+            "serializing on a shared lock and one project's burst now delays another"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_key_lock_does_not_outlive_its_burst(self, stub_assembly, loader):
+        """The per-key lock registry is bounded by the waiter count, not unbounded.
+
+        A lock dict keyed on (loader, project) would otherwise retain an entry per
+        project ever browsed, holding the loader alive with it.
+        """
+        await prompts._assemble_skills_catalog(loader, Path("/proj/a"))
+        assert prompts._catalog_assembly_locks == {}, (
+            "a key's assembly lock survived the last reader leaving, so the registry "
+            "grows once per project visited"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_different_loader_does_not_join(self, stub_assembly):
+        """Two readers holding DIFFERENT loaders never share one assembly.
+
+        The loader is the key's first element, so a different loader is a different
+        key and the two cannot collide on one in-flight entry. Were the loader left
+        out of the key, these two would collide and the second would be handed rows
+        assembled from a catalog it never asked for.
+        """
+        loader_a = object()
+        loader_b = object()
+        results = await asyncio.gather(
+            prompts._assemble_skills_catalog(loader_a, Path("/proj/a")),
+            prompts._assemble_skills_catalog(loader_b, Path("/proj/a")),
+        )
+        assert stub_assembly["n"] == 2, (
+            "a reader with a different loader joined an assembly started under another "
+            "loader, so it received rows for a catalog it never asked for"
+        )
+        assert results[0] is not results[1], "two distinct loaders were served the same object"
+
+
+class TestCrossAgentIsolationEndToEnd:
+    """Two agents in ONE process must each get their own listing, either order.
+
+    This is the shape a coarsened cache key produces: one caller sees too few
+    skills and another too many, decided by which asked first — an
+    order-dependent pair that reads like flakiness. Driving both agents through
+    the real endpoint in one process pins it directly, so a join that ever shared
+    the FILTERED result fails whichever agent asked second.
+
+    ``?agent=`` is applied downstream as a comprehension over the assembled rows,
+    so it correctly does NOT belong in the key — this test is what keeps that true
+    rather than merely currently-true.
+    """
+
+    @pytest.fixture
+    def home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # agent_skill_globs resolves its agents dir from a module constant
+        # computed at import time off the REAL home, so $HOME alone would leave
+        # it reading the operator's own ~/.kiro/agents and skipping the filter.
+        monkeypatch.setattr(
+            "kiro_crew.agent_discovery._KIRO_AGENTS_DIR", tmp_path / ".kiro" / "agents"
+        )
+        return tmp_path
+
+    @staticmethod
+    def _state() -> MagicMock:
+        from kiro_crew.skills import SkillsLoader
+
+        # A real loader, not a bare MagicMock: _get_skills treats any attribute
+        # as "already built", and a mock would be serialized into the response.
+        state = MagicMock(_slots={}, context_builder=None)
+        state._standalone_skills = SkillsLoader(install_builtins=False)
+        return state
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("order", [("custom", "plain"), ("plain", "custom")])
+    async def test_each_agent_gets_its_own_listing(self, home, order):
+        _write_skill(home / ".kiro" / "skills", "alpha")
+        _write_skill(home / ".kiro" / "skills", "beta")
+        agents_dir = home / ".kiro" / "agents"
+        agents_dir.mkdir(parents=True)
+        # `custom` maps one skill explicitly -> filtered envelope, {alpha}.
+        agents_dir.joinpath("custom.json").write_text(
+            json.dumps({"name": "custom", "resources": ["skill://~/.kiro/skills/alpha/SKILL.md"]})
+        )
+        # `plain` maps none -> legacy bare array, the whole catalog.
+        agents_dir.joinpath("plain.json").write_text(json.dumps({"name": "plain"}))
+
+        expected = {"custom": ({"alpha"}, True), "plain": ({"alpha", "beta"}, False)}
+        async with TestClient(TestServer(_make_app(self._state()))) as client:
+            for position, agent in enumerate(order, start=1):
+                resp = await client.get("/api/skills", params={"agent": agent})
+                assert resp.status == 200
+                payload = await resp.json()
+                want_names, want_envelope = expected[agent]
+                assert isinstance(
+                    payload, dict if want_envelope else list
+                ), f"{agent} got the wrong response shape when asked {position} of {len(order)}"
+                rows = payload["skills"] if want_envelope else payload
+                assert {
+                    s["name"] for s in rows
+                } == want_names, f"{agent} was served another agent's listing (order {order})"


### PR DESCRIPTION
## What this buys, stated first

**Concurrent readers of `GET /api/skills` stop each running their own filesystem scan.**
At 8-way concurrency the redundant-scan rate goes **0.0% → 87.5%** (measured, table below):
eight simultaneous skill-menu opens cost one assembly instead of eight.

**Nothing is stored and there is no expiry.** A read that is not part of a concurrent burst
always scans current on-disk state, so the base's recorded default — "No result cache: the
endpoint always reflects current on-disk state, so freshly created/installed skills appear
immediately" — is **preserved, not reversed**. No mutation path anywhere in the codebase owes
this change a call.

**What it costs, stated with it:** a reader that arrives while an assembly is already running
shares that assembly's rows, so it can be served data read up to one scan earlier. That is the
irreducible cost of coalescing at all, and it is bounded by one assembly for that key — the
assembly lock is per key, so no reader ever waits behind an unrelated project's scan. Outside
such a burst nothing is shared.

**This revision is substantially smaller than earlier ones, by subtraction.** Earlier
revisions also shipped a 3s stored entry. Review established that the store contributed none
of the measured win while obliging every present and future catalog mutator to invalidate it —
19 `invalidate_skills_catalog()` calls across 9 modules, a mutation-driven generation counter,
an exemption kwarg for background sweeps, and a silent-staleness defect class for any path
that forgot one (one such defect was found in review, in the conductor-skill toggle). The
store bought a repeat read within 3s, which for a project-scoped chat the frontend's 5-minute
`skillsCacheStaleTime` already covered. The store and the entire obligation were removed
together. The PR now touches **3 files** where it previously touched 14, and adds no new module.

## Problem / Motivation

`GET /api/skills` can take tens of seconds on a busy gateway. The assembly work itself is
**not** the problem — measured standalone on the affected host:

| measurement | result |
|---|---|
| capability-package skill rows (AIM roots) | **0.33s**, 3 consecutive runs, 275 rows |
| whole `~/.aim` tree censused | 13,607 dirs / 25,475 files in 1.70s |
| `/api/skills` end-to-end when the gateway is idle | **0.55–0.62s** |

The same endpoint on the same host, returning the same payload, was also observed at 41s, 69s
and 168s within twenty minutes. **Those contended figures are WITHDRAWN as motivation.** The
regime that produced them was largely event-loop contention from history flush, which
#7056/#7067 substantially fixed; the real fix landed elsewhere. What remains, and what this
PR addresses, is the redundant-scan half that neither of those PRs touches: under concurrency
every reader paid for its own scan.

## Why it matters

Opening the `$` skill-picker menu in several chats at once, or one chat re-opening it while a
previous request is still assembling, multiplied a ~0.6s filesystem scan by the number of
readers. That is the measured defect: 0% redundant-scan elimination at 8-way concurrency
before this change.

The endpoint is a victim rather than the cause of the original hang, and this PR is scoped to
the redundant-scan half only. It does not claim to fix the contention.

## What changed

The coalescing protocol lives in `_assemble_skills_catalog` in
`src/kiro_crew/dashboard/handlers/prompts.py`, alongside its only consumer:

- **One assembly lock per key** (`LoopBoundLock` values in a registry, the shape #4800
  established for exactly this): a fast path off the lock, then the lock, then a re-check under
  it. The re-check is the join — readers queued behind the leader take its rows instead of
  each scanning. Per key rather than global, so readers of DIFFERENT projects still scan in
  parallel as the base did; assembly is not reliably sub-second (it can run seconds long on
  large skills×agents catalogs), so a shared lock would have given a multi-project burst worse
  tail latency than the base. The registry entry is created and dropped under the same lock as
  the waiter count that bounds its life, so it cannot outlive the burst.
- **A waiter-scoped handoff:** the leader's rows are offered only while another reader for the
  same key is still inside the call, and are dropped when the last one leaves. There is no
  expiry to get wrong, and nothing survives the burst.
- **The loader is part of the key:** the key is `(loader, project dir)`, so two readers holding
  different loaders get different keys and cannot collide on one entry. `$HOME` is not in the
  key — it takes one value per process, so it distinguished nothing.

`?agent=` is deliberately **not** part of the key: it is applied downstream as a comprehension
over the assembled rows.

Two mechanisms present in earlier revisions are gone, and both removals were review findings.
An **epoch stamp** guarded against rows from a superseded assembly being served; the handoff is
published only after an await returns and dies with its burst, so a cancelled leader publishes
nothing and that state was unreachable (its own test had to forge it), while the epoch being
global meant a neighbouring project's
assembly invalidated a live handoff and forced a redundant scan. And the protocol briefly lived
in its **own leaf module**, justified by mutators outside the dashboard needing module-scope
access to the invalidator — with no invalidator there are no such callers, so it folded into
its single consumer and the injected-assembly indirection went with it.


### Scope — this is a bounded mitigation of the redundant-scan half

The contended samples are withdrawn and the root cause is out of scope. What is claimed is
the measured concurrency result below and nothing more.

### Deliberate limitations, documented in the code

- **No work preservation when the leader disconnects.** `assemble` is awaited inline, so
  cancelling the leader cancels the assembly and the next waiter starts over. That costs a
  repeated ~0.6s scan in the disconnect case and buys the removal of an in-flight task map,
  with its shields, done-callbacks and cancellation bookkeeping.
- **Mid-burst sharing** is the one staleness admitted, bounded by a single assembly for that key.

### Measured hit rate

| pattern | redundant scans eliminated |
|---|---|
| 8 simultaneous reads, before | **0.0%** (8 reads → 8 assemblies) |
| 8 simultaneous reads, after | **87.5%** (8 reads → 1 assembly) |

Measured against a counting assembler, so "shared one assembly" is asserted by the assembler
not running rather than by a latency measurement.

## Tests

`test/test_skills_catalog_cache.py`, 7 tests:

- **the join** — 8 concurrent readers produce exactly 1 assembly and all receive the same
  object
- **nothing is retained** — a later, non-concurrent read reassembles, and both the handoff and
  the waiter bookkeeping are empty afterwards
- **a different loader does not join** — the loader is part of the key, so two loaders are two
  keys and are served distinct objects
- **different keys assemble in parallel** — two projects DO assemble concurrently, so a single
  global lock cannot be reintroduced without failing here
- **a key lock does not outlive its burst** — the per-key registry is empty once the last
  reader leaves, so it cannot grow per project visited
- **cross-agent isolation end-to-end** — two agents driven through the real endpoint in both
  orders, so a join that ever shared the FILTERED result fails whichever asked second

## Follow-ups this does not cover

- The event-loop contention that produced the withdrawn 41–168s samples is out of scope and
  partly addressed by #7056/#7067.
- Work preservation across a leader disconnect, as described above.



