### PR TITLE
feat: let an edition draw its own phone-connection method kinds

### DIFF
--- a/website/docs/extension-seams.md
+++ b/website/docs/extension-seams.md
@@ -9,10 +9,10 @@ The backend has the sibling mechanism, Composed Platform Providers: see
 [`docs/system-specs/modules/platform-context.md`](../../docs/system-specs/modules/platform-context.md).
 The two are independent. Nothing here reads `CONTRACT_VERSION`.
 
-## The twelve registry seams
+## The thirteen registry seams
 
 Each entry is one registrar the edition may call, paired with the reader the core
-already calls. `src/extensions.ts` names exactly these twelve in its header.
+already calls. `src/extensions.ts` names exactly these thirteen in its header.
 `src/test/extensionSeams.test.tsx` exercises each one except the source-provider
 seam, which has its own suite in `src/test/sourceProviderSeam.test.ts`.
 
@@ -30,16 +30,17 @@ seam, which has its own suite in `src/test/sourceProviderSeam.test.ts`.
 | Panel-navigation chords | `hooks/useKeyboardShortcuts.ts` | `registerPanelShortcut()`, read by the shortcut handler and `DEFAULT_SHORTCUTS` |
 | Non-app route prefixes | `components/MigrationCheck.tsx` | `registerNonAppPrefix()`, read by `MigrationCheck` |
 | Source providers (Changes panel + sidebar chips) | `utils/pullRequestLinks.ts` | `registerSourceProvider()` to `sourceProviderDescriptor()` |
+| Phone-connection method renderers | `components/mobileConnectRenderers.tsx` | `registerMobileConnectRenderer()` to `getMobileConnectRenderers()` / `canRenderMobileConnectKind()` |
 
 Plus one **exported-transport** seam for edition-owned API methods. It is not a
 registry; see "API methods" below.
 
 Other `register*()` functions in `src/` (built-in surfaces, command-palette
 providers, tool pills, terminal sockets, highlight.js languages) are core-internal
-wiring, not edition seams. Only the twelve above are called from the composition
+wiring, not edition seams. Only the thirteen above are called from the composition
 root.
 
-Eleven of the twelve are **additive** — the edition contributes a surface. The
+Twelve of the thirteen are **additive** — the edition contributes a surface. The
 remaining one is **subtractive**: `suppressOverviewBuiltin()` removes a built-in
 Overview surface for a distribution whose environment makes it permanently
 inapplicable, which no additive seam can express. It is named `suppress*` rather
@@ -460,6 +461,31 @@ logo, no write affordances. The backend plugin contract — payload schema
 mutation hooks — is documented on `SourceProviderPlugin` in
 `source_providers.py`; this seam's suite is `src/test/sourceProviderSeam.test.ts`
 plus `test/test_source_provider_plugin.py` on the backend.
+
+**Phone-connection method renderers.**
+`registerMobileConnectRenderer({ kind, component })` supplies the "Connect your
+phone" dialog section that draws one `MobileConnectMethod.kind` contributed by the
+backend `mobile_connect` CPP seam. It keys on `kind`, not `id`, because that is
+the descriptor's own split: `id` is the governed identifier the
+`capabilities.mobile_connect` `methods` ruleset narrows on, while `kind` exists to
+name the renderer — so two methods may share one kind and a component that needs
+the ids reads `/api/mobile-connect/methods` itself. A blank kind, a duplicate, or
+a **built-in** kind (`tailnet_qr`, `login_link`) routes through
+`reportSeamCollision`: those two are drawn by core sections whose mint endpoints
+the core audits, so registering over one would be an override that silently
+redirects a credential mint, not a contribution.
+
+The registry is also the **single** definition of the renderable set, read by two
+consumers that used to carry it as matching literals: `canRenderMobileConnectKind()`
+gates the nav rail's row and `getMobileConnectRenderers()` supplies the dialog's
+sections. A kind neither drawn nor registered is still filtered out at the rail, so
+the row stays hidden rather than opening a dialog with an empty body — the seam adds
+a way to draw a method, it does not remove that guard. Registered sections render
+above the built-ins, each in its own `ErrorBoundary`, so a throwing renderer
+disables only itself. It **cannot widen governance**: the endpoint filters every id
+through `capabilities.mobile_connect` before the dialog sees a kind, and each mint
+endpoint re-runs that decision (`mint_denied_reason`), so a renderer for a denied or
+unoffered method draws nothing.
 
 ## Reactivity
 

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -52,6 +52,7 @@ import AgentImportFlow from './components/AgentImportFlow'
 import PrivacyChapter from './components/PrivacyChapter'
 import { OnboardingShellHost } from './components/OnboardingChapterShell'
 import { PREVIEW_EXPAND_EVENT } from './components/WebPreviewPanel'
