### PR TITLE
refactor(dashboard): retire the sync transfer-bundle builder

### DIFF
--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -979,12 +979,13 @@ async def api_instances_send_session(request: web.Request) -> web.Response:
             status=400,
         )
 
-    # The source is NOT flushed before bundling. A copy leaves the source
-    # untouched, and build_transfer_bundle already merges the on-disk transcript
-    # with the unflushed in-memory tail — so a flush here would add nothing
-    # except a duplication bug: save_slot_off_loop writes the tail to disk
-    # without clearing ``_dirty``, after which the bundle re-appends that same
-    # tail from memory and every unsaved turn lands twice in the copy.
+    # No flush HERE: the builder owns it. ``build_transfer_bundle_async`` flushes
+    # a dirty slot itself (best_effort=False) and only then takes its boundary
+    # slice, so by that point the tail is empty and the bundle comes wholly from
+    # disk. A flush at this call site would add nothing — and the version of this
+    # code that flushed here and then sliced on ``_resumed_count``, which the save
+    # does NOT advance, is what re-appended the same tail from memory and landed
+    # every unsaved turn twice in the copy.
     try:
         bundle = await build_transfer_bundle_async(state, slot, origin=local_instance_label())
     except SnapshotUnstable:

--- a/src/kiro_crew/dashboard/session_transfer.py
+++ b/src/kiro_crew/dashboard/session_transfer.py
@@ -2,8 +2,8 @@
 
 Two halves live here:
 
-* :func:`build_transfer_bundle` serialises one slot's visible conversation into
-  a portable, version-tagged dict. Called on the **sending** side.
+* :func:`build_transfer_bundle_async` serialises one slot's visible conversation
+  into a portable, version-tagged dict. Called on the **sending** side.
 * :func:`api_chat_slot_import` accepts such a dict and materialises it as a new
   slot. Called on the **receiving** side.
 
@@ -67,9 +67,8 @@ from kiro_crew.config.paths import kiro_sessions_dir
 # Layering: this module may import chat_handlers, never the reverse — the only
 # consumer of session_transfer is handlers_instances, which chat_handlers'
 # transitive graph does not reach. If chat_handlers ever needs session_transfer,
