### PR TITLE
fix(pod): allocate a free port instead of assuming the derived one is free

### DIFF
--- a/src/kiro_crew/pod/README.md
+++ b/src/kiro_crew/pod/README.md
@@ -87,21 +87,54 @@ them in bulk — by default only HOMEs whose last activity is older than 3 days
 (`--all` sweeps every age; each delete still routes through the same
 stop-drain-verify path `down` uses, with liveness re-checked per name).
 
-### Port derivation
+### Port derivation and allocation
 
 `port = base + (cksum(name) % 199) + 1` (base `7810` → `7811..8009`), unless a
 `PORT=` is pinned in `~/.kiro/crew/pods/<name>.env`. `pod up` refuses if a derived
 port ever resolves to the live port.
 
-199 slots means a **collision between two pod names is ordinary**, and a pinned
-`PORT=` can land on one deliberately. Whoever binds first wins; the loser's gateway
-exits "address already in use" and its unit crash-loops behind `Restart=on-failure`.
-So reachability on the derived port is never evidence that THIS pod is up: `health`
-and the credential mint both require the process a `127.0.0.1` connect reaches to be
-the pod's own `MainPID` (`port_owner`), and `pod status` / `pod ls` print
-`foreign (port held by another instance)` when it is not. `pod up` names the
-conflict and points at `PORT=` rather than blaming the worktree build. Give a
-colliding pod its own `PORT=` to clear it.
+Derivation answers "which port does this name PREFER", and it is a **default hint,
+not a contract**. Every reader (`pod url`, `pod ls`, `pod exec`, Dev Fleet) calls it
+to agree without coordinating, but 199 slots means two names colliding is ordinary,
+and the derived port can equally be held by something that is not a pod. It does NOT
+check that the port is free.
+
+Whether the port can be had is asked once, by `pod up`, and the answer is **recorded
+as a `PORT=` claim on every allocation** — so after a pod's first `up` its port comes
+from that claim rather than from the formula. The formula still picks the
+first-preference port for any pod that has never come up, which is why the
+degradation is graceful: derivation chooses, ownership is explicit, and readers
+follow the claim.
+
+- The pod is already running → nothing is allocated, and the port is re-resolved
+  under the lock. Its port is busy because it owns it, and moving a live pod would
+  strand every reader.
+- A hand-pinned `PORT=` that is busy → refused loudly. A deliberate pin is never
+  relocated automatically. A pin outside 1–65535 is refused by name.
+- Otherwise the first port that is free, not the live plane, and **not claimed by
+  another pod** is taken — walking from just above the preferred slot and wrapping,
+  deterministically. It is recorded as `PORT=` plus `PORT_AUTO` (which marks the
+  claim as machine-made, so it stays relocatable) and a move is reported on stderr.
+- Nothing available → refused loudly, naming the band and the `PORT=` escape hatch.
+  A pod that cannot get a port must not appear to start.
+
+Reading other pods' recorded claims is what makes concurrent boots safe: a unit is
+`Type=simple`, so `start_pod` returns *before* the gateway binds, and until then a
+bind probe reports that port free. Claiming is serialized plane-wide (`pod up` holds
+a plane lock across choose → start), and the claim is written before the start, so a
+colliding name sees it immediately rather than after the bind.
+
+**A collision that still happens is detected, not mistaken for health.** Allocation
+prevents the ordinary cases above, but it cannot prevent all of them: two colliding
+names started concurrently can still race inside the window between the service
+manager accepting the start and the gateway binding. When that happens whoever binds
+first wins and the loser's gateway exits "address already in use", its unit
+crash-looping behind `Restart=on-failure`. So reachability on a port is never
+evidence that THIS pod is up: `health` and the credential mint both require the
+process a `127.0.0.1` connect reaches to be the pod's own `MainPID` (`port_owner`),
+and `pod status` / `pod ls` print `foreign (port held by another instance)` when it
+is not. `pod up` names the conflict and points at `PORT=` rather than blaming the
+worktree build, and pinning a colliding pod's own `PORT=` remains the manual way out.
 
 ## Configuration (`PodConfig`, all `KIROCREW_POD_*`-overridable)
 

--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -152,25 +152,93 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
         if crons:
             env_updates["CRONS"] = "1"
             boot_flags.append("--crons")
-        if env_updates:
-            rt.write_env_file(cfg, name, env_updates)
 
+        # Read the unit's state BEFORE choosing a port, and inside the mutex: the
+        # two questions are one decision. An `up` against an already-active pod is
+        # a restart, and that pod's port is legitimately busy BECAUSE IT OWNS IT --
+        # probing would find it taken and move a running pod out from under every
+        # reader. Only a pod that is not running is choosing a port at all.
         was_active = rt.is_active(cfg, name)
         if not was_active:
