### PR TITLE
fix: repair three half-wired call sites found by the dead-code audit

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/backup.py
@@ -264,7 +264,16 @@ def run_snapshot_backup(account: str, profile: str, region: str, bucket: str) ->
         # entropy (the _stamp shape) rather than trusting the file name.
         key = f"snapshots/kirocrew-snapshot-{_stamp()}.tar.gz"
         _authorize_upload(account, profile, region)
-        storage.put_file(profile, region, bucket, "backup", key, str(payload), account=account)
+        storage.put_file(
+            profile,
+            region,
+            bucket,
+            "backup",
+            key,
+            str(payload),
+            account=account,
+            timeout=_PUSH_TIMEOUT_SECS,
+        )
         return _record_run(account, KIND_SNAPSHOT, key, payload.stat().st_size)
 
 
@@ -444,7 +453,16 @@ def run_sessions_backup(account: str, profile: str, region: str, bucket: str) ->
             raise RuntimeError("no session files to archive")
         key = f"sessions/{archive.name}"
         _authorize_upload(account, profile, region)
-        storage.put_file(profile, region, bucket, "backup", key, str(archive), account=account)
+        storage.put_file(
+            profile,
+            region,
+            bucket,
+            "backup",
+            key,
+            str(archive),
+            account=account,
+            timeout=_PUSH_TIMEOUT_SECS,
+        )
         return _record_run(account, KIND_SESSIONS, key, archive.stat().st_size)
 
 

--- a/src/kiro_crew/apps/builtins/mochi/pet_state_manager.py
+++ b/src/kiro_crew/apps/builtins/mochi/pet_state_manager.py
@@ -121,7 +121,19 @@ class PetStateManager:
         self.clear_persistent_mood(now_ms)
 
     def finish_walking(self, now_ms: int) -> None:
-        walk_duration = now_ms - (self._walk_started_at or 0)
+        # No walk open: nothing to finish. `/walk-done` is posted by the
+        # renderer's `useWalking` hook, which animates a move the SERVER never
+        # opened as a walk -- there is no `/walk-start` route, and `/pet-event`
+        # refuses `walk_start`. The state is the discriminator, not
+        # `_walk_started_at`: 0 is a legitimate `now_ms`. Falling through would
+        # read the duration as `now_ms` (never instant), arm `walk-restore`, and let
+        # `_restore_from_walk` force-broadcast `idle` over a live
+        # thinking/working state mid-turn -- while overwriting `_pet_state`
+        # first, so the `thinking -> other` edge is missed and
+        # `record_thinking_end` never fires.
+        if self._pet_state != "walking":
+            return
+        walk_duration = now_ms - self._walk_started_at
         self._walk_started_at = 0
 
         if walk_duration < INSTANT_WALK_THRESHOLD_MS:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1607,6 +1607,12 @@ class GatewayOrchestrator:
         self.consolidator: HistoryConsolidator | None = None
         self.cron_svc: CronService | None = None
         self.heartbeat_svc: HeartbeatService | None = None
+        # Declared here, not just assigned in `_init_autonudge`: that method
+        # returns early when `KIROCREW_AUTONUDGE=0`, BEFORE its only assignment,
+        # so with the flag off the attribute never existed at all -- and the
+        # seven `if self.autonudge_svc:` sites in the loop-CRUD handlers below
+        # would raise AttributeError rather than read a default.
+        self.autonudge_svc: AutoNudgeService | None = None
         # Secretary runtime service removed (Amazon-internal). Attribute stays
         # as an inert None so other modules referencing it degrade gracefully.
         self.secretary_svc: object | None = None

--- a/test/test_aws_control_backup.py
+++ b/test/test_aws_control_backup.py
@@ -146,6 +146,9 @@ class TestRunSnapshotBackup:
 
         authz.assert_called_once_with(ACCOUNT, "p", "us-west-2")
         put_file.assert_called_once()
+        # Same long-timeout contract as the sessions push: the declared
+        # `_PUSH_TIMEOUT_SECS` has to REACH the uploader, not sit unread.
+        assert put_file.call_args.kwargs["timeout"] == backup._PUSH_TIMEOUT_SECS
         pushed_key = put_file.call_args.args[4]
         assert pushed_key.startswith("snapshots/kirocrew-snapshot-")
         # Entropy suffix means the pushed key is NOT the engine's file name.
@@ -200,9 +203,12 @@ class TestRunSessionsBackup:
 
         pushed: dict[str, str] = {}
 
