### PR TITLE
fix(discord): route option-button presses through resume routing

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -1538,12 +1538,28 @@ under the 2000-char cap, splitting ordinary text with the shared
 and holding local-image markup for secure multipart extraction at the semantic
 steer/final seal. It rotates messages at the shared driver's structured steer
 boundaries with quote chips, renders trailing `[OPTIONS:]` as button action rows
-(`opt:<i>`, label recovered from the component at interaction time), and posts
+(`opt:<i>:<tag>`, label recovered from the component at interaction time; `<tag>`
+is `session_provenance_tag()` — a 12-hex SHA-256 digest of the session key the
+buttons were rendered for), and posts
 Approve/Deny buttons for interactive tool approvals. Approval `custom_id`s carry a
 per-prompt random nonce (`a:<request_id>:<nonce>:<1|0>`) validated at
 resolution: ACP request IDs are reusable across provider/gateway restarts, so a
 stale button without the matching nonce fails closed. The decision window
 denies by default on timeout and retires the nonce with it.
+
+**Option-press provenance.** Discord replays old components indefinitely, so an
+option press dispatches only when the session the conversation currently
+resolves to (via the resume binding, else the native DM session) is the one the
+tag names — a press carries a non-empty tag, and the tag implies resume routing
+even though the label never executes as a command (button labels are
+model-authored turn content, same rule as the queue drain). The tag is checked
+before the busy path — a press against a busy target is refused, never
+queued/steered, because the drain replays items tag-less — and re-checked after
+idle/daily rotation so it cannot run under a generation the tag never named. A
+mismatch (the chat was rebound or `!new`'d since the buttons were posted) and an
+untagged pre-provenance button both fail closed with a refusal naming the
+remedy; queue drains and AutoNudge fires dispatch untagged with commands off and
+keep their native-session affinity.
 
 Every turn closes with a **one-line footer** as Discord subtext (`-#`) on the
 final segment, rendered by the shared `format_turn_status` (see "Turn-status

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -4822,6 +4822,17 @@ class DashboardState:
             # which is unbounded on slow storage.
             target = await asyncio.to_thread(_resolve_channel_target, self, key, link)
             if target is None:
+                # The docstring's "logged and dropped" promise, kept: an
+                # unreachable, ungoverned or unregistered channel means the user
+                # was NOT told their conversation lost its way back, and a silent
+                # return here leaves that undeliverable notice invisible to the
+                # operator too (the SEL event records the removal, not the
+                # delivery failure).
+                logging.getLogger(__name__).warning(
+                    "inbound-unbind notice for %s undeliverable: no governed %s transport",
+                    key,
+                    link.channel_type,
+                )
                 return
             resolved, transport = target
             notice = _INBOUND_UNBIND_NOTICE.format(

--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -47,6 +47,7 @@ Dependency direction is ``discord -> messaging`` (allowed).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
@@ -269,17 +270,39 @@ def _neutralize_md(raw: str) -> str:
     return re.sub(r"[*_`\[\]()]", "", t)
 
 
-def build_option_components(options: list[str]) -> list[dict] | None:
+def session_provenance_tag(session_key: str) -> str:
+    """A short, stable, non-reversible tag naming the session that posted a message.
+
+    Stamped into option-button ``custom_id``s so a press can be checked against the
+    conversation's CURRENT target session: Discord replays old components
+    indefinitely, and a button minted by one session must not inject its choice
+    into whatever session the conversation was later rebound to. A hash rather
+    than the raw key because a custom_id is client-visible in guild threads and
+    internal session keys are not the channel's to see; unsalted and truncated
+    because this is an equality gate on state the caller already controls, not an
+    authentication token — forging the tag of a session buys exactly what typing a
+    message into the conversation already does. Stateless by design: it survives a
+    gateway restart, which a server-side registry of live buttons would not.
+    """
+    if not session_key:
+        return ""
+    return hashlib.sha256(session_key.encode("utf-8")).hexdigest()[:12]
+
+
+def build_option_components(options: list[str], origin_tag: str = "") -> list[dict] | None:
     """Build Discord button action rows from ``[OPTIONS:]`` labels.
 
-    ``custom_id`` is the index only (``opt:<i>``) -- Discord caps it at 100
-    chars and the label is recovered from the button text at interaction time.
-    Labels cap at 80 chars per the component spec. The ``max_buttons`` cap is
-    applied UPSTREAM via ``apply_options_cap`` (overflow degrades to numbered
-    text); the slice below is the platform hard-limit backstop only.
+    ``custom_id`` is ``opt:<i>:<origin_tag>`` (``opt:<i>`` when no tag is given --
+    the pre-provenance legacy shape) -- Discord caps it at 100 chars, which the
+    12-hex tag fits comfortably, and the label is recovered from the button text
+    at interaction time. Labels cap at 80 chars per the component spec. The
+    ``max_buttons`` cap is applied UPSTREAM via ``apply_options_cap`` (overflow
+    degrades to numbered text); the slice below is the platform hard-limit
+    backstop only.
     """
     if not options:
         return None
+    suffix = f":{origin_tag}" if origin_tag else ""
     rows: list[dict] = []
     row: list[dict] = []
     for i, opt in enumerate(options[:_MAX_BUTTONS]):
@@ -288,7 +311,7 @@ def build_option_components(options: list[str]) -> list[dict] | None:
                 "type": 2,  # button
                 "style": _STYLE_SECONDARY,
                 "label": opt[:_BUTTON_LABEL_CHARS],
-                "custom_id": f"opt:{i}",
+                "custom_id": f"opt:{i}{suffix}",
             }
         )
         if len(row) == _BUTTONS_PER_ROW:
@@ -703,7 +726,11 @@ class DiscordRenderer(Renderer):
         # the rotation above ran before that expansion -- re-check, or a
         # near-limit answer with over-cap options seals past the transport cap.
         await self._rotate_on_length()
-        components = build_option_components(opts) if opts else None
+        components = (
+            build_option_components(opts, session_provenance_tag(self._session_key))
+            if opts
+            else None
+        )
         sealed = bool(self._segment_text().strip()) or components is not None
         await self._seal_current(components=components)
         clean_summary = _neutralize_md(summary)
@@ -1189,7 +1216,11 @@ class DiscordRenderer(Renderer):
         body_text, opts = apply_options_cap(self._segment_text(), opts, self.capabilities)
         self._buf = []
         self._delivery_text = body_text
-        components = build_option_components(opts) if opts else None
+        components = (
+            build_option_components(opts, session_provenance_tag(self._session_key))
+            if opts
+            else None
+        )
         # No-rotation fallback: steers were injected but no marker rotated —
         # prepend one summary chip so they're still shown.
         if self._seal_count == 0 and self._steer_texts:

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -47,6 +47,7 @@ from kiro_crew.discord.renderer import (
     DiscordApprovalDecider,
     DiscordRenderer,
     build_model_components,
+    session_provenance_tag,
 )
 from kiro_crew.discord.session_resume import (
     DiscordSessionResume,
@@ -128,6 +129,36 @@ _MAX_COLLAPSED_ATTACHMENTS = IngestLimits().max_attachments
 #: Everything else targets a session or is a plain turn and must be refused until
 #: the user has been told — including a bare message, whose ``cmd`` is ``None``.
 _DETACH_EXEMPT_COMMANDS = frozenset({"new", "unlink", "sessions", "help", "status"})
+
+#: Refusal for an option press whose provenance tag does not name the
+#: conversation's CURRENT target session (rebound, `!new`, or idle-rotated).
+#: One constant, two gate sites (pre-busy and post-rotation), so the wording
+#: cannot drift between them.
+_STALE_OPTIONS_REFUSAL = (
+    "🔘 These buttons belong to a conversation this chat has since moved away "
+    "from, so your choice was NOT applied. Type it as a message instead, or "
+    "run `!sessions` to reattach the session that asked."
+)
+
+#: Refusal for a pre-provenance button (bare ``opt:<i>``): Discord replays old
+#: components indefinitely, so an untagged press can never prove which session
+#: it belongs to — fail closed rather than route it by current binding.
+_UNTAGGED_OPTIONS_REFUSAL = (
+    "🔘 These buttons predate a session-safety update, so which conversation "
+    "they belong to can no longer be verified and your choice was NOT applied. "
+    "Type it as a message instead."
+)
+
+#: Refusal for a valid press whose target session is mid-turn. A press must
+#: never be queued or steered: the busy queue stores bare text and the drain
+#: replays it WITHOUT the provenance tag, so a `!new` or idle rotation between
+#: enqueue and drain would execute the model-authored choice in a conversation
+#: the tag never named. Refusing is the only shape that keeps the provenance
+#: guarantee end to end.
+_BUSY_OPTIONS_REFUSAL = (
+    "🔘 That conversation is busy with another turn, so your choice was NOT "
+    "applied. Type it as a message once the turn finishes."
+)
 
 # How long a !model picker stays pressable, and how many pickers are retained.
 # Both bound unbounded growth (one entry per press-less !model), they are not UX
@@ -230,8 +261,40 @@ class DiscordDispatcher:
         *,
         drain: bool = True,
         interpret_commands: bool = True,
+        origin_tag: str = "",
     ) -> None:
-        """Drive one authorized inbound message through TurnDriver end-to-end."""
+        """Drive one authorized inbound message through TurnDriver end-to-end.
+
+        ``interpret_commands`` says whether *text* may execute as a command
+        (model-authored text never may). Resume routing is consulted when
+        ``interpret_commands`` is true OR the turn carries an ``origin_tag`` —
+        the tag implies routing, because validating it requires resolving the
+        binding to compare keys. The callers that dispatch with commands off
+        and no tag DEPEND on the skip: a queue drain replays messages that were
+        accepted for the native session while it was busy (a resumed session's
+        busy turn refuses instead of queueing, so a drained item's affinity is
+        native by construction), and an AutoNudge fire targets the native key
+        its loop resolved and rotation-checked — routing either into a binding
+        created later would run them in a session that never queued or armed
+        them. An ``[OPTIONS:]`` press dispatches with commands off but a
+        non-empty tag: the buttons were rendered on the bound session's own
+        reply, so the choice belongs to that session even though its label must
+        not execute as a command.
+
+        ``origin_tag`` is the provenance stamp a pressed option button carried
+        (see :func:`~kiro_crew.discord.renderer.session_provenance_tag`). When
+        non-empty, the turn runs ONLY if the session it resolves to is the one
+        that posted the buttons — checked before the busy path (so a stale press
+        cannot be queued and replayed tag-less) and AGAIN after idle/daily
+        rotation (so it cannot run under a generation the tag never named).
+        Discord replays old components indefinitely, so without this check a
+        button minted by one session would inject its model-authored choice into
+        whatever session the conversation was later rebound to (`!unlink` +
+        `!sessions`), or into a post-`!new` conversation that never asked the
+        question. An option press ALWAYS supplies a tag: untagged
+        (pre-provenance) presses are refused at the interaction boundary in
+        :meth:`on_interaction`, never dispatched here.
+        """
         assert self.client is not None, "DiscordDispatcher.client must be set"
         channel_id = msg.conversation_id
         self._routing_checks[channel_id] = self._routing_checks.get(channel_id, 0) + 1
@@ -274,7 +337,8 @@ class DiscordDispatcher:
         # destroyed they would compact or cancel the NATIVE DM session while the user
         # believes they drive the resumed one; deciding here makes that structural.
         route = RoutingDecision()
-        if interpret_commands and cmd not in _DETACH_EXEMPT_COMMANDS:
+        wants_routing = interpret_commands or bool(origin_tag)
+        if wants_routing and cmd not in _DETACH_EXEMPT_COMMANDS:
             async with self._routing_turn(channel_id) as queued:
                 route = await self._session_resume.route(channel_id)
                 if route.refusal is not None:
@@ -378,7 +442,28 @@ class DiscordDispatcher:
         # second resolver call let an unlink landing mid-decision route silently.
         resumed_key = route.resumed_key
         session_key = resumed_key or self._session_key(user_id, thread_id)
+        if origin_tag and session_provenance_tag(session_key) != origin_tag:
+            # The pressed button was minted by a session this conversation no
+            # longer targets (rebound via `!unlink`+`!sessions`, or rotated via
+            # `!new`). Running it would inject that session's model-authored
+            # choice into an unrelated transcript. The gate sits BEFORE the busy
+            # check so a stale press can neither run nor be QUEUED — `_handle_busy`
+            # enqueues raw text, and the drain replays it without the tag, so a
+            # queued stale press would execute unchecked later.
+            await self.client.send_message(channel_id, _STALE_OPTIONS_REFUSAL)
+            return
         if self.sessions.is_busy(session_key):
+            if origin_tag:
+                # A tagged press must never enter the busy path: `_handle_busy`
+                # enqueues BARE TEXT and the drain replays it without the tag,
+                # so a `!new` or idle rotation between enqueue and drain would
+                # execute the choice in a conversation the tag never named —
+                # and steer mode would inject it mid-turn with no check at all.
+                # Refuse instead; the user can re-press or type once the turn
+                # ends. This also covers the resumed-busy case below, with a
+                # press-specific remedy instead of the typed-message one.
+                await self.client.send_message(channel_id, _BUSY_OPTIONS_REFUSAL)
+                return
             if resumed_key is not None:
                 # Do NOT queue or steer into a resumed session's running turn.
                 # ``_drain_queue`` is only ever called from the tail of a
@@ -403,6 +488,16 @@ class DiscordDispatcher:
             daily_reset_hour=self.cfg.messaging.daily_reset_hour,
         )
         session_key = resumed_key or self._session_key(user_id, thread_id)
