### PR TITLE
fix(deploy): make JSON body-guard helpers documented decisions (#7028)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
@@ -259,10 +259,26 @@ def _redact_tree(value: Any) -> Any:
 
 
 async def _json_body(request: web.Request) -> dict[str, Any]:
-    """Parse a JSON object body, tolerating an empty one."""
+    """Parse a JSON object body, tolerating an empty one.
+
+    Diverges DELIBERATELY from the dashboard contract
+    (``dashboard/handlers/_shared.read_bounded_json``, which answers 400 for a
+    non-object): every call site here treats the result as a config *patch* and
+    only ever reads known keys off it (``set(patch)``, ``patch.items()``,
+    ``body.get(...)``), so an empty object is a legitimate no-op request. A
+    malformed OR non-object body therefore collapses to ``{}`` (an empty patch)
+    on purpose rather than a 400 — there is no field whose absence widens an
+    operation here, unlike ``session_storage._json_body``.
+
+    The catch is narrowed to the client-input failure set
+    (``LookupError`` from an unknown ``charset=`` codec, ``RecursionError`` from a
+    deeply nested body, ``ValueError``/``UnicodeDecodeError`` from undecodable or
+    non-JSON bytes) so a mid-read transport error (a client disconnect) still
+    propagates rather than being mislabelled a client mistake.
+    """
     try:
         body = await request.json()
-    except Exception:  # noqa: BLE001 - malformed body is a client error, not a crash
+    except (LookupError, RecursionError, ValueError):
         return {}
     return body if isinstance(body, dict) else {}
 

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_json_body_guard.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_json_body_guard.py
@@ -1,0 +1,71 @@
+"""``_json_body`` is the body guard every mutating auto_improvement route shares.
+
+It DELIBERATELY diverges from the dashboard's ``read_bounded_json`` contract: a
+malformed OR non-object body collapses to ``{}`` (an empty config patch), because
+every call site only reads known keys off the result and an empty patch is a safe
+no-op. What must NOT diverge is the catch width — it was ``except Exception``,
+which swallowed a mid-read transport error (a client disconnect) and mislabelled
+it as ``{}``. These tests pin the narrowed ``(LookupError, RecursionError,
+ValueError)`` catch: a client-input failure still yields ``{}``, but a transport
+error propagates.
+
+Runtime execution is deferred to CI, where aiohttp is installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.apps.builtins.auto_improvement.backend import routes
+
+
+def _req_raising(exc: Exception):
+    """A real ``web.Request`` whose ``.json()`` raises *exc*."""
+    request = make_mocked_request("PUT", "/api/apps/auto-improvement/config")
+
+    async def _json(*_args: object, **_kwargs: object) -> object:
+        raise exc
+
+    request.json = _json  # type: ignore[method-assign]
+    return request
+
+
+def _req_returning(value: object):
+    request = make_mocked_request("PUT", "/api/apps/auto-improvement/config")
+
+    async def _json(*_args: object, **_kwargs: object) -> object:
+        return value
+
+    request.json = _json  # type: ignore[method-assign]
+    return request
+
+
+@pytest.mark.asyncio
+async def test_a_non_object_body_becomes_an_empty_patch() -> None:
+    # Documented divergence: a non-object is a safe empty patch here, not a 400.
+    assert await routes._json_body(_req_returning([1, 2, 3])) == {}
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_becomes_an_empty_patch() -> None:
+    assert await routes._json_body(_req_raising(ValueError("bad json"))) == {}
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_charset_codec_is_tolerated_not_a_500() -> None:
+    # An unknown ``charset=`` codec raises LookupError, not ValueError. The old
+    # ``except Exception`` caught it by accident; the narrowed catch must still
+    # cover it so a bad codec is a tolerated empty patch, not an uncaught 500.
+    assert await routes._json_body(_req_raising(LookupError("unknown encoding"))) == {}
+
+
+@pytest.mark.asyncio
+async def test_a_transport_error_propagates_not_swallowed() -> None:
+    # A client disconnect mid-read is NOT a client-input mistake. The narrowed
+    # catch must let it propagate rather than reporting it as an empty patch.
+    class _Disconnect(Exception):
+        pass
+
+    with pytest.raises(_Disconnect):
+        await routes._json_body(_req_raising(_Disconnect("connection reset")))

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -6036,13 +6036,21 @@ async def _json_body(
 ) -> tuple[dict | None, web.Response | None]:
     """Parse a JSON object body; (body, None) on success, (None, 400) otherwise.
 
-    Pass ``code`` for endpoints whose error contract promises a
-    machine-readable ``code`` on every failure response; the rejection then
-    carries it alongside the human-readable ``error``.
+    Same 400-for-non-object / (body, None)-tuple contract as
+    ``dashboard/handlers/_shared.read_bounded_json``; the one deliberate
+    divergence is the optional ``code``: pass it for endpoints whose error
+    contract promises a machine-readable ``code`` on every failure response, and
+    the rejection then carries it alongside the human-readable ``error``.
+
+    The catch covers the client-input failure set
+    (``LookupError`` from an unknown ``charset=`` codec, ``RecursionError`` from a
+    deeply nested body, ``ValueError`` from undecodable or non-JSON bytes) so a
+    bad codec is a 400 rather than an uncaught 500, while a mid-read transport
+    error still propagates as itself.
     """
     try:
         body = await request.json() if request.content_length else {}
-    except ValueError:
+    except (LookupError, RecursionError, ValueError):
         if code:
             return None, web.json_response(
                 {"error": "invalid JSON body", "code": code}, status=400

--- a/src/kiro_crew/apps/builtins/issue_radar/backend/crew_routes.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/backend/crew_routes.py
@@ -390,10 +390,18 @@ async def _json_object(request: web.Request) -> tuple[dict, web.Response | None]
     Split out of :func:`_body_preamble` so the agent write path can read a body
     without the owner/repo gate it does not use — one implementation, so the two
     paths cannot drift on which malformed payload gets which refusal.
+
+    Follows the ``dashboard/handlers/_shared.read_bounded_json`` contract on
+    Q1/Q2 (400 for a non-object; catch spanning the client-input failure set of
+    ``LookupError``/``RecursionError``/``ValueError`` so an unknown ``charset=``
+    codec is a 400 and a mid-read transport error still propagates). The
+    deliberate divergence is the extra ``_holds_non_finite_number`` gate below:
+    ``NaN``/``Infinity`` decode fine here but are not valid JSON on the wire, so
+    they are refused rather than persisted.
     """
     try:
         raw = await request.json()
-    except Exception:
+    except (LookupError, RecursionError, ValueError):
         return {}, web.json_response(
             {"error": "request body must be JSON", "code": "invalid_json"}, status=400
         )

--- a/src/kiro_crew/apps/builtins/issue_radar/tests/test_crew_routes_json_object.py
+++ b/src/kiro_crew/apps/builtins/issue_radar/tests/test_crew_routes_json_object.py
@@ -1,0 +1,80 @@
+"""``_json_object`` is the body guard the agent write path shares with
+``_body_preamble``.
+
+It follows the dashboard's ``read_bounded_json`` contract on catch width: the
+catch was narrowed from ``except Exception`` to the client-input failure set
+``(LookupError, RecursionError, ValueError)`` so a mid-read transport error (a
+client disconnect) propagates as itself rather than being mislabelled a 400. A
+client-input failure (malformed JSON, an unknown ``charset=`` codec) still turns
+into a 400; a non-object body is a 400; a non-finite number is a 400 (the
+deliberate divergence). These tests pin that boundary so a future re-widening to
+``except Exception`` — which would swallow the disconnect again — fails loudly.
+
+Runtime execution is deferred to CI, where aiohttp is installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.apps.builtins.issue_radar.backend import crew_routes
+
+
+def _req(payload: object) -> web.Request:
+    """A real ``web.Request`` whose ``.json()`` yields (or raises) *payload*.
+
+    Mirrors ``test_pr_actions._req``: built on aiohttp's own
+    ``make_mocked_request`` so the handler runs against the actual Request type.
+    Passing an Exception makes ``.json()`` raise it, reaching the malformed-body
+    path.
+    """
+    request = make_mocked_request("POST", "/api/apps/issue-radar/agent/issue/comment")
+
+    async def _json(*_args: object, **_kwargs: object) -> object:
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+    request.json = _json  # type: ignore[method-assign]
+    return request
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_is_400() -> None:
+    body, early = await crew_routes._json_object(_req(ValueError("bad json")))
+    assert body == {}
+    assert early is not None
+    assert early.status == 400
+
+
+@pytest.mark.asyncio
+async def test_unknown_charset_codec_is_400_not_500() -> None:
+    # An unknown ``charset=`` codec raises LookupError, not ValueError. The old
+    # ``except Exception`` caught it by accident; the narrowed catch must still
+    # cover it so a bad codec is a 400, not an uncaught 500.
+    body, early = await crew_routes._json_object(_req(LookupError("unknown encoding")))
+    assert body == {}
+    assert early is not None
+    assert early.status == 400
+
+
+@pytest.mark.asyncio
+async def test_non_object_body_is_400() -> None:
+    body, early = await crew_routes._json_object(_req([1, 2, 3]))
+    assert body == {}
+    assert early is not None
+    assert early.status == 400
+
+
+@pytest.mark.asyncio
+async def test_transport_error_propagates_not_swallowed() -> None:
+    # A client disconnect mid-read is NOT a client-input mistake. The narrowed
+    # catch must let it propagate rather than reporting it as a 400. A re-widening
+    # to ``except Exception`` would swallow this and fail the test.
+    class _Disconnect(Exception):
+        pass
+
+    with pytest.raises(_Disconnect):
+        await crew_routes._json_object(_req(_Disconnect("connection reset")))

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
@@ -158,9 +158,20 @@ def _require_enabled(handler: Handler) -> Handler:
 
 
 async def _json_body(request: web.Request) -> dict[str, Any] | None:
+    """Parse a JSON object body; ``None`` when it is malformed or not an object.
+
+    Same Q1/Q2 posture as ``dashboard/handlers/_shared.read_bounded_json`` (a
+    non-object is refused, and the catch spans the client-input failure set of
+    ``LookupError``/``RecursionError``/``ValueError`` so an unknown ``charset=``
+    codec is a 400, not a 500). The deliberate divergence is the return shape:
+    this yields ``dict | None`` and lets each caller answer the 400 itself,
+    rather than the ``(body, response)`` tuple the shared helper returns. The
+    catch is narrowed from the previous ``except Exception`` so a mid-read
+    transport error propagates instead of being reported as a client mistake.
+    """
     try:
         body = await request.json()
-    except Exception:  # noqa: BLE001 — malformed body is a 400, not a 500
+    except (LookupError, RecursionError, ValueError):
         return None
     return body if isinstance(body, dict) else None
 

--- a/src/kiro_crew/apps/builtins/papyrus/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/routes.py
@@ -179,14 +179,25 @@ def _clean(text: str) -> str:
 
 
 async def _json_body(request: web.Request) -> dict[str, Any]:
-    """Read a JSON object body, or raise a 400 ``HTTPException``."""
+    """Read a JSON object body, or raise a 400 ``HTTPException``.
+
+    Same Q1/Q2 posture as ``dashboard/handlers/_shared.read_bounded_json`` (a
+    non-object is refused, and the catch spans the client-input failure set of
+    ``LookupError``/``RecursionError``/``ValueError`` so an unknown ``charset=``
+    codec is a 400, not a 500). Two deliberate divergences: the refusal is raised
+    as an ``HTTPException`` rather than returned as a ``(body, response)`` tuple,
+    matching this module's raise-based error envelope; and the ``MAX_BODY_BYTES``
+    Content-Length cap is enforced up front. The catch is narrowed from the
+    previous ``except Exception`` so a mid-read transport error propagates instead
+    of being reported as a client mistake.
+    """
     if request.content_length is not None and request.content_length > MAX_BODY_BYTES:
         raise web.HTTPRequestEntityTooLarge(
             max_size=MAX_BODY_BYTES, actual_size=request.content_length
         )
     try:
         body = await request.json()
-    except Exception as exc:
+    except (LookupError, RecursionError, ValueError) as exc:
         raise web.HTTPBadRequest(reason="request body must be JSON") from exc
     if not isinstance(body, dict):
         raise web.HTTPBadRequest(reason="request body must be a JSON object")

--- a/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
@@ -103,10 +103,20 @@ async def _json_object(
     array parses fine as JSON but has no ``.get``, so without this check every
     handler would raise ``AttributeError`` and return a 500 to a client that
     merely sent the wrong shape.
+
+    Follows the ``dashboard/handlers/_shared.read_bounded_json`` contract on
+    Q1/Q2 (400 for a non-object, catch spanning the client-input failure set).
+    The deliberate divergence is ``_strict_loads``: ``parse_constant`` rejects
+    ``NaN``/``Infinity``/``-Infinity`` at the boundary (see ``_reject_non_finite``)
+    so a non-finite number can never be persisted into a record the browser's
+    ``JSON.parse`` would then choke on. The catch is widened past
+    ``ValueError`` to include ``LookupError`` (an unknown ``charset=`` codec) and
+    ``RecursionError`` (a deeply nested body) so those become a 400, not a 500,
+    while a mid-read transport error still propagates.
     """
     try:
         body = await request.json(loads=_strict_loads)
-    except ValueError:
+    except (LookupError, RecursionError, ValueError):
         return None, _bad_request("invalid JSON", "invalid_json")
     if not isinstance(body, dict):
         return None, _bad_request("body must be a JSON object", "body_not_object")

--- a/src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from unittest import mock
 
 from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
 
 from kiro_crew.apps.builtins.personal_shopper.backend import routes as routes_mod
 from kiro_crew.apps.builtins.personal_shopper.backend.store import PreferenceStore
@@ -113,6 +113,42 @@ class TestBodyShapeIsAClientError(RoutesTestCase):
         )
         self.assertEqual(resp.status, 201)
         self.assertTrue((await resp.json())["id"])
