### PR TITLE
fix(scope): refuse a relative project dir instead of resolving it against the cwd

### DIFF
--- a/src/kiro_crew/project_scope.py
+++ b/src/kiro_crew/project_scope.py
@@ -108,9 +108,12 @@ def project_scope_satisfied(relpath: str, project_dir: str | Path | None) -> boo
     the scoped repo would admit the entry into EVERY session, and a packaged
     install would suppress it for every session.
 
-    Fails CLOSED. No project, an unusable one, a traversal fragment, or any
-    filesystem error all suppress the entry, so a surface whose project cannot be
-    established never inherits repository-specific instructions.
+    Fails CLOSED. No project, a RELATIVE one, an unusable one, a traversal
+    fragment, or any filesystem error all suppress the entry, so a surface whose
+    project cannot be established never inherits repository-specific
+    instructions. A relative project belongs on that list because the only way to
+    anchor one is ``Path.cwd()``, and reading that is the very dependence the
+    paragraph above rules out -- so it is refused rather than resolved.
 
     The fragment must name a path BELOW some ancestor, so every form that would
     resolve somewhere else is refused before any filesystem access:
@@ -146,8 +149,13 @@ def project_scope_satisfied(relpath: str, project_dir: str | Path | None) -> boo
     rel = relpath.strip().replace("\\", "/").strip("/")
     if not project_dir:
         return False
+    # Absolute FIRST: ``resolve()`` would anchor a relative project to
+    # ``Path.cwd()``, which is the dependence the docstring rules out.
     try:
-        root = Path(project_dir).resolve()
+        given = Path(project_dir)
+        if not given.is_absolute():
+            return False
+        root = given.resolve()
     except (OSError, RuntimeError, ValueError):
         return False
     for candidate in _walk_to_repo_root(root):

--- a/test/test_lesson_project_scope.py
+++ b/test/test_lesson_project_scope.py
@@ -218,6 +218,54 @@ class TestProjectScopeSatisfied:
         assert project_scope_satisfied("/src/pkg/", tmp_path) is False
         assert project_scope_satisfied("src/pkg", tmp_path) is True
 
+    def test_a_relative_project_is_refused_not_resolved_against_the_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        # The gate promises never to consult the process working directory, but
+        # ``Path.resolve()`` anchors a RELATIVE path to exactly that. Standing the
+        # process inside a tree that DOES hold the fragment is what makes the
+        # difference observable: resolving "." would find "src/pkg" here and admit
+        # the entry, which is the fail-open this gate exists to prevent.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        assert project_scope_satisfied("src/pkg", ".") is False
+        assert project_scope_satisfied("src/pkg", "") is False
+        assert project_scope_satisfied("src/pkg", "src") is False
+        assert project_scope_satisfied("src/pkg", Path("src") / "pkg") is False
+        # The same project named ABSOLUTELY still qualifies, so this refuses an
+        # unanchored value rather than the project itself.
+        assert project_scope_satisfied("src/pkg", tmp_path) is True
+
+    def test_a_relative_project_cannot_borrow_the_cwd_of_an_unrelated_tree(
+        self, tmp_path, monkeypatch
+    ):
+        # The sharper shape of the same fault: the SESSION's project is one tree
+        # and the gateway's cwd is another, so anchoring to cwd answers about the
+        # wrong repository entirely -- admitting an entry scoped to the checkout
+        # the gateway happens to sit in, for a session working somewhere else.
+        #
+        # The fixture is built so cwd is the ONLY way to reach a True: the
+        # fragment "pkg" exists in the gateway checkout and nowhere in the
+        # session's tree, and the relative project "src" lands inside the gateway
+        # checkout when resolved against its cwd.
+        gateway = tmp_path / "gateway-checkout"
+        (gateway / ".git").mkdir(parents=True)
+        (gateway / "src" / "pkg").mkdir(parents=True)
+        session = tmp_path / "elsewhere"
+        (session / "src").mkdir(parents=True)
+        (session / ".git").mkdir()
+        monkeypatch.chdir(gateway)
+
+        assert project_scope_satisfied("pkg", "src") is False
+        # The session's real project, named absolutely, does not hold the fragment
+        # -- which is the answer the gate should have given all along.
+        assert project_scope_satisfied("pkg", session / "src") is False
+        # Positive control: the gateway's own tree still qualifies when it is the
+        # project, so this refuses an unanchored value rather than a directory.
+        assert project_scope_satisfied("pkg", gateway / "src") is True
+
 
 class TestSkillLoaderSharesTheGate:
     """The skill gate must answer through the shared function, not a copy."""


### PR DESCRIPTION
## What is the problem?

`project_scope_satisfied` (`src/kiro_crew/project_scope.py`) is the gate that
decides whether a repository-scoped lesson or skill belongs in THIS session. Its
docstring is emphatic that one thing must never be consulted:

> *project_dir* is the SESSION's active project [...] The process working
> directory is deliberately not consulted: this runs in the gateway while it
> assembles context, so `Path.cwd()` is the gateway's own directory and says
> nothing about the repository the session works on. Answering from it would
> decide by install shape instead of by work -- a gateway started inside a
> checkout of the scoped repo would admit the entry into EVERY session, and a
> packaged install would suppress it for every session.

