### PR TITLE
fix(config): apply the write path's numeric bounds on load too

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -491,10 +491,21 @@ def _safe_int(value: object, default: int, lo: int | None = None, hi: int | None
     return result
 
 
-def _safe_nonnegative_int(value: object, default: int) -> int:
-    """Convert a legacy integer value and reject negative results."""
+def _safe_nonnegative_int(value: object, default: int, hi: int | None = None) -> int:
+    """Convert a legacy integer value and reject negative results.
+
+    *hi* caps the result. Deliberately a ceiling only, with no matching floor
+    argument: a negative value still returns *default* rather than clamping up to
+    0, because 0 is MEANINGFUL for the budgets this guards (a zero chunk budget
+    turns that sweep off). Clamping -1 to 0 would silently disable a sweep the
+    operator never asked to disable, where returning the default keeps it running.
+    The ceiling has no such ambiguity, and it is where the exposure was: an absurd
+    hand-edited budget loaded verbatim and became real scheduled work.
+    """
     result = _safe_int(value, default)
-    return result if result >= 0 else default
+    if result < 0:
+        return default
+    return result if hi is None else min(hi, result)
 
 
 def _port_or_unset(value: object) -> int:
@@ -4357,6 +4368,53 @@ MAX_SUBAGENTS_FIXED_FLOOR = 3
 AUTOCOMPACT_PCT_MIN = 5.0
 AUTOCOMPACT_PCT_MAX = 90.0
 
+# ── Load/write bound parity ────────────────────────────────────────────────────
+# Ranges for bounded numeric fields whose LOAD path previously applied no bounds
+# at all, while `_EDITABLE_CONFIG` rejected the same values at write time. A
+# hand-edited config.json goes nowhere near the dashboard API, so every one of
+# these loaded verbatim -- the same asymmetry #4688 and #4734 closed for the
+# security-relevant knobs.
+#
+# Defined HERE and imported by `_EDITABLE_CONFIG` rather than spelled twice, so
+# the write gate and the load clamp cannot drift. Three fields already clamped on
+# load but duplicated their literals across the two files; those now read from
+# these names too, which is the "two-literal drift" half of the same problem.
+#
+# Bounds are the ones the write path already declared. This change does not
+# re-litigate any range; it makes the load path honour what the API promised.
+COMPLETION_KEEP_CHARS_MIN = 0
+# Mirrors ``context_management.RESULT_FILE_MAX_BYTES`` (500 KB) rather than importing
+# it: ``context_management`` does ``from kiro_crew.config.loader import config_dir``, so
+# importing it here is a genuine circular import, not a style preference. The value is
+# therefore spelled in both places and pinned equal by
+# ``test_the_completion_keep_ceiling_matches_its_owner`` -- a test can import both
+# without the cycle, which is the only place the two spellings can be held together.
+COMPLETION_KEEP_CHARS_MAX = 512_000
+MCP_PROBE_TIMEOUT_MIN = 5
+MCP_PROBE_TIMEOUT_MAX = 120
+RECENT_TINT_COUNT_MIN = 0
+RECENT_TINT_COUNT_MAX = 10
+SESSION_TIMEOUT_MIN = 0
+SESSION_TIMEOUT_MAX = 86400
+POOL_TTL_SECS_MIN = 0
+POOL_TTL_SECS_MAX = 7200
+SOFT_STOP_BUDGET_MIN = 0.5
+SOFT_STOP_BUDGET_MAX = 60.0
+EXTRACTION_POOL_SIZE_MIN = 1
+EXTRACTION_POOL_SIZE_MAX = 10
+# knowledge.* budgets. These share a floor of 0, but 0 is MEANINGFUL for several
+# of them (a zero budget disables that sweep), so the floor is deliberately not
+# enforced by clamping a negative up to 0 -- see `_safe_nonnegative_int`, which
+# keeps returning the default for a negative value. Only the missing CEILING is
+# added here, which is where the actual exposure was: an absurd hand-edited
+# budget was loaded verbatim and became real work.
+AUTO_INGEST_CHUNK_BUDGET_MAX = 10000
+FOLDER_INGEST_CHUNK_BUDGET_MAX = 10000
+DEDUP_EVERY_N_SWEEPS_MAX = 288
+SWEEP_CHUNK_BUDGET_MAX = 50000
+KNOWLEDGE_MAX_SOURCES_MAX = 1000
+EMBED_RATE_LIMIT_MAX = 10000
+
 # (section, key, min, max) for each bounded field clamped at load time. The
 # mins match the runtime floors: subagent_auto_max has a floor of 3
 # (``subagent._LEGACY_DEFAULT_MAX`` — the auto-size minimum), so a value < 3 is
@@ -7673,7 +7731,10 @@ class KiroCrewConfig:
                     agent_data.get("completion_keep", "head")
                 ),
                 completion_keep_chars=_safe_int(
-                    agent_data.get("completion_keep_chars", 3000), 3000
+                    agent_data.get("completion_keep_chars", 3000),
+                    3000,
+                    COMPLETION_KEEP_CHARS_MIN,
+                    COMPLETION_KEEP_CHARS_MAX,
                 ),
                 subagent_result_ttl_secs=_safe_int(
                     agent_data.get("subagent_result_ttl_secs", 3600), 3600
@@ -7695,11 +7756,27 @@ class KiroCrewConfig:
                 max_channels=agent_data.get("max_channels", 1),
                 max_channel_agents=agent_data.get("max_channel_agents", 3),
                 soft_stop_budget_secs=max(
-                    0.5, min(60.0, _safe_float(agent_data.get("soft_stop_budget_secs", 10.0), 10.0))
+                    SOFT_STOP_BUDGET_MIN,
+                    min(
+                        SOFT_STOP_BUDGET_MAX,
+                        _safe_float(agent_data.get("soft_stop_budget_secs", 10.0), 10.0),
+                    ),
                 ),
             ),
             session=SessionConfig(
-                timeout_secs=session_data.get("timeout_secs", DEFAULT_SESSION_TIMEOUT),
+                # The only field in this group whose site had no `_safe_int` at all, so
+                # it is added here for consistency -- but NOT because the type was
+                # unhandled. Verified: on the base revision a hand-edited `"abc"` or
+                # `true` already loaded as the 3600 default, because
+                # `_validate_config_data` runs over the raw dict before section
+                # extraction and owns type handling. What was missing for this field, as
+                # for the other ten, is the RANGE: an int of 999999999 loaded verbatim.
+                timeout_secs=_safe_int(
+                    session_data.get("timeout_secs", DEFAULT_SESSION_TIMEOUT),
+                    DEFAULT_SESSION_TIMEOUT,
+                    SESSION_TIMEOUT_MIN,
+                    SESSION_TIMEOUT_MAX,
+                ),
                 empty_response_auto_continue=bool(
                     session_data.get("empty_response_auto_continue", True)
                 ),
@@ -7716,7 +7793,12 @@ class KiroCrewConfig:
                     POOL_SIZE_MAX,
                 ),
                 pool_agent=str(session_data.get("pool_agent", "")),
