### PR TITLE
fix(agent-sdk): prune stale subagent.py boundary count (9->8)

### DIFF
--- a/.github/agent-sdk-boundary-baseline.txt
+++ b/.github/agent-sdk-boundary-baseline.txt
@@ -1,6 +1,6 @@
 # Imports of the ACP layer from application code, as `<count> <path>`.
 # Both `kiro_crew.acp` and `kiro_crew.providers` count: providers re-exports ACP
-# shapes (LLMEvent, EVENT_*, is_claude_backend), so watching only `acp` would let
+# shapes (LLMEvent and the EVENT_* constants), so watching only `acp` would let
 # a consumer look migrated while still reading the backend's own types.
 #
 # The gate requires every OTHER file under src/ to be clean and none of these
@@ -64,7 +64,7 @@
 3 src/kiro_crew/slack/gateway.py
 3 src/kiro_crew/slack/handler.py
 1 src/kiro_crew/slack/transport_dispatch.py
-9 src/kiro_crew/subagent.py
+8 src/kiro_crew/subagent.py
 2 src/kiro_crew/subagent_persistence.py
 2 src/kiro_crew/task_executor.py
 1 src/kiro_crew/task_planner.py


### PR DESCRIPTION
## Summary

`main` was red on the `agent-sdk-boundary` gate, causing `Backend Tests` shard 1 (`Backend Tests (3.10, 1)` and `Backend Tests (Windows) (1)`) to fail on **every open PR** regardless of its diff, which `PR Readiness` then aggregates into a block. This unblocks main CI.

## Root cause (per issue #7145)

Two individually-green PRs were incompatible once merged:

- **#6939** added the gate and wrote `.github/agent-sdk-boundary-baseline.txt`, recording `9 src/kiro_crew/subagent.py`.
- **#6944** extracted `subagent_manager/` out of `subagent.py`, moving an ACP-layer import out of `subagent.py` and leaving its actual count at 8 while the baseline still recorded 9.

`test/test_agent_sdk_boundary.py::test_every_recorded_violation_still_exists` then failed on every PR:

```
AssertionError: these baseline entries are now lower than recorded; record the progress with
`python3 scripts/check_agent_sdk_boundary.py --update-baseline`: {'src/kiro_crew/subagent.py': (9, 8)}
```

## Change

Pure mechanical reconciliation via `python3 scripts/check_agent_sdk_boundary.py --update-baseline`. The diff touches **only** `.github/agent-sdk-boundary-baseline.txt`:

- `9 src/kiro_crew/subagent.py` -> `8 src/kiro_crew/subagent.py`
- a stale header-comment refresh

It does **not** baseline `subagent_manager/terminal.py`: that offender only surfaces under the git `origin/main...HEAD` scan scope, not the standalone `test_every_recorded_violation_still_exists` assertion, so decision (1) in the issue report does not arise here. This is the pure prune.

## Testing

- Reproduced the failing assertion against the real gate module and baseline; the `stale` dict is now empty after the update.
- The CLI gate (`python3 scripts/check_agent_sdk_boundary.py`) passes and the gate's self-test passes.
- Verified the diff is limited to the single baseline file.

Note: the project's pytest tooling could not be fully installed in this environment (`INTEGRATIONS_ONLY` / Repository access only network mode blocks the external deps that `test/conftest.py` imports at collection). Verification was done by executing the exact logic of the failing assertion against the real gate + baseline.

## Out of scope

The separate `test/test_cli_logging.py::TestDrainBeforeHardExit::test_no_listener_is_a_silent_no_op` shard-order flake noted in the issue was left untouched as requested.

Closes #7145