+        if origin_tag and session_provenance_tag(session_key) != origin_tag:
+            # REVALIDATE against the FINAL key: ``maybe_rotate`` above can bump
+            # the native generation between the pre-busy gate and here, and the
+            # turn must not run under a key the tag never named — the same
+            # invariant `!new` enforces, applied to the idle/daily reset. The
+            # pre-busy gate is kept too: it is what stops a stale press from
+            # being enqueued or probing busy state, which this later check
+            # cannot do.
+            await self.client.send_message(channel_id, _STALE_OPTIONS_REFUSAL)
+            return
         chan_id = f"discord:{channel_id}" if thread_id else f"discord:{user_id}"
         agent = self._resolve_agent()
         if resumed_key is not None:
@@ -1112,12 +1207,21 @@ class DiscordDispatcher:
             await self.client.edit_message(itx.channel_id, itx.message_id, outcome, components=[])
             return
 
-        # [OPTIONS:] choice: "opt:<i>" — label recovered from the button text.
+        # [OPTIONS:] choice: "opt:<i>:<origin-tag>" — label recovered from the
+        # button text. A bare "opt:<i>" is a pre-provenance button; Discord
+        # replays old components indefinitely, so its originating session can
+        # never be verified — refuse it here, fail closed, before any echo
+        # suggests the choice was sent.
         if data.startswith("opt:"):
