### PR TITLE
fix(sandbox): screen pinned-spawn PATH by directory identity, not lexically

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -6580,21 +6580,72 @@ def _resolve_spawn_target(
     return found
 
 
-def _absolutely_rooted_path(env: "Mapping[str, str] | None") -> "dict[str, str]":
-    """A copy of *env* whose ``PATH`` keeps only its absolute entries.
+def _pinned_spawn_path(
+    env: "Mapping[str, str] | None", *, chdir_fd: int | None = None
+) -> "dict[str, str]":
+    """A copy of *env* whose ``PATH`` keeps only entries safe under a pinned cwd.
 
     For resolving a command when the child's working directory is pinned by
-    descriptor: a relative entry (``''``, ``.``, ``tools``) is resolved against that
-    directory, which is the one place the pin says not to trust by name. Dropping
-    them can leave ``PATH`` empty, and that is the intended outcome -- the resolve
-    then raises ``FileNotFoundError`` exactly as an unresolvable command already
-    did, rather than silently searching somewhere else.
+    descriptor. Two screens, cheapest first:
+
+    * **Lexical** -- only absolute entries survive. A relative entry (``''``,
+      ``.``, ``tools``) is resolved against the pinned directory, which is the
+      one place the pin says not to trust by name.
+    * **Identity** (when *chdir_fd* is given) -- an absolute entry that IS the
+      pinned directory, or lives anywhere beneath it, is dropped too.
+      ``PATH=/home/me/.kiro/crew/workspace/bin:/usr/bin`` passes the lexical
+      screen unchanged, yet a binary planted behind such an entry wins the
+      child's own later lookup the moment the shim has entered the pinned
+      directory. Entries are compared by ``(st_dev, st_ino)`` ancestry walked
+      over descriptors -- never by pathname -- so a symlink or other alias of
+      the pinned directory cannot dodge the screen. An entry that cannot be
+      opened or walked is dropped, fail-closed per entry: an unopenable entry
+      cannot contribute a resolvable binary today, and dropping is the
+      direction that cannot be gamed by making a directory un-``stat``-able.
+
+    When the BOUND descriptor's own identity cannot be read there is nothing to
+    compare entries against, so the lexical screen stands alone for that spawn.
+    That is a deliberate degrade, not a silent fallback: in production
+    ``chdir_fd`` always originates from a real opened directory descriptor, and
+    one that cannot be ``fstat``-ed is one the shim's own ``fchdir`` rejects
+    before any command runs.
+
+    Dropping entries can leave ``PATH`` empty, and that is the intended outcome
+    -- the resolve then raises ``FileNotFoundError`` exactly as an unresolvable
+    command already did, rather than silently searching somewhere else.
     """
     source = dict(env if env is not None else os.environ)
     raw = source.get("PATH") or os.defpath
-    source["PATH"] = os.pathsep.join(
-        entry for entry in raw.split(os.pathsep) if entry and os.path.isabs(entry)
-    )
+    entries = [entry for entry in raw.split(os.pathsep) if entry and os.path.isabs(entry)]
+    bound_identity: "tuple[int, int] | None" = None
+    if chdir_fd is not None:
+        try:
+            bound_info = os.fstat(chdir_fd)
+        except OSError:
+            bound_identity = None
+        else:
+            bound_identity = (bound_info.st_dev, bound_info.st_ino)
+    if bound_identity is not None:
+        screened: list[str] = []
+        for entry in entries:
+            try:
+                entry_fd = _open_directory_descriptor(entry)
+            except OSError:
+                continue
+            try:
+                ancestors = _directory_ancestor_identities(entry_fd)
+            except OSError:
+                continue
+            finally:
+                os.close(entry_fd)
+            # The walk yields the entry's OWN identity first, so one membership
+            # test covers both "the entry IS the pinned directory" and "the
+            # entry lives beneath it".
+            if bound_identity in ancestors:
+                continue
+            screened.append(entry)
+        entries = screened
+    source["PATH"] = os.pathsep.join(entries)
     return source
 
 
@@ -6632,14 +6683,17 @@ async def create_subprocess_limited(
     re-verified would reopen the window the descriptor exists to close.
 
     Setting it also DROPS ``cwd`` from the spawn, since ``Popen`` would otherwise
-    chdir that pathname in the fork child before the shim ever runs, and narrows
-    ``PATH`` to its ABSOLUTE entries -- for the search that resolves a bare command
-    name here AND for the child's own environment. ``execvpe`` resolved a relative
-    entry against the child's cwd, the directory this descriptor exists to distrust,
-    and resolving ``argv[0]`` is not the last lookup that happens: the wrapper this
-    spawns looks its own target up on ``PATH`` after the shim has entered that
-    directory. ``PATH=.:/usr/bin`` would otherwise exec a binary out of the agent's
-    own workspace, ahead of the sandbox meant to contain it.
+    chdir that pathname in the fork child before the shim ever runs, and screens
+    ``PATH`` by directory IDENTITY -- for the search that resolves a bare command
+    name here AND for the child's own environment. Relative entries are dropped
+    (``execvpe`` resolved them against the child's cwd, the directory this
+    descriptor exists to distrust), and so is any absolute entry that is the
+    pinned directory itself or lives beneath it, compared by ``(st_dev, st_ino)``
+    ancestry rather than by pathname. Resolving ``argv[0]`` is not the last
+    lookup that happens: the wrapper this spawns looks its own target up on
+    ``PATH`` after the shim has entered that directory. ``PATH=.:/usr/bin`` --
+    or the same directory spelled absolutely -- would otherwise exec a binary
+    out of the agent's own workspace, ahead of the sandbox meant to contain it.
     """
     if "preexec_fn" in kwargs:
         raise TypeError(
@@ -6668,20 +6722,25 @@ async def create_subprocess_limited(
         kwargs["pass_fds"] = _pass_fds_including(kwargs.get("pass_fds"), chdir_fd)
         # THE INVARIANT: while the cwd is pinned by descriptor, NO resolution of a
         # program name -- not the one below, and not one the child performs later --
-        # may consult a relative PATH entry or the pinned directory. Three things
-        # enforce it together, and each was a hole on its own:
+        # may consult a relative PATH entry, the pinned directory, or anything
+        # inside it. Three things enforce it together, and each was a hole on its
+        # own:
         #
         # (a) `cwd` leaves the spawn. ``Popen`` chdirs it in the fork child BEFORE it
         #     execs the shim, so leaving it in place would resolve the very pathname
         #     the descriptor exists to bypass -- and fail the spawn outright
         #     (EACCES/ENOENT/ENOTDIR) if that name was removed or retargeted since the
         #     bind, with the pinned descriptor never reached.
-        # (b) The search below gets no cwd and an absolute-only PATH. A bare name IS
-        #     the normal shape here -- the macOS sandbox wrapper hands back "env" as
-        #     argv[0] and the Linux cgroup wrapper hands back "systemd-run" -- so the
-        #     search cannot simply be refused, and `execvpe` resolved a relative entry
-        #     against the child's cwd, i.e. the pinned workspace.
-        # (c) The CHILD gets that same absolute-only PATH. Resolving argv[0] here is
+        # (b) The search below gets no cwd and a PATH screened by directory IDENTITY:
+        #     relative entries are dropped, and so is any absolute entry that IS the
+        #     pinned directory or lives beneath it -- compared by (st_dev, st_ino)
+        #     ancestry, so an alias cannot dodge it. A bare name IS the normal shape
+        #     here -- the macOS sandbox wrapper hands back "env" as argv[0] and the
+        #     Linux cgroup wrapper hands back "systemd-run" -- so the search cannot
+        #     simply be refused, and `execvpe` resolved a relative entry against the
+        #     child's cwd, i.e. the pinned workspace. An absolute entry pointing INTO
+        #     that workspace reaches the same binary by a different spelling.
+        # (c) The CHILD gets that same screened PATH. Resolving argv[0] here is
         #     not the last resolution that happens: `env` looks `sandbox-exec` up on
         #     PATH itself, inside the child, after the shim has already entered the
         #     workspace. Narrowing only (b) left `PATH=.:/usr/bin` exec'ing a
@@ -6694,10 +6753,23 @@ async def create_subprocess_limited(
         # source, comments included, so writing either identifier here would make the
         # spawn chokepoint read as if it routed on its own behalf.
         kwargs.pop("cwd", None)
-        search_cwd = None
-        search_env = _absolutely_rooted_path(search_env)
+        pinned_env = search_env
+
+        def _screened_spawn_plan() -> "tuple[dict[str, str], str]":
+            # One worker-thread hop covers the identity screen AND the resolve:
+            # the screen opens and walks PATH entries and the resolve stats
+            # them, so a stalled NFS/autofs entry would block either one, and
+            # neither may freeze the event loop. Returning the screened env
+            # alongside the resolved target keeps clauses (b) and (c) fed from
+            # the SAME value by construction.
+            screened = _pinned_spawn_path(pinned_env, chdir_fd=chdir_fd)
+            if _needs_path_search(argv):
+                return screened, _resolve_spawn_target(argv, screened, None)
+            return screened, argv[0]
+
+        search_env, resolved = await asyncio.to_thread(_screened_spawn_plan)
         kwargs["env"] = search_env
-    if not _needs_path_search(argv):
+    elif not _needs_path_search(argv):
         # Explicit path: nothing to resolve, so no filesystem access and no
         # thread hop -- exec does the work.
         resolved = argv[0]

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -6598,10 +6598,14 @@ def _pinned_spawn_path(
       child's own later lookup the moment the shim has entered the pinned
       directory. Entries are compared by ``(st_dev, st_ino)`` ancestry walked
       over descriptors -- never by pathname -- so a symlink or other alias of
-      the pinned directory cannot dodge the screen. An entry that cannot be
-      opened or walked is dropped, fail-closed per entry: an unopenable entry
-      cannot contribute a resolvable binary today, and dropping is the
-      direction that cannot be gamed by making a directory un-``stat``-able.
+      the pinned directory cannot dodge the screen. A kept entry is emitted as
+      the OPENED descriptor's own canonical path, never the caller's spelling:
+      the child re-resolves its ``PATH`` strings later, so a spelling that
+      traverses a retargetable symlink could be pointed somewhere else between
+      this screen and that lookup. An entry that cannot be opened, walked, or
+      re-spelled is dropped, fail-closed per entry: an unopenable entry cannot
+      contribute a resolvable binary today, and dropping is the direction that
+      cannot be gamed by making a directory un-``stat``-able.
 
     When the BOUND descriptor's own identity cannot be read there is nothing to
     compare entries against, so the lexical screen stands alone for that spawn.
@@ -6626,6 +6630,12 @@ def _pinned_spawn_path(
         else:
             bound_identity = (bound_info.st_dev, bound_info.st_ino)
     if bound_identity is not None:
+        # Local import: hooks imports sandbox at call time, so a module-level
+        # dependency would be circular. `_fd_real_path` is private but already
+        # borrowed this way by `bound_agent_workspace_target` above; issue
+        # #6907 tracks promoting it to a shared home.
+        from kiro_crew.hooks import _fd_real_path
+
         screened: list[str] = []
         for entry in entries:
             try:
@@ -6634,16 +6644,29 @@ def _pinned_spawn_path(
                 continue
             try:
                 ancestors = _directory_ancestor_identities(entry_fd)
+                if bound_identity in ancestors:
+                    # The walk yields the entry's OWN identity first, so one
+                    # membership test covers both "the entry IS the pinned
+                    # directory" and "the entry lives beneath it".
+                    continue
+                # Keep the OPENED descriptor's own canonical path, never the
+                # caller's spelling. The child re-resolves whatever string ends
+                # up in its PATH, so a kept spelling that traverses a symlink
+                # could be retargeted between this screen and that lookup --
+                # the identity verified here must be the identity the child
+                # reaches. A canonical path has no symlink components, and one
+                # inside the pinned directory cannot exist here (its target
+                # would have failed the ancestry test above). Unresolvable ==
+                # dropped: falling back to the mutable spelling would reopen
+                # the window this screen exists to close.
+                resolved_entry = _fd_real_path(entry_fd)
             except OSError:
                 continue
             finally:
                 os.close(entry_fd)
-            # The walk yields the entry's OWN identity first, so one membership
-            # test covers both "the entry IS the pinned directory" and "the
-            # entry lives beneath it".
-            if bound_identity in ancestors:
+            if resolved_entry is None:
                 continue
-            screened.append(entry)
+            screened.append(resolved_entry)
         entries = screened
     source["PATH"] = os.pathsep.join(entries)
     return source
@@ -6734,12 +6757,15 @@ async def create_subprocess_limited(
         # (b) The search below gets no cwd and a PATH screened by directory IDENTITY:
         #     relative entries are dropped, and so is any absolute entry that IS the
         #     pinned directory or lives beneath it -- compared by (st_dev, st_ino)
-        #     ancestry, so an alias cannot dodge it. A bare name IS the normal shape
-        #     here -- the macOS sandbox wrapper hands back "env" as argv[0] and the
-        #     Linux cgroup wrapper hands back "systemd-run" -- so the search cannot
-        #     simply be refused, and `execvpe` resolved a relative entry against the
-        #     child's cwd, i.e. the pinned workspace. An absolute entry pointing INTO
-        #     that workspace reaches the same binary by a different spelling.
+        #     ancestry, so an alias cannot dodge it; kept entries are re-spelled from
+        #     the verified descriptor, so a retargetable symlink in the caller's
+        #     spelling cannot redirect the child's later lookup. A bare name IS the
+        #     normal shape here -- the macOS sandbox wrapper hands back "env" as
+        #     argv[0] and the Linux cgroup wrapper hands back "systemd-run" -- so the
+        #     search cannot simply be refused, and `execvpe` resolved a relative entry
+        #     against the child's cwd, i.e. the pinned workspace. An absolute entry
+        #     pointing INTO that workspace reaches the same binary by a different
+        #     spelling.
         # (c) The CHILD gets that same screened PATH. Resolving argv[0] here is
         #     not the last resolution that happens: `env` looks `sandbox-exec` up on
         #     PATH itself, inside the child, after the shim has already entered the

--- a/test/test_spawn_exec_shim.py
+++ b/test/test_spawn_exec_shim.py
@@ -432,6 +432,202 @@ class TestCreateSubprocessLimited:
                     "mytool", cwd=str(tmp_path), chdir_fd=9, env={"PATH": "tools:.:"}
                 )
 
+    @staticmethod
+    def _planted_tool(directory, body="#!/bin/sh\n"):
+        directory.mkdir(parents=True, exist_ok=True)
+        tool = directory / "mytool"
+        tool.write_text(body)
+        tool.chmod(0o755)
+        return tool
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_drops_an_absolute_path_entry_inside_the_pinned_directory(
+        self, tmp_path
+    ):
+        """The lexical screen alone kept this: absolute, yet inside the workspace.
+
+        ``PATH=<workspace>/bin:...`` reaches the same planted binary a relative
+        entry did, by a different spelling, so the identity screen must drop it
+        from the search AND from the child's environment (clause (c)). The
+        surviving entry's pathname deliberately EXTENDS the workspace's own
+        (``pinned-outside`` startswith ``pinned``): only an identity comparison
+        keeps it, so this also guards against a string-prefix reimplementation.
+        """
+        workspace = tmp_path / "pinned"
+        self._planted_tool(workspace / "bin", body="#!/bin/sh\nexit 9\n")
+        real_dir = tmp_path / "pinned-outside"
+        real = self._planted_tool(real_dir)
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        spawn = AsyncMock()
+        try:
+            with patch("asyncio.create_subprocess_exec", spawn):
+                await create_subprocess_limited(
+                    "mytool",
+                    chdir_fd=descriptor,
+                    env={"PATH": os.pathsep.join([str(workspace / "bin"), str(real_dir)])},
+                )
+        finally:
+            os.close(descriptor)
+        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_drops_the_pinned_directory_itself_as_a_path_entry(self, tmp_path):
+        """The E-is-the-bound-directory case, distinct from the descendant case."""
+        workspace = tmp_path / "pinned"
+        self._planted_tool(workspace, body="#!/bin/sh\nexit 9\n")
+        real_dir = tmp_path / "real-bin"
+        real = self._planted_tool(real_dir)
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        spawn = AsyncMock()
+        try:
+            with patch("asyncio.create_subprocess_exec", spawn):
+                await create_subprocess_limited(
+                    "mytool",
+                    chdir_fd=descriptor,
+                    env={"PATH": os.pathsep.join([str(workspace), str(real_dir)])},
+                )
+        finally:
+            os.close(descriptor)
+        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_drops_a_symlink_alias_of_the_pinned_directory(
+        self, tmp_path, monkeypatch
+    ):
+        """The screen is an identity check, not a pathname or realpath check.
+
+        The alias string shares no prefix with the workspace's own path, and
+        ``os.path.realpath`` is broken on purpose: a screen that compared
+        resolved pathname STRINGS would keep this entry, while descriptor
+        identity sees the same ``(st_dev, st_ino)`` regardless of spelling.
+        """
+        workspace = tmp_path / "pinned"
+        self._planted_tool(workspace, body="#!/bin/sh\nexit 9\n")
+        alias = tmp_path / "alias"
+        os.symlink(workspace, alias)
+        real_dir = tmp_path / "real-bin"
+        real = self._planted_tool(real_dir)
+        monkeypatch.setattr(sandbox.os.path, "realpath", lambda path, **_kwargs: os.fspath(path))
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        spawn = AsyncMock()
+        try:
+            with patch("asyncio.create_subprocess_exec", spawn):
+                await create_subprocess_limited(
+                    "mytool",
+                    chdir_fd=descriptor,
+                    env={"PATH": os.pathsep.join([str(alias), str(real_dir)])},
+                )
+        finally:
+            os.close(descriptor)
+        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_with_only_workspace_path_entries_resolves_nothing(self, tmp_path):
+        """The identity screen emptying PATH fails closed, exactly like the lexical one."""
+        workspace = tmp_path / "pinned"
+        self._planted_tool(workspace / "bin")
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with patch("asyncio.create_subprocess_exec", AsyncMock()):
+                with pytest.raises(FileNotFoundError):
+                    await create_subprocess_limited(
+                        "mytool",
+                        chdir_fd=descriptor,
+                        env={"PATH": os.pathsep.join([str(workspace), str(workspace / "bin")])},
+                    )
+        finally:
+            os.close(descriptor)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_drops_a_path_entry_that_cannot_be_opened(self, tmp_path):
+        """An unopenable entry is dropped, never kept.
+
+        It cannot contribute a resolvable binary today, and dropping is the
+        direction that cannot be gamed by making a directory un-``stat``-able.
+        Covers both a missing entry (ENOENT) and a file where a directory
+        should be (ENOTDIR).
+        """
+        workspace = tmp_path / "pinned"
+        workspace.mkdir()
+        missing = tmp_path / "missing"
+        not_a_dir = tmp_path / "not-a-dir"
+        not_a_dir.write_text("")
+        real_dir = tmp_path / "real-bin"
+        real = self._planted_tool(real_dir)
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        spawn = AsyncMock()
+        try:
+            with patch("asyncio.create_subprocess_exec", spawn):
+                await create_subprocess_limited(
+                    "mytool",
+                    chdir_fd=descriptor,
+                    env={"PATH": os.pathsep.join([str(missing), str(not_a_dir), str(real_dir)])},
+                )
+        finally:
+            os.close(descriptor)
+        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_bound_descriptor_degrades_to_the_lexical_screen(self, tmp_path):
+        """No bound identity to compare against => the absolute-only screen stands.
+
+        This is the deliberate degrade that keeps the placeholder-descriptor
+        tests above meaningful (a mocked spawn never opens fd 9), and it must
+        not silently become fail-open: relative entries still drop, absolute
+        entries are kept without an identity walk. A descriptor number at the
+        NOFILE soft limit can never be open, so the ``fstat`` failure is
+        deterministic -- and in production such a descriptor is one the shim's
+        own ``fchdir`` rejects before any command runs.
+        """
+        never_open = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+        real_dir = tmp_path / "real-bin"
+        real = self._planted_tool(real_dir)
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited(
+                "mytool",
+                chdir_fd=never_open,
+                env={"PATH": os.pathsep.join(["tools", ".", "", str(real_dir)])},
+            )
+        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+
+    @pytest.mark.asyncio
+    async def test_an_unpinned_spawn_env_is_byte_identical(self):
+        """No screen of any kind runs without a pin -- the whole env passes through."""
+        env = {"PATH": "tools:.:/usr/bin", "HOME": "/home/someone"}
+        spawn = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", spawn):
+            await create_subprocess_limited("/bin/true", env=dict(env))
+        assert spawn.await_args.kwargs["env"] == env
+
+    @pytest.mark.asyncio
+    async def test_pinned_screen_and_resolve_run_off_the_event_loop(self):
+        """The identity walk opens PATH entries, so it must not run on the loop.
+
+        Same hazard as the resolve's own stats: one stalled NFS/autofs entry
+        would freeze the gateway. The screen and the resolve share a single
+        worker-thread hop, which also pins that a pinned EXPLICIT-path spawn
+        takes the hop -- its child env still needs screening (clause (c)).
+        """
+        loop_thread = threading.get_ident()
+        ran_on: list[int] = []
+
+        def spy(env, *, chdir_fd=None):
+            ran_on.append(threading.get_ident())
+            return {"PATH": "/usr/bin"}
+
+        with (
+            patch("asyncio.create_subprocess_exec", AsyncMock()),
+            patch.object(sandbox, "_pinned_spawn_path", spy),
+        ):
+            await create_subprocess_limited("/bin/true", chdir_fd=9)
+        assert ran_on and ran_on[0] != loop_thread
+
     @pytest.mark.asyncio
     async def test_an_unpinned_spawn_still_resolves_a_relative_path_entry(self, tmp_path):
         """The refusal is scoped to a pinned spawn; ordinary callers are unchanged."""

--- a/test/test_spawn_exec_shim.py
+++ b/test/test_spawn_exec_shim.py
@@ -456,7 +456,8 @@ class TestCreateSubprocessLimited:
         workspace = tmp_path / "pinned"
         self._planted_tool(workspace / "bin", body="#!/bin/sh\nexit 9\n")
         real_dir = tmp_path / "pinned-outside"
-        real = self._planted_tool(real_dir)
+        self._planted_tool(real_dir)
+        canonical_dir = os.path.realpath(real_dir)
         descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
         spawn = AsyncMock()
         try:
@@ -468,8 +469,8 @@ class TestCreateSubprocessLimited:
                 )
         finally:
             os.close(descriptor)
-        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
-        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+        assert strip_spawn_shim(spawn.await_args.args) == (os.path.join(canonical_dir, "mytool"),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == canonical_dir
 
     @pytest.mark.asyncio
     async def test_chdir_fd_drops_the_pinned_directory_itself_as_a_path_entry(self, tmp_path):
@@ -477,7 +478,8 @@ class TestCreateSubprocessLimited:
         workspace = tmp_path / "pinned"
         self._planted_tool(workspace, body="#!/bin/sh\nexit 9\n")
         real_dir = tmp_path / "real-bin"
-        real = self._planted_tool(real_dir)
+        self._planted_tool(real_dir)
+        canonical_dir = os.path.realpath(real_dir)
         descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
         spawn = AsyncMock()
         try:
@@ -489,8 +491,8 @@ class TestCreateSubprocessLimited:
                 )
         finally:
             os.close(descriptor)
-        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
-        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+        assert strip_spawn_shim(spawn.await_args.args) == (os.path.join(canonical_dir, "mytool"),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == canonical_dir
 
     @pytest.mark.asyncio
     async def test_chdir_fd_drops_a_symlink_alias_of_the_pinned_directory(
@@ -508,7 +510,8 @@ class TestCreateSubprocessLimited:
         alias = tmp_path / "alias"
         os.symlink(workspace, alias)
         real_dir = tmp_path / "real-bin"
-        real = self._planted_tool(real_dir)
+        self._planted_tool(real_dir)
+        canonical_dir = os.path.realpath(real_dir)  # before realpath is broken below
         monkeypatch.setattr(sandbox.os.path, "realpath", lambda path, **_kwargs: os.fspath(path))
         descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
         spawn = AsyncMock()
@@ -521,8 +524,8 @@ class TestCreateSubprocessLimited:
                 )
         finally:
             os.close(descriptor)
-        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
-        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+        assert strip_spawn_shim(spawn.await_args.args) == (os.path.join(canonical_dir, "mytool"),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == canonical_dir
 
     @pytest.mark.asyncio
     async def test_chdir_fd_with_only_workspace_path_entries_resolves_nothing(self, tmp_path):
@@ -556,7 +559,8 @@ class TestCreateSubprocessLimited:
         not_a_dir = tmp_path / "not-a-dir"
         not_a_dir.write_text("")
         real_dir = tmp_path / "real-bin"
-        real = self._planted_tool(real_dir)
+        self._planted_tool(real_dir)
+        canonical_dir = os.path.realpath(real_dir)
         descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
         spawn = AsyncMock()
         try:
@@ -568,8 +572,63 @@ class TestCreateSubprocessLimited:
                 )
         finally:
             os.close(descriptor)
-        assert strip_spawn_shim(spawn.await_args.args) == (str(real),)
-        assert spawn.await_args.kwargs["env"]["PATH"] == str(real_dir)
+        assert strip_spawn_shim(spawn.await_args.args) == (os.path.join(canonical_dir, "mytool"),)
+        assert spawn.await_args.kwargs["env"]["PATH"] == canonical_dir
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_respells_a_kept_entry_from_the_verified_descriptor(self, tmp_path):
+        """A kept entry is the OPENED descriptor's canonical path, not the spelling.
+
+        The child re-resolves its ``PATH`` strings at its own lookup, so a kept
+        spelling that traverses a symlink could be retargeted between this
+        screen and that lookup -- pointing the child at a directory the screen
+        never verified. Emitting the descriptor-derived path pins the child to
+        the identity that passed the screen.
+        """
+        workspace = tmp_path / "pinned"
+        workspace.mkdir()
+        real_dir = tmp_path / "real-bin"
+        self._planted_tool(real_dir)
+        canonical_dir = os.path.realpath(real_dir)
+        link = tmp_path / "mutable-link"
+        os.symlink(real_dir, link)
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        spawn = AsyncMock()
+        try:
+            with patch("asyncio.create_subprocess_exec", spawn):
+                await create_subprocess_limited(
+                    "mytool", chdir_fd=descriptor, env={"PATH": str(link)}
+                )
+        finally:
+            os.close(descriptor)
+        # Both consumers see the canonical directory; the mutable spelling is gone.
+        assert spawn.await_args.kwargs["env"]["PATH"] == canonical_dir
+        assert strip_spawn_shim(spawn.await_args.args) == (os.path.join(canonical_dir, "mytool"),)
+
+    @pytest.mark.asyncio
+    async def test_chdir_fd_drops_an_entry_whose_canonical_path_is_unreadable(self, tmp_path):
+        """Unresolvable canonical path => the entry is dropped, never the raw spelling.
+
+        Falling back to the caller's spelling would reopen the retarget window
+        the re-spelling exists to close, so the degrade direction is DROP --
+        here that empties ``PATH`` and the resolve fails closed.
+        """
+        workspace = tmp_path / "pinned"
+        workspace.mkdir()
+        real_dir = tmp_path / "real-bin"
+        self._planted_tool(real_dir)
+        descriptor = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with (
+                patch("asyncio.create_subprocess_exec", AsyncMock()),
+                patch("kiro_crew.hooks._fd_real_path", return_value=None),
+            ):
+                with pytest.raises(FileNotFoundError):
+                    await create_subprocess_limited(
+                        "mytool", chdir_fd=descriptor, env={"PATH": str(real_dir)}
+                    )
+        finally:
+            os.close(descriptor)
 
     @pytest.mark.asyncio
     async def test_an_unreadable_bound_descriptor_degrades_to_the_lexical_screen(self, tmp_path):


### PR DESCRIPTION
Fixes #7095.

## What

`create_subprocess_limited(..., chdir_fd=fd)` sanitizes `PATH` while the child's working directory is pinned by descriptor — for its own `argv[0]` resolution AND for the child's environment. The screen was lexical: `os.path.isabs(entry)` only. That closes every relative spelling (`''`, `.`, `..`, `tools`), but an **absolute** entry that resolves *inside* the bound workspace (e.g. `PATH=/Users/me/.kiro/crew/workspace/bin:/usr/bin`) passed unchanged — and resolving `argv[0]` is not the last lookup that happens: the wrapper this spawns looks its own target up on `PATH` from inside the child, after the shim has already entered the bound directory. A binary planted behind such an entry would be exec'd ahead of the sandbox meant to contain it.

This PR makes the screen an **identity** check: after the cheap lexical filter, each surviving absolute entry is opened and its `(st_dev, st_ino)` ancestry (via the existing `_directory_ancestor_identities`, which walks by descriptor) is tested against the bound descriptor's identity. An entry that IS the pinned directory or lives anywhere beneath it — by any spelling, symlink aliases included — is dropped from the resolve search and from the child's environment alike. `_absolutely_rooted_path` is renamed `_pinned_spawn_path`, since the old name described only the lexical half.

## Severity, stated honestly

This is **not agent-reachable on a default install**: it requires the *gateway's own* `PATH` to already contain a directory inside the agent workspace, and an agent cannot edit the gateway's environment. It is a screen that did not enforce its stated invariant, in security-critical code, on a configuration an operator could plausibly create. Not an exploitable escape; not cosmetic either — the `chdir_fd` docstring and the `(a)/(b)/(c)` invariant comment both already claimed the pinned directory is untrusted for name resolution, and they over-claimed. Closing the gap and correcting the prose are the same change.

## Design decisions

- **Cost / event-loop**: the identity walk opens one descriptor per ancestor level per entry — filesystem work, with the same stalled-NFS/autofs hazard that motivated the existing `asyncio.to_thread` hop for the resolve. The screen therefore shares **one worker-thread hop** with the resolve (`_screened_spawn_plan`), which also means a pinned *explicit-path* spawn now takes the hop — its child env still needs screening (clause (c)). Returning the screened env alongside the resolved target keeps clauses (b) and (c) fed from the same value by construction.
- **Degrade, deliberate**: when the bound descriptor's own identity cannot be read (`os.fstat(chdir_fd)` raises), there is nothing to compare against, so the lexical absolute-only screen stands alone for that spawn. In production `chdir_fd` always originates from `bind_voice_safe_agent_workspace`'s real opened descriptor; one that cannot be `fstat`ed is one the shim's own `fchdir` rejects before any command runs (pinned by an existing test). **This is why every pre-existing `TestCreateSubprocessLimited` test passing a placeholder `chdir_fd=9` under a mocked spawn keeps passing untouched** — a zero-regression property asserted deliberately by `test_an_unreadable_bound_descriptor_degrades_to_the_lexical_screen`, not discovered. The degrade is pinned so it cannot silently become fail-open in a later refactor.
- **Fail-closed per entry**: a `PATH` entry that cannot be opened or walked is dropped. An unopenable entry cannot contribute a resolvable binary today, and dropping is the direction that cannot be gamed by making a directory un-`stat`-able.
- **Fail-closed on empty**: the screen emptying `PATH` still raises `FileNotFoundError` from the resolve, exactly as before. No fallback added.
- **Scope unchanged**: unpinned spawns keep full `execvpe` parity, relative entries included — pinned behavior only.

## Tests (all in `test/test_spawn_exec_shim.py::TestCreateSubprocessLimited`, real directory descriptors)

- absolute entry **inside** the workspace dropped — from the search AND the child env; planted binary loses to an outside entry whose pathname deliberately **extends the workspace's own** (`pinned-outside` startswith `pinned`), so the same test guards against a string-prefix reimplementation
- the **bound directory itself** as an entry dropped (the `E is bound` case)
- a **symlink alias** of the workspace dropped, with `os.path.realpath` deliberately broken in the test — proving the screen is descriptor identity, not pathname/realpath string comparison
- screen emptying `PATH` raises `FileNotFoundError`
- unopenable entries (ENOENT and ENOTDIR) dropped, resolution through the surviving entry still works
- the **degrade path** pinned (deterministically unreadable descriptor at the NOFILE soft limit)
- unpinned spawn env **byte-identical**
- screen + resolve run **off the event loop**

Red-before-fix: 6 of the new tests fail on unfixed source; the two behavior-preserving pins pass. Mutation checks, each killed: (1) revert to lexical `isabs`, (2) equality-only (drop the descendant half), (3) realpath string comparison instead of descriptor identity, (4) screen the search but not `kwargs["env"]`, (5) invert per-entry `OSError` to keep.

Full local verification: `test_spawn_exec_shim.py` + `test_sandbox_argv.py` + `test_spawn_audit` all green (255 passed); full backend suite vs an `origin/main` worktree with failure sets compared **both directions** — branch failures (107) are a strict subset of main's (108, the one main-only failure is an unrelated flake that passed on branch), identical 2 pre-existing setup errors. `black`/`isort`/`flake8`/`mypy` clean.

## Out of scope (audited, not fixed here)

- `_resolve_spawn_target`'s `if cwd:` relative-entry join — correct for the unpinned path, unreachable on the pinned one (the pinned branch passes `cwd=None`); claim re-verified on this tip.
- Broadening the screen to unpinned spawns — an `execvpe`-parity break, a product decision.

<!-- no-visual-delta -->
No screenshot evidence: backend-only change with no visual surface; the evidence is the focus of the test assertions above.