+
+
+def _req_raising(exc: Exception) -> web.Request:
+    """A real ``web.Request`` whose ``.json()`` raises *exc*.
+
+    ``_json_object`` only calls ``request.json``, so overriding it on a mocked
+    request exercises the catch directly without wiring a full transport.
+    """
+    request = make_mocked_request("POST", f"{_PREFIX}/preferences")
+
+    async def _json(*_args: object, **_kwargs: object) -> object:
+        raise exc
+
+    request.json = _json  # type: ignore[method-assign]
+    return request
+
+
+class TestJsonObjectCatchWidth(unittest.IsolatedAsyncioTestCase):
+    """The catch must span the client-input failure set, not ValueError alone."""
+
+    async def test_an_unknown_charset_codec_is_a_400_not_a_500(self) -> None:
+        # An unknown ``charset=`` on the request makes aiohttp's decode step raise
+        # LookupError (not a ValueError), which used to escape ``_json_object`` as
+        # a 500. It is a client-input mistake and must answer 400.
+        body, err = await routes_mod._json_object(
+            _req_raising(LookupError("unknown encoding: bogus-codec"))
+        )
+        self.assertIsNone(body)
+        assert err is not None
+        self.assertEqual(err.status, 400)
+
+    async def test_a_recursion_error_from_a_deep_body_is_a_400(self) -> None:
+        body, err = await routes_mod._json_object(_req_raising(RecursionError()))
+        self.assertIsNone(body)
+        assert err is not None
+        self.assertEqual(err.status, 400)
 
 
 class TestSearchArgumentValidation(RoutesTestCase):

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/routes.py
@@ -478,10 +478,25 @@ async def _read_body(request: web.Request) -> bytes | None:
 
 
 async def _json_body(request: web.Request) -> tuple[dict | None, web.Response | None]:
