### PR TITLE
fix(dashboard): make chat entry-cache bounds configurable (#7037)

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5652,6 +5652,8 @@
         "merge_queued_messages": false,
         "mcp_probe_timeout_secs": 15,
         "loop_stall_exit_after_secs": null,
+        "chat_entry_cache_max_entries": 4096,
+        "chat_entry_cache_max_bytes": 33554432,
         "cautious_boot": true,
         "widget_density": "more",
         "use_builtin_browser": true,
@@ -5952,6 +5954,34 @@
       "enumValues": null,
       "defaultValue": null,
       "nullable": true
+    },
+    {
+      "path": "dashboard.chat_entry_cache_max_entries",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Chat Entry Cache Max Entries",
+      "help": "Maximum number of persisted-message entries the chat save path memoises. The cache's working set is roughly the number of active chat slots times their window size, so the right bound is host-dependent: a gateway with many concurrent slots overflows this bound while the byte ceiling still has headroom, and the cache hit rate collapses to zero (every save re-pays redaction). Raise it on a many-slot host. Clamped to 256..262144. Read once at first use; a change takes effect on the next gateway restart.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 4096
+    },
+    {
+      "path": "dashboard.chat_entry_cache_max_bytes",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Chat Entry Cache Max Bytes",
+      "help": "Memory ceiling in bytes for the chat save path's persisted-message entry memo. Evicted alongside the entry-count bound; raise it together with the entry bound when a many-slot host needs a larger cache. Clamped to 4 MiB..512 MiB. Read once at first use; a change takes effect on the next gateway restart.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 33554432
     },
     {
       "path": "dashboard.cautious_boot",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3093,6 +3093,22 @@ LOOP_STALL_EXIT_AFTER_DEFAULT = 25
 LOOP_STALL_EXIT_AFTER_MANAGED_DEFAULT = 90
 _MANAGED_SERVICE_ENV = "KIROCREW_SERVICE_MANAGED"
 
+# dashboard.chat_entry_cache_max_entries / chat_entry_cache_max_bytes -- bounds
+# on the persisted-message entry memo in ``dashboard/chat_persistence.py``. The
+# right entry count is host-dependent: the cache's working set is roughly
+# ``active_slots x window_size``, so a gateway with many concurrent chat slots
+# overflows the entry bound while the byte bound still has headroom, and the LRU
+# then evicts each slot's window just before its next save (a zero-hit cliff,
+# every save re-paying redaction plus key derivation). The defaults match the
+# previous hardcoded values; raising the entry bound on a many-slot host is the
+# operator's call, with the byte ceiling still bounding memory.
+CHAT_ENTRY_CACHE_ENTRIES_MIN = 256
+CHAT_ENTRY_CACHE_ENTRIES_MAX = 262144
+CHAT_ENTRY_CACHE_ENTRIES_DEFAULT = 4096
+CHAT_ENTRY_CACHE_BYTES_MIN = 4 * 1024 * 1024
+CHAT_ENTRY_CACHE_BYTES_MAX = 512 * 1024 * 1024
+CHAT_ENTRY_CACHE_BYTES_DEFAULT = 32 * 1024 * 1024
+
 
 @dataclass
 class DashboardConfig:
@@ -3216,6 +3232,31 @@ class DashboardConfig:
             "liveness probe kills at roughly 20s independently, so a value "
             "above that only takes effect for a headless gateway — the desktop "
             "probe wins first and the stack dump is lost.",
+        ),
+    )
+    chat_entry_cache_max_entries: int = field(
+        default=CHAT_ENTRY_CACHE_ENTRIES_DEFAULT,
+        metadata=_meta(
+            "Chat Entry Cache Max Entries",
+            "Maximum number of persisted-message entries the chat save path "
+            "memoises. The cache's working set is roughly the number of active "
+            "chat slots times their window size, so the right bound is "
+            "host-dependent: a gateway with many concurrent slots overflows "
+            "this bound while the byte ceiling still has headroom, and the "
+            "cache hit rate collapses to zero (every save re-pays redaction). "
+            "Raise it on a many-slot host. Clamped to 256..262144. Read once "
+            "at first use; a change takes effect on the next gateway restart.",
+        ),
+    )
+    chat_entry_cache_max_bytes: int = field(
+        default=CHAT_ENTRY_CACHE_BYTES_DEFAULT,
+        metadata=_meta(
+            "Chat Entry Cache Max Bytes",
+            "Memory ceiling in bytes for the chat save path's persisted-message "
+            "entry memo. Evicted alongside the entry-count bound; raise it "
+            "together with the entry bound when a many-slot host needs a "
+            "larger cache. Clamped to 4 MiB..512 MiB. Read once at first use; "
+            "a change takes effect on the next gateway restart.",
         ),
     )
     cautious_boot: bool = field(
@@ -4385,6 +4426,18 @@ _SECURITY_BOUNDED_FIELDS: tuple[tuple[str, str, int, int], ...] = (
         "loop_stall_exit_after_secs",
         LOOP_STALL_EXIT_AFTER_MIN,
         LOOP_STALL_EXIT_AFTER_MAX,
+    ),
+    (
+        "dashboard",
+        "chat_entry_cache_max_entries",
+        CHAT_ENTRY_CACHE_ENTRIES_MIN,
+        CHAT_ENTRY_CACHE_ENTRIES_MAX,
+    ),
+    (
+        "dashboard",
+        "chat_entry_cache_max_bytes",
+        CHAT_ENTRY_CACHE_BYTES_MIN,
+        CHAT_ENTRY_CACHE_BYTES_MAX,
     ),
     ("session", "pool_size", 0, POOL_SIZE_MAX),
 )
