### PR TITLE
fix(chat): bound the $-menu skills fetch so a slow gateway fails visibly

### DIFF
--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -27,6 +27,13 @@ import {
   noteStaleOwnerResponse,
 } from './staleOwnerSignal'
 import { beginArtifactWrite, endArtifactWrite } from '../lib/artifactWrites'
+import { withDeadline } from '../lib/withDeadline'
+
+/** Deadline for `api.skills`. Measured on one host inside twenty minutes: 0.62s
+ *  healthy, then 9.76s, 41.41s, 168.71s for a byte-identical payload. 15s clears
+ *  the 9.76s case that still completed and cuts off the pathological ones.
+ *  Rationale in the CR description. */
+export const SKILLS_TIMEOUT_MS = 15_000
 import { installApiTransport } from './apiTransport'
 import type { SessionSummary } from '../types/sessionSummary'
 import { queryClient } from './queryClient'
@@ -1458,8 +1465,8 @@ function trackArtifactWrite(url: string, res: Promise<Response>): Promise<Respon
 const projectHeader = (projectKey?: string): HeadersInit | undefined =>
   projectKey ? { 'X-Steering-Project': projectKey } : undefined
 
-const get = (url: string, sessionKey?: string) =>
-  fetch(url, { headers: { ...(sessionKey ? { 'X-Session-Key': sessionKey } : _sk) } })
+const get = (url: string, sessionKey?: string, signal?: AbortSignal) =>
+  fetch(url, { headers: { ...(sessionKey ? { 'X-Session-Key': sessionKey } : _sk) }, ...(signal ? { signal } : {}) })
 const post = (url: string, body?: object, sessionKey?: string, extra?: HeadersInit) =>
   trackArtifactWrite(url, fetch(url, {
     method: 'POST',
@@ -2505,9 +2512,12 @@ export const api = {
   // {skills, agent_scoped: true, agent} instead of the bare array, so the
   // picker can cue the scope (and tell "nothing mapped" from "nothing exists").
   // Consume through lib/skillsPayload.ts unwrapSkills() rather than assuming an array.
-  skills: (sessionKey?: string, agent?: string) =>
-    get('/api/skills' + (agent ? '?agent=' + encodeURIComponent(agent) : ''),
-        sessionKey).then(j),
+  // Bounded HERE, not per initiator: react-query dedupes on the key, so the
+  // weakest initiator would otherwise decide whether the promise is bounded.
+  skills: (sessionKey?: string, agent?: string, signal?: AbortSignal) =>
+    withDeadline(SKILLS_TIMEOUT_MS, signal, s =>
+      get('/api/skills' + (agent ? '?agent=' + encodeURIComponent(agent) : ''),
+          sessionKey, s).then(j)),
   /** Project-skills trust: this chat's grant state plus every stored grant. */
   skillTrust: (sessionKey?: string) => get('/api/skills/-/trust', sessionKey).then(j),
   /** Grant trust to THIS chat's project. The server takes the directory from

--- a/website/src/api/queryClient.ts
+++ b/website/src/api/queryClient.ts
@@ -18,9 +18,24 @@ export const isThrottleError = (error: unknown): boolean =>
   typeof error === 'object' && error !== null
   && (error as { status?: unknown }).status === 429
 
-/** Retry up to 4 times on 429 throttles; keep the previous single retry otherwise. */
+/** True when the failure is a deadline WE set (lib/withDeadline's reason). */
+export const isDeadlineError = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null
+  && (error as { name?: unknown }).name === 'TimeoutError'
+
+/**
+ * Retry up to 4 times on 429 throttles; never retry a deadline we set ourselves;
+ * keep the previous single retry otherwise.
+ *
+ * The deadline clause binds HERE rather than per query, for the same reason the
+ * deadline itself binds inside `api.skills`: react-query dedupes on the key, so a
+ * per-initiator rule is only as strong as the weakest initiator of a shared key.
+ * Retrying a deadline also doubles the wait it exists to bound — a 15s bound
+ * settles at ~31s once the single retry and its backoff are counted.
+ */
 export const retryPolicy = (failureCount: number, error: unknown): boolean =>
-  isThrottleError(error) ? failureCount < 4 : failureCount < 1
+  isDeadlineError(error) ? false
+    : isThrottleError(error) ? failureCount < 4 : failureCount < 1
 
 /**
  * Jittered exponential backoff for throttles (1s → 2s → 4s → 8s, ±500ms so

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -1323,6 +1323,8 @@ function ChatInput({
   // cheap to call on every focus. The key and the session key must match
   // SkillPickerMenu's exactly — including the trailing agent segment — or the
   // prefetch warms a different entry and the menu still pays the fetch on open.
+  // The deadline binds HERE too, not only in the menu: react-query dedupes on that
+  // shared key, so the menu opening onto this fetch never runs its own queryFn.
   const queryClient = useQueryClient()
   const skillSlotKey = slotId ? `dashboard:${slotId}` : undefined
   const skillSlotKeyRef = useRef(skillSlotKey)
@@ -1332,7 +1334,7 @@ function ChatInput({
   const prefetchSkills = useCallback(() => {
     queryClient.prefetchQuery({
       queryKey: ['skills', skillSlotKey ?? null, project ?? null, agentName ?? null],
-      queryFn: () => api.skills(skillSlotKey, agentName),
+      queryFn: ({ signal }) => api.skills(skillSlotKey, agentName, signal),
       staleTime: skillsCacheStaleTime(project),
     })
   }, [queryClient, skillSlotKey, project, agentName])

--- a/website/src/components/SkillPickerMenu.tsx
+++ b/website/src/components/SkillPickerMenu.tsx
@@ -90,9 +90,11 @@ export default function SkillPickerMenu({
   // invalidateQueries({queryKey:['skills']}) call keeps working.
   // staleTime is long because skills change rarely. `enabled: open` keeps the
   // menu lazy — the focus-prefetch warms the same key separately.
+  // `loading` below is `isLoading && open` and isLoading clears only on settle,
+  // so an unbounded fetch leaves "Loading skills…" up forever.
   const { data, isLoading, isFetching, isError } = useQuery<SkillsPayload<SkillItem>>({
     queryKey: ['skills', slotKey ?? null, project ?? null, agent ?? null],
-    queryFn: () => api.skills(slotKey, agent),
+    queryFn: ({ signal }) => api.skills(slotKey, agent, signal),
     enabled: open,
     staleTime: skillsCacheStaleTime(project),
   })
@@ -210,7 +212,16 @@ export default function SkillPickerMenu({
   // catalog filtered to nothing by the query keeps the generic copy. Both
   // branches preserve the Enter/Ctrl+Enter release announcement.
   const mappedEmpty = agentScoped && items.length === 0
-  const emptyKey = mappedEmpty
+  // A settled ERROR is not an empty catalog: both release Enter, but "No matching
+  // skills" asserts something false about the user's skills.
+  const loadFailed = isError && items.length === 0
+  const emptyKey = loadFailed
+    ? (!releaseKeysWhenEmpty
+        ? 'components.skillPickerMenu.skills_load_failed'
+        : sendOnEnter === 'ctrl-enter'
+          ? 'components.skillPickerMenu.skills_load_failed_ctrl_enter_sends'
+          : 'components.skillPickerMenu.skills_load_failed_enter_sends')
+    : mappedEmpty
     ? (!releaseKeysWhenEmpty
         ? 'components.skillPickerMenu.no_skills_mapped_to_agent'
         : sendOnEnter === 'ctrl-enter'

--- a/website/src/components/commandPalette/providers/skillsProvider.ts
+++ b/website/src/components/commandPalette/providers/skillsProvider.ts
@@ -202,7 +202,7 @@ export function useSkillsProvider(opts?: {
         fetchSkills: () =>
           queryClient.fetchQuery<SkillItem[]>({
             queryKey: ['skills'],
-            queryFn: () => api.skills() as Promise<SkillItem[]>,
+            queryFn: ({ signal }) => api.skills(undefined, undefined, signal) as Promise<SkillItem[]>,
             staleTime: SKILLS_STALE_MS,
           }),
         hasActiveChat,

--- a/website/src/i18n/locales/bn.json
+++ b/website/src/i18n/locales/bn.json
@@ -7003,6 +7003,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "{{agent}}-এ কোনো স্কিল ম্যাপ করা নেই — Ctrl+Enter বার্তা পাঠাবে",
       "no_skills_mapped_to_agent_enter_sends": "{{agent}}-এ কোনো স্কিল ম্যাপ করা নেই — Enter বার্তা পাঠাবে",
       "scoped_to_agent": "এজেন্ট {{agent}}-এ সীমাবদ্ধ",
+      "skills_load_failed": "স্কিল লোড করা যায়নি",
+      "skills_load_failed_ctrl_enter_sends": "স্কিল লোড করা যায়নি — Ctrl+Enter বার্তা পাঠাবে",
+      "skills_load_failed_enter_sends": "স্কিল লোড করা যায়নি — Enter বার্তা পাঠাবে",
       "trust_needed_badge": "বিশ্বাস দরকার",
       "trust_needed_hint": "এই প্রকল্প থেকে। যাচাই করে ফোল্ডার বিশ্বাস করতে এটি বেছে নাও।"
     },

--- a/website/src/i18n/locales/de.json
+++ b/website/src/i18n/locales/de.json
@@ -7003,6 +7003,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "Keine Skills für {{agent}} zugeordnet — Ctrl+Enter sendet die Nachricht",
       "no_skills_mapped_to_agent_enter_sends": "Keine Skills für {{agent}} zugeordnet — Enter sendet die Nachricht",
       "scoped_to_agent": "Auf Agent {{agent}} beschränkt",
+      "skills_load_failed": "Skills konnten nicht geladen werden",
+      "skills_load_failed_ctrl_enter_sends": "Skills konnten nicht geladen werden — Ctrl+Enter sendet die Nachricht",
+      "skills_load_failed_enter_sends": "Skills konnten nicht geladen werden — Enter sendet die Nachricht",
       "trust_needed_badge": "Vertrauen nötig",
       "trust_needed_hint": "Aus diesem Projekt. Auswählen, um zu prüfen und dem Ordner zu vertrauen."
     },

--- a/website/src/i18n/locales/en-XA.json
+++ b/website/src/i18n/locales/en-XA.json
@@ -6600,7 +6600,10 @@
       "no_skills_mapped_to_agent": "[Ñø şķìĺĺş ɱàþþèð ţø {{agent}} ··················]",
       "no_skills_mapped_to_agent_ctrl_enter_sends": "[Ñø şķìĺĺş ɱàþþèð ţø {{agent}} — Çţŕĺ+Èñţèŕ şèñðş ţĥè ɱèşşàğè ··················]",
       "no_skills_mapped_to_agent_enter_sends": "[Ñø şķìĺĺş ɱàþþèð ţø {{agent}} — Èñţèŕ şèñðş ţĥè ɱèşşàğè ·······················]",
-      "scoped_to_agent": "[Şçøþèð ţø àğèñţ {{agent}} ··············]"
+      "scoped_to_agent": "[Şçøþèð ţø àğèñţ {{agent}} ··············]",
+      "skills_load_failed": "[Çøùĺðñ'ţ ĺøàð şķìĺĺş ··················]",
+      "skills_load_failed_ctrl_enter_sends": "[Çøùĺðñ'ţ ĺøàð şķìĺĺş — Çţŕĺ+Èñţèŕ şèñðş ţĥè ɱèşşàğè ··················]",
+      "skills_load_failed_enter_sends": "[Çøùĺðñ'ţ ĺøàð şķìĺĺş — Èñţèŕ şèñðş ţĥè ɱèşşàğè ·······················]"
     },
     "slotTagPopover": {
       "assign_tags": "[Àşşìğñ ţàğş ··········]",

--- a/website/src/i18n/locales/en.manual.json
+++ b/website/src/i18n/locales/en.manual.json
@@ -2188,7 +2188,10 @@
       "no_skills_mapped_to_agent": "No skills mapped to {{agent}}",
       "no_skills_mapped_to_agent_ctrl_enter_sends": "No skills mapped to {{agent}} — Ctrl+Enter sends the message",
       "no_skills_mapped_to_agent_enter_sends": "No skills mapped to {{agent}} — Enter sends the message",
-      "scoped_to_agent": "Scoped to agent {{agent}}"
+      "scoped_to_agent": "Scoped to agent {{agent}}",
+      "skills_load_failed": "Couldn't load skills",
+      "skills_load_failed_ctrl_enter_sends": "Couldn't load skills — Ctrl+Enter sends the message",
+      "skills_load_failed_enter_sends": "Couldn't load skills — Enter sends the message"
     },
     "snipOverlay": {
       "could_not_capture_the_selected_region_please_try": "Could not capture the selected region. Please try again."

--- a/website/src/i18n/locales/es.json
+++ b/website/src/i18n/locales/es.json
@@ -7108,6 +7108,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "No hay skills mapeadas a {{agent}}: Ctrl+Enter envía el mensaje",
       "no_skills_mapped_to_agent_enter_sends": "No hay skills mapeadas a {{agent}}: Enter envía el mensaje",
       "scoped_to_agent": "Limitado al agente {{agent}}",
+      "skills_load_failed": "No se pudieron cargar las skills",
+      "skills_load_failed_ctrl_enter_sends": "No se pudieron cargar las skills: Ctrl+Enter envía el mensaje",
+      "skills_load_failed_enter_sends": "No se pudieron cargar las skills: Enter envía el mensaje",
       "trust_needed_badge": "Requiere confianza",
       "trust_needed_hint": "De este proyecto. Selecciónala para revisarla y confiar en la carpeta."
     },

--- a/website/src/i18n/locales/fr.json
+++ b/website/src/i18n/locales/fr.json
@@ -7108,6 +7108,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "Aucune compétence mappée à {{agent}} — Ctrl+Enter envoie le message",
       "no_skills_mapped_to_agent_enter_sends": "Aucune compétence mappée à {{agent}} — Enter envoie le message",
       "scoped_to_agent": "Limité à l’agent {{agent}}",
+      "skills_load_failed": "Impossible de charger les compétences",
+      "skills_load_failed_ctrl_enter_sends": "Impossible de charger les compétences — Ctrl+Enter envoie le message",
+      "skills_load_failed_enter_sends": "Impossible de charger les compétences — Enter envoie le message",
       "trust_needed_badge": "Approbation requise",
       "trust_needed_hint": "De ce projet. Sélectionne-la pour l’examiner et approuver le dossier."
     },

--- a/website/src/i18n/locales/hi.json
+++ b/website/src/i18n/locales/hi.json
@@ -7003,6 +7003,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "{{agent}} से कोई स्किल मैप नहीं है — Ctrl+Enter संदेश भेज देगा",
       "no_skills_mapped_to_agent_enter_sends": "{{agent}} से कोई स्किल मैप नहीं है — Enter संदेश भेज देगा",
       "scoped_to_agent": "एजेंट {{agent}} तक सीमित",
+      "skills_load_failed": "स्किल लोड नहीं हो सकीं",
+      "skills_load_failed_ctrl_enter_sends": "स्किल लोड नहीं हो सकीं — Ctrl+Enter संदेश भेज देगा",
+      "skills_load_failed_enter_sends": "स्किल लोड नहीं हो सकीं — Enter संदेश भेज देगा",
       "trust_needed_badge": "भरोसा चाहिए",
       "trust_needed_hint": "इस प्रोजेक्ट से। इसे चुनो ताकि जाँच कर फ़ोल्डर पर भरोसा कर सको।"
     },

--- a/website/src/i18n/locales/it.json
+++ b/website/src/i18n/locales/it.json
@@ -7108,6 +7108,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "Nessuna skill mappata a {{agent}} — Ctrl+Invio invia il messaggio",
       "no_skills_mapped_to_agent_enter_sends": "Nessuna skill mappata a {{agent}} — Invio invia il messaggio",
       "scoped_to_agent": "Limitato all’agente {{agent}}",
+      "skills_load_failed": "Impossibile caricare le skill",
+      "skills_load_failed_ctrl_enter_sends": "Impossibile caricare le skill — Ctrl+Invio invia il messaggio",
+      "skills_load_failed_enter_sends": "Impossibile caricare le skill — Invio invia il messaggio",
       "trust_needed_badge": "Richiede attendibilità",
       "trust_needed_hint": "Da questo progetto. Selezionala per esaminarla e considerare attendibile la cartella."
     },

--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -6898,6 +6898,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "{{agent}} にマッピングされたスキルはありません — Ctrl+Enter でメッセージを送信します",
       "no_skills_mapped_to_agent_enter_sends": "{{agent}} にマッピングされたスキルはありません — Enter でメッセージを送信します",
       "scoped_to_agent": "エージェント {{agent}} に限定",
+      "skills_load_failed": "スキルを読み込めませんでした",
+      "skills_load_failed_ctrl_enter_sends": "スキルを読み込めませんでした — Ctrl+Enter でメッセージを送信します",
+      "skills_load_failed_enter_sends": "スキルを読み込めませんでした — Enter でメッセージを送信します",
       "trust_needed_badge": "信頼が必要",
       "trust_needed_hint": "このプロジェクトのスキルです。選択すると内容を確認してフォルダーを信頼できます。"
     },

--- a/website/src/i18n/locales/ko.json
+++ b/website/src/i18n/locales/ko.json
@@ -6898,6 +6898,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "{{agent}}에 매핑된 스킬 없음 — Ctrl+Enter 키를 누르면 메시지가 전송됩니다",
       "no_skills_mapped_to_agent_enter_sends": "{{agent}}에 매핑된 스킬 없음 — Enter 키를 누르면 메시지가 전송됩니다",
       "scoped_to_agent": "에이전트 {{agent}}(으)로 제한됨",
+      "skills_load_failed": "스킬을 불러올 수 없습니다",
+      "skills_load_failed_ctrl_enter_sends": "스킬을 불러올 수 없습니다 — Ctrl+Enter 키를 누르면 메시지가 전송됩니다",
+      "skills_load_failed_enter_sends": "스킬을 불러올 수 없습니다 — Enter 키를 누르면 메시지가 전송됩니다",
       "trust_needed_badge": "신뢰 필요",
       "trust_needed_hint": "이 프로젝트의 스킬입니다. 선택하면 내용을 확인하고 폴더를 신뢰할 수 있습니다."
     },

--- a/website/src/i18n/locales/pt.json
+++ b/website/src/i18n/locales/pt.json
@@ -7108,6 +7108,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "Nenhuma habilidade mapeada para {{agent}} — Ctrl+Enter envia a mensagem",
       "no_skills_mapped_to_agent_enter_sends": "Nenhuma habilidade mapeada para {{agent}} — Enter envia a mensagem",
       "scoped_to_agent": "Limitado ao agente {{agent}}",
+      "skills_load_failed": "Não foi possível carregar as habilidades",
+      "skills_load_failed_ctrl_enter_sends": "Não foi possível carregar as habilidades — Ctrl+Enter envia a mensagem",
+      "skills_load_failed_enter_sends": "Não foi possível carregar as habilidades — Enter envia a mensagem",
       "trust_needed_badge": "Precisa de confiança",
       "trust_needed_hint": "Deste projeto. Escolha-a para revisar e confiar na pasta."
     },

--- a/website/src/i18n/locales/ru.json
+++ b/website/src/i18n/locales/ru.json
@@ -7213,6 +7213,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "Нет навыков, сопоставленных с {{agent}} — Ctrl+Enter отправит сообщение",
       "no_skills_mapped_to_agent_enter_sends": "Нет навыков, сопоставленных с {{agent}} — Enter отправит сообщение",
       "scoped_to_agent": "Ограничено агентом {{agent}}",
+      "skills_load_failed": "Не удалось загрузить навыки",
+      "skills_load_failed_ctrl_enter_sends": "Не удалось загрузить навыки — Ctrl+Enter отправит сообщение",
+      "skills_load_failed_enter_sends": "Не удалось загрузить навыки — Enter отправит сообщение",
       "trust_needed_badge": "Нужно доверие",
       "trust_needed_hint": "Из этого проекта. Выбери его, чтобы просмотреть и доверять папке."
     },

--- a/website/src/i18n/locales/zh-CN.json
+++ b/website/src/i18n/locales/zh-CN.json
@@ -6898,6 +6898,9 @@
       "no_skills_mapped_to_agent_ctrl_enter_sends": "没有映射到 {{agent}} 的技能 —— 按 Ctrl+Enter 直接发送消息",
       "no_skills_mapped_to_agent_enter_sends": "没有映射到 {{agent}} 的技能 —— 按 Enter 直接发送消息",
       "scoped_to_agent": "已限定为代理 {{agent}}",
+      "skills_load_failed": "无法加载技能",
+      "skills_load_failed_ctrl_enter_sends": "无法加载技能 —— 按 Ctrl+Enter 直接发送消息",
+      "skills_load_failed_enter_sends": "无法加载技能 —— 按 Enter 直接发送消息",
       "trust_needed_badge": "需要信任",
       "trust_needed_hint": "来自此项目。选择它即可查看并信任此文件夹。"
     },

--- a/website/src/lib/withDeadline.ts
+++ b/website/src/lib/withDeadline.ts
@@ -1,0 +1,39 @@
+/** An `Error` and not a `DOMException`, which the abort reason would otherwise be:
+ *  the i18n gate exempts `Error` as a diagnostic callee, `DOMException` it reports. */
+function timeoutReason(): Error {
+  const e = new Error('deadline exceeded')
+  e.name = 'TimeoutError'
+  return e
+}
+
+/** Run `attempt` under a deadline, rejecting with TimeoutError if it has not
+ *  settled in `ms`. Relays `outer` (react-query's unmount/cancel signal) and
+ *  releases both the timer and the relay listener once settled.
+ *
+ *  Not `AbortSignal.timeout` + `AbortSignal.any`: the former exposes no handle
+ *  so its timer cannot be released, and the latter's browser floor sits well
+ *  above the rest of this codebase's. See the CR description. */
+export function withDeadline<T>(
+  ms: number,
+  outer: AbortSignal | undefined,
+  attempt: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const ac = new AbortController()
+  const timer = setTimeout(() => ac.abort(timeoutReason()), ms)
+  const relay = () => ac.abort(outer?.reason)
+  // A listener added to an already-aborted signal never fires, so we would
+  // otherwise sit out the full deadline on an abandoned request.
+  if (outer?.aborted) ac.abort(outer.reason)
+  else outer?.addEventListener('abort', relay, { once: true })
+
+  const release = () => {
+    clearTimeout(timer)
+    outer?.removeEventListener('abort', relay)
+  }
+  try {
+    return attempt(ac.signal).finally(release)
+  } catch (e) {
+    release()   // a synchronous throw never reaches the `finally` above
+    throw e
+  }
+}

--- a/website/src/test/ApiClient.coverage.test.tsx
+++ b/website/src/test/ApiClient.coverage.test.tsx
@@ -1360,7 +1360,9 @@ describe('publishToProvider', () => {
 describe('every api method issues one well-formed /api request', () => {
   // Exercised individually above with the fixtures they need (a Blob, a
   // ReadableStream, a File list, an object-URL download).
-  const HAND_TESTED = new Set(['sttTranscribe', 'uploadFiles', 'installFromRegistryStream', 'exportPlanYaml'])
+  // `skills` joins them because it wraps the fetch in a deadline, so it USES the
+  // signal argument rather than forwarding it; junk there is not a URL question.
+  const HAND_TESTED = new Set(['sttTranscribe', 'uploadFiles', 'installFromRegistryStream', 'exportPlanYaml', 'skills'])
 
   type AnyFn = (...args: unknown[]) => unknown
   const methods = Object.entries(api as unknown as Record<string, AnyFn>)

--- a/website/src/test/ChatInput.skillsPrefetchDeadline.test.tsx
+++ b/website/src/test/ChatInput.skillsPrefetchDeadline.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+
+const mockApi = vi.hoisted(() => ({
+  skills: vi.fn(),
+  skillTrust: vi.fn(),
+  grantSkillTrust: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import ChatInput from '../components/ChatInput'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  localStorage.clear()
+  mockApi.skillTrust.mockResolvedValue({ project: '/work/p', project_key: '/work/p' })
+  mockApi.grantSkillTrust.mockResolvedValue({ trusted: true })
+})
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('ChatInput — the focus prefetch goes through the bounded client', () => {
+  it('hands api.skills an AbortSignal on focus', async () => {
+    // Shares the menu's query key by design, so react-query dedupes and the
+    // deadline lives in the client; this site owes only the signal.
+    mockApi.skills.mockImplementation(() => new Promise(() => {}))
+    renderWithProviders(<ChatInput value="" onChange={vi.fn()} onSend={vi.fn()} />)
+    fireEvent.focus(screen.getByLabelText('Message input'))
+    await waitFor(() => expect(mockApi.skills).toHaveBeenCalled())
+    expect(mockApi.skills.mock.calls[0][2]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('does not leave the prefetch pending once it settles', async () => {
+    mockApi.skills.mockImplementation(() =>
+      new Promise((_res, rej) =>
+        setTimeout(() => rej(new DOMException('deadline exceeded', 'TimeoutError')), 5)))
+    renderWithProviders(<ChatInput value="" onChange={vi.fn()} onSend={vi.fn()} />)
+    fireEvent.focus(screen.getByLabelText('Message input'))
+    await waitFor(() => expect(mockApi.skills).toHaveBeenCalled())
+    // Settling is the whole point; an unhandled rejection here would fail the run.
+    await new Promise(r => setTimeout(r, 30))
+  })
+})

--- a/website/src/test/SkillPickerMenu.dedupe.test.tsx
+++ b/website/src/test/SkillPickerMenu.dedupe.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useRef } from 'react'
+
+/* ── Mock api/client BEFORE the component imports ── */
+const mockApi = vi.hoisted(() => ({ skills: vi.fn() }))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import SkillPickerMenu from '../components/SkillPickerMenu'
+import { skillsCacheStaleTime } from '../lib/skillsCache'
+
+const SLOT = 'dashboard:chat-1'
+const KEY = ['skills', SLOT, null, null]
+
+function Harness({ client, query = '', open = true, onSelect = vi.fn(), onClose = vi.fn() }: {
+  client: QueryClient; query?: string; open?: boolean
+  onSelect?: (i: { leaf: string; key: string }) => void; onClose?: () => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  return (
+    <QueryClientProvider client={client}>
+      <div>
+        <div ref={ref} data-testid="anchor">anchor</div>
+        <SkillPickerMenu query={query} anchorRef={ref} open={open}
+          onSelect={onSelect} onClose={onClose} slotKey={SLOT} />
+      </div>
+    </QueryClientProvider>
+  )
+}
+
+/** What the bounded client does to a wedged gateway: reject with TimeoutError. */
+const timesOut = () => () =>
+  new Promise((_resolve, reject) =>
+    setTimeout(() => reject(new DOMException('deadline exceeded', 'TimeoutError')), 5))
+
+beforeEach(() => { vi.clearAllMocks() })
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('SkillPickerMenu — deduping onto ChatInput\'s in-flight prefetch', () => {
+  /** ChatInput's focus prefetch, reproduced: same query key, same staleTime, and
+   *  the same signal pass-through. */
+  const startPrefetch = (client: QueryClient) =>
+    client.prefetchQuery({
+      queryKey: KEY,
+      queryFn: ({ signal }) => mockApi.skills(SLOT, undefined, signal),
+      staleTime: skillsCacheStaleTime(undefined),
+    })
+
+  it('reuses the in-flight promise — ONE fetch — and still settles, releasing Enter', async () => {
+    // Dedupe on the shared key means the menu never runs its own queryFn, which
+    // is why the deadline is bound in the client: the winner fetches for both.
+    mockApi.skills.mockImplementation(timesOut())
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
+    void startPrefetch(qc)
+    await waitFor(() => expect(mockApi.skills).toHaveBeenCalled())
+    const onSelect = vi.fn()
+    render(<Harness client={qc} query="grill" onSelect={onSelect} />)
+    await waitFor(() => expect(screen.queryByText('Loading skills…')).not.toBeInTheDocument())
+    await waitFor(() => expect(fireEvent.keyDown(document, { key: 'Enter' })).toBe(true))
+    expect(onSelect).not.toHaveBeenCalled()
+    // One call, not two: proof the dedupe happened rather than two independent
+    // fetches that would each have been bounded anyway.
+    expect(mockApi.skills).toHaveBeenCalledTimes(1)
+  })
+
+  it('every initiator hands api.skills a signal, so none of them can be the unbounded one', async () => {
+    mockApi.skills.mockImplementation(() => new Promise(() => {}))
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
+    void startPrefetch(qc)
+    await waitFor(() => expect(mockApi.skills).toHaveBeenCalled())
+    expect(mockApi.skills.mock.calls[0][2]).toBeInstanceOf(AbortSignal)
+    // And the menu's own queryFn, when IT wins the race, does the same.
+    mockApi.skills.mockClear()
+    const qc2 = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
+    render(<Harness client={qc2} query="grill" />)
+    await waitFor(() => expect(mockApi.skills).toHaveBeenCalled())
+    expect(mockApi.skills.mock.calls[0][2]).toBeInstanceOf(AbortSignal)
+  })
+})
+
+describe('SkillPickerMenu — a failed load is not an empty catalog', () => {
+  it('names the failure instead of claiming there are no matching skills', async () => {
+    mockApi.skills.mockRejectedValue(new Error('boom'))
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
+    render(<Harness client={qc} query="grill" />)
+    expect(await screen.findByText(/Couldn't load skills — Enter sends the message/))
+      .toBeInTheDocument()
+    // The false claim must be gone, not merely accompanied.
+    expect(screen.queryByText(/No matching skills/)).not.toBeInTheDocument()
+  })
+
+  it('still releases Enter on the error path — that half was already correct', async () => {
+    mockApi.skills.mockRejectedValue(new Error('boom'))
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
+    const onSelect = vi.fn(); const onClose = vi.fn()
+    render(<Harness client={qc} query="grill" onSelect={onSelect} onClose={onClose} />)
+    await screen.findByText(/Couldn't load skills/)
+    await waitFor(() => expect(fireEvent.keyDown(document, { key: 'Enter' })).toBe(true))
+    expect(onClose).toHaveBeenCalled()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('a genuinely empty catalog still says "No matching skills"', async () => {
+    // Negative control on the new branch: it must key on the ERROR, not fire for
+    // every empty list, or it would replace a true statement with a false one.
+    mockApi.skills.mockResolvedValue([])
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
+    render(<Harness client={qc} query="grill" />)
+    expect(await screen.findByText(/No matching skills/)).toBeInTheDocument()
+    expect(screen.queryByText(/Couldn't load skills/)).not.toBeInTheDocument()
+  })
+})

--- a/website/src/test/SkillPickerMenu.test.tsx
+++ b/website/src/test/SkillPickerMenu.test.tsx
@@ -27,7 +27,7 @@ function Harness({ query, open, onSelect = vi.fn(), onClose = vi.fn(), client, s
   onTrustRequest?: (i: { leaf: string; key: string }) => void
 }) {
   const ref = useRef<HTMLDivElement>(null)
-  const qc = client ?? new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const qc = client ?? new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
   return (
     <QueryClientProvider client={qc}>
       <div>
@@ -65,13 +65,13 @@ describe('SkillPickerMenu', () => {
   it('forwards the active agent to api.skills() and uses an agent-scoped cache key', async () => {
     render(<Harness query="" open slotKey="dashboard:chat-1" agent="custom-template" />)
     await waitFor(() => expect(mockApi.skills)
-      .toHaveBeenLastCalledWith('dashboard:chat-1', 'custom-template'))
+      .toHaveBeenLastCalledWith('dashboard:chat-1', 'custom-template', expect.any(AbortSignal)))
   })
 
   it('omits the agent argument when none is active', async () => {
     render(<Harness query="" open slotKey="dashboard:chat-1" />)
     await waitFor(() => expect(mockApi.skills)
-      .toHaveBeenLastCalledWith('dashboard:chat-1', undefined))
+      .toHaveBeenLastCalledWith('dashboard:chat-1', undefined, expect.any(AbortSignal)))
   })
 
   it('filters by leaf-name substring', async () => {
@@ -205,7 +205,7 @@ describe('SkillPickerMenu', () => {
     // isFetching, not isLoading. Seed a stale empty cache, then mount with a
     // never-settling fetch — the mount refetch is the in-flight window.
     mockApi.skills.mockImplementation(() => new Promise(() => {}))
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
     qc.setQueryData(['skills', null, null, null], [])
     await qc.invalidateQueries({ queryKey: ['skills'], refetchType: 'none' })
     const onSelect = vi.fn()
@@ -220,13 +220,13 @@ describe('SkillPickerMenu', () => {
   })
 
   it('after the skills fetch settles in an ERROR, Enter is released (trap must not survive the error path)', async () => {
-    // A failed fetch leaves the same empty state; keeping the swallow there
-    // would recreate the trap whenever /api/skills has a transient failure.
+    // A failed fetch leaves an empty list; keeping the swallow there would recreate
+    // the trap on any transient failure. The release is what this test pins.
     mockApi.skills.mockRejectedValue(new Error('boom'))
     const onSelect = vi.fn()
     const onClose = vi.fn()
     render(<Harness query="grill" open onSelect={onSelect} onClose={onClose} />)
-    expect(await screen.findByText(/No matching skills — Enter sends the message/)).toBeInTheDocument()
+    expect(await screen.findByText(/Couldn't load skills — Enter sends the message/)).toBeInTheDocument()
     await waitFor(() => expect(fireEvent.keyDown(document, { key: 'Enter' })).toBe(true))
     expect(onClose).toHaveBeenCalled()
     expect(onSelect).not.toHaveBeenCalled()
@@ -338,7 +338,7 @@ describe('SkillPickerMenu — agent scope cue', () => {
     // envelope without its own fetch — pin it by never letting the queryFn
     // settle.
     mockApi.skills.mockImplementation(() => new Promise(() => {}))
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
     qc.setQueryData(
       ['skills', 'dashboard:chat-1', '/work/project-a', 'custom-template'],
       { skills: SKILLS, agent_scoped: true, agent: 'custom-template' },
@@ -375,14 +375,14 @@ describe('SkillPickerMenu — project-skills trust', () => {
   it('sends the real slot key so the server resolves THIS chat project', async () => {
     render(<Harness query="" open slotKey="dashboard:chat-7" />)
     await waitFor(() => expect(mockApi.skills)
-      .toHaveBeenCalledWith('dashboard:chat-7', undefined))
+      .toHaveBeenCalledWith('dashboard:chat-7', undefined, expect.any(AbortSignal)))
   })
 
   it('refetches when the same slot switches projects', async () => {
     mockApi.skills
       .mockResolvedValueOnce([{ ...TRUSTED[0], key: 'kiro-workspace/project-a' }])
       .mockResolvedValueOnce([{ ...TRUSTED[0], key: 'kiro-workspace/project-b' }])
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
     const view = render(
       <Harness
         query=""
@@ -412,7 +412,7 @@ describe('SkillPickerMenu — project-skills trust', () => {
     mockApi.skills
       .mockResolvedValueOnce([{ ...TRUSTED[0], key: 'kiro-workspace/project-a' }])
       .mockResolvedValueOnce([{ ...TRUSTED[0], key: 'kiro-workspace/project-b' }])
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
     const view = render(
       <Harness query="" open slotKey="dashboard:chat-7" client={client} />,
     )

--- a/website/src/test/SkillPickerMenu.timeout.test.tsx
+++ b/website/src/test/SkillPickerMenu.timeout.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useRef } from 'react'
+
+/* ── Mock api/client BEFORE the component imports ── */
+const mockApi = vi.hoisted(() => ({ skills: vi.fn() }))
+vi.mock('../api/client', () => ({ api: mockApi }))
+
+import SkillPickerMenu from '../components/SkillPickerMenu'
+import { retryPolicy } from '../api/queryClient'
+
+/* The deadline lives in the client layer and is pinned there. What the MENU owes
+ * is passing react-query's signal through, and rendering a failure as a failure. */
+
+function Harness({ query = '', open = true, onSelect = vi.fn(), onClose = vi.fn(), client }: {
+  query?: string; open?: boolean; onSelect?: (i: { leaf: string; key: string }) => void
+  onClose?: () => void; client?: QueryClient
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const qc = client ?? new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
+  return (
+    <QueryClientProvider client={qc}>
+      <div>
+        <div ref={ref} data-testid="anchor">anchor</div>
+        <SkillPickerMenu query={query} anchorRef={ref} open={open} onSelect={onSelect} onClose={onClose} />
+      </div>
+    </QueryClientProvider>
+  )
+}
+
+/** What the bounded client does to a wedged gateway: reject with TimeoutError. */
+const timesOut = () => () =>
+  new Promise((_resolve, reject) =>
+    setTimeout(() => reject(new DOMException('deadline exceeded', 'TimeoutError')), 5))
+
+beforeEach(() => { vi.clearAllMocks() })
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('SkillPickerMenu — a timed-out skills fetch', () => {
+  it('runs the fetch ONCE under the production retry policy, not twice', async () => {
+    // Under the app's own default policy, not a `retry: false` client: the query
+    // must override that default for a deadline, or the wait doubles to ~31s.
+    mockApi.skills.mockImplementation(timesOut())
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: retryPolicy, retryDelay: 0 } },
+    })
+    render(<Harness client={qc} query="grill" />)
+    await waitFor(() => expect(screen.queryByText('Loading skills…')).not.toBeInTheDocument())
+    expect(mockApi.skills).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes react-query\'s AbortSignal to api.skills, so the client can bound and cancel it', async () => {
+    mockApi.skills.mockImplementation(() => new Promise(() => {}))
+    render(<Harness />)
+    await waitFor(() => expect(mockApi.skills).toHaveBeenCalled())
+    expect(mockApi.skills.mock.calls[0][2]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('leaves "Loading skills…" once the fetch settles', async () => {
+    // THE DEFECT: `loading = isLoading && open` and isLoading clears only on
+    // settle, so an unbounded fetch held the spinner up like a hang.
+    mockApi.skills.mockImplementation(timesOut())
+    render(<Harness query="grill" />)
+    expect(await screen.findByText('Loading skills…')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Loading skills…')).not.toBeInTheDocument())
+  })
+
+  it('names the failure and releases Enter, so the composer is not deadlocked', async () => {
+    // releaseKeysWhenEmpty admits `isError`, so a TimeoutError reaches the same
+    // settled state and hands Enter back rather than swallowing it forever.
+    mockApi.skills.mockImplementation(timesOut())
+    const onSelect = vi.fn()
+    render(<Harness query="grill" onSelect={onSelect} />)
+    expect(await screen.findByText(/Couldn't load skills — Enter sends the message/)).toBeInTheDocument()
+    await waitFor(() => expect(fireEvent.keyDown(document, { key: 'Enter' })).toBe(true))
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/test/apiSkillsDeadline.test.ts
+++ b/website/src/test/apiSkillsDeadline.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { api, SKILLS_TIMEOUT_MS } from '../api/client'
+
+/* The deadline lives inside `api.skills`, not at each initiator. That is the
+ * whole point: react-query dedupes on the query key, so binding per-caller
+ * leaves the promise unbounded whenever an unbounded initiator of the same key
+ * wins the race. Two keys are shared in the tree — ['skills'] across
+ * HookSkillsSelect / SkillsTab / the command palette, and
+ * ['skills', slot, project, agent] across ChatInput's prefetch and
+ * SkillPickerMenu — so whichever initiator wins, the fetch is the same one. */
+
+/** A wedged gateway: the response settles ONLY if the signal aborts. Given no
+ *  signal it can never settle, which is the pre-fix shape. */
+const wedgedFetch = vi.fn((_url: string, init?: RequestInit) =>
+  new Promise<Response>((_resolve, reject) => {
+    const s = init?.signal
+    if (!s) return
+    if (s.aborted) return reject(s.reason)
+    s.addEventListener('abort', () => reject(s.reason), { once: true })
+  }))
+
+const realTimeout = globalThis.setTimeout
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('fetch', wedgedFetch)
+})
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+/** Shrink the deadline without touching the production composition. */
+function shrinkDeadline(ms: number, record?: (asked: number) => void) {
+  vi.spyOn(globalThis, 'setTimeout').mockImplementation(((fn: () => void, asked?: number) => {
+    record?.(asked ?? 0)
+    return realTimeout(fn, ms)
+  }) as unknown as typeof globalThis.setTimeout)
+}
+
+describe('api.skills is bounded at the client, so every call site inherits it', () => {
+  it('rejects with TimeoutError when NO signal is passed — the previously-unbounded shape', async () => {
+    // Three settings-side callers invoke `api.skills()` with no arguments; before
+    // the wrap moved here they were unbounded. This is the proof they are not.
+    shrinkDeadline(20)
+    await expect(api.skills()).rejects.toSatisfy(
+      e => (e as Error)?.name === 'TimeoutError')
+    expect(wedgedFetch).toHaveBeenCalledTimes(1)
+    expect((wedgedFetch.mock.calls[0][1] as RequestInit).signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('rejects with TimeoutError for a slot-scoped call too', async () => {
+    shrinkDeadline(20)
+    await expect(api.skills('dashboard:chat-1', 'agent-x')).rejects.toSatisfy(
+      e => (e as Error)?.name === 'TimeoutError')
+  })
+
+  it('relays a caller signal, so react-query unmount/cancel still aborts', async () => {
+    shrinkDeadline(10_000)
+    const ac = new AbortController()
+    const p = api.skills(undefined, undefined, ac.signal)
+    ac.abort(new DOMException('unmounted', 'AbortError'))
+    await expect(p).rejects.toSatisfy(e => (e as Error)?.name === 'AbortError')
+  })
+
+  it('asks for SKILLS_TIMEOUT_MS, inside the measured window', async () => {
+    // Pinned on the value requested, not elapsed wall-clock: a 15s test.
+    const asked: number[] = []
+    shrinkDeadline(20, ms => asked.push(ms))
+    await expect(api.skills()).rejects.toThrow()
+    expect(asked).toContain(SKILLS_TIMEOUT_MS)
+    expect(SKILLS_TIMEOUT_MS).toBeGreaterThan(9_760)   // the slow-but-completed observation
+    expect(SKILLS_TIMEOUT_MS).toBeLessThan(41_410)     // the first pathological one
+  })
+
+  it('resolves untouched when the gateway answers in time', async () => {
+    // Negative control on the deadline: it must not fail a healthy fetch.
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(
+      new Response(JSON.stringify([{ key: 'grill', name: 'grill' }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }))))
+    await expect(api.skills()).resolves.toEqual([{ key: 'grill', name: 'grill' }])
+  })
+
+  // `skills` is excluded from the generic every-method URL sweep, which passes
+  // positional junk. These re-assert exactly what that sweep would have.
+  describe('URL construction (replacing the generic sweep\'s coverage)', () => {
+    const ok = () => vi.fn(() => Promise.resolve(
+      new Response('[]', { status: 200, headers: { 'Content-Type': 'application/json' } })))
+
+    it.each([
+      ['no arguments', [] as const, '/api/skills'],
+      ['a slot only', ['dashboard:chat-1'] as const, '/api/skills'],
+      ['an agent', [undefined, 'custom template'] as const, '/api/skills?agent=custom%20template'],
+    ])('builds a well-formed path with %s', async (_label, args, expected) => {
+      const f = ok()
+      vi.stubGlobal('fetch', f)
+      await api.skills(...(args as Parameters<typeof api.skills>))
+      expect(f).toHaveBeenCalledTimes(1)
+      const url = f.mock.calls[0][0] as unknown as string
+      expect(typeof url).toBe('string')
+      expect(url).toBe(expected)
+      expect(url.startsWith('/api/')).toBe(true)
+      for (const junk of ['undefined', '[object Object]', 'NaN', '/null']) {
+        expect(url.includes(junk), `leaked ${junk} into ${url}`).toBe(false)
+      }
+      // A GET carries no body.
+      expect((f.mock.calls[0][1] as RequestInit | undefined)?.body).toBeUndefined()
+    })
+  })
+})

--- a/website/src/test/skillsRetryPolicy.test.ts
+++ b/website/src/test/skillsRetryPolicy.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+
+import { retryPolicy, isDeadlineError, isThrottleError } from '../api/queryClient'
+
+/* A deadline we set ourselves must never be retried: the retry doubles the wait
+ * the deadline exists to bound, so a 15s bound settles at ~31s with its backoff. */
+
+const deadlineError = () => {
+  const e = new Error('deadline exceeded')
+  e.name = 'TimeoutError'
+  return e
+}
+const throttleError = () => Object.assign(new Error('Rate exceeded'), { status: 429 })
+
+beforeEach(() => { vi.clearAllMocks() })
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('retryPolicy — the deadline clause binds app-wide, not per query', () => {
+  it('refuses to retry a deadline error', () => {
+    expect(retryPolicy(0, deadlineError())).toBe(false)
+  })
+
+  it('keeps the single retry for an ordinary failure', () => {
+    // The clause must not become a blanket `retry: false`.
+    expect(retryPolicy(0, new Error('boom'))).toBe(true)
+    expect(retryPolicy(1, new Error('boom'))).toBe(false)
+  })
+
+  it('keeps the longer throttle ladder for a 429', () => {
+    expect(retryPolicy(0, throttleError())).toBe(true)
+    expect(retryPolicy(3, throttleError())).toBe(true)
+    expect(retryPolicy(4, throttleError())).toBe(false)
+  })
+
+  it('does not mistake a bare string, null, or another abort reason for a deadline', () => {
+    expect(isDeadlineError(null)).toBe(false)
+    expect(isDeadlineError('TimeoutError')).toBe(false)
+    expect(isDeadlineError({ name: 'AbortError' })).toBe(false)
+    // And the two clauses stay independent of each other.
+    expect(isThrottleError(deadlineError())).toBe(false)
+    expect(isDeadlineError(throttleError())).toBe(false)
+  })
+})
+
+describe('every initiator inherits it, whichever one raised the deadline', () => {
+  /** Run a query under the app's default policy and count queryFn invocations. */
+  async function attempts(queryKey: unknown[]) {
+    const fn = vi.fn(() => Promise.reject(deadlineError()))
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: retryPolicy, retryDelay: 0 } },
+    })
+    await qc.fetchQuery({ queryKey, queryFn: fn }).catch(() => {})
+    return fn.mock.calls.length
+  }
+
+  // One case per react-query initiator of `api.skills`, keyed as each one keys it.
+  // The three marked unfixed are the ones per-site threading missed.
+  it.each([
+    ['SkillPickerMenu', ['skills', 'dashboard:chat-1', null, null]],
+    ['ChatInput prefetch', ['skills', 'dashboard:chat-1', '/work/p', null]],
+    ['command palette', ['skills']],
+    ['HookSkillsSelect (was unfixed)', ['skills']],
+    ['SkillsTab (was unfixed)', ['skills']],
+    ['AgentSkillsEditor (was unfixed)', ['skills-catalog']],
+  ])('%s settles after ONE attempt', async (_label, key) => {
+    expect(await attempts(key as unknown[])).toBe(1)
+  })
+
+  it('a non-deadline failure still gets its retry, so the control can fail', async () => {
+    // Negative control on the assertion above: if the policy retried nothing at
+    // all, every case would read 1 and prove nothing. This one must read 2.
+    const fn = vi.fn(() => Promise.reject(new Error('boom')))
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: retryPolicy, retryDelay: 0 } },
+    })
+    await qc.fetchQuery({ queryKey: ['skills-control'], queryFn: fn }).catch(() => {})
+    expect(fn.mock.calls.length).toBe(2)
+  })
+})

--- a/website/src/test/withDeadline.test.ts
+++ b/website/src/test/withDeadline.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest'
+import { withDeadline } from '../lib/withDeadline'
+
+/** A request that settles ONLY when its signal aborts — a wedged endpoint. */
+const neverArrives = (signal: AbortSignal) => new Promise<string>((_res, rej) => {
+  if (signal.aborted) return rej(signal.reason)
+  signal.addEventListener('abort', () => rej(signal.reason), { once: true })
+})
+
+const name = (e: unknown) => (e as Error)?.name
+
+describe('withDeadline', () => {
+  it('rejects with TimeoutError when the attempt never settles on its own', async () => {
+    // A pending promise becomes a settled rejection, which is what a
+    // "has this settled?" gate needs to move on.
+    await expect(withDeadline(20, undefined, neverArrives)).rejects.toSatisfy(
+      e => name(e) === 'TimeoutError')
+  })
+
+  it('resolves untouched when the attempt beats the deadline', async () => {
+    await expect(withDeadline(5_000, undefined, () => Promise.resolve('ok'))).resolves.toBe('ok')
+  })
+
+  it('passes the attempt a signal that is live, not pre-aborted', async () => {
+    let seen: AbortSignal | undefined
+    await withDeadline(5_000, undefined, s => { seen = s; return Promise.resolve(1) })
+    expect(seen).toBeInstanceOf(AbortSignal)
+    expect(seen!.aborted).toBe(false)
+  })
+
+  it('propagates the outer signal, so unmount/cancel still aborts the request', async () => {
+    const ac = new AbortController()
+    const p = withDeadline(5_000, ac.signal, neverArrives)
+    ac.abort(new DOMException('unmounted', 'AbortError'))
+    await expect(p).rejects.toSatisfy(e => name(e) === 'AbortError')
+  })
+
+  it('honours an outer signal that was ALREADY aborted before the call', async () => {
+    // A listener added after the fact never fires, so without the up-front
+    // check this would sit out the full deadline on an abandoned request.
+    const ac = new AbortController()
+    ac.abort(new DOMException('gone', 'AbortError'))
+    await expect(withDeadline(5_000, ac.signal, neverArrives)).rejects.toSatisfy(
+      e => name(e) === 'AbortError')
+  })
+
+  it('clears the deadline timer once the attempt resolves', async () => {
+    // `AbortSignal.timeout` cannot: it exposes no handle, so a 15s timer
+    // outlives every successful call (measured: +10s on a teardown drain).
+    const clear = vi.spyOn(globalThis, 'clearTimeout')
+    await withDeadline(5_000, undefined, () => Promise.resolve('ok'))
+    expect(clear).toHaveBeenCalled()
+    clear.mockRestore()
+  })
+
+  it('clears the deadline timer when the attempt REJECTS', async () => {
+    const clear = vi.spyOn(globalThis, 'clearTimeout')
+    await expect(withDeadline(5_000, undefined, () => Promise.reject(new Error('boom'))))
+      .rejects.toThrow('boom')
+    expect(clear).toHaveBeenCalled()
+    clear.mockRestore()
+  })
+
+  it('clears the deadline timer when the attempt throws SYNCHRONOUSLY', () => {
+    // A sync throw skips the promise `finally`, so it leaks a timer without
+    // its own cleanup path.
+    const clear = vi.spyOn(globalThis, 'clearTimeout')
+    expect(() => withDeadline(5_000, undefined, () => { throw new Error('sync') }))
+      .toThrow('sync')
+    expect(clear).toHaveBeenCalled()
+    clear.mockRestore()
+  })
+
+  it('detaches its abort listener from the outer signal once settled', async () => {
+    // A react-query signal outlives one fetch, so a listener left attached
+    // keeps this controller reachable for the query's whole life.
+    const ac = new AbortController()
+    const remove = vi.spyOn(ac.signal, 'removeEventListener')
+    await withDeadline(5_000, ac.signal, () => Promise.resolve('ok'))
+    expect(remove).toHaveBeenCalledWith('abort', expect.any(Function))
+    remove.mockRestore()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`SkillPickerMenu` computes `const loading = isLoading && open`, and react-query's `isLoading` clears only when the query **resolves or rejects**. `api.skills` passed no `AbortSignal`, so a response that never arrives never settles, and the `$`-trigger menu shows `Loading skills…` indefinitely — indistinguishable from a hang.

`skills` was the outlier in its own file. Its siblings `chatSlotDetail`, `sendChat` and `fileSearch` all already accept an `AbortSignal`.

The latency that exposes it is real and measured. `GET /api/skills` on one host inside twenty minutes:

| observation | elapsed  | payload       |
| ----------- | -------- | ------------- |
| 1           | 0.62s    | 329,860 bytes |
| 2           | 9.76s    | 329,860 bytes |
| 3           | 41.41s   | 329,860 bytes |
| 4           | 168.71s  | 329,860 bytes |

Byte-identical each time, so the variance is not the skills scan (~0.6s) — it is event-loop contention in the gateway. That cause is being addressed separately by #7031 (a 3s server-side memo for this endpoint), which reduces exposure but does **not** fix this: any future slow path still spins forever, because the client has no deadline at all. This PR is the client-side half and does not overlap #7031.

## Why it matters

A spinner that never resolves is worse than an error. The user cannot tell "slow" from "broken", so the only recovery is a reload — and the menu is on the composer's typing path, so it is hit often.

There is a second, sharper consequence. The menu's `releaseKeysWhenEmpty` gate is
`!isFetching && (data !== undefined || isError) && matched.length === 0`. While the query is pending it is `false`, which is correct — it deliberately **swallows Enter** so a draft mid-`$token` is not sent by accident. But an unbounded pending state means Enter is swallowed *forever*: the composer cannot send at all until the page is reloaded. Verified in source rather than assumed: that gate already admits `isError`, so a settled rejection is enough to release the keys, and an existing test (`after the skills fetch settles in an ERROR, Enter is released`) pins it. A timeout therefore needs no downstream change — it just has to make the query settle.

## What changed

Four small pieces.

1. **`website/src/lib/withDeadline.ts`** (new, 40 lines) — runs an attempt under a deadline, relays the caller's signal, and releases both the timer and the relay listener on settle.

2. **`website/src/api/client.ts`** — `skills` gains an optional trailing `signal` (threaded through the shared `get()` helper, also a new optional trailing parameter, so every other caller is unaffected) **and the deadline is applied here, once**:

```ts
skills: (sessionKey?: string, agent?: string, signal?: AbortSignal) =>
  withDeadline(SKILLS_TIMEOUT_MS, signal, s =>
    get('/api/skills' + (agent ? '?agent=' + encodeURIComponent(agent) : ''),
        sessionKey, s).then(j)),
```

   Each of the three `queryFn`s that had been wrapping the call individually now just passes react-query's signal straight through — `({ signal }) => api.skills(slotKey, agent, signal)` — and the `withDeadline`/`SKILLS_TIMEOUT_MS` imports are gone from all three components.

3. **The deadline is not retried — bound once, app-wide.** `api/queryClient.ts` gains `isDeadlineError` and folds it into the existing default `retryPolicy` as a first clause. Without it the default retries any non-throttle failure once, so a 15s bound settled at **~31s** with its backoff — and because `isLoading`/`releaseKeysWhenEmpty` only settle when retries exhaust, the composer stayed un-sendable for twice the advertised window.

   An earlier revision threaded `retry:` per query at three sites. That repeated, for retry, the same weakness this PR argues against for the deadline: react-query dedupes on the key, so a per-initiator rule is only as strong as the weakest initiator sharing that key. Binding it in the default policy every query inherits closes all of them and is strictly smaller — three imports and three option lines deleted. It stays narrower than `retry: false`: an ordinary failure keeps its single retry and a throttle keeps the full 429 ladder, both pinned by assertion. A `TimeoutError` only ever originates from `lib/withDeadline`, so no other query's behaviour changes today.

4. **A failed load no longer renders as an empty catalog** — a new `isError` branch selects `skills_load_failed{,_enter_sends,_ctrl_enter_sends}` instead of the `no_matching_skills*` copy, with all 14 catalogs updated (`en-XA` regenerated via `npm run i18n:pseudo`). The key-release behaviour is unchanged: returning Enter to the composer was already correct.

### Why the deadline binds inside `api.skills` rather than at each initiator

An earlier revision of this PR threaded the deadline at three call sites, and this description argued for that. Both were wrong, and the reason is worth stating because it is the whole shape of the fix.

**React-query dedupes on the query key, so per-initiator binding is only as strong as the weakest initiator of that key.** Measured at source, there are two shared keys and six non-test call sites:

| query key | initiators |
| --- | --- |
| `['skills', slot, project, agent]` | `ChatInput.tsx:1337` (focus prefetch), `SkillPickerMenu.tsx:97` |
| `['skills']` | `HookSkillsSelect.tsx:30`, `skillsProvider.ts:206`, `SkillsTab.tsx:90` |
| `['skills-catalog']` | `AgentSkillsEditor.tsx:56` |

Whichever initiator wins the race is the one that actually fetches; the others reuse its promise and never run their own `queryFn`. So threading three of six left two live holes — the `$`-menu could dedupe onto `ChatInput`'s prefetch, and the command palette onto `SkillsTab` or `HookSkillsSelect` — and any initiator added later would silently reopen one. Wrapping once inside `api.skills` makes the hole structurally unreachable: every one of the six goes through the same bounded function, including the three (`AgentSkillsEditor`, `HookSkillsSelect`, `SkillsTab`) that this PR previously declared unbounded-and-deferred. It is also strictly smaller — three wraps and four import lines deleted.

Measured at source, there are **six** react-query initiators of `api.skills`, not five — the review notes name `SkillsTab` and `AgentSkillsEditor` as the unfixed pair but miss `HookSkillsSelect.tsx:32`, which also uses the bare `['skills']` key. So per-site threading had left **three** holes, two of them on the key the command palette dedupes onto. Folding the rule into the default policy closes all three, and the retry test carries one case per initiator.

One correction to the First Principles note, verified at source: its `client.ts:2770,2862,3091` and `SkillPickerMenu.tsx:158` coordinates have drifted by a rebase (the siblings are now at `:2772`/`:2864`/`:3093` and the `isError` gate at `:162`). Both underlying claims hold — `chatSlotDetail`/`sendChat`/`fileSearch` do take an `AbortSignal`, and the `isError` release gate does exist.

Both sibling pickers are untouched, each deferred for a named reason:

- **`FilePickerMenu.tsx:111`** — `#7068`'s work; touching it here would collide.
- **`SlashCommandMenu.tsx:189`** — carries the identical Enter-swallowing gate (`!isFetching && filtered.length === 0`) over `api.slashCommands()` (`client.ts:2396`, which takes no signal), so a wedged fetch swallows Enter on an unmatched `/xyz`. Same root cause, different endpoint and different cache key, so it needs its own bound, its own tests and its own measured latency evidence — none of which this diff carries. Deferred to a follow-up PR of its own, in the same shape as this one; widening the diff to a third picker now would invite fresh findings on a change that is otherwise ready.

### Why not `AbortSignal.any([signal, AbortSignal.timeout(N)])`

That is the direct expression of this and was the first implementation. Two things pushed it out, one of them measured:

- **`AbortSignal.timeout` exposes no handle, so its timer cannot be cancelled.** It therefore leaves a live 15s timer behind *every* successful menu open. That is a leak on its own terms, and it is observable: it stalled the teardown of an unrelated suite (`ChatInput.skillTrigger.test.tsx`) by 10s, because the shared test setup drains the DOM task queue before shutting its mock server down — 3.69s baseline to a 10,283ms suite failure. An `AbortController` plus an explicit `clearTimeout` on settle has neither problem.
- **Browser baseline.** The repo declares no `browserslist` and no vite/esbuild target override; `tsconfig.app.json` is `target: ES2020`, `lib: ["ES2023", "DOM", "DOM.Iterable"]`. `AbortSignal.timeout` already ships in-tree (`src/pages/DevFleetPage.tsx`, twice), floor Chrome 103 / Firefox 100 / Safari 16. `AbortSignal.any` has **no** existing use and a materially higher floor: Chrome 116 / Firefox 124 / Safari 17.4. A missing `any` throws *synchronously* inside `queryFn`, which react-query catches — turning "slow sometimes" into "the menu is empty every time it opens" on an older engine. The `AbortController` form needs no feature detection, so the question does not arise.

### Why the abort reason is an `Error`, not a `DOMException`

The timeout reason would naturally be `new DOMException('…', 'TimeoutError')` — that is what `AbortSignal.timeout` itself produces. Two i18n gates in `Frontend Lint & Type Check` refuse it, and both are zero-tolerance on added lines with no ceiling to raise:

- `check-i18n-strings.mjs` drives a second eslint pass whose `callees.exclude` carries `'^(Type)?Error$'` under the heading *"Diagnostics and dev-only output"* — but not `DOMException`, so both the message *and* the `'TimeoutError'` name argument were reported (2 findings on one line). Note it runs with `allowInlineConfig: false`, so an `eslint-disable` comment cannot dispose of this.
- `check-unit-literals.mjs` is a separate TypeScript-AST scan that never consults eslint's exclusions, and flagged `${ms}ms` as a number+unit literal on its own. Its documented dispositions are the `src/i18n/format.ts` helpers or a `ROUND_TRIP` parser entry — neither applies to an internal abort reason that nothing renders and nothing parses.

So the reason is built with `Error` (the exemption the repo already grants diagnostics) and the interpolated duration is dropped rather than reformatted — importing an i18n formatter into a leaf utility to translate a string no one reads would be the wrong trade. `.name` is still `'TimeoutError'`, which is what the tests assert and what the web standard uses.

### Choice of N = 15s

- Above the **9.76s** observation, which *did* complete. This direction matters more than it looks: a spurious timeout settles the menu empty, which (per the gate above) hands Enter back to the composer and can send a draft the user was still completing. Failing a recoverable fetch is worse than a slow list.
- Below the **41.41s** and **168.71s** observations, which it converts into a visible settled error.
- ~24x the healthy 0.62s, and far past any plausible willingness to wait on an autocomplete.

Both bounds are pinned by assertion (`> 9_760`, `< 41_410`), so moving the constant outside the measured window fails the suite rather than drifting silently.

### Noted, not changed

`skillsCacheStaleTime()` in `website/src/lib/skillsCache.ts` (a file this PR no longer touches) returns `0` when `project` is `undefined`, so on a project-less slot every reopen refetches — which is what makes this endpoint's latency user-visible as often as it is. I left it alone on purpose: the `0` is deliberate and load-bearing. Its own comment explains that without project identity the query key cannot observe a same-slot project switch, so caching would serve another project's catalog. That is a correctness trade, not an oversight, and narrowing it is a separate change with a separate argument.

## Tests

The deadline is now a **client-layer** guarantee, so it is pinned at that layer: `website/src/test/apiSkillsDeadline.test.ts` (new) drives the real `api.skills` against a stubbed `fetch` that only settles on abort. Its first case passes **no signal at all** — the exact shape `AgentSkillsEditor`, `HookSkillsSelect` and `SkillsTab` use — which is what proves those three are bounded now. The component suites keep what the components actually owe: passing react-query's signal through, rendering a settled failure as a failure, and — under the app's own default retry policy rather than a `retry: false` client — running the fetch exactly once.

Three existing arity assertions in `SkillPickerMenu.test.tsx` were updated for the new third argument.

**Counts**

| suite                                            | result                                     |
| ------------------------------------------------ | ------------------------------------------ |
| `apiSkillsDeadline.test.ts`                         | 8 passed                                        |
| `skillsRetryPolicy.test.ts`                         | 11 passed                                       |
| `withDeadline.test.ts`                              | 9 passed                                        |
| `SkillPickerMenu.timeout.test.tsx`                  | 4 passed                                        |
| `SkillPickerMenu.dedupe.test.tsx`                   | 5 passed                                        |
| `ChatInput.skillsPrefetchDeadline.test.tsx`         | 2 passed                                        |
| `SkillPickerMenu.test.tsx`                          | 39 passed                                       |
| `ApiClient.coverage.test.tsx`                       | 681 passed                                      |
| **full `vitest run src/`**                          | **1665 files, 26416 passed, 3 skipped, exit 0**  |
| `npx tsc -b`                                        | 0 errors                                        |
| `npx eslint src/ --max-warnings 659`                | 658 warnings, 0 errors (the base measures 658 too, so this diff adds none) |
| `npx jscpd .`                                       | exit 0                                          |
| `node scripts/i18n-check.mjs`                       | **19 checks · PASS**                            |

### One upstream baseline refresh, not mine

Rebasing onto `bb3d4943952a` brought in `20b3710c054a`, after which `test/test_agent_sdk_boundary.py::test_every_recorded_violation_still_exists` fails with `{'src/kiro_crew/subagent.py': (9, 8)}`: the baseline records 9 imports for that file while the tree has 8. Applied the refresh the gate itself prescribes (`--update-baseline`). The rule is unchanged and no exemption was added.

Narrowed to exactly the one prescribed line: the script also regenerates its own header comment, which would have rewritten an unrelated line of prose, so that line is left at upstream's text. The committed diff is the single count line and nothing else; the boundary suite then passes 25/25.

### Negative controls

A passing test proves nothing on its own, so each claim was checked by reverting the thing it asserts.

| # | reverted | expected to fail | actual |
| - | --- | --- | --- |
| 1 | the `withDeadline` wrap inside `api.skills` | the deadline tests | **3 of 5 failed**, each hanging the full 15s test timeout — which *is* the defect. The signal-relay and healthy-path cases correctly still passed, so the control discriminates |
| 2 | `clearTimeout(timer)` removed from `release()` | the 3 timer-release tests | **3 failed** |
| 3 | the `outer.aborted` up-front check removed | the already-aborted test | **1 failed**, after sitting out the full deadline — the exact cost the check exists to avoid |
| 4 | the `isError` copy branch removed | the two error-copy tests | **2 failed**; the *genuinely-empty* test still passed, which is the point — the branch must key on the error, not on emptiness |
| 5 | the `isDeadlineError` clause removed from the default `retryPolicy` | every initiator case | **7 failed** — all six initiators ran the fetch twice, which is the ~31s wait. The throttle-ladder, ordinary-retry and type-discrimination cases correctly still passed, so the control discriminates rather than failing wholesale |
| 6 | the clause widened to a blanket `retry: false` | the narrowing cases | **2 failed** — an ordinary failure lost its single retry and a 429 lost its ladder, so the narrowing cannot silently broaden |

### A harness collision, and where the tolerance belongs

Moving the wrap into `api.skills` made an existing test fail — `ApiClient.coverage.test.tsx`'s "every api method issues one well-formed /api request", which drives every method with uniform positional junk (`'sw-1'…'sw-4'`). The other signal-taking methods survive that because they only ever *forward* the signal to `fetch`, which the mock ignores; `withDeadline` was the first code to actually **use** it, so a string in the signal position threw `TypeError: outer?.addEventListener is not a function`.

An earlier revision absorbed this with a `typeof outer?.addEventListener === 'function'` guard in `withDeadline`. That was the wrong layer: production has zero non-signal producers across all six call sites, so the guard defended only against the harness. The guard is gone, and the tolerance now sits where the non-signal actually originates — `skills` joins the harness's own `HAND_TESTED` escape hatch (alongside the four methods already there for needing real fixtures), and that sweep's URL assertions are replicated verbatim against `api.skills` in `apiSkillsDeadline.test.ts`, so excluding it costs no coverage. Verified by the full suite passing with the guard removed: had anything outside the harness depended on it, that would have shown up here.

<!-- no-visual-delta -->

**Why no screenshot:** No layout, theme, or component change — no new markup and no styling. The change is behavioural (a stuck `Loading skills…` now settles) plus one string swap in the picker's existing `role="status"` empty-state slot: `No matching skills — Enter sends the message` becomes `Couldn't load skills — Enter sends the message` on the error path only. Both the old and new strings are in the diff verbatim, in the same element, so the visual result is fully judgeable from the diff and the catalog entries; a screenshot would show pre-existing chrome around one line of text.




