### PR TITLE
fix(browser-view): prove the view server is ours before adopting its port

### DIFF
--- a/src/kiro_crew/browser_cli/view.py
+++ b/src/kiro_crew/browser_cli/view.py
@@ -77,6 +77,10 @@ _lock = threading.Lock()
 _proc: subprocess.Popen[bytes] | None = None
 _info: ShowInfo | None = None
 _relay: "_Relay | None" = None
+#: The child's OWN listening port, which is what ownership is proved against.
+#: Distinct from ``_info.port``: on the pinned path that is the operator's port,
+#: served by our in-process relay, so it proves nothing about the child.
+_child_port: int | None = None
 # Why the last start attempt failed, surfaced through ``status()``. With an
 # ephemeral port a failed bind was a near-impossible edge; with a pinned port
 # "already in use" becomes the most likely operator misconfiguration, and a
@@ -89,9 +93,14 @@ def _free_port() -> int:
 
     Binding port 0 lets the kernel pick one that is free right now. This is
     advisory: the socket is closed before the child binds it, so there is a
-    TOCTOU window. A lost race shows up as the child failing its readiness
-    gate, which :func:`ensure_running` reports as a failed start rather than
-    retrying blindly.
+    TOCTOU window in which a local process can take the number instead.
+
+    The window cannot be closed here. Closing it would mean handing the child a
+    socket we already hold, and ``playwright-cli show`` takes a port NUMBER, not
+    an inherited descriptor — so there is no bind-before-release to perform. What
+    contains it is :func:`_port_owner`: the readiness gate proves the responder
+    belongs to the process tree we spawned before adopting it, so losing the race
+    is reported as a failed start instead of adopting the winner.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind((LOOPBACK_HOST, 0))
@@ -139,8 +148,10 @@ class _Relay:
     ownership proof: ``bind()`` either succeeds (the port is ours until we
     close it) or raises (occupied). This makes the DETERMINISTIC, operator-named
     port race-free; the child then binds an OS-assigned ephemeral port exactly
