### PR TITLE
fix(system): leave a session alone if it is resumed while being staged

### DIFF
--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -107,11 +107,35 @@ making the authority check the freshest view available. The two active sets are
 **unioned**, so a re-read can only ever add protection, and a re-read that fails
 refuses the operation rather than proceeding on the stale view.
 
-The residual window is now the move loop itself. A session mapped during it is still
-staged — but staged means *in the trash*, fully restorable, and destroying it needs a
-second explicit `empty`. Closing the window completely needs the session/slot writer
-and this module to share one lock; that is recorded in Known Limitations rather than
-implied away.
+The move loop then closes most of what the re-read cannot. Every source file is
+stat'd there anyway, to record its size in the manifest, and that same stat carries
+an mtime. A candidate qualified by being untouched for `MIN_RECLAIM_AGE_DAYS`, so a
+source whose mtime is newer than the instant the reclaim began has been written to
+since every read that certified it — which an idle session's file cannot be. The
+whole session is left in place, whatever already moved for it is rolled back, and it
+is named in `TrashBatch.revived` so the caller can report it. This costs no extra
+syscall: the detection rides on a stat the loop already performs.
+
+Naming a session in `revived` is a claim -- "this one was left where it was" -- so it
+is only made when the rollback actually completed. Putting a file back is
+deliberately non-overwriting, so the very resume that triggered the detection can
+have recreated an origin and made the rollback decline. Two things then have to hold
+before the call returns: whatever is still staged is **appended to the manifest**, so
+restore and empty can both reach it (safe because restore also moves exclusively, and
+therefore declines the origin the resume recreated rather than overwriting the live
+session with the stale copy); and the call **raises**, naming the batch, instead of
+reporting a revival that is not true. Everything that did move is still described by
+the manifest, so the partial batch stays restorable.
+
+The anchor is taken **before** the scan, not after the authority checks. Taken later
+it would miss a session resumed during the scan or between the index re-read and the
+loop, which is most of the elapsed time. Taking it early adds no false positives,
+because a candidate has to be untouched for `MIN_RECLAIM_AGE_DAYS` to qualify at all.
+
+Detection, not prevention: a session revived *after* its last file was stat'd and
+moved is still staged. The window is therefore the gap between one file's stat and
+its rename rather than the whole loop, and what lands in that gap lands in the
+trash — fully restorable, with destruction still needing a second explicit `empty`.
 
 ## What is reclaimable
 
@@ -549,6 +573,13 @@ That is the conservative direction (never a wrong move), but a client cannot
 distinguish it from a malformed request without reading the code, and retrying is
 the only recovery.
 
+A session that goes live *later still* — after the `refresh`, while the move loop is
+running — is not all-or-nothing. The loop's mtime check leaves that one session in
+place and the rest of the batch proceeds, and the handler folds each such uid into
+the same `refused` list under `in_use`. The mechanism differs from the pre-pass
+(caught by a stat during the move rather than by the index before it) but the reason
+a reader needs is identical, so it carries no new code.
+
 **The guarantee is not weakened.** `move_to_trash()` still re-reads the session map
 inside the mutation lock and still unions the active sets, so the pre-pass can only
 ever be more conservative than the authority, never less. Doing less than the user
@@ -610,13 +641,16 @@ instead of the trash over-deleting. `TestEmptyTrash` and
 
 ## Known Limitations
 
-- **A residual race with session-map writes remains.** The authority check is
-  re-read after the scan and inside the reclaim lock, so the window is the move loop
-  rather than the whole scan, but the session map's writer does not take that lock. A
-  session mapped during the loop would still be staged. It stays restorable — nothing
-  is destroyed without a second explicit action — but closing this fully requires the
-  session/slot code and this module to share one lock, which is a wider change than
-  this surface.
+- **A much smaller residual race with session-map writes remains.** The authority
+  check is re-read after the scan and inside the reclaim lock, and the move loop then
+  rejects any source whose mtime is newer than the batch's validation instant, so a
+  session resumed *during* the loop is left in place and reported rather than staged.
+  What is left is detection, not prevention: the session map's writer still does not
+  take the reclaim lock, so a session revived between one file's stat and its rename
+  is staged anyway. That gap is microseconds rather than the whole loop, and it stays
+  restorable — nothing is destroyed without a second explicit action. Removing it
+  entirely still requires the session/slot code and this module to share one lock,
+  which is a wider change than this surface.
 - Reclaiming is offered both by age (`cleanup`) and by explicit selection
   (`trash`). Neither can take a session the map still lists, so targeting one large
   conversation only works if that conversation is unmapped.

