### PR TITLE
fix(apps): validate the app name at scaffold entry, not only at install

### DIFF
--- a/src/kiro_crew/apps/scaffold.py
+++ b/src/kiro_crew/apps/scaffold.py
@@ -12,6 +12,7 @@ import struct
 import zlib
 from pathlib import Path
 
+from kiro_crew.apps.manifest import app_name_error
 from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger(__name__)
@@ -472,6 +473,25 @@ def scaffold_app(
 
     Returns the path to the created app directory.
     """
+    # FIRST, before *name* is used as a directory component OR copied into the
+    # manifest. `app_name_error` is the single app-name contract every path that
+    # admits an app already funnels through -- manifest validation, install,
+    # self-registration -- and scaffolding was the one door that skipped it. The
+    # cost of skipping it is not a containment failure but a DOOMED artifact: the
+    # scaffold reports success and writes `"name": <whatever was passed>`, then
+    # `kirocrew app install` refuses that manifest, so the error surfaces one
+    # command later than the mistake and names a file the user did not type.
+    #
+    # An absolute path already beneath *output_dir* is the case that reads as a
+    # containment bug and is not one: `_resolve_for_write` refuses an absolute
+    # component only when it LEAVES the root, so `--dir out` with name
+    # `out/demo` stays inside and passes, and the manifest then carries a full
+    # filesystem path as the app's identity. Validating the shape here refuses
+    # it for what it actually is -- not a kebab-case name.
+    err = app_name_error(name)
+    if err:
+        raise ValueError(err)
+
     if not display_name:
         display_name = name.replace("-", " ").title()
     if not description:

--- a/test/test_app_scaffold.py
+++ b/test/test_app_scaffold.py
@@ -13,6 +13,7 @@ from kiro_crew import platform_compat
 from kiro_crew.apps.manifest import AppManifest
 from kiro_crew.apps.scaffold import (
     _placeholder_icon_png,
+    _resolve_for_write,
     _write_sites,
     scaffold_app,
 )
@@ -416,6 +417,11 @@ class TestWriteContainment:
         assert list(outside.iterdir()) == []
 
     def test_name_with_traversal_is_refused(self, tmp_path):
+        # Refused by the NAME validator now, which runs before any path is
+        # derived -- "../evil" is not kebab-case. The containment guard behind it
+        # still refuses the same shape and is exercised directly in
+        # TestResolveForWrite below, so this stays an end-to-end assertion that
+        # nothing lands outside --dir rather than a test of which layer says no.
         out = tmp_path / "out"
         out.mkdir()
 
@@ -425,8 +431,17 @@ class TestWriteContainment:
         assert not (tmp_path / "evil").exists()
 
     def test_absolute_name_is_refused(self, tmp_path):
-        """joinpath discards the root for an absolute component, so an absolute
-        name would compare equal trivially while writing outside --dir."""
+        """An absolute name is refused, whether or not it escapes --dir.
+
+        Two independent reasons, and the ORDER matters for what a user sees. The
+        name validator refuses it first (an absolute path is not a kebab-case
+        app name), which is what makes the harmless-looking case fail too: an
+        absolute path already BENEATH --dir passes containment (joinpath discards
+        the root, and the result really is inside), so before validation it
+        scaffolded successfully and wrote the whole filesystem path into the
+        manifest as the app's identity. Containment still refuses the escaping
+        shape underneath -- see TestResolveForWrite.
+        """
         out = tmp_path / "out"
         out.mkdir()
         elsewhere = tmp_path / "elsewhere"
@@ -496,6 +511,125 @@ class TestWriteContainment:
 
         assert (real / "my-app" / "app.json").is_file()
         assert (app_dir / "README.md").is_file()
+
+
+class TestResolveForWrite:
+    """The containment guard, exercised DIRECTLY.
+
+    It used to be reached only through ``scaffold_app``, and the name validation
+    at scaffold entry now refuses the traversal and absolute-component shapes
+    before the guard sees them. Those scaffold-level tests still assert the
+    outcome that matters (nothing outside --dir), but the guard is
+    defense-in-depth for every OTHER caller and for a future one that skips the
+    name check, so its own branches are pinned here rather than depending on
+    which layer happens to refuse first.
+    """
+
+    def test_traversal_component_is_refused(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(ValueError):
+            _resolve_for_write(out, "..", "evil")
+
+    def test_absolute_component_escaping_the_root_is_refused(self, tmp_path):
+        # joinpath DISCARDS the root for an absolute component, so target would
+        # equal expected trivially while both point outside; the containment
+        # check has to run before the equality comparison.
+        out = tmp_path / "out"
+        out.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        with pytest.raises(ValueError):
+            _resolve_for_write(out, str(elsewhere / "evil"))
+
+    def test_the_root_itself_is_refused_as_a_target(self, tmp_path):
+        # `expected == resolved_root` is its own branch: an empty component
+        # resolves to the root, and scaffolding INTO --dir itself would treat the
+        # user's output directory as the app directory.
+        out = tmp_path / "out"
+        out.mkdir()
+        with pytest.raises(ValueError):
+            _resolve_for_write(out, "")
+
+    def test_a_plain_relative_component_resolves_beneath_the_root(self, tmp_path):
+        # The permit case, so the refusals above are not vacuously passing on a
+        # guard that rejects everything.
+        out = tmp_path / "out"
+        out.mkdir()
+        assert _resolve_for_write(out, "fine") == out.resolve() / "fine"
+
+
+class TestAppNameValidation:
+    """`scaffold_app` validates the name before it becomes a path OR an identity.
+
+    Backlog f-20260820-04: the scaffold was the one door into the app-name
+    contract that skipped `app_name_error`, so any non-kebab name produced a
+    manifest that `kirocrew app install` then refused -- the scaffold reported
+    success and the error surfaced one command later, naming a file the user
+    never typed.
+    """
+
+    def test_an_absolute_name_beneath_the_output_dir_is_refused(self, tmp_path):
+        """THE reported case, and the one that looks harmless.
+
+        `_resolve_for_write` refuses an absolute component only when it LEAVES
+        the root, so a name that is already inside --dir passes containment: the
+        write really does land in the right place. What was wrong is the
+        IDENTITY -- the manifest carried a full filesystem path as the app name.
+        """
+        out = tmp_path / "out"
+        out.mkdir()
+
+        with pytest.raises(ValueError, match="kebab-case"):
+            scaffold_app(out, str(out / "demo"))
+
+        # Nothing scaffolded: refused before the first directory is created.
+        assert list(out.iterdir()) == []
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "My App",  # spaces
+            "my_app",  # underscore
+            "UPPER",  # uppercase
+            "demo\n",  # trailing newline: KEBAB_RE's `$` admits it under match()
+            "-leading",  # hyphen boundaries
+            "trailing-",
+        ],
+    )
+    def test_a_non_kebab_name_is_refused_before_anything_is_written(self, bad, tmp_path):
+        # The CLASS, not just the reported instance: each of these previously
+        # scaffolded a complete app whose manifest install would reject.
+        out = tmp_path / "out"
+        out.mkdir()
+
+        with pytest.raises(ValueError, match="kebab-case"):
+            scaffold_app(out, bad)
+
+        assert list(out.iterdir()) == []
+
+    def test_a_reserved_name_is_refused_too(self, tmp_path):
+        # Validation delegates to the shared contract rather than re-deriving a
+        # kebab check, so the reserved-name rules come along for free -- "system"
+        # would shadow the reserved system.* notification channel namespace.
+        out = tmp_path / "out"
+        out.mkdir()
+
+        with pytest.raises(ValueError, match="reserved"):
+            scaffold_app(out, "system")
+
+        assert list(out.iterdir()) == []
+
+    def test_a_valid_kebab_name_still_scaffolds_an_installable_manifest(self, tmp_path):
+        # The permit case: the validation must not have narrowed the names that
+        # legitimately work, and the manifest it writes must satisfy the very
+        # contract that used to reject it at install time.
+        from kiro_crew.apps.manifest import app_name_error
+
+        app_dir = scaffold_app(tmp_path, "my-good-app")
+        manifest = json.loads((app_dir / "app.json").read_text(encoding="utf-8"))
+        assert manifest["name"] == "my-good-app"
+        assert app_name_error(manifest["name"]) is None
 
 
 class TestScaffold:


### PR DESCRIPTION
## What is the problem?

`scaffold_app` never validated the app name. Any name at all produced a
complete app skeleton, including names the app-name contract forbids -- so the
scaffold reported success, wrote `"name": <whatever was passed>` into `app.json`,
and `kirocrew app install` then refused that manifest. The error surfaced one
command later than the mistake, and named a file the user never typed.

The reported instance is the one that reads like a containment bug and is not.
`_resolve_for_write` refuses an absolute path component only when it **leaves**
the root:

```python
if not expected.is_relative_to(resolved_root) or expected == resolved_root:
    raise ValueError(...)
```

So `kirocrew app init --dir out out/demo` passes it. `joinpath` discards the root
for an absolute component, the result is `out/demo`, and that really is inside
`out` -- the write lands in the right place. What is wrong is the **identity**:
the manifest ends up carrying a full filesystem path as the app's name.

Confirmed against the tree before writing the fix:

```
output_dir : /tmp/tmp4f0e3o_j
name passed: /tmp/tmp4f0e3o_j/demo
scaffold   : SUCCEEDED -> /tmp/tmp4f0e3o_j/demo
manifest name: '/tmp/tmp4f0e3o_j/demo'
install-time verdict: app name must be kebab-case (lowercase alphanumeric + hyphens)
```

And the wider class it belongs to -- `My App`, `my_app`, `UPPER` and `demo\n` all
scaffolded a doomed manifest the same way. An empty name was already refused, by
the containment guard rather than by any name check.

## Why this issue matters to the user

`app init` is the first command a new app author runs, and it told them the
scaffold worked. The failure then arrived from a different command, quoting a
name they never typed (a whole path, or their own string reflected back), with
nothing connecting it to the argument that caused it. The fix moves the error to
the moment the mistake is made, in the words of the thing that was wrong.

Nothing here is a security fix: the write always stayed inside `--dir`. This is
about not producing an artifact that cannot be installed.

## How our fix solves it

Call the existing contract first, before *name* becomes either a directory
component or a manifest field:

```python
err = app_name_error(name)
if err:
    raise ValueError(err)
```

`app_name_error` is the single app-name contract that every other door already
funnels through -- manifest validation, install, discovery, external
self-registration -- and scaffolding was the one that skipped it. Reusing it
rather than re-deriving a kebab check means no second copy of the grammar to
drift, and the reserved-name rules (`system` would shadow the `system.*`
notification namespace; Windows device names; claimed dashboard routes) come
along for free.

Two things that needed no change, which is what keeps this scoped:

* **The CLI.** `_handle_app`'s `init` branch already catches `ValueError` from
  `scaffold_app` and prints a clean error line then exits 1, so the new refusal
  surfaces through the existing contract with no traceback.
* **The docs.** `docs/app-kit/manifest-reference.md` already states the rule and
  gives the exact regex. The scaffold now enforces what was already written down.

Four functional lines plus one import.

## What tests we did

`test/test_app_scaffold.py`: **97 passed**, up from 84. Also green:
`test_app_manifest.py`, `test_cli_commands_coverage.py`,
`test_mcp_gateway_apps_spool.py` (283 in the latter two). Targeted files with
`-n 4`; no full suite on this host, CI runs it on the merge ref.

New `TestAppNameValidation` covers the reported absolute-name-beneath-`--dir`
case, the wider non-kebab class as a parametrized set (including `demo\n`, which
matters because `KEBAB_RE`'s `$` admits a trailing newline under `match` and only
`fullmatch` rejects it), a reserved name to prove the delegation is real, and a
permit case asserting a valid name still scaffolds a manifest that
`app_name_error` accepts.

**One consequence worth flagging, because it could have gone unnoticed.**
Validating the name first means the traversal (`../evil`) and absolute-component
inputs used by two existing containment tests are now refused by the name check
*before* `_resolve_for_write` ever sees them. Those tests still pass, and still
assert the thing that matters -- nothing lands outside `--dir` -- but
`_resolve_for_write` had no direct tests of its own, so its coverage would have
silently dropped to whatever the symlink cases reach.

So new `TestResolveForWrite` exercises the guard directly: a traversal component,
an escaping absolute component, the `expected == resolved_root` branch, and a
permit case so the refusals are not vacuously passing on a guard that rejects
everything. The two scaffold-level tests keep their assertions and their comments
now say which layer refuses first, so neither docstring claims a mechanism it no
longer exercises.

Mutation-verified: removing the new validation reddens exactly the 8 new
name-validation cases and nothing else. Under that same mutant the new
`TestResolveForWrite` cases stay **green** -- which is the evidence that
defense-in-depth is genuinely intact, rather than assumed because the suite was
green.

flake8, isort and mypy clean on both files. Both are in
`.github/black-baseline.txt`, and `scripts/check_black_formatting.py` passes; I
deliberately did not run bare `black` on them, which would have reformatted
several hundred lines neither of these changes touches.

## Any other suggestions on the work

* `scaffold_app` has exactly one production caller (the CLI). If a route or MCP
  tool ever grows an app-scaffold entry point, this validation is now inside the
  function rather than at the CLI, so it inherits it.
* The `display_name` default is `name.replace("-", " ").title()`, which only
  reads sensibly for a kebab name -- another small thing that was silently
  incoherent for the inputs this now refuses.
* `_resolve_for_write` remains the guard for names that are valid kebab AND alias
  something on disk (the symlink cases). Those are the branches this PR did not
  shadow, and they were already covered.

Local backlog item f-20260820-04, raised as a GPT review finding on #4609 and
parked locally, where it was recorded as "the right fix is validating the name at
scaffold entry, out of scope for the containment PR". That is what this does.
