### PR TITLE
fix(config): key the config_dir memo on the home it resolved

### DIFF
--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -73,18 +73,19 @@ _WORKSPACE_DIR_NAME = "kirocrew-workspace"
 # filesystem probing. ``None`` means "not yet resolved this process".
 _resolved_home: Path | None = None
 
-# Memo for ``config_dir()``: ``(raw KIROCREW_HOME, _resolved_home at the time,
-# result)``. ``config_dir()`` is called from 323 sites and each uncached call
-# does a ``Path.resolve()`` + ``mkdir`` and, on the default path, a breadcrumb
-# read/write — measured 94.9us per call. Keying
-# on the RAW env value keeps the override honoured the moment it changes
-# (``KIROCREW_HOME`` is repointed per test by the suite's isolation fixture, and
-# by pods/worktrees at runtime), and keying on ``_resolved_home`` by identity
-# ties the default-path entry to the resolution cache below — so clearing
-# ``_resolved_home`` (which the test suite does per test) invalidates this memo
-# too instead of pinning a stale home. In a real process both keys are stable
-# after the first call, which is what makes the breadcrumb write
-# effectively once-per-process rather than once-per-call.
+# Memo for ``config_dir()``: ``(raw KIROCREW_HOME, the home the entry was built
+# from, result)``. ``config_dir()`` is called from 323 sites and each uncached
+# call does a ``Path.resolve()`` + ``mkdir`` and, on the default path, a
+# breadcrumb read/write — measured 94.9us per call. Keying on the RAW env value
+# keeps the override honoured the moment it changes (``KIROCREW_HOME`` is
+# repointed per test by the suite's isolation fixture, and by pods/worktrees at
+# runtime), and keying on the resolved home by identity ties the default-path
+# entry to the resolution cache above — so clearing ``_resolved_home`` (which
+# the test suite does per test) invalidates this memo too instead of pinning a
+# stale home. For that invalidation to hold, the default path stores the home it
+# RETURNED rather than a re-read of the global; see ``config_dir``. In a real
+# process both keys are stable after the first call, which is what makes the
+# breadcrumb write effectively once-per-process rather than once-per-call.
 _config_dir_memo: tuple[str | None, Path | None, Path] | None = None
 
 
@@ -283,7 +284,18 @@ def config_dir() -> Path:
     # Best-effort + idempotent; guarded so a breadcrumb failure never blocks the
     # data-home resolution the whole app depends on.
     _write_recovery_breadcrumb(d)
-    _config_dir_memo = (override_raw, _resolved_home, d)
+    # Key on ``d``, the home this call actually resolved, NOT on a re-read of
+    # ``_resolved_home``. The two normally hold the same object, but not always:
+    # the global is written only by ``_resolve_default_home``, so a resolution
+    # that bypasses it (a stubbed resolver in a test, or a reset of the global
+    # landing between the resolve above and this line) leaves the global ``None``
+    # while ``d`` is a real path. Storing that ``None`` as the key records an
+    # entry whose key is satisfied by every later "no override, home not yet
+    # resolved" call — the state the suite's isolation fixture recreates per
+    # test — so the unrelated ``d`` would be served as if freshly resolved.
+    # Keying on ``d`` keeps the invariant above literal: the entry is live only
+    # while the resolution cache still holds the same home.
+    _config_dir_memo = (override_raw, d, d)
     return d
 
 

--- a/test/test_lazy_data_home_paths.py
+++ b/test/test_lazy_data_home_paths.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from unittest.mock import patch
 
 SRC = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
 PATHS_MODULE = SRC / "config" / "paths.py"
@@ -555,3 +556,82 @@ class TestResolutionDoesNotRepeatStartupMaintenance:
         monkeypatch.setenv("KIROCREW_HOME", str(good))
         assert paths._valid_override_home() is not None
         assert paths.data_home().resolve() == good.resolve()
