### PR TITLE
fix(auto-improvement): title the session slot at birth, not by a later rename

### DIFF
--- a/website/src/apps/auto-improvement/lib/agentSession.ts
+++ b/website/src/apps/auto-improvement/lib/agentSession.ts
@@ -220,17 +220,23 @@ export function useAgentSession(): UseAgentSession {
           }
         }
 
-        // Fresh session: folder -> slot (filed) -> seed and run -> link.
+        // Fresh session: folder -> slot (filed + titled) -> seed and run -> link.
         const folderId = await resolveFolderId(repo)
-        const slot = await dispatch(createSlot({ folder_id: folderId })).unwrap()
+        // Title on the CREATE payload, not a rename afterwards. `createSlot`
+        // accepts it for the reason its own comment gives: the server pins the
+        // name (locking the background auto-titler out) and the create broadcast
+        // already carries it. A follow-up rename instead paints a generated title
+        // first and, being best-effort, can fail silently -- leaving the slot with
+        // whatever the auto-titler chooses. Same shape the Issue Radar path uses.
+        const slot = await dispatch(
+          createSlot({ folder_id: folderId, title: truncate(title) }),
+        ).unwrap()
         // The slot is persisted but not yet linked, so a failure before the seed
         // would leave an empty session that the next click cannot find. Rollback
         // covers exactly that window and stops the moment the seed is in flight:
         // once the POST may have been accepted the agent is starting, and
         // deleting the slot would cancel real work over a metadata hiccup.
         createdSlotKey = slot.key
-        // Best-effort readable title; the session works regardless.
-        api.renameSlot(slot.key, truncate(title)).catch(() => {})
         const seedInFlight = api.sendChat(prompt, slot.key)
         createdSlotKey = null
         const seeded = await seedInFlight

--- a/website/src/test/autoImprovementSession.test.ts
+++ b/website/src/test/autoImprovementSession.test.ts
@@ -214,3 +214,40 @@ describe('openSession re-entry latch (double-click cannot orphan a conversation)
     expect(body.slice(fin)).toMatch(/inFlight\.current\.delete\(/)
   })
 })