-        def fake_put(profile, region, bucket, section, key, local_path, *, account=None):
+        def fake_put(
+            profile, region, bucket, section, key, local_path, *, account=None, timeout=None
+        ):
             pushed["key"] = key
             pushed["local"] = local_path
+            pushed["timeout"] = timeout
             # The names inside the archive prove both halves were tarred.
             with tarfile.open(local_path) as tar:
                 pushed["names"] = sorted(tar.getnames())
@@ -214,6 +220,10 @@ class TestRunSessionsBackup:
             record = backup.run_sessions_backup(ACCOUNT, "p", "us-west-2", "bkt")
 
         assert pushed["key"].startswith("sessions/sessions-")
+        # A multi-GB sessions archive on a slow uplink needs the long timeout, not
+        # `put_file`'s own 600s default -- passing it is the whole point of
+        # `_PUSH_TIMEOUT_SECS` existing.
+        assert pushed["timeout"] == backup._PUSH_TIMEOUT_SECS
         assert pushed["names"] == ["cli/replay.log", "crew/t.jsonl"]
         assert record["key"] == pushed["key"]
         assert backup.last_runs(ACCOUNT)[backup.KIND_SESSIONS]["bytes"] > 0

--- a/test/test_mochi_small_modules.py
+++ b/test/test_mochi_small_modules.py
@@ -89,6 +89,57 @@ class TestPetStateManager:
         mgr.finish_walking(299)  # < 300ms: no delay
         assert mgr.current == "idle"
 
+    def test_unpaired_walk_done_is_a_noop(self) -> None:
+        """`/walk-done` can arrive for a walk the server never opened.
+
+        The renderer's `useWalking` hook animates a move and then posts
+        `/walk-done`, but nothing opens the walk server-side: there is no
+        `/walk-start` route and `/pet-event` refuses `walk_start`. Unguarded,
+        `finish_walking` read the duration as `now_ms` (never instant), armed
+        `walk-restore`, and `_restore_from_walk` force-broadcast `idle` over the
+        live state -- mid-turn, while a task was still thinking.
+        """
+        mgr, broadcasts = self._mk()
+        mgr.set_pet_state("thinking", 0)
+        before = list(broadcasts)
+
+        mgr.finish_walking(5_000)
+        mgr.tick(10_000)
+
+        assert mgr.current == "thinking"
+        assert broadcasts == before, "an unpaired walk-done must not broadcast a state change"
+
+    def test_unpaired_walk_done_does_not_end_the_thinking_stat(self) -> None:
+        """The clobber also ate the `thinking -> other` edge.
+
+        `_restore_from_walk` overwrote `_pet_state` BEFORE calling
+        `set_pet_state`, so `prev_state` read as `idle` and
+        `record_thinking_end` never fired -- the thinking-time stat leaked on
+        every move.
+        """
+
+        class _Stats:
+            def __init__(self) -> None:
+                self.ends = 0
+
+            def record_thinking_start(self, now_ms: int) -> None:
+                pass
+
+            def record_thinking_end(self, now_ms: int) -> None:
+                self.ends += 1
+
+        stats = _Stats()
+        mgr = PetStateManager(lambda ch, state: None, stats=stats)
+        mgr.set_pet_state("thinking", 0)
+
+        mgr.finish_walking(5_000)
+        mgr.tick(10_000)
+        assert mgr.current == "thinking"
+
+        # The real end of thinking still records exactly once.
+        mgr.set_pet_state("idle", 11_000)
+        assert stats.ends == 1
+
     def test_error_auto_recovers_after_3s(self) -> None:
         mgr, _ = self._mk()
         mgr.set_pet_state("idle", 0)

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -758,6 +758,18 @@ class TestDeliverResult:
 class TestShutdown:
     """Graceful shutdown."""
 
+    def test_autonudge_service_has_a_declared_default(self):
+        """`_init_autonudge` returns before assigning when the flag is off.
+
+        `KIROCREW_AUTONUDGE=0` makes `_init_autonudge` return at its feature-flag
+        guard, before its only `self.autonudge_svc = ...`. Without a declaration
+        the attribute does not exist, and the seven `if self.autonudge_svc:`
+        sites in the loop-CRUD handlers raise AttributeError instead of reading
+        a default -- unlike `cron_svc` and `heartbeat_svc`, which are declared.
+        """
+        orch = _make_orchestrator()
+        assert orch.autonudge_svc is None
+
     @pytest.mark.asyncio
     async def test_shutdown_with_no_services(self):
         orch = _make_orchestrator()


