### PR TITLE
ci(skills): gate this repository's markers out of shipped skill bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,38 @@ jobs:
           python3 scripts/check_changelog_history.py --test
           python3 scripts/check_changelog_history.py
 
+  builtin-skill-scope:
+    name: Builtin Skill Scope Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check for this repository's markers in shipped skill bodies
+        # Everything under src/kiro_crew/builtin_skills/ installs on every
+        # machine that installs Kiro Crew, so a skill body naming THIS
+        # repository -- its GitHub slug, a src/ checkout path, a test file, a
+        # workflow file -- is an instruction that resolves for one user and
+        # points an agent at a path that does not exist for everyone else.
+        # prepare-pr already solved it properly: repository specifics live in a
+        # profile keyed by repository, so the body stays portable. The
+        # kirocrew-dev/ family is exempt by directory (matched directly beneath
+        # builtin_skills/, so a nested or look-alike name cannot inherit it),
+        # because this repository is its subject matter rather than a leak.
+        # Product surface (the kirocrew CLI, ~/.kiro/crew paths, config keys) is
+        # deliberately NOT a marker -- see the script docstring for why the set
+        # is narrow, and for the repository paths it knowingly does not cover.
+        # No baseline: the tree's only two markers were fixed here, so the rule
+        # is absolute and no marker is exempted by record.
+        run: |
+          # Self-test first: one probe per marker class, both sides of the
+          # exemption, and the undecodable-file path, so a rule that silently
+          # stops matching fails here instead of shipping green.
+          python3 scripts/check_builtin_skill_scope.py --test
+          python3 scripts/check_builtin_skill_scope.py
+
   loop-bound-locks:
     name: Loop-Bound Locks Gate
     runs-on: ubuntu-latest

