### PR TITLE
perf(security): make the self-protection module-flag scan linear

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4348,7 +4348,53 @@ def _operands_lead_with(operands: "list[str]", spec: "tuple[object, ...]") -> bo
     return True
 
 
-def _self_module_name_index(tokens: "list[str]", i: int) -> "int | None":
+class _SelfModuleScan(NamedTuple):
+    """One token list's normalized forms plus its module-flag stop index.
+
+    ``norm[j]`` is what :func:`_normalize_operand` makes of token *j*, and ``stops[j]``
+    is the first index at or after *j* where the module-flag scan in
+    :func:`_self_module_name_index` stops.  Both are computed once per token list so
+    the scan does not repeat them for every interpreter token in it.
+    """
+
+    norm: "list[str]"
+    stops: "list[int]"
+
+
+def _is_self_module_flag(tok: str) -> bool:
+    """True where the module-flag scan in :func:`_self_module_name_index` stops.
+
+    The attached spelling only stops when the regex actually matches: ``-msomething``
+    that is not our module is an ordinary interpreter flag and the scan continues past
+    it, so the regex is part of the stop condition rather than a check made after it.
+    """
+    return tok == "-m" or (
+        tok.startswith("-m") and len(tok) > 2 and bool(_SELF_IMPORT_RE.search(tok[2:]))
+    )
+
+
+def _self_module_flag_scan(tokens: "list[str]") -> "_SelfModuleScan":
+    """Precompute one token list's normalized forms and module-flag stop indexes.
+
+    ``_self_module_name_index`` walked forward from each interpreter token to the first
+    module flag, normalizing every token it passed.  Called once per interpreter token
+    by ``_self_program_index``, that made the self-protection floor QUADRATIC in token
+    count: a command of interpreter words with no module flag among them re-walked and
+    re-normalized the whole tail every time.  Measured on the floor path, with one
+    product word present so its keyword gate opens: 0.03 s / 0.12 s / 0.49 s / 1.92 s
+    at 250 / 500 / 1000 / 2000 tokens -- about 4x per doubling, which reaches the
+    gateway's loop watchdog well inside a command an agent could emit.  Both passes
+    here are single and linear.
+    """
+    limit = len(tokens)
+    norm = [_normalize_operand(token).strip("\"'") for token in tokens]
+    stops = [limit] * (limit + 1)
+    for index in range(limit - 1, -1, -1):
+        stops[index] = index if _is_self_module_flag(norm[index]) else stops[index + 1]
+    return _SelfModuleScan(norm=norm, stops=stops)
+
+
+def _self_module_name_index(tokens: "list[str]", i: int, scan: "_SelfModuleScan") -> "int | None":
     """Index of the product module-name token in a ``python -m kiro_crew ...``
     invocation whose interpreter is at *i*, or None.
 
@@ -4356,26 +4402,35 @@ def _self_module_name_index(tokens: "list[str]", i: int) -> "int | None":
     scanning past other interpreter flags. The ``-c`` inline-program form has no
     positional subcommand token (the program builds its own argv), so it is left to
     the credential-mint import gate rather than matched here.
+
+    *scan* is REQUIRED, and must be :func:`_self_module_flag_scan` of the same *tokens*.
+    It is not optional-with-a-fallback on purpose: this function is called once per
+    token by a loop over those tokens, so a caller that could omit the scan could
+    silently reintroduce the quadratic this precompute exists to remove.  Requiring it
+    makes that a type error instead of a performance regression nobody notices.
     """