The implementation then anchors to exactly that:

```py
root = Path(project_dir).resolve()
```

`Path.resolve()` resolves a RELATIVE path against `Path.cwd()`. So for a relative
project the gate answers from the gateway's own working directory -- the
dependence the paragraph above exists to rule out, reintroduced by one call.

It is demonstrable rather than theoretical. Standing the process inside a tree
that holds the fragment, on current `main`:

```
project_scope_satisfied("src/pkg", ".")  ->  True
```

That is the fail-OPEN direction, and it is silent: the caller passed a project, so
nothing looks withheld and no error is raised.

**Reachability, stated plainly: no production call site passes a relative path
today.** The gate has three (`learn.py`, `skills.py`, `vector_memory.py`) and
each receives an absolute path -- the session's realpath'd `slot.project`, a
subagent's resolved cwd, or the task runner's work dir. This
PR fixes a latent hole in a guard, not a live incident, and does not claim
otherwise.

## Why this issue matters to the user

This gate is the mechanical half of a security-shaped promise. Its own module
docstring says the point is that a scope written as prose ("ignore this skill
outside repo X") depends on the model choosing to obey, while this check runs
before the instruction is ever rendered into the prompt. A repo-scoped lesson can
carry destructive repo-specific instructions; admitting it into an unrelated
session is the failure the gate was built to prevent.

The consequence of a relative project is not a missing lesson, it is the wrong
repository's instructions applied to someone else's work -- decided by where the
gateway process happens to have been started. And because the gate returns a
plain `True`, nothing downstream can tell that the answer came from the wrong
tree.

Guards like this are also exactly where latent holes matter more than usual: the
whole value of a fail-closed gate is that a caller does not have to be careful.
A guarantee that holds only while every call site keeps passing absolute paths is
a convention, not a guarantee -- and the next caller has no way to know it is
load-bearing.

## How our fix solves it

Refuse a non-absolute project rather than resolving it:

```py
try:
    given = Path(project_dir)
    if not given.is_absolute():
        return False
    root = given.resolve()
except (OSError, RuntimeError, ValueError):
    return False
```

Three things this gets right:

1. **Refusing is the fail-CLOSED direction**, consistent with how the gate
   already treats an absent project, an inadmissible fragment, and a filesystem
   error. An unanchored value cannot answer "is this project inside the
   repository this fragment names", so the honest answer is no.
2. **It is the codebase's existing reading of an unanchored project.** The
   auto-tag surface already treats `project="."` and `project="~"` as no project
   at all (`test_tag_session.py`: `test_dot_project_is_noop`,
   `test_tilde_project_is_noop`), so this aligns the scope gate with a judgment
   the tree had already made rather than inventing a rule.
3. **The check sits at the gate, not in the callers.** Three call sites
   (`learn.py`, `skills.py`, `vector_memory.py`, all fed by the context
   assembler) share this function precisely so the rule cannot drift; putting
   the anchoring requirement anywhere else would recreate the drift the shared
   module exists to prevent.

The absoluteness test is folded into the existing `try` block so the exception
surface is unchanged: a value whose `Path()` construction raises behaves exactly
as before.

The docstring's fail-closed enumeration now names the relative case, with the
reason, so the next reader does not have to re-derive why `resolve()` alone was
insufficient.

## What tests we did

Targeted runs only; CI runs the full suites.

- `pytest test/test_lesson_project_scope.py` -- 53 passed. That file covers the
  gate plus all three consuming surfaces (the skill loader, the JSONL lesson
  store, the vector lesson store), so a behaviour change in any consumer would
  have shown up here.
- **Two new tests, both mutation-verified red on the pre-fix gate** (`assert True
  is False` in each):
  - a relative project is refused rather than resolved -- `"."`, `""`, `"src"`
    and a relative `Path` are all rejected while the same project named
    absolutely still qualifies, so the refusal is about the anchoring and not
    about the directory;
  - a relative project cannot borrow the cwd of an UNRELATED tree. The fixture is
    built so cwd is the only route to a `True`: the fragment exists in the
    gateway checkout and nowhere in the session's tree, and it carries a positive
    control (the gateway tree named absolutely still qualifies) so the test
    cannot pass by rejecting everything.
- Checked that no existing test depends on relative-project matching: the only
  relative project in the suite is `test_tag_session.py`'s auto-tag no-op, which
  does not reach this gate and already expects nothing to happen.
- `flake8`, `isort --check-only`, and `scripts/check_black_formatting.py` clean on
  both touched files.

## Any other suggestions on the work

**The mirror-image case is already handled, and deliberately differently.** A
POSIX-absolute *fragment* is refused outright rather than reduced to a relative
one, because reducing `/etc/passwd` to `etc/passwd` is what once let a
repo-scoped entry match from the `/` ancestor. Worth noting the two rules point
the same way: the fragment must be relative, the project must be absolute, and
anything that would have to be guessed is refused.

**Callers could stop being trusted at all.** Every caller currently realpaths its
project before passing it, which is why this never fired. A stricter design would
have the gate reject anything it did not normalize itself, but that widens the
contract (a caller passing a legitimate symlinked project would start being
refused) and belongs in its own change with its own thought about what "the
session's project" means when the path is a link.