-                pool_ttl_secs=_safe_int(session_data.get("pool_ttl_secs", 1800), 1800),
+                pool_ttl_secs=_safe_int(
+                    session_data.get("pool_ttl_secs", 1800),
+                    1800,
+                    POOL_TTL_SECS_MIN,
+                    POOL_TTL_SECS_MAX,
+                ),
                 eager_spawn=bool(session_data.get("eager_spawn", True)),
                 archive_retention_days=_archive_retention_days(session_data),
                 watchdog_rss_max_mb=_safe_int(session_data.get("watchdog_rss_max_mb", 0), 0),
@@ -7838,13 +7920,19 @@ class KiroCrewConfig:
                     knowledge_data.get("auto_register_project_docs", False)
                 ),
                 auto_ingest_chunk_budget=_safe_nonnegative_int(
-                    knowledge_data.get("auto_ingest_chunk_budget", 150), 150
+                    knowledge_data.get("auto_ingest_chunk_budget", 150),
+                    150,
+                    AUTO_INGEST_CHUNK_BUDGET_MAX,
                 ),
                 folder_ingest_chunk_budget=_safe_nonnegative_int(
-                    knowledge_data.get("folder_ingest_chunk_budget", 300), 300
+                    knowledge_data.get("folder_ingest_chunk_budget", 300),
+                    300,
+                    FOLDER_INGEST_CHUNK_BUDGET_MAX,
                 ),
                 dedup_every_n_sweeps=_safe_nonnegative_int(
-                    knowledge_data.get("dedup_every_n_sweeps", 12), 12
+                    knowledge_data.get("dedup_every_n_sweeps", 12),
+                    12,
+                    DEDUP_EVERY_N_SWEEPS_MAX,
                 ),
                 doc_ingest_hosts=[
                     str(h)
@@ -7856,17 +7944,22 @@ class KiroCrewConfig:
                     knowledge_data.get("auto_discover_dirname", "knowledge-docs")
                 ).strip()[:128],
                 sweep_chunk_budget=_safe_nonnegative_int(
-                    knowledge_data.get("sweep_chunk_budget", 500), 500
+                    knowledge_data.get("sweep_chunk_budget", 500),
+                    500,
+                    SWEEP_CHUNK_BUDGET_MAX,
                 ),
