### PR TITLE
fix(frontend): stop a failed npm ci from destroying node_modules

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -866,7 +866,13 @@ Each step checks if the tool is already installed and skips if present.
    edits in another terminal to rescue them is the natural response to the
    prompt, and is exactly what would otherwise be reset away). Only `HEAD` can
    move in that window, so the re-check needs no second fetch.
-2. Rebuilds the dashboard via `build_frontend_sync()` (npm; non-fatal on failure)
+2. Rebuilds the dashboard via `build_frontend_sync()` (npm; non-fatal on failure).
+   Non-fatal also means non-destructive: `npm ci` deletes `node_modules` before it
+   installs, so the tree is moved aside and restored unless the install succeeds
+   (`node_modules_txn.NodeModulesBackup`). A failed install therefore costs the
+   rebuild, not the dependency tree -- which matters because the registry needed
+   to rebuild one is usually what was unavailable. The gateway's unattended
+   auto-apply takes the async sibling and is protected the same way.
 3. Reinstalls backend via `pip install -e .`
 
 ## Client Port Resolution

--- a/src/kiro_crew/frontend.py
+++ b/src/kiro_crew/frontend.py
@@ -25,6 +25,7 @@ from typing import Callable, Iterator, Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.node_modules_txn import NodeModulesBackup
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,10 @@ _SIBLING_DIR_NAME = "KiroCrewWebsite"
 # Build timeouts (seconds). npm installs/builds can be slow on cold caches.
 _INSTALL_TIMEOUT = 300
 _BUILD_TIMEOUT = 300
+#: How long to wait for a killed install tree to actually exit before restoring
+#: over it. Short by design: the group has already been SIGKILLed, so this only
+#: covers reaping, and waiting longer would delay a recovery that is already late.
+_REAP_TIMEOUT = 30
 # Seconds to wait for a SIGKILLed build to be reaped before giving up. SIGKILL is
 # not catchable, so this only covers the kernel tearing the tree down; there are
 # no pipes to drain because the build's output goes to DEVNULL.
@@ -621,22 +626,112 @@ def build_frontend_sync(
         if (website_dir / "package-lock.json").is_file()
         else ["install", "--no-audit", "--no-fund"]
     )
-    try:
-        r = subprocess.run(
-            [npm, *install_args],
-            cwd=str(website_dir), capture_output=True, timeout=_INSTALL_TIMEOUT,
-        )
-    except subprocess.TimeoutExpired:
-        log("  ⚠️  Frontend npm install timed out — dashboard may be stale")
-        return
-    if r.returncode != 0:
-        log("  ⚠️  Frontend npm install failed — dashboard may be stale")
-        return
+    # `npm ci` deletes node_modules BEFORE it installs, so a refusal from the
+    # registry leaves no tree at all -- and the registry is the one thing needed
+    # to rebuild one. Move it aside and put it back unless the install succeeds.
+    #
+    # The whole transaction runs under ONE holder of the staging lock, install
+    # included. That is not about `website/dist` -- it is what makes `begin`'s
+    # recovery branch safe. That branch adopts a backup it finds beside the tree,
+    # and it cannot tell a CRASHED earlier run's backup (adopt it) from a LIVE
+    # peer's (leave it alone); nothing on disk distinguishes them. Serializing the
+    # armed interval means a live peer cannot be in it, so the only backup `begin`
+    # can ever see is a dead run's. Without that, two updates could each adopt the
+    # other's stash and one's commit would delete the tree the other still needed.
+    #
+    # It must be one holder, not two: the lock is an flock keyed per
+    # open-file-description, so re-entering through a second open() in this same
+    # process would deadlock against itself (see _staging_lock). Hence the build
+    # and stage happen inside here too, via the _locked variant.
+    #
+    # The cost is real and deliberate: a peer now waits for an install (up to
+    # _INSTALL_TIMEOUT) rather than only for a build. Two frontend builds on one
+    # checkout were already mutually destructive, so waiting is the correct
+    # outcome, not a regression.
+    #
+    # RESIDUAL: this closes races between Kiro Crew's own Python flows. Dev Fleet's
+    # Pull+Build takes this same lock for its build+stage child, but its `npm ci`
+    # step runs from a generated stdlib-only script that cannot import kiro_crew
+    # and so cannot take it. A Pull+Build install overlapping one of these is
+    # therefore still possible; it is tracked separately rather than papered over.
+    backup = NodeModulesBackup(website_dir / "node_modules", lambda m: log(f"  ⚠️  {m}"))
 
-    # npm install does not touch website/dist, so only the build+stage pair
-    # needs the lock.
+    def _reap_tree(proc) -> None:
+        """Kill the install's whole process group, then wait for it.
+
+        Both halves matter. The GROUP, because `npm ci` spawns node and any
+        lifecycle scripts, and survivors would write into the directory being
+        restored. The WAIT, because a killed process is not yet a finished one.
+        Every failure is suppressed: the group can exit between the decision to
+        kill and the kill itself, and a ProcessLookupError escaping from a
+        best-effort reap would turn a recoverable install failure into a crash.
+        """
+        if proc is None or proc.returncode is not None:
+            return
+        with contextlib.suppress(ProcessLookupError, OSError, ValueError):
+            platform_compat.kill_process_tree(proc.pid, platform_compat.SIGKILL)
+        with contextlib.suppress(subprocess.TimeoutExpired, OSError, ValueError):
+            proc.communicate(timeout=_REAP_TIMEOUT)
+
+    proc = None
     try:
         with _staging_lock(proj_path / "src" / "kiro_crew" / "static"):
