### PR TITLE
perf(session-storage): reuse co-tenant cache in measure's reclaim block check

### DIFF
--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -92,7 +92,7 @@ the legacy stem fails instead of agreeing with itself.
 
 ## An instance that cannot see who is live must not reclaim
 
-`reclaim_block_reason()` blocks an isolated data home whose replay store is outside that home: its local session map cannot establish ownership of the shared store. It compares resolved paths and requires containment rather than checking environment-variable presence or a default path, so an unsafe override that falls back to the shared default cannot appear isolated. The legacy pre-migration home is a default, not isolation.
+`reclaim_block_reason()` blocks an isolated data home whose replay store is outside that home: its local session map cannot establish ownership of the shared store. It compares resolved paths and requires containment rather than checking environment-variable presence or a default path, so an unsafe override that falls back to the shared default cannot appear isolated. The legacy pre-migration home is a default, not isolation. `reclaim_block_reason` defaults to `cached=False` so mutation gates like `_move_to_trash_locked` always evaluate the live co-tenant state; display aggregators (`measure()`) pass `cached=True` to reuse the recent co-tenant scan from `list_units()`.
 
 `cotenant_sids()` handles discoverable pod candidates differently. A pod with its own replay store cannot own files in this store. A candidate that claims sessions but has no own store, or whose map cannot be read or parsed, makes `move_to_trash()` refuse because it can resume a session after the pre-move snapshot. A dev gateway at an arbitrary data home is not discoverable and remains a Known Limitation.
 

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -717,7 +717,7 @@ def measure(
         trash_bytes=sum(b.bytes for b in batches),
         trash_batches=len(batches),
         trash_same_filesystem=_same_filesystem(kiro_sessions_dir(), trash_root()),
-        reclaim_blocked_reason=reclaim_block_reason(),
+        reclaim_blocked_reason=reclaim_block_reason(cached=True),
     )
     # The per-store split stays out of the report but is the first thing worth
     # knowing when a total looks wrong.