+import { canRenderMobileConnectKind } from './components/mobileConnectRenderers'
 import { motion, AnimatePresence, useMotionValue } from 'framer-motion'
 import { animateDrawer, registerDrawerTargets, takeOverDrawer, safeAreaLeft } from './hooks/useDrawerSwipe'
 
@@ -160,6 +161,11 @@ import { countUpdatables, registryQueryFn, type UpdatableInstalledRow } from './
 // mount gate at the render site means the chunk is fetched exactly when it
 // can render.
 const UpdateFoundModal = lazy(() => import('./components/UpdateFoundModal'))
+// The dialog is lazy; the renderer registry it consults is NOT (imported at the
+// top of this file). The nav rail decides whether to show the "Connect your
+// phone" row before this chunk is ever fetched, so a predicate hiding inside it
+// would answer "cannot draw" for every method until the user had already opened
+// a dialog the row never offered.
 const MobileConnectModal = lazy(() => import('./components/MobileConnectModal'))
 // Same boundary, same reason: the pill renders nothing without an update,
 // so its code rides the on-demand chunk instead of the app core.
@@ -1169,11 +1175,13 @@ export default function App() {
     staleTime: 5 * 60_000,
     retry: false,
   })
-  // Only kinds this frontend can render: an edition's NEW method kind would
-  // otherwise show the rail row and then open an empty dialog.
+  // Only kinds this frontend can draw — a built-in section or an edition's
+  // registered renderer (`components/mobileConnectRenderers.tsx`). A kind
+  // nothing can draw would otherwise show the rail row and then open an empty
+  // dialog, so the predicate, not a literal list, is what gates the row.
   const mobileConnectKinds = (mobileConnectQuery.data?.methods ?? [])
     .map(m => m.kind)
-    .filter(k => k === 'tailnet_qr' || k === 'login_link')
+    .filter(canRenderMobileConnectKind)
   // Selected session's project directory: a terminal opened from the nav row
   // starts there (server default when no session is selected or it has none).
   const activeSlotProject = useAppSelector(selectActiveSlotProject)

--- a/website/src/components/MobileConnectModal.test.tsx
+++ b/website/src/components/MobileConnectModal.test.tsx
@@ -4,9 +4,11 @@
  * Pins the credential-safety contract and the seam's forward-compat shape:
  *  1. a QR/link credential is minted ONLY on explicit click, never on mount
  *     (the responses carry live session tokens);
- *  2. sections render per `kinds` from the governed methods endpoint, and an
- *     unrecognised kind renders NOTHING (an edition's new method degrades to
- *     absent on this frontend, never to a broken panel);
+ *  2. sections render per `kinds` from the governed methods endpoint; a kind with
+ *     neither a built-in section nor a registered renderer renders NOTHING (an
+ *     unknown method degrades to absent, never to a broken panel), while an
+ *     edition's kind draws through the renderer seam
+ *     (`mobileConnectRenderers.tsx`);
  *  3. the not-ready tailnet state routes to the real setup card instead of
  *     minting.
  */
@@ -27,6 +29,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../api/client', () => ({ api: mocks }))
 
 import MobileConnectModal from './MobileConnectModal'
