### PR TITLE
feat(docs-lint): check that a doc's source citations still point at real code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,8 +446,10 @@ jobs:
       - name: Lint documentation trees
         # Blocking gate: every internal link resolves, every doc is reachable from
         # its directory index, every directory holding docs has one, no code comment
-        # cites a doc that does not exist, and no doc whose filename is hardcoded in
-        # code has been renamed out from under its consumer.
+        # cites a doc that does not exist, no doc cites a source LINE past the end of
+        # the file it names, no module spec names a source file that exists nowhere,
+        # and no doc whose filename is hardcoded in code has been renamed out from
+        # under its consumer.
         # No setup-python step: ubuntu-latest ships Python 3 and the script is
         # stdlib-only.
         run: ./scripts/docs-lint.sh

--- a/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
+++ b/docs/request-for-change/rfc-crew-agent-sdk-boundary.md
@@ -216,7 +216,7 @@ kinds of undeclared hole:
 | `getattr`-by-name seams whose target the core never defines — `getattr(self, "_write_claude_local_settings", None)` (`acp/client.py:2742`, `:3351`) | 2 | Silent: no permission mode, and the context window collapses from 1M to 200K |
 | Methods returning a neutral value purely so a companion can override them — `_claude_session_mcp_servers() -> []` (`acp/client.py:2335-2346`) is the type case | 6 | Silent: a CC session gets **zero MCP tools**, as the docstring itself states |
 | `ClaudeCodeProvider is not None and isinstance(...)` guards against a name hard-coded to `None` (`session.py:170`, `subagent.py:131`) | 11 sites | Statically unreachable; nine `session.py` branches and two `subagent.py` branches are dead-but-maintained |
-| Defensive attribute probes across the provider boundary (`session.py:3356` `_proc`, `:3360` `_active_proc`, `chat_runner.py:867`, `knowledge/llm_pool.py:325`) | 4 | Duck typing in place of a type |
+| Defensive attribute probes across the provider boundary (`session_pid.py` (`_collect_active_pids`) probes `_proc` and `_active_proc`, `chat_runner.py:867`, `knowledge/llm_pool.py:325`) | 4 | Duck typing in place of a type |
 | Comment clusters naming the companion or a deleted module as the supplier of behaviour | 19 | The seam's real contract lives in prose |
 | Refusal / downgrade mechanisms, including the degrade log line at `config/loader.py:4647-4652` and five capability non-memberships | 9 | — |
 | Live `_is_claude` branches inside `acp/` | 13 | — |

--- a/docs/request-for-change/rfc-durable-run-coordinator.md
+++ b/docs/request-for-change/rfc-durable-run-coordinator.md
@@ -58,12 +58,13 @@ in-memory run/task registries, the admission queue, batch accounting, terminal
 report tasks, follow-up watchers, conversation retention, and the periodic
 reaper (`subagent.py:1347-1478`). The public `spawn()` path then handles identity,
 admission, approval, queueing, persistence, event publication, and task creation
-(`subagent.py:3038-3547`).
+(`subagent.py`: `spawn`, `_announce_rejection`, `_drain_queue`,
+`_spawn_with_approval`, and `_log_spawned`).
 
 The lifecycle discipline inside that module is valuable and must be preserved.
 In particular, terminal reporting and slot release are independently claimed by
-`_claim_finalize()` and `_release_slot()` (`subagent.py:2358-2404` and
-`2633-2656`). The system spec documents four distinct terminal guards and why
+`_claim_finalize()` and `_release_slot()` (`subagent.py`, both methods of
+`SubagentManager`). The system spec documents four distinct terminal guards and why
 collapsing them previously caused duplicate delivery, lost outcomes, or leaked
 slots (`docs/system-specs/modules/subagent.md:175-190`). The problem is not the
 existence of those invariants; it is that their state machine is distributed
@@ -98,13 +99,14 @@ The `spawn_run` MCP tool submits wave members through separate HTTP requests
 (`src/kiro_crew/mcp_tools/spawn.py:484-598`). A response can fail after the
 gateway accepted the request, so the caller and gateway maintain extra
 submission accounting and lost-submission reconciliation. The manager exposes
-`record_lost_submission()` and a stuck-wave reaper
-(`subagent.py:4504-4600`), while the dashboard handler reconciles the roster
+`record_lost_submission()` and a stuck-wave reaper `_sweep_stuck_waves()`
+(`subagent.py`), while the dashboard handler reconciles the roster
 against accepted IDs (`src/kiro_crew/dashboard/handlers/messaging.py:90-202`).
 
 The existing preassigned run ID is an important foundation: `spawn()` assigns
 identity before every exit path and preserves it through queueing
-(`subagent.py:3107-3116`). What is missing is a durable idempotency record that
+(`subagent.py`, the `_preassigned_id` parameter of `spawn()`). What is
+missing is a durable idempotency record that
 makes a repeated submission with the same command key return the same accepted
 decision rather than opening a reconciliation side protocol.
 
@@ -115,7 +117,7 @@ re-admits a cancelled report to orphan recovery. This prevents several local
 races, but completion state and the requirement to deliver it are represented
 by separate in-memory flags plus file-marker ordering. `settle_queued_delivery()`
 must wait for teardown before writing a delivered tombstone
-(`subagent.py:4722-4759`) because that tombstone also suppresses restart
+(`subagent.py`) because that tombstone also suppresses restart
 reconciliation.
 
 A transactional outbox makes the intended contract direct: committing a

--- a/docs/request-for-change/rfc-perpetual-agent.md
+++ b/docs/request-for-change/rfc-perpetual-agent.md
@@ -123,7 +123,7 @@ None of the four can host a perpetual agent as-is:
   cadence is hours to days it is a lost day. Cron's `_is_due` compares `now`
   against the stored deadline (`cron.py:2332`), so the same restart fires
   immediately on recovery. Separately, `binding_key_for` explicitly refuses
-  `cron:` / `hook:` / `subagent:` session keys (`mcp_core.py:3148`), so an
+  `cron:` / `hook:` / `subagent:` session keys (`autonudge.py`), so an
   autonudge loop cannot be bound to a cron-hosted session anyway.
 
 - **Heartbeat** is a tick counter with two unrelated jobs bolted together —
@@ -335,8 +335,9 @@ Guards on `next_wake`:
   (`cron:{job.id}`) and may mutate **only that job**. It is refused outright
   from any non-`cron:` session, and from a subagent, using the strict env-only
   resolution `monitor_start` already uses for the same reason
-  (`mcp_core.py:5754`–`:5761`) — a child process must not be able to PID-walk
-  into its parent's identity and reschedule it.
+  (`mcp_tools/control.py` (`monitor_start`), resolving via `mcp_core.py`
+  (`_resolve_session_key_strict`)) — a child process must not be able to
+  PID-walk into its parent's identity and reschedule it.
 
 ### §4 Cadence discipline — backoff, not a liveness gate
 
@@ -816,14 +817,15 @@ docs and sharper tool descriptions — cheap, and it does not put anyone's
 by a full interval instead of firing on recovery (`autonudge.py:457`), which is
 acceptable for a 5-minute poll and not for a multi-hour cadence. It also
 requires a live nudge-able slot, and `binding_key_for` refuses `cron:` keys
-outright (`mcp_core.py:3148`).
+outright (`autonudge.py`).
 
 ### A long-lived session that loops on `wait`
 
-**Rejected.** `wait` caps at 1800s (`mcp_core.py:4521`) and holds the agent
-subprocess and full context resident for the entire duration
-(`:4525`–`:4577`). A day of "life" costs a day of resident process, and any
-restart loses the pending wake and the turn.
+**Rejected.** `wait` caps at 1800s (`mcp_tools/control.py` (`wait`)) and holds
+the agent subprocess and full context resident for the entire duration, keeping
+the sleep alive with a keepalive ping every `mcp_core.py` `WAIT_PING_SECS`. A
+day of "life" costs a day of resident process, and any restart loses the
+pending wake and the turn.
 
 ### A separate long-running daemon per agent
 
@@ -837,7 +839,8 @@ believed everything was stopped.
 - **Self-rescheduling is self-scoped.** `agent_sleep` resolves its target from
   `KIROCREW_SESSION_KEY` and may write only that job. Strict env-only
   resolution (no PID walk) prevents a subagent from assuming its parent's
-  identity, matching the reasoning already recorded at `mcp_core.py:5761`.
+  identity, matching the reasoning already recorded at `mcp_core.py`
+  (`_resolve_session_key_strict`).
 - **The goal is not agent-writable.** Writes to `LIFE.md` are refused, so an
   agent cannot widen its own mandate. Boundaries live in the same file.
 - **No self-granted authority.** A perpetual agent cannot create another

--- a/docs/request-for-change/rfc-resumable-subagent-sessions.md
+++ b/docs/request-for-change/rfc-resumable-subagent-sessions.md
@@ -36,9 +36,9 @@ The single enforcement point for non-resumability is one tuple entry. `"subagent
 
 | Property | Today | Consequence |
 |---|---|---|
-| Turns | One logical prompt. The retry ladder may re-issue it or send one continuation (`subagent.py:3606-3676`), but nothing carries a *new* instruction | No HTTP route or MCP tool accepts a follow-up message into a run |
-| ACP session id | Persisted to `state.json` under the comment "Record session_id and provider type for session file cleanup" (`subagent.py:3571-3597`) | Read only by deletion paths (`subagent.py:1187-1192`, `subagent_persistence.py:275-280`). The one artifact needed to resume exists so it can be deleted |
-| Transcript | Assistant text chunks only (`subagent.py:3687`), truncated to `RESULT_FILE_MAX_BYTES = 512_000` with an in-file marker (`context_management.py:26,329-352`) | No roles, no prompt, no tool sequence — cannot be rendered as a conversation or replayed into one |
+| Turns | One logical prompt. The retry ladder may re-issue it or send one continuation (`subagent_manager/run.py`, `_stream_with_transient_retry` inside `_run_inner_impl`), but nothing carries a *new* instruction | No HTTP route or MCP tool accepts a follow-up message into a run |
+| ACP session id | Persisted to `state.json` under the comment "Record session_id and provider type for session file cleanup" (the `update_state` call in `subagent_manager/run.py`'s `_run_inner_impl`) | Read only by deletion paths (`subagent.py:1187-1192`, `subagent_persistence.py:275-280`). The one artifact needed to resume exists so it can be deleted |
+| Transcript | Assistant text chunks only (`write_result_chunk`, called from `subagent_manager/run.py`'s `_run_inner_impl` on assistant-text events), truncated to `RESULT_FILE_MAX_BYTES = 512_000` with an in-file marker (`context_management.py:26,329-352`) | No roles, no prompt, no tool sequence — cannot be rendered as a conversation or replayed into one |
 | Prompt | Only the redacted task line, in `state.json` | A run cannot be re-issued from disk |
 | Gateway restart | `_reconcile_orphans` (`subagent.py:1115`) identity-verifies the child PID (`subagent.py:1152-1168`), terminates it, tombstones `gateway_restart`, deletes its kiro session files, notifies the parent | Nothing partial is recoverable |
 | Retention | `mark_delivered` schedules folder pruning after `agent.subagent_result_ttl_secs` (default 3600, `config/loader.py:755-756`) | Within an hour of success nothing recoverable remains |
@@ -98,7 +98,7 @@ Records are written by a dedicated `ConversationLog` rooted at `~/.kiro/crew/sub
 
 Two placement decisions, both load-bearing:
 
