### PR TITLE
fix(auto-research): run to-knowledge store statements off the event loop

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -3183,7 +3183,7 @@ async def _handle_knowledge_status(request: web.Request) -> web.Response:
     # (it has not, until the user adds it), so no filesystem side effects here.
     uri = str((d / "findings_for_knowledge.md").resolve())
     try:
-        existing = store.get_source_by_uri(uri)
+        existing = await asyncio.to_thread(store.get_source_by_uri, uri)
     except Exception:
         logger.exception("knowledge-status lookup failed for %s", cid)
         return web.json_response({"in_library": False})
@@ -3222,7 +3222,7 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
     sanitized_path.write_text(redacted)
     uri = str(sanitized_path.resolve())
     # Dedup check
-    existing = store.get_source_by_uri(uri)
+    existing = await asyncio.to_thread(store.get_source_by_uri, uri)
     if existing:
         return web.json_response(
             {"error": "Already in Knowledge Library", "id": existing["id"]}, status=409
@@ -3245,19 +3245,35 @@ async def _handle_to_knowledge(request: web.Request) -> web.Response:
         if row
         else f"Research: {cid}"
     )
-    sid = store.add_source(name=name, source_type="local_file", uri=uri, properties={})
-    store.db.execute("UPDATE sources SET sync_status = 'syncing' WHERE id = ?", (sid,))
-    store.db.commit()
+
+    # The store hands out one connection per thread, so all statement work for
+    # this request runs off-loop in a single worker: a lock wait on the store's
+    # busy timeout must stall a thread, never the event loop (issue #7020's
+    # loop-stall class). ``add_source`` rides in the same closure because the
+    # status UPDATE needs its ``sid`` on the same per-thread connection.
+    def _add_source_marked_syncing() -> str:
+        new_sid = store.add_source(name=name, source_type="local_file", uri=uri, properties={})
+        store.db.execute("UPDATE sources SET sync_status = 'syncing' WHERE id = ?", (new_sid,))
+        store.db.commit()
+        return new_sid
+
+    sid = await asyncio.to_thread(_add_source_marked_syncing)
 
     async def _bg_ingest() -> None:
-        try:
-            await pipeline.ingest_file(uri, source_id=sid)
+        def _mark_synced() -> None:
             store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (sid,))
             store.db.commit()
-        except Exception:
-            logger.exception("Research findings ingestion failed for %s", cid)
+
+        def _mark_error() -> None:
             store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (sid,))
             store.db.commit()
+
+        try:
+            await pipeline.ingest_file(uri, source_id=sid)
+            await asyncio.to_thread(_mark_synced)
+        except Exception:
+            logger.exception("Research findings ingestion failed for %s", cid)
+            await asyncio.to_thread(_mark_error)
 
     task = asyncio.create_task(_bg_ingest())
     app_tasks = request.app.setdefault("_bg_tasks", set())

--- a/test/test_auto_research_handlers_coverage.py
+++ b/test/test_auto_research_handlers_coverage.py
@@ -1578,6 +1578,39 @@ class TestKnowledgeRoutes:
         assert any("'synced'" in s for s in statuses)
 
     @pytest.mark.asyncio
+    async def test_ingest_store_statements_run_off_the_event_loop(self, _isolate: Path):
+        """Issue #7020's loop-stall class: every store statement for the
+        to-knowledge flow must run in a worker thread, so a lock wait on the
+        store's busy timeout stalls a thread instead of the event loop (which
+        the watchdog would kill). Pins add_source, the syncing/synced UPDATEs,
+        and their commits to non-loop threads."""
+        import threading
+
+        cid = _campaign()
+        (h._campaign_dir(cid) / "FINDINGS.md").write_text("findings body")
+        loop_thread = threading.get_ident()
+        seen_threads: list[int] = []
+
+        def _record(*_a, **_k):
+            seen_threads.append(threading.get_ident())
+            return MagicMock()
+
+        store = MagicMock()
+        store.get_source_by_uri.side_effect = lambda *_a: (_record(), None)[1]
+        store.add_source.side_effect = lambda **_k: (_record(), 11)[1]
+        store.db.execute.side_effect = _record
+        store.db.commit.side_effect = _record
+        pipeline = SimpleNamespace(ingest_file=AsyncMock())
+        app = _app(state=SimpleNamespace(knowledge_store=store), knowledge_pipeline=pipeline)
+        resp = await h._handle_to_knowledge(_mk("POST", "k", app=app, match={"id": cid}))
+        assert resp.status == 201
+        await _drain_bg_tasks(app)
+        # get_source_by_uri + add_source + 2 UPDATEs + 2 commits all recorded,
+        # none on the loop.
+        assert len(seen_threads) >= 6
+        assert all(t != loop_thread for t in seen_threads)
+
+    @pytest.mark.asyncio
     async def test_ingest_failure_marks_the_source_errored(self, _isolate: Path):
         cid = _campaign()
         (h._campaign_dir(cid) / "FINDINGS.md").write_text("findings body")