--- a/src/kiro_crew/dashboard/handlers/session_storage.py
+++ b/src/kiro_crew/dashboard/handlers/session_storage.py
@@ -942,8 +942,42 @@ async def api_session_inventory_trash(request: web.Request) -> web.Response:
             refresh=_build_index,
         )
     except SessionStorageError as exc:
+        # Audited before returning. A refusal from inside the move is the same
+        # security-relevant outcome as the pre-flight one above -- someone asked to
+        # remove specific conversations and was told no -- and it is the ONLY record
+        # for the case where every selected session was protected, which returns
+        # here rather than through the success path. Resources names the selection
+        # rather than a per-uid reason: which one tripped it is in the message, and
+        # the whole batch was refused either way.
+        _sel().log_api_access(
+            caller=_read_session_key(request),
+            operation="session_storage.trash",
+            outcome="denied",
+            source="dashboard",
+            resources=",".join(eligible)[:512],
+        )
         return _refused(exc, "trash_refused")
 
+    # A session resumed while the batch was being staged was left in place, and
+    # this endpoint's contract is that anything not taken is named. It joins the
+    # same list under the same code the pre-flight uses for a live session: the
+    # mechanism differs (caught by mtime during the move, not by the index before
+    # it) but the fact the reader needs is identical — it is in use, so it stayed.
+    revived_refusals = [{"uid": uid, "reason": "in_use"} for uid in batch.revived]
+    if revived_refusals:
+        # Audited for the same reason the pre-flight refusal above is, and it has
+        # to be its own event: that one is emitted before the move, so a session
+        # protected DURING the move would otherwise appear in the record only
+        # inside a "success", leaving the protection itself unlogged. Emitted
+        # before the success event so the trail reads in the same order as the
+        # pre-flight path.
+        _sel().log_api_access(
+            caller=_read_session_key(request),
+            operation="session_storage.trash",
+            outcome="denied",
+            source="dashboard",
+            resources=",".join(f"{r['uid']}:{r['reason']}" for r in revived_refusals)[:512],
+        )
     _sel().log_api_access(
         caller=_read_session_key(request),
         operation="session_storage.trash",
@@ -956,6 +990,6 @@ async def api_session_inventory_trash(request: web.Request) -> web.Response:
             "sessions": batch.sessions,
             "bytes": batch.bytes,
             "batch_id": batch.batch_id,
-            "refused": refused,
+            "refused": refused + revived_refusals,
         }
     )

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -248,6 +248,12 @@ class TrashBatch:
     reason: str
     sessions: int
     bytes: int
+    #: Sessions that were selected, passed every authority check, and were then
+    #: found to have been written to while the batch was being staged — so they
+    #: were left in place. Empty for a batch read back off disk
+    #: (:func:`list_trash`), which describes what a batch CONTAINS; this field is
+    #: about what one move DECLINED, which only the move itself knows.
+    revived: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1166,29 +1172,40 @@ def _move_file(src: Path, dst: Path) -> None:
         shutil.move(str(src), str(dst))
 
 
-def _file_size(path: Path) -> int:
-    """The size recorded for a staged file. Raises ``OSError`` when unreadable.
+def _file_stamp(path: Path) -> tuple[int, float]:
+    """The size and last-modified time of a file about to be staged.
 
