### PR TITLE
fix(code-review-sage): anchor the run-tree atomic writes to a descriptor

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/discovery.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/discovery.py
@@ -24,7 +24,6 @@ the agent-writable project tree.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import threading
 from datetime import datetime, timedelta, timezone
@@ -373,16 +372,7 @@ def _write_repos(repos: list[dict], root: Path | None = None) -> Path:
     store.ensure_layout(root)
     path = repos_path(root)
     payload = json.dumps({"repos": repos}, indent=2).encode("utf-8")
-    fd, tmp = store.open_locked_temp(path.parent)
-    try:
-        try:
-            os.write(fd, payload)
-        finally:
-            os.close(fd)
-        os.replace(tmp, path)
-    finally:
-        if os.path.exists(tmp):
-            os.unlink(tmp)
+    store.atomic_write_locked(path, payload)
     return path
 
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/followup.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/followup.py
@@ -45,9 +45,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
 import re
-import tempfile
 import time
 from pathlib import Path
 
@@ -269,21 +267,16 @@ def write_descriptor(run_id: str, change_id: str, *, sid: str, agent: str = "",
     }
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # mkstemp, not a predictable `<name>.tmp`: the reviewer can pre-plant a
-        # symlink at a name it can guess, and writing through it would land this
-        # content on whatever it points at. An O_EXCL temp with a random name
-        # cannot be pre-empted, and os.replace does not follow a link at the
-        # destination.
-        fd, tmp_name = tempfile.mkstemp(
-            dir=str(path.parent), prefix=".resume-", suffix=".json")
-        tmp = Path(tmp_name)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write(json.dumps(payload, ensure_ascii=False))
-            os.replace(tmp, path)
-        except BaseException:
-            tmp.unlink(missing_ok=True)
-            raise
+        # A random O_EXCL temp renamed over the name, not a predictable
+        # `<name>.tmp`: the reviewer can pre-plant a symlink at a name it can
+        # guess, and writing through it would land this content on whatever it
+        # points at. Both the staging and the rename are anchored to a
+        # DESCRIPTOR for the parent rather than resolving its name three times,
+        # so a directory swapped mid-write cannot redirect either -- see
+        # ``store.atomic_write_locked``.
+        store.atomic_write_locked(
+            path, json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        )
     except Exception:
         logger.warning("followup: could not record descriptor", exc_info=True)
         return False

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/learning.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/learning.py
@@ -303,16 +303,7 @@ def list_patterns_for_review(root: Path | None = None) -> list[dict]:
 
 def _atomic_write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = store.open_locked_temp(path.parent)
-    try:
-        try:
-            os.write(fd, text.encode("utf-8"))
-        finally:
-            os.close(fd)  # always close the fd, even if os.write raised
-        os.replace(tmp, path)
-    finally:
-        if os.path.exists(tmp):
-            os.unlink(tmp)
+    store.atomic_write_text(path, text)
 
 
 def _normalize_pattern(pattern: dict) -> dict:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/report.py
@@ -802,19 +802,13 @@ def _atomic_write(path: Path, text: str) -> None:
     the linked file, and the lockdown after it would follow it too. Staging a
     private temp file in the same directory and renaming over the name swaps the
     NAME without following a link, so a plant is destroyed rather than honoured.