+import {
+  registerMobileConnectRenderer,
+  BUILTIN_MOBILE_CONNECT_KINDS,
+} from './mobileConnectRenderers'
 
 function mount(kinds: string[], onClose: () => void = () => {}) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -151,5 +157,90 @@ describe('MobileConnectModal', () => {
     // The tick swaps the icon; the label persists — assert the click didn't throw
     // and the value stayed rendered (the copy path completed).
     await waitFor(() => expect(screen.getByDisplayValue('https://ext/?token=once')).toBeInTheDocument())
+  })
+})
+
+describe('MobileConnectModal — edition renderer seam', () => {
+  // Registered once for the file: the registry is a module singleton read at
+  // render (registration is a composition-time act, not per-test state), and
+  // these kinds are unique to this block so no other test's `kinds` matches them.
+  registerMobileConnectRenderer({
+    kind: 'modal_test_tunnel_qr',
+    component: () => <div>edition tunnel section</div>,
+  })
+  registerMobileConnectRenderer({
+    kind: 'modal_test_throws',
+    component: () => {
+      throw new Error('renderer exploded')
+    },
+  })
+
+  it('draws a registered renderer for a kind the deployment offers', () => {
+    mount(['modal_test_tunnel_qr'])
+    expect(screen.getByText('edition tunnel section')).toBeInTheDocument()
+    // The edition owns its own mint endpoint, so no built-in mint is touched.
+    expect(mocks.tailnetMobile).not.toHaveBeenCalled()
+    expect(mocks.tailnetMobileQr).not.toHaveBeenCalled()
+    expect(mocks.mobileLoginLink).not.toHaveBeenCalled()
+  })
+
+  it('draws nothing for a registered kind the deployment does NOT offer', () => {
+    // The seam cannot widen governance: the endpoint filters every id through
+    // `capabilities.mobile_connect` before a kind reaches this dialog, so a
+    // renderer for a denied or absent method has no section to draw.
+    mount(['login_link'])
+    expect(screen.queryByText('edition tunnel section')).not.toBeInTheDocument()
+  })
+
+  it('renders the edition section above the built-in link, which keeps working', () => {
+    mount(['modal_test_tunnel_qr', 'login_link'])
+    const edition = screen.getByText('edition tunnel section')
+    const builtin = screen.getByText('Create sign-in link')
+    // DOCUMENT_POSITION_FOLLOWING: a contributed method is the deployment's
+    // primary way in, and the built-in link is the fallback beneath it.
+    expect(edition.compareDocumentPosition(builtin) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('a throwing renderer disables only itself', () => {
+    // Each section has its own ErrorBoundary, so one bad edition renderer must
+    // not blank the dialog and take the built-in sections down with it.
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      mount(['modal_test_throws', 'login_link'])
+      expect(screen.getByText('Use Kiro Crew on your phone')).toBeInTheDocument()
+      expect(screen.getByText('Create sign-in link')).toBeInTheDocument()
+    } finally {
+      err.mockRestore()
+    }
+  })
+
+  it('a throwing renderer that is the ONLY method still leaves usable content', () => {
+    // No `fallback={null}` here, unlike the Overview stat-card slot: a vanishing
+    // card leaves a grid of siblings, but this section can be the whole dialog,
+    // and emptying it would strand a user who arrived from a nav row that
+    // promised a way in.
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      mount(['modal_test_throws'])
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+      expect(screen.getByText('Try Again')).toBeInTheDocument()
+    } finally {
+      err.mockRestore()
+    }
+  })
+})
+
+describe('MobileConnectModal — every built-in kind actually draws', () => {
+  // Pins `BUILTIN_MOBILE_CONNECT_KINDS` to the sections that exist. A member
+  // added to that constant without a section here would report as drawable,
+  // show the nav row, and then open a dialog with an empty body — the exact
+  // outcome the renderer seam exists to prevent.
+  it.each(BUILTIN_MOBILE_CONNECT_KINDS)('%s renders a section', async kind => {
+    mocks.tailnetMobileQr.mockResolvedValue({ url: 'https://h/?t=x', image: 'data:image/png;base64,x' })
+    mocks.mobileLoginLink.mockResolvedValue({ url: 'https://ext/?token=once', expires_in: 300 })
+    mount([kind])
+    // Each built-in section's mint affordance is its proof of presence.
+    const affordance = kind === 'tailnet_qr' ? 'Show QR code' : 'Create sign-in link'
+    expect(await screen.findByText(affordance)).toBeInTheDocument()
   })
 })

--- a/website/src/components/MobileConnectModal.tsx
+++ b/website/src/components/MobileConnectModal.tsx
@@ -9,6 +9,8 @@ import { useAppSelector } from '../store'
 import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap'
 import { copyToClipboard } from '../utils/clipboard'
 import { parseErrorCode } from '../utils/errorReport'
+import ErrorBoundary from './ErrorBoundary'
+import { getMobileConnectRenderers } from './mobileConnectRenderers'
 
 /** Machine-readable code from a mint error's JSON body (same shape as the
  *  Settings card's helper): lets the UI blame configuration only when the
@@ -22,11 +24,15 @@ const linkErrorCode = (error: unknown): string | undefined =>
  * "Connect your phone" — the sidebar entry's centered dialog (mockup A1).
  *
  * Renders one section per governed method the `/api/mobile-connect/methods`
- * endpoint returned (the CPP `mobile_connect` seam). Kinds this frontend
- * knows: `tailnet_qr` (server-rendered QR carrying a live session token,
- * minted ONLY on explicit click) and `login_link` (one-time sign-in URL).
- * An unrecognised kind renders nothing — an edition's new method degrades to
- * absent on this frontend, never to a broken panel.
+ * endpoint returned (the CPP `mobile_connect` seam). The core draws two kinds
+ * itself: `tailnet_qr` (server-rendered QR carrying a live session token,
+ * minted ONLY on explicit click) and `login_link` (one-time sign-in URL). A
+ * downstream edition's kinds are drawn by the renderer seam in
+ * `mobileConnectRenderers.tsx`, and those sections come first: a deployment
+ * that contributes a method offers it as the primary way in, so the built-in
+ * link sits below as the fallback. A kind with neither a built-in section nor a
+ * registered renderer renders nothing, so an unknown method is absent rather
+ * than a broken panel.
  *
  * Credentials are minted on demand and never on mount: the QR/link responses
  * carry live tokens, so nothing here fetches one until the user asks.
@@ -45,6 +51,10 @@ export default function MobileConnectModal({
   useDialogFocusTrap(dialogRef, onClose)
 
   const hasQr = kinds.includes('tailnet_qr')
+  // Only renderers whose kind this deployment actually offers: the endpoint has
+  // already filtered every id through `capabilities.mobile_connect`, so a
+  // registered renderer for a denied or absent method draws nothing.
+  const editionSections = getMobileConnectRenderers().filter(r => kinds.includes(r.kind))
 
   return (
     <div
@@ -76,8 +86,23 @@ export default function MobileConnectModal({
             {t('components.mobileConnect.scan_with_your_phone_camera_to_continue_with_the_s')}
           </p>
         )}
+        {/* Edition sections, each in its own ErrorBoundary so a throwing
+            renderer disables only itself. Deliberately WITHOUT `fallback={null}`,
+            unlike the Overview stat-card slot: a card that vanishes leaves a grid
+            of siblings, but a registered section here can be the dialog's ONLY
+            content, and silently emptying it would strand a user who reached it
+            from a nav row that promised a way in. The default boundary keeps the
+            section occupied, which is also what makes counting these sections a
+            sound input to `standalone` below. */}
+        {editionSections.map(r => (
+          <ErrorBoundary key={r.kind} scope={`mobile-connect:${r.kind}`}>
+            <r.component onClose={onClose} />
+          </ErrorBoundary>
+        ))}
         {hasQr && <TailnetQrSection onClose={onClose} />}
