### PR TITLE
fix: dispatch plan chips on double-click and send now

### DIFF
--- a/docs/system-specs/modules/autopilot.md
+++ b/docs/system-specs/modules/autopilot.md
@@ -134,7 +134,10 @@ from the displayed text so a stray earlier marker cannot leak as raw syntax, and
 sets `isPlan` when both a plan header and a stage marker are present. Every
 plan-chip gesture in an orchestrator slot — single click, double-click, and the
 Send-now segment — goes straight to `api.planAction(slot, action)` instead of
-filling the composer or sending the label as chat text. A typed `Cancel` is not
+filling the composer or sending the label as chat text. The send gestures pass
+the row identity captured on the first click of the gesture, so a footer that
+replaces the reused chip between the two clicks of a double-click is refused
+rather than approving a stage the user never saw. A typed `Cancel` is not
 special-cased server-side, so routing those two send gestures through the same
 gate is what makes the stop control actually stop the plan.
 

--- a/docs/system-specs/modules/autopilot.md
+++ b/docs/system-specs/modules/autopilot.md
@@ -131,10 +131,12 @@ appears to skip the gate entirely.
 `parseOptions` (`website/src/pages/chat/AssistantMessage.tsx:49`) takes the
 **last** `[OPTION(S): …]` marker for the button list, strips **every** marker
 from the displayed text so a stray earlier marker cannot leak as raw syntax, and
-sets `isPlan` when both a plan header and a stage marker are present. A click on
-a plan option in an orchestrator slot goes straight to
-`api.planAction(slot, action)` (`ChatPage.tsx:5097`) instead of filling the input
-box.
+sets `isPlan` when both a plan header and a stage marker are present. Every
+plan-chip gesture in an orchestrator slot — single click, double-click, and the
+Send-now segment — goes straight to `api.planAction(slot, action)` instead of
+filling the composer or sending the label as chat text. A typed `Cancel` is not
+special-cased server-side, so routing those two send gestures through the same
+gate is what makes the stop control actually stop the plan.
 
 ## Stage Gates
 

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -470,8 +470,9 @@ interface ChatInputProps {
    *  chip debounces, and the row can advance inside that window); `undefined`
    *  when no `followUpSourceKey` is supplied. */
   onFollowUpSelect?: (option: string, event: React.MouseEvent, sourceKeyAtClick?: string | null) => void
-  /** Double-click a follow-up option — send with option text directly (bypasses setInput race) */
-  onFollowUpSend?: (text?: string) => void
+  /** Immediate send (double-click / Send-now). Second arg is the click-time
+   *  row identity FollowUpBar already snapshots for onSelect. */
+  onFollowUpSend?: (text?: string, sourceKeyAtClick?: string | null) => void
   /** Quick Send enabled — clicking sends immediately */
   quickSend?: boolean
   /** Layout mode for the follow-up bar: 'multiline' (default) or 'scroll' (original single-line). */
@@ -1241,8 +1242,8 @@ function ChatInput({
     if (steerActive && onSteer) onSteer()
     else onSend()
   }, [disabled, voiceTranscribing, steerActive, onSteer, onSend])
