### PR TITLE
fix(prepare-pr): accept a review stamp that elided the head SHA's middle

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
@@ -428,10 +428,17 @@ byte-for-byte instead of by eyeballing a diff of human text.
 
 Its `advisory` half is what you read when checking the exit conditions below:
 `unresolved_threads` (`null` there is the same "could not establish" as a `?`),
-`findings` per reviewer, and `stale_reviewers` / `blocking_reviewers`. Nothing
-else is emitted — ambient PR state (mergeable, merge state, review decision,
-check totals) stays in the prose above, which is where those conditions already
-read it, so there is no second copy to keep in sync.
+`findings` per reviewer, `stale_reviewers` / `blocking_reviewers`, and
+`elided_stamp_reviewers` — lanes whose freshness stamp MANGLED the head SHA
+(the workflows have the model retype it, so a lane can drop the middle and
+splice the head's prefix to its suffix). The gate verifies such a stamp against
+the current head and accepts it, which is why it is not a stale reviewer; the
+list exists so the emitter defect is still visible. Report it ONCE per head as
+a lane-quality note — it never blocks, and re-running that workflow usually
+produces a clean stamp. Nothing else is emitted — ambient PR state (mergeable,
+merge state, review decision, check totals) stays in the prose above, which is
+where those conditions already read it, so there is no second copy to keep in
+sync.
 
 Drive the cycle off the **exit code**, not off prose: `10` → report nothing and
 wait for the next cycle; `20` → drill in with `pr_findings.py` and act; `2` →

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_findings.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_findings.py
@@ -42,6 +42,46 @@ def sanitize(s):
 # (same rationale and env seam as pr_status.py: Bot-type alone is spoofable).
 REVIEWED_STAMP_RE = re.compile(r"\[([A-Z][A-Z0-9_-]*)-REVIEWED\]\s+([0-9a-f]{7,40})\b")
 BLOCK_MERGE_RE = re.compile(r"\[BLOCK-MERGE\]\s+([0-9a-f]{7,40})\b")
+
+
+def sha_matches(stamp_sha, head_sha):
+    """True when a stamped SHA identifies the current head.
+
+    Two spellings count, because the stamp is not machine-written. The review
+    workflows ask the MODEL to end its prose with `[<NAME>-REVIEWED] <sha>`
+    (see the prompt in .github/workflows/design-review.yml) and then read that
+    line back, so the 40 hex characters pass through a transcription step:
+
+    * A >=7-hex PREFIX of the head is the ordinary form. Short-SHA references
+      and the full 40 both land here, and a stamp naming an OLDER commit fails,
+      which is the freshness guard the marker exists for.
+    * An ELIDED head is the transcription artifact: a stamp that drops a
+      CONTIGUOUS MIDDLE span and splices the head's own prefix to its own
+      suffix. Observed on PR 4107, where the Design lane wrote 25 characters
+      (the head's first 14 followed by its last 11) and every consumer read the
+      PR as BLOCKED while PR Readiness was green.
+
+    The elided form is verified, not merely tolerated: the token must be
+    SHORTER than the head (a full-length token that is not a prefix names a
+    different commit, and stays rejected), it must split into a >=7-hex prefix
+    of the head plus a non-empty suffix of the head, and both halves must be
+    the head's own. That keeps the guard the strict match was protecting -- a
+    well-formed reference to another commit cannot pass, because it would have
+    to begin with 7+ characters of THIS head and end with this head's tail --
+    while a mangling of the current head no longer fails closed.
+    """
+    if not stamp_sha or not head_sha:
+        return False
+    if len(stamp_sha) >= 7 and head_sha.startswith(stamp_sha):
+        return True
+    if len(stamp_sha) >= len(head_sha):
+        return False
+    for cut in range(7, len(stamp_sha)):
+        if head_sha.startswith(stamp_sha[:cut]) and head_sha.endswith(stamp_sha[cut:]):
+            return True
+    return False
+
+
 DEFAULT_MARKER_AUTHORS = ("github-actions[bot]",)
 # Comment-key -> reviewer-name bindings, identical to pr_status.py's copy
 # (parity-pinned): reviewer identity comes from the workflow-authored leading
@@ -275,14 +315,14 @@ def extract_findings(comments, head_sha, bindings):
         if not name:
             continue
         fresh = any(
-            stamp_name == name and len(sha) >= 7 and head_sha.startswith(sha)
+            stamp_name == name and sha_matches(sha, head_sha)
             for stamp_name, sha in REVIEWED_STAMP_RE.findall(body)
         )
         if not fresh:
             continue
         reviewer = name.lower()
         block_merge = any(
-            len(sha) >= 7 and head_sha.startswith(sha) for sha in BLOCK_MERGE_RE.findall(body)
+            sha_matches(sha, head_sha) for sha in BLOCK_MERGE_RE.findall(body)
         )
         for kind, path, line, text in FINDING_RE.findall(body):
             try:

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
@@ -568,6 +568,46 @@ _MAX_COMMENT_PAGES = 50
 # current head filters both.
 REVIEWED_STAMP_RE = re.compile(r"\[([A-Z][A-Z0-9_-]*)-REVIEWED\]\s+([0-9a-f]{7,40})\b")
 BLOCK_MERGE_RE = re.compile(r"\[BLOCK-MERGE\]\s+([0-9a-f]{7,40})\b")
+
+
+def sha_matches(stamp_sha, head_sha):
+    """True when a stamped SHA identifies the current head.
+
+    Two spellings count, because the stamp is not machine-written. The review
+    workflows ask the MODEL to end its prose with `[<NAME>-REVIEWED] <sha>`
+    (see the prompt in .github/workflows/design-review.yml) and then read that
+    line back, so the 40 hex characters pass through a transcription step:
+
+    * A >=7-hex PREFIX of the head is the ordinary form. Short-SHA references
+      and the full 40 both land here, and a stamp naming an OLDER commit fails,
+      which is the freshness guard the marker exists for.
+    * An ELIDED head is the transcription artifact: a stamp that drops a
+      CONTIGUOUS MIDDLE span and splices the head's own prefix to its own
+      suffix. Observed on PR 4107, where the Design lane wrote 25 characters
+      (the head's first 14 followed by its last 11) and every consumer read the
+      PR as BLOCKED while PR Readiness was green.
+
+    The elided form is verified, not merely tolerated: the token must be
+    SHORTER than the head (a full-length token that is not a prefix names a
+    different commit, and stays rejected), it must split into a >=7-hex prefix
+    of the head plus a non-empty suffix of the head, and both halves must be
+    the head's own. That keeps the guard the strict match was protecting -- a
+    well-formed reference to another commit cannot pass, because it would have
+    to begin with 7+ characters of THIS head and end with this head's tail --
+    while a mangling of the current head no longer fails closed.
+    """
+    if not stamp_sha or not head_sha:
+        return False
+    if len(stamp_sha) >= 7 and head_sha.startswith(stamp_sha):
+        return True
+    if len(stamp_sha) >= len(head_sha):
+        return False
+    for cut in range(7, len(stamp_sha)):
+        if head_sha.startswith(stamp_sha[:cut]) and head_sha.endswith(stamp_sha[cut:]):
+            return True
+    return False
+
+
 FINDING_LINE_RE = re.compile(r"^\s*FINDING\b", re.MULTILINE)
 
 # Only comments authored by the repo's own workflow actor count as marker
@@ -652,14 +692,14 @@ def extract_findings(comments, head_sha, bindings):
         if not name:
             continue
         fresh = any(
-            stamp_name == name and len(sha) >= 7 and head_sha.startswith(sha)
+            stamp_name == name and sha_matches(sha, head_sha)
             for stamp_name, sha in REVIEWED_STAMP_RE.findall(body)
         )
         if not fresh:
             continue
         reviewer = name.lower()
         block_merge = any(
-            len(sha) >= 7 and head_sha.startswith(sha) for sha in BLOCK_MERGE_RE.findall(body)
+            sha_matches(sha, head_sha) for sha in BLOCK_MERGE_RE.findall(body)
         )
         for kind, path, line, text in FINDING_RE.findall(body):
             try:
@@ -1030,11 +1070,6 @@ def resolve_marker_authors(argv, environ):
     }
 
 