-    """Parse a JSON object body, or return the 400 to send back."""
+    """Parse a JSON object body, or return the 400 to send back.
+
+    Same 400-for-non-object / (body, None)-tuple contract as
+    ``dashboard/handlers/_shared.read_bounded_json``; the deliberate divergence is
+    the app-specific ``code`` values (``body_not_json`` / ``body_not_object``)
+    that the dashboard switches on. Unlike ``read_bounded_json`` this helper does
+    not cap the body — the size-bounded reader ``_read_body`` guards the raw-body
+    ``styles/import`` endpoint instead, not this JSON path.
+
+    The catch spans the client-input failure set: ``LookupError`` (an unknown
+    ``charset=`` codec) previously escaped as a 500 and is now a 400, and
+    ``RecursionError`` (a deeply nested body) is caught for the same reason.
+    ``UnicodeDecodeError`` is a ``ValueError`` subclass, so ``ValueError`` alone
+    already covers undecodable bytes; it is dropped from the tuple as redundant.
+    A mid-read transport error still propagates as itself.
+    """
     try:
         body = await request.json()
-    except (ValueError, UnicodeDecodeError):
+    except (LookupError, RecursionError, ValueError):
         return None, web.json_response(
             {"error": "request body must be JSON", "code": "body_not_json"}, status=400
         )