+            parts = data.split(":", 2)
+            origin_tag = parts[2] if len(parts) == 3 else ""
             choice_text = itx.label
             # Retire the buttons but KEEP the original answer text intact —
             # a components-only PATCH leaves the content unchanged.
             await self.client.edit_message_components(itx.channel_id, itx.message_id, [])
+            if not origin_tag:
+                await self.client.send_message(itx.channel_id, _UNTAGGED_OPTIONS_REFUSAL)
+                return
             if not choice_text:
                 await self.client.send_message(
                     itx.channel_id,
@@ -1142,7 +1246,20 @@ class DiscordDispatcher:
             # user was waiting on. Same rule and same reason as the queue drain, which
             # replays with commands off so a queued `!new` reaches the model as
             # literal text instead of executing.
-            await self.handle_message(synthetic, interpret_commands=False)
+            # UNLIKE the drain, the press still resolves the resumed binding: the
+            # buttons sit on the bound session's own reply, so the choice is that
+            # session's turn content — its non-empty `origin_tag` is what routes
+            # it (see ``handle_message``). Without routing the press ran in the
+            # NATIVE DM session — the click answered a question nobody asked
+            # there, while the bound session kept waiting (and if the binding died
+            # in between, routing now surfaces the Detached refusal instead of a
+            # silent native turn). The tag also closes the remaining window: the
+            # resolved target must BE the session that posted these buttons.
+            await self.handle_message(
+                synthetic,
+                interpret_commands=False,
+                origin_tag=origin_tag,
+            )
 
     # ── Public injection surface ────────────────────────────────────────────
     # Contract for out-of-band callers (AutoNudge fire path, the REST create

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -50,6 +50,7 @@ from kiro_crew.discord.renderer import (
     _extract_options,
     _strip_steering,
     build_option_components,
+    session_provenance_tag,
 )
 from kiro_crew.discord.transport import (
     DISCORD_CAPABILITIES,
@@ -1053,6 +1054,17 @@ class TestOptionComponents:
         total = sum(len(r["components"]) for r in comps)
         assert total == 25
 
+    def test_origin_tag_suffixes_every_custom_id(self) -> None:
+        """The provenance tag rides the custom_id; bare ids are the legacy shape.
+
+        ``opt:<i>:<tag>`` is what the press-side gate parses back out, so the
+        two halves meet exactly here.
+        """
+        comps = build_option_components(["a", "b"], "deadbeefcafe")
+        assert comps is not None
+        ids = [b["custom_id"] for row in comps for b in row["components"]]
+        assert ids == ["opt:0:deadbeefcafe", "opt:1:deadbeefcafe"]
+
 
 class TestExtractOptions:
     def test_no_options(self) -> None:
@@ -1687,6 +1699,16 @@ class TestRenderer:
         labels = [b["label"] for row in comps for b in row["components"]]
         assert labels == ["A", "B"]
         assert "[OPTIONS" not in cli.final_text()
+        # The sealed row is PROVENANCE-STAMPED with this renderer's session key —
+        # the producer half of the stale-press fix. Without this pin, reverting
+        # the call sites to untagged build_option_components(opts) keeps the
+        # whole suite green while every new button falls back to the legacy
+        # current-binding path, silently reopening cross-session injection.
+        ids = [b["custom_id"] for row in comps for b in row["components"]]
+        assert ids == [
+            f"opt:0:{session_provenance_tag('sk')}",
+            f"opt:1:{session_provenance_tag('sk')}",
+        ]
 
     @pytest.mark.asyncio
     async def test_long_options_before_streamed_steer_ack_become_buttons(self) -> None:
@@ -3073,7 +3095,8 @@ class TestInteractions:
     @pytest.mark.asyncio
     async def test_option_choice_reinjects_as_turn(self) -> None:
         d, cli, sess = _dispatcher({"u1"})
-        await d.on_interaction(self._itx("opt:0", label="Choice A"))
+        tag = session_provenance_tag(d.current_session_key("u1"))
+        await d.on_interaction(self._itx(f"opt:0:{tag}", label="Choice A"))
         # Buttons retired without clobbering the answer text.
         assert cli.component_edits == [("m1", [])]
         # Choice echoed as a quote, then answered as a fresh turn.
@@ -3083,9 +3106,19 @@ class TestInteractions:
         )
 
     @pytest.mark.asyncio
+    async def test_untagged_option_press_fails_closed(self) -> None:
+        """A pre-provenance button press is refused — its origin is unprovable."""
+        d, cli, sess = _dispatcher({"u1"})
+        await d.on_interaction(self._itx("opt:0", label="Choice A"))
+        assert cli.component_edits == [("m1", [])]
+        assert any("predate" in t for t, _ in cli.sent)
+        assert sess.successes == []
+
+    @pytest.mark.asyncio
     async def test_option_without_label_asks_to_type(self) -> None:
         d, cli, _ = _dispatcher({"u1"})
-        await d.on_interaction(self._itx("opt:0", label=""))
+        tag = session_provenance_tag(d.current_session_key("u1"))
+        await d.on_interaction(self._itx(f"opt:0:{tag}", label=""))
         assert any("type it instead" in t for t, _ in cli.sent)
 
 
@@ -3566,7 +3599,7 @@ class TestOptionChoiceIsNeverACommand:
                 channel_id="c1",
                 user_id="u1",
                 message_id="m1",
-                custom_id="opt:0",
+                custom_id=f"opt:0:{session_provenance_tag(before)}",
                 label="!new",
             )
         )

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -14,6 +14,7 @@ from kiro_crew.config.paths import config_dir
 from kiro_crew.discord import session_resume
 from kiro_crew.discord.client import DISCORD_CHUNK_LIMIT, DiscordInteraction
 from kiro_crew.discord.commands import parse_command, parse_command_argument