### PR DESCRIPTION
fix: repair three half-wired call sites found by the dead-code audit

Each of these is a symbol a dead-code scan reported as unreferenced where the
right answer was not to delete it: the declaration was correct and the behaviour
it promises never happened.

mochi: an unpaired /walk-done clobbered the live pet state

`finish_walking` has a caller (`/walk-done`, routes.py:1013); nothing opens the
walk server-side. There is no `/walk-start` route and `/pet-event` refuses
`walk_start` on purpose (`_CHAT_EVENTS`), so the renderer's `useWalking` hook
animates a move and posts `/walk-done` for a walk the backend never began.

Unguarded, `finish_walking` read the duration as `now_ms` -- never under
INSTANT_WALK_THRESHOLD_MS -- which armed `walk-restore`. `_restore_from_walk`
then found `_pending_state` unset, because nothing buffered it (the state was
never "walking"), and force-broadcast `idle` over whatever was live, mid-turn.
It also overwrote `_pet_state` BEFORE `set_pet_state`, so `prev_state` read as
`idle`, the `thinking -> other` edge was missed, and `record_thinking_end` never
fired -- the thinking-time stat leaked on every move.

`finish_walking` now returns early unless a walk is actually open. The state is
the discriminator rather than `_walk_started_at`, because 0 is a legitimate
`now_ms` and is also the field's initial value; `set_pet_state` buffers instead
of overwriting while walking (pet_state_manager.py:88-90), so
`_pet_state == "walking"` is exactly "a walk is open".

An earlier round of this PR wired `start_walking` into `on_move` instead. GPT 5.6
and Design Review both rejected that, correctly: `on_move` fires from the
SERVER-side queue poller for every agent-planned move, client or not, while the
only exit from `walking` is that same client-posted `/walk-done`. With no
dashboard tab open -- the normal case for an unattended run -- the pet would have
wedged in `walking` indefinitely. Nothing visible is lost by guarding instead,
because the walking animation is rendered client-side from the local `useWalking`
hook; server-side `_pet_state == "walking"` never drove it.

aws-control: _PUSH_TIMEOUT_SECS was declared and never read

Both backup pushes called `storage.put_file(...)` without `timeout=`, so
`put_file`'s own `timeout: int = 600` applied and the declared 3600s was dead. A
sessions archive up to the `_MAX_PINNED_TRANSFER_BYTES` ceiling on a slow uplink
was being killed at ten minutes. The two push tests now assert the timeout
reaches the uploader, so the constant cannot go unread again; the sessions
double's signature grew the kwarg it has to accept.

gateway: autonudge_svc had no declaration, unlike its two siblings

`cron_svc` and `heartbeat_svc` are declared in `__init__` as `X | None = None`.
`autonudge_svc` was only ever ASSIGNED, and `_init_autonudge` returns at its
feature-flag guard (gateway.py:5778) BEFORE that assignment -- so with
`KIROCREW_AUTONUDGE=0` the attribute never exists, and the seven
`if self.autonudge_svc:` sites in the Slack loop-CRUD handlers raise
AttributeError instead of reading a default. The declaration now sits beside its
two siblings, revert-verified by a test that fails with exactly that
AttributeError.

An earlier round also added `autonudge_svc.stop()` to `_shutdown`, on the
rationale that armed timers outlived teardown. GPT 5.6 falsified that rationale
and it is dropped: `_timer` catches CancelledError around its `asyncio.sleep`, so
cancelling a sleeping timer loses nothing, and it re-checks
`shutdown_event.is_set()` the moment it wakes (autonudge.py:1564), so a timer
waking during teardown already declines to dispatch. Nothing was firing into a
half-dismantled gateway. Worse, `_cancel_timer` guards done / closed-loop / self
but NOT "past the sleep and mid-dispatch", so `stop()` would hard-cancel such a
task and lose that nudge turn's response and cycle bookkeeping -- a loss the old
code did not have, since the timer task lives in the service's own `_timers`
rather than the `_handler_tasks` that `_shutdown` cancels. `stop()`'s only
remaining benefit at shutdown is clearing `_INSTANCE`, which needs no
cancellation and only matters for in-process re-init.

Verification: 1071 tests pass across the mochi, aws-control, gateway,
gateway-coverage and autonudge suites. Three new tests are revert-verified. One
pre-existing failure,
test_autonudge.py::TestSentinelPathRepair::test_unnormalized_path_escaping_legacy_is_preserved,
reproduces identically on unmodified origin/main (a `/local/home` home-path
shape, unrelated to this diff).