--- a/src/kiro_crew/deploy/handlers.py
+++ b/src/kiro_crew/deploy/handlers.py
@@ -1329,12 +1329,37 @@ def _strip_confirm_for_internal(request: web.Request, params: dict[str, Any]) ->
     return params
 
 
-async def _json_body(request: web.Request) -> dict[str, Any]:
+async def _json_body(
+    request: web.Request,
+) -> tuple[dict[str, Any] | None, web.Response | None]:
+    """Parse a JSON *object* body, following the ``read_bounded_json`` 400 contract.
+
+    Returns ``(body, None)`` on success, or ``(None, error_response)`` when the
+    caller should return early. Deploy has no app-specific reason to diverge from
+    the shared dashboard contract (``dashboard/handlers/_shared.py::read_bounded_json``),
+    so it answers a body-shape 400 for BOTH a malformed body and a valid-JSON body
+    that is not an object. Otherwise a bad-shape request collapses to ``{}`` and
+    surfaces as a downstream field error (e.g. ``400 invalid config: ...``) instead
+    of the body-shape mistake it actually is.
+
+    The catch spans the full client-input failure set: an unknown ``charset=`` codec
+    raises ``LookupError`` and undecodable bytes raise ``UnicodeDecodeError`` (a
+    ``ValueError``, not a ``json.JSONDecodeError``), so catching only the latter would
+    let those escape as a 500. Transport/disconnect errors are deliberately NOT caught
+    (no bare ``Exception``) so a client disconnect propagates rather than being reported
+    as a client mistake.
+    """
     try:
         body = await request.json()
