### PR TITLE
fix(ci): catch config-file references in the surface selector

### DIFF
--- a/scripts/ci-surface-tests.py
+++ b/scripts/ci-surface-tests.py
@@ -57,6 +57,7 @@ _BACKEND_FOREIGN = re.compile(
     | \.tsx?\b             # a TypeScript filename appearing in an assertion
     | \.mjs\b
     | \.plist\b
+    | tsconfig\.json       # the frontend's config file, referenced by bare name
     | entitlements
     | \bnpm\b
     | vitest
@@ -72,6 +73,13 @@ _BACKEND_FOREIGN = re.compile(
 # eyeball grep kept missing:
 #   1. string literals   -- '../../../src/kiro_crew/connections/registry.json'
 #   2. path segments     -- path.resolve(__dirname, '..', '..', '..', 'test')
+#
+# Backend-owned config extensions close the last bare-name gap: a spec reads
+# pyproject.toml / setup.cfg / a workflow .yml through a pre-computed root
+# constant, so neither the escape forms nor a package name appear on the
+# referencing line. .yaml is almost backend-owned (workflows, compose);
+# website/AUTOSDE.yaml is the one frontend-owned exception, and per the
+# header above over-matching it only costs CI time.
 # ---------------------------------------------------------------------------
 _FRONTEND_FOREIGN = re.compile(
     r"""
@@ -84,6 +92,9 @@ _FRONTEND_FOREIGN = re.compile(
     | test[\\/]fixtures                               # shared parity fixtures
     | \bdocker\b
     | \.py\b                                          # a Python file in an assertion
+    | \.toml\b                                        # backend-owned config extensions
+    | \.cfg\b
+    | \.ya?ml\b
     """,
     re.VERBOSE,
 )

--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -213,6 +213,84 @@ def test_frontend_escape_patterns_are_detected(selector, tmp_path) -> None:
     assert selector._is_cross_surface(inside, selector._FRONTEND_FOREIGN) is False
 
 
+def test_backend_owned_config_references_are_cross_surface(selector, tmp_path) -> None:
+    """A spec naming a backend-owned config file must stay in the must-run set.
+
+    pyproject.toml, setup.cfg and the other TOML/CFG/YAML configs are all
+    backend-owned (the one exception, website/AUTOSDE.yaml, only makes the
+    match over-broad, which costs CI time), and a spec reaches them through
+    a pre-computed root constant -- no ``../../../`` escape and no
+    ``kiro_crew`` marker on the referencing line:
+
+        const version = readFileSync(join(REPO_ROOT, 'pyproject.toml'), ...)
+
+    With only directory/name/`.py` markers in the pattern, such a spec was
+    classified single-surface and SKIPPED on a backend-only diff -- the
+    exact silent-drop this selector exists to prevent. Measured live guards
+    that this closes: ``releaseVersion.test.ts`` (pins release.yml's version
+    mapping) and ``frontendBlobReconcile.wireFormat.test.ts`` (pins the
+    reconcile script ci.yml runs).
+    """
+    toml = tmp_path / "a.test.ts"
+    toml.write_text(
+        "const REPO_ROOT = resolve(__dirname, '..', '..', '..')\n"
+        "const version = readFileSync(join(REPO_ROOT, 'pyproject.toml'), 'utf-8')\n"
+    )
+    assert selector._is_cross_surface(toml, selector._FRONTEND_FOREIGN) is True
+
+    cfg = tmp_path / "b.test.ts"
+    cfg.write_text("const defaults = readFileSync(join(REPO_ROOT, 'setup.cfg'), 'utf-8')\n")
+    assert selector._is_cross_surface(cfg, selector._FRONTEND_FOREIGN) is True
+
+    yaml = tmp_path / "c.test.ts"
+    yaml.write_text("// parity: release.yml maps v0.6.0-rc.2 to the wheel version 0.6.0rc2\n")
+    assert selector._is_cross_surface(yaml, selector._FRONTEND_FOREIGN) is True
+
+
+def test_frontend_owned_config_reference_is_cross_surface(selector, tmp_path) -> None:
+    """The mirror: a backend guard naming the frontend's config file by bare name.
+
+    ``tsconfig.json`` lives inside website/, so a realistic reference carries
+    ``website`` in its path -- but a guard that quotes the filename alone
+    (a joined path built from constants, a fixture table of config names)
+    had no marker at all. Bare extensions cannot close this direction the
+    way they close the mirror: the backend owns .toml/.cfg/.yaml/.json
+    configs of its own, so only frontend-owned config NAMES are added here.
+    """
+    guard = tmp_path / "test_tsconfig_parity.py"
+    guard.write_text(
+        "# parity: the shipped tsconfig.json must not gain references\n"
+        'TS_CONFIG = REPO / "tsconfig.json"\n'
+    )
+    assert selector._is_cross_surface(guard, selector._BACKEND_FOREIGN) is True
+
+
+def test_own_surface_config_references_stay_single_surface(selector, tmp_path) -> None:
+    """The asymmetry is the point: each surface's OWN configs must not trip it.
+
+    A backend test reading pyproject.toml or setup.cfg is reading its own
+    surface, and a frontend spec reading package.json or tsconfig.json is
+    doing the same -- neither is a parity guard. This pins that the new
+    terms went in per-direction, not as bare extensions on both patterns
+    (which would have flooded the must-run set: 51 backend files reference
+    a .yaml of their own).
+    """
+    backend_own = tmp_path / "test_own_cfg.py"
+    backend_own.write_text(
+        'VERSION = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]\n'
+        "PARSER = configparser.ConfigParser()\n"
+        'PARSER.read(ROOT / "setup.cfg")\n'
+    )
+    assert selector._is_cross_surface(backend_own, selector._BACKEND_FOREIGN) is False
+
+    frontend_own = tmp_path / "own-configs.test.ts"
+    frontend_own.write_text(
+        "const pkg = JSON.parse(readFileSync('package.json', 'utf-8'))\n"
+        "const ts = readFileSync('tsconfig.json', 'utf-8')\n"
+    )
+    assert selector._is_cross_surface(frontend_own, selector._FRONTEND_FOREIGN) is False
+
+
 # ---------------------------------------------------------------------------
 # Windows: the reduced scope must not name a suite Windows cannot collect
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

`scripts/ci-surface-tests.py` picks the tests that must still run when a diff touches one surface. It is deny-by-default on purpose: it may only skip a file it can positively prove is single-surface, because the alternative failure is invisible. A cross-surface parity guard (a pytest that reads `website/src/...`, or a vitest spec that asserts backend behavior) that gets misclassified as single-surface simply stops running on the other surface's diffs, and the drift it watches for ships green.

The two patterns that drive that decision had a blind spot: config files. `_BACKEND_FOREIGN` and `_FRONTEND_FOREIGN` match directories, package names, escape forms and source extensions, but a frontend spec can name a backend-owned config file through a pre-computed root constant with no marker anywhere on the referencing line:

```ts
const version = readFileSync(join(REPO_ROOT, 'pyproject.toml'), 'utf-8')
```

No `../../../` escape, no `kiro_crew`, no `.py`. The selector classified such a spec single-surface and the reduced backend-only run skipped it.

Two live guards were in that class: `website/src/utils/releaseVersion.test.ts` (pins the PEP 440 version mapping, with its comment naming `release.yml` as the other half of the contract) and `website/src/test/frontendBlobReconcile.wireFormat.test.ts` (pins the reconcile script that `ci.yml` runs). Both were provably-skippable before this change, so a backend-only reduced run never executed them.

## Why it matters

These files are parity guards by construction: their subject is release/CI behavior, expressed in a frontend file. A change to the version-mapping shape in `release.yml`, or to the reconcile script's wire format, lands on main, and the next backend-only reduced run never executes the tests that would catch the mismatch. The selector's own docstring calls this exact failure "a guard quietly stops running and the drift it protects against ships green."

The cost asymmetry is the design's whole bet, stated in the script's header: over-matching only costs CI time, while under-matching costs coverage. So the fix direction was never in question — close the class, measure the must-run growth, and keep it small.

## What changed (motivation → approach → change)

The terms went in per direction, not as bare extensions on both patterns:

- `_FRONTEND_FOREIGN` gains `\.toml\b`, `\.cfg\b` and `\.ya?ml\b`. The backend owns those config extensions (`pyproject.toml`, `setup.cfg`, compose files, workflow files); the frontend owns exactly one `.yaml` of its own (`website/AUTOSDE.yaml`), which makes the match slightly over-broad by one file class. Per the header's own philosophy, that over-match only costs CI time.
- `_BACKEND_FOREIGN` gains `tsconfig\.json`, the one frontend-owned config file a backend guard would reference by bare name. Bare extensions cannot go into the backend direction at all: 51 backend test files reference a `.yaml` of their own and 35 reference `.cfg` files, so bare terms there would flood the must-run set with genuinely single-surface files.

Measured cost, before → after: frontend must-run 177 → 197 of 1751 (+20, about 1%), backend unchanged at 382 of 1929. The twenty flips are parity guards like the two above, not noise: `TailnetMobileCard.test.tsx` pins the website-side AUTOSDE rule and `keyReference.test.ts` cites `ci.yml` behavior.

Three tests follow the file's existing `_is_cross_surface`-with-`tmp_path` pattern. Two are positive cases (backend-owned config references must classify cross-surface; the mirrored frontend-owned bare name must too), and the third pins the asymmetry: a backend test reading `pyproject.toml`/`setup.cfg` and a frontend spec reading `package.json`/`tsconfig.json` must stay single-surface, so the per-direction split cannot later erode into bare-extensions-everywhere and silently eat the CI saving.

## Tests

- I added the tests first and watched the two positive cases fail (`assert False is True`), then widened the patterns and watched them pass, so the assertions demonstrably catch the regression rather than merely going green.
- `pytest test/test_ci_surface_tests.py` → 43 passed, 1 failed. The failure (`test_explicit_cli_target_bypasses_collect_ignore`) is pre-existing on this Windows machine and unrelated to the diff: it asserts a subprocess-pytest collection behavior, fails identically on a clean checkout of `main` here (verified via stash), and looks like a local pytest-version quirk rather than a repo problem. Happy to dig into it in a separate PR if a maintainer wants.
- Selector counts before/after are the numbers above, measured with `--summary` on both surfaces; the strict-subset property (`test_selection_is_a_strict_subset`) still holds, so the reduced runs keep a real saving.

## Related Issues

No dedicated issue. I found the gap reading the selector while looking at how the reduced CI scopes decide what runs.

## Checklist

- [x] The deny-by-default contract is intact, and now pinned by the asymmetry test
- [x] Before/after must-run counts measured and included above
- [x] No docs changes needed: nothing in `docs/` describes the regex set, and the selector's own docstring already states the contract
- [x] Conventional Commits title