@@ -8082,6 +8135,22 @@ class KiroCrewConfig:
                         LOOP_STALL_EXIT_AFTER_MIN,
                         LOOP_STALL_EXIT_AFTER_MAX,
                     )
+                ),
+                chat_entry_cache_max_entries=_safe_int(
+                    dashboard_data.get(
+                        "chat_entry_cache_max_entries", CHAT_ENTRY_CACHE_ENTRIES_DEFAULT
+                    ),
+                    CHAT_ENTRY_CACHE_ENTRIES_DEFAULT,
+                    CHAT_ENTRY_CACHE_ENTRIES_MIN,
+                    CHAT_ENTRY_CACHE_ENTRIES_MAX,
+                ),
+                chat_entry_cache_max_bytes=_safe_int(
+                    dashboard_data.get(
+                        "chat_entry_cache_max_bytes", CHAT_ENTRY_CACHE_BYTES_DEFAULT
+                    ),
+                    CHAT_ENTRY_CACHE_BYTES_DEFAULT,
+                    CHAT_ENTRY_CACHE_BYTES_MIN,
+                    CHAT_ENTRY_CACHE_BYTES_MAX,
                 ),
                 cautious_boot=_safe_bool(dashboard_data.get("cautious_boot"), True),
                 auto_open_browser=dashboard_data.get("auto_open_browser", True),

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -19,7 +19,12 @@ from kiro_crew import model_registry
 from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.agent_discovery import agent_model_map
 from kiro_crew.atomic_write import atomic_write
