### PR TITLE
fix(chat): mount the pinned banner chevron by comparison, not by role

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -224,7 +224,7 @@ import { loadFileDrafts, saveFileDrafts as persistFileDrafts, setFileDraft } fro
 import { loadPasteDrafts, savePasteDrafts as persistPasteDrafts, setPasteDraft } from '../utils/chatPasteDrafts'
 import { loadSessionRefDrafts, saveSessionRefDrafts as persistSessionRefDrafts, setSessionRefDraft } from '../utils/chatSessionRefDrafts'
 import { addSessionRef, removeSessionRef, mergeSessionRefs, appendSessionRefLinks, type SessionRef } from '../utils/sessionRefs'
-import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, createPinnedPromptTextCache, type PinnedPromptText, pinHandoffY, pinPushTravel, jumpAnchorIdx, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
+import { findPinnedPromptIdx, findNextPromptIdx, computePinPush, nextPinnedPromptState, type PinnedPromptState, pinHandoffY, pinPushTravel, jumpAnchorIdx, DEFAULT_PINNED_CARD_H } from '../utils/pinnedPrompt'
 import {
   adoptSourceSelections,
   commitRevealedSource,
@@ -3363,7 +3363,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const pinFoldRef = useRef<HTMLDivElement | null>(null)
   const pinCardRef = useRef<HTMLDivElement | null>(null)
   const pinEnabledRef = useRef(true)
-  const [pinned, setPinned] = useState<{ idx: number; ts?: string; text: string; raw: string; full: string; images: string[]; bodyBeyondPreview: boolean; push: number; bannerH: number } | null>(null)
+  const [pinned, setPinned] = useState<PinnedPromptState | null>(null)
   const [pinExpanded, setPinExpanded] = useState(false)
   // Collapsed card height — the hand-off line is derived from it, so it must be
   // known even while nothing is pinned (no card mounted to measure). Seeded with
@@ -3373,13 +3373,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const pinCollapsedHRef = useRef(DEFAULT_PINNED_CARD_H)
   const onPinCollapsedHeight = useCallback((h: number) => {
     if (h > 0) pinCollapsedHRef.current = h
-  }, [])
-  // Memoised because `updatePinnedPrompt` runs once per animation frame of a
-  // scroll, and this walks the prompt (and its pastes) with three regexes.
-  const pinTextCacheRef = useRef<ReturnType<typeof createPinnedPromptTextCache> | null>(null)
-  const pinnedPromptText = useCallback((content: string, pastes: PasteBlock[]): PinnedPromptText => {
-    pinTextCacheRef.current ??= createPinnedPromptTextCache()
-    return pinTextCacheRef.current(content, pastes)
   }, [])
   // Recompute which prompt is pinned, and how far the incoming prompt has
   // pushed it out, from the current scroll position.
@@ -3457,23 +3450,18 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         ? subagentHeadline(sub)
         : null
     // Stored content is COLLAPSED (recollapsePastes), so a big paste is a
-    // `[ Paste #N ]` token; deriving through the paste layer is what unwraps it.
-    const derived = machineLabel
-      ? null
-      : pinnedPromptText(full, (pinItem.msg.meta?.pastes as PasteBlock[] | undefined) || [])
-    const text = machineLabel ?? derived?.text ?? ''
-    // Compare the RAW content (`prev.raw`), not `text` or the derived body:
-    // `text`, `full` and `images` are all derived from it, and an edit-and-resend
-    // that changes ONLY an attached image leaves the flattened preview text
-    // byte-identical. Comparing the source covers every derived value with one
-    // string compare — and returning `prev` unchanged matters because this runs
-    // once per animation frame during a scroll, so a fresh object (or a fresh
-    // `images` array) would re-render the banner on every one of them.
-    setPinned(prev => (prev && prev.idx === pinIdx && prev.push === push
-      && prev.raw === full && prev.bannerH === bannerH && prev.ts === pinItem.msg.ts)
-      ? prev
-      : { idx: pinIdx, ts: pinItem.msg.ts, text, raw: full, full: nudge ? nudge.body : (sub ? full : derived?.body ?? full), images: derived?.images ?? [], bodyBeyondPreview: !!machineLabel, push, bannerH })
-  }, [scrollerRef, pinnedPromptText])
+    // `[ Paste #N ]` token; the reducer unwraps it and decides whether to derive.
+    setPinned(prev => nextPinnedPromptState(prev, {
+      idx: pinIdx,
+      ts: pinItem.msg.ts,
+      raw: full,
+      pastes: (pinItem.msg.meta?.pastes as PasteBlock[] | undefined) || [],
+      machineLabel,
+      machineBody: nudge ? nudge.body : (sub ? full : undefined),
+      push,
+      bannerH,
+    }))
+  }, [scrollerRef])
   // rAF-throttle the per-scroll recompute: updatePinnedPrompt does a
   // querySelectorAll + getBoundingClientRect loop (a forced layout read), and a
   // fling fires scroll dozens of times/sec. Coalesce to at most once per frame,

