### PR TITLE
chore: lower the sdk-boundary baseline for subagent.py after #6944

### DIFF
--- a/.github/agent-sdk-boundary-baseline.txt
+++ b/.github/agent-sdk-boundary-baseline.txt
@@ -1,6 +1,6 @@
 # Imports of the ACP layer from application code, as `<count> <path>`.
 # Both `kiro_crew.acp` and `kiro_crew.providers` count: providers re-exports ACP
-# shapes (LLMEvent, EVENT_*, is_claude_backend), so watching only `acp` would let
+# shapes (LLMEvent and the EVENT_* constants), so watching only `acp` would let
 # a consumer look migrated while still reading the backend's own types.
 #
 # The gate requires every OTHER file under src/ to be clean and none of these
@@ -64,7 +64,7 @@
 3 src/kiro_crew/slack/gateway.py
 3 src/kiro_crew/slack/handler.py
 1 src/kiro_crew/slack/transport_dispatch.py
-9 src/kiro_crew/subagent.py
+8 src/kiro_crew/subagent.py
 2 src/kiro_crew/subagent_persistence.py
 2 src/kiro_crew/task_executor.py
 1 src/kiro_crew/task_planner.py


### PR DESCRIPTION
## Problem / Motivation
Every PR's `Backend Tests (*, 1)` shard is currently red on main's merge-ref: `test/test_agent_sdk_boundary.py::test_every_recorded_violation_still_exists` fails with `these baseline entries are now lower than recorded ... {'src/kiro_crew/subagent.py': (9, 8)}`. PR #6944 (subagent-manager boundaries refactor) reduced `subagent.py`'s ACP-layer import count from 9 to 8, and the downward ratchet baseline was not updated in the same change.

## Why it matters
The ratchet is double-sided: progress must be recorded or the gate fails. Until the baseline is lowered, every open PR inherits this failure through the merge commit CI builds, blocking unrelated work repo-wide.

## What changed (motivation → approach → change)
Ran the script's own remediation, exactly as the failing assertion instructs: `python3 scripts/check_agent_sdk_boundary.py --update-baseline`. It lowered the `subagent.py` entry to 8 and regenerated the file header (the header comment no longer names a removed re-export). No hand edits.

## Tests
`test/test_agent_sdk_boundary.py` — 25 passed locally with the updated baseline.

## Manual verification
N/A — the ratchet test is the verification.

## Screenshots / video
<!-- no-visual-delta -->
**Why no screenshot:** CI baseline file only; no rendered surface.

no linked issue: repo-wide CI unblock for a baseline missed by the merged #6944.