-    for j in range(i + 1, len(tokens)):
-        tok = _normalize_operand(tokens[j]).strip("\"'")
-        if tok == "-m":
-            nxt = _normalize_operand(tokens[j + 1]).strip("\"'") if j + 1 < len(tokens) else ""
-            return j + 1 if _SELF_IMPORT_RE.search(nxt) else None
-        if tok.startswith("-m") and len(tok) > 2 and _SELF_IMPORT_RE.search(tok[2:]):
-            return j  # attached -mkiro_crew
-    return None
+    limit = len(tokens)
+    j = scan.stops[i + 1]
+    if j >= limit:
+        return None
+    if scan.norm[j] == "-m":
+        nxt = scan.norm[j + 1] if j + 1 < limit else ""
+        return j + 1 if _SELF_IMPORT_RE.search(nxt) else None
+    return j  # attached -mkiro_crew
 
 
-def _self_program_index(tokens: "list[str]", i: int) -> "int | None":
+def _self_program_index(tokens: "list[str]", i: int, scan: "_SelfModuleScan") -> "int | None":
     """The argv index whose trailing operands the product CLI receives when the token
     at *i* launches it: *i* itself for the direct ``kirocrew`` form, or the module-name
     index for ``python -m kiro_crew``; else None.
+
+    *scan* is threaded through to :func:`_self_module_name_index` and is required for
+    the reason given there.
     """
     if _is_self_program(tokens[i]):
         return i
     if _PYTHON_PROGRAM_RE.match(_program_basename(tokens[i])):
-        return _self_module_name_index(tokens, i)
+        return _self_module_name_index(tokens, i, scan)
     return None
 
 
@@ -4391,8 +4446,11 @@ def _matches_self_subcommand(text_lower: str, spec: "tuple[object, ...]") -> boo
         return False
     for tokens in _self_token_frames(_shell_join_continuations(text_lower)):
         programs = _argv_programs(tokens)
+        # Once per FRAME, not once per token: this is the loop whose per-token scan
+        # made the floor quadratic.
+        scan = _self_module_flag_scan(tokens)
         for i in range(len(tokens)):
-            prog_idx = _self_program_index(tokens, i)
+            prog_idx = _self_program_index(tokens, i, scan)
             if prog_idx is None:
                 continue
             # ``echo kirocrew restart`` / ``echo python -m kiro_crew restart`` print words.

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -3779,3 +3779,142 @@ class TestStdinProgramTextScoping:
             f"echo {rule.pattern!r} >> notes.txt",
         ):
             assert security.is_denied(cmd) is None, f"rule fires on its own text: {cmd!r}"
