### PR TITLE
chore(agent-sdk): refresh the boundary baseline for subagent.py

### DIFF
--- a/.github/agent-sdk-boundary-baseline.txt
+++ b/.github/agent-sdk-boundary-baseline.txt
@@ -1,6 +1,6 @@
 # Imports of the ACP layer from application code, as `<count> <path>`.
 # Both `kiro_crew.acp` and `kiro_crew.providers` count: providers re-exports ACP
-# shapes (LLMEvent, EVENT_*, is_claude_backend), so watching only `acp` would let
+# shapes (LLMEvent and the EVENT_* constants), so watching only `acp` would let
 # a consumer look migrated while still reading the backend's own types.
 #
 # The gate requires every OTHER file under src/ to be clean and none of these
@@ -64,7 +64,7 @@
 3 src/kiro_crew/slack/gateway.py
 3 src/kiro_crew/slack/handler.py
 1 src/kiro_crew/slack/transport_dispatch.py
-9 src/kiro_crew/subagent.py
+8 src/kiro_crew/subagent.py
 2 src/kiro_crew/subagent_persistence.py
 2 src/kiro_crew/task_executor.py
 1 src/kiro_crew/task_planner.py


### PR DESCRIPTION
## What

Refresh the agent-SDK boundary baseline so it records the ACP import count
`src/kiro_crew/subagent.py` actually has. One generated file, produced by running the
command the failing test names.

## Why

`test/test_agent_sdk_boundary.py::test_every_recorded_violation_still_exists` is failing
on `main` right now:

```
AssertionError: these baseline entries are now lower than recorded; record the progress
with `python3 scripts/check_agent_sdk_boundary.py --update-baseline`:
{'src/kiro_crew/subagent.py': (9, 8)}
```

The ratchet is working as designed -- the count IMPROVED from 9 to 8 and it wants the
progress recorded so the gain cannot be silently given back. Nobody recorded it, so the
entry is stale and the test fails.

This is not one branch's problem. Pull-request CI tests the MERGE commit, so every open PR
in the repository inherits the failure in `Backend Tests` shard 1 (`3.10`, `3.12` and
`Windows` alike) regardless of what it changes. It cannot be cleared by re-running,
because the check is deterministic rather than flaky.

I found it from the other side, while triaging three red shards on
https://github.com/kirodotdev/KiroCrew/pull/7003 -- a frontend change whose only Python
edit is a module docstring. Three independent facts establish that it belongs to `main`:

1. **`main`'s own CI fails identically.** Run `33343419295`, job
   `Backend Tests (3.10, 1)`, on branch `main`, asserts the same
   `{'src/kiro_crew/subagent.py': (9, 8)}`.
2. **The gate postdates that branch's base.** `scripts/check_agent_sdk_boundary.py` is on
   `origin/main` and absent at `4950cff2f`, so it reaches the PR only via the merge commit.
3. **The file is not in that diff.** `src/kiro_crew/subagent.py` appears zero times in
   `git diff --name-only origin/main...HEAD` there.

And it reproduces with nothing else in play: on a worktree cut straight from `origin/main`
with no edits, that test file is 1 failed / 24 passed.

## How

Ran `python3 scripts/check_agent_sdk_boundary.py --update-baseline` and committed its
output unedited. Two lines move, both generated:

- `9 -> 8 src/kiro_crew/subagent.py`, the recorded count catching up;
- the header sentence listing the shapes `kiro_crew.providers` re-exports, which no longer
  names `is_claude_backend`. That symbol still exists in `kiro_crew/providers/acp.py` and
  `subagent.py` still imports it from there; it is simply no longer re-exported from the
  package root, and the tool regenerates that sentence from the live surface.

No commit has touched `subagent.py` since the baseline landed in #6939, so the reduction
came from that re-export surface changing rather than from the file itself. I deliberately
did not hand-edit either line: the file is generated, and the next person to run the
command should get exactly what is committed here.

## Testing

- `python3 -m pytest test/test_agent_sdk_boundary.py` on a clean `origin/main` worktree:
  **1 failed, 24 passed** before, **25 passed** after.
- `python3 scripts/check_agent_sdk_boundary.py` passes in both states (it scopes to changed
  files, which is why the staleness only surfaces through the test).

## Blocked features

None. This unblocks `Backend Tests` shard 1 for every open PR, not just the one that led
me here.
