### PR TITLE
fix(dashboard): give every chat_regenerate refusal a machine-readable code

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1262,
+    "missing_code": 1241,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1410,
+  "_compliant": 1438,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -47,9 +47,6 @@
     },
     "dashboard/chat_orchestrator.py": {
       "missing_code": 4
-    },
-    "dashboard/chat_regenerate.py": {
-      "missing_code": 21
     },
     "dashboard/chat_rewind.py": {
       "missing_code": 15

--- a/src/kiro_crew/dashboard/chat_regenerate.py
+++ b/src/kiro_crew/dashboard/chat_regenerate.py
@@ -31,11 +31,13 @@ async def api_chat_slot_regenerate(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     async with slot._lock:
         if slot.running:
-            return web.json_response({"error": "slot is running"}, status=409)
+            return web.json_response(
+                {"error": "slot is running", "code": "slot_running"}, status=409
+            )
 
         msgs = slot.messages
         ai_idx = -1
@@ -44,18 +46,25 @@ async def api_chat_slot_regenerate(request: web.Request) -> web.Response:
                 ai_idx = i
                 break
         if ai_idx < 0:
-            return web.json_response({"error": "no assistant message to regenerate"}, status=400)
+            return web.json_response(
+                {"error": "no assistant message to regenerate", "code": "no_assistant_message"},
+                status=400,
+            )
         u_idx = -1
         for i in range(ai_idx - 1, -1, -1):
             if msgs[i].get("role") == "user":
                 u_idx = i
                 break
         if u_idx < 0:
-            return web.json_response({"error": "no preceding user message"}, status=400)
+            return web.json_response(
+                {"error": "no preceding user message", "code": "no_user_message"}, status=400
+            )
 
         user_msg = msgs[u_idx].get("content", "")
         if not user_msg:
-            return web.json_response({"error": "empty user message"}, status=400)
+            return web.json_response(
+                {"error": "empty user message", "code": "empty_user_message"}, status=400
+            )
 
         ai_msg = msgs[ai_idx]
         _rv = ai_msg.get("variants")
@@ -126,22 +135,24 @@ async def api_chat_slot_switch_variant(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     if not isinstance(body, dict):
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     try:
         idx = int(body.get("index"))  # type: ignore[arg-type]
     except (TypeError, ValueError):
-        return web.json_response({"error": "invalid index"}, status=400)
+        return web.json_response({"error": "invalid index", "code": "index_invalid"}, status=400)
 
     async with slot._lock:
         if slot.running:
-            return web.json_response({"error": "slot is running"}, status=409)
+            return web.json_response(
+                {"error": "slot is running", "code": "slot_running"}, status=409
+            )
 
         target = None
         for m in reversed(slot.messages):
@@ -149,7 +160,7 @@ async def api_chat_slot_switch_variant(request: web.Request) -> web.Response:
                 target = m
                 break
         if target is None:
-            return web.json_response({"error": "no variants"}, status=400)
+            return web.json_response({"error": "no variants", "code": "no_variants"}, status=400)
         raw_target_variants = target.get("variants")
         variants: list[dict] = (
             list(raw_target_variants)  # type: ignore[arg-type]
@@ -157,11 +168,15 @@ async def api_chat_slot_switch_variant(request: web.Request) -> web.Response:
             else []
         )
         if idx < 0 or idx >= len(variants):
-            return web.json_response({"error": "index out of range"}, status=400)
+            return web.json_response(
+                {"error": "index out of range", "code": "index_out_of_range"}, status=400
+            )
 
         chosen = variants[idx]
         if not isinstance(chosen, dict):
-            return web.json_response({"error": "corrupt variant entry"}, status=400)
+            return web.json_response(
+                {"error": "corrupt variant entry", "code": "variant_corrupt"}, status=400
+            )
         target_dict: dict = target
         target_dict["content"] = chosen.get("content", "")
         slot.invalidate_source_links()
@@ -202,27 +217,31 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     # A valid-JSON but non-object body (array/scalar) has no .get(), so
     # body.get("index") would raise AttributeError -> 500. Reject it as a 400,
     # matching the guard in api_chat_slot_switch_variant above.
     if not isinstance(body, dict):
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
 
     index = body.get("index")
     ts = body.get("ts")
     content = (body.get("content") or "").strip()
     if not content:
-        return web.json_response({"error": "content is required"}, status=400)
+        return web.json_response(
+            {"error": "content is required", "code": "content_required"}, status=400
+        )
 
     async with slot._lock:
         if slot.running:
-            return web.json_response({"error": "slot is running"}, status=409)
+            return web.json_response(
+                {"error": "slot is running", "code": "slot_running"}, status=409
+            )
 
         msgs = slot.messages
 
@@ -232,12 +251,20 @@ async def api_chat_slot_edit_resend(request: web.Request) -> web.Response:
                 -1,
             )
             if not isinstance(index, int) or index < 0:
-                return web.json_response({"error": "user message not found for ts"}, status=400)
+                return web.json_response(
+                    {"error": "user message not found for ts", "code": "user_message_not_found"},
+                    status=400,
+                )
         elif isinstance(index, int) and 0 <= index < len(msgs):
             if msgs[index].get("role") != "user":
-                return web.json_response({"error": "index is not a user message"}, status=400)
+                return web.json_response(
+                    {"error": "index is not a user message", "code": "index_not_user_message"},
+                    status=400,
+                )
         else:
-            return web.json_response({"error": "index or ts required"}, status=400)
+            return web.json_response(
+                {"error": "index or ts required", "code": "index_or_ts_required"}, status=400
+            )
 
         del slot.messages[index:]
         slot._dirty = True

--- a/test/test_chat_regenerate_cov80.py
+++ b/test/test_chat_regenerate_cov80.py
@@ -527,3 +527,71 @@ async def test_edit_resend_logs_a_failing_background_turn(state, caplog) -> None
                 await asyncio.sleep(0)
 
     assert "edit-resend _run_chat failed" in caplog.text
+
+
+# ── machine-readable refusal codes ──
+# The tests above pin each refusal's human sentence. These pin the `code`
+# beside it, which is the half a caller can branch on: "slot is running" is a
+# developer sentence that a client must not string-match to tell a BUSY slot
+# (retry once the turn ends) from a MISSING one (stop and refresh).
+
+
+@pytest.mark.parametrize(
+    ("path", "body"),
+    [
+        ("regenerate", None),
+        ("switch-variant", {"index": 0}),
+        ("edit-resend", {"index": 0, "content": "edited"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_every_endpoint_refuses_a_busy_slot_with_slot_running(state, path, body) -> None:
+    """All three endpoints share one busy-slot refusal, so they must share one
+    code -- a client that special-cases the retryable case cannot be asked to
+    learn a different spelling per endpoint."""
+    slot = state.get_or_create_slot("s1")
+    slot.append("user", "hi")
+    slot.append("assistant", "hello v1")
+    await _busy(slot)
+    try:
+        async with _client(state) as client:
+            resp = await client.post(f"/api/chat/slots/s1/{path}", json=body)
+            assert resp.status == 409
+            payload = await resp.json()
+            assert payload["code"] == "slot_running"
+            # The human sentence is unchanged: the code is additive, so an
+            # existing client that renders `error` keeps working.
+            assert payload["error"] == "slot is running"
+    finally:
+        slot.task.cancel()
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "status", "code"),
+    [
+        ("regenerate", None, 404, "slot_not_found"),
+        ("switch-variant", {"index": 0}, 404, "slot_not_found"),
+        ("edit-resend", {"index": 0, "content": "x"}, 404, "slot_not_found"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_unknown_slot_refusals_carry_slot_not_found(state, path, body, status, code) -> None:
+    async with _client(state) as client:
+        resp = await client.post(f"/api/chat/slots/nope/{path}", json=body)
+        assert resp.status == status
+        assert (await resp.json())["code"] == code
+
+
+@pytest.mark.asyncio
+async def test_no_variants_refusal_carries_its_own_code(state) -> None:
+    """Distinct from a busy slot: nothing to switch to is permanent for this
+    row, so a client must not offer a retry."""
+    slot = state.get_or_create_slot("s1")
+    slot.append("user", "hi")
+    slot.append("assistant", "only reply")
+    async with _client(state) as client:
+        resp = await client.post("/api/chat/slots/s1/switch-variant", json={"index": 0})
+        assert resp.status == 400
+        payload = await resp.json()
+        assert payload["code"] == "no_variants"
+        assert payload["error"] == "no variants"

--- a/test/test_chat_regenerate_refusal_codes.py
+++ b/test/test_chat_regenerate_refusal_codes.py
@@ -1,0 +1,123 @@
+"""One spelling per refusal condition, across the dashboard.
+
+`test_error_code_contract.py` is the repo's gate for whether a refusal HAS a
+code, and `error-code-baseline.json` is its per-file worklist. Neither says
+anything about whether two modules refusing the SAME condition agree on the
+code they use -- and a code is only worth branching on if they do, otherwise a
+client needs one lookup table per endpoint and the shared vocabulary is a
+fiction.
+
+That is the gap this file covers, and the only one: the "no bare refusal body"
+scan lives in the contract test, which reads the AST and so also catches the
+hoisted-body and dynamic-status shapes a regex here would miss.
+
+The scan runs over whole-file text rather than line by line, because black
+wraps a long refusal so the sentence and the code land on DIFFERENT lines --
+it did exactly that to three sites in this module. A line-scoped scan silently
+skips every wrapped site, which is the worst failure available to a guard: it
+passes while the thing it promises to pin goes unchecked. `test_the_pair_
+pattern_still_matches` is what keeps that honest.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DASHBOARD = Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "dashboard"
+MODULE = DASHBOARD / "chat_regenerate.py"
+
+# An "error" sentence and the "code" beside it, tolerating the line break black
+# inserts between them. `[^"]+` for the sentence and an immediate comma keep a
+# match inside ONE body: two separate json_response calls always have `}` and
+# `status=` between them, which \s* cannot span.
+PAIR = re.compile(r'"error":\s*"(?P<sentence>[^"]+)"\s*,\s*"code":\s*"(?P<code>[a-z_]+)"', re.S)
+
+# Sentences whose code is settled across the whole dashboard tree, so a second
+# spelling is drift. Kept deliberately small: a sentence earns a place here only
+# once a recursive scan shows it already has exactly one spelling, otherwise the
+# guard reds on code it never asked to change.
+#
+# NOT here, and each for its own reason:
+#
+# - "not found" is a generic sentence whose SUBJECT differs per endpoint, and the
+#   tree correctly pairs it with five codes (slot_not_found, not_found,
+#   pin_not_found, instance_not_found, launch_job_not_found). There the code
+#   carries information the sentence does not, so demanding one spelling would
+#   be demanding a worse API.
+#
+# - "invalid JSON" is settled at 44 sites as `invalid_json` and diverges at
+#   exactly one: `handlers/security.py:1535` answers an UNPARSEABLE body with
+#   `invalid_value`, the code its own next guard uses for a parseable body whose
+#   `value` has the wrong type -- so that endpoint currently returns one code for
+#   two conditions, and its own audit line on the line above calls the branch
+#   `invalid_json`. It looks like a genuine bug, but fixing it changes a security
+#   endpoint's response contract and the test that pins it
+#   (`test_allow_all_rejects_unparseable_body_with_code`), which belongs in that
+#   endpoint's own change with its own review, not folded into this one. Pinning
+#   the sentence here before then would only red on existing code.
+SETTLED = {
+    "slot is running": "slot_running",
+}
+
+
+def test_settled_conditions_use_one_spelling_across_the_dashboard() -> None:
+    divergent: list[str] = []
+    seen: dict[str, int] = {s: 0 for s in SETTLED}
+    # rglob, not glob: `dashboard/handlers/` and `dashboard/routes/` hold most of
+    # the tree's refusals (~60 `invalid_json` sites between them), so a
+    # top-level-only scan would claim "across the dashboard" while never reading
+    # the files where drift is most likely. It found a real one when widened:
+    # `handlers/security.py` answered an unparseable body with `invalid_value`
+    # while its own audit line called the same branch `invalid_json`.
+    for path in sorted(DASHBOARD.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        for m in PAIR.finditer(text):
+            want = SETTLED.get(m.group("sentence"))
+            if want is None:
+                continue
+            seen[m.group("sentence")] += 1
+            if m.group("code") != want:
+                line = text[: m.start()].count("\n") + 1
+                rel = path.relative_to(DASHBOARD)
+                divergent.append(f"{rel}:{line} -> {m.group('code')!r} (want {want!r})")
+    # Reuse the settled spelling, or if the condition genuinely differs, give it
+    # a sentence of its own rather than a second code for the same words.
+    assert divergent == []
+    # A rename that empties the scan must fail rather than pass vacuously.
+    assert all(n > 0 for n in seen.values()), seen
+
+
+def test_this_module_carries_the_settled_spellings() -> None:
+    text = MODULE.read_text(encoding="utf-8")
+    found = {m.group("sentence"): m.group("code") for m in PAIR.finditer(text)}
+    assert found.get("slot is running") == "slot_running"
+    # Not in SETTLED (see its note), but this module still follows the tree's
+    # 44-site spelling, so a copy-paste of the outlier into here would show up.
+    assert found.get("invalid JSON") == "invalid_json"
+
+
+def test_the_pair_pattern_still_matches() -> None:
+    """Without this, a regex edit makes the guard above pass on zero sites."""
+    single = 'web.json_response({"error": "slot is running", "code": "slot_running"}, status=409)'
+    assert PAIR.search(single).group("code") == "slot_running"
+
+    # The shape black produces when the call is too long for one line: the
+    # sentence and the code are still one payload, but not one line.
+    wrapped = (
+        "web.json_response(\n"
+        '    {"error": "slot is running",\n'
+        '     "code": "slot_running"},\n'
+        "    status=409,\n"
+        ")"
+    )
+    assert PAIR.search(wrapped).group("code") == "slot_running"
+
+    # And it must not bridge two ADJACENT bodies: the sentence of the first
+    # must never pair with the code of the second.
+    two = (
+        'return web.json_response({"error": "slot is running"}, status=409)\n'
+        'return web.json_response({"error": "no variants", "code": "no_variants"}, status=400)\n'
+    )
+    pairs = [(m.group("sentence"), m.group("code")) for m in PAIR.finditer(two)]
+    assert pairs == [("no variants", "no_variants")]


### PR DESCRIPTION
## 1. What is the problem?

The three chat-regenerate endpoints (`regenerate`, `switch-variant`, `edit-resend`) refused with a bare body and nothing else:

```python
return web.json_response({"error": "slot is running"}, status=409)
return web.json_response({"error": "no variants"}, status=400)
```

21 refusal bodies, all shaped like that. The only thing a client gets is a sentence written for a developer reading a log, so the only way to tell one refusal from another is to string-match that sentence. Two consequences follow directly:

- A BUSY slot (409, retry once the turn ends) and a MISSING slot (404, stop -- the session is gone) are indistinguishable without parsing prose, so both surface as the same dead end.
- Any copy-edit to a message is a silent breaking change for whoever matched on it.

The rest of the dashboard does not work this way. `{"error": "<sentence>", "code": "<snake_case>"}` is the established shape, used across at least 12 modules -- `slot_not_found` alone appears 25 times, `invalid_json` 12. `chat_handlers.py:2903` already refuses a busy slot with the *identical* sentence AND a code. These endpoints were simply never brought onto it.

## 2. Why this issue matters to the user

The refusal is a normal thing to hit: press regenerate, or switch variant, while a turn is still running. What the user sees is the raw sentence fused into the surrounding notice -- internal vocabulary in a user-facing dead end -- and the client cannot do better, because it has nothing stable to branch on. It cannot say "this one is worth retrying in a moment" for a busy slot and "this session is gone" for a missing one, since telling them apart means matching developer prose that anyone is free to reword.

## 3. How our fix solves it

Every refusal body in the module now carries a `code` beside the sentence. **Codes are reused, not invented, wherever the condition already has one:**

| condition | code | precedent |
| --- | --- | --- |
| busy slot (409, x3 endpoints) | `slot_running` | `chat_handlers.py:2903`, identical sentence |
| unknown slot (404, x3) | `slot_not_found` | 25 existing sites |
| unparseable body (400, x4) | `invalid_json` | 12 existing sites |
| the 11 conditions specific to these endpoints | `no_variants`, `no_assistant_message`, `no_user_message`, `empty_user_message`, `index_invalid`, `index_out_of_range`, `variant_corrupt`, `content_required`, `user_message_not_found`, `index_not_user_message`, `index_or_ts_required` | the tree's `<noun>_<condition>` shape (`color_invalid`, `name_required`, `instance_invalid`) |

I checked the busy-slot code against the alternative spelling before settling: `turn_in_flight` also exists in `chat_handlers.py`, but it pairs with a different sentence ("a turn is in flight") and so states a different thing. `slot_running` is the one whose precedent carries this exact sentence.

**Additive only.** No `error` text changes and no status changes, so a client rendering `error` today is unaffected. The field reaches the frontend through machinery that already exists: `ApiError` deliberately retains the raw body ("kept so a caller can read structured fields that `friendlyErrText` collapses away"), and `src/api/pins.ts:58` already reads `data.code` off a refusal that way.

## 4. What tests we did

Targeted only (no full suite on this host), `pytest -n 4`.

- One structural guard in a new file, covering the gap the tree lacks: no dashboard module may spell a SETTLED refusal condition differently once it has a code. "Does a refusal have a code at all" is NOT here -- that is the repo's own `test_error_code_contract.py` (AST-based, so it also catches the hoisted-body and dynamic-status shapes a regex would miss), and this module's `missing_code: 21` entry in `error-code-baseline.json` is regenerated to zero by this PR with the documented `--update` command.
- The guard scans whole-file text, not line by line, because black wraps a long refusal so the sentence and the code land on different lines -- it did that to three sites in this very module. A line-scoped scan would skip every wrapped site while still passing, which is the worst failure a guard can have. `test_the_pair_pattern_still_matches` pins that: it asserts the pattern matches a single-line body AND a wrapped one, and does NOT bridge two adjacent bodies (so the first body's sentence can never pair with the second's code).
- It pins the two sentences whose spelling is genuinely settled tree-wide: `slot is running` -> `slot_running` (4 sites) and `invalid JSON` -> `invalid_json` (12 sites). `not found` is deliberately excluded and the reason is in the file: it is a generic sentence whose SUBJECT differs per endpoint, and the tree correctly pairs it with five codes (`slot_not_found` x28, `not_found` x10, `pin_not_found`, `instance_not_found`, `launch_job_not_found`). There the code carries information the sentence does not, so demanding one spelling would demand a worse API.
- Behavioural tests in the module's existing suite (fixtures reused, not duplicated): all three endpoints refuse a busy slot with `slot_running`, all three refuse an unknown slot with `slot_not_found`, and `no_variants` is pinned as distinct from a busy slot because it is permanent for that row and a client must NOT offer a retry. Each asserts the unchanged `error` sentence alongside the code, which is what makes "additive" a tested claim rather than an assurance.
- **Mutation-verified, four ways.** (1) Removing the code from one body reddens the behavioural test AND the repo's contract gate -- checked with my own scan deleted, which is how I know the coverage transferred rather than assuming it. (2) Renaming `slot_running` to `slot_busy` reddens the vocabulary guard with the exact line. (3) Making that same site both WRAPPED and divergent still reddens it (`chat_regenerate.py:39 -> 'slot_busy' (want 'slot_running')`) -- this is the case the earlier line-scoped version silently passed. (4) The Windows decode bug below was reproduced on Linux before fixing.
- Every `read_text()` in the new file passes `encoding="utf-8"`. A bare read takes the locale default, which on Windows is cp1252, and `chat_handlers.py` contains a byte it cannot decode -- this actually failed the Windows shard, and I reproduced it locally (cp1252 raises at that byte, utf-8 reads fine) rather than patching on the review's word. The tree's convention is the explicit encoding (2524 call sites).
- 46 tests green across the three files; the adjacent behaviour suite `test_dashboard_chat.py` (718 tests) and `test_slot_needs_input_status.py` (30) both green, which matters because they assert these endpoints' happy paths and refusal sentences.
- Gates: `flake8` and `isort` clean; the repo's diff-scoped black gate passes (it flagged two files, I ran black on exactly those and confirmed it rewrapped only my own long lines); `mypy` reports 0 errors in this module (its 2 errors are in `transcribe.py`, untouched here and failing on base).

## 5. Any other suggestions on the work

- **The consumer-side half is deliberately not here.** `regenerateSlot` and `switchVariant` are called only from `ChatPage.tsx`, which is the source-of-truth chat surface and off-limits to changes like this without the maintainers' say-so, so mapping codes to human copy there is not something I should fold into a backend PR. The codes are what unblocks that work whenever someone wants it; nothing in this PR depends on it.
- **A code with no client reading it yet is a fair thing to challenge.** My argument is that this is conformance to an existing server contract rather than speculative API surface: the shape, the delivery channel, and a working example of a client reading `data.code` all already exist. If you would rather it wait for its consumer, that is a reasonable call and I will not argue past this note.
- **`chat_rewind.py` has the same gap**, including the identical bare `{"error": "slot is running"}` 409 at line 119, plus ~9 other bare refusals. I left it alone on purpose: coding only its busy-slot line would leave one coded refusal among ten bare ones in that file, which is its own inconsistency. It wants the same treatment as a whole, in its own change. The vocabulary guard is written to stay green when that lands with this spelling, and to fail if it lands with a synonym.

