### PR TITLE
feat(skills): add explain-for skill with a measured eval harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ SESSION_SUMMARY.md
 # Internal migration worklog — deliberately untracked (contains pre-scrub notes)
 MOCHI_MIGRATION.md
 website/.vitest-reports/
+
+# Skill eval A/B outputs (regenerated per run; not review artifacts)
+evals/*/iteration-*/

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,107 @@
+# Skill evaluations
+
+Measured checks on bundled skills, one directory per skill.
+
+A skill is a prompt, and a prompt cannot be reviewed for correctness by reading
+it. These harnesses answer two questions a code review cannot:
+
+1. **Does the skill load when trigger matching is on?** Word-overlap trigger
+   matching is **opt-in**: `skills.max_triggered` defaults to `0`, which disables
+   it entirely, and the default discovery route is the Available Skills index plus
+   `skill_search` / `$skillname`. For an install that has turned it on
+   (`max_triggered > 0`), a skill auto-injects only when one of its `triggers`
+   phrases clears `_MIN_TRIGGER_OVERLAP` (0.7) — and beautiful guidance behind a
+   trigger that never fires is invisible dead weight for that whole population.
+   This is deterministic, so it is a CI gate.
+
+2. **Does the skill change the answer?** Each prompt is answered twice, once with
+   the skill body prepended and once bare, and both are graded against explicit
+   per-case assertions. This needs a model, so it is a local command, not a gate.
+
+What this does **not** cover is the default path. There, a skill is found through
+its `description`, which the generic bundled-skill frontmatter test already pins.
+
+## Layout
+
+```
+evals/<skill>/cases.json      prompts, expected audience/behaviour, assertions
+evals/<skill>/run_evals.py    --check (deterministic) and --run (A/B)
+evals/<skill>/iteration-N/    A/B outputs and grading, auto-incremented, gitignored
+```
+
+## Running
+
+```bash
+# Deterministic validation. No model, no tokens. What CI runs.
+python3 evals/explain-for/run_evals.py --check -v
+
+# The A/B measurement. Needs an agent CLI on PATH.
+python3 evals/explain-for/run_evals.py --run
+
+# One case, skill lane only
+python3 evals/explain-for/run_evals.py --run --test=2 --with-skill-only
+```
+
+`--run` re-runs `--check` first and refuses to spend tokens on an inconsistent
+case set. The CLI defaults to `kiro-cli chat --no-interactive --trust-tools=`;
+override with `EXPLAIN_FOR_EVAL_CLI`.
+
+## Adding a case
+
+Append to the `cases` array:
+
+```json
+{
+  "id": 13,
+  "name": "explain-oauth-partner",
+  "prompt": "Explain this to my wife: why login broke on her phone",
+  "audience": "Partner",
+  "expect_trigger": true,
+  "assertions": [
+    "Analogy comes from a shared daily routine, not from software",
+    "Explains that the phone held an expired key",
+    "Warm and patient in register",
+    "No jargon -- no 'token', 'session', or 'refresh'"
+  ]
+}
+```
+
+`audience` must match a row label in the skill's own audience tables, and the
+prompt must clear the trigger threshold — `--check` fails the case otherwise
+rather than letting it silently measure nothing.
+
+Set `expect_trigger: false` for a **control**: a prompt that contains explanation
+vocabulary but is not an audience request. Those pin the upper bound on trigger
+looseness, so a future widened trigger fails a test instead of quietly re-pitching
+ordinary questions.
+
+Do **not** reuse a prompt the skill spells out in its own "Worked shapes" section.
+The skill body is injected ahead of the prompt, so a duplicated example is already
+answered in the with-skill lane's context: the lane wins on recall and tells you
+nothing about unseen phrasing. `--check` fails the case for this, so the two files
+cannot silently converge as either one is edited.
+
+Four assertions per case works well. Write them as things a grader can point at
+in the text, not as tastes.
+
+## A longer trigger is LOOSER, not tighter
+
+Worth knowing before editing a skill's `triggers` line, because it reads backwards.
+Matching scores `|trigger_words ∩ message_words| / |trigger_words|` against a `0.7`
+floor — the threshold is a *fraction of the trigger*, so adding words buys slack:
+
+| Trigger length | Words that must appear | Effect |
+|---|---|---|
+| 1-3 words | all of them | exact; the phrase means what it says |
+| 4 words | any 3 | one word is optional, and you do not choose which |
+| 5 words | any 4 | same, one slot free |
+
+So `explain it to my` never actually required `my`: `{explain, it, to}` alone scores
+0.75 and fires, which matched "can you explain it to me" — an ordinary request with
+no audience in it at all. Collapsing it to the 3-word `explain to my` makes the
+possessive mandatory again and drops that prompt to 0.67. `break this down for` had
+the identical flaw (bare "break this down" scored 0.75) and became `break down for`.
+
+The rule: if one word in a trigger is the part carrying the meaning, the trigger has
+to be short enough that that word cannot be the one dropped. Control cases are how
+you find out you got it wrong.

