### PR TITLE
Add bmad-orchestrator to App Store registry

### DIFF
--- a/src/kiro_crew/apps/app-registry.json
+++ b/src/kiro_crew/apps/app-registry.json
@@ -16,5 +16,11 @@
     "gitUrl": "https://github.com/LeTeutz/todo-txt",
     "repo": "https://github.com/LeTeutz/todo-txt",
     "branch": "main"
+  },
+  {
+    "name": "bmad-orchestrator",
+    "gitUrl": "https://github.com/hugheba/kirocrew-bmad-app",
+    "repo": "https://github.com/hugheba/kirocrew-bmad-app",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
## Problem / Motivation

There is no one-click way for Kiro Crew users to install a BMAD-METHOD orchestration workflow. Setting it up by hand means hand-placing a custom agent JSON plus two skills and wiring the MCP surface — friction that keeps a useful, reusable capability from being discoverable in the App Store.

## Why it matters

BMAD-METHOD (40k+★) is a popular structured AI-driven development method. Packaging it as an installable app lets any Crew user go from idea → deploy through a guided, hybrid-autonomy loop without manual agent/skill setup, and gives the community a reference example of an app that bundles an agent + skills (not just UI).

## What changed (motivation → approach → change)

- **Goal:** make `bmad-orchestrator` installable from the built-in catalog.
- **Approach:** the app itself lives in its own repo ([hugheba/kirocrew-bmad-app](https://github.com/hugheba/kirocrew-bmad-app)) with an `app.json` that is the single source of truth for all display metadata; the registry entry stays minimal per the publishing guide.
- **Change:** appends one entry `{name: bmad-orchestrator, gitUrl, repo, branch: main}` to `src/kiro_crew/apps/app-registry.json`, matching the existing entries’ format. No code changes.

The app is designed clean-install-safe: baseline MCPs only (`kirocrew-core`, `kirocrew-cron`), a config-driven model-council panel, secrets via `${VAR}` expansion + `setup.configSchema`, relative resource paths, and BMAD attribution/trademark notice in its README.

## Tests

N/A — this PR only appends a data entry to `app-registry.json`. Validated the file parses as JSON and matches the existing entry schema; the referenced app repo installs cleanly (`installed bmad-orchestrator v1.0.0`) with no dependency-resolution errors.

## Manual verification

- Confirmed `app-registry.json` is valid JSON with the new entry appended (4 entries total).
- Verified the referenced app repo (`hugheba/kirocrew-bmad-app@main`) installs via the App Store and its live `app.json` is complete and secret-free (`dependencies` = `{managedBy, commands}`, no unresolved capabilities).

## Related Issues

N/A

## Checklist

- [x] At most two commits (one commit), Conventional Commits title (`feat(apps): add bmad-orchestrator to registry`)