### PR TITLE
feat(docs-lint): fail a doc that cites a source line past the end of the file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,8 +446,9 @@ jobs:
       - name: Lint documentation trees
         # Blocking gate: every internal link resolves, every doc is reachable from
         # its directory index, every directory holding docs has one, no code comment
-        # cites a doc that does not exist, and no doc whose filename is hardcoded in
-        # code has been renamed out from under its consumer.
+        # cites a doc that does not exist, no doc cites a source LINE past the end of
+        # the file it names, and no doc whose filename is hardcoded in code has been
+        # renamed out from under its consumer.
         # No setup-python step: ubuntu-latest ships Python 3 and the script is
         # stdlib-only.
         run: ./scripts/docs-lint.sh

--- a/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
+++ b/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
@@ -216,7 +216,7 @@ kinds of undeclared hole:
 | `getattr`-by-name seams whose target the core never defines — `getattr(self, "_write_claude_local_settings", None)` (`acp/client.py:2742`, `:3351`) | 2 | Silent: no permission mode, and the context window collapses from 1M to 200K |
 | Methods returning a neutral value purely so a companion can override them — `_claude_session_mcp_servers() -> []` (`acp/client.py:2335-2346`) is the type case | 6 | Silent: a CC session gets **zero MCP tools**, as the docstring itself states |
 | `ClaudeCodeProvider is not None and isinstance(...)` guards against a name hard-coded to `None` (`session.py:170`, `subagent.py:131`) | 11 sites | Statically unreachable; nine `session.py` branches and two `subagent.py` branches are dead-but-maintained |
-| Defensive attribute probes across the provider boundary (`session.py:3356` `_proc`, `:3360` `_active_proc`, `chat_runner.py:867`, `knowledge/llm_pool.py:325`) | 4 | Duck typing in place of a type |
+| Defensive attribute probes across the provider boundary (`session_pid.py` (`_collect_active_pids`) probes `_proc` and `_active_proc`, `chat_runner.py:867`, `knowledge/llm_pool.py:325`) | 4 | Duck typing in place of a type |
 | Comment clusters naming the companion or a deleted module as the supplier of behaviour | 19 | The seam's real contract lives in prose |
 | Refusal / downgrade mechanisms, including the degrade log line at `config/loader.py:4647-4652` and five capability non-memberships | 9 | — |
 | Live `_is_claude` branches inside `acp/` | 13 | — |

--- a/docs/request-for-change/rfc-durable-run-coordinator.md
+++ b/docs/request-for-change/rfc-durable-run-coordinator.md
@@ -58,12 +58,13 @@ in-memory run/task registries, the admission queue, batch accounting, terminal
 report tasks, follow-up watchers, conversation retention, and the periodic
 reaper (`subagent.py:1347-1478`). The public `spawn()` path then handles identity,
 admission, approval, queueing, persistence, event publication, and task creation
-(`subagent.py:3038-3547`).
+(`subagent.py`: `spawn`, `_announce_rejection`, `_drain_queue`,
+`_spawn_with_approval`, and `_log_spawned`).
 
 The lifecycle discipline inside that module is valuable and must be preserved.
 In particular, terminal reporting and slot release are independently claimed by
-`_claim_finalize()` and `_release_slot()` (`subagent.py:2358-2404` and
-`2633-2656`). The system spec documents four distinct terminal guards and why
+`_claim_finalize()` and `_release_slot()` (`subagent.py`, both methods of
+`SubagentManager`). The system spec documents four distinct terminal guards and why
 collapsing them previously caused duplicate delivery, lost outcomes, or leaked
 slots (`docs/system-specs/modules/subagent.md:175-190`). The problem is not the
 existence of those invariants; it is that their state machine is distributed
@@ -98,13 +99,14 @@ The `spawn_run` MCP tool submits wave members through separate HTTP requests
 (`src/kiro_crew/mcp_tools/spawn.py:484-598`). A response can fail after the
 gateway accepted the request, so the caller and gateway maintain extra
 submission accounting and lost-submission reconciliation. The manager exposes
-`record_lost_submission()` and a stuck-wave reaper
-(`subagent.py:4504-4600`), while the dashboard handler reconciles the roster
+`record_lost_submission()` and a stuck-wave reaper `_sweep_stuck_waves()`
+(`subagent.py`), while the dashboard handler reconciles the roster
 against accepted IDs (`src/kiro_crew/dashboard/handlers/messaging.py:90-202`).
 
 The existing preassigned run ID is an important foundation: `spawn()` assigns
 identity before every exit path and preserves it through queueing
-(`subagent.py:3107-3116`). What is missing is a durable idempotency record that
+(`subagent.py`, the `_preassigned_id` parameter of `spawn()`). What is
+missing is a durable idempotency record that
 makes a repeated submission with the same command key return the same accepted
 decision rather than opening a reconciliation side protocol.
 
@@ -115,7 +117,7 @@ re-admits a cancelled report to orphan recovery. This prevents several local
 races, but completion state and the requirement to deliver it are represented
 by separate in-memory flags plus file-marker ordering. `settle_queued_delivery()`
 must wait for teardown before writing a delivered tombstone
-(`subagent.py:4722-4759`) because that tombstone also suppresses restart
+(`subagent.py`) because that tombstone also suppresses restart
 reconciliation.
 
 A transactional outbox makes the intended contract direct: committing a

--- a/docs/request-for-change/rfc-perpetual-agent.md
+++ b/docs/request-for-change/rfc-perpetual-agent.md
@@ -123,7 +123,7 @@ None of the four can host a perpetual agent as-is:
   cadence is hours to days it is a lost day. Cron's `_is_due` compares `now`
   against the stored deadline (`cron.py:2332`), so the same restart fires
   immediately on recovery. Separately, `binding_key_for` explicitly refuses
-  `cron:` / `hook:` / `subagent:` session keys (`mcp_core.py:3148`), so an
+  `cron:` / `hook:` / `subagent:` session keys (`autonudge.py`), so an
   autonudge loop cannot be bound to a cron-hosted session anyway.
 
 - **Heartbeat** is a tick counter with two unrelated jobs bolted together —
