### PR TITLE
fix(issue-radar): stop one tab's UI-state save from clobbering another's

### DIFF
--- a/website/src/apps/issue-radar/context.tsx
+++ b/website/src/apps/issue-radar/context.tsx
@@ -8,7 +8,7 @@
 // touch Workspace's prop wiring. That's what lets multiple agents build
 // different views in parallel without editing the same file.
 import {
-  createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode,
+  createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode,
 } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
@@ -24,9 +24,9 @@ import { repoScopeKey } from './lib/links'
 import { DEFAULT_BULK_CHUNK } from './lib/prActions'
 import {
   asArray, coerceAiLanguage, coerceDashboardTab, coerceRefreshPrefs, coerceSortKey, consumeAutoSelectFirstIssue,
-  loadUiState, patchUiState, saveUiState, storedAiLanguage,
+  loadUiState, patchUiState, saveUiState,
 } from './lib/format'
-import type { RefreshPrefs } from './lib/format'
+import type { PersistedUiState, RefreshPrefs, UiStatePatch } from './lib/format'
 import type { RepoRef } from './lib/refLinks'
 
 /** GitHub author_association values that mark a repo member (maintainer). Kept
@@ -102,6 +102,34 @@ function loadCrewUi(): PersistedCrewUi {
     // Corrupt value, or storage blocked (private mode) — the defaults are a
     // usable page, exactly as loadUiState treats the same failure.
     return { crewView: { kind: 'none' }, crewFilter: 'all', crewSortKey: 'status', crewSortDir: 'asc' }
+  }
+}
+
+/** Merge a partial crew-UI patch over the stored document.
+ *
+ * The same reason `saveUiState` merges: this key is ONE document shared by every
+ * tab, so writing it whole from a single tab's React state reverts whatever
+ * another tab last put in the fields this tab did not touch. Only the keys the
+ * caller names move.
+ *
+ * @returns true when the document was written -- see `saveUiState` for why the
+ * caller's baseline must not advance on false. */
+function saveCrewUi(patch: Partial<PersistedCrewUi>): boolean {
+  try {
+    let stored: Record<string, unknown> = {}
+    try {
+      const raw = localStorage.getItem(CREW_UI_KEY)
+      if (raw) stored = JSON.parse(raw) as Record<string, unknown>
+    } catch {
+      // Corrupt document: write just the patch rather than dropping this tab's
+      // change, which is how loadCrewUi treats the same input.
+      stored = {}
+    }
+    localStorage.setItem(CREW_UI_KEY, JSON.stringify({ ...stored, ...patch }))
+    return true
+  } catch {
+    /* quota exceeded / private mode — persistence is best-effort */
+    return false
   }
 }
 