@@ -872,11 +872,12 @@ def cotenant_sids(*, cached: bool = False) -> tuple[frozenset[str], tuple[tuple[
 
     *cached* permits a recent pass over the pod maps to be reused, mirroring
     :func:`_scan_raw`'s flag: opt-in per call site, never global. It exists for
-    the read paths behind :func:`_scan_units`. The refusal derivation in
-    :func:`reclaim_block_reason` and the pre-move re-read in
-    :func:`move_to_trash` must never opt in — a stale answer there could let a
-    reclaim proceed against a store another instance still holds, which is the
-    exact staleness the pre-move re-read exists to close.
+    the read paths behind :func:`_scan_units` and display callers of
+    :func:`reclaim_block_reason`. The pre-move re-read in
+    :func:`move_to_trash` (and :func:`reclaim_block_reason`'s default) must
+    never opt in — a stale answer there could let a reclaim proceed against a
+    store another instance still holds, which is the exact staleness the
+    pre-move re-read exists to close.
     """
     global _cotenant_cache
     if cached:
@@ -968,7 +969,7 @@ def _has_own_replay_store(pod_home: Path) -> bool:
     return (pod_home / KIRO_BASE_DIR_NAME.lstrip(".")).is_dir() or (pod_home / "kiro").is_dir()
 
 
-def reclaim_block_reason() -> str:
+def reclaim_block_reason(*, cached: bool = False) -> str:
     """Why this instance must not reclaim, or ``""`` when it may.
 
     The exclusion set is built from THIS instance's session map, but the kiro-cli
@@ -995,6 +996,14 @@ def reclaim_block_reason() -> str:
     Pods are handled per session rather than per instance, because their mappings
     ARE discoverable: see :func:`cotenant_sids`. Only a pod whose map cannot be
     read still costs the whole instance its ability to reclaim.
+
+    *cached* permits reusing a recent pass over co-tenant pod mappings,
+    mirroring :func:`cotenant_sids`'s flag: opt-in per call site, never global.
+    It is passed by display aggregators like :func:`measure` to avoid paying an
+    extra uncached scan on top of :func:`list_units`. Mutation paths
+    (like :func:`_move_to_trash_locked`) keep the default ``cached=False`` so the
+    destructive operation always re-evaluates the authoritative state in real
+    time.
     """
 
     def _norm(path: Path) -> Path:
@@ -1017,7 +1026,7 @@ def reclaim_block_reason() -> str:
         # retired from here. Only checked when the store is the default one, since
         # that is the only store a pod reads.
         if _norm(kiro_home()) == home / KIRO_BASE_DIR_NAME:
-            _protected, refusals = cotenant_sids()
+            _protected, refusals = cotenant_sids(cached=cached)
             if refusals:
                 # !r, not plain interpolation: the directory name is
                 # agent-influenced and passes no identifier gate, so a newline

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -1706,6 +1706,44 @@ class TestCotenantCache:
 
         assert calls["n"] == 2, "the reclaim gate must re-enumerate the pod root on every call"
 
+    def test_reclaim_block_reason_reuses_cache_when_cached_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Display callers passing cached=True reuse the primed co-tenant pass."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+        session_storage.cotenant_sids(cached=True)  # prime
+        calls = self._count_pod_scans(monkeypatch)
+        session_storage.reclaim_block_reason(cached=True)
+        session_storage.reclaim_block_reason(cached=True)
+
+        assert calls["n"] == 0, "cached=True must reuse the primed co-tenant cache"
+
+    def test_measure_reuses_primed_cotenant_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """measure() opts into cached=True to avoid an extra co-tenant scan."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+        session_storage.cotenant_sids(cached=True)  # prime
+        calls = self._count_pod_scans(monkeypatch)
+        report = session_storage.measure(
+            session_storage.SessionIndex(),
+            units=[],
+            batches=[],
+        )
+
+        assert calls["n"] == 0, "measure() must reuse the primed co-tenant cache"
+        assert isinstance(report.reclaim_blocked_reason, str)
+
 
 class TestSharedStoreRefusal:
     """An isolated data home over a shared replay store cannot see who is live."""


### PR DESCRIPTION
## Problem / Motivation

On a default install, `measure()` (`src/kiro_crew/session_storage.py`) populates `reclaim_blocked_reason=reclaim_block_reason()`. `reclaim_block_reason` derives its co-tenant refusal check by calling `cotenant_sids(cached=False)`, bypassing the recently primed co-tenant scan populated during `list_units()` on the inventory screen (`_inventory_payload` → `list_units` + `measure`). Consequently, every inventory screen refresh pays a redundant uncached pod-root enumeration and per-pod map read.

## Why it matters

The session storage inventory screen is on the dashboard read path. Re-evaluating the full pod-root enumeration on every refresh adds unnecessary disk I/O when `list_units()` has already populated a fresh co-tenant cache moments earlier.

## What changed (motivation → approach → change)

- Added keyword-only `cached: bool = False` to `reclaim_block_reason(*, cached: bool = False) -> str` and forwarded `cached` to `cotenant_sids(cached=cached)`.
- Updated `measure()` to pass `reclaim_blocked_reason=reclaim_block_reason(cached=True)`, reusing the primed co-tenant scan on the display path.
- Preserved `cached=False` as the default on `reclaim_block_reason`, ensuring destructive mutation checks (such as `_move_to_trash_locked`) remain strictly uncached and authoritative.
- Updated documentation in `docs/system-specs/modules/session-storage.md` and docstrings in `src/kiro_crew/session_storage.py`.

## Tests

- Added `test_reclaim_block_reason_reuses_cache_when_cached_true` in `test/test_session_storage.py` asserting `reclaim_block_reason(cached=True)` reuses the primed cache without re-scanning the pod root.
- Added `test_measure_reuses_primed_cotenant_cache` in `test/test_session_storage.py` asserting `measure()` passes `cached=True` to avoid redundant co-tenant scans.
- Preserved `test_reclaim_block_reason_rereads_cotenants_despite_a_primed_cache` asserting that the default `reclaim_block_reason()` call remains strictly uncached.
- All 213 unit tests in `test/test_session_storage.py` and `test/test_session_storage_api.py` pass.

## Manual verification

N/A — unit coverage in `test/test_session_storage.py` isolates and asserts cache hit and miss behaviors.

## Related Issues

Closes #6320

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