-from kiro_crew.config.loader import KiroCrewConfig, config_dir
+from kiro_crew.config.loader import (
+    CHAT_ENTRY_CACHE_BYTES_DEFAULT,
+    CHAT_ENTRY_CACHE_ENTRIES_DEFAULT,
+    KiroCrewConfig,
+    config_dir,
+)
 from kiro_crew.dashboard.channel_slots import slot_closed_since
 from kiro_crew.dashboard.chat_utils import (
     _normalize_model,
@@ -1749,14 +1754,20 @@ def _archive_dropped_lines(
 # the bound is a cliff rather than a slope -- each save walks its window in
 # order, so with several slots taking turns the LRU evicts each window just
 # before its next save and the hit rate collapses to zero instead of degrading.
-# The entry bound is therefore chosen to hold several concurrent slot windows.
+# The default entry bound holds several concurrent slot windows; because the
+# right size is host-dependent (a gateway with many active slots overflows the
+# entry bound while the byte bound still has headroom), both the entry bound and
+# the byte ceiling are configurable
+# (``dashboard.chat_entry_cache_max_entries`` / ``chat_entry_cache_max_bytes``).
 #
 # The flush site skips the cache for a window longer than the entry bound, which
 # closes that cliff for ONE oversized window and nothing more. Several slots
 # whose COMBINED windows exceed the bound each stay under it individually, so
-# they take the cached path and hit the same zero-hit cliff unguarded. That is
-# accepted rather than fixed: detecting it needs a live view across slots, while
-# the cost of being wrong is only the key derivation on a miss.
+# they take the cached path and hit the same zero-hit cliff unguarded. Detecting
+# that needs a live view across slots, which no single save has; the mitigation
+# is the configurable entry bound above -- an operator whose host shows the
+# multi-slot cliff raises it -- while the cost of the residual case is only the
+# key derivation on a miss.
 #
 # The entry count alone does NOT bound memory, because an entry is as large as
 # its message: a cache full of megabyte-sized messages would retain gigabytes.
@@ -1766,7 +1777,7 @@ def _archive_dropped_lines(
 # per-entry ceiling above which an entry is computed but never stored (so one
 # huge message cannot evict the whole cache), and a total-byte ceiling evicted
 # alongside the entry count. Worst-case retention is the lesser of
-# ``_ENTRY_CACHE_MAX x _ENTRY_MAX_CACHEABLE_BYTES`` and ``_ENTRY_CACHE_MAX_BYTES``.
+# ``max_entries x _ENTRY_MAX_CACHEABLE_BYTES`` and the configured byte ceiling.
 #
 # Size is measured as the length of the key payload, which the front door has
 # already built for hashing, so it costs nothing extra. It measures the input
@@ -1777,12 +1788,73 @@ def _archive_dropped_lines(
 # holding identical message content share one entry; and a cached ``None`` (a
 # transient role) is a legitimate value, so membership -- not truthiness -- is
 # what distinguishes a hit from a miss.
-_ENTRY_CACHE_MAX = 4096
-_ENTRY_CACHE_MAX_BYTES = 32 * 1024 * 1024
+#
+# ``_ENTRY_MAX_CACHEABLE_BYTES`` stays a module constant: it guards against ONE
+# huge message evicting the whole cache, a shape that does not vary by host the
+# way the working-set bounds do.
 _ENTRY_MAX_CACHEABLE_BYTES = 256 * 1024
 _entry_cache_lock = threading.Lock()
 _entry_cache: OrderedDict[str, tuple[dict | None, int]] = OrderedDict()
 _entry_cache_bytes = 0
+
+# Lazily resolved ``(max_entries, max_bytes)`` for the entry cache. Resolved
+# once per process and then served from this module global: the builder runs on
+# every message of every flush, so it must not stat or parse ``config.json``
+# per call, and the one-time read keeps the hot path free of config I/O the way
+# the loader's push pattern does for the event loop. A changed value therefore
+# takes effect on the next gateway restart, which the config field descriptions
+# state. ``None`` means "not resolved yet"; tests reset it via the autouse
+# cache-isolation fixture in ``test/conftest.py``.
+_entry_cache_bounds_cached: tuple[int, int] | None = None
+_entry_cache_bounds_read_warned = False
+
+
+def _entry_cache_bounds() -> tuple[int, int]:
+    """Configured ``(max_entries, max_bytes)`` bounds for the entry cache.
+
+    Reads the validated config once (loader-clamped to the documented ranges)
+    and memoises the pair for the process lifetime. Falls back to the built-in
+    defaults when the loaded values are not real integers (a stubbed config
+    object would otherwise flow a non-numeric value into the eviction
+    comparison) -- that shape is process-permanent, so it latches. A config
+    read that RAISES falls back to the defaults for this call WITHOUT
+    latching, so a transient failure retries on the next call instead of
+    discarding an operator's setting for the process lifetime; ``load()``
+    degrades to defaults internally rather than raising, so a persistently
+    raising read is not a realistic hot-path cost. The memo is written only
+    after a successful read, which also makes concurrent first calls resolve
+    toward the config value: two successful readers store the same pair, and a
+    failing reader stores nothing.
+    """
+    global _entry_cache_bounds_cached, _entry_cache_bounds_read_warned
+    bounds = _entry_cache_bounds_cached
+    if bounds is None:
+        bounds = (CHAT_ENTRY_CACHE_ENTRIES_DEFAULT, CHAT_ENTRY_CACHE_BYTES_DEFAULT)
+        try:
+            dashboard = KiroCrewConfig.load().dashboard
+            max_entries = dashboard.chat_entry_cache_max_entries
+            max_bytes = dashboard.chat_entry_cache_max_bytes
+            if (
+                isinstance(max_entries, int)
+                and not isinstance(max_entries, bool)
+                and isinstance(max_bytes, int)
+                and not isinstance(max_bytes, bool)
+            ):
+                bounds = (max_entries, max_bytes)
+        except Exception:
+            # Log once per process: silently discarding a configured bound
+            # reproduces the exact symptom (a thrashing cache) the config
+            # exists to fix, with nothing to diagnose from.
+            if not _entry_cache_bounds_read_warned:
+                _entry_cache_bounds_read_warned = True
+                logger.warning(
+                    "chat entry-cache bounds config read failed; using defaults "
+                    "until a read succeeds",
+                    exc_info=True,
+                )
+            return bounds
+        _entry_cache_bounds_cached = bounds
+    return bounds
 
 
 def _approx_window_payload_bytes(window: list[dict]) -> int:
@@ -1851,15 +1923,17 @@ def _build_message_entry(m: dict) -> dict | None:
             return entry
     except Exception:
         return entry
+    # Resolve the configured bounds BEFORE taking the cache lock: the first call
+    # in the process reads config from disk, and that read must not run under a
+    # lock the flush path contends on.
+    max_entries, max_bytes = _entry_cache_bounds()
     with _entry_cache_lock:
         previous = _entry_cache.pop(key, None)
         if previous is not None:
             _entry_cache_bytes -= previous[1]
         _entry_cache[key] = (entry, size)
         _entry_cache_bytes += size
-        while _entry_cache and (
-            len(_entry_cache) > _ENTRY_CACHE_MAX or _entry_cache_bytes > _ENTRY_CACHE_MAX_BYTES
-        ):
+        while _entry_cache and (len(_entry_cache) > max_entries or _entry_cache_bytes > max_bytes):
             _, (_evicted_entry, evicted_size) = _entry_cache.popitem(last=False)
             _entry_cache_bytes -= evicted_size
     return entry
@@ -2772,11 +2846,13 @@ def _save_slot_to_history(
             # window whose payload exceeds the BYTE ceiling self-evicts the same
             # way at a far smaller message count, so it is gated too, on a cheap
             # lower-bound estimate rather than on a measurement that would itself
-            # cost what the bypass saves.
+            # cost what the bypass saves. Gated on the same configured bounds the
+            # cache evicts by, so raising them widens the cached path in step.
+            cache_max_entries, cache_max_bytes = _entry_cache_bounds()
             build_entry = (
                 _build_message_entry_uncached
-                if len(window) > _ENTRY_CACHE_MAX
-                or _approx_window_payload_bytes(window) > _ENTRY_CACHE_MAX_BYTES
+                if len(window) > cache_max_entries
+                or _approx_window_payload_bytes(window) > cache_max_bytes
                 else _build_message_entry
             )
             window_entries = [e for m in window if (e := build_entry(m)) is not None]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -583,16 +583,25 @@ def _isolate_message_entry_cache():
 
     The byte counter is part of the same state, so resetting only the dict would
     leave the memory ceiling mis-accounted and evict a healthy cache.
+
+    The memoised config bounds are reset for the same reason: they are resolved
+    once per process from whatever KIROCREW_HOME the first caller saw, so a test
+    that resolved them under its own home would otherwise leak its bounds into
+    every later test's cache behaviour.
     """
     from kiro_crew.dashboard import chat_persistence as _cp
 
     _cp._entry_cache.clear()
     _cp._entry_cache_bytes = 0
+    _cp._entry_cache_bounds_cached = None
+    _cp._entry_cache_bounds_read_warned = False
     try:
         yield
     finally:
         _cp._entry_cache.clear()
         _cp._entry_cache_bytes = 0
+        _cp._entry_cache_bounds_cached = None
+        _cp._entry_cache_bounds_read_warned = False
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -3166,6 +3166,53 @@ class TestSecurityBoundClamping:
             cfg = _load_from_dict({"session": {"pool_size": 1000}})
         assert cfg.session.pool_size == POOL_SIZE_MAX == 10
 
+    def test_chat_entry_cache_bounds_default_when_absent(self) -> None:
+        """Omitted from config.json, the entry-cache bounds are byte-identical
+        to the previous hardcoded constants (4096 entries / 32 MiB)."""
+        cfg = _load_from_dict({})
+        assert cfg.dashboard.chat_entry_cache_max_entries == 4096
+        assert cfg.dashboard.chat_entry_cache_max_bytes == 32 * 1024 * 1024
+
+    def test_chat_entry_cache_max_entries_clamped_at_both_ends(self) -> None:
+        from kiro_crew.config.loader import (
+            CHAT_ENTRY_CACHE_ENTRIES_MAX,
+            CHAT_ENTRY_CACHE_ENTRIES_MIN,
+        )
+
+        with unittest.mock.patch("kiro_crew.config.loader._log_config_clamp_event"):
+            low = _load_from_dict({"dashboard": {"chat_entry_cache_max_entries": 1}})
+            high = _load_from_dict({"dashboard": {"chat_entry_cache_max_entries": 10**9}})
+        assert low.dashboard.chat_entry_cache_max_entries == CHAT_ENTRY_CACHE_ENTRIES_MIN == 256
+        assert high.dashboard.chat_entry_cache_max_entries == CHAT_ENTRY_CACHE_ENTRIES_MAX == 262144
+
+    def test_chat_entry_cache_max_bytes_clamped_at_both_ends(self) -> None:
+        from kiro_crew.config.loader import (
+            CHAT_ENTRY_CACHE_BYTES_MAX,
+            CHAT_ENTRY_CACHE_BYTES_MIN,
+        )
+
+        with unittest.mock.patch("kiro_crew.config.loader._log_config_clamp_event"):
+            low = _load_from_dict({"dashboard": {"chat_entry_cache_max_bytes": 1024}})
+            high = _load_from_dict({"dashboard": {"chat_entry_cache_max_bytes": 10**12}})
+        assert low.dashboard.chat_entry_cache_max_bytes == CHAT_ENTRY_CACHE_BYTES_MIN
+        assert CHAT_ENTRY_CACHE_BYTES_MIN == 4 * 1024 * 1024
+        assert high.dashboard.chat_entry_cache_max_bytes == CHAT_ENTRY_CACHE_BYTES_MAX
+        assert CHAT_ENTRY_CACHE_BYTES_MAX == 512 * 1024 * 1024
+
+    def test_chat_entry_cache_bounds_in_range_preserved(self) -> None:
+        """A deliberate in-range setting is preserved verbatim -- the clamp must
+        not be a blanket overwrite."""
+        cfg = _load_from_dict(
+            {
+                "dashboard": {
+                    "chat_entry_cache_max_entries": 16384,
+                    "chat_entry_cache_max_bytes": 64 * 1024 * 1024,
+                }
+            }
+        )
+        assert cfg.dashboard.chat_entry_cache_max_entries == 16384
+        assert cfg.dashboard.chat_entry_cache_max_bytes == 64 * 1024 * 1024
+
     def test_session_start_timeout_default(self) -> None:
         """Omitted from config.json, the budget is the built-in 90s default."""
         cfg = _load_from_dict({})

--- a/test/test_message_entry_memoisation.py
+++ b/test/test_message_entry_memoisation.py
@@ -231,10 +231,11 @@ def test_transient_none_agrees_with_the_uncached_function() -> None:
 # ── bounds: entry count, total bytes, and per-entry rejection ─────────────────
 
 
-def test_cache_is_bounded_by_entry_count() -> None:
-    for i in range(chat_persistence._ENTRY_CACHE_MAX + 50):
+def test_cache_is_bounded_by_entry_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(chat_persistence, "_entry_cache_bounds_cached", (200, 10**9))
+    for i in range(250):
         _build_message_entry({"role": "assistant", "content": f"m{i}", "ts": f"t{i}"})
-    assert len(_entry_cache) == chat_persistence._ENTRY_CACHE_MAX
+    assert len(_entry_cache) == 200
 
 
 def test_byte_counter_tracks_the_stored_entries() -> None:
@@ -281,7 +282,7 @@ def test_total_byte_ceiling_evicts(monkeypatch: pytest.MonkeyPatch) -> None:
     """Bounding entries alone does not bound memory: an entry is as large as its
     message. With a low byte ceiling the cache must evict on bytes even though
     the entry count is nowhere near its own bound."""
-    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX_BYTES", 4000)
+    monkeypatch.setattr(chat_persistence, "_entry_cache_bounds_cached", (4096, 4000))
     for i in range(40):
         _build_message_entry({"role": "assistant", "content": "x" * 500, "ts": f"t{i}"})
     assert len(_entry_cache) < 40
@@ -323,7 +324,7 @@ def test_a_window_longer_than_the_bound_bypasses_the_cache(
     from kiro_crew.dashboard.chat import _save_slot_to_history
 
     monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
-    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX", 3)
+    monkeypatch.setattr(chat_persistence, "_entry_cache_bounds_cached", (3, 10**9))
     state = _make_state(tmp_path)
     slot = state.get_or_create_slot("s1")
     for i in range(5):
@@ -344,7 +345,7 @@ def test_a_window_within_the_bound_still_uses_the_cache(
     from kiro_crew.dashboard.chat import _save_slot_to_history
 
     monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
-    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX", 100)
+    monkeypatch.setattr(chat_persistence, "_entry_cache_bounds_cached", (100, 10**9))
     state = _make_state(tmp_path)
     slot = state.get_or_create_slot("s1")
     for i in range(5):
@@ -442,15 +443,14 @@ def test_a_window_past_the_byte_ceiling_bypasses_the_cache(
     """Such a window self-evicts through the byte ceiling at a message count well
     under the entry bound, so it hits 0% while still paying to hash every byte.
 
-    The message count stays under ``_ENTRY_CACHE_MAX`` and each message stays
+    The message count stays under the entry bound and each message stays
     under the per-entry cap, so neither of the other two bypasses can account for
     an empty cache here.
     """
     from kiro_crew.dashboard.chat import _save_slot_to_history
 
     monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
-    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX", 100)
-    monkeypatch.setattr(chat_persistence, "_ENTRY_CACHE_MAX_BYTES", 1000)
+    monkeypatch.setattr(chat_persistence, "_entry_cache_bounds_cached", (100, 1000))
     state = _make_state(tmp_path)
     slot = state.get_or_create_slot("s1")
     for i in range(5):
@@ -460,9 +460,151 @@ def test_a_window_past_the_byte_ceiling_bypasses_the_cache(
 
     _save_slot_to_history(state, slot, closed=True)
 
-    assert len(slot.messages) <= chat_persistence._ENTRY_CACHE_MAX
+    assert len(slot.messages) <= 100
     assert all(
         len(m.get("content") or "") < chat_persistence._ENTRY_MAX_CACHEABLE_BYTES
         for m in slot.messages
     )
+    assert len(_entry_cache) == 0
+
+
+# ── configurable bounds: the config values are what actually govern ───────────
+
+
+def _write_config(dashboard: dict) -> None:
+    """Write a minimal ``config.json`` under the test-pinned KIROCREW_HOME."""
+    from kiro_crew.config.loader import config_path
+
+    p = config_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"dashboard": dashboard}), encoding="utf-8")
+
+
+def test_bounds_default_when_config_is_absent() -> None:
+    """With no config file the bounds are the built-in defaults, byte-identical
+    to the previous hardcoded constants -- making the cache configurable must
+    not change behaviour for anyone who has not configured it."""
+    from kiro_crew.config.loader import (
+        CHAT_ENTRY_CACHE_BYTES_DEFAULT,
+        CHAT_ENTRY_CACHE_ENTRIES_DEFAULT,
+    )
+
+    assert chat_persistence._entry_cache_bounds() == (
+        CHAT_ENTRY_CACHE_ENTRIES_DEFAULT,
+        CHAT_ENTRY_CACHE_BYTES_DEFAULT,
+    )
+    assert chat_persistence._entry_cache_bounds() == (4096, 32 * 1024 * 1024)
+
+
+def test_bounds_default_when_the_config_cannot_be_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken config file must not break the save path: the bounds fall back
+    to the defaults, exactly like the restore paths tolerate a broken file."""
+
+    def boom() -> None:
+        raise RuntimeError("unreadable config")
+
+    monkeypatch.setattr(chat_persistence.KiroCrewConfig, "load", boom)
+    assert chat_persistence._entry_cache_bounds() == (4096, 32 * 1024 * 1024)
+
+
+def test_a_failing_config_read_does_not_latch_the_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient read failure must not discard an operator's setting for the
+    process lifetime: the memo is written only after a successful read, so the
+    next call retries and resolves the configured value."""
+    _write_config({"chat_entry_cache_max_entries": 512})
+
+    def boom() -> None:
+        raise OSError("transient read failure")
+
+    real_load = chat_persistence.KiroCrewConfig.load
+    monkeypatch.setattr(chat_persistence.KiroCrewConfig, "load", boom)
+    assert chat_persistence._entry_cache_bounds() == (4096, 32 * 1024 * 1024)
+    assert chat_persistence._entry_cache_bounds_cached is None  # not latched
+
+    monkeypatch.setattr(chat_persistence.KiroCrewConfig, "load", real_load)
+    assert chat_persistence._entry_cache_bounds()[0] == 512  # retried and won
+
+
+def test_bounds_are_read_from_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The configured values -- not the old constants -- are what the accessor
+    serves, and the read is memoised: a config change after the first resolve
+    is not observed until the next process (restart semantics)."""
+    _write_config(
+        {"chat_entry_cache_max_entries": 512, "chat_entry_cache_max_bytes": 8 * 1024 * 1024}
+    )
+    assert chat_persistence._entry_cache_bounds() == (512, 8 * 1024 * 1024)
+
+    calls = {"n": 0}
+    real_load = chat_persistence.KiroCrewConfig.load
+
+    def counting_load():
+        calls["n"] += 1
+        return real_load()
+
+    monkeypatch.setattr(chat_persistence.KiroCrewConfig, "load", counting_load)
+    assert chat_persistence._entry_cache_bounds() == (512, 8 * 1024 * 1024)
+    assert calls["n"] == 0  # memoised: no re-read per call
+
+
+def test_configured_entry_bound_governs_eviction() -> None:
+    """The CONFIGURED bound -- not the old 4096 constant -- is what evicts: a
+    workload above a configured 256 evicts down to exactly 256 (it would be
+    fully retained at the default), and re-resolving with a raised configured
+    bound retains the same workload. This is the property the config exists
+    for: a many-slot host raising the bound must actually stop the churn."""
+    workload = [
+        {"role": "assistant", "content": f"slot-window message {i}", "ts": f"t{i}"}
+        for i in range(300)
+    ]
+
+    _write_config({"chat_entry_cache_max_entries": 256})
+    for m in workload:
+        _build_message_entry(dict(m))
+    # Evicted at the configured 256; under the default 4096 all 300 would fit.
+    assert len(_entry_cache) == 256
+
+    _entry_cache.clear()
+    chat_persistence._entry_cache_bytes = 0
+    chat_persistence._entry_cache_bounds_cached = None  # re-resolve from config
+    _write_config({"chat_entry_cache_max_entries": 1024})
+    for m in workload:
+        _build_message_entry(dict(m))
+    assert len(_entry_cache) == 300  # retained under the raised configured bound
+
+    # And the retained entries are genuine hits on the next pass, not re-inserts.
+    for m in workload:
+        _build_message_entry(dict(m))
+    assert len(_entry_cache) == 300
+
+
+def test_flush_bypass_honors_the_configured_bounds(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The flush-site whole-window bypass reads the same configured bounds the
+    cache evicts by: a window that bypasses at the default entry bound takes the
+    cached path once the configured bound covers it."""
+    from kiro_crew.dashboard.chat import _save_slot_to_history
+
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+    _write_config({"chat_entry_cache_max_entries": 256})
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("s1")
+    for i in range(5):
+        slot.append("assistant", f"message {i}")
+    slot.drain()
+
+    # Below the configured bound: cached path populates the cache.
+    _entry_cache.clear()
+    _save_slot_to_history(state, slot, closed=True)
+    assert len(_entry_cache) > 0
+
+    # A memoised bound smaller than the window flips the SAME save to the
+    # uncached path -- proving the bypass reads the plumbed value, not a constant.
+    chat_persistence._entry_cache_bounds_cached = (3, 10**9)
+    _entry_cache.clear()
+    _save_slot_to_history(state, slot, closed=True)
     assert len(_entry_cache) == 0


### PR DESCRIPTION
## Problem / Motivation

The `_build_message_entry` memo cache in `src/kiro_crew/dashboard/chat_persistence.py` bounds its LRU with hardcoded module constants (`_ENTRY_CACHE_MAX = 4096`, `_ENTRY_CACHE_MAX_BYTES = 32 MiB`). The right entry bound is host-dependent: the cache's working set is roughly `active_slots × window_size`, so a gateway with many active chat slots (the reporter measured 85 slots / ~12,000 messages touched within an hour) exceeds the entry-count bound ~3× while the byte bound still has headroom. The LRU then evicts each slot's window just before its next save, and the hit rate collapses to ~0% -- every save re-pays the full `redact_credentials` cost plus key derivation (`json.dumps` + SHA-256) on paths that saturate the event loop. The module's own comment predicted exactly this multi-slot zero-hit cliff and marked it "accepted rather than fixed". Downstream, multi-hop endpoints degrade badly (`GET /api/skills` measured up to 168 s on the reporter's host).

## Why it matters

An operator running many concurrent chat slots has no lever at all today: the bounds are compile-time constants, so the only options are fewer slots or a source edit. The failure mode is a cliff rather than a slope, and once past it the whole gateway's responsiveness degrades -- the redaction cost lands on the flush paths of every slot, not just the busy ones.

## What changed (motivation → approach → change)

Symptom → cause: the entry-count bound, not the byte bound, is what overflows on many-slot hosts, and it is not configurable. Approach: follow the repo's own precedent for a host-dependent budget, `dashboard.loop_stall_exit_after_secs` (configurable with unchanged default, loader-clamped). Change:

- **`config/loader.py`**: two clamped `DashboardConfig` fields -- `dashboard.chat_entry_cache_max_entries` (default 4096, clamped 256..262144) and `dashboard.chat_entry_cache_max_bytes` (default 32 MiB, clamped 4 MiB..512 MiB). Both are registered in `_SECURITY_BOUNDED_FIELDS` (load-time clamp + SEL tamper event, same as the other bounded knobs) and coerced with `_safe_int` bounds at the construction site (catches numeric strings the dict-level clamp skips).
- **`dashboard/chat_persistence.py`**: a memoised `_entry_cache_bounds()` accessor resolves the pair once per process (no config stat/parse per message; a change applies on the next gateway restart, which the field help states). Both consumption sites read it: the cache insert/evict check and the flush-site whole-window bypass, so raising the bounds widens the cached path in step. The accessor fails closed to the built-in defaults on a raising config read (logged once per process, without latching, so a transient failure retries) and on non-integer values (a stubbed config object cannot flow a non-numeric bound into the eviction comparison). Bounds are resolved before the cache lock is taken, so the one-time disk read never runs under the contended lock. `_ENTRY_MAX_CACHEABLE_BYTES` deliberately stays hardcoded -- the per-entry ceiling does not vary by host the way the working-set bounds do, and the issue does not implicate it.
- The module comment no longer describes the multi-slot cliff as "accepted rather than fixed": it names the configurable bound as the mitigation.
- `config-baseline.json` regenerated (auto-generated schema artifact; gated by `test_config_baseline.py`).

Deliberately NOT done (per the issue's own cost/benefit note): no cross-slot working-set guard -- it needs a live view across slots that no single save has. Defaults are byte-identical in behavior; raising the entry count is the operator's choice, not this PR's.

## Tests

- `test_config_loader.py::TestSecurityBoundClamping`: defaults unchanged when the keys are absent (4096 / 32 MiB); both new keys clamped at both ends (256/262144 and 4 MiB/512 MiB); an in-range setting preserved verbatim.
- `test_message_entry_memoisation.py`:
  - `test_bounds_default_when_config_is_absent` / `test_bounds_default_when_the_config_cannot_be_loaded`: the accessor serves the built-in defaults with no config file and on a raising read.
  - `test_a_failing_config_read_does_not_latch_the_defaults`: a transient read failure does not discard a configured bound for the process lifetime -- the next successful read resolves it.
  - `test_bounds_are_read_from_config`: configured values are served, and the read is memoised (no per-call config load).
  - `test_configured_entry_bound_governs_eviction`: end-to-end through config -- a 300-message workload evicts to exactly a configured 256 (it would be fully retained at the default 4096) and is fully retained at a configured 1024, with genuine hits on a second pass.
  - `test_flush_bypass_honors_the_configured_bounds`: the flush-site whole-window bypass flips between the cached and uncached paths based on the plumbed bounds, not a constant.
  - Existing bound/eviction/byte-counter tests updated from patching the removed constants to patching the memo.

Pre-push review: GPT (`gpt-5.6-sol`) -- no blocking findings. Opus (`claude-opus-5`) -- no blocking findings, 3 advisories (silent config-read swallow, failure-latch race, eviction test not config-driven end-to-end), all fixed in this diff.

## Manual verification

N/A -- unit coverage sufficient: the change is config plumbing plus two comparison sites, and the eviction/bypass behavior is asserted end-to-end through a written `config.json` in the tests above. Full backend suite run locally; the only failures are pre-existing on pristine `main` in the same environment (verified by running the identical file set on a `main` worktree: failure sets match exactly).

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (config loader + persistence internals); no rendered surface is touched.

## Related Issues

Fixes #7037

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
