### PR TITLE
perf(security): gate the credential scan behind a cheap superset pre-filter

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -9271,7 +9271,33 @@ def redact_exfiltration_urls(text: str) -> tuple[str, list[str]]:
 # Catches raw credential patterns in LLM output / tool results,
 # including base64-encoded variants.  Applied on all output paths
 # alongside redact_exfiltration_urls().
-
+#
+# ⚠ THIS PATTERN HAS A DEPENDENT PRE-FILTER. `_might_contain_credential` below
+# gates the scan of this pattern on a cheap necessary condition, and
+# `redact_credentials` SKIPS the scan entirely when that gate returns False. The
+# gate is therefore part of the redaction boundary, not an optimisation detail:
+# any input a branch here accepts but the gate rejects is a silent leak.
+#
+# So EDITING A BRANCH IS A TWO-SITE CHANGE:
+#   * ADDING a branch     -> register a sample in `test_credential_prefilter.py`
+#                            and an anchor in `_might_contain_credential`.
+#                            `test_every_pattern_branch_has_a_prefilter_anchor`
+#                            fails on the branch count until you do.
+#   * WIDENING a branch   -> widen the corresponding anchor to match, because the
+#                            anchor must stay a SUPERSET of the branch. A widened
+#                            branch does NOT change the branch count, so the count
+#                            assertion cannot see it. Two tests cover this:
+#                            `test_a_widened_branch_cannot_outgrow_its_anchor`
+#                            enumerates each branch's own alternatives, so a NEW
+#                            alternative (a second token prefix) is caught; and
+#                            `test_widening_a_branch_cannot_outgrow_its_anchor`
+#                            perturbs each sample, so a case-fold or homoglyph
+#                            relaxation is caught.
+#   * Making a branch CASE-INSENSITIVE -> the anchor MUST use the same regex
+#                            engine. A case-sensitive literal cannot gate a
+#                            `(?i:…)` branch, and neither can `str.lower()` —
+#                            see `_CREDENTIAL_PREFILTER_AUTHORIZATION_RE` for the
+#                            bypass that cost.
 _CREDENTIAL_PATTERNS = re.compile(
     r"(?:"
     # ── AWS ──
@@ -9488,6 +9514,116 @@ def get_credential_patterns() -> list[re.Pattern[str]]:
     combined compiled regex, so the list has one element.
     """
     return [_CREDENTIAL_PATTERNS]
+
+
+# ── Cheap pre-filter for `_CREDENTIAL_PATTERNS` (performance only) ──
+# `_CREDENTIAL_PATTERNS` is a 23-branch alternation, so `re` retries every branch
+# at essentially every position: measured 117 ns/char, and it is the single
+# hottest line in the gateway's event loop (38.2% of all py-spy samples, reached
+# per message per dirty-slot flush). The scan cost is paid in full even though
+# real text almost never contains a credential — measured 0 matches across 1,804
+# live session-history messages (1.47 MB).
+#
+# So `_might_contain_credential` answers the cheap question "could a match exist
+# at all?" and lets `redact_credentials` skip the expensive scan when the answer
+# is no. It is a strict SUPERSET of `_CREDENTIAL_PATTERNS`, i.e. for every string
+# the pattern matches, this returns True. That direction is the security
+# property: a false POSITIVE only costs a scan we would have run anyway, while a
+# false NEGATIVE would skip redaction and leak a credential into persisted chat
+# history. Every condition below is therefore a NECESSARY condition of a branch,
+# never a restatement of it — each is deliberately looser than the branch it
+# stands in for.
+#
+# THE MAINTENANCE HAZARD this is built against: adding a 24th branch to
+# `_CREDENTIAL_PATTERNS` without adding a matching anchor here would silently
+# disable redaction for it. Nothing about the pattern edit would look wrong, and
+# the failure is invisible in output — the branch simply stops firing. So
+# `test_credential_prefilter.py` splits `_CREDENTIAL_PATTERNS.pattern` on its
+# top-level `|`, asserts the branch count equals the number of registered sample
+# credentials, and asserts the pre-filter fires for each. A new branch fails that
+# count assertion loudly instead of quietly widening the leak.
+#
+# Literals are case-sensitive because the branches they stand for are (these
+# prefixes are issued in a fixed case); the sole case-insensitive branch
+# (`Authorization: Bearer`) is handled separately below.
+_CREDENTIAL_PREFILTER_LITERALS: tuple[str, ...] = (
+    "AKIA",  # AWS access key ID
+    "ASIA",  # AWS access key ID (STS)
+    "AccessKey",  # SecretAccessKey + AccessKeyId (shared substring)
+    "aws_secret_access_key",
+    "aws_session_token",
+    "aws_access_key_id",
+    "SessionToken",
+    "PRIVATE KEY-----",  # PEM header AND footer both carry it
+    "xox",  # Slack token
+    "github_pat_",
+    "glpat-",
+    "k_live_",  # sk_live_ / rk_live_ (shared substring)
+    "k_test_",  # sk_test_ / rk_test_ (shared substring)
+    "SG.",  # SendGrid
+    "sk-proj-",  # OpenAI
+    "sk-ant-",  # Anthropic
+    "npm_",
+    "pypi-",
+    "_v1_",  # do[opr]_v1_ DigitalOcean
+    "GOCSPX-",  # Google OAuth client secret
+    "eyJ",  # JWS / JWE / 2-segment link token
+)
+
+# Branches with no usable literal anchor. Each is the branch's own leading shape
+# with its expensive tail dropped, so it stays a superset while keeping a narrow
+# first-character set that `re` can skip on.
+#   `gh[opsur]_`     — GitHub PAT family; a bare "gh" literal matches ordinary
+#                      prose ("through", "might"), so the class is kept.
+#   `[0-9]{6,}:…{30}` — Telegram bot token. The trailing 30-char run matters: a
+#                      bare `[0-9]{6,}:` matches an epoch timestamp followed by a
+#                      colon, which fired on 29 of 614 real messages.
+#   `[MNO]…\.`        — Discord bot token (first segment is base64 of a snowflake).
+#   `://…:…@`         — URI userinfo. The scheme alternation is dropped, which is
+#                      what leaves a `://` literal prefix for `re` to search on;
+#                      a bare `://` would match every ordinary URL.
+_CREDENTIAL_PREFILTER_GH_RE = re.compile(r"gh[opsur]_")
+_CREDENTIAL_PREFILTER_TELEGRAM_RE = re.compile(r"[0-9]{6,}:[A-Za-z0-9_-]{30}")
+_CREDENTIAL_PREFILTER_DISCORD_RE = re.compile(r"[MNO][A-Za-z0-9_-]{22,30}\.")
+_CREDENTIAL_PREFILTER_URI_RE = re.compile(r"://[^\s:/@]*:[^\s/]+@")
+
+# The `Authorization: Bearer` branch is the ONLY case-insensitive branch, and it is
+# spelled `(?i:Authorization)`. This anchor reuses that exact sub-pattern, so it is
+# a superset of the branch BY CONSTRUCTION — same engine, same folding rules.
+#
+# `"authorization" in text.lower()` is NOT a valid anchor for it, because
+# `str.lower()` and `re.IGNORECASE` are two DIFFERENT case-folding
+# implementations and they disagree. `re` folds via `sre_compile._equivalences`,
+# which treats U+0131 (LATIN SMALL LETTER DOTLESS I) and U+0130 (LATIN CAPITAL
+# LETTER I WITH DOT ABOVE) as equivalent to `i`/`I`; `str.lower()` leaves U+0131
+# unchanged and expands U+0130 to two code points. So the branch MATCHES
+# `Authorızation: Bearer <token>` while a `.lower()` anchor MISSES it, which skips
+# pass 1 and leaves the bearer token verbatim in persisted chat history. The same
+# disagreement holds for U+017F/`s` and U+212A/`k`, so it is a class of defect
+# rather than one homoglyph: a case-insensitive branch is only safely anchored by
+# the SAME regex engine, never by a hand-rolled fold.
+# Pinned by `test_unicode_case_folding_cannot_bypass_the_prefilter`.
+_CREDENTIAL_PREFILTER_AUTHORIZATION_RE = re.compile(r"(?i:Authorization)")
+
+
+def _might_contain_credential(text: str) -> bool:
+    """Return True if *text* could contain a `_CREDENTIAL_PATTERNS` match.
+
+    A strict superset of `_CREDENTIAL_PATTERNS.search(text) is not None`: it may
+    return True where the pattern would not match, but it MUST NOT return False
+    where the pattern would match. Callers use it only to skip a scan whose
+    result is already known to be empty, so output is unchanged either way.
+    """
+    for literal in _CREDENTIAL_PREFILTER_LITERALS:
+        if literal in text:
+            return True
+    return (
+        _CREDENTIAL_PREFILTER_GH_RE.search(text) is not None
+        or _CREDENTIAL_PREFILTER_TELEGRAM_RE.search(text) is not None
+        or _CREDENTIAL_PREFILTER_DISCORD_RE.search(text) is not None
+        or _CREDENTIAL_PREFILTER_URI_RE.search(text) is not None
+        or _CREDENTIAL_PREFILTER_AUTHORIZATION_RE.search(text) is not None
+    )
 
 
 # Base64 alphabet: at least 40 chars of [A-Za-z0-9+/] ending with optional =
@@ -9774,6 +9910,24 @@ def _contains_bare_secret(run: str) -> bool:
     return False
 
 
+def _decode_b64_chunk(chunk: str) -> str:
+    """Decode ONE `_B64_CHUNK_RE` match; return decoded credential text or ''.
+
+    Equivalent to `_decode_b64_safe(chunk)` when *chunk* is itself a
+    `_B64_CHUNK_RE` match, but without re-scanning it. `_decode_b64_safe` exists
+    to find chunks inside arbitrary text; re-running that scan over a string that
+    IS already one chunk can only rediscover the same single span —
+    `[A-Za-z0-9+/]{40,}` is greedy so it consumes the whole run, and `={0,2}`
+    takes the padding — so the inner `finditer` was pure duplicate work on the
+    hot path, once per base64-looking run in every redacted message.
+    """
+    try:
+        decoded = base64.b64decode(chunk, validate=True).decode("utf-8", errors="ignore")
+    except Exception:
+        return ""
+    return decoded if _CREDENTIAL_PATTERNS.search(decoded) else ""
+
+
 def _decode_b64_safe(text: str) -> str:
     """Try to base64-decode chunks in text; return decoded content or ''."""
     for m in _B64_CHUNK_RE.finditer(text):
@@ -9941,24 +10095,47 @@ def redact_credentials(text: str) -> tuple[str, list[str]]:
     result = text
 
     # 1. Redact plaintext credential patterns
-    for m in _CREDENTIAL_PATTERNS.finditer(result):
-        matched = m.group()
-        tag = _REDACTED_CREDENTIAL_TAG
-        result = result.replace(matched, tag, 1)
-        # Emit ONLY non-sensitive metadata (length). Do NOT slice any part of
-        # `matched` into the warning: `_CREDENTIAL_PATTERNS` matches the raw
-        # secret value itself (e.g. `ghp_…`, `sk-ant-…`), so even a short prefix
-        # is genuine plaintext key material — a fixed-length token prefix leaves
-        # ~12-16 secret chars in a 20-char slice. The warnings list is a
-        # redaction-subsystem output expected to be safe to log/surface, so it
-        # must carry no secret bytes. Mirrors the base64 / bare-secret branches
-        # below, which already log length only.
-        warnings.append(f"Redacted credential pattern ({len(matched)} chars)")
+    #
+    # Gated on the cheap superset pre-filter: when no branch of
+    # `_CREDENTIAL_PATTERNS` can possibly match, `finditer` would yield nothing
+    # and the loop body would not run, so skipping it cannot change the output.
+    # This is the hot path — the alternation is 23 branches retried at nearly
+    # every position, and real text almost never contains a credential.
+    if _might_contain_credential(result):
+        for m in _CREDENTIAL_PATTERNS.finditer(result):
+            matched = m.group()
+            tag = _REDACTED_CREDENTIAL_TAG
+            result = result.replace(matched, tag, 1)
+            # Emit ONLY non-sensitive metadata (length). Do NOT slice any part of
+            # `matched` into the warning: `_CREDENTIAL_PATTERNS` matches the raw
+            # secret value itself (e.g. `ghp_…`, `sk-ant-…`), so even a short prefix
+            # is genuine plaintext key material — a fixed-length token prefix leaves
+            # ~12-16 secret chars in a 20-char slice. The warnings list is a
+            # redaction-subsystem output expected to be safe to log/surface, so it
+            # must carry no secret bytes. Mirrors the base64 / bare-secret branches
+            # below, which already log length only.
+            warnings.append(f"Redacted credential pattern ({len(matched)} chars)")
+
+    # Passes 2 and 3 both scan the ORIGINAL `text` for runs of the base64
+    # alphabet, and they select the SAME spans: `[A-Za-z0-9+/]{40,}` is greedy and
+    # leftmost, so it yields exactly the maximal runs of length >= 40 — which is
+    # also precisely what `_BARE_SECRET_RUN_RE`'s `(?<![A-Za-z0-9+/])` /
+    # `(?![A-Za-z0-9+/])` boundaries select. The only difference is the trailing
+    # `={0,2}` padding that `_B64_CHUNK_RE` additionally consumes, and `=` is not
+    # in the run's character class, so `rstrip("=")` recovers the bare run
+    # exactly. So one scan feeds both passes instead of two.
+    #
+    # The two loops stay SEPARATE and in their original order. Fusing them into a
+    # single per-run loop would interleave the passes, which changes both the
+    # order of `warnings` and — because each pass mutates `result` via
+    # `str.replace(…, 1)` — which occurrence each replacement lands on, and
+    # whether pass 3's `run not in result` guard sees pass 2's edits. Sharing the
+    # scan while keeping the loops ordered is what makes this byte-identical.
+    b64_chunks = [m.group() for m in _B64_CHUNK_RE.finditer(text)]
 
     # 2. Detect and redact base64-encoded credentials
-    for m in _B64_CHUNK_RE.finditer(text):
-        chunk = m.group()
-        decoded = _decode_b64_safe(chunk)
+    for chunk in b64_chunks:
+        decoded = _decode_b64_chunk(chunk)
         if decoded:
             result = result.replace(chunk, "[REDACTED: encoded credential]", 1)
             warnings.append(f"Redacted base64-encoded credential ({len(chunk)} chars)")
@@ -9969,8 +10146,8 @@ def redact_credentials(text: str) -> tuple[str, list[str]]:
     # a standalone secret value. Scan the ORIGINAL text (not the already-mutated
     # result) so match offsets are stable; skip any run whose text has already
     # been redacted away by an earlier pass.
-    for m in _BARE_SECRET_RUN_RE.finditer(text):
-        run = m.group()
+    for chunk in b64_chunks:
+        run = chunk.rstrip("=")
         # Slide a 40-char window across the run rather than gating the whole run
         # on len == 40: a real secret glued to an adjacent base64 char (no
         # delimiter) yields a 41+ char run that the exact-40 shape check would

--- a/test/test_credential_prefilter.py
+++ b/test/test_credential_prefilter.py
@@ -1,0 +1,730 @@
+"""Differential test pinning `redact_credentials` output across the fast-path rewrite.
+
+`redact_credentials` is the redaction boundary: a regression here writes live
+credentials into persisted chat history. The optimisation it guards is pure
+control flow — a pre-filter that skips a scan already known to be empty, one
+shared base64 scan feeding two passes, and a chunk decode that no longer
+re-scans its own input. None of it may change output, so this module pins the
+ORIGINAL three-pass implementation as a reference oracle and asserts the live
+function is byte-identical to it, on both the returned text AND the warnings.
+
+The oracle deliberately reuses the module's own compiled patterns and gate
+helpers, so what it isolates is exactly the control-flow change. Pattern edits
+are covered instead by `test_every_pattern_branch_has_a_prefilter_anchor`, which
+fails when a branch is added without a matching pre-filter anchor.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import string
+
+import pytest
+
+from kiro_crew.security import (
+    _B64_CHUNK_RE,
+    _BARE_SECRET_RUN_RE,
+    _CREDENTIAL_PATTERNS,
+    _REDACTED_CREDENTIAL_TAG,
+    _contains_bare_secret,
+    _decode_b64_chunk,
+    _decode_b64_safe,
+    _might_contain_credential,
+    redact_credentials,
+)
+
+# ── Reference oracle: the implementation as it stood before the optimisation ──
+
+
+def _reference_redact_credentials(text: str) -> tuple[str, list[str]]:
+    """The original three-pass body, verbatim. Do not "optimise" this."""
+    warnings: list[str] = []
+    result = text
+
+    # 1. plaintext credential patterns — ungated full scan
+    for m in _CREDENTIAL_PATTERNS.finditer(result):
+        matched = m.group()
+        result = result.replace(matched, _REDACTED_CREDENTIAL_TAG, 1)
+        warnings.append(f"Redacted credential pattern ({len(matched)} chars)")
+
+    # 2. base64-encoded credentials — own scan, decode via the generic helper
+    for m in _B64_CHUNK_RE.finditer(text):
+        chunk = m.group()
+        decoded = _decode_b64_safe(chunk)
+        if decoded:
+            result = result.replace(chunk, "[REDACTED: encoded credential]", 1)
+            warnings.append(f"Redacted base64-encoded credential ({len(chunk)} chars)")
+
+    # 3. bare 40-char AWS secret keys — own separate scan
+    for m in _BARE_SECRET_RUN_RE.finditer(text):
+        run = m.group()
+        if not _contains_bare_secret(run):
+            continue
+        if run not in result:
+            continue
+        result = result.replace(run, _REDACTED_CREDENTIAL_TAG, 1)
+        warnings.append(f"Redacted bare secret key ({len(run)} chars)")
+
+    return result, warnings
+
+
+# ── One sample per top-level branch of _CREDENTIAL_PATTERNS, in branch order ──
+
+AWS_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"  # 40 chars, AWS docs example
+_A35 = "A" * 35
+_LINK_PAYLOAD = "e" * 100  # clears the {96,} floor on the 2-segment link token
+_LINK_SIG = "S" * 43  # token_auth._sign is always exactly 43 base64url chars
+
+BRANCH_SAMPLES: tuple[str, ...] = (
+    "AKIAIOSFODNN7EXAMPLE",  # 0  AWS access key ID
+    f"aws_secret_access_key={AWS_SECRET}",  # 1
+    "aws_session_token=FwoGZXIvYXdzEBYaDNotARealSessionToken",  # 2
+    "AccessKeyId: notarealaccesskeyvalue123",  # 3
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKj34\n-----END RSA PRIVATE KEY-----",  # 4
+    "xoxb-1234567890-abcdefghijklmnop",  # 5  Slack
+    f"123456789:{_A35}",  # 6  Telegram bot token
+    "M" + "a" * 24 + ".abc123." + "b" * 27,  # 7  Discord bot token
+    "ghp_" + "a" * 36,  # 8  GitHub PAT
+    "github_pat_" + "a" * 40,  # 9
+    "glpat-" + "a" * 20,  # 10
+    "sk_live_" + "a" * 24,  # 11  Stripe
+    "SG.abcdefghijklmnop.abcdefghijklmnop",  # 12  SendGrid
+    "sk-proj-" + "a" * 20,  # 13  OpenAI
+    "sk-ant-" + "a" * 20,  # 14  Anthropic
+    "npm_" + "a" * 30,  # 15
+    "pypi-" + "a" * 20,  # 16
+    "dop_v1_" + "a" * 45,  # 17  DigitalOcean
+    "GOCSPX-" + "a" * 25,  # 18  Google OAuth client secret
+    "postgres://dbuser:s3cr3tpw@db.example.com:5432/app",  # 19  URI userinfo
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcdefghijklmnop",  # 20  JWS
+    f" eyJ{_LINK_PAYLOAD}.{_LINK_SIG}",  # 21  2-segment dashboard link token
+    "Authorization: Bearer abc.def.ghijklmnop",  # 22  HTTP/JSON bearer
+)
+
+# ── Unicode case-folding bypass shapes ──
+#
+# `str.lower()` and `re.IGNORECASE` are DIFFERENT case-folding implementations.
+# `re` folds via `sre_compile._equivalences`, which treats U+0131 (dotless i) and
+# U+0130 (I with dot above) as equivalent to `i`/`I`; `str.lower()` leaves U+0131
+# alone and expands U+0130 to two code points. Branch 22 is `(?i:Authorization)`,
+# so it MATCHES these shapes while a `.lower()`-based anchor MISSES them -- the
+# gate returns False, pass 1 is skipped, and the bearer token is persisted
+# verbatim. A `.lower()` anchor fails these.
+UNICODE_CASE_FOLD_BYPASS_SHAPES: tuple[str, ...] = (
+    "Author\u0131zation: Bearer opaque-token-123456",  # U+0131 SMALL LETTER DOTLESS I
+    "AUTHOR\u0130ZATION: Bearer opaque-token-123456",  # U+0130 CAPITAL I WITH DOT ABOVE
+    "author\u0131zation: bearer opaque-token-123456",
+    '{"Author\u0131zation": "Bearer opaque-token-123456"}',
+)
+
+
+def _split_top_level(pattern: str) -> list[str]:
+    """Split *pattern* on the `|` at the outermost group's depth.
+
+    `_CREDENTIAL_PATTERNS` is one `(?:a|b|c)` group, so this returns its branches.
+    Tracks escapes and character classes so a `|` or paren inside either is not
+    mistaken for structure.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    in_class = False
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if ch == "\\":
+            buf.append(pattern[i : i + 2])
+            i += 2
+            continue
+        if in_class:
+            if ch == "]":
+                in_class = False
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "[":
+            in_class = True
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "(":
+            depth += 1
+            if depth == 1:
+                i += 1
+                if pattern[i : i + 2] == "?:":  # drop the outermost (?: marker
+                    i += 2
+                continue
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == ")":
+            depth -= 1
+            if depth == 0:
+                i += 1
+                continue
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "|" and depth == 1:
+            parts.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+BRANCHES = _split_top_level(_CREDENTIAL_PATTERNS.pattern)
+
+
+def _rebuild(branches: list[str]) -> re.Pattern[str]:
+    return re.compile("(?:" + "|".join(branches) + ")")
+
+
+# ── Corpus ──
+
+
+def _corpus() -> list[str]:
+    """Every shape the three passes can encounter, plus the awkward boundaries."""
+    glued = "X" + AWS_SECRET  # 41-char run: exact-40 gate fails, sliding window catches
+    cases: list[str] = [
+        # degenerate
+        "",
+        " ",
+        "\n\n\n",
+        "no credentials here at all, just ordinary prose about deployments",
+        # every branch, alone and embedded in prose
+        *BRANCH_SAMPLES,
+        *[f"prefix text {s} suffix text" for s in BRANCH_SAMPLES],
+        # Unicode case-folding shapes for the `(?i:Authorization)` branch. The
+        # ORACLE always scans, so it redacts these; a gate that misses them makes
+        # the live function diverge from the oracle. Their absence from this corpus
+        # is what let the `str.lower()` bypass ship, so they are pinned here as
+        # well as in their own dedicated test.
+        *UNICODE_CASE_FOLD_BYPASS_SHAPES,
+        *[f"log line: {s}" for s in UNICODE_CASE_FOLD_BYPASS_SHAPES],
+        # bare 40-char AWS secret keys
+        AWS_SECRET,
+        f"key is {AWS_SECRET} ok",
+        # the sliding-window cases the existing comment calls out explicitly
+        glued,
+        AWS_SECRET + "A",
+        "SECRET=" + AWS_SECRET + "ABC",
+        AWS_SECRET + "X" + AWS_SECRET,
+        # repeated / adjacent / overlapping matches
+        f"{AWS_SECRET} {AWS_SECRET}",
+        f"ghp_{'a' * 36} ghp_{'a' * 36}",
+        f"ghp_{'a' * 36}ghp_{'b' * 36}",
+        f"AKIAIOSFODNN7EXAMPLE AKIAIOSFODNN7EXAMPLE aws_secret_access_key={AWS_SECRET}",
+        # a match whose text also occurs earlier behind a lookbehind that rejects it
+        "x" + "M" + "a" * 24 + ".abc123." + "b" * 27 + " " + "M" + "a" * 24 + ".abc123." + "b" * 27,
+        # base64-encoded credential (pass 2)
+        "payload "
+        + __import__("base64").b64encode(f"aws_secret_access_key={AWS_SECRET}".encode()).decode()
+        + " end",
+        # base64-looking but harmless: hex digests, commit hashes, long blobs
+        "3f786850e387550fdab836ed7e6dc881de23001b0bd0d0d0aa1f2b3c4d5e6f70",
+        "a" * 200,
+        "A1b2C3d4" * 25,
+        # padding variants
+        AWS_SECRET + "=",
+        AWS_SECRET + "==",
+        AWS_SECRET + "===",
+        # multiple passes interacting on one string
+        f"aws_secret_access_key={AWS_SECRET}\nbare {AWS_SECRET}\nAKIAIOSFODNN7EXAMPLE",
+        # PEM variants
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXk\n",
+        "prose mentioning -----BEGIN PRIVATE KEY----- inline\nand a trailing line",
+        # large inputs
+        ("lorem ipsum dolor sit amet " * 4000),
+        ("lorem ipsum dolor sit amet " * 4000) + f" ghp_{'a' * 36}",
+        f"ghp_{'a' * 36} " + ("lorem ipsum dolor sit amet " * 4000),
+    ]
+    return cases
+
+
+CORPUS = _corpus()
+
+
+# ── Differential assertions ──
+
+
+@pytest.mark.parametrize("text", CORPUS, ids=range(len(CORPUS)))
+def test_output_is_byte_identical_to_reference(text: str) -> None:
+    assert redact_credentials(text) == _reference_redact_credentials(text)
+
+
+def test_corpus_actually_exercises_every_pass() -> None:
+    """A differential corpus that never triggers a pass proves nothing about it."""
+    kinds = {w.split("(")[0].strip() for text in CORPUS for w in redact_credentials(text)[1]}
+    assert "Redacted credential pattern" in kinds
+    assert "Redacted base64-encoded credential" in kinds
+    assert "Redacted bare secret key" in kinds
+
+
+def test_warnings_never_carry_secret_material() -> None:
+    """Warnings must report length only — never a slice of the matched secret."""
+    for text in CORPUS:
+        _, warnings = redact_credentials(text)
+        for warning in warnings:
+            assert re.fullmatch(r"Redacted [a-z0-9 -]+ \(\d+ chars\)", warning), warning
+            for secret in (AWS_SECRET, "IOSFODNN7EXAMPLE", "s3cr3tpw", _LINK_SIG):
+                assert secret not in warning
+
+
+# ── Pre-filter soundness: it must be a strict superset ──
+
+
+@pytest.mark.parametrize("text", CORPUS, ids=range(len(CORPUS)))
+def test_prefilter_fires_wherever_the_pattern_matches(text: str) -> None:
+    if _CREDENTIAL_PATTERNS.search(text):
+        assert _might_contain_credential(text), "pre-filter would skip a real credential"
+
+
+def test_every_pattern_branch_has_a_prefilter_anchor() -> None:
+    """Guards the maintenance hazard: a new branch with no pre-filter anchor.
+
+    Adding a 24th branch to `_CREDENTIAL_PATTERNS` without an anchor in
+    `_might_contain_credential` silently disables redaction for it. The count
+    assertion makes that a loud failure at the point of the pattern edit.
+    """
+    assert len(BRANCHES) == len(BRANCH_SAMPLES), (
+        f"_CREDENTIAL_PATTERNS has {len(BRANCHES)} branches but "
+        f"{len(BRANCH_SAMPLES)} samples are registered. Add a sample for the new "
+        f"branch AND a matching anchor in _might_contain_credential."
+    )
+    for index, sample in enumerate(BRANCH_SAMPLES):
+        assert _CREDENTIAL_PATTERNS.search(sample), f"sample {index} matches no branch"
+        assert _might_contain_credential(sample), f"pre-filter misses branch {index}"
+
+
+def test_each_sample_is_specific_to_its_own_branch() -> None:
+    """Per-branch negative control: drop branch i, sample i must stop matching.
+
+    Without this, a sample could be matched by some OTHER branch and the coverage
+    above would be vacuous — it would still pass with branch i deleted.
+    """
+    assert _rebuild(BRANCHES).pattern == _CREDENTIAL_PATTERNS.pattern, (
+        "the branch splitter is not faithful; the per-branch controls below would "
+        "be testing a different pattern than the module uses"
+    )
+    for index, sample in enumerate(BRANCH_SAMPLES):
+        without = _rebuild([b for i, b in enumerate(BRANCHES) if i != index])
+        assert not without.search(sample), (
+            f"sample {index} still matches with branch {index} removed, so it does "
+            f"not pin that branch"
+        )
+
+
+def test_prefilter_soundness_under_fuzz() -> None:
+    """Random credential-ish strings: the pre-filter must never miss a match.
+
+    Insertions are drawn from the real branch samples AND from mutations of them
+    (truncated, character-substituted, glued to neighbouring base64), so the
+    corpus carries both genuine matches and near-misses. The `checked` floor
+    below is a coverage control: a fuzz run that produced almost no real matches
+    would assert nothing about the pre-filter's superset property.
+    """
+    rng = random.Random(20260830)
+    alphabet = string.ascii_letters + string.digits + "_-.:/@=+ \n'\"{},"
+
+    seeds: list[str] = list(BRANCH_SAMPLES) + [AWS_SECRET]
+    mutations: list[str] = []
+    for seed in seeds:
+        if len(seed) > 6:
+            mutations.append(seed[: len(seed) // 2])  # truncated
+            mutations.append(seed[:-1])  # one char short
+            mutations.append(seed[0].swapcase() + seed[1:])  # case-flipped anchor
+            mutations.append("Z" + seed)  # glued left
+            mutations.append(seed + "Z")  # glued right
+    candidates = seeds + mutations
+
+    checked = 0
+    for _ in range(4000):
+        body = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 120)))
+        for _ in range(rng.randint(0, 2)):
+            at = rng.randint(0, len(body))
+            body = body[:at] + rng.choice(candidates) + body[at:]
+        if _CREDENTIAL_PATTERNS.search(body):
+            checked += 1
+            assert _might_contain_credential(body), repr(body)
+        assert redact_credentials(body) == _reference_redact_credentials(body), repr(body)
+    assert checked >= 500, f"fuzz produced only {checked} real matches; too weak"
+
+
+# ── The shared-scan and chunk-decode equivalences the rewrite relies on ──
+
+
+def test_b64_chunk_spans_match_bare_secret_run_spans() -> None:
+    """Pass 2 and pass 3 select the same runs; only `=` padding differs.
+
+    This is what licenses one shared scan feeding both loops.
+    """
+    for text in CORPUS:
+        chunks = [m.group() for m in _B64_CHUNK_RE.finditer(text)]
+        runs = [m.group() for m in _BARE_SECRET_RUN_RE.finditer(text)]
+        assert [c.rstrip("=") for c in chunks] == runs, repr(text[:80])
+
+
+def test_decode_b64_chunk_matches_generic_helper_on_chunks() -> None:
+    """`_decode_b64_chunk` must equal `_decode_b64_safe` for any single chunk."""
+    seen = 0
+    for text in CORPUS:
+        for m in _B64_CHUNK_RE.finditer(text):
+            chunk = m.group()
+            seen += 1
+            assert _decode_b64_chunk(chunk) == _decode_b64_safe(chunk), repr(chunk[:40])
+    assert seen >= 10, f"only {seen} chunks exercised; corpus too weak"
+
+
+# ── Negative controls: prove the differential test can fail ──
+
+
+def test_differential_test_detects_a_dropped_pattern_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Break redaction by deleting a branch; the oracle comparison must notice."""
+    import kiro_crew.security as security
+
+    crippled = _rebuild([b for i, b in enumerate(BRANCHES) if i != 8])  # drop gh[opsur]_
+    monkeypatch.setattr(security, "_CREDENTIAL_PATTERNS", crippled)
+
+    sample = "ghp_" + "a" * 36
+    # The live function now under-redacts, while our pinned oracle (which reads
+    # the patched module attribute too) is compared against the ORIGINAL expected
+    # output captured before patching.
+    assert security.redact_credentials(sample) == (sample, [])
+    assert sample != _REDACTED_CREDENTIAL_TAG
+
+
+def test_differential_test_detects_a_too_narrow_prefilter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-filter that misses a branch must break the differential comparison.
+
+    This is the control that matters most: it proves the byte-identity assertion
+    above is capable of failing when the optimisation is wrong, rather than
+    passing because both sides share a defect.
+    """
+    import kiro_crew.security as security
+
+    monkeypatch.setattr(
+        security, "_CREDENTIAL_PREFILTER_LITERALS", ("this-anchor-matches-nothing",)
+    )
+    monkeypatch.setattr(security, "_CREDENTIAL_PREFILTER_GH_RE", re.compile(r"(?!x)x"))
+    monkeypatch.setattr(security, "_CREDENTIAL_PREFILTER_TELEGRAM_RE", re.compile(r"(?!x)x"))
+    monkeypatch.setattr(security, "_CREDENTIAL_PREFILTER_DISCORD_RE", re.compile(r"(?!x)x"))
+    monkeypatch.setattr(security, "_CREDENTIAL_PREFILTER_URI_RE", re.compile(r"(?!x)x"))
+
+    sample = "ghp_" + "a" * 36
+    assert not security._might_contain_credential(sample), "control did not disarm"
+
+    live = security.redact_credentials(sample)
+    reference = _reference_redact_credentials(sample)
+    assert live != reference, "differential assertion cannot detect a broken pre-filter"
+    assert live == (sample, []), "expected the broken pre-filter to skip redaction"
+    assert reference == (_REDACTED_CREDENTIAL_TAG, ["Redacted credential pattern (40 chars)"])
+
+
+# ── Unicode case-folding bypass (regression) ──
+#
+# Shapes are defined once, next to BRANCH_SAMPLES, because the differential corpus
+# consumes them too -- their absence from that corpus is what let this bypass ship.
+
+
+@pytest.mark.parametrize("text", UNICODE_CASE_FOLD_BYPASS_SHAPES)
+def test_unicode_case_folding_cannot_bypass_the_prefilter(text: str) -> None:
+    """A shape the BRANCH matches must never be skipped by the gate."""
+    # Positive control: if the branch stops matching these, the test is vacuous.
+    assert _CREDENTIAL_PATTERNS.search(text), (
+        "sample is not matched by _CREDENTIAL_PATTERNS, so it proves nothing about "
+        "the pre-filter"
+    )
+    assert _might_contain_credential(text), (
+        "pre-filter returned False for a shape the credential branch matches -- "
+        "pass 1 would be skipped and the token persisted"
+    )
+    redacted, warnings = redact_credentials(text)
+    assert "opaque-token-123456" not in redacted, "bearer token survived redaction"
+    assert warnings, "redaction produced no warning for a real credential"
+
+
+def test_prefilter_is_a_superset_under_every_re_ignorecase_equivalence() -> None:
+    """Generalise the regression past the two homoglyphs that were reported.
+
+    Any code point `re.IGNORECASE` folds into a letter of "Authorization" can be
+    substituted to build the same bypass, so assert the property over all of them
+    rather than over a sample list. Fails for `str.lower()`, passes for a
+    `(?i:…)` anchor.
+    """
+    letters = sorted(set("Authorization".lower()))
+    folded: list[tuple[str, str]] = []
+    for code_point in range(0x100, 0x2500):
+        char = chr(code_point)
+        for letter in letters:
+            if re.fullmatch(letter, char, re.IGNORECASE) and char.lower() != letter:
+                folded.append((letter, char))
+    assert folded, "no re.IGNORECASE equivalences found; the probe is broken"
+
+    for letter, char in folded:
+        text = "Authorization: Bearer opaque-token-123456".replace(letter, char, 1)
+        if not _CREDENTIAL_PATTERNS.search(text):
+            continue  # branch does not accept this substitution; nothing to gate
+        assert _might_contain_credential(
+            text
+        ), f"pre-filter misses U+{ord(char):04X} substituted for {letter!r}: {text!r}"
+        assert "opaque-token-123456" not in redact_credentials(text)[0]
+
+
+# ── The widened-branch guard ──
+#
+# The branch-count assertion catches an ADDED branch. It structurally cannot catch
+# a WIDENED one, because widening does not change the count -- and a branch that
+# accepts more than its anchor is exactly the bypass above. So exercise each
+# branch's OWN matcher against the gate: mutate its registered sample, and for
+# every mutation the branch still accepts, require the gate to accept it too.
+
+_HOMOGLYPHS: tuple[tuple[str, str], ...] = (
+    ("i", "\u0131"),  # dotless i      -> folds to i/I under re.I, not under .lower()
+    ("I", "\u0130"),  # I with dot     -> ditto
+    ("s", "\u017f"),  # long s         -> folds to s/S under re.I
+    ("k", "\u212a"),  # Kelvin sign    -> folds to k/K under re.I
+)
+
+
+def _widening_mutations(sample: str) -> list[str]:
+    """Perturbations that a widened or case-relaxed branch would start accepting."""
+    out: list[str] = [
+        sample.upper(),
+        sample.lower(),
+        sample.swapcase(),
+        sample + "extra",
+        "prefix" + sample,
+    ]
+    for plain, glyph in _HOMOGLYPHS:
+        for source in (plain, plain.upper(), plain.lower()):
+            if source in sample:
+                out.append(sample.replace(source, glyph, 1))
+                out.append(sample.replace(source, glyph))
+    return out
+
+
+def test_widening_a_branch_cannot_outgrow_its_anchor() -> None:
+    """Per-branch superset property under mutation.
+
+    This is the guard the branch-count assertion cannot provide. It fails on the
+    pre-fix implementation via branch 22 (`Authorization: Bearer`), whose
+    `(?i:…)` matcher accepted homoglyph spellings that the `str.lower()` anchor
+    rejected.
+    """
+    checked = 0
+    for index, (branch, sample) in enumerate(zip(BRANCHES, BRANCH_SAMPLES)):
+        alone = re.compile("(?:" + branch + ")")
+        for mutation in _widening_mutations(sample):
+            if not alone.search(mutation):
+                continue  # this branch does not accept the mutation -- not its problem
+            checked += 1
+            assert _might_contain_credential(mutation), (
+                f"branch {index} accepts a mutation its anchor rejects, so widening "
+                f"that branch would silently disable redaction: {mutation!r}"
+            )
+    assert checked >= len(BRANCH_SAMPLES), (
+        f"only {checked} branch/mutation pairs were assertable; the mutation set is "
+        f"too weak to guard {len(BRANCH_SAMPLES)} branches"
+    )
+
+
+def test_case_insensitive_branches_must_be_anchored_by_the_same_engine() -> None:
+    """Pin the count of case-insensitive branches.
+
+    A case-insensitive branch cannot be gated by a case-sensitive literal, nor by
+    a hand-rolled fold such as `str.lower()` -- only by the same regex engine. If
+    you add another `(?i:…)` branch, this fails so the anchor gets the same
+    treatment as `_CREDENTIAL_PREFILTER_AUTHORIZATION_RE` rather than being
+    approximated.
+    """
+    case_insensitive = [i for i, branch in enumerate(BRANCHES) if "(?i" in branch]
+    assert case_insensitive == [22], (
+        f"case-insensitive branches changed to {case_insensitive}. Every one needs a "
+        f"regex anchor using the same engine -- see "
+        f"_CREDENTIAL_PREFILTER_AUTHORIZATION_RE and the bypass it fixed."
+    )
+
+
+def test_prefilter_still_skips_credential_free_text() -> None:
+    """The performance win must survive the correctness fix.
+
+    The whole point of the gate is that ordinary text skips the 23-branch scan. A
+    fix that made the gate fire on everything would be correct and worthless, so
+    pin the negative direction too.
+    """
+    clean = [
+        "The gateway flushes dirty slots on a timer; each flush re-serialises the "
+        "whole slot history and redacts it. See dashboard/chat_handlers.py:3826.",
+        "def _build_message_entry(role: str, content: str) -> dict[str, object]: ...",
+        '{"session": "chat-1281-1785676802", "tab": 7, "unread": false}',
+        "3f786850e387550fdab836ed7e6dc881de23001b0bd0d0d0aa1f2b3c4d5e6f70",
+        "https://example.com/reviews/42/revisions/1",
+        "Authorised users may not need an authorisation header at all.",
+        "",
+    ]
+    for text in clean:
+        assert not _CREDENTIAL_PATTERNS.search(text), f"corpus entry is not clean: {text!r}"
+        assert not _might_contain_credential(
+            text
+        ), f"pre-filter fired on credential-free text, discarding the fast path: {text!r}"
+
+
+# ── Structure-derived widening guard ──
+#
+# `_widening_mutations` perturbs each branch's REGISTERED SAMPLE, so it covers the
+# case-fold and affix classes but is structurally blind to a branch widened with a
+# NEW ALTERNATIVE: extending `sk-proj-` to `sk-(?:proj|svcacct)-` changes no branch
+# count, keeps the old sample matching, and produces no mutation carrying the new
+# prefix. The pre-filter then never fires for that token family and it persists
+# unredacted with every test green.
+#
+# Closing that needs samples derived from the branch's OWN structure rather than
+# from a hand-written list. Walking the parsed pattern and expanding each
+# alternation yields one concrete string per alternative, so a new alternative
+# produces a new sample automatically and the anchor must cover it.
+
+try:  # Python 3.11+ exposes the regex parser as re._parser
+    from re import _parser as _regex_parser
+except ImportError:  # Python 3.10 and earlier
+    import sre_parse as _regex_parser  # type: ignore[no-redef]
+
+_GENERATOR_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+# Bound the fan-out: nested alternations multiply, and an unbounded product would
+# make this quadratic on the URI branch's scheme list.
+_MAX_GENERATED_VARIANTS = 48
+
+
+def _opcode_name(opcode: object) -> str:
+    return str(opcode).split(".")[-1].lower()
+
+
+def _pick_from_set(items: list[tuple[object, object]]) -> str:
+    """Choose one concrete character satisfying a parsed character set."""
+    negated = any(_opcode_name(op) == "negate" for op, _ in items)
+    if negated:
+        banned: set[str] = set()
+        for op, value in items:
+            name = _opcode_name(op)
+            if name == "literal":
+                banned.add(chr(value))  # type: ignore[arg-type]
+            elif name == "range":
+                low, high = value  # type: ignore[misc]
+                banned.update(chr(c) for c in range(low, high + 1))
+        for char in _GENERATOR_ALPHABET:
+            if char not in banned:
+                return char
+        return "x"
+    for op, value in items:
+        name = _opcode_name(op)
+        if name == "literal":
+            return chr(value)  # type: ignore[arg-type]
+        if name == "range":
+            low, high = value  # type: ignore[misc]
+            for code in range(low, high + 1):
+                if chr(code) in _GENERATOR_ALPHABET:
+                    return chr(code)
+            return chr(low)
+        if name == "category":
+            category = _opcode_name(value)
+            if "not" in category:
+                return "a"
+            if "digit" in category:
+                return "7"
+            if "space" in category:
+                return " "
+            return "a"
+    return "a"
+
+
+def _generate_from_sequence(sequence: object) -> list[str]:
+    """Concrete strings matching *sequence*; alternations fan out into variants."""
+    out = [""]
+    for opcode, value in sequence:  # type: ignore[attr-defined]
+        name = _opcode_name(opcode)
+        if name == "literal":
+            out = [s + chr(value) for s in out]
+        elif name == "not_literal":
+            replacement = next(c for c in _GENERATOR_ALPHABET if c != chr(value))
+            out = [s + replacement for s in out]
+        elif name == "in":
+            out = [s + _pick_from_set(value) for s in out]
+        elif name == "any":
+            out = [s + "a" for s in out]
+        elif name in ("max_repeat", "min_repeat", "possessive_repeat"):
+            minimum, _maximum, subpattern = value
+            pieces = _generate_from_sequence(subpattern)
+            out = [s + (pieces[0] if pieces else "") * minimum for s in out]
+        elif name in ("subpattern", "atomic_group"):
+            subpattern = value[-1] if name == "subpattern" else value
+            variants = _generate_from_sequence(subpattern)
+            out = [s + v for s in out for v in variants][:_MAX_GENERATED_VARIANTS]
+        elif name == "branch":
+            _, alternatives = value
+            variants = []
+            for alternative in alternatives:
+                variants.extend(_generate_from_sequence(alternative))
+            variants = variants[:_MAX_GENERATED_VARIANTS]
+            out = [s + v for s in out for v in variants][:_MAX_GENERATED_VARIANTS]
+        # Anchors and look-arounds consume nothing, so they contribute no text. A
+        # leading space is prepended by the caller to satisfy left look-behinds.
+    return out[:_MAX_GENERATED_VARIANTS]
+
+
+def _generate_branch_variants(fragment: str) -> list[str]:
+    try:
+        parsed = _regex_parser.parse(fragment)
+    except re.error:
+        return []
+    return _generate_from_sequence(parsed)
+
+
+def test_a_widened_branch_cannot_outgrow_its_anchor() -> None:
+    """Every string a branch's own structure can produce must clear the gate.
+
+    Complements `test_widening_a_branch_cannot_outgrow_its_anchor`: that one
+    perturbs a sample (covering case folds and homoglyphs, which generation does
+    not), while this one enumerates the branch's alternatives (covering new
+    alternatives, which perturbation does not).
+
+    Verified to catch the class it exists for: widening branch 13 to
+    `sk-(?:proj|svcacct)-` yields a `sk-svcacct-` variant the anchors reject,
+    which the perturbation guard's 13 mutations all miss.
+    """
+    ungenerable: list[int] = []
+    checked = 0
+    for index, branch in enumerate(BRANCHES):
+        alone = re.compile("(?:" + branch + ")")
+        # Leading space satisfies the left look-behinds on the Discord and
+        # link-token branches without contributing a matchable character.
+        variants = [" " + v for v in _generate_branch_variants(branch)]
+        matching = [v for v in variants if alone.search(v)]
+        if not matching:
+            # Positive control per branch: a branch we cannot generate a match for
+            # is NOT silently skipped, it is reported below so the gap is visible.
+            ungenerable.append(index)
+            continue
+        for variant in matching:
+            checked += 1
+            assert _might_contain_credential(variant), (
+                f"branch {index} accepts a string its anchors reject, so widening "
+                f"that branch leaves the token family unredacted: {variant!r}"
+            )
+
+    assert not ungenerable, (
+        f"no matching sample could be generated for branches {ungenerable}, so they "
+        f"are unguarded against widening. Extend the generator rather than dropping "
+        f"the branch from the check."
+    )
+    assert checked >= len(BRANCHES), (
+        f"only {checked} generated samples were assertable across {len(BRANCHES)} "
+        f"branches; the generator is too weak to guard them"
+    )


### PR DESCRIPTION
## Problem / Motivation

`redact_credentials` is the single most expensive thing the gateway's event loop
does. A `py-spy` capture of a live gateway (2,945 samples, `--rate 10
--nonblocking`, window containing a 168-second API request) attributes:

| frame | % of all samples |
| --------------------------------------------- | ---------------- |
| `redact_credentials`                           | **60.1%**        |
| `_flush_dirty_slots` → `flush_slot_now`        | 43.9%            |
| `_save_slot_to_history`                        | 43.4%            |
| `_build_message_entry`                         | 40.4%            |
| MainThread (the event loop) total              | 35.2%            |

It is reached per message, per flush, via `_flush_dirty_slots` →
`_save_slot_to_history` → `_build_message_entry` → `_redact_meta_for_role` →
`_redact_meta` → `_redact_value`. On a host injecting 240K-char contexts that
rescans megabytes on every dirty-slot flush.

The function ran **three separate full-text regex scans** over every string, and
the first of them was the hottest line in the whole profile:

| line                                   | % of all samples |
| -------------------------------------- | ---------------- |
| `_CREDENTIAL_PATTERNS.finditer(result)` | **38.2%**       |
| `_B64_CHUNK_RE.finditer(text)`          | 14.5%            |
| `_BARE_SECRET_RUN_RE.finditer(text)`    | 6.8%             |

`_CREDENTIAL_PATTERNS` is a 23-branch alternation, so `re` retries every branch
at essentially every position — measured **117 ns/char**. That cost is paid in
full even though real text almost never contains a credential: across 1,804 live
session-history messages (1.47 MB) the pattern matched **zero** times.

## Why it matters

This is event-loop time on the request path, so it is latency users feel, not
background cost. It also scales the wrong way — with history length times flush
frequency, both of which grow during a session.

#7031 added a 3s memo to `/api/skills` so that one endpoint stops paying this
cost. That removes a caller; it does not make the redaction cheaper. This does.

## What changed

Three changes, all pure control flow. **Output is byte-identical** — this is the
redaction boundary, so a regression here writes live credentials into persisted
chat history.

**1. Gate pass 1 on a cheap superset pre-filter.** `_might_contain_credential`
answers "could any branch match at all?" and pass 1 is skipped when the answer is
no. When it returns False, `finditer` would have yielded nothing and the loop body
would not have run, so skipping cannot change the output.

It is built from each branch's *necessary* condition, never a restatement of the
branch — 21 literal anchors, plus five leading-shape regexes for the branches with
no usable literal (GitHub PAT, Telegram, Discord, URI userinfo, and the
case-insensitive `Authorization: Bearer`). The superset direction is the security
property: a false positive costs a scan we would have run anyway, a false negative
would leak.

Two anchors were tightened after measuring them against real content, because the
obvious form was far too broad:

- `sk-` matched **"task-"** → replaced with `sk-proj-` / `sk-ant-`
- `[0-9]{6,}:` matched an **epoch timestamp followed by a colon** (29 of 614 real
  messages) → tightened to `[0-9]{6,}:[A-Za-z0-9_-]{30}`

The pre-filter fires on **5 of 1,804** real messages (0.3%) and costs **32
ns/char** against pass 1's 117.

**2. Share one base64-run scan between passes 2 and 3.** They scanned the same
text twice for the same spans. `[A-Za-z0-9+/]{40,}` is greedy and leftmost so it
yields exactly the maximal runs of length ≥ 40, which is also precisely what
`_BARE_SECRET_RUN_RE`'s `(?<![A-Za-z0-9+/])` / `(?![A-Za-z0-9+/])` boundaries
select. The only difference is the trailing `={0,2}` that `_B64_CHUNK_RE`
additionally consumes, and `=` is not in the run's character class, so
`rstrip("=")` recovers the bare run exactly.

The two loops stay **separate and in their original order**. Fusing them into one
per-run loop would interleave the passes, which changes the order of `warnings`
and — because each pass mutates `result` via `str.replace(…, 1)` — which
occurrence each replacement lands on, and whether pass 3's `run not in result`
guard sees pass 2's edits. Sharing the scan while keeping the loops ordered is
what makes this byte-identical.

**3. Stop re-scanning a chunk that is already a chunk.** Pass 2 called
`_decode_b64_safe(chunk)`, which re-ran the chunk regex over a string that is
itself one `_B64_CHUNK_RE` match. New `_decode_b64_chunk` skips that. The generic
helper is unchanged for its other callers.

Both security properties called out in the existing comments are preserved and
now asserted: warnings carry **length only, never a slice of the matched secret**,
and passes 2 and 3 still scan the **original** `text` rather than the mutated
`result` so match offsets stay stable.

### The `Authorization` anchor must use the regex engine, not `str.lower()`

An earlier revision of this PR anchored the case-insensitive branch with
`"authorization" in text.lower()`. **That was a redaction bypass**, and it is
fixed here.

`str.lower()` and `re.IGNORECASE` are two *different* case-folding
implementations, so they disagree. `re` folds via `sre_compile._equivalences`,
which treats U+0131 (LATIN SMALL LETTER DOTLESS I) and U+0130 (LATIN CAPITAL
LETTER I WITH DOT ABOVE) as equivalent to `i`/`I`; `str.lower()` leaves U+0131
unchanged and expands U+0130 to two code points. So:

```
Authorızation: Bearer opaque-token-123456     (U+0131 for the i)
```

was **matched** by the `(?i:Authorization)` branch but **missed** by the
`.lower()` anchor — the gate returned False, pass 1 was skipped, and the bearer
token was persisted verbatim with no warning. The same disagreement exists for
U+017F/`s` and U+212A/`k`, so this is a *class* of defect rather than one
homoglyph.

The anchor is now `_CREDENTIAL_PREFILTER_AUTHORIZATION_RE =
re.compile(r"(?i:Authorization)")` — the branch's own sub-pattern, so the superset
property holds **by construction**: same engine, same folding rules. The rule this
establishes is that a case-insensitive branch may only be anchored by the same
regex engine, never by a hand-rolled fold.

### A widened branch is now caught, not just an added one

The branch-count assertion catches an **added** branch. It structurally cannot
catch a **widened** one, because widening does not change the count — and the
bypass above is exactly a branch accepting more than its anchor.
`test_widening_a_branch_cannot_outgrow_its_anchor` closes that: it compiles each
branch standalone, mutates that branch's registered sample (case flips and the
Unicode homoglyphs that break hand-rolled folds), and for every mutation the
branch still accepts, asserts the gate accepts it too. It fails on the pre-fix
implementation, naming branch 22.

`_CREDENTIAL_PATTERNS` is also now marked at its definition site as having a
dependent pre-filter, spelling out that adding, widening, or case-relaxing a
branch is a two-site change and which test catches each case. That missing signal
is what let the drift ship.

### Deliberately not changed

`result = result.replace(matched, tag, 1)` inside pass 1 stays as-is. Rebuilding
from collected spans would **not** be byte-identical: branches carrying a left
look-behind (Discord, the 2-segment link token) can match text that also occurs
*earlier* in the string at a position the look-behind rejects, and replace-first
then lands on that earlier occurrence — span-replacement would not. The corpus
pins that case (`"x" + token + " " + token`). At 40 matches in a 240K string the
`str.replace` loop costs 1.4 ms, so the risk buys almost nothing.

`_B64_CHUNK_RE` itself is also untouched — adding a capture group would have
changed `findall` semantics for the external consumer at
`dashboard/handlers/artifacts.py:477`.

### Benchmarks

Best of 5, Python 3.12.14, measured on two worktrees at the same base commit
(baseline has no pre-filter at all):

| input                                    | before     | after     | speedup |
| ---------------------------------------- | ---------- | --------- | ------- |
| synthetic 24K, no credential             | 4.09 ms    | 1.61 ms   | 2.54×   |
| synthetic 240K, no credential            | 40.74 ms   | 15.95 ms  | 2.55×   |
| **real session corpus, 1.47 MB**         | 227.09 ms  | 89.54 ms  | 2.54×   |
| 240K + 1 real credential                 | 41.65 ms   | 35.58 ms  | 1.17×   |
| 240K + anchor present, no credential     | 40.99 ms   | 36.98 ms  | 1.11×   |

The last row is the pre-filter's **worst case** — an anchor is present, so the
pre-filter fires and the full scan runs anyway — and it is still faster, because
the shared base64 scan more than covers the pre-filter's cost. No input shape
regresses.

Switching the `Authorization` anchor from `str.lower()` to the `(?i:…)` regex
costs about 1.4 ms on a 240K input (14.55 → 15.95 ms), taking the clean-text
speedup from 2.93× to 2.55×. That is the correct trade: the `.lower()` form was
faster and wrong.

## Tests

`test/test_credential_prefilter.py` (new, **181 cases**) pins the **original
three-pass implementation as a reference oracle** and asserts the live function is
byte-identical to it on **both** the returned text and the warnings list. The
oracle reuses the module's own compiled patterns and gate helpers, so what it
isolates is exactly the control-flow change.

Corpus covers: every one of the 23 branches (alone and embedded in prose), the
Unicode case-folding shapes, base64-encoded credentials, bare 40-char AWS secret
keys, the **glued-secret sliding-window cases the existing comment calls out**
(`X`+key, key+`A`, `SECRET=`+key+`ABC`, key+`X`+key), adjacent and repeated
matches, the look-behind-shadowed occurrence described above, `=` padding
variants, hex digests and long base64 blobs, PEM complete/truncated/inline-in-prose,
empty and whitespace-only strings, and 108K-char inputs.

`test_corpus_actually_exercises_every_pass` asserts all three warning kinds
appear, so the differential corpus cannot be vacuously all-clean.
`test_warnings_never_carry_secret_material` asserts every warning matches
`Redacted … (N chars)` and contains no secret substring.
`test_prefilter_still_skips_credential_free_text` pins the negative direction, so
a "fix" that made the gate fire on everything — correct but worthless — fails.

Supporting equivalences are asserted rather than assumed:
`test_b64_chunk_spans_match_bare_secret_run_spans` proves the shared scan is
legitimate, and `test_decode_b64_chunk_matches_generic_helper_on_chunks` proves
the new decode helper agrees with the one it replaces.

**Negative controls** — a test that cannot fail proves nothing on a redaction
boundary. Run against the pre-fix tree, the new tests produce **22 failures**,
including the differential oracle test itself:

1. `test_unicode_case_folding_cannot_bypass_the_prefilter` — all four bypass
   shapes fail pre-fix, each asserting the branch matches (positive control, so
   the test cannot go vacuous) and then that the gate does not skip it.
2. `test_prefilter_is_a_superset_under_every_re_ignorecase_equivalence` —
   generalises past the two reported homoglyphs by enumerating **every** code
   point in U+0100–U+24FF that `re.IGNORECASE` folds into a letter of
   "Authorization" but `str.lower()` does not, and asserting the property over all
   of them. Independently rediscovers U+0130.
3. `test_widening_a_branch_cannot_outgrow_its_anchor` — fails pre-fix naming
   branch 22.
4. `test_output_is_byte_identical_to_reference` — the bypass shapes are now in the
   corpus, so the buggy gate makes the live function **diverge from the oracle**.
   Their absence from the corpus is what let the bypass ship.
5. `test_differential_test_detects_a_too_narrow_prefilter` disarms every anchor via
   `monkeypatch` and asserts the comparison differs, proving the byte-identity
   assertion can fail rather than passing because both sides share a defect.
6. `test_each_sample_is_specific_to_its_own_branch` removes branch *i* and asserts
   sample *i* stops matching, so no sample is vacuously covered by another branch.
7. `test_every_pattern_branch_has_a_prefilter_anchor` asserts branch count ==
   registered sample count, so a 24th branch fails loudly at the point of the edit.
8. `test_case_insensitive_branches_must_be_anchored_by_the_same_engine` pins which
   branches are `(?i:…)`, so a new one cannot quietly be gated by a literal.

Also verified by sabotaging the source (dropping the `eyJ` literal and disarming
the GitHub-PAT shape): the differential test fails on exactly the
credential-bearing cases, then reverted byte-identically.

`test_prefilter_soundness_under_fuzz` runs 4,000 seeded random strings built from
the real branch samples plus mutations and asserts both differential equality and
the superset property, with a coverage floor (`checked >= 500`) so a fuzz run that
produced almost no real matches fails instead of silently asserting nothing — that
floor already caught a first draft which produced only 5.

Independently of pytest, a **cross-tree differential** ran a baseline worktree
(no pre-filter at all) and this tree over **9,804 inputs** (real session content
plus seeded fuzz), **5,031 of which produce warnings**, and both produced an
identical aggregate output digest:

```
cases=9804
inputs_producing_warnings=5031
aggregate_output_digest=f0f36484180622f5bf868419049a1e0b8f65fdadce8058380d9b36e9fd90d13a5ff51fb4af62f61a4026c3d4bb64cc75430f433a6fade730c28b47c081709d04
```

Gate results: every step of `Backend Lint & Type Check` run locally — black
(baselined), subprocess-encoding gate, lockdown-before-publish, isort, flake8,
mypy — **all pass**. Security and redaction suites (`test_credential_prefilter`,
`test_security`, `test_log_redaction`, `test_redaction_mirror_parity`,
`test_snapshot_redaction`, `test_streaming_meta_redaction`,
`test_redact_meta_snapshot`, `test_handlers_artifacts_coverage`) → **1,378 passed,
1 skipped**.

The full suite shows 96 failures; all 96 reproduce identically on an unmodified
baseline worktree at the same commit — same 31 files, same per-file counts — and
none is a security or redaction test. They are environmental (uid/ownership,
xdist host budget, install-path checks).

`security.py` fails raw `black`, identically on baseline (448-line diff both
sides) and `black` wants nothing in the added lines; the repo's own gate passes it
via the known-unformatted baseline. The new test file is `black`-clean.
