### PR TITLE
ci: close the last artipacked omission and ratchet the rule behind it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Check that every pytest test file sits under a collected root
         # setup.cfg pins `testpaths`, so a test_*.py file created outside those

--- a/test/test_workflow_checkout_credentials.py
+++ b/test/test_workflow_checkout_credentials.py
@@ -1,0 +1,156 @@
+"""Repo-wide ratchet for checkout credential persistence.
+
+`actions/checkout` writes the job's `GITHUB_TOKEN` into `.git/config` unless
+`persist-credentials: false` is set, leaving a live push-capable credential in
+the worktree for every later step to read (zizmor `artipacked`).
+
+PR #6492 swept this class: 51 checkouts were pure omissions and got the opt-out,
+and 11 were kept deliberately because the job authenticates a real git
+operation -- `git fetch origin` through the shared diff-base resolver, or
+`git push --force-with-lease` to open a bot PR. Each of those 11 got an inline
+`# persist-credentials retained:` comment naming the job and the operation.
+
+That convention then held only by habit, and a 12th instance leaked in with the
+`testpaths-coverage` gate (#6577's follow-on): a whole-tree scan that runs no
+git operation at all, so it never needed the credential and carried no comment
+explaining why it had one. Nothing failed -- the omission was invisible until
+the next manual zizmor triage.
+
+These tests make the convention machine-checked, so the decision has to be
+made rather than defaulted:
+
+  * a checkout either opts out, or states why it cannot;
+  * a checkout that opts out must not also claim retention, so a later fix
+    cannot leave a stale rationale behind that reads as an approved residual.
+
+Deliberately text-based, not YAML-parsed: the rationale lives in a COMMENT, and
+PyYAML discards comments, so a parsed representation cannot see the half of the
+invariant that carries the reasoning.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# The list-item form is the only one this repo uses for checkout steps.
+CHECKOUT_RE = re.compile(r"^(\s*)-\s+uses:\s+actions/checkout@")
+OPT_OUT = "persist-credentials: false"
+RETAINED_RE = re.compile(r"#\s*persist-credentials retained:")
+
+
+def _workflow_files() -> list[Path]:
+    return sorted(p for p in WORKFLOWS.glob("*.yml") if p.is_file())
+
+
+def _checkout_steps(path: Path) -> list[tuple[int, bool, bool]]:
+    """Every checkout step in one workflow.
+
+    Returns (line number, opts out, carries a retention rationale). The step's
+    own block is the run of lines indented deeper than its `- ` marker; the
+    rationale is searched in the unbroken run of comment lines directly above
+    it, which is where #6492 put all eleven.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    found: list[tuple[int, bool, bool]] = []
+
+    for i, line in enumerate(lines):
+        match = CHECKOUT_RE.match(line)
+        if match is None:
+            continue
+        indent = len(match.group(1))
+
+        body: list[str] = []
+        for following in lines[i + 1 :]:
+            if not following.strip():
+                continue
+            if len(following) - len(following.lstrip()) <= indent:
+                break
+            body.append(following)
+        opts_out = any(OPT_OUT in entry for entry in body)
+
+        rationale = False
+        for previous in reversed(lines[:i]):
+            stripped = previous.strip()
+            if not stripped:
+                break
+            if not stripped.startswith("#"):
+                break
+            if RETAINED_RE.search(previous):
+                rationale = True
+        found.append((i + 1, opts_out, rationale))
+
+    return found
+
+
+def test_the_scan_actually_finds_the_checkouts() -> None:
+    """Guard the guard: a regex that silently stops matching would make every
+    assertion below vacuously true, which is how a ratchet rots into decoration."""
+    total = sum(len(_checkout_steps(path)) for path in _workflow_files())
+    assert total > 40, (
+        f"only {total} checkout steps found across {len(_workflow_files())} workflows; "
+        "CHECKOUT_RE has stopped matching the form this repo uses"
+    )
+
+
+def test_every_checkout_either_opts_out_or_documents_why() -> None:
+    """The invariant. A checkout that keeps the credential must say why."""
+    offenders: list[str] = []
+    for path in _workflow_files():
+        for line_no, opts_out, rationale in _checkout_steps(path):
+            if not opts_out and not rationale:
+                offenders.append(f"{path.name}:{line_no}")
+
+    assert offenders == [], (
+        "these actions/checkout steps keep the GITHUB_TOKEN in .git/config with no "
+        f"stated reason: {', '.join(offenders)}. Either add\n"
+        "    with:\n"
+        f"      {OPT_OUT}\n"
+        "or, if the job genuinely authenticates a git operation, add a comment "
+        "directly above the step naming the job and the operation:\n"
+        "    # persist-credentials retained: <job>/<step> runs <git operation>"
+    )
+
+
+def test_no_checkout_both_opts_out_and_claims_retention() -> None:
+    """The other direction. A step that was later fixed must not keep a stale
+    rationale, which would read to the next auditor as an approved residual."""
+    contradictions: list[str] = []
+    for path in _workflow_files():
+        for line_no, opts_out, rationale in _checkout_steps(path):
+            if opts_out and rationale:
+                contradictions.append(f"{path.name}:{line_no}")
+
+    assert contradictions == [], (
+        f"these checkout steps set `{OPT_OUT}` yet still carry a "
+        f"`# persist-credentials retained:` comment: {', '.join(contradictions)}. "
+        "The credential is not retained; delete the stale comment."
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "add-contributor.yml",
+        "ci.yml",
+        "cleanup-temp-screenshots.yml",
+        "memory-benchmark.yml",
+        "test-durations.yml",
+    ],
+)
+def test_the_known_residual_carriers_still_state_their_reason(name: str) -> None:
+    """The five files that legitimately retain the credential somewhere. Pinned
+    by name so that stripping every rationale comment from one of them fails
+    here loudly, instead of quietly passing the invariant above by making the
+    step look like a plain opt-out."""
+    steps = _checkout_steps(WORKFLOWS / name)
+    assert any(rationale for _, _, rationale in steps), (
+        f"{name} carries no `# persist-credentials retained:` rationale on any "
+        "checkout. If its git operations were removed, the checkout should now "
+        f"set `{OPT_OUT}` and this file should come off this list."
+    )