+from kiro_crew.discord.renderer import session_provenance_tag
 from kiro_crew.discord.transport_dispatch import DiscordDispatcher
 from kiro_crew.messaging import resume_expectation
 from kiro_crew.messaging import session_resume as session_resume_core
@@ -391,7 +392,9 @@ def _message(text: str, channel_id: str = "c1", thread_id: str = "") -> InboundM
     )
 
 
-def _interaction(custom_id: str, message_id: str, channel_id: str = "c1") -> DiscordInteraction:
+def _interaction(
+    custom_id: str, message_id: str, channel_id: str = "c1", label: str = ""
+) -> DiscordInteraction:
     return DiscordInteraction(
         interaction_id="i1",
         interaction_token="tok",
@@ -399,7 +402,7 @@ def _interaction(custom_id: str, message_id: str, channel_id: str = "c1") -> Dis
         user_id="u1",
         message_id=message_id,
         custom_id=custom_id,
-        label="",
+        label=label,
         guild_id="",
     )
 
@@ -1173,6 +1176,241 @@ async def test_resumed_session_without_recorded_agent_falls_back() -> None:
     await dispatcher.handle_message(_message("continue here"))
 
     assert sessions.last_agent == "kirocrew"
+
+
+async def _bind_to_chat1(
+    dispatcher: DiscordDispatcher, client: _Client, log: _ConversationLog
+) -> None:
+    """Bind DM c1 to dashboard:chat-1 through the real picker flow."""
+    log.messages["dashboard:chat-1"] = [{"role": "assistant", "content": "prior"}]
+    await dispatcher.handle_message(_message("!sessions"))
+    custom_id, message_id = _picker_button(client)
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+    assert dispatcher._session_resume.resumed_session("c1") == "dashboard:chat-1"
+
+
+@pytest.mark.asyncio
+async def test_option_press_routes_into_resumed_session() -> None:
+    """An [OPTIONS:] press on a bound DM is the RESUMED session's turn content.
+
+    The press re-dispatches with ``interpret_commands=False`` because the label is
+    model-authored text that must never execute as a command — but that flag must
+    not also skip resume routing. The buttons were rendered on the bound session's
+    own reply (and carry its provenance tag), so the choice belongs to that
+    session. Before the fix the press ran in the native DM session: the click
+    answered a question nobody asked there, while the bound session kept waiting
+    for its answer (live incident 2026-08-30: a merge-approach choice for the
+    bound session green-lit the native session's parked debug plan instead).
+    """
+    log = _log()
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    await _bind_to_chat1(dispatcher, client, log)
+
+    tag = session_provenance_tag("dashboard:chat-1")
+    await dispatcher.on_interaction(_interaction(f"opt:0:{tag}", "m-opts", label="Ship option (a)"))
+
+    assert sessions.last_key == "dashboard:chat-1"
+    # The label reached the session as literal turn content, commands off.
+    assert any(t.startswith("> Ship option (a)") for t, _ in client.sent)
+
+
+@pytest.mark.asyncio
+async def test_untagged_press_is_refused_fail_closed() -> None:
+    """A pre-provenance button (bare ``opt:<i>``) is refused, never routed.
+
+    Discord replays old components indefinitely, so an untagged press can never
+    prove which session it belongs to — and routing it by current binding is
+    exactly the cross-session injection this fix exists to stop (server review
+    round 1, span 405abadda748: the legacy pass-through never ages out, so it
+    was the same hole with a different door). Fail closed with a type-it-instead
+    notice; no echo, no turn anywhere.
+    """
+    log = _log()
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    await _bind_to_chat1(dispatcher, client, log)
+
+    await dispatcher.on_interaction(_interaction("opt:0", "m-opts", label="Ship option (a)"))
+
+    assert any("predate" in t for t, _ in client.sent)
+    assert not any(t.startswith("> Ship option (a)") for t, _ in client.sent)
+    assert sessions.last_key == ""  # no turn ran anywhere
+
+
+@pytest.mark.asyncio
+async def test_tagged_press_is_revalidated_after_idle_rotation() -> None:
+    """Idle/daily rotation between the gate and the turn invalidates the tag.
+
+    ``maybe_rotate`` can bump the native generation AFTER the pre-busy gate
+    passed, so the turn would run under a key the tag never named. The gate is
+    re-run against the FINAL key after rotation — the same invariant ``!new``
+    enforces, applied to the reset nobody typed.
+    """
+    dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+    tag = session_provenance_tag(dispatcher.current_session_key("u1"))
+    scope = dispatcher._scope_id("u1")
+
+    def _rotate_now(*args: object, **kwargs: object) -> None:
+        dispatcher._conv.bump_gen(scope)
+
+    dispatcher._conv.maybe_rotate = _rotate_now  # type: ignore[method-assign]
+
+    await dispatcher.on_interaction(_interaction(f"opt:0:{tag}", "m-opts", label="Choice A"))
+
+    assert any("moved away" in t for t, _ in client.sent)
+    assert sessions.last_key == ""  # the rotated generation never ran the press
+
+
+@pytest.mark.asyncio
+async def test_stale_tagged_press_after_rebind_is_refused() -> None:
+    """A button minted by session A, pressed after the DM was rebound to B, refuses.
+
+    Discord replays old components indefinitely: A's reply keeps its live buttons
+    after ``!unlink`` + ``!sessions`` rebinds the DM to B. Routing alone would send
+    the press into B — injecting A's model-authored choice into an unrelated
+    transcript, the GPT round-1 blocker. The provenance tag makes the press valid
+    only while the conversation still targets the session that posted it.
+    """
+    log = _log_with_titles("Alpha plan", "Beta plan")
+    log.messages["dashboard:chat-0"] = [{"role": "assistant", "content": "prior a"}]
+    log.messages["dashboard:chat-1"] = [{"role": "assistant", "content": "prior b"}]
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+
+    # Bind A (chat-0) through the real picker, as the incident did.
+    await dispatcher.handle_message(_message("!sessions Alpha"))
+    custom_id, message_id = _picker_button(client)
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+    assert dispatcher._session_resume.resumed_session("c1") == "dashboard:chat-0"
+    stale_tag = session_provenance_tag("dashboard:chat-0")
+
+    # Rebind to B (chat-1): unlink, then pick again.
+    await dispatcher.handle_message(_message("!unlink"))
+    await dispatcher.handle_message(_message("!sessions Beta"))
+    custom_id, message_id = _picker_button(client)
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+    assert dispatcher._session_resume.resumed_session("c1") == "dashboard:chat-1"
+    sessions.last_key = ""
+
+    await dispatcher.on_interaction(
+        _interaction(f"opt:0:{stale_tag}", "m-old-opts", label="Ship option (a)")
+    )
+
+    assert any("moved away" in t for t, _ in client.sent)
+    assert sessions.last_key == ""  # no turn ran in B, in A, or natively
+
+
+@pytest.mark.asyncio
+async def test_press_tagged_for_pre_new_conversation_is_refused() -> None:
+    """``!new`` invalidates the previous conversation's buttons.
+
+    The native key embeds the generation, so a press carrying the pre-``!new``
+    tag no longer matches — honest, since the conversation that asked the
+    question is over. Before the tag the press ran silently in the fresh
+    generation, answering a question it never asked.
+    """
+    dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+    old_tag = session_provenance_tag(dispatcher.current_session_key("u1"))
+
+    await dispatcher.handle_message(_message("!new"))
+    assert dispatcher.current_session_key("u1") != ""
+    sessions.last_key = ""
+
+    await dispatcher.on_interaction(_interaction(f"opt:0:{old_tag}", "m-opts", label="Choice A"))
+
+    assert any("moved away" in t for t, _ in client.sent)
+    assert sessions.last_key == ""
+
+
+@pytest.mark.asyncio
+async def test_stale_press_against_busy_target_is_refused_not_queued() -> None:
+    """The provenance gate precedes the busy check — pinned as ordering.
+
+    A stale press must be refused BEFORE ``is_busy`` runs: the busy path either
+    queues (native) or posts the busy refusal (resumed), and a queued stale
+    press would be drained and replayed WITHOUT its tag, executing unchecked
+    later. It also must not leak whether the current target is mid-turn.
+    """
+    dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+    old_tag = session_provenance_tag(dispatcher.current_session_key("u1"))
+    await dispatcher.handle_message(_message("!new"))
+    sessions.last_key = ""
+    sessions.is_busy = lambda key: True  # type: ignore[method-assign]
+    enqueued: list = []
+    sessions.enqueue = lambda *a, **k: enqueued.append(a)  # type: ignore[attr-defined]
+
+    await dispatcher.on_interaction(_interaction(f"opt:0:{old_tag}", "m-opts", label="Choice A"))
+
+    assert any("moved away" in t for t, _ in client.sent)
+    assert not any("busy" in t for t, _ in client.sent)
+    assert enqueued == []
+    assert sessions.last_key == ""
+
+
+@pytest.mark.asyncio
+async def test_valid_tagged_press_against_busy_target_is_refused_not_queued_or_steered() -> None:
+    """A VALID press whose target is mid-turn refuses — it never enters the queue.
+
+    ``_handle_busy`` enqueues bare text (or steers it mid-turn), and the drain
+    replays queued text WITHOUT the provenance tag — so a ``!new`` or idle
+    rotation between enqueue and drain would execute the model-authored choice
+    in a conversation the tag never named (server review round 2, span
+    405abadda748). The busy path is therefore unreachable for any tagged press.
+    """
+    dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+    tag = session_provenance_tag(dispatcher.current_session_key("u1"))
+    sessions.is_busy = lambda key: True  # type: ignore[method-assign]
+    enqueued: list = []
+    sessions.enqueue = lambda *a, **k: enqueued.append(a)  # type: ignore[attr-defined]
+    steered: list = []
+    sessions.steer = lambda *a, **k: steered.append(a)  # type: ignore[attr-defined]
+
+    await dispatcher.on_interaction(_interaction(f"opt:0:{tag}", "m-opts", label="Choice A"))
+
+    assert any("busy" in t and "NOT applied" in t for t, _ in client.sent)
+    assert enqueued == [] and steered == []
+    assert sessions.last_key == ""  # no turn ran anywhere
+
+
+@pytest.mark.asyncio
+async def test_option_press_after_binding_destroyed_is_refused_not_native() -> None:
+    """A press whose binding died mid-flight gets the Detached refusal.
+
+    The refusal is the honest outcome routing already produces for a typed
+    message; the press must not fall back to a silent native turn, which is the
+    exact misroute the routing gate exists to stop.
+    """
+    log = _log()
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    await _bind_to_chat1(dispatcher, client, log)
+    stale_tag = session_provenance_tag("dashboard:chat-1")
+    # The binding dies out from under the DM (a housekeeping clear, not !unlink).
+    sessions.clear_mirror_link("dashboard:chat-1")
+
+    await dispatcher.on_interaction(
+        _interaction(f"opt:0:{stale_tag}", "m-opts", label="Ship option (a)")
+    )
+
+    assert any("Detached" in t for t, _ in client.sent)
+    assert sessions.last_key == ""  # no turn ran anywhere
+
+
+@pytest.mark.asyncio
+async def test_synthetic_dispatch_without_origin_tag_keeps_native_affinity() -> None:
+    """Untagged synthetic turns keep the legacy skip: native session, no routing.
+
+    Queue drains replay messages the native session accepted while busy, and
+    AutoNudge fires target the native key their loop rotation-checked — routing
+    either into a binding created later would run them in a session that never
+    queued or armed them. This pins that ``interpret_commands=False`` with no
+    ``origin_tag`` still means "skip routing" for those callers.
+    """
+    log = _log()
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    await _bind_to_chat1(dispatcher, client, log)
+
+    await dispatcher.handle_message(_message("nudge cycle text"), interpret_commands=False)
+
+    assert sessions.last_key != "dashboard:chat-1"
+    assert sessions.last_key.startswith("discord")
 
 
 @pytest.mark.asyncio