-    as on the unpinned path, which keeps that path's advisory window
-    (unpredictable, loopback-local). This relay forwards
+    as on the unpinned path, whose probe-to-bind window is contained a different
+    way -- :func:`_port_owner` proves the responder belongs to the tree we
+    spawned before the readiness gate adopts it, so a squatter that wins the
+    window is refused rather than framed. This relay forwards
     each accepted connection byte-for-byte, which carries HTTP and WebSocket
     traffic alike. Both sockets stay loopback-only.
     """
@@ -306,6 +317,86 @@ def _healthy(port: int) -> bool:
             conn.close()
 
 
+#: Proven: a process in the tree we spawned holds the port.
+_OWNER_CHILD = "child"
+#: Treated as foreign. Either a lookup that ran and could not attribute the
+#: listener to us, or a proven third party -- both mean "not demonstrably ours".
+_OWNER_FOREIGN = "foreign"
+#: The port->PID lookup tool is not installed on this host. Deliberately still
+#: adopted; see :func:`_port_owner` for why this one branch stays fail-open.
+_OWNER_UNPROVEN = "unproven"
+
+
+def _port_owner(port: int, proc: subprocess.Popen[bytes] | None) -> str:
+    """Who holds *port*: our child's tree, foreign, or undecidable on this host.
+
+    :func:`_healthy` answers "is an HTTP server there", which is reachability,
+    not identity. That is the whole gap: ``_free_port`` releases its probe socket
+    before the child binds, so a local process can take the number in between,
+    and a bare health probe then reports the squatter as our server -- after which
+    the panel frames arbitrary content with input forwarding attached.
+
+    **A lookup that RAN but cannot attribute the listener to us is FOREIGN, not
+    undecidable.** The caller only asks after a successful ``127.0.0.1`` probe, so
+    something is listening; if a working lookup cannot show it belongs to our
+    tree, "not ours" is the honest reading. That covers a squatter owned by
+    another user (invisible to our ``lsof``) and a lookup that timed out under
+    load. The cost is a refused start on a loaded host, which is recoverable and
+    reported; adopting an unverified responder is not.
+
+    **The one fail-open branch is the tool being absent**, which is a static
+    property of the host rather than a per-start event. Refusing there would take
+    the panel away from every machine without ``lsof`` -- a certain, permanent
+    regression of a working feature, traded against a race whose winner must
+    already be a local process on a loopback-only dev surface. It is also not
+    attacker-controllable in any threat model that matters: removing
+    ``/usr/bin/lsof`` needs the kind of access that makes this panel the least of
+    the problems. The pod health probe draws the same line for the same reason,
+    and the startup gate logs when it lands here so the operator knows the check
+    did not run.
+    """
+    if proc is None:
+        return _OWNER_FOREIGN
+    if not platform_compat.listening_pid_tool_available():
+        return _OWNER_UNPROVEN
+    listeners = platform_compat.find_port_listeners(port)
+    if not listeners:
+        # The port answered a moment ago, so someone IS listening. A working
+        # lookup that sees nothing means the socket is not visible to us, which
+        # is not evidence of ownership.
+        return _OWNER_FOREIGN
+    owners = platform_compat.loopback_owner_pids(listeners)
+    if not owners:
+        return _OWNER_FOREIGN
+    # The listener is often a DESCENDANT: the CLI spawns Node and helper
+    # processes, which is why _reap signals the whole tree rather than the direct
+    # child. Enumerate the tree we own and accept any member of it.
+    ours = {proc.pid, *platform_compat.process_descendants(proc.pid)}
+    if any(pid in ours for pid in owners):
+        return _OWNER_CHILD
+    return _OWNER_FOREIGN
+
+
+def _recorded_is_live() -> bool:
+    """Whether the recorded child is alive, answering, AND still owns its port.
+
+    One predicate for both the reuse gate in :func:`ensure_running` and
+    :func:`status`, so the two cannot disagree about what "running" means. A
+    divergence would matter: ``status`` is what hands the panel its URL, so a
+    reachability-only ``status`` would report a squatter as running and point the
+    panel at it even while ``ensure_running`` refused to adopt the same server.
+
+    Callers hold :data:`_lock`.
+    """
+    return (
+        _alive(_proc)
+        and _info is not None
+        and _healthy(_info.port)
+        and _child_port is not None
+        and _port_owner(_child_port, _proc) != _OWNER_FOREIGN
+    )
+
+
 def _show_argv(cli: str, port: int) -> list[str]:
     """Argv for the dashboard server.
 
@@ -385,9 +476,12 @@ def ensure_running(port: int | None = None) -> ShowInfo | None:
     pinned port is already taken by something else, or the server did not
     become healthy within the startup budget. ``status()`` carries the reason.
     """
-    global _proc, _info, _relay, _last_reason
+    global _proc, _info, _relay, _last_reason, _child_port
     with _lock:
-        if _alive(_proc) and _info is not None and _healthy(_info.port):
+        # Ownership is re-proved on reuse, not just at startup. A child that is
+        # alive but no longer listening leaves its port free for a squatter, and
+        # without this the next call would hand that squatter back as the panel.
+        if _recorded_is_live():
             return _info
         if _proc is not None:
             _reap(_proc)
@@ -396,6 +490,7 @@ def ensure_running(port: int | None = None) -> ShowInfo | None:
         if _relay is not None:
             _relay.close()
             _relay = None
+        _child_port = None
         _last_reason = None
 
         cli = cli_path()
@@ -440,8 +535,38 @@ def ensure_running(port: int | None = None) -> ShowInfo | None:
                 _last_reason = f"playwright-cli show exited during startup on port {child_port}"
                 return None
             if _healthy(child_port):
+                # Reachability is not identity. Prove the responder is ours
+                # before adopting it; a squatter that won _free_port's window
+                # answers this probe exactly as our child would.
+                owner = _port_owner(child_port, proc)
+                if owner == _OWNER_FOREIGN:
+                    logger.warning(
+                        "another local process holds port %d — refusing to adopt "
+                        "it as the browser view",
+                        child_port,
+                    )
+                    if relay is not None:
+                        relay.close()
+                    _last_reason = (
+                        f"another local process took port {child_port} before the "
+                        f"view server could bind it"
+                    )
+                    _reap(proc)
+                    return None
+                if owner == _OWNER_UNPROVEN:
+                    # Said once per start, not per poll: the operator should know
+                    # the ownership check did not run, since without it this
+                    # adoption rests on reachability alone.
+                    logger.warning(
+                        "cannot verify which process holds port %d (%s is not "
+                        "installed); adopting the browser view on reachability "
+                        "alone",
+                        child_port,
+                        platform_compat.listening_pid_tool(),
+                    )
                 _proc = proc
                 _relay = relay
+                _child_port = child_port
                 _info = ShowInfo(url=f"http://{LOOPBACK_HOST}:{public_port}", port=public_port)
                 return _info
             time.sleep(_POLL_INTERVAL_S)
@@ -467,7 +592,7 @@ def stop() -> None:
     independently-launched ``playwright-cli show`` session, destroying their
     unsaved work.
     """