-        {kinds.includes('login_link') && <LoginLinkSection standalone={!hasQr} />}
+        {kinds.includes('login_link') && (
+          <LoginLinkSection standalone={!hasQr && editionSections.length === 0} />
+        )}
       </div>
     </div>
   )

--- a/website/src/components/mobileConnectRenderers.tsx
+++ b/website/src/components/mobileConnectRenderers.tsx
@@ -1,0 +1,134 @@
+/**
+ * Renderer seam for phone-connection METHOD KINDS.
+ *
+ * The backend `mobile_connect` CPP seam decides WHICH phone-connection methods a
+ * deployment offers: `MobileConnectProvider.connect_methods()` returns
+ * `{id, kind}` descriptors and `capabilities.mobile_connect` governs which of
+ * them survive. A descriptor only NAMES a method, though — the credential is
+ * minted on the method's own endpoint, and the UI that drives that endpoint
+ * lives here. This registry is where a downstream edition supplies that UI, so a
+ * method the backend contributes has something to draw it.
+ *
+ * It is also the SINGLE definition of the renderable set, read by both
+ * consumers: `canRenderMobileConnectKind()` answers for the nav rail's row and
+ * `getMobileConnectRenderers()` supplies the dialog's sections. One definition
+ * with two readers cannot disagree the way two copies of a string literal can.
+ *
+ * Four properties are deliberate.
+ *
+ * **Keyed by `kind`, not by `id`.** That is the descriptor's own split: `id` is
+ * the GOVERNED identifier the `methods` ruleset narrows on, while `kind` names
+ * the frontend renderer. Two methods may legitimately share a kind (two tunnels,
+ * one drawing), so the renderer is per-kind and a component that needs the ids
+ * reads `/api/mobile-connect/methods` itself.
+ *
+ * **A built-in kind cannot be claimed.** `tailnet_qr` and `login_link` are drawn
+ * by core sections whose mint endpoints core audits, so registering over one is a
+ * collision, not an override: silently replacing them would let a composition
+ * step redirect a credential mint the core still believes it owns.
+ *
+ * **It cannot widen governance.** A renderer only draws a method the server
+ * already listed: the endpoint filters every id through
+ * `capabilities.mobile_connect` before the dialog sees a kind, and each built-in
+ * mint endpoint re-runs that decision (`mint_denied_reason`) because the filtered
+ * list is presentation, never the control. A renderer for a kind the deployment
+ * does not offer draws nothing at all. An edition's OWN mint endpoint is outside
+ * this seam and enforces its own authorization.
+ *
+ * **Registration is module-load, like every other frontend seam.** This registry
+ * is not reactive; the edition registers during composition, before the shell
+ * renders. The core registers nothing, so stock behavior is unchanged.
+ */
+import type { ComponentType } from 'react'
+import { reportSeamCollision } from '../apps/seamCollision'
+
+/**
+ * Method kinds the core draws itself, in `MobileConnectModal`.
+ *
+ * Every member must have a built-in section in that dialog — a member without
+ * one reports as drawable, shows the nav row, and then opens a dialog with an
+ * empty body, which is the outcome this seam exists to avoid.
+ * `MobileConnectModal.test.tsx` pins that each member draws.
+ */
+export const BUILTIN_MOBILE_CONNECT_KINDS = ['tailnet_qr', 'login_link'] as const
+
+export interface MobileConnectRenderer {
+  /**
+   * The `MobileConnectMethod.kind` this draws. Must not be a built-in kind.
+   */
+  kind: string
+  /**
+   * The section. Rendered inside the dialog with only `onClose`, matching the
+   * built-in sections: a section owner reads whatever else it needs itself, and
+   * dismisses the dialog when it navigates away.
+   */
+  component: ComponentType<{ onClose: () => void }>
+}
+
+const RENDERERS = new Map<string, MobileConnectRenderer>()
+
+const isBuiltin = (kind: string): boolean =>
+  (BUILTIN_MOBILE_CONNECT_KINDS as readonly string[]).includes(kind)
+
+/**
+ * Register the section that draws one phone-connection method kind.
+ *
+ * Rejected through `reportSeamCollision` (throws in dev/test, warns and ignores
+ * in production) when the kind is not a usable string, is a core-drawn built-in,
+ * or is already registered — core and first registration win, as in every
+ * additive seam.
+ */
+export function registerMobileConnectRenderer(renderer: MobileConnectRenderer): void {
+  // A non-string survives from untyped JS, and reaching for `.trim()` on it
+  // would throw a raw TypeError at composition — in production too, where every
+  // other rejection here degrades to warn-and-ignore. Route it to the same
+  // rejection instead of breaking that contract.
+  const kind = typeof renderer.kind === 'string' ? renderer.kind : ''
+  // Surrounding whitespace is rejected rather than trimmed away: the descriptor
+  // is compared verbatim by both readers, so storing a normalized key would
+  // register a kind that can never match the one the server sends.
+  if (!kind || kind !== kind.trim()) {
+    reportSeamCollision(
+      'mobileConnectRenderers',
+      'a renderer needs a non-empty method kind with no surrounding whitespace',
+    )
+    return
+  }
+  if (isBuiltin(kind)) {
+    reportSeamCollision(
+      'mobileConnectRenderers',
+      `kind ${kind} is drawn by a built-in section; a renderer cannot claim it`,
+    )
+    return
+  }
+  if (RENDERERS.has(kind)) {
+    reportSeamCollision(
+      'mobileConnectRenderers',
+      `kind ${kind} already has a renderer; ignoring the duplicate`,
+    )
+    return
+  }
+  RENDERERS.set(kind, { kind, component: renderer.component })
+}
+
+/**
+ * Registered renderers in registration order, or `[]` when none is registered.
+ *
+ * Order is the registrant's, so a deployment contributing several methods
+ * controls how they stack rather than inheriting endpoint or map ordering.
+ */
+export function getMobileConnectRenderers(): MobileConnectRenderer[] {
+  return [...RENDERERS.values()]
+}
+
+/**
+ * Whether this frontend can draw a method of `kind` — a built-in section or a
+ * registered renderer.
+ *
+ * This is what the nav rail filters on. A kind nothing can draw stays filtered
+ * out, so the row is hidden rather than opening a dialog with an empty body: the
+ * seam adds a way to draw a method, it does not remove that guard.
+ */
+export function canRenderMobileConnectKind(kind: string): boolean {
+  return isBuiltin(kind) || RENDERERS.has(kind)
+}