+
+
+class TestConfigDirMemoIsNotServedAfterTheHomeIsCleared:
+    """A ``config_dir()`` memo entry must not outlive the home it was built from.
+
+    The entry is keyed on ``(raw KIROCREW_HOME, resolved home)`` and the suite's
+    autouse isolation fixture clears ``_resolved_home`` per test precisely so a
+    home resolved by one test can never be served to the next. That invalidation
+    only holds if the default path keys the entry on the home it RETURNED. Keying
+    it on a re-read of the global records ``(None, None, <that test's dir>)``
+    whenever the resolution bypassed the global — a stubbed resolver, or a reset
+    of the global landing between the resolve and the store — and then every
+    later "no override, home not yet resolved" call, which is exactly the state
+    the fixture recreates, hits that entry and gets the unrelated directory.
+
+    MEASURED: with the key re-read from the global, running
+    ``test_first_resolution_still_performs_maintenance`` (it stubs the resolver)
+    before ``test/test_mcp_core.py::TestSpawnRunSessionKeyRouting::
+    test_falls_back_to_pid_file`` in one process made the latter fail — the MCP
+    session-key fallback looked for its ``session_pid_*.txt`` under the earlier
+    test's tmp dir. Under ``-n auto`` whether the two share a worker varies per
+    run, which is what made it an intermittent CI failure rather than a
+    reproducible one.
+    """
+
+    def test_entry_from_a_bypassed_resolution_is_not_served_later(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.config import paths
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        stubbed = tmp_path / "stubbed"
+        # The breadcrumb is incidental to what this test asserts, and it is the
+        # one part of the default path that writes OUTSIDE the resolved home:
+        # ``_write_recovery_breadcrumb`` targets ``Path.home()`` directly, so the
+        # first phase below -- which resolves through a stubbed resolver, before
+        # ``Path.home`` is patched -- would drop a real
+        # ``~/.kirocrew.breadcrumb`` on the machine running the suite.
+        monkeypatch.setattr(paths, "_write_recovery_breadcrumb", lambda _d: None)
+
+        # A resolution that never writes ``_resolved_home`` (what a stubbed
+        # resolver does, and what a concurrent reset of the global does).
+        with monkeypatch.context() as m:
+            m.setattr(paths, "_resolved_home", None)
+            m.setattr(paths, "_resolve_default_home", lambda: stubbed)
+            assert paths.config_dir() == stubbed
+            assert paths._resolved_home is None, "precondition: global left unset"
+
+        # The next caller's state: no override, resolution cache clear.
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        real_home = tmp_path / "real-home"
+        with patch("pathlib.Path.home", return_value=real_home):
+            resolved = paths.config_dir()
+
+        assert resolved == real_home / ".kiro" / "crew", (
+            f"config_dir() served a memo entry from a foreign home: {resolved}"
+        )
+
+    def test_the_memo_still_caches_a_normal_default_resolution(
+        self, tmp_path, monkeypatch
+    ):
+        """Negative control: the fix must not turn the memo off.
+
+        Two consecutive default-path calls must hit the entry, which is what keeps
+        the breadcrumb refresh once-per-process instead of once-per-call.
+        """
+        from kiro_crew.config import paths
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", None)
+        calls: list[int] = []
+        monkeypatch.setattr(paths, "_write_recovery_breadcrumb", lambda d: calls.append(1))
+
+        with patch("pathlib.Path.home", return_value=tmp_path / "home"):
+            first = paths.config_dir()
+            second = paths.config_dir()
+
+        assert first == second == tmp_path / "home" / ".kiro" / "crew"
+        assert calls == [1], f"memo did not serve the second call: {calls}"


### PR DESCRIPTION
## Problem / Motivation

`test/test_mcp_core.py::TestSpawnRunSessionKeyRouting::test_falls_back_to_pid_file` fails intermittently in CI:

```
FAILED test/test_mcp_core.py::TestSpawnRunSessionKeyRouting::test_falls_back_to_pid_file
  - AssertionError: assert '' == 'sess-from-pid'
```

The test is not the cause. `config_dir()` can hand a caller a data home that belongs to an **unrelated earlier test**, and the MCP session-key fallback — which resolves `config_dir()` to find `session_pid_<ppid>.txt` — then reads nothing and returns `""`.

## Why it matters

Two costs. The visible one is a flaky red on `main` and on every PR that happens to schedule the two tests onto one xdist worker, which burns reruns and trains reviewers to re-run instead of read. The latent one is the memo itself: `config_dir()` is called from ~323 sites, and an entry keyed on a state that no longer describes it is served as if freshly resolved — a wrong-data-home bug class, not just a test-ordering nuisance.

## What changed (motivation → approach → change)

**Symptom → cause.** `config_dir()` memoises under `(raw KIROCREW_HOME, resolved home, result)` so that clearing `_resolved_home` invalidates the entry rather than pinning a stale home — the suite's autouse `_isolate_kirocrew_home` fixture clears that global per test for exactly this reason. The default path stored the second key by **re-reading the `_resolved_home` global** instead of using the home it had just resolved:

```python
d = _resolve_default_home()
...
_config_dir_memo = (override_raw, _resolved_home, d)
```

`_resolved_home` is written only inside `_resolve_default_home()`. Any resolution that bypasses it leaves the global `None` while `d` is a real path — a test that stubs the resolver, or a reset of the global landing between the resolve and the store. The entry then goes in as `(None, None, <that test's dir>)`, and that key is satisfied by **every later "no override, home not yet resolved" call** — precisely the state the isolation fixture recreates per test. Those callers hit the entry and get the foreign directory.

**Reproduced deterministically** (one process, in this order):

```
pytest -n0 \
  "test/test_lazy_data_home_paths.py::TestResolutionDoesNotRepeatStartupMaintenance::test_first_resolution_still_performs_maintenance" \
  "test/test_mcp_core.py::TestSpawnRunSessionKeyRouting::test_falls_back_to_pid_file"
→ 1 failed, 1 passed      # AssertionError: assert '' == 'sess-from-pid'
```

The first test stubs `_resolve_default_home`; the second is the CI flake. Under `-n auto` whether the two land on one worker varies per run, which is what made it intermittent. After this change the same pair passes.

**Change.** The default path stores the home it returned: `_config_dir_memo = (override_raw, d, d)`. In a normal process `d` *is* the global's object, so the cache still hits and the breadcrumb refresh stays once-per-process. When the global is unset or has moved on, the key no longer matches and the entry is recomputed instead of served. The override path is deliberately unchanged: its raw-env key is non-`None`, so it can never be hit by a no-override call. The module comment now states the invariant it relies on.

## Tests

`test/test_lazy_data_home_paths.py`, new `TestConfigDirMemoIsNotServedAfterTheHomeIsCleared`:

- `test_entry_from_a_bypassed_resolution_is_not_served_later` — records an entry from a resolution that never writes the global, then asserts the next `config_dir()` (no override, cache cleared) resolves from `Path.home()`. **Red on base**: `config_dir() served a memo entry from a foreign home: .../stubbed`.
- `test_the_memo_still_caches_a_normal_default_resolution` — negative control: two consecutive default-path calls refresh the breadcrumb once, so the fix cannot pass by turning the memo off.

## Manual verification

N/A — unit coverage plus the deterministic reproducer above cover it; there is no user-facing surface.

## Related Issues

N/A — flake reported from a CI run, no issue filed.

## Checklist

- [x] At most two commits (one here), Conventional Commits title
- [x] Backend gates green locally: `check_black_formatting`, `isort --check-only`, `flake8`, `mypy src/kiro_crew/`, brand, changelog-history, testpaths-coverage
- [x] Full backend suite run on the branch: `75386 passed`; the 108 failures + 2 errors are byte-for-byte the same set the pristine base produces on those files in this sandbox (ssh/AF_UNIX/host-isolation environment cases), so no regression is attributable to this diff
