### PR TITLE
perf(security): make nested-payload extraction linear in token count

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3225,6 +3225,49 @@ def _is_shell_command_flag(token: str) -> bool:
     return token == "--command" or bool(_SHELL_COMMAND_FLAG_RE.match(token))
 
 
+def _is_shell_command_flag_or_herestring(token: str) -> bool:
+    """True where the shell-program scan in :func:`_nested_shell_payloads` stops.
+
+    Exactly the three conditions that loop broke on, in one predicate: a command
+    flag, the spaced herestring operator, and the glued spelling.  Kept together so
+    the precomputed stop index and the handling at that index cannot drift apart.
+    """
+    return _is_shell_command_flag(token) or token == "<<<" or token.startswith("<<<")
+
+
+def _is_env_split_flag(token: str) -> bool:
+    """True where the ``env -S`` scan in :func:`_nested_shell_payloads` stops."""
+    flag = token.lower()
+    return (
+        flag in {"-s", "--split-string"}
+        or (flag.startswith("-s") and len(token) > 2)
+        or flag.startswith("--split-string=")
+    )
+
+
+def _is_not_double_dash(token: str) -> bool:
+    """True where the ``--`` skip in :func:`_nested_shell_payloads` stops.
+
+    Named for the same reason the other two stop conditions are: the precomputed
+    index and the token the caller then reads must not drift apart.
+    """
+    return token != "--"
+
+
+def _next_stop_indexes(tokens: "list[str]", is_stop: "Callable[[str], bool]") -> "list[int]":
+    """For each index, the first index at or after it where *is_stop* holds.
+
+    One backward pass, so a forward scan per program token becomes a lookup and the
+    caller stays linear in token count.  Position ``len(tokens)`` means "no such
+    token", which reads the same as the original loops running off the end.
+    """
+    limit = len(tokens)
+    table = [limit] * (limit + 1)
+    for index in range(limit - 1, -1, -1):
+        table[index] = index if is_stop(tokens[index]) else table[index + 1]
+    return table
+
+
 def _nested_shell_payloads(tokens: "list[str]") -> "list[str]":
     """Literal shell-script payloads carried as an argument inside *tokens*.
 
@@ -3235,51 +3278,61 @@ def _nested_shell_payloads(tokens: "list[str]") -> "list[str]":
     this function.
     """
     payloads: list[str] = []
+    # Both scans below look for the FIRST token after a program that satisfies a stop
+    # predicate, handle it, and stop.  Walking forward per program made the function
+    # QUADRATIC in token count: in a run of interpreter tokens with no flag among them
+    # every one of them re-walks the whole tail, so a command padded with them stalls
+    # the synchronous permission gate (measured: 13.2 s for 16 000 tokens, ~4x per
+    # doubling).  The first-stop index is precomputed once per predicate in a single
+    # backward pass instead, which makes the whole function O(N) while returning the
+    # identical payload list -- the loops' only exits were that first stop token or the
+    # end of the list, so nothing else can change.
+    shell_stop = _next_stop_indexes(tokens, _is_shell_command_flag_or_herestring)
+    env_stop = _next_stop_indexes(tokens, _is_env_split_flag)
+    # ``--`` runs are precomputed for the same reason: a long run of them after the
+    # command flag is walked once per program token otherwise, which is quadratic even
+    # though the two scans above are not.
+    past_dashes = _next_stop_indexes(tokens, _is_not_double_dash)
+    limit = len(tokens)
     for i, token in enumerate(tokens):
         base = _program_basename(token)
         # A shell reached through a VARIABLE (``$SHELL -c '<payload>'``) runs the
         # payload exactly as a named shell does.  The recognizer already used for the
         # ``| $SHELL`` evaluator sink applies here too.
         if base in _NESTED_SHELL_PROGRAMS or _is_shell_variable_reference(token):
-            for j in range(i + 1, len(tokens)):
+            j = shell_stop[i + 1]
+            if j < limit:
                 if _is_shell_command_flag(tokens[j]):
                     # ``bash -c -- '<script>'`` is legal: ``--`` ends option parsing
                     # and the script is the token AFTER it.  Skip any run of them.
