### PR TITLE
fix(agents): route six kirocrew.json reads through the hardened spec reader

### DIFF
--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -144,6 +144,51 @@ SKILL_URI_PREFIX = "skill://"
 AGENT_SPEC_SUFFIX = ".agent-spec.json"
 
 
+def _audit_denied(*, operation: str, source: str, resources: str, error: str) -> None:
+    """Emit a denial audit row for a refused path, never raising.
+
+    BOTH denial paths in this module promise not to raise -- ``_read_agent_spec``
+    by the contract :func:`_warn_on_systematic_scan_failure` documents and its
+    callers read bare, and :func:`project_agent_names` in its own docstring
+    ("Never raises; an unreadable checkout yields an empty set"). Auditing the
+    denial must not become the one way to break either promise: for some
+    surfaces this is the process's FIRST SEL use, and constructing the singleton
+    mkdirs its home (``sel.py``), so an unwritable or hostile SEL directory
+    would abort whichever surface asked -- on exactly the hostile path the
+    refusal exists to handle.
+
+    The REFUSAL always stands, so nothing unaudited is ever read or scanned;
+    what is lost is the audit ROW. That is best-effort by the SEL API's own
+    design: ``log_api_access`` reserves fail-closed behaviour for its explicit
+    ``critical=True`` callers (``apps/admission.py``, the auto-improvement
+    server) and neither of these sites has ever been one. WARNING, not debug, so
+    an operator sees that the trail has a hole rather than finding out later.
+
+    The fallback names only the ``operation`` -- a fixed internal label. The
+    REFUSED PATH is deliberately not logged here: on this branch its resolved
+    target is a sensitive location (that is why it was refused), so writing it at
+    a default-visible level would leak the very thing the deny list protects.
+    The path already appears in the neighbouring ``debug`` line for anyone
+    debugging a specific file, and the SEL row -- the record designed to carry
+    it, redacted and clipped -- is what is being lost.
+    """
+    try:
+        _sel().log_api_access(
+            caller="agent_discovery",
+            operation=operation,
+            outcome="denied",
+            source=source,
+            resources=resources,
+            error=error,
+        )
+    except Exception:
+        logger.warning(
+            "SEL denial audit failed for a %s denial -- refusal stands, audit row lost",
+            operation,
+            exc_info=True,
+        )
+
+
 def _read_agent_spec(
     path: Path,
     *,
@@ -189,10 +234,8 @@ def _read_agent_spec(
         return None
     if is_sensitive_path(str(real)):
         logger.debug("Skipping sensitive agent config: %s", path)
-        _sel().log_api_access(
-            caller="agent_discovery",
+        _audit_denied(
             operation=operation,
-            outcome="denied",
             source=source,
             resources=str(real),
             error="sensitive path rejected",
@@ -355,10 +398,8 @@ def project_agent_names(project_dir: str | Path | None) -> frozenset[str]:
     # at a protected path, matching every other deny in this module.
     if is_sensitive_path(key):
         logger.debug("Skipping sensitive project dir for agent discovery: %s", project_dir)
-        _sel().log_api_access(
-            caller="agent_discovery",
+        _audit_denied(
             operation="project_agent_names",
-            outcome="denied",
             source="project_agent_names",
             resources=key,
             error="sensitive project dir rejected",

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -825,11 +825,14 @@ def _doctor_mcp_governance(
         logger.debug("config load failed in governance check", exc_info=True)
         declared = False
 
-    try:
-        spec = json.loads(agent_path.read_text(encoding="utf-8"))
-        servers = spec.get("mcpServers") or {}
-    except Exception:
-        servers = {}
+    # Same hardened reader as this file's other spec reads: the agents dir is
+    # user-writable, so an oversized or sensitively-symlinked spec is refused
+    # (and audited) rather than parsed. No try/except: the reader's contract is
+    # return-``None``-never-raise, which the five sibling sites migrated
+    # alongside this one also rely on bare. ``None`` degrades to no declared
+    # servers, exactly as the blanket ``except`` here used to.
+    spec = _read_agent_spec(agent_path, operation="doctor", source="cli")
+    servers = (spec or {}).get("mcpServers") or {}
     if not isinstance(servers, dict):
         # `or {}` only replaces a FALSY value, so a string or list here survives
         # and the membership walk below would raise, aborting the whole doctor

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1053,7 +1053,24 @@ def _load_steering_resources() -> str:
         cfg_path = kiro_agents_dir() / "kirocrew.json"
         if not cfg_path.exists():
             return ""
-        cfg = json.loads(safe_read_file(str(cfg_path)))
+        # The agents dir is user-writable and shared with other tools, so the
+        # spec goes through the hardened agent-spec reader. ``safe_read_file``
+        # screened the resolved target but read it with an unbounded
+        # ``fh.read()`` -- the size cap guards ``safe_read_file_bytes``, the
+        # other helper -- and emitted no SEL event, so an oversized spec was
+        # still read whole here and a refusal was never audited. Every outcome
+        # the blanket ``except`` below used to absorb (PermissionError on a
+        # sensitive target, AttributeError on non-object JSON) now arrives as
+        # ``None`` and returns the same empty string, without the read.
+        from kiro_crew.agent_discovery import _read_agent_spec
+
+        cfg = _read_agent_spec(
+            cfg_path,
+            operation="steering_resources",
+            source="unknown",
+        )
+        if cfg is None:
+            return ""
         resources = cfg.get("resources", [])
         parts: list[str] = []
         home_resolved = str(Path.home().resolve()) + os.sep

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew import platform_compat
+from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.config.loader import config_dir, read_local_secret
 from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.github_runner import prevalidated_gh_env
@@ -542,7 +543,21 @@ def _resolve_mcp_server(name: str) -> tuple[str, ...] | None:
             break
     if not cfg_path.exists():
         return None
-    cfg = json.loads(cfg_path.read_text())
+    # The agents dir is user-writable and shared with other tools, so this goes
+    # through the hardened agent-spec reader (size cap, sensitive-symlink
+    # screen, explicit UTF-8, non-object rejection, SEL denial event) instead of
+    # a bare ``read_text`` + ``json.loads``. ``None`` covers every unusable file
+    # -- including the malformed-JSON and non-UTF-8 cases the old form let
+    # escape as an unhandled JSONDecodeError / UnicodeDecodeError into the cron
+    # runner -- and degrades to "no such server", the same answer an absent
+    # entry already produced.
+    cfg = _read_agent_spec(
+        cfg_path,
+        operation="cron_resolve_mcp_server",
+        source="cron",
+    )
+    if cfg is None:
+        return None
     spec = cfg.get("mcpServers", {}).get(name)
     if not spec:
         return None

--- a/src/kiro_crew/dashboard/handlers/hooks.py
+++ b/src/kiro_crew/dashboard/handlers/hooks.py
@@ -108,7 +108,17 @@ async def api_kiro_hooks(request: web.Request) -> web.Response:
     # escaped as an unhandled 500 — and degrades the same way: no user hooks.
     # Off-loop: the reader stats + reads up to the size cap, and this handler
     # runs on the gateway event loop (review-adopted, no-blocking-call rule).
-    raw = await asyncio.to_thread(_read_agent_spec, agent_cfg)
+    # The labels are passed explicitly: they name the SEL denial event's
+    # operation and interface channel, and without them a refusal here is
+    # recorded under the reader's ``list_agents`` defaults -- attributing a
+    # hooks request's denial to an agent-listing cache warm, the exact
+    # misattribution the labels exist to prevent.
+    raw = await asyncio.to_thread(
+        _read_agent_spec,
+        agent_cfg,
+        operation="api_kiro_hooks",
+        source="dashboard",
+    )
     # The reader guarantees the TOP level is an object, not the "hooks" value:
     # a user-writable {"hooks": []} would reach hooks.items() below and escape
     # as a 500. Same degrade-as-absent rule as every other unusable shape.

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -1723,17 +1723,41 @@ def _find_server_spec_anywhere(name: str) -> dict | None:
     edition-contributed provider scopes.  Returns a shallow copy with
     ``disabled`` stripped (the caller decides whether to disable in its target
     scope).
+
+    The agents-dir candidate is an AGENT SPEC and is read through the hardened
+    reader (size cap, sensitive-symlink screen, non-object rejection, SEL denial
+    event) rather than the plain loader. It is statically first in merge order,
+    so it is read before the loop instead of being tagged inside one -- a
+    refused spec then degrades exactly as ``_load_json_or_empty``'s ``{}`` did,
+    contributing nothing and falling through to the next scope. The remaining
+    candidates are provider ``mcp.json`` files, not agent specs, so the
+    agent-spec reader does not describe them.
     """
-    candidates = [
-        kiro_agents_dir() / "kirocrew.json",
+
+    def _usable(data: dict[str, Any]) -> dict | None:
+        spec = data.get("mcpServers", {}).get(name)
+        if isinstance(spec, dict) and (spec.get("command") or spec.get("url")):
+            return {k: v for k, v in spec.items() if k != "disabled"}
+        return None
+
+    found = _usable(
+        _read_agent_spec(
+            kiro_agents_dir() / "kirocrew.json",
+            operation="mcp_find_server_spec",
+            source="dashboard",
+        )
+        or {}
+    )
+    if found is not None:
+        return found
+    for path in (
         _kirocrew_mcp_json(),
         _GLOBAL_MCP_JSON,
         *[s.global_json for s in _extra_mcp_scopes()],
-    ]
-    for p in candidates:
-        spec = _load_json_or_empty(p).get("mcpServers", {}).get(name)
-        if isinstance(spec, dict) and (spec.get("command") or spec.get("url")):
-            return {k: v for k, v in spec.items() if k != "disabled"}
+    ):
+        found = _usable(_load_json_or_empty(path))
+        if found is not None:
+            return found
     return None
 
 

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -750,17 +750,27 @@ def _load_agent_config(*, user_home: Path | None = None) -> dict[str, Any]:
 
     # Installed agent config (always check for mcpServers)
     from kiro_crew.agent import AGENT_FILENAME  # circular import: agent imports mcp_discovery
+    from kiro_crew.agent_discovery import _read_agent_spec
 
     installed = (
         (user_home / ".kiro" / "agents") if user_home else kiro_agents_dir()
     ) / AGENT_FILENAME
     if installed.is_file():
-        try:
-            loaded = json.loads(installed.read_text(encoding="utf-8"))
-            if isinstance(loaded, dict):
-                configs.append(loaded)
-        except (json.JSONDecodeError, OSError):
-            pass
+        # The agents dir is user-writable and shared with other tools, so this
+        # goes through the hardened agent-spec reader (size cap,
+        # sensitive-symlink screen, non-object rejection, SEL denial event)
+        # rather than a bare read_text + json.loads. It also closes a hole the
+        # old ``except`` could not: ``encoding="utf-8"`` on a non-UTF-8 spec
+        # raises UnicodeDecodeError, a ValueError rather than an OSError or a
+        # JSONDecodeError, so it escaped this handler entirely. ``None``
+        # degrades as absent, exactly as the swallowed exceptions did.
+        loaded = _read_agent_spec(
+            installed,
+            operation="mcp_discovery_agent_config",
+            source="unknown",
+        )
+        if loaded is not None:
+            configs.append(loaded)
 
     if not configs:
         return {}

--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -45,6 +45,7 @@ from kiro_crew.dashboard.handlers.agents import (
 )
 from kiro_crew.dashboard.handlers.mcp import (
     _collect_server_rows,
+    _find_server_spec_anywhere,
     _launch_specs_for,
     api_mcp_active,
 )
@@ -282,6 +283,245 @@ class TestLaunchSpecsFor:
         assert specs["srv"][0].command == "x"
 
 
+@pytest.fixture
+def agents_dir_resolver(agents_dir, monkeypatch):
+    """``agents_dir`` plus the ``config.paths`` resolver these two sites use.
+
+    They call ``config.paths.kiro_agents_dir()``, which honours its OWN override
+    and NOT ``agent.KIRO_AGENTS_DIR``, so the base fixture alone does not
+    redirect them. ``cron_script._resolve_mcp_server`` is ``lru_cache``d, so the
+    cache is cleared around the test instead of leaking a resolved answer into
+    the next one.
+    """
+    from kiro_crew.config import paths as config_paths
+    from kiro_crew.cron_script import _resolve_mcp_server
+
+    monkeypatch.setattr(config_paths, "_agents_dir_override", lambda: agents_dir)
+    _resolve_mcp_server.cache_clear()
+    yield agents_dir
+    _resolve_mcp_server.cache_clear()
+
+
+class TestFindServerSpecAnywhere:
+    """handlers.mcp._find_server_spec_anywhere -- the spec-recovery search.
+
+    Server names carry a suffix because the search falls through to the provider
+    ``mcp.json`` scopes, which are real files on a developer machine; a generic
+    name could be answered by one of those and read as a pass.
+    """
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_agent_spec_contributes_no_spec(self, agents_dir_resolver, kind):
+        _plant_refused(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "mcpServers": {"phantom-hr": {"command": "x"}}},
+            kind,
+        )
+
+        assert _find_server_spec_anywhere("phantom-hr") is None
+
+    def test_valid_agent_spec_still_found_under_the_same_cap(self, agents_dir_resolver):
+        _plant(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "mcpServers": {"real-hr": {"command": "x", "disabled": True}}},
+        )
+
+        assert _find_server_spec_anywhere("real-hr") == {"command": "x"}
+
+
+class TestResolveMcpServer:
+    """cron_script._resolve_mcp_server -- the zero-token script-cron path."""
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_agent_spec_resolves_to_no_server(self, agents_dir_resolver, kind):
+        from kiro_crew.cron_script import _resolve_mcp_server
+
+        _plant_refused(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "mcpServers": {"srv-hr": {"command": "c", "args": ["a"]}}},
+            kind,
+        )
+
+        assert _resolve_mcp_server("srv-hr") is None
+
+    def test_valid_agent_spec_still_resolves_under_the_same_cap(self, agents_dir_resolver):
+        from kiro_crew.cron_script import _resolve_mcp_server
+
+        _plant(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "mcpServers": {"srv-hr": {"command": "c", "args": ["a"]}}},
+        )
+
+        assert _resolve_mcp_server("srv-hr") == ("c", "a")
+
+    def test_malformed_spec_no_longer_escapes_as_a_decode_error(self, agents_dir_resolver):
+        """The differential case for THIS site.
+
+        The old bare ``read_text`` + ``json.loads`` had no ``except`` anywhere on
+        the path, so a half-written spec raised ``JSONDecodeError`` out of the
+        resolver and into the cron runner. Refusal now degrades to "no such
+        server", the same answer an absent entry gives.
+        """
+        from kiro_crew.cron_script import _resolve_mcp_server
+
+        (agents_dir_resolver / AGENT_FILENAME).write_text("{not json", encoding="utf-8")
+
+        assert _resolve_mcp_server("srv-hr") is None
+
+
+class TestLoadAgentConfig:
+    """mcp_discovery._load_agent_config -- the merged mcpServers view.
+
+    Feeds MCP discovery from several surfaces, which is why its label is
+    ``unknown`` rather than one interface channel.
+    """
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_agent_spec_contributes_no_servers(self, agents_dir_resolver, kind):
+        from kiro_crew.mcp_discovery import _load_agent_config
+
+        _plant_refused(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "mcpServers": {"phantom-md": {"command": "x"}}},
+            kind,
+        )
+
+        assert "phantom-md" not in _load_agent_config().get("mcpServers", {})
+
+    def test_valid_agent_spec_still_merges_under_the_same_cap(self, agents_dir_resolver):
+        from kiro_crew.mcp_discovery import _load_agent_config
+
+        _plant(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "mcpServers": {"real-md": {"command": "x"}}},
+        )
+
+        assert "real-md" in _load_agent_config().get("mcpServers", {})
+
+    def test_non_utf8_spec_no_longer_escapes_the_handler(self, agents_dir_resolver):
+        """The differential case for THIS site.
+
+        The old form passed ``encoding="utf-8"`` and caught only
+        ``(JSONDecodeError, OSError)``, so a non-UTF-8 spec raised
+        ``UnicodeDecodeError`` -- a ``ValueError`` -- straight through.
+        """
+        from kiro_crew.mcp_discovery import _load_agent_config
+
+        (agents_dir_resolver / AGENT_FILENAME).write_bytes(b'{"mcpServers": {"\xff": {}}}')
+
+        assert "phantom-md" not in _load_agent_config().get("mcpServers", {})
+
+
+class TestLoadSteeringResources:
+    """context._load_steering_resources -- dashboard steering injection.
+
+    ``unknown`` labels it because dashboard chat, Slack and cron sessions all
+    reach it through the same context builder.
+
+    The loader only accepts a ``file://`` resource that globs under
+    ``Path.home()`` and resolves inside it, so ``Path.home`` itself is redirected
+    at the isolated agents dir and the pattern is written relative to it.
+    Redirecting the resolver rather than ``HOME`` is what makes this work on
+    every platform: Windows ``expanduser`` reads ``USERPROFILE``, so setting
+    ``HOME`` alone left the real profile dir in play, the marker could never
+    load, and the refusal assertion passed vacuously while the valid-spec one
+    failed (same ``setattr(Path, "home", ...)`` shape as test_acp_client.py).
+    """
+
+    @staticmethod
+    def _plant_steering(agents_dir: Path, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: agents_dir))
+        (agents_dir / "steer.md").write_text("STEERING-MARKER", encoding="utf-8")
+
+    @pytest.mark.parametrize("kind", REFUSALS)
+    def test_refused_agent_spec_loads_no_steering(self, agents_dir_resolver, monkeypatch, kind):
+        from kiro_crew.context import _load_steering_resources
+
+        self._plant_steering(agents_dir_resolver, monkeypatch)
+        _plant_refused(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "resources": ["file://steer.md"]},
+            kind,
+        )
+
+        assert "STEERING-MARKER" not in _load_steering_resources()
+
+    def test_valid_agent_spec_still_loads_steering_under_the_same_cap(
+        self, agents_dir_resolver, monkeypatch
+    ):
+        from kiro_crew.context import _load_steering_resources
+
+        self._plant_steering(agents_dir_resolver, monkeypatch)
+        _plant(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {"name": "kirocrew", "resources": ["file://steer.md"]},
+        )
+
+        assert "STEERING-MARKER" in _load_steering_resources()
+
+    def test_absent_spec_still_returns_empty(self, agents_dir_resolver):
+        from kiro_crew.context import _load_steering_resources
+
+        assert _load_steering_resources() == ""
+
+
+class TestDenialAuditNeverRaises:
+    """A failing denial audit must not break either never-raise promise.
+
+    The refusal paths are the only places this module calls out to another
+    subsystem, and for some surfaces it is the process's FIRST SEL use --
+    constructing that singleton mkdirs its home. On an unwritable or hostile SEL
+    directory the audit therefore raises, and BOTH callers promise not to:
+    ``_read_agent_spec`` by the contract its ~15 bare call sites read it on, and
+    ``project_agent_names`` in its own docstring. Either raise would abort
+    whichever surface asked on exactly the hostile path the refusal handles --
+    and ``project_agent_names`` runs on EVERY turn of a project-agent-bound
+    session, with a caller-supplied path.
+    """
+
+    @staticmethod
+    def _break_sel(monkeypatch):
+        from kiro_crew import agent_discovery
+
+        monkeypatch.setattr(agent_discovery, "is_sensitive_path", lambda _p: True)
+
+        def _explode():
+            raise OSError("SEL home is not writable")
+
+        monkeypatch.setattr(agent_discovery, "_sel", _explode)
+        return agent_discovery
+
+    def test_reader_audit_failure_still_degrades_to_absent(self, tmp_path, monkeypatch, caplog):
+        spec = tmp_path / "evil.json"
+        spec.write_text(json.dumps({"name": "evil"}), encoding="utf-8")
+        agent_discovery = self._break_sel(monkeypatch)
+
+        with caplog.at_level("WARNING", logger="kiro_crew.agent_discovery"):
+            result = agent_discovery._read_agent_spec(spec, operation="doctor", source="cli")
+
+        # The spec is still REFUSED, so nothing unaudited is read; only the audit
+        # ROW is lost, and that hole in the trail is operator-visible.
+        assert result is None
+        assert any("audit row lost" in r.message for r in caplog.records)
+
+    def test_project_scan_audit_failure_still_yields_empty(self, tmp_path, monkeypatch, caplog):
+        agent_discovery = self._break_sel(monkeypatch)
+
+        with caplog.at_level("WARNING", logger="kiro_crew.agent_discovery"):
+            result = agent_discovery.project_agent_names(tmp_path)
+
+        assert result == frozenset()
+        assert any("audit row lost" in r.message for r in caplog.records)
+
+
 class TestSensitiveSymlinkGuard:
     """One representative surface proves the symlink guard flows through.
 
@@ -508,22 +748,27 @@ _EXPECTED_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
         ("list_agents", "unknown"),
         ("resolve_project_agent_name", "unknown"),
     ],
-    "kiro_crew/cli_doctor.py": [("doctor", "cli"), ("doctor", "cli")],
+    "kiro_crew/cli_doctor.py": [("doctor", "cli"), ("doctor", "cli"), ("doctor", "cli")],
     "kiro_crew/config/loader.py": [("load_config", "unknown")],
     "kiro_crew/connections/mint.py": [
         ("connections_mint", "dashboard"),
         ("connections_mint", "dashboard"),
     ],
+    "kiro_crew/context.py": [("steering_resources", "unknown")],
+    "kiro_crew/cron_script.py": [("cron_resolve_mcp_server", "cron")],
     "kiro_crew/dashboard/handlers/agents.py": [
         ("api_agent_detail", "dashboard"),
         ("api_agent_detail", "dashboard"),
         ("api_agents_sync", "dashboard"),
     ],
+    "kiro_crew/dashboard/handlers/hooks.py": [("api_kiro_hooks", "dashboard")],
     "kiro_crew/dashboard/handlers/mcp.py": [
         ("api_mcp_active", "dashboard"),
+        ("mcp_find_server_spec", "dashboard"),
         ("mcp_server_rows", "dashboard"),
         ("mcp_stub_eligibility", "dashboard"),
     ],
+    "kiro_crew/mcp_discovery.py": [("mcp_discovery_agent_config", "unknown")],
     "kiro_crew/session.py": [
         ("forward:operation", "forward:source"),
         ("resolve_agent_model", "unknown"),
@@ -532,7 +777,17 @@ _EXPECTED_CALL_SITE_LABELS: dict[str, list[tuple[str, str]]] = {
 
 
 def _read_agent_spec_call_sites() -> dict[str, list[tuple[str | None, str | None]]]:
-    """Return every direct ``_read_agent_spec`` call and its label pair."""
+    """Return every ``_read_agent_spec`` call site and its label pair.
+
+    A site that hands the reader off by REFERENCE counts too. ``asyncio.to_thread(
+    _read_agent_spec, path, operation=..., source=...)`` never produces a Call
+    node named ``_read_agent_spec``, so matching only direct calls left every
+    off-loop caller invisible to this ratchet -- and one such site really did
+    sit behind the reader's defaults, recording its denials as an agent-listing
+    cache warm. Any call that merely PASSES the reader is therefore a site as
+    well, and its labels are read from the handing-off call, which is where the
+    forwarded kwargs are written.
+    """
     src = Path(__file__).resolve().parent.parent / "src"
     sites: dict[str, list[tuple[str | None, str | None]]] = {}
     for path in sorted(src.rglob("*.py")):
@@ -547,7 +802,14 @@ def _read_agent_spec_call_sites() -> dict[str, list[tuple[str | None, str | None
                 else func.attr if isinstance(func, ast.Attribute) else ""
             )
             if name != "_read_agent_spec":
-                continue
+                # Not the reader itself -- but it is a site if it hands the
+                # reader off to be invoked elsewhere (to_thread, partial, an
+                # executor). Positional only: a callee is never passed by
+                # keyword in these shapes.
+                if not any(
+                    isinstance(arg, ast.Name) and arg.id == "_read_agent_spec" for arg in node.args
+                ):
+                    continue
             labels: dict[str, str | None] = {"operation": None, "source": None}
             for kw in node.keywords:
                 if kw.arg not in labels:


### PR DESCRIPTION
## 1. What is the problem?

`~/.kiro/agents/kirocrew.json` is user-writable and shared with other tools, so this project converged on one hardened reader for it -- `agent_discovery._read_agent_spec`, which applies a size cap (through `hooks.safe_read_file_bytes`), refuses a symlink whose RESOLVED target is sensitive (`kirocrew.json -> ~/.aws/credentials`) with a SEL `denied` event, rejects non-UTF-8 bytes and JSON that is not an object, and skips AppleDouble sidecars. #5423, #6695, #6723, #6726 and #6745 migrated call sites onto it one batch at a time.

Six reads were still outside it (this PR is one batch in that sequence, not its end -- see section 5):

| Site | State before this PR |
|---|---|
| `dashboard/handlers/mcp.py` `_find_server_spec_anywhere` | plain `_load_json_or_empty` -- no cap, no symlink screen, no audit |
| `cron_script.py` `_resolve_mcp_server` | bare `read_text()` + `json.loads` -- no cap, no screen, no audit, no explicit encoding, and no `except` anywhere on the path |
| `mcp_discovery.py` `_load_agent_config` | `read_text(encoding="utf-8")` + `json.loads` under `except (JSONDecodeError, OSError)` -- no cap, no screen, no audit, and `UnicodeDecodeError` (a `ValueError`) escapes that handler |
| `context.py` `_load_steering_resources` | `hooks.safe_read_file` -- symlink-screened, but an unbounded `fh.read()` (the cap guards `safe_read_file_bytes`, the other helper) and no SEL event |
| `cli_doctor.py` `_doctor_mcp_governance` | bare `read_text()` + `json.loads` inside a blanket `except` -- no cap, no screen, no audit |
| `dashboard/handlers/hooks.py` `api_kiro_hooks` | on the reader, but through `asyncio.to_thread` with NO labels |

The hooks case is the interesting one, and it is why the site list looked shorter than it was. `_read_agent_spec`'s `operation` / `source` arguments name the SEL denial event's user-facing operation and interface channel; the reader is shared by every surface, so a fixed label records a refusal served for one request under another request's name (that is #6722). The `TestCallSiteLabelRatchet` inventory is what keeps every caller honest -- but it matched only direct `_read_agent_spec(...)` calls, and `asyncio.to_thread(_read_agent_spec, path)` produces no such Call node. So the one off-loop caller in the tree was invisible to the ratchet and sat on the reader's `list_agents` defaults, filing a hooks request's denial as an agent-listing cache warm.

## 2. Why this issue matters to the user

Through the three unhardened paths, a multi-gigabyte "agent config" was read into memory whole, and a spec symlinked at a sensitive target was followed and parsed with no audit signal:

- `_find_server_spec_anywhere` is on the dashboard's MCP server recovery path (it backs the enable/disable and preservation flows), so it runs on ordinary user clicks.
- `_resolve_mcp_server` runs in the zero-token script-cron path, which is unattended. Worse than the missing cap there: with no `except` on that path, a half-written spec raised `JSONDecodeError` -- and a non-UTF-8 spec `UnicodeDecodeError`, since `read_text()` used the platform default encoding -- straight out of the resolver into the cron runner. A spec being rewritten as a cron fired was enough.
- `_load_agent_config` backs MCP discovery from several surfaces. Its `except` looked like it covered the parse, but the explicit `encoding="utf-8"` meant a non-UTF-8 spec raised `UnicodeDecodeError`, which is neither an `OSError` nor a `JSONDecodeError` -- so that one case escaped to the caller.

For the hooks site nothing was read unsafely; what was lost is the security trail. An operator investigating a refusal saw it attributed to the wrong surface, which is precisely the failure the labels were introduced to prevent.

## 3. How the fix solves it

**`_find_server_spec_anywhere`** searches four scopes in merge order, and only the first is an agent spec -- the other three are provider `mcp.json` files, which the agent-spec reader does not describe. The agents-dir spec is statically first, so it is read through the hardened reader BEFORE the loop, and the loop now covers just the three plain paths. A local closure picks a usable entry out of one scope, so neither the early return nor the laziness changes. A refused spec degrades exactly as `_load_json_or_empty`'s `{}` did: that scope contributes nothing and the search falls through.

**`_resolve_mcp_server`** now reads through the reader with `operation="cron_resolve_mcp_server"`, `source="cron"`. `None` covers every unusable file -- including the two decode errors the old form let escape -- and degrades to "no such server", the answer an absent entry already gave. `agent_discovery` imports only `agent_files`, `config.paths`, `executors`, `hooks`, `security` and `sel`, none of which import `cron_script`, so the import is safe at module level.

**`_load_agent_config`** reads through the reader with `operation="mcp_discovery_agent_config"`, `source="unknown"` (it serves several interfaces, which is what `unknown` is for). `None` degrades as absent, matching the exceptions it used to swallow. The import is function-local, next to the existing lazy `AGENT_FILENAME` import that the module's own comment marks as circular.

**`_load_steering_resources`** reads through the reader with `operation="steering_resources"`, `source="unknown"` (dashboard chat, Slack and cron all reach it through the same context builder). Every outcome the surrounding blanket `except` used to absorb -- `PermissionError` on a sensitive resolved target, `AttributeError` on non-object JSON -- now arrives as `None` and returns the same empty string, without the read happening at all. The import is function-local to keep `agent_discovery` off `context`'s module-import path.

**`_doctor_mcp_governance`** reads through the reader with the same `operation="doctor"`, `source="cli"` labels as the two sibling calls already in that file, degrading to no declared servers exactly as its blanket `except` did.

**One change to the SHARED READER itself, which affects more than the six sites above -- flagged separately because it deserves explicit sign-off.** `agent_discovery` has two denial paths, and both promised not to raise: `_read_agent_spec` by the contract `_warn_on_systematic_scan_failure` documents ("deliberately degrades per file to `None` -- callers depend on that contract") and its ~15 bare call sites read it on, and `project_agent_names` in its own docstring ("Never raises; an unreadable checkout yields an empty set"). Both nonetheless called `_sel().log_api_access(...)` unguarded, and `sel()` constructs the `SecurityEventLog` singleton on first use, which mkdirs its home -- so on an unwritable or hostile SEL directory the audit raised and aborted whichever surface asked, on exactly the hostile path the refusal exists to handle. `project_agent_names` runs on EVERY turn of a project-agent-bound session with a caller-supplied path.

Both emissions now go through one `_audit_denied` helper that cannot raise. The trade, stated plainly so it can be accepted or rejected on its own: **the audit row becomes best-effort.** On a broken SEL subsystem a denial is no longer recorded in the trail; it is logged at WARNING with `exc_info` instead, so an operator sees the hole rather than finding it later. What does NOT change is the refusal -- the spec is rejected and the scan yields nothing in either shape, so no unaudited read or scan ever happens. This is best-effort by the SEL API's own design: `log_api_access` reserves fail-closed behaviour for its explicit `critical=True` callers (`apps/admission.py:154`, the auto-improvement server, whose comment names it "AUDIT-OR-DENY"), and neither of these sites has ever been one -- the pre-existing behaviour was an unhandled `OSError` escaping construction, which is a crash rather than a control. Making these sites genuinely fail-closed is a separate, larger change to a shared reader and is not attempted here.

**`api_kiro_hooks`** passes `operation="api_kiro_hooks"`, `source="dashboard"` explicitly. `asyncio.to_thread` forwards `**kwargs`, so this needs no wrapper.

**The ratchet is widened so this class cannot hide again.** A call that merely PASSES `_read_agent_spec` positionally now counts as a call site, with its labels read from the handing-off call. That covers `to_thread`, `functools.partial` and executor submission without an allowlist of wrapper names to maintain. The inventory assertion is exact equality, so it confirmed the widened walker found the hooks site and nothing unexpected.

**Write paths are deliberately excluded.** `mcp._remove_from_agent_file`, `apps/bridges._read_mcp_json_unlocked`, `cli_doctor._doctor_mcp_tools` and `agent._load_existing_config` read the same file inside a read-modify-write under `bridges._mcp_lock`. Migrating a read whose result is then written back is not mechanical: a refused read must not be allowed to write a truncated map. That is the same fail-closed question #6745 had to settle for the mint spec-writer (where the pre-push GPT lane showed the draft's fallback would hand a refused file to a spawned child), and it deserves its own change rather than a swap smuggled into a read-hardening PR. None regresses today: each already returns early without writing when the parse yields nothing for the requested name.

## 4. What tests we did

All targeted (this host cannot run the full suite; CI does).

Extended `test/test_agent_spec_hardened_reads.py` with three classes in the file's existing shape -- each pinning that a refused spec degrades as absent and that a valid spec is unaffected under the same lowered cap -- plus a differential test per migrated read:

- `TestFindServerSpecAnywhere`: refused spec contributes no spec; a valid spec is still found (with `disabled` stripped, as before). Server names carry a suffix because the search falls through to the provider `mcp.json` scopes, which are real files on a developer machine -- a generic name could be answered by one of those and read as a pass.
- `TestResolveMcpServer`: refused spec resolves to no server; a valid spec still resolves to its argv; and a truncated spec returns `None` instead of raising.
- `TestLoadAgentConfig`: refused spec contributes no servers; a valid spec still merges; and a non-UTF-8 spec no longer escapes the handler.
- `TestLoadSteeringResources`: a refused spec loads no steering; a valid spec still loads it; an absent spec still returns empty. The loader only accepts a `file://` resource that globs under `Path.home()` and resolves inside it, so the test points `HOME` at the isolated agents dir and writes the pattern relative to it -- the first draft of this test planted the file under `tmp_path`, where it could never load, and passed vacuously until the mutation run caught it.
- A new `agents_dir_resolver` fixture: the existing `agents_dir` fixture redirects `agent.KIRO_AGENTS_DIR`, but these sites resolve through `config.paths.kiro_agents_dir()`, which honours its OWN override -- so the fixture installs `config.paths._agents_dir_override` too, and clears `_resolve_mcp_server`'s `lru_cache` on both sides of the test.

- `TestDenialAuditNeverRaises`: with `_sel` replaced by a raiser and `is_sensitive_path` forced True, BOTH denial paths still degrade (`_read_agent_spec` to `None`, `project_agent_names` to an empty set) and both emit the operator-visible warning.

Mutation-verified, one mutation per change:

- reverting the mcp read to `_load_json_or_empty` reddens `test_refused_agent_spec_contributes_no_spec[oversized]` (the uncapped loader parses the oversized spec and hands back the phantom server) and the ratchet inventory.
- reverting the cron read to `json.loads(read_text())` reddens all three cron tests, each with a distinct pre-fix failure: `AttributeError: 'list' object has no attribute 'get'` (non-object), the oversized spec resolving to real argv, and `JSONDecodeError` escaping the resolver.
- reverting the mcp_discovery read (kept generous -- the mutant still normalizes a non-object to absent) reddens the oversized case and the non-UTF-8 case, the latter with `UnicodeDecodeError` escaping exactly as described above.
- reverting the context.py read to `json.loads(safe_read_file(...))` reddens `test_refused_agent_spec_loads_no_steering[oversized]`: the uncapped read parses the oversized spec and the steering marker loads. This mutation is what exposed the vacuous first draft of the test, which passed under the mutant.
- removing the `_audit_denied` guard reddens both denial tests with `OSError: SEL home is not writable` -- the abort itself.
- dropping the hooks labels reddens both ratchet tests with `kiro_crew/dashboard/handlers/hooks.py calls _read_agent_spec without an explicit operation label` -- which also proves the widened walker is load-bearing, since the old walker could not see that call at all.

Runs:

- `pytest test/test_agent_spec_hardened_reads.py` -- 53 passed (32 before this PR)
- `pytest test/test_mcp_discovery.py` -- 196 passed, 4 skipped
- `pytest test/test_context.py test/test_context_management.py` -- 124 passed
- `pytest test/test_agent_spec_hardened_reads.py test/test_dashboard_agent_spec_reads.py test/test_agent_discovery.py` -- 106 passed (before the last two rounds)
- isort, flake8 clean on all six touched files; mypy clean on the source files; `black --check` clean on `context.py` and the test file (the other four source files are black-baseline entries and were not reformatted, so the diff carries no unrelated churn).

## 5. Any other suggestions on the work

**This PR is one batch, not the end of the series.** The #5423 -> #6695 -> #6723 -> #6726 -> #6745 sequence migrated call sites in batches, and so does this one. What remains is named here rather than implied.

- **The bypass class is still open, and that is the real mechanism.** `TestCallSiteLabelRatchet` inventories calls TO the reader, so it polices only sites that already use it -- nothing in the tree fails when a new bare `read_text` on the agents-dir spec is added, which is how these six accumulated. Closing it needs a second ratchet that scans `src/` for a read of a path built from `AGENT_FILENAME` / `"kirocrew.json"` outside `agent_discovery`, with the four write paths and `_walk_spec` below as named allowlist entries. Not built here: its own false-positive surface (about ten legitimate readers, several building the path indirectly) deserves its own review rather than riding along at the end of this one.
- **`doctor_deadpath.py` `_walk_spec` is deliberately NOT migrated.** It returns `(dead_paths, unreadable_reason)` and separates its failure modes on purpose -- `OSError` becomes `"unreadable (...)"`, `UnicodeError` becomes `"not valid UTF-8 (...)"`, the latter caught separately with a comment saying why. `_read_agent_spec` is reason-less by design, so routing this read through it would collapse both into one undifferentiated "unreadable" in the output of a command whose job is to say WHY a spec could not be read. Hardening it properly means giving the reader a refusal reason, which changes its API and its ten callers.
- **Four read-modify-write sites are deferred together:** `mcp._remove_from_agent_file`, `apps/bridges._read_mcp_json_unlocked`, `cli_doctor._doctor_mcp_tools`, and `agent._load_existing_config`. Each reads the spec and writes it back (three inside a lock), so each needs the same decision first: what a refused read may write. That is the fail-closed question #6745 settled for the mint spec-writer, and it is worth settling once for all four rather than site by site. None regresses today -- each already returns early without writing when the parse yields nothing.
- **The three provider `mcp.json` candidates in `_find_server_spec_anywhere`** stay on `_load_json_or_empty` -- user-writable JSON with no cap or screen, the identical threat one line away (raised by Design Review). They are NOT agent specs, so `_read_agent_spec` is the wrong reader: hardening them means a capped, screened loader for provider MCP files plus its own call-site sweep.
- **`_resolve_mcp_server` still raises `KeyError` on a url-only server entry.** `spec["command"]` assumes a stdio server; an http entry (`url`, no `command`) crashes the resolver. Unrelated to the read hardening -- the reader hands back a perfectly valid spec -- and this PR deliberately does not change what the function does with a spec it accepts.

**One coverage gap, disclosed rather than papered over.** The migrated `_doctor_mcp_governance` site has no behaviour test. I tried three assertions and none discriminated: the check never echoes an unrecognized server name, its silence depends on ambient identity and config (so asserting on it is host-dependent), and its `affected:` line did not separate the two states either -- each attempt stayed green with the read reverted. Its pin is the ratchet entry, which IS mutation-verified red when the read is reverted, plus the reader's own guard matrix. The other five migrated sites each carry a differential behaviour test.
