### PR TITLE
docs(rfc): record that #6853 landed

### DIFF
--- a/docs/request-for-change/rfc-transcript-section-markers.md
+++ b/docs/request-for-change/rfc-transcript-section-markers.md
@@ -5,7 +5,7 @@ author: rnoack
 created: 2026-08-29
 last-audited: 2026-08-29
 audited-at: 202770d13
-doc-pr:
+doc-pr: 7033
 implementation-prs: []
 tracking-issues: []
 supersedes: []
@@ -24,7 +24,7 @@ superseded-by: []
   this one adds a row, that one changes how rows are written),
   `rfc-tool-derived-diff-cards.md` (the nearest precedent for promoting a
   transcript-derived affordance into the dashboard),
-  [#6853](https://github.com/kirodotdev/KiroCrew/pull/6853) (open — exposes
+  [#6853](https://github.com/kirodotdev/KiroCrew/pull/6853) (merged — exposes
   `reset_conversation` as a boundary-deferred session directive; the context-side
   counterpart to this RFC's view-side marker, see §2.3).
 
@@ -94,7 +94,7 @@ The two compose rather than compete: **mark the section for the view, reset the
 conversation for the context.**
 
 That pairing is not hypothetical. [#6853](https://github.com/kirodotdev/KiroCrew/pull/6853)
-(open, not yet merged) adds `reset_conversation` as a session directive and MCP
+has landed on `main`, adding `reset_conversation` as a session directive and MCP
 tool, and it reaches the effect the four guards above block by **queuing the
 discard for a later turn boundary** rather than applying it inline — the same
 shape this RFC uses for a marker (§5.4, §5.5). Its own motivation is this
@@ -102,16 +102,17 @@ document's use case: *"use when a session walks a list of independent items one
 at a time … and carrying item N's context into item N+1 buys nothing but
 tokens."*
 
-So if #6853 lands, both halves become self-service from inside the turn that
-wants them, through one boundary-deferred directive each. Two differences worth
-keeping straight: `reset_conversation` is user-surface gated
+So the context half is already self-service from inside the turn that wants it;
+adopting this RFC makes the view half self-service too, through one
+boundary-deferred directive each. Two differences worth keeping straight:
+`reset_conversation` is user-surface gated
 (`_USER_SURFACE_DIRECTIVES`) and so also works on messaging channels, whereas a
 section marker is inherently dashboard-only because it is a rendering; and the
 two effects are independent — a caller may want a clean view without a clean
 context, or the reverse.
 
-This RFC does not depend on #6853. Without it the view half is still
-self-service and the context half stays an out-of-band action.
+This RFC does not depend on #6853. The view half stands on its own; #6853 having
+landed makes the pairing available, not required.
 
 ## 3. Goals
 
@@ -247,7 +248,7 @@ This is why `/note` defers its visible line, and the machinery already exists:
 already call it (`chat_runner.py:3988`, `:4406`; `chat_orchestrator.py:244`,
 `:839`). **Reuse it; do not add a second notion of "held".**
 
-That is worth stating precisely, because a second one is already in flight:
+That is worth stating precisely, because a second one already exists:
 [#6853](https://github.com/kirodotdev/KiroCrew/pull/6853) defers its discard
 through `slot._pending_discard_conversation_key`, consumed at a boundary in
 `chat_runner.py`, not through `_deferred_notes`. The two are not obviously
@@ -663,7 +664,7 @@ marker would vanish on one of the two write paths.
    `/note` deferral (`_deferred_notes`, flushed by `flush_deferred_notes`), while
    [#6853](https://github.com/kirodotdev/KiroCrew/pull/6853) introduces a second
    boundary path (`slot._pending_discard_conversation_key`, consumed in
-   `chat_runner.py`) that additionally waits on sub-agents. If both land there are
-   two answers to "what happens at a turn boundary", which is the kind of pair
-   that drifts. Whether they should be one seam is a maintainer call, and it is
-   not a prerequisite for either change.
+   `chat_runner.py`) that additionally waits on sub-agents. If a marker lands
+   there are two answers to "what happens at a turn boundary", which is the kind
+   of pair that drifts. Whether they should be one seam is a maintainer call, and
+   it is not a prerequisite for either change.


### PR DESCRIPTION
## Problem / Motivation

The transcript section markers RFC merged 78 seconds before #6853, the PR it
describes. So the RFC landed on `main` calling #6853 "open, not yet merged" and
hedging its conclusions on "if #6853 lands" — both false by the time anyone read
it. Its `doc-pr:` front-matter field was also left empty, because the number of
the PR that merges a document is not knowable while that PR is open.

## Why it matters

An RFC is a reference document, and a reader who follows the #6853 link now finds
a merged PR next to a document asserting the opposite. The bigger cost is to the
argument rather than the link: the RFC's central claim is that the two halves
compose ("mark the section for the view, reset the conversation for the
context"), and it framed both halves as contingent on a PR that has since
shipped. That understates what is already available on `main` and overstates what
this RFC still has to add. The empty `doc-pr:` separately breaks the convention
the index README states for that field, "the PR that merged this document".

## What changed

Docs only, one file, no code. `reset_conversation` was verified on `main` before
any rewording: it is a member of `DIRECTIVE_TOOLS` in
`src/kiro_crew/session_directive.py`, and `_reset_conversation` is defined in
`src/kiro_crew/dashboard/session_directive_apply.py`.

- `doc-pr:` set to `7033`.
- The `Related:` list says `(merged` where it said `(open`.
- The §2.3 paragraph says #6853 "has landed on `main`" instead of "(open, not yet
  merged)".
- "So if #6853 lands, both halves become self-service" is split by actual state:
  the context half already is, and adopting this RFC makes the view half so too.
- The closing independence note drops its counterfactual ("Without it the view
  half is still self-service") and states the design fact directly.
- §5 no longer calls the second boundary mechanism "already in flight", and the
  §11 open question asks "if a marker lands" rather than "if both land".

The last two were not in the obvious three: a sweep for every `#6853` mention
turned up six, and leaving those two would have left the document contradicting
itself two sections later.

Deliberately unchanged: `status: draft` and `implementation-prs: []`, since
nothing is implemented yet and that field belongs to the Phase 1 PR; and
`audited-at`, which records the commit the `file:line` citations were resolved
against and would be misleading to bump without actually re-resolving them.

## Tests

No tests. The change is prose plus one front-matter field in a `docs/` file, and
touches no code, schema, or build input. Verification instead was:

- A grep for every `#6853` mention in the file — six, each read and dispositioned,
  rather than only the three that were obviously stale.
- A stale-phrasing sweep ("not yet merged", "if both land", "in flight", "(open",
  …) re-run after editing and returning nothing, plus **the same sweep run against
  the pre-edit file as a positive control**, so the empty result is evidence about
  the document and not about the pattern.
- A YAML parse of the front matter confirming `doc-pr` reads as `7033` with
  `status`, `implementation-prs` and `audited-at` intact.
- `git diff --stat` confirming exactly one file changed.

A docs-only fork PR is expected to show a few checks resolving oddly rather than
failing on merit, since fork-triggered runs do not receive the secrets those
checks need.