-def sha_matches(stamp_sha, head_sha):
-    """True when a stamped SHA identifies the current head (>=7-hex prefix)."""
-    return bool(stamp_sha) and len(stamp_sha) >= 7 and head_sha.startswith(stamp_sha)
-
-
 def resolve_readiness_context(argv, environ):
     """Resolve the aggregate-readiness status-context name.
 
@@ -1385,10 +1420,16 @@ def evaluate_reviewer_markers(comments, head_sha, bindings, only=None):
     posted is not required, its CI gate covers absence).
     """
     if comments is None or not head_sha:
-        return {"ok": False, "stale": [], "blocking": [], "findings": {}}
+        return {"ok": False, "stale": [], "blocking": [], "findings": {}, "elided": []}
     fresh_by_name: dict = {name: False for name in (only or ())}
     findings: dict = {}
     blocking = set()
+    # Reviewers whose freshness rests on an ELIDED stamp (see sha_matches). The
+    # gate accepts those, but silently swallowing them would hide the emitter
+    # defect for good: nobody would learn a lane is mangling the SHA it was
+    # handed. Reported as an advisory note, never as a blocking reason -- and
+    # deliberately absent from progress_key, which a polling loop diffs.
+    elided = set()
     for c in comments:
         body = c.get("body") or ""
         name = bindings.get(comment_key(body))
