### PR TITLE
fix: restore scrollbar thumb on coarse pointers for overlay utility

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1637,6 +1637,15 @@ file-tree-container{
 .scrollbar-overlay::-webkit-scrollbar-thumb{background:transparent;border-radius:9999px;transition:background .2s}
 .scrollbar-overlay:hover::-webkit-scrollbar-thumb{background:var(--border)}
 .scrollbar-overlay:hover::-webkit-scrollbar-thumb:hover{background:var(--border-strong)}
+/* On touch the overlay utility would stay perpetually transparent: a finger never
+   produces the :hover that restores the thumb. A coarse pointer shows a persistent
+   thin thumb instead, so a capped scroll surface keeps a real affordance. Fine
+   pointers keep the hidden-until-hover behaviour so a scrollable box does not
+   always carry the global always-visible thumb. */
+@media (pointer: coarse) {
+  .scrollbar-overlay{scrollbar-color:var(--border) transparent}
+  .scrollbar-overlay::-webkit-scrollbar-thumb{background:var(--border)}
+}
 
 /* ── Send button sweep ── */
 .btn-sweep{position:relative;overflow:hidden}

--- a/website/src/test/ChatPage.composerChromeOcclusion.test.tsx
+++ b/website/src/test/ChatPage.composerChromeOcclusion.test.tsx
@@ -79,6 +79,17 @@ describe('composer status chrome cannot occlude the header rename editor', () =>
     expect(INDEX_CSS).toMatch(/\.scrollbar-overlay:hover::-webkit-scrollbar-thumb\{background:var\(--border\)/)
   })
 
+  it('restores a persistent thumb on coarse pointers, so a capped box has a touch affordance', () => {
+    // A finger never produces the :hover that reveals the thumb, so on touch
+    // (.scrollbar-overlay on a capped `max-h-[Nsvh]` stack) the scroller would
+    // show no cue that it scrolls. The utility must scope its persistent thumb
+    // to @media (pointer: coarse) — a permanent (unscoped) thumb would trip the
+    // hover-revealed assertion above on fine pointers. Precedence: the house
+    // already carries @media (pointer: coarse) blocks in index.css.
+    expect(INDEX_CSS).toMatch(/@media \(pointer: coarse\) \{[\s\S]*?\.scrollbar-overlay\{scrollbar-color:var\(--border\) transparent\}/)
+    expect(INDEX_CSS).toMatch(/@media \(pointer: coarse\) \{[\s\S]*?\.scrollbar-overlay::-webkit-scrollbar-thumb\{background:var\(--border\)\}/)
+  })
+
   it('caps the bar stack and scrolls it internally, so it never climbs into the band', () => {
     const cls = STACK![1]
     expect(cls).toMatch(/max-h-\[\d+svh\]/)


### PR DESCRIPTION
## Problem / Motivation

`.scrollbar-overlay` in `website/src/index.css:1633-1639` gates its thumb entirely behind `:hover`. On touch devices (no hover, `pointer: coarse`) all 8 call sites — including the chat composer's height-capped status-bar stack — scroll with no visible affordance.

Two review lanes in #6790 disagreed on this (First Principles subtracted the gating, GPT 5.6 restored it). Both observations are correct: the gating is needed on fine pointers to avoid an always-visible thumb, but it leaves touch affordance-free. The utility had no touch branch.

## Why it matters

On phones the capped stack is precisely for keyboard pressure; without a thumb or edge cue the user has no signal that the overflow scrolls. The mechanical fix is small but the visual treatment is a maintainer decision (persistent thumb vs ScrollEdgeStrip from #4074).

## What changed (motivation → approach → change)

- **Approach:** persistent thin thumb on touch, keep hover-gating on fine pointers. Chosen over the ScrollEdgeStrip cue because it is one change at the utility inherited by all 8 sites, with house precedent (`@media (pointer: coarse)` at lines 2277/2314).
- **Change:** `website/src/index.css` — added `@media (pointer: coarse) { .scrollbar-overlay{scrollbar-color:var(--border) transparent} .scrollbar-overlay::-webkit-scrollbar-thumb{background:var(--border)} }` after the hover rules, with a comment explaining the finger-never-hovers invariant.
- No per-component edits, no new color literals (uses `var(--border)` only), no new tokens.

## Tests

- **Updated:** `website/src/test/ChatPage.composerChromeOcclusion.test.tsx` — added `restores a persistent thumb on coarse pointers, so a capped box has a touch affordance` asserting both `scrollbar-color` and `::-webkit-scrollbar-thumb` rules are present inside `@media (pointer: coarse)`. Existing `keeps the thumb out of the way` assertions (transparent base + hover reveal) still pass, pinning that fine-pointer behavior is unchanged.

## Manual verification

- `npm run lint:theme-colors` — PASS (exit 0, advisory only, no literals)
- `npx eslint src/test/ChatPage.composerChromeOcclusion.test.tsx` — PASS
- Source-text regex verification against `src/index.css` — all 4 assertions PASS (base transparent, hover reveal, coarse scrollbar-color, coarse thumb)
- Vitest cannot start workers on this Windows partial-clone (forks timeout, threads reject `--max-old-space-size`), known env issue — CI on Linux will run it. Change is deterministic CSS + regex.

## Screenshots / video

N/A — 6px overlay thumb change; visual proof is the pinned source-text test. No layout/structural change.

## Related Issues

Fixes #6852
Related #4074 (horizontal ScrollEdgeStrip, not same class — noted as convergence point if cue is chosen later)

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