### PR DESCRIPTION
## Problem / Motivation

Two related things, one of which is a live omission and one of which is why it happened.

`.github/workflows/ci.yml` has a `testpaths-coverage` job whose checkout keeps the default `persist-credentials`, so the job's `GITHUB_TOKEN` is written into `.git/config` where every later step can read it (zizmor `artipacked`). The job runs `scripts/check_testpaths_coverage.py` whole-tree — no `fetch`, `push`, `tag` or `commit` — so it never needed the credential.

It was the **12th** `artipacked` finding on main, and the only one of the twelve that is fixable rather than documentable. The other eleven are deliberate: those jobs authenticate a real git operation, and each carries an inline comment naming the job and the operation.

The second problem is how it got in. PR #6492 swept this class — 51 omissions fixed, 11 residuals kept and each given a rationale comment — but that convention then held **only by habit**. Nothing checked it, so when the `testpaths-coverage` gate landed (a follow-on to #6577) its bare checkout passed review unnoticed. It surfaced only in a later manual zizmor triage.

## Why it matters

The concrete leak is small: a read-only gate holding a push-capable token it does not use. The structural problem is the one worth fixing. Every one of the remaining eleven `artipacked` findings is safe *because someone wrote down why*, and that made "is there a rationale comment?" a reliable proxy for "is this deliberate?" — a proxy that only works while the convention is actually enforced. Left as habit, the next credential-holding job to land is a coin flip, and the failure mode is silent: nothing breaks, the finding just sits in the audit output until a human happens to re-triage it.

## What changed (motivation → approach → change)

**The fix.** One opt-out on the `testpaths-coverage` checkout:

```yaml
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
```

**The approach for the ratchet.** The invariant to enforce is not "always set `persist-credentials: false`" — eleven jobs legitimately cannot. It is *the decision must be made rather than defaulted*: a checkout either opts out, or states why it cannot. That makes the rationale comment load-bearing, which forces one design consequence: the check is **text-based, not YAML-parsed**. The rationale lives in a comment and PyYAML discards comments, so a parsed representation cannot see the half of the invariant that carries the reasoning.