--- a/website/src/extensions.ts
+++ b/website/src/extensions.ts
@@ -19,6 +19,7 @@
  *   import { registerOverviewStatCards } from '@/pages/overviewStatCards'
  *   import { registerOverviewPanel }     from '@/pages/overviewPanel'
  *   import { registerSourceProvider }    from '@/utils/pullRequestLinks'
+ *   import { registerMobileConnectRenderer } from '@/components/mobileConnectRenderers'
  *
  * plus one SUPPRESSOR, for a built-in surface an edition's environment makes
  * permanently inapplicable (the registrars above can only add):

--- a/website/src/test/extensionSeams.test.tsx
+++ b/website/src/test/extensionSeams.test.tsx
@@ -39,6 +39,12 @@ import {
   suppressOverviewBuiltin,
   isOverviewBuiltinSuppressed,
 } from '../pages/overviewBuiltins'
+import {
+  registerMobileConnectRenderer,
+  getMobileConnectRenderers,
+  canRenderMobileConnectKind,
+  BUILTIN_MOBILE_CONNECT_KINDS,
+} from '../components/mobileConnectRenderers'
 import { apiTransport } from '../api/apiTransport'
 // Importing the client installs the blessed transport (installApiTransport runs
 // at client module load), so `apiTransport` is populated for the test below.