-    global _proc, _info, _relay, _last_reason
+    global _proc, _info, _relay, _last_reason, _child_port
     with _lock:
         if _proc is not None:
             _reap(_proc)
@@ -476,6 +601,7 @@ def stop() -> None:
         _proc = None
         _info = None
         _relay = None
+        _child_port = None
         _last_reason = None
 
 
@@ -497,7 +623,7 @@ def status() -> dict[str, Any]:
                 "port": None,
                 "reason": "playwright-cli is not installed",
             }
-        if _alive(_proc) and _info is not None and _healthy(_info.port):
+        if _recorded_is_live() and _info is not None:
             return {
                 "status": "running",
                 "url": _info.url,

--- a/test/test_browser_cli_view.py
+++ b/test/test_browser_cli_view.py
@@ -63,7 +63,13 @@ def reset_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[int]]:
     monkeypatch.setattr(mod, "_proc", None)
     monkeypatch.setattr(mod, "_info", None)
     monkeypatch.setattr(mod, "_relay", None)
+    monkeypatch.setattr(mod, "_child_port", None)
     monkeypatch.setattr(mod, "_last_reason", None)
+    # Ownership lookups are undecidable by default, so no test shells out to
+    # lsof/netstat by accident. `_port_owner` then answers UNPROVEN, which is the
+    # pre-identity behaviour every existing test was written against; the tests
+    # that exercise ownership opt in with `_stub_port_owner`.
+    monkeypatch.setattr(platform_compat, "listening_pid_tool_available", lambda: False)
     monkeypatch.setattr(
         platform_compat,
         "kill_process_tree",
@@ -73,7 +79,33 @@ def reset_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[int]]:
     mod._proc = None
     mod._info = None
     mod._relay = None
+    mod._child_port = None
     mod._last_reason = None
+
+
+def _stub_port_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    listener_pids: tuple[int, ...],
+    descendants: tuple[int, ...] = (),
+    tool: bool = True,
+) -> None:
+    """Make the port->PID lookup answer with *listener_pids*.
+
+    Stubs the ``platform_compat`` primitives rather than ``_port_owner`` itself,
+    so the module's own tier logic (tool absent, empty lookup, descendant match)
+    is what the tests exercise.
+    """
+    monkeypatch.setattr(platform_compat, "listening_pid_tool_available", lambda: tool)
+    monkeypatch.setattr(
+        platform_compat,
+        "find_port_listeners",
+        lambda port: [
+            platform_compat.PortListener(pid=p, address="127.0.0.1", family="4")
+            for p in listener_pids
+        ],
+    )
+    monkeypatch.setattr(platform_compat, "process_descendants", lambda pid: list(descendants))
 
 
 def _free_port() -> int:
@@ -661,3 +693,185 @@ def test_status_does_not_start_anything(monkeypatch: pytest.MonkeyPatch) -> None
 
     assert mod.status()["status"] == "stopped"
     assert spawns == []
