### PR TITLE
perf(security): cut the per-run decode and scan work in redaction passes 2 and 3

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -10225,6 +10225,24 @@ def _might_contain_credential(text: str) -> bool:
     )
 
 
+# Minimum string length at which `_might_contain_credential` is cheaper than the
+# `_CREDENTIAL_PATTERNS` alternation it gates. The pre-filter has a fixed ~590 ns
+# floor (21 substring searches plus 5 anchored regex calls) that does not shrink
+# with the input, so on a very short string the alternation simply wins: measured
+# 684 ns against 494 ns at 8 characters, crossing over at 12 and reaching 3.4x by
+# 256. Callers scanning SHORT strings -- a decoded base64 blob is typically 16-30
+# characters -- must gate on this rather than assume the pre-filter is
+# unconditionally cheaper.
+#
+# Held at 16 rather than the measured crossover of 12, deliberately: the gate is
+# verdict-neutral (the pre-filter is a proven superset, so either route reaches the
+# same answer), which makes a conservative threshold cost at most one alternation
+# scan on a 12-15 character blob and makes it robust to the crossover drifting as
+# the pre-filter's own cost changes. It has already drifted once -- adding the
+# case-insensitive Authorization anchor moved it from 16 to 12.
+_PREFILTER_MIN_LEN = 16
+
+
 # Base64 alphabet: at least 40 chars of [A-Za-z0-9+/] ending with optional =
 _B64_CHUNK_RE = re.compile(r"[A-Za-z0-9+/]{40,}={0,2}")
 
@@ -10243,6 +10261,16 @@ _B64_CHUNK_RE = re.compile(r"[A-Za-z0-9+/]{40,}={0,2}")
 # run of >=40 base64-alphabet chars (word-boundary look-arounds keep surrounding
 # prose intact and stop a longer high-entropy blob from being split and missed),
 # then require the *specific 40-char secret shape* per token.
+#
+# NO LONGER CONSULTED BY `redact_credentials`. Pass 3 derives its runs from
+# `_B64_CHUNK_RE` instead (`run = chunk.rstrip("=")`), because that one scan feeds
+# both pass 2 and pass 3 and the two patterns select identical spans. The only
+# remaining consumer here is `_text_contains_bare_secret`. That split is a
+# desync hazard: WIDENING THIS PATTERN ALONE (adding base64url `-_`, say) would
+# change the URL scan and leave the redactor untouched, silently. Any edit to the
+# character class or the `{40,}` floor must be mirrored in `_B64_CHUNK_RE` above.
+# `test_the_two_base64_run_patterns_stay_structurally_coupled` pins both literals
+# so such an edit fails loudly rather than drifting.
 _BARE_SECRET_RUN_RE = re.compile(r"(?<![A-Za-z0-9+/])[A-Za-z0-9+/]{40,}(?![A-Za-z0-9+/])")
 
 # Exactly-40 is the AWS secret-key length. Keeping the shape check length-exact
@@ -10323,6 +10351,12 @@ def _has_all_three_char_classes(text: str) -> bool:
     return False
 
 
+# The byte set counted as "printable" by :func:`_decodes_to_printable_text`: tab,
+# LF, CR and the printable ASCII range 0x20-0x7E. Held as ``bytes`` so the count
+# can be delegated to ``bytes.translate``, which runs in C.
+_PRINTABLE_BYTES: bytes = bytes(sorted({0x09, 0x0A, 0x0D} | set(range(0x20, 0x7F))))
+
+
 def _decodes_to_printable_text(token: str) -> bool:
     """Return True if *token* base64-decodes to mostly-printable ASCII.
 
@@ -10337,7 +10371,21 @@ def _decodes_to_printable_text(token: str) -> bool:
         return False
     if not raw:
         return False
-    printable = sum(1 for b in raw if 0x20 <= b <= 0x7E or b in (0x09, 0x0A, 0x0D))
+    # Count the printable bytes by DELETING them in C and measuring what is left,
+    # rather than testing every byte in a Python loop. ``translate(None, set)``
+    # returns exactly the bytes NOT in *set*, so ``len(raw) - len(...)`` is the
+    # member count -- an integer identity, so the ratio and the comparison below
+    # are bit-identical to the previous per-byte sum (asserted against a verbatim
+    # copy of that sum in ``test_printable_count_matches_the_per_byte_sum``,
+    # including all 256 single-byte inputs exhaustively).
+    #
+    # This is the single most expensive operation in pass 3, because the helper
+    # runs once per base64-alphabet run AND again per 40-char window as gate 7 of
+    # `_looks_like_secret_key`, and the old loop cost scaled with the DECODED byte
+    # count rather than with the 40-char window. Measured 14.6x at 48 bytes rising
+    # to 69x at 1500; a 2 KB encoded blob fell from 86.3 us to 1.2 us, which is
+    # 98% of what `_contains_bare_secret` spent on such a run.
+    printable = len(raw) - len(raw.translate(None, _PRINTABLE_BYTES))
     return printable / len(raw) >= _SECRET_PRINTABLE_DECODE_RATIO
 
 
@@ -10520,15 +10568,48 @@ def _decode_b64_chunk(chunk: str) -> str:
     takes the padding — so the inner `finditer` was pure duplicate work on the
     hot path, once per base64-looking run in every redacted message.
     """