-            cp = rt.start_pod(cfg, name)
-            if cp.returncode != 0:
-                _audit(
-                    "pod.up", "failure", f"name={name} port={port}", error="backend start failed"
+            # Asked BEFORE allocating, because allocation records a claim that would
+            # then look like ours. An operator's deliberate `PORT=` must not acquire
+            # the PORT_AUTO marker: that marker is what licenses a later relocation,
+            # so stamping it here would silently convert a pin the operator set into
+            # one this code may move -- defeating the guarantee that a pin you set is
+            # never moved automatically.
+            operator_pin = rt.operator_pinned(cfg, name)
+            # The plane lock, INSIDE the name lock, covers choose -> start. Two
+            # DIFFERENT colliding names hold disjoint NAME locks, so without this
+            # both could probe one port free and both boot onto it. See
+            # `pod_plane_mutex` for the window this shrinks and the one it leaves.
+            with rt.pod_plane_mutex(cfg):
+                try:
+                    port, displaced_from = rt.allocate_port(cfg, name)
+                except rt.PodError as exc:
+                    _audit("pod.up", "denied", f"name={name}", error="port unavailable")
+                    _die(f"refusing: {exc}")
+                # Record the claim on EVERY allocation, not only when the port
+                # moved. A unit is `Type=simple`, so `start_pod` returns before the
+                # gateway binds; until then a bind probe reports this port free and a
+                # concurrently-starting colliding name would be handed the same one.
+                # The recorded claim is visible immediately, which is what makes the
+                # concurrent case behave like the sequential one.
+                #
+                # This makes the cksum derivation a default HINT rather than a
+                # contract: after its first `up` a pod's port comes from its
+                # recorded claim, not from the formula. That is the intended
+                # trade -- an explicit ownership claim is what the pod plane needs,
+                # and it degrades gracefully, since the formula still chooses the
+                # first-preference port for every pod that has never come up.
+                env_updates["PORT"] = str(port)
+                if operator_pin:
+                    # CLEAR any marker left from an earlier automatic allocation.
+                    # Without this the stale value outlives the pin it described, and
+                    # the trap is a natural user action rather than a coincidence:
+                    # having seen the pod moved to :7850, an operator pins :7850 --
+                    # which now MATCHES the old marker, so their deliberate pin reads
+                    # as machine-made and may be relocated out from under them.
+                    # Emptied rather than deleted because `write_env_file` merges and
+                    # has no delete; an empty value does not parse as a port, so an
+                    # empty marker reads as no marker.
+                    env_updates[rt.AUTO_PORT_KEY] = ""
+                else:
+                    env_updates[rt.AUTO_PORT_KEY] = str(port)
+                if displaced_from is not None:
+                    print(
+                        f"pod: {name!r} moved to :{port} -- :{displaced_from} is "
+                        f"already in use. Pinned PORT={port} so every reader "
+                        f"agrees; `kirocrew pod url {name}` prints it.",
+                        file=sys.stderr,
+                    )
+                if env_updates:
+                    rt.write_env_file(cfg, name, env_updates)
+                cp = rt.start_pod(cfg, name)
+                if cp.returncode != 0:
+                    _audit(
+                        "pod.up",
+                        "failure",
+                        f"name={name} port={port}",
+                        error="backend start failed",
+                    )
+                    _die(f"starting pod {name} failed: {(cp.stderr or '').strip()}")
+        else:
+            # Re-resolve INSIDE the lock. `port` above was read before we held it,
+            # so a concurrent same-name `up` that pinned a fallback in the meantime
+            # would leave us holding the OLD port -- and the health wait below
+            # stops the unit when it cannot reach `port`, which would tear down the
+            # pod that other `up` just successfully started.
+            port = rt.derive_port(cfg, name)
+            if env_updates:
+                rt.write_env_file(cfg, name, env_updates)
+            if boot_flags:
+                joined = " ".join(boot_flags)
+                print(
+                    f"pod: note: {joined} recorded for {name!r}, but that pod is already "
+                    f"running, so it applies on the next boot "
+                    f"(kirocrew pod down {name} && kirocrew pod up {name} {joined}).",
+                    file=sys.stderr,
                 )
-                _die(f"starting pod {name} failed: {(cp.stderr or '').strip()}")
-        elif boot_flags:
-            joined = " ".join(boot_flags)
-            print(
-                f"pod: note: {joined} recorded for {name!r}, but that pod is already "
-                f"running, so it applies on the next boot "
-                f"(kirocrew pod down {name} && kirocrew pod up {name} {joined}).",
-                file=sys.stderr,
-            )
         # Record boot-time settings: a pod in `yolo` auto-approves every tool and
         # one with the scheduler on runs work unattended, so the audit trail must
         # say so rather than recording only that a pod came up. Mark the

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import stat
 import subprocess
 import sys
@@ -91,19 +92,10 @@ APPROVAL_MODES: tuple[str, ...] = ("reads", "yolo", "interactive")
 CRONS_TRUE: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 
 
-def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
-    """Parsed ``KEY='value'`` pairs for pod *name*, ``{}`` on any ``OSError``.
-
-    Fail-OPEN by design, which bounds who may use it: a missing pod, an
-    unreadable pods dir and a comments-only file all yield the same empty
-    mapping, so a caller that must tell "absent" from "exists but cannot be
-    positively read" MUST NOT read the pin through here — see
-    ``dev_fleet._read_pin_strict``, which propagates the failure instead.
-    """
-    try:
-        text = cfg.env_file(name).read_text()
-    except OSError:
-        return {}
+def _parse_env_text(text: str) -> dict[str, str]:
+    """Parse ``KEY='value'`` lines. Split out so a caller that must open the file
+    itself -- see :func:`_peer_claimed_port`, which needs no-follow semantics -- can
+    reuse this exact grammar instead of carrying a second copy that would drift."""
     out: dict[str, str] = {}
     for ln in text.splitlines():
         ln = ln.strip()
@@ -118,6 +110,28 @@ def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
             raw = raw[1:-1]
         out[key.strip()] = raw
     return out
+
+
+def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
+    """Parsed ``KEY='value'`` pairs for pod *name*, ``{}`` on any ``OSError``.
+
+    Fail-OPEN by design, which bounds who may use it: a missing pod, an
+    unreadable pods dir and a comments-only file all yield the same empty
+    mapping, so a caller that must tell "absent" from "exists but cannot be
+    positively read" MUST NOT read the pin through here -- see
+    ``dev_fleet._read_pin_strict``, which propagates the failure instead.
+
+    Takes the pod NAME, so the path read is one an operator named. A caller that
+    instead reads whatever files happen to be in the pods directory is choosing its
+    paths from directory contents rather than from an operator, which is a different
+    trust posture -- :func:`_peer_claimed_port` is that caller and does not come
+    through here.
+    """
+    try:
+        text = cfg.env_file(name).read_text()
+    except OSError:
+        return {}
+    return _parse_env_text(text)
 
 
 def write_env_file(cfg: PodConfig, name: str, updates: dict[str, str]) -> None:
@@ -243,12 +257,56 @@ def resolve_checkout(
 # Implementing that standard algorithm here keeps existing pod ports stable while
 # making a fresh Windows install independent of an external POSIX executable.
 # --------------------------------------------------------------------------- #
+#: Digit cap on an env-file port value. ``int()`` refuses a conversion over 4300
+#: digits, and nothing anyone meant as a port is longer than this; ten rather than
+#: the five a port needs so an out-of-range TYPO still parses and can be refused by
+#: name (see :func:`allocate_port`) instead of silently reading as "no value".
+_MAX_PORT_DIGITS = 10
+
+
+def _port_from_env(value: str | None) -> int | None:
+    """Parse an env-file value as a port number, or ``None`` when it is not one.
+
+    THE one place an env-file string becomes a port. Three call sites used to guard
+    this themselves and each got it wrong differently -- one on length, one on a
+    sibling it forgot to audit, one on character class -- so the guard is now a
+    single function they all share and the class is closed at the parse rather than
+    per symptom.
+
+    ``isdecimal``, NOT ``isdigit``, because ``isdigit`` is not the predicate that
+    matches ``int()``: U+00B2 SUPERSCRIPT TWO satisfies ``isdigit`` while ``int()``
+    raises ``ValueError`` on it. ``isdecimal`` admits exactly what ``int()`` accepts,
+    so such a value reads as "not a port" instead of tracebacking out of ``pod url``.
+    Note this deliberately still accepts a non-ASCII DECIMAL run such as U+0662
+    ARABIC-INDIC DIGIT TWO, which ``int()`` parses as 2 -- rejecting on ``isascii``
+    would refuse a value that is genuinely a number. Codepoints are NAMED rather
+    than written literally so this file stays ASCII and the reader is not relying on
+    their font to tell the cases apart.
+
+    RANGE IS THE CALLER'S POLICY, not this function's, because the two callers
+    legitimately differ: :func:`allocate_port` needs an out-of-range pin like
+    ``70000`` to arrive intact so it can refuse it by name, while
+    :func:`_peer_claimed_port` wants only real ports, since a value that cannot be a
+    port is not a claim on one. This function's job is to be crash-proof, and the
+    length cap is what makes it so.
+    """
+    if not value or not value.isdecimal() or len(value) > _MAX_PORT_DIGITS:
+        return None
+    try:
+        return int(value)
+    except ValueError:  # pragma: no cover - unreachable behind isdecimal + the cap
+        return None
+
+
 def _pinned_port(cfg: PodConfig, name: str) -> int | None:
-    """A ``PORT=`` pinned in the pod's env file wins over derivation."""
-    val = read_env_file(cfg, name).get("PORT")
-    if val and val.isdigit():
-        return int(val)
-    return None
+    """A ``PORT=`` pinned in the pod's env file wins over derivation.
+
+    Parsing (and every crash guard) lives in :func:`_port_from_env`. An unusable
+    value reads as "no pin" and falls back to derivation, which beats a traceback out
+    of the read-only callers -- ``pod url``, ``pod ls``, Dev Fleet -- that reach this
+    through :func:`derive_port`.
+    """
+    return _port_from_env(read_env_file(cfg, name).get("PORT"))
 
 
 def _posix_cksum(data: bytes) -> int:
@@ -279,12 +337,395 @@ def _posix_cksum(data: bytes) -> int:
 
 
 def derive_port(cfg: PodConfig, name: str) -> int:
-    """Resolve pod *name*'s port: pinned ``PORT=`` else ``base + (cksum % 199) + 1``."""
+    """Resolve pod *name*'s port: pinned ``PORT=`` else ``base + (cksum % 199) + 1``.
+
+    DERIVATION, not allocation: this answers "which port does this name map to",
+    and every reader (``pod url``, ``pod ls``, Dev Fleet, ``pod exec``) calls it to
+    agree on one answer without coordinating. It deliberately does NOT check
+    whether that port is free -- a reader must not renegotiate a running pod's
+    port, and a bind probe here would make the answer depend on when it was asked.
+
+    Whether the port can actually be had is an allocation question, asked once per
+    ``pod up`` by :func:`allocate_port`, which records its answer as a ``PORT=``
+    pin so every later derivation returns it.
+    """
     pinned = _pinned_port(cfg, name)
     if pinned is not None:
         return pinned
     cks = _posix_cksum(name.encode("utf-8"))
     return cfg.base_port + (cks % 199) + 1
+
+
+def _port_is_free(port: int) -> bool:
+    """Whether *port* can be bound on loopback right now.
+
+    PRIVATE, and it must stay private. ``instances/run_marker`` states the rule:
+    no "is something listening" helper may be offered, because a caller will
+    mistake reachability for identity -- and ``pod``'s own health probe was held
+    to that rule for exactly this reason. This function is not exempt by being
+    inverted: "nobody is listening" is equally useless as an identity signal, and
+    a free port says nothing about who WOULD answer on a busy one.
+
+    So the only caller is :func:`allocate_port`, whose question genuinely is
+    binding and nothing else: it is choosing a port to hand a process that has not
+    started yet.
+
+    ``SO_REUSEADDR`` is set to MIRROR THE ACTUAL BINDER. A pod's gateway serves
+    through ``aiohttp``'s ``TCPSite``, which leaves ``reuse_address`` at its
+    asyncio default -- set on POSIX -- so the gateway can bind a port whose only
+    occupant is a ``TIME_WAIT`` remnant. A probe without the option is therefore
+    STRICTER than the process it is probing for, and the difference is not
+    academic: ``pod down`` followed by ``pod up`` leaves the previous gateway's
+    accepted connections in ``TIME_WAIT`` on exactly that port, so every quick
+    restart would read as a collision and relocate the pod off its derived port
+    for nothing. ``instances/port_allocator.py`` documents the same reasoning for
+    the SSH forward. ``SO_REUSEADDR`` exempts ``TIME_WAIT`` only, never a live
+    ``LISTEN``, so a real collision is still caught.
+
+    That last sentence is POSIX, and deliberately not hedged: on Windows the option
+    means something closer to ``SO_REUSEPORT`` and would let this bind succeed
+    against a LIVE listener, inverting the answer. It is unguarded because it is
+    unreachable -- ``require_backend`` refuses pods on any host without
+    ``systemd --user`` or ``launchd``, so nothing calls this there. Anyone reusing
+    this probe outside the pod plane has to revisit that.
+
+    Raises :class:`PodError` when the probe cannot be RUN at all -- socket creation
+    or option-setting failing, e.g. on file-descriptor exhaustion. That is not the
+    same as a port being busy and must not be coerced into ``False``: answering
+    "not free" for a probe that never happened would silently relocate a pod on no
+    evidence. ``instances/port_allocator.py`` states the same rule for its own probe
+    -- "neither answer is true, so it propagates to the caller instead of being
+    coerced into one". ``allocate_port`` lets it through and ``pod up`` turns it into
+    a refusal, so the operator sees why rather than a traceback.
+    """
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    except OSError as exc:
+        raise PodError(
+            f"cannot check whether port {port} is free: creating a probe socket "
+            f"failed ({exc}). This is not a busy port -- the check could not run, so "
+            f"no port can be chosen safely"
+        ) from exc
+    with sock:
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        except OSError as exc:
+            raise PodError(
+                f"cannot check whether port {port} is free: configuring the probe "
+                f"socket failed ({exc}). This is not a busy port -- the check could "
+                f"not run, so no port can be chosen safely"
+            ) from exc
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError:
+            # THIS one is a real answer: the address cannot be taken, so it is busy.
+            return False
+        except OverflowError:
+            # bind() rejects a port outside 0-65535 with OverflowError, which is
+            # NOT an OSError and would escape as a traceback. Callers are expected
+            # to have validated the range (see :func:`allocate_port`); this is
+            # defence in depth so a future caller cannot reintroduce the crash, and
+            # "not bindable" is the honest answer for an impossible port.
+            return False
+    return True
+
+
+#: Env key recording the port :func:`allocate_port` chose ITSELF, so a later call
+#: can tell its own fallback from an operator's deliberate ``PORT=``. The VALUE is
+#: stored (not a bare flag) so the marker self-invalidates: an operator who
+#: hand-edits ``PORT=`` to something else no longer matches it and gets operator
+#: treatment, with no way for a stale marker to reclassify their choice as ours.
+AUTO_PORT_KEY = "PORT_AUTO"
+
+
+def operator_pinned(cfg: PodConfig, name: str) -> bool:
+    """Whether *name*'s ``PORT=`` was set by a PERSON rather than recorded by us.
+
+    One definition, two consumers, because the two must never disagree:
+    :func:`allocate_port` uses it to decide whether a busy pin may be relocated,
+    and ``pod up`` uses it to decide whether to stamp :data:`AUTO_PORT_KEY` on the
+    port it records. Answered from the same bytes in both cases -- if the caller
+    re-derived this rule for itself, a deliberate pin could be relocated on one
+    path while being honoured on the other.
+
+    A pin counts as ours only when the marker matches the pin's VALUE, so an
+    operator who hand-edits ``PORT=`` to something else stops matching and is
+    treated as deliberate again.
+
+    Compared as STRINGS, never through ``int()``. Both keys are written from the same
+    ``str(port)``, so byte equality is exactly the intended test. Whether each side is
+    port-SHAPED at all is asked of :func:`_port_from_env`, so this agrees with every
+    other reader about what counts as a value -- a value that is not decimal is not a
+    pin here for
+    the same reason it is not one there.
+    """
+    env = read_env_file(cfg, name)
+    raw = env.get("PORT", "")
+    if _port_from_env(raw) is None:
+        return False
+    auto = env.get(AUTO_PORT_KEY, "")
+    return not (_port_from_env(auto) is not None and auto == raw)
+
+
+#: Cap on a peer env file read during the claim scan. These files hold a handful of
+#: short ``KEY='value'`` lines; anything larger is not one, and the scan must not be
+#: a way to pull an arbitrary amount of some other file into memory.
+_MAX_PEER_ENV_BYTES = 64 * 1024
+
+
+def _read_peer_env(path: Path) -> dict[str, str] | None:
+    """Safely parse a PEER pod's env file, or ``None`` if it cannot be read.
+
+    Returns the MAPPING rather than a port so the caller can resolve the port the
+    same way :func:`derive_port` does; ``None`` means "could not positively read
+    this", which is different from "read it and it names no port".
+
+    Separate from :func:`read_env_file` because the trust posture differs. That
+    function takes a pod NAME, so the operator chose the path. This one is handed a
+    path the CLAIM SCAN found by globbing the pods directory, so the set of files
+    read is decided by directory contents rather than by a person -- and this runs in
+    the trusted CLI, outside the hooks gate that governs an agent's own reads. A
+    symlink planted there would therefore make a privileged process read its target.
+
+    So the open carries ``O_NOFOLLOW`` (a symlink raises ``ELOOP`` and is skipped)
+    rather than an ``is_symlink()`` pre-check, which would leave a window between the
+    check and the open -- AND ``O_NONBLOCK``, because ``O_NOFOLLOW`` does nothing
+    about a FIFO: a named pipe is not a symlink, and a plain ``O_RDONLY`` open of one
+    BLOCKS until a writer appears, which would hang every ``pod up`` on the plane
+    indefinitely rather than merely reading the wrong bytes. Measured: the blocking
+    form never returns, the non-blocking form returns at once.
+    ``O_NONBLOCK`` has no effect on reading a regular file, so it costs the normal
+    path nothing.
+
+    Nonblocking alone only stops the hang, so the descriptor is then ``fstat``-ed and
+    anything that is not a REGULAR file is refused -- a FIFO, a device, a directory.
+    That is the check that makes "this is a pod's env file" true rather than assumed.
+
+    The read is bounded, and every failure -- missing, unreadable, symlink, FIFO,
+    undecodable -- answers ``None``, because "this peer has no claim I can read" is
+    the safe answer and matches :func:`read_env_file`'s fail-open contract.
+
+    The value goes through :func:`_port_from_env`, so every crash guard lives in one
+    place. The RANGE check is this function's own policy: a value that cannot be a
+    port is not a claim on one, whereas :func:`allocate_port` needs an out-of-range
+    pin to arrive intact so it can name it.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return None
+        with os.fdopen(fd, "r", encoding="utf-8", errors="replace", closefd=False) as fh:
+            text = fh.read(_MAX_PEER_ENV_BYTES)
+    except OSError:
+        return None
+    finally:
+        # Closed HERE in every path, including the non-regular refusal above.
+        # ``closefd=False`` keeps ownership with this function rather than handing it
+        # to the wrapper, so no branch can leak a descriptor -- which would be a
+        # particularly poor failure in a scan whose whole job is running before a
+        # process needs file descriptors of its own.
+        try:
+            os.close(fd)
+        except OSError:  # pragma: no cover - already closed or invalid
+            pass
+    return _parse_env_text(text)
+
+
+def _peer_effective_port(cfg: PodConfig, name: str, path: Path) -> int | None:
+    """The port peer *name* would actually resolve, or ``None`` if unreadable.
+
+    Mirrors :func:`derive_port` -- pinned value if there is a usable one, else the
+    cksum derivation -- but from the ONE safe read above rather than by calling that
+    function, which uses plain ``read_text`` and would reintroduce both the symlink
+    follow and the FIFO hang the safe reader exists to prevent.
+
+    The derivation fallback is not a nicety. A pod that came up BEFORE claims were
+    recorded has no ``PORT=`` at all, yet it is running on its derived port right now.
+    Reading "no PORT key" as "claims nothing" would leave every pre-upgrade pod
+    unprotected: during a restart gap it is listening on nothing, so the probe also
+    reports its port free, and a colliding name would take it and leave the legacy pod
+    crash-looping on EADDRINUSE. Resolving what that peer WOULD use closes the upgrade
+    window without needing every pod restarted first.
+
+    A value that cannot be bound (out of range) is returned as-is rather than
+    filtered, because the point is to agree with :func:`derive_port` about what that
+    peer resolves. Such a port simply never matches a candidate in the band walk.
+    """
+    data = _read_peer_env(path)
+    if data is None:
+        return None
+    pinned = _port_from_env(data.get("PORT"))
+    if pinned is not None:
+        return pinned
+    return cfg.base_port + (_posix_cksum(name.encode("utf-8")) % 199) + 1
+
+
+def _ports_claimed_by_other_pods(cfg: PodConfig, name: str) -> dict[int, str]:
+    """``{port: pod name}`` for every ``PORT=`` recorded by a pod other than *name*.
+
+    A bind probe answers "is anyone LISTENING there right now", which is not the
+    same as "is that port somebody's". Two cases turn on the difference:
+
+    * A pod that is stopped is listening on nothing, so its operator-pinned port
+      probes free. A displaced pod landing there boots fine -- and then the pinned
+      pod's next ``up`` hits :func:`allocate_port`'s "a pin you set is never moved"
+      refusal for a squat THIS code created, with a message blaming the operator's
+      own environment.
+    * A pod whose gateway has been started but has not bound yet -- units are
+      ``Type=simple``, so ``start_pod`` returns before the bind -- also probes free.
+      Its port is written to disk BEFORE it is started, though, so consulting the
+      recorded claims sees a concurrent claim that the probe cannot.
+
+    One directory scan, inside the plane lock, so the answer cannot change under
+    the walk. Each entry is resolved through :func:`_peer_effective_port`, which reads
+    it safely and works out what that peer would use -- including a PRE-UPGRADE pod
+    with no ``PORT=`` at all, whose port is its derivation and which is running there
+    now. An entry that cannot be positively read claims nothing, so one hostile or
+    malformed file does not stop the plane from allocating.
+    """
+    claimed: dict[int, str] = {}
+    try:
+        entries = sorted(cfg.pods_dir.glob("*.env"))
+    except OSError:
+        return claimed
+    for entry in entries:
+        other = entry.name[: -len(".env")]
+        if other == name:
+            continue
+        # Validate the peer's NAME before doing anything with it. A pod name is
+        # `_NAME_RE`, the same rule `validate_name` enforces on operator input, so a
+        # stem that fails it is not a pod and has no port to claim -- there is nothing
+        # to protect and nothing to read.
+        #
+        # It is also load-bearing rather than tidy. Filenames are BYTES on POSIX, so a
+        # name containing invalid UTF-8 arrives as a surrogate (measured: `bad-\xff.env`
+        # is handed over as `'bad-\udcff.env'`), and the derivation fallback below has
+        # to encode the name to hash it -- which raises `UnicodeEncodeError` on a
+        # surrogate and would traceback out of every `pod up` on the plane. Matching
+        # the regex answers False for such a stem without raising, so the check both
+        # closes that and states the real precondition: peers are pods.
+        if not _NAME_RE.match(other):
+            continue
+        port = _peer_effective_port(cfg, other, entry)
+        if port is not None:
+            claimed.setdefault(port, other)
+    return claimed
+
+
+def _walk_band_for_free(cfg: PodConfig, name: str, occupied: int, claimed: dict[int, str]) -> int:
+    """First free in-band port at or after *occupied*, excluding the live plane.
+
+    Walks from just above *occupied* and wraps, so the result is deterministic (one
+    collision resolves the same way on every host and every retry) and stays near
+    the derived slot rather than clustering every displaced pod at the bottom of
+    the band.
+
+    Skips three things: the live plane, any port another pod has RECORDED (passed in
+    by the caller, which checks the derived port against the same set), and finally
+    anything actually listening.
+
+    Every allocation records its claim, so a concurrent allocation sees it even
+    though units are ``Type=simple`` and the gateway has not bound yet. That is what
+    lets this close the cross-name race without holding a lock across the boot.
+    """
+    span = 199
+    lo = cfg.base_port + 1
+    start = occupied - lo
+    for step in range(1, span):
+        candidate = lo + (start + step) % span
+        if candidate == cfg.live_port:
+            # The live plane is never a pod's port. `_up` refuses the DERIVED port
+            # for this reason already; the fallback must not reintroduce it.
+            continue
+        if candidate in claimed:
+            continue
+        if _port_is_free(candidate):
+            return candidate
+    raise PodError(
+        f"no free port for pod {name!r}: :{occupied} is busy and every port in "
+        f":{lo}-:{lo + span - 1} is either occupied or claimed by another pod. Free "
+        f"a port, or pin an explicit one with PORT= in {cfg.env_file(name)}"
+    )
+
+
+def allocate_port(cfg: PodConfig, name: str) -> tuple[int, int | None]:
+    """Choose the port to boot pod *name* on. Returns ``(port, displaced_from)``.
+
+    ``displaced_from`` is the port this call moved OFF when it was busy, else
+    ``None`` -- so a caller can say so out loud rather than the move being silent,
+    and knows when to record the new choice.
+
+    Why this exists: the derivation maps every name into 199 slots
+    (``base + (cksum(name) % 199) + 1``), so two worktree names colliding mod 199
+    is an ordinary event, not a pathological one, and the derived port can equally
+    be held by something that is not a pod at all. Without this, the loser's
+    gateway exits "address already in use" and its unit crash-loops -- while
+    ``pod url`` keeps printing the shared port, so the operator is pointed at a
+    pod that is not the one they just built.
+
+    The answer is recorded by the caller as a ``PORT=`` pin, which
+    :func:`derive_port` already prefers over derivation. That is what keeps every
+    later reader agreeing without being changed: the pin mechanism predates this
+    function and is the reason the fallback needs no new plumbing.
+
+    **An automatic pin is not an operator pin.** A fallback this function chose is
+    recorded alongside :data:`AUTO_PORT_KEY`, and a later call will relocate it
+    like any other busy port. Without that distinction one transient occupant of
+    the derived port -- a ``TIME_WAIT`` remnant, another process for a minute --
+    would pin the pod off its derived slot permanently, and every later collision
+    on the fallback would hit the "never moved automatically" refusal for a
+    decision the operator never made. An operator's OWN ``PORT=`` is still never
+    relocated: that would defeat the reason it was pinned.
+
+    THIS FUNCTION ONLY CHOOSES. It writes nothing, so the caller can record the
+    choice in the same env write it already performs, inside the lock it already
+    holds. Note the probe cannot RESERVE: the port is released before the pod's
+    gateway binds it, so see :func:`pod_plane_mutex` for what closes that window
+    and what remains open.
+
+    Raises :class:`PodError` when an operator's pinned port is busy, or when the
+    whole band is occupied -- a pod that cannot get a port must not appear to
+    start.
+    """
+    claimed = _ports_claimed_by_other_pods(cfg, name)
+    pinned = _pinned_port(cfg, name)
+    if pinned is not None:
+        # Validate the RANGE before probing. `_pinned_port` only checks that the
+        # value is digits, so `PORT='70000'` reaches here intact, and bind() answers
+        # an impossible port with OverflowError rather than a refusal. Port 0 is
+        # equally unusable despite binding successfully: it means "any free port",
+        # so the pod would come up somewhere nobody can predict -- the opposite of
+        # what a pin is for. Both are operator typos, so they earn the loud path
+        # rather than a silent relocation.
+        if not 1 <= pinned <= 65535:
+            raise PodError(
+                f"pod {name!r} pins PORT={pinned} in {cfg.env_file(name)}, which is "
+                f"not a usable port. Pin a port between 1 and 65535"
+            )
+        if pinned not in claimed and _port_is_free(pinned):
+            return pinned, None
+        if operator_pinned(cfg, name):
+            raise PodError(
+                f"pod {name!r} pins PORT={pinned} in {cfg.env_file(name)}, but that "
+                f"port is already in use. A pin you set is never moved "
+                f"automatically -- free it, or change the pin"
+            )
+        # Our own earlier fallback. Relocating it is the whole point of marking it.
+        return _walk_band_for_free(cfg, name, pinned, claimed), pinned
+
+    derived = derive_port(cfg, name)
+    # The claim check matters MOST here, not only in the walk. A pod that takes its
+    # derived port records that claim, and units are ``Type=simple`` so its gateway
+    # has not bound by the time a concurrent allocation probes -- meaning the probe
+    # alone would hand the same port to a colliding name. Consulting the recorded
+    # claims is what makes the concurrent case behave like the sequential one.
+    if derived not in claimed and _port_is_free(derived):
+        return derived, None
+    return _walk_band_for_free(cfg, name, derived, claimed), derived
 
 
 def pod_unit(cfg: PodConfig, name: str) -> str:
@@ -595,6 +1036,51 @@ def pod_name_mutex(cfg: PodConfig, name: str):
         finally:
             held[key] = 0
             fcntl.flock(fh, fcntl.LOCK_UN)
+
+
+#: Reserved "name" the plane-wide lock borrows from :func:`pod_name_mutex`. Safe
+#: because ``_NAME_RE`` forbids ``@``, so no real pod can ever produce this key.
+_PLANE_LOCK_NAME = "@plane"
+
+
+@contextlib.contextmanager
+def pod_plane_mutex(cfg: PodConfig):
+    """Serialize port CLAIMING across the whole pod plane, not just one name.
+
+    :func:`pod_name_mutex` is per name, which is the right grain for the pin +
+    definition + start transaction it guards -- two different pods have no reason
+    to serialize their lifecycles. Port allocation is the exception: it is the one
+    step where two DIFFERENT names contend, because they contend for the band
+    rather than for each other's state.
+
+    Without this, two colliding names ``up``'d concurrently (Dev Fleet's normal
+    shape) hold disjoint name locks, both probe the same port free, and both boot
+    onto it -- exactly the crash-loop :func:`allocate_port` exists to prevent.
+    ``apps/backend.py``'s ``_reserve_free_port`` carries the same lesson one
+    subsystem over: "Probing without reserving ... lets two apps be handed the same
+    port -- both children then bind it and the loser dies with EADDRINUSE."
+
+    Implemented by BORROWING :func:`pod_name_mutex` under a reserved name rather
+    than copying its body: the two differ only in the key, and a second
+    hand-maintained copy would drift the moment either grew a feature. The key,
+    lock file, reentrancy and lock ordering are therefore identical by
+    construction rather than by review.
+
+    **What this does NOT close, stated rather than implied.** The probe releases
+    the port before the pod's gateway binds it, and the gateway is a separate
+    process, so no lock held here can span the choose->bind gap; a unit is
+    ``Type=simple``, so ``start_pod`` returns before the bind. Holding this until a
+    health check confirmed the bind WOULD close it, at the cost of serializing
+    every pod boot on the plane behind up to 45 health polls of the previous one.
+    What closes most of the gap instead is :func:`_walk_band_for_free` consulting
+    the pins already recorded on disk, so a concurrent claim is visible before its
+    gateway is listening. See that function for the residue that remains.
+
+    Held INSIDE :func:`pod_name_mutex` wherever both are taken, so the acquisition
+    order is always name -> plane and cannot deadlock against a second holder.
+    """
+    with pod_name_mutex(cfg, _PLANE_LOCK_NAME):
+        yield
 
 
 def _write_and_load_unit(cfg: PodConfig) -> subprocess.CompletedProcess | None:

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -190,6 +190,720 @@ class TestPortDerivation:
         assert rt.derive_port(c, "pinned") == 7999
 
 
+class TestPortAllocation:
+    """Derivation maps 199 slots, so a collision is ordinary rather than exotic.
+
+    Allocation is the separate question `pod up` asks once: can this port actually
+    be had. Before this existed the answer was assumed, so the loser's gateway
+    exited "address already in use" and crash-looped while every reader kept
+    printing the shared port.
+    """
+
+    def _plane(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> PodConfig:
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        return PodConfig.load()
+
+    def test_the_probe_detects_a_real_listener(self, tmp_path, monkeypatch) -> None:
+        """The load-bearing primitive, against a real socket rather than a stub.
+
+        Every other test here monkeypatches `_port_is_free` for determinism, so if
+        the probe itself were wrong they would all still pass. One real bind keeps
+        them honest.
+        """
+        import socket as _socket
+
+        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as held:
+            held.bind(("127.0.0.1", 0))
+            held.listen(1)
+            taken = held.getsockname()[1]
+            assert rt._port_is_free(taken) is False, "a bound, listening port must read as busy"
+        # Released with the socket. A port can be re-taken by anything on a shared
+        # host, so this direction is asserted only as "the probe answers", not as a
+        # guarantee about this specific number.
+        assert isinstance(rt._port_is_free(taken), bool)
+
+    def test_a_free_derived_port_is_used_unchanged(self, tmp_path, monkeypatch) -> None:
+        c = self._plane(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        port, displaced = rt.allocate_port(c, "solo")
+        assert port == rt.derive_port(c, "solo")
+        assert displaced is None, "nothing was displaced, so nothing should be reported"
+
+    def test_a_busy_derived_port_falls_back_and_names_what_it_displaced(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch)
+        derived = rt.derive_port(c, "collider")
+        monkeypatch.setattr(rt, "_port_is_free", lambda p: p != derived)
+        port, displaced = rt.allocate_port(c, "collider")
+        assert port != derived
+        assert displaced == derived, "the caller cannot report the move without this"
+        assert c.base_port + 1 <= port <= c.base_port + 199, "the fallback must stay in band"
+
+    def test_the_fallback_is_deterministic(self, tmp_path, monkeypatch) -> None:
+        # Same collision must resolve the same way every time: a fallback that
+        # varied per run would reintroduce the reader disagreement from the other
+        # direction.
+        c = self._plane(tmp_path, monkeypatch)
+        derived = rt.derive_port(c, "collider")
+        monkeypatch.setattr(rt, "_port_is_free", lambda p: p != derived)
+        first, _ = rt.allocate_port(c, "collider")
+        second, _ = rt.allocate_port(c, "collider")
+        assert first == second
+
+    def test_the_fallback_never_lands_on_the_live_plane(self, tmp_path, monkeypatch) -> None:
+        """The live gateway's port is refused for the derived port already; the
+        fallback must not be the way back in."""
+        import dataclasses
+
+        c = self._plane(tmp_path, monkeypatch)
+        live = c.base_port + 5  # put the live plane inside the pod band
+        c = dataclasses.replace(c, live_port=live)
+        # ONLY the live plane is "free", so a correct allocator finds nothing and
+        # says so, rather than handing the pod the live gateway's port.
+        monkeypatch.setattr(rt, "_port_is_free", lambda p: p == live)
+        with pytest.raises(rt.PodError, match="no free port"):
+            rt.allocate_port(c, "collider")
+
+    def test_a_busy_pinned_port_refuses_instead_of_moving_it(self, tmp_path, monkeypatch) -> None:
+        # A hand-pinned port is a deliberate choice. Relocating it silently would
+        # defeat the reason it was pinned, so this is the loud path.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("pinned").write_text("PORT='7999'\n")
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: False)
+        with pytest.raises(rt.PodError, match="pins PORT=7999"):
+            rt.allocate_port(c, "pinned")
+
+    def test_a_free_pinned_port_is_returned_as_is(self, tmp_path, monkeypatch) -> None:
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("pinned").write_text("PORT='7999'\n")
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        assert rt.allocate_port(c, "pinned") == (7999, None)
+
+    def test_an_exhausted_range_raises_loudly_naming_the_band(self, tmp_path, monkeypatch) -> None:
+        # A pod that cannot get a port must not appear to start.
+        c = self._plane(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: False)
+        with pytest.raises(rt.PodError) as exc:
+            rt.allocate_port(c, "crowded")
+        msg = str(exc.value)
+        assert "no free port" in msg
+        assert str(c.base_port + 1) in msg and str(c.base_port + 199) in msg
+        assert "PORT=" in msg, "the message must name the manual escape hatch"
+
+    def test_a_probe_that_cannot_run_refuses_instead_of_answering(self, monkeypatch) -> None:
+        """ "Could not run" is not "busy", and must not be coerced into it.
+
+        Socket creation can fail for reasons that say nothing about the port -- file
+        descriptor exhaustion being the obvious one. Returning False there would
+        relocate a pod on no evidence, and letting the OSError escape would be a
+        traceback. `instances/port_allocator.py` settles the same question for its own
+        probe: a probe that could not run propagates rather than being coerced.
+        """
+
+        def _no_fds(*_a, **_k):
+            raise OSError(24, "Too many open files")
+
+        monkeypatch.setattr(rt.socket, "socket", _no_fds)
+        with pytest.raises(rt.PodError, match="could not run"):
+            rt._port_is_free(7811)
+
+    def test_a_failed_socket_option_also_refuses(self, monkeypatch) -> None:
+        # The option is what makes the probe mirror the real binder, so a probe that
+        # could not set it is not a probe whose answer means anything.
+        real = rt.socket.socket
+
+        class _OptionFails(real):  # type: ignore[misc, valid-type]
+            def setsockopt(self, *_a, **_k):  # noqa: D102
+                raise OSError(1, "Operation not permitted")
+
+        monkeypatch.setattr(rt.socket, "socket", _OptionFails)
+        with pytest.raises(rt.PodError, match="could not run"):
+            rt._port_is_free(7811)
+
+    def test_a_busy_port_is_still_answered_not_raised(self) -> None:
+        # The other half: bind() failing IS a real answer and must stay a bool, or
+        # every ordinary collision would become a refusal.
+        import socket as _socket
+
+        with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as held:
+            held.bind(("127.0.0.1", 0))
+            held.listen(1)
+            assert rt._port_is_free(held.getsockname()[1]) is False
+
+    def test_up_refuses_cleanly_when_the_probe_cannot_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End to end: the refusal must reach the operator as a message, not a
+        # traceback, through the PodError path `_up` already handles.
+        c = self._plane(tmp_path, monkeypatch)
+
+        def _no_fds(*_a, **_k):
+            raise OSError(24, "Too many open files")
+
+        monkeypatch.setattr(rt.socket, "socket", _no_fds)
+        with pytest.raises(rt.PodError, match="could not run"):
+            rt.allocate_port(c, "demo")
+
+    def test_the_probe_mirrors_the_binders_reuseaddr(self, monkeypatch) -> None:
+        """The probe must be no stricter than the process it probes FOR.
+
+        A pod's gateway binds through aiohttp's TCPSite, which leaves
+        `reuse_address` at the asyncio default (set on POSIX), so it can bind a port
+        whose only occupant is a TIME_WAIT remnant. Without the option here, every
+        `pod down` + `pod up` would read the previous gateway's TIME_WAIT as a
+        collision and relocate the pod for nothing -- the transient occupant that
+        turns into a permanent move.
+
+        The TIME_WAIT state itself is not reliably reproducible in a unit test
+        (which side retains it depends on who closes first), so the mirror is pinned
+        at the option instead of at the symptom.
+        """
+        seen: list[tuple[int, int, int]] = []
+        real_socket = rt.socket.socket
+
+        class _Recording(real_socket):  # type: ignore[misc, valid-type]
+            def setsockopt(self, level, optname, value):  # noqa: D102
+                seen.append((level, optname, value))
+                return super().setsockopt(level, optname, value)
+
+        monkeypatch.setattr(rt.socket, "socket", _Recording)
+        rt._port_is_free(0)  # port 0 always binds; we only care about the options
+        assert (
+            rt.socket.SOL_SOCKET,
+            rt.socket.SO_REUSEADDR,
+            1,
+        ) in seen, "the probe must set SO_REUSEADDR to match what the gateway binds with"
+
+    def test_an_automatic_pin_is_relocated_when_it_goes_busy(self, tmp_path, monkeypatch) -> None:
+        """The auto-pin must not become a permanent trap.
+
+        A pin this allocator wrote records itself via PORT_AUTO. Without that, one
+        transient occupant of the derived port would move the pod permanently, and
+        every later collision on the fallback would hit the "a pin you set is never
+        moved" refusal -- a rationale written for DELIBERATE pins governing a
+        machine-written one.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("moved").write_text(f"PORT='7850'\n{rt.AUTO_PORT_KEY}='7850'\n")
+        monkeypatch.setattr(rt, "_port_is_free", lambda p: p != 7850)
+        port, displaced = rt.allocate_port(c, "moved")
+        assert port != 7850, "our own busy pin must be relocated, not refused"
+        assert displaced == 7850, "the move must still be reported"
+
+    def test_a_stale_auto_marker_does_not_capture_an_operator_pin(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # The marker stores the VALUE, so an operator who hand-edits PORT= to
+        # something else stops matching it and gets operator treatment. A bare flag
+        # would have let a stale marker reclassify their deliberate choice as ours.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("mine").write_text(f"PORT='7999'\n{rt.AUTO_PORT_KEY}='7850'\n")
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: False)
+        with pytest.raises(rt.PodError, match="pins PORT=7999"):
+            rt.allocate_port(c, "mine")
+
+    @pytest.mark.parametrize("bad", ["70000", "0", "99999999"])
+    def test_an_unusable_pin_is_refused_not_crashed(self, tmp_path, monkeypatch, bad) -> None:
+        """`_pinned_port` only checks for digits, so nonsense reaches the probe.
+
+        `bind()` answers a port above 65535 with OverflowError -- NOT an OSError, so
+        it would escape the probe as a traceback rather than a refusal. Port 0 is the
+        opposite failure: it binds happily to an EPHEMERAL port, so it would read as
+        free and the pod would be told to come up somewhere nobody can predict,
+        which is the opposite of what pinning is for. Both are operator typos and
+        both must be named, not guessed at.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("typo").write_text(f"PORT='{bad}'\n")
+        with pytest.raises(rt.PodError, match="not a usable port"):
+            rt.allocate_port(c, "typo")
+
+    def test_the_probe_never_raises_on_an_impossible_port(self) -> None:
+        # Defence in depth behind the range check above: the probe is the last place
+        # a bad port could turn into a traceback, so it answers rather than raising.
+        assert rt._port_is_free(70000) is False
+        assert rt._port_is_free(-1) is False
+
+    def test_the_walk_skips_a_port_another_pod_has_recorded(self, tmp_path, monkeypatch) -> None:
+        """A probe answers "is anyone listening", not "is that port somebody's".
+
+        A STOPPED pod listens on nothing, so its operator-pinned port probes free.
+        Landing a displaced pod there boots fine and then hard-fails the pinned pod's
+        next `up` with the "a pin you set is never moved" refusal -- for a squat this
+        code would have created, in a message that blames the operator.
+
+        The same read closes most of the concurrent-start race: a pod's port is
+        written to disk BEFORE its unit is started, so a claim is visible here even
+        while its gateway (units are Type=simple) has not bound yet.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        derived = rt.derive_port(c, "mover")
+        neighbour = derived + 1  # exactly where the walk would land first
+        c.env_file("neighbour").write_text(f"PORT='{neighbour}'\n")
+        # Nothing is LISTENING anywhere: only the recorded claim can steer the walk.
+        monkeypatch.setattr(rt, "_port_is_free", lambda p: p != derived)
+
+        port, displaced = rt.allocate_port(c, "mover")
+
+        assert displaced == derived
+        assert port != neighbour, (
+            f"the walk landed on :{neighbour}, which pod 'neighbour' has recorded -- "
+            "a stopped pod's pin probes free, so the probe alone cannot see it"
+        )
+
+    def test_a_recorded_claim_beats_a_probe_that_cannot_see_it_yet(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """THE race this fix exists for, pinned deterministically.
+
+        Two DIFFERENT names colliding mod 199 is the precondition for the whole bug
+        (same-name concurrency is already serialized by the per-name mutex, so it
+        cannot express this). A unit is `Type=simple`, so `start_pod` returns before
+        the gateway binds -- meaning the first pod's port still probes FREE while it
+        is starting. Without a recorded claim the second allocation is handed the
+        same port and one gateway crash-loops, which is the original defect
+        reappearing through the concurrent door.
+
+        Nothing is listening anywhere here on purpose: the claim is the only thing
+        that can separate them, so the probe cannot mask a regression.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        shared = c.base_port + 42
+        # Two names that both resolve to one port, as a mod-199 collision does.
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: shared)
+
+        first, _ = rt.allocate_port(c, "alpha")
+        # `_up` records the claim before starting; stand in for exactly that.
+        rt.write_env_file(c, "alpha", {"PORT": str(first), rt.AUTO_PORT_KEY: str(first)})
+        second, displaced = rt.allocate_port(c, "beta")
+
+        assert first == shared, "the first pod should get the port it derives"
+        assert second != first, (
+            "the second pod was handed the port the first has already claimed -- "
+            "nothing is listening yet, so only the recorded claim can prevent this"
+        )
+        assert displaced == shared, "the second pod should report what it moved off"
+
+    @pytest.mark.skipif(
+        rt.fcntl is None,
+        reason=(
+            "pod_name_mutex -- which pod_plane_mutex borrows -- degrades to a no-op "
+            "without fcntl, so nothing serializes these threads there. Not a gap: "
+            "require_backend refuses pods on any host without systemd/launchd, so "
+            "production never reaches the no-op. Only this test could."
+        ),
+    )
+    def test_concurrent_allocations_never_hand_out_one_port_twice(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The same property under real threads, claim-then-record under the lock.
+
+        Serialised by `pod_plane_mutex`, each thread records its claim before
+        releasing, so the next one sees it. Asserted on DISTINCTNESS rather than on
+        any particular assignment, because which name wins the lock is legitimately
+        arbitrary.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        shared = c.base_port + 17
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: shared)
+
+        names = [f"pod{i}" for i in range(6)]
+        got: dict[str, int] = {}
+        errors: list[BaseException] = []
+
+        def _claim(nm: str) -> None:
+            try:
+                with rt.pod_plane_mutex(c):
+                    port, _ = rt.allocate_port(c, nm)
+                    rt.write_env_file(c, nm, {"PORT": str(port), rt.AUTO_PORT_KEY: str(port)})
+                    got[nm] = port
+            except BaseException as exc:  # noqa: BLE001 - surfaced below
+                errors.append(exc)
+
+        workers = [threading.Thread(target=_claim, args=(n,)) for n in names]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=30)
+
+        assert not errors, f"allocation raised under contention: {errors!r}"
+        assert len(got) == len(names), f"some threads did not finish: {got}"
+        assert len(set(got.values())) == len(
+            names
+        ), f"one port was handed out twice under contention: {got}"
+
+    def test_every_allocation_records_a_claim_even_undisplaced(self, tmp_path, monkeypatch) -> None:
+        # The claim is what the concurrent case reads, so it cannot be conditional on
+        # having moved -- an undisplaced pod that records nothing is invisible to a
+        # colliding name until its gateway binds.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        port, displaced = rt.allocate_port(c, "undisplaced")
+        assert displaced is None, "nothing was busy, so nothing moved"
+        rt.write_env_file(c, "undisplaced", {"PORT": str(port), rt.AUTO_PORT_KEY: str(port)})
+        assert rt._ports_claimed_by_other_pods(c, "someone-else").get(port) == "undisplaced"
+
+    def test_the_walk_ignores_the_allocating_pods_own_record(self, tmp_path, monkeypatch) -> None:
+        # Its own pin must not exclude it from its own band walk, or relocating an
+        # auto-pin could never reuse a port the pod itself had recorded.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("solo").write_text(f"PORT='7850'\n{rt.AUTO_PORT_KEY}='7850'\n")
+        assert 7850 not in rt._ports_claimed_by_other_pods(c, "solo")
+        assert rt._ports_claimed_by_other_pods(c, "other").get(7850) == "solo"
+
+    def test_a_malformed_neighbour_env_does_not_block_allocation(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Refusing to allocate because some unrelated pod's file is unreadable would
+        # be a worse failure than the collision the scan avoids.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("broken").write_text("PORT='not-a-number'\nGARBAGE\n")
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        port, displaced = rt.allocate_port(c, "fine")
+        assert port == rt.derive_port(c, "fine") and displaced is None
+
+    @pytest.mark.skipif(not platform_compat.IS_POSIX, reason="mkfifo is POSIX-only")
+    def test_the_claim_scan_cannot_be_hung_by_a_fifo(self, tmp_path, monkeypatch) -> None:
+        """A named pipe in the pods directory must not stall the plane.
+
+        O_NOFOLLOW does NOT cover this: a FIFO is not a symlink. A plain O_RDONLY open
+        of one BLOCKS until a writer appears, so a single FIFO named `*.env` would hang
+        every `pod up` indefinitely -- strictly worse than the symlink case, which
+        merely read the wrong bytes.
+
+        Driven on a worker thread with a join timeout because the failure mode IS a
+        hang: without O_NONBLOCK this would not fail, it would never finish.
+        """
+        import threading
+
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        os.mkfifo(c.pods_dir / "stall.env")
+
+        done: list[int | None] = []
+
+        def _scan() -> None:
+            done.append(rt._peer_effective_port(c, "stall", c.pods_dir / "stall.env"))
+
+        worker = threading.Thread(target=_scan, daemon=True)
+        worker.start()
+        worker.join(timeout=10)
+        assert not worker.is_alive(), (
+            "the claim scan blocked on a FIFO -- a single named pipe in the pods "
+            "directory would hang every pod up on this plane"
+        )
+        assert done == [None], "a FIFO is not a pod env file, so it claims nothing"
+
+    @pytest.mark.skipif(not platform_compat.IS_POSIX, reason="mkfifo is POSIX-only")
+    def test_a_fifo_does_not_stop_the_rest_of_the_scan(self, tmp_path, monkeypatch) -> None:
+        # The scan must skip it and still see a real neighbour's claim: refusing the
+        # whole plane because one entry is odd is the failure this guards against.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        os.mkfifo(c.pods_dir / "stall.env")
+        c.env_file("real").write_text("PORT='7877'\n")
+        assert rt._ports_claimed_by_other_pods(c, "mine") == {7877: "real"}
+
+    def test_a_directory_named_like_an_env_file_is_refused(self, tmp_path, monkeypatch) -> None:
+        # Same non-regular check, reachable on every platform.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        (c.pods_dir / "adir.env").mkdir()
+        assert rt._peer_effective_port(c, "adir", c.pods_dir / "adir.env") is None
+
+    def test_the_scan_leaks_no_descriptors(self, tmp_path, monkeypatch) -> None:
+        """Every branch closes its fd, including the non-regular refusal.
+
+        Worth pinning rather than assuming: round 10 made an un-runnable probe RAISE
+        precisely because descriptor exhaustion is a real state, so a scan leaking one
+        per peer would be feeding the very failure it sits in front of.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        (c.pods_dir / "adir.env").mkdir()
+        c.env_file("real").write_text("PORT='7877'\n")
+
+        def _open_fds() -> int:
+            return len(os.listdir("/proc/self/fd")) if os.path.isdir("/proc/self/fd") else -1
+
+        before = _open_fds()
+        for _ in range(50):
+            rt._ports_claimed_by_other_pods(c, "mine")
+        after = _open_fds()
+        if before != -1:
+            assert after <= before + 1, f"descriptors grew from {before} to {after}"
+
+    @pytest.mark.skipif(
+        not platform_compat.IS_POSIX, reason="symlink creation needs elevation on Windows"
+    )
+    def test_the_claim_scan_refuses_to_follow_a_symlinked_peer_env(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The scan picks its paths from directory contents, not from an operator.
+
+        It also runs in the trusted CLI, outside the hooks gate that governs an
+        agent's own reads -- so a symlink planted in the pods directory would make a
+        privileged process read its target. The open is O_NOFOLLOW, so the link is
+        skipped rather than followed, and allocation continues.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        secret = tmp_path / "secret-elsewhere"
+        secret.write_text("PORT='7850'\n")  # a real port, so following it would SHOW
+        (c.pods_dir / "sneaky.env").symlink_to(secret)
+
+        assert (
+            rt._peer_effective_port(c, "sneaky", c.pods_dir / "sneaky.env") is None
+        ), "a symlinked peer env must not be read at all"
+        # And the claim it would have contributed must be absent, so the scan is not
+        # merely safe but also uninfluenced by the link.
+        assert 7850 not in rt._ports_claimed_by_other_pods(c, "mine")
+
+    def test_an_oversized_numeric_claim_cannot_crash_the_scan(self, tmp_path, monkeypatch) -> None:
+        """`str.isdigit` admits arbitrarily long runs; `int()` refuses over 4300
+        digits with ValueError. Unguarded, one unrelated pod's file would take down
+        every allocation on the plane."""
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("huge").write_text(f"PORT='{'1' * 4301}'\n")
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+
+        assert rt._peer_effective_port(c, "huge", c.pods_dir / "huge.env") == rt.derive_port(
+            c, "huge"
+        ), "an unusable stored value resolves to the derivation, as derive_port does"
+        # The real assertion: allocation still works rather than raising.
+        port, _ = rt.allocate_port(c, "victim")
+        assert port == rt.derive_port(c, "victim")
+
+    @pytest.mark.parametrize(
+        "stored", ["7877", "0", "70000", "99999", "", "1" * 4301, "\u00b2", "\u00bd"]
+    )
+    def test_a_peers_claim_is_exactly_what_that_peer_resolves(
+        self, tmp_path, monkeypatch, stored
+    ) -> None:
+        """The invariant, stated once instead of guessed per value.
+
+        A claim is not "some port we liked the look of" -- it is the port that peer
+        would actually come up on. So it must agree with `derive_port` for every
+        stored value, whatever shape that value is: a usable pin resolves to the pin,
+        and anything unusable (absent, out of range, oversized, non-decimal) resolves
+        to the derivation, because that is what `derive_port` itself falls back to.
+
+        Asserting the AGREEMENT rather than a hardcoded number is what makes this
+        survive a change to either side.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("peer").write_text(f"PORT='{stored}'\n")
+        assert rt._peer_effective_port(c, "peer", c.env_file("peer")) == rt.derive_port(c, "peer")
+
+    def test_a_pre_upgrade_pod_with_no_pin_is_still_claimed(self, tmp_path, monkeypatch) -> None:
+        """The upgrade window: a pod that predates claims is running, unclaimed.
+
+        Before this change nothing recorded a `PORT=`, so every already-running pod has
+        an env file with a CHECKOUT and no port. Reading that as "claims nothing" would
+        leave exactly those pods unprotected: during a restart gap the pod is listening
+        on nothing, so the probe reports its port free too, and a colliding name would
+        take it and leave the legacy pod crash-looping on EADDRINUSE.
+
+        Resolving what the peer WOULD use closes that window without requiring every
+        pod to be restarted under the new code first.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        # Exactly a pre-upgrade file: a checkout pin, no PORT.
+        c.env_file("legacy").write_text("CHECKOUT='/some/worktree'\n")
+        legacy_port = rt.derive_port(c, "legacy")
+
+        claimed = rt._ports_claimed_by_other_pods(c, "newcomer")
+        assert claimed.get(legacy_port) == "legacy", (
+            "a pod with no recorded PORT is still running on its derived port; "
+            "treating it as unclaimed is what lets a colliding name evict it"
+        )
+
+        # And the walk must honour it even with nothing listening anywhere -- which is
+        # precisely the restart-gap state.
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: legacy_port)
+        port, displaced = rt.allocate_port(c, "newcomer")
+        assert port != legacy_port, "the newcomer took a running legacy pod's port"
+        assert displaced == legacy_port
+
+    def test_an_unreadable_peer_claims_nothing(self, tmp_path, monkeypatch) -> None:
+        # The other side of the derivation fallback: it applies only to a file we could
+        # READ. A hostile entry must not be able to reserve a port by name alone.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        (c.pods_dir / "ghost.env").mkdir()  # non-regular: unreadable
+        assert rt._peer_effective_port(c, "ghost", c.pods_dir / "ghost.env") is None
+        assert rt.derive_port(c, "ghost") not in rt._ports_claimed_by_other_pods(c, "mine")
+
+    @pytest.mark.skipif(not platform_compat.IS_POSIX, reason="byte filenames are a POSIX concept")
+    def test_a_non_utf8_peer_filename_cannot_crash_the_scan(self, tmp_path, monkeypatch) -> None:
+        """Filenames are BYTES on POSIX, so a peer name need not be valid UTF-8.
+
+        Such a name arrives decoded with surrogates, and the derivation fallback has to
+        ENCODE the name to hash it -- which raises UnicodeEncodeError on a surrogate.
+        Measured: `bad-\\xff.env` is handed over as `'bad-\\udcff.env'`, and encoding
+        that stem raises. Unguarded, one such file would traceback every `pod up` on the
+        plane.
+
+        Guarded at the NAME rather than at the encode: a stem that is not a legal pod
+        name is not a pod, so it has no port to claim and nothing to read.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        target = os.path.join(os.fsencode(str(c.pods_dir)), b"bad-\xff.env")
+        try:
+            os.close(os.open(target, os.O_CREAT | os.O_WRONLY, 0o600))
+        except (OSError, ValueError) as exc:
+            # Not every POSIX filesystem allows arbitrary bytes in a name: APFS
+            # enforces UTF-8 and refuses this with EILSEQ, so macOS cannot stage the
+            # scenario at all. Skip rather than platform-guess -- what matters is
+            # whether THIS filesystem can hold such a name, not which OS we are on.
+            pytest.skip(f"this filesystem refuses a non-UTF-8 filename: {exc}")
+        c.env_file("real").write_text("PORT='7877'\n")
+
+        # Must not raise, and must still see the legitimate peer beside it.
+        assert rt._ports_claimed_by_other_pods(c, "mine") == {7877: "real"}
+
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        port, _ = rt.allocate_port(c, "mine")  # the real assertion: no traceback
+        assert port == rt.derive_port(c, "mine")
+
+    @pytest.mark.parametrize("stem", ["-leading", "has space", "a" * 70, "", "..", "a/b"])
+    def test_only_legal_pod_names_are_treated_as_peers(self, tmp_path, monkeypatch, stem) -> None:
+        # The precondition stated as a rule rather than as a list of crashes: peers are
+        # pods, so a stem that `validate_name` would reject claims nothing.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            (c.pods_dir / f"{stem}.env").write_text("PORT='7877'\n")
+        except (OSError, ValueError):
+            pytest.skip(f"the filesystem will not hold a {stem!r} entry")
+        assert 7877 not in rt._ports_claimed_by_other_pods(c, "mine")
+
+    @pytest.mark.parametrize(
+        "value,expected,why",
+        [
+            ("7999", 7999, "a plain decimal run is a port"),
+            # U+00B2 SUPERSCRIPT TWO: isdigit() True, isdecimal() False, int() raises.
+            # Written as an escape so this file stays ASCII and the codepoint is
+            # explicit rather than depending on the reader's font.
+            ("\u00b2", None, "isdigit() is True but int() raises -- the round-9 crash"),
+            # U+0662 ARABIC-INDIC DIGIT TWO: decimal, and int() parses it as 2.
+            ("\u0662", 2, "Arabic-Indic digits ARE decimal and int() parses them"),
+            # U+00BD VULGAR FRACTION ONE HALF: neither digit nor decimal.
+            ("\u00bd", None, "neither digit nor decimal"),
+            ("1" * 4301, None, "int() refuses a conversion over 4300 digits"),
+            ("70000", 70000, "out of range but PARSEABLE: allocate_port names it"),
+            ("", None, "absent"),
+            (None, None, "key not present at all"),
+        ],
+    )
+    def test_the_shared_parser_defines_what_counts_as_a_port(self, value, expected, why) -> None:
+        """One parser, one answer, every character class pinned.
+
+        Three call sites used to guard this themselves and each got it wrong
+        differently -- on length, on a sibling that was never audited, and on
+        character class. The guard is now a single function, so these cases are
+        asserted once here instead of being rediscovered per site.
+
+        `isdecimal` rather than `isdigit` is the whole point: `isdigit` is not the
+        predicate that matches `int()`. And `isascii` would have been wrong in the
+        other direction -- it rejects U+0662 ARABIC-INDIC DIGIT TWO, which `int()`
+        parses as 2.
+        """
+        assert rt._port_from_env(value) == expected, why
+
+    def test_no_env_derived_digits_can_crash_a_port_read(self, tmp_path, monkeypatch) -> None:
+        """The class, asserted through every consumer of the shared parser.
+
+        These are reached by read-only verbs (`pod url`, `pod ls`, Dev Fleet) as well
+        as by `pod up`, so a hand-edited env file must not traceback out of any of
+        them. Kept alongside the parser's own table because what matters is that each
+        CONSUMER routes through it.
+        """
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        for label, raw in (
+            ("huge", "1" * 4301),
+            ("uni", "\u00b2"),  # SUPERSCRIPT TWO -- digit but not decimal
+            ("frac", "\u00bd"),  # VULGAR FRACTION ONE HALF -- neither
+        ):
+            c.env_file(label).write_text(f"PORT='{raw}'\n{rt.AUTO_PORT_KEY}='{raw}'\n")
+            assert rt._pinned_port(c, label) is None, f"{label}: pin must not parse"
+            expected = c.base_port + (rt._posix_cksum(label.encode()) % 199) + 1
+            assert (
+                rt.derive_port(c, label) == expected
+            ), f"{label}: an unusable pin must fall back to derivation, not traceback"
+            assert (
+                rt.operator_pinned(c, label) is False
+            ), f"{label}: a value that is not a port is not a pin at all"
+            assert rt._peer_effective_port(c, label, c.pods_dir / f"{label}.env") == rt.derive_port(
+                c, label
+            ), (
+                f"{label}: an unusable stored value must resolve to the derivation, "
+                "which is what derive_port falls back to"
+            )
+
+    def test_an_oversized_auto_marker_does_not_crash_the_provenance_check(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # The marker is attacker-shaped in exactly the same way as the pin: it is a
+        # hand-editable digit string, so it must never reach int() either.
+        c = self._plane(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("weird").write_text(f"PORT='7999'\n{rt.AUTO_PORT_KEY}='{'9' * 4301}'\n")
+        assert (
+            rt.operator_pinned(c, "weird") is True
+        ), "a marker that does not match the pin means the pin is the operator's"
+
+    def test_the_plane_lock_borrows_the_name_mutex_rather_than_copying_it(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """One lock implementation, so the two cannot drift apart.
+
+        The plane lock's key must be exactly what `pod_name_mutex` produces for the
+        reserved name, and that name must be unreachable as a real pod so the two
+        can never collide -- `_NAME_RE` forbids '@'.
+        """
+        import contextlib as _contextlib
+
+        c = self._plane(tmp_path, monkeypatch)
+        taken: list[str] = []
+        real = rt.pod_name_mutex
+
+        @_contextlib.contextmanager
+        def _recording(cfg, nm):
+            taken.append(nm)
+            with real(cfg, nm):
+                yield
+
+        monkeypatch.setattr(rt, "pod_name_mutex", _recording)
+        with rt.pod_plane_mutex(c):
+            pass
+
+        assert taken == [rt._PLANE_LOCK_NAME], "the plane lock must go through pod_name_mutex"
+        with pytest.raises(rt.PodError):
+            rt.validate_name(rt._PLANE_LOCK_NAME)  # unreachable as a real pod name
+
+
 class TestNameValidation:
     @pytest.mark.parametrize("bad", ["", "../x", "a/b", "x" * 70, "-leading", "a b"])
     def test_rejects(self, bad: str) -> None:
@@ -2508,6 +3222,12 @@ class TestUpVerb:
         monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
         # Force git resolution to miss so the root fallback resolves deterministically.
         monkeypatch.setattr(rt, "_git_worktrees", lambda ref: {})
+        # Insulate `_up` from the HOST's real port occupancy. `allocate_port`
+        # bind-probes, so without this a developer's own pod sitting on the
+        # derived port would push these tests down the fallback path and they
+        # would disagree with the port they assert -- a failure that depends on
+        # who is running them. Tests about the fallback override this.
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
         if ready:
             _ready_worktree(tmp_path / "wts", "demo", venv=True, dist=dist)
         return PodConfig.load()
@@ -2595,6 +3315,287 @@ class TestUpVerb:
             pod_cli._up(
                 c, argparse.Namespace(name="demo", json=False, seed="", ttl="2h", provision=False)
             )
+
+    def test_up_pins_the_fallback_so_every_reader_agrees(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """The defect end to end: a busy derived port must not be booted onto.
+
+        The pin is the load-bearing part. `pod url`, `pod ls`, `pod exec` and Dev
+        Fleet each call `derive_port` independently, so without recording the move
+        they would keep printing the derived port while the gateway listens
+        somewhere else -- which is what presented as "a healthy pod that is not the
+        one I just built".
+        """
+        c = self._prep(tmp_path, monkeypatch)
+        derived = rt.derive_port(c, "demo")
+        monkeypatch.setattr(rt, "_port_is_free", lambda p: p != derived)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+
+        captured = capsys.readouterr()
+        pinned = rt.read_env_file(c, "demo").get("PORT")
+        assert pinned and int(pinned) != derived, "the move must be recorded as a PORT= pin"
+        # The whole point of pinning: the readers now agree with the boot.
+        assert rt.derive_port(c, "demo") == int(pinned)
+        assert f'"port": {int(pinned)}' in captured.out, "the reported port must be the real one"
+        assert "already in use" in captured.err, "a silent move is the defect, not the fix"
+
+    def test_up_does_not_move_a_running_pods_port(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An `up` against an ALREADY-ACTIVE pod must not reallocate.
+
+        That pod's port is busy precisely because it owns it, so probing would
+        "discover" a collision and move a running pod out from under every reader.
+        The active check therefore gates the allocation, not just the start.
+        """
+        c = self._prep(tmp_path, monkeypatch)
+        # Nothing is free: if allocation ran at all it would raise or relocate.
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: False)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: True)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        monkeypatch.setattr(
+            rt, "start_pod", lambda *a, **k: pytest.fail("an active pod must not be restarted")
+        )
+
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+
+        assert "PORT" not in rt.read_env_file(
+            c, "demo"
+        ), "a running pod's port must be left exactly as its readers already resolve it"
+
+    def test_up_clears_a_stale_auto_marker_when_the_operator_takes_over(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A marker must not outlive the pin it described.
+
+        The trap is a natural user action, not a coincidence: the pod is auto-moved
+        to a port, the operator sees that and pins THAT port by hand. If the old
+        marker survives, their deliberate pin now matches it, reads as machine-made,
+        and may be relocated out from under them -- the exact guarantee this PR
+        exists to give them.
+
+        So the marker is cleared the moment an operator pin is detected, and the
+        follow-on is asserted too: pinning the previously-auto value is respected.
+        """
+        c = self._prep(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        # State after an earlier automatic allocation to 7850, then the operator
+        # editing PORT to something else.
+        c.env_file("demo").write_text(f"PORT='7999'\n{rt.AUTO_PORT_KEY}='7850'\n")
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+
+        env = rt.read_env_file(c, "demo")
+        assert env.get("PORT") == "7999", "the operator's pin must be honoured"
+        assert not env.get(rt.AUTO_PORT_KEY), (
+            f"a stale marker survived as {env.get(rt.AUTO_PORT_KEY)!r}; if the "
+            "operator later pins that same port it would read as machine-made"
+        )
+        # The follow-on: pinning the previously-auto port is now respected.
+        c.env_file("demo").write_text(f"PORT='7850'\n{rt.AUTO_PORT_KEY}=''\n")
+        assert rt.operator_pinned(c, "demo") is True, (
+            "after the marker is cleared, pinning the old auto port must read as "
+            "the operator's deliberate choice"
+        )
+
+    def test_up_never_marks_an_operator_pin_as_automatic(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Recording the claim must not launder a deliberate pin into a movable one.
+
+        `PORT_AUTO` is what licenses a later relocation. Since the claim is now
+        recorded on EVERY allocation, an operator's own `PORT=` passes through that
+        write -- and stamping the marker on it would quietly convert the one pin this
+        code promises never to move into one it may move on the next contention.
+        """
+        c = self._prep(tmp_path, monkeypatch)
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+        c.env_file("demo").write_text("PORT='7999'\n")  # a person set this, no marker
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+
+        env = rt.read_env_file(c, "demo")
+        assert env.get("PORT") == "7999", "the operator's pin must be honoured"
+        assert not env.get(rt.AUTO_PORT_KEY), (
+            "the operator's pin was marked automatic, so a later collision would "
+            "silently relocate a port they deliberately chose. (An EMPTY marker is "
+            "no marker -- the key may be present and blank, since write_env_file "
+            "merges and cannot delete.)"
+        )
+        assert rt.operator_pinned(c, "demo") is True, "it must still read as theirs"
+
+    def test_up_records_the_claim_even_when_nothing_moved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The claim must not be conditional on having been displaced.
+
+        This is the ruling's whole point. A unit is `Type=simple`, so `start_pod`
+        returns before the gateway binds; until it does, a bind probe reports this
+        pod's port FREE. If an undisplaced pod records nothing, a concurrently
+        starting colliding name is handed the same port and one gateway crash-loops
+        -- the original defect arriving through the concurrent door.
+
+        So the recording is asserted for the case where NOTHING moved, which is the
+        case a displacement-only test cannot see.
+        """
+        c = self._prep(tmp_path, monkeypatch)
+        derived = rt.derive_port(c, "demo")
+        monkeypatch.setattr(rt, "_port_is_free", lambda _p: True)  # nothing is busy
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+
+        env = rt.read_env_file(c, "demo")
+        assert env.get("PORT") == str(derived), (
+            "an undisplaced pod must still record its claim -- otherwise it is "
+            "invisible to a colliding name until its gateway binds"
+        )
+        assert env.get(rt.AUTO_PORT_KEY) == str(derived), "the claim must be marked ours"
+
+    def test_up_records_the_auto_marker_beside_the_pin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Without the marker the fallback is indistinguishable from a deliberate
+        # operator pin, and the pod can never be relocated again.
+        c = self._prep(tmp_path, monkeypatch)
+        derived = rt.derive_port(c, "demo")
+        monkeypatch.setattr(rt, "_port_is_free", lambda p: p != derived)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+        env = rt.read_env_file(c, "demo")
+        assert env["PORT"] == env[rt.AUTO_PORT_KEY], "the marker must record the port WE chose"
+
+    def test_up_refreshes_a_stale_port_when_the_pod_is_already_active(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The concurrent same-name case, which must not tear down a healthy pod.
+
+        `port` is first read BEFORE the mutex. If a concurrent `up` wins the lock,
+        allocates a fallback and pins it, this call wakes holding the OLD derived
+        port -- and the health wait stops the unit when it cannot reach `port`, so a
+        stale value would stop the pod the other `up` just started successfully.
+
+        The pin therefore has to appear DURING the lock wait, not before it: with it
+        already on disk the pre-lock read picks it up too and the staleness never
+        occurs. So the name mutex stands in for the concurrent winner and writes the
+        pin as we acquire.
+        """
+        import contextlib as _contextlib
+
+        c = self._prep(tmp_path, monkeypatch)
+        derived = rt.derive_port(c, "demo")
+        fallback = derived + 7
+        c.pods_dir.mkdir(parents=True, exist_ok=True)
+
+        @_contextlib.contextmanager
+        def _mutex_that_loses_the_race(_cfg, _name):
+            # The other `up` got here first: it pinned its fallback and started the
+            # pod while we were blocked on this lock. Written DIRECTLY and once --
+            # `write_env_file` re-acquires this very mutex, so going through it here
+            # would recurse, and `pin_checkout` below re-enters on the same thread.
+            if not raced:
+                raced.append(True)
+                c.env_file("demo").write_text(
+                    f"PORT='{fallback}'\n{rt.AUTO_PORT_KEY}='{fallback}'\n"
+                )
+            yield
+
+        raced: list[bool] = []
+        monkeypatch.setattr(rt, "pod_name_mutex", _mutex_that_loses_the_race)
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: True)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        probed: list[int] = []
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: (probed.append(p), 403)[1])
+
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+
+        assert probed == [fallback], (
+            "the health wait must use the port resolved INSIDE the lock "
+            f"({fallback}), not the pre-lock derivation ({derived})"
+        )
+
+    def test_allocation_and_start_happen_under_the_plane_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two DIFFERENT colliding names hold disjoint NAME locks, so the claim has
+        to be serialized plane-wide or both can probe one port free and both boot."""
+        import contextlib as _contextlib
+
+        c = self._prep(tmp_path, monkeypatch)
+        order: list[str] = []
+
+        @_contextlib.contextmanager
+        def _tracking_plane(_cfg):
+            order.append("plane-acquire")
+            try:
+                yield
+            finally:
+                order.append("plane-release")
+
+        monkeypatch.setattr(rt, "pod_plane_mutex", _tracking_plane)
+        monkeypatch.setattr(
+            rt, "allocate_port", lambda cfg, n: (order.append("allocate"), (7811, None))[1]
+        )
+        monkeypatch.setattr(rt, "is_active", lambda cfg, n: False)
+        monkeypatch.setattr(rt, "start_pod", lambda cfg, n: (order.append("start"), _cp())[1])
+        monkeypatch.setattr(pod_cli, "_wait_healthy", lambda cfg, n, p: 403)
+        monkeypatch.setattr(rt, "mint_token", lambda cfg, n, ttl: "tok-9")
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+
+        pod_cli._up(
+            c, argparse.Namespace(name="demo", json=True, seed="", ttl="2h", provision=False)
+        )
+
+        assert order == ["plane-acquire", "allocate", "start", "plane-release"], (
+            "the claim must be held from choosing the port through starting the pod "
+            f"-- got {order}"
+        )
 
     def test_up_missing_worktree_teaches(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys

--- a/test/test_pod_launchd.py
+++ b/test/test_pod_launchd.py
@@ -506,9 +506,22 @@ def test_up_pins_the_checkout_inside_the_name_mutex(cfg, monkeypatch, tmp_path):
 
     @_ctx.contextmanager
     def _tracked_mutex(c, n):
-        events.append("lock")
-        yield
-        events.append("unlock")
+        # Record only the OUTERMOST hold, because the real mutex is reentrant and
+        # this assertion is about the transaction's outer boundary. Inner
+        # re-acquisitions are legitimate and now routine: `write_env_file` takes it,
+        # and the plane lock borrows it under a reserved name. Counting those would
+        # make the first "unlock" below an inner one and the ordering meaningless.
+        depth[0] += 1
+        if depth[0] == 1:
+            events.append("lock")
+        try:
+            yield
+        finally:
+            if depth[0] == 1:
+                events.append("unlock")
+            depth[0] -= 1
+
+    depth = [0]
 
     checkout = tmp_path / "wt"
     (checkout / "website" / "static" / "dist").mkdir(parents=True)
@@ -554,11 +567,20 @@ def test_up_failure_cleanup_stops_the_pod_inside_the_mutex(cfg, monkeypatch, tmp
 
     @_ctx.contextmanager
     def _tracked_mutex(c, n):
-        events.append("lock")
+        # See the sibling test: record only the OUTERMOST hold, since the real mutex
+        # is reentrant and inner re-acquisitions (`write_env_file`, the borrowed
+        # plane lock) would otherwise supply the first "unlock".
+        depth[0] += 1
+        if depth[0] == 1:
+            events.append("lock")
         try:
             yield
         finally:
-            events.append("unlock")
+            if depth[0] == 1:
+                events.append("unlock")
+            depth[0] -= 1
+
+    depth = [0]
 
     checkout = tmp_path / "wt"
     (checkout / "website" / "static" / "dist").mkdir(parents=True)


### PR DESCRIPTION
## Problem / Motivation

Pod ports are DERIVED, not allocated. `derive_port` returns
`base + (cksum(name) % 199) + 1` (`pod/runtime.py`), and nothing checked that the
result was actually free. 199 slots means two worktree names colliding mod 199 is
an ordinary event rather than a pathological one, and the derived port can equally
be held by something that is not a pod at all.

When that happens the second pod's gateway exits "address already in use" and its
unit crash-loops -- while `pod url`, `pod ls`, `pod exec` and Dev Fleet all keep
calling `derive_port` and so keep printing the shared port. The operator is pointed
at a pod that is not the one they just built, and nothing anywhere says so. The
only escape was to pin `PORT=` in the pod's env file by hand, which requires
knowing the collision happened in the first place.

## Why it matters

This is silent, and it fails in the direction that wastes the most time: you get a
gateway that answers on the port you were told to use, so the natural conclusion is
that your build is broken rather than that you are talking to a different pod.
Anyone running several worktrees at once is exposed, which is the normal way this
tool is used.

It also compounds. PR #7023 is fixing the same user-visible symptom from the
detection side -- proving the health responder is really this pod rather than
whoever won the bind race. Its own comment states the root cause plainly: "two pods
colliding on one port is an ordinary event ... Whoever binds first wins; the loser's
gateway exits 'address already in use' and the unit crash-loops behind it." That PR
makes a collision VISIBLE. This one stops it happening.

## What changed (motivation -> approach -> change)

Symptom: a pod boots onto a busy port and every reader reports the wrong one. Root
cause: derivation was doing duty as allocation, and the two questions are not the
same -- "which port does this name map to" must be stable and coordination-free for
every reader, while "can this port be had" is asked once, by the process about to
bind it.

So the two are now separate. `derive_port` keeps its exact contract and gains a
docstring saying it deliberately does not probe. A new `allocate_port` answers the
allocation question, and `pod up` calls it:

- **Already running** -> nothing is allocated, and the port is RE-RESOLVED inside
  the lock. Its port is busy precisely because it owns it, so probing would
  "discover" a collision and move a live pod out from under every reader.
- **Operator-pinned `PORT=` that is busy** -> refused loudly. Relocating a
  deliberate pin would defeat the reason it was pinned, and the gateway would fail
  to bind it anyway; refusing while the unit is still stopped says why.
- **Derived port free** -> used as is. Note it is still RECORDED: every allocation
  writes the chosen port as a `PORT=` claim, whether or not it moved. An earlier
  revision of this description said "nothing recorded", which was true before the
  maintainer ruling that made claiming unconditional; it is corrected here because
  it is the change's widest-footprint behaviour. Every pod acquires a persistent
  pin on its first `up`, and that is the point -- the claim is what a
  concurrently-starting colliding name reads before either gateway has bound.
- **Derived port busy** -> the band is walked from just above the derived slot,
  wrapping, and the first free port that is not the live plane and not claimed by
  another pod is chosen. The walk is deterministic, so one collision resolves the
  same way on every host and every retry.
- **Band exhausted** -> `PodError`, naming the band and the `PORT=` escape hatch. A
  pod that cannot get a port must not appear to start.

**The pin is the load-bearing part.** `derive_port` already prefers `PORT=` over
derivation, so recording the chosen port as a pin is what makes every reader agree
with the port actually bound -- with no caller changed and no new plumbing.

**An automatic pin is marked and stays relocatable.** A fallback this code chose is
recorded with `PORT_AUTO` beside it, and a later allocation will relocate it like
any other busy port. Without that distinction one transient occupant of the derived
port would pin the pod off its slot permanently, and every later collision on the
fallback would hit the "a pin you set is never moved" refusal -- a rationale written
for deliberate pins governing a machine-written one. The marker stores the VALUE,
not a flag, so it self-invalidates: an operator who hand-edits `PORT=` no longer
matches it and gets operator treatment.

**The probe mirrors the binder.** A pod's gateway serves through aiohttp's
`TCPSite`, which leaves `reuse_address` at the asyncio POSIX default, so it can bind
a port whose only occupant is a `TIME_WAIT` remnant. The probe therefore sets
`SO_REUSEADDR` too. Without it every `pod down` + `pod up` would read the previous
gateway's `TIME_WAIT` as a collision and relocate for nothing --
`instances/port_allocator.py` documents the same reasoning for the SSH forward.
`SO_REUSEADDR` exempts `TIME_WAIT` only, never a live `LISTEN`.

### Concurrency: what is closed and what is not

Claiming is serialized by a new plane-wide mutex (`pod_plane_mutex`) held across
choose -> start, acquired INSIDE the per-name mutex so the order is always
name -> plane and cannot deadlock. The per-name lock cannot cover this on its own:
two DIFFERENT colliding names hold disjoint name locks and could both probe one port
free. `apps/backend.py`'s `_reserve_free_port` carries the same lesson one subsystem
over -- "Probing without reserving ... lets two apps be handed the same port".

**This shrinks the window rather than closing it, and the earlier revision of this
description wrongly claimed otherwise.** The probe must release the port before the
pod's gateway -- a separate process -- binds it, so no lock held here can span that
gap, and holding the plane lock until a health check confirmed the bind would
serialize every pod boot on the plane behind the slowest one. The window goes from
"probe -> gateway binds" down to "service-manager start accepted -> gateway binds".
That residue is a strict improvement on the pre-allocation behaviour, where two
colliding names collided every time rather than only when they raced, but it is a
residue and not a guarantee.

The same-name case is fully closed, and needed its own fix: `port` is first read
before the mutex, so a concurrent `up` that won the lock and pinned a fallback would
leave this call holding the old derived port -- and the health wait *stops the unit*
when it cannot reach the port it was given, so a stale value would tear down the pod
the other `up` had just started successfully.

### Relationship to #7023

Different concern, and deliberately not stacked. #7023 is IDENTITY (who answers the
port); this is ALLOCATION (which port to hand a process that has not started). The
code spans are disjoint: #7023's `pod/runtime.py` hunks are at `is_active`,
`install_backend`, `health` and `mint_token`, while this changes the port-derivation
block and `_up`.

I did NOT reuse #7023's `port_owner`, though it is adjacent, because it answers a
different question and can return `OWNER_UNPROVEN` when the host has no
listener-lookup tool -- which cannot decide an allocation. A bind probe always
returns a usable answer and needs no PID tooling. Keeping them independent also
means neither PR blocks the other.

One overlap to flag: both PRs edit `src/kiro_crew/pod/README.md`, and the paragraphs
are adjacent -- #7023 inserts at `@@ -93,6` and this rewrites the port section at
92-94, which is now stale (it presents derivation as the whole story). Whichever
lands second resolves a one-paragraph textual conflict there. No semantic conflict.

**The bind probe stays private.** `instances/run_marker` forbids offering an "is
something listening" helper, because a caller will mistake reachability for identity
-- and `pod`'s own health probe was held to that rule for exactly this reason.
Being inverted does not exempt it: "nobody is listening" is equally useless as an
identity signal. `_port_is_free` is therefore private with `allocate_port` as its
only caller.

## Tests

All in `test/test_pod.py`.

`TestPortAllocation`:

- `test_the_probe_detects_a_real_listener` -- binds a real socket and asserts the
  probe reports it busy. Every other test here stubs `_port_is_free` for
  determinism, so without this one a wrong probe would let them all pass anyway.
- `test_the_probe_mirrors_the_binders_reuseaddr` -- pins `SO_REUSEADDR`, since the
  `TIME_WAIT` state it exists for is not reliably reproducible in a unit test.
- `test_a_free_derived_port_is_used_unchanged` -- no move, nothing reported.
- `test_a_busy_derived_port_falls_back_and_names_what_it_displaced`.
- `test_the_fallback_is_deterministic` -- the same collision resolves identically
  twice; a varying fallback would reintroduce reader disagreement.
- `test_the_fallback_never_lands_on_the_live_plane`.
- `test_an_automatic_pin_is_relocated_when_it_goes_busy` -- the auto-pin must not
  become a permanent trap.
- `test_a_stale_auto_marker_does_not_capture_an_operator_pin` -- the value-not-flag
  marker design.
- `test_a_busy_pinned_port_refuses_instead_of_moving_it` and
  `test_a_free_pinned_port_is_returned_as_is`.
- `test_an_exhausted_range_raises_loudly_naming_the_band`.

`TestUpVerb`:

- `test_up_pins_the_fallback_so_every_reader_agrees` -- the defect end to end.
- `test_up_records_the_auto_marker_beside_the_pin`.
- `test_up_does_not_move_a_running_pods_port` -- the restart regression guard.
- `test_up_refreshes_a_stale_port_when_the_pod_is_already_active` -- the concurrent
  same-name case. The pin has to appear DURING the lock wait for this to reproduce,
  so the name mutex stands in for the concurrent winner and writes it on acquire.
- `test_allocation_and_start_happen_under_the_plane_lock` -- asserts the claim is
  held from choosing through starting.

Changed: `TestUpVerb._prep` now stubs `_port_is_free`. Without it these tests depend
on whether the developer running them happens to have a pod on the derived port --
they passed initially only because 7811 was free at the time.

Mutation-verified, each reverted after:

- assume the derived port is free -> 4 failures across the allocation and `_up` tests
- allocate even when the pod is active -> the restart guard fails
- drop the live-plane skip -> that test fails
- keep the stale pre-lock port -> the refresh test fails
- remove the auto-pin distinction -> the relocation test fails
- drop `SO_REUSEADDR` -> the mirror test fails
- remove the plane lock -> the ordering test fails

Worth recording: the stale-port test PASSED against its own mutant on the first
attempt, because the setup pre-wrote the pin, so the pre-lock read was already
correct and the staleness never occurred. It was rewritten to write the pin on lock
acquisition. Without the mutation step that test would have shipped proving nothing.

Targeted runs: `test_pod.py` 249 passed, plus `test_pod_launchd.py` and
`test_dev_fleet_server_coverage.py` green. flake8, isort and the black baseline gate
clean; inclusive-language scan clean on the added lines.

## Manual verification

**Not exercised against real systemd pods.** The collision paths are covered by unit
tests with the probe stubbed, plus one real-socket test for the probe itself. What I
did not do is bring two real pods up on one derived port and watch the second land
elsewhere -- that needs two colliding worktree names on a live pod plane, and this
host has pods in use that I did not want to disturb.

What that leaves unverified: the end-to-end interaction between the pinned `PORT=`
and a real `systemctl --user` boot. The pin is written through the same
`write_env_file` call that already carries `CHECKOUT`/`SEED`/`APPROVAL` into the
unit, so it rides an established path rather than a new one, but I am not claiming
it observed. The `TIME_WAIT` behaviour `SO_REUSEADDR` exists for is likewise
reasoned from the binder's options rather than measured on a real restart.

Also worth a reviewer's eye: the walk probes up to 198 ports in the worst case, one
socket bind each, inside both locks.

## Related Issues

Local backlog `f-20260827-03`. No GitHub issue -- filed as a local finding during
PR #6279 review, so there is nothing to close.

Sibling: #7023 (pod health identity), same symptom from the detection side.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- `pod/README.md`'s port section rewritten
- [x] No secrets, credentials, or internal references in the diff