+
+
+class TestSelfModuleIndexIsLinear:
+    """The self-protection floor's module-flag scan must stay LINEAR in token count.
+
+    ``_self_module_name_index`` walked forward from an interpreter token to the first
+    module flag, normalizing every token it passed.  ``_self_program_index`` called it
+    for every python-looking token and ``_matches_self_subcommand`` looped that over all
+    tokens, so a command of interpreter words with no module flag among them re-walked
+    and re-normalized the whole tail once per word: quadratic, on a floor that runs for
+    every command.
+
+    Reaching it needs only one product word anywhere in the text, which is what opens
+    the floor's cheap keyword gate (``_self_floor_can_fire``).  Padding alone does NOT
+    reproduce it -- ``python ... restart`` leaves that gate shut and the path is linear,
+    which is why the shape below carries ``kirocrew``.  Measured on base:
+    0.035 s / 0.125 s / 0.490 s / 1.937 s / 7.704 s at 250/500/1000/2000/4000 tokens,
+    4x per doubling, against 0.0027 s -> 0.0414 s after -- 186x at 4 000 tokens, and
+    the negative-verdict spelling pays the same cost to decide nothing.
+
+    The scan and the normalized forms are now computed once per token list.  Both the
+    verdicts and the complexity are pinned, since a rewrite that changed which token the
+    scan stops at would silently change what the floor denies.
+    """
+
+    # Every branch of the scan, with the index it must return for the interpreter at 0.
+    SHAPES: "list[tuple[list[str], object]]" = [
+        (["python", "-m", "kiro_crew", "restart"], 2),
+        (["python", "-mkiro_crew", "restart"], 1),
+        # A -m<something-else> is an ordinary interpreter flag: the scan must CONTINUE
+        # past it rather than stop, or the real module flag after it is never seen.
+        (["python", "-mjson", "-m", "kiro_crew"], 3),
+        (["python", "-msomething", "-mkiro_crew"], 2),
+        (["python", "-u", "-O", "-m", "kiro_crew"], 4),
+        # -m present but the module is not ours, and -m as the final token.
+        (["python", "-m", "json"], None),
+        (["python", "-m"], None),
+        (["python"], None),
+        (["python", "-mjson"], None),
+        # Quoting and dotted submodules the normalizer resolves.
+        (["python", "-m", "'kiro_crew'"], 2),
+        (["python", "-m", "kiro_crew.cli"], 2),
+    ]
+
+    def test_the_returned_index_is_unchanged(self):
+        from kiro_crew import security
+
+        for tokens, expected in self.SHAPES:
+            scan = security._self_module_flag_scan(list(tokens))
+            assert security._self_module_name_index(list(tokens), 0, scan) == expected, tokens
+
+    def test_a_shared_scan_answers_as_a_fresh_one_does(self):
+        """The scan is built once per frame and reused for every token in it, so a
+        stale or mismatched table would answer differently from one built for the call.
+        Pinned at every interpreter position, since that reuse is the whole optimization.
+        """
+        from kiro_crew import security
+
+        for tokens, expected in self.SHAPES:
+            shared = security._self_module_flag_scan(list(tokens))
+            for i in range(len(tokens)):
+                fresh = security._self_module_flag_scan(list(tokens))
+                assert security._self_module_name_index(
+                    list(tokens), i, shared
+                ) == security._self_module_name_index(list(tokens), i, fresh), (tokens, i)
+            assert security._self_module_name_index(list(tokens), 0, shared) == expected
+
+    def test_the_scan_is_a_required_argument(self):
+        """Not optional-with-a-fallback: this is called once per token by a loop over
+        those tokens, so a caller able to omit the scan could silently reintroduce the
+        quadratic. A type error is the point."""
+        import inspect
+
+        from kiro_crew import security
+
+        for fn in (security._self_module_name_index, security._self_program_index):
+            param = inspect.signature(fn).parameters["scan"]
+            assert param.default is inspect.Parameter.empty, fn.__name__
+
+    def test_the_floor_verdicts_are_unchanged(self):
+        from kiro_crew import security
+
+        for text in (
+            "kirocrew restart",
+            "python -m kiro_crew restart",
+            "python -mkiro_crew restart",
+            "python -mjson -m kiro_crew restart",
+            "python -msomething -m kiro_crew restart",
+            "python -u -O -m kiro_crew restart",
+            "python -m 'kiro_crew' restart",
+            "python -m kiro_crew -v restart",
+            "python python -m kiro_crew restart",
+        ):
+            assert security._is_self_restart(text), text
+
+        for text in (
+            "kirocrew doctor",
+            "python -m kiro_crew",
+            "python restart",
+            "python -m pytest test/test_restart.py",
+            "echo kirocrew restart",
+        ):
+            assert not security._is_self_restart(text), text
+
+    def test_the_stop_predicate_matches_the_handling(self):
+        from kiro_crew import security
+
+        for token in ("-m", "-mkiro_crew", "-mkiro_crew.cli"):
+            assert security._is_self_module_flag(token), token
+        # Not a stop: the scan has to keep going past these.
+        for token in ("-mjson", "-msomething", "python", "-u", "", "kiro_crew"):
+            assert not security._is_self_module_flag(token), token
+
+    def test_the_scan_is_linear_not_quadratic(self):
+        """Asserted two ways: a doubling ratio, which catches the quadratic regardless
+        of machine speed, and an absolute budget it could not meet on any runner."""
+        import time
+
+        from kiro_crew import security
+
+        def elapsed(n: int) -> float:
+            text = " ".join(["python"] * n + ["kirocrew", "restart"])
+            start = time.perf_counter()
+            security._is_self_restart(text)
+            return time.perf_counter() - start
+
+        elapsed(250)
+        small, large = elapsed(1000), elapsed(2000)
+        assert large < small * 3, f"{small:.4f}s -> {large:.4f}s looks super-linear"
+        # Base spent 1.94 s here; a quadratic scan cannot come near this ceiling.
+        assert large < 0.5, f"2k tokens took {large:.3f}s"
+
+    def test_the_padded_shape_that_does_not_open_the_gate_stays_cheap(self):
+        """Pins the reason the reported reproduction did not reproduce: without a
+        product word the floor's keyword gate stays shut and nothing is scanned."""
+        from kiro_crew import security
+
+        assert not security._self_floor_can_fire("python restart")
+        assert security._self_floor_can_fire("python kirocrew")