-                max_sources=_safe_nonnegative_int(knowledge_data.get("max_sources", 50), 50),
+                max_sources=_safe_nonnegative_int(
+                    knowledge_data.get("max_sources", 50), 50, KNOWLEDGE_MAX_SOURCES_MAX
+                ),
                 embed_rate_limit=_safe_nonnegative_int(
-                    knowledge_data.get("embed_rate_limit", 120), 120
+                    knowledge_data.get("embed_rate_limit", 120), 120, EMBED_RATE_LIMIT_MAX
                 ),
                 extraction_model=str(knowledge_data.get("extraction_model", "")).strip(),
                 extraction_pool_size=max(
-                    1,
+                    EXTRACTION_POOL_SIZE_MIN,
                     min(
-                        10, _safe_nonnegative_int(knowledge_data.get("extraction_pool_size", 3), 3)
+                        EXTRACTION_POOL_SIZE_MAX,
+                        _safe_nonnegative_int(knowledge_data.get("extraction_pool_size", 3), 3),
                     ),
                 ),
             ),
@@ -8071,7 +8164,10 @@ class KiroCrewConfig:
                 avatar=dashboard_data.get("avatar", ""),
                 merge_queued_messages=dashboard_data.get("merge_queued_messages", False),
                 mcp_probe_timeout_secs=_safe_int(
-                    dashboard_data.get("mcp_probe_timeout_secs", 15), 15
+                    dashboard_data.get("mcp_probe_timeout_secs", 15),
+                    15,
+                    MCP_PROBE_TIMEOUT_MIN,
+                    MCP_PROBE_TIMEOUT_MAX,
                 ),
                 loop_stall_exit_after_secs=(
                     None
@@ -8105,7 +8201,12 @@ class KiroCrewConfig:
                 sso_login_flags=str(dashboard_data.get("sso_login_flags", "")),
                 theme_color=dashboard_data.get("theme_color", ""),
                 language=str(dashboard_data.get("language", "")),
-                recent_tint_count=_safe_int(dashboard_data.get("recent_tint_count", 0), 0),
+                recent_tint_count=_safe_int(
+                    dashboard_data.get("recent_tint_count", 0),
+                    0,
+                    RECENT_TINT_COUNT_MIN,
+                    RECENT_TINT_COUNT_MAX,
+                ),
                 update_nudge=(
                     dashboard_data.get("update_nudge", {})
                     if isinstance(dashboard_data.get("update_nudge"), dict)

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -28,11 +28,30 @@ from kiro_crew.computer_use.types import MAX_TREE_NODES_LIMIT as _CU_MAX_TREE_NO
 from kiro_crew.computer_use.types import MIN_SCREENSHOT_MAX_PX as _CU_MIN_SCREENSHOT_MAX_PX
 from kiro_crew.config.loader import (
     _VALID_STT_PROVIDERS,
+    AUTO_INGEST_CHUNK_BUDGET_MAX,
     AUTOCOMPACT_PCT_MAX,
     AUTOCOMPACT_PCT_MIN,
+    COMPLETION_KEEP_CHARS_MIN,
+    DEDUP_EVERY_N_SWEEPS_MAX,
+    EMBED_RATE_LIMIT_MAX,
+    EXTRACTION_POOL_SIZE_MAX,
+    EXTRACTION_POOL_SIZE_MIN,
+    FOLDER_INGEST_CHUNK_BUDGET_MAX,
+    KNOWLEDGE_MAX_SOURCES_MAX,
     MAX_SUBAGENTS_FIXED_FLOOR,
+    MCP_PROBE_TIMEOUT_MAX,
+    MCP_PROBE_TIMEOUT_MIN,
+    POOL_TTL_SECS_MAX,
+    POOL_TTL_SECS_MIN,
+    RECENT_TINT_COUNT_MAX,
+    RECENT_TINT_COUNT_MIN,
+    SESSION_TIMEOUT_MAX,
+    SESSION_TIMEOUT_MIN,
+    SOFT_STOP_BUDGET_MAX,
+    SOFT_STOP_BUDGET_MIN,
     SUBAGENT_AUTO_MAX_CEILING,
     SUBAGENT_MAX_TURNS_CEILING,
+    SWEEP_CHUNK_BUDGET_MAX,
     KiroCrewConfig,
     config_path,
 )
@@ -1578,9 +1597,17 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     "agent.sandbox": {"type": "enum", "values": ["auto", "off"]},
     "agent.sandbox_allow_no_isolation": {"type": "bool"},
     "agent.completion_keep": {"type": "enum", "values": ["head", "tail", "both"]},
-    "agent.completion_keep_chars": {"type": "int", "min": 0, "max": RESULT_FILE_MAX_BYTES},
-    "agent.soft_stop_budget_secs": {"type": "float", "min": 0.5, "max": 60.0},
-    "session.timeout_secs": {"type": "int", "min": 0, "max": 86400},
+    "agent.completion_keep_chars": {
+        "type": "int",
+        "min": COMPLETION_KEEP_CHARS_MIN,
+        "max": RESULT_FILE_MAX_BYTES,
+    },
+    "agent.soft_stop_budget_secs": {
+        "type": "float",
+        "min": SOFT_STOP_BUDGET_MIN,
+        "max": SOFT_STOP_BUDGET_MAX,
+    },
+    "session.timeout_secs": {"type": "int", "min": SESSION_TIMEOUT_MIN, "max": SESSION_TIMEOUT_MAX},
     # Range shared with the load-time clamp in config/loader.py — one constant
     # pair, so the write gate and the load path cannot drift (issue #4734).
     "session.autocompact_pct": {
@@ -1590,7 +1617,7 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     },
     "session.pool_size": {"type": "int", "min": 0, "max": 10},
     "session.pool_agent": {"type": "str", "values_fn": _agent_values},
-    "session.pool_ttl_secs": {"type": "int", "min": 0, "max": 7200},
+    "session.pool_ttl_secs": {"type": "int", "min": POOL_TTL_SECS_MIN, "max": POOL_TTL_SECS_MAX},
     # Intent-level session summaries in the chat right panel. Only the boolean
     # enable is editable here: it spends tokens on turns the user did not ask to
     # pay for, so it is off by default and the Settings toggle is the single
@@ -1598,8 +1625,16 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     # config-file-only — they are power-user knobs, not first-run choices.
     "session_summary.enabled": {"type": "bool"},
     "auto_update": {"type": "bool"},
-    "dashboard.mcp_probe_timeout_secs": {"type": "int", "min": 5, "max": 120},
-    "dashboard.recent_tint_count": {"type": "int", "min": 0, "max": 10},
+    "dashboard.mcp_probe_timeout_secs": {
+        "type": "int",
+        "min": MCP_PROBE_TIMEOUT_MIN,
+        "max": MCP_PROBE_TIMEOUT_MAX,
+    },
+    "dashboard.recent_tint_count": {
+        "type": "int",
+        "min": RECENT_TINT_COUNT_MIN,
+        "max": RECENT_TINT_COUNT_MAX,
+    },
     # Per-version snooze/skip verdict for the proactive update popup, written
     # as ONE atomic record: the three fields only mean anything together, so
     # per-field writes would open both a crash window (old verdict paired
@@ -1701,14 +1736,26 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     "knowledge.auto_add_documents": {"type": "bool"},
     "knowledge.auto_register_project_docs": {"type": "bool"},
     "knowledge.auto_ingest_artifacts": {"type": "bool"},
-    "knowledge.auto_ingest_chunk_budget": {"type": "int", "min": 0, "max": 10000},
-    "knowledge.folder_ingest_chunk_budget": {"type": "int", "min": 0, "max": 10000},
-    "knowledge.dedup_every_n_sweeps": {"type": "int", "min": 0, "max": 288},
-    "knowledge.sweep_chunk_budget": {"type": "int", "min": 0, "max": 50000},
-    "knowledge.max_sources": {"type": "int", "min": 0, "max": 1000},
-    "knowledge.embed_rate_limit": {"type": "int", "min": 0, "max": 10000},
+    "knowledge.auto_ingest_chunk_budget": {
+        "type": "int",
+        "min": 0,
+        "max": AUTO_INGEST_CHUNK_BUDGET_MAX,
+    },
+    "knowledge.folder_ingest_chunk_budget": {
+        "type": "int",
+        "min": 0,
+        "max": FOLDER_INGEST_CHUNK_BUDGET_MAX,
+    },
+    "knowledge.dedup_every_n_sweeps": {"type": "int", "min": 0, "max": DEDUP_EVERY_N_SWEEPS_MAX},
+    "knowledge.sweep_chunk_budget": {"type": "int", "min": 0, "max": SWEEP_CHUNK_BUDGET_MAX},
+    "knowledge.max_sources": {"type": "int", "min": 0, "max": KNOWLEDGE_MAX_SOURCES_MAX},
+    "knowledge.embed_rate_limit": {"type": "int", "min": 0, "max": EMBED_RATE_LIMIT_MAX},
     "knowledge.extraction_model": {"type": "str"},
-    "knowledge.extraction_pool_size": {"type": "int", "min": 1, "max": 10},
+    "knowledge.extraction_pool_size": {
+        "type": "int",
+        "min": EXTRACTION_POOL_SIZE_MIN,
+        "max": EXTRACTION_POOL_SIZE_MAX,
+    },
     # Computer use — BUDGET KNOBS ONLY. There is deliberately no
     # "computer_use.enabled" key here: the primary enable lives on the keystone
     # ``computer_use.json`` (see config.loader.computer_use_state_path) so the

--- a/test/test_config_load_bounds_parity.py
+++ b/test/test_config_load_bounds_parity.py
@@ -1,0 +1,189 @@
+"""Load/write bound parity for `_EDITABLE_CONFIG`'s numeric fields.
+
+The dashboard API rejects an out-of-range value at WRITE time. A hand-edited
+`config.json` never reaches that API, so whatever bounds the load path fails to apply
+are simply not enforced -- the asymmetry #4688 and #4734 closed for the
+security-relevant knobs, still open for eleven others.
+
+The primary test here is a RATCHET over `_EDITABLE_CONFIG` rather than eleven
+hand-written cases. Eleven cases prove eleven fields; the ratchet proves the invariant
+and fails when the twelfth field is added with a write bound and no load bound, which is
+how this drifted in the first place.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest.mock
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard.handlers.core import _EDITABLE_CONFIG
+
+
+def _loaded(tmp_path: Path, data: dict) -> KiroCrewConfig:
+    """Load *data* as config.json through the real load path.
+
+    Goes through `KiroCrewConfig.load()` rather than constructing dataclasses: every
+    clamp under test lives on the load path, so a hand-built dataclass skips all of them
+    and proves nothing about what a hand-edited file produces.
+    """
+    (tmp_path / "config.json").write_text(json.dumps(data), encoding="utf-8")
+    with unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path):
+        return KiroCrewConfig.load()
+
+
+def _bounded_numeric_fields() -> list[tuple[str, str, str, float, float]]:
+    """Every `_EDITABLE_CONFIG` entry that declares a numeric range at write time."""
+    out: list[tuple[str, str, str, float, float]] = []
+    for path_key, spec in sorted(_EDITABLE_CONFIG.items()):
+        if spec.get("type") not in ("int", "float"):
+            continue
+        lo, hi = spec.get("min"), spec.get("max")
+        if lo is None or hi is None:
+            continue
+        section, _, leaf = path_key.partition(".")
+        if not section or not leaf or "." in leaf:
+            continue  # nested keys address a sub-dict, not a scalar on a config section
+        out.append((path_key, section, leaf, lo, hi))
+    return out
+
+
+BOUNDED_FIELDS = _bounded_numeric_fields()
+
+
+def test_the_field_inventory_is_not_silently_empty() -> None:
+    """Guards the ratchet itself.
+
+    Every assertion below is parametrised over `_EDITABLE_CONFIG`. If a refactor renamed
+    the table or changed a spec key, the parametrisation would collapse to zero cases and
+    the whole suite would pass while checking nothing.
+    """
+    assert len(BOUNDED_FIELDS) >= 15, f"only {len(BOUNDED_FIELDS)} bounded fields discovered"
+
+
+@pytest.mark.parametrize("path_key,section,leaf,lo,hi", BOUNDED_FIELDS, ids=lambda v: str(v))
+def test_a_value_above_the_write_ceiling_is_bounded_on_load(
+    path_key: str, section: str, leaf: str, lo: float, hi: float, tmp_path: Path
+) -> None:
+    """The ceiling the API enforces must also hold for a hand-edited file.
+
+    The ceiling is the half that matters: an absurd budget, timeout or pool size loaded
+    verbatim becomes real work, real memory or a real stall.
+    """
+    absurd = int(hi) * 1000 + 12345
+    cfg = _loaded(tmp_path, {section: {leaf: absurd}})
+    got = getattr(getattr(cfg, section), leaf)
+    assert got <= hi, (
+        f"{path_key} loaded {got!r} from a hand-edited {absurd!r}; the write path caps it "
+        f"at {hi}. Pass the bound at the coercion site (_safe_int's lo/hi, or "
+        f"_safe_nonnegative_int's hi)."
+    )
+
+
+@pytest.mark.parametrize("path_key,section,leaf,lo,hi", BOUNDED_FIELDS, ids=lambda v: str(v))
+def test_a_value_inside_the_range_is_stored_verbatim(
+    path_key: str, section: str, leaf: str, lo: float, hi: float, tmp_path: Path
+) -> None:
+    """The clamp must not be a blanket overwrite.
+
+    Without this the ceiling test above could be satisfied by pinning every field to its
+    default and ignoring the file, which would be a worse bug than the one being fixed.
+    """
+    inside = int(lo) + 1 if int(hi) > int(lo) + 1 else int(lo)
+    if not (lo <= inside <= hi):
+        pytest.skip(f"{path_key} has no representable interior value")
+    cfg = _loaded(tmp_path, {section: {leaf: inside}})
+    got = getattr(getattr(cfg, section), leaf)
+    assert got == inside, f"{path_key} rewrote a deliberate in-range {inside!r} to {got!r}"
+
+
+def test_type_handling_stays_upstream_and_this_change_only_adds_range(tmp_path: Path) -> None:
+    """Pins the division of labour, and corrects a claim this PR first got wrong.
+
+    `session.timeout_secs` was the only one of the eleven whose load site had no
+    `_safe_int` at all, and the first draft of this change asserted that a hand-edited
+    `"abc"` therefore reached the dataclass verbatim. That is FALSE, and measuring it is
+    what caught it: on the base revision `"abc"` and `true` already loaded as the 3600
+    default, because `_validate_config_data` runs over the raw dict before section
+    extraction and owns type handling.
+
+    So this is a CONTRACT test, not a regression test -- it passes on base too, which is
+    exactly the point. Types belong upstream; the only thing this change adds is the
+    range. Kept so nobody later "fixes" a type hole here that does not exist, or removes
+    the upstream pass believing the coercion at this site covers it.
+    """
+    assert _loaded(tmp_path, {"session": {"timeout_secs": "abc"}}).session.timeout_secs == 3600
+    assert _loaded(tmp_path, {"session": {"timeout_secs": True}}).session.timeout_secs == 3600
+    # A numeric STRING is still honoured (older writers stored these as strings), which is
+    # why the clamp has to live at the coercion site rather than only in the raw-dict pass.
+    assert _loaded(tmp_path, {"session": {"timeout_secs": "600"}}).session.timeout_secs == 600
+
+
+def test_a_negative_knowledge_budget_keeps_its_default_instead_of_clamping_to_zero(
+    tmp_path: Path,
+) -> None:
+    """Pins a deliberate asymmetry so it is not "tidied" into a clamp.
+
+    These budgets declare a write minimum of 0, but 0 is MEANINGFUL: a zero chunk budget
+    turns that sweep off. Clamping -1 up to 0 would silently disable a sweep the operator
+    never asked to disable, so `_safe_nonnegative_int` keeps returning the default for a
+    negative value and only the ceiling is applied.
+    """
+    cfg = _loaded(tmp_path, {"knowledge": {"sweep_chunk_budget": -1, "max_sources": -5}})
+    assert cfg.knowledge.sweep_chunk_budget == 500
+    assert cfg.knowledge.max_sources == 50
+
+
+def test_the_completion_keep_ceiling_matches_its_owner() -> None:
+    """The one bound that genuinely has to be spelled twice, pinned equal.
+
+    `context_management` does `from kiro_crew.config.loader import config_dir`, so the
+    loader cannot import `RESULT_FILE_MAX_BYTES` back without a circular import. The value
+    therefore lives in both modules, and this test is the only place the two spellings can
+    be held together -- a test imports both without the cycle.
+    """
+    from kiro_crew.config import loader
+    from kiro_crew.context_management import RESULT_FILE_MAX_BYTES
+
+    assert loader.COMPLETION_KEEP_CHARS_MAX == RESULT_FILE_MAX_BYTES, (
+        "the loader's completion-keep ceiling has drifted from context_management's "
+        "RESULT_FILE_MAX_BYTES; they must stay one number"
+    )
+
+
+def test_the_write_table_reads_its_bounds_from_the_loader_constants() -> None:
+    """Drift ratchet for the two-literal pairs.
+
+    The bounds were spelled twice -- once in the loader's clamp, once in
+    `_EDITABLE_CONFIG` -- so the two could disagree and nothing would notice. They now
+    share named constants. This is NOT tautological: it fails the moment someone
+    re-hardcodes a literal in either place.
+    """
+    from kiro_crew.config import loader
+
+    expected = {
+        "agent.soft_stop_budget_secs": (loader.SOFT_STOP_BUDGET_MIN, loader.SOFT_STOP_BUDGET_MAX),
+        "knowledge.extraction_pool_size": (
+            loader.EXTRACTION_POOL_SIZE_MIN,
+            loader.EXTRACTION_POOL_SIZE_MAX,
+        ),
+        "session.timeout_secs": (loader.SESSION_TIMEOUT_MIN, loader.SESSION_TIMEOUT_MAX),
+        "session.pool_ttl_secs": (loader.POOL_TTL_SECS_MIN, loader.POOL_TTL_SECS_MAX),
+        "dashboard.mcp_probe_timeout_secs": (
+            loader.MCP_PROBE_TIMEOUT_MIN,
+            loader.MCP_PROBE_TIMEOUT_MAX,
+        ),
+        "dashboard.recent_tint_count": (
+            loader.RECENT_TINT_COUNT_MIN,
+            loader.RECENT_TINT_COUNT_MAX,
+        ),
+    }
+    for path_key, (lo, hi) in expected.items():
+        spec = _EDITABLE_CONFIG[path_key]
+        assert (spec["min"], spec["max"]) == (lo, hi), (
+            f"{path_key} write bounds {(spec['min'], spec['max'])} no longer match the "
+            f"loader constants {(lo, hi)} -- the two spellings have drifted apart again"
+        )


### PR DESCRIPTION
## What is the problem?

`_EDITABLE_CONFIG` declares a numeric range for each bounded config field, and the
dashboard API rejects an out-of-range value at write time. The LOAD path applied no range
at all for eleven of them. A hand-edited `config.json` never goes near that API, so for
those eleven the declared ceiling was not enforced anywhere.

Measured with an AST cross-reference of every bounded numeric editable field against its
actual load expression -- 11 of 17 unbounded before, 0 of 17 after:

```
FIELD                                 WRITE BOUND   LOAD EXPRESSION (base revision)
agent.completion_keep_chars           0..512000     _safe_int(...get('completion_keep_chars', 3000), 3000)
dashboard.mcp_probe_timeout_secs      5..120        _safe_int(...get('mcp_probe_timeout_secs', 15), 15)
dashboard.recent_tint_count           0..10         _safe_int(...get('recent_tint_count', 0), 0)
knowledge.auto_ingest_chunk_budget    0..10000      _safe_nonnegative_int(..., 150)
knowledge.dedup_every_n_sweeps        0..288        _safe_nonnegative_int(..., 12)
knowledge.embed_rate_limit            0..10000      _safe_nonnegative_int(..., 120)
knowledge.folder_ingest_chunk_budget  0..10000      _safe_nonnegative_int(..., 300)
knowledge.max_sources                 0..1000       _safe_nonnegative_int(..., 50)
knowledge.sweep_chunk_budget          0..50000      _safe_nonnegative_int(..., 500)
session.pool_ttl_secs                 0..7200       _safe_int(...get('pool_ttl_secs', 1800), 1800)
session.timeout_secs                  0..86400      session_data.get('timeout_secs', DEFAULT)
```

Separately, three fields spelled their limits TWICE -- once in the loader's clamp, once in
`_EDITABLE_CONFIG` -- so the write gate and the load clamp could disagree and nothing would
notice. One of those three (`session.pool_size`) had already been reconciled; two had not.

This is the same asymmetry #4688 and #4734 closed for the security-relevant knobs, still
open for these.

## Why this issue matters to the user

The ceiling is the half with teeth. `session.timeout_secs` at 999999999 loaded verbatim;
so did a `sweep_chunk_budget` of fifty million. These are not cosmetic numbers -- they
become scheduled work, retained memory, and how long a stuck session sits before anything
reclaims it. A value the settings UI refuses to accept should not be reachable by editing a
file, and today it is.

Nothing here is remote-exploitable: it needs local write access to `config.json`. It
matters because the ceiling is the thing standing between a typo (or a well-meant
hand-tune) and a gateway that behaves badly in a way nobody can explain from the UI, which
shows a value the API would have rejected.

## How our fix solves it

**Bounds are applied at the coercion site**, not by extending `_SECURITY_BOUNDED_FIELDS`.
That is what `_safe_int`'s own docstring already prescribes, and the reason is load order:
the raw-dict pass skips anything that is not already an int, so a numeric string (`"1"`,
which older writers stored) slips past it and coerces afterwards -- the coercion site is
the only place the declared range actually holds. Two of these fields are also cosmetic
rather than security-relevant, and the raw-dict pass emits a SEL *security* event, so
routing them through it would have produced misleading security telemetry.

**`_safe_nonnegative_int` gains a ceiling argument only, deliberately with no floor.** 0 is
MEANINGFUL for the knowledge budgets -- a zero chunk budget turns that sweep off -- so
clamping a hand-edited `-1` up to `0` would silently disable a sweep the operator never
asked to disable. It keeps returning the default for a negative value. Only the ceiling is
added, which is where the exposure was.

**Bounds now live as named constants in the loader and are imported by `_EDITABLE_CONFIG`,**
so the two cannot drift. That also closes the two-literal duplication for
`agent.soft_stop_budget_secs` and `knowledge.extraction_pool_size`, which clamped correctly
but spelled their limits twice.

`agent.completion_keep_chars` is the one bound that must still be spelled twice:
`context_management` does `from kiro_crew.config.loader import config_dir`, so the loader
importing `RESULT_FILE_MAX_BYTES` back is a genuine circular import, not a style choice. The
value lives in both modules and a test pins them equal -- a test can import both without the
cycle, which is the only place the two spellings can be held together.

### One claim this PR made and then disproved

The first draft asserted that `session.timeout_secs` -- the only one of the eleven whose
site had no `_safe_int` at all -- therefore reached the dataclass with no coercion, so a
hand-edited `"abc"` arrived verbatim. **That is false.** Measuring it is what caught it: on
the base revision `"abc"` and `true` already load as the 3600 default, because
`_validate_config_data` runs over the raw dict before section extraction and owns type
handling. The comment and the test now state the real division of labour -- types upstream,
range here -- and the test is labelled a contract test rather than a regression test,
because it passes on base too.

## What tests we did

`test/test_config_load_bounds_parity.py`. The primary tests are a RATCHET parametrised over
`_EDITABLE_CONFIG` rather than eleven hand-written cases: eleven cases prove eleven fields,
the ratchet proves the invariant and fails when the twelfth field is added with a write
bound and no load bound -- which is how this drifted in the first place.

- `test_a_value_above_the_write_ceiling_is_bounded_on_load` -- writes `ceiling*1000+12345`
  for every bounded field and asserts the loaded value is within range.
- `test_a_value_inside_the_range_is_stored_verbatim` -- the necessary counterweight. Without
  it the ceiling test could be satisfied by pinning every field to its default and ignoring
  the file, which would be a worse bug than the one being fixed.
- `test_the_field_inventory_is_not_silently_empty` -- guards the ratchet itself: if a
  refactor renamed the table, the parametrisation would collapse to zero cases and the suite
  would pass while checking nothing.
- `test_a_negative_knowledge_budget_keeps_its_default_instead_of_clamping_to_zero` -- pins
  the deliberate floor asymmetry so it is not "tidied" into a clamp.
- `test_the_write_table_reads_its_bounds_from_the_loader_constants` and
  `test_the_completion_keep_ceiling_matches_its_owner` -- drift ratchets; they fail the
  moment someone re-hardcodes a literal in either place.
- `test_type_handling_stays_upstream_and_this_change_only_adds_range` -- the corrected
  contract test described above.

Mutation-verified by reverting BOTH source files to base and re-running: exactly **11
ceiling tests go red**, one per field in the table above, plus the 2 drift ratchets. The
two fields that were already bounded (`agent.soft_stop_budget_secs`,
`knowledge.extraction_pool_size`) stay green, which is what shows the ratchet discriminates
rather than failing everything.

Suites: 540 passed across `test_config_load_bounds_parity` + `test_config_loader` +
`test_config_baseline`, and 187 passed across the eight suites touching the editable-config
write path. `isort`, `flake8` and the black gate clean; `mypy` clean on both changed modules
(its two reported errors are in `transcribe.py`, untouched here). Full suites left to CI.

## Any other suggestions on the work

- The measurement tool was a scratch AST cross-reference, not shipped. It is worth
  considering as a real CI gate: it is what turned "eleven fields, from a review note ten
  days old" into a verified 11-of-17 before / 0-of-17 after, and it would catch the next
  drift without relying on the ratchet's runtime coverage. Left out here to keep the diff to
  the fix.
- `_EDITABLE_CONFIG` also contains bounded fields with only a `min` or only a `max`; those
  are outside this change, which pairs write ranges with load ranges where BOTH ends are
  declared.
- This touches `src/kiro_crew/config/loader.py`, which open PR #7041 also modifies in a
  different region (`resource_limits`). No functional overlap -- verified that PR's diff
  touches none of the fields here -- but whichever lands second may need a trivial rebase.