+    # NO LENGTH SHORT-CIRCUIT HERE, deliberately. It is tempting to skip the decode
+    # when `len(chunk) % 4` is non-zero, on the reasoning that `validate=True`
+    # rejects a length that is not a multiple of 4. That reasoning is INTERPRETER
+    # DEPENDENT and would be a redaction bypass: `binascii.a2b_base64`'s padding
+    # leniency changed with `strict_mode`, so on Python 3.10 and 3.11 a chunk of 40
+    # data characters plus one `=` (length 41) DECODES, while on 3.12 it raises.
+    # Skipping it would leave a base64-encoded credential in that shape unredacted
+    # on exactly the interpreters CI still builds. No version-invariant form of the
+    # test exists either -- 43 data characters plus `==` decodes on 3.10 while
+    # failing both a total-length and a stripped-length predicate. Pinned by
+    # `test_a_decode_length_precondition_would_be_version_dependent`.
     try:
         decoded = base64.b64decode(chunk, validate=True).decode("utf-8", errors="ignore")
     except Exception:
+        return ""
+    # Gate the alternation behind the cheap superset pre-filter, exactly as pass 1
+    # does. `_might_contain_credential` may return True where the pattern would not
+    # match but never False where it would, so the verdict cannot move -- only the
+    # cost. Real decoded blobs almost never look like credentials: 0 of 18 in the
+    # session corpus and 1 of 849 in a hash-heavy corpus reach the alternation.
+    #
+    # LENGTH-GATED, because here the pre-filter is NOT unconditionally cheaper. Its
+    # ~540 ns floor is fixed while the alternation's cost scales with length, so
+    # below `_PREFILTER_MIN_LEN` the alternation wins outright. A decoded blob is
+    # exactly the size where that matters -- 48 raw bytes from a 64-char run, and
+    # shorter once `errors="ignore"` drops invalid sequences, measured 12-31
+    # characters -- so this straddles the crossover instead of sitting above it.
+    if len(decoded) >= _PREFILTER_MIN_LEN and not _might_contain_credential(decoded):
         return ""
     return decoded if _CREDENTIAL_PATTERNS.search(decoded) else ""
 
 
 def _decode_b64_safe(text: str) -> str:
-    """Try to base64-decode chunks in text; return decoded content or ''."""
+    """Try to base64-decode chunks in text; return decoded content or ''.
+
+    Deliberately left UNOPTIMISED. `_decode_b64_chunk` above is the hot-path
+    single-chunk form, and this function is what pins it: the differential test
+    asserts the two agree on every chunk in the corpus, and the pre-optimisation
+    reference oracle calls this one. Applying the same gates here would make both
+    sides of that comparison share the change and the check would stop detecting
+    anything.
+    """
     for m in _B64_CHUNK_RE.finditer(text):
         try:
             decoded = base64.b64decode(m.group(), validate=True).decode("utf-8", errors="ignore")

--- a/test/test_credential_prefilter.py
+++ b/test/test_credential_prefilter.py
@@ -16,9 +16,12 @@ fails when a branch is added without a matching pre-filter anchor.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import random
 import re
 import string
+import sys
 
 import pytest
 
@@ -26,10 +29,14 @@ from kiro_crew.security import (
     _B64_CHUNK_RE,
     _BARE_SECRET_RUN_RE,
     _CREDENTIAL_PATTERNS,
+    _PREFILTER_MIN_LEN,
+    _PRINTABLE_BYTES,
     _REDACTED_CREDENTIAL_TAG,
+    _SECRET_PRINTABLE_DECODE_RATIO,
     _contains_bare_secret,
     _decode_b64_chunk,
     _decode_b64_safe,
+    _decodes_to_printable_text,
     _might_contain_credential,
     redact_credentials,
 )
@@ -187,6 +194,29 @@ def _rebuild(branches: list[str]) -> re.Pattern[str]:
 # ── Corpus ──
 
 
