### PR TITLE
fix(dev-fleet): isolate the sync runner and pin git's object graph

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -705,6 +705,26 @@ stdlib-only, so the copy needs no package context. Both halves matter: `-I` drop
 the cwd from `sys.path`, and the snapshot means an editable install cannot make
 the tree being synced supply the code doing the verifying.
 
+**The generated runner itself carries `-I` too, and for the same reason.** `python
+-c` puts the inherited cwd at `sys.path[0]`, ahead of the standard library, and
+the cwd a module-style app backend hands down is the gateway's own source root —
+which on the editable install Dev Fleet exists to manage *is* `<checkout>/src`,
+the tree being synced. So the runner's own startup imports (`os`, `shutil`,
+`subprocess`, `json`) resolve against that directory first, and the runner is the
+one process here that is **not** sandbox-wrapped: only the step argvs go through
+`sandboxed_spawn_argv`. Without `-I`, a `shutil.py` dropped in that directory runs
+arbitrary code outside the per-step sandbox. The shadowing module only has to be
+on disk when the runner *starts* — a revision an earlier sync already landed, or
+anything an agent wrote in the checkout between syncs, is enough — so this is not
+a race with the run's own merge. It is set on the interpreter rather than scrubbed
+inside the script so it holds for the process's whole life, including any import
+the runner grows later after a step has merged untrusted content. It costs
+nothing: the script is stdlib-only by design, and the `-E`/`-s` that `-I` implies
+remove env and user-site import sources it never uses. A mask from the sandbox
+could not substitute — an app backend's `extra_hidden_dirs` is silently dropped by
+`wrap_argv`'s nested passthrough (pinned in `test_sandbox_argv.py`), so it would
+read as a control at the call site and enforce nothing.
+
 **The install is skipped when the answer is already on disk.** Most syncs are
 backend-only and change nothing under `website/`, so paying a full scratch install
 to re-derive "is this lockfile installable" on every Pull + Build is cost without
@@ -970,6 +990,38 @@ Disk and loaded launchd definitions must both report `KeepAlive=true` and
 `GRACEFUL_SHUTDOWN_SECS` (10s), leaving the remaining budget for cleanup and
 exit before launchd escalates to SIGKILL. An agent with a legacy contract falls
 back to staged-only Make Live and names `kirocrew service install` as the repair.
+
+## Git environment hardening
+
+Every git invocation from this module — foreground inspection, the unattended
+background fetch, rebase, the sync pull, and any git a build step runs — carries
+`runtime._GIT_ENV_NEUTRALIZERS`, injected as **environment** rather than as
+per-call-site `-c` flags so one chokepoint covers call sites that have not been
+written yet. The environment form has the same precedence as `git -c`, so it
+overrides every config file, including an agent-writable repo-local one.
+
+Two different jobs live in that one dict, and they are worth keeping apart:
+
+- **Config-driven execution.** `GIT_ALLOW_PROTOCOL` / `GIT_PROTOCOL_FROM_USER`
+  make git itself refuse `ext::` and custom remote helpers; the four
+  `GIT_CONFIG_KEY_*` / `VALUE_*` pairs disable `core.fsmonitor` and
+  `core.hooksPath`, reset `credential.helper` to empty, and pin `core.sshCommand`
+  to plain `ssh`. Each of those is a config key a repo can set to name a program
+  git will spawn. (The operator's own *global* credential helpers are re-pinned
+  after the reset — see `_GIT_TRUSTED_HELPERS` — because a global config is
+  operator-owned rather than part of the repo attack surface.)
+- **Which object graph git answers from.** `GIT_NO_REPLACE_OBJECTS=1` is not a
+  config key and is not about code execution. A `refs/replace/<oid>` ref
+  substitutes one object for another in *every* read, so `log`,
+  `rev-list --count`, `merge-base` and `merge --ff-only` all answer about the
+  substitute graph — a history no checked-out commit names. Every git answer this
+  module acts on is a statement about the checkout on disk, so the real graph is
+  the only one that answers the question asked, and "behind by N commits" derived
+  from a grafted walk is simply wrong. `git replace` is a legitimate local
+  operation, so this is a correctness pin first and a tamper pin second. It is
+  therefore an env var in its own right and **not** one of the counted config
+  pairs: `GIT_CONFIG_COUNT` stays at 4. `platform/update_governance.py` and
+  `auto_improvement`'s clone setup pin it for the same reason.
 
 ## Output Redaction
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
@@ -127,16 +127,29 @@ def _find_cli() -> list[str]:
 # overrides every config file) so EVERY git invocation from this handler —
 # foreground inspection, the unattended background fetch, rebase, sync pull,
 # and any git a build step runs — is neutralized at one chokepoint instead of
