### PR TITLE
fix(chat): pinned prompt shows the pasted text, not the [ Paste #N ] placeholder

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -213,7 +213,7 @@ import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } fro
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
 import { loadSessionRefDrafts, saveSessionRefDrafts as persistSessionRefDrafts, setSessionRefDraft } from '../utils/chatSessionRefDrafts'
 import { addSessionRef, removeSessionRef, mergeSessionRefs, appendSessionRefLinks, type SessionRef } from '../utils/sessionRefs'
-import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, promptPreview, promptImages, promptBody, pinHandoffY, pinPushTravel, jumpAnchorIdx, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
+import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, createPinnedPromptTextCache, type PinnedPromptText, pinHandoffY, pinPushTravel, jumpAnchorIdx, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
 import {
   adoptSourceSelections,
   commitRevealedSource,
@@ -3363,6 +3363,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const onPinCollapsedHeight = useCallback((h: number) => {
     if (h > 0) pinCollapsedHRef.current = h
   }, [])
+  // Memoised because `updatePinnedPrompt` runs once per animation frame of a
+  // scroll, and this walks the prompt (and its pastes) with three regexes.
+  const pinTextCacheRef = useRef<ReturnType<typeof createPinnedPromptTextCache> | null>(null)
+  const pinnedPromptText = useCallback((content: string, pastes: PasteBlock[]): PinnedPromptText => {
+    pinTextCacheRef.current ??= createPinnedPromptTextCache()
+    return pinTextCacheRef.current(content, pastes)
+  }, [])
   // Recompute which prompt is pinned, and how far the incoming prompt has
   // pushed it out, from the current scroll position.
   const updatePinnedPrompt = useCallback(() => {
@@ -3438,7 +3445,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       : sub
         ? subagentHeadline(sub)
         : null
-    const text = machineLabel ?? promptPreview(full)
+    // Stored content is COLLAPSED (recollapsePastes), so a big paste is a
+    // `[ Paste #N ]` token; deriving through the paste layer is what unwraps it.
+    const derived = machineLabel
+      ? null
+      : pinnedPromptText(full, (pinItem.msg.meta?.pastes as PasteBlock[] | undefined) || [])
+    const text = machineLabel ?? derived?.text ?? ''
     // Compare the RAW content (`prev.raw`), not `text` or the derived body:
     // `text`, `full` and `images` are all derived from it, and an edit-and-resend
     // that changes ONLY an attached image leaves the flattened preview text
@@ -3449,8 +3461,8 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     setPinned(prev => (prev && prev.idx === pinIdx && prev.push === push
       && prev.raw === full && prev.bannerH === bannerH && prev.ts === pinItem.msg.ts)
       ? prev
-      : { idx: pinIdx, ts: pinItem.msg.ts, text, raw: full, full: nudge ? nudge.body : (sub ? full : promptBody(full)), images: machineLabel ? [] : promptImages(full), bodyBeyondPreview: !!machineLabel, push, bannerH })
-  }, [scrollerRef])
+      : { idx: pinIdx, ts: pinItem.msg.ts, text, raw: full, full: nudge ? nudge.body : (sub ? full : derived?.body ?? full), images: derived?.images ?? [], bodyBeyondPreview: !!machineLabel, push, bannerH })
+  }, [scrollerRef, pinnedPromptText])
   // rAF-throttle the per-scroll recompute: updatePinnedPrompt does a
   // querySelectorAll + getBoundingClientRect loop (a forced layout read), and a
   // fling fires scroll dozens of times/sec. Coalesce to at most once per frame,

