### PR TITLE
fix(security): bound the Slack input validators and route the proxy Content-Type through its allowlist

### DIFF
--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -1444,6 +1444,14 @@ class _DevProxyHandler(BaseHTTPRequestHandler):
             # would let it append headers or a second body (response splitting).
             if not _HEADER_NAME_RE.match(key):
                 continue
+            # The upstream is the project's own dev server but still an unaudited
+            # process, so its media type SELECTS one of our literals instead of
+            # being echoed -- which is what `_PROXY_CTYPES` and
+            # `_safe_upstream_ctype` are for. Forwarding it verbatim lost the
+            # charset normalisation: an upstream `text/html; charset=iso-8859-1`
+            # reached the browser as sent.
+            if key.lower() == "content-type":
+                value = _safe_upstream_ctype(value, self.path)
             # A redirect naming the dev server's OWN origin would take the iframe
             # off this proxy and onto the bare upstream port — and because cookies
             # are host-scoped but PORT-agnostic, the browser would then attach the
@@ -3944,11 +3952,13 @@ class Handler(BaseHTTPRequestHandler):
 
     def _send_raw(self, code: int, ctype: str, body: bytes) -> None:
         self.send_response(code)
-        # Every caller passes either a string literal, a `_guess_ctype` constant
-        # (closed extension map — no value is derived from the request path), or
-        # `_safe_upstream_ctype()` output. `_header_value` stays as defence in
-        # depth at the sink: a single CR/LF reaching send_header would let a
-        # caller append headers or a second response body (response splitting).
+        # Every caller passes either a string literal or a `_guess_ctype` constant
+        # (closed extension map — no value is derived from the request path). The
+        # proxied reply does not come through here: it applies
+        # `_safe_upstream_ctype` at its own `send_header` in `_DevProxyHandler`.
+        # `_header_value` stays as defence in depth at the sink: a single CR/LF
+        # reaching send_header would let a caller append headers or a second
+        # response body (response splitting).
         self.send_header("Content-Type", _header_value(ctype))
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -86,7 +86,9 @@ from kiro_crew.subagent_persistence import _agent_dir, read_state
 from kiro_crew.validation import (
     _EMOJI_NAME_RE,
     CHANNEL_ID_RE,
+    CHANNEL_MAX_LEN,
     CRON_SESSION_RE,
+    SLACK_THREAD_TS_RE,
     SPAWN_RUN_SCHEMA,
     ValidationError,
     validate_tool_args,
@@ -94,6 +96,28 @@ from kiro_crew.validation import (
 
 #: Seconds to wait for Slack when verifying a pasted token at save time.
 _TOKEN_VERIFY_TIMEOUT = 8
+
+#: A Slack message timestamp is `<10-digit epoch>.<6-digit sequence>` -- 17
+#: characters. The cap is what BOUNDS the value: these routes forward `ts` to
+#: Slack and write it into a SEL audit line, and the allowlist check that
+#: rejects an untracked channel runs AFTER that line is written.
+_SLACK_TS_MAX_LEN = 30
+
+
+def _is_slack_ts(value: object) -> bool:
+    """True for a Slack message timestamp that is safe to forward.
+
+    Uses the shared ``SLACK_THREAD_TS_RE`` rather than an inline
+    ``^\\d+\\.\\d+$``: ``\\d`` is Unicode-aware, so a string of Arabic-Indic
+    numerals satisfied the old check and was forwarded verbatim. The shared
+    pattern spells the class ``[0-9]`` to avoid precisely that.
+    """
+    return (
+        isinstance(value, str)
+        and len(value) <= _SLACK_TS_MAX_LEN
+        and bool(SLACK_THREAD_TS_RE.match(value))
+    )
+
 
 #: Public field name -> .env credential key for the two Slack secrets.
 _SLACK_SECRET_FIELDS = {
@@ -1839,7 +1863,7 @@ async def api_send_message(request: web.Request) -> web.Response:
 
     thread_ts = body.get("thread_ts")
     if thread_ts is not None:
-        if not isinstance(thread_ts, str) or not re.match(r"^\d+\.\d+$", thread_ts):
+        if not _is_slack_ts(thread_ts):
             return web.json_response(
                 {"error": "thread_ts must be a Slack timestamp string like '1712793600.123456'"},
                 status=400,
@@ -2445,12 +2469,12 @@ async def api_slack_pins(request: web.Request) -> web.Response:
     if not isinstance(channel, str):
         return web.json_response({"error": "invalid channel ID format"}, status=400)
     channel = channel.strip()
-    if not channel or not CHANNEL_ID_RE.match(channel):
+    if not channel or len(channel) > CHANNEL_MAX_LEN or not CHANNEL_ID_RE.match(channel):
         return web.json_response({"error": "invalid channel ID format"}, status=400)
 
     ts = body.get("ts", "")
     if action in ("add", "remove"):
-        if not isinstance(ts, str) or not re.match(r"^\d+\.\d+$", ts):
+        if not _is_slack_ts(ts):
             return web.json_response(
                 {"error": "ts must be a Slack timestamp string like '1712793600.123456'"},
                 status=400,
@@ -2540,10 +2564,10 @@ async def api_slack_reactions(request: web.Request) -> web.Response:
     if not isinstance(channel, str):
         return web.json_response({"error": "invalid channel ID format"}, status=400)
     channel = channel.strip()
-    if not channel or not CHANNEL_ID_RE.match(channel):
+    if not channel or len(channel) > CHANNEL_MAX_LEN or not CHANNEL_ID_RE.match(channel):
         return web.json_response({"error": "invalid channel ID format"}, status=400)
     ts = body.get("ts", "")
-    if not isinstance(ts, str) or not re.match(r"^\d+\.\d+$", ts):
+    if not _is_slack_ts(ts):
         return web.json_response(
             {"error": "ts must be a Slack timestamp string like '1712793600.123456'"},
             status=400,

--- a/test/test_design_tweak_backend.py
+++ b/test/test_design_tweak_backend.py
@@ -3110,6 +3110,59 @@ class TestDevProxyBodyCaps:
         assert server._OVERLAY_PATH.encode() in out
 
 
+class TestDevProxyContentTypeIsAllowlisted:
+    """A proxied reply carries one of OUR literals, never the upstream's value.
+
+    `_PROXY_CTYPES` and `_safe_upstream_ctype` exist because the dev server is the
+    project's own process but still an unaudited one whose headers land in our
+    response. The selector was written, tested in isolation, and never called:
+    `_relay_http` forwarded every upstream header through `_header_value` alone, so
+    the media type and its charset reached the browser as sent. `_header_value`
+    still stopped response splitting, which is why this survived -- what was lost
+    is the mapping to a closed set.
+    """
+
+    def _relay(self, monkeypatch, upstream_ctype, path="/"):
+        class _Conn:
+            def __init__(self, *a, **k):
+                pass
+
+            def request(self, *a, **k):
+                pass
+
+            def getresponse(self):
+                return _FakeUpstreamResponse(b"body", upstream_ctype)
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(server.http.client, "HTTPConnection", _Conn)
+        probe = _RelayProbe.__new__(_RelayProbe)
+        _RelayProbe.__init__(probe, path=path)
+        probe._relay_http()
+        assert not probe.errors
+        return {k.lower(): v for k, v in probe.sent_headers}
+
+    def test_upstream_charset_is_normalised(self, monkeypatch):
+        """The one case a verbatim forward actually changed browser behaviour."""
+        sent = self._relay(monkeypatch, "text/html; charset=iso-8859-1")
+        assert sent["content-type"] == "text/html; charset=utf-8"
+
+    def test_unrecognised_media_type_falls_back_to_the_request_path(self, monkeypatch):
+        sent = self._relay(monkeypatch, "bogus/thing", path="/app.css")
+        assert sent["content-type"] == _safe_ctype_for_css()
+
+    def test_a_header_smuggled_into_the_media_type_cannot_survive(self, monkeypatch):
+        sent = self._relay(monkeypatch, "evil/x\r\nSet-Cookie: a=b", path="/x.css")
+        assert sent["content-type"] == _safe_ctype_for_css()
+        assert "set-cookie" not in sent
+
+
+def _safe_ctype_for_css() -> str:
+    """The literal the selector maps an unknown media type on a `.css` path to."""
+    return server._safe_upstream_ctype("bogus/thing", "/x.css")
+
+
 class TestDevProcCrossPlatform:
     """Starting and stopping a project's dev server must not use POSIX-only calls.
 

--- a/test/test_slack_pins_reactions.py
+++ b/test/test_slack_pins_reactions.py
@@ -294,6 +294,52 @@ class TestSlackReactions:
         slack.add_reaction.assert_not_awaited()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_ts", ["1" * 40 + ".123456", "١٢٣٤٥٦٧٨٩٠.١٢٣٤٥٦"])
+    async def test_reaction_ts_is_bounded_and_ascii_only(self, bad_ts):
+        """`ts` is forwarded to Slack and written into the SEL audit line.
+
+        That audit line is written BEFORE the untracked-channel rejection, so an
+        unbounded value lands in the log either way. The old inline `^\\d+\\.\\d+$`
+        carried no length cap, and `\\d` is Unicode-aware, so a string of
+        Arabic-Indic numerals satisfied it and was forwarded verbatim.
+        """
+        slack = MagicMock()
+        slack.add_reaction = AsyncMock()
+        app = _make_app(slack)
+        with _patch_tracked(True):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/slack/reactions",
+                    json={
+                        "channel": TRACKED,
+                        "ts": bad_ts,
+                        "emoji": "eyes",
+                        "action": "add",
+                    },
+                )
+        assert resp.status == 400
+        slack.add_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reaction_channel_is_length_bounded(self):
+        """`CHANNEL_ID_RE` is `[A-Z0-9]+` -- unbounded without `CHANNEL_MAX_LEN`."""
+        slack = MagicMock()
+        slack.add_reaction = AsyncMock()
+        app = _make_app(slack)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/slack/reactions",
+                json={
+                    "channel": "C" + "A" * 64,
+                    "ts": TS,
+                    "emoji": "eyes",
+                    "action": "add",
+                },
+            )
+        assert resp.status == 400
+        slack.add_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_reaction_invalid_action(self):
         slack = MagicMock()
         app = _make_app(slack)


### PR DESCRIPTION
fix(security): bound the Slack input validators and route the proxy Content-Type through its allowlist

Two input-validation controls that were written, tested, and never reached the
code path they were written for. Both were found by a dead-code audit: the
scanner reported the validator as unreferenced, and in each case the right
reading was not "delete it" but "the check is not running".

design_tweak: the dev-server proxy forwarded Content-Type verbatim

`_PROXY_CTYPES` is a closed table of our own literals, and its selector
`_safe_upstream_ctype` exists because the previewed dev server is the project's
own process but still an unaudited one whose headers land in OUR response. The
table's comment states the contract: "its `Content-Type` is not forwarded
verbatim -- it only SELECTS a value from this table."

That was false. `_relay_http` passed every upstream header through
`_header_value` alone, and `_safe_upstream_ctype` had zero callers -- only
direct unit tests, which is why it looked covered. `_header_value` strips CR/LF,
so response splitting was still prevented and this never became the
`py/http-response-splitting` class it guards; what was lost is the mapping to a
closed set. Concretely, an upstream `text/html; charset=iso-8859-1` reached the
browser as sent instead of being normalised to `charset=utf-8`, and an
unrecognised media type was echoed instead of being resolved from the request
path.

The relay now runs the header through the selector before the sink.
`_header_value` stays where it is as defence in depth. Two stale comments went
with it: `_send_raw`'s claimed one of its callers passes `_safe_upstream_ctype`
output (neither does -- both pass literals), and the `_refuse` docstring's
reference to a path scrub is left alone here, being a separate item.

messaging: three Slack timestamp validators were unbounded and Unicode-aware

`api_slack_reactions`, the pins route, and one send path each validated a Slack
message timestamp with an inline `^\d+\.\d+$`. Two defects, both reachable from
an authenticated request:

  * No upper bound. The value is forwarded to Slack and written into the SEL
    audit line at `resources=f"channel={channel}"` -- and that line is written
    BEFORE `is_tracked_channel` rejects an untracked channel, so an oversized
    value lands in the log whether or not the call proceeds.
  * `\d` is Unicode-aware. A string of Arabic-Indic numerals satisfied the
    pattern and was forwarded verbatim. The shared `SLACK_THREAD_TS_RE` spells
    its class `[0-9]` for exactly this reason and was already available.

All three now go through one `_is_slack_ts` helper: ASCII-only via the shared
pattern, capped at 30 characters (a real timestamp is 17). The two channel
checks matched `CHANNEL_ID_RE` -- `[A-Z0-9]+`, unbounded -- without
`CHANNEL_MAX_LEN`; `cron.py:535` already pairs the two, and these now do too.

Verification: 22 tests pass across the two suites. Six new tests, all
revert-verified: with the production change stashed and the tests kept, every
one fails, and the proxy failure prints
`assert 'evil/xSet-Cookie: a=b' == 'text/css'` -- the upstream media type
arriving intact. 21 pre-existing failures in test_design_tweak_backend.py
(`_static_response` returning 403) reproduce identically on unmodified
origin/main and are untouched by this diff.

Not run: `black` over these two files. The repo targets a newer Python than the
local interpreter, so a full pass reflows unrelated pre-existing code and splits
a trailing comment off its `return` in `_static_response`. Every added line was
hand-kept under 100 columns and `black --check --diff` confirms it wants to
change none of them; flake8 and isort are clean.