-- **Not the chat sessions directory.** `ConversationLog.list_sessions` globs every `*.jsonl` in its root with no prefix filter (`history.py:1406-1424`), and that listing has ten call sites across eight modules — `GET /api/sessions` and `api_sessions_clear` (`dashboard/handlers/sessions.py:401,693`), the `list_sessions` MCP tool (`mcp_core.py:5480`), slot rehydration (`dashboard/chat_persistence.py:326,476`), chat handlers (`dashboard/chat_handlers.py:2252`), folders (`dashboard/chat_folders.py:130`), followup suggestions (`suggestions.py:96`), artifact companion-session resolution (`dashboard/handlers/artifacts.py:696`), and `sync_bridge.py:28` — plus in-class use by `search_sessions` (`history.py:1523,1552`), which is how `search_chat_history` reaches it. Writing records there publishes every run to all of them on day one and puts records inside `api_sessions_clear`'s blast radius.
+- **Not the chat sessions directory.** `ConversationLog.list_sessions` globs every `*.jsonl` in its root with no prefix filter (`history.py:1406-1424`), and that listing has ten call sites across eight modules — `GET /api/sessions` and `api_sessions_clear` (`dashboard/handlers/sessions.py:401,693`), the `list_sessions` MCP tool (`mcp_tools/sessions.py`, `list_sessions`), slot rehydration (`dashboard/chat_persistence.py:326,476`), chat handlers (`dashboard/chat_handlers.py:2252`), folders (`dashboard/chat_folders.py:130`), followup suggestions (`suggestions.py:96`), artifact companion-session resolution (`dashboard/handlers/artifacts.py:696`), and `sync_bridge.py:28` — plus in-class use by `search_sessions` (`history.py:1523,1552`), which is how `search_chat_history` reaches it. Writing records there publishes every run to all of them on day one and puts records inside `api_sessions_clear`'s blast radius.
 - **A sibling of `subagents/`, not a child.** `subagent_persistence` treats every child directory of `_SUBAGENTS_DIR` as a run id (`list_orphans` at `subagent_persistence.py:224-241`, `read_state(d.name)` at `:236`), and `"records"` is a legal id, so `delete_agent_folder("records")` would `rmtree` the store.
 
 Record rows use the existing schema. `tools` carries tool **names in order** (`append` types it `list[str]`, `history.py:1029-1037`); per-call arguments and results are out of scope for v1 (Open question 3).
