### PR TITLE
test(mcp): compare a socket to its derived path, not a port substring

### DIFF
--- a/test/test_mcp_api_base_resolution.py
+++ b/test/test_mcp_api_base_resolution.py
@@ -45,6 +45,22 @@ def _bases(monkeypatch: pytest.MonkeyPatch, mcp: Any, sequence: list[str]) -> No
     monkeypatch.setattr(mcp, "_resolve_api_target", lambda: (next(it, last), ""))
 
 
+def _sock_for(port: int) -> str:
+    """The socket path the product derives for *port*, derived the same way.
+
+    Assertions about which gateway a transport reached compare against THIS,
+    never a port substring of the path. The path contains the data home, whose
+    isolation directory is named ``<counter>-kirocrew-home`` from a per-process
+    allocation counter — so a worker that has handed out 5,476 paths puts the
+    literal ``5476`` in every path it builds afterwards. A substring check then
+    reports whichever port the counter happens to equal: the negative form fails
+    a correct socket, and the positive form passes a wrong one.
+    """
+    from kiro_crew.dashboard.origin import dashboard_socket_path
+
+    return str(dashboard_socket_path(port))
+
+
 def _retry_resolution(monkeypatch: pytest.MonkeyPatch, mcp: Any, port: int, source: str) -> None:
     """Script what ``_resolve_api_port`` answers when the replay re-resolves."""
     monkeypatch.setattr(mcp, "_resolve_api_port", lambda: (port, source))
@@ -389,7 +405,7 @@ class TestMcpComputerReplay:
         assert computer._invoke("dashboard:chat-1", "computer_get_state", {}) == {"text": "done"}
         (_, _), (url, sock) = seen
         assert ":7788" in url
-        assert "7788" in sock and "5476" not in sock, f"replay dialled {url} with socket {sock!r}"
+        assert sock == _sock_for(7788), f"replay dialled {url} with socket {sock!r}"
 
     def test_http_error_on_replay_surfaces_the_backend_body(
         self, computer: Any, mcp: Any, monkeypatch
@@ -456,9 +472,8 @@ class TestOneResolutionPerAttempt:
         assert mcp._send("/api/x", headers={}, method="GET") == {"ok": True}
         ((url, sock),) = seen
         assert ":7788" in url
-        assert (
-            "7788" in sock and "9999" not in sock
-        ), f"one attempt aimed TCP at {url} and the unix socket at {sock}"
+        expected = _sock_for(7788)
+        assert sock == expected, f"one attempt aimed TCP at {url} and the unix socket at {sock}"
 
     def test_a_stable_source_still_resolves_once_and_pins(self, mcp: Any, monkeypatch) -> None:
         """Control: the caching rule for stable sources must not change.
@@ -527,9 +542,8 @@ class TestOneResolutionPerAttempt:
         assert len(seen) == 2, "the refused attempt must still be replayed once"
         assert len(runs) == 2, f"two attempts ran the discovery chain {len(runs)} times: {runs}"
         (url1, sock1), (url2, sock2) = seen
-        assert ":5476" in url1 and "5476" in sock1, "first attempt must be self-consistent"
+        assert ":5476" in url1 and sock1 == _sock_for(5476), "first attempt must be self-consistent"
         assert ":7788" in url2, "the replay must dial the re-resolved port"
-        assert (
-            "7788" in sock2 and "9999" not in sock2
-        ), f"the replay aimed TCP at {url2} and the unix socket at {sock2}"
-        assert "5476" not in sock2, "the replay must not reuse the refused resolution"
+        replayed = _sock_for(7788)
+        assert sock2 == replayed, f"the replay aimed TCP at {url2} and the unix socket at {sock2}"
+        assert sock2 != _sock_for(5476), "the replay must not reuse the refused resolution"


### PR DESCRIPTION
## Problem

`Backend Tests (Windows) (2)` failed on an unrelated frontend-only PR with:

```
FAILED test/test_mcp_api_base_resolution.py::TestMcpComputerReplay::test_the_replay_pairs_a_fresh_socket_with_the_re_resolved_base
  AssertionError: replay dialled http://127.0.0.1:7788/api/computer-use/invoke with socket
  'C:\...\pytest-0\popen-gw2\i0\5476-kirocrew-home\dashboard-7788.sock'
= 1 failed, 17692 passed, 549 skipped, 5 xfailed in 847.27s =
```

The socket in that message is **correct** — `dashboard-7788.sock` is exactly the re-resolved port's socket, which is what the test exists to prove. What failed is the guard beside it:

```python
assert "7788" in sock and "5476" not in sock
```

`sock` is a whole PATH, and the path contains the data home. `conftest._isolation_dirs` names that directory `<counter>-kirocrew-home` from a **per-process allocation counter** — so a worker that has handed out 5,476 paths writes the literal `5476` into every path it builds from then on. The number is a counter value that happened to equal the default port; nothing about the socket was wrong.

That makes the assertion report on the counter rather than on the socket. It is reachable on any platform — Windows shard 2 is simply where the shard's test count pushed the counter onto a decoy value.

## Why it is worse than one flaky assertion

The same shape appears **four times across two test methods**, and it fails in two opposite directions:

- **Negative form** (`"5476" not in sock`, `"9999" not in sock`) — fails a *correct* socket. This is the red CI.
- **Positive form** (`"5476" in sock1`, asserting the first attempt is self-consistent) — **passes a *wrong* socket**. On a path already containing `5476`, a socket named `dashboard-6000.sock` satisfies it, so the assertion is inert exactly when the counter collides. This direction produces no red; it silently stops guarding.

## What changed

One helper, and every socket assertion compares against it:

```python
def _sock_for(port: int) -> str:
    from kiro_crew.dashboard.origin import dashboard_socket_path
    return str(dashboard_socket_path(port))
```

`dashboard_socket_path` is the single place the product derives the path (both the server that binds it and the client that dials it already agree through it), so the test now checks the socket against the same function under test rather than against a hand-spelled substring — and follows the naming scheme if it ever changes.

`assert sock == _sock_for(7788)` also subsumes both halves of the old conjunction: being port 7788's socket is already proof it is not 5476's. The one negative that carried distinct intent is kept as an explicit, path-safe `assert sock2 != _sock_for(5476), "the replay must not reuse the refused resolution"`.

No production code changed, and no assertion was weakened or removed — each one now tests strictly more than before.

## Verification

The failure was reproduced deterministically instead of waited for: `--basetemp` pointed at a directory whose own name contains the decoy number puts that number in every path, the same way the counter does.

| basetemp path contains | before | after |
|---|---|---|
| `5476` | **2 failed**, 21 passed | 23 passed |
| `9999` | **2 failed**, 21 passed | 23 passed |
| `1` (benign) | 23 passed | 23 passed |

Two failures per decoy, not one, which is what showed the sibling assertions were armed too. The benign row is the control: it passes before and after, so the reproduction is the colliding path and not the harness.

The inert direction was verified rather than asserted: on a path containing `5476`, `"5476" in sock` returns `True` for a socket named `dashboard-6000.sock`, while `sock == _sock_for(5476)` returns `False`.

Repo swept for the same shape elsewhere (a port literal matched as a substring of a path/home/dir value) — no other occurrences.

`black --check`, `isort --check-only`, `flake8` clean on the touched file; `test_mcp_api_base_resolution.py`, `test_mcp_core.py` and `test_mcp_shared.py` pass (89 tests).

**Why no screenshot:** test-only change, no user-visible surface.