+            if not backup.begin():
+                return
+            try:
+                try:
+                    # Popen rather than subprocess.run: run() never exposes the
+                    # pid, and without it only the direct child can be signalled
+                    # on timeout. `npm ci` spawns node and any lifecycle scripts
+                    # the lockfile asks for, and those keep writing into
+                    # node_modules after their parent dies -- so a survivor would
+                    # race the rollback and land its leftovers in the restored
+                    # tree. Its own group, so the whole tree can be signalled.
+                    proc = subprocess.Popen(
+                        [npm, *install_args],
+                        cwd=str(website_dir),
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        start_new_session=platform_compat.IS_POSIX,
+                        creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+                    )
+                except OSError as exc:
+                    backup.rollback()
+                    log(f"  ⚠️  Frontend npm install could not start ({exc}) — tree left as it was")
+                    return
+                try:
+                    proc.communicate(timeout=_INSTALL_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    # A timeout KILLS npm mid-install, so what it leaves is a
+                    # PARTIAL tree -- exactly what the rollback exists for, not a
+                    # reason to skip it.
+                    _reap_tree(proc)
+                    backup.rollback()
+                    log("  ⚠️  Frontend npm install timed out — the dependency tree was left as it was")
+                    return
+                if proc.returncode != 0:
+                    backup.rollback()
+                    log("  ⚠️  Frontend npm install failed — the dependency tree was left as it was")
+                    return
+                backup.commit()
+            except BaseException:
+                # Ctrl-C is the case this exists for: KeyboardInterrupt is a
+                # BaseException, so none of the handlers above see it, and without
+                # this the tree would stay stashed under its backup name while the
+                # path the rest of the app reads is simply missing. Covers the
+                # whole armed interval, so no future edit inside it can
+                # reintroduce the gap. rollback() is a no-op once commit() or an
+                # earlier rollback disarmed it.
+                #
+                # Reap FIRST, and note WHY that is not optional here: the install
+                # runs in its own session (so its whole tree can be signalled on
+                # timeout), which also means a terminal Ctrl-C does NOT reach it --
+                # SIGINT goes to the foreground process group, and npm is no longer
+                # in it. So npm survives the interrupt and would keep writing into
+                # the directory being restored.
+                _reap_tree(proc)
+                backup.rollback()
+                raise
             _npm_build_and_stage_locked(website_dir, proj_path, npm, log)
     except OSError as exc:
         log(f"  ⚠️  Could not acquire the static/dist staging lock: {exc}")
@@ -683,47 +778,202 @@ async def build_frontend_async(
         if (website_dir / "package-lock.json").is_file()
         else ["install", "--no-audit", "--no-fund"]
     )
-    npm_i = await asyncio.create_subprocess_exec(
-        npm, *install_args,
-        cwd=str(website_dir),
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    try:
-        await asyncio.wait_for(npm_i.wait(), timeout=_INSTALL_TIMEOUT)
-    except asyncio.TimeoutError:
-        try:
-            npm_i.kill()
-        except ProcessLookupError:
-            pass
-        await npm_i.wait()
-        _warn("Frontend npm install timed out -- dashboard may be stale")
-        return
-    if npm_i.returncode != 0:
-        _warn("Frontend npm install failed -- dashboard may be stale")
-        return
+    # `npm ci` deletes node_modules BEFORE it installs. This is the UNATTENDED
+    # path: the gateway's auto-apply reaches it at boot with no operator, and it
+    # never retries, because the next boot sees the commit already applied. So a
+    # registry refusal here destroyed the tree until a human happened to notice.
+    #
+    # The transaction's removals and renames are BLOCKING filesystem work on a
+    # tree of tens of thousands of files, so they run in a worker thread for the
+    # same reason the build+stage below does: on the event loop they would stall
+    # the gateway's heartbeat and every in-flight request. And it collects its
+    # messages instead of warning directly, because `_warn` reaches
+    # `push_progress`, which belongs to the LOOP thread -- they are replayed here.
+    txn_log: list[str] = []
+    backup = NodeModulesBackup(website_dir / "node_modules", txn_log.append)
 
-    # The build and the stage run under ONE lock holder, in a worker thread.
-    # Vite empties website/dist, so a peer flow staging concurrently would copy
-    # a partially written tree; and acquiring a blocking flock on the event loop
-    # would freeze the gateway for the length of someone else's build.
+    def _drain() -> None:
+        while txn_log:
+            _warn(txn_log.pop(0))
+
+    # Submitted through the executor DIRECTLY rather than loop.run_in_executor, so
+    # the concurrent future is in hand: a cancelled `await` does NOT cancel work
+    # that has already started in the thread, and the lock must not be released
+    # while such a step is still renaming or removing the tree -- that would admit
+    # a peer mid-mutation. Tracked here, drained in the finally.
+    inflight: list = []
+
+    async def _offload(step):
+        future = subprocess_executor().submit(step)
+        inflight.append(future)
+        try:
+            result = await asyncio.wrap_future(future)
+        finally:
+            _drain()
+        # Reached only when the step actually completed. A cancelled await skips
+        # this, so the future stays tracked and the finally waits for it.
+        inflight.remove(future)
+        return result
+
+    async def _kill_and_wait(proc) -> None:
+        """Kill npm AND its descendants, then wait, before anything clears the tree.
+
+        `npm ci` is not a leaf: it spawns node and any lifecycle scripts the
+        lockfile asks for, and those keep writing into `node_modules` after their
+        parent dies. Killing only the direct child therefore left writers racing
+        the rollback. `kill_and_reap` signals the whole group, which is why the
+        spawn below opens a session of its own -- a child sharing our group has no
+        tree to signal and the group kill is skipped for it.
+
+        The wait is the load-bearing half: a killed child is not a finished one.
+        """
+        if proc is None:
+            return
+        if proc.returncode is not None:
+            # Already exited: nothing to signal, and nothing to wait for. This
+            # matters because the interruption handlers also cover the build and
+            # stage, which run AFTER the install has finished -- reaping there
+            # would signal a pid that is gone (or, worse, reused).
+            return
+        with contextlib.suppress(asyncio.CancelledError, ProcessLookupError, OSError):
+            await platform_compat.kill_and_reap(proc)
+
+    npm_i = None
+    # ONE holder of the staging lock spans this whole transaction, install
+    # included. That is what makes `begin`'s recovery branch safe: it adopts a
+    # backup it finds beside the tree and cannot tell a CRASHED earlier run's from
+    # a LIVE peer's, because nothing on disk distinguishes them. Serializing the
+    # armed interval means a live peer cannot be inside it, so the only backup
+    # `begin` can see is a dead run's. See build_frontend_sync for the same
+    # reasoning, its cost, and the Dev Fleet residual.
+    #
+    # It is entered and exited through the executor because taking a blocking
+    # flock on the event loop would freeze the gateway for the length of someone
+    # else's install -- and it must be ONE holder, since the lock is keyed per
+    # open-file-description and re-entering in this process would deadlock.
+    lock = contextlib.ExitStack()
+    static_parent = proj_path / "src" / "kiro_crew" / "static"
     messages: list[str] = []
-
-    def _locked_build_and_stage() -> bool:
-        # Collect rather than calling _warn: this runs on a worker thread, and
-        # _warn reaches push_progress, which belongs to the loop thread.
+    staged = False
+    try:
+        await _offload(lambda: lock.enter_context(_staging_lock(static_parent)))
+    except OSError as exc:
+        _warn(f"Could not acquire the static/dist staging lock: {exc}")
+        return
+    try:
+        # begin() is INSIDE the protected interval: it arms the transaction in a
+        # worker thread, so a cancellation delivered just after the rename but
+        # before the body would otherwise leave the tree stashed with nothing to
+        # put it back.
+        if not await _offload(backup.begin):
+            return
         try:
-            with _staging_lock(proj_path / "src" / "kiro_crew" / "static"):
+            npm_i = await asyncio.create_subprocess_exec(
+                npm, *install_args,
+                cwd=str(website_dir),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                # Its own group, so the whole install tree can be signalled --
+                # see _kill_and_wait. No-op on the platform that lacks each half.
+                start_new_session=platform_compat.IS_POSIX,
+                creationflags=platform_compat.CREATE_NEW_PROCESS_GROUP,
+            )
+        except OSError as exc:
+            await _offload(backup.rollback)
+            _warn(f"Frontend npm install could not start ({exc}) -- tree left as it was")
+            return
+        try:
+            await asyncio.wait_for(npm_i.wait(), timeout=_INSTALL_TIMEOUT)
+        except asyncio.TimeoutError:
+            await _kill_and_wait(npm_i)
+            # Killed mid-install, so what is on disk is PARTIAL. Restore before
+            # reporting, so the message is true by the time anyone reads it.
+            await _offload(backup.rollback)
+            _warn("Frontend npm install timed out -- the dependency tree was left as it was")
+            return
+        if npm_i.returncode != 0:
+            await _offload(backup.rollback)
+            _warn("Frontend npm install failed -- the dependency tree was left as it was")
+            return
+        await _offload(backup.commit)
+
+        # Still inside the SAME holder, so this calls the _locked variant --
+        # re-entering _staging_lock here would deadlock against ourselves. Vite
+        # empties website/dist, so a peer staging concurrently would copy a
+        # partially written tree.
+        def _build_and_stage() -> bool:
+            # Collect rather than calling _warn: this runs on a worker thread, and
+            # _warn reaches push_progress, which belongs to the loop thread.
+            #
+            # OSError is caught HERE rather than left to the interruption handlers
+            # below. The build spawns its own npm, so a missing binary raises
+            # FileNotFoundError -- an OSError -- and letting that propagate would
+            # turn a reported build failure into an exception escaping this helper,
+            # which on the unattended path means it escapes into the gateway's
+            # auto-apply. Reporting it keeps the caller's contract: this function
+            # warns and returns, it does not raise for a failed build.
+            try:
                 return _npm_build_and_stage_locked(
                     website_dir, proj_path, npm, messages.append
                 )
-        except OSError as exc:
-            messages.append(f"Could not acquire the static/dist staging lock: {exc}")
-            return False
+            except OSError as exc:
+                messages.append(f"Frontend build could not run: {exc}")
+                return False
 
-    staged = await asyncio.get_running_loop().run_in_executor(
-        subprocess_executor(), _locked_build_and_stage
-    )
+        # Through _offload, NOT raw run_in_executor: that is what puts the future
+        # in `inflight` so the `finally` waits for it before releasing the lock.
+        # Otherwise a cancellation here releases the flock while this thread is
+        # still running `npm run build` (which rewrites website/dist) and staging
+        # it, and a peer would publish a bundle vite is mid-rewrite -- the mixed
+        # bundle the lock exists to prevent. Before this PR the lock was taken
+        # INSIDE the worker, so a cancelled await could not release it early.
+        staged = await _offload(_build_and_stage)
+    except asyncio.CancelledError:
+        # Gateway shutdown during the install. Left alone this strands the tree:
+        # ours stays stashed while npm keeps writing a fresh one, and if npm gets
+        # far enough BOTH paths exist -- which the next run can only read as
+        # ambiguous, refusing every build until someone clears one by hand.
+        #
+        # Reap FIRST. The child outlives its cancelled parent, so clearing the
+        # directory it is writing would race it.
+        await _kill_and_wait(npm_i)
+        # Then roll back SYNCHRONOUSLY rather than through the executor. This is
+        # MAINTAINER-ADJUDICATED, not a preference: `executors.py` registers an
+        # atexit shutdown that calls `shutdown(wait=False, cancel_futures=True)`,
+        # so at interpreter exit -- which is exactly when this path runs -- queued
+        # executor work is CANCELLED and running work is not waited for. Offloading
+        # here would turn a guaranteed recovery into a probabilistic one in the one
+        # scenario the transaction exists for. Shielding the await does not help:
+        # it protects the await, not the queued future. A brief block during a
+        # shutdown that is already ending is the cheaper side of that trade.
+        backup.rollback()
+        _drain()
+        raise
+    except BaseException:
+        # Any other interruption across the armed interval -- SystemExit, or a
+        # cancellation raised somewhere an await is not expected. Unlike the
+        # cancelled case above this task is still live, so the cleanup can go
+        # through the executor, and the re-raise waits for it to finish.
+        await _kill_and_wait(npm_i)
+        await _offload(backup.rollback)
+        raise
+    finally:
+        # Drain before releasing. A cancelled await leaves its executor step
+        # RUNNING, so the lock would otherwise be released while a thread is still
+        # renaming or removing the tree, admitting a peer into a half-applied
+        # transaction. Waited on synchronously, for the same adjudicated reason the
+        # cancellation rollback is synchronous: this runs during shutdown, where a
+        # further await is not guaranteed to resume and the executor is being torn
+        # down with cancel_futures=True.
+        for future in inflight:
+            with contextlib.suppress(Exception):
+                future.result(timeout=_REAP_TIMEOUT)
+        _drain()
+        # Releasing is an flock release and a file close -- microseconds, unlike
+        # the tree work -- so doing it inline is safe even on the cancelled path.
+        with contextlib.suppress(Exception):
+            lock.close()
+
     for message in messages:
         # Surface the specific cause (build timeout / build failure / staging
         # refusal / lock failure) rather than one generic line: without it the

--- a/src/kiro_crew/node_modules_txn.py
+++ b/src/kiro_crew/node_modules_txn.py
@@ -1,0 +1,202 @@
+"""Make a failed ``npm ci`` a no-op instead of damage.
+
+``npm ci`` DELETES ``node_modules`` before it installs. So an install that
+fails partway -- an expired registry token, a network drop, a timeout kill --
+leaves the caller with no dependency tree at all, and the one thing needed to
+rebuild it (the registry) is exactly what was unavailable. The tree is not
+stale, it is gone.
+
+This module is the in-process half of that transaction: move the tree aside,
+put it back unless the install succeeded. Its callers are
+:func:`kiro_crew.frontend.build_frontend_sync` and
+:func:`kiro_crew.frontend.build_frontend_async`.
+
+WHY THIS IS NOT THE ONLY COPY. Dev Fleet's Pull+Build runs the same transaction
+in ``dev_fleet/server.py``, spelled out inline in a generated stdlib-only
+script. That duplication is deliberate and must stay: that script runs while the
+repository is being merged underneath it, so it must not import ``kiro_crew`` --
+what it does cannot be allowed to change with the revision being installed. The
+two copies therefore share SEMANTICS, not code, and the tests pin the one
+agreement that matters between them: the backup path. Change the suffix here and
+that test fails.
+
+Sharing the suffix is not cosmetic. Dev Fleet reconciles a leftover backup
+before it runs anything, so a crashed auto-update that left one gets healed the
+next time an operator presses Pull+Build. The unattended update path has no
+recovery of its own -- it never retries, because the next boot sees the commit
+already applied -- so inheriting Dev Fleet's is the only self-heal it gets.
+
+The rules below were learned in that script, and are repeated here because a
+symlinked or dangling ``node_modules`` is a real layout, not a hypothetical: a
+worktree that links into a shared store has one.
+
+Log messages here are deliberately ASCII. They are emitted through BOTH callers
+-- one prints to a console, the other pushes to the update-progress feed -- and
+a non-ASCII character printed to a Windows codepage console raises
+UnicodeEncodeError, which would turn a recovery message into a second failure.
+Callers own their own prefixes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+#: Suffix appended to the tree path to name its backup. MUST match the literal
+#: in ``dev_fleet/server.py``'s generated runner, so the two flows recognise
+#: each other's leftovers instead of stepping on them.
+BACKUP_SUFFIX = ".kirocrew-sync-backup"
+
+
+def _gone(path: Path) -> bool:
+    """Remove ``path`` and report whether it is actually gone.
+
+    ``rmtree`` REFUSES a symlink ("Cannot call rmtree on a symbolic link") and
+    ``ignore_errors=True`` swallows that refusal -- which once left a symlinked
+    tree's backup undeletable, so every later run saw both paths and refused as
+    ambiguous. A permanent wedge escapable only by hand. So: unlink links,
+    rmtree only real trees.
+
+    The outcome is CONFIRMED rather than assumed because every removal here
+    decides what the next rename does; a partial removal that is silently
+    ignored leaves a directory in place, makes the rename fail, and can end with
+    a PARTIAL tree restored over a good one.
+    """
+    if os.path.islink(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    else:
+        shutil.rmtree(path, ignore_errors=True)
+    # lexists, not exists: a DANGLING symlink is still something at this path,
+    # and reporting it as gone would let the caller proceed as if it were clear.
+    return not os.path.lexists(path)
+
+
+class NodeModulesBackup:
+    """Move a dependency tree aside for the length of an install.
+
+    Explicit ``begin`` / ``commit`` / ``rollback`` rather than a context
+    manager, because the two callers differ in exactly the way a context manager
+    cannot bridge: one awaits its install, the other does not. The policy lives
+    here once; each caller supplies only its own control flow.
+    """
+
+    def __init__(self, tree: "str | Path", log: Callable[[str], None]) -> None:
+        self.tree = Path(tree)
+        self.backup = Path(str(self.tree) + BACKUP_SUFFIX)
+        self._log = log
+        self.armed = False
+
+    def begin(self) -> bool:
+        """Reconcile leftovers, then move the tree aside.
+
+        Returns False when the caller must NOT install. That is a refusal, not
+        an error: the safe move is to leave the disk exactly as found.
+        """
+        # lexists, not isdir, for every presence gate. isdir FOLLOWS a symlink,
+        # so a DANGLING tree reads as absent -- and then the backup-only branch
+        # below renames a directory onto a dangling link, which fails ENOTDIR.
+        have_tree = os.path.lexists(self.tree)
+        have_backup = os.path.lexists(self.backup)
+
+        if have_tree and have_backup:
+            # Genuinely AMBIGUOUS, and no rule can be right:
+            #   * killed DURING npm ci -> the tree is the partial one npm was
+            #     writing and the backup is the last good one;
+            #   * a backup that outlived a SUCCESSFUL install (its cleanup
+            #     failed) -> the tree is good and the backup is stale.
+            # Nothing on disk distinguishes those, so either choice destroys the
+            # good copy in one of them. Touch NEITHER, and say what to remove --
+            # otherwise every later attempt refuses identically and the operator
+            # has to deduce it.
+            self._log(
+                "A previous dependency-tree backup is still beside the tree, so "
+                "the install was not attempted (removing either one by hand "
+                f"clears this). tree: {self.tree}, backup: {self.backup}"
+            )
+            # This is the ONE state that needs a human, and it is reachable on the
+            # unattended path, where the caller's log goes to an update-progress
+            # feed that is dropped when no dashboard client is attached. Without a
+            # second channel a hard kill mid-install would turn into an indefinite
+            # silent build stall. The gateway log is the one an operator can read
+            # after the fact.
+            logger.warning(
+                "node_modules transaction refusing: both %s and %s exist; remove "
+                "one by hand. Nothing was installed and neither path was touched.",
+                self.tree,
+                self.backup,
+            )
+            return False
+
+        if have_backup:
+            # Backup only: unambiguous recovery, so claim it before installing.
+            # This is the branch that heals a crashed unattended update.
+            self._log("Restoring a dependency tree left behind by an earlier run")
+            try:
+                os.rename(self.backup, self.tree)
+            except OSError as exc:
+                self._log(f"Could not restore the stashed dependency tree: {exc}")
+                return False
+            have_tree = True
+
+        if have_tree:
+            try:
+                os.rename(self.tree, self.backup)
+            except OSError as exc:
+                # Could not protect the tree, so do not run a step that would
+                # delete it. Refusing costs one install; proceeding costs the
+                # tree with no way back.
+                self._log(
+                    "Could not move the dependency tree aside, so the install "
+                    f"was not attempted: {exc}"
+                )
+                return False
+            self.armed = True
+        # Nothing to protect (a first install) is a legitimate success: the
+        # caller may proceed, and rollback has nothing to put back.
+        return True
+
+    def commit(self) -> None:
+        """Install succeeded -- drop the backup."""
+        if not self.armed:
+            return
+        self.armed = False
+        if not _gone(self.backup):
+            # The new tree is in place and good, so this is untidiness rather
+            # than damage -- but it MUST be reported, because the next run sees
+            # both paths and refuses as ambiguous.
+            self._log(
+                "Installed successfully but could not remove the old "
+                "dependency-tree backup; remove it to avoid a refusal on the "
+                f"next build: {self.backup}"
+            )
+
+    def rollback(self) -> None:
+        """Install failed -- put the original tree back."""
+        if not self.armed:
+            return
+        self.armed = False
+        # Clear whatever the failed install left at the destination first, or the
+        # rename below fails and the good copy stays stranded in the backup.
+        if os.path.lexists(self.tree) and not _gone(self.tree):
+            self._log(
+                "Could not clear the partial dependency tree, so the good one "
+                f"is left at {self.backup}; move it back by hand"
+            )
+            return
+        try:
+            os.rename(self.backup, self.tree)
+        except OSError as exc:
+            self._log(
+                f"Could not restore the dependency tree ({exc}); the good copy "
+                f"is still at {self.backup}; move it back by hand"
+            )
+            return
+        self._log("Install failed, so the previous dependency tree was restored")

--- a/test/test_frontend_dist_resolve.py
+++ b/test/test_frontend_dist_resolve.py
@@ -302,11 +302,20 @@ def test_build_frontend_sync_spawns_resolved_npm_path(tmp_path, monkeypatch):
     class _Result:
         returncode = 0
 
-    def _fake_run(cmd, **kw):
-        calls.append(cmd)
-        return _Result()
+        def __init__(self, cmd, **kw):
+            calls.append(cmd)
 
-    monkeypatch.setattr(frontend.subprocess, "run", _fake_run)
+        def communicate(self, timeout=None):
+            return (b"", b"")
+
+        def wait(self, timeout=None):
+            return 0
+
+    # The install moved from subprocess.run to Popen -- run never exposes a pid,
+    # so only the direct child could be signalled on timeout, leaving npm's
+    # descendants writing into the dependency tree while it is restored. Both the
+    # install and the build are now recorded through this one seam.
+    monkeypatch.setattr(frontend.subprocess, "Popen", _Result)
     frontend.build_frontend_sync(tmp_path, log=lambda *a: None)
 
     assert calls, "no subprocess was spawned"

--- a/test/test_frontend_edition_build.py
+++ b/test/test_frontend_edition_build.py
@@ -154,13 +154,23 @@ def test_no_edition_dir_is_never_missing():
 
 
 def _popen_recorder(seen: list) -> type:
-    """Record the build spawn: the build runs through ``subprocess.Popen``."""
+    """Record a spawn: BOTH the install and the build run through ``subprocess.Popen``.
+
+    The install moved from ``subprocess.run`` to ``Popen`` so its pid is available
+    -- ``run`` never exposes one, and without a pid only the direct child can be
+    signalled on timeout, leaving npm's descendants writing into the dependency
+    tree while it is restored. So this fake answers both protocols: ``communicate``
+    for the install, ``wait`` for the build.
+    """
 
     class _P:
         returncode = 0
 
         def __init__(self, argv, **kwargs):
             seen.append((argv, kwargs.get("env")))
+
+        def communicate(self, timeout=None):
+            return (b"", b"")
 
         def wait(self, timeout=None):
             return 0

--- a/test/test_node_modules_txn.py
+++ b/test/test_node_modules_txn.py
@@ -1,0 +1,788 @@
+"""A failed ``npm ci`` must not cost the caller its dependency tree.
+
+``npm ci`` deletes ``node_modules`` before it installs, so an install that fails
+partway leaves nothing behind -- and the registry needed to rebuild is exactly
+what was unavailable. These pin that both frontend build helpers move the tree
+aside and put it back.
+
+The async helper matters most: the gateway's auto-apply reaches it at boot with
+no operator present, and it never retries, because the next boot sees the commit
+already applied. Before this, a registry refusal there destroyed the tree
+silently and reported success.
+
+Every test drives the install through a FAKE npm, so nothing here touches a
+registry or a real tree.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import frontend
+from kiro_crew import node_modules_txn as nmt
+from kiro_crew.node_modules_txn import BACKUP_SUFFIX, NodeModulesBackup
+
+MARKER = "left-by-the-previous-install"
+
+
+@pytest.fixture(autouse=True)
+def _clean_edition_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An edition env would divert both helpers before they reach npm."""
+    monkeypatch.delenv("KIROCREW_EDITION_DIR", raising=False)
+    monkeypatch.delenv("KIROCREW_ALLOW_EDITION", raising=False)
+
+
+def _website(tmp_path: Path, *, with_tree: bool = True) -> Path:
+    """A project whose website/ has a lockfile (so the `npm ci` branch is taken)."""
+    w = tmp_path / "website"
+    w.mkdir()
+    (w / "package-lock.json").write_text("{}")
+    if with_tree:
+        tree = w / "node_modules"
+        tree.mkdir()
+        (tree / "sentinel.txt").write_text(MARKER)
+    return w
+
+
+def _tree_intact(tmp_path: Path) -> bool:
+    return (tmp_path / "website" / "node_modules" / "sentinel.txt").read_text() == MARKER
+
+
+def _gates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(frontend.shutil, "which", lambda _n: "/usr/bin/npm")
+    monkeypatch.setattr(frontend, "_stage_dist", lambda *_a, **_k: None)
+    monkeypatch.setattr(frontend, "_stage_dist_locked", lambda *_a, **_k: None, raising=False)
+
+
+def _deleting_popen(rc: int, *, times_out: bool = False, interrupts: bool = False):
+    """A fake npm that behaves like the real one: DELETE the tree, then fail.
+
+    The delete is what makes these tests meaningful. A fake that merely reported
+    a non-zero exit would pass against the unfixed code and prove nothing, since
+    the defect is that npm's own deletion is never undone.
+    """
+
+    class _P:
+        # Never signalled: `platform_compat.kill_process_tree` is patched out in
+        # these tests, so no real pid is needed and none can be hit.
+        pid = -1
+
+        def __init__(self, argv, **kwargs) -> None:
+            self.returncode = None
+            self._times_out = times_out
+            tree = Path(kwargs.get("cwd", ".")) / "node_modules"
+            if tree.exists():
+                for child in tree.iterdir():
+                    child.unlink()
+                tree.rmdir()
+            if interrupts:
+                tree.mkdir()
+                raise KeyboardInterrupt()
+            if times_out:
+                # Killed mid-install leaves a PARTIAL tree, which the rollback
+                # has to clear before it can put the good one back.
+                tree.mkdir()
+                (tree / "half-written").write_text("partial")
+            elif rc == 0:
+                tree.mkdir()
+                (tree / "fresh.txt").write_text("installed")
+
+        def communicate(self, timeout=None):
+            if self._times_out:
+                raise subprocess.TimeoutExpired(["npm"], timeout or 0)
+            self.returncode = rc
+            return (b"", b"")
+
+        def wait(self, timeout=None):
+            # The BUILD step shares this seam (`npm run build` is also a Popen),
+            # and it reports through wait() rather than communicate().
+            self.returncode = 0 if rc == 0 else rc
+            return self.returncode
+
+    return _P
+
+
+def _patch_tree_kill(monkeypatch: pytest.MonkeyPatch, seen: list[int] | None = None) -> None:
+    """Replace the real process-tree killer with an inert recorder.
+
+    Never let a test run the real one: it signals a process GROUP, and a fake pid
+    is either the test runner's own -- which kills pytest and its xdist workers
+    mid-run -- or someone else's.
+    """
+
+    def _fake(pid, sig=None):
+        if seen is not None:
+            seen.append(pid)
+        return True
+
+    monkeypatch.setattr(frontend.platform_compat, "kill_process_tree", _fake)
+
+
+class TestSyncBuild:
+    def test_restores_the_tree_when_the_install_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _website(tmp_path)
+        _gates(monkeypatch)
+        _patch_tree_kill(monkeypatch)
+        monkeypatch.setattr(frontend.subprocess, "Popen", _deleting_popen(1))
+        msgs: list[str] = []
+
+        frontend.build_frontend_sync(tmp_path, log=msgs.append)
+
+        assert _tree_intact(tmp_path), "a failed install must not cost the tree"
+        assert not (tmp_path / "website" / ("node_modules" + BACKUP_SUFFIX)).exists()
+        assert any("restored" in m for m in msgs), msgs
+
+    def test_restores_the_tree_when_the_install_times_out(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A timeout is KILLED mid-install, so the tree is partial -- the case most
+        # likely to be forgotten, because the code path is an exception handler.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        killed: list[int] = []
+        _patch_tree_kill(monkeypatch, killed)
+        monkeypatch.setattr(frontend.subprocess, "Popen", _deleting_popen(1, times_out=True))
+        msgs: list[str] = []
+
+        frontend.build_frontend_sync(tmp_path, log=msgs.append)
+
+        assert _tree_intact(tmp_path)
+        assert any("timed out" in m for m in msgs), msgs
+        # The whole install TREE is signalled, not just npm: it spawns node and
+        # lifecycle scripts, and a survivor would write into the tree being
+        # restored.
+        assert killed, "the install tree was not signalled before the rollback"
+
+    def test_drops_the_backup_when_the_install_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The other half: a backup left behind after SUCCESS is what makes the
+        # next run refuse as ambiguous, so success must clean up after itself.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        _patch_tree_kill(monkeypatch)
+        monkeypatch.setattr(frontend.subprocess, "Popen", _deleting_popen(0))
+
+        frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+        website = tmp_path / "website"
+        assert not (website / ("node_modules" + BACKUP_SUFFIX)).exists()
+        assert (website / "node_modules" / "fresh.txt").exists()
+
+    def test_restores_the_tree_on_keyboard_interrupt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Ctrl-C during `kirocrew update`. KeyboardInterrupt is a BaseException,
+        # so none of the ordinary handlers see it -- without explicit cover the
+        # tree stays stashed under its backup name while the path the rest of the
+        # app reads is simply missing.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        _patch_tree_kill(monkeypatch)
+        monkeypatch.setattr(frontend.subprocess, "Popen", _deleting_popen(1, interrupts=True))
+
+        with pytest.raises(KeyboardInterrupt):
+            frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+        assert _tree_intact(tmp_path), "Ctrl-C must not strand the tree"
+        assert not (
+            website_backup := tmp_path / "website" / ("node_modules" + BACKUP_SUFFIX)
+        ).exists(), website_backup
+
+    def test_ctrl_c_kills_npm_before_restoring(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The install runs in its OWN session so its whole tree can be signalled on
+        # timeout. That has a consequence: a terminal Ctrl-C does not reach it,
+        # because SIGINT goes to the foreground process group and npm is no longer
+        # in it. So npm survives the interrupt, and restoring the tree while it is
+        # still writing would land its leftovers in the restored copy.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        order: list[str] = []
+
+        def _kill(pid, sig=None):
+            order.append("killed")
+            return True
+
+        monkeypatch.setattr(frontend.platform_compat, "kill_process_tree", _kill)
+
+        class _P:
+            pid = -1
+            returncode = None
+
+            def __init__(self, argv, **kwargs) -> None:
+                tree = Path(kwargs.get("cwd", ".")) / "node_modules"
+                if tree.exists():
+                    for child in tree.iterdir():
+                        child.unlink()
+                    tree.rmdir()
+                tree.mkdir()
+                self._interrupted = False
+
+            def communicate(self, timeout=None):
+                # Interrupt HERE, not in __init__: the handle has to exist for the
+                # reap to be reachable at all, which is the property under test.
+                if not self._interrupted:
+                    self._interrupted = True
+                    raise KeyboardInterrupt()
+                return (b"", b"")
+
+        real_rollback = NodeModulesBackup.rollback
+
+        def _spy(self) -> None:
+            order.append("restore")
+            real_rollback(self)
+
+        monkeypatch.setattr(NodeModulesBackup, "rollback", _spy)
+        monkeypatch.setattr(frontend.subprocess, "Popen", _P)
+
+        with pytest.raises(KeyboardInterrupt):
+            frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+        assert _tree_intact(tmp_path), "Ctrl-C must not strand the tree"
+        # The kill must come BEFORE the restore, or the restore races a live npm.
+        assert order == ["killed", "restore"], order
+
+
+def _popen_ok():
+    class _P:
+        returncode = 0
+
+        def __init__(self, argv, **kwargs) -> None:
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+    return _P
+
+
+class _FakeProc:
+    """An inert stand-in for an asyncio child process.
+
+    Deliberately carries NO usable pid and these tests never let the real
+    `platform_compat.kill_and_reap` run: that helper signals a process GROUP, and
+    a fake pid is either our own -- in which case a test could signal pytest and
+    its xdist workers -- or someone else's. Tests that care about the reap patch
+    the helper with a recorder (see `_patch_reap`); the property that the real
+    helper CAN signal npm's tree is asserted separately, on the spawn kwargs.
+    """
+
+    returncode = 0
+
+    def kill(self) -> None:  # pragma: no cover - overridden where asserted
+        pass
+
+    async def communicate(self):
+        return (b"", b"")
+
+    async def wait(self):
+        return self.returncode
+
+
+def _patch_reap(monkeypatch: pytest.MonkeyPatch, order: list[str] | None = None) -> None:
+    """Replace the real group-killer with an inert recorder."""
+
+    async def _fake_reap(proc, **_kw) -> None:
+        if order is not None:
+            order.append("reaped")
+        proc.kill()
+
+    monkeypatch.setattr(frontend.platform_compat, "kill_and_reap", _fake_reap)
+
+
+class TestAsyncBuild:
+    """The unattended path: no operator, no retry."""
+
+    def _fake_exec(self, monkeypatch: pytest.MonkeyPatch, rc: int) -> None:
+        async def _exec(*argv, **kwargs):
+            cwd = Path(kwargs.get("cwd", "."))
+            tree = cwd / "node_modules"
+            if tree.exists():
+                for child in tree.iterdir():
+                    child.unlink()
+                tree.rmdir()
+
+            class _Proc(_FakeProc):
+                returncode = rc
+
+                async def wait(self):
+                    return rc
+
+            return _Proc()
+
+        monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _exec)
+        _patch_reap(monkeypatch)
+
+    def test_restores_the_tree_when_the_unattended_install_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _website(tmp_path)
+        _gates(monkeypatch)
+        self._fake_exec(monkeypatch, 1)
+        progress: list[tuple[str, str]] = []
+
+        asyncio.run(
+            frontend.build_frontend_async(
+                str(tmp_path), push_progress=lambda k, m: progress.append((k, m))
+            )
+        )
+
+        assert _tree_intact(tmp_path), "the unattended path must not destroy the tree"
+        assert any("restored" in m for _k, m in progress), progress
+
+    def test_no_longer_calls_a_destroyed_tree_merely_stale(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The old wording said "dashboard may be stale", which described the
+        # served bundle correctly and the dependency tree not at all -- the tree
+        # was gone. Whatever the message says now, it must not claim staleness.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        self._fake_exec(monkeypatch, 1)
+        progress: list[tuple[str, str]] = []
+
+        asyncio.run(
+            frontend.build_frontend_async(
+                str(tmp_path), push_progress=lambda k, m: progress.append((k, m))
+            )
+        )
+
+        assert not any("may be stale" in m for _k, m in progress), progress
+
+    def test_restores_the_tree_when_the_task_is_cancelled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Gateway shutdown mid-install. Left alone this strands the tree: ours
+        # stays stashed while npm keeps writing a fresh one, and if npm gets far
+        # enough BOTH paths exist, which the next run can only read as ambiguous
+        # -- refusing every build until someone clears one by hand.
+        _website(tmp_path)
+        _gates(monkeypatch)
+
+        killed: list[bool] = []
+
+        async def _exec(*argv, **kwargs):
+            class _Proc(_FakeProc):
+                returncode = None
+
+                async def wait(self):
+                    raise asyncio.CancelledError()
+
+                def kill(self):
+                    killed.append(True)
+
+            return _Proc()
+
+        monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _exec)
+        _patch_reap(monkeypatch)
+
+        async def _drive() -> None:
+            await frontend.build_frontend_async(str(tmp_path))
+
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_drive())
+
+        assert _tree_intact(tmp_path), "cancellation must not strand the tree"
+        assert not (tmp_path / "website" / ("node_modules" + BACKUP_SUFFIX)).exists()
+        assert killed, "the npm child must be killed, not left writing"
+
+    def test_waits_for_npm_before_clearing_what_it_was_writing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A killed child is not a finished one. If the rollback clears the tree
+        # npm is still writing into, the two race and the restored tree can end
+        # up with the child's leftovers in it. So the reap must be ordered
+        # BEFORE the cleanup, not merely requested.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        order: list[str] = []
+
+        async def _exec(*argv, **kwargs):
+            class _Proc(_FakeProc):
+                returncode = None
+
+                async def wait(self):
+                    raise asyncio.CancelledError()
+
+                def kill(self):
+                    order.append("killed")
+
+            return _Proc()
+
+        monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _exec)
+        _patch_reap(monkeypatch, order)
+        real_rollback = NodeModulesBackup.rollback
+
+        def _spy(self) -> None:
+            order.append("cleanup")
+            real_rollback(self)
+
+        monkeypatch.setattr(NodeModulesBackup, "rollback", _spy)
+
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(frontend.build_frontend_async(str(tmp_path)))
+
+        assert "cleanup" in order, order
+        assert order.index("reaped") < order.index("cleanup"), order
+
+    def test_spawns_npm_in_its_own_group_so_descendants_can_be_killed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # `npm ci` is not a leaf: it spawns node and any lifecycle scripts the
+        # lockfile asks for, and those keep writing into node_modules after their
+        # parent dies. kill_and_reap can only signal a tree if the child has one
+        # of its own, so the spawn must open a new session/group -- without it the
+        # group kill is skipped and descendants outlive the rollback.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        spawned: list[dict] = []
+
+        async def _exec(*argv, **kwargs):
+            spawned.append(kwargs)
+
+            class _Proc(_FakeProc):
+                returncode = 1
+
+                async def wait(self):
+                    return 1
+
+            return _Proc()
+
+        monkeypatch.setattr(frontend.asyncio, "create_subprocess_exec", _exec)
+        _patch_reap(monkeypatch)
+        asyncio.run(frontend.build_frontend_async(str(tmp_path)))
+
+        assert spawned, "npm was not spawned"
+        kw = spawned[0]
+        assert kw.get("start_new_session") == frontend.platform_compat.IS_POSIX
+        assert kw.get("creationflags") == frontend.platform_compat.CREATE_NEW_PROCESS_GROUP
+
+    def test_the_blocking_cleanup_does_not_run_on_the_event_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # node_modules is tens of thousands of files, so the recursive removal and
+        # rename are real blocking work. On the loop they stall the gateway's
+        # heartbeat and every in-flight request, which is why the build+stage in
+        # this same function already runs in a worker thread.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        self._fake_exec(monkeypatch, 1)
+
+        loop_thread = threading.get_ident()
+        ran_on: list[int] = []
+        real_rollback = NodeModulesBackup.rollback
+
+        def _spy(self) -> None:
+            ran_on.append(threading.get_ident())
+            real_rollback(self)
+
+        monkeypatch.setattr(NodeModulesBackup, "rollback", _spy)
+
+        asyncio.run(frontend.build_frontend_async(str(tmp_path)))
+
+        assert ran_on, "rollback did not run"
+        assert all(
+            t != loop_thread for t in ran_on
+        ), "the dependency-tree rollback ran on the event loop thread"
+
+
+class TestTransactionPolicy:
+    """Direct tests of the primitive, for the cases neither caller can reach."""
+
+    def test_refuses_when_a_tree_and_a_backup_both_exist(self, tmp_path: Path) -> None:
+        # Nothing on disk distinguishes "killed during install" (backup is good)
+        # from "cleanup failed after success" (tree is good), so either choice
+        # destroys the good copy in one reading. Touch neither.
+        tree = tmp_path / "node_modules"
+        tree.mkdir()
+        (tree / "a").write_text("tree")
+        backup = Path(str(tree) + BACKUP_SUFFIX)
+        backup.mkdir()
+        (backup / "b").write_text("backup")
+        msgs: list[str] = []
+
+        assert NodeModulesBackup(tree, msgs.append).begin() is False
+        assert (tree / "a").read_text() == "tree"
+        assert (backup / "b").read_text() == "backup"
+        assert any("by hand" in m for m in msgs), msgs
+
+    def test_the_refusal_also_reaches_the_log(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The refusal is the one state that needs a human, and it is reachable on
+        # the UNATTENDED path -- where the caller's log goes to an update-progress
+        # feed that is dropped when no dashboard client is attached. Without a
+        # second channel a hard kill mid-install becomes an indefinite silent
+        # build stall.
+        tree = tmp_path / "node_modules"
+        tree.mkdir()
+        Path(str(tree) + BACKUP_SUFFIX).mkdir()
+
+        with caplog.at_level("WARNING"):
+            assert NodeModulesBackup(tree, lambda _m: None).begin() is False
+
+        assert any(
+            "refusing" in r.message or "refusing" in r.getMessage() for r in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+
+    def test_adopts_a_backup_left_by_a_crashed_run(self, tmp_path: Path) -> None:
+        # This is the branch that heals a crashed unattended update, and it is
+        # why the suffix is shared with Dev Fleet's runner.
+        tree = tmp_path / "node_modules"
+        backup = Path(str(tree) + BACKUP_SUFFIX)
+        backup.mkdir()
+        (backup / "sentinel.txt").write_text(MARKER)
+        msgs: list[str] = []
+
+        txn = NodeModulesBackup(tree, msgs.append)
+        assert txn.begin() is True
+        txn.rollback()
+
+        assert (tree / "sentinel.txt").read_text() == MARKER
+        assert not backup.exists()
+
+    def test_a_symlinked_tree_is_still_protected(self, tmp_path: Path) -> None:
+        # A worktree that links node_modules into a shared store has one, and
+        # rmtree REFUSES a symlink -- so the naive cleanup left the backup
+        # undeletable and wedged every later run as ambiguous.
+        store = tmp_path / "store"
+        store.mkdir()
+        (store / "sentinel.txt").write_text(MARKER)
+        tree = tmp_path / "node_modules"
+        os.symlink(store, tree)
+
+        txn = NodeModulesBackup(tree, lambda _m: None)
+        assert txn.begin() is True
+        txn.rollback()
+
+        assert os.path.islink(tree)
+        assert (tree / "sentinel.txt").read_text() == MARKER
+        assert not os.path.lexists(Path(str(tree) + BACKUP_SUFFIX))
+
+    def test_a_dangling_tree_link_does_not_crash_the_transaction(self, tmp_path: Path) -> None:
+        # lexists, not isdir: isdir follows the link, so a DANGLING one reads as
+        # absent and the backup-only branch renames a directory onto it (ENOTDIR).
+        tree = tmp_path / "node_modules"
+        os.symlink(tmp_path / "does-not-exist", tree)
+
+        txn = NodeModulesBackup(tree, lambda _m: None)
+        assert txn.begin() is True
+        txn.rollback()
+
+        assert os.path.lexists(tree)
+
+    def test_a_first_install_with_no_tree_is_allowed(self, tmp_path: Path) -> None:
+        txn = NodeModulesBackup(tmp_path / "node_modules", lambda _m: None)
+        assert txn.begin() is True
+        assert txn.armed is False
+        txn.rollback()  # nothing to put back, must not raise
+        txn.commit()
+
+
+class TestSerialization:
+    """The armed interval is serialized, which is what makes adoption safe."""
+
+    def test_the_install_runs_inside_the_staging_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # `begin` adopts a backup it finds beside the tree and cannot tell a
+        # CRASHED run's from a LIVE peer's -- nothing on disk distinguishes them.
+        # Holding the lock across the armed interval is what guarantees a live
+        # peer cannot be inside it, so the only backup `begin` can see is a dead
+        # run's. If the install were outside the lock, two updates could each adopt
+        # the other's stash and one commit would delete the tree the other needed.
+        _website(tmp_path)
+        _gates(monkeypatch)
+        _patch_tree_kill(monkeypatch)
+        order: list[str] = []
+
+        import contextlib as _ctx
+
+        @_ctx.contextmanager
+        def _spy_lock(static_parent):
+            order.append("lock-acquired")
+            try:
+                yield
+            finally:
+                order.append("lock-released")
+
+        monkeypatch.setattr(frontend, "_staging_lock", _spy_lock)
+
+        class _P(_deleting_popen(1)):
+            def __init__(self, argv, **kwargs) -> None:
+                order.append("install")
+                super().__init__(argv, **kwargs)
+
+        monkeypatch.setattr(frontend.subprocess, "Popen", _P)
+
+        frontend.build_frontend_sync(tmp_path, log=lambda _m: None)
+
+        assert order.index("lock-acquired") < order.index("install"), order
+        assert order.index("install") < order.index("lock-released"), order
+
+    def test_a_lock_refusal_does_not_touch_the_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If the lock cannot be taken we must not install, because installing is
+        # what deletes the tree. Refusing leaves the disk exactly as found.
+        _website(tmp_path)
+        _gates(monkeypatch)
+
+        def _refuse(static_parent):
+            raise OSError("lock held elsewhere")
+
+        monkeypatch.setattr(frontend, "_staging_lock", _refuse)
+
+        def _forbidden(argv, **kwargs):  # pragma: no cover - must not be reached
+            raise AssertionError("installed without holding the lock")
+
+        monkeypatch.setattr(frontend.subprocess, "Popen", _forbidden)
+        msgs: list[str] = []
+
+        frontend.build_frontend_sync(tmp_path, log=msgs.append)
+
+        assert _tree_intact(tmp_path)
+        assert not (tmp_path / "website" / ("node_modules" + BACKUP_SUFFIX)).exists()
+        assert any("staging lock" in m for m in msgs), msgs
+
+
+class TestFailurePaths:
+    """The branches that run when the filesystem refuses.
+
+    These are the whole point of the module -- it exists because a failure
+    mid-transaction must not cost the tree -- so a refusal to rename or remove has
+    to be handled and REPORTED rather than left to surface as a traceback from a
+    best-effort helper. Each test patches only the operation under test, and only
+    for the paths it owns, so nothing global is broken for the rest of the suite.
+    """
+
+    def _fail_rename(
+        self, monkeypatch: pytest.MonkeyPatch, doomed: str, err: str = "EXDEV"
+    ) -> None:
+        real = os.rename
+
+        def _rename(src, dst):
+            if doomed in str(src):
+                raise OSError(err)
+            return real(src, dst)
+
+        monkeypatch.setattr(nmt.os, "rename", _rename)
+
+    def test_reports_when_the_tree_cannot_be_moved_aside(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Could not protect the tree, so the caller must NOT install: refusing
+        # costs one install, proceeding costs the tree with no way back.
+        tree = tmp_path / "node_modules"
+        tree.mkdir()
+        (tree / "sentinel.txt").write_text(MARKER)
+        self._fail_rename(monkeypatch, "node_modules")
+        msgs: list[str] = []
+
+        assert NodeModulesBackup(tree, msgs.append).begin() is False
+        assert (tree / "sentinel.txt").read_text() == MARKER
+        assert any("could not move" in m.lower() for m in msgs), msgs
+
+    def test_reports_when_a_stashed_tree_cannot_be_adopted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tree = tmp_path / "node_modules"
+        backup = Path(str(tree) + BACKUP_SUFFIX)
+        backup.mkdir()
+        (backup / "sentinel.txt").write_text(MARKER)
+        self._fail_rename(monkeypatch, BACKUP_SUFFIX)
+        msgs: list[str] = []
+
+        assert NodeModulesBackup(tree, msgs.append).begin() is False
+        assert (backup / "sentinel.txt").read_text() == MARKER
+        assert any("could not restore the stashed" in m.lower() for m in msgs), msgs
+
+    def test_reports_a_backup_it_could_not_remove_after_success(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The new tree is good, so this is untidiness rather than damage -- but it
+        # MUST be reported, because the next run sees both paths and refuses.
+        tree = tmp_path / "node_modules"
+        tree.mkdir()
+        txn = NodeModulesBackup(tree, lambda _m: None)
+        assert txn.begin() is True
+        msgs: list[str] = []
+        txn._log = msgs.append
+        monkeypatch.setattr(nmt.shutil, "rmtree", lambda *_a, **_k: None)
+
+        txn.commit()
+
+        assert any("could not remove the old" in m.lower() for m in msgs), msgs
+
+    def test_leaves_the_good_copy_named_when_the_partial_cannot_be_cleared(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Refusing to rename over a tree it could not clear is the safe half: the
+        # good copy stays whole under its backup name and the message names it.
+        tree = tmp_path / "node_modules"
+        tree.mkdir()
+        (tree / "sentinel.txt").write_text(MARKER)
+        txn = NodeModulesBackup(tree, lambda _m: None)
+        assert txn.begin() is True
+        tree.mkdir()  # the failed install's partial tree
+        msgs: list[str] = []
+        txn._log = msgs.append
+        monkeypatch.setattr(nmt.shutil, "rmtree", lambda *_a, **_k: None)
+
+        txn.rollback()
+
+        assert any("could not clear the partial" in m.lower() for m in msgs), msgs
+        assert (Path(str(tree) + BACKUP_SUFFIX) / "sentinel.txt").read_text() == MARKER
+
+    def test_names_the_backup_when_the_restore_rename_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tree = tmp_path / "node_modules"
+        tree.mkdir()
+        (tree / "sentinel.txt").write_text(MARKER)
+        txn = NodeModulesBackup(tree, lambda _m: None)
+        assert txn.begin() is True
+        msgs: list[str] = []
+        txn._log = msgs.append
+        self._fail_rename(monkeypatch, BACKUP_SUFFIX)
+
+        txn.rollback()
+
+        assert any("could not restore the dependency tree" in m.lower() for m in msgs), msgs
+        assert (Path(str(tree) + BACKUP_SUFFIX) / "sentinel.txt").read_text() == MARKER
+
+
+def test_the_backup_suffix_matches_dev_fleets_runner() -> None:
+    """The one agreement the two copies of this transaction must keep.
+
+    Dev Fleet's Pull+Build runs the same transaction from a generated
+    stdlib-only script that must NOT import kiro_crew, because it executes while
+    the repository is being merged underneath it. So the code cannot be shared --
+    but the backup PATH must be identical, or the two flows stop recognising each
+    other's leftovers: Dev Fleet would no longer heal a crashed update, and each
+    would see the other's backup as an unexplained directory.
+    """
+    server = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "kiro_crew"
+        / "apps"
+        / "builtins"
+        / "dev_fleet"
+        / "server.py"
+    ).read_text(encoding="utf-8")
+    assert BACKUP_SUFFIX == ".kirocrew-sync-backup"
+    assert f"'{BACKUP_SUFFIX}'" in server, (
+        "dev_fleet/server.py no longer spells this suffix; the two halves of the "
+        "node_modules transaction have diverged"
+    )


### PR DESCRIPTION
## What is the problem?

`npm ci` DELETES `node_modules` before it installs. Both frontend build helpers in
`src/kiro_crew/frontend.py` ran it bare, with no backup:

```python
npm_i = await asyncio.create_subprocess_exec(npm, "ci", ...)
...
if npm_i.returncode != 0:
    _warn("Frontend npm install failed -- dashboard may be stale")
    return
```

So an install that fails partway leaves no dependency tree at all -- and the registry
needed to rebuild one is exactly what was unavailable when it failed. "May be stale"
described the served bundle accurately (the old `static/dist` does survive) and the
dependency tree not at all: the tree was gone.

**The async helper is the one that matters, because nobody is watching it.** The
gateway's auto-apply reaches it at boot as a background task, with no operator:

- `auto_update` defaults to **true** (`config/loader.py:7195`), and a boot task fires
  the check unconditionally (`slack/gateway.py:10238`).
- An enterprise `min_version` policy floor applies an update **even when auto_update is
  off** (`slack/gateway.py:8790`).
- It runs AFTER `git reset --hard` has already landed the new revision
  (`slack/gateway.py:9438`), then calls the build (`slack/gateway.py:9502`).
- The helper **returns rather than raising**, so the update continued to pip,
  restarted, and reported SUCCESS with the tree destroyed.
- There is **no retry**: the next boot early-returns because the commit is already
  applied, so a persistent cause (an expired registry token, an offline host) left the
  tree broken until a human happened to notice.

The third sibling site, Dev Fleet's Pull+Build, was hardened by #6541. This finishes the
job at the two that were missed.

## Why this issue matters to the user

An unattended update silently destroys the ability to build the frontend, then tells the
user it succeeded. The running dashboard keeps working -- it serves the prebuilt bundle
-- so nothing looks wrong until the next build, which fails for a reason that has
nothing to do with whatever the user changed. On a host whose registry token expired,
this is the difference between "the update was skipped" and "the checkout is broken and
I cannot tell why."

## How our fix solves it -- chain from symptom to root cause

1. **The symptom is a missing `node_modules` after a failed update.** Nothing deleted it
   by mistake; `npm ci` deletes it by design, first thing.
2. **The cause is that the delete is not part of a transaction.** The install has a
   failure path, but the deletion it already performed has no undo, so every failure
   mode -- non-zero exit, timeout kill, exec failure -- ends in the same damage.
3. **So the tree is moved aside and put back unless the install succeeded.** A new
   `NodeModulesBackup` (`begin` / `commit` / `rollback`) wraps both sites. `begin`
   returns False to mean "do not install", which is a refusal rather than an error: the
   safe move is to leave the disk exactly as found.
4. **The timeout path rolls back too.** Being killed mid-install is precisely what
   leaves a PARTIAL tree, so it is the case the rollback exists for, not one to skip.
   `OSError` from a failed spawn is handled for the same reason.
5. **The messages stop claiming staleness**, because the previous wording is what made
   this invisible: it named a consequence mild enough to ignore.

**Explicit `begin`/`commit`/`rollback` rather than a context manager** because the two
callers differ in exactly the way a context manager cannot bridge -- one awaits its
install and one does not. The policy lives in one place; each caller supplies only its
own control flow.

**Move-aside rather than install-to-staging-and-swap.** `npm ci` installs into
`<pkg>/node_modules` relative to the package, so staging would mean copying the whole
`website/` tree to a scratch location and back -- far more I/O, and a second copy of the
same failure modes. Move-aside is one rename in each direction, and it is the shape
already proven in-tree by #6541.

## Why the Dev Fleet copy deliberately stays

Dev Fleet's Pull+Build runs this same transaction, spelled out inline in a generated
**stdlib-only** script (`dev_fleet/server.py`). That copy must stay, and it cannot call
this module: the script executes while the repository is being merged underneath it, so
it must not import `kiro_crew` -- what it does cannot be allowed to change with the
revision being installed. That is a genuine constraint, not duplication to clean up, so
the two copies share SEMANTICS, not code.

They DO share the backup path, and that is load-bearing rather than cosmetic. Dev Fleet
reconciles a leftover backup before it runs anything, so a crashed unattended update
gets healed the next time an operator presses Pull+Build -- the only self-heal the
unattended path has, given it never retries. A test pins the suffix agreement so the two
halves cannot drift apart silently.

The primitive keeps the rules that script learned the hard way, because a symlinked or
dangling `node_modules` is a real layout and not a hypothetical (a worktree that links
into a shared store has one):

- presence is tested with `lexists`, so a DANGLING link does not read as absent and then
  get a directory renamed onto it (ENOTDIR);
- symlinks are unlinked rather than handed to `rmtree`, which refuses them while
  `ignore_errors=True` swallows the refusal -- the bug that once wedged every later run;
- removals whose outcome decides the next rename are CONFIRMED, so a partial removal
  cannot end with a partial tree restored over a good one;
- a tree AND a backup both present is treated as genuinely AMBIGUOUS: nothing on disk
  distinguishes "killed during install" (backup is good) from "cleanup failed after
  success" (tree is good), so it touches neither and names which to remove.

## What tests we did

Targeted only -- the full suite is CI's job. `pytest -n 4`.

- `test/test_node_modules_txn.py` (new, 11 cases). Integration through both helpers with
  a FAKE npm that behaves like the real one -- it DELETES the tree and then fails, which
  is what makes these tests meaningful; a fake that merely returned non-zero would pass
  against the unfixed code and prove nothing. Plus direct tests of the primitive for the
  cases neither caller can reach: both-present refusal, adopting a backup left by a
  crashed run, a symlinked tree, a dangling tree link, and a first install with no tree.
- **Red on base, verified by restoring `frontend.py` to its base content with the tests
  in place: 4 failed, 7 passed.** The four are the two "tree survives a failed install"
  cases (sync and async), the timeout case, and the case asserting the message no longer
  says "may be stale" -- which failed with the literal old string
  `[('warning', 'Frontend npm install failed -- dashboard may be stale')]`. With the fix,
  11 passed.
- One of these tests initially passed on base and was strengthened rather than kept: the
  timeout fake created a partial tree without deleting the existing one, so the original
  tree survived even unfixed. It now deletes first, as `npm ci` does, and reds on base.
- 69 tests pass across `test_frontend_edition_build.py`,
  `test_frontend_dist_resolve.py` and the new file. flake8 clean, isort clean, black
  baseline gate passed, mypy clean on both changed source files.

## Any other suggestions on the work

- **#6541's restore path has no test.** `kirocrew-sync-backup` appears only in
  `dev_fleet/server.py` and nowhere in `test/`, so the transaction that PR added is
  covered for its exit codes but not for the behaviour that matters -- that a failed
  sync actually puts the tree back. This PR pins the shared suffix, which would catch a
  silent divergence, but the Dev Fleet restore itself is still unverified. Worth a
  follow-up; it needs a harness that can drive the generated script.
- **The "dashboard may be stale" wording appears to be a pattern.** It reads as mild and
  was attached to the most destructive outcome in this flow. Other best-effort paths
  that log a soft warning for a hard failure may be worth an audit.
- **Open PR #7123 touches `npm_preflight.py`** and is semantically compatible -- it only
  adds a skip when the frontend subtree is unchanged, which means `npm ci` does not run
  and so cannot delete anything. No textual overlap with this diff.

Refs f-20260828-02
