### PR TITLE
fix(taskrunner): persist a run's git workspace across a restart

### DIFF
--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1870,6 +1870,18 @@ class TaskRunner:
                         "tokens_used": run.tokens_used,
                         "replan_count": run.replan_count,
                         "work_dir": run.work_dir,
+                        # Git-workspace identity. `work_dir` alone is NOT enough:
+                        # init_workspace() OVERWRITES it with the worktree path,
+                        # so a restored run pointed at a worktree while every
+                        # field that says which worktree it is -- and whether git
+                        # coordination is even on -- came back at its default.
+                        # git_coord reads all six after a restart.
+                        "branch_name": run.branch_name,
+                        "base_branch": run.base_branch,
+                        "worktree_path": run.worktree_path,
+                        "repo_root": run.repo_root,
+                        "git_enabled": run.git_enabled,
+                        "commit_hashes": run.commit_hashes,
                         "original_input": run.original_input,
                         "source": run.source,
                         "spec_content": run.spec_content,
@@ -1999,6 +2011,7 @@ class TaskRunner:
                     )
                     for t in item.get("task_details", item.get("tasks", []))
                 ]
+                _worktree_path = item.get("worktree_path", "")
                 run = Project(
                     spec_path=item["spec_path"],
                     spec_content=item.get("spec_content", ""),
@@ -2011,6 +2024,21 @@ class TaskRunner:
                     tokens_used=item.get("tokens_used", 0),
                     replan_count=item.get("replan_count", 0),
                     work_dir=item.get("work_dir", ""),
+                    branch_name=item.get("branch_name", ""),
+                    base_branch=item.get("base_branch", ""),
+                    worktree_path=_worktree_path,
+                    repo_root=item.get("repo_root", ""),
+                    # An entry written before the git identity was persisted
+                    # carries none of these, and `git_enabled` defaults to True
+                    # -- the one combination that must not survive: git ops
+                    # enabled while nothing records WHICH worktree they target.
+                    # Absent an explicit value, enable git coordination only
+                    # when the worktree location is actually known; otherwise
+                    # fall back to the documented "task continues without git
+                    # coordination" behaviour instead of committing into a path
+                    # no longer identified.
+                    git_enabled=bool(item.get("git_enabled", bool(_worktree_path))),
+                    commit_hashes=list(item.get("commit_hashes", [])),
                     original_input=item.get("original_input", ""),
                     source=item.get("source", ""),
                     tasks=tasks,

--- a/test/test_taskrunner_atomic_persistence.py
+++ b/test/test_taskrunner_atomic_persistence.py
@@ -69,6 +69,113 @@ class TestPersistRoundTrip:
         assert reloaded._runs["t1"].tasks[0].title == "step one"
 
 
+class TestGitWorkspaceIdentitySurvivesRestart:
+    """`work_dir` alone does not describe a run's git workspace.
+
+    ``git_coord.init_workspace()`` OVERWRITES ``work_dir`` with the worktree
+    path, so restoring only ``work_dir`` leaves a run pointed AT a worktree
+    while every field saying which worktree it is came back empty -- and
+    ``git_enabled`` came back at its ``True`` default. ``git_coord`` reads all
+    six of these after a restart: ``git_enabled`` gates every git op,
+    ``branch_name`` gates retry's workspace validation, ``worktree_path`` +
+    ``repo_root`` drive cleanup and recovery, ``base_branch`` is the range for
+    the step-diff summary, and ``commit_hashes`` is what a revert pops.
+    """
+
+    def _git_run(self, task_id: str = "g1") -> TaskRun:
+        run = _make_run(task_id)
+        run.work_dir = "/repos/proj/../.kirocrew-work/g1"
+        run.branch_name = "kirocrew/task/g1"
+        run.base_branch = "main"
+        run.worktree_path = "/repos/.kirocrew-work/g1"
+        run.repo_root = "/repos/proj"
+        run.git_enabled = True
+        run.commit_hashes = ["abc1234", "def5678"]
+        return run
+
+    def test_every_git_field_round_trips(self, tmp_path: Path) -> None:
+        runner = _make_runner(tmp_path)
+        runner._runs["g1"] = self._git_run()
+        runner._persist_runs()
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+        back = reloaded._runs["g1"]
+
+        assert back.branch_name == "kirocrew/task/g1"
+        assert back.base_branch == "main"
+        assert back.worktree_path == "/repos/.kirocrew-work/g1"
+        assert back.repo_root == "/repos/proj"
+        assert back.git_enabled is True
+        assert back.commit_hashes == ["abc1234", "def5678"]
+
+    def test_a_restored_run_still_gates_retry_validation(self, tmp_path: Path) -> None:
+        """The consequence that matters: `retry_from_task` skips workspace
+        validation entirely when `branch_name` is empty, so losing it across a
+        restart silently re-opened the very defect the validation was added for
+        -- steps dispatching against a worktree nothing had checked."""
+        runner = _make_runner(tmp_path)
+        runner._runs["g1"] = self._git_run()
+        runner._persist_runs()
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+
+        assert reloaded._runs["g1"].branch_name, (
+            "branch_name did not survive the restart, so retry's "
+            "`if run.branch_name and not await workspace_is_valid(run)` guard "
+            "short-circuits and never validates the workspace"
+        )
+
+    def test_a_legacy_entry_does_not_enable_git_without_an_identity(
+        self, tmp_path: Path
+    ) -> None:
+        """An entry written before these fields were persisted carries none of
+        them. `git_enabled` must NOT come back at its `True` default there: git
+        ops enabled while nothing records which worktree they target is the one
+        combination this must not reconstruct. Falling back to "no git
+        coordination" is the documented behaviour for a workspace git cannot be
+        pointed at."""
+        runner = _make_runner(tmp_path)
+        runner._runs["g1"] = self._git_run()
+        runner._persist_runs()
+
+        runs_file = tmp_path / "runs.json"
+        data = json.loads(runs_file.read_text(encoding="utf-8"))
+        for key in (
+            "branch_name",
+            "base_branch",
+            "worktree_path",
+            "repo_root",
+            "git_enabled",
+            "commit_hashes",
+        ):
+            data[0].pop(key, None)
+        runs_file.write_text(json.dumps(data), encoding="utf-8")
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+        back = reloaded._runs["g1"]
+
+        assert back.git_enabled is False
+        assert back.worktree_path == ""
+        assert back.branch_name == ""
+        assert back.commit_hashes == []
+
+    def test_an_explicit_git_enabled_false_is_honoured(self, tmp_path: Path) -> None:
+        """A non-git run (`git_enabled=False` from the start, run in place) must
+        stay disabled -- the fallback only applies when the value is absent."""
+        runner = _make_runner(tmp_path)
+        plain = _make_run("g2")
+        plain.git_enabled = False
+        runner._runs["g2"] = plain
+        runner._persist_runs()
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+        assert reloaded._runs["g2"].git_enabled is False
+
+
 class TestLoadRunsResilience:
     def test_missing_file_seeds_fresh(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

A run's git-workspace identity is never written to the runs registry, so any run that survives a gateway restart comes back pointed at a worktree it can no longer identify.

`_serialize_runs` writes an **explicit field list**, and six fields `git_coord` reads are absent from it: `branch_name`, `base_branch`, `worktree_path`, `repo_root`, `git_enabled` and `commit_hashes`. `_load_runs` likewise constructs `Project(...)` from an explicit kwarg list that omits all six, so they come back at their dataclass defaults.

`work_dir` **is** persisted — and that is what turns a lossy gap into a harmful one, because `git_coord.init_workspace()` *overwrites* `work_dir` with the worktree path. So a restored run points **at** a worktree while every field that says *which* worktree it is comes back empty, and `git_enabled` comes back at its `True` default.

## Why it matters

Concretely, after any restart:

- **`git_enabled` True with no identity** — `commit_step` runs `git add -A` and commits against `run.work_dir`, a worktree path nothing has validated.
- **`branch_name` empty** — `retry_from_task`'s guard is `if run.branch_name and not await git_coord.workspace_is_valid(run):`, so workspace validation is **skipped entirely**. The retry-path worktree check is bypassed for exactly the runs most likely to need it, silently re-opening the defect that check exists to catch (#3792): steps dispatch against a dead worktree and report themselves completed.
- **`worktree_path` empty** — `finalize()` is `if run.worktree_path:`, so cleanup becomes a no-op and the worktree leaks for the life of the machine.
- **`base_branch` empty** — `get_state_summary` builds `git log --oneline {base_branch}..HEAD`, which is not a valid range.
- **`commit_hashes` empty** — `revert_step` is `if not run.git_enabled or not run.commit_hashes:`, so a failed step can no longer be reverted.

A restart is not an exotic event, and a resumed run is by definition one that already had trouble. This is the state in which the git-coordination guarantees quietly stop holding.

## What changed (motivation → approach → change)

Symptom: a resumed run behaves as though it never had a git workspace, while still holding a `work_dir` that points into one. Root cause: the registry's serializer and loader are explicit allow-lists, and the git-identity fields were never added to either. The fix is at that cause rather than at any one consequence — patching `retry_from_task`'s guard, or `finalize`'s, would each paper over one symptom of the same missing state.

- All six fields are now persisted alongside `work_dir` in `_serialize_runs`, and restored in `_load_runs`.
- **Backward compatibility** for an entry written before this change, which carries none of them: `git_enabled` falls back to whether the worktree location is actually known (`bool(worktree_path)`) rather than to the dataclass default of `True`. Git ops enabled while nothing records which worktree they target is the one combination that must not be reconstructed; absent an identity the run falls back to the documented *"task continues without git coordination"* behaviour instead of committing into a path it can no longer name. An explicitly persisted `git_enabled: false` — an ordinary non-git run — is still honoured, so the fallback cannot re-enable one.

## Tests

`test/test_taskrunner_atomic_persistence.py`, new class `TestGitWorkspaceIdentitySurvivesRestart`:

- **`test_every_git_field_round_trips`** — all six fields survive persist + load.
- **`test_a_restored_run_still_gates_retry_validation`** — a restored run still carries `branch_name`. The assertion message names the guard it feeds, so the consequence is visible where the test fails rather than only in review.
- **`test_a_legacy_entry_does_not_enable_git_without_an_identity`** — an entry with the six keys stripped from `runs.json` comes back with git coordination **off** and an empty identity, instead of `git_enabled=True` with nothing to point at.
- **`test_an_explicit_git_enabled_false_is_honoured`** — an ordinary non-git run stays disabled, so the fallback only applies when the value is genuinely absent.

Mutation-verified: dropping the six keys from `_serialize_runs` fails the round-trip test and the `branch_name` test, and only those.

## Manual verification

N/A — unit coverage sufficient. The defect is entirely in the serialize/load round trip, which the tests drive directly through `_persist_runs` / `_load_runs` (including a hand-edited legacy `runs.json`); there is no integration surface a manual pass would reach that these do not.

## Screenshots / video

N/A — no user-visible UI change.

## Related Issues

no linked issue: found while reviewing the retry-path worktree validation in #3827, which is where the `branch_name` consequence surfaced. This is the separate persistence defect underneath it, fixed on its own so #3827 stays scoped to the retry path.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no behaviour a doc describes changes; the spec's "task continues without git coordination" fallback is what the legacy-entry path now defers to
- [x] No secrets, credentials, or internal references in the diff
