### PR TITLE
fix(test): isolate SEL chain-lock path per test (#7029)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1752,6 +1752,17 @@ def _isolate_sel_default_dir(tmp_path_factory):
     run and belongs to no individual test, so nothing deletes it underneath the
     writer, and the thread is not churned per test.
 
+    This provides per-WORKER isolation. ``_isolate_sel_per_test`` (function-scoped,
+    below) layers per-TEST isolation on top: it repoints ``_default_dir()`` at a
+    fresh per-test subdirectory under the session ``_isolation_root`` and resets the
+    singleton so each test's default ``sel()`` resolves its OWN
+    ``_chain_lock_path()``. That is what closes issue #7029 -- with distinct
+    chain-lock paths, no concurrent SEL writer contends for a given test's lock, so
+    a trust assertion no longer depends on winning a cross-process lock race. This
+    session fixture stays the stable fallback the daemon thread can safely re-create
+    against, and the per-test dirs live inside the managed tmp tree so a late flush
+    strands nothing.
+
     Patches the ``_default_dir()`` accessor rather than a captured constant, because
     the module resolves its default lazily so that importing ``kiro_crew.sel`` never
     triggers the one-time data-home migration as an import side effect. Tests that
@@ -1773,6 +1784,82 @@ def _isolate_sel_default_dir(tmp_path_factory):
     finally:
         _sel._default_dir = original_default
         _sel.SecurityEventLog._instance = original_instance
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sel_per_test(_isolation_dirs):
+    """Give each test its OWN SEL directory on top of the per-worker one above.
+
+    The session fixture makes the writer's directory stable and worker-local, but
+    every test on a worker still shares that ONE directory -- and therefore ONE
+    ``_chain_lock_path()`` (``self._dir/trust/security_events.lock``), the sidecar
+    the cross-process chain lock is taken on. That is a shared cross-process lock,
+    so a concurrent SEL writer (another test's daemon ``sel-writer`` thread, or a
+    sibling instance mid-append) holding it makes an unrelated test's assertion
+    depend on winning a lock race: when the on-loop single-shot acquire finds the
+    lock held it refuses to wait (by design -- it must not stall the event loop),
+    the fail-closed audit in ``activate_scoped`` raises, the grant is refused, and
+    a trust assertion reads False through no fault of the test asserting it. Issue
+    #7029 is exactly that flake.
+
+    This fixture removes the shared writer instead of coping with the race: it
+    points ``_default_dir()`` at a UNIQUE per-test subdirectory and resets the SEL
+    singleton so the default ``sel()`` this test builds binds ``self._dir`` -- and
+    thus resolves a ``_chain_lock_path()`` -- that no other test shares. With
+    distinct lock paths there is no cross-process contender for a given test's
+    chain lock, so the on-loop acquire cannot be denied by a foreign holder.
+
+    The per-test directory lives under the session ``_isolation_root`` tmp tree
+    (via ``_isolation_dirs``), NOT the operator's real home, which is what keeps
+    the daemon-thread-recreates-the-dir hazard the session fixture documents
+    harmless here: if a prior test's writer thread is still bound to its own
+    now-unused per-test dir and flushes late, ``_flush_batch`` re-creating that dir
+    only touches a path inside the managed isolation root, which the retention
+    policy already owns -- it cannot strand a directory outside it. The NEXT test's
+    reset hands out a brand-new instance and dir regardless.
+
+    TRADEOFF -- accepted cost, stated so the count is not surprising. The session
+    fixture chose session scope precisely so the daemon writer thread is "not
+    churned per test." Resetting the singleton every test reverses that for one
+    path only: any test that emits a NON-critical async SEL event through the
+    default ``sel()`` builds a fresh instance, so its first async append starts a
+    new ``sel-writer`` daemon thread (``_ensure_writer``) and registers a new
+    ``atexit.flush`` handler -- neither joined nor stopped, both accumulating for
+    the worker's process lifetime. We accept this deliberately as the cost of
+    per-test lock-path isolation, and it is safe rather than merely tolerated: the
+    threads are daemons (they die with the interpreter, joining nothing) and every
+    per-test dir lives inside the managed tmp tree (a late flush strands nothing).
+    We do NOT try to close the prior instance's writer in teardown -- stopping or
+    joining the daemon from a fixture teardown risks blocking or racing the drain,
+    which would trade this benign churn for real flakiness, the opposite of the
+    fix. Crucially, the #7029 flake path itself pays NONE of this: ``activate_scoped``
+    audits with ``critical=True``, which ``_flush_batch``-es INLINE and spawns no
+    thread, so the trust tests add no ``sel-writer`` thread and no ``atexit``
+    handler. So this fixture changes the COUNT of threads/handlers created over a
+    run for the non-critical async callers, not the lifecycle of any one of them,
+    and never for the audit path #7029 is about.
+
+    Patches ``_default_dir()`` directly (like the session fixture), so it wins over
+    ``KIROCREW_HOME`` regardless of ordering with ``_isolate_kirocrew_home``. Tests
+    that manage their own ``SecurityEventLog`` (passing ``base_dir`` and resetting
+    ``_instance``) are unaffected. Tolerates ``kiro_crew.sel`` not importing, the
+    same as the session fixture.
+    """
+    try:
+        from kiro_crew import sel as _sel
+    except ImportError:  # pragma: no cover - partial checkout
+        yield
+        return
+    prev_default = _sel._default_dir
+    prev_instance = _sel.SecurityEventLog._instance
+    per_test_dir = _isolation_dirs("sel")
+    _sel._default_dir = lambda: per_test_dir
+    _sel.SecurityEventLog._instance = None
+    try:
+        yield
+    finally:
+        _sel._default_dir = prev_default
+        _sel.SecurityEventLog._instance = prev_instance
 
 
 #: ``~/.kiro`` paths production binds at IMPORT time, which ``KIROCREW_HOME`` cannot

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -291,6 +291,40 @@ which testpath asked for the workers.
   add a subsystem with a background worker, ask which directory its thread captured
   and whether anything deletes that directory underneath it.
 
+  Session scope alone is only per-**worker**, and that left a second, subtler hazard:
+  every test on a worker shared the one directory, hence one `_chain_lock_path()`
+  (`self._dir/trust/security_events.lock`) — the sidecar the cross-process chain lock
+  is taken on. So a concurrent SEL writer (another test's `sel-writer` daemon, or a
+  sibling instance mid-append) holding that shared lock made an *unrelated* test's
+  assertion depend on winning a lock race: the on-loop acquire is a single-shot that
+  correctly refuses to wait, `activate_scoped`'s fail-closed audit then raises, the
+  grant is refused, and a trust assertion reads False through no fault of the test
+  asserting it. MEASURED: that is #7029, the issue-radar trust assertion failing
+  nondeterministically on the `Backend Tests (3.10, 2)` shard. The **on-loop refusal
+  and the fail-closed grant refusal are correct and must not be loosened** — both are
+  pinned by `test_a_grant_whose_audit_fails_is_never_usable` — so the fix is
+  test-isolation, not product: `_isolate_sel_per_test` (function-scoped, in the same
+  conftest) layers **per-test** isolation on top of the per-worker session dir. It
+  repoints `_default_dir()` at a fresh per-test subdirectory (under the session
+  `_isolation_root`, so a late flush by a stale writer thread strands nothing outside
+  the managed tree) and resets the singleton, so each test's default `sel()` resolves
+  its own `_chain_lock_path()` and no foreign writer can contend for it. This is an
+  ACCEPTED tradeoff, not a free lunch: session scope existed so the `sel-writer`
+  daemon thread is "not churned per test," and resetting the singleton every test
+  reverses that for the non-critical async path — a test that emits a non-critical
+  async SEL event through the default `sel()` builds a fresh instance whose first
+  append starts a new `sel-writer` daemon and registers a new `atexit.flush`, so the
+  per-test reset changes the *count* of threads/handlers created over a run (they are
+  never joined or stopped, and accumulate for the worker's process lifetime). It is
+  safe because the threads are daemons and every per-test dir lives inside the managed
+  tmp tree, so a late recreate strands nothing; we do NOT stop/join the prior writer in
+  teardown because doing so from a fixture risks blocking or racing the drain and would
+  reintroduce flakiness. The #7029 audit path pays none of it: `activate_scoped` audits
+  `critical=True`, which flushes INLINE and spawns no thread, so the trust tests add no
+  `sel-writer` thread or `atexit` handler. A green run alone does not prove the race is
+  gone (the issue is a flake); `test_a_foreign_chain_lock_holder_cannot_deny_trust`
+  in `test/test_issue_radar_crew_runtime.py` is the differential pin.
+
 - **When you stub a lifecycle method, SPY and delegate — never replace.** A stub that
   only records the call leaves whatever that method was supposed to stop still running.
   The worked example cost 19 failures in files that contain no metrics code at all:

--- a/test/test_issue_radar_crew_runtime.py
+++ b/test/test_issue_radar_crew_runtime.py
@@ -1973,6 +1973,145 @@ class TestDisablingTheAppRevokesInline(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(cr.install_app_disable_hook(self.state))
 
 
+class TestForeignChainLockCannotDenyTrust(unittest.IsolatedAsyncioTestCase):
+    """Differential regression pin for issue #7029: an SEL chain-lock race.
+
+    THE FLAKE. ``sync_trust`` -> ``activate_scoped`` audits fail-closed to the SEL
+    on the event loop BEFORE it commits the grant. That audit takes the SEL's
+    cross-process chain lock -- a real ``flock`` on ``self._dir/trust/
+    security_events.lock`` -- and on the loop thread the acquire is a SINGLE
+    nonblocking attempt that fails closed if the lock is held by a foreign writer
+    (``sel._acquire_chain_lock_on_loop``). That refusal is CORRECT and pinned by
+    ``test_a_grant_whose_audit_fails_is_never_usable``; it must not be loosened.
+
+    The defect #7029 records is test-isolation, not product: while the rootdir
+    conftest only isolated the SEL dir per *worker* (``_isolate_sel_default_dir``,
+    session-scoped), every test on a worker shared ONE ``_dir`` and therefore ONE
+    ``_chain_lock_path()``. So a concurrent SEL writer on the same worker (another
+    test's ``sel-writer`` daemon, or a sibling instance mid-append) could hold that
+    shared lock while an *unrelated* test ran ``sync_trust``, the on-loop acquire
+    refused, the audit failed, the grant was refused, and the trust assertion read
+    False -- every component behaving as specified, the shard nondeterministic.
+    ``_isolate_sel_per_test`` closes it by giving each test its own SEL dir and thus
+    its own chain-lock path.
+
+    This test pins the property that makes the race impossible. It is a REGRESSION
+    pin, and because the issue is recorded as a FLAKE, a green run alone is not
+    evidence: the two assertions that carry the pin are the structural one (the
+    default ``sel()`` this test's ``activate_scoped`` uses resolves a chain-lock
+    path unique to this test, not a shared one) and the behavioral one (a real
+    foreign ``flock`` on a DIFFERENT test's/worker's chain-lock path does NOT make
+    ``_effectively_trusted`` read False). The mechanism check that a foreign hold on
+    the SAME path still denies (fail-closed intact) guards the guardrail: the fix
+    isolates the path, it does not weaken the refusal.
+    """
+
+    def setUp(self) -> None:
+        # Scoped grants live in the process-wide singleton; reset so one test's
+        # grant cannot leak into the next (mirrors the other classes here).
+        reset_singleton()
+        self.addCleanup(reset_singleton)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    @staticmethod
+    def _chain_lock_path_for(base_dir: Path) -> Path:
+        """The sidecar ``_chain_lock_path()`` would take for a log rooted at *base_dir*.
+
+        Mirrors ``sel.SecurityEventLog._chain_lock_path`` for the normal
+        (non-legacy-key-fallback) case: ``<base>/trust/security_events.lock``.
+        """
+        from kiro_crew import sel as sel_mod
+
+        return base_dir / sel_mod._TRUST_SUBDIR / sel_mod._SEL_LOCK_FILE
+
+    @contextlib.contextmanager
+    def _foreign_hold(self, lock_path: Path):
+        """Hold *lock_path*'s advisory lock as a FOREIGN writer would.
+
+        A real ``flock`` taken through :mod:`platform_compat` on a fresh fd, NOT
+        registered in ``sel._CHAIN_HOLDS`` -- so the on-loop single-shot acquire in
+        the SEL under test reads it as a foreign process's hold and refuses it,
+        exactly like a concurrent xdist worker's ``sel-writer`` would. This is the
+        contender #7029 blamed for denying an unrelated test's audit.
+        """
+        import os
+
+        from kiro_crew import platform_compat
+
+        lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        got = platform_compat.try_acquire_lock(fd, exclusive=True)
+        self.assertTrue(got, "could not simulate the foreign chain-lock holder")
+        try:
+            yield
+        finally:
+            platform_compat.release_lock(fd)
+            os.close(fd)
+
+    async def _grant_trust_on_loop(self, slot: Any) -> bool:
+        """Run the real ``sync_trust`` grant path on the event-loop thread.
+
+        ``IsolatedAsyncioTestCase`` runs this coroutine on the loop, so the SEL
+        audit inside ``activate_scoped`` takes the loop-side single-shot chain-lock
+        acquire -- the same path that failed in the issue. Returns whether the
+        shared approval path would then auto-approve the slot.
+        """
+        cr.sync_trust(slot, {"id": "c_7029", "unattended": True, "enabled": True})
+        return _effectively_trusted(slot)
+
+    async def test_a_foreign_chain_lock_holder_cannot_deny_trust(self) -> None:
+        from kiro_crew import sel as sel_mod
+
+        # The default SEL that activate_scoped audits through. Per-test isolation
+        # (_isolate_sel_per_test) binds this to a dir unique to THIS test.
+        default_lock = sel_mod.sel()._chain_lock_path()
+
+        # Structural pin: the default chain-lock path is this test's own, not a
+        # path shared with any other test. A second log rooted elsewhere resolves a
+        # DIFFERENT sidecar -- which pre-#7029 (one shared dir per worker) it did
+        # not, so a foreign hold could land on the very path this audit needs.
+        foreign_root = self.root / "foreign-worker"
+        foreign_lock = self._chain_lock_path_for(foreign_root)
+        self.assertNotEqual(
+            default_lock,
+            foreign_lock,
+            "the default SEL must not share a chain-lock path with another root",
+        )
+
+        # Behavioral pin: a foreign writer holding a DIFFERENT chain lock cannot
+        # deny this test's audit, because the audit takes ITS OWN lock. This is the
+        # assertion #7029 asks for: a concurrent holder of another test's chain lock
+        # can no longer make _effectively_trusted read False.
+        slot = _FakeSlot("crew-c_7029")
+        with self._foreign_hold(foreign_lock):
+            self.assertTrue(
+                await self._grant_trust_on_loop(slot),
+                "a foreign holder of a DIFFERENT chain lock denied trust -- the SEL "
+                "dir is not isolated per test (issue #7029)",
+            )
+
+    async def test_a_foreign_hold_on_the_same_path_still_fails_closed(self) -> None:
+        """The guardrail behind the guardrail: the fix isolates the path, it does
+        NOT loosen the on-loop refusal. A foreign writer holding the SEL's OWN
+        chain-lock path must still make the fail-closed audit refuse the grant --
+        that refusal is pinned by ``test_a_grant_whose_audit_fails_is_never_usable``
+        and this asserts the isolation change left it intact."""
+        from kiro_crew import sel as sel_mod
+
+        own_lock = sel_mod.sel()._chain_lock_path()
+        slot = _FakeSlot("crew-c_7029")
+        with self._foreign_hold(own_lock):
+            self.assertFalse(
+                await self._grant_trust_on_loop(slot),
+                "a foreign hold on the SEL's OWN chain lock must still fail closed",
+            )
+        # And with the contender gone the grant is usable again, so the refusal was
+        # the lock race, not a wedged control.
+        self.assertTrue(await self._grant_trust_on_loop(slot))
+
+
 class TestGrantRenewal(unittest.TestCase):
     """Renewal is a SLIDE, not a re-activation, and that is a security property.
 


### PR DESCRIPTION
## Summary

Fixes the flaky test `test/test_issue_radar_crew_runtime.py::TestDisablingTheAppRevokesInline::test_enabling_again_restores_trust_and_the_loop` (issue #7029).

The defect is test isolation, **not** product behaviour. The rootdir `conftest.py` fixture `_isolate_sel_default_dir` is session-scoped (per xdist worker), so every test on a worker shared ONE SEL directory and therefore ONE cross-process chain-lock path (`<dir>/trust/security_events.lock`). When a concurrent SEL writer on the same worker held that shared lock and the failing test ran its fail-closed on-loop audit via `activate_scoped`, the on-loop single-shot chain-lock acquire correctly refused to wait, the audit raised, the grant was refused fail-closed, and `_effectively_trusted` correctly read False. Every component behaved as specified; the flake was a trust assertion depending on winning a lock race.

## Direction chosen: (1) isolate the SEL log per test/worker

Per the auto-pipeline triage on the issue, Direction 1 was mandated because it retires the whole class of race rather than coping with one assertion (2) or trading away shard parallelism (3).

## Changes

- **`conftest.py`**: new autouse **function-scoped** fixture `_isolate_sel_per_test`, layered on the existing per-worker session fixture. It repoints `kiro_crew.sel._default_dir` at a unique per-test subdir (under the managed `_isolation_root`, so late daemon-thread flushes strand nothing) and resets `SecurityEventLog._instance`, so each test's default `sel()` resolves its own chain-lock path and no foreign writer can contend for it.
- **`test/test_issue_radar_crew_runtime.py`**: new differential regression class `TestForeignChainLockCannotDenyTrust` (`IsolatedAsyncioTestCase`). It holds a REAL foreign `flock` and exercises the real on-loop path, pinning: (a) structurally, that the default SEL chain-lock path is unique to the test; (b) behaviorally, that a foreign holder of a *different* chain-lock path can no longer make `_effectively_trusted` read False; plus a same-path check proving the fail-closed refusal was NOT loosened.
- **`docs/system-specs/common/testing-conventions.md`**: documents the per-worker-vs-per-test hazard and the accepted daemon-thread churn tradeoff.

## Guardrails held

`src/kiro_crew/sel.py` and `src/kiro_crew/safety_override.py` are **untouched** (verified via git diff), so the on-loop refusal and the fail-closed grant refusal are intact. `test_enabling_again_restores_trust_and_the_loop` and the guardrail sibling `test_a_grant_whose_audit_fails_is_never_usable` are **unchanged**.

## Testing

- Static checks PASS: `py_compile` of all changed files, clean imports of `sel.py`/`safety_override.py`, `black --check` and `isort --check-only` clean on changed files.
- **The test suite could NOT be run in-sandbox.** The sandbox network mode is INTEGRATIONS_ONLY ("Repository access only"), which blocks PyPI, so `pytest-asyncio`, `pytest-xdist`, and runtime deps (`croniter`) are not installable and the target test file cannot be collected. **Real execution of the failing test, the untouched sibling, and the new differential test is deferred to CI.** Because this is recorded as a flake, a single green run is not sufficient evidence; the differential assertion in `TestForeignChainLockCannotDenyTrust` is what closes it.

Closes #7029