-    except json.JSONDecodeError:
-        return {}
-    return body if isinstance(body, dict) else {}
+    except (LookupError, RecursionError, ValueError):
+        return None, web.json_response(
+            {"error": "invalid JSON body", "code": "invalid_json"}, status=400
+        )
+    if not isinstance(body, dict):
+        return None, web.json_response(
+            {"error": "body must be a JSON object", "code": "body_not_object"}, status=400
+        )
+    return body, None
 
 
 @_internal_denied
@@ -1364,7 +1389,10 @@ async def _handle_put_config(request: web.Request) -> web.Response:
     denied = _deny_restricted(request, "config_update")
     if denied:
         return denied
-    body = await _json_body(request)
+    body, err = await _json_body(request)
+    if err is not None:
+        return err
+    assert body is not None  # _json_body returns (dict, None) on success
     try:
         profile = validate_field(str(body.get("profile", "")), _PROFILE_SPEC)
         region = validate_field(str(body.get("region", "")), _REGION_SPEC)
@@ -1404,7 +1432,11 @@ async def _handle_deploy(request: web.Request) -> web.Response:
             },
             status=403,
         )
-    params = _strip_confirm_for_internal(request, await _json_body(request))
+    params, err = await _json_body(request)
+    if err is not None:
+        return err
+    assert params is not None  # _json_body returns (dict, None) on success
+    params = _strip_confirm_for_internal(request, params)
     status, payload = await _do_deploy(params)
     return web.json_response(_sanitize_response(payload), status=status)
 
@@ -1414,7 +1446,10 @@ async def _handle_recall(request: web.Request) -> web.Response:
     denied = _deny_restricted(request, "recall")
     if denied:
         return denied
-    params = await _json_body(request)
+    params, err = await _json_body(request)
+    if err is not None:
+        return err
+    assert params is not None  # _json_body returns (dict, None) on success
     status, payload = await _do_recall(params)
     return web.json_response(_sanitize_response(payload), status=status)
 
@@ -1424,7 +1459,10 @@ async def _handle_destroy(request: web.Request) -> web.Response:
     denied = _deny_restricted(request, "destroy")
     if denied:
         return denied
-    params = await _json_body(request)
+    params, err = await _json_body(request)
+    if err is not None:
+        return err
+    assert params is not None  # _json_body returns (dict, None) on success
     status, payload = await _do_destroy(params)
     return web.json_response(_sanitize_response(payload), status=status)
 
@@ -1474,7 +1512,10 @@ async def _handle_verify(request: web.Request) -> web.Response:
     denied = _deny_restricted(request, "verify")
     if denied:
         return denied
-    body = await _json_body(request)
+    body, err = await _json_body(request)
+    if err is not None:
+        return err
+    assert body is not None  # _json_body returns (dict, None) on success
     try:
         profile, _region = await _resolve_profile(body)
     except _ProfileResolveError as e:
@@ -1550,7 +1591,10 @@ async def _handle_profiles_post(request: web.Request) -> web.Response:
     denied = _deny_restricted(request, "profile_create")
     if denied:
         return denied