@@ -335,8 +335,9 @@ Guards on `next_wake`:
   (`cron:{job.id}`) and may mutate **only that job**. It is refused outright
   from any non-`cron:` session, and from a subagent, using the strict env-only
   resolution `monitor_start` already uses for the same reason
-  (`mcp_core.py:5754`–`:5761`) — a child process must not be able to PID-walk
-  into its parent's identity and reschedule it.
+  (`mcp_tools/control.py` (`monitor_start`), resolving via `mcp_core.py`
+  (`_resolve_session_key_strict`)) — a child process must not be able to
+  PID-walk into its parent's identity and reschedule it.
 
 ### §4 Cadence discipline — backoff, not a liveness gate
 
@@ -816,14 +817,15 @@ docs and sharper tool descriptions — cheap, and it does not put anyone's
 by a full interval instead of firing on recovery (`autonudge.py:457`), which is
 acceptable for a 5-minute poll and not for a multi-hour cadence. It also
 requires a live nudge-able slot, and `binding_key_for` refuses `cron:` keys
-outright (`mcp_core.py:3148`).
+outright (`autonudge.py`).
 
 ### A long-lived session that loops on `wait`
 
-**Rejected.** `wait` caps at 1800s (`mcp_core.py:4521`) and holds the agent
-subprocess and full context resident for the entire duration
-(`:4525`–`:4577`). A day of "life" costs a day of resident process, and any
-restart loses the pending wake and the turn.
+**Rejected.** `wait` caps at 1800s (`mcp_tools/control.py` (`wait`)) and holds
+the agent subprocess and full context resident for the entire duration, keeping
+the sleep alive with a keepalive ping every `mcp_core.py` `WAIT_PING_SECS`. A
+day of "life" costs a day of resident process, and any restart loses the
+pending wake and the turn.
 
 ### A separate long-running daemon per agent
 
@@ -837,7 +839,8 @@ believed everything was stopped.
 - **Self-rescheduling is self-scoped.** `agent_sleep` resolves its target from
   `KIROCREW_SESSION_KEY` and may write only that job. Strict env-only
   resolution (no PID walk) prevents a subagent from assuming its parent's
-  identity, matching the reasoning already recorded at `mcp_core.py:5761`.
+  identity, matching the reasoning already recorded at `mcp_core.py`
+  (`_resolve_session_key_strict`).
 - **The goal is not agent-writable.** Writes to `LIFE.md` are refused, so an
   agent cannot widen its own mandate. Boundaries live in the same file.
 - **No self-granted authority.** A perpetual agent cannot create another

--- a/docs/request-for-change/rfc-resumable-subagent-sessions.md
+++ b/docs/request-for-change/rfc-resumable-subagent-sessions.md
@@ -36,9 +36,9 @@ The single enforcement point for non-resumability is one tuple entry. `"subagent
 
 | Property | Today | Consequence |
 |---|---|---|
-| Turns | One logical prompt. The retry ladder may re-issue it or send one continuation (`subagent.py:3606-3676`), but nothing carries a *new* instruction | No HTTP route or MCP tool accepts a follow-up message into a run |
-| ACP session id | Persisted to `state.json` under the comment "Record session_id and provider type for session file cleanup" (`subagent.py:3571-3597`) | Read only by deletion paths (`subagent.py:1187-1192`, `subagent_persistence.py:275-280`). The one artifact needed to resume exists so it can be deleted |
-| Transcript | Assistant text chunks only (`subagent.py:3687`), truncated to `RESULT_FILE_MAX_BYTES = 512_000` with an in-file marker (`context_management.py:26,329-352`) | No roles, no prompt, no tool sequence — cannot be rendered as a conversation or replayed into one |
+| Turns | One logical prompt. The retry ladder may re-issue it or send one continuation (`subagent_manager/run.py`, `_stream_with_transient_retry` inside `_run_inner_impl`), but nothing carries a *new* instruction | No HTTP route or MCP tool accepts a follow-up message into a run |
+| ACP session id | Persisted to `state.json` under the comment "Record session_id and provider type for session file cleanup" (the `update_state` call in `subagent_manager/run.py`'s `_run_inner_impl`) | Read only by deletion paths (`subagent.py:1187-1192`, `subagent_persistence.py:275-280`). The one artifact needed to resume exists so it can be deleted |
+| Transcript | Assistant text chunks only (`write_result_chunk`, called from `subagent_manager/run.py`'s `_run_inner_impl` on assistant-text events), truncated to `RESULT_FILE_MAX_BYTES = 512_000` with an in-file marker (`context_management.py:26,329-352`) | No roles, no prompt, no tool sequence — cannot be rendered as a conversation or replayed into one |
 | Prompt | Only the redacted task line, in `state.json` | A run cannot be re-issued from disk |
 | Gateway restart | `_reconcile_orphans` (`subagent.py:1115`) identity-verifies the child PID (`subagent.py:1152-1168`), terminates it, tombstones `gateway_restart`, deletes its kiro session files, notifies the parent | Nothing partial is recoverable |
 | Retention | `mark_delivered` schedules folder pruning after `agent.subagent_result_ttl_secs` (default 3600, `config/loader.py:755-756`) | Within an hour of success nothing recoverable remains |
@@ -98,7 +98,7 @@ Records are written by a dedicated `ConversationLog` rooted at `~/.kiro/crew/sub
 
 Two placement decisions, both load-bearing:
 