--- a/website/src/test/pinnedPrompt.pasteTokens.test.tsx
+++ b/website/src/test/pinnedPrompt.pasteTokens.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PinnedPrompt from '../pages/chat/PinnedPrompt'
+import {
+  createPinnedPromptTextCache,
+  derivePinnedPromptText,
+  expandPastesCapped,
+  pasteSignature,
+  promptBody,
+  promptImages,
+  promptPreview,
+  PINNED_PASTE_HEAD_CHARS,
+} from '../utils/pinnedPrompt'
+import { formatToken, type PasteBlock } from '../utils/pasteTokens'
+
+// `id` is unique PER BLOCK, as makePasteId mints it -- deriving it from `seq`
+// would hand two distinct blocks the same id and mask an aliasing defect.
+let blockIds = 0
+const block = (seq: number, content: string): PasteBlock =>
+  ({ id: `b${seq}-${++blockIds}`, seq, lines: content.split('\n').length, content })
+
+describe('derivePinnedPromptText — paste tokens', () => {
+  const paste = block(1, 'first line\nsecond line\nthird line')
+  const token = formatToken(paste)
+
+  it('does not leave the token standing in the collapsed preview', () => {
+    // The defect: a paste-only prompt pinned as a bare token and said nothing.
+    const { text } = derivePinnedPromptText(token, [paste])
+    expect(text).not.toContain('Paste #1')
+    expect(text).toBe('first line second line third line')
+  })
+
+  it('NEGATIVE CONTROL: the pre-fix derivation did leave the token', () => {
+    // The old path, pinned so the assertions above cannot pass vacuously.
+    expect(promptPreview(token)).toContain('Paste #1')
+    expect(promptBody(token)).toContain('Paste #1')
+  })
+
+  it('does not leave the token standing in the expanded body either', () => {
+    // Expanding used to reward the click with the same placeholder.
+    const { body } = derivePinnedPromptText(token, [paste])
+    expect(body).not.toContain('Paste #1')
+    expect(body).toBe('first line\nsecond line\nthird line')
+  })
+
+  it('keeps line structure in the body and flattens it in the preview', () => {
+    const { text, body } = derivePinnedPromptText(`before\n${token}\nafter`, [paste])
+    expect(text).toBe('before first line second line third line after')
+    expect(body).toContain('\n')
+    expect(body.startsWith('before\n')).toBe(true)
+    expect(body.endsWith('\nafter')).toBe(true)
+  })
+
+  it('substitutes every token, and each from its own block', () => {
+    const a = block(1, 'alpha')
+    const b = block(2, 'beta')
+    const { text } = derivePinnedPromptText(`${formatToken(a)} then ${formatToken(b)}`, [a, b])
+    expect(text).toBe('alpha then beta')
+  })
+
+  it('reduces to the previous behaviour with no blocks', () => {
+    const plain = 'just typed text with ```\ncode\n``` in it'
+    const derived = derivePinnedPromptText(plain, [])
+    expect(derived.text).toBe(promptPreview(plain))
+    expect(derived.body).toBe(promptBody(plain))
+    expect(derived.images).toEqual(promptImages(plain))
+  })
+
+  it('reduces to the previous behaviour when a block has no token in the text', () => {
+    // Content whose token was already expanded (or lost) must not be rewritten.
+    const orphan = block(9, 'unreferenced')
+    const plain = 'no token here'
+    expect(derivePinnedPromptText(plain, [orphan]).text).toBe(promptPreview(plain))
+    expect(derivePinnedPromptText(plain, [orphan]).body).toBe(promptBody(plain))
+  })
+})
+
+describe('derivePinnedPromptText — the paste is verbatim text, not markdown', () => {
+  it('does not thumbnail an image that was inside the paste', () => {
+    // Substituting before the image pass would invent an attachment.
+    const p = block(1, 'look at this:\n![alt](/inside.png)\ndone')
+    const { images } = derivePinnedPromptText(formatToken(p), [p])
+    expect(images).toEqual([])
+  })
+
+  it('still collects a real attachment typed alongside the paste', () => {
+    const p = block(1, 'pasted body line one\nline two')
+    const { images } = derivePinnedPromptText(`![real](/r.png)\n${formatToken(p)}`, [p])
+    expect(images).toEqual(['/r.png'])
+  })
+
+  it('does not delete a pasted line that spelled image markdown', () => {
+    const p = block(1, 'a\n![alt](/inside.png)\nb')
+    const { body } = derivePinnedPromptText(formatToken(p), [p])
+    expect(body).toContain('![alt](/inside.png)')
+  })
+
+  it('does not fold a fence that was inside the paste into an ellipsis', () => {
+    const p = block(1, 'x\n```js\nconst a = 1\n```\ny')
+    const { body } = derivePinnedPromptText(formatToken(p), [p])
+    expect(body).toContain('const a = 1')
+    expect(body).toContain('```js')
+  })
+
+  it('still folds a fence the user TYPED outside the paste', () => {
+    const p = block(1, 'pasted one\npasted two')
+    const fence = '```'
+    const typed = `see ${fence}\ntyped\n${fence} and ${formatToken(p)}`
+    const { text } = derivePinnedPromptText(typed, [p])
+    expect(text).toBe('see … and pasted one pasted two')
+  })
+})
+
+describe('expandPastesCapped', () => {
+  it('caps a huge block and marks that it was cut', () => {
+    const huge = block(1, 'z'.repeat(PINNED_PASTE_HEAD_CHARS * 3))
+    const out = expandPastesCapped(formatToken(huge), [huge])
+    expect(out.length).toBe(PINNED_PASTE_HEAD_CHARS + 2)
+    expect(out.endsWith(' …')).toBe(true)
+  })
+
+  it('does not mark a block that fits', () => {
+    const small = block(1, 'short')
+    expect(expandPastesCapped(formatToken(small), [small])).toBe('short')
+  })
+
+  it('caps at the boundary without adding a false ellipsis', () => {
+    // Exactly at the budget is not truncation, so no marker.
+    const exact = block(1, 'y'.repeat(PINNED_PASTE_HEAD_CHARS))
+    const out = expandPastesCapped(formatToken(exact), [exact])
+    expect(out.length).toBe(PINNED_PASTE_HEAD_CHARS)
+    expect(out.endsWith('…')).toBe(false)
+  })
+
+  it('bounds what the card can ever be handed, per block', () => {
+    // The negative control for the cap: without it, the card would receive the
+    // whole paste and the scroll-path derivation would walk it every frame.
+    const a = block(1, 'a'.repeat(PINNED_PASTE_HEAD_CHARS * 2))
+    const b = block(2, 'b'.repeat(PINNED_PASTE_HEAD_CHARS * 2))
+    const raw = `${formatToken(a)}${formatToken(b)}`
+    const out = expandPastesCapped(raw, [a, b])
+    expect(out.length).toBeLessThan(a.content.length + b.content.length)
+    expect(out.length).toBe((PINNED_PASTE_HEAD_CHARS + 2) * 2)
+  })
+
+  it('applies mapBlock to the substituted text only', () => {
+    const p = block(1, 'one\ntwo')
+    const out = expandPastesCapped(`keep\tthis ${formatToken(p)}`, [p], s => s.replace(/\s+/g, ' '))
+    // The block's newline is flattened; the surrounding tab is untouched.
+    expect(out).toBe('keep\tthis one two')
+  })
+
+  it('leaves content alone when no token matches a block', () => {
+    const orphan = block(7, 'nope')
+    expect(expandPastesCapped('plain text', [orphan])).toBe('plain text')
+  })
+
+  it('ignores a token whose seq has no block', () => {
+    // findTokenRanges pairs by seq; an unpaired token is left as written rather
+    // than substituted from the wrong block.
+    const p = block(1, 'mine')
+    const stray = formatToken(block(4, 'irrelevant'))
+    const out = expandPastesCapped(`${formatToken(p)} ${stray}`, [p])
+    expect(out).toBe(`mine ${stray}`)
+  })
+})
+
+describe('the card renders what the derivation hands it', () => {
+  // The real component, given exactly the props ChatPage now computes. jsdom has
+  // no layout, so the banner can never mount through ChatPage's own geometry.
+  const paste = block(1, 'Window: last 7 days\nShadow branch 59,990\nPPCore 173,632')
+  const prompt = `"\n${formatToken(paste)}\n"`
+
+  const renderCard = (expanded: boolean) => {
+    const { text, body, images } = derivePinnedPromptText(prompt, [paste])
+    return render(
+      <PinnedPrompt
+        text={text}
+        fullText={body}
+        images={images}
+        pushUp={0}
+        bannerH={40}
+        expanded={expanded}
+        onToggleExpanded={() => {}}
+        onJump={() => {}}
+        onCollapsedHeight={() => {}}
+      />,
+    )
+  }
+
+  it('shows the paste, not the placeholder, on the collapsed card', () => {
+    renderCard(false)
+    expect(screen.getByTestId('pinned-prompt').textContent).toContain('Shadow branch 59,990')
+    expect(screen.getByTestId('pinned-prompt').textContent).not.toContain('Paste #1')
+  })
+
+  it('shows the paste, not the placeholder, on the expanded card', () => {
+    renderCard(true)
+    expect(screen.getByTestId('pinned-prompt').textContent).toContain('PPCore 173,632')
+    expect(screen.getByTestId('pinned-prompt').textContent).not.toContain('Paste #1')
+  })
+
+  it('NEGATIVE CONTROL: the pre-fix props put the placeholder on the card', () => {
+    // Same component and prompt, derived the old way.
+    render(
+      <PinnedPrompt
+        text={promptPreview(prompt)}
+        fullText={promptBody(prompt)}
+        images={promptImages(prompt)}
+        pushUp={0}
+        bannerH={40}
+        expanded={false}
+        onToggleExpanded={() => {}}
+        onJump={() => {}}
+        onCollapsedHeight={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('pinned-prompt').textContent).toContain('Paste #1')
+  })
+})
+
+describe('the pinned-text cache does not alias two distinct pastes', () => {
+  // Same seq and same line count, so formatToken yields IDENTICAL collapsed text
+  // for both — and equal content length, so a seq+length signature collides.
+  const first = block(1, 'alpha\nbravo\ncharlie')
+  const second = block(1, 'delta\nechos\nfoxtrot')
+
+  it('the two really are indistinguishable to a seq+length key', () => {
+    // Guard: without this the test could pass for the wrong reason.
+    expect(second.content.length).toBe(first.content.length)
+    expect(second.lines).toBe(first.lines)
+    expect(formatToken(second)).toBe(formatToken(first))
+  })
+
+  it('gives distinct blocks distinct signatures despite matching seq and length', () => {
+    expect(pasteSignature([second])).not.toBe(pasteSignature([first]))
+  })
+
+  it('derives the second prompt from its OWN paste, not the first one cached', () => {
+    const cache = createPinnedPromptTextCache()
+    const prompt = formatToken(first)
+    expect(cache(prompt, [first]).text).toBe('alpha bravo charlie')
+    expect(cache(prompt, [second]).text).toBe('delta echos foxtrot')
+  })
+
+  it('CONTROL: still serves the cache when the same prompt and block return', () => {
+    // Proves the fix separates distinct blocks rather than neutering the memo.
+    const cache = createPinnedPromptTextCache()
+    const prompt = formatToken(first)
+    expect(cache(prompt, [first])).toBe(cache(prompt, [first]))
+  })
+})

--- a/website/src/utils/pinnedPrompt.ts
+++ b/website/src/utils/pinnedPrompt.ts
@@ -1,6 +1,7 @@
 import type { DisplayItem } from '../pages/chat/types'
 import { TURN_OPENER_ROLES } from '../pages/chat/groupDisplayItems'
 import { mdImageDestToPath } from './fileTokens'
+import { type PasteBlock, findTokenRanges } from './pasteTokens'
 
 /**
  * Geometry + selection helpers for the pinned-prompt banner (the most recent
@@ -352,6 +353,130 @@ export function promptImages(content: string): string[] {
     }
   }
   return out
+}
+
+/**
+ * Per-block character budget applied when a pinned prompt's `[ Paste #N · M
+ * lines ]` tokens are substituted for the text they stand for.
+ *
+ * Unbounded substitution is not an option here. The store deliberately keeps a
+ * sent prompt's content in its COLLAPSED, token-bearing form (`recollapsePastes`
+ * in pasteTokens) precisely so nothing downstream measures or lays out hundreds
+ * of KB, and this module's consumer re-derives once per animation frame of a
+ * scroll. A cap keeps both properties: enough text to fill the three-line
+ * collapsed card and the scrollable expanded strip from real content, far short
+ * of the sizes that froze the tab. The rest stays one click away — the card's
+ * body IS a jump-to-turn button, and the bubble it jumps to has the paste in
+ * full behind its own chip.
+ */
+export const PINNED_PASTE_HEAD_CHARS = 12000
+
+/**
+ * Substitute every `[ Paste #N · M lines ]` token in `content` for a head-capped
+ * copy of its block's text, optionally passing that text through `mapBlock`.
+ *
+ * Ranges come from `findTokenRanges` — the same locator the bubble, the composer
+ * highlight layer and the copy handler use — so the pinned card can never
+ * disagree with them about which token belongs to which block. The splice walks
+ * right-to-left so each write leaves the earlier ranges' offsets valid.
+ *
+ * A truncated block ends in ` …` so the card never implies the paste stopped
+ * where the cap did.
+ */
+export function expandPastesCapped(
+  content: string,
+  blocks: PasteBlock[],
+  mapBlock?: (text: string) => string,
+): string {
+  const ranges = findTokenRanges(content, blocks)
+  if (!ranges.length) return content
+  let out = content
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const { start, end, block } = ranges[i]
+    const capped = block.content.length > PINNED_PASTE_HEAD_CHARS
+      ? block.content.slice(0, PINNED_PASTE_HEAD_CHARS) + ' …'
+      : block.content
+    const body = mapBlock ? mapBlock(capped) : capped
+    out = out.slice(0, start) + body + out.slice(end)
+  }
+  return out
+}
+
+/** Everything the pinned card renders, derived from one prompt in one pass. */
+export interface PinnedPromptText {
+  /** Flattened, clamp-ready preview for the COLLAPSED card. */
+  text: string
+  /** Line-preserving body for the EXPANDED card. */
+  body: string
+  /** Image sources to thumbnail. */
+  images: string[]
+}
+
+/** Collapse every whitespace run to a single space, as `promptPreview` does. */
+function flattenWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Derive all three pinned-card values from a prompt's stored content and blocks.
+ *
+ * The store holds a sent prompt COLLAPSED, so reading `msg.content` straight
+ * gave the card the literal `[ Paste #N ]` token — the empty-card failure images
+ * already have an exemption for, and the placeholder the copy handler rejects as
+ * "worthless on the other end" (UserMessage).
+ *
+ * Substitution happens AFTER the three prose passes, never before: they rewrite
+ * markdown, and a paste is verbatim text the user is SHOWING us, so running them
+ * over it would thumbnail an image the prompt never attached and delete the
+ * pasted line that spelled it. The token holds no markdown and no newline, so it
+ * survives all three untouched and substituting into their output exempts the
+ * paste from them exactly. With no blocks this is the previous behaviour.
+ */
+export function derivePinnedPromptText(content: string, blocks: PasteBlock[]): PinnedPromptText {
+  // Computed from the ORIGINAL content on purpose: an image inside a paste is
+  // pasted text, not an attachment.
+  const images = promptImages(content)
+  if (!blocks.length) return { text: promptPreview(content), body: promptBody(content), images }
+  return {
+    text: expandPastesCapped(promptPreview(content), blocks, flattenWhitespace),
+    body: expandPastesCapped(promptBody(content), blocks),
+    images,
+  }
+}
+
+/**
+ * Cache key for a prompt's paste blocks.
+ *
+ * `id` is what makes two blocks distinguishable, and it is load-bearing rather
+ * than belt-and-braces. `seq` restarts per draft (`nextSeq` is max+1) and an
+ * equal character length is ordinary, so a seq+length pair aliases two
+ * same-shaped pastes of the same size and different text — and because the token
+ * text embeds seq and line count, such a pair ALSO yields identical collapsed
+ * content, which is the cache's other half. `id` is minted once per block
+ * (`makePasteId`) and never reused, so it separates them without hashing the
+ * text.
+ */
+export function pasteSignature(blocks: PasteBlock[]): string {
+  return blocks.map(b => `${b.id}:${b.seq}:${b.content.length}`).join(',')
+}
+
+/**
+ * Single-slot memo for `derivePinnedPromptText`, owned by the caller across
+ * renders. One slot is enough because only one prompt is pinned at a time, and
+ * the caller runs once per animation frame of a scroll — which is what the memo
+ * exists to keep the three regex walks out of.
+ */
+export function createPinnedPromptTextCache(): (content: string, pastes: PasteBlock[]) => PinnedPromptText {
+  let hit: { sig: string; content: string; value: PinnedPromptText } | null = null
+  return (content, pastes) => {
+    // Two values, not one joined key, so neither can absorb the other's
+    // characters.
+    const sig = pasteSignature(pastes)
+    if (hit && hit.sig === sig && hit.content === content) return hit.value
+    const value = derivePinnedPromptText(content, pastes)
+    hit = { sig, content, value }
+    return value
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem / Motivation

The pinned-prompt banner shows `[ Paste #1 · 28 lines ]` instead of the text that
token stands for — in both its collapsed and its expanded state. For a prompt
whose whole body was a paste, the card conveys nothing at all about the turn, and
clicking the chevron rewards you with the same placeholder.

## Why it matters

The banner exists to answer *which turn am I reading*. A prompt whose body is a
pasted log, stack trace or transcript is exactly the prompt most worth
summarising, and it is the one the banner currently says nothing about — the same
empty-card failure images already carry an exemption for (`promptPreview` strips
image markdown, so an image-only prompt used to pin blank; the fix there was to
render thumbnails rather than drop the content).

Expanding is worse than uninformative: the card's whole purpose in that state is
"read it properly", it already scrolls at `max-h-[40vh]`, and today the chevron
returns the token again. That is the dead end the `bodyBeyondPreview` flag was
introduced to fix for nudges.

## What changed (motivation → approach → change)

This is a leak, not a design choice. `recollapsePastes` deliberately keeps a sent
prompt's `content` in its collapsed, token-bearing form so nothing downstream
measures or lays out hundreds of KB — and `updatePinnedPrompt` read `msg.content`
straight, making the banner the one consumer of a user message's text that never
goes through the paste layer. Every other one does:

| Consumer                                            | What it does with the token                                                  |
| --------------------------------------------------- | ---------------------------------------------------------------------------- |
| bubble (`renderUserContentInner`)                   | renders it as an expandable `PastedChip`                                      |
| copy (`UserMessage.handleCopy`)                     | swaps it for the block content — the label is *"worthless on the other end"*  |
| composer (`PasteHighlightLayer`, `PasteHoverLayer`)  | resolves it to its block                                                     |
| pinned banner                                       | printed it verbatim                                                          |

`derivePinnedPromptText(content, blocks)` in `utils/pinnedPrompt.ts` now returns
the three values the card needs — collapsed preview, expanded body, thumbnails —
with paste tokens substituted for the text they stand for. `ChatPage` calls it
through a one-entry memo instead of calling `promptPreview` / `promptBody` /
`promptImages` directly.

Three properties it was built to hold:

**Substitution happens *after* the prose passes, never before.** `promptPreview`,
`promptBody` and `promptImages` rewrite markdown, and a paste is verbatim text the
user is *showing* us. Expanding first would thumbnail an image that was only ever
quoted inside the paste and delete the pasted line that spelled it — the
phantom-thumbnail shape `splitFences` already exists to prevent. The token holds
no markdown and no newline, so it survives all three passes untouched, which makes
substituting into their output exactly equivalent to exempting the paste from them.

**Bounded, at `PINNED_PASTE_HEAD_CHARS` (12 000) per block.** Unbounded
substitution would undo the reason the store keeps the prompt collapsed. A
truncated block ends in ` …`; the rest stays one click away, since the card's body
is itself a jump-to-turn button and the bubble it lands on has the paste in full
behind its own chip.

**Memoised, because the derivation is on the scroll path.** `updatePinnedPrompt`
is rAF-throttled and runs once per animation frame of a scroll. Today that is free
because the string is a ~24-char token; expanding a paste there would run three
whole-string regex walks per frame. The cache is keyed on the stored content plus a
`seq:length` signature per block — a sent block is immutable, so that identifies it
without hashing its text. The machine-label paths (nudge, subagent completion) skip
the derivation entirely.

With no blocks, or a block whose token is not present, `derivePinnedPromptText`
reduces to the previous behaviour exactly.

## Tests

`website/src/test/pinnedPrompt.pasteTokens.test.tsx`, 22 tests:

- both states show the paste rather than the token, asserted on the pure
  derivation **and** through a render of the real `PinnedPrompt` with exactly the
  props `ChatPage` now computes;
- **two negative controls** pinning the pre-fix behaviour — `promptPreview` /
  `promptBody` on the raw content still contain `Paste #1`, and the same component
  given the old props still renders it — so the positive assertions cannot pass
  vacuously;
- the verbatim-text guarantees: no phantom thumbnail from an image inside a paste,
  a real attachment typed alongside is still collected, a pasted image-markdown
  line is not deleted, a fence inside the paste is not folded to an ellipsis while
  one the user *typed* still is;
- the cap: truncation marker present above the budget, absent exactly at it, and a
  bound on what two large blocks can ever hand the card.

**Mutation-checked**: disabling the substitution inside `derivePinnedPromptText`
fails 9 of the 22, and the negative controls correctly keep passing.

## Manual verification

| Gate                                 | Result                                                                          |
| ------------------------------------ | ------------------------------------------------------------------------------- |
| `npm run typecheck`                  | clean                                                                           |
| `npx eslint` on the touched files    | 0 errors; the 13 warnings are pre-existing (identical count on the base commit)  |
| `npx vitest run` (full suite)        | 1677 files, 26 475 passed, 1 expected fail, 3 skipped                            |
| `npm run lint:i18n`                  | 477 untranslated across 103 files, at/below the 1015 baseline (no new strings)    |

Not covered, stated plainly: the `ChatPage` wiring itself is typecheck- and
suite-covered but not render-tested. jsdom reports zero-size rects, so the banner
can never mount through `ChatPage`'s geometry — the render test drives
`PinnedPrompt` directly with the derived props instead.

## Related Issues

N/A — reported from use of the dashboard.