+
+describe('the slot is titled at birth, not renamed afterwards', () => {
+  /**
+   * `createSlot` accepts `title` on its payload precisely so a caller does not have
+   * to rename afterwards: the server PINS the name (which locks the background
+   * auto-titler out) and the create broadcast already carries it. Renaming after the
+   * fact has two costs — the generated title paints first and visibly jumps, and the
+   * rename is a second request that can fail. This module's rename was
+   * fire-and-forget (`.catch(() => {})`), so a failure left the slot named by the
+   * auto-titler with nothing reporting it.
+   *
+   * Asserted structurally on the source, matching the sibling suite above: the hook
+   * needs Redux + router providers to render, and the property that matters here is
+   * WHERE the title travels, which reads exactly.
+   */
+  const TITLE_SRC = readFileSync(
+    join(__dirname, '..', 'apps', 'auto-improvement', 'lib', 'agentSession.ts'),
+    'utf-8',
+  )
+
+  it('passes the title on the createSlot payload', () => {
+    expect(TITLE_SRC).toMatch(/createSlot\(\{[^}]*\btitle\b/)
+  })
+
+  it('does not rename the slot after creating it', () => {
+    // The whole point: a second request that can fail silently. Scoped to
+    // openSession so an unrelated future rename elsewhere does not trip this.
+    const body = TITLE_SRC.slice(TITLE_SRC.indexOf('const openSession'))
+    expect(body).not.toMatch(/renameSlot\(/)
+  })
+
+  it('still bounds the title length it hands over', () => {
+    // The create payload replaced the rename, so the truncation the rename applied
+    // has to travel with it -- otherwise the fix silently lengthens every title.
+    expect(TITLE_SRC).toMatch(/createSlot\(\{[^}]*title:\s*truncate\(/)
+  })
+})


### PR DESCRIPTION
<!-- no-visual-delta -->

**Why no screenshot:** the rendered output is unchanged -- a still frame of the
sidebar looks identical before and after, because whenever the rename SUCCEEDED
the steady state was already correct. What changes is which request carries the
title, so the two observable deltas are a sub-second transient (the generated
title no longer paints first) and a failure mode (a lost rename no longer leaves
the slot auto-titled), and neither is something a screenshot can show. No layout,
theme, copy, or component result is touched. Pinned by three structural
assertions instead, which is the instrument that can actually distinguish this
change.

## What is the problem?

Opening an Auto Improvement session creates the chat slot **untitled**, then
fires a separate rename at it:

```ts
const slot = await dispatch(createSlot({ folder_id: folderId })).unwrap()
createdSlotKey = slot.key
// Best-effort readable title; the session works regardless.
api.renameSlot(slot.key, truncate(title)).catch(() => {})
```

Between those two lines the slot exists with no name of its own, and the rename
is fire-and-forget -- `.catch(() => {})` swallows every failure. So there are two
distinct defects on one line:

1. **A visible flash.** The slot is broadcast untitled, the background
   auto-titler is free to name it, and the real title arrives afterwards, so the
   session name paints once and then jumps.
2. **Silent loss.** If the rename request fails, or the tab is closed, or the
   gateway restarts between the create and the rename, nothing retries and
   nothing reports it. The slot keeps whatever the auto-titler chose, and the
   caller's name is simply gone.

`createSlot` already accepts `title` on its payload, and its own comment in
`store/chatSlice.ts` describes this exact failure as the reason it does:

> Title at BIRTH, for the same reason folder membership rides this payload: the
> server pins it (locking the background auto-titler out) and the create
> broadcast already carries it, where a follow-up rename paints a generated title
> first and can fail silently, leaving the caller's name unset.

The sibling Issue Radar path already passes it that way
(`apps/issue-radar/lib/agentSession.ts`, "folder -> slot (filed + titled)"). Auto
Improvement was the one caller left doing it the old way.

## Why this issue matters to the user

The slot title is how a user finds an Auto Improvement session again in the
sidebar. When the rename is lost, the session is still there and still working,
but it is labelled with an LLM-generated guess instead of the subject the user
clicked -- so the one identifier they would search for is the one thing that did
not survive. The title flash is smaller but hits every open, not just the failing
ones.

## How our fix solves it

Pass the title on the create payload and delete the rename:

```ts
const slot = await dispatch(
  createSlot({ folder_id: folderId, title: truncate(title) }),
).unwrap()
```

That closes both halves at once, and neither is a new mechanism -- the server
already pins a title supplied at create, which is what locks the auto-titler out,
and the create broadcast already carries it, which is what removes the flash.
There is no longer a window in which the slot is untitled, so there is nothing
for a crash to interrupt and no second request to fail.

`truncate` travels onto the create payload rather than being dropped. The rename
was applying it (`TITLE_MAX`, "keep slot titles short enough to read in the
folder's session list"), so passing the raw title would have silently lengthened
every Auto Improvement slot name -- a behaviour change hiding inside a fix.

Two files, +47/-4, no new imports and no API change: `createSlot` already
accepted the field.

## What tests we did

Three assertions added to the existing `autoImprovementSession.test.ts` suite:
the title is on the `createSlot` payload, `openSession` contains no `renameSlot`
call, and the truncation is still applied.

They are STRUCTURAL, for the same reason the sibling re-entry-latch suite in that
same file is: the hook needs Redux and router providers to render, and the
property that matters here is WHERE the title travels, which reads exactly off
the source. The third assertion exists specifically so the truncation cannot be
lost in a later refactor without a test noticing.

Mutation-verified: restoring the create-then-rename shape reddens exactly those
three and leaves the other 22 green, so each one is load-bearing rather than
decorative.

Targeted vitest run only (`vitest run src/test/autoImprovementSession.test.ts`,
25/25) -- no full suite on this host; CI runs it on the merge ref. `tsc --noEmit`
reports nothing for either touched file, and eslint is clean on both.

## Any other suggestions on the work

* `truncate` is now used once in this module and is also exported for
  `AutoImprovementPage`. If a future change moves title formatting to the
  callers, this is the place it would collapse -- worth noting, not worth doing
  here.
* Worth a grep the next time someone touches slot creation: `createSlot` has
  several callers and this was the last one in an app path building a titled
  session in two steps. `command-bar` and `personal-shopper` create untitled
  slots deliberately (the user names them by typing), so they are correct as-is.

Local backlog item f-20260818-05, raised as a First Principles review finding on
#4319 and parked locally rather than filed. Verified still present on main before
this change.