-  const sendFollowUp = useCallback((text?: string) => {
-    if (!disabled) onFollowUpSend?.(text)
+  const sendFollowUp = useCallback((text?: string, sourceKeyAtClick?: string | null) => {
+    if (!disabled) onFollowUpSend?.(text, sourceKeyAtClick)
   }, [disabled, onFollowUpSend])
   const { botName } = useBranding()
   const isMobile = useIsMobile()

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -849,7 +849,23 @@ export default function ChatPane({
               setFollowUpPicked(next)
             }
           }}
-          onFollowUpSend={(text?: string) => doSend(text)}
+          onFollowUpSend={(text?: string) => {
+            // Double-click and the Send-now segment call onSend, not onSelect
+            // (#6240). A plan label must still hit the plan endpoint — a typed
+            // Cancel never stops the plan, and Go All loses auto-run.
+            if (text && followUpIsPlan && isPlanAction(text)) {
+              if (!paneSlot) return
+              if (paneSlot.mode === 'orchestrator') {
+                planActionMutationRef.current.mutate({
+                  slot: slotKey,
+                  action: text,
+                  clickedSourceKey: followUpSourceKey,
+                })
+                return
+              }
+            }
+            doSend(text)
+          }}
           project={paneSlot?.project ?? ''}
           onUploadFiles={uploadFiles}
           pendingFiles={pendingFiles}

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -176,6 +176,15 @@ export default function ChatPane({
   // click handler see the in-flight state, not the render it closed over.
   const planActionMutation = usePlanActionMutation(slotKey, followUpSourceKey)
   const planActionMutationRef = useRef(planActionMutation); planActionMutationRef.current = planActionMutation
+  // One spelling for every plan-chip gesture (single-click, double-click,
+  // Send-now). `sourceKeyAtClick` is the row the gesture started on.
+  const dispatchPlanFollowUp = (action: string, sourceKeyAtClick?: string | null): boolean => {
+    if (!(followUpIsPlan && isPlanAction(action))) return false
+    if (!paneSlot) return true
+    if (paneSlot.mode !== 'orchestrator') return false
+    planActionMutationRef.current.mutate({ slot: slotKey, action, clickedSourceKey: sourceKeyAtClick })
+    return true
+  }
   const followUpOptionsKey = followUpOptions.join('\x00')
   useEffect(() => { setFollowUpPicked(new Set()) }, [followUpOptionsKey, slotKey])
   // Quick Send parity with ChatPage: same query key, so the cache is shared
@@ -794,27 +803,9 @@ export default function ChatPane({
             // chat. A plan-SHAPED message carrying non-protocol labels keeps
             // the composer path — dispatching those would 400 server-side
             // while also skipping the append, leaving a dead chip.
-            if (followUpIsPlan && isPlanAction(o)) {
-              // Slot record not yet delivered (the first WS slots snapshot
-              // can land after this pane hydrates its transcript from the
-              // detail fetch, e.g. on a reload with a restored grid): the
-              // mode is UNKNOWN, so neither dispatching nor appending is
-              // safe — appending would type an approval label into the
-              // composer, the reported bug. No-op until the record resolves.
-              if (!paneSlot) return
-              if (paneSlot.mode === 'orchestrator') {
-                // No isPending pre-check here: single-flight lives in the
-                // hook's per-slot latch, which drops a duplicate Go/Go All
-                // but must let Cancel through — a render-scoped isPending
-                // check would swallow the stop control while a Go settles.
-                // `sourceKeyAtClick` is the row the user actually clicked on
-                // (the chip debounces 220ms and the row can be replaced by a
-                // byte-identical footer inside that window without remounting
-                // the chip); the hook refuses it if it no longer matches.
-                planActionMutationRef.current.mutate({ slot: slotKey, action: o, clickedSourceKey: sourceKeyAtClick })
-                return
-              }
-            }
+            // Slot record not yet delivered: dispatchPlanFollowUp no-ops
+            // rather than appending an approval label (the reported bug).
+            if (dispatchPlanFollowUp(o, sourceKeyAtClick)) return
             // One-click Quick Send takes the same gate as ChatPage: enabled +
             // no shift + not busy + not already in multi-select.
             if (tryQuickSend(o, dashCfg?.quick_send, e.shiftKey, busy, followUpPickedRef.current.size, (t: string) => doSend(t))) return
@@ -849,21 +840,11 @@ export default function ChatPane({
               setFollowUpPicked(next)
             }
           }}
-          onFollowUpSend={(text?: string) => {
-            // Double-click and the Send-now segment call onSend, not onSelect
-            // (#6240). A plan label must still hit the plan endpoint — a typed
-            // Cancel never stops the plan, and Go All loses auto-run.
-            if (text && followUpIsPlan && isPlanAction(text)) {
-              if (!paneSlot) return
-              if (paneSlot.mode === 'orchestrator') {
-                planActionMutationRef.current.mutate({
-                  slot: slotKey,
-                  action: text,
-                  clickedSourceKey: followUpSourceKey,
-                })
-                return
-              }
-            }
+          onFollowUpSend={(text?: string, sourceKeyAtClick?: string | null) => {
+            // Double-click and Send-now share dispatchPlanFollowUp with
+            // single-click (#6240). `sourceKeyAtClick` is the first-click
+            // row — a straddled double-click on a replaced footer is refused.
+            if (text && dispatchPlanFollowUp(text, sourceKeyAtClick)) return
             doSend(text)
           }}
           project={paneSlot?.project ?? ''}

--- a/website/src/components/FollowUpBar.tsx
+++ b/website/src/components/FollowUpBar.tsx
@@ -15,8 +15,13 @@ interface FollowUpBarProps {
    * every existing caller keeps typechecking and behaves exactly as before.
    */
   onSelect: (option: string, event: React.MouseEvent, sourceKeyAtClick?: string | null) => void
-  /** Double-click sends with this option's text directly (bypasses setInput race). */
-  onSend?: (text?: string) => void
+  /**
+   * Immediate send (double-click / Send-now). Second arg is the row identity
+   * captured on the FIRST click of the gesture — same snapshot `onSelect`
+   * already receives — so a footer that replaces the reused chip between the
+   * two clicks of a double-click cannot approve the replacement stage.
+   */
+  onSend?: (text?: string, sourceKeyAtClick?: string | null) => void
   quickSend?: boolean
   /** 'multiline' (default) wraps onto multiple rows; 'scroll' is a single-line horizontally-scrollable view. */
   layout?: FollowUpLayout
@@ -231,7 +236,7 @@ interface ChipProps {
   picked: ReadonlySet<string>
   quickSend: boolean | undefined
   onSelect: (option: string, event: React.MouseEvent, sourceKeyAtClick?: string | null) => void
-  onSend?: (text?: string) => void
+  onSend?: (text?: string, sourceKeyAtClick?: string | null) => void
   className: string
   /** Position in the row, used for the entrance stagger. */
   index: number
@@ -252,6 +257,11 @@ interface ChipProps {
  */
 function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className, index, animating, sourceKey }: ChipProps) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // First-click row identity for the in-flight gesture. A double-click is
+  // click(detail=1) then dblclick; the footer can be replaced on the reused
+  // chip between those two, so onSend must use the key from the FIRST click,
+  // not whatever row is current when the second lands.
+  const armedSourceKeyRef = useRef<string | null | undefined>(undefined)
   useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
 
   const useDebouncedClick = !!onSend && !(quickSend && !isPicked && picked.size === 0)
@@ -305,17 +315,21 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
     // current now". Read through the render closure deliberately: a ref would
     // be re-read when the timer fires, which is exactly the bug.
     const sourceKeyAtClick = sourceKey
+    armedSourceKeyRef.current = sourceKeyAtClick
     timerRef.current = setTimeout(() => {
       timerRef.current = null
+      armedSourceKeyRef.current = undefined
       onSelect(option, synth, sourceKeyAtClick)
     }, FOLLOWUP_CHIP_DEBOUNCE_MS)
   }
 
-  const handleDoubleClick = () => {
+  const handleImmediateSend = () => {
     if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null }
+    const clickedKey = armedSourceKeyRef.current !== undefined ? armedSourceKeyRef.current : sourceKey
+    armedSourceKeyRef.current = undefined
     // Pass option text directly to send() so it doesn't race with setInput.
     // If already picked, send() will use the current input (which already contains o).
-    onSend?.(isPicked ? undefined : option)
+    onSend?.(isPicked ? undefined : option, clickedKey)
   }
 
   // Inside the split-button wrapper the WRAPPER (below) is the capped, shrink-0
@@ -333,7 +347,7 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
       // prompt clears"). Deliberate keyboard (tab) activation still toggles.
       onMouseDown={(e) => e.preventDefault()}
       onClick={handleClick}
-      onDoubleClick={handleDoubleClick}
+      onDoubleClick={handleImmediateSend}
       className={mainChipClassName}
       style={showSendSegment ? undefined : entrance.style}
       title={title}
@@ -358,7 +372,7 @@ function Chip({ option, isPicked, picked, quickSend, onSelect, onSend, className
         aria-label={i18nT('components.followUpBar.send_now_2', { option })}
         title={i18nT('components.followUpBar.send_now')}
         onMouseDown={(e) => e.preventDefault()}
-        onClick={(e) => { e.stopPropagation(); if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null }; onSend?.(isPicked ? undefined : option) }}
+        onClick={(e) => { e.stopPropagation(); handleImmediateSend() }}
         className={sendSegmentClassName(isPicked)}
       >
         <ArrowUp size={13} />

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -5239,6 +5239,19 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // `mode` prop is always '' — the slot's own mode is the source of truth for
   // header identity (Autopilot icon + tooltip).
   const effectiveMode = currentSlot?.mode || mode
+  // One spelling for every plan-chip gesture (single-click, double-click,
+  // Send-now). `sourceKeyAtClick` is the row the gesture started on.
+  const dispatchPlanFollowUp = (action: string, sourceKeyAtClick?: string | null): boolean => {
+    if (!(followUpIsPlan && isPlanAction(action) && effectiveMode === 'orchestrator' && activeSlot)) {
+      return false
+    }
+    planActionMutationRef.current.mutate({
+      slot: activeSlot,
+      action,
+      clickedSourceKey: sourceKeyAtClick,
+    })
+    return true
+  }
   const title = currentSlot?.title && currentSlot.title !== currentSlot.key ? currentSlot.title : activeSlot || ''
   const displayMode = approvalMode === 'yolo' ? 'yolo' : currentSlot?.trust ? 'trust' : currentSlot?.trust_reads ? 'trust_reads' : 'normal'
   // Resolve model for existing slots that don't have one stored
@@ -7965,18 +7978,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               onSend={() => send()}
               canSteer={composerBusy}
               onSteer={steer}
-              onFollowUpSend={(text?: string) => {
-                // Double-click and the Send-now segment call onSend, not
-                // onSelect (#6240). Same plan gate as the single-click
-                // branch below: a typed Cancel never stops the plan.
-                if (text && followUpIsPlan && isPlanAction(text) && effectiveMode === 'orchestrator' && activeSlot) {
-                  planActionMutationRef.current.mutate({
-                    slot: activeSlot,
-                    action: text,
-                    clickedSourceKey: followUpSourceKey,
-                  })
-                  return
-                }
+              onFollowUpSend={(text?: string, sourceKeyAtClick?: string | null) => {
+                // Double-click and Send-now share dispatchPlanFollowUp with
+                // single-click (#6240). First-click row identity refuses a
+                // straddled double-click on a replaced footer.
+                if (text && dispatchPlanFollowUp(text, sourceKeyAtClick)) return
                 send(text)
               }}
               disabled={
@@ -8154,17 +8160,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 // Plan options (Go / Go All / Cancel) dispatch directly — no input fill.
                 // Non-protocol labels on a plan-shaped message keep the composer path:
                 // the endpoint would 400 them while the append was already skipped.
-                if (followUpIsPlan && isPlanAction(o) && effectiveMode === 'orchestrator' && activeSlot) {
-                  // No isPending pre-check: single-flight lives in the hook's
-                  // per-slot latch, which drops a duplicate Go/Go All but lets
-                  // Cancel through — a render-scoped isPending check would
-                  // swallow the stop control while a Go settles.
-                  // `sourceKeyAtClick` is the row the click was made on (the
-                  // chip debounces 220ms and an identical replacement footer
-                  // does not remount it); the hook refuses a stale one.
-                  planActionMutationRef.current.mutate({ slot: activeSlot, action: o, clickedSourceKey: sourceKeyAtClick })
-                  return
-                }
+                if (dispatchPlanFollowUp(o, sourceKeyAtClick)) return
                 // One-click: enabled + no shift + not busy + not already in multi-select
                 if (tryQuickSend(o, dashCfg?.quick_send, e.shiftKey, slotRunning, followUpPickedRef.current.size, send)) return
                 // Regular options: toggle. Click unpicked → append + mark; click

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -7965,7 +7965,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               onSend={() => send()}
               canSteer={composerBusy}
               onSteer={steer}
-              onFollowUpSend={(text?: string) => send(text)}
+              onFollowUpSend={(text?: string) => {
+                // Double-click and the Send-now segment call onSend, not
+                // onSelect (#6240). Same plan gate as the single-click
+                // branch below: a typed Cancel never stops the plan.
+                if (text && followUpIsPlan && isPlanAction(text) && effectiveMode === 'orchestrator' && activeSlot) {
+                  planActionMutationRef.current.mutate({
+                    slot: activeSlot,
+                    action: text,
+                    clickedSourceKey: followUpSourceKey,
+                  })
+                  return
+                }
+                send(text)
+              }}
               disabled={
                 /* Streaming, compaction, and stopping all
                    keep the input interactive: api_chat queues on slot.running and

--- a/website/src/test/ChatPage.followUpToggle.test.tsx
+++ b/website/src/test/ChatPage.followUpToggle.test.tsx
@@ -303,4 +303,22 @@ describe('ChatPage plan follow-ups (issue #5893 parity)', () => {
     expect(composer().value).toBe('Approve it')
     expect(api.planAction).not.toHaveBeenCalled()
   })
+
+  it('double-click on a plan chip dispatches the plan action, never sendChat (issue #6240)', async () => {
+    await renderPage(ASSISTANT_WITH_PLAN, 'orchestrator', 'Go', 'chat-plan-dbl')
+    fireEvent.doubleClick(chip('Go'))
+    await waitFor(() => expect(api.planAction).toHaveBeenCalledTimes(1))
+    expect(api.planAction).toHaveBeenCalledWith('chat-plan-dbl', 'Go')
+    expect(api.sendChat).not.toHaveBeenCalled()
+    expect(composer().value).toBe('')
+  })
+
+  it('Send now on a plan chip dispatches the plan action, never sendChat (issue #6240)', async () => {
+    await renderPage(ASSISTANT_WITH_PLAN, 'orchestrator', 'Go', 'chat-plan-sendnow')
+    fireEvent.click(screen.getByRole('button', { name: 'Send now: Go All' }))
+    await waitFor(() => expect(api.planAction).toHaveBeenCalledTimes(1))
+    expect(api.planAction).toHaveBeenCalledWith('chat-plan-sendnow', 'Go All')
+    expect(api.sendChat).not.toHaveBeenCalled()
+    expect(composer().value).toBe('')
+  })
 })

--- a/website/src/test/ChatPane.followUpOptions.test.tsx
+++ b/website/src/test/ChatPane.followUpOptions.test.tsx
@@ -690,6 +690,29 @@ describe('ChatPane plan follow-ups dispatch (issue #5893)', () => {
     expect(composer().value).toBe('')
   })
 
+  it('a double-click whose footer is REPLACED between clicks never dispatches (issue #6240 race)', async () => {
+    // First click of a double-click arms the chip with row-1. A byte-identical
+    // replacement footer reuses the chip; the second click must hand the
+    // FIRST-click key to onSend so the hook refuses the replacement stage.
+    const store = await renderPane('pane-plan-dbl-stale', { mode: 'orchestrator' }, PLAN_MESSAGES)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Go' })).toBeTruthy())
+    vi.useFakeTimers()
+    await act(async () => { fireEvent.click(chip('Go'), { detail: 1 }) })
+    await act(async () => {
+      store.dispatch(appendSlotMessage({
+        slot: 'pane-plan-dbl-stale',
+        message: { role: 'assistant', content: ASSISTANT_WITH_PLAN, ts: '2026-08-25T00:06:00Z' } as never,
+      }))
+    })
+    await act(async () => {
+      fireEvent.click(chip('Go'), { detail: 2 })
+      fireEvent.doubleClick(chip('Go'))
+    })
+    expect(api.planAction).not.toHaveBeenCalled()
+    expect(api.sendChat).not.toHaveBeenCalled()
+    expect(composer().value).toBe('')
+  })
+
   it('Send now on a NON-plan chip still sends the label through the pane\'s send path', async () => {
     await renderPane('pane-plan-sendnow-plain', { mode: 'orchestrator' }, PANE_MESSAGES)
     await waitFor(() => expect(screen.getByRole('button', { name: 'Alpha' })).toBeTruthy())

--- a/website/src/test/ChatPane.followUpOptions.test.tsx
+++ b/website/src/test/ChatPane.followUpOptions.test.tsx
@@ -665,6 +665,42 @@ describe('ChatPane plan follow-ups dispatch (issue #5893)', () => {
     expect(api.planAction).toHaveBeenCalledWith('pane-bg', 'Go')
   })
 
+  it('double-click on a plan chip dispatches the plan action, never sendChat (issue #6240)', async () => {
+    // Single-click is the #5893 / #6040 path. Double-click used to call
+    // onSend(label) and type "Go" / "Cancel" as ordinary chat.
+    await renderPane('pane-plan-dbl', { mode: 'orchestrator' }, PLAN_MESSAGES)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Go' })).toBeTruthy())
+    fireEvent.doubleClick(chip('Go'))
+    await waitFor(() => expect(api.planAction).toHaveBeenCalledTimes(1))
+    expect(api.planAction).toHaveBeenCalledWith('pane-plan-dbl', 'Go')
+    expect(api.sendChat).not.toHaveBeenCalled()
+    expect(composer().value).toBe('')
+  })
+
+  it('Send now on a plan chip dispatches the plan action, never sendChat (issue #6240)', async () => {
+    // The visible split-button segment is the discoverable form of the same
+    // onSend bypass. Cancel is the sharp edge: a typed Cancel never stops the
+    // plan.
+    await renderPane('pane-plan-sendnow', { mode: 'orchestrator' }, PLAN_MESSAGES)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Send now: Cancel' }))
+    await waitFor(() => expect(api.planAction).toHaveBeenCalledTimes(1))
+    expect(api.planAction).toHaveBeenCalledWith('pane-plan-sendnow', 'Cancel')
+    expect(api.sendChat).not.toHaveBeenCalled()
+    expect(composer().value).toBe('')
+  })
+
+  it('Send now on a NON-plan chip still sends the label through the pane\'s send path', async () => {
+    await renderPane('pane-plan-sendnow-plain', { mode: 'orchestrator' }, PANE_MESSAGES)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Alpha' })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Send now: Alpha' }))
+    await waitFor(() => expect(api.sendChat).toHaveBeenCalledTimes(1))
+    const [wireText, slot] = (api.sendChat as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(wireText).toBe('Alpha')
+    expect(slot).toBe('pane-plan-sendnow-plain')
+    expect(api.planAction).not.toHaveBeenCalled()
+  })
+
   it('a click whose footer is REPLACED during the 220ms debounce never dispatches (host forwards the click-time row)', async () => {
     // End-to-end proof of the wiring, not just the hook: FollowUpBar snapshots
     // its sourceKey at click time, ChatInput forwards it, and the pane hands it

--- a/website/src/test/FollowUpBar.test.tsx
+++ b/website/src/test/FollowUpBar.test.tsx
@@ -133,7 +133,7 @@ describe('FollowUpBar', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Go' }), { detail: 1 })
       fireEvent.click(screen.getByRole('button', { name: 'Go' }), { detail: 2 })
       fireEvent.dblClick(screen.getByRole('button', { name: 'Go' }))
-      expect(onSend).toHaveBeenCalledWith('Go')
+      expect(onSend).toHaveBeenCalledWith('Go', undefined)
       expect(onSend).toHaveBeenCalledTimes(1)
       expect(onSelect).not.toHaveBeenCalled() // timer cancelled
       act(() => { vi.advanceTimersByTime(250) })
@@ -150,7 +150,7 @@ describe('FollowUpBar', () => {
       fireEvent.dblClick(screen.getByRole('button', { name: 'Go' }))
       expect(onSelect).not.toHaveBeenCalled()
       expect(onSend).toHaveBeenCalledTimes(1)
-      expect(onSend).toHaveBeenCalledWith(undefined)
+      expect(onSend).toHaveBeenCalledWith(undefined, undefined)
     })
 
     it('chip title hints at double-click capability', () => {
@@ -180,7 +180,7 @@ describe('FollowUpBar', () => {
       render(<FollowUpBar options={['Go']} picked={new Set()} onSelect={onSelect} onSend={onSend} />)
       fireEvent.click(screen.getByRole('button', { name: 'Send now: Go' }))
       expect(onSend).toHaveBeenCalledTimes(1)
-      expect(onSend).toHaveBeenCalledWith('Go')
+      expect(onSend).toHaveBeenCalledWith('Go', undefined)
       expect(onSelect).not.toHaveBeenCalled()
     })
 
@@ -189,7 +189,7 @@ describe('FollowUpBar', () => {
       const onSend = vi.fn()
       render(<FollowUpBar options={['Go']} picked={new Set(['Go'])} onSelect={onSelect} onSend={onSend} />)
       fireEvent.click(screen.getByRole('button', { name: 'Send now: Go' }))
-      expect(onSend).toHaveBeenCalledWith(undefined)
+      expect(onSend).toHaveBeenCalledWith(undefined, undefined)
     })
 
     it('clicking the send segment cancels a pending debounced onSelect from the main chip', () => {
@@ -527,6 +527,33 @@ describe('FollowUpBar', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Go All' }), { detail: 1 })
       act(() => { vi.advanceTimersByTime(FOLLOWUP_CHIP_DEBOUNCE_MS + 30) })
       expect(onSelect).toHaveBeenCalledWith('Go All', expect.any(Object), 'row-1')
+    })
+
+    it('hands onSend the sourceKey from FIRST click when the row advances mid-double-click', () => {
+      const onSelect = vi.fn()
+      const onSend = vi.fn()
+      const bar = (sourceKey: string) => (
+        <FollowUpBar options={PLAN} picked={new Set()} onSelect={onSelect} onSend={onSend} sourceKey={sourceKey} />
+      )
+      const { rerender } = render(bar('row-1'))
+      const go = screen.getByRole('button', { name: 'Go' })
+      fireEvent.click(go, { detail: 1 })
+      rerender(bar('row-2'))
+      expect(screen.getByRole('button', { name: 'Go' })).toBe(go)
+      fireEvent.click(go, { detail: 2 })
+      fireEvent.dblClick(go)
+      expect(onSend).toHaveBeenCalledTimes(1)
+      expect(onSend).toHaveBeenCalledWith('Go', 'row-1')
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('hands onSend the current sourceKey on a Send-now click with no prior arm', () => {
+      const onSelect = vi.fn()
+      const onSend = vi.fn()
+      render(<FollowUpBar options={PLAN} picked={new Set()} onSelect={onSelect} onSend={onSend} sourceKey="row-1" />)
+      fireEvent.click(screen.getByRole('button', { name: 'Send now: Go' }))
+      expect(onSend).toHaveBeenCalledWith('Go', 'row-1')
+      expect(onSelect).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** Dispatch-only change — plan chips look the same; double-click and Send now now hit the plan endpoint instead of chatting the label.

## Problem / Motivation

On an orchestrator plan footer, a **double-click** or a click on the visible **Send now** arrow sent the chip label (`Go`, `Go All`, `Cancel`) as ordinary chat instead of POSTing `/api/chat/slots/{slot}/plan-action`.

`Cancel` is the sharp edge: a typed Cancel is not special-cased server-side, so the user pressed the stop control and the plan kept running.

## Why it matters

Single-click already dispatched correctly (#6040 / #5893). The two remaining send gestures skipped that gate, so the discoverable Send-now control and a habitual double-click both bypassed the plan endpoint and its per-slot single-flight latches.

## What changed (motivation → approach → change)

FollowUpBar's double-click and Send-now segment call `onSend`, not `onSelect`. Hosts wired `onSend` straight to `send()` / `doSend()`.

`onSend` now carries the same click-time row identity `onSelect` already receives, so a footer that replaces the reused chip between the two clicks of a double-click is refused instead of approving the next stage. ChatPage and ChatPane each have one `dispatchPlanFollowUp` helper used by every gesture. SideChat and ChatEmbed still drop `followUpIsPlan` on purpose (#6057 / #6754).

The autopilot spec names all three gestures and the first-click row snapshot.

## Tests

- FollowUpBar: double-click after a mid-gesture footer replacement hands `onSend` the first-click key; Send-now hands the current key.
- ChatPane: double-click on `Go` and Send now on `Cancel` dispatch `planAction`; a straddled double-click after a replacement footer does not dispatch; Send now on a non-plan chip still sends the label.
- ChatPage: double-click on `Go` and Send now on `Go All` dispatch `planAction`.

`npx vitest run src/test/FollowUpBar.test.tsx src/test/ChatPane.followUpOptions.test.tsx src/test/ChatPage.followUpToggle.test.tsx` — 90 passed.

## Manual verification

N/A — unit coverage drives the real ChatPage/ChatPane handlers through the real FollowUpBar gestures, including the replaced-footer race. No visual change.

## Related Issues

Fixes #6240

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (autopilot frontend-rendering section)
- [x] No secrets, credentials, or internal references in the diff