-# per-call-site flags. All four keys are attacker-configurable via an
+# per-call-site flags. The config keys are attacker-configurable via an
 # agent-writable ``.git/config`` and would otherwise execute code:
 #   * protocol pin  — ``ext::``/custom remote helpers refused by git itself
 #   * core.fsmonitor / core.hooksPath — repo-registered executables
 #   * credential.helper (reset to empty list) — helper commands
 #   * core.sshCommand (pinned to plain ``ssh``) — arbitrary command on fetch
+#
+# GIT_NO_REPLACE_OBJECTS is the odd one out: not a config key and not about code
+# execution, but about WHICH OBJECT GRAPH git answers from. A
+# ``refs/replace/<oid>`` ref substitutes one object for another in every read, so
+# ``log``, ``rev-list --count``, ``merge-base`` and ``merge --ff-only`` all answer
+# about the SUBSTITUTE graph — a history no checked-out commit names. Every git
+# answer this handler acts on is a statement about the checkout on disk, so the
+# real graph is the only one that answers the question asked. Grafting is a
+# legitimate local operation (``git replace``), so this is a correctness pin
+# first and a tamper pin second, and it is an env var rather than a config pair
+# so no config precedence applies to it at all. ``update_governance`` and
+# ``auto_improvement``'s clone setup already pin it for the same reason.
 # Harmless for non-git commands (pip/npm ignore GIT_*).
 _GIT_ENV_NEUTRALIZERS: dict[str, str] = {
     "GIT_ALLOW_PROTOCOL": "https:ssh",
     "GIT_PROTOCOL_FROM_USER": "0",
+    "GIT_NO_REPLACE_OBJECTS": "1",
     "GIT_CONFIG_COUNT": "4",
     "GIT_CONFIG_KEY_0": "core.fsmonitor",
     "GIT_CONFIG_VALUE_0": "false",

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -7,6 +7,7 @@ import hmac as _hmac  # noqa: F401
 import hmac as _hmac_mod
 import json
 import os
+import shutil
 import sys
 import textwrap
 import threading
@@ -2185,6 +2186,10 @@ def test_escalation_cleanup_removes_empty_builtin_via_pinned_fd(tmp_path, monkey
 def _assert_git_neutralizers(env):
     assert env["GIT_ALLOW_PROTOCOL"] == "https:ssh"
     assert env["GIT_PROTOCOL_FROM_USER"] == "0"
+    # Not a config key and not about code execution: it pins WHICH OBJECT GRAPH
+    # git answers from, so every answer this handler acts on describes the
+    # history the checkout actually holds rather than a grafted substitute.
+    assert env["GIT_NO_REPLACE_OBJECTS"] == "1"
     # Full config-driven-execution neutralizer set, injected as env so it
     # covers EVERY git call (background fetch, rebase, sync pull included).
     pairs = {
@@ -3278,6 +3283,9 @@ def test_git_env_neutralizers_present():
     n = mod._GIT_ENV_NEUTRALIZERS
     assert n["GIT_ALLOW_PROTOCOL"] == "https:ssh"
     assert n["GIT_PROTOCOL_FROM_USER"] == "0"
+    assert n["GIT_NO_REPLACE_OBJECTS"] == "1"
+    # GIT_NO_REPLACE_OBJECTS is an env var in its own right, NOT one of the
+    # config pairs, so the count must not have grown to cover it.
     assert n["GIT_CONFIG_COUNT"] == "4"
     assert n["GIT_CONFIG_KEY_0"] == "core.fsmonitor"
     assert n["GIT_CONFIG_VALUE_0"] == "false"
@@ -3287,6 +3295,100 @@ def test_git_env_neutralizers_present():
     assert n["GIT_CONFIG_VALUE_2"] == ""
     assert n["GIT_CONFIG_KEY_3"] == "core.sshCommand"
     assert n["GIT_CONFIG_VALUE_3"] == "ssh"
+
+
+@pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git is required to exercise a real refs/replace graft",
+)
+def test_the_neutralizers_answer_from_the_real_object_graph(tmp_path, monkeypatch):
+    """A ``refs/replace`` graft must not change what Dev Fleet's git reads report.
+
+    Pinned by BEHAVIOUR against a real repository rather than by asserting the
+    variable is present, because the claim is about git's own semantics: a
+    ``refs/replace/<oid>`` ref substitutes one object for another in EVERY read, so
+    ``rev-list --count`` walks the substitute's parents and answers about a history
+    no checked-out commit names. Dev Fleet acts on exactly that number -- it is how
+    "behind by N commits" and the sync's own decisions are formed -- so the real
+    graph is the only one that answers the question asked.
+
+    The unpinned reading is asserted too, so this test fails if git ever stops
+    honouring the graft and the pin becomes a no-op nobody would notice.
+    """
+    import subprocess
+
+    git = shutil.which("git")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # An exported GIT_DIR/GIT_WORK_TREE is PLANTED rather than assumed absent,
+    # because it is what makes the allowlist below observable instead of a claim.
+    # This decoy stands in for the operator's real checkout: drop the filtering
+    # and every ``run()`` retargets here, so the suite mutates a repository
+    # outside tmp_path and the graft assertions answer about a history this test
+    # never built.
+    decoy = tmp_path / "decoy.git"
+    decoy.mkdir()
+    monkeypatch.setenv("GIT_DIR", str(decoy))
+    monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path / "decoy-work"))
+
+    # The base env is the module's OWN allowlist (`_is_safe_env_key`, what
+    # `_build_env` filters through) rather than a merge over `os.environ`,
+    # because git takes its location from the environment and those variables
+    # outrank ``-C <repo>``: an exported ``GIT_DIR``, ``GIT_WORK_TREE`` or
+    # ``GIT_INDEX_FILE`` would send the ``add``/``commit``/``replace`` below at an
+    # unrelated repository, so running the suite would mutate an operator's real
+    # index and refs. ``GIT_REPLACE_REF_BASE`` and ``GIT_NO_REPLACE_OBJECTS``
+    # would also decide the graft assertions before they were made. An allowlist
+    # removes the whole class in one place, including any variable git adds later.
+    #
+    # Global and system config are excluded for the mirror-image reason: a
+    # ``commit.gpgsign`` or ``core.hooksPath`` in the operator's ``~/.gitconfig``
+    # would fail these fixture commits on their machine and nowhere else.
+    # Repository-local config still applies, which is what the identity below is
+    # set through.
+    base_env = {k: v for k, v in os.environ.items() if mod._is_safe_env_key(k)}
+    base_env["GIT_CONFIG_GLOBAL"] = os.devnull
+    base_env["GIT_CONFIG_SYSTEM"] = os.devnull
+
+    def run(*args, env=None):
+        proc = subprocess.run(
+            [git, "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
+            env={**base_env, **(env or {})},
+        )
+        assert proc.returncode == 0, proc.stderr
+        return proc.stdout.strip()
+
+    run("init", "-q")
+    run("config", "user.email", "t@example.invalid")
+    run("config", "user.name", "T")
+    oids = []
+    for i in range(3):
+        (repo / "f.txt").write_text(f"{i}\n", encoding="utf-8")
+        run("add", "f.txt")
+        run("commit", "-q", "-m", f"c{i}")
+        oids.append(run("rev-parse", "HEAD"))
+
+    # Three commits, so HEAD's history is three deep.
+    assert run("rev-list", "--count", "HEAD") == "3"
+    # Graft HEAD onto the root, which shortens the history git reports.
+    run("replace", "--graft", oids[2], oids[0])
+
+    # Ungrafted the reading is the truth; grafted it is not. Both are asserted so
+    # neither half of the pin can rot silently.
+    assert run("rev-list", "--count", "HEAD") == "2"
+    assert (
+        run("rev-list", "--count", "HEAD", env={"GIT_NO_REPLACE_OBJECTS": "1"}) == "3"
+    )
+    assert run("rev-list", "--count", "HEAD", env=mod._GIT_ENV_NEUTRALIZERS) == "3"
+
+    # Nothing reached the decoy, so the allowlist rather than luck is what kept
+    # every mutation above inside tmp_path.
+    assert list(decoy.iterdir()) == [], "an inherited GIT_DIR retargeted the fixture"
 
 
 # =============================================================================

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -3183,6 +3183,49 @@ class TestMacOsNestingDetection:
         # EPERMs, and reading that as a host verdict is the bug this fixes.
         mock_detect.assert_not_called()
 
+    @patch("kiro_crew.sandbox.detect_backend")
+    def test_the_passthrough_silently_drops_extra_hidden_dirs(
+        self, mock_detect, monkeypatch, tmp_path
+    ):
+        """A caller's ``extra_hidden_dirs`` is UNENFORCED on the passthrough.
+
+        It is not a bug -- a nested re-wrap is denied by design on both platforms,
+        so there is no mount namespace to build and nothing to bind-mask into --
+        but it is a fact a caller must not build a security control on, and it is
+        invisible from the call site: the wrap returns successfully, and the mask
+        it was asked for simply does not exist.
+
+        This bites hardest where it is least visible. Every app backend is spawned
+        through ``wrap_argv`` by ``apps/backend.py``, so it runs with this marker
+        set, and every spawn IT then wraps takes this branch. Dev Fleet's sync is
+        exactly that shape -- it wraps each sync step from inside the sandbox -- so
+        a mask an app backend asks for to keep a step away from one of its own paths
+        would cover nothing while reading, at the call site, as a control. An app
+        backend that needs such a boundary has to get it somewhere other than here:
+        the sync runner keeps the synced checkout off its import path with the
+        interpreter's own ``-I`` rather than with a mask.
+
+        CHARACTERIZATION, NOT A CONTRACT. If nested confinement ever becomes
+        possible, this test is one of the things that should change WITH it -- it
+        records what the passthrough does today so a caller cannot be misled by it,
+        and it is not an argument for keeping the behaviour.
+        """
+        secret = tmp_path / "provenance"
+        secret.mkdir()
+        monkeypatch.setenv("KIROCREW_SANDBOX_ACTIVE", "1")
+        monkeypatch.setattr(sandbox_mod, "_macos_sandbox_state", lambda: True)
+        with patch("kiro_crew.sel.sel"):
+            result, cleanup = wrap_argv(
+                ["/usr/bin/npm", "ci"], mode="strict", extra_hidden_dirs=(str(secret),)
+            )
+
+        # No launcher script, so nothing exists that COULD carry a bind-mask...
+        assert cleanup is None
+        # ...and the path appears nowhere in what will actually be executed.
+        assert not any(str(secret) in arg for arg in result)
+        assert result[-2:] == ["/usr/bin/npm", "ci"]
+        mock_detect.assert_not_called()
+
     @patch("kiro_crew.sandbox.detect_backend", return_value="none")
     def test_forged_marker_without_kernel_confirmation_is_refused(
         self, mock_detect, monkeypatch


### PR DESCRIPTION
## Problem / Motivation

Two gaps in the Dev Fleet sync's git-environment hardening, both about what git
*answers*, not what it executes:

1. A `refs/replace/<oid>` ref substitutes one object for another in **every** git
   read. `git replace` is a legitimate, purely-local operation, but with it in
   place `log`, `rev-list --count`, `merge-base`, and `merge --ff-only` all answer
   about a **substitute** object graph — a history no checked-out commit names.
   Dev Fleet acts on every one of those answers as a statement about the checkout
   on disk, so a grafted walk makes "behind by N commits" (and the rebase/merge
   decisions built on it) simply wrong.

2. `wrap_argv`'s **nested passthrough** silently drops a caller's
   `extra_hidden_dirs` — an app backend already runs under
   `KIROCREW_SANDBOX_ACTIVE`, so a re-wrap returns the argv unchanged *before*
   the mask is consulted. Nothing was misled by this yet, but it reads at the
   call site like a security control and enforces nothing, which is a footgun for
   any future app-backend code that reaches for it.

## Why it matters

(1) is a correctness pin first and a tamper pin second: a legitimate local graft
already produces wrong sync decisions, and a malicious one is an unaudited way to
steer them. (2) protects a future caller from building a boundary on a no-op.

## What changed (motivation → approach → change)

- **`_GIT_ENV_NEUTRALIZERS` gains `GIT_NO_REPLACE_OBJECTS=1`.** It is pinned as an
  environment variable (same precedence as `git -c`, overriding any
  agent-writable repo config) so it covers every git invocation from the module
  at one chokepoint. It is **not** one of the numbered config pairs, so
  `GIT_CONFIG_COUNT` stays at 4 — pinned by a test, since a neutralizer added as a
  fifth pair would silently disable `core.sshCommand`.
  `platform/update_governance.py` and `auto_improvement`'s clone setup already pin
  it for the same reason.
- **A characterization test in `test_sandbox_argv.py`** records that the nested
  passthrough drops `extra_hidden_dirs` today — explicitly a characterization, not
  a contract, so a future caller cannot be misled and so the behavior is visible
  if nested confinement ever becomes possible.
- **Docs (`dev-fleet.md`)** gain a "Git environment hardening" section explaining
  the two jobs the neutralizer dict now does, and a note that the generated sync
  runner already carries `-I` (existing main behavior) as the isolation boundary a
  sandbox mask cannot substitute for.

Note on scope: an earlier head of this branch also added `-I` to the sync runner
and withdrew a frontend-build skip. Main has since **superseded** both — the sync
runner is now a digest-verified snapshot run by path under `-I`, and build+stage
is unconditional again — so after rebasing onto current main this PR carries only
the two additions above plus their docs. The runner-`-I` goal is fully achieved
by main's snapshot design; the docs describe that existing behavior rather than
introducing it.

## Tests

- `test_git_env_neutralizers_present` — asserts `GIT_NO_REPLACE_OBJECTS=1` is in
  the sync env and that `GIT_CONFIG_COUNT` stays 4.
- `test_the_neutralizers_answer_from_the_real_object_graph` — runs real git in a
  `tmp_path` repo with a planted `refs/replace` graft and proves `rev-list
  --count` answers from the real graph under the neutralizer.
- `test_the_passthrough_silently_drops_extra_hidden_dirs` — characterizes that a
  nested `wrap_argv` returns the argv with no mask and no launcher script.

All hermetic (every git runs `-C <tmp_path>` with global/system config pinned to
`os.devnull` and inherited `GIT_*` stripped).

## Manual verification

N/A — unit coverage is sufficient; the neutralizer test exercises the real git
behavior end-to-end in a throwaway repo.

## Related Issues

Refs #7132.

## Pattern harvest

Rule candidate: agents-md

Pattern: a git/tool environment-hardening list that pins *code execution* (protocol, hooks, credential helper, sshCommand) but not *which object graph / namespace the tool answers from*. `GIT_NO_REPLACE_OBJECTS=1` closes that gap here, matching the `update_governance` and `auto_improvement` clone-setup pins. Any site that trusts a git count/ancestry answer about the on-disk checkout should pin the real object graph alongside the protocol/helper pins.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