+# Fixtures for the pass-2/pass-3 per-run cases below. Deliberately deterministic
+# so corpus ids stay stable across runs.
+_B64_RUN_40 = "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0"  # 40 chars, len % 4 == 0
+# base64 of readable prose -> decodes to printable, so the run-level gate in
+# `_contains_bare_secret` returns before the sliding window runs.
+_PRINTABLE_BLOB = base64.b64encode(
+    b"the quick brown fox jumps over the lazy dog while deploying"
+).decode()
+# base64 of bytes 0x00-0x2F -> 19 of 48 bytes printable (0.40), below the 0.85
+# ratio, so this reaches the sliding window instead.
+_GARBAGE_BLOB = base64.b64encode(bytes(range(48))).decode()
+# 30 bare UTF-8 continuation bytes: a valid 40-char base64 chunk that decodes to
+# 30 raw bytes but to the EMPTY string once `errors="ignore"` drops them all. This
+# is the only way a decoded string lands below `_PREFILTER_MIN_LEN`, since a chunk
+# is at least 40 base64 characters and so always decodes to >= 30 bytes.
+_SHORT_DECODE_BLOB = base64.b64encode(bytes([0x80] * 30)).decode()
+# A real encoded credential with its padding stripped, so the corpus can carry the
+# misaligned shapes whose decodability differs between 3.10/3.11 and 3.12.
+_ENCODED_CRED_STEM = (
+    base64.b64encode(f"aws_secret_access_key={AWS_SECRET}".encode()).decode().rstrip("=")
+)
+
+
 def _corpus() -> list[str]:
     """Every shape the three passes can encounter, plus the awkward boundaries."""
     glued = "X" + AWS_SECRET  # 41-char run: exact-40 gate fails, sliding window catches
@@ -242,6 +272,50 @@ def _corpus() -> list[str]:
         ("lorem ipsum dolor sit amet " * 4000),
         ("lorem ipsum dolor sit amet " * 4000) + f" ghp_{'a' * 36}",
         f"ghp_{'a' * 36} " + ("lorem ipsum dolor sit amet " * 4000),
+        # ── blast radius of the pass-2/pass-3 per-run work ──
+        # Many hex digests in one string. Each is a 64-char base64-alphabet run
+        # that IS 4-aligned, so every one reaches the decode; this is the shape
+        # the per-run cost was measured on.
+        " ".join(f"{i:064x}" for i in range(40)),
+        " ".join(f"{i:064X}" for i in range(40)),  # uppercase: different gate path
+        # Runs at each length residue: %4 == 0 decodes, the rest cannot.
+        _B64_RUN_40,  # 40, %4 == 0
+        _B64_RUN_40 + "a",  # 41, %4 == 1
+        _B64_RUN_40 + "ab",  # 42, %4 == 2
+        _B64_RUN_40 + "abc",  # 43, %4 == 3
+        _B64_RUN_40 + "abcd",  # 44, %4 == 0
+        # A long non-decodable run beside a decodable one, in one string.
+        _B64_RUN_40 + "a" + " and " + _B64_RUN_40,
+        # Padding variants layered onto each residue, since `={0,2}` is consumed
+        # by the chunk regex and shifts the length the precondition sees.
+        _B64_RUN_40 + "ab" + "==",  # 44 total -> decodes
+        _B64_RUN_40 + "abc" + "=",  # 44 total -> decodes
+        _B64_RUN_40 + "abcd" + "=",  # 45 total -> cannot decode
+        _B64_RUN_40 + "abcd" + "==",  # 46 total -> cannot decode
+        # Decodes to printable TEXT: the run-level gate exits before the slide.
+        _PRINTABLE_BLOB,
+        f"blob {_PRINTABLE_BLOB} end",
+        # Decodes to high-entropy GARBAGE: reaches the sliding window.
+        _GARBAGE_BLOB,
+        f"blob {_GARBAGE_BLOB} end",
+        # Decodes to the EMPTY string once invalid UTF-8 is dropped: the only
+        # shape that lands below the pre-filter length gate.
+        _SHORT_DECODE_BLOB,
+        f"blob {_SHORT_DECODE_BLOB} end",
+        # A real encoded credential whose decoded text sits BELOW the pre-filter
+        # length gate, so the gate is skipped and the alternation runs directly.
+        base64.b64encode(b"ghp_" + b"a" * 36).decode(),
+        # ... and one comfortably ABOVE it, so the gate is applied.
+        base64.b64encode(
+            f"aws_secret_access_key={AWS_SECRET} trailing prose to lengthen".encode()
+        ).decode(),
+        # An encoded credential in the MISALIGNED padding shapes whose decodability
+        # is interpreter dependent (40 data chars + one `=` decodes on 3.10/3.11 and
+        # raises on 3.12). Whichever way the decode goes, live and oracle must agree.
+        _ENCODED_CRED_STEM + "=",
+        _ENCODED_CRED_STEM + "==",
+        _ENCODED_CRED_STEM,
+        f"payload {_ENCODED_CRED_STEM}= end",
     ]
     return cases
 
@@ -367,6 +441,34 @@ def test_b64_chunk_spans_match_bare_secret_run_spans() -> None:
         chunks = [m.group() for m in _B64_CHUNK_RE.finditer(text)]
         runs = [m.group() for m in _BARE_SECRET_RUN_RE.finditer(text)]
         assert [c.rstrip("=") for c in chunks] == runs, repr(text[:80])