-                    k = j + 1
-                    while k < len(tokens) and tokens[k] == "--":
-                        k += 1
-                    if k < len(tokens):
+                    k = past_dashes[j + 1]
+                    if k < limit:
                         payloads.append(tokens[k])
-                    break
                 # A HERESTRING feeds the script on stdin instead of as an argument
                 # (``bash <<< '<script>'``), so its text is a command just the same.
                 # Both the spaced and glued spellings arrive here.
-                if tokens[j] == "<<<":
-                    if j + 1 < len(tokens):
+                elif tokens[j] == "<<<":
+                    if j + 1 < limit:
                         payloads.append(tokens[j + 1])
-                    break
-                if tokens[j].startswith("<<<"):
+                elif tokens[j].startswith("<<<"):
                     payloads.append(tokens[j][3:])
-                    break
         elif base in _ENV_SPLIT_PROGRAMS:
             # ``env -S '<script>'`` / ``env --split-string '<script>'`` splits the
             # payload into a command and runs it, so its text is a command line.
-            for j in range(i + 1, len(tokens)):
+            j = env_stop[i + 1]
+            if j < limit:
                 # ``is_denied`` lowercases its input, so compare case-insensitively:
                 # the real flag is ``-S`` but it arrives here as ``-s``.
                 flag = tokens[j].lower()
                 if flag in {"-s", "--split-string"}:
-                    if j + 1 < len(tokens):
+                    if j + 1 < limit:
                         payloads.append(tokens[j + 1])
-                    break
-                if flag.startswith("-s") and len(tokens[j]) > 2:
+                elif flag.startswith("-s") and len(tokens[j]) > 2:
                     payloads.append(tokens[j][2:])
-                    break
-                if flag.startswith("--split-string="):
+                elif flag.startswith("--split-string="):
                     payloads.append(tokens[j].split("=", 1)[1])
-                    break
         elif base in _NESTED_SHELL_VERBS or token in _NESTED_SHELL_VERBS:
-            if i + 1 < len(tokens):
+            if i + 1 < limit:
                 payloads.append(tokens[i + 1])
     # ``bash<<<'<payload>'`` glues the program, the operator and the payload into ONE
     # token, so the program never appears as a token of its own for the walk above to

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -4233,3 +4233,126 @@ class TestPythonStdinDetectorStepsOverOutputRedirects:
             "pytest tests/ *> out",
         ):
             assert not security._is_credential_mint(cmd.lower()), cmd
