### PR TITLE
docs(chat): correct the slot-detail limit comments to collapse-before-slice

### DIFF
--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -228,8 +228,8 @@ export default function ChatPane({
   // One-time hydrate of this slot's message history via React Query + the api
   // client (caching + cross-pane dedup; staleTime Infinity keeps it one-shot —
   // live updates arrive through the WS store routing, not a refetch).
-  // Bounding a streaming slot would slice its in-flight response: the limit cuts
-  // RAW rows and the chunk run only collapses after, leaving the tail alone.
+  // Unbounded while streaming is deliberate, not a raw-row guard: the handler
+  // collapses chunk runs BEFORE computing total and slicing, even mid-stream.
   // A background slot's stream state reads idle until an SSE frame arrives, so
   // the slot record is the signal; latch only once unbounded so a turn that starts
   // while the bounded fetch is still in flight can still upgrade it.

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -1425,8 +1425,8 @@ function pagingCursorAfterKeptHead(
  *  treating it as absent would read a later non-zero count as growth.
  *
  *  A count from a RUNNING response is refused, because it is not comparable with
- *  a settled one: the server counts raw rows, so a streaming response is inflated
- *  by rows that collapse when the turn ends. Retaining it makes the next warm read
+ *  a settled one: an unbounded read counts raw rows, so a streaming response is
+ *  inflated by rows that collapse at turn end. Retaining it makes the next warm read
  *  that ordinary collapse as a truncation and suppress the rescue, dropping a live
  *  row -- the opposite direction to the re-append the baseline exists to prevent.
  *  Refusing leaves no baseline rather than a wrong one, which is the same
@@ -1450,8 +1450,8 @@ async function fetchSlotDetail(key: string, limit?: number) {
   // A limit takes the handler's most-recent-N slice. `undefined` keeps the
   // unbounded shape, which two callers still need: refreshSlot replaces the
   // active transcript in place (a bound would shrink history the user already
-  // paged in), and a STREAMING warm/switch fetch (the server's limit slices raw
-  // chunk rows). Omit the arg when unbounded so those keep the one-argument shape.
+  // paged in), and a STREAMING warm/switch fetch (deliberate, though the handler
+  // collapses before slicing). Omit the arg when unbounded to keep the one-arg shape.
   const d = await (limit === undefined ? api.chatSlotDetail(key) : api.chatSlotDetail(key, limit))
   type QueueItem = string | { content: string; id: string }
   return { key, nextBefore: d.next_before || 0, messages: filterMessages(d.messages || []), running: d.running || false, stopping: d.stopping || false, hasMore: d.has_more || false, total: d.total || 0, queue: ((d.queue || []) as QueueItem[]).map((q: QueueItem) => typeof q === 'string' ? { content: q, queueId: crypto.randomUUID(), ts: new Date().toISOString() } : { content: q.content, queueId: q.id, ts: new Date().toISOString() }), context: d.context_pct != null ? { pct: d.context_pct, used: d.context_used_tokens ?? undefined, window: d.context_window_tokens ?? undefined } : undefined }
@@ -1524,9 +1524,8 @@ export const switchSlot = createAsyncThunk<
     // Bounded to the page size so opening a long session costs one page, not the
     // whole chained transcript; `loadOlderMessages` walks back from the cursor
     // this fetch returns. Unbounded while the slot is streaming, for the same
-    // reason warmSlotCache and ChatPane's hydrate are: the server's limit slices
-    // RAW rows, and a streaming response is many chunk rows that only collapse
-    // afterwards -- bounding it would keep just the tail.
+    // reason warmSlotCache and ChatPane's hydrate are -- deliberately, not because a
+    // bound would cut raw rows: the handler collapses chunk runs BEFORE it slices.
     // `slotRun` and not `selectSlotStreamState`: switchSlot.pending has already
     // assigned `activeSlot = key` by the time this body runs, so that selector
     // would always take its active-slot branch and report `slotState`, which
@@ -2208,8 +2207,8 @@ export const warmSlotCache = createAsyncThunk(
   async (key: string, { getState }) => {
     const state = (getState() as { chat: ChatState }).chat
     if (state.activeSlot === key) return null
-    // The server's limit slices RAW rows, and a streaming response is many chunk
-    // rows that only collapse afterwards -- bounding it would keep just the tail.
+    // Unbounded while streaming is deliberate, not a raw-row guard: the handler
+    // collapses chunk runs BEFORE computing total and slicing, even mid-stream.
     const streaming = (state.slotRun[key]?.state ?? 'idle') !== 'idle'
     // Captured BEFORE the fetch: two warms for one slot resolve in any order,
     // and the later-dispatched response is the newer view of the transcript.

--- a/website/src/test/ChatPane.hydrateBound.test.tsx
+++ b/website/src/test/ChatPane.hydrateBound.test.tsx
@@ -111,8 +111,8 @@ describe('ChatPane hydrate is bounded', () => {
   })
 
   it('hydrates a slot that is already mid-turn unbounded, so the tail is not all it shows', async () => {
-    // A background slot's stream state reads idle until an SSE frame arrives, so
-    // the bound cut raw chunk rows and the pane showed only the response tail.
+    // Stream state reads idle until an SSE frame arrives, so the slot record is the
+    // signal. Unbounded is deliberate: the handler collapses chunk runs before slicing.
     renderPane('pane-running-1', { running: true })
     await waitFor(() => expect(api.chatSlotDetail).toHaveBeenCalled())
     const [slot, limit] = (api.chatSlotDetail as ReturnType<typeof vi.fn>).mock.calls[0]
@@ -231,8 +231,8 @@ describe('ChatPane hydrate is bounded', () => {
 })
 
 /* A pane can mount against an IDLE slot and have the user start a turn before the
- * bounded fetch is served. The server slices RAW rows, so that page would be the tail
- * of the in-flight response -- the limit must still be upgradable at that point. */
+ * bounded fetch is served, so the limit must still be upgradable at that point. The
+ * handler collapses chunk runs before slicing, so a bound is not a raw-row hazard. */
 describe('a turn that starts while the bounded fetch is in flight upgrades the limit', () => {
   it('refetches unbounded when an idle slot starts running mid-hydrate', async () => {
     // Never resolves: pins the pane in the window where the bounded fetch is in flight.

--- a/website/src/test/chatSlice.switchSlotBound.test.ts
+++ b/website/src/test/chatSlice.switchSlotBound.test.ts
@@ -113,9 +113,8 @@ describe('switchSlot initial load bound', () => {
     expect(st.slotOldestIndex).toBe(0)
   })
 
-  // Same guard as warmSlotCache and ChatPane's hydrate: the server's limit
-  // slices RAW rows, and a streaming response is many chunk rows that only
-  // collapse afterwards — bounding it would keep just the tail.
+  // Same guard as warmSlotCache and ChatPane's hydrate -- deliberate, not a raw-row
+  // guard: the handler collapses chunk runs BEFORE it slices, even mid-stream.
   it('switches to a streaming slot unbounded', async () => {
     mockDetail({ running: true })
     const store = makeStore({ slotRun: { 'slot-a': { state: 'streaming' } } })

--- a/website/src/test/chatSlice.warmSlotCacheBound.test.ts
+++ b/website/src/test/chatSlice.warmSlotCacheBound.test.ts
@@ -142,8 +142,8 @@ describe('warmSlotCache hydrate bound', () => {
     expect(store.getState().chat.slotPaneHasMore['bg-slot']).toBe(false)
   })
 
-  // A streaming response lives as many raw chunk rows that only collapse after the
-  // server slices, so bounding a running slot would hydrate just its tail.
+  // Unbounded while streaming is deliberate, not a raw-row guard: the handler
+  // collapses chunk runs BEFORE computing total and slicing, even mid-stream.
   it('warms a streaming slot unbounded', async () => {
     ;(api.chatSlotDetail as ReturnType<typeof vi.fn>).mockResolvedValue(detail)
     const store = makeStore('active-slot', { slotRun: { 'bg-slot': { state: 'streaming' } } })
@@ -730,8 +730,8 @@ describe('switching away from a pane whose own fetch has not landed', () => {
   })
 
   // A count taken while the turn is RUNNING is not comparable with a settled
-  // one: the server counts raw rows, so a streaming response is inflated by rows
-  // that collapse when the turn ends. Retaining it makes the next warm read that
+  // one: an unbounded read counts raw rows, so a streaming response is inflated by
+  // rows that collapse at turn end. Retaining it makes the next warm read that
   // normal collapse as a truncation, and the suppression then DROPS a live row --
   // the opposite direction to the re-append this baseline exists to prevent.
   it('does not retain a count from a running response, so a later collapse is not read as a rewind', async () => {


### PR DESCRIPTION
## Problem / Motivation

Six comments across four files assert that the slot-detail endpoint's `limit` slices **raw** wire
rows, and that bounding a streaming slot "would keep just the tail" — i.e. mostly `chunk` rows of the
reply in flight. That is false against the current server, and it is load-bearing: it reads as the
reason two callers pass `undefined` while streaming, so anyone reasoning about page sizes starts from
a wrong model of what a `limit` counts.

The server actually collapses first:

- `_collapse_wire_rows` (`src/kiro_crew/dashboard/chat_utils.py`) folds runs of `chunk` into a single
  row and drops `done`. It folds an **unterminated, still-streaming** run too, via the trailing
  `if run: out.append(_merged(run))` after its loop — so mid-stream is not a special case.
- In the slot-detail handler (`src/kiro_crew/dashboard/chat_handlers.py`) that helper runs **before**
  `total` is computed and **before** the slice: collapse → `total = len(all_msgs)` →
  `start = max(0, end - limit)` → slice.

So a `limit` takes N **collapsed** rows — one row per displayed message — even while a reply is
streaming. The helper's own docstring states the intent: this is what "lets this run ahead of a slice
without changing what the slice renders as."

## Why it matters

A comment that misstates a server contract is worse than no comment: it is the premise an earlier
investigation reasoned from, and it sent that investigation down a wrong path before the claim was
measured. Every surviving copy re-teaches the error to the next reader, and there were six of them —
three in the store, one in a component, two in tests — so the wrong model looked corroborated by
repetition.

## What changed (motivation → approach → change)

Comments only. Each stale justification is replaced with the mechanism that actually holds — the
handler collapses chunk runs before computing `total` and slicing — and each replacement stays within
the repo's 2-line comment budget.

- `website/src/store/chatSlice.ts` — `fetchSlotDetail`, the `switchSlot` thunk, the `warmSlotCache`
  thunk.
- `website/src/components/ChatPane.tsx` — the hydrate-limit comment. This copy was not on the
  original list; a grep for the phrasing found it, and leaving it would have made the fix partial.
- `website/src/test/chatSlice.switchSlotBound.test.ts`,
  `website/src/test/ChatPane.hydrateBound.test.tsx` and
  `website/src/test/chatSlice.warmSlotCacheBound.test.ts` — the header comments above the streaming
  cases.

Two further comments name the same server model but describe the **unbounded** read, where `total` is
computed at `chat_handlers.py:1849` with no fold, so a streaming response's count genuinely is
inflated by rows that collapse at turn end (measured: 310 raw rows against 11 collapsed messages for
the same slot). Those are `retainServerTotal`'s docstring in `website/src/store/chatSlice.ts` and its
test counterpart in `website/src/test/chatSlice.warmSlotCacheBound.test.ts`. They are **not** deleted,
because deleting them would assert something false and would leave `retainServerTotal`'s
`if (running) return` guard justified by a rationale contradicting it. Instead each now scopes the
claim to an unbounded read, so neither can be misread as a statement about the bounded path.

Deliberately **not** changed: the `streaming || cached > 0 ? undefined : LIMIT` branch in either
thunk. Only its stated justification was wrong. Whether the `streaming` disjunct is still needed at
all is a separate question and is left open here — this PR does not answer it, and both call sites
are byte-identical to `main`.

The comments no longer claim a reason for that disjunct beyond it being deliberate, because none of
the reasons available at source support the old one.

## Tests

No test changes — the three touched test files (`chatSlice.switchSlotBound.test.ts`,
`ChatPane.hydrateBound.test.tsx`, `chatSlice.warmSlotCacheBound.test.ts`) are modified only in comment
lines above their `describe`/`it` blocks. Assertions and fixtures are untouched, and the mocks in them
return fixed payloads and do no slicing, so nothing in them ever depended on the stale claim.

Existing suites confirm no behaviour moved:

```
cd website && npx vitest run src/store \
  src/test/chatSlice.switchSlotBound.test.ts src/test/ChatPane.hydrateBound.test.tsx \
  src/test/chatSlice.warmSlotCacheBound.test.ts
```

8 files, 140 tests passing — identical to the baseline captured on the same worktree before the edit.

## Manual verification

<!-- no-visual-delta -->

**Why no screenshot:** the diff changes comment lines only, so there is no rendered difference to
capture — `git diff` filtered to lines that are not comments is empty, and no executable line moved.

N/A for runtime behaviour — the diff contains no executable line. Verified mechanically instead:

- `git diff -U0`, filtered to lines that are not comments, is **empty**: every changed line begins
  `//`, `*`, or `/*`.
- The four stale phrasings (`slices RAW rows`, `slices raw`, `keep just the tail`,
  `collapse afterwards`) reach **0** occurrences repo-wide, against a positive control confirming the
  same grep does reach all four edited files.
- The two guard expressions are unchanged: a diff against `main` scoped to
  `streaming || cached` returns nothing.
- Committed with hooks enabled, so the comment-length gate passed on its own terms.

## Related Issues

Grew out of #6839, which is where the claim was measured false. Related open issues #7044 and #7045
are deliberately untouched: the stale phrasing is listed in #7045 as a distractor, which this removes,
but neither issue is resolved here.