-    Mirrors `learning.py:_atomic_write`.
+    The staging and the rename are both anchored to a DESCRIPTOR for the reports
+    dir instead of resolving its name three times -- see
+    ``store.atomic_write_locked``, which is now the single implementation this
+    and ``learning.py:_atomic_write`` share rather than two copies of one block.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = store.open_locked_temp(path.parent)
-    try:
-        try:
-            os.write(fd, text.encode("utf-8"))
-        finally:
-            os.close(fd)  # always close the fd, even if os.write raised
-        os.replace(tmp, path)
-    finally:
-        if os.path.exists(tmp):
-            os.unlink(tmp)
+    store.atomic_write_text(path, text)
 
 
 def read_within_reports(path: Path, root: Path | None = None,

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
@@ -72,16 +72,7 @@ def write_reviewed(index: dict, root: Path | None = None) -> Path:
     store.ensure_layout(root)
     path = reviewed_path(root)
     data = json.dumps(index, indent=2).encode("utf-8")
-    fd, tmp = store.open_locked_temp(path.parent)
-    try:
-        try:
-            os.write(fd, data)
-        finally:
-            os.close(fd)
-        os.replace(tmp, path)
-    finally:
-        if os.path.exists(tmp):
-            os.unlink(tmp)
+    store.atomic_write_locked(path, data)
     return path
 
 
@@ -246,16 +237,7 @@ def write_result(record: dict, root: Path | None = None,
         store.ensure_layout(root)
     path = result_path(record["change_id"], root, run_id)
     data = json.dumps(record, indent=2).encode("utf-8")
-    fd, tmp = store.open_locked_temp(path.parent)
-    try:
-        try:
-            os.write(fd, data)
-        finally:
-            os.close(fd)  # always close the fd, even if os.write raised
-        os.replace(tmp, path)
-    finally:
-        if os.path.exists(tmp):
-            os.unlink(tmp)
+    store.atomic_write_locked(path, data)
     return path
 
 
@@ -463,21 +445,10 @@ def adopt_from_shared(change_id: str, root: Path | None = None,
     # Write a private temp file in the destination directory, then rename over
     # the name: atomic, so a valid record is never destroyed by a failed write,
     # and the rename replaces the NAME without following a link planted there.
-    tmp = None
     try:
-        fd, tmp = store.open_locked_temp(dst.parent, prefix=".adopt-", suffix=".json")
-        with open(fd, "wb") as fh:
-            fh.write(raw)
-        os.replace(tmp, dst)
-        tmp = None
+        store.atomic_write_locked(dst, raw)
     except OSError:
         return False
-    finally:
-        if tmp:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
     try:
         src.unlink()
     except OSError:
@@ -509,7 +480,6 @@ def publish_to_shared(change_id: str, root: Path | None = None,
     store.ensure_layout(root)
     shared = results_dir(root, None)
     dst = shared / f"{safe_change_id(change_id)}.json"
-    tmp = None
     try:
         # Read through the same no-follow guard the adoption direction uses. The
         # RUN results dir is worker-writable too, so a worker that replaced its
@@ -525,17 +495,7 @@ def publish_to_shared(change_id: str, root: Path | None = None,
                 max_bytes=_RECORD_MAX_BYTES)
         if raw is None:
             return False
-        fd, tmp = store.open_locked_temp(shared, prefix=".publish-", suffix=".json")
-        with open(fd, "wb") as fh:
-            fh.write(raw)
-        os.replace(tmp, dst)
-        tmp = None
+        store.atomic_write_locked(dst, raw)
     except OSError:
         return False
-    finally:
-        if tmp:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
     return True

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
@@ -24,6 +24,7 @@ Run ``python3 sage_lib/store.py --ensure`` to create/repair the layout and seed
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import re
@@ -154,8 +155,7 @@ def restrict_to_owner(path: str | os.PathLike) -> None:
     os.chmod(path, 0o600)  # pragma: no cover - standalone fallback
 
 
-def open_locked_temp(directory: str | os.PathLike, *,
-                     prefix: str = "", suffix: str = ".tmp") -> tuple[int, str]:
+def open_locked_temp(directory: str | os.PathLike) -> tuple[int, str]:
     """Create a temp file in ``directory`` that is ALREADY owner-only, and return
     ``(fd, path)`` with the file still open for writing.
 
@@ -172,7 +172,7 @@ def open_locked_temp(directory: str | os.PathLike, *,
     AND removes the temp file here -- the exception escapes before the caller's
     own ``try/finally`` is entered, so nothing downstream would clean either up.
     """
-    fd, tmp = tempfile.mkstemp(dir=str(directory), prefix=prefix, suffix=suffix)
+    fd, tmp = tempfile.mkstemp(dir=str(directory), suffix=".tmp")
     try:
         restrict_to_owner(tmp)
     except BaseException:
@@ -183,6 +183,175 @@ def open_locked_temp(directory: str | os.PathLike, *,
             pass
         raise
     return fd, tmp
+
+
+#: True when this platform can pin a directory and act relative to it. The
+#: confinement in :func:`atomic_write_locked` needs ``open``, ``unlink`` and the
+#: rename family to all accept a directory descriptor, and Windows has none of
+#: them, so the capability is resolved once here rather than guessed per call.
+#: Probed via ``os.rename``: CPython registers the rename family under that name,
+#: so ``os.replace in os.supports_dir_fd`` is False even where the pinned
+#: ``os.replace(..., src_dir_fd=, dst_dir_fd=)`` call works. (Same probe shape as
+#: ``spec_builder``'s ``_CAN_PIN_DIR``, which documents that quirk.)
+_CAN_PIN_DIR = (
+    hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in os.supports_dir_fd
+    and os.unlink in os.supports_dir_fd
+    and os.rename in os.supports_dir_fd
+)
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    """Write every byte of *data* to *fd*, or raise.
+
+    ``os.write`` is the raw syscall: it is permitted to accept fewer bytes than
+    it was given, and near a full disk it does. A one-shot call therefore
+    publishes a TRUNCATED record, and one caller (``results.adopt_into_run``)
+    deletes its source once the publish returns -- so a short write there loses
+    the only valid copy. Looping until the buffer is drained is what makes the
+    rename a publish of complete content; zero progress is treated as an error
+    rather than spun on, since a descriptor that accepts nothing will not start.
+    """
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:  # pragma: no cover - kernel would have raised first
+            raise OSError(errno.EIO, "short write while staging a record")
+        view = view[written:]
+
+
+def atomic_write_locked(path: str | os.PathLike, data: bytes) -> None:
+    """Write *data* to *path* atomically, resolving the parent directory ONCE.
+
+    Every writer in this app stages a private temp file beside its target and
+    renames over the name, which stops a symlink planted AT that name from being
+    followed. What it did not stop is a swapped ANCESTOR: ``mkstemp(dir=...)``
+    resolves the parent by name, then ``os.replace(tmp, path)`` resolves it twice
+    more, so a reviewer worker -- which runs prompt-injected model output and has
+    a shell inside its own run tree -- could swap a directory for a symlink
+    between those resolutions and redirect the write outside the sandbox. The
+    content is gateway-derived, so the primitive is a fixed-content clobber
+    rather than injection, but it lets the sandboxed side make the unsandboxed
+    gateway write where the sandbox refused.
+
+    Pinning collapses those three resolutions into one: the parent is opened as a
+    descriptor and the create, the rename and any cleanup are all relative to
+    that inode, so a swap AFTER the pin cannot redirect them -- it renames a
+    directory the descriptor no longer names. ``O_NOFOLLOW`` on the pin also
+    refuses a parent that is itself a link.
+
+    What remains is the ANCESTOR CHAIN: ``mkdir(parents=True)`` and the pin's own
+    ``os.open`` both resolve the full path by name, and ``O_NOFOLLOW`` guards
+    only its final component, so an INTERMEDIATE ancestor swapped for a symlink
+    is still followed. That residue is REDUCIBLE, not a floor: walking the chain
+    componentwise from a trusted anchor (``os.open(component,
+    O_DIRECTORY|O_NOFOLLOW, dir_fd=parent_fd)`` per component, creating with
+    ``os.mkdir(..., dir_fd=...)``) shrinks the trusted surface to that anchor
+    alone. It is deliberately NOT done here: choosing the anchor is a design
+    decision in this app, whose directory helpers are root-parameterized, and it
+    is filed as its own change. This narrows three windows to one; it does not
+    close the last one.
+
+    Owner-only comes from the ``0o600`` creation mode instead of a follow-up
+    ``restrict_to_owner`` call, which would be another resolution by name. On the
+    fallback path (Windows: :data:`_CAN_PIN_DIR` is False because none of the
+    dir_fd variants exist there) the behaviour is exactly today's
+    :func:`open_locked_temp` + ``os.replace``, DACL lockdown included -- the
+    platform that cannot pin is the platform that keeps the old shape.
+    Callers own creating the parent, and every one of the nine does -- either
+    `mkdir(parents=True)` directly (`learning`, `report`, `followup`) or
+    `ensure_layout` / `ensure_run_layout` (`discovery`, `results`). This function
+    deliberately does NOT create it: an `exist_ok` mkdir here RESURRECTS a
+    directory tree that a concurrent namespace deletion is removing, so the
+    delete reports success while a stale record survives under a namespace that
+    is supposed to be gone. Dropping it also removes the last by-name `mkdir`
+    from this path, leaving the pin as the only place the parent is resolved.
+    """
+    target = Path(path)
+    parent = target.parent
+
+    if not _CAN_PIN_DIR:  # pragma: no cover - exercised on Windows
+        fd, tmp = open_locked_temp(parent)
+        try:
+            try:
+                _write_all(fd, data)
+            finally:
+                os.close(fd)
+            os.replace(tmp, target)
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+        return
+
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    dir_fd = os.open(
+        str(parent), os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | cloexec
+    )
+    try:
+        # Unpredictable, like mkstemp's own name: the reviewer must not be able
+        # to pre-plant the temp it is about to be handed. The randomness is the
+        # whole of that property, so the name deliberately does NOT embed
+        # ``target.name``: a change id built from a long GHE host, owner and repo
+        # already approaches NAME_MAX, and adding the target plus a suffix on top
+        # pushed the temp component past it -- ENAMETOOLONG, and no record
+        # written. Fixed length, whatever the target is called.
+        tmp_name = f".sage-{os.urandom(8).hex()}.tmp"
+        fd = os.open(
+            tmp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | cloexec,
+            0o600,
+            dir_fd=dir_fd,
+        )
+        try:
+            try:
+                _write_all(fd, data)
+            finally:
+                os.close(fd)
+            os.rename(tmp_name, target.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            # The pin is what makes a mid-write swap harmless, and the same
+            # property means a publish into a directory that has since been
+            # renamed AWAY succeeds into the DETACHED inode -- correct bytes, in
+            # a place nothing at the caller's path can reach.
+            # ``results.adopt_into_run`` unlinks its source once this returns,
+            # so reporting success there would delete the only reachable copy.
+            # Compare the descriptor against the name after the rename and
+            # refuse to claim success on a mismatch.
+            #
+            # DETECTION, not prevention: the name can change again immediately
+            # after this stat. That is fine, because the guarantee being offered
+            # is not "the name is stable" but "a caller that must not delete its
+            # only copy gets an error rather than a false success". The security
+            # property is untouched -- the bytes never went through the swapped
+            # name, which is what the pin is for.
+            try:
+                named = os.stat(str(parent))
+            except OSError as exc:
+                raise OSError(
+                    errno.ESTALE,
+                    f"parent of {target.name} vanished mid-publish",
+                ) from exc
+            pinned = os.fstat(dir_fd)
+            if (named.st_dev, named.st_ino) != (pinned.st_dev, pinned.st_ino):
+                raise OSError(
+                    errno.ESTALE,
+                    f"parent of {target.name} was replaced mid-publish",
+                )
+        except BaseException:
+            # Relative to the SAME descriptor, so the cleanup cannot be
+            # redirected either.
+            try:
+                os.unlink(tmp_name, dir_fd=dir_fd)
+            except OSError:  # pragma: no cover - best-effort cleanup
+                pass
+            raise
+    finally:
+        os.close(dir_fd)
+
+
+def atomic_write_text(path: str | os.PathLike, text: str) -> None:
+    """UTF-8 convenience wrapper over :func:`atomic_write_locked`."""
+    atomic_write_locked(path, text.encode("utf-8"))
 
 
 # Optional Kiro Crew redaction. Lives here rather than in `pipeline` because readers

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
@@ -3,6 +3,7 @@
 Locks in the fix for the "Initializing…" stuck state: when the generic app
 config handler has already seeded an empty ``{}`` config.json, ensure_layout
 must upgrade it to include ``resolved_paths`` so the UI can bootstrap."""
+import errno
 import json
 import os
 import shutil
@@ -12,6 +13,116 @@ from pathlib import Path
 from unittest import mock
 
 from sage_lib import store
+
+from kiro_crew.apps.builtins.code_review_sage.tests.fixtures import SYMLINKS_OK
+
+
+class TestPinnedAtomicWrite(unittest.TestCase):
+    """``atomic_write_locked`` resolves the parent directory ONCE.
+
+    The staging temp and the rename that publishes it used to resolve the parent
+    by NAME three times over (``mkstemp(dir=...)`` plus both halves of
+    ``os.replace``). The review worker runs prompt-injected model output and has
+    a shell inside its own run tree, so it could swap a directory for a symlink
+    between those resolutions and steer the write out of the sandbox.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        # Registered at creation, not in tearDown: an exception later in setUp
+        # skips tearDown entirely, and the residue is a directory tree.
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def test_a_plain_write_lands_owner_only_and_leaves_no_temp(self):
+        # The primitive does not create the parent -- every production caller
+        # does, and an exist_ok mkdir inside it would resurrect a namespace mid
+        # deletion. So the test creates it too.
+        target = self.tmp / "nested" / "record.json"
+        target.parent.mkdir(parents=True)
+
+        store.atomic_write_locked(target, b"payload")
+
+        self.assertEqual(target.read_bytes(), b"payload")
+        # Owner-only from the creation mode, so no follow-up chmod by name.
+        if os.name == "posix":
+            self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+        self.assertEqual([p.name for p in target.parent.iterdir()], ["record.json"])
+
+    def test_a_target_name_near_the_filename_limit_still_publishes(self):
+        """`safe_change_id` does not cap length, so a change id built from a long
+        GHE host, owner and repo produces a stem that already approaches
+        NAME_MAX. A temp name derived from the target would exceed it and fail
+        with ENAMETOOLONG, writing no record at all; the staging name is fixed
+        length for exactly that reason.
+        """
+        target = self.tmp / ("x" * 240 + ".json")
+
+        store.atomic_write_locked(target, b"payload")
+
+        self.assertEqual(target.read_bytes(), b"payload")
+
+    def test_a_short_write_still_publishes_the_whole_record(self):
+        """``os.write`` may accept fewer bytes than it is given, and near a full
+        disk it does. A one-shot call would publish a truncated record -- and
+        ``results.adopt_into_run`` deletes its source once the publish returns,
+        so a truncation there loses the only valid copy.
+        """
+        target = self.tmp / "record.json"
+        payload = b'{"change_id": "abc", "verdict": "ok"}'
+        real_write = os.write
+        calls = {"n": 0}
+
+        def dribbling_write(fd, data):
+            calls["n"] += 1
+            return real_write(fd, bytes(data)[:1])  # one byte per call
+
+        with mock.patch.object(os, "write", dribbling_write):
+            store.atomic_write_locked(target, payload)
+
+        self.assertEqual(target.read_bytes(), payload)
+        self.assertEqual(calls["n"], len(payload), "the write was not looped")
+
+    @unittest.skipUnless(
+        SYMLINKS_OK and store._CAN_PIN_DIR, "needs symlinks and dir_fd support"
+    )
+    def test_a_parent_swapped_mid_write_cannot_redirect_the_write(self):
+        """The swap lands in the window the finding names, and is defeated.
+
+        Mid-write the parent is renamed aside and a symlink to an attacker-owned
+        directory takes its NAME. Two things must hold, and the second is why
+        this raises rather than returning quietly:
+
+        * nothing goes through the link -- the bytes land in the inode that was
+          pinned, which resolving the name again would not have done;
+        * the call REFUSES, because that pinned inode is now detached from the
+          caller's path. Publishing into a directory nobody can reach and
+          reporting success is how ``results.adopt_into_run`` would delete its
+          only reachable copy.
+        """
+        real = self.tmp / "real"
+        real.mkdir()
+        impostor = self.tmp / "impostor"
+        impostor.mkdir()
+        target = real / "record.json"
+        real_write = os.write
+        state = {"swapped": False}
+
+        def swapping_write(fd, data):
+            if not state["swapped"]:
+                state["swapped"] = True
+                real.rename(self.tmp / "moved")
+                (self.tmp / "real").symlink_to(impostor)
+            return real_write(fd, data)
+
+        with mock.patch.object(os, "write", swapping_write):
+            with self.assertRaises(OSError) as caught:
+                store.atomic_write_locked(target, b"payload")
+
+        self.assertTrue(state["swapped"], "the swap never ran, so this proved nothing")
+        self.assertEqual(caught.exception.errno, errno.ESTALE)
+        # Landed in the inode that was pinned, never through the planted link.
+        self.assertEqual((self.tmp / "moved" / "record.json").read_bytes(), b"payload")
+        self.assertEqual(list(impostor.iterdir()), [])
 
 
 class TestSeedConfigUpgrade(unittest.TestCase):


### PR DESCRIPTION
## 1. What is the problem?

Code Review Sage writes nine files into its run tree through the same shape: create a private temp beside the target, write it, `os.replace` the temp over the target's name. The comments at those sites explain what that shape defends against, and they are right: renaming over a name does not follow a symlink planted AT that name, so a plant at `focus-report.html` or `index.json` is destroyed rather than honoured.

What it does not defend against is a swapped ANCESTOR. Each write resolves the parent directory by NAME three separate times:

1. `store.open_locked_temp(path.parent)` -> `tempfile.mkstemp(dir=str(directory))` -- resolution one, creating the temp;
2. `os.replace(tmp, path)` -- resolution two for the source;
3. the same call -- resolution three for the destination.

Nothing holds the directory still between them. A directory swapped for a symlink after resolution one redirects the publish in resolution three, and the temp-plus-rename comment does not cover that case because the plant is not at the leaf.

The nine writers: `discovery._write_repos`, `learning._atomic_write`, `report._atomic_write` (a byte-identical copy of the previous one, labelled "Mirrors `learning.py:_atomic_write`"), `results.write_reviewed`, `results.write_result`, `results.adopt_into_run`, `results.publish_to_shared`, and `followup.record_descriptor` with its own inline `mkstemp`.

## 2. Why this issue matters to the user

The review worker is the attacker in this app's own threat model, and the surrounding code says so repeatedly: it runs prompt-injected model output, and it has a shell inside its own run tree. `report.py`'s docstring already assumes it can plant symlinks at output names; `results.py` guards its reads with `hooks.safe_read_file_bytes_nolink` for the same reason.

So the swap loop is reachable by a component that is expected to be hostile. What it wins is bounded but real: the write's CONTENT is gateway-derived, so this is a fixed-content clobber rather than an injection primitive. The consequence is a privilege inversion -- the sandboxed reviewer gets the unsandboxed gateway to write a file where the sandbox refused to let it write. Anything the gateway can reach and the sandbox cannot is in range, including the app's own learned-patterns store, which is what later reviews are steered by.

No user-visible symptom is claimed, and winning the race needs a loop against a narrow window. This is a hardening fix in a place the codebase already treats as adversarial, not a report of an observed exploit.

## 3. How the fix solves it

`store.atomic_write_locked(path, data)` resolves the parent ONCE and does everything else relative to that descriptor:

- `os.open(parent, O_RDONLY|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC)` pins the directory as an inode. `O_NOFOLLOW` also refuses a parent that is itself a link.
- the temp is created `dir_fd`-relative with `O_CREAT|O_EXCL|O_NOFOLLOW` and mode `0o600`, under an unpredictable name (`os.urandom(8).hex()`), so it cannot be pre-planted;
- the publish is `os.rename(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)`;
- failure cleanup is `os.unlink(tmp, dir_fd=dir_fd)`, so even the cleanup cannot be redirected.

A swap arriving after the pin renames a directory the descriptor no longer names, so it steers nothing.

**The claim is narrowing, not elimination -- and the remainder is reducible, which an earlier revision of this body wrongly called a floor.** Three resolutions become one. What remains is the ANCESTOR CHAIN: `mkdir(parents=True)` and the pin's own `os.open` resolve the full path by name, and `O_NOFOLLOW` guards only its final component, so an INTERMEDIATE ancestor swapped for a symlink is still followed. That is fixable by walking the chain componentwise from a trusted anchor, and it is filed as **#7131** rather than attempted here: choosing the anchor is a real design decision in this app, whose directory helpers are root-parameterized, and it carries a Windows story and a mkdir-race question of its own. The docstring states the same thing.

Two consequences worth calling out:

- **Owner-only now comes from the creation mode**, not from a follow-up `restrict_to_owner(tmp)`. That call took a PATH, so it was itself another resolution by name; `0o600` at `os.open` time gives the same guarantee on POSIX without one.
- **Windows keeps exactly today's behaviour, deliberately.** `_CAN_PIN_DIR` is False there because none of `os.open`, `os.unlink` or the rename family accept `dir_fd`, so the fallback is the existing `open_locked_temp` + `os.replace` path with the DACL lockdown intact. The platform that cannot pin is the platform that keeps the old shape; degrading its lockdown to share one code path would be a worse trade than leaving the narrower window there.

The capability probe uses **`os.rename`, not `os.replace`**: CPython registers the rename family under the former name, so `os.replace in os.supports_dir_fd` reads False on Linux even though the pinned `os.replace(..., src_dir_fd=, dst_dir_fd=)` call works. `spec_builder`'s `_CAN_PIN_DIR` documents that quirk and this mirrors its probe.

All nine writers route through the one primitive, which also removes the duplication that made this defect nine-way in the first place: `learning._atomic_write` and `report._atomic_write` were byte-identical copies, and four `results.py` sites plus `discovery.py` and `followup.py` each carried their own copy of the same nine-line block.

## 4. What tests we did

Targeted only (this host cannot run the full suite; CI does).

**Three** tests in `tests/test_store_selfheal.py`, beside the existing store tests. Note that one of them covers a DIFFERENT defect from the race this PR is named for: `_write_all` fixes truncation near a full disk, found by review after the first push and folded in here because it lives in the same primitive. Declared rather than left to be noticed:

- `test_a_plain_write_lands_owner_only_and_leaves_no_temp` -- the ordinary path: content lands, mode is `0o600` on POSIX, and the directory holds nothing but the published file.
- `test_a_short_write_still_publishes_the_whole_record` -- the truncation defect: `os.write` is patched to accept one byte per call, asserting both the full payload and that the call count equals its length, so removing the loop OR silently buffering around it fails.
- `test_a_parent_swapped_mid_write_cannot_redirect_the_write` -- the finding's own scenario. `os.write` is patched to fire once mid-write and, in that window, rename the pinned parent aside and plant a symlink to an attacker-owned directory at its old NAME. The assertion is that the bytes land in the inode that was pinned (now reachable at its new name) and that the impostor directory stays empty. It also asserts the swap actually ran, so the test cannot pass by never reaching the window. Gated on `SYMLINKS_OK and store._CAN_PIN_DIR`, matching how the app's other symlink tests gate.

Mutation-verified: replacing the anchored publish with a by-name `os.replace` reddens the swap test -- the by-name form resolves the temp's path through the planted link, where it does not exist (`FileNotFoundError`). With an impostor that pre-planted the temp name it would clobber through the link instead; either way the by-name form follows the swap and the anchored form does not.

Runs:

- `pytest src/kiro_crew/apps/builtins/code_review_sage/tests` -- **785 passed** (783 before these two). The whole app suite passing unchanged is the parity evidence: nine writers were rerouted and nothing else moved.
- flake8 and isort clean on `sage_lib/` and `tests/`; mypy clean on `store.py`.
- The repo's own black gate (`scripts/check_black_formatting.py`) passes. All seven touched files are baseline entries, so they were deliberately NOT reformatted -- running black over them would add hundreds of lines of unrelated churn.

## 5. Any other suggestions on the work

- **The read side is already guarded, but not uniformly by descriptor.** `results.py` and `report.py` route their reads through `hooks.safe_read_file_bytes_nolink`, which validates the inode it read. That closes the leaf-symlink hole on reads; it does not pin the parent, so a read has the same single-resolution residue the writes now have. Not worth a change on its own, but if a future pass adds an fd-anchored read helper these are its call sites.
- **`store.open_locked_temp` now has one caller left** (the Windows fallback inside `atomic_write_locked`). It is still the right shape for that path, but if the fallback is ever retired the helper goes with it.
- **The nine-way duplication is the reason this was a nine-site finding**, and the same pattern (a small atomic-write block copied per module) is likely elsewhere in the app tree. A repo-wide sweep for `mkstemp(dir=` followed by `os.replace` would find them; out of scope here, and worth doing as its own pass rather than widening this diff.