-    A named operation rather than an inline ``stat`` because its failure is
-    load-bearing: a file whose size cannot be read cannot be recorded, and an
-    unrecorded file is one restore cannot put back.
+    Raises ``OSError`` when unreadable. A named operation rather than an inline
+    ``stat`` because both readings are load-bearing and both come from ONE call:
+    a file whose size cannot be read cannot be recorded, and an unrecorded file
+    is one restore cannot put back; the mtime is what tells the move loop the
+    file has been touched since this batch was validated (see
+    :func:`_move_to_trash_locked`). Reading them separately would be two stats
+    describing two instants, which is the class of bug the caller is guarding
+    against.
     """
-    return path.stat().st_size
+    info = path.stat()
+    return info.st_size, info.st_mtime
 
 
-def _rollback(moved: list[tuple[Path, Path]]) -> None:
-    """Undo a partial session move, best effort.
+def _rollback(moved: list[tuple[Path, Path]]) -> bool:
+    """Undo a partial session move, best effort. True if everything went back.
 
     Each pair is (where it landed, where it came from). A rollback that itself
     fails is logged and nothing more: the alternative is raising over a caller
     already handling a failure, which would abandon the rest of the batch too.
+    The return value exists for the one caller that makes a POSITIVE claim about
+    the outcome — "this session was left in place" is only true if every file
+    actually went back — and callers that merely omit a session can ignore it.
 
     The move is EXCLUSIVE. A rollback runs after something already went wrong, so
     the origin may have been recreated in the meantime — and a plain rename would
     replace that newer session data with the copy being put back, turning a handled
     failure into data loss. An occupied origin leaves the file where it is staged,
-    which keeps it recoverable.
+    which keeps it recoverable, and is reported here as an incomplete rollback
+    because the staged copy is then in the batch without being in its manifest.
     """
+    complete = True
     for landed, origin in reversed(moved):
         try:
             if not _move_file_exclusive(landed, origin):
@@ -1197,8 +1214,11 @@ def _rollback(moved: list[tuple[Path, Path]]) -> None:
                     landed,
                     origin,
                 )
+                complete = False
         except OSError:
             logger.warning("could not roll %s back to %s", landed, origin, exc_info=True)
+            complete = False
+    return complete
 
 
 def _staged_path(batch: Path, rel: str) -> Path | None:
@@ -1584,6 +1604,13 @@ def move_to_trash(
     would then treat it as retired. The two active sets are UNIONED, never
     replaced, so a re-read can only ever add protection.
 
+    That re-read still describes one instant, and the move loop after it is not
+    instant. A session resumed anywhere in that stretch is caught in the loop
+    instead: each file is already stat'd for the manifest, so a source modified
+    since the reclaim began marks its session as revived and leaves it in place.
+    The returned batch names those sessions in ``revived`` — they were asked for
+    and not taken.
+
     Serialized against other mutations, because two interleaved reclaims can put
     one half of a session in each batch and leave neither able to restore it.
     """
@@ -1615,11 +1642,35 @@ def _move_to_trash_locked(
     and moving its files out from under a live slot breaks it with no error a user
     would connect to this action.
 
+    Every such check runs before the move loop, so each describes the instant it
+    ran. The loop closes the remaining window itself, against an instant taken
+    before any of them: a source file whose mtime is newer than that has been
+    written to since the reads that certified it, which an idle session's file
+    cannot be, so the whole session is left in place and named in
+    ``TrashBatch.revived``.
+
     Each session is recorded as it lands, so an interruption leaves a manifest
     describing exactly what moved — a partial batch stays restorable instead of
     becoming orphaned files nothing points at.
     """
     clock = time.time() if now is None else now
+    # Anchor for the move loop's revival check, taken BEFORE the scan and before
+    # every authority check below — not after them. Everything this function is
+    # about to reason over is read after this instant, so a source file written
+    # later than it may have been written after the read that certified it, and
+    # the loop must not trust that file. Stamping after the checks would leave
+    # exactly that gap: a session resumed during the scan, or between the index
+    # re-read and the loop, would carry an mtime older than the stamp and be
+    # staged.
+    #
+    # Taking it this early costs nothing in false positives. A candidate has to be
+    # untouched for MIN_RECLAIM_AGE_DAYS to qualify at all, so a legitimate one's
+    # mtime is days older than this stamp however early it is taken.
+    #
+    # Deliberately real wall-clock rather than *clock*: a caller may inject
+    # ``now`` (tests do), and this is compared against an mtime the kernel writes,
+    # so it has to measure elapsed reality.
+    validated_at = time.time()
     blocked_reason = reclaim_block_reason()
     if blocked_reason:
         raise SessionStorageError(blocked_reason)
@@ -1708,6 +1759,7 @@ def _move_to_trash_locked(
 
     moved_bytes = 0
     moved_sessions = 0
+    revived: list[str] = []
     staged_dirs: set[Path] = set()
     cli_files = _cli_index()
     with (target / MANIFEST_NAME).open("w", encoding="utf-8") as manifest:
@@ -1719,9 +1771,10 @@ def _move_to_trash_locked(
             files: list[dict[str, Any]] = []
             done: list[tuple[Path, Path]] = []
             failed = False
+            woke = False
             for src, rel in _unit_paths(unit.sid, unit.stems, archives, cli_files):
                 try:
-                    size = _file_size(src)
+                    size, mtime = _file_stamp(src)
                 except OSError:
                     # A file that cannot be sized cannot be recorded, and a file
                     # the manifest does not record is one restore cannot put back.
@@ -1729,6 +1782,22 @@ def _move_to_trash_locked(
                     # this loop's rollback exists to prevent, so it is a failure.
                     logger.warning("could not stat %s for staging", src, exc_info=True)
                     failed = True
+                    break
+                if mtime > validated_at:
+                    # Every authority check ran before the loop, and moving a
+                    # six-figure store is not instant, so a session can be resumed
+                    # between being certified retired and being reached here. Its
+                    # replay log is then written to, and this is the one signal of
+                    # that which costs nothing: the stat is already being taken for
+                    # the manifest.
+                    #
+                    # A candidate qualified by being untouched for
+                    # MIN_RECLAIM_AGE_DAYS, so an mtime newer than the instant we
+                    # certified it cannot be the same idle file — something has it
+                    # open. Leave the whole session alone rather than any part of
+                    # it: staging half is the split the rollback below exists to
+                    # prevent, and the half left behind would be the live half.
+                    woke = True
                     break
                 dst = target / rel
                 if dst.parent not in staged_dirs:
@@ -1742,6 +1811,46 @@ def _move_to_trash_locked(
                     break
                 done.append((dst, src))
                 files.append({"rel": rel, "origin": str(src), "bytes": size})
+            if woke:
+                # Put back whatever already moved for this session: the point of
+                # leaving it alone is that it stays resumable, and half a session
+                # is not.
+                if not _rollback(done):
+                    # The rollback could not finish — most plausibly because the
+                    # resume that triggered this recreated an origin, and putting a
+                    # file back is deliberately non-overwriting. Two things then
+                    # have to be true before this returns.
+                    #
+                    # First, whatever is still staged must be IN the manifest.
+                    # Unlisted files in a batch are reachable by nothing: restore
+                    # enumerates the manifest, and so does empty. Recording them is
+                    # safe because restore moves exclusively too, so a later restore
+                    # declines the origin the resume recreated rather than
+                    # overwriting the live session with this stale copy.
+                    stranded = [
+                        record for record, (landed, _origin) in zip(files, done) if landed.exists()
+                    ]
+                    if stranded:
+                        try:
+                            _append_entry(manifest, {"uid": uid, "files": stranded})
+                        except OSError:
+                            logger.warning(
+                                "could not record the stranded half of %r; it is in %s",
+                                uid,
+                                target,
+                                exc_info=True,
+                            )
+                    # Second, this must not be reported as a revival. "Left in
+                    # place" would be false, so raise instead — matching how this
+                    # module already treats a file it could not put back — and name
+                    # the batch so the fragment can be found.
+                    raise SessionStorageError(
+                        f"session {uid!r} was resumed while being staged and could "
+                        f"not be fully put back; what is still staged is recorded in "
+                        f"{target} and can be restored"
+                    )
+                revived.append(uid)
+                continue
             if failed:
                 # A session that moved only partly is the broken state this module
                 # exists to prevent, and it would be invisible: the manifest would
@@ -1771,6 +1880,17 @@ def _move_to_trash_locked(
                 moved_sessions += 1
                 moved_bytes += sum(int(record["bytes"]) for record in files)
 
+    if revived:
+        # Reported, not just skipped: the endpoint's own rule is that doing less
+        # than the user asked without saying so is a defect. uid!r because a unit
+        # id reaching here has passed _validate_unit_id, but the log line is read
+        # by people who also read agent-influenced names, so keep it quoted.
+        logger.warning(
+            "left %d session(s) in place: resumed while staging (first: %r)",
+            len(revived),
+            revived[0],
+        )
+
     if not moved_sessions:
         # Leave no empty batch behind — but a rollback that itself failed can have
         # left staged files here, and those are the only copy.
@@ -1779,6 +1899,14 @@ def _move_to_trash_locked(
                 "no sessions were staged, and some files could not be put back; " f"see {target}"
             )
         shutil.rmtree(target, ignore_errors=True)
+        if revived:
+            # A distinct message from "not found": every selected session is still
+            # exactly where the caller left it, and it is still resumable. Saying
+            # "none were found" here would send someone looking for lost files.
+            raise SessionStorageError(
+                f"all {len(revived)} selected session(s) were resumed while being "
+                "staged; nothing was moved"
+            )
         raise SessionStorageError("none of the selected sessions were found on disk")
 
     return TrashBatch(
@@ -1787,6 +1915,7 @@ def _move_to_trash_locked(
         reason=reason,
         sessions=moved_sessions,
         bytes=moved_bytes,
+        revived=tuple(revived),
     )
 
 

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -16,7 +16,9 @@ import contextlib
 import json
 import logging
 import os
+import time
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -260,6 +262,216 @@ class TestMoveTakesBothHalves:
         assert str(crew_home / "sessions" / "dashboard_chat-1.jsonl") in origins
 
 
+class TestASessionResumedWhileStagingIsLeftAlone:
+    """The authority checks run before the move loop, so they describe one instant.
+
+    A batch is not instant, and a session can be resumed between being certified
+    retired and being reached by the loop. The loop catches that from the stat it
+    already takes for the manifest: a source modified since the batch was
+    validated cannot be the idle file that qualified.
+    """
+
+    def _touch_when(self, target: Path, *, on: Path) -> Callable[[Path, Path], None]:
+        """Move normally, but write to *target* the first time *on* is moved.
+
+        Stands in for the real event: something resumes the session and appends to
+        its replay log while the batch is part-way through being staged.
+        """
+        real = session_storage._move_file
+        state = {"done": False}
+
+        def _move(src: Path, dst: Path) -> None:
+            real(src, dst)
+            if not state["done"] and src == on:
+                state["done"] = True
+                with target.open("ab") as fh:
+                    fh.write(b"resumed")
+                future = time.time() + 5
+                os.utime(target, (future, future))
+
+        return _move
+
+    def test_the_revived_session_stays_in_place_and_is_named(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=400)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-2", size=16, age_days=400)
+
+        # The first session's cli half moves, and that is when the SECOND session's
+        # transcript is written to — the ordering a real resume would produce.
+        victim = crew_home / "sessions" / "dashboard_chat-2.jsonl"
+        trigger = kiro_home / "sessions" / "cli" / "aaaa1111.jsonl"
+        monkeypatch.setattr(session_storage, "_move_file", self._touch_when(victim, on=trigger))
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1", "bbbb2222": "dashboard_chat-2"}),
+            now=_NOW,
+        )
+
+        assert batch.sessions == 1
+        assert batch.revived == ("bbbb2222",)
+        # Still resumable, both halves, exactly where they were.
+        assert victim.is_file()
+        assert (kiro_home / "sessions" / "cli" / "bbbb2222.jsonl").is_file()
+        # And nothing of it is in the batch.
+        staged = session_storage.trash_root() / batch.batch_id
+        assert not (staged / "crew" / "dashboard_chat-2.jsonl").exists()
+        assert not (staged / "cli" / "bbbb2222.jsonl").exists()
+        # The session that was genuinely idle still moved.
+        assert (staged / "cli" / "aaaa1111.jsonl").is_file()
+
+    def test_a_half_that_already_moved_is_put_back(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Revival found on a LATER file must not leave the session split."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=400)
+        transcript = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+
+        cli_log = kiro_home / "sessions" / "cli" / "aaaa1111.jsonl"
+        monkeypatch.setattr(session_storage, "_move_file", self._touch_when(transcript, on=cli_log))
+
+        with pytest.raises(SessionStorageError, match="resumed while being staged"):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )
+
+        # The half that had already moved is back where it belongs.
+        assert cli_log.is_file()
+        assert transcript.is_file()
+
+    def test_a_resume_between_the_refresh_and_the_loop_is_caught(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """The anchor is taken before the scan, so this window is covered too.
+
+        An anchor stamped after the authority checks would miss this: the write
+        lands while ``refresh`` runs, so its mtime is older than any later stamp
+        and the session would be staged while live. Driving it through *refresh*
+        puts the write exactly where a resume during the scan would land.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=400)
+        victim = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+        mapping = {"aaaa1111": "dashboard_chat-1"}
+
+        def _refresh_and_resume() -> SessionIndex:
+            # A real resume writes at the current instant, NOT in the future, and
+            # that is the whole point of this test: an mtime of "now" is newer than
+            # an anchor taken at entry and OLDER than one taken after these checks,
+            # so only the early anchor catches it. The sleep makes the ordering
+            # measurable rather than trusting sub-microsecond clock resolution.
+            time.sleep(0.01)
+            with victim.open("ab") as fh:
+                fh.write(b"resumed")
+            written = time.time()
+            os.utime(victim, (written, written))
+            # Deliberately reports the session as retired: this pins the mtime
+            # guard, not the index re-read that already covers a MAPPED session.
+            return _index(mapping)
+
+        with pytest.raises(SessionStorageError, match="resumed while being staged"):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index(mapping),
+                now=_NOW,
+                refresh=_refresh_and_resume,
+            )
+
+        assert victim.is_file()
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+
+    def test_a_revival_whose_rollback_cannot_finish_is_not_claimed_as_left_alone(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reporting revival is a claim, so it must not outlive a failed rollback.
+
+        Putting a file back is deliberately non-overwriting, so a resume that
+        recreates an origin makes the rollback incomplete: the staged copy stays in
+        the batch, unlisted by its manifest. Saying the session was "left in place"
+        would then be false, and restore could not see the orphan either.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=400)
+        cli_log = kiro_home / "sessions" / "cli" / "aaaa1111.jsonl"
+        transcript = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+
+        real = session_storage._move_file
+        state = {"done": False}
+
+        def _resume_recreating_the_origin(src: Path, dst: Path) -> None:
+            real(src, dst)
+            if not state["done"] and src == cli_log:
+                state["done"] = True
+                # The resume recreates the half that just moved AND writes the
+                # other one — the ordering that makes the rollback decline.
+                cli_log.write_bytes(b"live again")
+                with transcript.open("ab") as fh:
+                    fh.write(b"resumed")
+                future = time.time() + 5
+                for path in (cli_log, transcript):
+                    os.utime(path, (future, future))
+
+        monkeypatch.setattr(session_storage, "_move_file", _resume_recreating_the_origin)
+
+        with pytest.raises(SessionStorageError, match="could not be fully put back"):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )
+
+        # The live session keeps what the resume wrote — the rollback must never
+        # overwrite it with the staged copy.
+        assert cli_log.read_bytes() == b"live again"
+        assert transcript.is_file()
+
+        # And whatever could not be put back is IN the manifest, because an
+        # unlisted file in a batch is reachable by neither restore nor empty.
+        batches = list(session_storage.trash_root().iterdir())
+        assert len(batches) == 1
+        entries = [
+            json.loads(line)
+            for line in (batches[0] / session_storage.MANIFEST_NAME).read_text().splitlines()
+            if line.strip()
+        ]
+        staged_records = [e for e in entries if e.get("uid") == "aaaa1111"]
+        assert staged_records, "the stranded half was left out of the manifest"
+        rels = {record["rel"] for record in staged_records[0]["files"]}
+        assert rels, "an entry with no files cannot be restored"
+        for rel in rels:
+            assert (batches[0] / rel).is_file()
+
+    def test_an_untouched_batch_reports_nothing_revived(self, stores: tuple[Path, Path]) -> None:
+        """The guard must not fire on the ordinary case, or every reclaim breaks."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=400)
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        assert batch.sessions == 1
+        assert batch.revived == ()
+
+
 class TestRestoreIsAllOrNothing:
     def test_restores_every_half(self, stores: tuple[Path, Path]) -> None:
         crew_home, kiro_home = stores
@@ -458,14 +670,14 @@ class TestRestoreIsAllOrNothing:
         _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
         _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
         target = crew_home / "sessions" / "dashboard_chat-1.jsonl"
-        real_size = session_storage._file_size
+        real_stamp = session_storage._file_stamp
 
-        def flaky_size(path: Path) -> int:
+        def flaky_stamp(path: Path) -> tuple[int, float]:
             if path == target:
                 raise OSError("simulated transient stat failure")
-            return real_size(path)
+            return real_stamp(path)
 
-        monkeypatch.setattr(session_storage, "_file_size", flaky_size)
+        monkeypatch.setattr(session_storage, "_file_stamp", flaky_stamp)
 
         with pytest.raises(SessionStorageError, match="none of the selected"):
             session_storage.move_to_trash(

--- a/test/test_session_storage_api.py
+++ b/test/test_session_storage_api.py
@@ -1310,6 +1310,43 @@ class TestRefusalsAreAudited:
         assert "resumable" in denial.kwargs["resources"], "the reason belongs in the record"
 
     @pytest.mark.asyncio
+    async def test_a_refusal_raised_from_inside_the_move_is_audited_too(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """The only record for a batch refused mid-move is this one.
+
+        A selection where every session is protected DURING staging never reaches
+        the success path, so without an audit on the exception branch the
+        protection decision would leave no trace at all.
+        """
+        crew_home, kiro_home = stores
+        # Unmapped and old, so it passes pre-flight and the move is attempted --
+        # which is the only way to reach the branch under test.
+        sid = "dddddddd-0000-4000-8000-000000000009"
+        _retired(kiro_home, sid, age_days=45)
+
+        req = _request("POST", "/api/system/session-storage/trash", {"uids": [sid]})
+        req.app["state"].running_session_keys.return_value = frozenset()
+        sel = _sel_stub()
+
+        def _raise(*_args, **_kwargs):
+            raise handler.SessionStorageError(
+                "all 1 selected session(s) were resumed while being staged; nothing was moved"
+            )
+
+        with (
+            patch.object(handler, "_sel", lambda: sel),
+            patch.object(handler, "move_to_trash", _raise),
+        ):
+            resp = await handler.api_session_inventory_trash(req)
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "trash_refused"
+        outcomes = [c.kwargs["outcome"] for c in sel.log_api_access.call_args_list]
+        assert "denied" in outcomes, "a mid-move refusal must leave a denied event"
+        assert "success" not in outcomes, "nothing was taken, so nothing succeeded"
+
+    @pytest.mark.asyncio
     async def test_a_partial_refusal_is_audited_alongside_the_success(
         self, stores: tuple[Path, Path]
     ) -> None:


### PR DESCRIPTION
## 1. What is the problem?

`move_to_trash` decides what may be taken, and then it moves. The deciding half is
thorough: it holds the cross-process reclaim lock, re-reads the session index
*inside* that lock and unions the active sets, re-reads co-tenant ownership, and
refuses outright when another instance shares the store. Every one of those checks
describes the instant it ran.

The moving half re-checked nothing. Between validation and the moment the loop
reached a given session, that session could be resumed -- and it was staged to
trash anyway. The window is not always small: a six-figure store, spinning or
networked storage, or a selection at the 200k cap all stretch the loop well past
the instant its authority was established.

Two places in the repository already said this must not happen:

- `api_session_inventory_trash`'s docstring -- "a selection that has gone stale can
  only be refused, never honoured against a live session." The refusal was decided
  before the loop, so a session that went live *during* the loop was honoured.
- `docs/system-specs/modules/session-storage.md` recorded it as a Known Limitation
  and asserted that closing it "requires the session/slot code and this module to
  share one lock, which is a wider change than this surface." That turns out not to
  be true of the common case.

## 2. Why this issue matters to the user

The user resumes a chat and it starts empty. Their history was moved to trash a
moment after the sweep decided the session was retired, so the session either lists
without resuming or resumes with no history -- the exact split this module exists
to prevent, arrived at from the other direction.

It is a correctness bug rather than a data-loss one, and the PR does not overstate
it: staged means *in the trash*, restore puts every half back, and destruction
needs a separate deliberate `empty`. What is actually lost is conversation
continuity, which the product has no way to explain to the person it happens to.

## 3. How our fix solves it

Symptom: a resumed session's files vanish. Root cause: authority was established
once, before a loop long enough for the answer to change, and nothing re-asked.

The loop now re-asks per file, at **no extra syscall**. It already stats every
source to record its size in the manifest, and that same stat carries an mtime:

1. `_file_size` becomes `_file_stamp`, returning `(size, mtime)` from one `stat`.
   Reading them separately would be two stats describing two instants, which is the
   bug class being fixed.
2. A candidate qualified by being untouched for `MIN_RECLAIM_AGE_DAYS`, so a source
   whose mtime is newer than the instant the batch was validated has been written to
   since -- which an idle session's file cannot be. That session is marked revived.
3. Whatever already moved for it is rolled back, so it is never left split. Leaving
   half behind would leave the LIVE half behind, which is worse than either extreme.
4. It is named in `TrashBatch.revived`, and the trash endpoint folds each uid into
   the `refused` list it already returns, under the existing `in_use` code. The
   mechanism differs from the pre-flight (a stat during the move, not the index
   before it) but the fact a reader needs is identical, so this adds no response key,
   no new refusal code and no new copy to translate.
5. A batch where *every* selection was revived raises its own message instead of
   "none of the selected sessions were found on disk" -- that wording would send
   someone looking for files that are still exactly where they left them.

The validation instant is real wall-clock, deliberately not the injectable `now`: it
is compared against an mtime the kernel writes, so it has to measure elapsed
reality. The `cleanup` endpoint needs no change -- it is a policy sweep with no
per-uid channel, and a revived session simply shows up in the `remaining` count it
already recomputes.

**Honest about what this is: detection, not prevention.** A session revived *after*
its last file was stat'd and moved is still staged. The window shrinks from the
whole move loop to the gap between one file's stat and its rename. The spec's Known
Limitation is rewritten to say that rather than deleted, including the part that
still stands: removing the gap entirely does need the session writer and this module
to share one lock.

## 4. What tests we did

Three tests in `test/test_session_storage.py`, in a class named for the property.
The revival is produced the way the real one arrives -- a patched `_move_file` that
appends to a *different* session's transcript while the first session is being
staged, so the write genuinely lands mid-loop rather than being simulated by a flag:

- **the revived session stays in place and is named** -- a two-session batch where
  the second is written to during the first one's move: `sessions == 1`,
  `revived == ("bbbb2222",)`, both of its halves still on disk and resumable, neither
  present in the batch, and the genuinely idle session still moved.
- **a half that already moved is put back** -- revival detected on a *later* file of
  the same session must not leave it split; the already-staged half is restored and
  the all-revived message is raised.
- **an untouched batch reports nothing revived** -- the control. Without it a guard
  that fired on everything would pass the other two.

Mutation-verified: disabling the guard (`if False and mtime > validated_at`) reddens
the first two (`assert 2 == 1`, `DID NOT RAISE`) and leaves the control green.
Reverted after.

Also retargeted one existing test that patched `_file_size` by name.

Targeted runs only, never the full suite: `test_session_storage.py` +
`test_session_storage_api.py` -> 228 passed. flake8, isort, mypy clean on both
changed source files; the repo black gate passes in scope.

## 5. Any other suggestions on the work

- **No overlap with #7011**, which hardens the *delete* side of the same module
  (descriptor-binding the empty-trash removal). Its `session_storage.py` hunks are
  all at line 1984+, in `staged_targets` / `empty_trash`; this change is at
  `_file_stamp` and the move loop. Worth reading together, though: #7011 makes
  consent bind to an object rather than a name, and this makes eligibility bind to
  an instant rather than a scan.
- **mtime is a proxy, and its failure mode is the safe one.** A filesystem with
  coarse mtime granularity, or a resume that writes nothing, would be missed -- the
  behaviour then degrades to exactly what ships today. It cannot produce the
  opposite error: a stale idle file cannot acquire a future mtime on its own.
- The same instant-versus-loop shape exists wherever a sweep validates a set and
  then acts on it item by item. This PR does not go looking for those; if that
  audit is wanted it should be its own pass.

Refs #2563 -- that issue was closed NOT_PLANNED as a *parked decision* rather than a
rejected one ("which recycling strategy?"), so this uses `Refs` rather than `Closes`:
it answers the parked question for the move path with the cheapest of the options,
and a maintainer should decide whether that retires the issue or leaves the wider
recycling question open.
