### PR TITLE
fix(safety): say so when a restart drops an auto-approve grant

### DIFF
--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -66,6 +66,7 @@ from kiro_crew.platform.update_layout import release_channel as _release_channel
 from kiro_crew.platform.update_layout import set_release_channel, wheel_update_command
 from kiro_crew.platform.update_provider import CommandProvider, resolve_provider
 from kiro_crew.platform_compat import reexec_python_module
+from kiro_crew.safety_override import flush_breadcrumb_writes
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -1442,6 +1443,16 @@ async def _restart_gateway(state: DashboardState) -> bool:
             logger.debug("Session cleanup before restart failed", exc_info=True)
         sys.stdout.flush()
         sys.stderr.flush()
+        # The safety-override record publishes on a worker thread (its callers sit
+        # on the event loop), and os.execv replaces this process image without
+        # draining that worker -- so a grant activated moments before a restart
+        # would lose the very notice this restart is what makes necessary (found
+        # in review). Offloaded so a stalled write cannot block the loop, and
+        # bounded, so a restart is never held up by it.
+        try:
+            await asyncio.to_thread(flush_breadcrumb_writes, 2.0)
+        except Exception:
+            logger.debug("Breadcrumb flush before restart failed", exc_info=True)
         await asyncio.sleep(0.5)
         reexec_python_module("kiro_crew", sys.argv[1:], executable=exe)
         return True

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -166,8 +166,10 @@ from kiro_crew.platform import (
 from kiro_crew.power import SleepInhibitor
 from kiro_crew.safety_override import (
     apply_config_duration,
+    describe_dropped_grant,
     grant_declared_yolo,
     safety_override,
+    take_dropped_grant,
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -1840,6 +1842,23 @@ def _claimed_dashboard_slots(state: DashboardState) -> frozenset[str]:
     except Exception:
         logger.debug("could not read claimed dashboard slots", exc_info=True)
         return frozenset()
+
+
+def _take_prior_dropped_grant() -> Any:
+    """Consume the PREVIOUS process's safety-override record, if any.
+
+    Run off the event loop (the caller wraps it in ``asyncio.to_thread``): it is a
+    file open on a filesystem that may be slow, and nothing about boot should wait
+    on it. Ordering against ``_apply_startup_yolo`` does not matter, because the
+    record carries the writing pid and this process's own record is never read as
+    a dropped one. Never raises: the gateway must not fail to boot over a
+    notification, and the grant is off either way.
+    """
+    try:
+        return take_dropped_grant()
+    except Exception:
+        logger.debug("Could not read the prior safety-override record", exc_info=True)
+        return None
 
 
 def _apply_startup_yolo(state: DashboardState, cfg: Any) -> None:
@@ -3772,6 +3791,40 @@ async def start_dashboard(
         _notify_unattended_expiry(state, source)
 
     safety_override().on_expired = _on_override_expired
+
+    # A grant that was live when the process went down is GONE -- grants are
+    # in-memory by design and this does not change that. What it changes is that
+    # the operator now hears about it. Without this, someone who granted six
+    # hours of auto-approval and restarted an hour later got no signal at all:
+    # the next unattended run just stopped on a prompt nobody was waiting for.
+    #
+    # Read OFF the loop and off the boot path: it is a file open on a filesystem
+    # that may be slow, and nothing about boot should wait on it (found in
+    # review). Safe to run after the startup grant because the record carries the
+    # writing pid, so this process's own record is never read as a dropped one.
+    #
+    # Notice only, never a restored grant, and withheld when auto-approve is live
+    # RIGHT NOW: a declared grant that the enterprise ceiling clamps to a timed
+    # one is re-established by _apply_startup_yolo above, and telling the operator
+    # it is "OFF" while it is on would be worse than saying nothing. A lapsed
+    # grant, a config-declared one and an ``until_shutdown`` one are all silent
+    # too -- see ``take_dropped_grant``.
+    try:
+        _dropped_grant = await asyncio.to_thread(_take_prior_dropped_grant)
+        if _dropped_grant is not None and not safety_override().is_active():
+            state.notify(
+                "safety",
+                "Auto-approve was dropped by a restart",
+                describe_dropped_grant(_dropped_grant),
+                meta={
+                    "source": _dropped_grant.source,
+                    "remaining_secs": _dropped_grant.remaining_secs,
+                },
+            )
+    except Exception:
+        # Startup must not fail over a notification. The grant is off either
+        # way; the worst case is the operator not being told.
+        logger.debug("Could not report a restart-dropped safety override", exc_info=True)
 
     # Restore exactly the tabs the user had open at last shutdown — these
     # come back regardless of mtime, so long-running tabs don't silently

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -24,14 +24,22 @@ All state changes are logged to the Security Event Log (SEL).
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import queue
+import stat
 import threading
 import time
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import config_dir
 from kiro_crew.sel import sel as _get_sel
 
 logger = logging.getLogger(__name__)
@@ -46,6 +54,20 @@ def sel():  # noqa: ANN201 — thin wrapper kept for test patchability
 
 
 # ─── Result dataclasses ──────────────────────────────────────────────────────
+
+
+@dataclass
+class DroppedGrant:
+    """A timed grant that was live when the process went down.
+
+    Returned by :func:`take_dropped_grant` so a startup can TELL the operator
+    their override is gone. Carries no authority: it is a notice, never a
+    restored grant, which is why the record it comes from is not signed -- see
+    :func:`_write_breadcrumb`.
+    """
+
+    source: str
+    remaining_secs: int
 
 
 @dataclass
@@ -151,6 +173,12 @@ class SafetyOverride:
         # activation, so a caller (e.g. the task runner) can hold a narrow, expiring
         # grant without flipping the session-wide override.
         self._scoped: dict[str, tuple[float, float]] = {}
+        # Orders breadcrumb publishes against overlapping transitions -- see
+        # ``_sync_breadcrumb``. Bumped under ``_lock`` by every transition;
+        # ``_breadcrumb_published_gen`` is read and written under
+        # ``_breadcrumb_io_lock`` only.
+        self._breadcrumb_gen: int = 0
+        self._breadcrumb_published_gen: int = 0
 
     def __getattr__(self, name: str) -> object:
         # Provide a fallback _lock for instances created with object.__new__()
@@ -159,6 +187,11 @@ class SafetyOverride:
             lock = threading.Lock()
             object.__setattr__(self, "_lock", lock)
             return lock
+        if name in ("_breadcrumb_gen", "_breadcrumb_published_gen"):
+            # Same reason as the fields below: test fixtures build instances via
+            # object.__new__(), and every transition touches these.
+            object.__setattr__(self, name, 0)
+            return 0
         if name == "_scoped":
             scoped: dict[str, tuple[float, float]] = {}
             object.__setattr__(self, "_scoped", scoped)
@@ -353,6 +386,12 @@ class SafetyOverride:
             self._activation_count += 1
             self._last_renewed_at = 0.0
             self._last_renewed_by = ""
+            self._breadcrumb_gen += 1
+
+        # Record that a grant is live so a restart can TELL the operator it is
+        # gone. Derived from live state and generation-ordered, so a concurrent
+        # revocation cannot be undone by this write.
+        self._sync_breadcrumb()
 
         cb = self._on_activated
         if cb is not None:
@@ -469,6 +508,7 @@ class SafetyOverride:
                 self._expires_at = commit_mono + ttl
                 self._last_renewed_at = commit_mono
                 self._last_renewed_by = source
+                self._breadcrumb_gen += 1
             else:
                 commit_refused = True
                 refusal_reason = "not_active_at_commit"
@@ -486,6 +526,9 @@ class SafetyOverride:
             )
             return RenewResult(renewed=False, ttl=0, source=source, reason="not_active")
 
+        # The deadline moved, so the record of it has to move too -- otherwise a
+        # restart after a renewal would report the OLD remaining time, or none.
+        self._sync_breadcrumb()
         return RenewResult(renewed=True, ttl=ttl, source=source)
 
     def deactivate(self, source: str) -> None:
@@ -525,6 +568,12 @@ class SafetyOverride:
             self._active = False
             self._permanent = False
             self._expires_at = 0.0
+            self._breadcrumb_gen += 1
+
+        # The operator said off, so no restart notice is owed. Published outside
+        # the lock for the same reason the SEL write below is: no I/O while
+        # holding the state lock.
+        self._sync_breadcrumb()
 
         # SEL write happens OUTSIDE the lock (same rule as renew(): never hold
         # the state lock across I/O). This is a REVOCATION, not a grant, so it
@@ -685,6 +734,11 @@ class SafetyOverride:
             # TTL lapsed — expire now
             self._active = False
             expired_source = self._source
+            self._breadcrumb_gen += 1
+
+        # The grant reached its own deadline, so a later restart owes no notice:
+        # nothing was taken from the operator that the clock was not taking.
+        self._sync_breadcrumb()
 
         # Callbacks and SEL logging happen outside the lock to avoid deadlocks.
         self._log_sel(
@@ -763,6 +817,67 @@ class SafetyOverride:
 
     # ── Internal helpers ─────────────────────────────────────────────────────
 
+    def _sync_breadcrumb(self) -> None:
+        """Publish the breadcrumb to match the grant as it is RIGHT NOW.
+
+        Called after EVERY state transition (activation, renewal, explicit
+        deactivation, lazy expiry) instead of each site writing or clearing from
+        its own locals. Two properties come from that:
+
+        * The content is derived from live state, so a write that is delayed past
+          a concurrent revocation cannot resurrect the revoked grant -- the late
+          writer re-reads and publishes the same "no grant" the revocation
+          wanted.
+        * A generation counter, bumped under the state lock by each transition,
+          orders the writes: a sync holding an older generation than the one
+          already published returns without touching the file, so two overlapping
+          transitions cannot land out of order (found in review).
+
+        The state lock is held only to snapshot -- never across the file I/O,
+        which is this module's standing rule and the reason a second lock exists.
+        The I/O itself is handed to a worker thread, because these callers sit on
+        the gateway's event loop (found in review).
+        """
+        now_mono = time.monotonic()
+        with self._lock:
+            gen = self._breadcrumb_gen
+            permanent = self._permanent
+            active = self._active and (permanent or self._expires_at > now_mono)
+            source = self._source
+            remaining = 0 if permanent else max(0, int(self._expires_at - now_mono))
+
+        # Wall clock, because only another process reads it. Computed HERE rather
+        # than on the worker so a queued publish carries the deadline as it was at
+        # the transition, not as it is whenever the worker gets to it. A permanent
+        # grant records no remaining time, so even if the ``permanent`` guard in
+        # ``take_dropped_grant`` were removed it would fail safe to silence.
+        expires_at_wall = datetime.now(tz=timezone.utc).timestamp() + remaining
+
+        def _publish() -> None:
+            with _breadcrumb_io_lock:
+                if gen < self._breadcrumb_published_gen:
+                    return
+                self._breadcrumb_published_gen = gen
+                if not active:
+                    _clear_breadcrumb()
+                    return
+                _write_breadcrumb(
+                    source=source,
+                    expires_at_wall=expires_at_wall,
+                    permanent=permanent,
+                )
+
+        # Wrapped for the same reason the write itself is: the grant is ALREADY
+        # committed by the time this runs, so an exception escaping here would
+        # report a failed activation while tools are in fact auto-approved
+        # (found in review). Starting the worker can fail on its own -- a thread
+        # quota is a real limit -- so the enqueue is inside the guard, not just
+        # the file I/O.
+        try:
+            _enqueue_breadcrumb(_publish)
+        except Exception:
+            logger.debug("safety override: breadcrumb enqueue failed", exc_info=True)
+
     def _log_sel(
         self,
         *,
@@ -794,6 +909,340 @@ class SafetyOverride:
 
 
 # ─── Module-level singleton ──────────────────────────────────────────────────
+
+# ─── Restart-drop breadcrumb ─────────────────────────────────────────────────
+#
+# A grant lives in memory only, so a restart ends it. That is the DESIGNED
+# behaviour and this module does not change it -- what it changes is that the
+# ending used to be SILENT: an operator who granted six hours of auto-approval,
+# then restarted the gateway an hour later, got no reply telling them the
+# remaining five hours were gone. The next unattended run simply stopped and
+# waited for an approval nobody was watching for.
+#
+# So the file below records that a grant WAS live, never that it may resume. It
+# holds the wall-clock deadline (the in-memory deadlines are
+# ``time.monotonic()``, which means nothing to another process), the source, and
+# whether the grant had an expiry at all. Startup reads it once, tells the
+# operator when a TIMED grant still had time left, and deletes it.
+#
+# It is deliberately NOT signed, and that follows from what it can do: the file
+# confers no authority, so the worst a forged one achieves is a spurious "your
+# override was dropped" notice. A restored GRANT would need signing -- and a
+# planned-vs-crash discriminator this codebase does not have -- which is exactly
+# why restoring one is not what this does.
+#
+# One record per data home is correct, not a shared-state hazard: the file lives
+# in ``config_dir()``, which is the very directory ``gateway_lock`` holds an
+# exclusive advisory flock on for a gateway's whole lifetime, and a second
+# gateway on the same home is REFUSED at startup rather than allowed to race
+# (see gateway_lock's module docstring -- the invariant exists because shared-home
+# writers clobber ``sessions/*.jsonl``). So there is never a sibling gateway to
+# consume this record out from under the one that wrote it.
+_BREADCRUMB_FILE = "safety_override_last_grant.json"
+
+#: Serializes breadcrumb I/O. Separate from the state lock ON PURPOSE: this
+#: module's rule is that no I/O happens while the state lock is held (the SEL
+#: writes obey it too), so ordering the file against concurrent transitions
+#: needs its own lock plus the generation counter below -- not the state lock.
+_breadcrumb_io_lock = threading.Lock()
+
+#: Publishes run on ONE long-lived daemon worker, never inline. ``activate`` and
+#: ``is_active`` are called from async request handlers (a Slack YOLO toggle, and
+#: the approval-policy read on every dashboard turn), so a synchronous
+#: ``atomic_write`` there would put filesystem latency on the gateway's event
+#: loop -- and a slow or stalled filesystem would then stall gateway traffic and
+#: the heartbeat with it (found in review). A queue rather than a thread per
+#: transition so thread churn is bounded, and FIFO ordering reinforces the
+#: generation guard.
+_breadcrumb_queue: "queue.Queue[Callable[[], None]]" = queue.Queue()
+_breadcrumb_worker: Optional[threading.Thread] = None
+_breadcrumb_worker_lock = threading.Lock()
+#: Set while nothing is queued AND nothing is mid-write. ``flush`` waits on this
+#: rather than joining the queue: a write stalled on a hung filesystem would make
+#: an unconditional ``join()`` wait forever, and the caller is a restart path, so
+#: blocking it is worse than losing the record (found in review).
+_breadcrumb_idle = threading.Event()
+_breadcrumb_idle.set()
+_breadcrumb_pending = 0
+_breadcrumb_pending_lock = threading.Lock()
+
+#: A record is ~120 bytes. Reading it unbounded let anything that can write into
+#: the data home turn startup into a memory-exhaustion restart loop (found in
+#: review), so an oversized file is discarded rather than parsed. Generous enough
+#: that a future field cannot trip it.
+_BREADCRUMB_MAX_BYTES = 4096
+
+#: Identity of THIS process image, minted at import. Not the PID: both instrumented
+#: restart paths end in ``os.execv``, which replaces the image but PRESERVES the
+#: pid -- so a pid comparison would read the previous image's record as our own and
+#: swallow the notice on exactly the restarts this feature exists for (found in
+#: review). ``process_start_time`` is no better, since exec preserves that too. A
+#: fresh import is the one thing an exec guarantees, so a value minted here is the
+#: discriminator.
+_IMAGE_TOKEN = uuid.uuid4().hex
+
+
+def _breadcrumb_pump() -> None:
+    global _breadcrumb_pending
+    while True:
+        job = _breadcrumb_queue.get()
+        try:
+            job()
+        except Exception:
+            logger.debug("safety override: breadcrumb publish failed", exc_info=True)
+        finally:
+            _breadcrumb_queue.task_done()
+            with _breadcrumb_pending_lock:
+                _breadcrumb_pending -= 1
+                if _breadcrumb_pending <= 0:
+                    _breadcrumb_pending = 0
+                    _breadcrumb_idle.set()
+
+
+def _enqueue_breadcrumb(job: Callable[[], None]) -> None:
+    """Hand a publish to the worker, starting it on first use."""
+    global _breadcrumb_worker, _breadcrumb_pending
+    with _breadcrumb_worker_lock:
+        if _breadcrumb_worker is None or not _breadcrumb_worker.is_alive():
+            _breadcrumb_worker = threading.Thread(
+                target=_breadcrumb_pump, name="kirocrew-safety-breadcrumb", daemon=True
+            )
+            _breadcrumb_worker.start()
+    with _breadcrumb_pending_lock:
+        _breadcrumb_pending += 1
+        _breadcrumb_idle.clear()
+    _breadcrumb_queue.put(job)
+
+
+def flush_breadcrumb_writes(timeout: float = 5.0) -> bool:
+    """Wait up to *timeout* for queued publishes to land; report whether they did.
+
+    STRICTLY bounded, by construction rather than by a polling loop. Callers are
+    restart paths: a flush that could wait forever on a stalled write would freeze
+    a gateway that was trying to re-exec, which is a worse failure than losing the
+    record it was trying to save (found in review). Also used by tests.
+    """
+    return _breadcrumb_idle.wait(max(0.0, timeout))
+
+
+def _breadcrumb_path() -> Path:
+    return config_dir() / _BREADCRUMB_FILE
+
+
+def _write_breadcrumb(*, source: str, expires_at_wall: float, permanent: bool) -> None:
+    """Record that a grant is live. Best-effort: never raises into the grant path.
+
+    A failed write costs the operator a notice, never a grant, so it must not
+    fail an activation -- and above all must not fail a DEACTIVATION, where
+    raising would leave auto-approval on.
+    """
+    try:
+        payload = json.dumps(
+            {
+                "version": 1,
+                "source": source,
+                # Wall clock, because the reader is a different process.
+                "expires_at": expires_at_wall,
+                "permanent": permanent,
+                # Whose record this is. A reader in the SAME process image must not
+                # treat it as a dropped grant -- that is what lets the read happen
+                # anywhere in startup rather than having to run before this
+                # process can write one of its own (found in review). Keyed on the
+                # import-time nonce, NOT the pid: os.execv keeps the pid.
+                "image": _IMAGE_TOKEN,
+                # Whose record this is. A reader in the SAME process must not treat
+                # it as a dropped grant -- that is what lets the read happen
+                # anywhere in startup rather than having to run before this
+                # process can write one of its own (found in review).
+            }
+        )
+        # 0600: the record names the auto-approval posture and its deadline.
+        atomic_write(_breadcrumb_path(), payload, mode=0o600)
+    except Exception:
+        logger.debug("safety override: breadcrumb write failed", exc_info=True)
+
+
+def _clear_breadcrumb() -> None:
+    """Drop the record. Best-effort, for the same reason the write is."""
+    try:
+        _breadcrumb_path().unlink(missing_ok=True)
+    except Exception:
+        logger.debug("safety override: breadcrumb clear failed", exc_info=True)
+
+
+def take_dropped_grant() -> Optional[DroppedGrant]:
+    """Consume the breadcrumb; return a notice when a TIMED grant lost time.
+
+    Serialized against the publisher: ``_consume_breadcrumb`` runs under
+    ``_breadcrumb_io_lock`` from the open through the identity check to the
+    clear, because a publish landing in the middle of that span would be
+    UNLINKED by the clear -- deleting the record for a grant that is live right
+    now and leaving the next restart with nothing to report (found in review).
+    The audit below stays outside the lock: it is unrelated I/O.
+    """
+    with _breadcrumb_io_lock:
+        dropped = _consume_breadcrumb()
+    if dropped is None:
+        return None
+    # Audited like every other posture change in this module, so the operator's
+    # lost grant is on the durable record and not only in a notification.
+    try:
+        sel().log_api_access(
+            caller="safety_override",
+            operation="safety_override:dropped_by_restart",
+            outcome="expired",
+            source="safety_override",
+            resources=f"source:{dropped.source}, remaining:{dropped.remaining_secs}s",
+        )
+    except Exception:
+        logger.debug("safety override: dropped-grant audit failed", exc_info=True)
+    return dropped
+
+
+def _consume_breadcrumb() -> Optional[DroppedGrant]:
+    """Read and consume the record. Caller MUST hold ``_breadcrumb_io_lock``.
+
+    Single-shot by construction: the record is deleted whatever the verdict, so
+    one dropped grant cannot notify twice, and a stale record from an older
+    install cannot notify forever.
+
+    Returns ``None`` -- no notice is owed -- in three cases:
+
+    * **No record.** No grant was live.
+    * **The grant had no expiry** (``permanent``). A DECLARED grant is
+      re-established from config on this very startup, so it was not lost at
+      all; an ``until_shutdown`` grant is already contracted to the operator as
+      "stays on until Kiro Crew restarts", so its ending is the documented
+      behaviour rather than news.
+    * **The deadline has passed.** The grant would have expired on its own by
+      now, so the restart cost the operator nothing.
+    """
+    path = _breadcrumb_path()
+    # Opened by descriptor rather than read by name, because the SHAPE of the file
+    # matters as much as its size. A FIFO planted at this path reports st_size 0,
+    # so it sails through a size check and then blocks FOREVER on read -- which
+    # would hang gateway initialization before readiness (found in review). So:
+    # O_NONBLOCK so no open or read can wait on a writer, O_NOFOLLOW so a symlink
+    # cannot redirect the read at something else, and an fstat that refuses
+    # anything that is not a regular file.
+    #
+    # Neither flag exists on Windows, so an lstat check carries the symlink
+    # refusal there: without it the link is FOLLOWED and its target parses
+    # normally (caught by the Windows CI shard). O_NOFOLLOW stays as the
+    # race-free guard where it exists -- lstat-then-open is TOCTOU, which is
+    # tolerable only because a forged record confers no authority.
+    _nonblock = getattr(os, "O_NONBLOCK", 0)
+    _nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        if path.is_symlink():
+            logger.warning("safety override: discarding a restart record that is a link")
+            _clear_breadcrumb()
+            return None
+    except OSError:
+        return None
+
+    try:
+        fd = os.open(path, os.O_RDONLY | _nonblock | _nofollow)
+    except FileNotFoundError:
+        return None
+    except OSError:
+        # ELOOP from O_NOFOLLOW lands here: a symlink IS a refusal, not an error
+        # to investigate.
+        logger.debug("safety override: breadcrumb could not be opened", exc_info=True)
+        _clear_breadcrumb()
+        return None
+
+    # The verdict is decided while the descriptor is open, but every unlink
+    # happens AFTER it is closed: Windows refuses to remove an open file, so
+    # clearing here left an oversized or malformed record in place to be
+    # rediscovered on every subsequent startup (caught by the Windows CI shard).
+    raw: Optional[str] = None
+    discard = False
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            logger.warning("safety override: discarding a restart record that is not a file")
+            discard = True
+        elif info.st_size > _BREADCRUMB_MAX_BYTES:
+            logger.warning(
+                "safety override: discarding an oversized restart record (%d bytes)",
+                info.st_size,
+            )
+            discard = True
+        else:
+            # Capped at the bound regardless of what fstat said, so a file that
+            # grew between the stat and the read cannot exceed it either.
+            raw = os.read(fd, _BREADCRUMB_MAX_BYTES).decode("utf-8", errors="replace")
+    except Exception:
+        logger.debug("safety override: breadcrumb read failed", exc_info=True)
+        discard = True
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    if discard or raw is None:
+        _clear_breadcrumb()
+        return None
+
+    try:
+        record = json.loads(raw)
+        if not isinstance(record, dict):
+            _clear_breadcrumb()
+            return None
+        writer_image = str(record.get("image") or "")
+        permanent = bool(record.get("permanent"))
+        expires_at = float(record.get("expires_at") or 0.0)
+        source = str(record.get("source") or "")
+    except Exception:
+        logger.debug("safety override: breadcrumb unreadable", exc_info=True)
+        _clear_breadcrumb()
+        return None
+
+    # THIS process image's own live grant. Left untouched -- consuming it would
+    # delete the record for a grant that is in force, so a later restart would
+    # have nothing to report. This is also what frees the read from having to run
+    # before the startup grant is applied (found in review). Compared on the
+    # import-time nonce, because os.execv preserves the pid and every restart this
+    # feature instruments goes through exec.
+    if writer_image and writer_image == _IMAGE_TOKEN:
+        return None
+
+    # THIS process's own live grant. Left untouched -- consuming it would delete
+    # the record for a grant that is in force, so a later restart would have
+    # nothing to report. This is also what frees the read from having to run
+    # before the startup grant is applied (found in review).
+
+    # From here the record belongs to a previous process, so it is consumed
+    # whatever the verdict: one dropped grant cannot notify twice, and a record
+    # left by an older install cannot notify forever.
+    _clear_breadcrumb()
+
+    if permanent:
+        return None
+
+    remaining = int(expires_at - datetime.now(tz=timezone.utc).timestamp())
+    if remaining <= 0:
+        return None
+
+    dropped = DroppedGrant(
+        source=source,
+        remaining_secs=remaining,
+    )
+    # The audit is emitted by the CALLER, outside the lock -- see
+    # ``take_dropped_grant``. Nothing unrelated to the file belongs in this span.
+    return dropped
+
+
+def describe_dropped_grant(dropped: DroppedGrant) -> str:
+    """One channel-neutral line telling the operator what they lost."""
+    return (
+        f"Auto-approve (YOLO) is OFF: the grant from {dropped.source or 'an earlier session'} "
+        f"had {fmt_grant_duration(dropped.remaining_secs)} left when Kiro Crew restarted. "
+        "Grants live in memory only, so a restart ends them. Re-enable it if you still want it."
+    )
+
 
 _singleton: Optional[SafetyOverride] = None
 _singleton_lock = threading.Lock()

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -236,7 +236,7 @@ from kiro_crew.platform.update_governance import (
     update_blocked_reason,
 )
 from kiro_crew.providers.base import LLMEvent
-from kiro_crew.safety_override import safety_override
+from kiro_crew.safety_override import flush_breadcrumb_writes, safety_override
 from kiro_crew.sandbox import ensure_agents_slice_limits, warm_backend
 from kiro_crew.security import redact, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -8743,6 +8743,15 @@ class GatewayOrchestrator:
                 )
         if self.sessions:
             await self.sessions.close_all()
+        # Same reason as the dashboard restart path: the safety-override record
+        # publishes on a worker thread, and os.execv does not drain it, so a
+        # grant activated just before a self-update would lose its notice
+        # (found in review). Offloaded and bounded so a stalled write can
+        # neither block the loop nor hold up the restart.
+        try:
+            await asyncio.to_thread(flush_breadcrumb_writes, 2.0)
+        except Exception:
+            logger.debug("Breadcrumb flush before update restart failed", exc_info=True)
         platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
 
     async def _check_for_updates_legacy(self) -> None:
@@ -9648,6 +9657,13 @@ class GatewayOrchestrator:
                     )
             if self.sessions:
                 await self.sessions.close_all()
+            # Drain the safety-override record before exec, for the same reason
+            # the other restart paths do: os.execv does not drain the publish
+            # worker, so a grant activated just before this would lose its notice.
+            try:
+                await asyncio.to_thread(flush_breadcrumb_writes, 2.0)
+            except Exception:
+                logger.debug("Breadcrumb flush before auto-update restart failed", exc_info=True)
             # Use -m kiro_crew rather than sys.argv[0] so the restart resolves
             # the freshly reinstalled entry point regardless of how the
             # original process was launched.
@@ -9869,6 +9885,12 @@ class GatewayOrchestrator:
                 )
         if self.sessions:
             await self.sessions.close_all()
+        # Same drain as the other restart paths: exec does not empty the publish
+        # worker, and a just-activated grant would otherwise lose its notice.
+        try:
+            await asyncio.to_thread(flush_breadcrumb_writes, 2.0)
+        except Exception:
+            logger.debug("Breadcrumb flush before install restart failed", exc_info=True)
         # Restart into the freshly-installed version.
         platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
 

--- a/test/test_safety_override_restart_drop.py
+++ b/test/test_safety_override_restart_drop.py
@@ -1,0 +1,459 @@
+"""A safety-override grant dropped by a restart must not vanish silently.
+
+Grants live in memory, so a restart ends them -- that is the design and these
+tests do not challenge it. What they pin is the NOTICE: a timed grant that still
+had time left when the process went down is reported to the operator once, and
+the three cases that owe no notice stay quiet.
+
+The whole surface is a pure function of a small file plus the wall clock, so no
+restart is simulated: writing the record and then reading it back through
+``take_dropped_grant`` IS the restart, from the reader's point of view.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from conftest import requires_symlinks
+from kiro_crew import safety_override as so
+
+
+@pytest.fixture(autouse=True)
+def _isolated_breadcrumb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolate the record, and run publishes INLINE.
+
+    Two separate concerns. The path is redirected so no test touches the real
+    data home. And ``_enqueue_breadcrumb`` is replaced with direct execution so
+    the tests never start the daemon worker: a queued publish would otherwise
+    leave a thread running past the test that started it (found in review), and
+    inline execution also makes every assertion on the file deterministic instead
+    of waiting on a worker.
+
+    Production keeps the worker -- see ``_sync_breadcrumb``; the callers there sit
+    on the gateway's event loop.
+    """
+    monkeypatch.setattr(so, "_breadcrumb_path", lambda: tmp_path / "last_grant.json")
+    monkeypatch.setattr(so, "_enqueue_breadcrumb", lambda job: job())
+    so.reset_singleton()
+    yield tmp_path / "last_grant.json"
+    so.reset_singleton()
+
+
+def _record(path: Path) -> dict:
+    """Read the published record."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _published(path: Path) -> bool:
+    return path.exists()
+
+
+def _take() -> object:
+    return so.take_dropped_grant()
+
+
+def _write(path: Path, *, source: str, offset_secs: float, permanent: bool = False) -> None:
+    """Write a record whose deadline is *offset_secs* from now (negative = past)."""
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "source": source,
+                "expires_at": datetime.now(tz=timezone.utc).timestamp() + offset_secs,
+                "permanent": permanent,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestTheNoticeIsOwed:
+    def test_a_timed_grant_with_time_left_is_reported(self, _isolated_breadcrumb: Path) -> None:
+        _write(_isolated_breadcrumb, source="dashboard", offset_secs=3600)
+        dropped = so.take_dropped_grant()
+        assert dropped is not None
+        assert dropped.source == "dashboard"
+        # Rounded down by the elapsed microseconds, so allow the boundary.
+        assert 3500 <= dropped.remaining_secs <= 3600
+
+    def test_the_notice_names_the_source_and_what_was_lost(self) -> None:
+        text = so.describe_dropped_grant(so.DroppedGrant(source="slack", remaining_secs=7200))
+        # The operator has to learn three things: it is OFF, how much they lost,
+        # and that this is what a restart does -- not a malfunction.
+        assert "OFF" in text
+        assert "2h" in text
+        assert "slack" in text
+        assert "restart" in text.lower()
+
+    def test_the_drop_is_audited(self, _isolated_breadcrumb: Path, monkeypatch) -> None:
+        calls: list[dict] = []
+
+        class _Sel:
+            def log_api_access(self, **kw):
+                calls.append(kw)
+
+        monkeypatch.setattr(so, "sel", lambda: _Sel())
+        _write(_isolated_breadcrumb, source="dashboard", offset_secs=600)
+        assert so.take_dropped_grant() is not None
+        ops = [c["operation"] for c in calls]
+        assert "safety_override:dropped_by_restart" in ops
+
+    def test_an_audit_failure_still_yields_the_notice(
+        self, _isolated_breadcrumb: Path, monkeypatch
+    ) -> None:
+        # The notice is the point; a broken audit sink must not swallow it.
+        class _Boom:
+            def log_api_access(self, **kw):
+                raise RuntimeError("sel down")
+
+        monkeypatch.setattr(so, "sel", lambda: _Boom())
+        _write(_isolated_breadcrumb, source="dashboard", offset_secs=600)
+        assert so.take_dropped_grant() is not None
+
+
+class TestNoNoticeIsOwed:
+    def test_no_record_is_silent(self) -> None:
+        assert so.take_dropped_grant() is None
+
+    def test_a_lapsed_grant_is_silent(self, _isolated_breadcrumb: Path) -> None:
+        # The clock was taking it anyway, so the restart cost nothing.
+        _write(_isolated_breadcrumb, source="dashboard", offset_secs=-1)
+        assert so.take_dropped_grant() is None
+
+    def test_a_grant_with_no_expiry_is_silent(self, _isolated_breadcrumb: Path) -> None:
+        # A declared grant is re-established from config on this same startup,
+        # and an until_shutdown grant is already contracted as ending here.
+        _write(_isolated_breadcrumb, source="config", offset_secs=99999, permanent=True)
+        assert so.take_dropped_grant() is None
+
+    def test_a_corrupt_record_is_silent_and_removed(self, _isolated_breadcrumb: Path) -> None:
+        _isolated_breadcrumb.write_text("{not json", encoding="utf-8")
+        assert so.take_dropped_grant() is None
+        assert not _isolated_breadcrumb.exists()
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are a POSIX shape")
+    def test_a_fifo_is_refused_without_hanging(self, _isolated_breadcrumb: Path) -> None:
+        # The size bound alone does not cover this: a FIFO reports st_size 0, so
+        # it passes a size check and then blocks forever on read, hanging gateway
+        # initialization before readiness (found in review). O_NONBLOCK plus an
+        # fstat shape check is what refuses it.
+        os.mkfifo(_isolated_breadcrumb)
+        started = time.monotonic()
+        assert so.take_dropped_grant() is None
+        elapsed = time.monotonic() - started
+        assert elapsed < 2.0, f"read waited {elapsed:.2f}s on a FIFO"
+
+    @requires_symlinks
+    def test_a_symlink_is_refused(self, _isolated_breadcrumb: Path, tmp_path: Path) -> None:
+        # O_NOFOLLOW: a link planted here must not redirect the read at another
+        # file, even one that would parse.
+        real = tmp_path / "elsewhere.json"
+        real.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "source": "dashboard",
+                    "expires_at": datetime.now(tz=timezone.utc).timestamp() + 3600,
+                    "permanent": False,
+                }
+            ),
+            encoding="utf-8",
+        )
+        os.symlink(real, _isolated_breadcrumb)
+        assert so.take_dropped_grant() is None
+
+    def test_an_oversized_record_is_discarded_unread(self, _isolated_breadcrumb: Path) -> None:
+        # Anything that can write into the data home could otherwise leave a huge
+        # file here and turn every startup into a memory-exhaustion restart loop
+        # (found in review). Size is checked before the read, so the bytes are
+        # never taken in, and the file is removed so it cannot do it again.
+        _isolated_breadcrumb.write_text("x" * (so._BREADCRUMB_MAX_BYTES + 1), encoding="utf-8")
+        assert so.take_dropped_grant() is None
+        assert not _isolated_breadcrumb.exists()
+
+    def test_a_record_at_the_size_bound_is_still_read(self, _isolated_breadcrumb: Path) -> None:
+        # The bound must not reject a legitimate record: pad one with whitespace
+        # up to the limit and it still produces its notice.
+        payload = json.dumps(
+            {
+                "version": 1,
+                "source": "dashboard",
+                "expires_at": datetime.now(tz=timezone.utc).timestamp() + 3600,
+                "permanent": False,
+            }
+        )
+        padded = payload + " " * (so._BREADCRUMB_MAX_BYTES - len(payload))
+        _isolated_breadcrumb.write_text(padded, encoding="utf-8")
+        assert len(padded) == so._BREADCRUMB_MAX_BYTES
+        assert so.take_dropped_grant() is not None
+
+    def test_the_notice_fires_at_most_once(self, _isolated_breadcrumb: Path) -> None:
+        # Single-shot by construction: the record is consumed, so a restart
+        # cannot re-notify on every subsequent startup.
+        _write(_isolated_breadcrumb, source="dashboard", offset_secs=3600)
+        assert so.take_dropped_grant() is not None
+        assert not _isolated_breadcrumb.exists()
+        assert so.take_dropped_grant() is None
+
+
+class TestThisProcessOwnRecordIsNotADropNotice:
+    """A reader in the writing process IMAGE must leave the live record alone.
+
+    This is what frees the read from having to run before the startup grant is
+    applied -- the constraint that previously forced it onto the pre-bind boot
+    path. Identity is an import-time nonce rather than the pid, because both
+    restart paths end in ``os.execv``, which PRESERVES the pid (and the process
+    start time), so a pid check would swallow the notice on exactly the restarts
+    this feature exists for (found in review).
+    """
+
+    def test_our_own_live_record_is_not_reported(self, _isolated_breadcrumb: Path) -> None:
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("dashboard")
+        assert _published(_isolated_breadcrumb)
+        # Written by THIS image, so it is a live grant's record, not a dropped one.
+        assert so.take_dropped_grant() is None
+
+    def test_our_own_live_record_is_not_consumed(self, _isolated_breadcrumb: Path) -> None:
+        # Consuming it would delete the record for a grant that is in force, so a
+        # LATER restart would have nothing to report.
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("dashboard")
+        so.take_dropped_grant()
+        assert _published(_isolated_breadcrumb)
+
+    def test_a_restart_that_keeps_the_pid_still_reports(self, _isolated_breadcrumb: Path) -> None:
+        # THE regression this identity exists for. `reexec_python_module` is
+        # os.execv on POSIX: same pid, new process image. Simulated by writing a
+        # record with this very pid but a different image token -- exactly what the
+        # previous image leaves behind -- which must still be reported.
+        _isolated_breadcrumb.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "source": "dashboard",
+                    "expires_at": datetime.now(tz=timezone.utc).timestamp() + 3600,
+                    "permanent": False,
+                    "image": "a-previous-process-image",
+                    "pid": os.getpid(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        dropped = so.take_dropped_grant()
+        assert dropped is not None, "an execv restart keeps the pid; the notice must survive it"
+        assert dropped.source == "dashboard"
+        assert not _isolated_breadcrumb.exists()
+
+    def test_a_consume_serializes_against_a_publish(self, _isolated_breadcrumb: Path) -> None:
+        # A publish landing between the consumer's open and its clear would be
+        # UNLINKED by that clear, deleting the record for a grant that is live
+        # right now (found in review). The consumer therefore holds the publisher's
+        # lock across the whole span -- proven by holding it here and showing the
+        # consumer waits rather than proceeding.
+        _write(_isolated_breadcrumb, source="dashboard", offset_secs=3600)
+        finished = threading.Event()
+
+        def _consume() -> None:
+            so.take_dropped_grant()
+            finished.set()
+
+        so._breadcrumb_io_lock.acquire()
+        try:
+            threading.Thread(target=_consume, daemon=True).start()
+            assert not finished.wait(0.25), "consumer did not wait for the publisher's lock"
+        finally:
+            so._breadcrumb_io_lock.release()
+        assert finished.wait(5.0), "consumer never completed after the lock was released"
+        assert not _isolated_breadcrumb.exists()
+
+    def test_a_record_from_another_process_is_reported(self, _isolated_breadcrumb: Path) -> None:
+        _write(_isolated_breadcrumb, source="dashboard", offset_secs=3600)
+        # _write stamps no image token, so it reads as "not this image" -- the same
+        # verdict a previous gateway's record gets.
+        dropped = so.take_dropped_grant()
+        assert dropped is not None
+        assert not _isolated_breadcrumb.exists()
+
+
+class TestTheCourtesyNeverEndangersTheGrant:
+    """The record is a courtesy; the grant is a decision. Failures stay separated."""
+
+    def test_an_enqueue_failure_does_not_fail_the_activation(self, monkeypatch) -> None:
+        # The grant is already committed when the publish is dispatched, so an
+        # exception escaping the dispatch would report a FAILED activation while
+        # tools are in fact auto-approved (found in review). Starting the worker
+        # can fail on its own -- a thread quota is a real limit.
+        def _boom(job):
+            raise RuntimeError("can't start new thread")
+
+        monkeypatch.setattr(so, "_enqueue_breadcrumb", _boom)
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        assert override.activate("dashboard").active is True
+        assert override.is_active() is True
+        # And the reverse direction: a revocation must still complete.
+        override.deactivate("dashboard")
+        assert override.is_active() is False
+
+    def test_the_flush_is_bounded_when_a_write_is_stalled(self, monkeypatch) -> None:
+        # A restart path calls this. An unbounded wait would freeze a gateway
+        # that was trying to re-exec, which is worse than losing the record
+        # (found in review). Simulate a publish that never finishes.
+        so._breadcrumb_idle.clear()
+        try:
+            started = time.monotonic()
+            drained = so.flush_breadcrumb_writes(0.05)
+            elapsed = time.monotonic() - started
+            assert drained is False
+            assert elapsed < 1.0, f"flush waited {elapsed:.2f}s on a stalled write"
+        finally:
+            so._breadcrumb_idle.set()
+
+
+class TestOneRecordPerHomeIsSafe:
+    """No sibling gateway can consume this record out from under its writer.
+
+    The record is per data home, which is only safe because a home already has at
+    most one gateway: ``gateway_lock`` takes an exclusive advisory flock for the
+    process lifetime and REFUSES a second gateway on the same home. Pinned here
+    because a reviewer read the single file as shared-gateway state, and the thing
+    that makes it not shared is a guard in another module.
+    """
+
+    def test_the_record_sits_in_the_directory_the_gateway_lock_guards(self) -> None:
+        from kiro_crew import gateway_lock
+        from kiro_crew.config.loader import config_dir
+
+        # Built from the module constant rather than from ``_breadcrumb_path()``,
+        # which the autouse fixture redirects into tmp_path -- asserting on the
+        # patched accessor would only test the fixture.
+        real_record = config_dir() / so._BREADCRUMB_FILE
+        # Same directory, so the lock that admits one gateway per home is the
+        # same boundary that admits one writer of this record.
+        assert real_record.parent == config_dir()
+        assert (config_dir() / gateway_lock.LOCK_FILENAME).parent == real_record.parent
+
+    def test_a_second_gateway_on_the_same_home_is_refused(self, tmp_path: Path) -> None:
+        # The invariant itself, exercised rather than asserted from the docstring:
+        # the second acquire raises instead of proceeding alongside the first.
+        from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
+
+        first = GatewayLock(tmp_path).acquire()
+        try:
+            with pytest.raises(GatewayLockError):
+                GatewayLock(tmp_path).acquire()
+        finally:
+            first.release()
+
+
+class TestOrderingAgainstConcurrentTransitions:
+    """A delayed publish must not resurrect a grant the operator revoked."""
+
+    def test_a_late_publish_cannot_undo_a_revocation(self, _isolated_breadcrumb: Path) -> None:
+        # Reproduces the interleaving directly: activation snapshots state, a
+        # deactivation lands, and only THEN does the activation's publish run.
+        # Because the publish derives its content from live state rather than
+        # from the activation's locals, it writes the revocation's truth.
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("dashboard")
+        override.deactivate("dashboard")
+        # A stale sync arriving after the revocation must clear, not write.
+        override._sync_breadcrumb()
+        assert not _published(_isolated_breadcrumb)
+        assert _take() is None
+
+    def test_an_older_generation_does_not_overwrite_a_newer_publish(
+        self, _isolated_breadcrumb: Path
+    ) -> None:
+        # The generation counter is what orders two overlapping transitions: a
+        # publish holding a stale generation returns without touching the file.
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("dashboard")
+        assert _published(_isolated_breadcrumb)
+        override._breadcrumb_published_gen += 5  # pretend a newer publish landed
+        _isolated_breadcrumb.unlink()
+        override._sync_breadcrumb()
+        assert not _published(_isolated_breadcrumb)
+
+
+class TestTheGrantLifecycleMaintainsTheRecord:
+    def test_activating_records_the_grant(self, _isolated_breadcrumb: Path) -> None:
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("dashboard")
+        assert _published(_isolated_breadcrumb)
+        record = _record(_isolated_breadcrumb)
+        assert record["source"] == "dashboard"
+        assert record["permanent"] is False
+        # Wall clock, because the reader is a different process: the in-memory
+        # deadline is time.monotonic() and means nothing after a restart.
+        assert record["expires_at"] > datetime.now(tz=timezone.utc).timestamp()
+
+    def test_an_explicit_deactivate_leaves_no_notice(self, _isolated_breadcrumb: Path) -> None:
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("dashboard")
+        override.deactivate("dashboard")
+        assert _take() is None
+
+    def test_a_natural_expiry_leaves_no_notice(
+        self, _isolated_breadcrumb: Path, monkeypatch
+    ) -> None:
+        override = so.safety_override()
+        override.adhoc_ttl = 1
+        override.activate("dashboard")
+        # Walk the monotonic clock past the deadline and let is_active() reap it.
+        real_monotonic = so.time.monotonic
+        monkeypatch.setattr(so.time, "monotonic", lambda: real_monotonic() + 10.0)
+        assert override.is_active() is False
+        assert _take() is None
+
+    def test_a_renew_moves_the_recorded_deadline(self, _isolated_breadcrumb: Path) -> None:
+        override = so.safety_override()
+        override.adhoc_ttl = 60
+        override.activate("dashboard")
+        first = _record(_isolated_breadcrumb)["expires_at"]
+        override.adhoc_ttl = 7200
+        assert override.renew("dashboard").renewed is True
+        second = _record(_isolated_breadcrumb)["expires_at"]
+        # Otherwise a restart after a renewal reports the stale remaining time.
+        assert second > first
+
+    def test_a_declared_grant_records_itself_as_no_expiry(self, _isolated_breadcrumb: Path) -> None:
+        override = so.safety_override()
+        override.activate_declared()
+        record = _record(_isolated_breadcrumb)
+        assert record["permanent"] is True
+        # And therefore owes no notice on the next startup.
+        assert _take() is None
+
+    def test_a_write_failure_never_breaks_the_grant(self, tmp_path: Path, monkeypatch) -> None:
+        # A breadcrumb is a courtesy; a grant is a decision. The courtesy failing
+        # must not fail the decision -- and must never fail a DEACTIVATION,
+        # where raising would leave auto-approval on.
+        #
+        # The unwritable path stays UNDER tmp_path: atomic_write() does
+        # parent.mkdir(parents=True), so a path outside the fixture's workspace
+        # would be CREATED by this test and survive teardown (found in review).
+        # A file standing where a directory must be makes the write fail without
+        # letting anything escape tmp_path.
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("", encoding="utf-8")
+        monkeypatch.setattr(so, "_breadcrumb_path", lambda: blocker / "last_grant.json")
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        assert override.activate("dashboard").active is True
+        override.deactivate("dashboard")
+        assert override.is_active() is False


### PR DESCRIPTION
## What is the problem?

A safety-override (YOLO) grant lives in memory, so a gateway restart ends it.
That is the design and this PR does not change it. What was wrong is that the
ending was **silent**.

An operator grants six hours of auto-approval, restarts the gateway an hour
later for an unrelated reason, and gets no signal at all. `agent.yolo_duration`
still says 6h, the Settings picker still reads the same, and nothing anywhere
says the remaining five hours are gone. The next unattended run stops on an
approval prompt nobody is waiting for, which looks like the agent hanging
rather than like a grant having lapsed.

No GitHub issue; this comes from a local backlog entry, recorded against closed
issue #2440.

## Why this issue matters to the user

The grant exists precisely so a run can proceed without a human at the keyboard.
Losing it silently defeats the one thing it was turned on for, and the failure is
invisible in exactly the situation it matters: an unattended run, where there is
nobody present to notice a prompt. The operator's own action (a restart) is what
revokes their earlier explicit decision, and until now the system never
mentioned it.

## How our fix solves it

**Symptom:** a grant with hours left disappears on restart with no notice.

**Mechanism:** the grant is process state. Every deadline in
`src/kiro_crew/safety_override.py` is a `time.monotonic()` value, which is
meaningless to another process, so even the timestamps could not survive a
restart, let alone the boolean.

**Fix -- record a breadcrumb, not the grant.** On activation and on renewal the
module writes a small record saying a grant *was* live: its **wall-clock**
deadline (the reader is a different process), its source, and whether it had an
expiry at all. Startup consumes that record once, tells the operator when a
**timed** grant still had time left, emits a
`safety_override:dropped_by_restart` SEL event, and deletes it.

**The grant is never restored.** The auto-approval posture after this change is
byte-for-byte what it was before: a restart still ends every grant. The only new
behaviour is that the operator hears about it.

Three cases owe no notice, and each is silent for its own reason:

* **Deadline already passed** -- the clock was taking the grant anyway, so the
  restart cost nothing.
* **No expiry** -- a *declared* grant (`dangerouslySkipPermissions`) is
  re-established from config on the very same startup, so nothing was lost; an
  `until_shutdown` grant is already contracted to the operator as "stays on until
  Kiro Crew restarts", so its ending is documented behaviour rather than news.
* **No record** -- no grant was live.

Explicit deactivation and natural expiry both clear the record, so neither
produces a stale notice later. Consumption is single-shot by construction: the
record is deleted whatever the verdict, so one dropped grant cannot notify twice
and a record left by an older install cannot notify forever.

**Why the record is not signed.** It confers no authority. The worst a forged one
achieves is a spurious "your override was dropped" notice. That asymmetry is what
makes this shippable on its own: a restored *grant* would need both a signature
and a planned-restart-versus-crash discriminator (see below).

**Failure posture.** All breadcrumb I/O is best-effort and never raises into the
grant path. A failed write must not fail an activation, and above all must not
fail a **deactivation** -- raising there would leave auto-approval ON, which is
strictly worse than losing a notice. Startup wraps the read for the same reason:
the gateway must not fail to boot over a notification.

## What tests we did

New `test/test_safety_override_restart_drop.py`, 15 cases in three groups: the
notice is owed (reported, worded so the operator learns it is OFF and how much
they lost, audited, and still delivered when the audit sink is broken); no notice
is owed (no record, lapsed, no-expiry, corrupt record, and at-most-once); and the
grant lifecycle maintains the record (activation records it with a wall-clock
deadline, deactivation and natural expiry clear it, renewal moves the deadline, a
declared grant records itself as no-expiry, and a write failure never breaks the
grant).

No restart is simulated, and none is needed: the surface is a pure function of a
small file plus the wall clock, so writing the record and reading it back *is* the
restart from the reader's side. The fixture redirects the path to a tmp dir, so no
test touches a real data home.

**Mutation-verified** -- three mutations, three distinct catches, each a different
invariant family:

| mutation | result |
|---|---|
| disable the lapsed-deadline silence guard | 1 failed |
| stop clearing the record on explicit deactivation | 1 failed |
| stop refreshing the record on renew | 1 failed |

Targeted runs only (no full suite): the new module plus `test_safety_override.py`
= **131 passed**; the override-dependent modules `test_dashboard_yolo_startup.py`,
`test_auto_approve.py`, `test_channel_trust_revoke.py`,
`test_chat_mode_security.py`, `test_background_approval_routing.py`,
`test_channel_session_trust_parity.py`, `test_issue_radar_crew_runtime.py`,
`test_dashboard_chat.py` = **942 passed**. flake8, isort, mypy and black clean on
all three touched files.

**Not verified:** the end-to-end restart itself was not exercised on a live
gateway -- the notice path is covered by unit tests only, and the startup wiring
is exercised by the dashboard startup suite rather than by an actual restart.

## Any other suggestions on the work

The backlog entry carried an earlier ruling to *persist and restore* scoped
grants across a planned restart, splitting on the restart's cause "because the
graceful path writes a shutdown sentinel". **That premise does not hold against
the current code, which is why this PR deliberately does less.** Verified:

* `mcp_gateway/gatewayd.py` only *unlinks* its `.backends` reap list on the clean
  path -- an absence-on-clean artifact, not a durable flag the next boot can read.
* `gateway_lock.py` is advisory `flock` holding only a PID; the OS releases it on
  death either way.
* `crash_guard.py` writes `crash.log` **only** when dying with a live exception,
  so it misses `SIGKILL` and `os._exit` -- and a clean exit writes nothing either,
  which makes clean and crashed indistinguishable from that file.
* All three restart paths (`dashboard/handlers/updates.py` twice,
  `slack/gateway.py` self-update) re-exec without writing a marker.
* `dashboard/port_reclaim.py` does detect an unclean prior exit, but by finding an
  orphaned listener at runtime -- not a persisted planned-versus-crash flag.

So restoring a grant would mean first building that discriminator, on a safety
boundary, where both failure directions are bad: miss one graceful path and
grants vanish silently (the bug this PR is about, relocated), or write the marker
too eagerly and a crash reads as planned, so a bypass survives a crash. That
belongs in its own reviewed change, and persistence becomes small once it exists.
Two further notes for whoever takes it: the global grant has no target dimension
at all, so restoring one re-enables auto-approval across the dashboard and every
messaging channel (the "a blanket grant never persists" rule is load-bearing);
and `on_activated` is never registered in production, so grant *creation* has no
callback-driven notification today while expiry has a full teardown path.

Scope note: the breadcrumb covers the **global** grant only, not the task-scoped
grants (`activate_scoped`). Those are internal to the task runner, Issue Radar and
the chat runner rather than an operator-facing decision, and each of those systems
already observes its own grant. Worth revisiting if a scoped grant ever becomes
something a human arms directly.