@@ -358,6 +364,66 @@ describe('overviewBuiltins — built-in suppression seam', () => {
     // this path.
     expect(() => suppressOverviewBuiltin('tailnet-mobile')).not.toThrow()
     expect(isOverviewBuiltinSuppressed('tailnet-mobile')).toBe(true)
+  })
+})
+
+describe('mobileConnectRenderers — phone-connection method renderer seam', () => {
+  // The registry is a module singleton, so every test here is self-contained on
+  // its OWN kind and none asserts an absolute registry size — an assertion like
+  // that passes or fails on test ORDER once a sibling has registered (it fails
+  // under --sequence.shuffle). The "core registers nothing" claim is the one
+  // that genuinely needs an untouched registry, so it takes a fresh module.
+  it('registers nothing of its own — a fresh registry is empty', async () => {
+    vi.resetModules()
+    const fresh = await import('../components/mobileConnectRenderers')
+    expect(fresh.getMobileConnectRenderers()).toEqual([])
+    for (const kind of fresh.BUILTIN_MOBILE_CONNECT_KINDS) {
+      expect(fresh.canRenderMobileConnectKind(kind)).toBe(true)
+    }
+    expect(fresh.canRenderMobileConnectKind('seam_test_unregistered')).toBe(false)
+  })
+
+  it('registering a kind is what makes it drawable', () => {
+    const Comp = () => null
+    expect(canRenderMobileConnectKind('seam_test_new')).toBe(false)
+    registerMobileConnectRenderer({ kind: 'seam_test_new', component: Comp })
+    // The single definition of the renderable set: this predicate is what gates
+    // the nav rail's row, so registering is what makes the row appear at all.
+    expect(canRenderMobileConnectKind('seam_test_new')).toBe(true)
+    expect(getMobileConnectRenderers()).toContainEqual({ kind: 'seam_test_new', component: Comp })
+  })
+
+  it('refuses a built-in kind — that would be an override, not a contribution', () => {
+    // `tailnet_qr` and `login_link` are drawn by core sections whose mint
+    // endpoints the core audits. Silently replacing one would let a composition
+    // step redirect a credential mint the core still believes it owns.
+    expect(() =>
+      registerMobileConnectRenderer({ kind: 'tailnet_qr', component: () => null }),
+    ).toThrow(/drawn by a built-in section/)
+    expect(getMobileConnectRenderers().some(r => r.kind === 'tailnet_qr')).toBe(false)
+  })
+
+  it('refuses a kind that could never match a descriptor verbatim', () => {
+    // Blank, whitespace-padded, and non-string all route to one rejection: the
+    // readers compare the server's `kind` verbatim, so normalizing here would
+    // register a key nothing can ever match, and reaching for `.trim()` on a
+    // non-string would throw a raw TypeError in production instead of degrading.
+    for (const kind of ['', '   ', ' padded_qr ', 123 as unknown as string]) {
+      expect(() => registerMobileConnectRenderer({ kind, component: () => null })).toThrow(
+        /non-empty method kind with no surrounding whitespace/,
+      )
+    }
+    expect(getMobileConnectRenderers().some(r => r.kind.includes('padded'))).toBe(false)
+  })
+
+  it('throws on a duplicate kind in dev/test; the first renderer keeps it', () => {
+    const first = () => null
+    const second = () => null
+    registerMobileConnectRenderer({ kind: 'seam_test_dup', component: first })
+    expect(() =>
+      registerMobileConnectRenderer({ kind: 'seam_test_dup', component: second }),
+    ).toThrow(/already has a renderer/)
+    expect(getMobileConnectRenderers().find(r => r.kind === 'seam_test_dup')?.component).toBe(first)
   })
 })
 