+
+
+class TestNestedPayloadExtractionIsLinear:
+    """``_nested_shell_payloads`` must stay LINEAR in token count.
+
+    It runs inside the synchronous PreToolUse gate, on every command, through the
+    self-protection floor (``_self_token_frames``) and the deny tiers.  Both of its
+    scans used to walk forward per program token looking for the first command flag,
+    so a command padded with interpreter tokens -- none of which is a flag -- made
+    every one of them re-walk the whole tail: quadratic, and measured at 13.2 s for
+    16 000 tokens, growing ~4x per doubling.  At that size the gateway's own loop
+    watchdog fires and the process exits, so this is a denial of service reachable
+    from any agent- or injection-authored command.
+
+    The fix precomputes each scan's first-stop index in one backward pass.  The
+    payload list is unchanged by construction -- the loops' only exits were that
+    first stop token or the end of the list -- and both properties are pinned here:
+    the SET, so the transformation cannot silently drop or invent a payload, and the
+    COMPLEXITY, so a future edit cannot reintroduce a per-program walk.
+    """
+
+    # Every shape the extractor recognises, with the payloads it must produce.
+    SHAPES: "list[tuple[list[str], list[str]]]" = [
+        (["bash"] * 8 + ["-c", "x"], ["x"] * 8),
+        (["bash", "-c", "--", "--", "x"], ["x"]),
+        # A ``--`` run that reaches the end of the list yields NOTHING: there is no
+        # script token after it.  Worth pinning because the scan still has to traverse
+        # the run, so this is the shape whose cost buys no payload at all.
+        (["$0"] * 3 + ["-c"] + ["--"] * 3, []),
+        (["$0"] * 3 + ["-c"] + ["--"] * 3 + ["x"], ["x"] * 3),
+        (["bash", "-c", "--", "x", "--", "y"], ["x"]),
+        (["bash", "--", "-c", "x"], ["x"]),
+        (["bash", "<<<", "x"], ["x"]),
+        (["bash", "<<<x"], ["x"]),
+        (["bash<<<x"], ["x"]),
+        (["env", "-Sx"], ["x"]),
+        (["env", "--split-string=x"], ["x"]),
+        (["env", "--split-string", "x"], ["x"]),
+        (["eval", "x"], ["x"]),
+        (["$SHELL", "-c", "x"], ["x"]),
+        (["bash", "-c"], []),
+        (["bash", "-c", "--"], []),
+        (["a=(rm -rf)", "${a[@]}"], ["rm -rf"]),
+        ([], []),
+    ]
+
+    def test_the_payload_set_is_unchanged(self):
+        from kiro_crew import security
+
+        for tokens, expected in self.SHAPES:
+            assert security._nested_shell_payloads(list(tokens)) == expected, tokens
+
+    def test_the_scan_is_linear_not_quadratic(self):
+        """Asserted two ways, because either alone is weak: a doubling RATIO, which
+        catches the quadratic regardless of machine speed, and an absolute budget a
+        quadratic scan could not meet on any runner.
+        """
+        import time
+
+        from kiro_crew import security
+
+        def elapsed(n: int) -> float:
+            tokens = ["bash", "x"] * (n // 2)
+            start = time.perf_counter()
+            security._nested_shell_payloads(tokens)
+            return time.perf_counter() - start
+
+        # Warm the interpreter so the first call's import/JIT noise is not measured.
+        elapsed(2000)
+        small, large = elapsed(8000), elapsed(16000)
+        # Linear doubles; the old quadratic quadrupled.  The bound is generous
+        # (3x for a 2x input) so scheduler noise on a shared runner cannot red it,
+        # while a quadratic scan's 4x cannot pass.
+        assert large < small * 3, f"{small:.4f}s -> {large:.4f}s looks super-linear"
+        # ...and the absolute floor: the quadratic took ~13 s at this size.
+        assert large < 1.0, f"16k tokens took {large:.3f}s"
+
+    def test_a_long_double_dash_run_is_also_linear(self):
+        """The ``--`` skip after a command flag was a THIRD forward walk, and fixing
+        the two scans did not fix it: every program token found the same flag and then
+        re-walked the whole run, so ``$0 ... -c -- -- ...`` stayed quadratic (measured
+        4x per doubling) even with the scans linear."""
+        import time
+
+        from kiro_crew import security
+
+        def elapsed(n: int) -> float:
+            tokens = ["$0"] * n + ["-c"] + ["--"] * n
+            start = time.perf_counter()
+            security._nested_shell_payloads(tokens)
+            return time.perf_counter() - start
+
+        elapsed(500)
+        small, large = elapsed(4000), elapsed(8000)
+        assert large < small * 3, f"{small:.4f}s -> {large:.4f}s looks super-linear"
+        assert large < 1.0, f"8k+8k tokens took {large:.3f}s"
+
+    def test_the_stop_predicates_match_the_handling(self):
+        """The precomputed index and the branch taken at that index are two places
+        that must agree.  Each predicate is therefore asserted to hold exactly on the
+        tokens its handler knows how to process."""
+        from kiro_crew import security
+
+        for token in ("-c", "<<<", "<<<glued"):
+            assert security._is_shell_command_flag_or_herestring(token), token
+        for token in ("x", "--", "bash", ""):
+            assert not security._is_shell_command_flag_or_herestring(token), token
+
+        for token in ("-s", "--split-string", "-Sx", "--split-string=x"):
+            assert security._is_env_split_flag(token), token
+        for token in ("x", "-c", "--", ""):
+            assert not security._is_env_split_flag(token), token
+
+        assert not security._is_not_double_dash("--")
+        for token in ("x", "-c", "", "---"):
+            assert security._is_not_double_dash(token), token
+
+    def test_the_index_table_reads_as_no_such_token_past_the_end(self):
+        from kiro_crew import security
+
+        table = security._next_stop_indexes(["a", "-c", "b"], lambda t: t == "-c")
+        assert table == [1, 1, 3, 3], table
+        assert security._next_stop_indexes([], lambda t: True) == [0]


### PR DESCRIPTION
## 1. What is the problem?

`_nested_shell_payloads` is quadratic in token count, and it runs inside the synchronous PreToolUse permission gate on every command -- reached both by the self-protection floor (`_self_token_frames`) and by the deny tiers.

Both of its scans walk forward from each interpreter token looking for the first command flag. In a run of interpreter tokens where none of them is a flag, every one of them re-walks the whole tail:

| tokens | time |
|---|---|
| 2 000 | 0.209 s |
| 8 000 | 3.302 s |
| 16 000 | 13.206 s |

About 4x per doubling. At the 54.7 KB / 16 000-token mark a single call takes ~13 s, and `is_denied` evaluates several deny targets per tool call, so the gateway's own 25-second loop watchdog fires and the process exits.

## 2. Why this issue matters to the user

The input is a command, and commands on this path are model-authored -- so the padding needed to trigger this can arrive from ordinary agent output or from prompt injection, with no operator action. The failure mode is not a slow gate: it is the gateway exiting, which takes every live session with it. And because the cost is paid in the *permission* gate, it is paid before any decision is reached, so there is no configuration or opt-out that avoids it.

This was found while reviewing [PR #7013](https://github.com/kirodotdev/KiroCrew/pull/7013) (the quote-normalized deny view). Measurement there showed the stall is pre-existing and independent of that change: `_self_token_frames`, untouched by it, accounts for 13.11 s of a 13.33 s total. A maintainer therefore ruled the cause-level fix out of that PR and into this one, so it gets reviewed on its own terms.

## 3. How our fix solves it

Each scan's first-stop index is precomputed once in a single backward pass (`_next_stop_indexes`), turning a per-program forward walk into a lookup. The function becomes O(N).

Review then caught a **third** forward walk that fixing the two scans did not fix: the `--` run skipped after a command flag (`bash -c -- -- script`). Every program token found the same flag and re-walked the whole run, so `$0 ... -c -- -- ...` stayed quadratic at 4x per doubling -- and that shape reaches the end of the list, so it produces no payload at all and the cost bought nothing. It is now the same one-pass lookup: 2x per doubling, 0.5408 s -> 0.0213 s at 8 001 tokens.

**The payload list is unchanged by construction**, which is the property that makes this safe: each loop's only exits were the first stop token or the end of the list, so the precomputed index selects exactly the token the walk would have stopped at, and the handling at that index is untouched. Nothing about *which* payloads are found changes -- only how the position is located.

Measured after the change, same shape:

| tokens | before | after | speedup |
|---|---|---|---|
| 2 000 | 0.209 s | 0.0040 s | 52x |
| 8 000 | 3.302 s | 0.0161 s | 205x |
| 16 000 | 13.206 s | 0.0320 s | 413x |

Two details are deliberate. The stop conditions are **named predicates** (`_is_shell_command_flag_or_herestring`, `_is_env_split_flag`) rather than inline conditions, because the precomputed index and the branch taken at that index are two places that must agree -- naming them lets both be pinned. And `_next_stop_indexes` returns `len(tokens)` for "no such token", which reads the same way the original loops ran off the end.

Two alternatives were rejected on the merits. **Bounding the scan by token count** is a silent security bypass, not a fix: pad a command past the bound and nested-payload inspection switches off, at which point `bash -c 'rm -rf "/"'` is not seen -- the raw text does not contain the rule (it is quoted) and the re-join keeps the payload's inner quotes. **Removing the nested-payload walk** from the calling PR would have deleted coverage a maintainer had explicitly ruled in, and per the numbers would have addressed 2% of the cost while leaving the floor's 13 s intact.

## 4. What tests we did

`TestNestedPayloadExtractionIsLinear` in `test/test_denied_commands_security.py`:

- **The payload set is unchanged** -- a `SHAPES` table pinning the exact payload list for every form the extractor recognises: `-c`, `-c` with a `--` run, spaced and glued herestrings, a glued program (`bash<<<x`), `env -S` in all three spellings, bare verbs, `$SHELL -c`, array expansion, and the shapes that must yield nothing -- including a `--` run that reaches the end of the list, `--` before the flag, and a second `--` after the script that must *not* be skipped.
- **The scan is linear** -- asserted two ways, because either alone is weak: a doubling ratio (catches a quadratic regardless of machine speed, bounded generously at 3x for a 2x input so runner noise cannot red it, while a quadratic's 4x cannot pass) and an absolute budget the quadratic could not meet on any runner. Asserted for the interpreter-run shape and separately for the `--`-run shape.
- **The stop predicates match the handling**, and the index table reads correctly past the end.

**Equivalence was established before writing the edit**, and re-established after the `--` fix against the **genuine base implementation** rather than a paraphrase of it: the base revision's function is extracted with the `ast` module and exec'd against the live module's globals, so all nine of its parts participate. 15 adversarial shapes plus 8 000 randomized token lists over an alphabet including `--` runs, `sed -e`, `xargs`, `alias`, arrays and empty tokens -- zero mismatches.

Paraphrasing this function produced a false result **twice** on this change, which is why the harness now execs the real thing. The first draft of the transformation reproduced only the parts I had read, missing the `sed` `e`-flag, multiword `alias` and pipe-into-evaluator sections and the trailing `if p.strip()` filter -- 166 mismatches. Then the first harness for the `--` round made the same mistake in the *reference* and reported 356 mismatches that were all artifacts of its own omissions. The committed change touches only the two scans and the `--` skip, leaving those sections byte-identical.

**Mutation-verified red on base:** with `security.py` stashed and the tests kept, the linearity test and both helper tests fail, while the payload-set test passes -- correct, since it is the no-regression control that must be green on both sides.

Targeted runs (never the full suite): `test_denied_commands_security.py` + `test_governance_self_protection.py` + `test_security.py` + `test_push_branch_gate.py` -- **1687 passed, 1 skipped**. flake8, isort, mypy clean; black gate passes in scope.

## 5. Any other suggestions on the work

- **The self-protection floor gets the same speedup for free**, since `_self_token_frames` calls this function -- that path was the larger share of the measured cost, so the win is not confined to the deny tiers.
- **One sibling quadratic exists on this same gate path, and it is worse than this one.** The description originally said I had not audited for siblings; a reviewer pointed out the audit is one grep, so here it is. `grep "for j in range(i + 1, len("` under `src/` returns two hits. `security.py:4413` (`_self_module_name_index`) is a real sibling: `_self_program_index` calls it per python-looking token and `_matches_self_subcommand` loops that over all tokens, so with no `-m` present every scan runs to the end. Measured, once one product word opens the floor's keyword gate: 0.0326 / 0.1243 / 0.4881 / **1.9206 s** at 250/500/1000/2000 tokens -- 4x per doubling, about an order of magnitude worse per token than the defect fixed here, and negative-verdict shapes pay the whole cost to decide nothing. (`python ... restart` padding alone does NOT reproduce it -- the gate stays shut and the path is linear.) `knowledge/dedup.py:532` is pairwise by design and off the gate; not a sibling. Left for its own change, on the same grounds this one was split out: different function, pre-existing, wants its own before/after numbers.
- The tell for this defect class is a forward `for j in range(i + 1, len(tokens))` or a `while` skip over a repeated token, inside a loop over tokens -- and the `--` walk this review caught is the argument for looking, since fixing the two obvious scans left a third walk in the branch I was editing. "The scans are linear now" was not the same claim as "the function is linear now".
- The `SHAPES` table is the useful artifact to keep even if the algorithm changes again: it is the first explicit statement anywhere in the tree of what this extractor is supposed to return for each spelling.