+
+
+def test_the_two_base64_run_patterns_stay_structurally_coupled() -> None:
+    """Pin both run patterns against a SILENT widening of one of them.
+
+    Pass 3 stopped reading `_BARE_SECRET_RUN_RE` when the shared scan landed -- it
+    derives runs from `_B64_CHUNK_RE` now. `_BARE_SECRET_RUN_RE` is still live for
+    `_text_contains_bare_secret`, so the two can be edited independently, and
+    widening one alone (base64url `-_`, say) would change the URL scan while leaving
+    the redactor untouched. The span-equality test above catches that only if the
+    corpus happens to carry the widened shape, so pin the literals here too: an edit
+    to either fails at this assertion, which names the shared-scan invariant.
+    """
+    assert _B64_CHUNK_RE.pattern == r"[A-Za-z0-9+/]{40,}={0,2}"
+    assert _BARE_SECRET_RUN_RE.pattern == r"(?<![A-Za-z0-9+/])[A-Za-z0-9+/]{40,}(?![A-Za-z0-9+/])"
+
+    # Assert the coupling itself -- shared alphabet and shared {40,} floor -- so the
+    # intent survives a cosmetic re-spelling of either literal.
+    alphabet = "[A-Za-z0-9+/]"
+    assert _B64_CHUNK_RE.pattern.count(alphabet) == 1
+    assert _BARE_SECRET_RUN_RE.pattern.count(alphabet) == 3  # body plus 2 look-arounds
+    assert "{40,}" in _B64_CHUNK_RE.pattern
+    assert "{40,}" in _BARE_SECRET_RUN_RE.pattern
+
+    # Negative control: prove this assertion can detect a base64url widening.
+    widened = _BARE_SECRET_RUN_RE.pattern.replace("A-Za-z0-9+/", "A-Za-z0-9+/\\-_")
+    assert widened != _BARE_SECRET_RUN_RE.pattern, "control failed to mutate the pattern"
+    assert widened.count(alphabet) != 3, "a widened character class must fail the pin"
 
 
 def test_decode_b64_chunk_matches_generic_helper_on_chunks() -> None:
@@ -728,3 +830,262 @@ def test_a_widened_branch_cannot_outgrow_its_anchor() -> None:
         f"only {checked} generated samples were assertable across {len(BRANCHES)} "
         f"branches; the generator is too weak to guard them"
     )