-    body = await _json_body(request)
+    body, body_err = await _json_body(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # _json_body returns (dict, None) on success
     try:
         name = validate_field(str(body.get("name", "")), _PROFILE_SPEC)
         region = validate_field(str(body.get("region", "")) or DEFAULT_REGION, _REGION_SPEC)
@@ -1618,7 +1662,10 @@ async def _handle_profiles_put(request: web.Request) -> web.Response:
     denied = _deny_restricted(request, "profile_update")
     if denied:
         return denied
-    body = await _json_body(request)
+    body, err = await _json_body(request)
+    if err is not None:
+        return err
+    assert body is not None  # _json_body returns (dict, None) on success
     # match_info name is LLM/user-influenceable — validate like the POST path
     # before it reaches the registry lookup / error strings / audit call.
     try:
@@ -2236,8 +2283,13 @@ async def _handle_pending_confirm(request: web.Request) -> web.Response:
     # This handler is @_internal_denied, so the flag can only originate from a
     # cookie/token-authenticated human, never from the MCP caller.
     if entry.get("override_scan_required"):
-        body = await _json_body(request)
-        if body.get("override_scan") is True:
+        # Deliberate divergence from the _json_body 400 contract: the pending
+        # entry was already popped above, so answering a body-shape 400 here
+        # would drop it. A malformed or absent body therefore means "no
+        # override" — _do_deploy re-blocks on the same findings, which is the
+        # conservative outcome — rather than an error response.
+        body, _body_err = await _json_body(request)
+        if body is not None and body.get("override_scan") is True:
             params["override_scan"] = True
             _audit("pending_confirm", entry_id, "allowed",
                    error="human override_scan on non-credential findings")

--- a/test/test_deploy_handlers_coverage.py
+++ b/test/test_deploy_handlers_coverage.py
@@ -70,8 +70,13 @@ class _NonRestrictedState:
 class _FakeReq:
     """Request double with a non-restricted app state installed."""
 
-    def __init__(self, body=None, *, match_info=None, query=None, headers=None):
+    def __init__(self, body=None, *, match_info=None, query=None, headers=None, json_exc=None):
         self._body = {} if body is None else body
+        # When set, ``json()`` raises this instead of decoding ``_body`` — used to
+        # exercise the widened catch set (LookupError for an unknown charset codec,
+        # UnicodeDecodeError for undecodable bytes) and to prove transport errors
+        # propagate rather than being swallowed as a 400.
+        self._json_exc = json_exc
         self.headers = headers if headers is not None else {"X-Session-Key": "dashboard:ui"}
         self.app = {"state": _NonRestrictedState()}
         self.match_info = match_info or {}
@@ -79,6 +84,8 @@ class _FakeReq:
         self.rel_url = SimpleNamespace(query=self.query)
 
     async def json(self):
+        if self._json_exc is not None:
+            raise self._json_exc
         if isinstance(self._body, str):
             raise json.JSONDecodeError("bad", self._body, 0)
         return self._body
@@ -835,12 +842,89 @@ class TestDoList:
 
 class TestAdapters:
     @pytest.mark.asyncio
-    async def test_json_body_tolerates_invalid_json(self):
-        assert await handlers._json_body(_FakeReq("not json")) == {}
+    async def test_json_body_accepts_object(self):
+        body, err = await handlers._json_body(_FakeReq({"profile": "p"}))
+        assert body == {"profile": "p"} and err is None
 
     @pytest.mark.asyncio
-    async def test_json_body_rejects_non_object(self):
-        assert await handlers._json_body(_FakeReq([1, 2])) == {}
+    async def test_json_body_rejects_malformed_with_400(self):
+        # A malformed body is a body-shape mistake, not "no arguments given":
+        # answer 400 rather than collapsing to {} (the old buggy behaviour).
+        body, err = await handlers._json_body(_FakeReq("not json"))
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _payload(err)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_json_body_rejects_non_object_with_400(self):
+        body, err = await handlers._json_body(_FakeReq([1, 2]))
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _payload(err)["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    async def test_json_body_widened_catch_lookup_error(self):
+        # An unknown ``charset=`` codec raises LookupError from request.json();
+        # the old ``except json.JSONDecodeError`` let it escape as a 500.
+        body, err = await handlers._json_body(
+            _FakeReq(json_exc=LookupError("unknown encoding: bogus")))
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _payload(err)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_json_body_widened_catch_unicode_decode_error(self):
+        # Undecodable bytes raise UnicodeDecodeError — a ValueError, not a
+        # JSONDecodeError — so the widened catch must turn it into a 400.
+        exc = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        body, err = await handlers._json_body(_FakeReq(json_exc=exc))
+        assert body is None
+        assert err is not None and err.status == 400
+        assert _payload(err)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_json_body_lets_transport_errors_propagate(self):
+        # A client disconnect must NOT be reported as a client-shape 400: the
+        # helper does not catch bare Exception, so it propagates.
+        class _Disconnect(Exception):
+            pass
+
+        with pytest.raises(_Disconnect):
+            await handlers._json_body(_FakeReq(json_exc=_Disconnect("connection reset")))
+
+    @pytest.mark.asyncio
+    async def test_put_config_non_object_body_is_body_shape_400(self):
+        # Previously reachable bug: a non-object body collapsed to {}, so
+        # validate_field ran on profile=""/region="" and answered
+        # "400 invalid config: ..." — a field error for a body-shape mistake.
+        resp = await handlers._handle_put_config(_FakeReq([]))
+        assert resp.status == 400
+        body = _payload(resp)
+        assert body["code"] == "body_not_object"
+        assert "invalid config" not in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_config_malformed_body_is_body_shape_400(self):
+        resp = await handlers._handle_put_config(_FakeReq("not json"))
+        assert resp.status == 400
+        assert _payload(resp)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_deploy_malformed_body_returns_400(self, monkeypatch):
+        # The body-shape 400 fires before deploy proceeds with empty params.
+        monkeypatch.setattr(handlers, "publish_denied_reason", lambda *a, **kw: "")
+        resp = await handlers._handle_deploy(_FakeReq("not json"))
+        assert resp.status == 400 and _payload(resp)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_recall_malformed_body_returns_400(self):
+        resp = await handlers._handle_recall(_FakeReq("not json"))
+        assert resp.status == 400 and _payload(resp)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_destroy_malformed_body_returns_400(self):
+        resp = await handlers._handle_destroy(_FakeReq("not json"))
+        assert resp.status == 400 and _payload(resp)["code"] == "invalid_json"
 
     @pytest.mark.asyncio
     async def test_get_config_returns_registry_default(self):

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -1689,6 +1689,18 @@ async def test_json_body_empty_request_is_empty_dict():
 
 
 @pytest.mark.asyncio
+async def test_json_body_unknown_charset_is_400_not_500():
+    # An unknown ``charset=`` codec makes aiohttp's decode step raise LookupError,
+    # not JSONDecodeError. The catch was ValueError-only, so this used to escape as
+    # a 500; it is a client-input mistake and must answer 400. Guards the widened
+    # (LookupError, RecursionError, ValueError) catch against a regression.
+    body, err = await mod._json_body(
+        _raw_request(b"{}", json_error=LookupError("unknown encoding: bogus-codec"))
+    )
+    assert body is None and err is not None and err.status == 400
+
+
+@pytest.mark.asyncio
 async def test_worktree_remove_handler_rejects_non_bool_force(monkeypatch):
     _sel_capture(monkeypatch)
     monkeypatch.setattr(mod, "_valid_worktree_names", AsyncMock(return_value={"feat"}))

--- a/test/test_pptx_maker_routes.py
+++ b/test/test_pptx_maker_routes.py
@@ -37,7 +37,7 @@ from typing import Callable
 from unittest import mock
 
 from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase
+from aiohttp.test_utils import AioHTTPTestCase, make_mocked_request
 
 from conftest import make_dir_link
 from kiro_crew.apps.builtins.pptx_maker.backend import engine, paths, provision, routes
@@ -1346,6 +1346,45 @@ class TestWorkerResponseContract(unittest.TestCase):
         string rather than an absent key that throws in the client."""
         resp = routes._worker_response(500, {})
         self.assertEqual(json.loads(resp.body), {"error": "", "code": ""})
+
+
+def _json_req_raising(exc: Exception) -> web.Request:
+    """A real ``web.Request`` whose ``.json()`` raises *exc*.
+
+    ``_json_body`` only calls ``request.json``, so overriding it exercises the
+    catch directly without wiring a full transport.
+    """
+    request = make_mocked_request("POST", "/api/apps/pptx-maker/decks")
+
+    async def _json(*_args: object, **_kwargs: object) -> object:
+        raise exc
+
+    request.json = _json  # type: ignore[method-assign]
+    return request
+
+
+class TestJsonBodyCatchWidth(unittest.IsolatedAsyncioTestCase):
+    """The catch must span the client-input failure set.
+
+    ``UnicodeDecodeError`` is a ``ValueError`` subclass, so the old
+    ``(ValueError, UnicodeDecodeError)`` tuple never covered ``LookupError`` from an
+    unknown ``charset=`` codec — that escaped as a 500. The widened catch turns it
+    into the 400 it always was."""
+
+    async def test_an_unknown_charset_codec_is_a_400_not_a_500(self) -> None:
+        body, err = await routes._json_body(
+            _json_req_raising(LookupError("unknown encoding: bogus-codec"))
+        )
+        self.assertIsNone(body)
+        assert err is not None
+        self.assertEqual(err.status, 400)
+        self.assertEqual(json.loads(err.body)["code"], "body_not_json")
+
+    async def test_a_recursion_error_from_a_deep_body_is_a_400(self) -> None:
+        body, err = await routes._json_body(_json_req_raising(RecursionError()))
+        self.assertIsNone(body)
+        assert err is not None
+        self.assertEqual(err.status, 400)
 
 
 class TestIconProvisionedMarker(unittest.TestCase):


### PR DESCRIPTION
Closes #7028.

Follow-up from the First Principles review of #7012, which consolidated the dashboard's two JSON-object body guards into `_shared.read_bounded_json` but only scanned `src/kiro_crew/dashboard/`. This PR extends the same contract to the trees that scan never walked.

## Part 1 — the real deploy bug

`src/kiro_crew/deploy/handlers.py::_json_body` previously collapsed **both** malformed and non-object bodies to `{}` and caught only `json.JSONDecodeError`.

- Now returns `tuple[dict | None, web.Response | None]`, matching `dashboard/handlers/_shared.read_bounded_json`.
- Answers a body-shape **400** (`invalid_json` / `body_not_object`) for both malformed and valid-JSON-non-object bodies, instead of the previously reachable `_handle_put_config([]) -> "400 invalid config: ..."` field-level mislabel.
- Widens the catch from `json.JSONDecodeError` to `(LookupError, RecursionError, ValueError)`, so an unknown `charset=` codec and undecodable bytes become a **400** rather than escaping as a **500**.
- Bare `Exception` is deliberately **not** caught, so client disconnects propagate.
- All four call sites (`_handle_put_config`, `_handle_deploy`, `_handle_recall`, `_handle_destroy`) consume the tuple, with their deny/internal/publish gates still ordered ahead of the body read.

## Part 2 — audit the seven `apps/builtins/` helpers

Each helper was made a **documented decision** against the issue's three questions. This is **not** a collapse of all eight onto the shared helper — deliberate divergences were preserved.

- **Catch-width fixes** (added `LookupError`; an unknown codec was escaping as 500): `dev_fleet`, `personal_shopper`, `pptx_maker`.
- **Transport-propagation fixes** (narrowed `except Exception` so disconnects propagate): `auto_improvement`, `ops_mission_control`, `papyrus`, `issue_radar`.
- `auto_improvement` keeps `{}`-on-non-object as a **documented** safe empty-patch no-op (call sites only read known keys).
- Every helper gained a docstring referencing `read_bounded_json`.
- Preserved deliberately: `issue_radar`/`personal_shopper` strict non-finite parsing, `papyrus`/`pptx_maker` size caps, `pptx_maker` error-code dict-literal contract.

## Verification

- Static (per the sandbox's INTEGRATIONS_ONLY network mode): AST parse OK on all edited files; `isort --check-only` PASS; black ratchet green.
- **Runtime pytest is deferred to CI:** `aiohttp` is not installed in the sandbox and cannot be installed under the restricted network mode, so the aiohttp-importing handler tests could not execute locally. New/updated tests were written to pass with `aiohttp` present and to fail if the fixes were reverted (real aiohttp request doubles raising the exact exception classes; propagation guards via `pytest.raises`). These run in CI:
  - `test/test_deploy_handlers_coverage.py`
  - `test/test_dev_fleet_server_coverage.py`
  - `test/test_pptx_maker_routes.py`
  - new files under `apps/builtins/{auto_improvement,issue_radar,personal_shopper}/tests/`

## Review

Passed internal semantic review (APPROVED on v2). v1 flagged two issues — a `pptx_maker` docstring citing a nonexistent byte cap, and a missing `issue_radar` propagation test — both fixed before this PR.