--- a/website/src/test/pinnedPrompt.pasteTokens.test.tsx
+++ b/website/src/test/pinnedPrompt.pasteTokens.test.tsx
@@ -2,10 +2,9 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import PinnedPrompt from '../pages/chat/PinnedPrompt'
 import {
-  createPinnedPromptTextCache,
   derivePinnedPromptText,
   expandPastesCapped,
-  pasteSignature,
+  nextPinnedPromptState,
   promptBody,
   promptImages,
   promptPreview,
@@ -219,34 +218,75 @@ describe('the card renders what the derivation hands it', () => {
   })
 })
 
-describe('the pinned-text cache does not alias two distinct pastes', () => {
+describe('the pinned reducer does not alias two distinct pastes', () => {
   // Same seq and same line count, so formatToken yields IDENTICAL collapsed text
-  // for both — and equal content length, so a seq+length signature collides.
+  // for both -- and equal content length, so a content-shape key would collide.
   const first = block(1, 'alpha\nbravo\ncharlie')
   const second = block(1, 'delta\nechos\nfoxtrot')
+  const prompt = formatToken(first)
+
+  const input = (b: PasteBlock, over: Record<string, unknown> = {}) => ({
+    idx: 4, ts: 't1', raw: prompt, pastes: [b], machineLabel: null, push: 0, bannerH: 40, ...over,
+  })
 
   it('the two really are indistinguishable to a seq+length key', () => {
-    // Guard: without this the test could pass for the wrong reason.
     expect(second.content.length).toBe(first.content.length)
     expect(second.lines).toBe(first.lines)
     expect(formatToken(second)).toBe(formatToken(first))
   })
 
-  it('gives distinct blocks distinct signatures despite matching seq and length', () => {
-    expect(pasteSignature([second])).not.toBe(pasteSignature([first]))
+  it('derives the second message from its OWN paste, not the first one held', () => {
+    const a = nextPinnedPromptState(null, input(first))
+    const b = nextPinnedPromptState(a, input(second, { idx: 9, ts: 't2' }))
+    expect(a.text).toBe('alpha bravo charlie')
+    expect(b.text).toBe('delta echos foxtrot')
   })
 
-  it('derives the second prompt from its OWN paste, not the first one cached', () => {
-    const cache = createPinnedPromptTextCache()
-    const prompt = formatToken(first)
-    expect(cache(prompt, [first]).text).toBe('alpha bravo charlie')
-    expect(cache(prompt, [second]).text).toBe('delta echos foxtrot')
+  it('CONTROL: an unchanged scroll frame returns the IDENTICAL object', () => {
+    // The no-re-render property the reducer replaced the cache to keep.
+    const a = nextPinnedPromptState(null, input(first))
+    expect(nextPinnedPromptState(a, input(first))).toBe(a)
   })
 
-  it('CONTROL: still serves the cache when the same prompt and block return', () => {
-    // Proves the fix separates distinct blocks rather than neutering the memo.
-    const cache = createPinnedPromptTextCache()
-    const prompt = formatToken(first)
-    expect(cache(prompt, [first])).toBe(cache(prompt, [first]))
+  it('carries the derivation forward when only the push geometry moved', () => {
+    const a = nextPinnedPromptState(null, input(first))
+    const b = nextPinnedPromptState(a, input(first, { push: 12 }))
+    expect(b).not.toBe(a)
+    expect(b.push).toBe(12)
+    // Same strings, so no regex walk was needed to produce them.
+    expect(b.text).toBe(a.text)
+    expect(b.full).toBe(a.full)
+    expect(b.images).toBe(a.images)
+  })
+})
+
+describe('bodyBeyondPreview earns the expand chevron', () => {
+  it('is set for a SHORT multiline paste, whose body the preview flattens away', () => {
+    // The defect: this shape never clamps, so the flag is the only thing that can
+    // mount the chevron -- and the body is the whole point of expanding.
+    const p = block(1, 'first\nsecond\nthird')
+    const st = nextPinnedPromptState(null, {
+      idx: 1, ts: 't', raw: formatToken(p), pastes: [p], machineLabel: null, push: 0, bannerH: 40,
+    })
+    expect(st.text).toBe('first second third')
+    expect(st.full).toBe('first\nsecond\nthird')
+    expect(st.bodyBeyondPreview).toBe(true)
+  })
+
+  it('NEGATIVE CONTROL: a genuinely single-line paste does NOT earn one', () => {
+    const p = block(1, 'one single line of pasted text')
+    const st = nextPinnedPromptState(null, {
+      idx: 1, ts: 't', raw: formatToken(p), pastes: [p], machineLabel: null, push: 0, bannerH: 40,
+    })
+    expect(st.full).toBe(st.text)
+    expect(st.bodyBeyondPreview).toBe(false)
+  })
+
+  it('stays set for a machine row, whose label is not its body', () => {
+    const st = nextPinnedPromptState(null, {
+      idx: 1, ts: 't', raw: 'payload', pastes: [], machineLabel: 'Auto-nudge - cycle 17',
+      machineBody: 'Babysit the run. Check CI.', push: 0, bannerH: 40,
+    })
+    expect(st.bodyBeyondPreview).toBe(true)
   })
 })

--- a/website/src/utils/pinnedPrompt.ts
+++ b/website/src/utils/pinnedPrompt.ts
@@ -1,7 +1,7 @@
 import type { DisplayItem } from '../pages/chat/types'
 import { TURN_OPENER_ROLES } from '../pages/chat/groupDisplayItems'
 import { mdImageDestToPath } from './fileTokens'
-import { type PasteBlock, findTokenRanges } from './pasteTokens'
+import { type PasteBlock, expandAll } from './pasteTokens'
 
 /**
  * Geometry + selection helpers for the pinned-prompt banner (the most recent
@@ -388,18 +388,14 @@ export function expandPastesCapped(
   blocks: PasteBlock[],
   mapBlock?: (text: string) => string,
 ): string {
-  const ranges = findTokenRanges(content, blocks)
-  if (!ranges.length) return content
-  let out = content
-  for (let i = ranges.length - 1; i >= 0; i--) {
-    const { start, end, block } = ranges[i]
-    const capped = block.content.length > PINNED_PASTE_HEAD_CHARS
-      ? block.content.slice(0, PINNED_PASTE_HEAD_CHARS) + ' …'
-      : block.content
-    const body = mapBlock ? mapBlock(capped) : capped
-    out = out.slice(0, start) + body + out.slice(end)
-  }
-  return out
+  // Safe to delegate: `findTokenRanges` pairs a token to a block by `seq`, and
+  // the spread preserves it, so rewriting content cannot move a range.
+  return expandAll(content, blocks.map(b => {
+    const capped = b.content.length > PINNED_PASTE_HEAD_CHARS
+      ? b.content.slice(0, PINNED_PASTE_HEAD_CHARS) + ' …'
+      : b.content
+    return { ...b, content: mapBlock ? mapBlock(capped) : capped }
+  }))
 }
 
 /** Everything the pinned card renders, derived from one prompt in one pass. */
@@ -444,38 +440,70 @@ export function derivePinnedPromptText(content: string, blocks: PasteBlock[]): P
   }
 }
 
-/**
- * Cache key for a prompt's paste blocks.
- *
- * `id` is what makes two blocks distinguishable, and it is load-bearing rather
- * than belt-and-braces. `seq` restarts per draft (`nextSeq` is max+1) and an
- * equal character length is ordinary, so a seq+length pair aliases two
- * same-shaped pastes of the same size and different text — and because the token
- * text embeds seq and line count, such a pair ALSO yields identical collapsed
- * content, which is the cache's other half. `id` is minted once per block
- * (`makePasteId`) and never reused, so it separates them without hashing the
- * text.
- */
-export function pasteSignature(blocks: PasteBlock[]): string {
-  return blocks.map(b => `${b.id}:${b.seq}:${b.content.length}`).join(',')
+/** The pinned banner's complete state, owned by the transcript page. */
+export interface PinnedPromptState {
+  idx: number
+  ts?: string
+  text: string
+  raw: string
+  full: string
+  images: string[]
+  bodyBeyondPreview: boolean
+  push: number
+  bannerH: number
+}
+
+/** What the scroll recompute knows before any derivation is done. */
+export interface PinnedPromptInput {
+  idx: number
+  ts?: string
+  /** Stored (collapsed) prompt content — the identity the derivation keys on. */
+  raw: string
+  pastes: PasteBlock[]
+  /** Compact label a machine-authored row shows instead of its payload. */
+  machineLabel: string | null
+  /** Body such a row reveals when expanded, when it differs from `raw`. */
+  machineBody?: string
+  push: number
+  bannerH: number
 }
 
 /**
- * Single-slot memo for `derivePinnedPromptText`, owned by the caller across
- * renders. One slot is enough because only one prompt is pinned at a time, and
- * the caller runs once per animation frame of a scroll — which is what the memo
- * exists to keep the three regex walks out of.
+ * Next banner state, or `prev` itself when nothing a reader can see has moved.
+ *
+ * Derivation lives HERE rather than ahead of the call because the caller runs
+ * once per animation frame of a scroll: on a frame that moved only the push
+ * geometry the second branch carries the already-derived text forward, so the
+ * three regex walks happen once per pinned message instead of once per frame.
+ * That is what the cache this replaced was for.
+ *
+ * Identity is `(idx, raw, ts)` — the message — so two prompts that collapse to
+ * the same token text cannot share a derivation the way a content-shape key let
+ * them.
  */
-export function createPinnedPromptTextCache(): (content: string, pastes: PasteBlock[]) => PinnedPromptText {
-  let hit: { sig: string; content: string; value: PinnedPromptText } | null = null
-  return (content, pastes) => {
-    // Two values, not one joined key, so neither can absorb the other's
-    // characters.
-    const sig = pasteSignature(pastes)
-    if (hit && hit.sig === sig && hit.content === content) return hit.value
-    const value = derivePinnedPromptText(content, pastes)
-    hit = { sig, content, value }
-    return value
+export function nextPinnedPromptState(
+  prev: PinnedPromptState | null,
+  input: PinnedPromptInput,
+): PinnedPromptState {
+  const { idx, ts, raw, pastes, machineLabel, machineBody, push, bannerH } = input
+  const sameMsg = prev !== null && prev.idx === idx && prev.raw === raw && prev.ts === ts
+  if (sameMsg && prev.push === push && prev.bannerH === bannerH) return prev
+  if (sameMsg) return { ...prev, push, bannerH }
+  const derived = machineLabel === null ? derivePinnedPromptText(raw, pastes) : null
+  const text = machineLabel ?? derived?.text ?? ''
+  const full = machineBody ?? derived?.body ?? raw
+  return {
+    idx,
+    ts,
+    text,
+    raw,
+    full,
+    images: derived?.images ?? [],
+    // By COMPARISON, not by being machine-authored: a short multiline paste never
+    // clamps, so this flag is the only thing that can reach its body.
+    bodyBeyondPreview: full !== text,
+    push,
+    bannerH,
   }
 }
 


### PR DESCRIPTION
## Problem / Motivation

#7106 ("fix(chat): pinned prompt shows paste contents, not the collapsed token", squash
`32a4efd50`) taught the pinned-prompt banner to render a paste's real text instead of
`[ Paste #1 · 28 lines ]`. It merged at head `b8741f767` while a fourth round of fixes was still
in flight, so three changes were verified and pushed but never landed. All three are live on
`main` today.

The first is a user-visible bug that makes the merged feature unreachable on the most ordinary
case. `ChatPage.tsx` sets `bodyBeyondPreview: !!machineLabel`, which is `false` for every
ordinary prompt — the flag is only ever true for a nudge or a subagent row.
`PinnedPrompt.tsx:214` then reads:

```ts
const showChevron = clamped || images.length > 0 || bodyBeyondPreview || expanded
```

A short multiline paste never clamps (it is short) and carries no images, so no chevron mounts.
The line-preserving body #7106 added has no control that can reveal it.

The other two are structural findings raised against the same work. `expandPastesCapped` was a
third copy of the `findTokenRanges` right-to-left splice, named independently by two AI lanes
(Design, First Principles). And `createPinnedPromptTextCache` plus `pasteSignature` had zero
non-test consumers once the derivation moved.

## Why it matters

Without the first change the merged feature cannot be reached at all on a short multiline paste,
which is the common shape — a few lines of log, a stack fragment, a snippet. The paste's real
text is derived, stored in state, and passed to the card, and then nothing renders a control to
open it. The banner looks exactly as it did before #7106 for that input.

Keying the flag on "is this row machine-authored" answers a different question from the one the
chevron asks, which is "is there more here than the preview shows". Comparing the two strings
asks the real question, and is correct in all three branches: a nudge body and a subagent body
both differ from their compact labels, so those keep their chevron.

Accepted cost: a prompt that differs from its preview only in collapsed interior whitespace now
earns a chevron that reveals nothing new. That is cosmetic, and strictly better than a body no
control can reach.

## What changed

**1. Chevron by comparison, not by role.** `bodyBeyondPreview: full !== text`, computed where
both strings are already in hand.

**2. `expandPastesCapped` delegates to `expandAll`.** Behaviour-preserving: `findTokenRanges`
pairs a token to its block by `seq`, and the spread preserves `seq`, so rewriting content cannot
move a range. Rejected alternative: adding a `mapBlock` parameter to `expandAll` — that widens a
function with three other callers to serve one.

**3. Subtraction.** `createPinnedPromptTextCache` and `pasteSignature` are deleted and replaced
by a pure `nextPinnedPromptState(prev, input)` reducer in `pinnedPrompt.ts`. It keeps the
identical-object-on-unchanged-frame property the cache had, and adds one it did not: on a
geometry-only frame it spreads `prev` forward, so the three regex walks run once per pinned
message rather than once per animation frame of a scroll. Identity is `(idx, raw, ts)` — the
message — so two prompts collapsing to the same token text can no longer share a derivation the
way a content-shape key allowed.

`ChatPage.tsx` moves to the reducer as its caller, which is what lets the cache go. Its diff is
confined to the pinned-prompt region; the mobile-drawer work `main` landed after `b8741f767` is
untouched.

## Tests

`website/src/test/pinnedPrompt.pasteTokens.test.tsx` — 29 tests, including three that pin the
chevron flag directly: set for a short multiline paste, a negative control asserting a genuinely
single-line paste does **not** earn one, and set for a machine row whose label is not its body.
Two more cover the reducer's frame behaviour: an unchanged frame returns the identical object,
and a geometry-only frame carries the derivation forward.

Mutation control on the chevron fix: reverting `bodyBeyondPreview` to the shipped
`machineLabel !== null` fails exactly the short-multiline-paste test (1 failed / 28 passed), so
the assertion detects the defect rather than passing vacuously.

Gates, from `website/`:

| Gate | Result |
| --------------------------------- | ------------------------------------------ |
| `npx tsc -b`                      | 0 errors                                   |
| `npx eslint src/`                 | 0 errors, 658 warnings                     |
| `npx jscpd .`                     | pass — 1 pre-existing clone in `scripts/`  |
| `npm run i18n:check`              | `[i18n] 19 checks · PASS`                  |
| `npx vitest run`                  | 1689 files / 26687 passed, 3 skipped       |

The eslint count is 658 both with and without this change — measured against a clean checkout of
the same base by reverting only these three files — so it adds no warning. No detector was
weakened: no baseline or ceiling raise, no `--max-warnings` bump, no `eslint-disable`, no i18n
re-snapshot.