@@ -413,17 +441,14 @@ export function IssueRadarProvider({
   const setAiLanguage = useCallback((code: string) => {
     const next = coerceAiLanguage(code)
     setAiLanguageState(next)
-    // Written HERE as a targeted merge rather than left to the whole-document save
-    // below: that save rewrites every field from one tab's React state, so a second
-    // tab persisting an unrelated change would otherwise overwrite this choice with
-    // whatever it read at mount, and the agents would silently go back to English.
-    //
-    // This is a per-field guard, not the general fix. Every other field in the
-    // document still loses to a stale tab. If you are adding a field that needs the
-    // same protection, make `saveUiState` merge over the on-disk document instead of
-    // copying this pair of calls -- the cause is the whole-document write, and one
-    // carve-out per field does not scale. `patchUiState` deliberately excludes
-    // `refresh`, so that field needs its validated setter path either way.
+    // Written HERE as a targeted merge, and this is now the ONLY writer of the field:
+    // the save effect below no longer sends it at all. That effect used to rewrite
+    // every field from one tab's React state, so this pair of calls was a per-field
+    // guard against a second tab reverting the choice to whatever it read at mount.
+    // The general fix has since landed -- `saveUiState` merges, and the effect sends
+    // only the fields that tab actually changed -- so a new field needs no carve-out
+    // here. `patchUiState` still excludes `refresh`, which keeps its validated
+    // setter path.
     patchUiState({ aiLanguage: next })
   }, [])
 
@@ -489,18 +514,54 @@ export function IssueRadarProvider({
   // Persist the crews page + chip filter on their own key (see CREW_UI_KEY), for
   // the same reason the blob below is persisted: leaving Issue Radar and coming
   // back should land on the crew you were reading.
+  //
+  // Both halves of the fix below apply here too, and for the same reason -- this
+  // key is one document shared by every tab. Writing it whole on mount is the
+  // worse half: merely OPENING a second tab reverted the first tab's crew page.
+  const lastWrittenCrew = useRef<PersistedCrewUi | null>(null)
   useEffect(() => {
-    try {
-      localStorage.setItem(CREW_UI_KEY, JSON.stringify({ crewView, crewFilter, crewSortKey, crewSortDir }))
-    } catch {
-      /* quota exceeded / private mode — persistence is best-effort */
+    const current: PersistedCrewUi = { crewView, crewFilter, crewSortKey, crewSortDir }
+    const prev = lastWrittenCrew.current
+    // First run after mount establishes the baseline WITHOUT writing.
+    if (prev === null) { lastWrittenCrew.current = current; return }
+    const changed: Partial<PersistedCrewUi> = {}
+    for (const key of Object.keys(current) as (keyof PersistedCrewUi)[]) {
+      // By VALUE: `crewView` is a fresh object every render. It is diffed as ONE
+      // value rather than member-wise like `refresh`, because it is a single
+      // discriminated selection whose fields always move together, where
+      // `refresh` holds five independent settings owned by separate controls.
+      if (JSON.stringify(current[key]) !== JSON.stringify(prev[key])) {
+        // @ts-expect-error -- indexed write across a union of field types; key and
+        // value are read from the same object so they agree by construction.
+        changed[key] = current[key]
+      }
     }
+    if (Object.keys(changed).length === 0) { lastWrittenCrew.current = current; return }
+    // The baseline records what is DURABLE, so it advances only when the write
+    // landed. Persistence is best-effort and a full quota is swallowed; advancing
+    // anyway would mark these fields stored while the document still holds the old
+    // ones, so the next change would diff them as unchanged, never resend them, and
+    // the edit would survive only in this tab until a reload discarded it. Holding
+    // the baseline back re-sends them on the next change instead.
+    if (saveCrewUi(changed)) lastWrittenCrew.current = current
   }, [crewView, crewFilter, crewSortKey, crewSortDir])
 
   // Persist the view / filter / selection state on every change so navigating
   // away from Issue Radar and back restores the same page (see loadUiState).
+  //
+  // Only the fields THIS tab changed are written. The effect fires on any single
+  // change, so sending the whole object would rewrite every other field from this
+  // tab's mount-time copy and revert a second tab's edits -- the clobber that used
+  // to need a per-field carve-out for `aiLanguage`. Diffing against the document we
+  // last wrote is the other half of `saveUiState`'s merge: merging alone cannot help
+  // while the payload still carries every field.
+  //
+  // `aiLanguage` is deliberately absent: `setAiLanguage` patches it directly, so this
+  // effect has no business writing it at all. It no longer needs the read-back
+  // carve-out either -- a field this tab did not change is now simply not sent.
+  const lastWritten = useRef<Partial<PersistedUiState> | null>(null)
   useEffect(() => {
-    saveUiState({
+    const current: Partial<PersistedUiState> = {
       mainView, dashboardTab, settingsTarget,
       selectedIssue, query,
       selectedLabels: [...selectedLabels],
@@ -512,11 +573,46 @@ export function IssueRadarProvider({
       prCreatedByMember,
       prStateFilter, prSortKey, prSortDir,
       refresh: refreshPrefs,
-      // Read back from the store rather than written from this tab's state: this
-      // save fires on any unrelated change, and a tab whose copy predates another
-      // tab's language change must not carry that stale value back to disk.
-      aiLanguage: storedAiLanguage(),
-    })
+    }
+    const prev = lastWritten.current
+    // First run after mount establishes the baseline WITHOUT writing: a tab that is
+    // merely opened must not persist anything, or opening a second tab would itself
+    // be the clobber this fix exists to prevent.
+    if (prev === null) { lastWritten.current = current; return }
+    // Compared by VALUE, not identity: `selectedLabels` / `prSelectedLabels` are
+    // fresh arrays every render and `settingsTarget` / `refresh` are objects, so
+    // reference equality would report every field as changed on every run and put
+    // the whole document back on the wire.
+    const changed: UiStatePatch = {}
+    for (const key of Object.keys(current) as (keyof PersistedUiState)[]) {
+      if (key === 'refresh') continue
+      if (JSON.stringify(current[key]) !== JSON.stringify(prev[key])) {
+        // @ts-expect-error -- indexed write across a union of field types; the key
+        // and value are read from the same object so they agree by construction.
+        changed[key] = current[key]
+      }
+    }
+    // `refresh` is diffed MEMBER-WISE, not as one value. It holds five independent
+    // settings, so sending the whole object on any change reproduces the clobber one
+    // level down: a tab that toggled background polling and a tab that changed an
+    // interval would each revert the other's member. Only the members this tab moved
+    // are sent, and `saveUiState` merges them over the stored ones.
+    const prevRefresh = prev.refresh
+    if (prevRefresh) {
+      const refreshPatch: Partial<RefreshPrefs> = {}
+      for (const key of Object.keys(refreshPrefs) as (keyof RefreshPrefs)[]) {
+        if (refreshPrefs[key] !== prevRefresh[key]) {
+          // @ts-expect-error -- same indexed-write narrowing as above.
+          refreshPatch[key] = refreshPrefs[key]
+        }
+      }
+      if (Object.keys(refreshPatch).length > 0) changed.refresh = refreshPatch
+    }
+    if (Object.keys(changed).length === 0) { lastWritten.current = current; return }
+    // The baseline records what is DURABLE, so it advances only when the write
+    // landed -- see the crew effect above for why a swallowed failure that advanced
+    // it anyway would lose the edit on the next change.
+    if (saveUiState(changed)) lastWritten.current = current
   }, [
     mainView, dashboardTab, settingsTarget, selectedIssue, query,
     selectedLabels, requestedByMe, assignedToMe, createdByMember, stateFilter, sortKey, sortDir,

--- a/website/src/apps/issue-radar/lib/format.ts
+++ b/website/src/apps/issue-radar/lib/format.ts
@@ -242,15 +242,6 @@ export function resolveAiLanguage(pref: string): string {
   return AI_LANGUAGE_CHOICES.some(l => l.code === tag) ? tag : ''
 }
 
-/** The stored preference, coerced but NOT resolved (`''` still means follow).
- *
- * A whole-document save has to write back the value that is currently on disk,
- * which for an unset preference is the empty string, so this deliberately does
- * NOT resolve the follow-the-dashboard case to a concrete tag. */
-export function storedAiLanguage(): string {
-  return coerceAiLanguage(loadUiState().aiLanguage)
-}
-
 
 /** Compact "now / 5m ago / 3h ago / 2d ago" from an epoch-ms timestamp.
  * Used for the issue-list "Updated …" footer; returns '' for a falsy input
@@ -475,11 +466,55 @@ export function coerceDashboardTab(value: unknown): DashboardTab {
   return (DASHBOARD_TABS as readonly string[]).includes(value as string) ? (value as DashboardTab) : 'overview'
 }
 
-export function saveUiState(state: PersistedUiState) {
+/** What a caller may hand `saveUiState`: any subset of the document, and for
+ * `refresh` any subset of ITS members too. `refresh` is a document of its own, so a
+ * caller that changed one member must be able to say so without restating the rest --
+ * see `saveUiState` for why sending the whole object is a clobber one level down. */
+export type UiStatePatch =
+  Partial<Omit<PersistedUiState, 'refresh'>> & { refresh?: Partial<RefreshPrefs> }
+
+/** Merge the given fields into the persisted UI state, leaving every other field
+ * on disk untouched.
+ *
+ * This USED to take the whole `PersistedUiState` and overwrite the document, which
+ * made two dashboard tabs clobber each other: the provider's save effect fires on
+ * any view/filter/selection change, so a tab persisting one unrelated edit rewrote
+ * every other field from whatever it read at mount, reverting the other tab's work.
+ *
+ * Merging is only half the fix and does not work on its own -- a caller that still
+ * passes every field overwrites with the same stale values, because its payload wins
+ * the spread. The caller must send ONLY the fields it actually changed; the provider
+ * does that by diffing against the document it last wrote. Both halves are required,
+ * so keep them together if this is ever refactored.
+ *
+ * `refresh` is merged MEMBER-WISE for the same reason the document is: it holds five
+ * independent settings, so replacing the whole object reproduces the clobber one level
+ * down -- one tab toggling background polling and another changing an interval would
+ * each revert the other's member. Only the members the caller names are written.
+ *
+ * Unlike `patchUiState` this MAY carry `refresh`, because its one caller builds those
+ * values from `refreshPrefs`, which only ever comes out of `coerceRefreshPrefs` in
+ * `setRefreshPrefs`. `patchUiState` keeps the narrower type for the connect flow,
+ * where no such guarantee exists.
+ *
+ * @returns true when the document was written, false when the write was swallowed
+ * (quota exceeded / private mode). A caller that tracks what it last PERSISTED must
+ * not advance that record on false, or the fields in this patch would count as
+ * stored while the document on disk still holds the old ones. */
+export function saveUiState(patch: UiStatePatch): boolean {
   try {
-    localStorage.setItem(UI_STATE_KEY, JSON.stringify(state))
+    const stored = loadUiState()
+    const next: Record<string, unknown> = { ...stored, ...patch }
+    if (patch.refresh) {
+      // Spread the STORED members under the patch, so a member this caller did not
+      // name keeps whatever another tab last wrote for it.
+      next.refresh = { ...(stored.refresh ?? {}), ...patch.refresh }
+    }
+    localStorage.setItem(UI_STATE_KEY, JSON.stringify(next))
+    return true
   } catch {
     /* quota exceeded / private mode — persistence is best-effort */
+    return false
   }
 }
 
@@ -500,11 +535,11 @@ export function patchUiState(
   // cannot introduce the bypass in the first place.
   patch: Partial<Omit<PersistedUiState, 'refresh'>>,
 ) {
-  try {
-    localStorage.setItem(UI_STATE_KEY, JSON.stringify({ ...loadUiState(), ...patch }))
-  } catch {
-    /* best-effort, same as saveUiState */
-  }
+  // The body is `saveUiState`'s -- the merge is the same operation, and this
+  // signature is the only difference worth keeping. `patch.refresh` is
+  // unrepresentable here, so the nested-merge branch there is simply never taken.
+  // The write result is passed through for the same reason it exists there.
+  return saveUiState(patch)
 }
 
 /** Pending "open the first issue" intent, set at connect time.

--- a/website/src/test/IssueRadarAiLanguage.test.ts
+++ b/website/src/test/IssueRadarAiLanguage.test.ts
@@ -46,7 +46,7 @@ vi.mock('../apps/issue-radar/context', async () => {
 
 const {
   AI_LANGUAGE_CHOICES, AI_LANGUAGE_FOLLOW, UI_STATE_KEY,
-  coerceAiLanguage, patchUiState, resolveAiLanguage, storedAiLanguage,
+  coerceAiLanguage, patchUiState, resolveAiLanguage,
 } = await import('../apps/issue-radar/lib/format')
 const { buildInvestigationPrompt } = await import('../apps/issue-radar/lib/investigate.prompt')
 const { useInvestigate } = await import('../apps/issue-radar/lib/investigate')
@@ -231,6 +231,13 @@ describe('the settings row survives a narrow viewport', () => {
 })
 
 describe('a second tab cannot erase the choice', () => {
+  // Reads the field straight off the stored document. This used to be a
+  // `storedAiLanguage()` export in format.ts, which existed only because a
+  // whole-document save had to write the on-disk value back; the save is now a
+  // per-field merge, so nothing in the app needs it and only this file reads it.
+  const storedLang = () =>
+    coerceAiLanguage((JSON.parse(localStorage.getItem(UI_STATE_KEY) || '{}') as { aiLanguage?: unknown }).aiLanguage)
+
   it('keeps the newest stored value when a stale whole-document save lands', () => {
     // The UI state is persisted as ONE document per tab. Tab A picks a language;
     // tab B then saves an unrelated change from React state it read at mount. If
@@ -238,12 +245,12 @@ describe('a second tab cannot erase the choice', () => {
     // the agents would quietly go back to English.
     localStorage.setItem(UI_STATE_KEY, JSON.stringify({ query: 'crash', aiLanguage: '' }))
     patchUiState({ aiLanguage: 'ja' })
-    expect(storedAiLanguage()).toBe('ja')
+    expect(storedLang()).toBe('ja')
 
     // What a stale tab's whole-document save now writes for this field.
-    const staleTabWrites = storedAiLanguage()
+    const staleTabWrites = storedLang()
     localStorage.setItem(UI_STATE_KEY, JSON.stringify({ query: 'other', aiLanguage: staleTabWrites }))
-    expect(storedAiLanguage()).toBe('ja')
+    expect(storedLang()).toBe('ja')
   })
 
   it('patches only the language, leaving the rest of the document intact', () => {
@@ -256,8 +263,18 @@ describe('a second tab cannot erase the choice', () => {
   it('writes the language from its own setter and never from the whole-state save', async () => {
     const src = await readFile(join(__dirname, '..', 'apps/issue-radar/context.tsx'), 'utf8')
     expect(src).toMatch(/patchUiState\(\{ aiLanguage: next \}\)/)
-    expect(src).toMatch(/aiLanguage: storedAiLanguage\(\)/)
-    // The bare state variable in the saved document is the defect itself.
+    // The save effect must not write this field AT ALL any more. It used to send
+    // `aiLanguage: storedAiLanguage()` -- a read-back carve-out that kept a stale tab
+    // from reverting the choice while the effect still rewrote the whole document.
+    // The effect now sends only the fields that tab changed, so the carve-out is gone
+    // and the setter is the single writer. A payload line for this field, whether the
+    // bare variable or the read-back, is the defect returning.
     expect(src).not.toMatch(/\n      aiLanguage,\n/)
+    expect(src).not.toMatch(/aiLanguage: storedAiLanguage\(\)/)
+    // And the helper that carve-out needed is gone from format.ts. Re-exporting it
+    // is how the read-back would come back, so pin its absence rather than only the
+    // call site: with the function deleted, the assertion above cannot fail on its own.
+    const fmt = await readFile(join(__dirname, '..', 'apps/issue-radar/lib/format.ts'), 'utf8')
+    expect(fmt).not.toMatch(/export function storedAiLanguage/)
   })
 })

--- a/website/src/test/IssueRadarContextCoverage.test.tsx
+++ b/website/src/test/IssueRadarContextCoverage.test.tsx
@@ -235,16 +235,18 @@ describe('persisted crew UI', () => {
     expect(ctx.crewSortKey).toBe('status')
   })
 
-  it('writes the crews UI back to its own key on change', async () => {
+  it('writes only the changed crews-UI fields back to its own key', async () => {
     renderProvider()
     await waitFor(() => expect(ctx.crews).toHaveLength(2))
     await drive(() => ctx.setCrewFilter('working'))
     await waitFor(() => {
+      // Only the fields that MOVED are written: `crewFilter` here, and `crewView`
+      // because resolving the roster selects the first crew after mount. The two
+      // sort fields never left their mount values, so they are absent -- writing
+      // them would be this tab reasserting its own copy over another tab's.
       expect(JSON.parse(localStorage.getItem(CREW_UI_KEY) ?? '{}')).toEqual({
         crewView: { kind: 'crew', id: 'c1' },
         crewFilter: 'working',
-        crewSortKey: 'status',
-        crewSortDir: 'asc',
       })
     })
   })
@@ -708,5 +710,104 @@ describe('repo switch', () => {
     expect(ctx.selectedPull).toBeNull()
     // A crew id names a crew in ONE repo's store, so the page cannot carry over.
     expect(ctx.crewView).toEqual({ kind: 'none' })
+  })
+})
+
+describe('persisted UI state does not clobber another tab', () => {
+  it('writes only the fields this tab changed', async () => {
+    renderProvider()
+    await readyIssues()
+
+    // A SECOND dashboard tab persists its own state while this provider is mounted.
+    // Written straight to the store because that is exactly what the other tab's own
+    // save does, and this provider has no way to know it happened.
+    const fromOtherTab = { query: 'other-tab-search', selectedIssue: 4242, aiLanguage: 'zh-CN' }
+    localStorage.setItem(UI_STATE_KEY, JSON.stringify({
+      ...JSON.parse(localStorage.getItem(UI_STATE_KEY) || '{}'),
+      ...fromOtherTab,
+    }))
+
+    // This tab now changes ONE unrelated field. It used to rewrite the whole
+    // document from its own React state, so the other tab's three fields were
+    // reverted to this tab's mount-time values.
+    await drive(() => ctx.cycleSort('updated'))
+
+    const doc = JSON.parse(localStorage.getItem(UI_STATE_KEY) || '{}')
+    expect(doc.sortKey).toBe('updated')
+    expect(doc.query).toBe('other-tab-search')
+    expect(doc.selectedIssue).toBe(4242)
+    expect(doc.aiLanguage).toBe('zh-CN')
+  })
+
+  it('persists nothing merely by mounting', async () => {
+    // The first effect run establishes the diff baseline without writing. If it
+    // wrote, opening a second tab would itself revert the first tab's state -- the
+    // clobber, caused by the fix instead of the bug.
+    const seeded = { query: 'already-here', sortKey: 'updated', selectedIssue: 7 }
+    localStorage.setItem(UI_STATE_KEY, JSON.stringify(seeded))
+
+    renderProvider()
+    await readyIssues()
+
+    expect(JSON.parse(localStorage.getItem(UI_STATE_KEY) || '{}')).toMatchObject(seeded)
+  })
+
+  it('re-sends a field whose write was refused, once storage recovers', async () => {
+    renderProvider()
+    await readyIssues()
+
+    // A full quota is swallowed by the save helper. The baseline must NOT advance
+    // over a write that never reached the document.
+    const setItem = Storage.prototype.setItem
+    Storage.prototype.setItem = () => { throw new Error('QuotaExceededError') }
+    try {
+      await drive(() => ctx.setQuery('typed-while-full'))
+    } finally {
+      Storage.prototype.setItem = setItem
+    }
+    expect(JSON.parse(localStorage.getItem(UI_STATE_KEY) || '{}').query).toBeUndefined()
+
+    // Storage recovers and an unrelated field changes. If the refused write had
+    // advanced the baseline, this diff would call the query unchanged and never send
+    // it -- the edit would live only in this tab until a reload discarded it.
+    await drive(() => ctx.cycleSort('updated'))
+
+    const doc = JSON.parse(localStorage.getItem(UI_STATE_KEY) || '{}')
+    expect(doc.sortKey).toBe('updated')
+    expect(doc.query).toBe('typed-while-full')
+  })
+})
+
+// The crews page keeps its own document on a second key (CREW_UI_KEY, declared
+// above), and it had the same whole-document write -- with no baseline guard at
+// all, so merely opening a tab reverted it.
+describe('persisted crew UI state does not clobber another tab', () => {
+  it('writes only the crew fields this tab changed', async () => {
+    renderProvider()
+    await readyIssues()
+
+    const fromOtherTab = { crewFilter: 'active', crewView: { kind: 'detail', id: 'crew-7' } }
+    localStorage.setItem(CREW_UI_KEY, JSON.stringify({
+      ...JSON.parse(localStorage.getItem(CREW_UI_KEY) || '{}'),
+      ...fromOtherTab,
+    }))
+
+    // One unrelated crew field moves in THIS tab.
+    await drive(() => ctx.cycleCrewSort('name'))
+
+    const doc = JSON.parse(localStorage.getItem(CREW_UI_KEY) || '{}')
+    expect(doc.crewSortKey).toBe('name')
+    expect(doc.crewFilter).toBe('active')
+    expect(doc.crewView).toEqual({ kind: 'detail', id: 'crew-7' })
+  })
+
+  it('persists no crew state merely by mounting', async () => {
+    const seeded = { crewFilter: 'active', crewSortKey: 'name', crewSortDir: 'desc' }
+    localStorage.setItem(CREW_UI_KEY, JSON.stringify(seeded))
+
+    renderProvider()
+    await readyIssues()
+
+    expect(JSON.parse(localStorage.getItem(CREW_UI_KEY) || '{}')).toMatchObject(seeded)
   })
 })

--- a/website/src/test/issueRadarUiStateMerge.test.ts
+++ b/website/src/test/issueRadarUiStateMerge.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { loadUiState, patchUiState, saveUiState } from '../apps/issue-radar/lib/format'
+
+// Issue Radar's provider persists view / filter / selection state on every change.
+// It used to write the WHOLE document from one tab's React state, so two dashboard
+// tabs clobbered each other: a tab persisting one unrelated edit rewrote every other
+// field from whatever it read at mount, reverting the other tab's work. `aiLanguage`
+// had a per-field carve-out; its siblings did not.
+//
+// The fix has two halves and neither works alone -- `saveUiState` merges over the
+// on-disk document, AND its caller sends only the fields it changed. These pin the
+// persistence half; the provider's diffing half is exercised through the context.
+describe('issue-radar saveUiState merges instead of overwriting', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('leaves fields it was not given alone', () => {
+    saveUiState({ query: 'from-tab-a', sortKey: 'updated', requestedByMe: true })
+    // A second tab persists one unrelated change.
+    saveUiState({ mainView: 'settings' })
+
+    const doc = loadUiState()
+    expect(doc.mainView).toBe('settings')
+    expect(doc.query).toBe('from-tab-a')
+    expect(doc.sortKey).toBe('updated')
+    expect(doc.requestedByMe).toBe(true)
+  })
+
+  it('still overwrites a field it IS given', () => {
+    // The merge must not turn into an append-only store: a field the caller sends
+    // is the caller's current value and has to win.
+    saveUiState({ query: 'first' })
+    saveUiState({ query: 'second' })
+    expect(loadUiState().query).toBe('second')
+  })
+
+  it('does not revert a language set through its own writer', () => {
+    // The case that used to need a carve-out: `setAiLanguage` patches the field
+    // directly, and an unrelated save from another tab must not undo it.
+    patchUiState({ aiLanguage: 'zh-CN' })
+    saveUiState({ sortKey: 'created' })
+    expect(loadUiState().aiLanguage).toBe('zh-CN')
+  })
+
+  it('preserves a nested refresh block written by another tab', () => {
+    // `refresh` is the one field with a validated domain, and `patchUiState` excludes
+    // it by type -- so `saveUiState` is its only merge-capable writer and must not
+    // drop it when persisting something else.
+    saveUiState({ refresh: { pollInBackground: true, listPollMs: 60_000 } })
+    saveUiState({ prQuery: 'unrelated' })
+
+    const doc = loadUiState()
+    expect(doc.prQuery).toBe('unrelated')
+    expect(doc.refresh).toMatchObject({ pollInBackground: true, listPollMs: 60_000 })
+  })
+
+  it('merges refresh MEMBER-WISE so two tabs do not revert each other', () => {
+    // The clobber one level down: `refresh` holds five independent settings, so
+    // replacing the whole object on any change means the tab that toggled polling and
+    // the tab that changed an interval each undo the other's member.
+    saveUiState({ refresh: { pollInBackground: true } })   // tab B toggles polling
+    saveUiState({ refresh: { listPollMs: 30_000 } })       // tab A changes an interval
+
+    expect(loadUiState().refresh).toMatchObject({
+      pollInBackground: true,   // tab B's setting survived tab A's write
+      listPollMs: 30_000,
+    })
+  })
+
+  it('still overwrites a refresh member it IS given', () => {
+    // Member-wise merge must not become append-only either.
+    saveUiState({ refresh: { listPollMs: 30_000 } })
+    saveUiState({ refresh: { listPollMs: 120_000 } })
+    expect(loadUiState().refresh).toMatchObject({ listPollMs: 120_000 })
+  })
+
+  it('writes into an empty store without inventing fields', () => {
+    saveUiState({ query: 'only' })
+    expect(loadUiState()).toEqual({ query: 'only' })
+  })
+})
+
+// Persistence is best-effort, so a failed write is swallowed rather than thrown --
+// but the helper has to SAY whether it landed. The provider keeps a baseline of the
+// document it last persisted and diffs against it; if a swallowed failure counted as
+// a write, the fields in it would be marked stored while the document still held the
+// old ones, so the next change would diff them as unchanged and never resend them.
+describe('issue-radar saveUiState reports whether the write landed', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('returns true on a normal write', () => {
+    expect(saveUiState({ query: 'ok' })).toBe(true)
+    expect(patchUiState({ query: 'also-ok' })).toBe(true)
+  })
+
+  it('returns false and leaves the document alone when storage refuses', () => {
+    saveUiState({ query: 'durable' })
+
+    const setItem = Storage.prototype.setItem
+    Storage.prototype.setItem = () => { throw new Error('QuotaExceededError') }
+    try {
+      expect(saveUiState({ query: 'refused' })).toBe(false)
+    } finally {
+      Storage.prototype.setItem = setItem
+    }
+
+    expect(loadUiState().query).toBe('durable')
+  })
+})


### PR DESCRIPTION
## What is the problem?

Issue Radar's provider persists view / filter / selection state on every change, and
it wrote the WHOLE persisted document from that one tab's React state:

```ts
useEffect(() => { saveUiState({ mainView, dashboardTab, query, /* ...20 more... */ }) }, [...])
```

The effect fires on ANY single edit. So a second dashboard tab open on the app, which
holds its own copy of every field from when it mounted, rewrites all of them the
moment the user changes one unrelated thing in it. Two tabs silently revert each
other's refresh preferences, filters and selection.

`aiLanguage` was already protected, by a per-field carve-out: its setter patches it
directly, and the whole-document save read it back from the store instead of sending
this tab's copy. The code flagged that as a stopgap rather than the fix, in the
comment above the setter -- "this is a per-field guard, not the general fix. Every
other field in the document still loses to a stale tab... make `saveUiState` merge
over the on-disk document instead of copying this pair of calls -- the cause is the
whole-document write, and one carve-out per field does not scale." This is that
general fix.

The same defect existed **twice in this file**. Twenty lines above the effect above,
the crews page persisted its own four-field document on a second key
(`CREW_UI_KEY`) the same whole-document way -- and with no baseline guard at all, so
it wrote on mount. That one was worse: merely OPENING a second tab reverted whichever
crew page the first tab was on, with no user edit needed.

## Why this issue matters to the user

Two dashboard tabs is an ordinary way to use the app -- one on the issue list, one on
a pull request. The loss is silent and it hits state the user deliberately set: a
refresh interval they chose to keep provider cost down, a label filter they built up,
the issue they had selected. Nothing signals it; the next render just shows the other
tab's older view, and the natural reading is that the app forgot.

## How our fix solves it -- chain from symptom to root cause

1. **The symptom is one tab reverting another's fields.** The persisted document is a
   single localStorage key, and last write wins.
2. **The cause is that a write carries fields the writer never changed.** The save
   effect sends all ~23 fields from its own state, so its mount-time copy of the 22
   it did not touch overwrites whatever another tab has since stored.
3. **So the write is now a merge, and the payload is only what changed.** Two halves,
   and neither works alone:
   - `saveUiState` merges its payload over the on-disk document rather than replacing
     it. Alone this changes nothing, because a payload carrying every field still
     wins the spread.
   - The provider diffs against the document it last wrote and sends only the changed
     keys. Alone this would still hand a whole document to a replacing writer.

   Both are required, and the code says so at each half so a later refactor cannot
   keep one and drop the other.
4. **`refresh` is merged and diffed MEMBER-WISE, not as one value.** It holds five
   independent settings, so treating it as a single field reproduced the same clobber
   one level down: a tab toggling background polling and a tab changing an interval
   still reverted each other's member. A new `UiStatePatch` type makes "a subset of
   the document, and for `refresh` a subset of its members" expressible rather than a
   convention.
5. **A freshly mounted tab writes nothing.** The first effect run establishes the diff
   baseline and returns without writing -- otherwise merely OPENING a second tab
   would be the clobber, caused by the fix instead of the bug.
6. **The baseline records what is DURABLE.** It advances only when the write actually
   landed. Persistence is best-effort and a full quota is swallowed; advancing over a
   swallowed failure would mark those fields stored while the document still held the
   old ones, so the next change would diff them as unchanged, never resend them, and
   the edit would survive only in that tab until a reload discarded it. Both save
   helpers now return whether the write landed, which is the only way the caller can
   tell, and holding the baseline back re-sends the field on the next change.
7. **Comparison is by value, not identity.** `selectedLabels` / `prSelectedLabels` are
   fresh arrays every render and `settingsTarget` / `refresh` are objects, so
   reference equality would mark every field changed on every run and put the whole
   document straight back on the wire.
8. **The crews document gets the identical mechanism**, since it was the identical
   defect: a `saveCrewUi` merge, a baseline ref, and a by-value per-key diff.
   `crewView` is diffed as ONE value rather than member-wise, because it is a single
   discriminated selection whose fields always move together -- diffing it member-wise
   could pair a `kind` from one write with an `id` from another and synthesize a
   selection neither tab ever held. The comment at the diff says so.
9. **The carve-out is gone.** `aiLanguage` is no longer named by the effect at all;
   `setAiLanguage` patches it and is now its only writer. A new persisted field needs
   no per-field guard.

`patchUiState` keeps its narrower type, which still excludes `refresh` -- that field
has a validated domain (`coerceInterval`, a real provider-budget hazard) and keeps its
`setRefreshPrefs` path. `saveUiState` may carry it because its one caller builds the
value from that coerced state, and the docstring records why the two writers differ.
Its BODY is now a call to `saveUiState`: the merge is one operation, and the signature
was the only difference worth keeping. `storedAiLanguage` is deleted -- it existed only
because a whole-document save had to write the on-disk value back, so this change
removed its last consumer.

## What tests we did

Targeted only -- the full suite is CI's job.

- `website/src/test/issueRadarUiStateMerge.test.ts` (new, 9 cases): the persistence
  half. Fields not passed survive; a field that IS passed still wins (the merge must
  not become append-only); a language set through its own writer survives an unrelated
  save; a nested `refresh` block survives; `refresh` merges member-wise so two tabs do
  not revert each other, and a member that IS given still wins; an empty store gains
  no invented fields; and the write-result contract -- `true` on a normal write,
  `false` with the document untouched when storage refuses.
- `website/src/test/IssueRadarContextCoverage.test.tsx` (5 new cases in the existing
  harness): the provider half, through the real effect. Another tab's `query`,
  `selectedIssue` and `aiLanguage` are written to the store, this tab then changes one
  unrelated field, and all three survive; mounting over a seeded document persists
  nothing; a field whose write was refused is re-sent once storage recovers; and the
  same clobber and mount cases again for the crews document.
- **Every half mutation-verified independently.** Removing the merge fails 3 of the
  persistence cases. Bypassing the diff and sending the whole object fails the provider
  case with `expected '' to be 'other-tab-search'` -- literally the other tab's search
  reverting to this tab's mount-time empty string. Removing the nested `refresh` merge
  fails with `expected { listPollMs: 30000 } to match object { pollInBackground: true,
  ... }`. Removing the crew merge fails 3 cases; removing the crew mount guard fails
  with `expected { crewFilter: 'all', ... } to match object { crewFilter: 'active',
  ... }`, which is the clobber itself. Advancing the baselines regardless of the write
  result fails with `expected undefined to be 'typed-while-full'`.
- `IssueRadarAiLanguage.test.ts` carried a source-text ratchet asserting the carve-out
  line `aiLanguage: storedAiLanguage()` was present. Rather than delete the assertion,
  it is retargeted at the stronger property: the effect must not name that field at
  all, in either form. Deleting `storedAiLanguage` would have left that ratchet passing
  for free -- a regex for a function that no longer exists cannot fail -- so it now
  also pins that `format.ts` does not re-export the helper, which is how the read-back
  would actually come back.
- **One pre-existing test encoded the defect and was corrected.** "writes the crews UI
  back to its own key on change" asserted `toEqual` on all four crew fields after
  changing only one, i.e. it pinned the whole-document write. It now asserts only the
  fields that moved and, via `toEqual`, pins that untouched fields are NOT written.
- 140 tests pass across the 7 touched and adjacent Issue Radar suites; `tsc --noEmit`
  clean; eslint 0 errors on every touched file (one pre-existing
  `react-hooks/exhaustive-deps` warning about `pullsFirstPageQuery.data`, present on
  `main`, which only shifted line number as this change grew the file).

## Visual evidence

<!-- no-visual-delta -->

**Why no screenshot:** this change is persistence-only. It alters how Issue Radar's
localStorage documents are WRITTEN -- a whole-document overwrite becomes a per-key
merge, for the UI-state document and for the crews document on `CREW_UI_KEY`;
`refresh` is merged and diffed member-wise; and each diff baseline advances only when
the write actually landed. It changes no rendered output, no layout, no copy and no
control. Every pixel is identical on both sides of the diff; what differs is whether a
second tab's stored settings survive, which is observable only across a reload and is
pinned by the provider-level tests above rather than by an image.

The surface also could not be captured honestly. Issue Radar renders its welcome
carousel until a repo is connected (`IssueRadarPage.tsx:97`), and connecting one inside
an isolated pod needs a live GitHub credential, because a repo lacking a `permissions`
block is healed through a provider round-trip (`routes.py:763`). A first-run capture was
taken and deliberately NOT attached: it is a real screenshot of the app that
demonstrates nothing about this change, and decorative evidence is worse than a
declared absence.

## Any other suggestions on the work

- **Code Review Sage has the same shape.** `website/src/apps/code-review-sage/lib/persist.ts`
  exports its own `saveUiState` that also replaces its whole document, called from that
  app's context. It is a separate module with separate state and no shared code path
  with this one, so it is deliberately NOT in this diff -- but if two tabs on Sage lose
  state, this is the same defect and the same two-part fix applies.
- **The diff baseline is per-mount, not cross-tab.** This makes a tab stop writing
  fields it did not change, which is what removes the clobber. It does not give the two
  tabs a shared view: if both change the SAME field, last write still wins, which is
  the right semantics for a per-browser view preference and needs no coordination.
- `PersistedUiState` is now the payload type in `Partial` form, so a field added to the
  interface is picked up by the diff automatically -- there is no per-field list to keep
  in sync, which was the scaling objection the old comment raised.

Refs f-20260818-15

