### PR TITLE
fix(sel): re-resolve the trust-root path at one seam (#2588)

### DIFF
--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -3312,6 +3312,23 @@ def sel() -> SecurityEventLog:
     return SecurityEventLog()
 
 
+def _trust_root_key_loads(path: Path) -> bool:
+    """True when *path* is a regular file currently holding a usable key.
+
+    ``stat`` only — the caller reads the bytes just after, and the point here is
+    to answer "does the resolved path still resolve?" without paying a read on
+    the healthy path. ``S_ISREG`` is load-bearing rather than tidiness: a
+    candidate location an actor can create is a place they can put a FIFO, and
+    opening one blocks in-kernel forever, which an ``asyncio`` timeout cannot
+    reclaim because the thread is stuck in a syscall.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    return stat.S_ISREG(st.st_mode) and st.st_size >= _HMAC_KEY_MIN_BYTES
+
+
 def sel_hmac_key_path() -> Path:
     """Canonical on-disk location of the SEL trust-root key (``sel_hmac.key``).
 
@@ -3326,11 +3343,63 @@ def sel_hmac_key_path() -> Path:
     (e.g. via ``config_dir()``; ``_default_dir()`` honors ``KIROCREW_HOME`` the
     same way, so resolving through the shared accessor keeps the trust root
     single under isolated-home deployments).
+
+    RE-RESOLVES per call. ``_hmac_key_file`` is decided once inside
+    ``_load_or_create_hmac_key`` and a legacy install can leave it on the legacy
+    location after a failed migration; a sibling process that later completes
+    that migration deletes the file this process is still naming. Without
+    re-resolution every dependent protocol inherits that dead path and has to
+    grow its own recovery, which is one fallback per caller instead of the class
+    being closed (the shape ``session_pid_sig`` was left in by #2574).
+
+    What re-resolution does NOT touch is the audit chain. The chain is signed
+    and verified with ``self._hmac_key``, the BYTES read once at init, and no
+    record carries a key id or generation marker — so re-reading the key file
+    into the signing key mid-process would orphan every record already chained
+    (which is why ``_load_or_create_hmac_key`` raises rather than regenerating,
+    and why migration moves bytes with ``os.replace``). This accessor returns a
+    PATH that the signing and verification code never reads. The anchor stays
+    pinned to the bytes cached at init; only the path handed to dependent
+    protocols follows the file.
+
+    A relocated candidate is adopted ONLY when its bytes equal the key this
+    process already validated at init. Adopting an unverified file would be a
+    downgrade rather than a fix: the resolved path vanishing is exactly the
+    moment an actor who can write the trust directory would plant a key of their
+    own, and handing dependents a path is handing them signing material. When
+    nothing verifies, the resolved path is returned unchanged so the operator
+    report keeps naming the file that actually broke, and
+    ``session_pid_sig._load_hmac_key`` still recovers from the in-memory copy.
     """
     inst = SecurityEventLog._instance
-    if inst is not None and getattr(inst, "_initialized", False):
-        return inst._hmac_key_file
-    return _default_dir() / _TRUST_SUBDIR / _HMAC_KEY_FILE
+    if inst is None or not getattr(inst, "_initialized", False):
+        # No singleton in this process (the verifying MCP process, typically):
+        # this branch already recomputes on every call, so it was never frozen.
+        return _default_dir() / _TRUST_SUBDIR / _HMAC_KEY_FILE
+    resolved: Path = inst._hmac_key_file
+    if _trust_root_key_loads(resolved):
+        return resolved
+    anchor: bytes | None = getattr(inst, "_hmac_key", None)
+    if not anchor:
+        return resolved
+    base: Path = inst._dir
+    # Same precedence as _load_or_create_hmac_key: the trust/ location first,
+    # the legacy sibling-of-the-log location second.
+    for cand in (base / _TRUST_SUBDIR / _HMAC_KEY_FILE, base / _HMAC_KEY_FILE):
+        if cand == resolved or not _trust_root_key_loads(cand):
+            continue
+        try:
+            found = cand.read_bytes()
+        except OSError:
+            continue
+        if hmac.compare_digest(found, anchor):
+            logger.debug(
+                "SEL trust root re-resolved %s -> %s (same key bytes)",
+                resolved,
+                cand,
+            )
+            return cand
+    return resolved
 
 
 def _sel_hmac_key_bytes() -> bytes | None:
@@ -3348,10 +3417,13 @@ def _sel_hmac_key_bytes() -> bytes | None:
     record from that in-memory copy, so the audit chain is immune to the key
     file moving, being deleted, losing read permission, or being truncated
     afterwards. The dependent protocol that re-reads the file on every use is
-    not, and its resolved path is never re-resolved — which is how a gateway
-    ends up publishing unsigned identities forever while its audit chain still
-    looks healthy. These are the same bytes, already validated at init
-    (``>= _HMAC_KEY_MIN_BYTES``, see ``_load_or_create_hmac_key``).
+    not. ``sel_hmac_key_path`` re-resolves a relocation whose bytes match this
+    anchor (#2588), so what reaches here is the residue it cannot resolve — a
+    key deleted, unreadable, truncated, or replaced by bytes that are not the
+    anchor — which is how a gateway would otherwise end up publishing unsigned
+    identities forever while its audit chain still looks healthy. These are the
+    same bytes, already validated at init (``>= _HMAC_KEY_MIN_BYTES``, see
+    ``_load_or_create_hmac_key``).
 
     Returns ``None`` when no initialized singleton exists in this process (the
     verifying MCP process, typically) or the cached key is unusable.

--- a/src/kiro_crew/session_pid_sig.py
+++ b/src/kiro_crew/session_pid_sig.py
@@ -132,12 +132,14 @@ def _load_hmac_key() -> bytes | None:
     else while a verifier can still read it. When the file does NOT load, fall
     back to the identical bytes the live ``SecurityEventLog`` validated at init
     (:func:`kiro_crew.sel.sel_hmac_key_bytes`). Without that fallback this
-    protocol dies permanently the moment the resolved path stops resolving —
-    the path is frozen at SEL init and never re-resolved, while SEL itself
-    keeps signing from its cached copy, so a key file relocated by a concurrent
-    process (legacy -> ``trust/`` migration), deleted, chmod'd, or truncated
-    takes down every identity-dependent MCP tool with no failing audit chain to
-    point at it.
+    protocol dies permanently the moment the resolved path stops resolving.
+    :func:`kiro_crew.sel.sel_hmac_key_path` now re-resolves per call (#2588), so
+    a key relocated by a concurrent process (legacy -> ``trust/`` migration) is
+    followed rather than mourned; this fallback still carries the cases no path
+    can resolve away — deleted, chmod'd, truncated, or a relocation whose bytes
+    do not match the anchor and so are deliberately not adopted — where SEL
+    itself keeps signing from its cached copy and would otherwise leave every
+    identity-dependent MCP tool dead with no failing audit chain to point at it.
     """
     try:
         raw = sel_hmac_key_path().read_bytes()

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -2417,6 +2417,106 @@ class TestHmacKeyTrustDirMigration:
         self._reset()
 
 
+class TestTrustRootPathReResolution:
+    """``sel_hmac_key_path()`` re-resolves per call (#2588).
+
+    ``_hmac_key_file`` is decided once at init, and a failed legacy migration
+    leaves it on the legacy location; a sibling process that later completes the
+    migration deletes the file this process still names. The accessor follows the
+    key instead of every dependent protocol growing its own recovery — but only
+    to a file whose bytes are the anchor this process already validated, and
+    never by moving what the audit chain signs with.
+    """
+
+    def _reset(self) -> None:
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+
+    def test_resolved_path_is_returned_while_it_loads(self, tmp_path: Path) -> None:
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert sel_mod.sel_hmac_key_path() == tmp_path / "trust" / "sel_hmac.key"
+
+    def test_relocation_to_the_trust_dir_is_followed(self, tmp_path: Path) -> None:
+        """The #2539 shape: this process kept the legacy path after a failed
+        migration, then a sibling process completed it."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        canonical = tmp_path / "trust" / "sel_hmac.key"
+        # Pin the instance to the legacy location the way a failed migration does.
+        log._hmac_key_file = tmp_path / "sel_hmac.key"
+        assert not (tmp_path / "sel_hmac.key").exists()
+
+        assert sel_mod.sel_hmac_key_path() == canonical
+
+    def test_relocation_to_the_legacy_location_is_followed(self, tmp_path: Path) -> None:
+        SecurityEventLog(base_dir=tmp_path, sync=True)
+        legacy = tmp_path / "sel_hmac.key"
+        os.replace(tmp_path / "trust" / "sel_hmac.key", legacy)
+
+        assert sel_mod.sel_hmac_key_path() == legacy
+
+    def test_a_candidate_with_other_bytes_is_not_adopted(self, tmp_path: Path) -> None:
+        """The no-downgrade property. The resolved path vanishing is exactly when
+        an actor who can write the trust dir would plant a key of their own;
+        handing a dependent protocol that path hands it signing material."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        canonical = tmp_path / "trust" / "sel_hmac.key"
+        planted = b"p" * 32
+        assert log._hmac_key != planted
+        canonical.write_bytes(planted)
+        log._hmac_key_file = tmp_path / "sel_hmac.key"
+
+        # Unchanged, so the operator report still names the file that broke and
+        # session_pid_sig recovers from the validated in-memory copy instead.
+        assert sel_mod.sel_hmac_key_path() == tmp_path / "sel_hmac.key"
+
+    def test_a_short_candidate_is_not_adopted(self, tmp_path: Path) -> None:
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        (tmp_path / "trust" / "sel_hmac.key").write_bytes(b"short")
+        log._hmac_key_file = tmp_path / "sel_hmac.key"
+
+        assert sel_mod.sel_hmac_key_path() == tmp_path / "sel_hmac.key"
+
+    def test_re_resolution_never_moves_what_the_chain_signs_with(self, tmp_path: Path) -> None:
+        """The reason item 1 of #2588 was deferred does not apply: the accessor
+        returns a PATH the signing and verification code never reads, so a
+        relocation cannot orphan records already chained."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log_tool_invocation(
+            session_key="s1", tool_name="t1", tool_kind="tool", outcome="ok"
+        )
+        anchor = log._hmac_key
+        legacy = tmp_path / "sel_hmac.key"
+        os.replace(tmp_path / "trust" / "sel_hmac.key", legacy)
+
+        assert sel_mod.sel_hmac_key_path() == legacy
+        assert log._hmac_key == anchor
+        log.log_tool_invocation(
+            session_key="s2", tool_name="t2", tool_kind="tool", outcome="ok"
+        )
+        total, valid = log.verify_integrity()
+        assert (total, valid) == (2, 2)
+
+    def test_no_singleton_resolves_the_trust_default(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(sel_mod, "_default_dir", lambda: tmp_path)
+        assert SecurityEventLog._instance is None
+
+        assert sel_mod.sel_hmac_key_path() == tmp_path / "trust" / "sel_hmac.key"
+
+    def test_key_loads_predicate_rejects_a_directory(self, tmp_path: Path) -> None:
+        d = tmp_path / "sel_hmac.key"
+        d.mkdir()
+        assert sel_mod._trust_root_key_loads(d) is False
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO semantics")
+    def test_key_loads_predicate_rejects_a_fifo(self, tmp_path: Path) -> None:
+        """Asserted on the predicate rather than through the accessor on purpose:
+        without the ``S_ISREG`` guard the failure mode is an unbounded in-kernel
+        block on open, which would hang CI instead of failing it."""
+        fifo = tmp_path / "sel_hmac.key"
+        os.mkfifo(fifo)
+        assert sel_mod._trust_root_key_loads(fifo) is False
+
+
 class TestSizeRotation:
     """The log is closed at a size cap and retained as N segments (issue #4843).
 

--- a/test/test_session_pid_sig.py
+++ b/test/test_session_pid_sig.py
@@ -300,12 +300,14 @@ class TestDomainSeparation:
 
 
 class TestTrustRootRecovery:
-    """The resolved trust-root path is frozen at ``SecurityEventLog`` init and
-    never re-resolved, while SEL keeps signing from key bytes it cached at that
-    moment. So a key file that later moves (a concurrent legacy -> ``trust/``
-    migration), is deleted, loses read permission, or is truncated silently
-    takes this protocol down for the life of the process — with a healthy audit
-    chain giving no hint. Recovery reads the same bytes SEL validated at init.
+    """SEL signs from key bytes it cached at init, while this protocol re-reads
+    the file on every call. Since #2588 the shared accessor re-resolves a key
+    that MOVED (a concurrent legacy -> ``trust/`` migration), so what reaches
+    recovery is the residue no path can resolve: a key deleted, unreadable,
+    truncated, or replaced by bytes that are not the anchor. Those would
+    otherwise take this protocol down for the life of the process — with a
+    healthy audit chain giving no hint. Recovery reads the same bytes SEL
+    validated at init.
     """
 
     def test_missing_file_recovers_from_live_sel_key(self, cfg):
@@ -376,6 +378,48 @@ class TestTrustRootRecovery:
         session_pid_sig.publish_session_pid(4242, SESSION_KEY)
         assert not (cfg / "session_pid_4242.sig").exists()
         assert session_pid_sig.verify_session_pid(4242) == ""
+
+
+class TestTrustRootRelocationIsFollowed:
+    """#2588 item 1, from the dependent protocol's side.
+
+    Deliberately does NOT use the ``cfg`` fixture: that fixture patches
+    ``sel_hmac_key_path`` to a fixed path, which is exactly the seam under test.
+    A real singleton is required because re-resolution is verified against the
+    key bytes it validated at init.
+    """
+
+    def test_a_relocated_key_is_read_from_the_file_not_memory(self, tmp_path):
+        """The class is closed rather than worked around: the accessor follows
+        the moved file, so a verifier in ANOTHER process resolves the same bytes.
+        The memory fallback is stubbed to different bytes, so a result equal to
+        the real key can only have come from the file."""
+        from kiro_crew.sel import SecurityEventLog
+
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        try:
+            log = SecurityEventLog(base_dir=tmp_path, sync=True)
+            key = log._hmac_key
+            # A failed migration left this process naming the legacy location;
+            # the key actually lives in trust/ because a sibling completed it.
+            log._hmac_key_file = tmp_path / "sel_hmac.key"
+            assert not (tmp_path / "sel_hmac.key").exists()
+
+            with patch.object(
+                session_pid_sig, "config_dir", return_value=tmp_path
+            ), patch.object(
+                session_pid_sig, "_sel_hmac_key_bytes", return_value=b"\xfe" * 32
+            ):
+                session_pid_sig._reported.clear()
+                loaded = session_pid_sig._load_hmac_key()
+                session_pid_sig._reported.clear()
+
+            assert loaded == key
+            assert loaded != b"\xfe" * 32
+        finally:
+            SecurityEventLog._instance = None
+            SecurityEventLog._initialized = False
 
 
 class TestSigningUnavailableReport:


### PR DESCRIPTION
## 1. What is the problem?

`sel_hmac_key_path()` returned `_hmac_key_file`, a path decided once inside
`_load_or_create_hmac_key()` and never recomputed. That method can legitimately
end on either of two locations: normally `trust/sel_hmac.key`, but on a legacy
install whose migration fails it keeps the legacy `<dir>/sel_hmac.key`. When a
sibling process later completes the same migration, the file this process is
still naming is gone.

Every dependent protocol resolves the trust root through that one accessor, so
each of them inherits the dead path. #2574 answered it where it hurt first, with
a recovery fallback in `session_pid_sig._load_hmac_key()`. That is one caller
growing a fallback, not the class being closed: the next protocol to resolve the
trust root inherits the same frozen path and needs its own.

## 2. Why this issue matters to the user

The trust root keys the sidecar that proves a session's identity. When it stops
resolving, identity-dependent MCP tools fail for the life of the process while
the audit chain still looks healthy, because SEL keeps signing from its cached
copy -- so there is no failing chain to point at the cause. #2574 made that
recoverable for one protocol and observable in `kirocrew doctor`; the underlying
path was still frozen for everyone else.

## 3. How our fix solves it

The accessor now re-resolves per call. When the resolved path no longer holds a
usable key it looks at the `trust/` location and then the legacy sibling
location, in the same precedence `_load_or_create_hmac_key()` uses. A relocation
is followed once, for every present and future dependent.

Three things make that safe rather than merely shorter.

**It cannot move what the audit chain signs with.** This was the stated reason
the item was deferred out of #2574, and it does not apply to this seam. The chain
is signed and verified with `self._hmac_key` -- the bytes read once at init -- and
no record carries a key id or generation marker, so re-reading the key file into
the signing key would orphan every record already chained. That is why
`_load_or_create_hmac_key()` raises rather than regenerating on a short key, and
why the legacy migration moves bytes with `os.replace`. This accessor returns a
PATH that the signing and verification code never reads. A test asserts exactly
that: after a relocation the chain still verifies and `_hmac_key` is unchanged.

**A candidate is adopted only when its bytes are the anchor.** The resolved path
vanishing is precisely the moment an actor able to write the trust directory
would plant a key of their own, and handing a dependent protocol a path is
handing it signing material -- so adopting an unverified file would be a
downgrade, not a fix. The candidate's bytes are compared to the key this process
already validated at init, with `hmac.compare_digest`. When nothing verifies the
resolved path is returned unchanged, so the operator report keeps naming the file
that actually broke and the in-memory fallback still covers it.

**A candidate location is a location an actor can create.** That includes
creating a FIFO there, and opening one blocks in-kernel where an `asyncio`
timeout cannot reclaim the thread. `_trust_root_key_loads()` requires
`stat.S_ISREG` before any read, and answers the "does it still resolve?" question
with a single `stat` so the healthy path pays no read.

The pre-init branch is untouched: with no singleton in this process it already
recomputed on every call and was never frozen.

Docstrings in `sel.py` and `session_pid_sig.py` that asserted the path is never
re-resolved are corrected rather than left contradicting the code, and
`TestTrustRootRecovery`'s docstring now states what the fallback still carries
(deleted, unreadable, truncated, or bytes that are not the anchor).

### What is deliberately NOT in this PR

Review established that the same stale `_hmac_key_file` also decides which inode
the cross-process **chain lock** is taken on, and that the resulting divergence is
**pre-existing on main** -- a same-process probe produced it identically with and
without this change. A re-resolving version of `_chain_lock_path()` was carried
here for five review rounds; each round surfaced a further state, and the last
one showed why the approach needs more than this PR: `_CHAIN_HOLDS` is keyed by
the lock path, so the transition itself has to be serialized, which means a mutex
on a path consulted per append.

That hunk is reverted and the work is filed as #7077, with all five rounds written
up as its requirements. Nothing regresses by reverting, because the divergence
predates this PR.

## 4. What tests we did

10 new tests. Targeted runs only; CI runs the suites in full.

- `TestTrustRootPathReResolution` (9, `test/test_sel.py`): the healthy path is
  returned unchanged; relocation to `trust/` and to the legacy location are both
  followed; a candidate with other bytes and a short candidate are both refused;
  the chain still verifies across a relocation with `_hmac_key` unchanged; the
  no-singleton branch still resolves the `trust/` default; and the predicate
  rejects a directory and a FIFO. The FIFO case asserts on the predicate rather
  than through the accessor on purpose -- without the `S_ISREG` guard the failure
  mode is an unbounded block, which would hang CI instead of failing it.
- `TestTrustRootRelocationIsFollowed` (1, `test/test_session_pid_sig.py`): the
  dependent protocol reads a relocated key from the FILE, proven by stubbing the
  memory fallback to different bytes, so a result equal to the real key can only
  have come from the file. It deliberately avoids the `cfg` fixture, which patches
  `sel_hmac_key_path` to a fixed path -- the very seam under test.
- Non-vacuity: with `src/kiro_crew/sel.py` reverted to base and the new tests
  kept, 6 of 10 fail. The 4 that pass on base are the unchanged-behaviour guards
  (healthy path, no-singleton default, and the two refusal cases base satisfies
  vacuously).
- Regression: 74 pass across the re-resolve, rotation-serialization, cross-process
  and dependent-protocol suites, and 71 across size-rotation, singleton,
  key-management and segment-dir. Re-run after rebasing onto current main, since
  the base advanced during review. No pinned contract changed.
- Gates on the four touched files: flake8, isort, mypy clean. All four are in
  `.github/black-baseline.txt` and none becomes newly clean, so the formatting
  gate is unaffected.

## 5. Any other suggestions on the work

**Item 2 of #2588 is not in this PR, and this does not foreclose it.** Making
deny-before-audit structural by registering `sel_audit_middleware` outermost is a
policy call, and measuring it turned up two costs the issue does not name: the
host and CSRF refusals already emit `outcome="denied"` through `_audit_denied`, so
outermost placement produces a second overlapping record for the same 403 unless
deduplicated; and the two entrypoints run different audit method sets (dashboard
`{POST,PUT,DELETE,PATCH}`, headless also `GET`), so the identical reorder has
different volume consequences per server. One reassurance: static assets and
non-`/api/` routes are unaffected, because the middleware's `/api/` prefix gate is
independent of its position. Detail is in a comment on the issue.

Left deliberately alone: `session_pid_sig`'s fallback is kept as defence in
depth. Re-resolution shrinks the window it covers but does not close it -- a key
deleted, unreadable, truncated, or replaced by non-anchor bytes still reaches it.

Refs #2588