+
+
+# ── Per-run work in passes 2 and 3: independent oracles ──
+#
+# `_decodes_to_printable_text` is reached THROUGH `_contains_bare_secret`, which
+# the reference oracle above also calls. So the byte-identity assertion shares
+# that helper with the implementation and structurally cannot detect a change
+# inside it. These tests supply the missing oracle: a verbatim copy of the
+# pre-rewrite body, compared against the live one.
+
+
+def _reference_printable_count(raw: bytes) -> int:
+    """The per-byte sum `_decodes_to_printable_text` used before the rewrite."""
+    return sum(1 for b in raw if 0x20 <= b <= 0x7E or b in (0x09, 0x0A, 0x0D))
+
+
+def _reference_decodes_to_printable_text(token: str) -> bool:
+    """Verbatim pre-rewrite body of `_decodes_to_printable_text`."""
+    try:
+        raw = base64.b64decode(token + "=" * (-len(token) % 4), validate=False)
+    except Exception:
+        return False
+    if not raw:
+        return False
+    printable = _reference_printable_count(raw)
+    return printable / len(raw) >= _SECRET_PRINTABLE_DECODE_RATIO
+
+
+def _translate_count(raw: bytes) -> int:
+    """The live count: delete the printable set in C and measure the remainder."""
+    return len(raw) - len(raw.translate(None, _PRINTABLE_BYTES))
+
+
+def test_printable_count_matches_the_per_byte_sum() -> None:
+    """The translate-based count must equal the per-byte sum for every input.
+
+    Exhaustive over all 256 single-byte values -- which is a complete proof for
+    the membership question itself, since `translate` decides each byte
+    independently -- then fuzzed over multi-byte inputs to cover the length
+    arithmetic.
+    """
+    for b in range(256):
+        raw = bytes([b])
+        assert _translate_count(raw) == _reference_printable_count(raw), hex(b)
+
+    rng = random.Random(20260830)
+    for _ in range(4000):
+        raw = bytes(rng.randrange(256) for _ in range(rng.randint(0, 300)))
+        assert _translate_count(raw) == _reference_printable_count(raw), repr(raw[:24])
+
+
+def test_decodes_to_printable_text_matches_the_reference_implementation() -> None:
+    """The live helper must agree with the pre-rewrite body on every input.
+
+    Covers the shapes the rewrite is exposed to: every base64 run in the corpus,
+    both `=`-stripped and as matched, plus fuzzed runs across every length
+    residue and padding form.
+    """
+    checked = 0
+    for text in CORPUS:
+        for m in _B64_CHUNK_RE.finditer(text):
+            chunk = m.group()
+            for candidate in (chunk, chunk.rstrip("=")):
+                checked += 1
+                assert _decodes_to_printable_text(candidate) == (
+                    _reference_decodes_to_printable_text(candidate)
+                ), repr(candidate[:48])
+    assert checked >= 40, f"only {checked} runs exercised; corpus too weak"
+
+    rng = random.Random(11)
+    alphabet = string.ascii_letters + string.digits + "+/"
+    for _ in range(3000):
+        n = rng.randint(0, 200)
+        token = "".join(rng.choice(alphabet) for _ in range(n)) + rng.choice(("", "=", "=="))
+        assert _decodes_to_printable_text(token) == _reference_decodes_to_printable_text(
+            token
+        ), repr(token[:48])
+
+
+def test_a_decode_length_precondition_would_be_version_dependent() -> None:
+    """Records why `_decode_b64_chunk` carries NO length short-circuit.
+
+    Skipping the decode when `len(chunk) % 4` is non-zero looks sound -- and IS
+    sound on 3.12, where `validate=True` rejects such a length. It is a REDACTION
+    BYPASS on 3.10 and 3.11: `binascii.a2b_base64`'s padding leniency changed with
+    `strict_mode`, so a chunk of 40 data characters plus one `=` decodes there, and
+    skipping it would leave an encoded credential unredacted. No version-invariant
+    predicate exists either -- 43 data characters plus `==` decodes on 3.10 while
+    failing both a total-length and a stripped-length test.
+
+    So assert the property that DOES hold on every interpreter: the hot-path chunk
+    helper agrees with the ungated `_decode_b64_safe`, for exactly the misaligned
+    shapes that motivated the rejected guard. Whether they decode may differ by
+    version; that the two helpers agree may not.
+    """
+    payload = f"aws_secret_access_key={AWS_SECRET}"
+    stem = base64.b64encode(payload.encode()).decode().rstrip("=")
+
+    misaligned = 0
+    for shape in (stem, stem + "=", stem + "==", stem[:-1], stem[:-1] + "=", stem[:-2] + "=="):
+        assert _decode_b64_chunk(shape) == _decode_b64_safe(shape), repr(shape[:40])
+        if len(shape) % 4:
+            misaligned += 1
+    assert misaligned >= 2, "shapes no longer exercise a non-4-aligned chunk"
+
+    # And the credential in its canonical, correctly padded form is still redacted,
+    # on every interpreter -- the guard's removal must not have cost detection.
+    canonical = base64.b64encode(payload.encode()).decode()
+    assert _decode_b64_chunk(canonical), "canonical encoded credential must be detected"
+
+
+def test_decode_gate_agrees_with_the_ungated_helper_across_the_length_gate() -> None:
+    """Both sides of `_PREFILTER_MIN_LEN` must agree with the ungated helper.
+
+    Below the threshold the pre-filter is skipped and the alternation runs
+    directly; at or above it the pre-filter gates the alternation. `_decode_b64_safe`
+    is ungated and untouched, so it is the oracle for both sides, and this asserts
+    the corpus actually reaches each one.
+
+    Note the asymmetry the gate relies on: a chunk is at least 40 base64
+    characters, so it always decodes to at least 30 raw bytes, and a decoded
+    STRING shorter than the threshold only arises when `errors="ignore"` discards
+    invalid UTF-8. No `_CREDENTIAL_PATTERNS` branch matches text that short, so the
+    below-threshold path is reached only by non-credential blobs -- and even if one
+    existed, skipping the pre-filter runs the FULL alternation, never less.
+    """
+    below = above = 0
+    for text in CORPUS:
+        for m in _B64_CHUNK_RE.finditer(text):
+            chunk = m.group()
+            assert _decode_b64_chunk(chunk) == _decode_b64_safe(chunk), repr(chunk[:40])
+            # Classify by what actually decodes, NOT by `len(chunk) % 4`: whether a
+            # misaligned chunk decodes is interpreter dependent (see
+            # `test_a_decode_length_precondition_would_be_version_dependent`), so a
+            # length test here would silently skip real cases on 3.10 and 3.11.
+            try:
+                decoded = base64.b64decode(chunk, validate=True).decode("utf-8", errors="ignore")
+            except binascii.Error:
+                continue
+            if len(decoded) >= _PREFILTER_MIN_LEN:
+                above += 1
+            else:
+                below += 1
+
+    assert below > 0, "corpus never produces a decoded blob below the length gate"
+    assert above > 0, "corpus never produces a decoded blob at or above the length gate"
+
+    # And a real encoded credential, which necessarily sits above the gate, is
+    # still detected through it.
+    cred = base64.b64encode(
+        f"aws_secret_access_key={AWS_SECRET} trailing prose to lengthen".encode()
+    ).decode()
+    assert _decode_b64_chunk(cred) == _decode_b64_safe(cred)
+    assert _decode_b64_chunk(cred), "the gate must not hide a real encoded credential"
+
+
+def test_chunk_and_repadded_run_are_not_interchangeable_decode_inputs() -> None:
+    """Records why pass 2's decode is NOT shared with pass 3's.
+
+    Pass 2 decodes the chunk as matched with `validate=True`; pass 3 reaches
+    `_decodes_to_printable_text`, which strips `=`, re-pads to a multiple of 4 and
+    decodes with `validate=False`. Those two inputs coincide only when the chunk
+    as written already carries minimal padding, so the results are NOT one value
+    and sharing the decode between the passes would not be sound.
+    """
+    differing = 0
+    for text in CORPUS:
+        for m in _B64_CHUNK_RE.finditer(text):
+            chunk = m.group()
+            run = chunk.rstrip("=")
+            if run + "=" * (-len(run) % 4) != chunk:
+                differing += 1
+    assert differing > 0, (
+        "no corpus chunk's padding differs from its re-padded run, so the "
+        "decode-sharing hazard is unexercised"
+    )
+
+
+# ── Negative controls for the per-run work: prove these tests can fail ──
+
+
+def test_printable_equivalence_control_detects_a_narrowed_byte_set() -> None:
+    """Prove `test_printable_count_matches_the_per_byte_sum` can fail.
+
+    Drop tab/LF/CR from the byte set -- the exact mistake a hand-written set
+    would make -- and the count must diverge from the per-byte sum.
+    """
+    narrowed = bytes(sorted(set(range(0x20, 0x7F))))
+    raw = b"line one\nline two\ttabbed\r\n"
+
+    narrowed_count = len(raw) - len(raw.translate(None, narrowed))
+    assert narrowed_count != _reference_printable_count(
+        raw
+    ), "the equivalence assertion cannot detect a narrowed printable set"
+    assert _translate_count(raw) == _reference_printable_count(raw)
+
+
+def test_differential_test_detects_a_too_narrow_decoded_blob_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prove the byte-identity assertion catches a broken decoded-blob gate.
+
+    Disarm the pre-filter that pass 2 now consults, so a genuine base64-encoded
+    credential is skipped instead of redacted. The reference oracle decodes via
+    the ungated `_decode_b64_safe`, so it still redacts and the comparison must
+    diverge. Without this control the gate could be arbitrarily narrow and the
+    differential test would still pass.
+    """
+    import kiro_crew.security as security
+
+    monkeypatch.setattr(security, "_might_contain_credential", lambda text: False)
+
+    payload = f"aws_secret_access_key={AWS_SECRET}"
+    sample = "payload " + base64.b64encode(payload.encode()).decode() + " end"
+    assert len(payload) >= _PREFILTER_MIN_LEN, "payload must clear the length gate"
+
+    live = security.redact_credentials(sample)
+    reference = _reference_redact_credentials(sample)
+    assert live != reference, "the differential test cannot detect a broken blob gate"
+    assert "[REDACTED: encoded credential]" in reference[0]
+    assert (
+        "[REDACTED: encoded credential]" not in live[0]
+    ), "expected the disarmed gate to leak the encoded credential"
+
+
+def test_a_length_short_circuit_would_leak_an_encoded_credential() -> None:
+    """Control for the REJECTED `len(chunk) % 4` short-circuit.
+
+    Simulate the guard and show it can only ever suppress detection, never improve
+    it. On 3.10 and 3.11 it drops a decodable credential chunk outright; on 3.12
+    the shape does not decode anyway, which is exactly why the defect was invisible
+    when the change was tested on 3.12 alone.
+    """
+    payload = f"aws_secret_access_key={AWS_SECRET}"
+    stem = base64.b64encode(payload.encode()).decode().rstrip("=")
+
+    # Only shapes the rejected guard would actually have rejected. `stem + "="` is
+    # the canonical 4-aligned form here, so it must NOT be counted as misaligned.
+    misaligned = [s for s in (stem, stem + "=", stem + "==") if len(s) % 4]
+    assert misaligned, "no misaligned shape constructed"
+
+    leaked = 0
+    for shape in misaligned:
+        real = _decode_b64_chunk(shape)
+        guarded = ""  # what the rejected `len(chunk) % 4` guard would have returned
+        assert not (guarded and not real), "guard cannot detect more than no guard"
+        if real:
+            leaked += 1
+
+    if sys.version_info < (3, 12):
+        assert leaked >= 1, (
+            "expected the lenient pre-3.12 decoder to make the length guard a "
+            "redaction bypass on at least one misaligned shape"
+        )
+    else:
+        assert leaked == 0, (
+            "3.12 rejects these shapes outright, which is exactly why the bypass "
+            "was invisible when the change was tested on 3.12 alone"
+        )


### PR DESCRIPTION
## Problem / Motivation

`redact_credentials` runs three passes. #7056 cut most of the *scanning* cost by
gating pass 1 behind a cheap superset pre-filter and feeding passes 2 and 3 from
one shared base64 scan. What it did not touch is the **per-run work inside the
pass 2 and pass 3 loop bodies**, which is now the largest remaining term on
content carrying many base64-alphabet runs.

Measured on this branch's base (#7056's head, `0235df78`), pass 2 + pass 3 loop
bodies with the shared scan excluded:

| corpus | size | loop bodies | share of `redact_credentials` |
| -------------------------------- | -------- | ----------- | ----------------------------- |
| real session text | 981.5 KB | 1.01 ms | 1.9% of 53.4 ms |
| hash-heavy (commit ids, digests) | 98.3 KB | 11.0 ms | 68% of 16.1 ms |
| blob-heavy (encoded attachments) | 313.8 KB | 35.8 ms | 78% of 47.1 ms |

Two costs drive that:

1. **`_decodes_to_printable_text` counted printable bytes in a Python loop.** It
   runs once per base64 run *and* again per 40-char window as gate 7 of
   `_looks_like_secret_key`, and its cost scaled with the **decoded byte count**
   rather than with the 40-char window. On a 2 KB encoded blob it was 86.3 us of
   the 88.2 us `_contains_bare_secret` spent on that run — 98%.
2. **Pass 2 ran the full 23-branch alternation over every decoded blob.** Real
   decoded blobs are almost never credentials: 0 of 18 in the session corpus and
   1 of 849 in the hash-heavy corpus.

## Why it matters

This is the redaction boundary; a regression writes live credentials into
persisted chat history. So the constraint is byte-identical `(text, warnings)`
output, and the value has to be stated honestly:

- **On ordinary session text this is a no-op** (53.4 ms -> 53.8 ms, inside noise),
  because 981 KB of real text contains only 116 qualifying runs. The remaining
  cost there is pass 1 and the shared scan, which #7056 owns.
- The win is on **hash-heavy and blob-heavy** content — build logs, git output,
  commit lists, encoded attachments — where the loop bodies were 68–78% of the
  function.

**A digest-keyed cache for `redact_credentials` was in flight concurrently**
(branch `perf/redact-credentials-cache`), so these figures are **miss-path cost**.
That is deliberate: a cache cannot help a miss, and this change targets exactly
the term a cache leaves behind. I checked for a cache at the function entry first
and found none — `redact_credentials` carries no memo, and the only sha256 cache
nearby is `_entry_cache` in `chat_persistence.py`, keyed on the whole **message
dict** in front of the entry *builder*, which misses on every new message. Do not
read the numbers above as a whole-workload improvement a landed cache would absorb.

**Stacking:** #7056 is still open, so this branches off **its head** rather than
`main`, and the diff against `main` includes its commit. I expect **#7056 to merge
first**, then the cache PR and this one in either order — the cache lands at the
function *entry* and this lands in the pass 2/3 *loop bodies*.

## What changed in code

Two changes in `src/kiro_crew/security.py`, three executable lines.

**1. `_decodes_to_printable_text` counts printable bytes with `bytes.translate`.**
`translate(None, _PRINTABLE_BYTES)` returns exactly the bytes *not* in the set, so
`len(raw) - len(...)` is the member count. An integer identity, so the ratio and
the comparison are bit-identical to the previous per-byte sum. Measured 14.6x at
48 bytes rising to 69x at 1500.

**2. Pass 2's decoded-blob scan is gated behind the pre-filter, length-gated.**
`_might_contain_credential` is a proven superset of `_CREDENTIAL_PATTERNS`, so the
verdict cannot move. It is **not** unconditionally cheaper, though: its ~590 ns
floor is fixed while the alternation scales with length, so the crossover was
measured rather than assumed — 8 chars 684 vs 494 ns (alternation wins), 12 chars
746 vs 898 (pre-filter wins), 3.4x by 256. Decoded blobs (measured 12–31 chars)
genuinely straddle that line.

`_PREFILTER_MIN_LEN` is held at **16**, above the measured crossover of 12, on
purpose. The gate is verdict-neutral — the pre-filter is a proven superset, so
either route reaches the same answer — which makes a conservative threshold cost at
most one alternation scan on a 12–15 character blob, and makes it robust to the
crossover drifting as the pre-filter's own cost changes. It has already drifted
once: this PR was rebased onto a revision of #7056 that replaced the `.lower()`
substring check with a case-insensitive `Authorization` anchor, moving the crossover
from 16 to 12. The figures above are re-measured against that implementation.

### A third optimisation was written, then removed as unsound — read this before re-adding it

An earlier revision short-circuited pass 2's decode when `len(chunk) % 4` was
non-zero, reasoning that `validate=True` rejects such a length. **That is
interpreter dependent and is a redaction bypass on the versions CI builds.**
`binascii.a2b_base64`'s padding leniency changed with `strict_mode`:

| chunk shape | 3.10 | 3.11 | 3.12 |
| ------------------------------------ | ---------- | ---------- | ------ |
| 40 data chars + `=` (len 41, %4 = 1) | **decodes** | **decodes** | raises |
| 40 data chars + `==` (len 42, %4 = 2) | **decodes** | **decodes** | raises |
| 43 data chars + `==` (len 45, %4 = 1) | **decodes** | raises | raises |

So on 3.10 the guard skipped a chunk that *does* decode, leaving a base64-encoded
credential unredacted. No version-invariant form of the predicate exists either:
`43 data chars + "=="` decodes on 3.10 while failing both a total-length and a
stripped-length test. The guard is gone, the reasoning is recorded at the call
site, and `test_a_decode_length_precondition_would_be_version_dependent` plus
`test_a_length_short_circuit_would_leak_an_encoded_credential` pin it.

Removing it cost essentially nothing measurable — it was the least valuable of the
three changes, and the benchmark below is *after* its removal.

### Also deliberately not done

- **Passes 2 and 3 remain separate sequential loops.** Fusing them would change the
  order of `warnings`, which occurrence each `str.replace(..., 1)` lands on, and
  whether pass 3's `run not in result` guard sees pass 2's edits. Computation is
  shared; control flow is not.
- **The decode is not shared between the passes.** Pass 2 decodes the chunk as
  matched with `validate=True`; pass 3 reaches `_decodes_to_printable_text`, which
  strips `=`, re-pads and decodes with `validate=False`. Those inputs coincide only
  when the chunk already carries minimal padding — measured **867 same, 249
  differing** — so they are not one value. Pinned by
  `test_chunk_and_repadded_run_are_not_interchangeable_decode_inputs`.
- **`_decode_b64_safe` is left unoptimised on purpose.** It is the independent
  oracle for `_decode_b64_chunk`; applying the same gates would make both sides of
  that comparison share the change and it would stop detecting anything.
- **`_shannon_entropy` (4.8 us, the costliest single window gate) and
  `_vowel_ratio` are untouched.** Entropy is worth revisiting, but a
  precomputed-term rewrite must be proven bit-identical or it can flip a verdict at
  the `>= 4.3` boundary, and that belongs in its own change.

## Tests

`test/test_credential_prefilter.py`, the differential test #7056 added, extended
from 157 to **213 passing**. It pins the pre-optimisation implementation as a
reference oracle and asserts byte-identical `(text, warnings)`.

**Verified on Python 3.10 AND 3.12** — 213 passed on each. The removed guard is
exactly why: it passes on 3.12 and fails on 3.10, so a single-version run cannot
see it.

**Corpus extended toward this change's blast radius:** 40 hex digests in one string
(both cases), runs at every length residue 40–44, a long non-decodable run beside a
decodable one, padding variants per residue, blobs decoding to printable text / to
high-entropy garbage / to the empty string once invalid UTF-8 is dropped, encoded
credentials on both sides of the length gate, and an encoded credential in the
misaligned padding shapes whose decodability differs by interpreter.

**New independent oracles.** `_decodes_to_printable_text` is reached *through*
`_contains_bare_secret`, which the reference oracle also calls — so the
byte-identity assertion shares that helper and structurally cannot detect a change
inside it. Two tests close that gap against a verbatim copy of the pre-rewrite
body: all 256 single-byte values exhaustively (a complete proof for the membership
question, since `translate` decides each byte independently) plus 4000 fuzzed
multi-byte inputs, and 3000 fuzzed tokens across every residue and padding form.

**Negative controls.** Each sabotage was applied to the real source, the guarding
test observed, and the file restored and verified by sha256:

| sabotage | on 3.10 | on 3.12 |
| ----------------------------------------------------- | ------- | ---------- |
| printable byte set narrowed (drops tab/LF/CR) | CAUGHT | CAUGHT |
| decoded-blob gate too narrow (anchors only on `ghp_`) | CAUGHT | CAUGHT |
| the removed `len(chunk) % 4` guard put back | CAUGHT | not caught |

The third row is the point: the same defect is caught on 3.10 and invisible on
3.12. The blob-gate sabotage fails `test_output_is_byte_identical_to_reference`,
i.e. an encoded credential slips through and the differential test notices.

**Suite results.** `test_credential_prefilter.py` 213 passed on 3.10 and on 3.12;
with `test_security.py`, 1208 passed / 1 skipped / 0 failed on 3.12. All 21
redaction-related test files ran clean against a baseline worktree at the same
commit, the delta being the new tests. `scripts/check_black_formatting.py` passes,
and `isort --check-only src/kiro_crew test conftest.py xdist_budget.py` is clean —
note that the isort failure was **pre-existing at #7056's head**
(`_REDACTED_CREDENTIAL_TAG` misplaced in the import block), so #7056 will hit the
same gate on its own; this PR fixes it in passing.

**Benchmark**, baseline and optimised interleaved back to back in two passes so
neither is a stale capture, same session files and RNG seed on both sides:

| corpus | size | loop bodies before -> after | whole function before -> after |
| ------------ | -------- | --------------------------- | ----------------------------- |
| real-session | 981.5 KB | 1.01 -> 0.90 ms | 53.4 -> 53.8 ms (noise) |
| hash-heavy | 98.3 KB | 11.0 -> 9.05 ms (-17%) | 16.1 -> 13.6 ms (-16%) |
| blob-heavy | 313.8 KB | 35.8 -> 6.62 ms (**-82%**) | 47.1 -> 15.4 ms (**-67%**) |