**What was built.** `test/test_workflow_checkout_credentials.py`, four assertions over every `actions/checkout` in `.github/workflows`:

1. **The invariant** — each checkout either sets `persist-credentials: false` or carries a `# persist-credentials retained:` comment directly above it. The failure message prints the offending `file:line` and both remedies.
2. **The other direction** — a checkout that *does* opt out must not still carry a retention comment. Without this, a later fix can leave a stale rationale behind that reads to the next auditor as an approved residual, and the convention silently stops meaning anything.
3. **The residual carriers are pinned by name** — the five files that legitimately retain the credential must each still state a reason somewhere. Stripping every rationale out of one of them would otherwise pass assertion 1 by making the step look like a plain opt-out.
4. **Guard the guard** — the scan must still match more than 40 checkouts, so a regex that quietly stops matching cannot make the whole suite vacuously green.

## Tests

`test/test_workflow_checkout_credentials.py` — 8 tests (4 assertions, one of them parametrized over the 5 residual-carrying files).

**Mutation-verified in both directions**, which is the only evidence that a ratchet actually ratchets:

| Mutation | Result |
|---|---|
| Revert the `ci.yml` opt-out | fails with exactly `ci.yml:345` |
| Plant a stale `# persist-credentials retained:` above an already-opted-out checkout | fails with exactly `ci.yml:68` |

Regression scope: **546 tests pass** across the 14 existing suites that read `ci.yml` (`test_black_gate_contract`, `test_local_gate`, `test_pr_readiness_evaluate`, `test_prepare_pr_status`, `test_node_version_pins`, `test_vendor_manifest`, and the rest) plus `test_workflow_secret_and_cache_scope.py`.

Gates: `black --check`, `isort --check-only`, `flake8` clean on the new file; `scripts/check_black_formatting.py` passes with both changed files in scope.

## Manual verification

zizmor 1.29.0, `--no-online-audits`, this branch vs main:

```
total:       104   (main: 105)
artipacked:   11   (main:  12)
```

The remaining 11 were each read against their job to confirm the credential is genuinely required — 8 run `git fetch origin` through the shared diff-base resolver (`brand-lint`, `focus-cue-lint`, `changelog-history`, `harness-parity`, `frontend-lint`, `frontend-test`, `e2e`), and 4 run `git push --force-with-lease` to open a bot PR (`add-contributor`, `cleanup-temp-screenshots`, `memory-benchmark`, `test-durations`). All 11 already carry their rationale comment, so assertion 1 passes on them without any new annotation being added by this PR.

## Related Issues

Follow-on to #6492 (zizmor round 1) and #6639 (round 2). Closes the last `artipacked` omission; the audit ticket for the class is already closed, so this needs no new ticket.

Also audited during this pass and deliberately **not** changed, recorded here so the next triage does not re-derive it:

- **11 `dangerous-triggers` (High)** — all structurally mitigated, verified from source including the four fork review lanes (`design`, `first-principles`, `opus`, `ux`) that were not in the round-1 audit. Every one checks out `base_sha` with `persist-credentials: false`; the fork head exists only as git objects from `git fetch refs/pull/$PR/head` and is consumed as `git diff base...head > patch` — never applied, never checked out. No `git apply`, `git checkout`, `git switch`, `git worktree`, `git merge` or `download-artifact` in any of them.
- **81 `template-injection` (Informational)** — all dismissed after tracing every interpolated value: 44 are repository variables, 24 are step outputs from GitHub-owned or regex-validated sources, 13 are tag-derived version outputs. The credentialed publish lanes are reachable only from `nightly.yml` (schedule/dispatch) and `release.yml` (tag push), never from a PR-triggered workflow.
- **1 `superfluous-actions` (Informational)** — `softprops/action-gh-release` in `release.yml` could be `gh release`; a supply-chain surface reduction worth doing separately, not a security issue, and the action is already SHA-pinned.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the invariant and its history are documented in the new test module's docstring, which is where a future auditor will look
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