### PR DESCRIPTION
## What

Adds a frontend **renderer seam** so a downstream edition can draw its own phone-connection method kinds in the "Connect your phone" dialog.

The backend `mobile_connect` CPP seam already decides *which* methods a deployment offers — `MobileConnectProvider.connect_methods()` returns `{id, kind}` descriptors and `capabilities.mobile_connect` governs which survive. But a descriptor only *names* a method. The UI that drives its mint endpoint lives in the frontend, and the renderable set was written into two consumers as matching string literals:

- `App.tsx` filtered `kind === 'tailnet_qr' || kind === 'login_link'` before showing the nav rail row;
- `MobileConnectModal` tested the same two strings again to pick a section.

A contributed method fell through both. Hiding the rail row rather than opening an empty dialog was the *correct* outcome — and also a dead end with no way out short of patching core on every sync.

## How

New `website/src/components/mobileConnectRenderers.tsx`:

```ts
registerMobileConnectRenderer({ kind, component })   // registrar (edition)
getMobileConnectRenderers()                          // reader (the dialog)
canRenderMobileConnectKind(kind)                     // reader (the nav rail)
```

- **Keyed on `kind`, not `id`** — that is the descriptor's own split. `id` is the governed identifier the `methods` ruleset narrows on; `kind` names the frontend renderer. Two methods may share a kind, so a component that needs the ids reads `/api/mobile-connect/methods` itself.
- **Single definition of the renderable set.** The predicate gates the rail row and the reader supplies the dialog's sections, so the two consumers cannot diverge the way two copies of a literal can. A kind neither drawn nor registered is still filtered out at the rail — the seam adds a way to draw a method, it does not remove that guard.
- **A built-in kind cannot be claimed.** `tailnet_qr` / `login_link` are drawn by core sections whose mint endpoints the core audits, so registering over one is a collision, not an override — silently replacing one would redirect a credential mint the core still believes it owns. A kind that could never match a descriptor verbatim (blank, whitespace-padded, or not a string) is refused through the same `reportSeamCollision` path, which throws in dev/test and warns-and-ignores in production — including the non-string case, which would otherwise throw a raw `TypeError` at composition.
- **It cannot widen governance.** The methods endpoint filters every id through `capabilities.mobile_connect` **fail-closed** before the dialog sees a kind, and each built-in mint endpoint re-runs that decision (`mint_denied_reason`) because the filtered list is presentation, never the control. A renderer receives only `onClose` — no token, no id, no credential — so it cannot obtain anything the server had not already authorized. An edition's own mint endpoint is outside this seam and enforces its own authorization.
- Registered sections render **above** the built-ins (a contributed method is the deployment's primary way in; the built-in link is the fallback beneath it), each in its own `ErrorBoundary`. That boundary deliberately keeps its **default fallback** rather than `fallback={null}` as the Overview stat-card slot uses: a vanishing card leaves a grid of siblings, but a section here can be the dialog's only content, and silently emptying it would strand a user who arrived from a nav row that promised a way in.
- The registry is **not** in the lazily-loaded dialog chunk: the rail decides whether to show the row before that chunk is ever fetched. The lazy dialog imports the same ES-module instance, so it observes the same registrations.

This is the thirteenth frontend registry seam. `extensions.ts` and `website/docs/extension-seams.md` are updated (counts, table row, per-seam validation).

## Stock behavior is unchanged

The core registers nothing, so `getMobileConnectRenderers()` returns `[]`, `canRenderMobileConnectKind` reduces to exactly what the old literals answered, and the dialog's built-in section order plus `LoginLinkSection`'s `standalone` divider logic are unchanged for every input combination (`!hasQr && editionSections.length === 0` reduces to `!hasQr`). No new user-facing strings, so no catalog churn — a registered section owns its own copy.

## Testing

- `src/test/extensionSeams.test.tsx` — 5 cases: a fresh registry is empty and only built-ins are drawable, registering is what makes a kind drawable, a built-in kind is refused, a non-matchable kind is refused (blank / whitespace-padded / non-string), and a duplicate is refused with the first renderer kept.
- `src/components/MobileConnectModal.test.tsx` — 6 cases: a registered renderer draws for an offered kind (and touches no built-in mint), draws nothing for a kind the deployment does not offer, renders above the built-in link which keeps working, a throwing renderer disables only itself, a throwing renderer that is the *only* method still leaves usable content, and every member of `BUILTIN_MOBILE_CONNECT_KINDS` actually draws a section (pinning the constant to the sections that exist, so a future member cannot reintroduce the empty-dialog case).
- Every test in the new suites is **order-independent**: verified green under `--sequence.shuffle` across 6 seeds. The only shuffle failures in `extensionSeams.test.tsx` are pre-existing cases in the sibling seam suites (`capsuleSegments`, `overviewStatCards`, `overviewPanel`, `overviewBuiltins`), untouched by this PR.
- Local gates green: `tsc --noEmit`, `eslint src/ --max-warnings 659` (658), `npm run i18n:check`, `npm run build`, 71 tests passed.

## Visual evidence

<!-- no-visual-delta -->

**Why no screenshot:** this PR has no visual delta in any build a screenshot could be taken of. The core registers nothing into the new registry, so `getMobileConnectRenderers()` returns `[]` and the dialog renders pixel-for-pixel what it rendered before — same sections, same order, same `standalone` divider for every input combination. The seam's only visible effect requires a *registered* renderer, which exists solely in a downstream edition build (`KIROCREW_EDITION_DIR`), not in this repository. A screenshot here would therefore show the unchanged dialog and evidence nothing.

What a screenshot would have shown is covered by assertions on the rendered DOM instead: a registered section appearing, its position above the built-in link, the built-in link still working beside it, and the failure path where a throwing renderer that is the only method still leaves usable content rather than an empty dialog.