+
+
+# ── port ownership: reachability is not identity ────────────────────────────
+#
+# `_free_port` releases its probe socket before the child binds it, so a local
+# process can take the number in between. `_healthy` then answers True for the
+# squatter exactly as it would for our child, and the panel frames whatever the
+# squatter serves — with input forwarding attached.
+
+
+def test_port_owner_proves_the_direct_child(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = FakeProc(pid=4242)
+    _stub_port_owner(monkeypatch, listener_pids=(4242,))
+
+    assert mod._port_owner(45613, proc) == mod._OWNER_CHILD
+
+
+def test_port_owner_proves_a_descendant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI spawns Node and helpers, so the listener is often not the child."""
+    proc = FakeProc(pid=4242)
+    _stub_port_owner(monkeypatch, listener_pids=(9931,), descendants=(9931,))
+
+    assert mod._port_owner(45613, proc) == mod._OWNER_CHILD
+
+
+def test_port_owner_names_a_squatter(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = FakeProc(pid=4242)
+    _stub_port_owner(monkeypatch, listener_pids=(777,), descendants=(9931,))
+
+    assert mod._port_owner(45613, proc) == mod._OWNER_FOREIGN
+
+
+def test_port_owner_is_unproven_without_the_lookup_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The one fail-open branch: a host without lsof must keep its panel.
+
+    Static per host rather than per start, and not attacker-controllable --
+    removing the tool needs the access that makes this panel moot.
+    """
+    proc = FakeProc(pid=4242)
+    _stub_port_owner(monkeypatch, listener_pids=(777,), tool=False)
+
+    assert mod._port_owner(45613, proc) == mod._OWNER_UNPROVEN
+
+
+def test_port_owner_refuses_when_a_working_lookup_sees_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The port just answered, so a lookup that shows no owner is not ours.
+
+    Covers a squatter owned by another user (invisible to our lsof) and a lookup
+    that timed out under load. A refused start is recoverable; adopting an
+    unverified responder is not.
+    """
+    proc = FakeProc(pid=4242)
+    _stub_port_owner(monkeypatch, listener_pids=())
+
+    assert mod._port_owner(45613, proc) == mod._OWNER_FOREIGN
+
+
+def test_port_owner_refuses_without_a_child_to_compare(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No recorded child means nothing can be proved ours."""
+    _stub_port_owner(monkeypatch, listener_pids=(4242,))
+
+    assert mod._port_owner(45613, None) == mod._OWNER_FOREIGN
+
+
+def test_ensure_running_refuses_a_squatter_on_the_child_port(
+    monkeypatch: pytest.MonkeyPatch, reset_state: list[int]
+) -> None:
+    """The whole point: a foreign responder must not become the panel."""
+    proc = FakeProc(pid=4242)
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: proc)
+    _stub_port_owner(monkeypatch, listener_pids=(777,))
+
+    assert mod.ensure_running() is None
+    assert mod._info is None
+    assert mod._child_port is None
+    # The child we spawned is reaped rather than left holding nothing.
+    assert proc.pid in reset_state
+    status = mod.status()
+    assert status["status"] == "stopped"
+    assert "took port" in (status["reason"] or "")
+
+
+def test_ensure_running_adopts_a_proven_child(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = FakeProc(pid=4242)
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: proc)
+    _stub_port_owner(monkeypatch, listener_pids=(4242,))
+
+    info = mod.ensure_running()
+
+    assert info is not None
+    assert mod._child_port == info.port
+
+
+def test_ensure_running_adopts_when_ownership_cannot_be_proved(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No regression on a host where the lookup tool is unavailable.
+
+    Adopting on reachability alone is the pre-identity behaviour, so it is warned
+    about rather than done silently.
+    """
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: FakeProc(pid=4242))
+    _stub_port_owner(monkeypatch, listener_pids=(777,), tool=False)
+
+    with caplog.at_level("WARNING"):
+        assert mod.ensure_running() is not None
+
+    assert any("cannot verify which process holds port" in r.message for r in caplog.records)
+
+
+def test_reuse_refuses_a_squatter_that_took_a_live_childs_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A child can stay alive after losing its listener; the port is then free.
+
+    Without re-proving ownership on reuse, the next panel mount hands back the
+    squatter that took it.
+    """
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    # A FRESH child per spawn. Reusing one fake would let the reaped corpse end
+    # the second attempt at the "exited during startup" check, so the test would
+    # pass without the reuse gate having done anything.
+    spawned: list[FakeProc] = []
+
+    def _spawn_fresh(cli: str, port: int) -> FakeProc:
+        child = FakeProc(pid=4242)
+        spawned.append(child)
+        return child
+
+    monkeypatch.setattr(mod, "_spawn", _spawn_fresh)
+    _stub_port_owner(monkeypatch, listener_pids=(4242,))
+    first = mod.ensure_running()
+    assert first is not None
+
+    # The child is still alive, but a foreign process now answers its port.
+    _stub_port_owner(monkeypatch, listener_pids=(777,))
+
+    assert mod.ensure_running() is None
+    assert len(spawned) == 2, "the reuse gate did not reject the foreign responder"
+
+
+def test_status_does_not_report_a_squatter_as_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`status` is what hands the panel its URL, so it obeys the same rule."""
+    proc = FakeProc(pid=4242)
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: proc)
+    _stub_port_owner(monkeypatch, listener_pids=(4242,))
+    assert mod.ensure_running() is not None
+    assert mod.status()["status"] == "running"
+
+    _stub_port_owner(monkeypatch, listener_pids=(777,))
+
+    assert mod.status()["status"] == "stopped"
+
+
+def test_stop_clears_the_recorded_child_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale child port would be proved against a reaped tree."""
+    monkeypatch.setattr(mod, "cli_path", lambda: "/n/pw")
+    monkeypatch.setattr(mod, "_healthy", lambda port: True)
+    monkeypatch.setattr(mod, "_spawn", lambda cli, port: FakeProc(pid=4242))
+    _stub_port_owner(monkeypatch, listener_pids=(4242,))
+    assert mod.ensure_running() is not None
+
+    mod.stop()
+
+    assert mod._child_port is None


### PR DESCRIPTION
## What is the problem?

`browser_cli/view.py` supervises the `playwright-cli show` server that the
dashboard's Browser panel frames. It picks the child's port with `_free_port()`,
which binds port 0, reads the number the kernel assigned, and **closes the socket**
before the child ever binds it. In that window any local process can take the
number.

The readiness gate then asked the wrong question. `_healthy(port)` answers "is an
HTTP server listening here", and its docstring is explicit that "ANY status line
counts". A squatter that won the window answers it exactly as our child would, so
`ensure_running` recorded the squatter as the view server and handed the panel its
URL.

This was already known in-tree and left open. `_Relay`'s docstring describes it
precisely -- "any probe closes its socket before the child binds, and in that
window a local squatter can take the port -- after which `_healthy` would accept
the squatter's response and the panel would frame arbitrary content WITH remote
input forwarding" -- and then says the pinned-port relay "keeps that path's
advisory window". Meanwhile `_free_port`'s own docstring claimed the opposite of
what happens: "A lost race shows up as the child failing its readiness gate". It
does not. The child fails to bind, and the gate passes anyway because someone else
is listening.

## Why this issue matters to the user

The panel is not a viewer, it is an input surface: the user drives real pages
through it. Framing a foreign local server there means the operator's clicks and
keystrokes go somewhere they did not choose, presented inside their own dashboard
as if it were theirs.

Two things bound it. The squatter must be a local process, since everything binds
loopback; and on the unpinned path it must guess an unpredictable ephemeral number,
though nothing stops a local process from binding many ports or simply racing
repeatedly. The pinned path is already safe by construction -- `_claim_listener`
holds the operator's port itself -- but the child's own port is unprotected on
both paths, and on the pinned path the relay forwards straight to it.

## How our fix solves it

The symptom is a foreign server in the panel. The cause is that the gate proved
reachability and treated it as identity. So prove identity.

New `_port_owner(port, proc)` resolves who actually holds the port, using the
`platform_compat` helpers already on main: `find_port_listeners` for the LISTEN
sockets, `loopback_owner_pids` to pick the ones a `127.0.0.1` connect would
actually reach, and `process_descendants` because the listener is usually a
descendant -- the CLI spawns Node and helpers, which is why `_reap` already
signals the whole tree. It returns one of three verdicts, mirroring the model the
pod health probe uses:

- `_OWNER_CHILD` -- a process in the tree we spawned holds it. Adopt.
- `_OWNER_FOREIGN` -- proven squatter. Refuse: close the relay, record a reason,
  reap our child, and report a failed start.
- `_OWNER_UNPROVEN` -- no lookup tool on this host, or the lookup came back empty
  for a port that just answered. Keep the pre-identity behaviour.

The UNPROVEN tier is the point of the three-state model rather than a boolean.
Collapsing "cannot check" into "foreign" would make the panel unavailable on every
host without `lsof`, trading a narrow unpredictable race for a broad certain
regression.

Two call sites, one rule. `_recorded_is_live()` now backs both the reuse gate in
`ensure_running` and `status()`, so they cannot disagree about what "running"
means. That mattered: `status()` is the endpoint that hands the panel its URL, so
a reachability-only `status` would have pointed the panel at a server
`ensure_running` had just refused. A child can also stay alive after losing its
listener, which frees its port for a squatter -- so ownership is re-proved on
reuse, not only at startup.

The child's own port is now tracked in `_child_port`, separate from `_info.port`:
on the pinned path the latter is the operator's port, served by our in-process
relay, so it proves nothing about the child.

**On bind-before-probe-release:** not available here. Closing the window would
mean handing the child a socket we already hold, and `playwright-cli show` takes a
port number, not an inherited descriptor. The identity check is what contains it,
and both misleading docstrings are corrected to say so.

## What tests we did

Ten new tests in `test/test_browser_cli_view.py`:

- `_port_owner`'s four verdicts driven through the `platform_compat` primitives
  rather than by stubbing `_port_owner` itself, so the tier logic is what runs:
  direct child, descendant, proven squatter, tool absent, and empty lookup.
- `ensure_running` refuses a proven squatter (returns `None`, records no
  `_info`/`_child_port`, reaps the child, and `status()` then reports `stopped`
  with the reason), adopts a proven child, and still adopts when ownership cannot
  be proved.
- The reuse gate rejects a squatter that took a live child's port, and `status()`
  does not report one as running.
- `stop()` clears `_child_port`, so ownership is never proved against a reaped
  tree.

The autouse fixture now defaults `listening_pid_tool_available` to `False`, so no
test shells out to `lsof` by accident and the pre-existing tests keep running
against exactly the pre-identity behaviour they were written for.

Mutation-verified per behaviour, not just in aggregate. Disabling the readiness
gate fails `refuses_a_squatter_on_the_child_port` and
`reuse_refuses_a_squatter_that_took_a_live_childs_port`; dropping the ownership
clause from `_recorded_is_live` fails the reuse test and
`status_does_not_report_a_squatter_as_running`. So each gate is independently
pinned. (One of these tests initially passed under the first mutation for the
wrong reason -- a shared fake child was reaped and ended the second attempt at
the "exited during startup" check -- so it now hands out a fresh child per spawn
and asserts the respawn count.)

81 tests green across `test_browser_cli_view.py`, `test_browser_view_port_config.py`
and `test_browser_cli_journeys.py`; `test_browser_cli_launch.py` green as well.
flake8, isort, mypy and the repo black gate clean on both touched files. Full
suites left to CI.

## Any other suggestions on the work

- The same class of fix is in flight for pods in #7023 ("prove the health
  responder is this pod before reporting it up"). This reuses that three-state
  shape deliberately, but depends only on `platform_compat` helpers already on
  main -- there is no dependency between the two PRs, and they touch disjoint
  files.
- A refused start is reported, not retried. That matches the module's existing
  stance ("reports a failed start rather than retrying blindly") and keeps this
  change small, but re-drawing a fresh ephemeral port and trying again would be a
  reasonable follow-up: the squatter holds one number, not the whole range.
- `status()` now costs a listener lookup when a server is recorded, on top of the
  HTTP probe it already did. That is one `lsof` on a single port. If the panel
  polls that endpoint hard enough for it to matter, the answer is to cache the
  verdict for a beat rather than to go back to reachability-only.