### PR DESCRIPTION
## Problem / Motivation

The `POST /campaigns/{id}/to-knowledge` handler in the auto_research app runs six SQLite statements directly on the gateway event loop: `add_source` + the `sync_status = 'syncing'` UPDATE/commit inline in `_handle_to_knowledge`, and the `'synced'` / `'error'` UPDATE/commit pairs inside the `_bg_ingest` task. A lock wait on the knowledge store's busy timeout therefore stalls the event loop itself — the loop-stall class described in #7020 — instead of stalling a worker thread. This is the auto_research member of the on-loop SQLite cleanup tracked at #7019.

## Why it matters

An event-loop stall starves every session and channel at once, and a long enough stall trips the loop watchdog, which kills the gateway and drops every in-flight turn (#1572's symptom class). Nothing in the resulting logs attributes the restart to a research-app query.

One scoping correction to #7020's arithmetic, verified against this tree: the six baselined statements run on the **knowledge store's** connection (10s effective busy timeout), not the 30s auto_research connection — AST analysis (direct + transitive) shows every `_get_db()` path in the module is already reached only through `asyncio.to_thread`, so the 30s timeout never meets the loop and no timeout change is needed. The on-loop hazard itself is real regardless of which connection carries it, and remedy 1 (offload) is applied as the issue prefers.

## What changed (motivation → approach → change)

Symptom: statement work on the loop → root cause: the to-knowledge flow was written inline in `async def`s while the rest of the module already routes store work through `asyncio.to_thread` sync closures → change: the same established pattern is applied to the remaining six statements.

- `_handle_to_knowledge`: `add_source` + the `'syncing'` UPDATE/commit now run in one `to_thread` closure. `add_source` rides in the same closure because the UPDATE needs its `sid` on the same per-thread connection (the store hands out one connection per thread).
- `_bg_ingest`: the `'synced'` and `'error'` UPDATE/commit pairs each run via `to_thread` closures, preserving the exact SQL literals the existing tests pin.
- Round 2 (First Principles finding): the two remaining on-loop store SELECTs — the dedup `get_source_by_uri` inside `_handle_to_knowledge` and the lookup in `_handle_knowledge_status` — are now also `to_thread`-wrapped, so the file carries zero on-loop knowledge-store calls.

No behaviour change: same statements, same order, same error handling — only the thread they execute on. The issue's remedy 2 (lowering the 30s timeout) is unnecessary per the scoping correction above, and the numeric-pin gate idea stays with its own review as the issue suggests. Note for #6997: once this merges, its `sync-io-in-async-baseline.txt` entry of 6 for this file will over-count (harmless for a shrink-only ratchet, prunable on its next rebase).

## Tests

- New `test_ingest_store_statements_run_off_the_event_loop`: records the executing thread of `add_source`, both UPDATEs, and both commits, and asserts none ran on the event-loop thread (≥5 recorded calls, all off-loop).
- Existing `test_ingest_writes_a_sanitized_copy_and_marks_it_synced` and `test_ingest_failure_marks_the_source_errored` continue to pin the success/error status transitions and the exact SQL literals — 196/196 in `test_auto_research_handlers_coverage.py`.

## Manual verification

N/A — unit coverage sufficient: the change is thread placement of five calls, which the new test observes directly via thread idents.

## Related Issues

Fixes #7020. Part of the #7019 cleanup; ratchet context in #3057 / PR #6997; user-visible symptom class #1572.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
