### PR TITLE
fix: per-path optimistic overlay for remaining settings mutations (#6890)

### DIFF
--- a/website/src/pages/settings/ChatPanel.tsx
+++ b/website/src/pages/settings/ChatPanel.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { SettingsSection, SettingsCard, SettingsToggle, SettingsSelect, SettingsInput, SettingsButtonGroup } from '../../components/settings'
 import { loadChatConfig, saveChatConfig, type ChatConfig, type ContentWidth, type DashboardConfig, type SendMode } from '../chat/ChatSettings'
 import { api } from '../../api/client'
+import { useOptimisticConfigPaths, setConfigPathValue } from './useOptimisticConfigPaths'
 import { useAvailableModels } from '../../hooks/useAvailableModels'
 import { EFFORT_LEVELS, effortLabel, modelSupportsEffort } from '../../lib/effort'
 import { isMac } from '../../utils/platform'
@@ -112,26 +113,6 @@ type KirocrewConfigShape = {
   dashboard?: { user_role?: string; user_role_other?: string; user_technical_level?: string; prevent_sleep?: boolean }
 }
 
-/**
- * Return a copy of `cfg` with the dot-separated `path` set to `value`,
- * shallow-cloning only the objects along the path. Used on a config PATCH's
- * success to write the ACCEPTED value into the query cache at that one path,
- * so a transiently failed settle-time refetch cannot leave the display on a
- * pre-PATCH value the server no longer holds.
- */
-function setConfigValue(cfg: KirocrewConfigShape, path: string, value: unknown): KirocrewConfigShape {
-  const keys = path.split('.')
-  const next: Record<string, unknown> = { ...cfg }
-  let cursor = next
-  for (let i = 0; i < keys.length - 1; i++) {
-    const child = cursor[keys[i]]
-    cursor[keys[i]] = typeof child === 'object' && child !== null ? { ...(child as Record<string, unknown>) } : {}
-    cursor = cursor[keys[i]] as Record<string, unknown>
-  }
-  cursor[keys[keys.length - 1]] = value
-  return next as KirocrewConfigShape
-}
-
 export function ChatPanel() {
   const qc = useQueryClient()
   const [chatCfg, setChatCfg] = useState<ChatConfig>(loadChatConfig)
@@ -147,99 +128,79 @@ export function ChatPanel() {
     saveErrorPathRef.current = null
     rawSetSaveError(msg)
   }
-  const setPickerSaveError = (path: string, msg: string) => {
+  const setPathSaveError = (path: string, msg: string) => {
     saveErrorPathRef.current = path
     rawSetSaveError(msg)
   }
-
-  // ── Optimistic pending values for the model/effort pickers ──
-  // Each picker renders `pending ?? server`, so a pick shows in the trigger
-  // immediately instead of after the PATCH → invalidate → refetch round-trip.
-  // The overlay is keyed by config path, so concurrent picks on different
-  // pickers cannot touch each other's display: a failed mutation only stops
-  // masking its OWN path, and a settle-time refetch lands in the query cache
-  // UNDER every still-pending overlay rather than clobbering it.
-  //
-  // Ownership is a monotonic token, not the picked value: `setPending`
-  // returns the token from `onMutate` (react-query hands it back to
-  // `onSettled` as the mutation context), and only the entry's own token may
-  // clear it. Guarding on the value instead would let pick A → pick B →
-  // pick A on one picker have A₁'s settle clear the entry A₃ owns, flashing
-  // the stale cache value while A₃ is still in flight.
-  const pendingSeqRef = useRef(0)
-  // Latest token per path, readable synchronously from mutation callbacks
-  // (state would be a stale closure there): lets a superseded mutation's
-  // late failure recognise it no longer owns the path's display.
-  const latestTokenRef = useRef<Record<string, number>>({})
-  const [pendingCfg, setPendingCfg] = useState<Record<string, { value: string; token: number } | undefined>>({})
-  const setPending = (path: string, value: string): number => {
-    const token = ++pendingSeqRef.current
-    latestTokenRef.current[path] = token
-    setPendingCfg(prev => ({ ...prev, [path]: { value, token } }))
-    // A fresh attempt supersedes a stale failure banner from THIS picker:
-    // without this the trigger would show the new pick while its own last
-    // pick's error still hangs above it in the same frame. Failures from any
-    // other source — another picker included — stay up: this pick says
-    // nothing about whether that other setting saved.
+  // A fresh attempt supersedes a stale failure banner from ITS OWN path:
+  // without this a control would show the new value while its own last
+  // save's error still hangs above it in the same frame. Failures from any
+  // other source — another control included — stay up: this save says
+  // nothing about whether that other setting persisted.
+  const clearOwnPathError = (path: string) => {
     if (saveErrorPathRef.current === path) setSaveError('')
-    return token
   }
-  const clearPending = (path: string, token: unknown) =>
-    setPendingCfg(prev => {
-      // A newer pick on the same path owns the display now; leave it alone.
-      if (prev[path]?.token !== token) return prev
-      const next = { ...prev }
-      delete next[path]
-      return next
-    })
+
+  // ── Per-path optimistic pending values (shared overlay hook) ──
+  // Every optimistic save on this panel renders `shown(path, server)`, so a
+  // save displays immediately instead of after its round-trip, and
+  // concurrent saves on different paths cannot touch each other's display.
+  // Full lifecycle contract: useOptimisticConfigPaths.ts.
+  const overlay = useOptimisticConfigPaths(qc)
 
   // ── Dashboard config (server-side) ──
   const dashQ = useQuery<DashboardConfig>({
     queryKey: ['dashboardConfig'],
     queryFn: () => api.dashboardConfig(),
   })
-  const dashCfg = dashQ.data ?? { restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more' as const, verbosity: 'default' as const, quick_send: false, session_grid: false, tail_fork_enabled: false, link_previews: false, mcp_app_panel: false, auto_open_git_panel: false, folder_suggestions_enabled: true, use_builtin_browser: true }
+  // Shown config: the in-flight save when one is pending, else the server's.
+  // Toggles both render this and BUILD THEIR PAYLOAD from it (setDash), so a
+  // second toggle during a save carries the first one's value forward.
+  const dashCfg = overlay.shown(
+    'dashboardConfig',
+    dashQ.data ?? { restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more' as const, verbosity: 'default' as const, quick_send: false, session_grid: false, tail_fork_enabled: false, link_previews: false, mcp_app_panel: false, auto_open_git_panel: false, folder_suggestions_enabled: true, use_builtin_browser: true },
+  )
 
   // ── Feature Tips opt-out (server-side per-user state) ──
   const tipsQ = useQuery<{ enabled_config: boolean; opted_out: boolean }>({
     queryKey: ['tipsStatus'],
     queryFn: () => api.tipsStatus(),
   })
-  const tipsMut = useMutation({
+  const tipsOpts = overlay.mutationOpts<boolean>({
+    queryKey: ['tipsStatus'],
     mutationFn: (enable: boolean) => api.tipsFeedback('', enable ? 'optin' : 'optout'),
-    onMutate: async (enable) => {
-      await qc.cancelQueries({ queryKey: ['tipsStatus'] })
-      const prev = qc.getQueryData<{ enabled_config: boolean; opted_out: boolean }>(['tipsStatus'])
-      if (prev) qc.setQueryData(['tipsStatus'], { ...prev, opted_out: !enable })
-      return { prev }
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) qc.setQueryData(['tipsStatus'], ctx.prev)
-      setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_tips_preference'))
-    },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: ['tipsStatus'] })
+    path: () => 'tipsStatus.opted_out',
+    displayValue: enable => !enable,
+    applyToCache: (cached, enable) => ({ ...(cached as { enabled_config: boolean; opted_out: boolean }), opted_out: !enable }),
+    onFailure: () => setPathSaveError('tipsStatus.opted_out', i18nT('pages.settings.chatPanel.failed_to_save_tips_preference')),
+    onSupersede: clearOwnPathError,
+  })
+  const tipsMut = useMutation({
+    ...tipsOpts,
+    onSettled: (data: unknown, err: unknown, enable: boolean, token: number | undefined) => {
+      tipsOpts.onSettled(data, err, enable, token)
       // Drop any cached/in-flight tip so a running Chat view can't display a
       // tip fetched before the preference changed.
       qc.removeQueries({ queryKey: ['tips-next'] })
     },
   })
   const tipsConfigOff = tipsQ.data ? !tipsQ.data.enabled_config : false
+  const shownOptedOut = overlay.shown('tipsStatus.opted_out', tipsQ.data?.opted_out)
 
-  const dashMut = useMutation({
+  // The dashboard config is written whole (the endpoint takes the full
+  // object), so its overlay path is the object itself: a toggle builds its
+  // payload from the SHOWN config, a second toggle therefore already carries
+  // the first one's in-flight value, and the monotonic token keeps a slow
+  // earlier save from clobbering the newer one's display or cache write.
+  const dashMut = useMutation(overlay.mutationOpts<DashboardConfig>({
+    queryKey: ['dashboardConfig'],
     mutationFn: (next: DashboardConfig) => api.updateDashboardConfig(next),
-    onMutate: async (next) => {
-      await qc.cancelQueries({ queryKey: ['dashboardConfig'] })
-      const prev = qc.getQueryData<DashboardConfig>(['dashboardConfig'])
-      qc.setQueryData(['dashboardConfig'], next)
-      return { prev }
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) qc.setQueryData(['dashboardConfig'], ctx.prev)
-      setSaveError(i18nT('pages.settings.chatPanel.failed_to_save_dashboard_config'))
-    },
-    onSettled: () => qc.invalidateQueries({ queryKey: ['dashboardConfig'] }),
-  })
+    path: () => 'dashboardConfig',
+    displayValue: next => next,
+    applyToCache: (_cached, next) => next,
+    onFailure: () => setPathSaveError('dashboardConfig', i18nT('pages.settings.chatPanel.failed_to_save_dashboard_config')),
+    onSupersede: clearOwnPathError,
+  }))
 
   // ── KiroCrew config (server-side) ──
   const mcQ = useQuery<KirocrewConfigShape>({
@@ -250,62 +211,30 @@ export function ChatPanel() {
 
   /**
    * Mutation options for a config PATCH with an OPTIMISTIC display: the seven
-   * Model-section selectors render `pending ?? server`, so a pick shows
+   * Model-section selectors render `shown(path, server)`, so a pick shows
    * immediately instead of waiting for the PATCH + refetch round-trip.
+   * Lifecycle (per-path pending entry, monotonic ownership token,
+   * token-guarded success cache write, error-path refetch) lives in
+   * useOptimisticConfigPaths — this factory only binds the panel's query
+   * key, PATCH call, and path-scoped failure banner. `''` is a meaningful
+   * value here ("model default" / fallback "disabled"); the overlay's
+   * explicit entry check preserves it.
    *
-   * The pending entry is per config PATH, never a whole-config snapshot:
-   * snapshotting the whole object would capture another picker's in-flight
-   * optimistic value and restore it on this mutation's failure, transiently
-   * reverting a pick the user never undid. With the overlay, an error only
-   * stops masking this mutation's own path.
-   *
-   * On success the ACCEPTED value is first written into the cache at this
-   * path only, so a transiently failed settle-time refetch (which
-   * invalidateQueries swallows) cannot leave the display on a pre-PATCH
-   * value the server no longer holds. `onSuccess` then RETURNS the
-   * invalidateQueries promise — react-query awaits it before `onSettled` —
-   * so by the time the pending entry clears, a completed refetch has already
-   * replaced that write with the server's authoritative answer (which may
-   * differ from the pick when the backend normalises it). The refetch cannot
-   * clobber a DIFFERENT picker's in-flight pick, because that picker's
-   * overlay still masks the cache until its own settle. On error the cache
-   * was never written, but the refetch still runs: a PATCH can fail after
-   * persisting (5xx after apply, proxy timeout), and only the server can say
-   * which value survived. `''` is a meaningful value here ("model default" /
-   * fallback "disabled"), hence `??` over truthiness everywhere the overlay
-   * is read.
-   *
-   * The failure banner is token-guarded: a pick that has been superseded by
-   * a newer pick on the same path reports nothing when it eventually fails —
+   * The failure banner is token-guarded by the hook: a pick superseded by a
+   * newer pick on the same path reports nothing when it eventually fails —
    * the newer pick owns the display, and a stale "failed to save" beside a
-   * value that did persist is exactly the co-render this fix removes.
+   * value that did persist is exactly the co-render this prevents.
    */
-  const optimisticConfigOpts = (path: string, errMsg: (err: unknown) => string) => ({
-    mutationFn: (v: string) => api.patchConfig(path, v),
-    onMutate: (v: string) => setPending(path, v),
-    onSuccess: (_data: unknown, v: string, token: unknown) => {
-      // Only the path's LATEST pick may write its accepted value: with A→B
-      // in flight on one picker and B settling first, A's later settle would
-      // otherwise overwrite B in the cache, and a failed refetch would leave
-      // stale A displayed while the server holds B.
-      if (latestTokenRef.current[path] === token) {
-        const cur = qc.getQueryData<KirocrewConfigShape>(['kirocrewConfig'])
-        if (cur) qc.setQueryData(['kirocrewConfig'], setConfigValue(cur, path, v))
-      }
-      return qc.invalidateQueries({ queryKey: ['kirocrewConfig'] })
-    },
-    onError: (err: unknown, _v: string, token: unknown) => {
-      // Stop masking immediately (token-guarded and idempotent with the
-      // onSettled clear) so no intermediate frame shows the failed pick
-      // beside its own failure banner.
-      clearPending(path, token)
-      if (latestTokenRef.current[path] === token) setPickerSaveError(path, errMsg(err))
-    },
-    onSettled: (_data: unknown, err: unknown, _v: string, token: unknown) => {
-      clearPending(path, token)
-      if (err) qc.invalidateQueries({ queryKey: ['kirocrewConfig'] })
-    },
-  })
+  const optimisticConfigOpts = (path: string, errMsg: (err: unknown) => string) =>
+    overlay.mutationOpts<string>({
+      queryKey: ['kirocrewConfig'],
+      mutationFn: (v: string) => api.patchConfig(path, v),
+      path: () => path,
+      displayValue: v => v,
+      applyToCache: (cached, v) => setConfigPathValue(cached as KirocrewConfigShape, path, v),
+      onFailure: err => setPathSaveError(path, errMsg(err)),
+      onSupersede: clearOwnPathError,
+    })
 
   // ── User profile (About You) ──
   // Same slugs as onboarding step 2 (OnboardingFlow.tsx), validated by the
@@ -384,7 +313,7 @@ export function ChatPanel() {
   // "auto" (default) = backend availability-aware routing, concrete id =
   // tried first with "auto" as the final fallthrough.
   const fallbackModel = mcCfg?.agent?.fallback_model ?? 'auto'
-  const shownFallbackModel = pendingCfg['agent.fallback_model']?.value ?? fallbackModel
+  const shownFallbackModel = overlay.shown('agent.fallback_model', fallbackModel)
   const fallbackMut = useMutation(
     optimisticConfigOpts('agent.fallback_model', (err: unknown) => {
       // Surface the backend's actual deny reason (e.g. an unentitled id)
@@ -446,7 +375,7 @@ export function ChatPanel() {
   // '' in config means "unset" and resolves the same way 'auto' does, so both
   // render as the 'auto' option rather than as a missing selection.
   const defaultModel = mcCfg?.agent?.model || 'auto'
-  const shownDefaultModel = pendingCfg['agent.model']?.value ?? defaultModel
+  const shownDefaultModel = overlay.shown('agent.model', defaultModel)
   const modelOptions = availableModels.map(m => m.name)
   // A model the live backend no longer advertises must still be selectable,
   // otherwise the select would silently jump to another entry and a stray
@@ -463,7 +392,7 @@ export function ChatPanel() {
   )
 
   const defaultEffort = mcCfg?.agent?.reasoning_effort ?? ''
-  const shownDefaultEffort = pendingCfg['agent.reasoning_effort']?.value ?? defaultEffort
+  const shownDefaultEffort = overlay.shown('agent.reasoning_effort', defaultEffort)
   // Effort is only meaningful on reasoning-capable models. Rather than hide the
   // row (which would make the setting look absent), keep it visible and
   // disabled with an explanatory hint. Gated on the SHOWN model so the row's
@@ -485,8 +414,8 @@ export function ChatPanel() {
   // these rows label it differently from the chat row's Default (auto).
   const backgroundModel = mcCfg?.agent?.role_models?.background || 'auto'
   const subagentModel = mcCfg?.agent?.role_models?.subagent || 'auto'
-  const shownBackgroundModel = pendingCfg['agent.role_models.background']?.value ?? backgroundModel
-  const shownSubagentModel = pendingCfg['agent.role_models.subagent']?.value ?? subagentModel
+  const shownBackgroundModel = overlay.shown('agent.role_models.background', backgroundModel)
+  const shownSubagentModel = overlay.shown('agent.role_models.subagent', subagentModel)
   // A pinned model the live backend no longer advertises must stay selectable
   // (same reasoning as the chat-default picker), so prepend what is missing —
   // both the shown value and the persisted one, so neither vanishes while a
@@ -524,8 +453,8 @@ export function ChatPanel() {
   // rather than folded into this copy fix.
   const backgroundEffort = mcCfg?.agent?.role_efforts?.background ?? ''
   const subagentEffort = mcCfg?.agent?.role_efforts?.subagent ?? ''
-  const shownBackgroundEffort = pendingCfg['agent.role_efforts.background']?.value ?? backgroundEffort
-  const shownSubagentEffort = pendingCfg['agent.role_efforts.subagent']?.value ?? subagentEffort
+  const shownBackgroundEffort = overlay.shown('agent.role_efforts.background', backgroundEffort)
+  const shownSubagentEffort = overlay.shown('agent.role_efforts.subagent', subagentEffort)
   const bgEffortSupported = modelSupportsEffort(shownBackgroundModel !== 'auto' ? shownBackgroundModel : shownDefaultModel)
   const subEffortSupported = modelSupportsEffort(shownSubagentModel !== 'auto' ? shownSubagentModel : shownDefaultModel)
   const effortLabels = EFFORT_LEVELS.map(l => (l === '' ? i18nT('pages.settings.chatPanel.model_default') : effortLabel(l)))
@@ -765,7 +694,7 @@ export function ChatPanel() {
           <SettingsSelect label={i18nT('pages.settings.chatPanel.response_verbosity')} description={i18nT('pages.settings.chatPanel.how_terse_the_agent_s_prose_is_ultra_concise_cap')} value={asVerbosity(dashCfg.verbosity)} options={VERBOSITY_OPTIONS} optionLabels={[i18nT('pages.settings.chatPanel.default_normal_length'), i18nT('pages.settings.chatPanel.concise_trim_filler'), i18nT('pages.settings.chatPanel.ultra_concise_3_sentences'), i18nT('pages.settings.chatPanel.answer_only_details_on_request')]} onChange={v => setDash({ verbosity: v as VerbosityLevel })} disabled={dashDisabled} />
           <SettingsToggle label={i18nT('pages.settings.chatPanel.show_context_percentage')} description={i18nT('pages.settings.chatPanel.display_usage_percentage_next_to_the_context_pro')} checked={chatCfg.showContextPct} onChange={v => setChat('showContextPct', v)} />
           <SettingsToggle label={i18nT('pages.settings.chatPanel.show_token_usage')} description={i18nT('pages.settings.chatPanel.display_used_and_total_tokens_next_to_the_contex')} checked={chatCfg.showContextTokens} onChange={v => setChat('showContextTokens', v)} />
-          <SettingsToggle label={i18nT('pages.settings.chatPanel.feature_tips')} description={tipsConfigOff ? i18nT('pages.settings.chatPanel.disabled_by_instance_config_tips_enabled_false') : i18nT('pages.settings.chatPanel.show_occasional_feature_discovery_tips_above_the')} checked={!!tipsQ.data && tipsQ.data.enabled_config && !tipsQ.data.opted_out} onChange={v => tipsMut.mutate(v)} disabled={tipsConfigOff || tipsQ.isLoading || tipsQ.isError} />
+          <SettingsToggle label={i18nT('pages.settings.chatPanel.feature_tips')} description={tipsConfigOff ? i18nT('pages.settings.chatPanel.disabled_by_instance_config_tips_enabled_false') : i18nT('pages.settings.chatPanel.show_occasional_feature_discovery_tips_above_the')} checked={!!tipsQ.data && tipsQ.data.enabled_config && !shownOptedOut} onChange={v => tipsMut.mutate(v)} disabled={tipsConfigOff || tipsQ.isLoading || tipsQ.isError} />
           <SettingsToggle label={i18nT('pages.settings.chatPanel.folder_suggestions')} description={i18nT('pages.settings.chatPanel.offer_to_file_a_new_session_into_a_matching_fold')} checked={dashCfg.folder_suggestions_enabled} onChange={v => setDash({ folder_suggestions_enabled: v })} disabled={dashDisabled} />
         </SettingsCard>
       </SettingsSection>

--- a/website/src/pages/settings/DisplayPanel.tsx
+++ b/website/src/pages/settings/DisplayPanel.tsx
@@ -18,6 +18,7 @@ import { PALETTE_NAMES, INTENSITY_NAMES } from '../../utils/sessionColors'
 import type { DefaultColorSetting, PaletteName, IntensityName, SessionColorMode } from '../../utils/sessionColors'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api, ApiError } from '../../api/client'
+import { useOptimisticConfigPaths, setConfigPathValue } from './useOptimisticConfigPaths'
 import { parseErrorCode } from '../../utils/errorReport'
 import { clampTintCount, RECENT_TINT_COUNT } from '../../utils/recencyTint'
 import { useLanguage } from '../../i18n/LanguageProvider'
@@ -140,63 +141,57 @@ export function DisplayPanel() {
   const defaultColor = useAppSelector(s => s.dashboard.sessionDefaultColor) as DefaultColorSetting
 
   // Recency-tint count is persisted server-side (dashboard.recent_tint_count) via the shared
-  // kirocrewConfig query, so the choice follows the user across browsers/restarts. Optimistic
-  // cache write makes the sidebar tint (which reads the same query) re-rank instantly.
+  // kirocrewConfig query, so the choice follows the user across browsers/restarts.
   const qc = useQueryClient()
-  const mcQ = useQuery<{ dashboard?: { recent_tint_count?: number; terminal?: { shell?: string } } }>({
+  type KirocrewCfg = { dashboard?: { recent_tint_count?: number; terminal?: { shell?: string } } }
+  const mcQ = useQuery<KirocrewCfg>({
     queryKey: ['kirocrewConfig'],
     queryFn: () => api.kirocrewConfig(),
   })
+  // Per-path optimistic display shared by the tint and shell saves below.
+  // Both PATCH the same ['kirocrewConfig'] object, so a whole-object
+  // onMutate snapshot here is a live race: a tint rollback would restore a
+  // pre-shell-save snapshot, transiently reverting an in-flight shell save
+  // (and vice versa). Each control instead renders `shown(path, server)`;
+  // full lifecycle contract in useOptimisticConfigPaths.ts. The sidebar tint
+  // (which reads the same query) re-ranks when the save is accepted rather
+  // than at click time — the stepper itself stays instant via the overlay.
+  const overlay = useOptimisticConfigPaths(qc)
   const recentTintCount = clampTintCount(mcQ.data?.dashboard?.recent_tint_count)
-  const tintMut = useMutation({
+  const shownTintCount = overlay.shown('dashboard.recent_tint_count', recentTintCount)
+  const tintMut = useMutation(overlay.mutationOpts<number>({
+    queryKey: ['kirocrewConfig'],
     mutationFn: (value: number) => api.patchConfig('dashboard.recent_tint_count', value),
-    onMutate: async (value: number) => {
-      await qc.cancelQueries({ queryKey: ['kirocrewConfig'] })
-      const prev = qc.getQueryData<{ dashboard?: { recent_tint_count?: number } }>(['kirocrewConfig'])
-      const next = structuredClone(prev ?? {})
-      next.dashboard = { ...(next.dashboard ?? {}), recent_tint_count: value }
-      qc.setQueryData(['kirocrewConfig'], next)
-      return { prev }
-    },
-    onError: (_e, _v, ctx) => { if (ctx?.prev) qc.setQueryData(['kirocrewConfig'], ctx.prev) },
-    onSettled: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-  })
+    path: () => 'dashboard.recent_tint_count',
+    displayValue: v => v,
+    applyToCache: (cached, value) => setConfigPathValue(cached as KirocrewCfg, 'dashboard.recent_tint_count', value),
+  }))
+  // Steps are computed from the SHOWN count so rapid clicks stack on the
+  // in-flight value instead of re-incrementing a stale server value.
   const setTintCount = (n: number) => tintMut.mutate(clampTintCount(n))
 
   // Default shell for the built-in terminal — persisted server-side
   // (dashboard.terminal.shell) because the SHELL is spawned by the gateway
   // host, unlike the terminal font above, which is a per-client rendering
   // choice and stays in localStorage. Drafted locally and committed on blur so
-  // a half-typed path is never persisted. The write mirrors tintMut above:
-  // optimistic cache write + rollback, because onSuccess clears the draft and
-  // React Query serves the stale cache while refetching — without the
-  // optimistic write the just-saved value blinks back to the previous one for
-  // a round-trip, which reads as a failed save. Errors are mapped from the
-  // response's machine-readable `code` to catalog keys: the backend's English
-  // sentence must never render verbatim in a 12-language dashboard.
-  type KirocrewCfg = { dashboard?: { recent_tint_count?: number; terminal?: { shell?: string } } }
+  // a half-typed path is never persisted. The overlay keeps the just-saved
+  // value shown after onSuccess clears the draft, because React Query serves
+  // the stale cache while refetching — without it the value would blink back
+  // to the previous one for a round-trip, which reads as a failed save.
+  // Errors are mapped from the response's machine-readable `code` to catalog
+  // keys: the backend's English sentence must never render verbatim in a
+  // 12-language dashboard.
   const serverShell = mcQ.data?.dashboard?.terminal?.shell ?? ''
+  const shownShell = overlay.shown('dashboard.terminal.shell', serverShell)
   const [shellDraft, setShellDraft] = useState<string | null>(null)
   const [shellError, setShellError] = useState<string | null>(null)
-  const shellMut = useMutation({
+  const shellOpts = overlay.mutationOpts<string>({
+    queryKey: ['kirocrewConfig'],
     mutationFn: (value: string) => api.patchConfig('dashboard.terminal.shell', value),
-    onMutate: async (value: string) => {
-      await qc.cancelQueries({ queryKey: ['kirocrewConfig'] })
-      const prev = qc.getQueryData<KirocrewCfg>(['kirocrewConfig'])
-      const next = structuredClone(prev ?? {})
-      next.dashboard = {
-        ...(next.dashboard ?? {}),
-        terminal: { ...(next.dashboard?.terminal ?? {}), shell: value },
-      }
-      qc.setQueryData(['kirocrewConfig'], next)
-      return { prev }
-    },
-    onSuccess: () => {
-      setShellDraft(null)
-      setShellError(null)
-    },
-    onError: (e, _value, ctx) => {
-      if (ctx?.prev) qc.setQueryData(['kirocrewConfig'], ctx.prev)
+    path: () => 'dashboard.terminal.shell',
+    displayValue: v => v,
+    applyToCache: (cached, value) => setConfigPathValue(cached as KirocrewCfg, 'dashboard.terminal.shell', value),
+    onFailure: e => {
       const code = e instanceof ApiError ? parseErrorCode(e.body) : undefined
       setShellError(i18nT(
         code === 'shell_not_executable'
@@ -204,12 +199,20 @@ export function DisplayPanel() {
           : 'pages.settings.displayPanel.terminal_shell_save_failed',
       ))
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
+    onSupersede: () => setShellError(null),
+  })
+  const shellMut = useMutation({
+    ...shellOpts,
+    onSuccess: (data: unknown, value: string, token: number) => {
+      setShellDraft(null)
+      setShellError(null)
+      return shellOpts.onSuccess(data, value, token)
+    },
   })
   const commitShell = () => {
     if (shellDraft === null) return
     const value = shellDraft.trim()
-    if (value === serverShell) {
+    if (value === shownShell) {
       setShellDraft(null)
       setShellError(null)
       return
@@ -383,10 +386,10 @@ export function DisplayPanel() {
           <SettingsInput
             label={i18nT('pages.settings.displayPanel.terminal_shell')}
             description={i18nT('pages.settings.displayPanel.terminal_shell_desc')}
-            value={shellDraft ?? serverShell}
+            value={shellDraft ?? shownShell}
             onChange={setShellDraft}
             onBlur={commitShell}
-            disabled={shellMut.isPending}
+            disabled={shellMut.isPending || !mcQ.isSuccess}
             configKey="dashboard.terminal.shell"
             aria-label={i18nT('pages.settings.displayPanel.terminal_shell')}
           />
@@ -516,10 +519,11 @@ export function DisplayPanel() {
           <SettingsStepper
             label={i18nT('pages.settings.displayPanel.highlight_recent_sessions')}
             description={i18nT('pages.settings.displayPanel.highlight_the_n_most_recently_active_sessions_wi')}
-            value={recentTintCount}
-            onIncrement={() => setTintCount(recentTintCount + 1)}
-            onDecrement={() => setTintCount(recentTintCount - 1)}
+            value={shownTintCount}
+            onIncrement={() => setTintCount(shownTintCount + 1)}
+            onDecrement={() => setTintCount(shownTintCount - 1)}
             onReset={() => setTintCount(RECENT_TINT_COUNT)}
+            disabled={!mcQ.isSuccess}
           />
           {/* Color swatches use raw buttons — circular color dots don't fit SettingsButtonGroup's text-button pattern */}
           <div className="flex flex-col gap-1.5 py-1.5" data-setting-label={i18nT('pages.settings.displayPanel.default_for_new_sessions')}>

--- a/website/src/pages/settings/SkillsPanel.tsx
+++ b/website/src/pages/settings/SkillsPanel.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { SettingsSection, SettingsCard, SettingsToggle } from '../../components/settings'
 import { api } from '../../api/client'
+import { useOptimisticConfigPaths, setConfigPathValue } from './useOptimisticConfigPaths'
 
 import { i18nT } from '../../i18n/t'
 import ErrorNotice from '../../components/ErrorNotice'
@@ -18,35 +19,44 @@ type SkillsCfg = { auto_create_from_sessions?: boolean; approval_required?: bool
 export function SkillsPanel() {
   const qc = useQueryClient()
   const [saveError, setSaveError] = useState('')
+  // Which path produced the current banner: a retry on the SAME path clears
+  // its stale failure, but a save on the other toggle says nothing about
+  // whether this one persisted, so its failure stays up.
+  const saveErrorPathRef = useRef<string | null>(null)
 
   const cfgQ = useQuery<{ skills?: SkillsCfg }>({
     queryKey: ['kirocrewConfig'],
     queryFn: () => api.kirocrewConfig(),
   })
   const skills = cfgQ.data?.skills
-  const autoCreate = skills?.auto_create_from_sessions ?? false
+  // Both toggles PATCH the shared ['kirocrewConfig'] object. A whole-object
+  // onMutate snapshot here would capture ANOTHER PANEL's in-flight optimistic
+  // value on the same query key and restore it on failure (the panel's own
+  // two toggles are mutually disabled while a save is pending, so the
+  // within-panel interleave is unreachable). Each toggle instead renders
+  // `shown(path, server)`; lifecycle in useOptimisticConfigPaths.ts.
+  const overlay = useOptimisticConfigPaths(qc)
+  const autoCreate = overlay.shown('skills.auto_create_from_sessions', skills?.auto_create_from_sessions ?? false)
   // approval_required defaults ON — generated skills stay gated behind review.
-  const approvalRequired = skills?.approval_required ?? true
+  const approvalRequired = overlay.shown('skills.approval_required', skills?.approval_required ?? true)
 
-  const patchMut = useMutation({
-    mutationFn: ({ path, value }: { path: string; value: boolean }) =>
-      api.patchConfig(path, value),
-    onMutate: async ({ path, value }) => {
-      await qc.cancelQueries({ queryKey: ['kirocrewConfig'] })
-      const prev = qc.getQueryData<{ skills?: SkillsCfg }>(['kirocrewConfig'])
-      const key = path.split('.')[1]
-      qc.setQueryData<{ skills?: SkillsCfg }>(['kirocrewConfig'], (old) => ({
-        ...(old ?? {}),
-        skills: { ...(old?.skills ?? {}), [key]: value },
-      }))
-      return { prev }
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) qc.setQueryData(['kirocrewConfig'], ctx.prev)
+  const patchMut = useMutation(overlay.mutationOpts<{ path: string; value: boolean }>({
+    queryKey: ['kirocrewConfig'],
+    mutationFn: ({ path, value }) => api.patchConfig(path, value),
+    path: v => v.path,
+    displayValue: v => v.value,
+    applyToCache: (cached, { path, value }) => setConfigPathValue(cached as { skills?: SkillsCfg }, path, value),
+    onFailure: (_err, { path }) => {
+      saveErrorPathRef.current = path
       setSaveError(i18nT('pages.settings.skillsPanel.failed_to_save_skills_setting'))
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: ['kirocrewConfig'] }),
-  })
+    onSupersede: path => {
+      if (saveErrorPathRef.current === path) {
+        saveErrorPathRef.current = null
+        setSaveError('')
+      }
+    },
+  }))
 
   const disabled = cfgQ.isLoading || patchMut.isPending
 

--- a/website/src/pages/settings/useOptimisticConfigPaths.ts
+++ b/website/src/pages/settings/useOptimisticConfigPaths.ts
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react'
+import type { QueryClient, QueryKey } from '@tanstack/react-query'
+
+/**
+ * Return a copy of `cfg` with the dot-separated `path` set to `value`,
+ * shallow-cloning only the objects along the path. Used on a config PATCH's
+ * success to write the ACCEPTED value into the query cache at that one path,
+ * so a transiently failed settle-time refetch cannot leave the display on a
+ * pre-PATCH value the server no longer holds.
+ */
+export function setConfigPathValue<T>(cfg: T, path: string, value: unknown): T {
+  const keys = path.split('.')
+  const next: Record<string, unknown> = { ...(cfg as Record<string, unknown>) }
+  let cursor = next
+  for (let i = 0; i < keys.length - 1; i++) {
+    const child = cursor[keys[i]]
+    cursor[keys[i]] = typeof child === 'object' && child !== null ? { ...(child as Record<string, unknown>) } : {}
+    cursor = cursor[keys[i]] as Record<string, unknown>
+  }
+  cursor[keys[keys.length - 1]] = value
+  return next as T
+}
+
+type PendingEntry = { value: unknown; token: number }
+
+export type OptimisticPathMutation<TVars, TData> = {
+  /** Query key whose cached object this mutation's settle reconciles. */
+  queryKey: QueryKey
+  mutationFn: (vars: TVars) => Promise<TData>
+  /** The overlay path these vars write — one display slot per path. */
+  path: (vars: TVars) => string
+  /** The value the overlay shows at that path while the request is in flight. */
+  displayValue: (vars: TVars) => unknown
+  /** Token-guarded success write of the ACCEPTED value into the cached object. */
+  applyToCache: (cached: unknown, vars: TVars) => unknown
+  /** Failure report, invoked only when this mutation still owns its path. */
+  onFailure?: (err: unknown, vars: TVars) => void
+  /** A fresh attempt began on `path` — clear that path's stale failure state. */
+  onSupersede?: (path: string) => void
+}
+
+/**
+ * Per-config-path optimistic display for settings mutations that share a
+ * query key. Each control renders `shown(path, server)` — the pending value
+ * while a save is in flight, the server value otherwise — so concurrent
+ * saves on different paths can never transiently revert each other's
+ * display, which is exactly what a whole-object onMutate snapshot/rollback
+ * does: the snapshot captures another save's in-flight optimistic value and
+ * an error restores it, and an unconditional settle-time refetch returns
+ * server state that does not yet include the other save's un-applied write.
+ *
+ * Ownership is a monotonic token, not the written value: `mutationOpts`
+ * returns the token from `onMutate` (react-query hands it back to the settle
+ * callbacks as the mutation context), and only the entry's own token may
+ * clear it. Guarding on the value instead would let save A → save B → save A
+ * on one path have A₁'s settle clear the entry A₃ owns, flashing the stale
+ * cache value while A₃ is still in flight.
+ *
+ * The settle lifecycle mirrors the model pickers this was extracted from:
+ * on success the ACCEPTED value is written into the cache at this path only
+ * (token-guarded, so a superseded save never overwrites a newer settled one),
+ * then the returned `invalidateQueries` promise is awaited by react-query
+ * before `onSettled` — by the time the pending entry clears, a completed
+ * refetch has already replaced that write with the server's authoritative
+ * answer. On error the cache was never written, but the refetch still runs:
+ * a request can fail after persisting (5xx after apply, proxy timeout), and
+ * only the server can say which value survived. `''` and `false` are
+ * meaningful values, hence the explicit entry check in `shown` rather than
+ * truthiness or `??`.
+ */
+export function useOptimisticConfigPaths(qc: QueryClient) {
+  const pendingSeqRef = useRef(0)
+  // Latest token per path, readable synchronously from mutation callbacks
+  // (state would be a stale closure there): lets a superseded mutation's
+  // late settle recognise it no longer owns the path's display.
+  const latestTokenRef = useRef<Record<string, number>>({})
+  // Whether THIS hook instance is still mounted. The token refs above are
+  // per instance, but the query cache is global: after an unmount → remount
+  // (tab switch and back), a save begun by the OLD instance still passes its
+  // own ownership check when it settles — its ref never saw the new
+  // instance's saves — and would write a stale value over one the new
+  // instance's save already persisted. A dead instance therefore never
+  // writes the cache; it still invalidates, so the server's answer lands
+  // either way. The effect body re-arms the flag because a Strict-Mode
+  // mount runs the previous cleanup first.
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+  const [pending, setPending] = useState<Record<string, PendingEntry | undefined>>({})
+
+  const beginPending = (path: string, value: unknown): number => {
+    const token = ++pendingSeqRef.current
+    latestTokenRef.current[path] = token
+    setPending(prev => ({ ...prev, [path]: { value, token } }))
+    return token
+  }
+  const clearPending = (path: string, token: unknown) =>
+    setPending(prev => {
+      // No token (onMutate threw) or a newer save on the same path owns the
+      // display now; leave the map untouched — returning the same reference
+      // also skips a pointless re-render.
+      if (token === undefined || prev[path]?.token !== token) return prev
+      const next = { ...prev }
+      delete next[path]
+      return next
+    })
+
+  /** The value a control displays: the path's pending save, else the server's. */
+  const shown = <T,>(path: string, server: T): T => {
+    const entry = pending[path]
+    return entry === undefined ? server : (entry.value as T)
+  }
+
+  /**
+   * Build `useMutation` options wiring a mutation into the overlay. Call
+   * sites needing an extra side effect (clear a local draft on success, drop
+   * a dependent query on settle) spread the result and wrap the callback,
+   * delegating back to the wrapped one.
+   */
+  const mutationOpts = <TVars, TData = unknown>(cfg: OptimisticPathMutation<TVars, TData>) => ({
+    mutationFn: cfg.mutationFn,
+    onMutate: (vars: TVars): number => {
+      const path = cfg.path(vars)
+      const token = beginPending(path, cfg.displayValue(vars))
+      cfg.onSupersede?.(path)
+      return token
+    },
+    onSuccess: (_data: TData, vars: TVars, token: number) => {
+      const path = cfg.path(vars)
+      // Only the path's LATEST save may write its accepted value: with A→B
+      // in flight on one path and B settling first, A's later settle would
+      // otherwise overwrite B in the cache, and a failed refetch would leave
+      // stale A displayed while the server holds B.
+      if (mountedRef.current && latestTokenRef.current[path] === token) {
+        const cached = qc.getQueryData(cfg.queryKey)
+        if (cached !== undefined) qc.setQueryData(cfg.queryKey, cfg.applyToCache(cached, vars))
+      }
+      return qc.invalidateQueries({ queryKey: cfg.queryKey })
+    },
+    onError: (err: unknown, vars: TVars, token: number | undefined) => {
+      // Stop masking immediately (token-guarded and idempotent with the
+      // onSettled clear) so no intermediate frame shows the failed value
+      // beside its own failure report.
+      const path = cfg.path(vars)
+      clearPending(path, token)
+      if (token !== undefined && latestTokenRef.current[path] === token) cfg.onFailure?.(err, vars)
+    },
+    onSettled: (_data: TData | undefined, err: unknown, vars: TVars, token: number | undefined) => {
+      clearPending(cfg.path(vars), token)
+      if (err) qc.invalidateQueries({ queryKey: cfg.queryKey })
+    },
+  })
+
+  return { shown, mutationOpts }
+}

--- a/website/src/test/ChatPanel.optimisticWrites.test.tsx
+++ b/website/src/test/ChatPanel.optimisticWrites.test.tsx
@@ -1,0 +1,167 @@
+// Settings ▸ Chat — tips + dashboard-config optimistic writes through the
+// per-path overlay (#6890). The model pickers' contract is pinned in
+// ChatPanel.optimisticPickers.test.tsx; this file covers the two remaining
+// mutations this panel converted: the Feature-Tips toggle (['tipsStatus'])
+// and the whole-object dashboard config (['dashboardConfig']).
+//
+// SettingsSelect wraps Radix Select, which needs pointer APIs jsdom lacks —
+// same lightweight mock the sibling ChatPanel suites use.
+vi.mock('@radix-ui/react-select', async () => await import('./__mocks__/@radix-ui/react-select'))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+const { tipsFeedbackMock, tipsStatusMock, dashboardConfigMock, updateDashboardConfigMock } = vi.hoisted(() => ({
+  tipsFeedbackMock: vi.fn(() => Promise.resolve({ ok: true })),
+  tipsStatusMock: vi.fn(() => Promise.resolve({ enabled_config: true, opted_out: false })),
+  dashboardConfigMock: vi.fn(() =>
+    Promise.resolve({ restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more', quick_send: false })
+  ),
+  updateDashboardConfigMock: vi.fn(() => Promise.resolve({})),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    dashboardConfig: dashboardConfigMock,
+    kirocrewConfig: () => Promise.resolve({ agent: { model: 'auto', reasoning_effort: '' } }),
+    models: () => Promise.resolve([{ model_name: 'auto', description: 'Default' }]),
+    patchConfig: () => Promise.resolve({}),
+    updateDashboardConfig: updateDashboardConfigMock,
+    tipsStatus: tipsStatusMock,
+    tipsFeedback: tipsFeedbackMock,
+  },
+}))
+
+import { ChatPanel } from '../pages/settings/ChatPanel'
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+function defer(mock: ReturnType<typeof vi.fn>) {
+  let resolve!: (v: unknown) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  mock.mockImplementationOnce(() => promise as never)
+  return { resolve, reject }
+}
+
+const tipsToggle = () => screen.getByRole('switch', { name: 'Feature Tips' })
+const quickSendToggle = () => screen.getByRole('switch', { name: 'Quick Send' })
+
+beforeEach(() => {
+  tipsFeedbackMock.mockReset().mockImplementation(() => Promise.resolve({ ok: true }))
+  tipsStatusMock.mockReset().mockImplementation(() =>
+    Promise.resolve({ enabled_config: true, opted_out: false })
+  )
+  dashboardConfigMock.mockReset().mockImplementation(() =>
+    Promise.resolve({ restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more', quick_send: false })
+  )
+  updateDashboardConfigMock.mockReset().mockImplementation(() => Promise.resolve({}))
+})
+
+describe('ChatPanel — Feature Tips toggle through the overlay', () => {
+  it('shows the flip immediately, and a failure rolls back only the tips path', async () => {
+    const dTips = defer(tipsFeedbackMock)
+    const dDash = defer(updateDashboardConfigMock)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(tipsToggle()).toBeChecked())
+    await waitFor(() => expect(quickSendToggle()).not.toHaveAttribute('aria-disabled'))
+    expect(quickSendToggle()).not.toBeChecked()
+
+    // A dashboard save is in flight at the same time — the cross-mutation
+    // pairing the whole-snapshot writes could interleave on.
+    fireEvent.click(quickSendToggle())
+    await waitFor(() => expect(quickSendToggle()).toBeChecked())
+
+    fireEvent.click(tipsToggle())
+    // Pre-settle: the toggle reads OFF while only the initial status fetch
+    // has run — display comes from the overlay, not a cache write.
+    await waitFor(() => expect(tipsToggle()).not.toBeChecked())
+    expect(tipsFeedbackMock).toHaveBeenCalledWith('', 'optout')
+    expect(tipsStatusMock).toHaveBeenCalledTimes(1)
+
+    // The tips save FAILS: its own display rolls back, the in-flight
+    // dashboard toggle keeps its optimistic value.
+    dTips.reject(new Error('boom'))
+    await waitFor(() => expect(tipsToggle()).toBeChecked())
+    expect(await screen.findByText(/Failed to save tips preference/)).toBeInTheDocument()
+    expect(quickSendToggle()).toBeChecked()
+
+    dashboardConfigMock.mockImplementation(() =>
+      Promise.resolve({ restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: false, widget_density: 'more', quick_send: true })
+    )
+    dDash.resolve({})
+    await waitFor(() => expect(quickSendToggle()).toBeChecked())
+  })
+
+  it('keeps the refetched opt-out after a successful settle', async () => {
+    const dTips = defer(tipsFeedbackMock)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(tipsToggle()).toBeChecked())
+    fireEvent.click(tipsToggle())
+    await waitFor(() => expect(tipsToggle()).not.toBeChecked())
+
+    tipsStatusMock.mockImplementation(() =>
+      Promise.resolve({ enabled_config: true, opted_out: true })
+    )
+    dTips.resolve({ ok: true })
+    await waitFor(() => expect(tipsStatusMock).toHaveBeenCalledTimes(2))
+    expect(tipsToggle()).not.toBeChecked()
+  })
+})
+
+describe('ChatPanel — dashboard config through the overlay', () => {
+  it("a slow earlier save's success does not clobber a newer toggle's display", async () => {
+    // Two dashboard toggles in quick succession: the second payload is built
+    // from the SHOWN config, so it already carries the first value; the
+    // monotonic token keeps the first save's settle from overwriting the
+    // second's display or cache write.
+    const d1 = defer(updateDashboardConfigMock)
+    const d2 = defer(updateDashboardConfigMock)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(quickSendToggle()).not.toHaveAttribute('aria-disabled'))
+    expect(quickSendToggle()).not.toBeChecked()
+    const mergeToggle = screen.getByRole('switch', { name: 'Merge Queued Messages' })
+
+    fireEvent.click(quickSendToggle())
+    await waitFor(() => expect(quickSendToggle()).toBeChecked())
+    fireEvent.click(mergeToggle)
+    await waitFor(() => expect(mergeToggle).toBeChecked())
+    // The second payload composes on the first's in-flight value.
+    expect(updateDashboardConfigMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ quick_send: true, merge_queued_messages: true })
+    )
+
+    // The OLDER save settles first; the server still reports the pre-save
+    // config, so a wrongful cache write or pending clear would be visible as
+    // either toggle dropping back.
+    d1.resolve({})
+    await waitFor(() => expect(dashboardConfigMock.mock.calls.length).toBeGreaterThan(1))
+    expect(quickSendToggle()).toBeChecked()
+    expect(mergeToggle).toBeChecked()
+
+    dashboardConfigMock.mockImplementation(() =>
+      Promise.resolve({ restore_sessions: false, restore_window_minutes: 30, merge_queued_messages: true, widget_density: 'more', quick_send: true })
+    )
+    d2.resolve({})
+    await waitFor(() => expect(quickSendToggle()).toBeChecked())
+    await waitFor(() => expect(mergeToggle).toBeChecked())
+  })
+
+  it('a failed dashboard save rolls back its display and reports the failure', async () => {
+    const d1 = defer(updateDashboardConfigMock)
+    wrap(<ChatPanel />)
+    await waitFor(() => expect(quickSendToggle()).not.toHaveAttribute('aria-disabled'))
+    expect(quickSendToggle()).not.toBeChecked()
+    fireEvent.click(quickSendToggle())
+    await waitFor(() => expect(quickSendToggle()).toBeChecked())
+
+    d1.reject(new Error('boom'))
+    await waitFor(() => expect(quickSendToggle()).not.toBeChecked())
+    expect(await screen.findByText(/Failed to save dashboard config/)).toBeInTheDocument()
+  })
+})

--- a/website/src/test/DisplayPanel.optimisticWrites.test.tsx
+++ b/website/src/test/DisplayPanel.optimisticWrites.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+
+/**
+ * Settings → Display: concurrent optimistic saves on the shared
+ * ['kirocrewConfig'] key (#6890).
+ *
+ * The recency-tint stepper and the Default-shell field PATCH sibling paths of
+ * one cached object. With a whole-object onMutate snapshot, a tint save that
+ * starts BEFORE a shell save and then fails restores a pre-shell snapshot,
+ * transiently reverting the in-flight shell save — the live race named in the
+ * issue. Both writes now go through the per-path overlay, so a failure only
+ * stops masking its own path.
+ */
+
+const { patchConfigMock, kirocrewConfigMock } = vi.hoisted(() => ({
+  patchConfigMock: vi.fn((_path: string, _value: unknown) => Promise.resolve({})),
+  kirocrewConfigMock: vi.fn(() => Promise.resolve({})),
+}))
+
+vi.mock('../api/client', () => {
+  /** Minimal stand-in with the same shape the panel reads (status + body). */
+  class ApiError extends Error {
+    status: number
+    body: string
+    constructor(status: number, message: string, body = '') {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+      this.body = body
+    }
+  }
+  return {
+    api: {
+      kirocrewConfig: kirocrewConfigMock,
+      patchConfig: patchConfigMock,
+      installTheme: vi.fn(() => Promise.resolve({ ok: true })),
+    },
+    ApiError,
+  }
+})
+
+// Same provider doubles as DisplayPanel.terminalShell.test.tsx — the panel
+// reads all of these on render and none is under test here.
+const zoomCtx = {
+  zoom: 100,
+  zoomSupported: true,
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  reset: vi.fn(),
+  family: 'sans',
+  setFontFamily: vi.fn(),
+  cycleFamily: vi.fn(),
+}
+vi.mock('../hooks/ZoomProvider', () => ({
+  useZoomCtx: () => zoomCtx,
+}))
+
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => ({
+    preference: 'dark',
+    setTheme: vi.fn(),
+    colorTheme: 'default',
+    setColorTheme: vi.fn(),
+    allThemes: [{ value: 'default', label: 'Default', custom: false }],
+    theme: 'dark',
+    themeVersion: 0,
+    themeSwitching: false,
+    addCustomTheme: vi.fn(),
+    deleteCustomTheme: vi.fn(),
+    loadCustomThemes: vi.fn(),
+  }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+  CUSTOM_THEMES_CHANGED_EVENT: 'custom-themes-changed',
+}))
+
+vi.mock('../hooks/useUIMode', () => ({
+  useUIMode: () => ({
+    uiMode: 'chat',
+    setUIMode: vi.fn(),
+    toggleUIMode: vi.fn(),
+  }),
+  UIModeProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('../hooks/useSessionPalette', () => ({
+  useSessionPalette: () => ({
+    paletteColors: ['#ff0000', '#00ff00', '#0000ff'],
+    colorMode: 'tint' as const,
+    paletteName: 'trailhead',
+    intensity: 'clear',
+    boost: {
+      activePct: [60, 60, 60],
+      idlePct: [30, 30, 30],
+    },
+  }),
+}))
+
+import { DisplayPanel } from '../pages/settings/DisplayPanel'
+
+const TINT_PATH = 'dashboard.recent_tint_count'
+
+/** The tint stepper's own field row — the panel has other steppers (zoom),
+ *  so its buttons and value must be queried within this row. */
+const tintField = () => {
+  const el = document.querySelector('[data-setting-label="Highlight recent sessions"]')
+  expect(el).not.toBeNull()
+  return within(el as HTMLElement)
+}
+const SHELL_PATH = 'dashboard.terminal.shell'
+
+function seed(shell: string, tint: number) {
+  kirocrewConfigMock.mockImplementation(() =>
+    Promise.resolve({ dashboard: { terminal: { shell }, recent_tint_count: tint } }),
+  )
+}
+
+/** Per-path deferred PATCHes: each config path gets its own held-open promise. */
+function deferPatchesByPath() {
+  const held: Record<string, { resolve: (v: unknown) => void; reject: (e: unknown) => void }> = {}
+  patchConfigMock.mockImplementation(((path: string) => {
+    return new Promise((resolve, reject) => { held[path] = { resolve, reject } })
+  }) as never)
+  return held
+}
+
+describe('DisplayPanel — concurrent tint/shell optimistic saves', () => {
+  beforeEach(() => {
+    patchConfigMock.mockReset()
+    patchConfigMock.mockImplementation(() => Promise.resolve({}))
+    seed('/bin/bash', 3)
+  })
+
+  it("a failed tint save does not revert an in-flight shell save's display", async () => {
+    const held = deferPatchesByPath()
+    renderWithProviders(<DisplayPanel />)
+    const input = (await screen.findByLabelText('Default shell')) as HTMLInputElement
+    await waitFor(() => expect(input.value).toBe('/bin/bash'))
+
+    // Tint save starts FIRST — the direction where a whole-object snapshot
+    // captures the pre-shell state that a later rollback would restore.
+    fireEvent.click(tintField().getByLabelText('Increase'))
+    await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith(TINT_PATH, 4))
+
+    // Shell save starts while the tint PATCH is still in flight.
+    fireEvent.change(input, { target: { value: '/usr/bin/fish' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith(SHELL_PATH, '/usr/bin/fish'))
+
+    // The tint save FAILS. Only the tint display may roll back.
+    held[TINT_PATH].reject(new Error('boom'))
+    await waitFor(() => expect(tintField().getByText('3')).toBeInTheDocument())
+
+    // The shell save succeeds; the server now reports the new shell. Hold the
+    // settle-time refetch open: this is exactly the window where the old
+    // snapshot rollback left the cache on the pre-shell value and the input
+    // (draft already cleared) blinked back to /bin/bash.
+    seed('/usr/bin/fish', 3)
+    let releaseRefetch!: (v: unknown) => void
+    kirocrewConfigMock.mockImplementationOnce(
+      () => new Promise(res => { releaseRefetch = res }) as never,
+    )
+    held[SHELL_PATH].resolve({})
+    // Draft cleared after success…
+    await waitFor(() => expect(input.value).toBe('/usr/bin/fish'))
+    releaseRefetch({ dashboard: { terminal: { shell: '/usr/bin/fish' }, recent_tint_count: 3 } })
+    // …and the value survives the refetch too.
+    await waitFor(() => expect(input.value).toBe('/usr/bin/fish'))
+  })
+
+  it('the stepper shows the pending count immediately and stacks rapid clicks on it', async () => {
+    const held = deferPatchesByPath()
+    renderWithProviders(<DisplayPanel />)
+    await screen.findByLabelText('Default shell')
+    await waitFor(() => expect(tintField().getByText('3')).toBeInTheDocument())
+
+    fireEvent.click(tintField().getByLabelText('Increase'))
+    // Pre-settle: the PATCH is held open and the config mock still reports 3,
+    // so the count reading 4 can only be coming from the overlay.
+    await waitFor(() => expect(tintField().getByText('4')).toBeInTheDocument())
+
+    // A second click steps from the SHOWN value, not the stale server one.
+    fireEvent.click(tintField().getByLabelText('Increase'))
+    await waitFor(() => expect(patchConfigMock).toHaveBeenCalledWith(TINT_PATH, 5))
+    await waitFor(() => expect(tintField().getByText('5')).toBeInTheDocument())
+
+    seed('/bin/bash', 5)
+    held[TINT_PATH].resolve({})
+    await waitFor(() => expect(tintField().getByText('5')).toBeInTheDocument())
+  })
+})

--- a/website/src/test/SkillsPanel.optimisticWrites.test.tsx
+++ b/website/src/test/SkillsPanel.optimisticWrites.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+/**
+ * Settings → Skills: optimistic toggle writes through the per-path overlay
+ * (#6890). The panel PATCHes sibling paths of the shared ['kirocrewConfig']
+ * object; the whole-object onMutate snapshot it used to take could restore
+ * another save's in-flight value on failure. Pinned here: the toggle flips
+ * immediately without a cache write, a failure rolls back only its own path
+ * and raises the banner, and a retry on the same path clears the stale
+ * banner.
+ */
+
+const { patchConfigMock, kirocrewConfigMock } = vi.hoisted(() => ({
+  patchConfigMock: vi.fn((_path: string, _value: unknown) => Promise.resolve({})),
+  kirocrewConfigMock: vi.fn(() =>
+    Promise.resolve({ skills: { auto_create_from_sessions: false, approval_required: true } }),
+  ),
+}))
+
+vi.mock('../api/client', () => ({
+  api: { kirocrewConfig: kirocrewConfigMock, patchConfig: patchConfigMock },
+}))
+
+import { SkillsPanel } from '../pages/settings/SkillsPanel'
+
+const AUTO_PATH = 'skills.auto_create_from_sessions'
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+function deferPatch() {
+  let resolve!: (v: unknown) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  patchConfigMock.mockImplementation(() => promise as never)
+  return { resolve, reject }
+}
+
+const autoToggle = () =>
+  screen.getByRole('switch', { name: /Auto-generate skills from sessions/ })
+
+describe('SkillsPanel — optimistic toggle via the per-path overlay', () => {
+  beforeEach(() => {
+    patchConfigMock.mockReset()
+    patchConfigMock.mockImplementation(() => Promise.resolve({}))
+    kirocrewConfigMock.mockClear()
+    kirocrewConfigMock.mockImplementation(() =>
+      Promise.resolve({ skills: { auto_create_from_sessions: false, approval_required: true } }),
+    )
+  })
+
+  it('flips the toggle immediately while the PATCH is in flight, then keeps the refetched value', async () => {
+    const { resolve } = deferPatch()
+    wrap(<SkillsPanel />)
+    const label = await screen.findByText('Auto-generate skills from sessions')
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(1))
+    fireEvent.click(label)
+
+    // Pre-settle: the toggle already reads ON while only the initial config
+    // fetch has run — the display comes from the overlay, not a cache write.
+    await waitFor(() => expect(autoToggle()).toBeChecked())
+    expect(patchConfigMock).toHaveBeenCalledWith(AUTO_PATH, true)
+    expect(kirocrewConfigMock).toHaveBeenCalledTimes(1)
+
+    kirocrewConfigMock.mockImplementation(() =>
+      Promise.resolve({ skills: { auto_create_from_sessions: true, approval_required: true } }),
+    )
+    resolve({})
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(2))
+    expect(autoToggle()).toBeChecked()
+  })
+
+  it('a failed save rolls back its own toggle and shows the banner; a retry clears it', async () => {
+    const { reject } = deferPatch()
+    wrap(<SkillsPanel />)
+    const label = await screen.findByText('Auto-generate skills from sessions')
+    await waitFor(() => expect(kirocrewConfigMock).toHaveBeenCalledTimes(1))
+    fireEvent.click(label)
+    await waitFor(() => expect(autoToggle()).toBeChecked())
+
+    reject(new Error('boom'))
+    await waitFor(() => expect(autoToggle()).not.toBeChecked())
+    expect(await screen.findByText(/Failed to save skills setting/)).toBeInTheDocument()
+
+    // A fresh attempt on the SAME path supersedes its stale failure banner.
+    patchConfigMock.mockImplementation(() => Promise.resolve({}))
+    kirocrewConfigMock.mockImplementation(() =>
+      Promise.resolve({ skills: { auto_create_from_sessions: true, approval_required: true } }),
+    )
+    fireEvent.click(label)
+    await waitFor(() =>
+      expect(screen.queryByText(/Failed to save skills setting/)).not.toBeInTheDocument(),
+    )
+    await waitFor(() => expect(autoToggle()).toBeChecked())
+  })
+})

--- a/website/src/test/useOptimisticConfigPaths.test.tsx
+++ b/website/src/test/useOptimisticConfigPaths.test.tsx
@@ -1,0 +1,216 @@
+// useOptimisticConfigPaths — the shared per-path optimistic overlay (#6890),
+// extracted from the Settings ▸ Chat model pickers' merged fix shape.
+//
+// The contract pinned here, once, for every settings panel that uses it:
+//   * a save's value shows IMMEDIATELY via the overlay, while the query cache
+//     is untouched (no whole-object onMutate snapshot exists to restore);
+//   * a failure stops masking only its OWN path — a concurrent save on a
+//     sibling path sharing the query key keeps its in-flight display;
+//   * ownership is a monotonic token: a superseded save's slow success
+//     neither clears the newer pending entry nor writes its stale value into
+//     the cache, and its late failure reports nothing;
+//   * the error path still refetches (a request can fail after persisting);
+//   * a fresh attempt on a path fires onSupersede with that path, so the
+//     panel can clear that path's stale failure state.
+//
+// Panel-level race tests (DisplayPanel tint/shell, SkillsPanel, ChatPanel
+// tips/dashboard) assert the conversion of each call site; the mechanism
+// itself is pinned here against a minimal two-path harness.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider, useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
+import React, { useState } from 'react'
+
+import { useOptimisticConfigPaths, setConfigPathValue } from '../pages/settings/useOptimisticConfigPaths'
+
+type Cfg = { a?: string; b?: string }
+
+const fetchCfg = vi.fn<() => Promise<Cfg>>()
+const patchA = vi.fn<(v: string) => Promise<unknown>>()
+const patchB = vi.fn<(v: string) => Promise<unknown>>()
+const onFailureA = vi.fn()
+const onSupersedeA = vi.fn()
+
+/** Two mutations on sibling paths of ONE query key — the defect's shape. */
+function Harness() {
+  const qc = useQueryClient()
+  const cfgQ = useQuery<Cfg>({ queryKey: ['cfg'], queryFn: fetchCfg })
+  const overlay = useOptimisticConfigPaths(qc)
+  const [errA, setErrA] = useState('')
+  const mutA = useMutation(overlay.mutationOpts<string>({
+    queryKey: ['cfg'],
+    mutationFn: patchA,
+    path: () => 'a',
+    displayValue: v => v,
+    applyToCache: (cached, v) => setConfigPathValue(cached as Cfg, 'a', v),
+    onFailure: (err, v) => { onFailureA(err, v); setErrA('save of a failed') },
+    onSupersede: p => { onSupersedeA(p); setErrA('') },
+  }))
+  const mutB = useMutation(overlay.mutationOpts<string>({
+    queryKey: ['cfg'],
+    mutationFn: patchB,
+    path: () => 'b',
+    displayValue: v => v,
+    applyToCache: (cached, v) => setConfigPathValue(cached as Cfg, 'b', v),
+  }))
+  return (
+    <div>
+      <output data-testid="a">{overlay.shown('a', cfgQ.data?.a ?? '')}</output>
+      <output data-testid="b">{overlay.shown('b', cfgQ.data?.b ?? '')}</output>
+      <output data-testid="errA">{errA}</output>
+      <button onClick={() => mutA.mutate('a1')}>saveA1</button>
+      <button onClick={() => mutA.mutate('a2')}>saveA2</button>
+      <button onClick={() => mutB.mutate('b1')}>saveB1</button>
+    </div>
+  )
+}
+
+function wrap() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}><Harness /></QueryClientProvider>)
+}
+
+/** A request whose settle the test controls — the in-flight window. */
+function defer(mock: ReturnType<typeof vi.fn>) {
+  let resolve!: (v: unknown) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+  mock.mockImplementationOnce(() => promise as never)
+  return { resolve, reject }
+}
+
+beforeEach(() => {
+  fetchCfg.mockReset().mockImplementation(() => Promise.resolve({ a: 'a0', b: 'b0' }))
+  patchA.mockReset().mockImplementation(() => Promise.resolve({}))
+  patchB.mockReset().mockImplementation(() => Promise.resolve({}))
+  onFailureA.mockClear()
+  onSupersedeA.mockClear()
+})
+
+describe('useOptimisticConfigPaths — contract', () => {
+  it('shows the pending value immediately, without touching the query cache', async () => {
+    const dA = defer(patchA)
+    wrap()
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+    fireEvent.click(screen.getByText('saveA1'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a1'))
+    // Pre-settle: only the initial fetch has run — the display can only be
+    // coming from the overlay, never from an onMutate cache write.
+    expect(fetchCfg).toHaveBeenCalledTimes(1)
+    expect(onSupersedeA).toHaveBeenCalledWith('a')
+    dA.resolve({})
+    await waitFor(() => expect(fetchCfg).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('a')).toHaveTextContent('a0')
+  })
+
+  it("a failure rolls back only its own path — a sibling save's in-flight display survives", async () => {
+    const dB = defer(patchB)
+    const dA = defer(patchA)
+    wrap()
+    await waitFor(() => expect(screen.getByTestId('b')).toHaveTextContent('b0'))
+    fireEvent.click(screen.getByText('saveB1'))
+    fireEvent.click(screen.getByText('saveA1'))
+    await waitFor(() => expect(screen.getByTestId('b')).toHaveTextContent('b1'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a1'))
+
+    // A fails while B is still in flight: A rolls back, B must not move.
+    dA.reject(new Error('boom'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+    expect(screen.getByTestId('b')).toHaveTextContent('b1')
+    expect(screen.getByTestId('errA')).toHaveTextContent('save of a failed')
+    expect(onFailureA).toHaveBeenCalledTimes(1)
+    dB.resolve({})
+  })
+
+  it("a superseded save's slow success neither clears the newer pending nor writes the cache", async () => {
+    const d1 = defer(patchA)
+    const d2 = defer(patchA)
+    wrap()
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+    fireEvent.click(screen.getByText('saveA1'))
+    fireEvent.click(screen.getByText('saveA2'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a2'))
+
+    // The OLDER save settles first. Its success must not clear the newer
+    // pending entry (display keeps a2) and must not write a1 into the cache:
+    // the refetch it triggers still reports the original server value, so a
+    // wrongful write would be visible once the newer entry clears.
+    d1.resolve({})
+    await waitFor(() => expect(fetchCfg).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('a')).toHaveTextContent('a2')
+
+    // The newer save fails; only now does the display fall back — to the
+    // server's value, not to the superseded save's a1.
+    d2.reject(new Error('boom'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+  })
+
+  it("a superseded save's late failure reports nothing — the newer save owns the path", async () => {
+    const d1 = defer(patchA)
+    const d2 = defer(patchA)
+    wrap()
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+    fireEvent.click(screen.getByText('saveA1'))
+    fireEvent.click(screen.getByText('saveA2'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a2'))
+
+    d1.reject(new Error('boom'))
+    fetchCfg.mockImplementation(() => Promise.resolve({ a: 'a2', b: 'b0' }))
+    d2.resolve({})
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a2'))
+    expect(onFailureA).not.toHaveBeenCalled()
+    expect(screen.getByTestId('errA')).toHaveTextContent('')
+  })
+
+  it('refetches after a failure, so a server-side apply is not rolled back blind', async () => {
+    const dA = defer(patchA)
+    wrap()
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+    fireEvent.click(screen.getByText('saveA1'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a1'))
+
+    // The server persisted the write before answering 5xx: the error-path
+    // refetch is what brings the surviving value back.
+    fetchCfg.mockImplementation(() => Promise.resolve({ a: 'a1', b: 'b0' }))
+    dA.reject(new Error('boom'))
+    await waitFor(() => expect(fetchCfg).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a1'))
+  })
+
+  it("an unmounted instance's late success never writes the cache over a newer instance's save", async () => {
+    // The ownership tokens are per hook INSTANCE, but the query cache is
+    // global: a save begun before an unmount → remount still passes its own
+    // instance's token check when it settles late, because that dead ref
+    // never saw the new instance's saves. The mounted guard is what keeps it
+    // from writing a stale value the new instance's save already superseded
+    // on the server.
+    const d1 = defer(patchA)
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const first = render(<QueryClientProvider client={qc}><Harness /></QueryClientProvider>)
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+    fireEvent.click(screen.getByText('saveA1'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a1'))
+
+    // Tab switch: the panel unmounts with the save still in flight, then a
+    // fresh instance mounts against the SAME query client.
+    first.unmount()
+    const d2 = defer(patchA)
+    render(<QueryClientProvider client={qc}><Harness /></QueryClientProvider>)
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a0'))
+
+    // The new instance saves a2; the server accepts and reports it.
+    fireEvent.click(screen.getByText('saveA2'))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a2'))
+    fetchCfg.mockImplementation(() => Promise.resolve({ a: 'a2', b: 'b0' }))
+    d2.resolve({})
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a2'))
+
+    // The DEAD instance's save settles last, and its settle-time refetch
+    // fails — the one condition under which a wrongful cache write would
+    // stick and show. The display must stay on the newer accepted value.
+    fetchCfg.mockImplementationOnce(() => Promise.reject(new Error('offline')))
+    d1.resolve({})
+    await waitFor(() => expect(fetchCfg.mock.calls.length).toBeGreaterThan(2))
+    await waitFor(() => expect(screen.getByTestId('a')).toHaveTextContent('a2'))
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Five Settings mutations outside the Model pickers still use the whole-object-snapshot + unconditional-invalidate optimistic write on shared query keys (`['kirocrewConfig']`, `['tipsStatus']`, `['dashboardConfig']`). Concurrent saves on one key can transiently revert each other's display: an error-path snapshot restore erases another save's in-flight value, and a success-path premature refetch returns server state that does not yet include the other save's un-applied write. The live instance named in the issue: a failed recency-tint save restores a pre-shell-save snapshot, reverting an in-flight terminal-shell save. Follow-up recorded from the First Principles review of the Model-picker fix, which converged and test-pinned the fix shape for exactly this defect class.

## Why it matters

A user who changes two settings in quick succession can watch their first change visibly undo itself — a display lying about what persisted — and, with the shared failure banner, can be told a save failed for a value that actually persisted (or vice versa). Same mechanism the picker fix removed, surviving on five lower-traffic sites.

## What changed (motivation → approach → change)

- **Root cause**: `onMutate` snapshots the WHOLE cached object and restores it on error, and `onSettled` unconditionally invalidates — both operate at object granularity while concurrent mutations own only one path each.
- **Approach**: extract the merged Model-picker pattern into a shared hook rather than replicating it five times (the issue explicitly blesses the extraction; five call sites justify it).
- **Change**:
  - New `website/src/pages/settings/useOptimisticConfigPaths.ts`: per-config-path pending overlay (each control renders `shown(path, server)`), monotonic ownership tokens per path, token-guarded success cache write (only a path's latest save writes the accepted value), error path still refetches (a request can fail after persisting). `setConfigValue` moves here as `setConfigPathValue`.
  - `ChatPanel.tsx`: the seven model/effort pickers move onto the hook as a pure extraction (their 18-test contract passes unchanged); `tipsMut` (`['tipsStatus']`) and `dashMut` (`['dashboardConfig']`) convert off whole-snapshot writes. The dashboard config is overlaid whole — the endpoint writes the full object — with payloads composed from the shown config, so a second toggle carries the first one's in-flight value and the token keeps a slow earlier save from clobbering the newer display.
  - `DisplayPanel.tsx`: `tintMut` + `shellMut` convert (the tint↔shell pair is the issue's live race). Both controls now wait for the config query to resolve before accepting input, matching the pickers — this closes a pre-load window where a success cache-write would have had no cached object to land in.
  - `SkillsPanel.tsx`: the toggle PATCH converts; its shared failure banner becomes path-scoped (a retry clears only its own stale failure).

**Known, deliberate trade-offs** (each inherited from or consistent with the merged picker pattern):
- The sidebar recency tint (same query key) re-ranks when the save is *accepted* rather than at click time; the stepper itself stays instant through the overlay. A click-time per-path cache write was considered and declined: a sibling path's settle-time refetch can still transiently drop it, so it would not make the other surface race-free — it would only widen the hook's surface.
- Token ownership means a superseded save's late success does not write the cache (pinned by the picker suite). The narrow residual — newer save fails first, older save then succeeds, and *both* consecutive refetches also fail — leaves a stale display until the next refetch; accepted as in the reference implementation.
- Two rapid whole-object dashboard saves can still reorder **server-side** (pre-existing endpoint property, unchanged by this PR, which is display-scoped).

## Tests

- `useOptimisticConfigPaths.test.tsx` — pins the hook contract once: pending shows immediately with the cache untouched; a failure rolls back only its own path while a sibling's in-flight display survives; a superseded save's slow success neither clears the newer pending nor writes the cache, and its late failure reports nothing; the error path refetches.
- `DisplayPanel.optimisticWrites.test.tsx` — the issue's live race: a failed tint save does not revert an in-flight shell save (asserted through the held-open settle refetch window where the old code blinked back); the stepper shows pending counts and stacks rapid clicks on the shown value.
- `SkillsPanel.optimisticWrites.test.tsx` — optimistic flip pre-settle; failure rolls back its own path with the banner; a retry on the same path clears the stale banner.
- `ChatPanel.optimisticWrites.test.tsx` — tips failure rolls back only the tips path while a concurrent dashboard toggle keeps its display; a slow earlier dashboard save's success does not clobber a newer toggle (payload composition on the shown config asserted); dashboard failure rolls back with its banner.
- `ChatPanel.optimisticPickers.test.tsx` (pre-existing, 18 tests) passes unchanged — the extraction is behavior-preserving for the pickers.

Full frontend suite: 26457 passed, 0 failed. `npx tsc -b` clean, eslint clean on changed files.

## Manual verification

N/A — unit coverage sufficient: every converted site's race and rollback path is asserted at the component level with held-open requests; no visual change to verify.

**CI review round 1**: the GPT lane found a real residual the pre-push lanes missed — an unmounted hook instance's late success passed its own per-instance token check and could write a stale value over a newer instance's accepted save. Fixed with a mounted guard on the success cache write (a dead instance still invalidates, never writes), mutation-verified by a new contract test that fails without the guard.

## Pre-push review

Two blind model-pinned lanes on the staged diff. GPT (gpt-5.6-sol): 3 findings — 1 fixed (pre-load input gating on DisplayPanel), 2 dispositioned above as inherited/pre-existing trade-offs. Opus (claude-opus-5): PASS, 4 advisories — 2 fixed (`clearPending` no-op on missing token; SkillsPanel comment scoped to the reachable cross-panel race), 2 declined with rationale recorded above.

<!-- no-visual-delta -->
**Why no screenshot:** display-logic only — nothing rendered changes; the tint/shell controls gain the same query-resolved disabled gating the model pickers already had, and every conversion is pinned by component tests instead.

Closes #6890
