### PR TITLE
fix(slack): resolve the channel's home workspace before starting a mirror stream

### DIFF
--- a/src/kiro_crew/slack/client.py
+++ b/src/kiro_crew/slack/client.py
@@ -533,6 +533,24 @@ class RealSlackClient(SlackClientOps):
     ) -> str | None:
         """Start a streaming message via chat.startStream with task plan mode."""
         try:
+            # Resolve this channel's home workspace before reading the cache.
+            # Inbound Slack handlers call ensure_channel_team() once per message,
+            # so a stream started from a Slack event always finds a warm cache.
+            # The dashboard->Slack MIRROR does not: it starts a stream with no
+            # inbound event behind it, and this cache is per-process in memory, so
+            # a gateway restart -- or a session linked from Slack and then driven
+            # only from the dashboard -- leaves the channel unresolved. With
+            # neither a cached team nor an explicit team_id, an org-wide install
+            # rejects chat.startStream with missing_recipient_team_id and the
+            # stream silently demotes to the non-streaming chat.update surface.
+            #
+            # Resolving the HOME team needs only the channel, which every caller
+            # already has, so this is fixed here rather than by threading a
+            # team_id (or a linking user) down from each call site. Costs nothing
+            # for the inbound callers: ensure_channel_team returns without an API
+            # call when the channel is already cached or already known
+            # unresolvable, which one inbound message per channel guarantees.
+            await self.ensure_channel_team(channel)
             body: dict[str, Any] = {
                 "channel": channel,
                 "thread_ts": thread_ts,

--- a/test/test_review_mode.py
+++ b/test/test_review_mode.py
@@ -391,24 +391,116 @@ class TestTeamIdInjection:
 
     @pytest.mark.asyncio
     async def test_start_stream_falls_back_to_recipient_when_no_cache(self) -> None:
-        """When the channel is unknown to the cache, recipient team_id is
-        the only signal we have for workspace routing."""
+        """When the channel's home team cannot be resolved, the recipient team_id
+        is the only signal left for workspace routing.
+
+        ``conversations_info`` is stubbed (single-workspace shape) because
+        ``start_stream`` now attempts resolution first; a bare MagicMock would
+        make this assert on a swallowed TypeError rather than on the fallback.
+        """
         c = self._client()
         c._web.api_call = AsyncMock(return_value={"ts": "1"})
+        c._web.conversations_info = AsyncMock(return_value=self._info_resp({"id": "C_unseen"}))
         await c.start_stream("C_unseen", "thread1", team_id="TRECIPIENT")
         body = c._web.api_call.await_args.kwargs["json"]
         assert body["team_id"] == "TRECIPIENT"
 
+    @staticmethod
+    def _info_resp(channel_payload: dict) -> MagicMock:
+        """A conversations_info response in the shape the SDK returns.
+
+        ``ensure_channel_team`` reads ``resp.data``, so a bare dict resolves to
+        nothing and would make a resolution assertion pass vacuously.
+        """
+        resp = MagicMock()
+        resp.data = {"channel": channel_payload}
+        return resp
+
     @pytest.mark.asyncio
     async def test_start_stream_omits_team_id_when_neither_known(self) -> None:
-        """Single-workspace install: no cache, no recipient — no team_id
-        in the body."""
+        """Single-workspace install: resolution finds no ``context_team_id``, and
+        no recipient was supplied, so no team_id reaches the body.
+
+        ``conversations_info`` is stubbed with the single-workspace shape rather
+        than left a bare MagicMock: ``start_stream`` now resolves the channel's
+        home team first, and a non-awaitable stub would make this pass on a
+        swallowed TypeError instead of on the behaviour being asserted.
+        """
         c = self._client()
         c._web.api_call = AsyncMock(return_value={"ts": "1"})
+        c._web.conversations_info = AsyncMock(return_value=self._info_resp({"id": "C1"}))
         await c.start_stream("C1", "thread1")
         body = c._web.api_call.await_args.kwargs["json"]
         assert "team_id" not in body
         assert "recipient_team_id" not in body
+
+    @pytest.mark.asyncio
+    async def test_start_stream_resolves_home_team_when_cache_is_cold(self) -> None:
+        """Regression: the dashboard->Slack mirror starts a stream with no inbound
+        event behind it, so this per-process cache can be cold (a gateway restart,
+        or a session linked from Slack then driven only from the dashboard). It
+        threads no team_id and has no linking user to thread, so before this the
+        body carried neither team_id nor recipient_team_id and an org-wide install
+        rejected the call with missing_recipient_team_id -- silently demoting the
+        mirror's tool-animation stream. The channel alone is enough to resolve it.
+        """
+        c = self._client()
+        c._web.api_call = AsyncMock(return_value={"ts": "1"})
+        c._web.conversations_info = AsyncMock(
+            return_value=self._info_resp({"id": "C1", "context_team_id": "THOME"})
+        )
+
+        await c.start_stream("C1", "thread1")
+
+        c._web.conversations_info.assert_awaited_once_with(channel="C1")
+        body = c._web.api_call.await_args.kwargs["json"]
+        assert body["team_id"] == "THOME"
+        assert body["recipient_team_id"] == "THOME"
+        # Resolved once, then cached for the rest of the process.
+        assert c._channel_team["C1"] == "THOME"
+
+    @pytest.mark.asyncio
+    async def test_start_stream_costs_no_lookup_when_already_cached(self) -> None:
+        """The inbound callers must not pay an extra API call: one inbound message
+        per channel already warmed this cache, and a warm channel short-circuits
+        before conversations_info."""
+        c = self._client()
+        c._web.api_call = AsyncMock(return_value={"ts": "1"})
+        c._web.conversations_info = AsyncMock()
+        c.record_channel_team("C1", "TCHANNEL_A")
+
+        await c.start_stream("C1", "thread1")
+
+        c._web.conversations_info.assert_not_awaited()
+        assert c._web.api_call.await_args.kwargs["json"]["team_id"] == "TCHANNEL_A"
+
+    @pytest.mark.asyncio
+    async def test_start_stream_does_not_retry_an_unresolvable_channel(self) -> None:
+        """A channel whose home team cannot be resolved costs one lookup per
+        process, not one per stream -- otherwise a single-workspace install would
+        pay a failed conversations_info on every mirrored turn."""
+        c = self._client()
+        c._web.api_call = AsyncMock(return_value={"ts": "1"})
+        c._web.conversations_info = AsyncMock(return_value=self._info_resp({"id": "C1"}))
+
+        await c.start_stream("C1", "thread1")
+        await c.start_stream("C1", "thread2")
+
+        assert c._web.conversations_info.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_start_stream_survives_a_failing_home_team_lookup(self) -> None:
+        """Resolution is best-effort: a conversations_info failure must not take
+        the stream down with it, since the pre-existing behaviour (no team_id) is
+        still a working single-workspace call."""
+        c = self._client()
+        c._web.api_call = AsyncMock(return_value={"ts": "1"})
+        c._web.conversations_info = AsyncMock(side_effect=RuntimeError("slack down"))
+
+        ts = await c.start_stream("C1", "thread1")
+
+        assert ts == "1"
+        assert "team_id" not in c._web.api_call.await_args.kwargs["json"]
 
     @pytest.mark.asyncio
     async def test_start_stream_derives_recipient_team_from_cache(self) -> None:


### PR DESCRIPTION
## 1. What is the problem?

The dashboard-to-Slack mirror starts a streaming message so a linked Slack thread
shows live tool animations while a dashboard turn runs. On an org-wide (Enterprise
Grid) install that stream can be rejected and silently disappear.

`RealSlackClient.start_stream` routes by a channel-to-workspace cache
(`_channel_team`). Two facts about that cache decide this bug:

* it is populated **only** by `ensure_channel_team()`, and the only caller of that
  is the inbound Slack event handler ("Inbound handlers call this once per
  message"); and
* it lives in **process memory**, while the dashboard-to-Slack link itself is
  persisted in the session map.

The mirror is the only one of the five `start_stream` call sites with no inbound
Slack event behind it -- the other four are reached from Slack events, so their
cache is already warm. So the mirror can reach `start_stream` with the channel
unresolved. Two ways in:

1. the gateway restarts, clearing the in-memory cache while the persisted link
   survives; or
2. a session is linked from Slack and then driven only from the dashboard.

It also threads no `team_id`, because there is none to thread: the link record
returns only `(thread_ts, channel_id)`.

With neither a cached team nor an explicit `team_id`, the body carries no
`team_id` and no `recipient_team_id`, and an org-wide install rejects
`chat.startStream` with `missing_recipient_team_id`. The call is wrapped in a
`try/except` that returns `None`, and the caller coerces that to `""`, so nothing
surfaces above debug level.

## 2. Why this issue matters to the user

The mirrored thread loses its live tool animation and silently falls back to the
non-streaming `chat.update` surface. Nothing is logged at warning level and no
error reaches the user, so the Slack side just looks less capable than it is --
and it degrades exactly on the installs where it is hardest to notice, because
whether it happens depends on whether the gateway has processed an inbound message
for that channel since it last started.

The restart path makes it worse than a one-time glitch: the link is durable, so a
user who set it up days ago and only uses the dashboard gets the degraded surface
on every turn until something else warms the cache.

## 3. How our fix solves it

Symptom to cause to fix: the stream demotes -> Slack rejects the call for a
missing recipient workspace -> nothing had resolved this channel's workspace,
because only inbound handlers do that and the mirror is not one -> resolve it in
`start_stream` itself.

```python
async def start_stream(self, channel, thread_ts, ...):
    try:
        await self.ensure_channel_team(channel)
        body = {...}
```

**Why at the client rather than at the mirror call site.** Resolving the HOME
workspace needs only the channel, which every caller already has. Fixing it here
covers the mirror and any future caller that is not driven by an inbound event,
and it puts the fix in the same place that already owns this routing.

**Why not thread a `team_id` (or a linking user) down from the mirror.** That was
the shape this looked like from the outside, and it is not needed. The error names
the RECIPIENT TEAM, and for a channel message the recipient's workspace *is* the
channel's workspace -- which `conversations_info` answers from the channel alone.
Widening the persisted Slack link record to carry the linking user would be a
schema change bought for nothing.

**Why this costs the inbound callers nothing.** `ensure_channel_team` returns
before any API call when the channel is already cached, or already recorded in
`_channel_team_unresolvable`. One inbound message per channel guarantees one or
the other, and inbound handlers already call it per message. The only new lookup
is the case being fixed: a channel that gets a stream without ever having received
an inbound message. That is one `conversations_info` per channel per process, and
a failure is recorded so it is not retried per stream.

**What is deliberately unchanged.** The existing precedence is untouched -- the
cached home team still wins for `body["team_id"]`, an explicit `team_id` still
wins for `recipient_team_id`. Resolution is best-effort, so a single-workspace
install (no `context_team_id`) behaves exactly as before: no `team_id` in the body.

## 4. What tests we did

Five assertions in `TestTeamIdInjection`, each mutation-verified by removing the
warm-up:

| Case | Asserts |
| --- | --- |
| cold cache (the mirror case) | resolves from the channel; body carries `team_id` AND `recipient_team_id`; cached for the process |
| warm cache (the inbound callers) | `conversations_info` is **not** awaited; routing unchanged |
| unresolvable channel | resolved once across two streams, not once per stream |
| failing lookup | the stream still returns its ts; no `team_id`, i.e. the pre-fix single-workspace behaviour |
| single-workspace install | no `team_id` and no `recipient_team_id` |

Removing `await self.ensure_channel_team(channel)` reddens the cold-cache case
(`Expected conversations_info to have been awaited once`) and the no-retry case
(`assert 0 == 1`), and leaves the other three green -- so the warm-cache and
best-effort guarantees are pinned independently of the fix they protect.

**Two pre-existing tests in this class were passing for the wrong reason.**
`test_start_stream_omits_team_id_when_neither_known` and
`test_start_stream_falls_back_to_recipient_when_no_cache` drove `start_stream`
with a bare `MagicMock` `_web` and an empty cache. Once `start_stream` resolves
first, they would have kept passing only because awaiting a `MagicMock` raises
`TypeError` and `ensure_channel_team` swallows it. Both now stub
`conversations_info` with the real single-workspace shape, so they assert on the
behaviour their docstrings claim. A shared `_info_resp()` helper builds the
response with `.data`, because `ensure_channel_team` reads `resp.data` and a plain
dict resolves to nothing -- my first draft of the cold-cache test failed for
exactly that reason, which is the check working.

Run targeted (this host cannot take a full pytest run; CI covers the rest):
`test_review_mode.py` (29 in this class), plus `test_slack_renderer.py` and
`test_slack_handler.py` for the other `start_stream` callers (288 total), plus
`test_slack_mirror_unlink.py`, `test_slack_events_coverage.py` and
`test_slack_golden_transcript.py` (188). flake8, isort and mypy clean on both
touched files. `slack/client.py` is in `.github/black-baseline.txt` and stays
there; black's one complaint in that file is on a pre-existing logger call this
diff does not touch.

## 5. Any other suggestions on the work

* **The demotion is still silent.** This fixes the cause, but the shape that hid
  it remains: `start_stream` catches everything and returns `None`, and the mirror
  coerces that to `""`. Any future reason the stream cannot start will disappear
  the same way. Worth a follow-up that logs a rejected stream at warning level
  with the Slack error code, rather than widening this diff.
* **`_channel_team` is per process by design and that is fine here**, but it does
  mean the first mirrored turn after a restart pays one `conversations_info`.
  Persisting the map would remove that; it is not worth it for one bounded lookup.
* **Not reproduced against a real Grid install.** No Enterprise Grid workspace was
  available, so the rejection path rests on the error name already documented in
  this file (`missing_recipient_team_id`, from the earlier fix that added the
  cache fallback for the renderer) plus the unit coverage above, not on a live
  call.