--- a/test/test_inbound_unbind_notice.py
+++ b/test/test_inbound_unbind_notice.py
@@ -246,19 +246,29 @@ class TestDelivery:
         ],
     )
     @pytest.mark.asyncio
-    async def test_an_undeliverable_notice_is_a_silent_noop(
-        self, state: DashboardState, transport, permit: bool
+    async def test_an_undeliverable_notice_is_a_logged_noop(
+        self, state: DashboardState, transport, permit: bool, caplog
     ) -> None:
-        """The binding is already gone and audited; a failed notice adds nothing."""
+        """The binding is already gone and audited; a failed notice adds nothing —
+        but the drop itself must be visible to the operator. The user was NOT told
+        their conversation lost its way back, and the SEL event records the
+        removal, not the delivery failure, so a fully silent return here is a
+        traceless gap (live incident 2026-08-30: a destroyed binding produced no
+        channel notice and no log line naming why)."""
         state.channel_transports["discord"] = transport or _Transport(proactive=False)
 
         with patch(
             "kiro_crew.platform.governance_profiles.vet_and_audit",
             return_value=SimpleNamespace(permitted=permit),
         ):
-            await state._notify_inbound_unbind(KEY, LINK, "entry_deleted")
+            with caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.state"):
+                await state._notify_inbound_unbind(KEY, LINK, "entry_deleted")
 
         assert state.channel_transports["discord"].sent == []
+        assert any(
+            "undeliverable" in record.message or "Failed to deliver" in record.message
+            for record in caplog.records
+        )
 
 
 class TestNoticeIsSafeAndHuman:


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

Pressing an `[OPTIONS:]` button in a Discord DM that is bound to a dashboard session (`!sessions`) runs the choice in the **wrong session**. The press re-dispatches with `interpret_commands=False` so the model-authored label can never execute as a command — but the resume-routing gate was keyed on that same flag, so every press also skipped resumed-session resolution and silently ran in the DM's native session.

Live incident (2026-08-30, this repo's own dogfood install): a DM was bound to the "Connections workstream handoff" session, which asked a rebase-vs-reset question and offered buttons. The user's click — "Proceed with the merge approach (ff-only sync, no reset --hard)" — never reached that session. It ran in the native DM session instead, which read it as a green light for **its** parked debug plan and started executing (a `git fetch` on an unrelated clone), while the bound session kept waiting for its answer. Typed messages routed correctly the whole time; only button presses misrouted.

## Why it matters

Buttons are the primary affordance the bot itself offers for decisions. Every bound-DM user who answers by click instead of by typing gets silent cross-session injection: the wrong workstream acts on a model-authored instruction, the right workstream stalls, and nothing tells the user either happened. In the incident this caused real unintended git activity.

## What changed (motivation → approach → change)

Symptom → root cause: `handle_message` gated routing on `interpret_commands`, conflating two orthogonal concerns — *may this text execute as a command* vs *should this turn consult the resumed-session binding*. The `opt:` press needs commands OFF and routing ON.

Change 1 — split the concerns without widening the API: the routing gate becomes `wants_routing = interpret_commands or bool(origin_tag)`. A press carries a non-empty provenance tag (see Change 2) and the tag *implies* routing — validating it requires resolving the binding to compare keys — so no extra parameter is needed. The callers that depend on the skip keep it by construction: queue drains replay messages the native session accepted while busy (a resumed session's busy turn refuses instead of queueing, so drained items' affinity is native by construction) and AutoNudge fires target the native key their loop rotation-checked; both dispatch with commands off and no tag. All four production call sites audited; none changes behavior except the press. The spec (`docs/system-specs/modules/messaging.md`) is updated in the same commit: the `opt:<i>` wire contract becomes `opt:<i>:<tag>` and the press-provenance refusal behaviors are documented.

Change 2 — provenance, because routing alone is not enough: Discord replays old components indefinitely, so routing a press by *current* binding would let a stale button (posted by session A, pressed after `!unlink` + `!sessions` rebound the DM to session B) inject A's model-authored choice into B. Each options row now carries a provenance tag — `custom_id = "opt:<i>:<12-hex sha256 of the posting session's key>"` (no raw key exposed; 19 chars, well under Discord's 100-char cap; stateless, so it survives gateway restarts where a server-side registry would not). A press runs only when the conversation's resolved current target IS the session that posted the buttons; otherwise it is refused with the remedy named ("type it instead, or `!sessions` to reattach"). The gate sits before the busy check so a stale press can neither run nor be queued and replayed tag-less by the drain. Forging a tag buys nothing: it only passes when the conversation already targets that session, which typing a message already reaches.

Consequences by case: unchanged binding → press routes to the originator (the incident fix); rebind then stale press → refused; binding destroyed mid-flight → the existing "Detached" refusal instead of a silent native turn; `!new` or an idle/daily rotation → pre-rotation buttons refused (the tag is checked before the busy path AND re-checked against the final key after `maybe_rotate`, so a rotation firing mid-dispatch cannot run the press under a generation the tag never named); target session mid-turn → the press is **refused, never queued or steered** (the busy queue stores bare text and the drain replays it tag-less, so a queued press would execute unchecked after a `!new` — the press-shaped busy refusal names the re-press/type remedy); unbound DMs → unchanged for typed messages. Pre-provenance (untagged) buttons are **refused fail-closed** at the interaction boundary with a type-it-instead notice: Discord replays components indefinitely, so an untagged press can never prove which session it belongs to, and routing it by current binding would be the same injection through an unexpiring door (server review round 1).

Change 3 (observability, same incident): the undeliverable inbound-unbind notice (`_notify_inbound_unbind`, `target is None`) returned silently despite its docstring promising "logged and dropped" — it now logs the warning, so a user left without a detach notice is at least visible to the operator.

## Tests

All red-first (each proven failing with the production change stashed, passing with it):

- `test_option_press_routes_into_resumed_session` — a tagged press on a bound DM dispatches into the bound session as literal turn content (the incident case; fails on main with the press landing in `discord:kirocrew:direct:u1`).
- `test_stale_tagged_press_after_rebind_is_refused` — the review blocker's exact scenario: bind A, `!unlink`, bind B, press A's button → refusal, no turn anywhere.
- `test_press_tagged_for_pre_new_conversation_is_refused` — `!new` invalidates pre-rotation buttons.
- `test_tagged_press_is_revalidated_after_idle_rotation` — an idle/daily rotation firing between the gate and the turn invalidates the tag (the post-`maybe_rotate` re-check; red without it).
- `test_untagged_press_is_refused_fail_closed` + `test_untagged_option_press_fails_closed` — pre-provenance buttons are refused with no echo and no turn (red without the boundary refusal).
- `test_stale_press_against_busy_target_is_refused_not_queued` + `test_valid_tagged_press_against_busy_target_is_refused_not_queued_or_steered` — no press, stale or valid, ever enters the busy queue or steer path (red without the busy refusal).
- `test_option_press_after_binding_destroyed_is_refused_not_native` — a tagged press whose binding died gets the Detached refusal, never a silent native turn.
- `test_synthetic_dispatch_without_origin_tag_keeps_native_affinity` — pins the legacy skip for drain/AutoNudge-shaped callers.
- `test_options_become_buttons_and_never_stream` (extended) + `test_origin_tag_suffixes_every_custom_id` — the producer half: sealed options rows must carry the posting session's tag.
- `test_an_undeliverable_notice_is_a_logged_noop` (updated, strengthened) — all four undeliverable variants keep `sent == []` and now must produce the warning.

`test/test_discord_sessions.py` + `test/test_discord.py` + `test/test_inbound_unbind_notice.py`: 358 passed. black / isort / flake8 / mypy clean.

## Manual verification

N/A — unit coverage sufficient: the misroute and both refusal paths are pinned end-to-end at the dispatcher boundary with the real picker/bind flow; the incident's exact click sequence is the first test.

## Related Issues

no linked issue: found and diagnosed live on the dogfood install (2026-08-30 session-transcript forensics); no tracking issue existed.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — behavior documented in docstrings at the changed sites
- [x] No secrets, credentials, or internal references in the diff