--- a/evals/explain-for/cases.json
+++ b/evals/explain-for/cases.json
@@ -1,0 +1,222 @@
+{
+  "skill": "explain-for",
+  "notes": [
+    "Each case is one user prompt plus the audience the skill is expected to resolve,",
+    "and the assertions a graded answer must satisfy. 'audience' must appear verbatim",
+    "as a row label in the skill's audience tables -- run_evals.py --check enforces that,",
+    "so a case can never test an audience the skill does not define.",
+    "expect_trigger=false marks a control case: the prompt contains the word 'explain'",
+    "but is NOT an audience request, so the trigger phrases must NOT fire on it."
+  ],
+  "cases": [
+    {
+      "id": 1,
+      "name": "queue-age5",
+      "prompt": "Explain like I am five what a message queue is",
+      "audience": "Age 5",
+      "expect_trigger": true,
+      "assertions": [
+        "Contains no technical jargon at all (no 'broker', 'consumer', 'enqueue', 'throughput')",
+        "Uses a concrete physical analogy a small child has touched, not an abstract one",
+        "Conveys waiting in order -- first in is first served",
+        "Warm and delighted in tone, never a definition read aloud"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "rate-limit-manager",
+      "prompt": "Explain this rate limiting to my manager",
+      "audience": "Manager",
+      "expect_trigger": true,
+      "assertions": [
+        "Leads with user or business impact, not with mechanism",
+        "Names a cost, a timeline, or a risk in concrete terms",
+        "Ends on a decision that is the manager's to make",
+        "Does not walk through implementation detail unless asked"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "recursion-age15",
+      "prompt": "Break this recursion down for a 15 year old",
+      "audience": "Age 15",
+      "expect_trigger": true,
+      "assertions": [
+        "Correctly conveys that a function calls itself",
+        "Mentions a base case or stopping condition",
+        "Analogy comes from phones, games, or social apps rather than office work",
+        "Casual register without performed teen slang"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "cache-invalidation-default",
+      "prompt": "Dumb it down: why does cache invalidation keep going wrong",
+      "audience": "Age 5",
+      "expect_trigger": true,
+      "assertions": [
+        "Defaults to the simplest audience because the phrasing asks for the plainest possible framing and names nobody",
+        "Explains staleness -- something kept after it stopped being true",
+        "Zero jargon; no 'TTL', 'eviction', or 'coherence'",
+        "Does not ask the user which audience to use, because the phrasing already answered that"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "migration-parent",
+      "prompt": "Explain this database migration to my mom",
+      "audience": "Parents",
+      "expect_trigger": true,
+      "assertions": [
+        "Respectful throughout, with no trace of talking down",
+        "Analogy drawn from home life or technology she already uses",
+        "Conveys that the data moved shape without naming schema mechanics",
+        "Warm, conversational register rather than a lecture"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "load-429-designer",
+      "prompt": "Simplify this for a designer: the API returns 429 under load",
+      "audience": "Designer",
+      "expect_trigger": true,
+      "assertions": [
+        "Frames the failure as what the user perceives, not as an HTTP status",
+        "Says something about the interaction or flow that breaks",
+        "Suggests or implies a design response, such as feedback or a retry state",
+        "Avoids backend implementation detail"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "eventual-consistency-graduate",
+      "prompt": "Explain eventual consistency in plain english for a graduate seminar",
+      "audience": "Graduate",
+      "expect_trigger": true,
+      "assertions": [
+        "Uses correct terminology rather than avoiding it",
+        "Engages a trade-off, a bound, or an edge case instead of only defining the term",
+        "Assumes distributed-systems foundations already held",
+        "Stays precise -- no analogy that misstates the guarantee"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "merge-conflict-age5",
+      "prompt": "Explain like I am 5 how git merge conflicts happen",
+      "audience": "Age 5",
+      "expect_trigger": true,
+      "assertions": [
+        "Conveys two people changing the same thing at once",
+        "No version-control vocabulary at all",
+        "Analogy uses objects or people a child knows",
+        "Short, playful, and encouraging"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "incident-support",
+      "prompt": "Break this incident down for our support team",
+      "audience": "Support",
+      "expect_trigger": true,
+      "assertions": [
+        "Describes the observable symptom a user would report first",
+        "Says how to recognise or confirm the case",
+        "States what support should actually do or say",
+        "Does not require reading code to be actionable"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "slip-director",
+      "prompt": "Explain it to my director why the migration slipped two weeks",
+      "audience": "Director",
+      "expect_trigger": true,
+      "assertions": [
+        "Frames the slip against strategy or resource allocation, not task mechanics",
+        "Honest about the cause without burying it in detail",
+        "States the consequence for the plan going forward",
+        "Ends on what is being asked of or decided by the director"
+      ]
+    },
+    {
+      "id": 16,
+      "name": "control-ci-question",
+      "prompt": "Can you explain for a second why the CI job failed",
+      "expect_trigger": false,
+      "assertions": [
+        "Answers the CI question directly",
+        "Does not pitch the answer at a child or any other audience level"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "retry-flow-like-a-manager",
+      "prompt": "explain it to me like a manager: how the retry backoff works",
+      "audience": "Manager",
+      "expect_trigger": true,
+      "assertions": [
+        "Leads with what the retry behaviour costs or risks, not with the algorithm",
+        "Frames it as a decision or an expectation a manager can hold",
+        "Draws a diagram only if it shows the sequence, and does not draw an architecture diagram",
+        "Avoids implementation vocabulary like 'jitter' or 'exponential' without a plain gloss"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "lifecycle-diagram-engineer",
+      "prompt": "Explain this session lifecycle to my teammate, an engineer",
+      "audience": "Engineer",
+      "expect_trigger": true,
+      "assertions": [
+        "Uses a diagram, because a lifecycle is a sequence of states",
+        "The diagram is a mermaid or excalidraw fence rather than ASCII art",
+        "The prose carries what the diagram cannot, instead of restating the boxes",
+        "Uses real terminology without apologising for it"
+      ]
+    },
+    {
+      "id": 17,
+      "name": "slow-query-middle-school",
+      "prompt": "explain like im in middle school why this query is slow",
+      "audience": "Middle school",
+      "expect_trigger": true,
+      "assertions": [
+        "Introduces any technical term together with its definition rather than assuming it",
+        "Walks the reason step by step instead of stating a conclusion",
+        "Uses a concrete example of the work the database is doing",
+        "Does not drop to Age-5 register -- the reader can follow cause and effect"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "control-commit-diff",
+      "prompt": "Explain the difference between these two commits",
+      "expect_trigger": false,
+      "assertions": [
+        "Compares the commits directly",
+        "Does not introduce an audience calibration the user never asked for"
+      ]
+    },
+    {
+      "id": 14,
+      "name": "control-explain-it-to-me",
+      "prompt": "Can you explain it to me",
+      "expect_trigger": false,
+      "assertions": [
+        "Explains the thing under discussion directly",
+        "Does not pitch the answer at a child or ask which audience to use"
+      ]
+    },
+    {
+      "id": 15,
+      "name": "control-break-this-down",
+      "prompt": "Break this down",
+      "expect_trigger": false,
+      "assertions": [
+        "Breaks the subject down at the level the conversation is already using",
+        "Does not pitch the answer at a named audience"
+      ]
+    }
+  ]
+}

--- a/evals/explain-for/run_evals.py
+++ b/evals/explain-for/run_evals.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Evaluate the ``explain-for`` skill.
+
+Two modes, because only one of them can run in CI:
+
+``--check`` (default)
+    Deterministic. No model, no network. Validates that the case set and the
+    skill agree with each other, and -- the load-bearing part -- that every
+    prompt actually *reaches* the skill through Crew's word-overlap trigger
+    matching. A well-written skill nobody triggers is worth nothing, and that
+    failure is invisible to a prose review. Exits non-zero on any problem, so a
+    test can gate on it.
+
+``--run``
+    The A/B measurement: each prompt answered twice, once with the skill body
+    prepended and once bare, then both graded against the case's assertions by
+    the same CLI acting as judge. Needs a working agent CLI and costs tokens, so
+    it is a local command, not a CI gate. Results land in ``iteration-N/``.
+
+Stdlib only, Python 3.8+, subprocess called with argument lists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+SKILL_FILE = REPO_ROOT / "src" / "kiro_crew" / "builtin_skills" / "explain-for" / "SKILL.md"
+CASES_FILE = HERE / "cases.json"
+
+# Crew's own trigger threshold. Imported when the package is importable so the
+# gate cannot silently drift from the loader; the literal is the fallback for a
+# bare checkout.
+_FALLBACK_MIN_OVERLAP = 0.7
+
+DEFAULT_CLI = ["kiro-cli", "chat", "--no-interactive", "--trust-tools="]
+DEFAULT_TIMEOUT = 300
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+
+
+def min_trigger_overlap() -> float:
+    try:
+        from kiro_crew.skills import _MIN_TRIGGER_OVERLAP  # type: ignore
+
+        return float(_MIN_TRIGGER_OVERLAP)
+    except Exception:
+        return _FALLBACK_MIN_OVERLAP
+
+
+def read_skill() -> Tuple[Dict[str, str], str]:
+    """Return (frontmatter, body) for the skill under test."""
+    text = SKILL_FILE.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise SystemExit(f"{SKILL_FILE}: no YAML frontmatter")
+    end = text.find("\n---", 3)
+    if end == -1:
+        raise SystemExit(f"{SKILL_FILE}: unterminated frontmatter")
+    meta: Dict[str, str] = {}
+    for line in text[3:end].splitlines():
+        if ":" in line and not line.startswith((" ", "\t", "#")):
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    body = text[end + 4 :].lstrip("\n")
+    return meta, body
+
+
+def audience_labels(body: str) -> List[str]:
+    """First-column labels of the skill's AUDIENCE tables.
+
+    Scoped to tables whose header row's first cell is literally ``Audience``.
+    An earlier version collected the first column of *every* markdown table in
+    the body, which silently absorbed any other table the skill grew -- the
+    diagram "does this have a shape?" table, for instance -- so a case could
+    declare an audience like "A definition, a single fact" and pass the
+    coherence check against a row that is not an audience at all.
+    """
+    labels: List[str] = []
+    in_audience_table = False
+    for line in body.splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            in_audience_table = False  # any non-table line ends the current table
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if not cells or not cells[0]:
+            continue
+        first = cells[0]
+        if set(first) <= set("-: "):
+            continue  # separator row, keeps whatever scope the header set
+        if first.lower() == "audience":
+            in_audience_table = True
+            continue
+        if first.lower().startswith("the thing") or not in_audience_table:
+            in_audience_table = False
+            continue
+        labels.append(first)
+    return labels
+
+
+def parse_triggers(meta: Dict[str, str]) -> List[str]:
+    raw = meta.get("triggers", "")
+    return [t.strip().lower() for t in raw.split(",") if t.strip()]
+
+
+def worked_shape_prompts(body: str) -> List[str]:
+    """The example prompts the skill spells out in its own "Worked shapes" section.
+
+    An eval prompt that duplicates one of these measures recall, not skill: the
+    skill body is injected ahead of the prompt, so the answer is already in the
+    context and the with-skill lane wins for a reason the skill would not
+    reproduce on unseen phrasing.
+    """
+    section: List[str] = []
+    inside = False
+    for line in body.splitlines():
+        if line.strip().startswith("## "):
+            inside = "worked shape" in line.lower()
+            continue
+        if inside:
+            section.append(line)
+    return [m.strip().lower() for m in re.findall(r'\*\*"([^"]+)"\*\*', "\n".join(section))]
+
+
+def best_overlap(prompt: str, triggers: Sequence[str]) -> Tuple[float, Optional[str]]:
+    """Crew's scoring: per-phrase word-set overlap, best phrase wins.
+
+    Mirrors ``SkillsLoader.get_triggered_skills``. Negative (``!``) triggers are
+    honoured as an immediate exclusion.
+    """
+    text_words = set(re.findall(r"\w+", prompt.lower()))
+    best = 0.0
+    winner: Optional[str] = None
+    for trigger in triggers:
+        if trigger.startswith("!"):
+            neg = set(re.findall(r"\w+", trigger[1:]))
+            if neg and neg <= text_words:
+                return 0.0, None
+            continue
+        words = set(re.findall(r"\w+", trigger))
+        if not words:
+            continue
+        overlap = len(words & text_words) / len(words)
+        if overlap > best:
+            best, winner = overlap, trigger
+    return best, winner
+
+
+# --------------------------------------------------------------------------- #
+# --check
+# --------------------------------------------------------------------------- #
+
+
+def run_check(verbose: bool) -> int:
+    meta, body = read_skill()
+    spec = json.loads(CASES_FILE.read_text(encoding="utf-8"))
+    cases = spec.get("cases", [])
+    triggers = parse_triggers(meta)
+    labels = audience_labels(body)
+    shapes = worked_shape_prompts(body)
+    threshold = min_trigger_overlap()
+    problems: List[str] = []
+
+    if not cases:
+        problems.append("cases.json defines no cases")
+    if not triggers:
+        problems.append("skill declares no triggers, so nothing can auto-load it")
+    if not shapes:
+        # The duplicate-prompt rule below is only as good as this list. An empty
+        # list makes it pass every case without checking anything, and that
+        # silence is indistinguishable from success -- so an empty parse is a
+        # failure, not a skipped rule. It goes empty if the "Worked shapes"
+        # heading is renamed or the examples stop being **"bold-quoted"**.
+        problems.append(
+            "no worked-shape examples parsed out of the skill, so the duplicate-prompt "
+            "rule would pass vacuously -- check the 'Worked shapes' heading and that its "
+            'examples are still **"bold-quoted"**'
+        )
+    for field in ("name", "description"):
+        if not meta.get(field):
+            problems.append(f"skill frontmatter missing required '{field}'")
+
+    seen_ids, seen_names = set(), set()
+    exercised: set = set()
+    for case in cases:
+        cid = case.get("id")
+        name = case.get("name", "?")
+        prompt = case.get("prompt", "")
+        tag = f"case {cid} ({name})"
+
+        if cid in seen_ids:
+            problems.append(f"{tag}: duplicate id")
+        seen_ids.add(cid)
+        if name in seen_names:
+            problems.append(f"{tag}: duplicate name")
+        seen_names.add(name)
+        if not prompt:
+            problems.append(f"{tag}: empty prompt")
+            continue
+
+        assertions = case.get("assertions") or []
+        if len(assertions) < 2:
+            problems.append(f"{tag}: needs at least 2 assertions, has {len(assertions)}")
+
+        expect = bool(case.get("expect_trigger", True))
+        score, winner = best_overlap(prompt, triggers)
+        fires = score >= threshold
+        if expect and fires and winner:
+            exercised.add(winner)
+
+        if expect and not fires:
+            problems.append(
+                f"{tag}: prompt does NOT trigger the skill "
+                f"(best overlap {score:.2f} < {threshold}) -- the skill would never load "
+                f"for this prompt, so the case cannot measure it"
+            )
+        elif not expect and fires:
+            problems.append(
+                f"{tag}: control prompt WRONGLY triggers on '{winner}' "
+                f"(overlap {score:.2f} >= {threshold}) -- the trigger set is too loose"
+            )
+
+        audience = case.get("audience")
+        if expect and not audience:
+            problems.append(f"{tag}: expected to trigger but names no audience")
+        if audience and audience not in labels:
+            problems.append(
+                f"{tag}: audience '{audience}' is not a row in the skill's tables "
+                f"(known: {', '.join(labels)})"
+            )
+
+        if prompt.strip().lower() in shapes:
+            problems.append(
+                f"{tag}: prompt duplicates one of the skill's own worked-shape examples, "
+                f"so the with-skill lane would be reciting an answer already in its context "
+                f"instead of generalising -- pick phrasing the skill does not spell out"
+            )
+
+        if verbose:
+            verdict = "fires" if fires else "silent"
+            print(f"  {tag}: {verdict} ({score:.2f}) via {winner or '-'}")
+
+    # Every declared trigger needs a case that actually fires on it. A trigger no
+    # case exercises is untested surface: it can be too loose, or dead, and the
+    # suite would stay green either way -- which is the same shape of gap as a
+    # gate that passes vacuously.
+    unexercised = [t for t in triggers if not t.startswith("!") and t not in exercised]
+    if unexercised:
+        problems.append(
+            "trigger(s) no passing case fires on: "
+            + ", ".join(repr(t) for t in unexercised)
+            + " -- add a case whose prompt matches, or drop the trigger"
+        )
+
+    print()
+    if problems:
+        print(f"CHECK FAILED -- {len(problems)} problem(s):")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print(f"CHECK PASSED -- {len(cases)} cases, {len(triggers)} triggers, {len(labels)} audiences")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# --run
+# --------------------------------------------------------------------------- #
+
+
+def cli_argv() -> List[str]:
+    override = os.environ.get("EXPLAIN_FOR_EVAL_CLI")
+    return override.split() if override else list(DEFAULT_CLI)
+
+
+def ask(argv: Sequence[str], prompt: str, timeout: int) -> Optional[str]:
+    """Run one CLI call. Returns the answer text, or None if the call FAILED.
+
+    None means the harness never got an answer -- a timeout, a non-zero exit, an
+    empty stdout. That is deliberately NOT a string: an earlier version returned
+    a ``"<TIMEOUT>"`` sentinel, which then flowed into the grader and came back
+    as every criterion FAILing. A transport failure was being recorded as the
+    model failing the content criteria, so the pass rate -- the entire output of
+    ``--run`` -- silently moved for a reason that had nothing to do with the
+    skill. Callers must branch on None instead of grading it.
+    """
+    try:
+        proc = subprocess.run(
+            list(argv) + [prompt],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"    ! CLI call timed out after {timeout}s", flush=True)
+        return None
+
+    # THE GATE, stated once and exhaustively: a result is an answer only if the
+    # process exited 0 AND produced non-empty stdout. Anything else is an error,
+    # never content.
+    #
+    # This is deliberately a closed enumeration rather than a list of observed
+    # failures, because the observed-failure approach was tried and cost three
+    # review rounds on this one function -- a "<TIMEOUT>" sentinel that got
+    # graded, a partially-parsed grader reply back-filled as FAILs, and a
+    # non-zero exit whose stdout was returned as the model's answer. A
+    # subprocess can only fail three ways: it never finished, it finished
+    # badly, or it finished with nothing to say. All three are covered here and
+    # there is no fourth axis, so this closes the family instead of the instance.
+    out = (proc.stdout or "").strip()
+    if proc.returncode != 0 or not out:
+        why = "exited non-zero" if proc.returncode != 0 else "produced no output"
+        err = (proc.stderr or "").strip()[:400]
+        print(f"    ! CLI call {why} (rc={proc.returncode}) {err}", flush=True)
+        return None
+    return out
+
+
+#: The ONLY shape a grader line may take. Anchored at both ends, so the whole
+#: line is the claim -- there is no leading or trailing room for prose. An
+#: optional ``.`` after the index is the one tolerance (a grader writing
+#: ``1.|PASS|...``); casing and padding around the token are the others.
+_VERDICT_LINE_RE = re.compile(r"^\s*(\d+)\.?\s*\|\s*(PASS|FAIL)\s*\|(.*)$", re.IGNORECASE)
+
+
+def parse_grading(raw: str, count: int) -> Optional[List[Tuple[bool, str]]]:
+    """Parse a grader reply into one verdict per criterion, or None if unusable.
+
+    The invariant is a **positive grammar**: the reply is a grading only if every
+    non-blank line matches one exact shape, and the indices those lines carry
+    are precisely 1..count with each appearing **exactly once**. Anything else
+    is an errored grading, not a set of failures.
+
+    Stated positively on purpose. The earlier version scavenged recognisable
+    lines out of arbitrary text and skipped the rest, then bolted on a check per
+    malformation as each was found -- a sentinel string graded as an answer, a
+    partial reply back-filled as FAILs, a non-zero exit returned as content, and
+    duplicate verdicts for one criterion overwriting each other. Each fix was
+    right for its own case and none of them bounded the next, because the ways a
+    model can reply wrongly are not enumerable in advance. Matching one accepted
+    shape inverts that: novel malformations fail by default instead of needing to
+    be predicted, so "unparseable" and "judged" can never be confused again.
+
+    Consequences worth naming, since they are the point rather than side effects:
+
+    - A repeated index is refused outright. A grader that contradicts itself has
+      not judged that criterion, and silently keeping either verdict invents an
+      answer the grader did not give.
+    - An index outside 1..count is refused, so renumbered or over-long replies
+      cannot shift verdicts onto the wrong criterion.
+    - A stray prose line -- even alongside a full set of valid verdicts --
+      makes the whole reply unusable. A grader that ignores "output nothing
+      else" has already departed from its instructions, so its verdicts have
+      lost the claim to be read as verdicts.
+
+    Blank lines are the sole exception: they carry no claim, so they are skipped
+    rather than treated as a violation.
+
+    Pure and model-free on purpose: this is the part of ``--run`` that CI can
+    actually test.
+    """
+
+    def _unusable(reason: str) -> None:
+        print(f"    ! grader reply unusable: {reason}", flush=True)
+
+    seen: Dict[int, Tuple[bool, str]] = {}
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        match = _VERDICT_LINE_RE.match(line)
+        if match is None:
+            _unusable(f"line is not a verdict: {line.strip()[:60]!r}")
+            return None
+        idx = int(match.group(1))
+        if not 1 <= idx <= count:
+            _unusable(f"criterion {idx} is outside the expected 1..{count}")
+            return None
+        if idx in seen:
+            _unusable(f"criterion {idx} received more than one verdict")
+            return None
+        seen[idx] = (match.group(2).upper() == "PASS", match.group(3).strip())
+
+    missing = [i for i in range(1, count + 1) if i not in seen]
+    if missing:
+        _unusable(f"no verdict for criterion {', '.join(str(i) for i in missing)} of {count}")
+        return None
+    return [seen[i] for i in range(1, count + 1)]
+
+
+def grade(
+    argv: Sequence[str], answer: str, assertions: Sequence[str], timeout: int
+) -> Optional[List[Tuple[bool, str]]]:
+    """Ask the CLI to judge one answer against its assertions.
+
+    Returns None when the grading is unusable -- either the grader call itself
+    failed, or it replied and the reply did not carry a verdict for every
+    criterion. In both cases the answer was never actually judged, so it must
+    not reach the tally. See ``parse_grading`` for the invariant.
+    """
+    numbered = "\n".join(f"{i}. {a}" for i, a in enumerate(assertions, 1))
+    prompt = (
+        "You are grading one answer against explicit criteria. Do not be generous.\n"
+        "For EACH numbered criterion output exactly one line:\n"
+        "  <number>|PASS or FAIL|one short sentence of evidence quoted from the answer\n"
+        "Output nothing else.\n\n"
+        f"CRITERIA:\n{numbered}\n\n"
+        f"ANSWER TO GRADE:\n{answer}\n"
+    )
+    raw = ask(argv, prompt, timeout)
+    if raw is None:
+        return None
+    return parse_grading(raw, len(assertions))
+
+
+def next_iteration_dir() -> Path:
+    n = 1
+    while (HERE / f"iteration-{n}").exists():
+        n += 1
+        if n > 999:
+            raise SystemExit("too many iteration directories")
+    out = HERE / f"iteration-{n}"
+    out.mkdir(parents=True)
+    return out
+
+
+def run_evals(only: Optional[int], with_skill_only: bool, timeout: int) -> int:
+    argv = cli_argv()
+    if not shutil.which(argv[0]):
+        print(f"agent CLI '{argv[0]}' not on PATH.")
+        print("Set EXPLAIN_FOR_EVAL_CLI to the non-interactive command to use.")
+        return 2
+
+    _, body = read_skill()
+    spec = json.loads(CASES_FILE.read_text(encoding="utf-8"))
+    cases = [c for c in spec.get("cases", []) if only is None or c.get("id") == only]
+    if not cases:
+        print(f"no case matched --test={only}")
+        return 2
+
+    out_root = next_iteration_dir()
+    lanes = ["with-skill"] if with_skill_only else ["with-skill", "baseline"]
+    tally: Dict[str, List[int]] = {lane: [0, 0] for lane in lanes}
+    # Calls that never produced a gradeable answer. Counted separately and kept
+    # OUT of the tally: folding a transport failure in as FAILs would move the
+    # pass rate for a reason unrelated to the skill, in whichever lane happened
+    # to time out, and nothing in the output would say so.
+    errors: Dict[str, int] = {lane: 0 for lane in lanes}
+
+    for case in cases:
+        name = case["name"]
+        prompt = case["prompt"]
+        assertions = case.get("assertions") or []
+        case_dir = out_root / name
+        case_dir.mkdir(parents=True, exist_ok=True)
+        print(f"\n--- Case {case['id']}: {name} ---")
+
+        for lane in lanes:
+            if lane == "with-skill":
+                # What the trigger-injection path delivers: the skill body ahead
+                # of the user's message.
+                full = f"{body}\n\n---\n\nUser request: {prompt}"
+            else:
+                full = prompt
+            print(f"  [{lane}]")
+            answer = ask(argv, full, timeout)
+            if answer is None:
+                errors[lane] += 1
+                (case_dir / f"{lane}.txt").write_text("", encoding="utf-8")
+                (case_dir / f"{lane}.grading.txt").write_text(
+                    "ERROR no answer: the CLI call failed, so this lane was not graded\n",
+                    encoding="utf-8",
+                )
+                print("    ERROR -- not graded, excluded from the pass rate")
+                continue
+            (case_dir / f"{lane}.txt").write_text(answer, encoding="utf-8")
+
+            graded = grade(argv, answer, assertions, timeout)
+            if graded is None:
+                errors[lane] += 1
+                (case_dir / f"{lane}.grading.txt").write_text(
+                    "ERROR grader failed: the answer exists but was not graded\n",
+                    encoding="utf-8",
+                )
+                print("    ERROR -- grader failed, excluded from the pass rate")
+                continue
+            lines = []
+            for i, (ok, evidence) in enumerate(graded, 1):
+                verdict = "PASS" if ok else "FAIL"
+                print(f"    {verdict}  #{i} -- {evidence}")
+                lines.append(f"{verdict} #{i} {assertions[i - 1]}\n    {evidence}")
+                tally[lane][0] += 1 if ok else 0
+                tally[lane][1] += 1
+            (case_dir / f"{lane}.grading.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print("\n" + "=" * 41)
+    print(f"  PASS RATE -- {out_root.name}")
+    print("=" * 41)
+    rates = {}
+    for lane in lanes:
+        passed, total = tally[lane]
+        pct = (passed / total * 100) if total else 0.0
+        rates[lane] = pct
+        suffix = f"  [{errors[lane]} errored, ungraded]" if errors[lane] else ""
+        print(f"  {lane:<12} {passed}/{total} ({pct:.1f}%){suffix}")
+    # A delta between lanes graded on different numbers of cases is not a
+    # comparison, so say that rather than printing a number that looks like one.
+    if len(lanes) == 2:
+        if errors["with-skill"] or errors["baseline"]:
+            print(f"  {'delta':<12} not comparable -- the lanes graded different case sets")
+        else:
+            print(f"  {'delta':<12} {rates['with-skill'] - rates['baseline']:+.1f}%")
+    if any(errors.values()):
+        print(
+            f"  {'errors':<12} {sum(errors.values())} call(s) never answered -- rerun those cases"
+        )
+    print("=" * 41)
+    print(f"  results: {out_root}")
+    return 1 if any(errors.values()) else 0
+
+
+# --------------------------------------------------------------------------- #
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="deterministic validation only (default)"
+    )
+    parser.add_argument(
+        "--run", action="store_true", help="run the A/B measurement through an agent CLI"
+    )
+    parser.add_argument("--test", type=int, metavar="ID", help="restrict --run to one case id")
+    parser.add_argument("--with-skill-only", action="store_true", help="skip the baseline lane")
+    parser.add_argument(
+        "--timeout", type=int, default=DEFAULT_TIMEOUT, help="per-CLI-call timeout in seconds"
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="print per-case trigger scores in --check"
+    )
+    args = parser.parse_args()
+
+    if args.run:
+        rc = run_check(args.verbose)
+        if rc != 0:
+            print("\nrefusing to spend tokens on an inconsistent case set.")
+            return rc
+        return run_evals(args.test, args.with_skill_only, args.timeout)
+    return run_check(args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kiro_crew/builtin_skills/explain-for/SKILL.md
+++ b/src/kiro_crew/builtin_skills/explain-for/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: explain-for
+description: Explain a topic, a piece of code, an error, or a design decision calibrated to one named audience — a 5-year-old, a 5th grader, a manager, a designer, a graduate student, a parent. Resolves who the explanation is for (from the request, or from what memory already records about that person), establishes the ground truth before simplifying, then tunes vocabulary, analogy source, tone, depth and framing to that audience instead of producing one generic explanation.
+triggers: explain like i am, explain like im, explain like a, explain to my, break down for, dumb it down, simplify this for, in plain english
+---
+
+# explain-for — write it for one named audience
+
+One explanation cannot serve everyone. This skill makes you name the audience
+first, verify the facts second, and only then write.
+
+## Step 0 — check that this is actually an audience request
+
+Trigger matching here is word-overlap against the phrases above, so it is
+probabilistic and it will sometimes fire on a request that merely contains the
+word "explain". Before entering the skill, confirm the user wants an explanation
+**pitched at somebody**. If they just want to know why CI failed, answer that
+question normally and ignore everything below.
+
+## Step 1 — resolve the audience
+
+Pick exactly one audience.
+
+**Check memory before guessing.** Crew carries a persistent user profile, and a
+request like "explain this to my daughter" or "break this down for Priya" often
+resolves against something already recorded — an age, a role, an interest.
+Search memory and lessons for that person and use what is there; guessing an age
+the profile already contradicts is the most visible way this skill fails.
+
+If nothing resolves and no audience is named, do not silently invent one:
+
+- Explicit smallest-audience phrasing ("dumb it down", "explain like I am")
+  means **Age 5**. That is the request.
+- Anything else with no audience — ask which audience in one line, or state the
+  row you assumed in one clause so the user can correct it.
+
+If the request names someone you cannot classify (a specific colleague, a title
+absent from the tables), map them onto the nearest row and say which row.
+
+### Ages
+
+| Audience | Calibration |
+|---|---|
+| Age 5 | Smallest words. Analogies from toys, animals, candy, playground. One idea per sentence. |
+| Age 10 | Elementary. Cause-and-effect is fine. Analogies from school, sports, video games. |
+| Age 15 | Some abstraction is fine. Analogies from phones, games, social apps. Casual, never try-hard. |
+| Age 20-30 | Direct and clear. Analogies from work, money, daily logistics. |
+| Age 40+ | Respectful, unhurried. Analogies from home ownership, career, running a household. |
+
+### Education level
+
+| Audience | Calibration |
+|---|---|
+| 5th grade | Concrete examples, zero jargon. |
+| Middle school | Introduce a term only with its definition attached. Step-by-step logic. |
+| Senior high | Moderate complexity. Proper terms, each explained once. |
+| College | Academic framing. Technical terms with brief context. Theory plus one application. |
+| Graduate | Assume the foundation. Spend the words on nuance, trade-offs, edge cases. Be precise. |
+
+### Job role
+
+| Audience | They care about | Frame it as |
+|---|---|---|
+| Manager | Impact, timeline, risk, cost | The business outcome and the decision that is now open |
+| Engineer | Mechanism, architecture, trade-offs | Implementation, performance, maintainability |
+| Designer | The user's experience | Interaction, flow, accessibility, what the user perceives |
+| Director | Strategy, ROI | Market position, resource allocation, the big picture |
+| Product manager | User value, scope | Feature impact, what to build and what to cut |
+| Colleague | Their own work | What changes for them and what they must know to collaborate |
+| Support | Symptoms and remedies | How it fails, how to detect it, what to do about it |
+
+### Relationships
+
+| Audience | Tone | Analogy source |
+|---|---|---|
+| Partner | Warm, patient, conversational | Shared routines, household tasks |
+| Parents | Respectful, never condescending | Technology they already use, home analogies |
+| Kids | Playful, encouraging, short | Games, cartoons, animals, school |
+| Friend | Casual, some humour | Pop culture, shared interests |
+
+## Step 2 — establish the ground truth before simplifying
+
+A simplified wrong answer is worse than no answer, and simplification is exactly
+where wrong answers hide. This is the step that gets skipped.
+
+- **Code** — read the actual files with your file and code-search tools. Do not
+  explain from the identifier names. Trace what calls it and what it returns.
+- **An error** — find the root cause, not the surface string. The frame that
+  reports the failure is often not the one that caused it.
+- **A concept** — state it once, precisely, for yourself before you soften it. If
+  you cannot, you do not understand it yet.
+- **An internal design or decision** — the claim and what it depends on. Search
+  the knowledge library when the answer plausibly lives in a stored doc.
+
+When the source material is large — a whole subsystem, a long log, a wide search
+— delegate the reading to a sub-agent and have it return the distilled mechanism.
+The explanation is short; the reading behind it does not need to sit in your
+context.
+
+If the ground truth is genuinely unknown, say so plainly at the audience's level
+rather than inventing a clean story.
+
+## Step 3 — write it
+
+1. **What it is** — one sentence, no analogy yet.
+2. **One analogy** — anchored in something this audience touches daily.
+3. **The detail that matters** — only the layers this audience can use.
+4. **So what** — why it matters to *them*, in their terms.
+
+Language rules that flip with the audience:
+
+- **Non-technical** (young, family, business): no jargon at all; define a term on
+  the spot if it is unavoidable. Concrete beats abstract. Use "you".
+- **Technical** (engineer, graduate): use the real terminology — omitting it
+  reads as condescension. Spend the words on trade-offs and edge cases. Be brief;
+  they already hold the context.
+- **Business** (manager, director): lead with impact, quantify where you honestly
+  can, skip mechanism unless asked, and end on the decision.
+
+Length follows the audience: short for a child, dense for a specialist.
+
+## Draw it when the thing has a shape
+
+One picture really does beat a page of prose — but only when what you are
+explaining *is* a shape. Ask that first, because the answer is not always yes:
+
+| The thing you are explaining | Draw it? |
+|---|---|
+| A sequence, a flow, a lifecycle | **Yes** — order is what a diagram shows best |
+| A hierarchy, a containment, a topology | **Yes** — nesting is hard to hold in sentences |
+| A state change, or a before/after | **Yes** — put both states side by side |
+| A number that moved, a share, a trend | **Yes** — one chart, not a paragraph of figures |
+| A definition, a single fact, a judgement call | **No** — a box with words in it is not a diagram |
+| A trade-off between two options | Usually no — the reasoning is the content, not the layout |
+
+Scale it to the audience the same way you scale the words. For a child the
+picture often *is* the explanation and the text is a caption. For a manager, one
+before/after or one impact chart, never an architecture diagram. For an engineer
+or a graduate, the real mechanism, drawn precisely. For a parent, draw the
+analogy, not the system.
+
+What is available, in ascending cost:
+
+| Tool | Reach for it when | What it buys |
+|---|---|---|
+| ` ```mermaid ` fence | a sequence, flow, state machine, hierarchy or ER | cheapest by far; renders inline, click to enlarge |
+| ` ```excalidraw ` fence | the drawing should look hand-made rather than official | informal register, full colour control from the scene |
+| `<mcwidget>` | quantities, a colour-coded comparison, a real chart, a before/after panel, a small interactive probe | sandboxed iframe with **Tailwind preloaded**, the dashboard theme palette as CSS variables, and Chart.js / D3 from the allowed CDNs |
+| an image file via `image-authoring` | the result must outlive the chat or be pasted elsewhere | a real file you can attach or save as an artifact |
+
+Two rules that matter more than the picture:
+
+- **A wrong diagram is worse than wrong prose.** It reads as authoritative and it
+  gets screenshotted into other people's documents. Step 2 applies with more
+  force here, not less: do not draw a mechanism you have not actually traced.
+- **A diagram that restates the text adds nothing.** If the caption already says
+  everything the boxes say, delete one of them. The picture should carry the part
+  the sentences were bad at.
+
+### Colour it, and make every colour mean something
+
+**The default is deliberately flat, so a plain diagram will look plain.** In chat,
+mermaid is initialised with one accent seed plus greys — contrast-safe on any
+theme pack, but it gives every node the same fill. Colour has to come from the
+source: `classDef` for a role you reuse, `style` for a one-off.
+
+```
+flowchart LR
+    classDef happy fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef bad fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+    classDef focus fill:#fef3c7,stroke:#d97706,color:#78350f
+
+    A[request] --> B{cache hit?}
+    B -->|yes| C[serve instantly]:::happy
+    B -->|no| D[fetch from origin]:::focus
+    D -->|origin down| E[error]:::bad
+```
+
+Two rules keep that from turning into decoration:
+
+- **A colour is a claim.** Green means this path is fine, red means it fails,
+  amber means this is the part under discussion. Colour used only to look lively
+  sends the reader hunting for a meaning that is not there, which is worse than
+  one flat palette. If you cannot say what a colour *means*, leave the node
+  default.
+- **Pick values that read on light AND dark.** The same source renders under both
+  themes, and the host pins mermaid's theme precisely because a theme pack can
+  set an accent that disappears into the background. Mid-tone fills with a darker
+  stroke and an explicit `color:` survive both; near-white and near-black fills do
+  not.
+
+Scale it like everything else: for a child colour is doing real work, separating
+the parts before the labels can be read. For an engineer, colour only the two or
+three nodes that carry the point. For a manager, colour the outcome, not the
+machinery.
+
+### Reach for a widget when the content is quantities or comparison
+
+`<mcwidget>` is not only the interaction escape hatch, and it is under-used for
+explanations. It is the right call whenever the honest answer is a **chart, a
+colour-coded table, or two states side by side** — things markdown cannot
+express. Inside one you get Tailwind with no setup, Chart.js or D3 from the
+allowed CDNs, and the dashboard's own palette as CSS variables (`var(--accent)`,
+`var(--ok)`, `var(--warn)`, `var(--danger)`, `var(--card)`, plus the `-subtle`
+tints).
+
+Use those variables instead of hardcoded colours so the widget matches whatever
+theme the reader is on — that is why they are injected. Load the `widgets` skill
+before emitting one; it carries the format rules and the full variable list. Keep
+the body to a few KB and write a file instead once it grows past that.
+
+Still prefer markdown when markdown suffices: a widget wrapping three bullet
+points is overhead, not richness.
+
+## Delivery in Crew
+
+- **Terseness is suspended for this reply.** An explanation request is the
+  documented exception to the answer-only and concise verbosity levels. Do not
+  compress an Age-5 explanation into one clipped line because a verbosity block
+  says to — the request itself lifted that rule for this turn.
+- **Persist what gets forwarded.** An explanation written for a manager, a
+  director or a customer usually gets pasted somewhere else. Save it as an
+  artifact so it outlives the chat scrollback and can be revised, instead of
+  regenerating it next week from a different mood.
+
+## Rules
+
+- Never talk down. An Age-5 explanation should feel delightful, not diminishing;
+  a manager explanation should leave them able to decide, not sidelined.
+- For code, explain the **purpose** before the **mechanism**. Nobody needs the
+  syntax before they know why the code exists.
+- Ruthless simplification is allowed and often correct: the core idea at 80%
+  accuracy beats a 100% accurate explanation the audience abandons. What is not
+  allowed is a simplification that inverts the meaning or invents a mechanism
+  that does not exist.
+- Do not stack two audiences into one answer. If the user needs both, write two
+  clearly labelled explanations.
+- Keep the user's language, analogies included. A translated American analogy
+  lands as noise — pick one from the audience's own daily life.
+
+## Worked shapes
+
+**"Dumb it down: what is a race condition"** — Age 5. Two children reach for the same
+crayon at the same moment. Who ends up holding it depends on whose hand was
+faster that second, so the picture comes out different every time you try. Nothing
+is broken; the order just is not decided.
+
+**"Explain this to my mother: why her login keeps signing her out"** — Parents.
+Check memory first for what she already uses. Then: the app keeps a pass that is
+deliberately short-lived, like a parking receipt that runs out, and it asks for the
+password again rather than trusting an old one. Respectful, no "token", no
+"session".
+
+**"Explain to a graduate student why we picked at-least-once delivery"** — Graduate.
+Use the real terms; skipping them here reads as condescension. Spend the words
+where the actual content is: the duplicate-delivery obligation this pushes onto
+every consumer, and why idempotency became the caller's problem rather than the
+broker's.
+
+Note the second one: the audience is a person, so the audience is looked up before
+it is guessed, and the analogy is drawn from her life rather than translated from
+somebody else's.

--- a/test/test_explain_for_skill.py
+++ b/test/test_explain_for_skill.py
@@ -1,0 +1,401 @@
+"""The ``explain-for`` skill must stay reachable, and its eval set must stay honest.
+
+Three joints, all of which a prose review of SKILL.md cannot see:
+
+(1) **Reachability.** The skill auto-loads only when one of its ``triggers``
+    phrases clears ``_MIN_TRIGGER_OVERLAP`` word-overlap against the user's
+    message. A skill whose triggers never fire on the phrasing it was written for
+    is dead weight that still costs catalog space, and nothing else in the suite
+    checks that. Asserted here through the **real** ``SkillsLoader``, not through
+    a reimplementation of its scoring, so the assertion cannot drift from the
+    loader it is meant to pin.
+
+(2) **Control prompts.** Word-overlap fires on ordinary phrasing, and this skill
+    changes how an answer is written. A prompt that merely contains "explain"
+    must NOT pull it in, or every incidental "explain why CI failed" gets pitched
+    at a five-year-old. The control cases in ``cases.json`` pin that boundary, so
+    loosening a trigger is a test failure rather than a surprise in production.
+
+(3) **Case/skill coherence.** Every case names the audience the skill is expected
+    to resolve. If ``cases.json`` names an audience the skill's tables never
+    define, the case is measuring nothing. ``run_evals.py --check`` owns that
+    rule; this suite runs it so CI enforces it too.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, SkillsConfig
+from kiro_crew.skills import SkillsLoader
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL_DIR = ROOT / "src" / "kiro_crew" / "builtin_skills" / "explain-for"
+SKILL_FILE = SKILL_DIR / "SKILL.md"
+EVAL_DIR = ROOT / "evals" / "explain-for"
+CASES_FILE = EVAL_DIR / "cases.json"
+RUNNER = EVAL_DIR / "run_evals.py"
+
+
+def _cases() -> list[dict]:
+    return json.loads(CASES_FILE.read_text(encoding="utf-8"))["cases"]
+
+
+def _case_id(case: dict) -> str:
+    return f"{case['id']}-{case['name']}"
+
+
+@pytest.fixture
+def loader(tmp_path: Path) -> SkillsLoader:
+    """A loader over a skills tree holding only explain-for.
+
+    Two things are pinned deliberately, and neither is incidental.
+
+    **Only this skill is installed.** With the whole bundled set present,
+    ``max_triggered`` could evict explain-for behind an unrelated skill, and the
+    reachability assertions would then be measuring trigger competition rather
+    than this skill's own triggers.
+
+    **``config`` is passed explicitly, and the fixture is function-scoped.**
+    ``SkillsLoader(config=None)`` falls back to ``KiroCrewConfig.load()``, which
+    resolves ``config_dir()`` — and that CREATES the operator's real data home as
+    a side effect (see ``_isolate_kirocrew_home`` in the rootdir ``conftest.py``),
+    which ``no-test-side-effects`` forbids. A module-scoped fixture is built
+    BEFORE that function-scoped autouse isolation applies, so the scope is load
+    bearing here, not a performance choice.
+
+    Passing the config also decides the verdict rather than inheriting it:
+    ``max_triggered`` defaults to **0**, which disables word-overlap trigger
+    matching altogether — on a stock install skills are found through the
+    Available Skills index and ``skill_search``, not through triggers. So these
+    assertions describe the **opt-in** population that has set
+    ``max_triggered > 0``; they are not a claim that the skill auto-injects for
+    everyone. Read from a real config the value happens to be non-zero on a
+    developer box and 0 on a clean CI home, so inheriting it would make the
+    assertions pass locally and fail in CI for a reason that has nothing to do
+    with the triggers under test. ``1`` is the tightest non-zero cap, so these
+    assertions state that explain-for is reachable even when a message may flag
+    one skill.
+    """
+    dest = tmp_path / "skills" / "explain-for"
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_text(SKILL_FILE.read_text(encoding="utf-8"), encoding="utf-8")
+    return SkillsLoader(
+        skills_path=tmp_path / "skills",
+        install_builtins=False,
+        config=KiroCrewConfig(skills=SkillsConfig(max_triggered=1)),
+    )
+
+
+class TestReachability:
+    def test_skill_is_discovered(self, loader: SkillsLoader):
+        assert "explain-for" in [s["name"] for s in loader.list_skills()]
+
+    def test_declares_triggers(self):
+        meta = SkillsLoader._parse_frontmatter(SKILL_FILE)
+        assert meta.get("triggers"), "no triggers: the skill can never auto-load"
+
+    @pytest.mark.parametrize("case", _cases(), ids=_case_id)
+    def test_trigger_expectation_holds(self, loader: SkillsLoader, case: dict):
+        triggered = loader.get_triggered_skills(case["prompt"])
+        fired = "explain-for" in triggered
+        if case.get("expect_trigger", True):
+            assert fired, (
+                f"prompt {case['prompt']!r} does not reach explain-for, so the skill "
+                "would never load for the phrasing it was written for"
+            )
+        else:
+            assert not fired, (
+                f"control prompt {case['prompt']!r} pulls in explain-for; the trigger "
+                "set is loose enough to re-pitch an ordinary question at an audience"
+            )
+
+
+class TestCaseCoherence:
+    @pytest.mark.parametrize("case", _cases(), ids=_case_id)
+    def test_audience_is_defined_by_the_skill(self, case: dict):
+        audience = case.get("audience")
+        if audience is None:
+            assert not case.get("expect_trigger", True), "a triggering case must name an audience"
+            return
+        body = SKILL_FILE.read_text(encoding="utf-8")
+        assert f"| {audience} |" in body, (
+            f"audience {audience!r} is not a row in the skill's tables, so the case "
+            "grades against a calibration the skill never describes"
+        )
+
+    def test_runner_check_mode_passes(self):
+        """The eval runner's own deterministic gate, run as a test."""
+        proc = subprocess.run(
+            [sys.executable, str(RUNNER), "--check"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(ROOT),
+            timeout=120,
+        )
+        assert proc.returncode == 0, f"run_evals.py --check failed:\n{proc.stdout}\n{proc.stderr}"
+
+    def test_the_duplicate_prompt_rule_has_something_to_compare_against(self):
+        """The runner must actually find the skill's worked-shape examples.
+
+        The duplicate-prompt rule compares each case against that parsed list, so
+        an empty list does not disable the rule loudly -- it makes it pass every
+        case while checking nothing. The parse is coupled to the ``## Worked
+        shapes`` heading and the ``**"..."**`` quoting, either of which a later
+        edit to the skill could change without touching this harness.
+        """
+        proc = subprocess.run(
+            [sys.executable, str(RUNNER), "--check", "-v"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(ROOT),
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "would pass vacuously" not in proc.stdout, (
+            "the runner parsed no worked-shape examples out of the skill, so the "
+            "duplicate-prompt rule is checking nothing"
+        )
+
+
+class TestGradingIsAllOrNothing:
+    """A grading counts only if every criterion got an explicit parsed verdict.
+
+    This is the one part of ``--run`` that CI can test, because it is pure. It
+    matters because the alternative is silent: back-filling a missing criterion
+    as FAIL blames the answer for the GRADER's formatting, and the corrupted
+    number lands in the pass rate that ``--run`` exists to produce. A timeout is
+    caught one layer up in ``ask``; these are the cases where the grader replied
+    and the reply was not usable.
+    """
+
+    @staticmethod
+    def _load():
+        """Reach the script's pure helpers without leaving a trace beside it.
+
+        Two gates constrain this line and their obvious fixes are opposite:
+        ``no-test-side-effects`` forbids writing ``__pycache__`` into the
+        checkout (which plain ``importlib`` does, and which this repo's
+        ``verify_vendor_manifest.py`` gate independently punishes), while
+        Semgrep's ``exec-detected`` rule forbids reaching for a dynamic
+        compile-and-evaluate to dodge that.
+
+        Neither prescription is applied. The shared requirement is simply that
+        the load leave nothing behind, so bytecode writing is suppressed for the
+        duration of the import and the flag is restored afterwards. It is
+        process-local, and under xdist each worker is its own process, so the
+        worst case for a neighbouring import in that window is that it is not
+        cached.
+
+        ``test_loading_the_script_leaves_no_bytecode`` asserts the outcome
+        rather than trusting this comment: if a later edit drops the guard, a
+        test fails instead of a gate quietly filling the tree.
+        """
+        previous = sys.dont_write_bytecode
+        sys.dont_write_bytecode = True
+        try:
+            spec = importlib.util.spec_from_file_location("_run_evals_undertest", RUNNER)
+            assert spec and spec.loader
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+        finally:
+            sys.dont_write_bytecode = previous
+
+    def _parse(self, raw: str, count: int):
+        return self._load().parse_grading(raw, count)
+
+    def test_loading_the_script_leaves_no_bytecode(self):
+        """The guard above must actually hold, not just be documented."""
+        cache = RUNNER.parent / "__pycache__"
+        before = sorted(p.name for p in cache.glob("*.pyc")) if cache.is_dir() else []
+        self._load()
+        after = sorted(p.name for p in cache.glob("*.pyc")) if cache.is_dir() else []
+        assert after == before, (
+            f"loading {RUNNER.name} wrote bytecode into the checkout: "
+            f"{sorted(set(after) - set(before))}"
+        )
+
+    def test_a_well_formed_reply_parses_every_verdict(self):
+        raw = "1|PASS|uses a toy analogy\n2|FAIL|says 'idempotent'\n3|PASS|two sentences"
+        got = self._parse(raw, 3)
+        assert got == [
+            (True, "uses a toy analogy"),
+            (False, "says 'idempotent'"),
+            (True, "two sentences"),
+        ]
+
+    def test_a_reply_missing_one_criterion_is_unusable(self):
+        """The failure this closes: criterion 3 would have been recorded FAIL."""
+        raw = "1|PASS|fine\n2|PASS|fine"
+        assert self._parse(raw, 3) is None
+
+    def test_a_prose_reply_is_unusable_rather_than_all_failures(self):
+        raw = "I think the answer is pretty good overall, though a bit long."
+        assert self._parse(raw, 4) is None
+
+    def test_an_empty_reply_is_unusable(self):
+        assert self._parse("", 2) is None
+
+    def test_renumbered_lines_do_not_silently_shift_verdicts(self):
+        """A grader answering 2,3,4 for a 3-criterion case is not a valid grading."""
+        raw = "2|PASS|a\n3|PASS|b\n4|PASS|c"
+        assert self._parse(raw, 3) is None
+
+    def test_a_verdict_that_is_neither_word_is_not_a_verdict(self):
+        """ "unsure" must not read as FAIL -- that is the silent direction.
+
+        A prefix test would count every non-PASS token against the answer, so a
+        hedging grader would depress the pass rate with no sign that it had
+        hedged rather than judged.
+        """
+        for token in ("unsure", "N/A", "SKIP", "MAYBE", "-", "FAILED?"):
+            raw = f"1|PASS|ok\n2|{token}|hmm"
+            assert self._parse(raw, 2) is None, f"{token!r} was accepted as a verdict"
+
+    def test_a_near_miss_of_pass_does_not_read_as_pass(self):
+        """ "PASSABLE" starts with PASS but is not PASS."""
+        assert self._parse("1|PASSABLE|ok", 1) is None
+
+    def test_verdict_tokens_are_case_and_space_insensitive(self):
+        """Only the token identity is strict; casing and padding are not."""
+        assert self._parse("1|  pass  |ok\n2|Fail|nope", 2) == [(True, "ok"), (False, "nope")]
+
+    def test_a_repeated_criterion_is_unusable(self):
+        """A self-contradicting grader has not judged that criterion.
+
+        The pre-grammar parser assigned by index into a dict, so the LAST line
+        for an index silently won and the "every criterion has a verdict" check
+        still passed -- the reply looked complete while half of it was
+        discarded. Refusing outright is the only reading that does not invent a
+        verdict the grader never settled on.
+        """
+        assert self._parse("1|PASS|good\n1|FAIL|actually bad\n2|PASS|ok", 2) is None
+
+    def test_a_repeated_criterion_is_unusable_even_when_it_agrees(self):
+        """Duplication is the defect; agreement between the copies is luck."""
+        assert self._parse("1|PASS|good\n1|PASS|good\n2|PASS|ok", 2) is None
+
+    def test_an_index_above_the_criterion_count_is_unusable(self):
+        assert self._parse("1|PASS|a\n2|PASS|b\n3|PASS|c", 2) is None
+
+    def test_index_zero_is_unusable(self):
+        """Criteria are 1-based, so a 0 means the grader was not counting ours."""
+        assert self._parse("0|PASS|a\n1|PASS|b", 1) is None
+
+    def test_prose_alongside_a_full_set_of_verdicts_is_unusable(self):
+        """The whole reply is the claim, not the lines that happen to parse.
+
+        A grader that ignores "output nothing else" has already left its
+        instructions, so its verdicts stop being trustworthy as verdicts. This
+        is the case a reject-known-bad parser cannot reach: every criterion has a
+        well-formed verdict, and the reply is still not a grading.
+        """
+        raw = "Here are my verdicts:\n1|PASS|fine\n2|PASS|fine"
+        assert self._parse(raw, 2) is None
+
+    def test_a_trailing_summary_line_is_unusable(self):
+        raw = "1|PASS|fine\n2|FAIL|nope\nOverall: 1 of 2 passed."
+        assert self._parse(raw, 2) is None
+
+    def test_blank_lines_around_the_verdicts_are_tolerated(self):
+        """Blank lines assert nothing, so they are the one thing skipped."""
+        raw = "\n1|PASS|ok\n\n2|FAIL|nope\n\n"
+        assert self._parse(raw, 2) == [(True, "ok"), (False, "nope")]
+
+    def test_a_reason_containing_a_pipe_is_kept_whole(self):
+        """The reason is the rest of the line, not the next field."""
+        assert self._parse("1|PASS|uses a|b analogy", 1) == [(True, "uses a|b analogy")]
+
+    def test_an_index_with_a_trailing_dot_still_parses(self):
+        assert self._parse("1.|PASS|ok", 1) == [(True, "ok")]
+
+
+class TestOnlyACleanCallIsAnAnswer:
+    """``ask`` returns content only for exit 0 with non-empty stdout.
+
+    Stated as a closed enumeration rather than a list of observed failures: a
+    subprocess either never finished, finished badly, or finished with nothing
+    to say. Handling them one at a time cost three review rounds on this
+    function, so these tests pin the whole gate instead of the last instance.
+
+    Model-free -- the "CLI" here is a Python one-liner, so this runs anywhere.
+    """
+
+    @staticmethod
+    def _ask(program: str, timeout: int = 30):
+        mod_spec = importlib.util.spec_from_file_location("_run_evals_ask", RUNNER)
+        assert mod_spec and mod_spec.loader
+        previous = sys.dont_write_bytecode
+        sys.dont_write_bytecode = True
+        try:
+            mod = importlib.util.module_from_spec(mod_spec)
+            mod_spec.loader.exec_module(mod)
+        finally:
+            sys.dont_write_bytecode = previous
+        return mod.ask([sys.executable, "-c", program], "ignored-prompt", timeout)
+
+    def test_exit_zero_with_output_is_an_answer(self):
+        assert self._ask("print('the answer')") == "the answer"
+
+    def test_non_zero_exit_is_not_an_answer_even_with_output(self):
+        """The round-3 case: it printed something, so it looked like content."""
+        assert self._ask("import sys; print('partial'); sys.exit(1)") is None
+
+    def test_exit_zero_with_empty_output_is_not_an_answer(self):
+        assert self._ask("pass") is None
+
+    def test_output_on_stderr_alone_is_not_an_answer(self):
+        assert self._ask("import sys; sys.stderr.write('boom')") is None
+
+
+class TestSkillContent:
+    def test_names_the_verbosity_exception(self):
+        """The terseness levels would otherwise compress the explanation away.
+
+        An explanation request is the documented exception to answer-only /
+        concise, and an agent under one of those levels needs the skill to say so
+        or it clips the very output the user asked to be expansive.
+        """
+        body = SKILL_FILE.read_text(encoding="utf-8").lower()
+        assert "verbosity" in body and "terseness" in body
+
+    def test_requires_ground_truth_before_simplifying(self):
+        body = SKILL_FILE.read_text(encoding="utf-8").lower()
+        assert "ground truth" in body
+
+    def test_names_the_mechanism_for_colouring_a_diagram(self):
+        """Saying "use colour" is not actionable without the mechanism.
+
+        Chat initialises mermaid with a single accent seed plus greys, so a
+        diagram is monochrome unless the SOURCE colours it. ``classDef`` is the
+        only way an agent can do that, and an agent told to "make it colourful"
+        with no mechanism either emits a flat diagram anyway or invents a theme
+        directive the host does not honour.
+        """
+        body = SKILL_FILE.read_text(encoding="utf-8")
+        assert "classDef" in body, "no colouring mechanism named"
+        assert "A colour is a claim" in body, (
+            "the semantic-colour rule is missing, so the guidance reads as "
+            "'add colour' and decoration satisfies it"
+        )
+
+    def test_offers_widgets_beyond_interaction(self):
+        """The widget tier must cover charts and comparisons, not only interaction.
+
+        Scoped to interaction alone it never gets reached for the case it is
+        actually best at -- a quantity or a side-by-side that markdown cannot
+        express -- so an explanation that wanted a chart gets a paragraph of
+        figures instead.
+        """
+        body = SKILL_FILE.read_text(encoding="utf-8")
+        assert "mcwidget" in body
+        assert "not only the interaction escape hatch" in body


### PR DESCRIPTION
## Problem / Motivation

Crew has no skill for pitching an explanation at a specific person, and no way to tell whether a bundled skill works at all. Both gaps are the same gap: a skill is a prompt, and a prompt cannot be reviewed for correctness by reading it. Two failure modes are entirely invisible to a prose review of a `SKILL.md`, for any install that has enabled word-overlap trigger matching (`skills.max_triggered > 0`):

1. A skill whose `triggers` never clear the loader's `0.7` word-overlap threshold for the phrasing it was written for. It ships, it reads beautifully, it never loads.
2. A trigger set loose enough that an ordinary "explain why CI failed" pulls the skill in, and the answer comes back pitched at a five-year-old.

## Why it matters

Word-overlap trigger matching is **opt-in**: `skills.max_triggered` defaults to `0`, which disables it, and a stock install discovers skills through the Available Skills index plus `skill_search` / `$skillname`. So the two failures above land on the population that has turned trigger matching on (`max_triggered > 0`), not on every user — and for that population they land silently. The first is dead weight occupying catalog space that `skill_search` still has to rank; the second actively degrades unrelated answers. Nothing in the suite currently checks either one, for any skill, so today both ship undetected.

The default discovery path is not what this harness covers: there a skill is found through its `description`, which the generic bundled-skill frontmatter test already pins.

## What changed (motivation → approach → change)

**Goal → approach.** The trigger set is the only route to a bundled skill, and whether it works is a numeric property of the trigger phrases against real user phrasing. Prose cannot assert it. So the approach is not "write the skill more carefully"; it is to make that property testable first, then write the skill against the test.

**What was built.**

`src/kiro_crew/builtin_skills/explain-for/SKILL.md` — 21 audiences across four axes (age, education level, job role, relationship), each a table row carrying its own calibration. Three ordered steps: resolve the audience, establish the ground truth, then write. Four joints are specific to Crew rather than generic explanation advice:

- **Step 0 self-gate.** Trigger matching is word-overlap and therefore probabilistic, so the skill opens by telling the agent to confirm the request is actually pitched at somebody and otherwise answer normally. This is the prose half of the control-case boundary below; the tests are the mechanical half.
- **Memory-first audience resolution.** "explain this to my daughter" usually resolves against the persistent user profile. Guessing an age the profile already contradicts is the most visible way this skill fails, so checking memory precedes guessing, and an unresolvable audience is asked about rather than invented.
- **Verbosity interaction named.** An explanation request is the documented exception to the answer-only and concise verbosity levels. Unless the skill says so, an agent running under one of those levels clips the very output the user asked to be expansive.
- **Surface and persistence.** Only the dashboard renders markdown tables and widgets, so on Slack the audience tables would arrive as unreadable pipes. And an explanation written for a director gets forwarded, so it belongs in an artifact rather than in chat scrollback.

`src/kiro_crew/builtin_skills/explain-for/SKILL.md` — 21 audiences across four axes (age, education level, job role, relationship), each a table row carrying its own calibration. Three ordered steps: resolve the audience, establish the ground truth, then write. Four joints are specific to Crew rather than generic explanation advice:

- **Step 0 self-gate.** Trigger matching is word-overlap and therefore probabilistic, so the skill opens by telling the agent to confirm the request is actually pitched at somebody and otherwise answer normally. This is the prose half of the control-case boundary below; the tests are the mechanical half.
- **Memory-first audience resolution.** "explain this to my daughter" usually resolves against the persistent user profile. Guessing an age the profile already contradicts is the most visible way this skill fails, so checking memory precedes guessing, and an unresolvable audience is asked about rather than invented.
- **Verbosity interaction named.** An explanation request is the documented exception to the answer-only and concise verbosity levels. Unless the skill says so, an agent running under one of those levels clips the very output the user asked to be expansive.
- **Surface and persistence.** Only the dashboard renders markdown tables, diagram fences and widgets, so on Slack a table arrives as pipes and a `mermaid` fence as raw source. And an explanation written for a director gets forwarded, so it belongs in an artifact rather than in chat scrollback.

It also carries a **"Draw it when the thing has a shape"** section, because for an explanation skill the picture is often the payload. The decision is framed as a shape question first — a sequence, a hierarchy, a state change or a number that moved is worth drawing; a definition or a trade-off is not, since a box with words in it is not a diagram. Then it scales like the prose: for a child the picture *is* the explanation, for a manager one before/after and never an architecture diagram, for an engineer the real mechanism drawn precisely. Two rules carry more weight than the picture: a wrong diagram is worse than wrong prose because it reads as authoritative and gets screenshotted into other people's documents, and a diagram that restates the caption should be deleted.

**The trigger set is 3-word-dominant on purpose**, because the matcher makes a longer trigger *looser*: overlap is scored as a fraction of the trigger against a `0.7` floor, so a 4-word trigger admits any 3 and you do not choose which word drops. `explain it to my` therefore never required `my` — `{explain, it, to}` alone scored 0.75 and matched "can you explain it to me", an ordinary request with no audience in it. It became the 3-word `explain to my`, where the possessive is mandatory again; `break this down for` had the identical flaw (bare "break this down" scored 0.75) and became `break down for`. `explain like a` was then added to cover "explain it to me like a manager", which the tightened set would otherwise miss. Control cases pin all of it.

`evals/explain-for/` — 17 cases: 13 covering all four audience axes, plus 4 **controls** that carry explanation vocabulary but are not audience requests. `run_evals.py` has two modes, because only one of them can honestly run in CI:

- `--check` is deterministic — no model, no network. It validates that every case's declared audience is a real row in the skill's audience tables, that each prompt's trigger outcome matches its declared expectation, that **every declared trigger has at least one case that fires on it**, and that no case reuses a prompt the skill spells out in its own "Worked shapes" section. Non-zero exit, so a test can gate on it. It imports `_MIN_TRIGGER_OVERLAP` from `kiro_crew.skills` so the threshold cannot drift away from the loader it is checking.
- `--run` is the A/B measurement: each prompt answered twice (skill body prepended vs bare), both graded against that case's assertions by the CLI acting as judge, pass rate and delta printed, outputs written to a gitignored `iteration-N/`. It re-runs `--check` first and refuses to spend tokens on an inconsistent case set.

Three of those `--check` rules exist because a gate that cannot fail is the failure mode this PR is about:

> - **Duplicate-prompt.** The skill body is injected *ahead* of the prompt, so a case reusing a worked-shape example is answered from context in the with-skill lane — the lane wins on recall and the delta says nothing about unseen phrasing.
> - **Vacuous parse.** That rule is only as good as the parsed example list, and the parse is coupled to the `## Worked shapes` heading and the `**"..."**` quoting. An empty parse would make it pass every case while checking nothing, so an empty parse is itself a failure.
> - **Trigger coverage.** A trigger no case exercises is untested surface — it can be too loose, or dead, and the suite stays green either way. `explain like im` was in exactly that state.

`test/test_explain_for_skill.py` — asserts the trigger expectations through the **real** `SkillsLoader.get_triggered_skills`, not a reimplementation of its scoring, over a temp skills tree holding only this skill. The isolation is deliberate: with the full bundled set installed, `max_triggered` could evict explain-for behind an unrelated skill, and the assertion would then be measuring trigger competition instead of this skill's own triggers.

The fixture is function-scoped and passes its config explicitly, and both of those are load-bearing rather than stylistic. `SkillsLoader(config=None)` falls through to `KiroCrewConfig.load()` → `config_dir()`, which *creates* the operator's real data home — and a module-scoped fixture is built before the function-scoped autouse `_isolate_kirocrew_home` can redirect it, which `no-test-side-effects` forbids. Passing the config also decides the verdict instead of inheriting it: `max_triggered` defaults to **0**, which makes `get_triggered_skills` return nothing at all, so reading it from a real config yields a non-zero value on a developer box and 0 on a clean CI home. The reasoning is recorded in the fixture docstring, where the next reader will be.

`evals/` sits outside `src/`, so the harness is deliberately not packaged into the wheel. No packaging change was needed for the skill itself — `setup.cfg`'s existing `builtin_skills/**/*` glob already covers it.

## Tests

40 tests in `test/test_explain_for_skill.py`:

- **Reachability** — the skill is discovered, declares triggers, and each of the 17 cases' trigger expectation holds through the real loader.
- **Control boundary** — the 4 control prompts must NOT pull the skill in. These are the assertions that keep a future widened trigger from silently re-pitching ordinary questions.
- **Case coherence** — every case's audience is a row the skill actually defines; `run_evals.py --check` is executed as a test so CI enforces case/skill agreement rather than trusting the local dev loop; and one test asserts the duplicate-prompt rule still has examples to compare against, so it cannot degrade into a vacuous pass.
- **Content joints** — the verbosity exception and the ground-truth step stay named in the skill, since both are load-bearing and easy to drop in a later edit.

**Proven RED, not assumed** — every guard was watched failing against the mistake it exists for, then reverted to green:

| Guard | Injected mistake | Observed failure |
|---|---|---|
| Control boundary | added `explain for a` to the triggers | `control prompt 'Can you explain for a second why the CI job failed' pulls in explain-for` |
| Control boundary | restored `explain it to my` / `break this down for` | `control prompt WRONGLY triggers on 'explain it to my' (overlap 0.75 >= 0.7)` |
| Reachability | dropped the fixture's config pin | `prompt 'Explain this database migration to my mom' does not reach explain-for` |
| Vacuous parse | renamed the `## Worked shapes` heading | `no worked-shape examples parsed out of the skill, so the duplicate-prompt rule would pass vacuously` |
| Trigger coverage | deleted the `explain like im` case | `trigger(s) no passing case fires on: 'explain like im'` |
| Audience coherence | declared a diagram-table row as an audience | `audience 'A definition, a single fact, a judgement call' is not a row in the skill's tables` |

That last one was found by writing the diagram section: `audience_labels()` had been globbing the first column of **every** table in the skill, so the new "does this have a shape?" table's rows silently became valid audiences (21 → 28). It is now scoped to `Audience`-headed tables.

The generic bundled-skill gates (`test_image_authoring_skill.py` frontmatter parametrization, `test_builtin_skill_packaging.py`) also pick the new skill up automatically and pass — 70 together.

## Manual verification

`--check -v` prints the per-case trigger score, which is the property under test:

```
  case 1 (queue-age5): fires (1.00) via eli5
  case 2 (rate-limit-manager): fires (1.00) via explain to my
  case 3 (recursion-age15): fires (1.00) via break down for
  case 4 (cache-invalidation-default): fires (1.00) via dumb it down
  case 5 (migration-parent): fires (1.00) via explain to my
  case 6 (load-429-designer): fires (1.00) via simplify this for
  case 7 (eventual-consistency-graduate): fires (1.00) via in plain english
  case 8 (merge-conflict-age5): fires (1.00) via explain like i am
  case 9 (incident-support): fires (1.00) via break down for
  case 10 (slip-director): fires (1.00) via explain to my
  case 11 (retry-flow-like-a-manager): fires (1.00) via explain like a
  case 12 (lifecycle-diagram-engineer): fires (1.00) via explain to my
  case 17 (slow-query-middle-school): fires (1.00) via explain like im
  case 13 (control-commit-diff): silent (0.33) via explain like im
  case 14 (control-explain-it-to-me): silent (0.67) via explain to my
  case 15 (control-break-this-down): silent (0.67) via break down for
  case 16 (control-ci-question): silent (0.67) via explain like a

CHECK PASSED -- 17 cases, 9 triggers, 21 audiences
```

Every positive case clears the 0.7 threshold at 1.00; all four controls sit below it. Note the controls land at 0.67 — deliberately just under, which is what the tightened 3-word triggers buy.

The skill is also installed locally at `~/.kiro/crew/skills/explain-for/`, byte-identical to the packaged copy, and was exercised live end to end: `explain tunnel to my 5` fired at 1.00 via `explain to my`, the memory check surfaced a real conflict (the recorded children are 8 and 10, so "my 5" resolves to no one in the profile and the Age 5 row was named explicitly instead of assumed), and the answer carried a `mermaid` diagram because a tunnel is a flow — the top row of the new shape table.

`--run` was deliberately not executed for this PR: it costs tokens and its results are not reproducible across runs, which is exactly why it is a local command and not a gate. The deterministic half is what CI relies on.

- `--check` is deterministic — no model, no network. It validates that every case's declared audience is a real row in the skill's tables, that each prompt's trigger outcome matches its declared expectation, and that no case reuses a prompt the skill spells out in its own "Worked shapes" section. Non-zero exit, so a test can gate on it. It imports `_MIN_TRIGGER_OVERLAP` from `kiro_crew.skills` so the threshold cannot drift away from the loader it is checking.
- `--run` is the A/B measurement: each prompt answered twice (skill body prepended vs bare), both graded against that case's assertions by the CLI acting as judge, pass rate and delta printed, outputs written to a gitignored `iteration-N/`. It re-runs `--check` first and refuses to spend tokens on an inconsistent case set.

That third `--check` rule exists because the skill body is injected *ahead* of the prompt. A case that reuses a worked-shape example is answered from context in the with-skill lane, so the lane wins on recall and the delta says nothing about unseen phrasing. The two files would drift into that state silently as either one is edited, so the rule is mechanical rather than a note. It is also written so it cannot stop guarding: the parse is coupled to the `## Worked shapes` heading and the `**"..."**` quoting, and an empty parse would make the rule pass every case while checking nothing — so an empty parse is itself a `--check` failure, with a test pinning that.

`test/test_explain_for_skill.py` — asserts the trigger expectations through the **real** `SkillsLoader.get_triggered_skills`, not a reimplementation of its scoring, over a temp skills tree holding only this skill. The isolation is deliberate: with the full bundled set installed, `max_triggered` could evict explain-for behind an unrelated skill, and the assertion would then be measuring trigger competition instead of this skill's own triggers.

The fixture is function-scoped and passes its config explicitly, and both of those are load-bearing rather than stylistic. `SkillsLoader(config=None)` falls through to `KiroCrewConfig.load()` → `config_dir()`, which *creates* the operator's real data home — and a module-scoped fixture is built before the function-scoped autouse `_isolate_kirocrew_home` can redirect it, which `no-test-side-effects` forbids. Passing the config also decides the verdict instead of inheriting it: `max_triggered` defaults to **0**, which makes `get_triggered_skills` return nothing at all, so reading it from a real config yields a non-zero value on a developer box and 0 on a clean CI home. The reasoning is recorded in the fixture docstring, where the next reader will be.

`evals/` sits outside `src/`, so the harness is deliberately not packaged into the wheel. No packaging change was needed for the skill itself — `setup.cfg`'s existing `builtin_skills/**/*` glob already covers it.

## Related Issues

no linked issue: this adds a new bundled skill and the eval scaffolding for it, rather than resolving a tracked report.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `evals/README.md` documents the harness and how to add a case
- [x] No secrets, credentials, or internal references in the diff
