### PR TITLE
fix: preserve ConfirmationRequired across the plugin error boundary

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -15,6 +15,7 @@ import base64
 import contextlib
 import fnmatch
 import hashlib
+import itertools
 import json
 import logging
 import os
@@ -653,11 +654,19 @@ def source_link_path_markers() -> tuple[str, ...]:
             continue
         if isinstance(extra, str) or not isinstance(extra, Iterable):
             continue
-        for marker in list(extra)[:_MAX_PLUGIN_PATH_MARKERS]:
+        for marker in itertools.islice(extra, _MAX_PLUGIN_PATH_MARKERS):
             # At least two characters beyond the leading slash: a bare "/" (or a
             # one-character marker) would admit essentially every URL and turn
-            # the prefilter into a full parse of the whole transcript.
-            if isinstance(marker, str) and marker.startswith("/") and len(marker) >= 3:
+            # the prefilter into a full parse of the whole transcript. The upper
+            # bound keeps a runaway string out of the scanner's per-candidate
+            # substring checks; no realistic path marker approaches it. islice
+            # rather than list()[:n] so a generator-returning hook is consumed
+            # only up to the cap instead of exhausted before slicing.
+            if (
+                isinstance(marker, str)
+                and marker.startswith("/")
+                and 3 <= len(marker) <= _MAX_PLUGIN_PATH_MARKER_LEN
+            ):
                 markers.append(marker)
     return tuple(dict.fromkeys(markers))
 
@@ -666,6 +675,10 @@ def source_link_path_markers() -> tuple[str, ...]:
 # with several URL shapes, small enough that the scanner's per-candidate cost
 # stays bounded no matter how many providers register.
 _MAX_PLUGIN_PATH_MARKERS = 8
+
+# Ceiling on one marker's length: markers are substring-searched against every
+# URL candidate in a transcript, so their size is part of the scanner's cost.
+_MAX_PLUGIN_PATH_MARKER_LEN = 64
 
 
 def _plugin_for_change(ref: SourceRef) -> SourceProviderPlugin | None:
@@ -716,6 +729,14 @@ def _plugin_errors(plugin_id: str) -> Iterator[None]:
 
     The exception TYPE is preserved so each caller's own handling, and the
     status code each maps to, are unchanged; only the message is scrubbed.