-- **Not the chat sessions directory.** `ConversationLog.list_sessions` globs every `*.jsonl` in its root with no prefix filter (`history.py:1406-1424`), and that listing has ten call sites across eight modules — `GET /api/sessions` and `api_sessions_clear` (`dashboard/handlers/sessions.py:401,693`), the `list_sessions` MCP tool (`mcp_core.py:5480`), slot rehydration (`dashboard/chat_persistence.py:326,476`), chat handlers (`dashboard/chat_handlers.py:2252`), folders (`dashboard/chat_folders.py:130`), followup suggestions (`suggestions.py:96`), artifact companion-session resolution (`dashboard/handlers/artifacts.py:696`), and `sync_bridge.py:28` — plus in-class use by `search_sessions` (`history.py:1523,1552`), which is how `search_chat_history` reaches it. Writing records there publishes every run to all of them on day one and puts records inside `api_sessions_clear`'s blast radius.
+- **Not the chat sessions directory.** `ConversationLog.list_sessions` globs every `*.jsonl` in its root with no prefix filter (`history.py:1406-1424`), and that listing has ten call sites across eight modules — `GET /api/sessions` and `api_sessions_clear` (`dashboard/handlers/sessions.py:401,693`), the `list_sessions` MCP tool (`mcp_tools/sessions.py`, `list_sessions`), slot rehydration (`dashboard/chat_persistence.py:326,476`), chat handlers (`dashboard/chat_handlers.py:2252`), folders (`dashboard/chat_folders.py:130`), followup suggestions (`suggestions.py:96`), artifact companion-session resolution (`dashboard/handlers/artifacts.py:696`), and `sync_bridge.py:28` — plus in-class use by `search_sessions` (`history.py:1523,1552`), which is how `search_chat_history` reaches it. Writing records there publishes every run to all of them on day one and puts records inside `api_sessions_clear`'s blast radius.
 - **A sibling of `subagents/`, not a child.** `subagent_persistence` treats every child directory of `_SUBAGENTS_DIR` as a run id (`list_orphans` at `subagent_persistence.py:224-241`, `read_state(d.name)` at `:236`), and `"records"` is a legal id, so `delete_agent_folder("records")` would `rmtree` the store.
 
 Record rows use the existing schema. `tools` carries tool **names in order** (`append` types it `list[str]`, `history.py:1029-1037`); per-call arguments and results are out of scope for v1 (Open question 3).
