### PR TITLE
fix(kas): project mcpServers so an agent's own MCP servers exist on the KAS backend

### DIFF
--- a/src/kiro_crew/acp/kas_agents.py
+++ b/src/kiro_crew/acp/kas_agents.py
@@ -15,16 +15,25 @@ Two properties of KAS's schema drive the mapping and are easy to get wrong:
   ``agent.tools ?? []``. The list is therefore always emitted explicitly, and an
   ambiguous spec fails closed rather than guessing ``*``.
 
-Deliberately NOT projected, each for a reason a reader would otherwise have to
-rediscover:
+``mcpServers`` IS projected, minus the names that arrive as session-level broker
+stubs. It was previously omitted on the reasoning that ``@server`` entries in
+``tools`` resolve wherever the server was declared and that carrying the servers
+twice risks a double registration. The first half is true; the second described a
+case that only arises for a STUBBED server, and stubs are opt-in per server
+(``mcp_gateway.stub_servers``, empty by default). With nothing stubbed the
+session-level param is an empty array, so omitting the block left a KAS session
+holding ``tools: ["@kirocrew-core", ...]`` and no definition of what
+``kirocrew-core`` is — refs naming nothing, and every Crew tool silently absent.
+kiro-cli never had this: it reads the spec off disk itself via ``--agent``.
 
-* ``mcpServers`` — Crew injects broker stubs as the session-level ``mcpServers``
-  param, and a session-injected server outranks an agent-declared one. Carrying
-  them twice risks a double registration. ``@server`` entries in ``tools`` still
-  resolve, because KAS tags every MCP tool with ``@<server>`` from the server's
-  name regardless of where it was declared.
-* ``model`` — the model is set through its own protocol verb, so it has exactly
-  one owner rather than being pinned in two places that can disagree.
+Filtering by the stub set keeps the original reason intact (a stubbed server is
+still declared exactly once, by the injection that outranks this block) while
+removing the case where the omission left the session with nothing. Two fields
+are dropped on the way through — see :func:`_project_mcp_servers`.
+
+``model`` is still deliberately NOT projected: the model is set through its own
+protocol verb, so it has exactly one owner rather than being pinned in two places
+that can disagree.
 
 ``permissions`` IS projected, and is the one field that changes behaviour rather
 than just describing it. KAS's policy is keyed by its own capability vocabulary
@@ -46,6 +55,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew.acp.kas_permissions import allowed_tools_to_permissions
+from kiro_crew.mcp_cleanup import KIROCREW_BIN_MCP_SERVERS
 from kiro_crew.platform.governance import may_skip_gate_now
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
@@ -56,6 +66,34 @@ logger = logging.getLogger(__name__)
 KAS_MAX_CUSTOM_AGENTS = 50
 
 _PROMPT_FILE_SCHEME = "file://"
+
+#: Kiro Crew's OWN managed MCP servers — the ones whose ``env`` may retain a
+#: single Crew-authored key through projection (see :func:`_project_mcp_servers`).
+#:
+#: Imported from :mod:`kiro_crew.mcp_cleanup`, which already pins this set to
+#: ``agent._MANAGED_MCP_SERVERS`` with a ratchet test and imports nothing heavier
+#: than ``config.paths`` — so this projection leaf stays off the config-loader /
+#: aiohttp import chain without spelling the four names a third time.
+MANAGED_MCP_SERVER_NAMES = frozenset(KIROCREW_BIN_MCP_SERVERS)
+
+#: Fields that carry a secret. ``env`` "routinely holds tokens and API keys"
+#: (``mcp_gateway.session_servers``) and a remote entry's ``headers`` can hold a
+#: static ``Authorization`` value, so neither crosses the wire intact.
+_CREDENTIAL_BEARING_FIELDS = ("env", "headers")
+
+#: The ONLY env key that survives for one of Crew's own managed servers. It pins
+#: the data home, so dropping it would have the shims read a different one than
+#: the gateway — that is the whole reason managed ``env`` is not simply withheld.
+#:
+#: Everything else is withheld even on a managed server. "Crew authored this
+#: server" is not "Crew authored every key now in its env": the entry lives in a
+#: user-editable agent file, so a hand-added secret is reachable under a managed
+#: name and would otherwise be the one credential path left onto the wire.
+_MANAGED_ENV_KEYS_KEPT = frozenset({"KIROCREW_HOME"})
+
+#: Crew-internal bookkeeping on a rewritten entry. Never belongs on the wire: an
+#: unknown field can fail a strict schema, and it means nothing to the backend.
+_WRAPPER_MARKERS = ("_kirocrew_mcp_gateway_wrapped", "_mc_mcp_gateway_wrapped")
 
 #: Pseudo-filesystems whose contents are process/kernel state, not documents.
 _PSEUDO_FS_ROOTS = ("/proc", "/sys", "/dev")
@@ -283,14 +321,131 @@ def _ceiling_permitted(allowed_tools: Any, agent_id: str) -> list[str]:
     return permitted
 
 
