### PR TITLE
perf(dev-fleet): skip the sync preflight install when the frontend is untouched

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -659,6 +659,45 @@ stdlib-only, so the copy needs no package context. Both halves matter: `-I` drop
 the cwd from `sys.path`, and the snapshot means an editable install cannot make
 the tree being synced supply the code doing the verifying.
 
+**The install is skipped when the answer is already on disk.** Most syncs are
+backend-only and change nothing under `website/`, so paying a full scratch install
+to re-derive "is this lockfile installable" on every Pull + Build is cost without
+information. `_install_already_proven` skips it, and only when BOTH hold: `git
+diff --name-only <ref> -- website` is empty, meaning the incoming ref changes no
+path under the frontend half at all, AND `website/node_modules` is populated (not
+merely present — an interrupted `npm ci` leaves an empty directory, which proves
+nothing). Without a tree there is no evidence, so a fresh checkout's first sync
+still probes. Anything the comparison cannot answer — a failing or missing `git`,
+a timeout — probes as well: the unknown case costs an install rather than a
+guarantee.
+
+A populated tree is evidence, not a verified install, and the bound is worth
+stating: a prior frontend sync whose post-merge `npm ci` died partway can leave a
+partial tree beside the merged lockfile, and later backend-only syncs will skip on
+it, since from there on the subtree is unchanged and nothing re-examines it. The
+consequence is the same class as the dead-registry residual — the skip decides only
+whether this sync pays for a rehearsal, so a refusal lands one step later rather
+than never, and the transaction keeps the checkout consistent either way. Issue
+[#7132](https://github.com/kirodotdev/KiroCrew/issues/7132) tracks the stronger
+evidence check that would close it.
+
+The condition is the whole subtree rather than just `package-lock.json` /
+`package.json` / `.npmrc`, and the difference is load-bearing. With those three
+identical but frontend SOURCE changed, a skipped probe lets the merge land, and a
+failing `npm ci` afterwards leaves the checkout with new source and the
+previously-built bundle — the stale-bundle half of the very defect this section
+exists to prevent. Requiring the entire subtree to be unchanged makes that
+unreachable: with no frontend change there is no new bundle owed, so a failed sync
+leaves the frontend byte-for-byte as it was.
+
+What makes the skip safe rather than merely cheap is where a failure lands. Under
+this condition the transaction above restores the tree on any non-zero step, the
+lockfile it matches did not change, and neither did the source the bundle was
+built from. A skipped probe can only leave a state a later `npm ci` fixes, never
+one no revision produced. A skip is reported on the run's `preflight:` detail line
+rather than the generic pass line, so it is visible in the log instead of
+inferable from a missing pause.
+
 **Failure causes reach the dashboard as an exit code, not as text.** The probe
 exits with a reserved code (41-45) and the runner owns two more (46 ambiguous
 tree, 47 restore failed); `npm_preflight.explain_exit` maps each to one

--- a/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/npm_preflight.py
@@ -35,9 +35,10 @@ retrieval at all: against a lockfile pinning a tarball that 404s, measured,
 ``npm ci --dry-run --ignore-scripts`` exits 0 and reports "added 1 package"
 while the same command without ``--dry-run`` exits 1 on the missing tarball. A
 dry run would therefore pass exactly the case this module exists to catch, so
-the probe has to fetch. The cost of that honesty is one script-free install per
-sync -- seconds against a warm cache -- which is cheap next to the emptied
-``node_modules`` it prevents.
+the probe has to fetch. That install is cheap next to the emptied
+``node_modules`` it prevents -- and it is no longer paid on every sync:
+:func:`_install_already_proven` skips it when the incoming ref touches nothing
+under ``website/`` and a populated tree is already there to answer for it.
 
 The flags otherwise MIRROR the real step exactly. A probe that resolves
 differently from the install is worse than no probe: it either passes what will
@@ -262,6 +263,87 @@ def _extract(git: str, repo: str, ref: str, subdir: str, dest: Path) -> tuple[in
     return None
 
 
+def _install_already_proven(git: str, repo: str, ref: str) -> str | None:
+    """Reason to SKIP the probe install, or ``None`` to run it.
+
+    The probe answers "can the INCOMING lockfile be installed?", and it pays a
+    real script-free install to answer honestly. But when the incoming ref
+    changes NOTHING under ``website/``, that question has already been put to
+    disk: no new resolution is arriving, and a populated ``node_modules`` sits
+    beside the one that is already there. Re-deriving it costs a full scratch
+    install on every backend-only sync -- the common case, since most syncs move
+    Python and never touch the frontend half at all.
+
+    Both halves are load-bearing, and the skip is refused unless both hold:
+
+    * **The whole frontend subtree is unchanged**, not merely its resolution
+      inputs. Comparing only ``package-lock.json`` / ``package.json`` /
+      ``.npmrc`` was not enough, and the gap is worth stating because it is
+      subtle: with those three identical but frontend SOURCE changed, a skipped
+      probe lets the merge land, and a failing ``npm ci`` afterwards leaves the
+      checkout with new source and the previously-built bundle. Requiring the
+      entire subtree to be identical makes that unreachable -- with no frontend
+      change there is no new bundle to be missing, so a failed sync leaves the
+      frontend byte-for-byte as it was.
+    * **A populated tree to point at.** With no ``node_modules`` there is no
+      evidence at all -- so a fresh checkout's first sync still probes, which is
+      exactly when the answer is least known. Populated rather than merely
+      present, because an interrupted ``npm ci`` can leave an empty directory
+      behind and an empty tree proves nothing.
+
+      Be precise about what populated does NOT prove: it is evidence, not a
+      verified install. A prior FRONTEND sync whose post-merge ``npm ci`` died
+      partway can leave a partial tree beside the merged lockfile, and a later
+      backend-only sync will skip on it -- the subtree is unchanged from there
+      on, so nothing re-examines it. That stays benign for the same reason the
+      dead-registry residual does: the skip decides only whether this sync PAYS
+      for a rehearsal, so a refusal lands one step later instead of never, and
+      the transaction keeps the checkout consistent either way. The evidence test
+      tracked in #7132 should cover this scenario and not only the interrupted
+      one.
+
+    What makes skipping SAFE rather than merely cheap is where a failure lands.
+    The probe exists because ``npm ci`` deletes ``node_modules`` first, so a
+    refusal after the merge used to leave new source beside an emptied tree.
+    Under this condition that outcome is not reachable: the runner's transaction
+    moves the tree aside and puts it back on any non-zero step, the lockfile did
+    not change, and neither did the source the bundle was built from.
+    A skipped probe can only leave a state a later ``npm ci`` fixes.
+
+    ``git diff`` rather than a byte comparison of the resolution files, because
+    the question is about the whole subtree and git already answers exactly that
+    against the working tree. Anything it cannot answer -- a failing or missing
+    git, a timeout -- returns ``None`` and the probe runs, so the unknown case
+    costs an install rather than a guarantee.
+    """
+    try:
+        proc = subprocess.run(  # nosec B603 - argv list, no shell
+            [git, "-C", repo, "diff", "--name-only", ref, "--", _FRONTEND_SUBDIR],
+            capture_output=True,
+            timeout=60,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0 or (proc.stdout or b"").strip():
+        # Non-zero: the comparison could not be made, so nothing is established.
+        # Non-empty: at least one path under the frontend half differs.
+        return None
+    node_modules = Path(repo) / _FRONTEND_SUBDIR / "node_modules"
+    try:
+        if not any(node_modules.iterdir()):
+            return None
+    except OSError:
+        # Absent, a file, or unreadable -- in every case there is no tree to
+        # treat as evidence, so probe.
+        return None
+    return (
+        f"skipped the install: the incoming ref changes nothing under "
+        f"{_FRONTEND_SUBDIR}/ and its node_modules is populated, so no new "
+        "resolution is arriving and no new bundle is owed"
+    )
+
+
 def probe(
     *,
     git: str,
@@ -292,6 +374,14 @@ def probe(
         failure = _extract(git, repo, ref, _FRONTEND_SUBDIR, tmp)
         if failure:
             return failure
+        # Asked AFTER the extraction, which is deliberate rather than leftover:
+        # `_extract` is what establishes that the incoming ref carries a readable
+        # lockfile at all, and that precondition should hold before any verdict
+        # is returned. Three small `git show` calls are nothing against the
+        # install being skipped.
+        proven = _install_already_proven(git, repo, ref)
+        if proven:
+            return EXIT_OK, proven
         try:
             proc = subprocess.run(  # nosec B603 - argv list, no shell
                 [npm, "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
@@ -355,7 +445,12 @@ def main(argv: list[str] | None = None) -> int:
         ref=args.ref,
     )
     if code == EXIT_OK:
-        print(f"{DETAIL_PREFIX}incoming lockfile is installable", flush=True)
+        # The detail carries the SKIP reason when the install was not needed, and
+        # is empty when it ran and passed. Printing it rather than the generic
+        # line is what keeps a skipped probe visible: an operator reading the run
+        # log should never have to infer from a missing pause that the safety
+        # step did not run.
+        print(f"{DETAIL_PREFIX}{detail or 'incoming lockfile is installable'}", flush=True)
         return EXIT_OK
     # The DIAGNOSIS travels as the exit code, which the gateway maps through
     # explain_exit(). Only a human-readable detail goes to stdout, and it is log

--- a/test/test_dev_fleet_npm_preflight.py
+++ b/test/test_dev_fleet_npm_preflight.py
@@ -357,3 +357,187 @@ class TestScratchFilesystemFailures:
         )
         assert code == np.EXIT_TRANSIENT
         assert "timed out" in detail
+
+
+def _tree(root: Path, *, populated: bool = True) -> str:
+    """A checkout whose frontend half has a dependency tree. Returns the repo path."""
+    nm = root / "website" / "node_modules"
+    nm.mkdir(parents=True, exist_ok=True)
+    if populated:
+        (nm / ".package-lock.json").write_bytes(b"{}")
+    return str(root)
+
+
+def _git(*, changed: list[str] | None = None, rc: int = 0, boom: Exception | None = None):
+    """A ``git`` stub for the subtree comparison. ``changed`` is what diff reports."""
+
+    def fake_run(argv, **kw):
+        if boom is not None:
+            raise boom
+        out = "\n".join(changed or []).encode()
+        return subprocess.CompletedProcess(argv, rc, out, b"")
+
+    return fake_run
+
+
+class TestSkipWhenTheFrontendIsUntouched:
+    """The probe pays a real install to be honest; it should pay only when the
+    answer is not already on disk.
+
+    Most syncs are backend-only and change nothing under ``website/``, so
+    re-deriving "is this lockfile installable" costs a full scratch install for
+    an answer the populated tree beside those same files already gives.
+    """
+
+    def test_skips_when_the_frontend_subtree_is_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(changed=[]))
+        reason = np._install_already_proven("/usr/bin/git", _tree(tmp_path), "origin/main")
+        assert reason and "changes nothing under" in reason
+        assert "website/" in reason
+
+    @pytest.mark.parametrize(
+        "changed,why",
+        [
+            (["website/package-lock.json"], "a new lockfile is a new resolution"),
+            (["website/package.json"], "npm ci verifies the lockfile against package.json"),
+            (["website/.npmrc"], ".npmrc carries settings that change resolution"),
+            (
+                ["website/src/App.tsx"],
+                "changed SOURCE owes a new bundle: with the three resolution inputs "
+                "identical but source changed, a skipped probe lets the merge land and "
+                "a failing npm ci afterwards leaves new source beside the "
+                "previously-built bundle -- the gap that made comparing only the "
+                "resolution files insufficient",
+            ),
+            (["website/index.html"], "any frontend path at all is a frontend change"),
+        ],
+    )
+    def test_probes_when_anything_under_the_frontend_changed(
+        self, tmp_path, monkeypatch, changed, why
+    ):
+        monkeypatch.setattr(np.subprocess, "run", _git(changed=changed))
+        assert (
+            np._install_already_proven("/usr/bin/git", _tree(tmp_path), "origin/main") is None
+        ), why
+
+    def test_probes_when_there_is_no_dependency_tree(self, tmp_path, monkeypatch):
+        """With nothing installed there is no evidence, so a fresh checkout's
+        first sync still probes -- which is when the answer is least known.
+
+        The subtree is reported UNCHANGED here, so the missing tree is the only
+        thing that can make this probe.
+        """
+        monkeypatch.setattr(np.subprocess, "run", _git(changed=[]))
+        (tmp_path / "website").mkdir(parents=True)
+        assert np._install_already_proven("/usr/bin/git", str(tmp_path), "origin/main") is None
+
+    def test_probes_when_the_tree_is_present_but_empty(self, tmp_path, monkeypatch):
+        """An interrupted `npm ci` leaves an empty directory behind, and an empty
+        tree proves nothing about installability."""
+        monkeypatch.setattr(np.subprocess, "run", _git(changed=[]))
+        repo = _tree(tmp_path, populated=False)
+        assert np._install_already_proven("/usr/bin/git", repo, "origin/main") is None
+
+    def test_probes_when_node_modules_is_a_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(np.subprocess, "run", _git(changed=[]))
+        web = tmp_path / "website"
+        web.mkdir(parents=True)
+        (web / "node_modules").write_bytes(b"not a tree")
+        assert np._install_already_proven("/usr/bin/git", str(tmp_path), "origin/main") is None
+
+    @pytest.mark.parametrize(
+        "kwargs,why",
+        [
+            ({"rc": 128}, "a failed comparison establishes nothing"),
+            ({"boom": OSError("no git")}, "a missing git establishes nothing"),
+            ({"boom": subprocess.TimeoutExpired("git", 60)}, "a timeout establishes nothing"),
+        ],
+    )
+    def test_an_unanswerable_comparison_probes(self, tmp_path, monkeypatch, kwargs, why):
+        """The unknown case must cost an install, never a guarantee."""
+        monkeypatch.setattr(np.subprocess, "run", _git(**kwargs))
+        assert (
+            np._install_already_proven("/usr/bin/git", _tree(tmp_path), "origin/main") is None
+        ), why
+
+    def test_the_skip_makes_the_install_not_run_at_all(self, tmp_path, monkeypatch):
+        """The point of the decision is the cost it removes, so pin that no npm
+        process is started -- not merely that the verdict is OK."""
+        repo = _tree(tmp_path)
+
+        def fake_run(argv, **kw):
+            if "ci" in argv:
+                pytest.fail(f"npm must not run when the install is already proven: {argv}")
+            if "diff" in argv:
+                return subprocess.CompletedProcess(argv, 0, b"", b"")
+            return subprocess.CompletedProcess(argv, 0, b"{}", b"")
+
+        monkeypatch.setattr(np.subprocess, "run", fake_run)
+        code, detail = np.probe(
+            git="/usr/bin/git", npm="/usr/bin/npm", repo=repo, ref="origin/main"
+        )
+        assert code == np.EXIT_OK
+        assert "skipped the install" in detail
+
+    def test_a_touched_frontend_still_pays_for_the_install(self, tmp_path, monkeypatch):
+        """The saving must not become a hole: when the frontend DID change, the
+        install runs exactly as before."""
+        repo = _tree(tmp_path)
+        ran: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            if "ci" in argv:
+                ran.append(list(argv))
+                return subprocess.CompletedProcess(argv, 0, b"added 1 package", b"")
+            if "diff" in argv:
+                return subprocess.CompletedProcess(argv, 0, b"website/package-lock.json\n", b"")
+            return subprocess.CompletedProcess(argv, 0, b"{}", b"")
+
+        monkeypatch.setattr(np.subprocess, "run", fake_run)
+        code, _ = np.probe(git="/usr/bin/git", npm="/usr/bin/npm", repo=repo, ref="origin/main")
+        assert code == np.EXIT_OK
+        assert ran, "a touched frontend must still be probed by a real install"
+
+    def test_the_comparison_is_scoped_to_the_frontend_half(self, tmp_path, monkeypatch):
+        """A backend-only sync must not be disqualified by its own backend diff,
+        so the diff has to be pathspec-limited rather than repo-wide.
+
+        This assertion is also what pins the pathspec WIDE enough, and it carries
+        that alone. The stub returns whatever ``changed`` says regardless of the
+        pathspec, so the source-file row in the parametrized set above would keep
+        passing if the pathspec were narrowed back to the three resolution files
+        -- mutation-checked, and only this test reddened. The pair is what covers
+        the gap: that row pins that a source change in the diff means probe, this
+        one pins that the diff is asked about the whole subtree.
+        """
+        seen: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            seen.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        monkeypatch.setattr(np.subprocess, "run", fake_run)
+        np._install_already_proven("/usr/bin/git", _tree(tmp_path), "origin/main")
+        assert seen and "--" in seen[0] and seen[0][-1] == np._FRONTEND_SUBDIR, seen
+
+    def test_the_cli_reports_a_skip_rather_than_the_generic_pass_line(self, monkeypatch, capsys):
+        """A skipped safety step must be visible in the run log. Otherwise the
+        only trace is a missing pause, which nobody reads as a decision."""
+        monkeypatch.setattr(np, "probe", lambda **kw: (np.EXIT_OK, "skipped the install: because"))
+        rc = np.main(
+            ["--git", "/usr/bin/git", "--npm", "/usr/bin/npm", "--repo", "/repo", "--ref", "r"]
+        )
+        assert rc == np.EXIT_OK
+        out = capsys.readouterr().out
+        assert "skipped the install: because" in out
+        assert "incoming lockfile is installable" not in out
+
+    def test_the_cli_still_reports_a_real_pass_when_the_install_ran(self, monkeypatch, capsys):
+        monkeypatch.setattr(np, "probe", lambda **kw: (np.EXIT_OK, ""))
+        assert (
+            np.main(
+                ["--git", "/usr/bin/git", "--npm", "/usr/bin/npm", "--repo", "/repo", "--ref", "r"]
+            )
+            == np.EXIT_OK
+        )
+        assert "incoming lockfile is installable" in capsys.readouterr().out

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -723,18 +723,22 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # npm_preflight is the sync's pre-merge installability probe, and like
         # dep_sync it runs AS one of the sync steps -- which server.py already
         # wrapped through sandboxed_spawn_argv before handing it to the runner.
-        # So both of its spawns are already inside that sandbox, and routing them
-        # again would nest one sandbox inside itself; the chokepoint is applied at
-        # the call site, exactly as for server.py::worker.
+        # So all three of its spawns are already inside that sandbox, and routing
+        # them again would nest one sandbox inside itself; the chokepoint is
+        # applied at the call site, exactly as for server.py::worker.
         #
-        # Neither argv is agent-influenced. _extract spawns
+        # No argv is agent-influenced. _extract spawns
         # `<git> -C <repo> show <remote>/<base branch>:website/<fixed filename>`:
         # the binary comes from _trusted_bin (never PATH), the repo from the
         # operator-configured checkout, the branch from the BASE_BRANCH constant,
-        # and the three filenames from a module-level tuple. probe spawns
-        # `<npm> ci --ignore-scripts --no-audit --no-fund` with cwd set to its own
-        # mkdtemp scratch directory -- not a repository, and not a path any caller
-        # supplies.
+        # and the three filenames from a module-level tuple.
+        # _install_already_proven spawns
+        # `<git> -C <repo> diff --name-only <ref> -- website` from the same three
+        # sources, with the pathspec a module-level constant; it only READS, and
+        # its answer decides whether the install below is skipped.
+        # probe spawns `<npm> ci --ignore-scripts --no-audit --no-fund` with cwd
+        # set to its own mkdtemp scratch directory -- not a repository, and not a
+        # path any caller supplies.
         #
         # The lockfile it installs IS repo-controlled, but that is input data to
         # npm rather than steering of argv or cwd, it is the same content the real
@@ -742,6 +746,7 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # from getting code executed. A filesystem-scoped wrapper here would also
         # block the scratch-directory writes that are the whole point of the probe.
         "apps/builtins/dev_fleet/npm_preflight.py::_extract",
+        "apps/builtins/dev_fleet/npm_preflight.py::_install_already_proven",
         "apps/builtins/dev_fleet/npm_preflight.py::probe",
         # Foreground last-resort restart (Make Live on hosts with no drivable
         # service manager): a detached `kirocrew restart --port <marker port>`,


### PR DESCRIPTION
## What is the problem?

Dev Fleet's Pull + Build runs a full `npm ci` into a scratch directory on **every** sync, including ones that change no frontend file at all.

That install is the dependency preflight, and it earns its cost when the lockfile is new: `npm ci` deletes `website/node_modules` before it installs, so a registry that refuses one package used to leave the checkout with new source, a new lockfile and no frontend dependencies. The probe answers "can the incoming lockfile be installed?" between `fetch` and `merge`, where a refusal still costs nothing. It performs a real script-free install rather than `npm ci --dry-run` for a measured reason documented in the module: a dry run does not attempt retrieval, so against a lockfile pinning a tarball that 404s it exits 0 and reports "added 1 package" -- it would pass exactly the case the probe exists to catch.

The gap is that nothing asks whether the question is open. In `_sync_start_locked` the probe is gated on one condition:

```python
frontend_half = not frontend.edition_configured()
...
if frontend_half:
    preflight_steps = [( ... npm_preflight ... )]
```

So on any ordinary checkout it runs unconditionally. A backend-only sync -- the common case, since most syncs move Python and never touch `website/` -- pays a full scratch install plus its registry traffic to re-derive an answer that is already sitting on disk.

## Why this issue matters to the user

Pull + Build is an interactive button. The operator presses it and waits, and this step is on the critical path before the merge even starts, so its cost is wall-clock time they watch. It also spends registry bandwidth and scratch disk (the probe needs roughly a `node_modules` worth of space, which is why it has its own `EXIT_NO_SPACE` class) on every press.

**The win here is partial, and it is worth saying so up front rather than in a footnote.** This removes the SMALLEST of three redundant frontend costs a backend-only sync pays; the real `npm ci --prefix website` and the vite build still run unconditionally and together outweigh the probe, so the operator will still notice a wait. Those two are tracked as #7132 and the reasons they are a separate change are in section 5.

None of that buys anything when the sync changes no resolution input. The lockfile being installed is the same lockfile whose install is already unpacked in the checkout.

## How our fix solves it

Symptom: an install on every sync. Cause: the probe never asked whether its question was already answered. Fix: ask, and skip only when the answer is provably on disk.

`_install_already_proven` returns a skip reason, or `None` to run the install, and it refuses to skip unless **both** hold:

- **The whole frontend subtree is unchanged** between the incoming ref and the working tree -- `git diff --name-only <ref> -- website` empty, not merely the resolution files identical. This started as a comparison of `package-lock.json` / `package.json` / `.npmrc` alone, and GPT 5.6 found the gap that made it insufficient: with those three identical but frontend SOURCE changed, a skipped probe lets the merge land, and a failing `npm ci` afterwards leaves the checkout with new source and the previously-built bundle -- the stale-bundle half of the very defect the probe exists to prevent. Requiring the entire subtree to be identical makes that unreachable, since with no frontend change there is no new bundle owed. It is also what the item asked for in the first place: skip when the diff touches no frontend files.
- **There is a populated `website/node_modules`** to point at. That tree beside those exact files IS an install of that exact resolution -- it is the evidence. Populated rather than merely present, because an interrupted `npm ci` leaves an empty directory behind and an empty tree proves nothing. With no tree there is no evidence at all, so a fresh checkout's first sync still probes, which is exactly when the answer is least known.

**What makes this safe rather than merely cheap is where a failure lands.** The probe exists because a refusal after the merge left new source beside an emptied tree. Under the unchanged-inputs condition that outcome is unreachable: the runner's `node_modules` transaction (same subsystem, already on main) moves the tree aside and restores it on any non-zero step, and the lockfile it matches did not change -- so a post-merge npm failure restores a tree that is still correct for the merged source. A skipped probe can only leave a state a later `npm ci` fixes, never one no revision produced. That reasoning is why the skip is conditioned on resolution inputs specifically, and why it would NOT be safe as a blanket skip.

Placement: the check lives inside the probe, after the extraction and before the install. It cannot live at step-assembly time in `server.py`, because the incoming ref is created by the sync's own `fetch` step (`+refs/heads/<base>:refs/kirocrew/sync-base-<pid>`) and does not exist yet when the step list is built. After the extraction is the first moment both sides are readable, and before the install is the point of skipping it.

The decision asks `git` and reads one directory -- no `npm`, no network, and nothing that touches the checkout's own `node_modules`. That is what lets the choice to skip a safety probe be tested without running the thing it guards: `npm` is the guarded step, `git` is not.

A skip is reported on the run's `preflight:` detail line instead of the generic pass line, so `main()` now prints the detail when there is one. A skipped safety step should be visible in the log, not inferable from a missing pause.

## What tests we did

Targeted only, with an explicit worker cap (`-p no:randomly -n 4`) -- 55 passed in `test/test_dev_fleet_npm_preflight.py` and 296 in the `test_dev_fleet_app.py` sync/preflight group. CI runs the full suite.

**No real `npm ci` was run to test this.** The decision is exercised against real temp trees with `subprocess.run` stubbed, so `git` answers from a fixture while any `npm ci` invocation fails the test outright. Sixteen new cases in the existing suite:

- The skip fires when the frontend subtree is untouched, and its reason says so -- an operator reading the log must be able to tell why the safety step did not run.
- It does NOT fire for any changed frontend path (parametrized over the lockfile, `package.json`, `.npmrc`, a `.tsx` source file and `index.html`). The source row carries the reason the narrower condition was insufficient in its own assertion message, so the rationale sits on the case it explains rather than in a second test that asserted the same thing -- First Principles asked for that consolidation.
- It does NOT fire with no dependency tree, a present-but-empty tree, or `node_modules` as a file rather than a directory.
- It does NOT fire when the comparison cannot be answered (parametrized over a non-zero `git`, a missing `git`, and a timeout) -- the unknown case costs an install, never a guarantee.
- The diff is pathspec-limited to the frontend half, so a backend-only sync is not disqualified by its own backend diff.
- `probe()` starts no npm process at all when the skip fires -- the point is the cost removed, not the verdict -- and still pays for the install when the frontend did change.
- The CLI reports the skip reason rather than the generic pass line, and still reports the generic line when the install really ran.

Mutation-verified both load-bearing conditions: dropping the populated-tree requirement reddens all three evidence cases, and narrowing the pathspec back to the three resolution files reddens the scope assertion. That second mutation is also documented in the test itself, because it showed the pathspec-width guarantee rests on the scope assertion ALONE -- the stub returns its fixture regardless of pathspec, so the source-only case would have kept passing under the narrowed form. The pair is what covers the gap, and a reader should not have to rediscover which half does what.

Two earlier versions of these tests were wrong in ways the mutations caught rather than the assertions. The first no-tree test passed for the wrong reason (it wrote a differing `.npmrc`, so it would have survived deleting the evidence check); it now reports the subtree as unchanged so the missing tree is the only thing that can make it probe.

Pre-existing probe tests pass unchanged: they use a non-existent `repo=/repo`, where the comparison cannot be answered and the probe therefore runs, exactly as it should. Gates: isort, flake8 and black clean; mypy clean on the touched module (its 2 remaining errors are in `src/kiro_crew/transcribe.py`, untouched here and pre-existing); black baseline, brand and docs-lint pass with real scope after the commit.

## Any other suggestions on the work

- **The spec moves with the code.** `docs/system-specs/modules/dev-fleet.md` documented the preflight as unconditional, so it is updated in the same commit with the skip condition and the safety argument above -- otherwise the spec would keep describing a step that no longer always runs.
- **This does not weaken the destructive-path guard, and it is worth being precise about why.** The probe is an early-refusal optimization on top of the transaction, not the only thing standing between a bad lockfile and an emptied tree. The transaction is what makes the emptied tree unreachable; the probe is what makes the refusal land before the merge. Skipping the probe when the lockfile is unchanged gives up the early refusal for a case where there is nothing new to refuse.
- **A residual worth naming rather than hiding:** with the npm cache cleared AND the registry unavailable AND nothing under `website/` changed, the sync now discovers that after the merge instead of before it. Note the cache condition is required, not optional -- retrieval is integrity-addressed, so a dead registry is invisible to an install whose packages are all cached, which is the normal state of a checkout whose `node_modules` was just installed. When it does happen the transaction restores `node_modules`, the lockfile still matches, and the frontend source and bundle are untouched, so the checkout stays consistent; the operator simply sees the failure one step later. That is the trade, and it is the only behaviour change.
- **What is deliberately NOT skipped, and it is most of the wait.** Only the probe. On a backend-only sync of a non-edition checkout the run still pays two further steps unconditionally: the real `npm ci --prefix website` (`server.py:5047`) and the `npm build + stage` (`server.py:5063`). Both outweigh the probe -- one deletes and reinstalls the tree, the other rebuilds the SPA -- so this PR removes the SMALLEST of three redundant costs, and the operator will still notice a wait. First Principles raised the proportion and it is right; the description said "cost without information" without saying what was left, and this bullet is the correction. Deferred rather than folded in because it is a different kind of change: skipping the probe alters only what is verified, while skipping the install and the build alters what the sync PRODUCES, needs a stronger evidence test than "node_modules is non-empty" (`npm ci` is also what repairs a partially-populated tree), and has to reach a step list that is assembled before the incoming ref exists. **Filed as #7132** at Design Review's request, so it survives the merge rather than living only in this description -- an untracked deferral of a PR's own residue is the kind that evaporates, which is exactly why the issue this PR's own subsystem came from (#6698) had to be filed.
- **The comparison is against the working tree, deliberately.** `git diff <ref> -- website` compares the ref to the tree, so a locally modified frontend file counts as changed and the probe runs -- which is also the case where an `--ff-only` merge is most likely to refuse anyway. Comparing against the working tree rather than `HEAD` is what keeps a dirty checkout on the probing path. This also replaces an earlier byte-comparison that would have been a silent no-op on a CRLF checkout (`core.autocrlf` makes the worktree bytes differ from the LF blob `git show` returns); `git diff` is line-ending aware, so the widened condition removed that platform quirk as a side effect rather than needing a caveat.

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.



