### PR TITLE
test: give each test its own SEL root so chain-lock races cannot refuse trust (#7029)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1775,6 +1775,67 @@ def _isolate_sel_default_dir(tmp_path_factory):
         _sel.SecurityEventLog._instance = original_instance
 
 
+@pytest.fixture
+def sel_private_root(tmp_path_factory):
+    """Bind the SEL singleton to a directory PRIVATE to the requesting test.
+
+    ``_isolate_sel_default_dir`` above gives every test on a worker ONE shared
+    SEL directory, which is the right default tier: the writer is a daemon
+    thread on a process singleton, and a per-test ``tmp_path`` would be deleted
+    underneath it (see that fixture's docstring). But one shared root also
+    means one shared CHAIN LOCK, and a test whose assertion transitively
+    depends on a fail-closed critical audit WINNING that lock can be refused by
+    a concurrent writer it never created — the loop-side acquire is a single
+    non-blocking attempt by design (issue #7029, the issue-radar trust flake).
+
+    This is the per-test tier of the same seam. It rebinds the singleton to a
+    fresh directory nothing else writes, so no other test — on this worker or
+    any other — can hold this test's chain lock:
+
+    * The directory comes from ``tmp_path_factory``, whose numbered dirs are
+      never deleted mid-run (a lingering writer can never resurrect a removed
+      path) and whose basetemp is already per-xdist-worker (``popen-gwN``), so
+      the isolation holds across workers as well as across tests.
+    * The instance is built ``sync=True``: every event is written inline on its
+      caller's thread and NO background writer starts, so the only writers on
+      this root are the test's own threads — which the module-level chain-hold
+      registry already lets join one another.
+    * ``_default_dir()`` is deliberately NOT repointed: the displaced shared
+      directory stays reachable through it, which is what lets a differential
+      test hold the SHARED root's lock and prove this test no longer contends
+      for it.
+
+    Teardown restores the PRIOR singleton (not ``None``), so later tests on
+    this worker resume the session default exactly where it left off instead of
+    minting a second instance — and a second writer thread — on the same
+    directory.
+    """
+    try:
+        from kiro_crew.sel import SecurityEventLog
+    except ImportError:  # pragma: no cover - partial checkout
+        yield None
+        return
+    root = tmp_path_factory.mktemp("sel-private")
+    prior_instance = SecurityEventLog._instance
+    SecurityEventLog._instance = None
+    SecurityEventLog._initialized = False
+    try:
+        # Inside the try: ``__new__`` publishes to ``_instance`` before
+        # ``__init__`` runs, so a failing ``_init_locked`` would otherwise
+        # orphan the half-built object AND lose ``prior_instance`` — every
+        # later test on this worker would then re-init against the shared
+        # default with a second writer thread, the exact hazard the restore
+        # exists to prevent.
+        SecurityEventLog(base_dir=root, sync=True)
+        yield root
+    finally:
+        SecurityEventLog._instance = prior_instance
+        # Class attribute only (each instance shadows it in __new__); reset to
+        # the declared default for symmetry with test_sel.py's convention —
+        # the restored instance keeps its own per-instance _initialized=True.
+        SecurityEventLog._initialized = False
+
+
 #: ``~/.kiro`` paths production binds at IMPORT time, which ``KIROCREW_HOME`` cannot
 #: reach: the module captured an absolute path from ``Path.home()`` before any test
 #: set an environment variable, so the env override is read too late to matter.

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -291,6 +291,15 @@ which testpath asked for the workers.
   add a subsystem with a background worker, ask which directory its thread captured
   and whether anything deletes that directory underneath it.
 
+  One shared directory also means one shared **chain lock**, and that is the wrong
+  tier for a test whose assertion depends on a fail-closed critical SEL write
+  *winning* that lock — on the event-loop thread the acquire is a single non-blocking
+  attempt, so any sibling's writer holding the lock at the wrong moment refuses the
+  audit and fails the test with no code defect anywhere (issue #7029, the issue-radar
+  trust flake). Such tests request `sel_private_root` (rootdir conftest): it rebinds
+  the singleton to a per-test, per-xdist-worker directory built `sync=True` — no
+  background writer at all — so no concurrent writer exists to contend with.
+
 - **When you stub a lifecycle method, SPY and delegate — never replace.** A stub that
   only records the call leaves whatever that method was supposed to stop still running.
   The worked example cost 19 failures in files that contain no metrics code at all:

--- a/test/test_issue_radar_crew_runtime.py
+++ b/test/test_issue_radar_crew_runtime.py
@@ -25,6 +25,7 @@ import ast
 import asyncio
 import contextlib
 import inspect
+import os
 import re
 import tempfile
 import threading
@@ -33,6 +34,10 @@ from pathlib import Path
 from typing import Any, cast
 from unittest import mock
 
+import pytest
+
+import kiro_crew.sel as sel_mod
+from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.issue_radar.backend import crew_runtime as cr
 from kiro_crew.apps.builtins.issue_radar.backend import crew_store as cs
 from kiro_crew.apps.builtins.issue_radar.backend import provider
@@ -54,6 +59,25 @@ def _effectively_trusted(slot: Any) -> bool:
     this module must never write. So the tests below ask the real consumer.
     """
     return chat_runner._slot_is_trusted(slot)
+
+
+@pytest.fixture(autouse=True)
+def _private_sel_root_per_test(sel_private_root):
+    """Every test in this module gets its OWN SEL root (issue #7029).
+
+    The trust assertions here transitively depend on a fail-closed critical SEL
+    audit WINNING the chain lock: ``sync_trust`` → ``activate_scoped`` audits
+    before it grants, and on the event-loop thread the lock acquire is a single
+    non-blocking attempt that refuses rather than stall the loop — correct
+    product behaviour that must not be loosened. On a SHARED root that turns
+    every trust assertion into a lock race against writers this module never
+    created (another test's still-flushing events, another xdist worker on the
+    same path). ``sel_private_root`` (rootdir conftest) removes the concurrent
+    writer instead of coping with it: a fresh per-test, per-worker directory
+    that nothing else writes. ``TestSelRootIsolation`` below pins the property
+    differentially.
+    """
+    yield
 
 
 # ── fakes ───────────────────────────────────────────────────────────────────
@@ -2133,6 +2157,129 @@ class TestAutoApproveProvenance(unittest.TestCase):
         slot = _FakeSlot("chat-1")
         slot._trust = True
         self.assertEqual(chat_runner._auto_approve_reason(slot, False), "trust")
+
+
+#: SEL roots already claimed by a test in this module, on this worker. Uniqueness
+#: across workers needs no bookkeeping: the roots are ``tmp_path_factory`` dirs
+#: under per-worker basetemps, so two workers cannot mint the same path. The
+#: REUSE assertion below therefore only bites when both claim tests land on one
+#: worker (``--dist load`` may split them); the not-the-shared-default leg holds
+#: per test on every worker regardless.
+_CLAIMED_SEL_ROOTS: set[str] = set()
+
+
+class TestSelRootIsolation(unittest.IsolatedAsyncioTestCase):
+    """The per-test SEL root that closes issue #7029, pinned differentially.
+
+    Every trust assertion in this file requires a fail-closed critical SEL
+    audit to WIN the chain lock, and on the event-loop thread that acquire is a
+    single non-blocking attempt (``sel.py``) with a fail-closed refusal behind
+    it (``safety_override.py``) — both correct product behaviour, pinned by
+    their own tests, and deliberately not touched here. What THESE tests pin is
+    the test-isolation property that makes depending on that lock safe: the
+    root the audit writes through belongs to this test alone, so no sibling
+    test's writer can ever hold this test's lock.
+
+    Written to FAIL on the shared-root arrangement this module had before
+    (one session-scoped SEL directory per worker), not merely to pass on the
+    private one — see each test's body for which leg is the differential.
+    """
+
+    def setUp(self):
+        if getattr(sel_mod._default_dir, "__module__", "") == "kiro_crew.sel":
+            # The rootdir conftest displaces ``_default_dir`` with a
+            # session-scoped closure; the ORIGINAL still installed means that
+            # isolation never ran (raw ``python -m unittest``, or pytest from
+            # a foreign rootdir). In that world ``_default_dir()`` — and the
+            # ``sel()`` the tests below touch — would resolve, CREATE, and
+            # initialize against the operator's REAL data home before any
+            # assertion could fail. Probe the seam by identity: even calling
+            # ``config_dir()`` to compare paths would itself create the home
+            # on first use, so the check must not invoke anything.
+            self.skipTest("requires the rootdir conftest SEL isolation")
+        reset_singleton()
+        self.addCleanup(reset_singleton)
+
+    async def test_a_holder_of_the_shared_default_root_cannot_refuse_trust(self):
+        """A concurrent writer on the SHARED root no longer reaches this module.
+
+        The holder below stands in for the writer the flake needed: it takes
+        the chain lock of the DEFAULT SEL root — the directory ``sel()`` would
+        resolve WITHOUT this module's per-test isolation, and the one a sibling
+        test's writer would actually hold — through its own file description,
+        which is how a foreign holder looks to ``flock``. On the shared-root
+        arrangement the fail-closed trust audit loses its single-shot acquire
+        against exactly this and the grant is refused (the #7029 failure
+        verbatim); with a private per-test root the holder is a stranger to the
+        audit, and trust must be granted.
+        """
+        # setUp already skipped when the isolation seam is absent, so this is
+        # the displaced session directory, never the operator's data home.
+        shared = sel_mod._default_dir()
+        lock_dir = shared / sel_mod._TRUST_SUBDIR
+        lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        lock_file = lock_dir / sel_mod._SEL_LOCK_FILE
+        # Same flags the code under test opens the sidecar with (sel.py), so
+        # the staged holder is byte-faithful on Windows too.
+        fd = os.open(
+            lock_file,
+            os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+        try:
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")  # Windows locks a byte RANGE; give it a byte
+            # The displaced session singleton's writer may itself be flushing
+            # to this root right now (its holds span one append batch), so a
+            # single-shot acquire here would inherit the very flake this
+            # commit retires. Retry non-blocking attempts — never a blocking
+            # acquire on the event-loop thread — until the transient hold
+            # clears; the budget is generous because a miss fails the test.
+            for _ in range(200):
+                if platform_compat.try_acquire_lock(fd, exclusive=True):
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                self.fail("could not stage the foreign holder on the shared root")
+            try:
+                slot = _FakeSlot("crew-c_7029iso")
+                slot._app = cr.APP_NAME
+                granted = cr.sync_trust(
+                    slot, {"id": "c_7029iso", "unattended": True, "enabled": True}
+                )
+                self.assertTrue(
+                    granted,
+                    "trust was refused: the audit contended for the SHARED root's "
+                    "chain lock, so this test's SEL root is not private (#7029)",
+                )
+                self.assertTrue(_effectively_trusted(slot))
+            finally:
+                platform_compat.release_lock(fd)
+        finally:
+            os.close(fd)
+        # The audit went somewhere real: fail-closed was not merely bypassed.
+        body = sel_mod.sel()._path.read_text(encoding="utf-8")
+        self.assertIn("safety_override:activate_scoped", body)
+
+    async def test_this_tests_sel_root_is_private_first_claim(self):
+        self._claim_root()
+
+    async def test_this_tests_sel_root_is_private_second_claim(self):
+        """Second claimant: on the pre-#7029 arrangement both tests resolve the
+        one session directory, so whichever of the pair runs second trips the
+        reuse assertion (and both trip the shared-default one)."""
+        self._claim_root()
+
+    def _claim_root(self) -> None:
+        root = str(sel_mod.sel()._dir)
+        self.assertNotEqual(
+            Path(root),
+            sel_mod._default_dir(),
+            "sel() resolved the SHARED default root: tests on this worker would "
+            "contend for one chain lock (#7029)",
+        )
+        self.assertNotIn(root, _CLAIMED_SEL_ROOTS, "SEL root reused across tests (#7029)")
+        _CLAIMED_SEL_ROOTS.add(root)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Closes #7029

## Problem

`test_enabling_again_restores_trust_and_the_loop` fails nondeterministically on the `Backend Tests (3.10, 2)` shard. The chain (all correct product behaviour, none of it changed here):

1. a concurrent writer holds the SEL chain lock;
2. the loop-side acquire is a **single non-blocking attempt** by design (`sel.py`) and refuses;
3. the fail-closed critical audit in `activate_scoped` therefore refuses the scoped grant (`safety_override.py:576` — "SEL audit failed; refusing scoped safety override activation");
4. `_effectively_trusted` reads False and the assertion fails.

The defect is **test isolation**: every test on an xdist worker shared ONE session-scoped SEL directory (`_isolate_sel_default_dir`), so a trust assertion transitively depended on winning a lock race against writers the test never created.

## Fix (direction 1 from the issue, as pinned by triage)

Remove the concurrent writer instead of coping with it:

- **`conftest.py` (rootdir)** — new **`sel_private_root`** fixture, the per-test tier of the existing `_isolate_sel_default_dir` seam: rebinds the `SecurityEventLog` singleton to a fresh `tmp_path_factory` directory (never deleted mid-run, so a lingering writer can never resurrect a removed path; basetemp is already per-xdist-worker `popen-gwN`), built `sync=True` so **no background writer starts at all**. `_default_dir()` is deliberately not repointed, keeping the displaced shared root observable for the differential test. Teardown restores the **prior** instance (not `None`) so the session default resumes without minting a second writer on the shared dir; construction happens inside the `try` so a failing init still restores it.
- **`test/test_issue_radar_crew_runtime.py`** — module-wide autouse hookup, plus `TestSelRootIsolation`:
  - `test_a_holder_of_the_shared_default_root_cannot_refuse_trust` — stages a foreign-fd flock on the **shared default root's** sidecar and drives `sync_trust`; pre-change this reproduces #7029 verbatim (trust refused), post-change the holder is a stranger to the audit. Skips outside pytest (raw `unittest` would resolve the operator's real `~/.kiro/crew`); stages its holder with bounded non-blocking retries so a transient flush by the displaced session writer cannot flake the staging step.
  - two claim tests pinning that no two tests resolve one SEL root (and never the shared default).
- **`docs/system-specs/common/testing-conventions.md`** — documents when the per-test tier applies.

Guardrails honoured: `src/kiro_crew/sel.py` and `src/kiro_crew/safety_override.py` **untouched**; sibling `test_a_grant_whose_audit_fails_is_never_usable` **byte-unchanged** and green.

## Acceptance evidence

1. Flaky test passes with isolation: full module `123 passed` (see below).
2. **Differential demonstrated both ways** (isolation hook temporarily neutralized, then restored — run twice, including on the final amended text):
   - pre-change: `3 failed`, lock test failing through the exact production line `ERROR kiro_crew.safety_override: SEL audit failed; refusing scoped safety override activation` → `AssertionError: trust was refused...`
   - post-change: `3 passed`.
3. Sibling test byte-unchanged (`git diff main -- <file> | grep test_a_grant_whose_audit_fails` → no hunks) and green.
4. Full backend suite vs pristine-main control (same host, same commands): failure sets **byte-identical** — 96 failed + 2 errors on both sides (known host-env failures), zero regression delta.
5. Repeated under xdist: 5× full-module `-n auto` runs + 3× post-amend runs, all `123 passed`; 4× stress runs interleaving `test_safety_override.py` (SEL-heavy neighbor) all green.

## Pre-push review (dual model-pinned lanes)

- **GPT 5.6 Sol: BLOCKING** — the differential test's own staging acquire was a single-shot that could lose a transient race against the displaced session writer (re-importing the flake into the new test). Adopted via a bounded retry of non-blocking attempts (`try_acquire_lock` + `asyncio.sleep`), never a blocking acquire on the loop thread — variant of the suggested `to_thread` fix, since `platform_compat` exposes no bare blocking acquire function.
- **Opus 5: BLOCKING** — under raw `python -m unittest` (no fixtures), the differential test would mkdir/flock inside the operator's **real** data home and could wedge a live gateway's chain lock (AUTOSDE `no-test-side-effects`). Adopted the suggested skip-guard (`_default_dir() == config_dir()` probes "isolation not installed"). Also adopted: Medium (singleton construction moved inside `try` so a failing init cannot orphan the prior instance), both Lows (O_NOFOLLOW/O_BINARY mirroring for Windows byte-fidelity; per-worker scope documented on the reuse assertion), and a comment clarifying the class-attr `_initialized` reset.

## Testing

- `isort` / `flake8` clean on changed files (branch output byte-identical to main's); `mypy src/kiro_crew/`: Success, 1177 files; `scripts/check_black_formatting.py` passed.
- Frontend untouched.