@@ -1407,11 +1448,19 @@ def evaluate_reviewer_markers(comments, head_sha, bindings, only=None):
                 fresh_by_name[name] = fresh_by_name.get(name, False) or fresh
                 if fresh:
                     findings[name] = len(FINDING_LINE_RE.findall(body))
+                    if not any(head_sha.startswith(sha) for sha in own_stamps):
+                        elided.add(name)
         for sha in BLOCK_MERGE_RE.findall(body):
             if sha_matches(sha, head_sha):
                 blocking.add(name or "(unattributed)")
     stale = sorted(n for n, fresh in fresh_by_name.items() if not fresh)
-    return {"ok": True, "stale": stale, "blocking": sorted(blocking), "findings": findings}
+    return {
+        "ok": True,
+        "stale": stale,
+        "blocking": sorted(blocking),
+        "findings": findings,
+        "elided": sorted(elided),
+    }
 
 
 def head_run_exists(repo, head_sha):
@@ -1516,6 +1565,7 @@ def build_report(
         "advisory": {
             "blocking_reviewers": sorted(marker_eval.get("blocking") or []),
             "bot_comments_readable": bool(marker_eval.get("ok")),
+            "elided_stamp_reviewers": sorted(marker_eval.get("elided") or []),
             "findings": dict(marker_eval.get("findings") or {}),
             "stale_reviewers": sorted(marker_eval.get("stale") or []),
             "unresolved_threads": n_unresolved,
@@ -1822,11 +1872,15 @@ def main(argv):
     else:
         for name in sorted(marker_eval["findings"]):
             print(
-                "  - {}: fresh{}{}".format(
+                "  - {}: fresh{}{}{}".format(
                     sanitize(name),
                     "  [BLOCK-MERGE]" if name in marker_eval["blocking"] else "",
                     "  ({} advisory FINDING line(s))".format(marker_eval["findings"][name])
                     if marker_eval["findings"][name]
+                    else "",
+                    "  [stamp elided the head's middle - emitter transcription "
+                    "artifact, verified against this head]"
+                    if name in (marker_eval.get("elided") or ())
                     else "",
                 )
             )

--- a/test/test_prepare_pr_findings.py
+++ b/test/test_prepare_pr_findings.py
@@ -161,6 +161,7 @@ class TestMarkerRegexParity:
         status = _load_status()
         for helper in (
             "span_hash",
+            "sha_matches",
             "extract_findings",
             "parse_disposition_record",
             "fetch_disposition_comments",

--- a/test/test_prepare_pr_status.py
+++ b/test/test_prepare_pr_status.py
@@ -319,6 +319,7 @@ def test_report_emits_only_the_consumed_surface(capsys) -> None:
     assert set(report["advisory"]) == {
         "blocking_reviewers",
         "bot_comments_readable",
+        "elided_stamp_reviewers",
         "findings",
         "stale_reviewers",
         "unresolved_threads",
@@ -1443,6 +1444,134 @@ def test_stale_reviewer_stamp_blocks_a_would_be_clean_pr() -> None:
     _install_fake_gh(module, _pr_payload(_clean_checks()), comments=comments)
 
     assert module.main(["pr_status.py", "42"]) == 20
+
+
+# A realistic head: the all-`f` fixture cannot exercise elision, because any
+# splice of it is also a prefix of it.
+_MIXED_HEAD = "db7c4361f0a92be5147c3d8e6b0af215934cde78"
+# The shape the Design lane actually emitted on PR 4107: the head's first 14
+# characters spliced to its last 11, middle dropped, 25 characters total.
+_ELIDED = _MIXED_HEAD[:14] + _MIXED_HEAD[-11:]
+
+
+class TestShaMatches:
+    """The stamp is model-transcribed, so the freshness test has to tell a
+    MANGLED head from a reference to a DIFFERENT commit."""
+
+    def test_exact_and_prefix_forms_match(self) -> None:
+        module = _load_script()
+        assert module.sha_matches(_MIXED_HEAD, _MIXED_HEAD)
+        assert module.sha_matches(_MIXED_HEAD[:7], _MIXED_HEAD)
+        assert module.sha_matches(_MIXED_HEAD[:12], _MIXED_HEAD)
+
+    def test_prefix_shorter_than_seven_is_not_a_reference(self) -> None:
+        module = _load_script()
+        assert not module.sha_matches(_MIXED_HEAD[:6], _MIXED_HEAD)
+
+    def test_elided_middle_matches_the_head_it_mangles(self) -> None:
+        """PR 4107's exact failure: 25 characters, prefix+suffix of this head."""
+        module = _load_script()
+        assert len(_ELIDED) == 25
+        assert not _MIXED_HEAD.startswith(_ELIDED)  # the old test rejected it
+        assert module.sha_matches(_ELIDED, _MIXED_HEAD)
+
+    def test_another_commit_is_still_rejected(self) -> None:
+        """The freshness guard survives: a well-formed reference to a different
+        commit cannot pass, in full or short form."""
+        module = _load_script()
+        other = "a" * 40
+        assert not module.sha_matches(other, _MIXED_HEAD)
+        assert not module.sha_matches(other[:12], _MIXED_HEAD)
+        # Same length as the head but not equal -- no elision can be claimed.
+        cousin = _MIXED_HEAD[:39] + ("0" if _MIXED_HEAD[39] != "0" else "1")
+        assert not module.sha_matches(cousin, _MIXED_HEAD)
+
+    def test_elision_needs_seven_head_characters_of_its_own(self) -> None:
+        """A splice whose prefix half is too short identifies nothing: it would
+        let a token borrow the head's tail with almost no head of its own."""
+        module = _load_script()
+        assert not module.sha_matches(_MIXED_HEAD[:3] + _MIXED_HEAD[-11:], _MIXED_HEAD)
+        assert not module.sha_matches(_MIXED_HEAD[-11:], _MIXED_HEAD)
+
+    def test_empty_inputs_are_not_a_match(self) -> None:
+        module = _load_script()
+        assert not module.sha_matches("", _MIXED_HEAD)
+        assert not module.sha_matches(None, _MIXED_HEAD)
+        assert not module.sha_matches(_MIXED_HEAD, "")
+
+
+def test_elided_design_stamp_no_longer_reads_as_stale() -> None:
+    """The reported harm: the Design lane mangled its own stamp and every
+    prepare-pr/babysit loop read exit 20 BLOCKED while PR Readiness was green."""
+    module = _load_script()
+    comments = json.dumps(
+        [
+            _bot_comment(f"No findings.\n[GPT-REVIEWED] {_MIXED_HEAD}"),
+            _bot_comment(
+                f"Design-Verdict: PASS\n[DESIGN-REVIEWED] {_ELIDED}",
+                key="design-review",
+            ),
+        ]
+    )
+    _install_fake_gh(
+        module,
+        _pr_payload(_clean_checks(), headRefOid=_MIXED_HEAD),
+        comments=comments,
+    )
+
+    assert module.main(["pr_status.py", "42"]) == 0
+
+
+def test_elided_stamp_is_reported_rather_than_silently_accepted(capsys) -> None:
+    """Tolerance without a trace would hide the emitter defect for good, so the
+    reviewer is named in the advisory block and in the prose line."""
+    module = _load_script()
+    comments = json.dumps(
+        [
+            _bot_comment(
+                f"Design-Verdict: PASS\n[DESIGN-REVIEWED] {_ELIDED}",
+                key="design-review",
+            ),
+        ]
+    )
+    _install_fake_gh(
+        module,
+        _pr_payload(_clean_checks(), headRefOid=_MIXED_HEAD),
+        comments=comments,
+    )
+
+    assert module.main(["pr_status.py", "42", "--json"]) == 0
+    out = capsys.readouterr().out
+    report = json.loads([ln for ln in out.strip().splitlines() if ln.strip()][-1])
+    assert report["advisory"]["elided_stamp_reviewers"] == ["DESIGN"]
+    assert "stamp elided the head's middle" in out
+    # The note is advisory only: it must not enter progress_key, which a polling
+    # loop compares byte-for-byte to tell a stalled PR from a moving one.
+    assert "elided" not in json.dumps(report["progress_key"])
+
+
+def test_an_exact_stamp_reports_no_elision(capsys) -> None:
+    """The audit line is not decoration: it appears only for a mangled stamp."""
+    module = _load_script()
+    comments = json.dumps(
+        [
+            _bot_comment(
+                f"Design-Verdict: PASS\n[DESIGN-REVIEWED] {_MIXED_HEAD}",
+                key="design-review",
+            ),
+        ]
+    )
+    _install_fake_gh(
+        module,
+        _pr_payload(_clean_checks(), headRefOid=_MIXED_HEAD),
+        comments=comments,
+    )
+
+    assert module.main(["pr_status.py", "42", "--json"]) == 0
+    out = capsys.readouterr().out
+    report = json.loads([ln for ln in out.strip().splitlines() if ln.strip()][-1])
+    assert report["advisory"]["elided_stamp_reviewers"] == []
+    assert "stamp elided" not in out
 
 
 def test_block_merge_for_current_head_blocks_even_when_readiness_passed() -> None:


### PR DESCRIPTION
## What is the problem?

The review lanes do not write their own freshness stamp. Each workflow asks the
MODEL to end its review prose with `[<NAME>-REVIEWED] <sha>` -- see the prompt in
`.github/workflows/design-review.yml` -- and then reads that line back. So 40 hex
characters pass through a transcription step, and a model can mangle them.

On PR 4107 (head `db7c436...`) the Design lane wrote 25 characters instead of 40:
the head's first 14 spliced directly to its last 11, with the middle dropped.
`pr_status.py` tests a stamp by asking whether it is a `>=7`-hex PREFIX of the
head, and an elided token is not a prefix of anything, so the lane read as
STALE. Every `prepare-pr` and `babysit` loop on that PR then reported exit 20
BLOCKED while `PR Readiness` was green -- the loop's own instructions say to trust
the stamp over the check conclusion, so the false BLOCKED was authoritative. It
cleared only because the workflow happened to be re-run and the model retyped
the SHA correctly that time.

This is a fail-closed gate tripping on its own emitter's typo. The failure is
not rare-by-construction either: every lane's stamp is model-typed, so any of
the five can produce it on any head.

## Why this issue matters to the user

An agent driving a PR to green reads exit 20 and starts looking for something to
fix. There is nothing to fix -- the reviews all passed -- so the loop either burns
rounds re-reading logs, force-pushes to re-trigger the lanes hoping the stamp
comes out clean, or escalates a green PR to a human as blocked. On a babysit loop
polling every five minutes, a single mistyped SHA can hold a mergeable PR in a
false-blocked state indefinitely, because nothing in the loop can distinguish
"the reviewer has not looked at this head" from "the reviewer looked and
mistyped the head".

## How our fix solves it

Symptom: a mangled stamp reads as stale. Cause: the freshness test is
prefix-only, and a mangling is not a prefix. Root cause: the stamp's SHA is
model-authored, and the consumer treated it as if it were machine-authored.
`pr_status.py` already applies exactly that distinction to the reviewer's
IDENTITY -- its comment says identity "must come from WORKFLOW-AUTHORED bytes,
never from model output", which is why the lane is identified by the workflow's
own leading HTML key. The SHA is the remaining model-authored field on the same
line, and this change gives it the tolerance that fact requires.

`sha_matches` now accepts a second spelling beside the prefix:

- `>=7`-hex **prefix** of the head -- unchanged, and still what a full 40-char or
  short-SHA stamp matches on.
- **Elided head** -- a token that splits into a `>=7`-hex prefix of the head plus
  a non-empty suffix of the head, and is SHORTER than the head.

The guard the strict match was protecting is intact, which is the point of doing
it this way rather than by restamping the comment: a well-formed reference to a
DIFFERENT commit cannot pass, because it would have to begin with 7+ characters
of THIS head and end with this head's tail. A full-length token that is not the
head is rejected outright. So the change admits manglings of the current head,
never another commit.

Two supporting decisions:

- The predicate is defined once and carried byte-identically by `pr_findings.py`
  (the two scripts are standalone-copyable by design and cannot import each
  other), and the existing byte-identical-helper parity test now pins it. That
  also removes the two inline `len(sha) >= 7 and head_sha.startswith(sha)`
  copies in each file, so there is one definition of freshness instead of five.
- Accepting an elided stamp silently would hide the emitter defect permanently --
  nobody would ever learn a lane is mangling the SHA it was handed.
  `evaluate_markers` records which lanes needed the tolerance; the prose line
  marks them and `--json`'s `advisory` block lists them in
  `elided_stamp_reviewers`. `test_report_emits_only_the_consumed_surface` pins
  that every emitted field has a named consumer, so the babysit skill documents
  this one as a report-once lane-quality note. It stays OUT of `progress_key`,
  which a polling loop compares byte-for-byte to tell a stalled PR from a moving
  one.

Deliberately NOT changed: the review workflows' own `grep -qF "[DESIGN-REVIEWED]
$HEAD"` gates. Those fail closed inside the lane that owns the stamp, where the
remedy is re-running that one workflow, and their symptom is a "could not
complete" notice rather than a false BLOCKED on an unrelated consumer. Making
four workflows each carry a shell copy of this predicate would duplicate the
logic without touching the reported harm.

## What tests we did

- `test/test_prepare_pr_status.py` (targeted, `-n 4`): a new `TestShaMatches`
  class covering exact/prefix forms, a 6-char prefix (rejected), PR 4107's exact
  25-character elision (accepted), a different commit in full and short form
  (rejected), a same-length near-miss (rejected), a splice whose prefix half is
  under 7 characters and a suffix-only token (both rejected), and empty inputs.
- Two integration tests through `main()`: an elided `[DESIGN-REVIEWED]` stamp on
  an otherwise clean PR now exits 0 where it exited 20, and the tolerance is
  reported -- `advisory.elided_stamp_reviewers == ["DESIGN"]`, the prose carries
  the note, and `progress_key` does not. A third pins that an exact stamp reports
  no elision, so the note cannot become decoration.
- Mutation-verified: removing the elision branch reds exactly the three new
  behaviour tests (`assert 20 == 0` twice, plus the predicate case) and nothing
  else.
- Existing suites unchanged: `test_prepare_pr_status.py`,
  `test_prepare_pr_findings.py`, `test_agent_template_skills.py`,
  `test_babysit_pr_watch.py` -- 272 passed together.
- `flake8` clean on the four touched files; `isort --check-only` clean; the
  diff-scoped `check_black_formatting.py` passes with the branch's 5 files in
  scope. `mypy` reports 29 errors on these files both on this branch and on
  base (A/B'd), so they are inherited, not introduced. Full suites left to CI.

## Any other suggestions on the work

- The deeper fix is to stop having a model transcribe a SHA at all: the posting
  step already knows `$HEAD`, so it could strip any model-emitted stamp and
  append a workflow-authored one. That was rejected here because the model-typed
  stamp is currently what catches a lane REGURGITATING an older review body
  verbatim -- restamping would launder exactly that case -- so replacing it needs
  a different freshness proof rather than a one-line edit.
- `elided_stamp_reviewers` is the signal to watch: if one lane shows up in it
  repeatedly, that lane's prompt is the thing to fix, and this tolerance is what
  makes the pattern observable instead of silently costing a re-run each time.