--- a/scripts/check_builtin_skill_scope.py
+++ b/scripts/check_builtin_skill_scope.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""check_builtin_skill_scope.py -- keep this repository out of shipped skills.
+
+Every file under ``src/kiro_crew/builtin_skills/`` installs on every machine that
+installs Kiro Crew. A skill body that names THIS repository -- its GitHub slug, a
+source path only a dev checkout has, a test file, a workflow file -- is giving an
+instruction that resolves for exactly one reader: someone working on Kiro Crew
+itself. For everyone else it is a dead reference, and for an agent it is worse
+than dead: a confident pointer at a path that does not exist, which the agent
+will try.
+
+``prepare-pr`` already solved this properly and is the pattern this gate keeps:
+repository specifics live in a PROFILE keyed by repository
+(``prepare-pr/profiles/``, resolved by ``resolve_profile.py``), so the skill body
+says "run the gate floor" and the profile says what that means here. Anything
+repository-shaped that a skill needs either resolves from the repository being
+acted on, or belongs in a profile, or the skill is not a builtin.
+
+## Nothing is exempted by record
+
+The rule is absolute: a marker outside ``kirocrew-dev/`` fails. There is no
+baseline file and no per-file allowance, so the gate has nothing to forgive and
+cannot drift into forgiving everything. A repository shape that a skill genuinely
+needs is a signal to move the specific into a profile, not to record an exception.
+
+## What counts as a marker
+
+Four classes, all of which are only meaningful while working on this repository:
+
+* ``kirodotdev/KiroCrew`` -- this repository by name, including a github.com URL.
+* ``src/kiro_crew/...`` -- a SOURCE-CHECKOUT path. An installed wheel has
+  ``kiro_crew/`` with no ``src/`` prefix, so this form resolves only in a clone.
+* ``test/test_*.py`` -- this repository's test layout.
+* ``.github/workflows/*.yml`` -- this repository's CI.
+
+## What is deliberately NOT a marker
+
+The PRODUCT surface. ``kirocrew`` CLI commands, ``~/.kiro/crew/...`` runtime
+paths, config keys, dashboard routes, MCP tool names: those ship WITH the skill
+and are correct on every install. Confusing the two would gate the very content
+builtin skills exist to carry, so the rule names repository shapes only and this
+list is the reason the marker set is narrow rather than "any path".
+
+## What a skill body must be
+
+A regular UTF-8 text file. A symlink is refused before any read -- one pointing at
+``/dev/zero`` makes the read stream nulls until CI kills the job -- and that closes
+the whole class, because git carries only regular files, symlinks and gitlinks, so
+there is no other route to a device file or FIFO in a checkout. A body that cannot
+be decoded fails too, rather than being skipped: a gate that silently passes what
+it could not read ships the one file nobody scanned.
+
+## Known limit, on purpose
+
+Repository paths OUTSIDE the four classes are not caught -- ``website/src/
+index.css`` and ``docs/system-specs/...`` are as checkout-only as
+``src/kiro_crew/``, and ``theme-pack-authoring`` legitimately cites the first one
+today. Widening the set means fixing those references in the same breath, which is
+a content change with its own argument to make; this gate covers the four shapes
+that were actually leaking. Read it as "these four shapes are extinct", not as
+"no repository path can reach a skill".
+
+## The kirocrew-dev family is exempt, structurally
+
+``builtin_skills/kirocrew-dev/`` is the family FOR developing this repository --
+``prepare-pr``, ``babysit``, ``writing-tests``, ``kirocrew-worktree-dev``. A
+Kiro Crew path there is the subject matter, not a leak, and 26 of the tree's 28
+markers live in it. That exemption is a directory rule rather than 26 recorded
+lines on purpose: it is a property of what the family IS, so it stays true as
+those skills are edited, where a per-line list would just record today's bytes
+and demand churn on every edit.
+
+It is matched as the family directory DIRECTLY beneath ``builtin_skills/``, not as
+any path segment: a nested ``widgets/kirocrew-dev/`` would otherwise inherit the
+exemption and ship a leak under a name that only looks exempt.
+
+The consequence to be honest about: this gate does NOT judge whether that family
+should ship to every install at all. It only stops the leak spreading to skills
+that claim to be repository-agnostic.
+
+## Usage
+
+    python3 scripts/check_builtin_skill_scope.py             # gate
+    python3 scripts/check_builtin_skill_scope.py --test      # self-test the rule
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL_ROOT = Path("src") / "kiro_crew" / "builtin_skills"
+
+# The family whose subject matter IS this repository.
+EXEMPT_FAMILY = "kirocrew-dev"
+
+# One pattern per marker class, kept separate so a violation can name WHICH
+# class it tripped -- "this is a source-checkout path" is actionable where
+# "matched the marker regex" is not.
+MARKER_CLASSES: tuple[tuple[str, str, str], ...] = (
+    (
+        "repo-slug",
+        # NOT preceded by "github.com/": a bare slug ("file it on
+        # kirodotdev/KiroCrew") is an instruction only a contributor can act on,
+        # but an https://github.com/kirodotdev/KiroCrew/... URL RESOLVES on every
+        # machine because this repository is public, so it is a citation. Treating
+        # both alike forces a downgrade -- it turns a fetchable link to the
+        # authoritative theming contract into prose an installed reader cannot
+        # follow at all -- on every skill that cites the project's own public docs.
+        # The lookbehind is deliberately narrow rather than a whole-line
+        # exemption: one line can carry both a citation and a real instruction.
+        r"(?<!github\.com/)kirodotdev/KiroCrew",
+        "names this repository as a place to act; a reader elsewhere has no such repo",
+    ),
+    (
+        "checkout-path",
+        r"\bsrc/kiro_crew/[A-Za-z0-9_./-]+",
+        "a source-checkout path; an installed wheel has no src/ prefix",
+    ),
+    (
+        "test-path",
+        r"\btest/test_[A-Za-z0-9_]+\.py",
+        "this repository's test layout",
+    ),
+    (
+        "workflow-path",
+        r"\.github/workflows/[A-Za-z0-9._-]+\.ya?ml",
+        "this repository's CI",
+    ),
+)
+
+REMEDY = (
+    "Resolve it from the repository being acted on, move it into a profile the\n"
+    "way prepare-pr/profiles does, or move the skill under builtin_skills/\n"
+    "kirocrew-dev/ if it is genuinely a skill for developing this repository."
+)
+
+
+def marker_hits(text: str) -> list[tuple[int, str, str]]:
+    """(line_no, class_name, matched_text) for every marker in ``text``.
+
+    Line-numbered because a count alone cannot be acted on, and one line can
+    carry two classes (a github.com URL that also contains a source path), so
+    each class is scanned independently rather than through one alternation.
+    """
+    hits: list[tuple[int, str, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for name, pattern, _why in MARKER_CLASSES:
+            for match in re.finditer(pattern, line):
+                hits.append((line_no, name, match.group(0)))
+    hits.sort()
+    return hits
+
+
+def is_exempt(rel_path: Path) -> bool:
+    """Whether ``rel_path`` is inside the family this repository is the subject of.
+
+    The family must sit DIRECTLY beneath ``builtin_skills/``. Matching any path
+    segment would exempt a nested ``widgets/kirocrew-dev/SKILL.md``, and matching
+    a prefix would exempt a ``kirocrew-devtools/`` sibling -- both would ship a
+    leak under a name that merely resembles the exempt one.
+    """
+    prefix = SKILL_ROOT.parts
+    parts = rel_path.parts
+    if parts[: len(prefix)] != prefix:
+        return False
+    return len(parts) > len(prefix) and parts[len(prefix)] == EXEMPT_FAMILY
+
+
+def scan_tree(root: Path) -> tuple[dict[str, list[tuple[int, str, str]]], list[tuple[str, str]]]:
+    """(marker hits per repo-relative path, (path, reason) for what could not be scanned).
+
+    Unscannable files are RETURNED rather than skipped: a gate that silently
+    passes what it could not read is a gate that ships the one file nobody
+    scanned.
+
+    A symlink is refused BEFORE any read. Following one is a real hang: a
+    candidate pointing at ``/dev/zero`` makes ``read_text`` stream nulls until the
+    job is killed (measured: the read does not return). Refusing symlinks closes
+    that whole class for anything a checkout can produce, because git's object
+    model carries only regular files, symlinks and gitlinks -- there is no other
+    route to a device file or a FIFO in the tree. A skill body is prose in a
+    regular file; the tree has never held a symlinked one.
+    """
+    found: dict[str, list[tuple[int, str, str]]] = {}
+    unscannable: list[tuple[str, str]] = []
+    skill_root = root / SKILL_ROOT
+    if not skill_root.is_dir():
+        return found, unscannable
+    for path in sorted(skill_root.rglob("*.md")):
+        rel = path.relative_to(root)
+        if is_exempt(rel):
+            continue
+        if path.is_symlink():
+            unscannable.append(
+                (rel.as_posix(), "is a symlink; a skill body must be a regular file")
+            )
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            unscannable.append(
+                (rel.as_posix(), "cannot be read as UTF-8 text, so it cannot be scanned")
+            )
+            continue
+        hits = marker_hits(text)
+        if hits:
+            found[rel.as_posix()] = hits
+    return found, unscannable
+
+
+def _annot_message(value: str) -> str:
+    """Escape a workflow-command MESSAGE per GitHub's documented rules.
+
+    The runner parses ``::`` commands on every output line, so an untrusted byte
+    reaching an annotation unescaped is a forged-annotation vector rather than a
+    cosmetic problem: a filename carrying LF + ``::error::`` would make the runner
+    render a second annotation this gate never emitted.
+    """
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _annot_property(value: str) -> str:
+    """Escape a workflow-command PROPERTY value (``file=``, ``line=``).
+
+    Property values additionally escape ``:`` and ``,``, which are the property
+    and command separators -- otherwise a name containing either could split the
+    property list and move the annotation to a file of the author's choosing.
+    """
+    return _annot_message(value).replace(":", "%3A").replace(",", "%2C")
+
+
+def _report(
+    current: dict[str, list[tuple[int, str, str]]], unscannable: list[tuple[str, str]]
+) -> int:
+    why = {name: reason for name, _pattern, reason in MARKER_CLASSES}
+    for rel, hits in sorted(current.items()):
+        for line_no, name, text in hits:
+            print(
+                "::error file={},line={}::{}: {} -- {}".format(
+                    _annot_property(rel),
+                    line_no,
+                    name,
+                    _annot_message(repr(text)),
+                    why[name],
+                )
+            )
+    for rel, reason in sorted(unscannable):
+        print("::error file={}::{}".format(_annot_property(rel), _annot_message(reason)))
+    if current or unscannable:
+        if current:
+            print(f"\n{REMEDY}", file=sys.stderr)
+        total = sum(len(hits) for hits in current.values())
+        print(
+            f"builtin-skill-scope gate FAILED: {total} marker(s) in "
+            f"{len(current)} file(s), {len(unscannable)} unscannable file(s).",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "builtin-skill-scope gate passed: no repository markers in a shipped skill "
+        f"outside {EXEMPT_FAMILY}/."
+    )
+    return 0
+
+
+_PROBES: tuple[tuple[str, str, int], ...] = (
+    ("clean prose", "Open the dashboard and pick a theme.\n", 0),
+    ("product CLI is not a marker", "Run `kirocrew pod up mypod --provision`.\n", 0),
+    ("runtime path is not a marker", "Scripts live under `~/.kiro/crew/crons/`.\n", 0),
+    (
+        "installed package path is not a marker",
+        "See `kiro_crew/dashboard/theme_validate.py`.\n",
+        0,
+    ),
+    ("repo slug", "File it on kirodotdev/KiroCrew please.\n", 1),
+    (
+        "a resolvable public URL to this repo is NOT a marker",
+        "See https://github.com/kirodotdev/KiroCrew/blob/main/README.md\n",
+        0,
+    ),
+    ("checkout path", "Edit `src/kiro_crew/dashboard/state.py`.\n", 1),
+    ("test path", "Run `test/test_prepare_pr_status.py`.\n", 1),
+    ("workflow path", "Wire it into `.github/workflows/ci.yml`.\n", 1),
+    ("workflow path, yaml spelling", "See .github/workflows/ci.yaml\n", 1),
+    (
+        "two classes on one line are both reported",
+        "`src/kiro_crew/x.py` is covered by `test/test_x.py`.\n",
+        2,
+    ),
+    (
+        "two markers on separate lines",
+        "First `src/kiro_crew/a.py`.\nThen `src/kiro_crew/b.py`.\n",
+        2,
+    ),
+)
+
+
+def self_test() -> int:
+    failures = 0
+    for desc, text, expected in _PROBES:
+        got = len(marker_hits(text))
+        ok = got == expected
+        failures += 0 if ok else 1
+        print(f"  [{'ok' if ok else 'FAIL'}] {desc}: expected {expected}, got {got}")
+    # The exemption and the unreadable path are part of the rule, so both are
+    # self-tested rather than left to the test suite alone -- CI runs --test
+    # first precisely so a weakened rule fails before the gate reports green.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        leak = "Edit `src/kiro_crew/x.py`.\n"
+        for rel in (
+            f"{EXEMPT_FAMILY}/prepare-pr/SKILL.md",
+            f"{EXEMPT_FAMILY}/prepare-pr/references/notes.md",
+            "widgets/SKILL.md",
+            f"widgets/{EXEMPT_FAMILY}/SKILL.md",
+            "kirocrew-devtools/SKILL.md",
+        ):
+            path = root / SKILL_ROOT / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(leak, encoding="utf-8")
+        undecodable = root / SKILL_ROOT / "widgets" / "binary.md"
+        undecodable.write_bytes(b"\xff\xfe not utf-8 \x80\x81")
+        # A symlink is refused before any read. The target is a dangling path on
+        # purpose: refusal must not depend on it existing, and pointing a probe at
+        # /dev/zero would make a regression HANG this self-test instead of failing
+        # it (that hang is real -- it is why the guard exists).
+        #
+        # Creating one can be UNAVAILABLE rather than merely awkward: on Windows
+        # it needs SeCreateSymbolicLinkPrivilege, which an ordinary account does
+        # not hold, and this self-test runs from the prepare-pr gate floor on
+        # contributor machines as well as on ubuntu in CI. Letting the OSError
+        # escape would abort the gate with a crash instead of a verdict, so the
+        # probe is skipped where the privilege is missing and says so -- the same
+        # probe-not-guess approach test/conftest.py's requires_symlinks takes.
+        linked = root / SKILL_ROOT / "widgets" / "linked.md"
+        symlinks_available = True
+        try:
+            linked.symlink_to(root / "nowhere.md")
+        except (OSError, NotImplementedError, AttributeError):
+            symlinks_available = False
+        found, unscannable = scan_tree(root)
+        flagged = set(found)
+        reasons = dict(unscannable)
+        cases = (
+            (
+                f"{EXEMPT_FAMILY}/ body is exempt",
+                f"{SKILL_ROOT.as_posix()}/{EXEMPT_FAMILY}/prepare-pr/SKILL.md" not in flagged,
+            ),
+            (
+                f"nested {EXEMPT_FAMILY}/ reference file is exempt",
+                f"{SKILL_ROOT.as_posix()}/{EXEMPT_FAMILY}/prepare-pr/references/notes.md"
+                not in flagged,
+            ),
+            (
+                "a repository-agnostic body is scanned",
+                f"{SKILL_ROOT.as_posix()}/widgets/SKILL.md" in flagged,
+            ),
+            (
+                f"a NESTED {EXEMPT_FAMILY}/ does not inherit the exemption",
+                f"{SKILL_ROOT.as_posix()}/widgets/{EXEMPT_FAMILY}/SKILL.md" in flagged,
+            ),
+            (
+                "a look-alike sibling does not inherit the exemption",
+                f"{SKILL_ROOT.as_posix()}/kirocrew-devtools/SKILL.md" in flagged,
+            ),
+            (
+                "an undecodable body is reported, not skipped",
+                "UTF-8" in reasons.get(f"{SKILL_ROOT.as_posix()}/widgets/binary.md", ""),
+            ),
+        )
+        for desc, ok in cases:
+            failures += 0 if ok else 1
+            print(f"  [{'ok' if ok else 'FAIL'}] {desc}")
+        total = len(_PROBES) + len(cases)
+        if symlinks_available:
+            ok = "symlink" in reasons.get(f"{SKILL_ROOT.as_posix()}/widgets/linked.md", "")
+            failures += 0 if ok else 1
+            total += 1
+            print(f"  [{'ok' if ok else 'FAIL'}] a symlinked body is refused unread")
+        else:
+            print("  [skip] symlink refusal: no privilege to create one here")
+    if failures:
+        print(f"self-test: {failures} probe(s) failed", file=sys.stderr)
+        return 1
+    print(f"self-test: all {total} probes passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--test" in argv:
+        return self_test()
+    current, unreadable = scan_tree(ROOT)
+    return _report(current, unreadable)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/profiles/kirocrew.json
@@ -21,6 +21,8 @@
     "BASE=\"$(git merge-base HEAD origin/main)\" && HARNESS_BASE_REF=\"$BASE\" python3 scripts/check_harness_parity.py",
     "python3 scripts/check_loop_bound_locks.py --test",
     "python3 scripts/check_loop_bound_locks.py",
+    "python3 scripts/check_builtin_skill_scope.py --test",
+    "python3 scripts/check_builtin_skill_scope.py",
     "python3 scripts/check_testpaths_coverage.py --test",
     "python3 scripts/check_testpaths_coverage.py",
     "python3 scripts/check_changelog_history.py --test",

--- a/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
+++ b/src/kiro_crew/builtin_skills/theme-pack-authoring/SKILL.md
@@ -8,8 +8,8 @@ triggers: theme pack, custom theme, theme.json, variables.json, overrides.css, i
 
 House rules for building theme packs. The authoritative contract is
 [`website/docs/theming-contract.md`](https://github.com/kirodotdev/KiroCrew/blob/main/website/docs/theming-contract.md);
-this skill is the task-oriented digest, plus the traps that cost real
-debugging time.
+this skill is the self-contained task-oriented digest, plus the traps that cost
+real debugging time.
 
 ## Pack anatomy
 
@@ -74,7 +74,7 @@ a level-0 pack shipping a font is refused.
 Two blocks, `dark` and `light`, each holding up to **54 allowlisted variables**.
 Required minimum per block: `--bg`, `--text`, `--accent`. Unknown keys are
 REJECTED (install fails), so do not invent variables; the allowlist is
-`_THEME_CSS_VARS` in `src/kiro_crew/dashboard/theme_validate.py`.
+`_THEME_CSS_VARS` in `kiro_crew/dashboard/theme_validate.py`.
 
 - To clone a built-in theme's palette, transcribe its block from
   `website/src/index.css` (e.g. `[data-theme="kiro-dark"]`), keeping only

--- a/test/test_builtin_skill_scope.py
+++ b/test/test_builtin_skill_scope.py
@@ -1,0 +1,305 @@
+"""Behavioural tests for scripts/check_builtin_skill_scope.py.
+
+Local backlog f-20260818-08. Everything under ``src/kiro_crew/builtin_skills/``
+installs on every machine that installs Kiro Crew, so a skill body naming THIS
+repository resolves for exactly one reader and points an agent at a path that does
+not exist for anyone else. ``prepare-pr`` already solved it -- repository
+specifics live in a profile keyed by repository -- and this gate keeps the rest of
+the tree from regressing.
+
+The rule is absolute: no baseline, no recorded exemptions. Three properties carry
+it and all three are tested rather than assumed -- the marker set must catch
+repository shapes WITHOUT catching the product surface a builtin skill exists to
+describe, the exemption must not be inheritable by a nested or look-alike
+directory, and a file the gate cannot read must fail rather than pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from skill_script_helpers import load_skill_script
+
+from conftest import requires_symlinks
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_builtin_skill_scope.py"
+SKILL_REL = "src/kiro_crew/builtin_skills"
+
+
+# The name the injection test needs contains LF and ':', both of which Windows
+# rejects outright (OSError 22). PROBE for it rather than guessing the platform,
+# the same way test/conftest.py's requires_symlinks probes for the symlink
+# privilege instead of blanket-skipping Windows: the assertion is about a name a
+# fork author could commit, so it should run wherever such a name can exist.
+#
+# Skipping it loses nothing about the DEFENCE -- the escaping itself is covered by
+# formatter tests that run on every platform. What this one adds is proof the
+# scanner reaches such a file at all, which only means anything where the file
+# can be created.
+def _can_create_exotic_filename() -> bool:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            Path(tmp, "a\n::b.md").write_text("x", encoding="utf-8")
+        except (OSError, ValueError):
+            return False
+        return True
+
+
+requires_exotic_filenames = pytest.mark.skipif(
+    not _can_create_exotic_filename(),
+    reason="this platform rejects a filename containing LF or ':'",
+)
+
+
+@pytest.fixture(scope="module")
+def gate():
+    return load_skill_script("check_builtin_skill_scope", SCRIPT)
+
+
+def _write(root: Path, rel: str, text: str) -> None:
+    path = root / SKILL_REL / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestTheMarkerSet:
+    """Repository shapes are markers; the product surface is not. Getting the
+    second half wrong would gate the content builtin skills exist to carry."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "File it on kirodotdev/KiroCrew please.",
+            "Edit `src/kiro_crew/dashboard/state.py`.",
+            "Run `test/test_prepare_pr_status.py` first.",
+            "Wire it into `.github/workflows/ci.yml`.",
+            "See .github/workflows/pr-readiness.yaml",
+        ],
+    )
+    def test_repository_shapes_are_flagged(self, gate, text: str) -> None:
+        assert gate.marker_hits(text + "\n"), text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "See https://github.com/kirodotdev/KiroCrew/blob/main/README.md",
+            "Contract: [theming](https://github.com/kirodotdev/KiroCrew/blob/main/x.md)",
+        ],
+    )
+    def test_a_resolvable_public_url_is_not_a_marker(self, gate, text: str) -> None:
+        """This repository is PUBLIC (checked, not assumed), so a github.com URL
+        into it resolves on every machine -- it is a citation, not an instruction
+        only a contributor can act on. Treating both alike forces a downgrade: it
+        replaces a fetchable link to the authoritative theming contract with prose
+        an installed reader cannot follow."""
+        assert gate.marker_hits(text + "\n") == [], text
+
+    def test_a_bare_slug_next_to_a_url_is_still_flagged(self, gate) -> None:
+        """The narrowing is a lookbehind on `github.com/`, not a whole-line
+        exemption: a line may carry both a citation and a real instruction."""
+        hits = gate.marker_hits(
+            "See https://github.com/kirodotdev/KiroCrew/blob/main/x.md, "
+            "then file it on kirodotdev/KiroCrew.\n"
+        )
+        assert [name for _line, name, _text in hits] == ["repo-slug"]
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Run `kirocrew pod up mypod --provision`.",
+            "Scripts must live under `~/.kiro/crew/crons/`.",
+            "Set `session.autocompact_pct` in the config.",
+            "Call the `monitor_start` MCP tool.",
+            # No src/ prefix: this is what an installed wheel actually has, so
+            # flagging it would make the remedy impossible to write.
+            "See `kiro_crew/dashboard/theme_validate.py`.",
+            "Open the dashboard's Browser panel.",
+        ],
+    )
+    def test_the_product_surface_is_not_a_marker(self, gate, text: str) -> None:
+        assert gate.marker_hits(text + "\n") == [], text
+
+    def test_each_hit_names_its_class_and_line(self, gate) -> None:
+        """A bare match is not actionable -- the remedy differs per class."""
+        hits = gate.marker_hits("intro\n`src/kiro_crew/a.py` and `test/test_a.py`\n")
+        assert [(line, name) for line, name, _text in hits] == [
+            (2, "checkout-path"),
+            (2, "test-path"),
+        ]
+
+    def test_two_markers_on_one_line_both_report(self, gate) -> None:
+        assert len(gate.marker_hits("`src/kiro_crew/a.py` vs `src/kiro_crew/b.py`\n")) == 2
+
+
+class TestTheExemptionIsNotInheritable:
+    def test_the_family_is_exempt(self, gate, tmp_path: Path) -> None:
+        """This repository is that family's subject matter, not a leak in it."""
+        _write(tmp_path, "kirocrew-dev/prepare-pr/SKILL.md", "Edit `src/kiro_crew/x.py`.\n")
+        found, unscannable = gate.scan_tree(tmp_path)
+        assert found == {} and unscannable == []
+
+    def test_a_nested_reference_file_is_exempt_too(self, gate, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "kirocrew-dev/prepare-pr/references/gate-floor.md",
+            "Run `test/test_prepare_pr_profiles.py`.\n",
+        )
+        assert gate.scan_tree(tmp_path)[0] == {}
+
+    def test_a_repository_agnostic_family_is_scanned(self, gate, tmp_path: Path) -> None:
+        _write(tmp_path, "widgets/SKILL.md", "Edit `src/kiro_crew/x.py`.\n")
+        assert list(gate.scan_tree(tmp_path)[0]) == [f"{SKILL_REL}/widgets/SKILL.md"]
+
+    def test_a_nested_family_directory_does_not_inherit_the_exemption(
+        self, gate, tmp_path: Path
+    ) -> None:
+        """Matching any path segment would let an agnostic skill ship a leak by
+        putting it in a subdirectory that merely shares the exempt name."""
+        _write(tmp_path, "widgets/kirocrew-dev/SKILL.md", "Edit `src/kiro_crew/x.py`.\n")
+        assert list(gate.scan_tree(tmp_path)[0]) == [f"{SKILL_REL}/widgets/kirocrew-dev/SKILL.md"]
+
+    def test_a_look_alike_sibling_does_not_inherit_the_exemption(
+        self, gate, tmp_path: Path
+    ) -> None:
+        _write(tmp_path, "kirocrew-devtools/SKILL.md", "Edit `src/kiro_crew/x.py`.\n")
+        assert list(gate.scan_tree(tmp_path)[0]) == [f"{SKILL_REL}/kirocrew-devtools/SKILL.md"]
+
+    def test_a_path_outside_the_skill_root_is_never_exempt(self, gate) -> None:
+        assert gate.is_exempt(Path("docs/kirocrew-dev/notes.md")) is False
+
+
+class TestAnUnscannableBodyFails:
+    def test_undecodable_markdown_is_reported_not_skipped(self, gate, tmp_path: Path) -> None:
+        """A gate that silently passes what it could not decode ships the one
+        file nobody scanned."""
+        path = tmp_path / SKILL_REL / "widgets" / "binary.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\xff\xfe not utf-8 \x80\x81")
+        found, unscannable = gate.scan_tree(tmp_path)
+        assert found == {}
+        assert [rel for rel, _why in unscannable] == [f"{SKILL_REL}/widgets/binary.md"]
+        assert "UTF-8" in dict(unscannable)[f"{SKILL_REL}/widgets/binary.md"]
+
+    @requires_symlinks
+    def test_a_symlinked_body_is_refused_without_being_read(self, gate, tmp_path: Path) -> None:
+        """The rule is "a body is a regular file", which is what makes it safe to
+        enforce: deciding per target would mean READING the target to decide, and
+        a candidate symlinked to /dev/zero streams nulls until CI kills the job
+        (measured out of band -- deliberately not reproduced here, because a test
+        that hangs on regression burns the job timeout instead of failing).
+
+        The target is therefore a dangling path: refusal must not depend on the
+        target existing, let alone on what it contains."""
+        path = tmp_path / SKILL_REL / "widgets" / "linked.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.symlink_to(tmp_path / "nowhere.md")
+        found, unscannable = gate.scan_tree(tmp_path)
+        assert found == {}
+        assert "symlink" in dict(unscannable)[f"{SKILL_REL}/widgets/linked.md"]
+
+    @requires_symlinks
+    def test_a_symlink_to_a_clean_body_is_still_refused(self, gate, tmp_path: Path) -> None:
+        """The rule is "a body is a regular file", not "a body must not be
+        dangerous": deciding per target would mean reading the target to decide."""
+        real = tmp_path / SKILL_REL / "widgets" / "SKILL.md"
+        real.parent.mkdir(parents=True, exist_ok=True)
+        real.write_text("Clean prose.\n", encoding="utf-8")
+        (tmp_path / SKILL_REL / "widgets" / "alias.md").symlink_to(real)
+        _found, unscannable = gate.scan_tree(tmp_path)
+        assert [rel for rel, _why in unscannable] == [f"{SKILL_REL}/widgets/alias.md"]
+
+    def test_an_unscannable_file_alone_fails_the_gate(self, gate, capsys) -> None:
+        assert gate._report({}, [("a.md", "is a symlink")]) == 1
+        out = capsys.readouterr()
+        assert "1 unscannable file" in out.err
+        assert "is a symlink" in out.out, "the reason must reach the annotation"
+
+
+class TestAnnotationsCannotBeForged:
+    """The runner parses `::` commands on every output line, so an untrusted
+    filename reaching an annotation unescaped forges annotations rather than
+    merely looking odd. Reachable from a fork: ci.yml runs on `pull_request`, so
+    the checkout contains the PR's files."""
+
+    def test_a_newline_in_a_name_cannot_open_a_second_annotation(self, gate, capsys) -> None:
+        forged = "widgets/a\n::error::forged.md"
+        assert gate._report({forged: [(1, "test-path", "test/test_a.py")]}, []) == 1
+        out = capsys.readouterr().out
+        assert "%0A" in out
+        assert "\n::error::forged" not in out
+        # Exactly one annotation line, which is the property under test.
+        assert len([ln for ln in out.splitlines() if ln.startswith("::error")]) == 1
+
+    def test_a_colon_or_comma_cannot_split_the_property_list(self, gate, capsys) -> None:
+        assert gate._report({}, [("widgets/a:b,c.md", "is a symlink")]) == 1
+        line = capsys.readouterr().out.splitlines()[0]
+        assert "file=widgets/a%3Ab%2Cc.md::" in line
+
+    def test_a_percent_is_escaped_first(self, gate, capsys) -> None:
+        """`%` must go first or the escapes would be double-decoded by the runner."""
+        assert gate._report({}, [("widgets/100%.md", "is a symlink")]) == 1
+        assert "widgets/100%25.md" in capsys.readouterr().out
+
+    def test_the_marker_text_is_escaped_too(self, gate, capsys) -> None:
+        """Marker text comes from file CONTENT, so it is untrusted as well."""
+        assert gate._report({"a.md": [(1, "repo-slug", "kirodotdev/KiroCrew%0A")]}, []) == 1
+        assert "%250A" in capsys.readouterr().out
+
+    @requires_exotic_filenames
+    def test_a_real_newline_named_file_is_scanned_and_annotated_safely(
+        self, gate, tmp_path: Path, capsys
+    ) -> None:
+        """End to end, not just the formatter: git can carry a name containing a
+        newline, so the scanner must reach one and still emit one annotation."""
+        d = tmp_path / SKILL_REL / "widgets"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "a\n::error::forged.md").write_text("Edit `src/kiro_crew/x.py`.\n", encoding="utf-8")
+        found, unscannable = gate.scan_tree(tmp_path)
+        assert len(found) == 1 and unscannable == []
+        assert gate._report(found, unscannable) == 1
+        out = capsys.readouterr().out
+        assert len([ln for ln in out.splitlines() if ln.startswith("::error")]) == 1
+
+
+class TestTheGateFailsOnAMarker:
+    def test_a_single_marker_fails(self, gate, capsys) -> None:
+        current = {"a.md": [(1, "checkout-path", "src/kiro_crew/a.py")]}
+        assert gate._report(current, []) == 1
+        err = capsys.readouterr().err
+        assert "1 marker(s) in 1 file(s)" in err
+        assert "prepare-pr/profiles" in err, "the remedy must name the profile pattern"
+
+    def test_a_clean_tree_passes(self, gate) -> None:
+        assert gate._report({}, []) == 0
+
+
+class TestTheCommittedTreeAgrees:
+    def test_the_real_tree_is_clean(self, gate) -> None:
+        """No baseline exists, so this is the whole ratchet: the shipped tree
+        must carry zero markers outside the exempt family."""
+        found, unscannable = gate.scan_tree(ROOT)
+        assert found == {}, f"markers present: {found}"
+        assert unscannable == []
+
+    def test_there_is_no_baseline_to_rot(self, gate) -> None:
+        """The shrink-only baseline was deleted deliberately -- ~90 lines of
+        machinery to forgive two markers is a worse trade than fixing them, and
+        a gate with nothing to forgive cannot drift into forgiving everything."""
+        assert not (ROOT / ".github" / "builtin-skill-scope-baseline.txt").exists()
+        source = SCRIPT.read_text(encoding="utf-8")
+        assert "--update-baseline" not in source
+
+    def test_the_self_test_passes(self, gate, capsys) -> None:
+        assert gate.self_test() == 0
+        assert "FAIL" not in capsys.readouterr().out
+
+    def test_the_gate_is_wired_into_ci(self) -> None:
+        """A scanner nothing runs is documentation. Also pinned in the prepare-pr
+        gate floor by test_prepare_pr_profiles.py."""
+        ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        assert "python3 scripts/check_builtin_skill_scope.py --test" in ci
+        assert "python3 scripts/check_builtin_skill_scope.py\n" in ci


### PR DESCRIPTION
## Problem / Motivation

Everything under `src/kiro_crew/builtin_skills/` installs on every machine that
installs Kiro Crew. A skill body that tells the reader to act on **this**
repository -- edit a `src/` checkout path, run a test file, wire a workflow --
gives an instruction that only one reader can follow: someone working on Kiro
Crew itself. For everyone else it is dead, and for an agent it is worse than
dead: a confident pointer at a path that does not exist, which the agent will try.

`prepare-pr` already solved this and was the only part of the tree that had. Its
repository specifics live in a **profile keyed by repository**
(`prepare-pr/profiles/`, resolved by `resolve_profile.py`), so the body says "run
the gate floor" and the profile says what that means here. No other builtin skill
had an equivalent guard, so nothing stopped the next edit from writing a
repository path into a skill that ships everywhere.

Measured on the tree: 31 skill bodies, and all but two of the markers live in the
`kirocrew-dev/` family -- which is the family *for* developing this repository, so
those are its subject matter rather than a leak.

## Why it matters

This is the regression direction, not a cleanup. The handful of live markers were
small enough to fix in this change; what was missing is anything that notices the
next one. A skill body is the highest-leverage place in the tree for a wrong path,
because an agent reads it as an instruction rather than as prose.

## What changed

`scripts/check_builtin_skill_scope.py` scans every `.md` under `builtin_skills`
for four marker classes, reported **by class name** because the remedy differs per
class:

| class | shape | why it is repository-specific |
| --- | --- | --- |
| `repo-slug` | a bare `kirodotdev/KiroCrew` **not** preceded by `github.com/` | names this repository as a place to act |
| `checkout-path` | `src/kiro_crew/...` | an installed wheel has `kiro_crew/` with **no** `src/` prefix, so this form resolves only in a clone |
| `test-path` | `test/test_*.py` | this repository's test layout |
| `workflow-path` | `.github/workflows/*.yml` | this repository's CI |

**The rule is absolute -- no baseline, nothing exempted by record.** The tree's
two live markers are fixed here instead: `theme-pack-authoring`'s
`src/kiro_crew/dashboard/theme_validate.py` becomes `kiro_crew/...` so it resolves
inside an installed package. A shrink-only baseline was written first and deleted
during review: ~90 lines of machinery to keep forgiving two markers in one file is
a worse trade than fixing them, and a gate with nothing to forgive cannot rot into
one that forgives everything.

**A resolvable public URL to this repository is deliberately not a marker.** This
repository is public, so `https://github.com/kirodotdev/KiroCrew/blob/main/...`
resolves on every machine -- it is a citation, not an instruction only a
contributor can act on. An earlier revision of this PR treated both alike, which
made the gate force a real downgrade: it replaced a fetchable link to the
authoritative theming contract with prose an installed reader could not follow at
all. Design Review caught that, the link is restored, and the narrowing is a
lookbehind rather than a whole-line exemption so a line may carry both a citation
and a real instruction.

**The product surface is not a marker either** -- the `kirocrew` CLI,
`~/.kiro/crew/...` runtime paths, config keys, MCP tool names. Those ship *with*
the skill and are correct on every install. Six probes pin that half, including
`kiro_crew/dashboard/theme_validate.py` (no `src/` prefix) staying clean, because
otherwise the remedy would be impossible to write.

**The `kirocrew-dev/` family is exempt by directory**, matched as the family
*directly beneath* `builtin_skills/` so that neither a nested
`widgets/kirocrew-dev/` nor a look-alike `kirocrew-devtools/` sibling can inherit
it. What the gate deliberately does **not** judge is whether that family should
ship to every install at all.

**A skill body must be a regular UTF-8 text file.** A symlink is refused before
any read -- one pointing at `/dev/zero` makes the read stream nulls until CI kills
the job (measured) -- and that closes the class, because git carries only regular
files, symlinks and gitlinks. An undecodable body fails rather than being skipped:
a gate that silently passes what it could not read ships the one file nobody
scanned.

**Annotations are escaped per GitHub's workflow-command rules.** A filename is
attacker-chosen on a fork PR, and the runner parses `::` commands on every output
line, so `%`, carriage return and line feed are escaped in messages and `:`/`,`
additionally in property values. Marker text is escaped too, since it comes from
file content.

Wired into `ci.yml` as its own job (self-test, then gate) and into the prepare-pr
gate floor as **both** entries, which `test_prepare_pr_profiles.py` requires of
every blocking scan.

## Tests

Targeted runs only; CI runs the full suite.

- `test/test_builtin_skill_scope.py`, 37 cases: the marker set (repository shapes
  flagged, product surface and public URLs not, and a bare slug beside a URL still
  flagged); the exemption (family exempt, nested reference files exempt, an
  agnostic family scanned, and neither a nested nor a look-alike directory
  inheriting it); unscannable bodies (undecodable and symlinked both refused, with
  the reason reaching the annotation); annotation forging (LF cannot open a second
  annotation, `:`/`,` cannot split the property list, `%` is escaped first, marker
  text is escaped, plus one end-to-end case on a real file whose *name* contains
  `\n::error::`); and agreement with the committed tree (clean, no baseline to rot,
  self-test passes, gate wired into CI).
- `python3 scripts/check_builtin_skill_scope.py --test`: 19 probes, run first in CI
  so a rule that silently stops matching fails there instead of shipping green.
- Two capability probes rather than platform guesses, matching
  `test/conftest.py`'s `requires_symlinks` reasoning: the symlink cases skip where
  the privilege is missing, and the exotic-filename case skips where the OS rejects
  LF or `:` in a name. Both were CI failures first (an unelevated-Windows crash and
  a Windows `OSError 22`) and are fixed rather than papered over.
- Mutation-verified in six independent weakenings, each caught by the tests that
  claim it: any-segment exemption matching, disabling the `checkout-path` class,
  removing the symlink guard, skipping undecodable files silently, dropping the
  annotation escaping, and removing the public-URL narrowing.
- Gates green: `flake8`, `isort`, `check_black_formatting.py`,
  `check_subprocess_encoding.py`, `check_testpaths_coverage.py`,
  `check_harness_parity.py`, `docs_lint.py`, `test_prepare_pr_profiles.py`, and the
  repo's pinned `woke` 0.19.0 run over the added lines (checksum verified against
  `code-review.yml`).

## Other suggestions

- **Known limit, declared in the script.** Repository paths outside the four
  classes are not caught: `website/...` and `docs/system-specs/...` are as
  checkout-only as `src/kiro_crew/`, and there are 4 such references in 2
  non-exempt skills today (`theme-pack-authoring` lines 10 and 80, `web-verify`
  lines 26 and 144). Widening the set means fixing those references in the same
  breath, which is a content argument this gate should not smuggle in. Read the
  gate as "these four shapes are extinct", not "no repository path can reach a
  skill".
- **The annotation-escaping hazard has siblings.** `check_black_formatting.py:247`
  and `check_subprocess_encoding.py:385,420,428` still interpolate a
  fork-controllable path raw into `::error file=`. Same defect, different scripts;
  captured locally rather than folded in here, since each needs its own tests.
- **Design's packaging idea is the better long-term answer** for public-docs
  citations: shipping the theming contract in a packaged doc tree would let the
  skill point at something that resolves offline. That is a packaging change, not
  a scanner change.