@@ -108,7 +108,7 @@ Record rows use the existing schema. `tools` carries tool **names in order** (`a
 | When | What |
 |---|---|
 | Record creation (spawn) | Metadata: redacted prompt |
-| ACP session established | Metadata: sid, cwd, provider, agent — written here, not at terminal, so a run orphaned by a restart is still resume-eligible. The same values are already captured in one `update_state` call at `subagent.py:3571-3597` |
+| ACP session established | Metadata: sid, cwd, provider, agent — written here, not at terminal, so a run orphaned by a restart is still resume-eligible. The same values are already captured in one `update_state` call in `subagent_manager/run.py` (`_run_inner_impl`) |
 | Per completed turn | An assistant row, appended and awaited before the turn is acknowledged |
 | Terminal (success, failure, cancel, `_force_reap`, orphan reconcile) | Metadata: tool order, outcome, dropped-row count |
 
@@ -118,7 +118,7 @@ Record rows use the existing schema. `tools` carries tool **names in order** (`a
 
 **Archive pruning must be scoped.** `_cleanup_old_archives` is throttled by a module-global `_last_cleanup` and defaults its window to `session.archive_retention_days` (`history.py:495,511,528`). The record base passes an explicit `retention_days`, and the throttle is keyed per base dir so a record rotation cannot consume the chat store's prune window.
 
-**Redaction** is at write, single-pass, reusing the redactors the run already applies before it stores its task line and streams its result (`subagent.py:2359,2385,2418` for the task; the result path at `subagent.py:3873-3886`). If redaction raises, the row is dropped, the dropped-row count increments, and the record view labels itself incomplete. A record is never written unredacted.
+**Redaction** is at write, single-pass, reusing the redactors the run already applies before it stores its task line and streams its result (`subagent_manager/admission.py`'s `spawn_impl` runs `redact_exfiltration_urls` + `redact_credentials` over the task; the result path applies `subagent.py`'s `_redact` to each assistant chunk in `subagent_manager/run.py`'s `_run_inner_impl`). If redaction raises, the row is dropped, the dropped-row count increments, and the record view labels itself incomplete. A record is never written unredacted.
 
 `result.txt`, `state.json`, and `tombstone.json` keep their current format and role; `result.txt` remains the fast path for `spawn_status` paging/grep and the completion-event pointer. Record-write failures are surfaced through the record's own metadata and the `spawn_status` response — **not** by adding a field to `state.json`.
 
@@ -130,14 +130,14 @@ Keeping the kiro session files means touching **four** unlink sites:
 
 | Unlink site | Reached by |
 |---|---|
-| `AcpSessionHandle._cleanup_transcript` (`acp/session_handle.py:799-814`), via `destroy()` (`:775`) | the session-sharing arm — the default — through `AcpSessionProvider.shutdown` (`acp/session_provider.py:173`) from `subagent.py:2989-2991` |
+| `AcpSessionHandle._cleanup_transcript` (`acp/session_handle.py:799-814`), via `destroy()` (`:775`) | the session-sharing arm — the default — through `AcpSessionProvider.shutdown` (`acp/session_provider.py:173`) from `subagent_manager/run.py`'s `_teardown_run_session_impl` |
 | `AcpSessionProvider.cleanup_session` (`acp/session_provider.py:180-200`) | `SessionManager._safe_cleanup` |
 | `AcpProvider.cleanup_session` (`providers/acp.py:1124-1141`) | `SessionManager._safe_cleanup` |
 | `_cleanup_session_files_sync` (`subagent_persistence.py:293`) | tombstone prune (`:280`) and orphan reconcile (`subagent.py:1187-1195`) |
 
-reached from four subagent call sites: `_teardown_run_session` (`subagent.py:2992`), `_force_reap` (`subagent.py:2035` — the deadline/stop path, exactly the long run retention exists for), tombstone prune, and orphan reconcile.
+reached from four subagent call sites: `_teardown_run_session` (`subagent_manager/run.py`, `_teardown_run_session_impl`), `_force_reap` (`subagent.py:2035` — the deadline/stop path, exactly the long run retention exists for), tombstone prune, and orphan reconcile.
 
-`keep_transcript` cannot be a parameter at the point of call: the shared arm calls the `LLMProvider.shutdown` ABC method, and `destroy()` has seven other callers, all non-subagent background sessions (`acp/session_provider.py:126,138`, `suggestions.py:202`, `llm_helpers.py:299`, `tips.py:759`, `dashboard/handlers/cron.py:141`, `apps/builtins/code_review_sage/sage_lib/review_pool.py:490`). It is therefore **per-session-handle** state, not per-provider — a provider instance serves many sessions, so a sticky provider-level flag would retain unrelated background transcripts on disk. It is set on the run's handle before teardown, consumed by `destroy()`, and cleared in a `finally`. `terminate_session` stays unconditional: it is the RSS reclaim on a multiplexed process (`acp/runtime.py:905-926`), and only the unlink is deferred. `release`'s cleanup is already gated on `_SUBAGENT_PREFIX` (`session.py:3140`), so the dedicated arm's change touches no other caller.
+`keep_transcript` cannot be a parameter at the point of call: the shared arm calls the `LLMProvider.shutdown` ABC method, and `destroy()` has seven other callers, all non-subagent background sessions (`acp/session_provider.py:126,138`, `suggestions.py:202`, `llm_helpers.py:299`, `tips.py:759`, `dashboard/handlers/cron.py:141`, `apps/builtins/code_review_sage/sage_lib/review_pool.py:490`). It is therefore **per-session-handle** state, not per-provider — a provider instance serves many sessions, so a sticky provider-level flag would retain unrelated background transcripts on disk. It is set on the run's handle before teardown, consumed by `destroy()`, and cleared in a `finally`. `terminate_session` stays unconditional: it is the RSS reclaim on a multiplexed process (`acp/runtime.py:905-926`), and only the unlink is deferred. `release`'s cleanup is already gated on `_SUBAGENT_PREFIX` (`session.py`, passed through to `SessionAllocationService.release` in `session_allocation.py`), so the dedicated arm's change touches no other caller.
 
 Retention is a **new** policy, not an inherited one: `_cleanup_old_archives` prunes archives only (`history.py:511-556`) and live session JSONL is never age-pruned. Two config keys: `agent.subagent_record_retention_enabled` (default **off** through Phase 3, flipped on in Phase 4) and `agent.subagent_record_retention_days` (Open question 1). `result.txt` keeps the existing `subagent_result_ttl_secs` lifecycle and expires first.
 
@@ -147,7 +147,7 @@ Retained kiro session files are excluded from `/api/usage`, which counts every `
 
 ### Promotion
 
-Promotion **mints a fresh chat slot through the same slot-creation path the UI uses** and hands it the sid. It does not turn the record into a slot: `_normalize_slot_key` folds `[^\w\-.]` to `_` (`dashboard/state.py:668`) and `_history_key_for` re-namespaces to `dashboard:<slot>` (`dashboard/chat_utils.py:369-375`), so a record-derived slot key would never match the record's identity and `SessionMap.get` could never find the sid. The real slot-creation path is also required for liveness: `_expire_idle` expires any `dashboard:` session whose key is absent from `_active_dashboard_slots` (`session.py:3826-3836`), a set fed only by the dashboard's create/delete/resume/restore path (`session.py:3809-3816`).
+Promotion **mints a fresh chat slot through the same slot-creation path the UI uses** and hands it the sid. It does not turn the record into a slot: `_normalize_slot_key` folds `[^\w\-.]` to `_` (`dashboard/state.py:668`) and `_history_key_for` re-namespaces to `dashboard:<slot>` (`dashboard/chat_utils.py:369-375`), so a record-derived slot key would never match the record's identity and `SessionMap.get` could never find the sid. The real slot-creation path is also required for liveness: `_expire_idle` expires any `dashboard:` session whose key is absent from `_active_dashboard_slots` (`session_cleanup.py`, `SessionCleanup._expire_idle`), a set fed only by the dashboard's create/delete/resume/restore path (`set_active_dashboard_slots`, called from `_sync_dashboard_slots` in `dashboard/chat_utils.py`).
 
 Branch selection is on the **load outcome**, not on pre-checks:
 
@@ -175,7 +175,7 @@ flowchart LR
 
 ### Phase 0: Prove whether `session/load` works for the default path
 
-The resume upgrade assumes a sid created as an extra session on a **parent's** runtime is loadable from a new kiro-cli process after that session is terminated, while the parent process is still alive. Nothing in this repo asserts that: `terminate_session`'s contract is kiro-cli's in-memory session map (`acp/runtime.py:905-926`), and `drain_active_turns` documents kiro-cli releasing an on-disk session lock only on a subsequent SIGTERM (`session.py:2829-2832`).
+The resume upgrade assumes a sid created as an extra session on a **parent's** runtime is loadable from a new kiro-cli process after that session is terminated, while the parent process is still alive. Nothing in this repo asserts that: `terminate_session`'s contract is kiro-cli's in-memory session map (`acp/runtime.py:905-926`), and `drain_active_turns` documents kiro-cli releasing an on-disk session lock only on a subsequent SIGTERM (the `_DRAIN_ACTIVE_TURNS_TIMEOUT_SECS` comment in `session.py`; the drain itself is `drain_active_turns` in `session_lifecycle.py`).
 
 - Manual probe against real kiro-cli: create a shared session, terminate it, keep the files, `session/load` the sid from a second process while the first lives.
 - Deliverable: a **recorded verdict**, plus — if the lock is process-scoped — a decision on whether a lock held by the run's *own parent* relaxes branch 2's refusal into a labelled replay, or stays a refusal.
@@ -226,7 +226,7 @@ Entry blocker: Open question 4 (which records are surfaced) is answered.
 | `/api/usage` | Tallies unchanged; retained kiro session files are excluded in `_parse_sessions` |
 | `_STATELESS_PREFIXES` | Unchanged. `subagent:` stays stateless; execution keys never resume |
 | Session sharing | On by default. No un-promoted run is forced onto a dedicated process. If a negative Phase 0 makes resume dedicated-only, dedicated spawning is opt-in per call, never a default |
-| Concurrency cap and auto-sizing | Unchanged. A record holds no process and no `_Session`, so the idle sweep (`session.py:3818-3865`, which iterates live sessions only) never sees it. A promoted slot counts against the dashboard slot budget, not the subagent cap |
+| Concurrency cap and auto-sizing | Unchanged. A record holds no process and no `_Session`, so the idle sweep (`SessionCleanup._expire_idle` in `session_cleanup.py`, which iterates live sessions only) never sees it. A promoted slot counts against the dashboard slot budget, not the subagent cap |
 | Non-subagent background sessions | Unchanged: `keep_transcript` is per-session-handle, so no background session's transcript is retained as a side effect (Phase 2 criterion) |
 | Dashboard slot filters | Unchanged; records are not slots and add no surface to the three filter predicates |
 

--- a/docs/request-for-change/rfc-s3-backup.md
+++ b/docs/request-for-change/rfc-s3-backup.md
@@ -63,7 +63,7 @@ repository writes crew state to a remote store.
 **P1 — the bundle omits the conversations.** No component stages the transcript
 store `session_storage.py:7-10` documents (`<data home>/sessions/*.jsonl` +
 `sessions/archive/`, resolver `:277`; `<kiro home>/sessions/cli/<sid>.*`, resolver
-`config/paths.py:698`). `uploads/` is excluded outright on the dashboard path
+`config/paths.py` (`kiro_sessions_dir`)). `uploads/` is excluded outright on the dashboard path
 (`portability.py:62`) and absent from `CORE_FILES`; `artifacts/` is in neither.
 Measured on one install: 385 MB irreplaceable (322 MB transcripts, 28 MB uploads,
 22 MB memory DBs, < 2 MB config + artifacts) against a ~30 MB bundle today. Small

--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -21,12 +21,17 @@ and a machine catches for free:
    the reference reads as authoritative while pointing at nothing. This repo
    accumulated several such citations, including a "frozen contract" module
    whose spec and conformance-gate docs were never ported.
+4. **Stale line citations.** A doc points at ``session.py:3356`` of a file that
+   now has 2520 lines. Source moves every day and the citation does not, so it
+   sends the reader to nothing while reading as precise — and when it overshoots
+   the end of the file it is usually because the code moved to another module
+   entirely, which is the part the doc most needs to say.
 
-Checks 1-3 are the structural invariants behind the repository rule that a code
+Checks 1-4 are the structural invariants behind the repository rule that a code
 change must also update the docs and the indexes. The rule is only real if a
 machine enforces it.
 
-The fourth check guards the other direction: some documentation filenames are an
+The fifth check guards the other direction: some documentation filenames are an
 API. ``src/kiro_crew/docs/*.md`` is packaged and read at runtime, and specific
 filenames are hardcoded in Python and TypeScript. Renaming one of those without
 updating its consumers breaks a shipped feature rather than a link.
@@ -196,6 +201,35 @@ _CONFLICT_MARKER_RE = re.compile(r"^(?:[<>|]{7}(?:\s|$)|={7}$)")
 # A documentation path cited from source code, e.g. ``docs/system-specs/x.md``.
 _CODE_DOC_REF_RE = re.compile(r"(?:website/)?docs/[A-Za-z0-9][A-Za-z0-9/_.-]*\.md")
 
+# A SOURCE path cited from documentation -- the opposite direction from
+# ``_CODE_DOC_REF_RE`` -- optionally with a line or line range:
+# ``acp/types.py``, ``session.py:300``, ``sandbox.py:2252-2262``, ``kiro.py:80,90``.
+# Only inside backticks: a bare path in prose is usually a sentence about a
+# directory, and the backticks are what make it a citation.
+_SOURCE_CITE_RE = re.compile(
+    r"`([A-Za-z0-9_][A-Za-z0-9_./-]*\.(?:py|ts|tsx|js|jsx|mjs|yml|yaml|json|sh|toml|cfg))"
+    r"(?::(\d+(?:[-,]\d+)*))?`"
+)
+
+# Trees a cited source path may live in. Deliberately NOT a list of prefixes to
+# join the citation onto: a doc cites a source file relative to whatever root its
+# reader is standing in -- the package (``acp/types.py``), the repo
+# (``scripts/x.py``), the website bundle (``apps/builtinRegistry.ts``, really under
+# ``website/src/``), an app's own root (``providers/pagerduty.py``, really under
+# ``apps/builtins/ops_mission_control/backend/``) or a skill's
+# (``scripts/reaper.sh``). Those roots cannot be enumerated, so the citation is
+# matched as a path SUFFIX against the files that actually exist here, and only a
+# path matching NOTHING is reported.
+_SOURCE_CITE_TREES: tuple[str, ...] = (
+    "src",
+    "website",
+    "scripts",
+    "test",
+    "packaging",
+    ".github",
+)
+
+
 # Citations that look like doc paths but are not references to THIS repo's docs:
 # upstream project paths, and test fixture data that merely contains a filename.
 _CODE_REF_IGNORE_SUBSTRINGS: tuple[str, ...] = (
@@ -242,6 +276,7 @@ class Findings:
     broken_links: list[str] = field(default_factory=list)
     unreachable: list[str] = field(default_factory=list)
     phantom_refs: list[str] = field(default_factory=list)
+    stale_line_cites: list[str] = field(default_factory=list)
     coupling: list[str] = field(default_factory=list)
     missing_index: list[str] = field(default_factory=list)
     changelog_preamble: list[str] = field(default_factory=list)
@@ -252,6 +287,7 @@ class Findings:
             len(self.broken_links)
             + len(self.unreachable)
             + len(self.phantom_refs)
+            + len(self.stale_line_cites)
             + len(self.coupling)
             + len(self.missing_index)
             + len(self.changelog_preamble)
@@ -348,6 +384,43 @@ def _resolve_link(doc: Path, target: str, root: Path) -> Path | None:
         # Root-relative links are resolved against the repo root.
         return (root / clean.lstrip("/")).resolve()
     return (doc.parent / clean).resolve()
+
+
+def _source_file_index(root: Path) -> dict[str, list[Path]]:
+    """Every source file in the scanned trees, keyed by each of its path suffixes.
+
+    Built once per run and cached on the function, because the citation check asks
+    "does any file end with this path" for a few hundred citations and walking the
+    trees per citation would make the gate the slowest thing in CI.
+    """
+    cached = getattr(_source_file_index, "_cache", None)
+    if cached is not None and cached[0] == root:
+        return cached[1]
+    index: dict[str, list[Path]] = {}
+    for tree in _SOURCE_CITE_TREES:
+        base = root / tree
+        if not base.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            _prune(root, dirpath, dirnames)
+            for name in sorted(filenames):
+                path = Path(dirpath) / name
+                parts = _rel(path, root).split("/")
+                # Register every suffix, so a citation from any root matches.
+                for start in range(len(parts)):
+                    index.setdefault("/".join(parts[start:]), []).append(path)
+    _source_file_index._cache = (root, index)  # type: ignore[attr-defined]
+    return index
+
+
+def _resolve_source_cite(root: Path, ref: str) -> list[Path]:
+    """Files whose path ends with ``ref``. Empty means the citation names nothing.
+
+    More than one match is normal and is not a finding: ``app.json`` is a real
+    filename in several builtin apps, and a doc naming it is not wrong just
+    because it did not say which one.
+    """
+    return _source_file_index(root).get(ref.lstrip("./"), [])
 
 
 def _read(path: Path) -> str:
@@ -556,6 +629,99 @@ def check_code_citations(root: Path, findings: Findings) -> None:
                         findings.phantom_refs.append(f"{rel_path}:{lineno} -> {ref}")
 
 
+def check_source_citations(root: Path, docs: list[Path], findings: Findings) -> None:
+    """A line number a doc cites must be inside the file it names.
+
+    ``check_code_citations`` guards code -> docs. This guards docs -> code, which
+    rots faster and more quietly: source moves every day, and a doc that says
+    "see ``session.py:3356``" of a 2520-line file sends the reader to nothing while
+    reading as precise. Exactly one claim here is decidable without judgement --
+    the cited line exists -- and that is the whole check.
+
+    A citation is matched as a path SUFFIX against the files that exist, because a
+    doc cites relative to whatever root its reader stands in: the package
+    (``acp/types.py``), the repo (``scripts/x.py``), the website bundle
+    (``apps/builtinRegistry.ts``, really under ``website/src/``), an app's own root
+    (``providers/pagerduty.py``) or a skill's (``scripts/reaper.sh``). Those roots
+    cannot be enumerated. Several matches is normal and not a finding: ``app.json``
+    is a real filename in two dozen builtin apps, and the citation is wrong only
+    when the line is past the end of EVERY candidate.
+
+    Two neighbouring checks were built, measured against the real tree, and left
+    OUT -- recorded here so nobody re-adds one believing it was merely forgotten.
+
+    An unresolvable PATH is not reported here. Four narrowings each left a
+    different family of false positives: bare template names in the app-kit docs
+    (1960 hits), design docs listing files they propose to create (48, then 78 -- a
+    file list in a table cell carries no "proposes" verb to detect it by), runtime
+    data in the user's ``~/.kiro/crew`` (637, and still ``data/config.json`` at 52),
+    and third-party layouts (``zoneinfo/__init__.py``,
+    ``playwright-core/browsers.json``).
+
+    That class IS shippable, and the shape was measured rather than guessed, so it
+    is recorded here for whoever picks it up. What separates a stale citation from a
+    correct unresolvable one is not the path's SHAPE but the doc's GENRE: an RFC, a
+    plan and a migration design name files precisely because they do not exist
+    (``browser/setup.py`` sits in a "what is deleted" table; ``notifications/
+    bridge.py`` sits next to the words "zero implementation code exists"), while a
+    module spec names files it claims are there now. A pattern allowlist provably
+    cannot draw that line -- ``browser/**`` would have to be allowlisted to silence
+    four deletion-table entries, and the same pattern suppresses four of the real
+    findings. Scoping the class to ``docs/system-specs/modules/`` leaves 19 findings
+    of which 11 are real, and the 8 residuals collapse to three refs confined to
+    that tree (``data/*``, ``config/*``, ``src/index.*``). Scope plus those three:
+    11 findings, no false positives.
+
+    A cited SYMBOL is not checked either. A table row pairs independent columns --
+    ``docs/architecture/mcp.md`` lists a server, its entry point
+    ``mcp_computer.py``, and its tool names, which really live in
+    ``computer_use/cli.py`` -- so same-line adjacency is not a claim about where a
+    name is defined. Dropping adjacency to ask only "does this identifier exist
+    anywhere" flags every name an RFC proposes: 572 hits repo-wide, ~100 in one
+    RFC, nearly all correct writing about code that does not exist yet.
+
+    Both gaps are the same judgement: a check whose findings are mostly false
+    trains a maintainer to skim past the gate, which costs more than the gap.
+
+    The line check is honest about its own reach too -- it catches a citation
+    pointing PAST the end of a file, never one that has drifted to the wrong line
+    inside it. That is the argument for citing a symbol NAME wherever a doc can: a
+    name survives the refactor that moves the line.
+    """
+    for doc in docs:
+        rel_doc = _rel(doc, root)
+        if _is_uncurated(rel_doc):
+            continue
+        try:
+            text = _read(doc)
+        except OSError:
+            continue
+        # A fenced block is sample code or terminal output, not a citation.
+        for lineno, line in enumerate(_strip_fences(text).splitlines(), start=1):
+            for match in _SOURCE_CITE_RE.finditer(line):
+                ref, lines = match.group(1), match.group(2)
+                if not lines:
+                    # A path with no line number makes no checkable claim here.
+                    # Reporting an unresolvable one was measured and left out --
+                    # see this function's docstring.
+                    continue
+                targets = _resolve_source_cite(root, ref)
+                if not targets:
+                    continue
+                cited = max(int(n) for n in re.split(r"[-,]", lines))
+                # With several candidates the citation is only wrong when the line
+                # is past the end of EVERY one of them: any file that is long
+                # enough is a reading on which the citation makes sense.
+                lengths = {t: len(_read(t).splitlines()) for t in targets}
+                if any(total >= cited for total in lengths.values()):
+                    continue
+                longest = max(lengths, key=lambda t: lengths[t])
+                findings.stale_line_cites.append(
+                    f"{rel_doc}:{lineno} -> {ref}:{lines} "
+                    f"but {_rel(longest, root)} has {lengths[longest]} line(s)"
+                )
+
+
 def check_code_coupled_docs(root: Path, findings: Findings) -> None:
     """Docs whose filenames are hardcoded in code must still exist.
 
@@ -617,6 +783,7 @@ def run(root: Path) -> Findings:
     check_changelog_preambles(root, docs, findings)
     check_conflict_markers(root, docs + entry_points, findings)
     check_code_citations(root, findings)
+    check_source_citations(root, docs, findings)
     check_code_coupled_docs(root, findings)
     return findings
 
@@ -652,6 +819,11 @@ def _report(findings: Findings, doc_count: int) -> int:
         "documentation paths cited from code that do not exist",
         findings.phantom_refs,
         "write the missing doc, or correct the citation",
+    )
+    _emit(
+        "line citations pointing past the end of the file",
+        findings.stale_line_cites,
+        "cite a symbol name instead: a name survives the refactor that moves the line",
     )
     _emit(
         "code-coupled docs missing",
@@ -767,6 +939,36 @@ def _self_test() -> int:
         )
         return "phantom_refs"
 
+    def plant_stale_line_cite(root: Path) -> str:
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text("# Ok\n\nSee `small.py:900`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
+    def plant_stale_line_cite_in_an_rfc(root: Path) -> str:
+        # The path exemption above must NOT carry the line check with it: a line
+        # number is a claim about code that exists now, even inside a proposal.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        rfc = root / "docs" / "request-for-change"
+        rfc.mkdir()
+        (root / "docs" / "README.md").write_text(
+            "# Docs\n\n- [Ok](ok.md)\n- [Rfc](request-for-change/rfc-x.md)\n", encoding="utf-8"
+        )
+        (rfc / "rfc-x.md").write_text("# Rfc\n\nToday: `small.py:900`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
+    def plant_stale_line_range(root: Path) -> str:
+        # The END of a range is what must be inside the file: a range whose start
+        # is valid and whose end is past EOF is still a citation into nothing.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text("# Ok\n\nSee `small.py:1-40`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
     def plant_coupling(root: Path) -> str:
         pkg = root / "src" / "kiro_crew"
         pkg.mkdir(parents=True)
@@ -793,6 +995,54 @@ def _self_test() -> int:
             else:
                 print(f"  ok  {label} ignored")
 
+    def source_cite_immunity_probe(label: str, build) -> None:
+        """Assert a legitimate citation shape is NOT reported.
+
+        Each shape here was MEASURED as a false positive on the real tree before
+        its exemption existed, so the probe records the evidence rather than a
+        hunch -- and pins the exemption so a later widening of the rule fails here
+        instead of burying the real findings again.
+        """
+        nonlocal failures
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir(parents=True)
+            (root / "docs" / "README.md").write_text("# Docs\n\n- [Ok](ok.md)\n", encoding="utf-8")
+            (root / "docs" / "ok.md").write_text("# Ok\n\nBody.\n", encoding="utf-8")
+            field = build(root)
+            if getattr(run(root), field):
+                print(f"  FAIL {label} was flagged")
+                failures += 1
+            else:
+                print(f"  ok  {label} ignored")
+
+    def allow_unresolvable_path(root: Path) -> str:
+        # Deliberate gap, pinned: a path that resolves nowhere is NOT reported.
+        # Four measured rounds could not separate real rot from runtime and vendor
+        # paths without a curated allowlist; see check_source_citations.
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\nState lives in `cron/jobs.json` and `acp/ghost.py`.\n", encoding="utf-8"
+        )
+        return "stale_line_cites"
+
+    def allow_fenced_sample(root: Path) -> str:
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\n```\nsee `small.py:900`\n```\n", encoding="utf-8"
+        )
+        return "stale_line_cites"
+
+    def allow_in_range_cite(root: Path) -> str:
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\nSee `small.py:2` and `small.py:1-3`.\n", encoding="utf-8"
+        )
+        return "stale_line_cites"
+
     print("Running docs-lint self-test...")
     clean_probe()
     probe("broken link", plant_broken_link)
@@ -803,10 +1053,16 @@ def _self_test() -> int:
     probe("conflict marker (bare separator)", plant_conflict_marker)
     probe("conflict marker (full three-way)", plant_conflict_marker_head)
     probe("conflict marker (uncurated tree)", plant_conflict_marker_uncurated)
+    probe("line citation past EOF", plant_stale_line_cite)
+    probe("line citation past EOF inside an RFC", plant_stale_line_cite_in_an_rfc)
+    probe("line RANGE ending past EOF", plant_stale_line_range)
     probe("phantom spec citation", plant_phantom_ref)
     probe("code-coupled doc missing", plant_coupling)
 
     # Code-markup immunity is an inverse assertion (nothing should fire).
+    source_cite_immunity_probe("unresolvable path (deliberate gap)", allow_unresolvable_path)
+    source_cite_immunity_probe("fenced sample citation", allow_fenced_sample)
+    source_cite_immunity_probe("in-range line citation", allow_in_range_cite)
     code_immunity_probe("fenced example link", "# Ok\n\n```md\n[example](does-not-exist.md)\n```\n")
     code_immunity_probe("inline-code example link", "# Ok\n\nSpoken as `[label](url)` aloud.\n")
     code_immunity_probe(


### PR DESCRIPTION
## Problem / Motivation

Documentation cites source by line number, and source moves every day. The citation does not, so it rots silently and keeps reading as precise. Five RFCs currently point at `session.py:3356`, `mcp_core.py:5754` and `subagent.py:4722-4759` in files that now have 2520, 2085 and 2366 lines — 26 citations that send the reader to nothing.

Nothing notices. `scripts/docs_lint.py` already guards code → docs (a comment citing a spec path must resolve). The reverse direction — a doc citing source — was unguarded.

## Why it matters

The 26 stale citations are the visible half. The invisible half is what they were hiding: **eight of them pointed at code that had moved MODULE, not just line.** `binding_key_for` is in `autonudge.py`, not `mcp_core.py`. `monitor_start` and `wait` are in `mcp_tools/control.py`. The `_proc` / `_active_proc` probes moved to `session_pid.py` when #6921 split `SessionManager`. Most of the resumable-subagent citations now land in `subagent_manager/run.py`, `session_cleanup.py` and `session_lifecycle.py` behind one-line facades.

A reader following `mcp_core.py:5754` does not learn that the tool now lives in another module — they learn nothing at all, and the doc keeps its authority. A line number cannot carry that fact. A module plus a symbol can, and it survives the next refactor.

## What changed (motivation → approach → change)

**Motivation → approach.** The rule has to be enforceable before the citations are worth fixing, so the check lands with its own findings already at zero.

**Change.**

- **`scripts/docs_lint.py` — new `check_source_citations`**, a sibling of `check_code_citations` in the same file rather than a new script: same `Findings`, same `--test`, same reporting, already wired into CI.
  - A citation is matched as a path **suffix** against the files that exist, because a doc cites relative to whatever root its reader stands in — the package (`acp/types.py`), the repo (`scripts/x.py`), the website bundle (`apps/builtinRegistry.ts`, really under `website/src/`), an app's own root (`providers/pagerduty.py`) or a skill's (`scripts/reaper.sh`). Those roots cannot be enumerated, and a fixed base list reported 5 false positives in `website/docs/` alone.
  - Several matches is normal and **not** a finding: `app.json` is a real filename in two dozen builtin apps. The citation is wrong only when the line is past the end of *every* candidate.
  - A fenced block is sample output, not a citation, so fences are stripped first.
- **The 26 citations fixed** across five RFCs, each line number replaced with a symbol name. Every one of the **42 symbols written was grep-verified** against the file it names before it was committed.
- **`.github/workflows/ci.yml`** — the `Lint documentation trees` step comment enumerates what the blocking gate covers; a check it does not mention reads as not covered. One comment line, no behaviour change: the job already runs `--test` then `docs-lint.sh`.

### Two checks measured and deliberately left out

Both are recorded in `check_source_citations` with their measured counts, so nobody re-adds one believing it was merely forgotten.

**An unresolvable PATH.** Four narrowings, each leaving a different family of false positives:

| rule | findings |
|---|---|
| raw | 1960 (bare template names in the app-kit docs) |
| + require the parent directory to exist | 48 (design docs listing files they propose) |
| + suffix match from any root | 637 (runtime data in the user's `~/.kiro/crew`) |
| + require a directory component | 78 (design docs again — no verb to detect them by) |
| + exempt proposal trees | 52 (runtime data *with* a directory, plus vendor layouts) |

What separates real rot from a correct unresolvable path is the doc's **genre**, not the path's shape: `browser/setup.py` sits in a "what is deleted" table, and `notifications/bridge.py` sits next to the words "zero implementation code exists". A pattern allowlist provably cannot draw that line — `browser/**` would silence four deletion-table entries *and* four of the real findings. Scoping the class to `docs/system-specs/modules/` plus three refs (`data/*`, `config/*`, `src/index.*`) gives **11 findings, 0 false positives**. That is the follow-up, measured rather than guessed.

**A cited SYMBOL.** A table row pairs independent columns — `docs/architecture/mcp.md` lists a server, its entry point `mcp_computer.py`, and its tool names, which really live in `computer_use/cli.py` — so same-line adjacency is not a claim about where a name is defined. Dropping adjacency to ask only "does this identifier exist anywhere" flags every name an RFC *proposes*: 572 repo-wide, ~100 in one RFC, nearly all correct writing about code that does not exist yet.

Both gaps are one judgement: a check whose findings are mostly false trains a maintainer to skim past the gate, which costs more than the gap it closes.

## Tests

The gate's own `--test` grows from 15 probes to 22, and runs before the gate in the same CI step per `docs/ci/harness-parity-gate.md`.

Three probes plant a defect the check must catch:

- a single line number past EOF
- a **range whose end** is past EOF while its start is valid
- a stale line citation **inside an RFC** — the path-class exemption must not carry the line check with it

Two pin the deliberate gaps, so re-widening the rule fails here rather than quietly burying the real findings again:

- an unresolvable path is **not** reported
- an in-range citation, single and range, is not reported

Plus the pre-existing fenced-sample immunity probe, which keeps a `` `small.py:900` `` inside a code fence from being read as a citation.

There is no pytest file for this linter by design: the self-test *is* the harness, and CI runs it as its own step.

## Manual verification

```
$ python3 scripts/docs_lint.py --test
  ok  line citation past EOF detected
  ok  line RANGE ending past EOF detected
  ok  line citation past EOF inside an RFC detected
  ok  unresolvable path (deliberate gap) ignored
  ok  in-range line citation ignored
Self-test passed

$ python3 scripts/docs_lint.py
docs-lint: scanned 245 markdown files under docs, src/kiro_crew/docs, website/docs

All documentation checks passed
```

Before the citation fixes the same command reported 26 findings in five files, so the check is proven to fail as well as to pass on this tree.

Also green locally: `./scripts/docs-lint.sh`, `check_brand_name.py`, `check_changelog_history.py`, `check_black_formatting.py`, `isort --check-only`, `flake8`, `mypy`, and `ci.yml` parses. The linter is stdlib-only and CI runs it on `ubuntu-latest`'s system `python3` with no `setup-python`, so it was verified under **both 3.9 and 3.12**.

Every symbol written into the five docs was verified present in the file it names by a script that greps each one; all 42 pass.

## Screenshots / video

n/a — no user-visible surface.

## Related Issues

No linked issue: this is a docs-hygiene gate found while fixing citations for the agent-SDK boundary work. The #6921 and #6939 references above are history, not work this PR closes. The follow-up recorded in `check_source_citations` (path class scoped to `docs/system-specs/modules/`, 11 real findings) is the natural next PR.

## Checklist

- [x] Gate self-tests before it runs, per `docs/ci/harness-parity-gate.md`
- [x] The gate's own findings are at zero on this branch, so it lands enforcing
- [x] Deliberate gaps are documented with their measured counts and pinned by probes
- [x] Every symbol written into a doc was verified present in the file it names
- [x] Verified under both Python 3.9 and 3.12 (CI uses the system `python3`)
- [x] No behaviour change outside the linter; no product code touched
- [x] Lint, format, type, and doc gates green locally

## Contribution License Agreement

By submitting this pull request I confirm that my contribution is made under the terms of the project's license.