-# move _append_unflushed_tail and its collaborators down to chat_persistence
-# first rather than creating the cycle.
-from kiro_crew.dashboard.chat_handlers import _append_unflushed_tail
+# move the shared collaborators down to chat_persistence first rather than
+# creating the cycle.
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop, session_was_deleted
 from kiro_crew.dashboard.chat_utils import (
     _sync_dashboard_slots,
@@ -509,14 +508,24 @@ def _join_layer_b(sessions: Any, sm_key: str, sid: str) -> bool:
 async def build_transfer_bundle_async(
     state: DashboardState, slot: _ChatSlot, *, origin: str = ""
 ) -> dict[str, Any]:
-    """:func:`build_transfer_bundle` with the disk read off the event loop.
+    """Serialise *slot*'s visible conversation into a portable bundle, with the
+    disk read off the event loop.
 
-    The two builders size the un-flushed tail DIFFERENTLY: this one keeps a
-    ``_disk_window_len`` boundary slice, valid only because the flush below runs
-    first — the save folds a durable injector's ``append_if_absent`` copy into
-    the window and advances the boundary, so the counter is honest by the time
-    the tail is snapshotted. The sync sibling cannot flush, so it sizes by
-    message id instead — see the comment at its tail merge.
+    Carries the FULL conversation rather than only the window currently held in
+    memory — a long-running session keeps just its tail resident, and bundling
+    ``slot.messages`` alone would silently truncate the transfer to that tail.
+    *origin* is a human label for where the session came from (an instance name
+    or ``"local"``); it is recorded for provenance and shown on arrival.
+
+    The un-flushed tail is a ``_disk_window_len`` boundary slice, which is valid
+    only because the flush below runs first: the save folds a durable injector's
+    ``append_if_absent`` copy into the window and advances the boundary, so the
+    counter is honest by the time the tail is snapshotted. A caller that bundled
+    WITHOUT flushing could not use this slice — a durable injector
+    (``cron_inject``, ``workflow_inject``, ``crew_chat``) puts the same row into
+    the window and onto disk without a save, so the boundary would start one row
+    too early and ship the injection twice. There is deliberately no such
+    caller: this is the only builder, and it always flushes.
 
     The transcript read is synchronous file IO plus JSON parsing over a whole
     session, which is exactly the "large synchronous file IO" the
@@ -775,62 +784,6 @@ def _read_and_assemble(
         # which means there was never a context to carry.
         layer_b_skipped = True
     return _assemble_bundle(history, title, agent, origin, layer_b, layer_b_skipped)
-
-
-def build_transfer_bundle(
-    state: DashboardState,
-    slot: _ChatSlot,
-    *,
-    origin: str = "",
-    history: list[dict] | None = None,
-) -> dict[str, Any]:
-    """Serialise *slot*'s visible conversation into a portable bundle.
-
-    Carries the FULL conversation rather than only the window currently held in
-    memory — a long-running session keeps just its tail resident, and bundling
-    ``slot.messages`` alone would silently truncate the transfer to that tail.
-
-    *history* supplies an already-read on-disk transcript so the blocking read
-    can happen in a thread; when omitted it is read inline, which is fine for
-    tests and any caller not on the event loop. It must be the FULL chained
-    corpus (:func:`_read_chained_history`'s shape): the tail merge below indexes
-    it with ``slot._disk_older_count``, so a single-file or partial read would
-    mis-size the window region.
-
-    *origin* is a human label for where the session came from (an instance name
-    or ``"local"``); it is recorded for provenance and shown on arrival.
-    """
-    all_messages: list[dict] = (
-        list(history)
-        if history is not None
-        else _read_chained_history(state, slot_history_key(slot))
-    )
-    # Append the resident messages that are not on disk yet, so the bundle carries
-    # the tail the user can actually see.
-    #
-    # Sized by MESSAGE IDENTITY, not by ``_disk_window_len``. That counter
-    # advances only on the save and load paths, but a durable injector
-    # (``cron_inject``, ``workflow_inject``, ``crew_chat``) appends the same row
-    # to the window AND to disk without going through a save — the disk read
-    # above already returns the row while the counter has not moved, so a
-    # boundary slice starts one row too early and ships the injection twice.
-    # The read path rejected this exact estimator for this exact job (#4137,
-    # measured: substituting it broke the duplication regression) and replaced
-    # it with :func:`_append_unflushed_tail`, which matches window rows against
-    # the disk read by ``meta.mid`` — the id a durable injector stamps on both
-    # copies — falling back to an ordered body comparison when any row in the
-    # disk window region lacks an id, and merges in only the rows disk does not
-    # already hold. (The async sibling keeps its boundary snapshot: it flushes a
-    # dirty slot first, and the save both folds the injector's durable copy into
-    # the window and advances the boundary, so its slice is taken against a
-    # counter the flush just made honest.)
-    all_messages = _append_unflushed_tail(slot, all_messages)
-    return _assemble_bundle(
-        all_messages,
-        slot.title if slot._titled else "",
-        slot.agent,
-        origin,
-    )
 
 
 def _assemble_bundle(

--- a/test/test_session_transfer.py
+++ b/test/test_session_transfer.py
@@ -1,8 +1,9 @@
 """Session transfer between instances — bundle, validation, and import.
 
-Covers the two halves of the feature (``build_transfer_bundle`` on the sending
-side, ``api_chat_slot_import`` on the receiving side) plus the tunnel-manager
-delivery hop, with the emphasis on the invariants a reviewer would want pinned:
+Covers the two halves of the feature (``build_transfer_bundle_async`` on the
+sending side, ``api_chat_slot_import`` on the receiving side) plus the
+tunnel-manager delivery hop, with the emphasis on the invariants a reviewer would
+want pinned:
 
 * **copy, never move** — the source is untouched and the target key is new;
 * **project does NOT travel** — the documented decision that an imported
@@ -25,7 +26,7 @@ from aiohttp import web
 from kiro_crew.dashboard.session_transfer import (
     BUNDLE_VERSION,
     _validate_bundle,
-    build_transfer_bundle,
+    build_transfer_bundle_async,
     local_instance_label,
 )
 
@@ -71,7 +72,8 @@ def _state(messages):
     return SimpleNamespace(conversation_log=_FakeLog(messages))
 
 
-def test_bundle_carries_only_visible_roles():
+@pytest.mark.asyncio
+async def test_bundle_carries_only_visible_roles():
     msgs = [
         {"role": "user", "content": "hi", "ts": "t1"},
         {"role": "tool", "content": "tool frame", "ts": "t2"},
@@ -79,7 +81,7 @@ def test_bundle_carries_only_visible_roles():
         {"role": "system", "content": "sys", "ts": "t4"},
     ]
     slot = _slot(msgs)
-    bundle = build_transfer_bundle(_state(msgs), slot, origin="mac")
+    bundle = await build_transfer_bundle_async(_state(msgs), slot, origin="mac")
 
     assert bundle["bundle_version"] == BUNDLE_VERSION
     assert bundle["origin"] == "mac"
@@ -87,164 +89,49 @@ def test_bundle_carries_only_visible_roles():
     assert [m["content"] for m in bundle["messages"]] == ["hi", "hello"]
 
 
-def test_bundle_does_not_carry_project_or_model():
+@pytest.mark.asyncio
+async def test_bundle_does_not_carry_project_or_model():
     """The two fields deliberately dropped — a dangling path and an
     entitlement-specific model id (see the module docstring in the source)."""
     msgs = [{"role": "user", "content": "hi", "ts": ""}]
     slot = _slot(msgs, project="/Volumes/workplace/only-on-my-mac")
     slot.model = "some-model-id"
-    bundle = build_transfer_bundle(_state(msgs), slot)
+    bundle = await build_transfer_bundle_async(_state(msgs), slot)
 
     assert "project" not in bundle
     assert "model" not in bundle
     assert "/Volumes/workplace/only-on-my-mac" not in json.dumps(bundle)
 
 
-def test_bundle_reads_full_history_not_just_resident_window():
+@pytest.mark.asyncio
+async def test_bundle_reads_full_history_not_just_resident_window():
     """A long session keeps only a tail in memory; the bundle must be complete."""
     on_disk = [{"role": "user", "content": f"turn {i}", "ts": ""} for i in range(10)]
     # slot.messages holds only the last two — bundling those would truncate.
     # disk_older=8 is what a real slot reports: eight on-disk rows precede the
     # resident window, and the tail merge must scan only the window region.
     slot = _slot(on_disk[-2:], disk_older=8)
-    bundle = build_transfer_bundle(_state(on_disk), slot)
+    bundle = await build_transfer_bundle_async(_state(on_disk), slot)
 
     assert len(bundle["messages"]) == 10
     assert bundle["messages"][0]["content"] == "turn 0"
 
 
-def test_bundle_appends_unflushed_tail():
-    on_disk = [{"role": "user", "content": "persisted", "ts": ""}]
-    slot = _slot(on_disk, dirty=True)
-    slot.messages = on_disk + [{"role": "assistant", "content": "not yet saved", "ts": ""}]
-    slot._resumed_count = 1
-    bundle = build_transfer_bundle(_state(on_disk), slot)
-
-    assert [m["content"] for m in bundle["messages"]] == ["persisted", "not yet saved"]
-
-
-def test_durably_injected_row_is_not_duplicated_in_the_bundle():
-    """Regression for #4684 — mirrors #4137's duplication test on the read path.
-
-    A durable injector (``cron_inject``/``workflow_inject``/``crew_chat``) puts
-    the same row into the window AND onto disk with one ``meta.mid``, without a
-    save — so ``_disk_window_len`` does not move while the disk read already
-    returns the row. Sizing the un-flushed tail as
-    ``slot.messages[slot._disk_window_len:]`` then re-appends the injected row
-    on top of its own disk copy, and the exported bundle carries it twice.
-
-    Both rows here carry ids, so this exercises the id-matching arm — the one a
-    durable injector's rows actually take.
-    """
-    persisted = {"role": "user", "content": "hello", "ts": "t1", "meta": {"mid": "m-1"}}
-    injected = {
-        "role": "assistant",
-        "content": "cron result",
-        "ts": "t2",
-        "meta": {"mid": "m-2"},
-    }
-    slot = _slot([persisted])  # boundary == 1: the save never saw the injection
-    slot.messages = [persisted, dict(injected)]
-    bundle = build_transfer_bundle(_state([persisted, dict(injected)]), slot)
-
-    assert [m["content"] for m in bundle["messages"]] == ["hello", "cron result"], (
-        "a durably-injected row the disk read already returned was appended again"
-    )
-
-
-def test_durably_injected_row_is_not_duplicated_when_older_rows_have_no_id():
-    """Same contract on the ordered-comparison arm.
-
-    A transcript written before ids existed holds id-less rows, so the id arm is
-    ineligible (it requires EVERY window-region disk row to carry one) and the
-    tail must be sized by the ordered body walk instead — which must equally
-    refuse to re-append the injected row.
-    """
-    persisted = {"role": "user", "content": "hello", "ts": "t1"}  # pre-id era row
-    injected = {
-        "role": "assistant",
-        "content": "cron result",
-        "ts": "t2",
-        "meta": {"mid": "m-2"},
-    }
-    slot = _slot([persisted])
-    slot.messages = [persisted, dict(injected)]
-    bundle = build_transfer_bundle(_state([persisted, dict(injected)]), slot)
-
-    assert [m["content"] for m in bundle["messages"]] == ["hello", "cron result"], (
-        "a durably-injected row the disk read already returned was appended again"
-    )
-
-
-def test_genuinely_owed_row_still_travels_after_an_injection():
-    """Control, mirroring #4137's: a fix that merely stopped appending would pass
-    the duplication tests above and silently drop a real un-flushed turn here."""
-    persisted = {"role": "user", "content": "hello", "ts": "t1", "meta": {"mid": "m-1"}}
-    injected = {
-        "role": "assistant",
-        "content": "cron result",
-        "ts": "t2",
-        "meta": {"mid": "m-2"},
-    }
-    owed = {"role": "user", "content": "follow-up", "ts": "t3", "meta": {"mid": "m-3"}}
-    slot = _slot([persisted])
-    slot.messages = [persisted, dict(injected), owed]
-    bundle = build_transfer_bundle(_state([persisted, dict(injected)]), slot)
-
-    assert [m["content"] for m in bundle["messages"]] == [
-        "hello",
-        "cron result",
-        "follow-up",
-    ], "each turn must appear exactly once, with the owed turn last"
-
-
-def test_durably_injected_row_with_a_frozen_prefix_is_not_duplicated():
-    """The sync path's one new field dependency: ``_disk_older_count``.
-
-    The tail merge scans only the disk WINDOW region, ``all_msgs[disk_older:]``.
-    With two frozen-prefix rows ahead of the window, an off-by-one in that
-    offset would either let a prefix occurrence fund a false id match (dropping
-    an owed row) or re-append the injected row. Exercise the injection with a
-    non-zero prefix to pin the arithmetic.
-    """
-    prefix = [
-        {"role": "user", "content": "old 0", "ts": "t0", "meta": {"mid": "m-p0"}},
-        {"role": "assistant", "content": "old 1", "ts": "t0b", "meta": {"mid": "m-p1"}},
-    ]
-    persisted = {"role": "user", "content": "hello", "ts": "t1", "meta": {"mid": "m-1"}}
-    injected = {
-        "role": "assistant",
-        "content": "cron result",
-        "ts": "t2",
-        "meta": {"mid": "m-2"},
-    }
-    owed = {"role": "user", "content": "follow-up", "ts": "t3", "meta": {"mid": "m-3"}}
-    slot = _slot([persisted], disk_older=2)
-    slot.messages = [persisted, dict(injected), owed]
-    bundle = build_transfer_bundle(_state(prefix + [persisted, dict(injected)]), slot)
-
-    assert [m["content"] for m in bundle["messages"]] == [
-        "old 0",
-        "old 1",
-        "hello",
-        "cron result",
-        "follow-up",
-    ], "each turn must appear exactly once, prefix intact, owed turn last"
-
-
-def test_bundle_title_marker_does_not_compound_across_hops():
+@pytest.mark.asyncio
+async def test_bundle_title_marker_does_not_compound_across_hops():
     """A session bounced back and forth must not grow one prefix per hop."""
     msgs = [{"role": "user", "content": "hi", "ts": ""}]
     slot = _slot(msgs, title="⇄ Already imported once")
-    bundle = build_transfer_bundle(_state(msgs), slot)
+    bundle = await build_transfer_bundle_async(_state(msgs), slot)
 
     assert bundle["title"] == "Already imported once"
 
 
-def test_bundle_untitled_slot_carries_empty_title():
+@pytest.mark.asyncio
+async def test_bundle_untitled_slot_carries_empty_title():
     msgs = [{"role": "user", "content": "hi", "ts": ""}]
     slot = _slot(msgs, title="slot-1", titled=False)
-    assert build_transfer_bundle(_state(msgs), slot)["title"] == ""
+    assert (await build_transfer_bundle_async(_state(msgs), slot))["title"] == ""
 
 
 @pytest.mark.asyncio
@@ -316,24 +203,6 @@ async def test_send_handler_sends_each_turn_exactly_once(monkeypatch):
     assert resp.status == 200, resp.body
     contents = [m["content"] for m in captured["bundle"]["messages"]]
     assert contents == ["persisted", "unsaved turn"], contents
-
-
-def test_bundle_accepts_a_prefetched_history_without_touching_disk():
-    """The async wrapper reads the transcript in a thread and passes it in; the
-    assembler must use it rather than re-reading."""
-
-    class _Exploding:
-        def read_messages_chained(self, _key):
-            raise AssertionError("must not read disk when history is supplied")
-
-    slot = _slot([])
-    slot.messages = []
-    state = SimpleNamespace(conversation_log=_Exploding())
-    prefetched = [{"role": "user", "content": "from thread", "ts": ""}]
-
-    bundle = build_transfer_bundle(state, slot, history=prefetched)
-
-    assert [m["content"] for m in bundle["messages"]] == ["from thread"]
 
 
 @pytest.mark.asyncio
@@ -457,45 +326,15 @@ async def test_import_offloads_agent_resolution_and_skips_it_when_unhinted(monke
     monkeypatch.setattr(st.asyncio, "to_thread", real_to_thread)
 
 
-def test_bundle_ignores_the_resume_count_and_ships_each_turn_once():
-    """Regression, restated for the id-based tail (#4684).
-
-    Originally this pinned "the boundary is ``_disk_window_len``, not
-    ``_resumed_count``": slicing on the resume count (0 for a slot created in
-    this gateway run) appended the entire resident window on top of the disk
-    history and duplicated every persisted turn. The sync builder no longer
-    slices on ANY counter — the tail is sized by message identity — so the
-    surviving contract is the one that always mattered: with two of three
-    window rows already on disk, each turn appears exactly once and the
-    un-flushed one still travels, regardless of what either counter says.
-    """
-    persisted = [
-        {"role": "user", "content": "one", "ts": ""},
-        {"role": "assistant", "content": "two", "ts": ""},
-    ]
-    unsaved = {"role": "user", "content": "three", "ts": ""}
-
-    slot = _slot(persisted)
-    slot.messages = persisted + [unsaved]
-    # A fresh (never-rehydrated) slot that has flushed: resume count is still 0,
-    # but two window messages are on disk.
-    slot._resumed_count = 0
-    slot._disk_window_len = 2
-    slot._dirty = True
-
-    bundle = build_transfer_bundle(_state(persisted), slot)
-
-    assert [m["content"] for m in bundle["messages"]] == ["one", "two", "three"]
-
-
-def test_bundle_appends_nothing_when_everything_is_persisted():
+@pytest.mark.asyncio
+async def test_bundle_appends_nothing_when_everything_is_persisted():
     persisted = [{"role": "user", "content": "one", "ts": ""}]
     slot = _slot(persisted)
     slot.messages = list(persisted)
     slot._disk_window_len = 1
     slot._dirty = False
 
-    bundle = build_transfer_bundle(_state(persisted), slot)
+    bundle = await build_transfer_bundle_async(_state(persisted), slot)
 
     assert [m["content"] for m in bundle["messages"]] == ["one"]
 
@@ -654,7 +493,8 @@ async def test_import_refuses_when_the_durable_save_fails(monkeypatch):
     assert state._slots == {}
 
 
-def test_bundle_redacts_assistant_content_on_the_way_out():
+@pytest.mark.asyncio
+async def test_bundle_redacts_assistant_content_on_the_way_out():
     """The bundle leaves this host, so redaction cannot be left to the receiver.
 
     A transcript written before the redactors existed (or carried in from a
@@ -667,7 +507,7 @@ def test_bundle_redacts_assistant_content_on_the_way_out():
         {"role": "assistant", "content": f"noted {secret}", "ts": ""},
     ]
     slot = _slot(msgs)
-    bundle = build_transfer_bundle(_state(msgs), slot)
+    bundle = await build_transfer_bundle_async(_state(msgs), slot)
     user_msg, assistant_msg = bundle["messages"]
 
     assert secret not in assistant_msg["content"]
@@ -688,7 +528,8 @@ def test_session_transfer_is_registered_as_an_egress_sink():
     assert "dashboard/session_transfer.py" not in NON_EGRESS_REDACTION_MODULES
 
 
-def test_bundle_redacts_the_title_on_the_way_out():
+@pytest.mark.asyncio
+async def test_bundle_redacts_the_title_on_the_way_out():
     """A title is generated from user content, and the resume path assigns a
     client-supplied title with no scan of its own — so it can carry a credential
     that would otherwise leave the host verbatim."""
@@ -696,7 +537,7 @@ def test_bundle_redacts_the_title_on_the_way_out():
     msgs = [{"role": "user", "content": "hi", "ts": ""}]
     slot = _slot(msgs, title=f"debugging {secret}")
 
-    bundle = build_transfer_bundle(_state(msgs), slot)
+    bundle = await build_transfer_bundle_async(_state(msgs), slot)
 
     assert secret not in bundle["title"]
 
@@ -763,7 +604,8 @@ async def test_snapshot_rechecks_pending_rewrite_after_the_await():
         st.asyncio.to_thread = real_to_thread  # type: ignore[assignment]
 
 
-def test_bundle_reads_the_transcript_key_not_the_session_key():
+@pytest.mark.asyncio
+async def test_bundle_reads_the_transcript_key_not_the_session_key():
     """Regression: an unbound channel slot's session key names a phantom file.
 
     ``surface_channel_session`` deliberately surfaces a channel-born slot
@@ -791,7 +633,7 @@ def test_bundle_reads_the_transcript_key_not_the_session_key():
     slot.channel_origin = True
     slot.key = "slack_1700000000"
 
-    bundle = st.build_transfer_bundle(SimpleNamespace(conversation_log=_Log()), slot)
+    bundle = await build_transfer_bundle_async(SimpleNamespace(conversation_log=_Log()), slot)
 
     assert reads, "expected a transcript read"
     # The phantom dashboard-prefixed key must NOT be what we read.


### PR DESCRIPTION
## What is the problem?

`session_transfer.py` carried TWO bundle builders, and only one of them was
reachable in production.

`build_transfer_bundle_async` is the export path: `handlers_instances.py` awaits
it, and it is the only production caller. The synchronous `build_transfer_bundle`
had none left after the async builder landed -- every remaining call site was a
test.

They were not wrapper and wrapped. They shared `_assemble_bundle` and nothing
else, and they sized the un-flushed tail by DIFFERENT rules: the async builder
flushes a dirty slot itself and then takes a `_disk_window_len` boundary slice,
while the sync one could not flush and so merged by message identity through
`_append_unflushed_tail`. So the module documented, tested, and obliged future
readers to keep straight two answers to the same question, one of which nothing
called.

## Why this issue matters to the user

Nothing is visibly broken today, which is exactly the risk profile worth
removing. The failure mode is a future edit: a change to how a bundle is
assembled has two places to land, and the one with no production caller has no
production signal when it drifts. A tail-sizing bug has already been shipped and
fixed once on this surface (the `_resumed_count` slice that duplicated every
unsaved turn in a copied session), so this is a defect class with a track record,
not a hypothetical.

The dead builder also made the module's own documentation misleading. The caller
comment in `handlers_instances.py` still justified not flushing by saying "
`build_transfer_bundle` already merges the on-disk transcript with the unflushed
in-memory tail" -- a claim about a function that is not called on that path, and
false about the one that is, because the async builder DOES flush.

## How our fix solves it

Symptom: two builders to keep in sync. Cause: the sync builder outlived its
callers. Fix: delete it and let the tests exercise the one entry point production
uses.

- **Deleted `build_transfer_bundle`** and its now-unused `_append_unflushed_tail`
  import. The helper itself stays: it has a production caller on the read path
  (`chat_handlers.py:1873`), which is where its identity-matching arm is actually
  load-bearing.
- **Rewired 9 tests** onto `build_transfer_bundle_async`. These pin bundle
  ASSEMBLY -- which roles travel, that `project`/`model` are dropped, full history
  rather than the resident window, the title marker not compounding across hops,
  an untitled slot's empty title, credential redaction of content and of the
  title, and that the TRANSCRIPT key is read rather than the session key. All are
  independent of how the caller reaches a thread, so they hold on the async path
  unchanged; they are now `@pytest.mark.asyncio`, which is this file's dominant
  convention (57 existing marks).
- **Removed 7 tests** that pinned only the deleted path's own mechanics: four
  durable-injector duplication cases plus one owed-row control, the
  `_resumed_count` case, and the `history=` prefetch case whose parameter no
  longer exists. Where that mechanism still matters it is still covered -- see
  below.
- **Corrected the two stale comments** that named the deleted function: the
  module docstring, and the `handlers_instances.py` flush justification, which now
  says what actually happens (the builder owns the flush, and the historical
  `_resumed_count` duplication is why a flush at the call site was wrong).
- The async builder's docstring no longer describes a "sync sibling"; it states
  the boundary slice's precondition directly -- valid because it flushes first,
  and there is deliberately no caller that bundles without flushing.

## What tests we did

Targeted only; the full suites are left to CI.

- `test/test_session_transfer.py`: **128 passed** (135 on main; the difference is
  the 7 removed cases, not a skip).
- **The removed duplication coverage is not lost.** `_append_unflushed_tail` is
  what those cases actually exercised, and it keeps both its production caller
  and its coverage: `test/test_dashboard_chat.py` + `test/test_slot_detail_inflight_tail.py`
  = **731 passed**, with 32 references to that helper in the former. The transfer
  path's own each-turn-exactly-once invariant remains pinned by the surviving
  async tests (`test_send_handler_sends_each_turn_exactly_once`, which documents
  the `_resumed_count` history explicitly, and the snapshot-retry test).
- `mypy src/kiro_crew/` at package scope: zero errors in either changed source
  file (the 4 reported are pre-existing in `transcribe.py` and `cloudwatch.py`
  boto3 stubs, absent from CI's own run). flake8 + isort clean on all three
  touched files.
- Net effect: 264 lines deleted, 60 added.

## Any other suggestions on the work

- I did NOT fold in a follow-on I noticed: `_append_unflushed_tail` is imported
  from `chat_handlers` by a module whose own comment says the layering only holds
  in one direction. With the transfer path no longer using it, that import is
  gone and the note is now about "shared collaborators" generically -- if someone
  wants the helper moved down to `chat_persistence` as that comment suggests,
  that is its own change.
- One honest note on scope: converting the 9 rewired cases to async is slightly
  more diff than a bespoke sync runner around the coroutine would have been. I
  chose it because the file already has 57 `@pytest.mark.asyncio` tests and
  because it drives the builder the way production does -- awaited on a loop --
  rather than inventing a second way to call it, which is the same duplication
  this PR is removing.