@@ -108,7 +108,7 @@ Record rows use the existing schema. `tools` carries tool **names in order** (`a
 | When | What |
 |---|---|
 | Record creation (spawn) | Metadata: redacted prompt |
-| ACP session established | Metadata: sid, cwd, provider, agent — written here, not at terminal, so a run orphaned by a restart is still resume-eligible. The same values are already captured in one `update_state` call at `subagent.py:3571-3597` |
+| ACP session established | Metadata: sid, cwd, provider, agent — written here, not at terminal, so a run orphaned by a restart is still resume-eligible. The same values are already captured in one `update_state` call in `subagent_manager/run.py` (`_run_inner_impl`) |
 | Per completed turn | An assistant row, appended and awaited before the turn is acknowledged |
 | Terminal (success, failure, cancel, `_force_reap`, orphan reconcile) | Metadata: tool order, outcome, dropped-row count |
 
@@ -118,7 +118,7 @@ Record rows use the existing schema. `tools` carries tool **names in order** (`a
 
 **Archive pruning must be scoped.** `_cleanup_old_archives` is throttled by a module-global `_last_cleanup` and defaults its window to `session.archive_retention_days` (`history.py:495,511,528`). The record base passes an explicit `retention_days`, and the throttle is keyed per base dir so a record rotation cannot consume the chat store's prune window.
 
-**Redaction** is at write, single-pass, reusing the redactors the run already applies before it stores its task line and streams its result (`subagent.py:2359,2385,2418` for the task; the result path at `subagent.py:3873-3886`). If redaction raises, the row is dropped, the dropped-row count increments, and the record view labels itself incomplete. A record is never written unredacted.
+**Redaction** is at write, single-pass, reusing the redactors the run already applies before it stores its task line and streams its result (`subagent_manager/admission.py`'s `spawn_impl` runs `redact_exfiltration_urls` + `redact_credentials` over the task; the result path applies `subagent.py`'s `_redact` to each assistant chunk in `subagent_manager/run.py`'s `_run_inner_impl`). If redaction raises, the row is dropped, the dropped-row count increments, and the record view labels itself incomplete. A record is never written unredacted.
 
 `result.txt`, `state.json`, and `tombstone.json` keep their current format and role; `result.txt` remains the fast path for `spawn_status` paging/grep and the completion-event pointer. Record-write failures are surfaced through the record's own metadata and the `spawn_status` response — **not** by adding a field to `state.json`.
 
@@ -130,14 +130,14 @@ Keeping the kiro session files means touching **four** unlink sites:
 
 | Unlink site | Reached by |
 |---|---|
-| `AcpSessionHandle._cleanup_transcript` (`acp/session_handle.py:799-814`), via `destroy()` (`:775`) | the session-sharing arm — the default — through `AcpSessionProvider.shutdown` (`acp/session_provider.py:173`) from `subagent.py:2989-2991` |
+| `AcpSessionHandle._cleanup_transcript` (`acp/session_handle.py:799-814`), via `destroy()` (`:775`) | the session-sharing arm — the default — through `AcpSessionProvider.shutdown` (`acp/session_provider.py:173`) from `subagent_manager/run.py`'s `_teardown_run_session_impl` |
 | `AcpSessionProvider.cleanup_session` (`acp/session_provider.py:180-200`) | `SessionManager._safe_cleanup` |
 | `AcpProvider.cleanup_session` (`providers/acp.py:1124-1141`) | `SessionManager._safe_cleanup` |
 | `_cleanup_session_files_sync` (`subagent_persistence.py:293`) | tombstone prune (`:280`) and orphan reconcile (`subagent.py:1187-1195`) |
 
-reached from four subagent call sites: `_teardown_run_session` (`subagent.py:2992`), `_force_reap` (`subagent.py:2035` — the deadline/stop path, exactly the long run retention exists for), tombstone prune, and orphan reconcile.
+reached from four subagent call sites: `_teardown_run_session` (`subagent_manager/run.py`, `_teardown_run_session_impl`), `_force_reap` (`subagent.py:2035` — the deadline/stop path, exactly the long run retention exists for), tombstone prune, and orphan reconcile.
 
-`keep_transcript` cannot be a parameter at the point of call: the shared arm calls the `LLMProvider.shutdown` ABC method, and `destroy()` has seven other callers, all non-subagent background sessions (`acp/session_provider.py:126,138`, `suggestions.py:202`, `llm_helpers.py:299`, `tips.py:759`, `dashboard/handlers/cron.py:141`, `apps/builtins/code_review_sage/sage_lib/review_pool.py:490`). It is therefore **per-session-handle** state, not per-provider — a provider instance serves many sessions, so a sticky provider-level flag would retain unrelated background transcripts on disk. It is set on the run's handle before teardown, consumed by `destroy()`, and cleared in a `finally`. `terminate_session` stays unconditional: it is the RSS reclaim on a multiplexed process (`acp/runtime.py:905-926`), and only the unlink is deferred. `release`'s cleanup is already gated on `_SUBAGENT_PREFIX` (`session.py:3140`), so the dedicated arm's change touches no other caller.
+`keep_transcript` cannot be a parameter at the point of call: the shared arm calls the `LLMProvider.shutdown` ABC method, and `destroy()` has seven other callers, all non-subagent background sessions (`acp/session_provider.py:126,138`, `suggestions.py:202`, `llm_helpers.py:299`, `tips.py:759`, `dashboard/handlers/cron.py:141`, `apps/builtins/code_review_sage/sage_lib/review_pool.py:490`). It is therefore **per-session-handle** state, not per-provider — a provider instance serves many sessions, so a sticky provider-level flag would retain unrelated background transcripts on disk. It is set on the run's handle before teardown, consumed by `destroy()`, and cleared in a `finally`. `terminate_session` stays unconditional: it is the RSS reclaim on a multiplexed process (`acp/runtime.py:905-926`), and only the unlink is deferred. `release`'s cleanup is already gated on `_SUBAGENT_PREFIX` (`session.py`, passed through to `SessionAllocationService.release` in `session_allocation.py`), so the dedicated arm's change touches no other caller.
 
 Retention is a **new** policy, not an inherited one: `_cleanup_old_archives` prunes archives only (`history.py:511-556`) and live session JSONL is never age-pruned. Two config keys: `agent.subagent_record_retention_enabled` (default **off** through Phase 3, flipped on in Phase 4) and `agent.subagent_record_retention_days` (Open question 1). `result.txt` keeps the existing `subagent_result_ttl_secs` lifecycle and expires first.
 
@@ -147,7 +147,7 @@ Retained kiro session files are excluded from `/api/usage`, which counts every `
 
 ### Promotion
 
-Promotion **mints a fresh chat slot through the same slot-creation path the UI uses** and hands it the sid. It does not turn the record into a slot: `_normalize_slot_key` folds `[^\w\-.]` to `_` (`dashboard/state.py:668`) and `_history_key_for` re-namespaces to `dashboard:<slot>` (`dashboard/chat_utils.py:369-375`), so a record-derived slot key would never match the record's identity and `SessionMap.get` could never find the sid. The real slot-creation path is also required for liveness: `_expire_idle` expires any `dashboard:` session whose key is absent from `_active_dashboard_slots` (`session.py:3826-3836`), a set fed only by the dashboard's create/delete/resume/restore path (`session.py:3809-3816`).
+Promotion **mints a fresh chat slot through the same slot-creation path the UI uses** and hands it the sid. It does not turn the record into a slot: `_normalize_slot_key` folds `[^\w\-.]` to `_` (`dashboard/state.py:668`) and `_history_key_for` re-namespaces to `dashboard:<slot>` (`dashboard/chat_utils.py:369-375`), so a record-derived slot key would never match the record's identity and `SessionMap.get` could never find the sid. The real slot-creation path is also required for liveness: `_expire_idle` expires any `dashboard:` session whose key is absent from `_active_dashboard_slots` (`session_cleanup.py`, `SessionCleanup._expire_idle`), a set fed only by the dashboard's create/delete/resume/restore path (`set_active_dashboard_slots`, called from `_sync_dashboard_slots` in `dashboard/chat_utils.py`).
 
 Branch selection is on the **load outcome**, not on pre-checks:
 
@@ -175,7 +175,7 @@ flowchart LR
 
 ### Phase 0: Prove whether `session/load` works for the default path
 
-The resume upgrade assumes a sid created as an extra session on a **parent's** runtime is loadable from a new kiro-cli process after that session is terminated, while the parent process is still alive. Nothing in this repo asserts that: `terminate_session`'s contract is kiro-cli's in-memory session map (`acp/runtime.py:905-926`), and `drain_active_turns` documents kiro-cli releasing an on-disk session lock only on a subsequent SIGTERM (`session.py:2829-2832`).
+The resume upgrade assumes a sid created as an extra session on a **parent's** runtime is loadable from a new kiro-cli process after that session is terminated, while the parent process is still alive. Nothing in this repo asserts that: `terminate_session`'s contract is kiro-cli's in-memory session map (`acp/runtime.py:905-926`), and `drain_active_turns` documents kiro-cli releasing an on-disk session lock only on a subsequent SIGTERM (the `_DRAIN_ACTIVE_TURNS_TIMEOUT_SECS` comment in `session.py`; the drain itself is `drain_active_turns` in `session_lifecycle.py`).
 
 - Manual probe against real kiro-cli: create a shared session, terminate it, keep the files, `session/load` the sid from a second process while the first lives.
 - Deliverable: a **recorded verdict**, plus — if the lock is process-scoped — a decision on whether a lock held by the run's *own parent* relaxes branch 2's refusal into a labelled replay, or stays a refusal.
@@ -226,7 +226,7 @@ Entry blocker: Open question 4 (which records are surfaced) is answered.
 | `/api/usage` | Tallies unchanged; retained kiro session files are excluded in `_parse_sessions` |
 | `_STATELESS_PREFIXES` | Unchanged. `subagent:` stays stateless; execution keys never resume |
 | Session sharing | On by default. No un-promoted run is forced onto a dedicated process. If a negative Phase 0 makes resume dedicated-only, dedicated spawning is opt-in per call, never a default |
-| Concurrency cap and auto-sizing | Unchanged. A record holds no process and no `_Session`, so the idle sweep (`session.py:3818-3865`, which iterates live sessions only) never sees it. A promoted slot counts against the dashboard slot budget, not the subagent cap |
+| Concurrency cap and auto-sizing | Unchanged. A record holds no process and no `_Session`, so the idle sweep (`SessionCleanup._expire_idle` in `session_cleanup.py`, which iterates live sessions only) never sees it. A promoted slot counts against the dashboard slot budget, not the subagent cap |
 | Non-subagent background sessions | Unchanged: `keep_transcript` is per-session-handle, so no background session's transcript is retained as a side effect (Phase 2 criterion) |
 | Dashboard slot filters | Unchanged; records are not slots and add no surface to the three filter predicates |
 

--- a/docs/request-for-change/rfc-s3-backup.md
+++ b/docs/request-for-change/rfc-s3-backup.md
@@ -63,7 +63,7 @@ repository writes crew state to a remote store.
 **P1 — the bundle omits the conversations.** No component stages the transcript
 store `session_storage.py:7-10` documents (`<data home>/sessions/*.jsonl` +
 `sessions/archive/`, resolver `:277`; `<kiro home>/sessions/cli/<sid>.*`, resolver
-`config/paths.py:698`). `uploads/` is excluded outright on the dashboard path
+`config/paths.py` (`kiro_sessions_dir`)). `uploads/` is excluded outright on the dashboard path
 (`portability.py:62`) and absent from `CORE_FILES`; `artifacts/` is in neither.
 Measured on one install: 385 MB irreplaceable (322 MB transcripts, 28 MB uploads,
 22 MB memory DBs, < 2 MB config + artifacts) against a ~30 MB bundle today. Small

--- a/docs/request-for-change/rfc-transcript-section-markers.md
+++ b/docs/request-for-change/rfc-transcript-section-markers.md
@@ -151,7 +151,7 @@ if role == "system" and cls_val:
 ```
 
 — `dashboard/chat_persistence.py:1914-1916`. Meanwhile `ConversationLog.append`
-persists any truthy `cls` (`history.py:2815`). A `cls`-carried marker on any role
+persists any truthy `cls` (`history.py`, `append`). A `cls`-carried marker on any role
 other than `system` is silently dropped on the dashboard's persist path. `meta`
 persists for every role (`chat_persistence.py:1917-1918`), which is where the
 label belongs.
@@ -172,7 +172,8 @@ every time a break was drawn.
 A new role is cheap on the wire: `ChatMessage.role` is an open `string`
 (`website/src/types/index.ts:950-952`), and the transcript read path has no role
 allowlist — `_read_messages_locked` skips only the `_type: "metadata"` header and
-appends every other JSON line verbatim (`history.py:4987-4989`).
+appends every other JSON line verbatim (`history_projection.py`,
+`TranscriptReadProjection`).
 
 One thing to *not* do: leave the new role out of `_QUESTION_RETIRING_ROLES`
 (`dashboard/state.py:2063`, currently `{user, nudge}`, mirrored by the frontend's
@@ -231,7 +232,7 @@ if exclude_last_n > 0:
 ```
 
 — `context.py:1524-1525` (`_replay_rows`), identically at `:1571-1572`
-(`_recall_rows`), and `history.py:2966-2968` (`recent()`, whose docstring at
+(`_recall_rows`), and `history.py` (`recent`, whose docstring at
 `:2950` says "drops that many trailing raw entries BEFORE role filtering").
 
 So any row appended after the current-turn user row becomes the physical tail,
@@ -503,7 +504,8 @@ absent.
 `_recall_rows` (`:1552`) — an old session resumed by a new gateway, or the
 reverse, sees no prompt change.
 
-**Read path.** No role allowlist (`history.py:4987-4989`), so an older gateway
+**Read path.** No role allowlist (`history_projection.py`,
+`TranscriptReadProjection`), so an older gateway
 reading a transcript containing markers parses them as ordinary rows.
 
 ## 9. Security considerations
@@ -630,7 +632,7 @@ marker would vanish on one of the two write paths.
 1. **`exclude_last_n`: positional or role-aware?** `flush_deferred_notes`'s
    docstring (`dashboard/state.py:3956-3961`) explains the hazard in terms of
    recall-eligible rows; the code slices raw-positionally (`context.py:1525`,
-   `:1572`; `history.py:2967`). Making the exclusion skip the last
+   `:1572`; `history.py`, `recent`). Making the exclusion skip the last
    *recall-eligible* row would match the stated intent and make mid-turn appends
    safe outright, retiring the deferral machinery for both `/note` and this
    feature. **Not proposed here** — it changes a hot path on behalf of a view

--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -601,7 +601,7 @@ Writers: `apps/manager.py` (`_BUILTIN_APPS`, `_DEFAULT_ON_BUILTINS`,
 `_DEFAULT_ON_BACKFILL`, `register_builtin_apps`, `backfill_default_on_builtins`),
 `agent.py::run_first_run_setup`, `apps/discovery.py::discover_builtin_apps`,
 `apps/registry.py::_apply_trust_fields`;
-consumers: `website/src/pages/AppsPage.tsx` (`pickFeatured`),
+consumers: `website/src/pages/apps/useAppsData.ts` (`pickFeatured`),
 `website/src/components/appstore/types.ts` (`isVerified`, `sourceLabel`).
 
 ## 13. An app token's WebSocket stream is scoped by its manifest, deny-by-default

--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -483,7 +483,7 @@ every write-side unit test still green — so test the round-trip
 - **Restricted sessions** — POST/PATCH/DELETE are denied when the dashboard
   classifies the session as restricted (`_is_restricted_session`).
 - **SEL audit** — every mutation emits a `log_tool_invocation` event from the
-  HTTP layer (`api/dashboard/handlers/artifacts.py`). Reads are not audited.
+  HTTP layer (`dashboard/handlers/artifacts.py`). Reads are not audited.
   `_audit` redacts caller-supplied text before it reaches the SEL writer (which
   signs bytes as-written and does NOT redact): the `error` string and every
   string leaf of `extra` metadata pass through `redact_via_context`, so an

--- a/docs/system-specs/modules/autopilot.md
+++ b/docs/system-specs/modules/autopilot.md
@@ -369,7 +369,7 @@ however long the plan runs.
 
 | Area | Location |
 |------|----------|
-| Tracker limits, timeout, `timeout_human`, caps, stale-session cleanup | `tests/test_context_management.py` |
+| Tracker limits, timeout, `timeout_human`, caps, stale-session cleanup | `test/test_context_management.py` |
 | Stage loop guard lifetime, shrink clamp, plan-action routing, plan detection scoped to planning turns, widget-origin `go all` refusal | `test/test_dashboard_chat.py` |
 | Prompt binds the "Autopilot" name | `test/test_prompt_autopilot_binding_rule.py` |
 | `parseOptions` marker/plan parsing | `website/src/test/AssistantMessage.test.tsx` |

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -1252,7 +1252,8 @@ contract — its path and format are internal and may change without notice.
 ## Computer Use Commands
 
 `kirocrew computer {doctor [--json] | apps | call}` — hand-rolled dispatch
-mirroring `browser/cli.py` (see [computer-use.md](computer-use.md)).
+rather than argparse subparsers, because the parent CLI forwards `REMAINDER`
+(see [computer-use.md](computer-use.md)).
 
 **`doctor`** reports, in order: whether the platform is supported (macOS today;
 Windows and Linux report a typed refusal), whether the keystone primary enable at

--- a/docs/system-specs/modules/command-bar.md
+++ b/docs/system-specs/modules/command-bar.md
@@ -135,11 +135,11 @@ Both directions have to work in the UI, and one of them nearly did not. The Apps
 builds its Discover shelf from the network-fetched catalog, which carries no row for this
 app, and its Library list hides disabled builtins -- so with the app off it would have
 appeared on neither surface and could only be re-enabled over the API. Library therefore
-keeps listing a disabled builtin that declares `ui.overlays`
-(`website/src/pages/AppsPage.tsx`): an app allowed to replace a host surface is the one
-class a reader turns off and then needs to find again, and its own description tells them
-to disable it to get the old surface back. The rule is keyed on the capability, not on this
-app's name, and it changes nothing for the default-off builtins that have no overlay.
+keeps listing a disabled builtin unless its manifest sets `hidden`
+(`keepInLibrary` in `website/src/pages/apps/useAppsData.ts`): an app a reader turns off and
+then needs to find again has to stay on the one surface that carries Enable, and this app's
+own description tells them to disable it to get the old surface back. The rule is keyed on
+being installed, not on this app's name, and it lists the other default-off builtins too.
 
 ## Deliberately not here
 

--- a/docs/system-specs/modules/computer-use.md
+++ b/docs/system-specs/modules/computer-use.md
@@ -1581,10 +1581,14 @@ a result.
 `computer_use/screencast.py` + `website/src/components/ComputerUseLiveView.tsx`.
 The machine being driven is often not the machine the operator is looking at (a
 cloud Mac, a session reached over the reverse SSH tunnel, or another Space), so a
-floating picture-in-picture panel mirrors what the agent sees. Same shape as the
-browse mirror (`browser/screencast.py` → `/api/browser/frame` → WS →
-`BrowserLiveView`), for the same reason: it rides an existing capture rather than
-opening a new one.
+floating picture-in-picture panel mirrors what the agent sees. It rides an
+existing capture rather than opening a new one: `emit_snapshot_frame` POSTs the
+already-encoded JPEG to the loopback `/api/computer-use/frame` ingress, which
+rebroadcasts it to OWNER websockets as a `computer_use_frame` event. The
+in-gateway browse mirror this shape was modelled on is gone — browsing now runs
+through the external `playwright-cli` binary (`kiro_crew/browser_cli/`), which
+serves its own dashboard (`playwright-cli show`, supervised by
+`browser_cli/view.py`) instead of relaying frames through the gateway.
 
 **It is a RELAY, not a capture.** `capture_snapshot_image` hands the JPEG it just
 encoded for the model to `emit_snapshot_frame`. There is no timer, no second
@@ -2313,8 +2317,9 @@ dead button that only reproduces in a packaged build.
 
 ## The CLI (`kirocrew computer`) — and what is deliberately not ported
 
-`computer_use/cli.py`. Three verbs, hand-rolled dispatch mirroring
-`browser/cli.py`. Full command reference in [cli.md](cli.md).
+`computer_use/cli.py`. Three verbs, hand-rolled dispatch rather than argparse
+subparsers (the parent CLI forwards `REMAINDER`). Full command reference in
+[cli.md](cli.md).
 
 | Verb | For | Gated on the primary enable? |
 |---|---|---|

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -652,9 +652,9 @@ specified compatibility change.
 ### Security
 
 - **Network binding**: dashboard binds to `127.0.0.1` only (loopback), never `0.0.0.0`. Prevents unauthenticated remote access from network-adjacent attackers.
-- **Token authentication**: `dashboard/token_auth.py` validates a signed HMAC session token on every request. Pure stdlib — no external deps. Returns `401` if invalid. The enterprise SSO status surface (`dashboard/sso_status.py`) is an inert stub in the OSS build — no cookie validation is performed.
+- **Token authentication**: `dashboard/token_auth.py` validates a signed HMAC session token on every request. Pure stdlib — no external deps. Returns `401` if invalid. The enterprise SSO status surface (`sso_status.py`) is an inert stub in the OSS build — no cookie validation is performed.
 - **WebSocket origin validation**: `ws.py:_check_ws_origin()` validates the `Origin` header on every WebSocket upgrade request before accepting the connection. Rejects missing Origin (non-browser clients) and cross-origin requests. Only allows `http://127.0.0.1:{port}`, `http://localhost:{port}`, and `http://kirocrew.localhost:5476`. Prevents cross-origin WebSocket hijacking where a malicious page could connect to `ws://127.0.0.1:5476/api/ws` and passively exfiltrate conversation data.
-- **Token authentication**: `dashboard/token_auth.py` validates the signed HMAC session token on every request including WebSocket upgrades. Pure stdlib — no external deps. Returns `401` if invalid. The enterprise SSO status surface (`dashboard/sso_status.py`) is an inert stub in the OSS build — no cookie validation is performed.
+- **Token authentication**: `dashboard/token_auth.py` validates the signed HMAC session token on every request including WebSocket upgrades. Pure stdlib — no external deps. Returns `401` if invalid. The enterprise SSO status surface (`sso_status.py`) is an inert stub in the OSS build — no cookie validation is performed.
 - **CSRF protection**: `server.py` CSRF middleware validates `Origin` header on all non-safe HTTP methods (POST, PUT, DELETE). Same allowed origins as WebSocket.
 - **Source-provider mutation ownership**: GitHub/GitLab source reads may use a signed machine-local bootstrap subject (`local-app` / `local-startup`) before an owner is configured, but every provider mutation remains owner-only. When one of those signed local dashboard sessions reaches a mutation with no configured owner, the gateway still returns `403` but labels the already-denied response with `code: "owner_not_configured"`; the Changes panel, review threads, and Code Review Sage replace the server's English fallback with localized guidance and link to Settings → Channels → Slack. App tokens, unauthenticated requests, and non-local subjects retain the generic forbidden body so the response does not disclose the install's owner state.
 - **Prerequisite mutations**: agent-spec repair is the ONLY one left — there is
@@ -1341,7 +1341,7 @@ React 18 + TypeScript + Vite 5 + Redux Toolkit + React Router v7 + Tailwind CSS 
 - `.focus-ring` — unified focus outline (`border-color + box-shadow + glow`) for all inputs/textareas
 - `.card-glow`, `.stat-accent`, `.btn-sweep`, `.streaming-cursor`, `.think-bar`, `.typing-dots`
 
-**Shared UI components** (`frontend/src/components/`):
+**Shared UI components** (`website/src/components/`):
 - `ui.tsx` — `Card`, `CardTitle`, `Btn`, `SendBtn`, `Input`, `Badge`, `AimBadge`, `StatCard` (with skeleton loading), `Skeleton`, `EmptyState`, `PageHeader`
 - `AgentSelector.tsx` — reusable agent dropdown with portal positioning, ARIA roles (`listbox`/`option`/`aria-selected`), `AimBadge` source pills, outside-click-to-close
 - `ProjectAnimation.tsx` — image-based animation: KiroCrew logo (`icon-192.png`) with orbiting rings and pulsing glow. Theme-aware via `var(--accent-glow)`. Used in ProjectsPage empty state.
@@ -1364,7 +1364,7 @@ React 18 + TypeScript + Vite 5 + Redux Toolkit + React Router v7 + Tailwind CSS 
 
 **Streaming rendering** — Two-layer architecture: (1) `useBlockAssembler` hook parses raw text into `ContentBlock[]` via state machine tracking `paragraph`/`fenced_code` states; (2) `BlockRenderer` dispatches each block to specialized renderers (`MarkdownBlock`, `CodeBlock`, `DiffBlock`, `MermaidBlock`, `ExcalidrawBlock`). During streaming (`streaming=true`), unclosed code fences produce blocks with `complete: false` that render as provisional views. Diagram blocks are held at the placeholder until the fence closes — a half-streamed Mermaid graph or Excalidraw scene is not yet valid, so drawing it would only flash the fallback. On completion (`streaming=false`), full reparse from content produces clean final blocks. `ChatMessage.rawText` preserves the original unprocessed text as source of truth for reparse.
 
-**Security** — All `dangerouslySetInnerHTML` content sanitized via DOMPurify (`frontend/src/api/helpers.ts`):
+**Security** — All `dangerouslySetInnerHTML` content sanitized via DOMPurify (`website/src/api/helpers.ts`):
 - `md()` — renders markdown-like formatting (code blocks, bold, italic) + DOMPurify sanitize
 - `sanitize()` — DOMPurify wrapper for pre-escaped HTML
 - `esc()` — plain text HTML escaping
@@ -1417,7 +1417,7 @@ React 18 + TypeScript + Vite 5 + Redux Toolkit + React Router v7 + Tailwind CSS 
 
 ### Agent Selector Component
 
-Shared `AgentSelector` component (`frontend/src/components/AgentSelector.tsx`) used by Chat, Tasks, and Cron:
+Shared `AgentSelector` component (`website/src/components/AgentSelector.tsx`) used by Chat, Tasks, and Cron:
 - `createPortal` renders to `document.body` — escapes `overflow` clipping
 - `fixed` positioning with viewport-aware placement (flips up if overflows bottom, aligns right edge)
 - `z-[9999]`, `max-w-[340px]`, agent name truncation for long names
@@ -1429,7 +1429,7 @@ Shared `AgentSelector` component (`frontend/src/components/AgentSelector.tsx`) u
 
 ### InfoTip Component
 
-Reusable `?` button (`frontend/src/components/InfoTip.tsx`) for contextual help across all pages:
+Reusable `?` button (`website/src/components/InfoTip.tsx`) for contextual help across all pages:
 - Portal-rendered to `document.body` — escapes `overflow: hidden` on `card-glow` parents
 - `fixed` positioning with viewport-aware placement
 - Solid background (`var(--card)`), strong shadow, `z-[9999]`

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -1655,7 +1655,7 @@ TTL-bounded picker registry resolves the index against the exact list it posted
 and refuses an expired, evicted or already-consumed one rather than applying a
 model from a stale advertisement.
 
-### Resume-binding expectations (`discord/resume_expectation.py`)
+### Resume-binding expectations (`messaging/resume_expectation.py`)
 
 An inbound resume binding lives on the bound session's `session_map.json` row. A recycle, restart prune, or dashboard unlink can destroy that row and the only evidence the channel was attached, so the resolver silently falls back to its DM session; the expectation record makes that loss reportable.
 

--- a/docs/system-specs/modules/papyrus.md
+++ b/docs/system-specs/modules/papyrus.md
@@ -544,13 +544,16 @@ Two views behind one route:
 
 Dependency decisions, both deliberate:
 
-- **Monaco, not CodeMirror.** Monaco is already vendored here
-  (`@monaco-editor/react` + `monaco-editor`, loaded from the local bundle by
-  `utils/monacoLocal.ts`), so the upstream CodeMirror stack is not reintroduced.
-  Monaco ships no TeX grammar, so `latexLanguage.ts` registers a small Monarch
-  tokenizer; if that registration fails, Monaco falls back to plaintext, which is
-  the correct degradation. Compiler diagnostics are pushed into Monaco's own
-  **marker store**, so squiggles survive scrolling/folding/resize for free.
+- **The Pierre editor, not CodeMirror.** Pierre is already vendored here
+  (`@pierre/diffs` + `@pierre/trees`, behind the one lazy chunk every code surface
+  shares in `website/src/pierre`), so the upstream CodeMirror stack is not
+  reintroduced. Pierre's own extension table sends `.tex` to the coarser `tex`
+  grammar, so `PIERRE_EXTENSION_OVERRIDES` in `website/src/pierre/config.ts` maps
+  `.tex`, `.ltx`, `.sty` and `.cls` to `latex`, which additionally scopes section
+  titles and cross-reference and citation keys. Until that chunk resolves the pane
+  renders plain text (`PlainCodeFallback`), which is the correct degradation.
+  Compiler diagnostics are pushed into the editor's own **marker store**, so
+  squiggles survive scrolling/folding/resize for free.
 - **The browser's PDF viewer, not `pdfjs-dist`.** Upstream shipped ~1 MB of JS
   plus a worker chunk and a hand-written text layer to reproduce what Chrome,
   Firefox, Safari and Edge all do natively (selection, find-in-page, zoom,
@@ -722,7 +725,7 @@ that host reports `supported: false` and keeps the manual install path.
 | `website/src/apps/papyrus/CoAuthorPanel.tsx` | Embedded native chat |
 | `website/src/apps/papyrus/api.ts` | Typed fetch wrapper |
 | `website/src/apps/papyrus/lib.ts` | Pure helpers (tree, word count, persistence) |
-| `website/src/apps/papyrus/latexLanguage.ts` | Monaco LaTeX tokenizer |
+| `website/src/pierre/config.ts` | LaTeX grammar override for `.tex`/`.ltx`/`.sty`/`.cls` |
 | `website/public/app-assets/papyrus/` | Icon + light/dark hero art |
 
 ## Tests

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -956,10 +956,13 @@ hardcode was removed, so a package-installed agent is now classified
 and `"builtin"` for the rest) rather than the former `"aim"` literal. Importers
 (`subagent`, `mcp_core`, `conductor_skill`, dashboard agents) were updated to the
 new module/class names.
-- `browser/auth.py::register_browser_auth_provider(provider)` — module-level
-  registration hook (twin of `register_acp_backends`); every `browser/auth`
-  helper delegates to it when present, else the OSS default. `browser/cli.py`
-  auth subcommands now delegate through the helpers.
+- **`register_browser_auth_provider(provider)` — removed with the playwright-cli
+  migration.** The module that carried this seam is gone, so there is no
+  browser-auth provider hook to register at all: browsing runs through the
+  external `playwright-cli` binary (`kiro_crew/browser_cli/`), and a logged-in
+  session reaches that binary through the CLI's own surfaces (`state-save` /
+  `state-load`, `attach --extension`) rather than through an in-process
+  provider.
 - `hooks.register_internal_read_path(read_id, rel_path)` — guarded seam adding a
   fixed-path entry to `_INTERNAL_READ_ALLOWLIST` (rejects `..`/absolute/
   non-sensitive/repoint).

--- a/docs/system-specs/modules/taskrunner.md
+++ b/docs/system-specs/modules/taskrunner.md
@@ -123,7 +123,7 @@ TaskRun = Project
 ```
 
 These files import from `kiro_crew.taskrunner` and require no changes:
-- `dashboard/handlers.py` → `StepStatus`, `TaskRun`
+- `dashboard/handlers/taskrunner.py` → `StepStatus`, `TaskRun`
 - `dashboard/server.py` → `TaskRunner`
 - `dashboard/state.py` → `TaskRunner`
 - `git_coord.py` → `Step`, `TaskRun`

--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -21,12 +21,23 @@ and a machine catches for free:
    the reference reads as authoritative while pointing at nothing. This repo
    accumulated several such citations, including a "frozen contract" module
    whose spec and conformance-gate docs were never ported.
+4. **Stale line citations.** A doc points at ``session.py:3356`` of a file that
+   now has 2520 lines. Source moves every day and the citation does not, so it
+   sends the reader to nothing while reading as precise — and when it overshoots
+   the end of the file it is usually because the code moved to another module
+   entirely, which is the part the doc most needs to say.
+5. **Phantom code.** A module spec names a source file that exists nowhere. The
+   spec claims to describe code that is there now, so an unresolvable path is
+   either a rename it missed or a dependency that left the tree — one of these
+   was still explaining why the editor uses Monaco, which had been deleted
+   outright. Checked only in ``docs/system-specs/modules/``: an RFC or a
+   migration design names files precisely BECAUSE they do not exist yet.
 
-Checks 1-3 are the structural invariants behind the repository rule that a code
+Checks 1-5 are the structural invariants behind the repository rule that a code
 change must also update the docs and the indexes. The rule is only real if a
 machine enforces it.
 
-The fourth check guards the other direction: some documentation filenames are an
+The sixth check guards the other direction: some documentation filenames are an
 API. ``src/kiro_crew/docs/*.md`` is packaged and read at runtime, and specific
 filenames are hardcoded in Python and TypeScript. Renaming one of those without
 updating its consumers breaks a shipped feature rather than a link.
@@ -196,6 +207,140 @@ _CONFLICT_MARKER_RE = re.compile(r"^(?:[<>|]{7}(?:\s|$)|={7}$)")
 # A documentation path cited from source code, e.g. ``docs/system-specs/x.md``.
 _CODE_DOC_REF_RE = re.compile(r"(?:website/)?docs/[A-Za-z0-9][A-Za-z0-9/_.-]*\.md")
 
+# A SOURCE path cited from documentation -- the opposite direction from
+# ``_CODE_DOC_REF_RE`` -- optionally with a line or line range:
+# ``acp/types.py``, ``session.py:300``, ``sandbox.py:2252-2262``, ``kiro.py:80,90``.
+# Only inside backticks: a bare path in prose is usually a sentence about a
+# directory, and the backticks are what make it a citation.
+_SOURCE_CITE_RE = re.compile(
+    r"`([A-Za-z0-9_][A-Za-z0-9_./-]*\.(?:py|ts|tsx|js|jsx|mjs|yml|yaml|json|sh|toml|cfg))"
+    r"(?::(\d+(?:[-,]\d+)*))?`"
+)
+
+# A line number long enough to be nothing but noise. CPython caps int(str) at
+# 4300 digits and raises ValueError past it, so an absurd citation in a fork PR's
+# doc would abort the whole gate rather than be reported. A real file has fewer
+# than ten digits of lines; anything longer is not a citation to adjudicate, so it
+# is reported as malformed and never converted.
+_MAX_LINE_DIGITS = 9
+
+# Trees a cited source path may live in. Deliberately NOT a list of prefixes to
+# join the citation onto: a doc cites a source file relative to whatever root its
+# reader is standing in -- the package (``acp/types.py``), the repo
+# (``scripts/x.py``), the website bundle (``apps/builtinRegistry.ts``, really under
+# ``website/src/``), an app's own root (``providers/pagerduty.py``, really under
+# ``apps/builtins/ops_mission_control/backend/``) or a skill's
+# (``scripts/reaper.sh``). Those roots cannot be enumerated, so the citation is
+# matched as a path SUFFIX against the files that actually exist here, and only a
+# path matching NOTHING is reported.
+_SOURCE_CITE_TREES: tuple[str, ...] = (
+    "src",
+    "website",
+    "scripts",
+    "test",
+    "packaging",
+    ".github",
+    # The docs site's own tree. Its `package-lock.json` is git-tracked and was
+    # reported purely because this list did not name the tree -- the tell was its
+    # two sibling citations resolving fine under `website`. Adding the tree is the
+    # fix; allowlisting the ref would have permanently silenced rot on a live file.
+    "site",
+    # Docs cite each other's committed assets: `governance.md` names
+    # `docs/guides/assets/security-policy.example.json`, which exists and is even a
+    # working relative markdown link. Same reasoning as `site` -- a missing tree is
+    # a resolver bug, not a citation to excuse.
+    "docs",
+)
+
+# Docs where an UNRESOLVABLE source path is a finding. Scoped by GENRE, and that
+# is the whole design: what separates a stale citation from a correct
+# unresolvable one is not the path's shape but what the document is FOR.
+#
+# A module spec describes code that exists now, so a path it names and cannot be
+# found is rot. An RFC, a plan and a migration design name files precisely
+# BECAUSE they do not exist -- `browser/setup.py` sits in a "what is deleted"
+# table, `notifications/bridge.py` sits beside the words "zero implementation
+# code exists" -- and an app-kit guide names files in the READER's project
+# (`app.json`, `ui/src/App.tsx`).
+#
+# A shape-based allowlist provably cannot draw that line. Silencing those four
+# deletion-table entries needs `browser/**`, and that same pattern suppresses
+# four of the real findings. Only WHICH DOC separates them.
+#
+# Measured on the tree this shipped against: unscoped, 38 findings of which 11
+# were real (27 false). Scoped here: 19 findings, the same 11 real, and the 8
+# residuals are the three refs below.
+_PATH_CITE_DOC_PREFIXES: tuple[str, ...] = ("docs/system-specs/modules/",)
+
+# Refs that cannot resolve here and are still correct. EXACT refs, not patterns,
+# so a new unresolvable path is reported rather than absorbed by a wildcard --
+# each of these was traced to the file it really names before it was listed.
+_UNRESOLVABLE_REF_OK: frozenset[str] = frozenset(
+    {
+        # -- This crew's own RUNTIME data, under ~/.kiro/crew. Written by the code
+        #    that resolves each path; never present in a checkout.
+        #
+        # ops-mission-control's app data dir. `store.py`'s `incidents_dir()` /
+        # `index_path()` join `app_data_dir(APP_NAME)` from `apps/manager.py`.
+        "data/config.json",
+        "incidents/index.json",
+        # The same two files spelled from the home root, in security.py's
+        # write-protect table (`_CREW_HOME_PREFIXES` + the literal suffix).
+        "apps/ops-mission-control/data/rotation.yaml",
+        "apps/ops-mission-control/data/incidents/index.json",
+        # spec-builder's trust keystone: `config_dir() / "trust" / ...`.
+        "trust/spec-builder-decisions.json",
+        # Optional dev-only override read from KIROCREW_PROJECT_DIR by
+        # `agent.py`'s `_shipped_defaults()`; the shipped file is
+        # `config/defaults.json`, which resolves.
+        "agents/defaults.json",
+        #
+        # -- FOREIGN homes. `onboarding_import.py` reads other tools' config dirs
+        #    to offer an import, so naming their layout is the point.
+        #
+        # Antigravity / Gemini (`~/.gemini`, `_GEMINI_CONFIG_RELATIVE_PATHS`).
+        # All three spellings are probed, because Antigravity is closed-source and
+        # its subpath moved between releases; the first is the live one.
+        "config/mcp_config.json",
+        "antigravity/mcp_config.json",
+        "antigravity-cli/settings.json",
+        # Hermes Agent (`~/.hermes`, `_scan_hermes`), OpenClaw
+        # (`OPENCLAW_STATE_DIR`), and any registered install descended from
+        # Kiro Crew (`_scan_lineage_install`) -- all three name this relative path.
+        "cron/jobs.json",
+        #
+        #
+        # -- GENERATED or VENDORED at build/install time. Present in a wheel or a
+        #    provisioned install, never in a checkout, and each is gitignored.
+        #
+        # Stamped by `scripts/stamp-distribution.sh` during packaging; imported
+        # through a try/except ImportError precisely because a checkout lacks it.
+        "kiro_crew/_build_info.py",
+        # Bundle inside the vendored npm package @agentclientprotocol/claude-agent-acp,
+        # resolved out of the gitignored node_modules by `acp/client.py`.
+        "dist/acp-agent.js",
+        # playwright-core's own browser registry, inside the npm dependency.
+        "playwright-core/browsers.json",
+        # Relative to ENGINE_ROOT -- `engine_root()` is
+        # ~/.kiro/crew/apps/pptx-maker/data/vendor/sdpm, a checkout `provision.py`
+        # installs at runtime. Two backend comments cite it the same way.
+        "skill/sdpm/api.py",
+        #
+        # -- ANOTHER REPOSITORY.
+        #
+        # The `@kiro/agent` package's own entry point, and a sibling package in
+        # that same repo; the citing doc says "Confirmed against @kiro/agent source".
+        "src/index.ts",
+        "packages/acp-type-covenant/capabilities/auth/get-access-token.ts",
+        # A bug-repro test the auto-improvement spine tells the agent to CREATE in
+        # the external target repo under test (github.com/Zedmor/chess_test), which
+        # keeps its suite in `tests/` plural. Rewriting it to this repo's `test/`
+        # would make the sentence false.
+        "tests/test_bug_src_search_py_negamax_root.py",
+    }
+)
+
+
 # Citations that look like doc paths but are not references to THIS repo's docs:
 # upstream project paths, and test fixture data that merely contains a filename.
 _CODE_REF_IGNORE_SUBSTRINGS: tuple[str, ...] = (
@@ -242,6 +387,8 @@ class Findings:
     broken_links: list[str] = field(default_factory=list)
     unreachable: list[str] = field(default_factory=list)
     phantom_refs: list[str] = field(default_factory=list)
+    stale_line_cites: list[str] = field(default_factory=list)
+    phantom_source_paths: list[str] = field(default_factory=list)
     coupling: list[str] = field(default_factory=list)
     missing_index: list[str] = field(default_factory=list)
     changelog_preamble: list[str] = field(default_factory=list)
@@ -252,6 +399,8 @@ class Findings:
             len(self.broken_links)
             + len(self.unreachable)
             + len(self.phantom_refs)
+            + len(self.stale_line_cites)
+            + len(self.phantom_source_paths)
             + len(self.coupling)
             + len(self.missing_index)
             + len(self.changelog_preamble)
@@ -284,6 +433,26 @@ def _prune(root: Path, dirpath: str, dirnames: list[str]) -> None:
     dirnames[:] = keep
 
 
+def _is_regular_file(path: Path) -> bool:
+    """A real file in THIS tree -- never a symlink, whatever it points at.
+
+    This gate walks a tree a fork PR controls, and every file it lists is a file
+    it may later read in full. A symlink is therefore an arbitrary read primitive:
+    ``src/kiro_crew/evil.py -> /dev/zero`` plus a citation naming it makes the read
+    never finish, and a symlink into a credential path makes it exfiltration. Note
+    ``Path.is_file()`` FOLLOWS symlinks, so the symlink test must be explicit.
+
+    Applied at BOTH walks. The markdown walk has the identical hole (a symlinked
+    ``docs/evil.md``) and it feeds every other check in this file, so guarding only
+    the citation index would leave the same hazard one filename away.
+    """
+    try:
+        return path.is_file() and not path.is_symlink()
+    except OSError:
+        # A broken or recursive link raises rather than answering; that is a no.
+        return False
+
+
 def _walk_markdown(root: Path, subdir: str) -> list[Path]:
     """Every ``*.md`` under ``subdir``, skipping vendored and artifact trees."""
     base = root / subdir
@@ -293,8 +462,11 @@ def _walk_markdown(root: Path, subdir: str) -> list[Path]:
     for dirpath, dirnames, filenames in os.walk(base):
         _prune(root, dirpath, dirnames)
         for name in sorted(filenames):
-            if name.endswith(".md"):
-                out.append(Path(dirpath) / name)
+            if not name.endswith(".md"):
+                continue
+            path = Path(dirpath) / name
+            if _is_regular_file(path):
+                out.append(path)
     return out
 
 
@@ -348,6 +520,45 @@ def _resolve_link(doc: Path, target: str, root: Path) -> Path | None:
         # Root-relative links are resolved against the repo root.
         return (root / clean.lstrip("/")).resolve()
     return (doc.parent / clean).resolve()
+
+
+def _source_file_index(root: Path) -> dict[str, list[Path]]:
+    """Every source file in the scanned trees, keyed by each of its path suffixes.
+
+    Built once per run and cached on the function, because the citation check asks
+    "does any file end with this path" for a few hundred citations and walking the
+    trees per citation would make the gate the slowest thing in CI.
+    """
+    cached = getattr(_source_file_index, "_cache", None)
+    if cached is not None and cached[0] == root:
+        return cached[1]
+    index: dict[str, list[Path]] = {}
+    for tree in _SOURCE_CITE_TREES:
+        base = root / tree
+        if not base.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            _prune(root, dirpath, dirnames)
+            for name in sorted(filenames):
+                path = Path(dirpath) / name
+                if not _is_regular_file(path):
+                    continue
+                parts = _rel(path, root).split("/")
+                # Register every suffix, so a citation from any root matches.
+                for start in range(len(parts)):
+                    index.setdefault("/".join(parts[start:]), []).append(path)
+    _source_file_index._cache = (root, index)  # type: ignore[attr-defined]
+    return index
+
+
+def _resolve_source_cite(root: Path, ref: str) -> list[Path]:
+    """Files whose path ends with ``ref``. Empty means the citation names nothing.
+
+    More than one match is normal and is not a finding: ``app.json`` is a real
+    filename in several builtin apps, and a doc naming it is not wrong just
+    because it did not say which one.
+    """
+    return _source_file_index(root).get(ref.lstrip("./"), [])
 
 
 def _read(path: Path) -> str:
@@ -556,6 +767,141 @@ def check_code_citations(root: Path, findings: Findings) -> None:
                         findings.phantom_refs.append(f"{rel_path}:{lineno} -> {ref}")
 
 
+def check_source_citations(root: Path, docs: list[Path], findings: Findings) -> None:
+    """A line number a doc cites must be inside the file it names.
+
+    ``check_code_citations`` guards code -> docs. This guards docs -> code, which
+    rots faster and more quietly: source moves every day, and a doc that says
+    "see ``session.py:3356``" of a 2520-line file sends the reader to nothing while
+    reading as precise. Exactly one claim here is decidable without judgement --
+    the cited line exists -- and that is the whole check.
+
+    A citation is matched as a path SUFFIX against the files that exist, because a
+    doc cites relative to whatever root its reader stands in: the package
+    (``acp/types.py``), the repo (``scripts/x.py``), the website bundle
+    (``apps/builtinRegistry.ts``, really under ``website/src/``), an app's own root
+    (``providers/pagerduty.py``) or a skill's (``scripts/reaper.sh``). Those roots
+    cannot be enumerated. Several matches is normal and not a finding: ``app.json``
+    is a real filename in two dozen builtin apps, and the citation is wrong only
+    when the line is past the end of EVERY candidate.
+
+    Two neighbouring checks were built, measured against the real tree, and left
+    OUT -- recorded here so nobody re-adds one believing it was merely forgotten.
+
+    An unresolvable PATH is reported too, but ONLY from a module spec, and that
+    scope is the whole design rather than a convenience. Five narrowings were
+    measured against the real tree, and each one that keyed on the path's SHAPE
+    left a different family of false positives behind:
+
+    ======================================  =======  ====  =====
+    rule                                    findings real  false
+    ======================================  =======  ====  =====
+    raw                                        1960     -      -
+    + require the parent directory to exist      48     -      -
+    + suffix match from any root                637     -      -
+    + require a directory component              78     -      -
+    scoped to ``docs/system-specs/modules/``     41    20     21
+    ======================================  =======  ====  =====
+
+    What separates a stale citation from a correct unresolvable one is not the
+    path's shape but what the DOCUMENT IS FOR. An RFC, a plan and a migration
+    design name files precisely because they do not exist -- ``browser/setup.py``
+    sits in a "what is deleted" table, ``notifications/bridge.py`` beside the words
+    "zero implementation code exists" -- and an app-kit guide names files in the
+    READER's project. A module spec describes code that is there now, so a path it
+    cannot resolve is rot. A shape-based allowlist provably cannot draw that line:
+    silencing those four deletion-table entries needs ``browser/**``, and the same
+    pattern suppresses four real findings.
+
+    The 21 residuals inside the scope were each traced to the code that BUILDS the
+    path, and they are exact refs in :data:`_UNRESOLVABLE_REF_OK` rather than
+    patterns, so a new unresolvable path is reported instead of absorbed. Two of
+    them turned out to be resolver bugs rather than exemptions -- ``site/`` and
+    ``docs/`` were missing from the scanned trees, and ``site/package-lock.json``
+    is git-tracked, so an exact-ref entry there would have silenced rot on a live
+    file forever. Those became trees.
+
+    A cited SYMBOL is still not checked, and the reason is structural. A table row
+    pairs independent columns -- ``docs/architecture/mcp.md`` lists a server, its
+    entry point ``mcp_computer.py``, and its tool names, which really live in
+    ``computer_use/cli.py`` -- so same-line adjacency is not a claim about where a
+    name is defined. Dropping adjacency to ask only "does this identifier exist
+    anywhere" flags every name an RFC proposes: 572 repo-wide, ~100 in one RFC.
+
+    A check whose findings are mostly false trains a maintainer to skim past the
+    gate, which costs more than the gap it closes.
+
+    A cited SYMBOL is not checked either. A table row pairs independent columns --
+    ``docs/architecture/mcp.md`` lists a server, its entry point
+    ``mcp_computer.py``, and its tool names, which really live in
+    ``computer_use/cli.py`` -- so same-line adjacency is not a claim about where a
+    name is defined. Dropping adjacency to ask only "does this identifier exist
+    anywhere" flags every name an RFC proposes: 572 hits repo-wide, ~100 in one
+    RFC, nearly all correct writing about code that does not exist yet.
+
+    Both gaps are the same judgement: a check whose findings are mostly false
+    trains a maintainer to skim past the gate, which costs more than the gap.
+
+    The line check is honest about its own reach too -- it catches a citation
+    pointing PAST the end of a file, never one that has drifted to the wrong line
+    inside it. That is the argument for citing a symbol NAME wherever a doc can: a
+    name survives the refactor that moves the line.
+    """
+    for doc in docs:
+        rel_doc = _rel(doc, root)
+        # NOT gated on `_is_uncurated`. That exemption is about CURATION -- an
+        # archive is not required to be indexed or styled -- and it says nothing
+        # about whether a citation inside it is true. A reader who opens an
+        # archived doc still follows its line numbers. The path class needs no
+        # exemption either: its own scope is `docs/system-specs/modules/`, which
+        # no uncurated tree is inside.
+        paths_must_resolve = rel_doc.startswith(_PATH_CITE_DOC_PREFIXES)
+        try:
+            text = _read(doc)
+        except OSError:
+            continue
+        # A fenced block is sample code or terminal output, not a citation.
+        for lineno, line in enumerate(_strip_fences(text).splitlines(), start=1):
+            for match in _SOURCE_CITE_RE.finditer(line):
+                ref, lines = match.group(1), match.group(2)
+                targets = _resolve_source_cite(root, ref)
+                if not targets:
+                    if paths_must_resolve and "/" in ref and ref not in _UNRESOLVABLE_REF_OK:
+                        findings.phantom_source_paths.append(f"{rel_doc}:{lineno} -> {ref}")
+                    continue
+                if not lines:
+                    continue
+                parts = re.split(r"[-,]", lines)
+                if any(len(n) > _MAX_LINE_DIGITS for n in parts):
+                    # Never converted: `int()` raises past CPython's digit cap, and
+                    # an uncaught ValueError here would abort the gate on input a
+                    # fork PR controls.
+                    findings.stale_line_cites.append(
+                        f"{rel_doc}:{lineno} -> {ref}:{lines} names no plausible line"
+                    )
+                    continue
+                cited = max(int(n) for n in parts)
+                if cited < 1:
+                    # Files are 1-indexed, so `:0` points at nothing. Reported
+                    # rather than skipped: it reads as precise and is not.
+                    findings.stale_line_cites.append(
+                        f"{rel_doc}:{lineno} -> {ref}:{lines} is not a line number "
+                        "(files are 1-indexed)"
+                    )
+                    continue
+                # With several candidates the citation is only wrong when the line
+                # is past the end of EVERY one of them: any file that is long
+                # enough is a reading on which the citation makes sense.
+                lengths = {t: len(_read(t).splitlines()) for t in targets}
+                if any(total >= cited for total in lengths.values()):
+                    continue
+                longest = max(lengths, key=lambda t: lengths[t])
+                findings.stale_line_cites.append(
+                    f"{rel_doc}:{lineno} -> {ref}:{lines} "
+                    f"but {_rel(longest, root)} has {lengths[longest]} line(s)"
+                )
+
+
 def check_code_coupled_docs(root: Path, findings: Findings) -> None:
     """Docs whose filenames are hardcoded in code must still exist.
 
@@ -617,6 +963,7 @@ def run(root: Path) -> Findings:
     check_changelog_preambles(root, docs, findings)
     check_conflict_markers(root, docs + entry_points, findings)
     check_code_citations(root, findings)
+    check_source_citations(root, docs, findings)
     check_code_coupled_docs(root, findings)
     return findings
 
@@ -652,6 +999,16 @@ def _report(findings: Findings, doc_count: int) -> int:
         "documentation paths cited from code that do not exist",
         findings.phantom_refs,
         "write the missing doc, or correct the citation",
+    )
+    _emit(
+        "source paths cited from a module spec that do not exist",
+        findings.phantom_source_paths,
+        "correct the path, or say plainly that the code was deleted",
+    )
+    _emit(
+        "line citations pointing past the end of the file",
+        findings.stale_line_cites,
+        "cite a symbol name instead: a name survives the refactor that moves the line",
     )
     _emit(
         "code-coupled docs missing",
@@ -767,6 +1124,106 @@ def _self_test() -> int:
         )
         return "phantom_refs"
 
+    def plant_phantom_source_path(root: Path) -> str:
+        # A module spec naming a file that exists nowhere -- the case the class
+        # reports. The doc has to sit in the scoped tree to be checked at all.
+        pkg = root / "src" / "kiro_crew" / "acp"
+        pkg.mkdir(parents=True)
+        (pkg / "real.py").write_text("x = 1\n", encoding="utf-8")
+        spec_dir = root / "docs" / "system-specs" / "modules"
+        spec_dir.mkdir(parents=True)
+        (root / "docs" / "README.md").write_text(
+            "# Docs\n\n- [Ok](ok.md)\n- [Spec](system-specs/modules/thing.md)\n",
+            encoding="utf-8",
+        )
+        (spec_dir / "thing.md").write_text(
+            "# Thing\n\nThe handler lives in `acp/ghost.py`.\n", encoding="utf-8"
+        )
+        return "phantom_source_paths"
+
+    def plant_citation_of_a_symlinked_file(root: Path) -> str:
+        # A symlink is an arbitrary read primitive in a tree a fork PR controls, so
+        # it is never indexed -- which makes a citation naming it UNRESOLVABLE, and
+        # in a module spec that is a finding. Pointed at a real file in-tree, so
+        # the probe proves the exclusion rather than the hazard.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "real.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        try:
+            (pkg / "linked.py").symlink_to(pkg / "real.py")
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows
+            return "phantom_source_paths"
+        spec_dir = root / "docs" / "system-specs" / "modules"
+        spec_dir.mkdir(parents=True)
+        (root / "docs" / "README.md").write_text(
+            "# Docs\n\n- [Ok](ok.md)\n- [Spec](system-specs/modules/thing.md)\n",
+            encoding="utf-8",
+        )
+        (spec_dir / "thing.md").write_text(
+            "# Thing\n\nSee `kiro_crew/linked.py:900`.\n", encoding="utf-8"
+        )
+        return "phantom_source_paths"
+
+    def plant_stale_line_cite(root: Path) -> str:
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text("# Ok\n\nSee `small.py:900`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
+    def plant_absurd_line_number(root: Path) -> str:
+        # 4301 digits: past CPython's int(str) cap, so converting it raises and
+        # would abort the whole gate on input a fork PR controls.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\nSee `small.py:" + "9" * 4301 + "`.\n", encoding="utf-8"
+        )
+        return "stale_line_cites"
+
+    def plant_line_zero(root: Path) -> str:
+        # Files are 1-indexed, so `:0` reads as precise and points at nothing.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text("# Ok\n\nSee `small.py:0`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
+    def plant_stale_line_cite_in_an_uncurated_tree(root: Path) -> str:
+        # An archive is exempt from CURATION -- indexes, style -- but a reader who
+        # opens it still follows its line numbers, so the line check applies.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        archive = root / "docs" / "archive"
+        archive.mkdir()
+        (archive / "old.md").write_text("# Old\n\nSee `small.py:900`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
+    def plant_stale_line_cite_in_an_rfc(root: Path) -> str:
+        # The path exemption above must NOT carry the line check with it: a line
+        # number is a claim about code that exists now, even inside a proposal.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        rfc = root / "docs" / "request-for-change"
+        rfc.mkdir()
+        (root / "docs" / "README.md").write_text(
+            "# Docs\n\n- [Ok](ok.md)\n- [Rfc](request-for-change/rfc-x.md)\n", encoding="utf-8"
+        )
+        (rfc / "rfc-x.md").write_text("# Rfc\n\nToday: `small.py:900`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
+    def plant_stale_line_range(root: Path) -> str:
+        # The END of a range is what must be inside the file: a range whose start
+        # is valid and whose end is past EOF is still a citation into nothing.
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text("# Ok\n\nSee `small.py:1-40`.\n", encoding="utf-8")
+        return "stale_line_cites"
+
     def plant_coupling(root: Path) -> str:
         pkg = root / "src" / "kiro_crew"
         pkg.mkdir(parents=True)
@@ -793,6 +1250,99 @@ def _self_test() -> int:
             else:
                 print(f"  ok  {label} ignored")
 
+    def source_cite_immunity_probe(label: str, build) -> None:
+        """Assert a legitimate citation shape is NOT reported.
+
+        Each shape here was MEASURED as a false positive on the real tree before
+        its exemption existed, so the probe records the evidence rather than a
+        hunch -- and pins the exemption so a later widening of the rule fails here
+        instead of burying the real findings again.
+        """
+        nonlocal failures
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs").mkdir(parents=True)
+            (root / "docs" / "README.md").write_text("# Docs\n\n- [Ok](ok.md)\n", encoding="utf-8")
+            (root / "docs" / "ok.md").write_text("# Ok\n\nBody.\n", encoding="utf-8")
+            field = build(root)
+            if getattr(run(root), field):
+                print(f"  FAIL {label} was flagged")
+                failures += 1
+            else:
+                print(f"  ok  {label} ignored")
+
+    def allow_unresolvable_path_outside_a_spec(root: Path) -> str:
+        # The scope IS the rule: an RFC or a guide names files it proposes or that
+        # belong to the reader, so an unresolvable path there is correct writing.
+        # Pinned, because widening the class past module specs re-buries the real
+        # findings 27:11 (measured).
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\nThis adds `acp/planned.py` and reads `cron/jobs.json`.\n",
+            encoding="utf-8",
+        )
+        return "phantom_source_paths"
+
+    def allow_allowlisted_ref_in_a_spec(root: Path) -> str:
+        # Inside the scope, an allowlisted ref stays silent -- each entry was
+        # traced to the code that builds the path before it was listed.
+        spec_dir = root / "docs" / "system-specs" / "modules"
+        spec_dir.mkdir(parents=True)
+        (root / "docs" / "README.md").write_text(
+            "# Docs\n\n- [Ok](ok.md)\n- [Spec](system-specs/modules/thing.md)\n",
+            encoding="utf-8",
+        )
+        (spec_dir / "thing.md").write_text(
+            "# Thing\n\nState lives in `cron/jobs.json`.\n", encoding="utf-8"
+        )
+        return "phantom_source_paths"
+
+    def allow_bare_filename_in_a_spec(root: Path) -> str:
+        # A citation with no directory names a runtime or generated file the repo
+        # cannot adjudicate; only a path WITH a directory is a checkable claim.
+        spec_dir = root / "docs" / "system-specs" / "modules"
+        spec_dir.mkdir(parents=True)
+        (root / "docs" / "README.md").write_text(
+            "# Docs\n\n- [Ok](ok.md)\n- [Spec](system-specs/modules/thing.md)\n",
+            encoding="utf-8",
+        )
+        (spec_dir / "thing.md").write_text(
+            "# Thing\n\nThe gateway rewrites `mcp.json`.\n", encoding="utf-8"
+        )
+        return "phantom_source_paths"
+
+    def allow_symlinked_doc(root: Path) -> str:
+        # The markdown walk skips symlinks for the same reason, so a symlinked doc
+        # contributes no findings of its own -- it is never opened.
+        (root / "docs" / "real-extra.md").write_text(
+            "# Extra\n\nSee `nope/ghost.py:900`.\n", encoding="utf-8"
+        )
+        try:
+            (root / "docs" / "linked.md").symlink_to(root / "docs" / "real-extra.md")
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows
+            pass
+        (root / "docs" / "README.md").write_text(
+            "# Docs\n\n- [Ok](ok.md)\n- [Extra](real-extra.md)\n", encoding="utf-8"
+        )
+        return "unreachable"
+
+    def allow_fenced_sample(root: Path) -> str:
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\n```\nsee `small.py:900`\n```\n", encoding="utf-8"
+        )
+        return "stale_line_cites"
+
+    def allow_in_range_cite(root: Path) -> str:
+        pkg = root / "src" / "kiro_crew"
+        pkg.mkdir(parents=True)
+        (pkg / "small.py").write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+        (root / "docs" / "ok.md").write_text(
+            "# Ok\n\nSee `small.py:2` and `small.py:1-3`.\n", encoding="utf-8"
+        )
+        return "stale_line_cites"
+
     print("Running docs-lint self-test...")
     clean_probe()
     probe("broken link", plant_broken_link)
@@ -803,10 +1353,26 @@ def _self_test() -> int:
     probe("conflict marker (bare separator)", plant_conflict_marker)
     probe("conflict marker (full three-way)", plant_conflict_marker_head)
     probe("conflict marker (uncurated tree)", plant_conflict_marker_uncurated)
+    probe("phantom source path in a module spec", plant_phantom_source_path)
+    probe("citation of a symlinked file", plant_citation_of_a_symlinked_file)
+    probe("line citation past EOF", plant_stale_line_cite)
+    probe("line citation past EOF inside an RFC", plant_stale_line_cite_in_an_rfc)
+    probe("line citation in an uncurated tree", plant_stale_line_cite_in_an_uncurated_tree)
+    probe("absurd line number (past the int digit cap)", plant_absurd_line_number)
+    probe("line zero", plant_line_zero)
+    probe("line RANGE ending past EOF", plant_stale_line_range)
     probe("phantom spec citation", plant_phantom_ref)
     probe("code-coupled doc missing", plant_coupling)
 
     # Code-markup immunity is an inverse assertion (nothing should fire).
+    source_cite_immunity_probe(
+        "unresolvable path outside a module spec", allow_unresolvable_path_outside_a_spec
+    )
+    source_cite_immunity_probe("allowlisted ref inside a spec", allow_allowlisted_ref_in_a_spec)
+    source_cite_immunity_probe("bare filename inside a spec", allow_bare_filename_in_a_spec)
+    source_cite_immunity_probe("symlinked doc is not walked", allow_symlinked_doc)
+    source_cite_immunity_probe("fenced sample citation", allow_fenced_sample)
+    source_cite_immunity_probe("in-range line citation", allow_in_range_cite)
     code_immunity_probe("fenced example link", "# Ok\n\n```md\n[example](does-not-exist.md)\n```\n")
     code_immunity_probe("inline-code example link", "# Ok\n\nSpoken as `[label](url)` aloud.\n")
     code_immunity_probe(


### PR DESCRIPTION
## Problem / Motivation

`scripts/docs_lint.py` already guards code → docs: a comment citing a spec path must resolve. The reverse direction was unguarded, and it rots faster, because source moves every day and a citation does not.

This is not a legacy backlog. An RFC merged **today** (#7033) arrived citing `history.py:4987-4989` in a file that has 2668 lines — five stale citations in a doc hours old. Five other RFCs pointed at `session.py:3356`, `mcp_core.py:5754` and `subagent.py:4722-4759` in files with 2520, 2085 and 2366 lines.

## Why it matters

The stale citations are the visible half. The invisible half is what they were hiding.

**Eight line citations pointed at code that had changed MODULE, not just line.** `binding_key_for` is in `autonudge.py`, not `mcp_core.py`. `monitor_start` and `wait` are in `mcp_tools/control.py`. The `_proc` / `_active_proc` probes moved to `session_pid.py` with #6921. Most of the resumable-subagent citations now land in `subagent_manager/run.py`, `session_cleanup.py` and `session_lifecycle.py` behind one-line facades. A reader following `mcp_core.py:5754` does not learn the tool moved — they learn nothing, and the doc keeps its authority.

**Three path citations could not be fixed by swapping the path**, because the sentence around it had also stopped being true:

- **`papyrus.md`** explained a Monaco dependency, twice. Monaco is gone from the repo outright — `monacoLocal.ts` deleted, `monaco-editor` absent from `website/package.json` — so the whole "Monaco, not CodeMirror" rationale was false, not merely mis-pathed.
- **`command-bar.md`** described a `ui.overlays` carve-out keeping a disabled builtin listed in Library. #6213 moved the file, then a later commit **deleted the carve-out**: the predicate is now `keepInLibrary`, keyed on `hidden`. Citing the new path alone would have left a false rule in the spec.
- **`platform-context.md`** documented `register_browser_auth_provider`, a registration seam that went with the module the playwright-cli migration removed. There is no hook to register any more.

## What changed (motivation → approach → change)

**Motivation → approach.** Two claims about a citation are decidable without judgement. Both land in the existing `docs-lint` job, and the citations they flag are fixed in the same commit so the checks land enforcing.

**No new CI job and no new workflow step.** The job already runs `--test` then `docs-lint.sh`. The added tree walk costs **0.02s** (9.62s → 9.64s measured).

**Change.**

- **`scripts/docs_lint.py` — one new check, `check_source_citations`**, sibling to the existing `check_code_citations`, with two finding classes:
  - **a cited LINE must be inside the file it names** — every doc tree;
  - **a path cited BY A MODULE SPEC must resolve** — `docs/system-specs/modules/` only.
- **31 citations fixed across 16 docs.** 11 line citations replaced with symbol names (the form that survives the refactor that moved the line) and 20 paths corrected.
- **`.github/workflows/ci.yml`** — one comment line, so the step's enumeration of what the gate covers stays complete.

### Resolution: path suffix, not a fixed base list

A doc cites relative to whatever root its reader stands in — the package (`acp/types.py`), the repo (`scripts/x.py`), the website bundle (`apps/builtinRegistry.ts`, really under `website/src/`), an app's own root (`providers/pagerduty.py`) or a skill's (`scripts/reaper.sh`). Those roots cannot be enumerated; a fixed base list produced 5 false positives in `website/docs/` alone. Several matches is normal and **not** a finding — `app.json` is a real filename in two dozen builtin apps — so a line is wrong only when it is past the end of *every* candidate.

### The path class is scoped by GENRE, and that is the design

Five narrowings, measured. Every one that keyed on the path's **shape** left a different family of false positives:

| rule | findings |
|---|---:|
| raw | 1960 |
| + require the parent directory to exist | 48 |
| + suffix match from any root | 637 |
| + require a directory component | 78 |
| **scoped to `docs/system-specs/modules/`** | **41** (20 real, 21 residual) |

What separates a stale citation from a correct unresolvable one is what the **document is for**. An RFC or a migration design names files precisely *because* they do not exist — `browser/setup.py` sits in a "what is deleted" table, `notifications/bridge.py` beside the words "zero implementation code exists" — and an app-kit guide names files in the reader's own project. A shape-based allowlist provably cannot draw that line: silencing those four deletion-table entries needs `browser/**`, which suppresses four of the real findings.

### The 21 residuals are exact refs, and two were resolver bugs

Each was traced to the code that **builds** the path before being listed, and they are exact refs rather than patterns, so a new unresolvable path is reported instead of absorbed:

- **this crew's runtime data** — `incidents/index.json` and `data/config.json` via `store.py`'s `index_path()` over `app_data_dir(APP_NAME)`; `trust/spec-builder-decisions.json` via `config_dir()`; `agents/defaults.json` via `agent.py`'s `_shipped_defaults()`;
- **foreign homes** — `onboarding_import.py` reads other tools' config dirs to offer an import. `cron/jobs.json` alone covers **three** unrelated owners (Hermes `~/.hermes`, OpenClaw `OPENCLAW_STATE_DIR`, any registered lineage install), each built by a different `_scan_*`. That is why patterns were rejected: one ref, three owners;
- **generated or vendored** — `kiro_crew/_build_info.py` (stamped by `scripts/stamp-distribution.sh`, imported through `try/except ImportError` precisely because a checkout lacks it), `dist/acp-agent.js` and `playwright-core/browsers.json` (gitignored `node_modules`), `skill/sdpm/api.py` (under a runtime-provisioned `engine_root()`);
- **another repository** — `src/index.ts` and `packages/acp-type-covenant/...` in `@kiro/agent`; `tests/test_bug_src_search_py_negamax_root.py` is a repro the auto-improvement spine tells the agent to *create* in the external target repo, which keeps its suite in `tests/` plural.

**Two findings were not exemptions — they were bugs in the resolver.** `site/` and `docs/` were missing from the scanned trees. `site/package-lock.json` is git-tracked (its two sibling citations under `website/` resolved fine, which was the tell), so an exact-ref entry there would have silenced rot on a live file forever. Both became trees.

### A cited SYMBOL is deliberately not checked

Recorded in `check_source_citations` so nobody re-adds it believing it was forgotten. A table row pairs independent columns — `docs/architecture/mcp.md` lists a server, its entry point `mcp_computer.py`, and its tool names, which really live in `computer_use/cli.py` — so same-line adjacency is not a claim about where a name is defined. Dropping adjacency to ask only "does this identifier exist anywhere" flags every name an RFC *proposes*: 572 repo-wide, ~100 in one RFC.

Both gaps are one judgement: a check whose findings are mostly false trains a maintainer to skim past the gate, which costs more than the gap it closes.

## Tests

The gate's own `--test` grows from 15 probes to 26 and runs before the gate in the same CI step per `docs/ci/harness-parity-gate.md`.

Four plant a defect the check must catch:

- a single line number past EOF
- a **range whose end** is past EOF while its start is valid
- a stale line citation **inside an RFC** — the path-class scope must not carry the line check with it
- a phantom path inside a module spec

Five pin the deliberate exemptions, so re-widening the rule fails here rather than quietly re-burying the real findings 21:20:

- an unresolvable path **outside** a module spec (the genre scope)
- an allowlisted ref **inside** a spec
- a bare filename with no directory
- an in-range line citation, single and range
- a citation inside a fenced code block

Every path and symbol written into the 16 docs was verified present by script: 63 symbols and 17 paths across both halves of the change.

There is no pytest file for this linter by design — the self-test *is* the harness, and CI runs it as its own step.

## Manual verification

```
$ python3 scripts/docs_lint.py --test
  ok  line citation past EOF detected
  ok  line RANGE ending past EOF detected
  ok  line citation past EOF inside an RFC detected
  ok  phantom source path in a module spec detected
  ok  unresolvable path outside a module spec ignored
  ok  allowlisted ref inside a spec ignored
  ok  bare filename inside a spec ignored
  ok  in-range line citation ignored
Self-test passed

$ python3 scripts/docs_lint.py
docs-lint: scanned 246 markdown files under docs, src/kiro_crew/docs, website/docs

All documentation checks passed
```

Before the fixes the same command reported 26 line findings and 41 path findings, so both classes are proven to fail as well as to pass on this tree.

Also green: `./scripts/docs-lint.sh`, `check_brand_name.py`, `check_changelog_history.py`, `check_black_formatting.py`, `flake8`, `mypy`, and `ci.yml` parses. Verified under **both 3.9 and 3.12**, since CI runs the system `python3` with no `setup-python`.

## Screenshots / video

n/a — no user-visible surface.

## Related Issues

No linked issue: docs-hygiene, found while fixing citations for the agent-SDK boundary work. The #6921, #6213 and #7033 references above are history, not work this PR closes. Supersedes #7146, which is closed in favour of this single PR.

Two things found while doing this and left out of scope, both in source rather than docs: `src/kiro_crew/computer_use/cli.py`'s module docstring still says "Hand-rolled dispatch mirroring ``browser/cli.py``", and `dashboard/handlers/computer_use.py` references a now-absent `api_browser_frame`.

## Checklist

- [x] No new CI job or workflow step; the added cost is 0.02s on an existing job
- [x] Gate self-tests before it runs, per `docs/ci/harness-parity-gate.md`
- [x] The gate's own findings are at zero, so it lands enforcing
- [x] Every exemption is an exact ref traced to the code that builds the path
- [x] Two would-be exemptions were fixed as resolver bugs instead of allowlisted
- [x] Every path and symbol written into a doc was verified present by script
- [x] Verified under both Python 3.9 and 3.12 (CI uses the system `python3`)
- [x] No behaviour change outside the linter; no product code touched
- [x] Lint, format, type, and doc gates green locally

## Contribution License Agreement

By submitting this pull request I confirm that my contribution is made under the terms of the project's license.