### PR DESCRIPTION
## 1. What is the problem?

The self-protection floor's module-flag scan is quadratic in token count, and the floor runs on every command inside the synchronous PreToolUse gate.

`_self_module_name_index` walks forward from an interpreter token to the first module flag, normalizing every token it passes. `_self_program_index` calls it for **every** python-looking token, and `_matches_self_subcommand` loops that over all tokens. With no module flag present, each interpreter word re-walks and re-normalizes the whole tail.

Measured on `_is_self_restart`:

| tokens | time |
|---|---|
| 250 | 0.0348 s |
| 500 | 0.1248 s |
| 1 000 | 0.4904 s |
| 2 000 | 1.9373 s |
| 4 000 | **7.7042 s** |

4x per doubling. 4 000 tokens is 28 KB -- well inside a single tool call.

Reaching it costs one product word. The floor's cheap keyword gate (`_self_floor_can_fire`) stands in front, and one occurrence of the product name anywhere in the text opens it. **Padding alone does not reproduce it** -- `python ... restart` leaves the gate shut and the path stays linear -- which is worth stating because that was the shape first reported, and checking it is what located the real trigger.

## 2. Why this issue matters to the user

The gateway's loop watchdog exits the process when a turn stalls, taking every live session with it. A command reaches this path with no operator action: the text is model-authored, so ordinary agent output or prompt injection can carry the padding.

Two details make it worse than a slow gate. The cost is paid in the **permission** decision, before any allow/deny answer exists, so no configuration avoids it. And the spelling *without* the subcommand pays the identical cost to return `False` -- a padded string does not need to look like a plausible command, only to be long and mention the product once.