+
+    Deliberately NOT ``except Exception``: an unlisted type (a plugin's bare
+    ``RuntimeError``, ``KeyError``, its own class) propagates to a generic 500
+    whose body carries no exception text, so there is nothing to scrub on that
+    route. That safety lives in the response handlers only writing
+    ``SourceProviderError`` / ``ValueError`` text into client-visible bodies --
+    anyone widening a handler to render other exception text must widen this
+    boundary in the same change.
     """
     try:
         yield
@@ -728,6 +749,20 @@ def _plugin_errors(plugin_id: str) -> Iterator[None]:
     except SourceProviderError as exc:
         raise SourceProviderError(
             _safe_error_text(str(exc), fallback=f"the {plugin_id} source provider failed")
+        ) from exc
+    except ConfirmationRequired as exc:
+        # A ``ValueError`` subclass with response semantics: it is what makes
+        # `_owner_mutation_response` add ``confirmationRequired: True`` to the
+        # 400 body, which is the client's only cue to offer the confirm-and-
+        # retry affordance. Downcasting it to the parent arm below turns a
+        # plugin's answerable refusal into a dead-end error, so it keeps its
+        # type just as the ``SourceProviderError`` subclasses above keep
+        # theirs. (Defined later in the module; an ``except`` clause is only
+        # resolved when this context manager actually runs.)
+        raise ConfirmationRequired(
+            _safe_error_text(
+                str(exc), fallback=f"the {plugin_id} source provider needs confirmation"
+            )
         ) from exc
     except ValueError as exc:
         raise ValueError(

--- a/test/test_source_provider_plugin.py
+++ b/test/test_source_provider_plugin.py
@@ -156,6 +156,37 @@ def test_path_markers_include_the_plugin_contribution(plugin) -> None:
         assert builtin in markers
 
 
+def test_path_markers_refuse_prefilter_defeating_contributions(plugin) -> None:
+    # A bare "/" (or any one-character marker) would admit essentially every
+    # URL and turn the prefilter into a full parse of the whole transcript,
+    # and an unbounded marker inflates every substring check the scanner runs.
+    # Only the well-formed contribution survives.
+    plugin.path_markers = lambda: ["/", "/x", "cr/", "/" + "a" * 100, "/ok/"]
+    markers = source.source_link_path_markers()
+    assert "/ok/" in markers
+    for rejected in ("/", "/x", "cr/", "/" + "a" * 100):
+        assert rejected not in markers
+
+
+def test_path_markers_cap_consumption_of_a_generator_hook(plugin) -> None:
+    # "Bounded per plugin" must hold for the materialization step too: islice
+    # stops pulling at the cap, so a generator-returning hook is not exhausted
+    # before slicing.
+    consumed: list[int] = []
+
+    def markers_gen():
+        for index in range(50):
+            consumed.append(index)
+            yield f"/gen{index:02d}/"
+
+    plugin.path_markers = lambda: markers_gen()
+    contributed = [m for m in source.source_link_path_markers() if m.startswith("/gen")]
+    assert len(contributed) == source._MAX_PLUGIN_PATH_MARKERS
+    # islice may look one element past the cap, but a list()-then-slice would
+    # have consumed all 50 -- the exhaustion is what the bound forbids.
+    assert len(consumed) <= source._MAX_PLUGIN_PATH_MARKERS + 1
+
+
 @pytest.mark.asyncio
 async def test_fetch_pull_request_dispatches_redacts_and_caches(plugin) -> None:
     first = await source.fetch_pull_request(CR_URL)
@@ -267,6 +298,24 @@ async def test_capacity_error_from_a_plugin_keeps_its_retryable_type(plugin) -> 
     plugin.fetch_full = fetch_full
     with pytest.raises(source.SourceCapacityError):
         await source.fetch_pull_request(CR_URL)
+
+
+@pytest.mark.asyncio
+async def test_confirmation_required_from_a_plugin_keeps_its_answerable_type(plugin) -> None:
+    # `ConfirmationRequired` is what makes the mutation response carry
+    # `confirmationRequired: True` -- the client's only cue to offer the
+    # confirm-and-retry affordance. The redaction boundary must not downcast
+    # it to the plain-`ValueError` arm (which would render a dead-end error),
+    # and its message is scrubbed like any other plugin failure text.
+    async def enable_auto_merge(ref, *, confirm_immediate_merge: bool = False):
+        raise source.ConfirmationRequired(
+            "would merge now; token=ghp_0123456789abcdefghijklmnopqrstuvwxyz"
+        )
+
+    plugin.enable_auto_merge = enable_auto_merge
+    with pytest.raises(source.ConfirmationRequired) as excinfo:
+        await source.enable_pull_request_auto_merge(CR_URL)
+    assert "ghp_" not in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/website/src/test/sourceProviderSeam.test.ts
+++ b/website/src/test/sourceProviderSeam.test.ts
@@ -121,6 +121,22 @@ describe('extraction through the registry', () => {
       { url: 'https://github.com/acme/widgets/pull/12', provider: 'github', number: 12, repo: 'widgets', kind: 'change' },
     ])
   })
+
+  it('hands each descriptor a fresh URL — one mutating it cannot blind the next', () => {
+    // URL is mutable, so without a per-descriptor copy this first descriptor's
+    // pathname rewrite would be what the acme parser (registered after it)
+    // receives, and the real match would silently never happen.
+    registerSourceProvider({
+      ...acmeProvider,
+      id: 'vandal',
+      parse(url) {
+        url.pathname = '/defaced'
+        return null
+      },
+    })
+    registerSourceProvider(acmeProvider)
+    expect(parseSourceLinkUrl(CR_URL)?.provider).toBe('acme')
+  })
 })
 
 describe('chip labels', () => {


### PR DESCRIPTION
Follow-up to #6925, addressing the [post-merge audit](https://github.com/kirodotdev/KiroCrew/pull/6925#issuecomment-5471194109). One real defect, two test gaps the audit showed the suite could not falsify, and two of the smaller hardening notes.

## The defect: `ConfirmationRequired` downcast on the plugin path

`_plugin_errors()` had no arm for `ConfirmationRequired(ValueError)`, so a plugin's `enable_auto_merge` raising it to request the confirm-and-retry round trip was flattened to plain `ValueError`: `isinstance(exc, ConfirmationRequired)` in `_owner_mutation_response` went `False`, the 400 body dropped `confirmationRequired: true`, and the dashboard rendered a dead-end error with no confirm affordance — the only thing the forwarded `confirm_immediate_merge` parameter exists to enable. Fixed with a subclass arm ahead of `except ValueError`, matching the three `SourceProviderError` subclass arms above it. Only registered providers were affected; the built-in GitLab path raises outside the boundary.

## Closing the two unfalsifiable guards

- **Backend:** a plugin contributing `["/", "/x", "cr/", "/" + "a"*100, "/ok/"]` now pins that only `/ok/` survives `source_link_path_markers()` — previously removing the `len >= 3` check left 20/20 green.
- **Frontend:** a descriptor that rewrites `url.pathname` and returns `null` is registered ahead of the acme descriptor, pinning the fresh-`URL`-per-descriptor copy in `parseRegisteredCandidate` — previously passing the shared object left 17/17 green.

## Smaller notes from the audit

- `itertools.islice` replaces `list(extra)[:_MAX_PLUGIN_PATH_MARKERS]`, so a generator-returning `path_markers()` hook is no longer exhausted before slicing ("bounded per plugin" now holds for the materialization step); pinned by a counting-generator test.
- An individual marker now has a length ceiling (`_MAX_PLUGIN_PATH_MARKER_LEN = 64`), since markers are substring-searched against every URL candidate.
- `_plugin_errors`' docstring now names the real reason a narrow catch is safe (handlers only write `SourceProviderError`/`ValueError` text into response bodies) and instructs anyone widening a handler to widen the boundary in the same change.

Not taken here: the capability-drift decision (deriving descriptor `capabilities` server-side from hook presence) is a design change that deserves its own PR; the `Basic`-auth / presigned-URL redaction patterns live in `security.py` and are separate scope.

## Testing

- `pytest test/test_source_provider_plugin.py` — 23 passed (3 new).
- Falsification by mutation, each reddening exactly its pinning test: removed the `ConfirmationRequired` arm; relaxed the min-length bound; relaxed the max-length bound; reverted islice to list-slice; shared the `URL` object across descriptors (vitest 1 failed / 17 passed).
- `test/test_source_providers.py` + comment-guard suite: 489 passed; the 2 `test_provider_executable_accepts_*` failures are the known temp-ancestor-ownership environment dependency (uid 65534 userns host), present unmodified on `main`.
- `tsc -b` clean, `vitest run src/test/sourceProviderSeam.test.ts` 18/18, black/isort/flake8/mypy (`--platform linux`) clean on touched files.