+def _project_mcp_servers(
+    spec: dict[str, Any],
+    agent_id: str,
+    stub_server_names: frozenset[str],
+) -> dict[str, dict[str, Any]]:
+    """The spec's ``mcpServers``, minus stubbed names and minus two field classes.
+
+    Three subtractions, each load-bearing:
+
+    * **stubbed names** — those arrive as the session-level ``mcpServers`` param,
+      which outranks an agent-declared entry. Emitting both is the double
+      registration this block was originally omitted to avoid.
+    * **``autoApprove``** — an auto-approved MCP tool is approved by the host and
+      emits no permission request, so ``hooks.on_tool_call`` (the always-on deny
+      floor, the sensitive-path check, the governance ceiling) never runs for it.
+      ``agent.py`` states the rule for Crew's own servers ("DELIBERATELY NO
+      ``autoApprove`` KEY, and none may ever be added"); relaying one copied from
+      a spec would grant through this path what that rule refuses on the other,
+      and on KAS there is no wire slot for hooks at all. Auto-approve reaches KAS
+      only as ``permissions``, derived from the ceiling-filtered ``allowedTools``.
+    * **``env`` and ``headers``** — projection puts these on the wire, and a
+      declared server's env routinely holds tokens. Every server is filtered; the
+      classes differ only in what survives. A server Crew did not author loses
+      both fields outright. One of Crew's OWN managed servers keeps exactly
+      ``KIROCREW_HOME`` out of its env and nothing else, because that key is the
+      only reason managed env is projected at all: without it the shims read a
+      different data home than the gateway. A managed entry still lives in a
+      user-editable agent file, so a hand-added key under a managed name is
+      withheld like any other.
+
+    A non-managed server therefore starts without its credentials and may fail to
+    authenticate — which is still strictly better than today, where it does not
+    start at all. The drop is logged with KEY NAMES ONLY so an operator can see
+    why, without the value reaching a log.
+
+    Note what this canNOT reach: ``command``, ``args`` and ``url`` are how the
+    server is launched or addressed, so a secret embedded THERE (an ``--api-key``
+    argv, a signed query string) still crosses the wire. Stripping them would not
+    withhold a credential, it would unmake the server — the exact "declared but
+    absent" state this function exists to end — so the residue is accepted and
+    stated rather than papered over.
+    """
+    servers = spec.get("mcpServers")
+    if not isinstance(servers, dict):
+        return {}
+
+    out: dict[str, dict[str, Any]] = {}
+    for name, entry in servers.items():
+        if not isinstance(name, str) or not name or not isinstance(entry, dict):
+            continue
+        if name in stub_server_names:
+            continue
+        projected = {k: v for k, v in entry.items() if k not in _WRAPPER_MARKERS}
+        projected.pop("autoApprove", None)
+        managed = name in MANAGED_MCP_SERVER_NAMES
+        withheld = _withhold_credential_fields(projected, managed=managed)
+        if withheld:
+            logger.info(
+                "agent %r: not relaying %s for MCP server %r — the field can carry "
+                "a credential. The server is still declared; it may need its "
+                "credentials supplied another way.",
+                agent_id,
+                "/".join(withheld),
+                name,
+            )
+        out[name] = projected
+    return out
+
+
+def _withhold_credential_fields(
+    projected: dict[str, Any],
+    *,
+    managed: bool,
+) -> list[str]:
+    """Strip credential-bearing fields from one projected server entry in place.
+
+    Returns the FIELD NAMES something was withheld from, for the caller's log —
+    never a value, and never the withheld env keys, since a key name in a
+    third-party server's env is itself operator-supplied.
+
+    *managed* keeps ``_MANAGED_ENV_KEYS_KEPT`` alive in ``env``; everything else
+    goes either way, ``headers`` included. A managed server has no legitimate
+    ``headers`` (all four are local stdio processes), so retaining it would only
+    forward whatever a hand edit put there.
+    """
+    withheld: list[str] = []
+    if projected.get("headers"):
+        projected.pop("headers", None)
+        withheld.append("headers")
+
+    env = projected.get("env")
+    if not env:
+        projected.pop("env", None)
+        return withheld
+    if not managed or not isinstance(env, dict):
+        # Non-managed, or a malformed env that cannot be filtered key-by-key.
+        projected.pop("env", None)
+        withheld.append("env")
+        return withheld
+
+    kept = {k: v for k, v in env.items() if k in _MANAGED_ENV_KEYS_KEPT}
+    if len(kept) != len(env):
+        withheld.append("env")
+    if kept:
+        projected["env"] = kept
+    else:
+        projected.pop("env", None)
+    return withheld
+
+
 def to_client_custom_agent(
     agent_id: str,
     spec: dict[str, Any],
     prompt: str,
+    *,
+    stub_server_names: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Project one Crew agent spec onto a KAS ``ClientCustomAgent`` descriptor.
 
     Pure: *prompt* is already-resolved content (see :func:`resolve_prompt`).
+
+    *stub_server_names* are the servers that will arrive as the session-level
+    ``mcpServers`` param and must not also be declared here — see
+    :func:`_project_mcp_servers`. The default is empty, which is correct for a
+    caller with no shared gateway: nothing is stubbed, so nothing is subtracted.
     """
     if not agent_id:
         raise KasAgentTranslationError("agent id must be non-empty")
@@ -354,6 +509,10 @@ def to_client_custom_agent(
         if entries:
             out["resources"] = entries
 
+    mcp_servers = _project_mcp_servers(spec, agent_id, stub_server_names)
+    if mcp_servers:
+        out["mcpServers"] = mcp_servers
+
     return out
 
 
@@ -376,7 +535,12 @@ def load_agent_spec(agents_dir: Path, agent_id: str) -> dict[str, Any]:
     return raw
 
 
-def build_kas_custom_agents(agents_dir: Path, agent_id: str) -> list[dict[str, Any]]:
+def build_kas_custom_agents(
+    agents_dir: Path,
+    agent_id: str,
+    *,
+    stub_server_names: frozenset[str] = frozenset(),
+) -> list[dict[str, Any]]:
     """Build the ``_meta.kiro.customAgents`` batch that binds *agent_id* on KAS.
 
     One entry: KAS registers the injected agent, it then surfaces as a mode, and
@@ -387,7 +551,11 @@ def build_kas_custom_agents(agents_dir: Path, agent_id: str) -> list[dict[str, A
     A prompt-less spec (e.g. ``kirocrew-lite``) is projected with the small
     :data:`_KAS_FALLBACK_PROMPT` so it satisfies KAS's non-empty-prompt
     requirement instead of crashing the session (see :func:`resolve_prompt`).
+
+    *stub_server_names* is forwarded to :func:`_project_mcp_servers`; the caller
+    holds the gateway overlay this session will inject from, so it is the only
+    layer that can answer which names are stubbed.
     """
     spec = load_agent_spec(agents_dir, agent_id)
     prompt = resolve_prompt(spec, agent_id=agent_id, agents_dir=agents_dir)
-    return [to_client_custom_agent(agent_id, spec, prompt)]
+    return [to_client_custom_agent(agent_id, spec, prompt, stub_server_names=stub_server_names)]

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -89,7 +89,7 @@ from kiro_crew.config.paths import kiro_agents_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.env import augmented_path, resolve_krb5_ccname
 from kiro_crew.executors import subprocess_executor
-from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
+from kiro_crew.mcp_gateway.session_servers import injection_server_names, pooled_session_servers
 from kiro_crew.metrics.events import (
     CHILD_PERMISSION_DENIED,
     CHILD_PERMISSION_ROUTED,
@@ -2709,6 +2709,14 @@ class AcpRuntime:
         Materializes first for the same reason the kiro spawn path does: the
         managed default spec may not exist yet, and reading it is what the
         projection needs. File I/O is offloaded — this runs on the loop.
+
+        The projection needs to know which servers will ALSO arrive as
+        session-level broker stubs, because a session-injected server outranks an
+        agent-declared one and declaring both is a double registration. Only this
+        layer holds the overlay that answers it, so the set is resolved here and
+        passed down. ``injection_server_names`` is one file read with no shaping
+        (it exists to be callable on the session path) and returns an empty set
+        when nothing is stubbed, which is the default.
         """
         if self._acp_backend == ACP_BACKEND_KAS and agent:
 
@@ -2719,7 +2727,23 @@ class AcpRuntime:
                     logger.warning(
                         "pre-session agent materialization failed for %r", agent, exc_info=True
                     )
-                return build_kas_custom_agents(kiro_agents_dir(), agent)
+                try:
+                    stubbed = injection_server_names(self._mcp_gateway_overlay, agent)
+                except Exception:
+                    # An unreadable overlay must not cost the session its agent.
+                    # Empty is the SAFE direction here: it declares a stubbed
+                    # server twice (the injection still wins) rather than
+                    # withholding one that nothing else will supply.
+                    logger.debug(
+                        "stubbed-server lookup failed for %r; projecting every "
+                        "declared server",
+                        agent,
+                        exc_info=True,
+                    )
+                    stubbed = frozenset()
+                return build_kas_custom_agents(
+                    kiro_agents_dir(), agent, stub_server_names=stubbed
+                )
 
             try:
                 return await asyncio.to_thread(_build)

--- a/test/test_kas_agents.py
+++ b/test/test_kas_agents.py
@@ -99,13 +99,14 @@ class TestToolsFailClosed:
 class TestDeliberateOmissions:
     """Fields left out on purpose; each would misbehave if projected.
 
-    ``mcpServers`` would double-register against the session-level injection,
-    and ``model`` would compete with the dedicated model verb. ``permissions``
-    is NOT in this list — see :class:`TestPermissionsProjection`; it is absent
-    only when the spec gives nothing to derive it from.
+    ``model`` would compete with the dedicated model verb. ``permissions`` is NOT
+    in this list — see :class:`TestPermissionsProjection`; it is absent only when
+    the spec gives nothing to derive it from. ``mcpServers`` is no longer in this
+    list either: omitting it left a KAS session with ``@server`` refs naming
+    nothing — see :class:`TestMcpServersProjection`.
     """
 
-    @pytest.mark.parametrize("key", ["mcpServers", "model", "welcomeMessage"])
+    @pytest.mark.parametrize("key", ["model", "welcomeMessage"])
     def test_key_is_not_projected(self, key):
         assert key not in to_client_custom_agent("a", _spec(), "p")
 
@@ -464,4 +465,313 @@ class TestAgainstTheRealBundledSpec:
         assert spec.get("allowedTools"), "expected the real spec to still carry allowedTools"
         out = to_client_custom_agent(spec["name"], spec, "p")
         assert "allowedTools" not in out
+
+    def test_the_bundled_template_carries_refs_but_declares_no_servers(self):
+        """Why the ref list alone cannot be the fixture for the test below.
+
+        ``defaults.json`` ships ``@kirocrew-*`` refs with NO ``mcpServers`` key:
+        the entries are written at rebuild time by ``agent.build_agent_config``.
+        So the shipped template is not a spec any session ever runs, and asserting
+        ref/declaration parity against it would be asserting the wrong thing.
+        """
+        spec = self._bundled()
+        assert any(t.startswith("@") for t in spec["tools"])
+        assert "mcpServers" not in spec
+
+    def test_every_mcp_ref_resolves_to_a_declaration_on_a_materialized_spec(self):
+        """The defect this change fixes, on the real ref list.
+
+        Takes the shipped template's own ``@`` refs and adds the ``mcpServers``
+        block ``rebuild_agent_config`` writes for them, which is the shape a live
+        session actually loads. A ``@server`` ref with no matching entry mounts
+        nothing, so before this projection a stock KAS session advertised Crew's
+        whole tool surface and could reach none of it.
+        """
+        spec = self._bundled()
+        refs = [t[1:] for t in spec["tools"] if t.startswith("@")]
+        assert refs, "expected the real template to still carry @server refs"
+        spec["mcpServers"] = {
+            name: {"command": "/opt/kirocrew", "args": [f"mcp-{name.split('-')[-1]}"]}
+            for name in refs
+        }
+
+        out = to_client_custom_agent(spec["name"], spec, "p")
+
+        declared = set(out.get("mcpServers") or {})
+        assert set(refs) <= declared, f"refs naming nothing: {sorted(set(refs) - declared)}"
+
+
+class TestMcpServersProjection:
+    """``mcpServers`` reaches KAS, minus three things.
+
+    KAS honouring an agent-declared block is not an assumption here: it was
+    verified with an A/B probe against a live session using a uniquely-named
+    witness server, twice per arm. Without the block a stock KAS session gets
+    ``tools: ["@kirocrew-core", ...]`` and no definition of what that names.
+    """
+
+    def test_declared_server_is_projected(self):
+        out = to_client_custom_agent("a", _spec(), "p")
+        assert out["mcpServers"] == {"kirocrew-core": {"command": "x"}}
+
+    def test_absent_or_malformed_block_emits_nothing(self):
+        assert "mcpServers" not in to_client_custom_agent("a", _spec(mcpServers={}), "p")
+        assert "mcpServers" not in to_client_custom_agent("a", _spec(mcpServers=None), "p")
+        assert "mcpServers" not in to_client_custom_agent("a", _spec(mcpServers=[]), "p")
+
+    def test_malformed_entries_are_skipped_not_fatal(self):
+        out = to_client_custom_agent(
+            "a",
+            _spec(mcpServers={"good": {"command": "x"}, "bad": "nope", "": {"command": "y"}}),
+            "p",
+        )
+        assert out["mcpServers"] == {"good": {"command": "x"}}
+
+    def test_stubbed_names_are_withheld(self):
+        """A stubbed server arrives as the session-level param, which outranks an
+        agent-declared entry — declaring both is the double registration this
+        block was originally omitted to avoid."""
+        out = to_client_custom_agent(
+            "a",
+            _spec(mcpServers={"kirocrew-core": {"command": "x"}, "other": {"command": "y"}}),
+            "p",
+            stub_server_names=frozenset({"kirocrew-core"}),
+        )
+        assert out["mcpServers"] == {"other": {"command": "y"}}
+
+    def test_all_names_stubbed_emits_nothing(self):
+        out = to_client_custom_agent(
+            "a", _spec(), "p", stub_server_names=frozenset({"kirocrew-core"})
+        )
         assert "mcpServers" not in out
+
+    def test_auto_approve_is_never_relayed(self):
+        """An autoApproved MCP tool is approved by the host and emits no permission
+        request, so Crew's deny floor / sensitive-path check / governance ceiling
+        never run for it. Auto-approve reaches KAS only as ``permissions``."""
+        out = to_client_custom_agent(
+            "a",
+            _spec(mcpServers={"third-party": {"command": "x", "autoApprove": ["dangerous"]}}),
+            "p",
+        )
+        assert out["mcpServers"] == {"third-party": {"command": "x"}}
+
+    def test_auto_approve_is_stripped_from_a_managed_server_too(self):
+        out = to_client_custom_agent(
+            "a",
+            _spec(mcpServers={"kirocrew-core": {"command": "x", "autoApprove": ["t"]}}),
+            "p",
+        )
+        assert "autoApprove" not in out["mcpServers"]["kirocrew-core"]
+
+    def test_managed_server_keeps_the_one_env_key_it_needs(self):
+        """Crew's own env pins KIROCREW_HOME; dropping it would have the shims
+        read a different data home than the gateway."""
+        out = to_client_custom_agent(
+            "a",
+            _spec(
+                mcpServers={
+                    "kirocrew-core": {"command": "x", "env": {"KIROCREW_HOME": "/h"}}
+                }
+            ),
+            "p",
+        )
+        assert out["mcpServers"]["kirocrew-core"]["env"] == {"KIROCREW_HOME": "/h"}
+
+    def test_a_hand_added_env_key_under_a_managed_name_is_withheld(self):
+        """A managed entry still lives in a user-editable agent file, so being
+        managed cannot mean "every key now in this env is Crew's". Only
+        KIROCREW_HOME survives; the neighbouring secret does not reach the wire.
+        """
+        out = to_client_custom_agent(
+            "a",
+            _spec(
+                mcpServers={
+                    "kirocrew-core": {
+                        "command": "x",
+                        "env": {"KIROCREW_HOME": "/h", "OPENAI_API_KEY": "sk-live"},
+                    }
+                }
+            ),
+            "p",
+        )
+        assert out["mcpServers"]["kirocrew-core"]["env"] == {"KIROCREW_HOME": "/h"}
+
+    def test_a_managed_env_of_only_secrets_leaves_no_env_at_all(self):
+        out = to_client_custom_agent(
+            "a",
+            _spec(mcpServers={"kirocrew-cron": {"command": "x", "env": {"T": "s"}}}),
+            "p",
+        )
+        entry = out["mcpServers"]["kirocrew-cron"]
+        assert "env" not in entry
+        assert entry == {"command": "x"}
+
+    def test_headers_are_withheld_from_a_managed_server_too(self):
+        """All four managed servers are local stdio processes with no legitimate
+        headers, so retaining the field would only forward a hand edit."""
+        out = to_client_custom_agent(
+            "a",
+            _spec(
+                mcpServers={
+                    "kirocrew-core": {
+                        "command": "x",
+                        "headers": {"Authorization": "Bearer live"},
+                    }
+                }
+            ),
+            "p",
+        )
+        assert out["mcpServers"]["kirocrew-core"] == {"command": "x"}
+
+    def test_a_malformed_managed_env_is_dropped_not_filtered(self):
+        """A non-dict env cannot be filtered key-by-key, so it fails toward
+        withholding rather than forwarding an unknown shape."""
+        out = to_client_custom_agent(
+            "a",
+            _spec(mcpServers={"kirocrew-core": {"command": "x", "env": "TOKEN=s"}}),
+            "p",
+        )
+        assert out["mcpServers"]["kirocrew-core"] == {"command": "x"}
+
+    def test_a_withheld_managed_key_is_not_named_in_the_log(self, caplog):
+        with caplog.at_level("INFO"):
+            to_client_custom_agent(
+                "a",
+                _spec(
+                    mcpServers={
+                        "kirocrew-core": {
+                            "command": "x",
+                            "env": {"KIROCREW_HOME": "/h", "SECRET_TOKEN": "sekrit"},
+                        }
+                    }
+                ),
+                "p",
+            )
+        assert "sekrit" not in caplog.text
+        assert "SECRET_TOKEN" not in caplog.text
+
+    @pytest.mark.parametrize("field", ["env", "headers"])
+    def test_credential_bearing_field_is_withheld_from_an_unmanaged_server(self, field):
+        out = to_client_custom_agent(
+            "a",
+            _spec(mcpServers={"third-party": {"command": "x", field: {"TOKEN": "secret"}}}),
+            "p",
+        )
+        entry = out["mcpServers"]["third-party"]
+        assert field not in entry
+        # Withheld, not dropped: the server is still declared and still mounts.
+        assert entry == {"command": "x"}
+
+    def test_withheld_credential_is_not_logged_by_value(self, caplog):
+        with caplog.at_level("INFO"):
+            to_client_custom_agent(
+                "a",
+                _spec(mcpServers={"third-party": {"command": "x", "env": {"K": "sekrit"}}}),
+                "p",
+            )
+        assert "third-party" in caplog.text
+        assert "sekrit" not in caplog.text
+
+    def test_wrapper_marker_never_reaches_the_wire(self):
+        """Crew-internal bookkeeping on a rewritten entry. An unknown field can
+        fail a strict schema and means nothing to the backend."""
+        out = to_client_custom_agent(
+            "a",
+            _spec(
+                mcpServers={
+                    "srv": {"command": "x", "_kirocrew_mcp_gateway_wrapped": True},
+                }
+            ),
+            "p",
+        )
+        assert out["mcpServers"]["srv"] == {"command": "x"}
+
+    def test_the_spec_is_not_mutated(self):
+        spec = _spec(mcpServers={"third-party": {"command": "x", "autoApprove": ["t"]}})
+        to_client_custom_agent("a", spec, "p")
+        assert spec["mcpServers"]["third-party"]["autoApprove"] == ["t"]
+
+    def test_the_managed_name_set_is_the_shared_one(self):
+        """Not a third spelling of the four names: this is the set
+        ``mcp_cleanup`` already ratchet-pins to ``agent._MANAGED_MCP_SERVERS``."""
+        from kiro_crew.mcp_cleanup import KIROCREW_BIN_MCP_SERVERS
+
+        assert kas_agents.MANAGED_MCP_SERVER_NAMES == frozenset(
+            KIROCREW_BIN_MCP_SERVERS
+        )
+
+
+class TestRuntimeSuppliesTheStubbedSet:
+    """The seam between the overlay and the projection.
+
+    ``_project_mcp_servers`` can be perfect and the feature still wrong if the
+    runtime never tells it which names are stubbed: every stubbed server would be
+    declared twice. Only the runtime holds the overlay, so this is the one place
+    that can get it right, and nothing else asserts it.
+    """
+
+    @staticmethod
+    def _runtime(monkeypatch, overlay, seen):
+        from kiro_crew.acp import runtime as runtime_mod
+
+        rt = object.__new__(runtime_mod.AcpRuntime)
+        rt._acp_backend = runtime_mod.ACP_BACKEND_KAS
+        rt._mcp_gateway_overlay = overlay
+
+        monkeypatch.setattr(runtime_mod, "ensure_agent_materialized", lambda _a: None)
+        monkeypatch.setattr(runtime_mod, "kiro_agents_dir", lambda: Path("/agents"))
+
+        def _capture(_dir, agent, *, stub_server_names=frozenset()):
+            seen.append(stub_server_names)
+            return [{"id": agent}]
+
+        monkeypatch.setattr(runtime_mod, "build_kas_custom_agents", _capture)
+        return rt
+
+    @pytest.mark.asyncio
+    async def test_the_overlay_set_is_forwarded(self, monkeypatch):
+        from kiro_crew.acp import runtime as runtime_mod
+
+        seen: list[frozenset] = []
+        rt = self._runtime(monkeypatch, "/overlay", seen)
+        monkeypatch.setattr(
+            runtime_mod, "injection_server_names", lambda _o, _a: frozenset({"kirocrew-core"})
+        )
+
+        await rt._kas_custom_agents("kirocrew")
+
+        assert seen == [frozenset({"kirocrew-core"})]
+
+    @pytest.mark.asyncio
+    async def test_no_overlay_forwards_an_empty_set(self, monkeypatch):
+        """The default install: nothing stubbed, so nothing is subtracted."""
+        from kiro_crew.acp import runtime as runtime_mod
+
+        seen: list[frozenset] = []
+        rt = self._runtime(monkeypatch, None, seen)
+        monkeypatch.setattr(runtime_mod, "injection_server_names", lambda _o, _a: frozenset())
+
+        await rt._kas_custom_agents("kirocrew")
+
+        assert seen == [frozenset()]
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_overlay_still_yields_an_agent(self, monkeypatch):
+        """Fail toward declaring too much, never toward an agent with no servers:
+        a double declaration is harmless (the injection outranks it), while
+        withholding a server nothing else supplies is the bug being fixed."""
+        from kiro_crew.acp import runtime as runtime_mod
+
+        seen: list[frozenset] = []
+        rt = self._runtime(monkeypatch, "/overlay", seen)
+
+        def _boom(_o, _a):
+            raise OSError("overlay unreadable")
+
+        monkeypatch.setattr(runtime_mod, "injection_server_names", _boom)
+
+        out = await rt._kas_custom_agents("kirocrew")
+
+        assert seen == [frozenset()]
+        assert out == [{"id": "kirocrew"}]


### PR DESCRIPTION
fix(kas): project mcpServers so an agent's own MCP servers exist on the KAS backend

## Problem

On the KAS ACP backend, Kiro Crew's own MCP servers are missing from a stock
install. `spawn_run`, `learn_add`, `cron_list`, the artifact tools — none of them
resolve, and nothing says why.

The cause is a projection gap. `kas_agents.to_client_custom_agent` emits
`tools: ["@kirocrew-core", "@kirocrew-cron", ...]` but no `mcpServers` block, so
those refs name servers the session has never heard of. An unreferenced server
contributes no tools; a ref with no server behind it mounts nothing at all.

The omission was deliberate and its reasoning is in the module docstring: broker
stubs arrive as the session-level `mcpServers` param, a session-injected server
outranks an agent-declared one, and carrying both risks a double registration.
The first half is correct. The second describes a case that only arises for a
*stubbed* server — and stubs are opt-in per server via
`mcp_gateway.stub_servers`, which is **empty by default**
(`config/loader.py`: "Empty by default: an unstubbed server is launched by the
session itself"). With nothing stubbed the param is an empty array, so the
omission left the session with zero server definitions.

That also made an unrelated performance knob decide a functional outcome: whether
a Crew tool exists on KAS depended on whether its server happened to be listed in
`stub_servers`.

kiro-cli never had this. It gets `--agent <name>` and reads
`~/.kiro/agents/<name>.json` itself, so the servers reach it off disk and
`session/new` carries `mcpServers: []`. Only the KAS path depends on Crew putting
them on the wire.

The repo's own test already described the shipped state without anyone noticing:
`test_kas_agents.py` asserts `tools` keeps its `@` entries because "losing it
would leave the agent nominally configured but unable to reach its own tools" —
which is exactly what was happening, one layer down.

## What changed

`to_client_custom_agent` now projects `mcpServers`, with three subtractions.

1. **Stubbed names are withheld.** They arrive as the session-level param, which
   outranks an agent-declared entry — this preserves the original reason for the
   omission (declared exactly once) while removing the case where it left the
   session with nothing. The set comes from the existing
   `injection_server_names()`, which was written for this exact overlap problem
   and is deliberately cheap enough for the session path.

2. **`autoApprove` is never relayed**, for any server. An auto-approved MCP tool
   is approved by the host and emits no permission request, so
   `hooks.on_tool_call` — the always-on deny floor, the sensitive-path check, the
   governance ceiling — never runs for it. `agent.py` states the rule for Crew's
   own servers ("DELIBERATELY NO `autoApprove` KEY, and none may ever be added");
   relaying one copied out of a spec would grant through this path what that rule
   refuses on the other, and on KAS there is no wire slot for hooks at all.
   Auto-approve still reaches KAS as `permissions`, derived from the
   ceiling-filtered `allowedTools`.

3. **`env` and `headers` are filtered on EVERY server; the classes differ only
   in what survives.** Projection puts these on the wire, and a declared server's
   `env` "routinely holds tokens and API keys" (`mcp_gateway/session_servers.py`)
   while a remote entry's `headers` can hold a static `Authorization`.

   * A server Crew did not author loses both fields outright.
   * One of Crew's own managed servers keeps **exactly `KIROCREW_HOME`** out of
     its `env`, and nothing else. That key is the only reason managed `env` is
     projected at all — without it the shims read a different data home than the
     gateway. `headers` goes even on a managed server: all four are local stdio
     processes with no legitimate use for it.

   The managed narrowing is the fix for a real hole an earlier revision had
   (GPT 5.6, `kas_agents.py:365`): a managed entry lives in a **user-editable**
   agent file, so "Crew authored this server" was never "Crew authored every key
   now in its `env`". A hand-added secret under a managed name was the one
   credential path still reaching the wire.

   A third-party server therefore starts without its credentials and may fail to
   authenticate. That is still strictly better than today, where it does not start
   at all, and the withholding is logged at INFO with **field names only** — not
   the withheld env keys, since a key name in a declared server's env is itself
   operator-supplied.

   **Stated residue:** `command`, `args` and `url` are how a server is launched or
   addressed, so a secret embedded there (an `--api-key` argv, a signed query
   string) still crosses the wire. Stripping them would not withhold a credential,
   it would unmake the server — the exact "declared but absent" state this change
   exists to end — so this is accepted and documented in the function, not
   papered over.

Also stripped: the internal `_kirocrew_mcp_gateway_wrapped` marker, which is
Crew bookkeeping and can fail a strict schema.

`MANAGED_MCP_SERVER_NAMES` is `frozenset(mcp_cleanup.KIROCREW_BIN_MCP_SERVERS)` —
the set that module already ratchet-pins to `agent._MANAGED_MCP_SERVERS`. An
earlier revision spelled the four names locally to keep this projection leaf off
the config-loader / aiohttp import chain; First Principles Review pointed out that
`mcp_cleanup` imports nothing heavier than `config.paths`, making the copy a third
spelling of one set. Verified before switching: importing `mcp_cleanup` alone pulls
none of `aiohttp` / `mcp_discovery` / `agent`, and the local copy's stated
justification was already void, since the pre-existing `kas_permissions` import on
the same line pulls `kiro_crew.agent` regardless.

`model` is still not projected — it has its own protocol verb and one owner.

## Tests

`test/test_kas_agents.py`

* `TestMcpServersProjection` — declared server projected; absent / `{}` / `None` /
  wrong-type block emits nothing; malformed entries skipped rather than fatal;
  stubbed names withheld; all-stubbed emits nothing; `autoApprove` stripped from
  third-party **and** managed entries; `env`/`headers` withheld from an unmanaged
  server (parametrized) while the server stays declared; the withheld value never
  reaches the log; wrapper marker never reaches the wire; the input spec is not
  mutated; and the managed-name set IS the shared `mcp_cleanup` one.
* Managed-server credential narrowing (this round): the one needed env key
  survives; a hand-added key alongside it does not; an env of only secrets leaves
  no `env` at all; `headers` is withheld from a managed server too; a malformed
  (non-dict) managed `env` is dropped rather than filtered; and neither the
  withheld value nor the withheld KEY NAME reaches the log.
* `TestRuntimeSuppliesTheStubbedSet` — the seam that nothing else covered: the
  overlay's set is forwarded, no overlay forwards an empty set, and an unreadable
  overlay still yields an agent (failing toward declaring too much, never toward
  an agent with no servers).
* `TestAgainstTheRealBundledSpec` — records that `defaults.json` ships `@` refs
  with **no** `mcpServers` key (the entries are written at rebuild time), so the
  ref/declaration parity assertion runs against a materialized-shaped spec built
  from the template's own ref list.

Two assertions that pinned the omission were retired: the `mcpServers` case in
`TestDeliberateOmissions` and the `"mcpServers" not in out` line in
`test_the_real_spec_carries_keys_KAS_cannot_take`.

## Manual verification

**The premise was verified against a live KAS session before any of this was
written.** A/B probe with a uniquely-named witness server (`probe-only-echo`, a
name in no other MCP source on the machine) and `create_session(mcp_servers=[])`
so the stub path could contribute nothing: projection off → not spawned,
projection on → spawned. Two runs per arm, four for four consistent. An earlier
attempt using `creds-agent` proved nothing, because that name is also in the
host's own settings — the unique name is what makes the result unambiguous.

Then the **shipped** code was re-probed end to end, with the witness path moved to
argv so `env` itself could be the thing under test:

* projected fields for the third-party entry: `['args', 'command']` — `env` and
  `autoApprove` both absent;
* the server **was** spawned by KAS (witness written, pid recorded);
* the spawned process reported `PROBE_SECRET` **not** in its environment — the
  withholding confirmed from inside the child, not just from the projection.

Mutation-checked all six behaviours, each reverted in isolation with the pinning
test re-run: stub filter, `autoApprove` strip, credential withholding, wrapper
marker strip, the managed-name drift guard, and the runtime seam. All six were
caught, then restored. A regression test that has not been seen to fail proves
nothing.

475 tests green across `test_kas_agents`, `test_kas_permissions`,
`test_acp_runtime`, `test_mcp_gateway_session_inject` and
`test_mcp_gateway_cluster_fixes`. flake8, isort, mypy clean; black gate passes.

## Known limitation

This restores the **servers**. It does not supply a per-call **caller identity**,
so the tools that authorize on one still refuse when none can be resolved:
`cron_add` and the other `cron_*` writes (the resolved key is stored as the job's
owner), the four `session_control` tools, `list_sessions`, the `chat_folder_*`
tools, `session_ledger_read` / `record` (the key *is* the row key),
`issue_radar_crew_*`, `send_notification`, `send_message` with `channel_type`,
`workflow_run` on a saved ref, `file_send`'s native-channel leg, and `wait`'s
deadline publication.

On the session-unbound multiplexed runtime that identity arrives as a per-call
`_meta.kirocrew.caller` block, which today only the broker stub transports — so
it exists for servers in `mcp_gateway.stub_servers`. Decoupling it is a separate
change with its own threat model and is deliberately not attempted here.

**Correction to an earlier draft of this section:** it also listed the
session-directive tools (`monitor_start`, `monitor_update`, `autonudge_stop`,
`set_project`, `suggest_followup`, `ask_question`). That was wrong. Those are
stateless by design — the directive payload carries no session key
(`session_directive.py`: "and NO session key ... A session-aware consumer ...
applies the effect against ITS OWN session"), `set_project` and
`suggest_followup` resolve no identity at all, and the other four guard with
`if _autonudge_binding_key(sk) is None and sk:`, whose `and sk` conjunct lets an
empty key fall straight through to the directive. Their blocker is the
consumer-side identity gate, not this one.

(The docstring at `mcp_core.py:684-687` still claims those four "fail closed"
without the pid-sidecar branch. It is stale — filed separately rather than
touched here, to keep this diff to one concern.)

## Screenshots

N/A — no user-visible surface changes; the effect is which tools exist in a KAS
session.



## Rebase and review round

Rebased onto current `main`; head `94423a6f6`. The projection diff is unchanged by the
rebase. This head additionally carries the review-round fixes above:

* **GPT 5.6 BLOCKING** (`kas_agents.py:365`, managed-name trust forwarding
  user-added credentials) — **fixed**: managed `env` narrowed to an allowlist of
  exactly `KIROCREW_HOME`, managed `headers` now withheld too.
* **First Principles CONCERNS** (`MANAGED_MCP_SERVER_NAMES` a third copy of a
  four-name set) — **fixed**: imported from `mcp_cleanup` and the local drift test
  replaced with one asserting it IS that shared set.
* **Opus 4.8 advisory** (a secret in `args` / `url` also crosses the wire) —
  **accepted as stated residue, not fixed**: those fields are how the server is
  launched or addressed, so dropping them would unmake the server rather than
  withhold a credential. Now documented in `_project_mcp_servers` and above.

Gates on this head: 83 `test_kas_agents` tests (5 new), flake8, isort, mypy, black
all clean. Each of the three new behaviours mutation-checked — managed env
forwarded wholesale, managed headers retained, malformed managed env forwarded —
all three caught by a pinning test, then restored.


## Pattern harvest

The bug was not a wrong line; it was a comment that stayed true while the
condition under it stopped being true. `mcpServers` was omitted deliberately, and
the module docstring gave the reason: a session-injected server outranks an
agent-declared one, so carrying both risks a double registration. That reason is
sound — but it only describes a *stubbed* server, and stubs are opt-in per server
with an empty default. So on a stock install the guarded-against case could not
arise, and all the omission did was leave the session with zero server
definitions. The safety note outlived its precondition, and because it read as
intentional, nobody re-derived it.

What made it invisible for so long is the second half: an unreferenced server
contributes no tools, and a `@server` ref with no server behind it mounts nothing
— both fail by producing *absence*, not an error. The repo even had a test
asserting `tools` keeps its `@` entries "because losing it would leave the agent
nominally configured but unable to reach its own tools", which is exactly the
state that was shipping, one layer down.

Rule candidate: when a field is deliberately dropped at a translation boundary,
the justifying comment must name the CONDITION under which the hazard is real, not
just the hazard — and if that condition is config-dependent, the drop belongs
behind the same config, not applied unconditionally. A conditional hazard
documented as an unconditional rule is indistinguishable from a correct decision
on later reading.

Second, narrower candidate from this round's review: "we authored this object" does
not survive the object becoming user-editable. The managed-server `env` bypass was
safe when Crew wrote those entries and unsafe the moment a human could add a key to
them, so trust anchored on provenance needs an allowlist of the specific keys
relied upon, not a whole-field exemption.