This is the sibling of [PR #7122](https://github.com/kirodotdev/KiroCrew/pull/7122). That PR fixed the same defect class in `_nested_shell_payloads`; a reviewer there ran the grep for siblings and named this one, and a maintainer ruled it out of that PR and into this one so it gets its own numbers. Per token it is roughly an order of magnitude worse than the one already fixed.

## 3. How our fix solves it

The normalized token forms and the flag's stop index are computed **once per token list** (`_self_module_flag_scan`) and threaded through the two callers, so the scan becomes a lookup. Both passes are single and linear, and the redundant re-normalization disappears with them.

| tokens | before | after | speedup |
|---|---|---|---|
| 250 | 0.0348 s | 0.0027 s | 13x |
| 500 | 0.1248 s | 0.0053 s | 24x |
| 1 000 | 0.4904 s | 0.0105 s | 47x |
| 2 000 | 1.9373 s | 0.0207 s | 94x |
| 4 000 | 7.7042 s | 0.0414 s | **186x** |

2x per doubling after.

Three choices worth stating. **The scan is a required argument**, not optional with a fallback: this function is called once per token by a loop over those tokens, so a caller *able* to omit the scan could silently reintroduce the quadratic the precompute exists to remove -- requiring it makes that a type error instead of a performance regression nobody notices. (Review asked for this subtraction on the narrower grounds that no production caller omits it; the footgun is the stronger reason.) **The stop condition is a named predicate** (`_is_self_module_flag`) because it is subtler than it looks: `-m<other-module>` is an ordinary interpreter flag and the scan must *continue* past it, so the module regex is part of the stop condition rather than a check made after stopping -- getting that wrong would change which token the floor reads as the module name. And the change is confined to the scan: I did not touch the keyword gate, since a cheaper gate would be a security decision rather than a complexity one.

`_self_token_frames` on this shape is 0.0115 s at 2 000 tokens and linear, so it is not a contributor here and is left alone -- worth measuring rather than assuming, because on a different shape it was the dominant cost in the sibling review.

## 4. What tests we did

`TestSelfModuleIndexIsLinear` in `test/test_denied_commands_security.py`:

- **The returned index is unchanged** -- a `SHAPES` table covering every branch: separate flag, attached matching, attached non-matching that must be scanned past, other interpreter flags before the flag, `-m` with a foreign module, `-m` as the final token, quoted and dotted module names, and absent.
- **The floor verdicts are unchanged** -- 14 command lines asserted positive or negative through `_is_self_restart`.
- **Threaded reuse is safe** -- a shared scan and a freshly built one answer identically at every interpreter position, which is the property per-frame reuse depends on.
- **The scan is a required argument** -- pinned by signature, so the omittable path cannot come back.
- **The stop predicate matches the handling**, including the `-mjson` case that must *not* stop.
- **Linearity**, by doubling ratio (catches a quadratic regardless of machine speed) and absolute ceiling (base spent 1.94 s where the ceiling is 0.5 s).
- **The gate-shut shape**, pinning why the reported reproduction did not reproduce.

**Equivalence proven against the genuine base implementation**, ast-extracted and exec'd against the live module's globals rather than paraphrased -- on the sibling change a hand-written reference produced false mismatches twice, so it is not done here. Two levels: the index function over 15 adversarial shapes plus 8 000 randomized token lists, at every interpreter position and with both a shared and a per-call scan (**0 mismatches**); and the caller, by extracting all three base functions into one namespace so they chain into the real base predicate, over 4 336 command lines against both floor specs (**0 mismatches**).

**Mutation-verified against base:** 5 of the 7 tests fail (linearity, required-argument, stop predicate, index table, shared-vs-fresh) while the two pure-behavior controls pass -- the floor verdicts on 14 command lines and the gate-shut shape, both of which call only public predicates and so must be green on both sides. The deep equivalence evidence lives in the harnesses rather than the suite, because it needs the base function to compare against.

Targeted runs (never the full suite): `test_denied_commands_security.py` + `test_security.py` + `test_governance_self_protection.py` + `test_push_branch_gate.py` -- **1690 passed, 1 skipped**. flake8, isort, mypy clean; black gate passes in scope.

## 5. Any other suggestions on the work

- **The grep is not clean in this tree, and my earlier claim that it was is wrong.** I wrote "two hits" from a measurement taken in the sibling PR's worktree, where `_nested_shell_payloads` is already linear -- a number carried across trees, which is the error I was otherwise being careful to avoid. In THIS tree `for j in range(i + 1, len(` under `src/` has three hits: `security.py:3207` and `security.py:3230`, both `_nested_shell_payloads` on the same gated path, fixed by [PR #7122](https://github.com/kirodotdev/KiroCrew/pull/7122) but not present here because that PR is unmerged; and `knowledge/dedup.py:532`, pairwise by design and off the gate. The permission path is closed for this pattern only once both land, and this PR does not depend on that ordering.
- **The keyword gate is load-bearing for performance, not just for cost.** It is the only reason padding without a product word is harmless, and it was written as a correctness short-circuit ("may fire / provably cannot"). Anything that widens it -- a new name hint, a new machinery pattern -- widens what can reach scans like this one. That is an argument for keeping these scans linear rather than for tightening the gate.
- **The two fixes share a shape worth naming in review**: a helper that scans forward from an index, called once per index by its caller. Neither instance looked expensive at its own call site; both were quadratic through the caller. A reviewer checking "is this linear?" has to look one level up. That is also why `scan` is a required argument here rather than optional -- an omittable precompute is an omittable fix.
