### PR TITLE
feat(session-control): add session_close to archive a peer session

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -174,7 +174,6 @@ src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
 src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py
 src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/local_review.py
 src/kiro_crew/changelog.py
-src/kiro_crew/channel.py
 src/kiro_crew/channel_history.py
 src/kiro_crew/channel_transcript_migration.py
 src/kiro_crew/cli_bench.py
@@ -308,7 +307,6 @@ src/kiro_crew/mcp_caller.py
 src/kiro_crew/mcp_cleanup.py
 src/kiro_crew/mcp_core.py
 src/kiro_crew/mcp_cron.py
-src/kiro_crew/mcp_dashboard.py
 src/kiro_crew/mcp_discovery.py
 src/kiro_crew/mcp_gateway/abort.py
 src/kiro_crew/mcp_gateway/app_call.py
@@ -385,7 +383,6 @@ src/kiro_crew/suggestions.py
 src/kiro_crew/testing/channel_fixtures.py
 src/kiro_crew/testing/fake_acp_backend.py
 src/kiro_crew/tips.py
-src/kiro_crew/validation.py
 src/kiro_crew/vector_memory.py
 src/kiro_crew/webhooks.py
 src/kiro_crew/weixin/client.py

--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -3,13 +3,14 @@
 ## Overview
 
 Session control lets one of the user's chat sessions observe and interrupt
-another: open a new session, stop an in-flight turn, and read a transcript tail.
+another: open a new session, stop an in-flight turn, close (archive) a session,
+and read a transcript tail.
 It exists because a session cannot see what its peers are doing. A session that
 has spent an hour on a PR cannot tell whether the session watching the build has
 finished, and today the only way to find out is for the human to switch tabs and
 look. Session control lets the session ask directly.
 
-Three MCP tools on `kirocrew-dashboard`, three strict-internal routes, one config
+Five MCP tools on `kirocrew-dashboard`, five strict-internal routes, one config
 switch. Every route is on `_STRICT_INTERNAL_API_PATHS`; an unlisted one is
 unreachable in production because the caller's `X-Internal-Secret` is ignored.
 
@@ -17,6 +18,8 @@ unreachable in production because the caller's `X-Internal-Secret` is ignored.
 |------|-------|--------------|
 | `session_create` | `POST /api/session-control/create` | Open a new, empty session in the caller's workspace |
 | `session_stop` | `POST /api/session-control/stop` | Stop another session's in-flight turn |
+| `session_close` | `POST /api/session-control/close` | Close (archive) another session, as the tab ✕ does — heavier than stop, and recoverable rather than a delete |
+| `session_send` | `POST /api/session-control/send` | Deliver a message that another session runs as its next turn |
 | `session_read_message` | `GET /api/session-control/read` | Read another session's transcript tail + liveness |
 
 **One verb here writes into another session's conversation: `session_send`.**
@@ -58,10 +61,10 @@ and its keys are what `target` accepts.
 
 ## Authorization
 
-Deny-by-default, and checked in **one** place — `authorize_target` — for the two
-verbs that take a target, so a guard cannot be present on `stop` and missing on
-`read`. (`session_create` has no target to authorize; it checks the caller's own
-eligibility with the same refusals.) Every refusal is recorded in the SEL as
+Deny-by-default, and checked in **one** place — `authorize_target` — for every
+verb that takes a target (`stop`, `send`, `close`, `read`), so a guard cannot be
+present on one and missing on another. (`session_create` has no target to
+authorize; it checks the caller's own eligibility with the same refusals.) Every refusal is recorded in the SEL as
 `session_control.<op>` with `outcome=denied`, so an attempt to reach a session
 that is out of bounds is visible after the fact even though nothing happened.
 
@@ -91,17 +94,17 @@ Two notes on scope:
 - **Only sessions the dashboard currently holds are addressable.** A closed tab
   is out of reach on purpose — waking one would resurrect a conversation the
   user put away. This is narrower than `list_sessions`, which also lists history.
-- **All three tools are on `CHANNEL_AGENT_BLOCKED_TOOLS`, including the read.** A
-  channel agent is contained to channel posts, and session control crosses that
-  boundary in both directions: a stop reaches the user through one of their
-  dashboard transcripts, and `session_read_message` pulls a private dashboard
-  conversation into a channel other humans can see. Containment is about what
-  crosses the boundary, not about who writes, so the read is blocked alongside
-  the rest. `session_create` earns its place for a different reason: it writes
-  nothing into an existing conversation, but it puts a persistent,
-  sidebar-visible session outside that containment.
+- **Every target-taking tool is on `CHANNEL_AGENT_BLOCKED_TOOLS`, including the
+  read.** A channel agent is contained to channel posts, and session control
+  crosses that boundary in both directions: a stop or close reaches the user
+  through one of their dashboard transcripts, and `session_read_message` pulls a
+  private dashboard conversation into a channel other humans can see. Containment
+  is about what crosses the boundary, not about who writes, so the read is
+  blocked alongside the rest. `session_create` earns its place for a different
+  reason: it writes nothing into an existing conversation, but it puts a
+  persistent, sidebar-visible session outside that containment.
 
-All three tools additionally require a **signed** caller identity
+All these tools additionally require a **signed** caller identity
 (`_resolve_session_key_strict`), not the lenient `/proc` ancestor walk. A
 subagent spawned by `spawn_run` lives under its parent slot's process tree, so
 the walk resolves it to the parent — and since authorization here is entirely
@@ -222,13 +225,53 @@ separates "was never running" from "its cancel is still in flight", because a
 de-duplicated retry reaches that reply routinely and rendering both as "nothing to
 stop" would tell the second caller the opposite of what happened.
 
+## Closing archives, and re-checks at the point of no return
+
+`session_close` is the tool-side equivalent of the tab ✕. It is **non-destructive**:
+the conversation is saved to history (`closed=True`) and can be reopened later, so
+closing dismisses the LIVE tab, it does not delete the transcript. It is a
+strictly heavier act than `session_stop` — an in-flight turn is cancelled first
+and its work discarded — so the tool description tells the caller to read the
+session before closing it. It reuses the dashboard's own close path
+(`close_slot`), the same sequence the ✕ button runs: a synchronous tombstone,
+auto-nudge-loop retirement BEFORE the awaits so no nudge resurrects the tab, the
+owning app's close hook with rollback, persist-as-closed, and per-tab session
+teardown. Its three failure modes surface as their own codes at HTTP 500
+(`nudge_retire_failed`, `app_close_hook_failed`, `history_save_failed`), which is
+why the routes now forward a 500 rather than degrading it to 400.
+
+**Authorization is re-asserted at the point of no return.** `authorize_target`
+runs before `close_slot`, but `close_slot` then awaits — auto-nudge retirement
+takes the AutoNudge lock, and the app hook awaits external work — and a target
+that was unmirrored and unlinked at admission can gain a channel mirror or link
+in that window. Archiving a now-channel-backed session it was never allowed to
+reach is exactly the boundary the `mirrored_target` / `linked_session_target`
+guards hold, so `close_target` passes a SYNCHRONOUS `pre_pop_check` that runs
+immediately before the slot is popped, after every await (the nudge retirements
+and the app hook). It re-runs `authorize_target` with `skip_enabled_check=True` —
+omitting the one part of that gate that can read config on the loop, since the
+feature was already confirmed enabled at admission and disabling it mid-close is
+not a containment boundary — and compares the re-resolved slot to the one being
+closed **by identity**: a concurrent close-and-reopen can re-mint the same key
+onto a different session, and popping that would tear down the replacement while
+saving the stale slot (409 `target_replaced`). Being synchronous is the whole
+point — there is no suspension between the last retirement, this re-check, and
+the pop, so nothing (a channel mirror/link landing, a re-mint, or a racing
+`monitor_start` arming a loop) can change between the final authorization and the
+archival; an awaited re-check, by contrast, reopens exactly those windows. Any
+refusal aborts the close, rolls back the retired nudge loop, and surfaces as the
+guard's own status. This is the same "re-gate adjacent to the mutation, comparing
+identity not presence" discipline `create_session` uses for its slot allocation,
+and the same theme as the queued-drain re-check (#5911). The human ✕ path passes
+no check — the person owns the tab and closes it unconditionally.
+
 ## Configuration
 
-`agent.session_control` (bool, default **false**). Off makes all three tools
-refuse with a message naming the switch, so an agent that has not been granted it
+`agent.session_control` (bool, default **false**). Off makes every tool refuse
+with a message naming the switch, so an agent that has not been granted it
 reports why rather than failing silently.
 
-Default-off is the deliberate part. The three tools ride on the existing
+Default-off is the deliberate part. The tools ride on the existing
 assignable `kirocrew-dashboard` server rather than a new one, so an operator who
 had already assigned that server to an agent for folder organization would
 otherwise find that agent able to read peer transcripts and stop peer turns purely

--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -62,6 +62,7 @@ CHANNEL_AGENT_BLOCKED_TOOLS: tuple[str, ...] = (
     "session_send",
     "session_read_message",
     "session_create",
+    "session_close",
 )
 
 # Boundary-aware matcher: the tool name must stand alone in the rendered
@@ -418,7 +419,9 @@ class Channel:
         }
 
     @classmethod
-    def deserialize(cls, data: dict[str, Any], broadcast_fn: Any = None, save_fn: Any = None) -> "Channel":
+    def deserialize(
+        cls, data: dict[str, Any], broadcast_fn: Any = None, save_fn: Any = None
+    ) -> "Channel":
         """Restore a channel from serialized data."""
         ch = cls(id=data["id"], topic=data["topic"])
         ch.orchestrator_id = data.get("orchestrator_id")
@@ -436,7 +439,9 @@ class Channel:
                 session_key=ad.get("session_key", f"channel:{data['id']}:{ad['id']}"),
                 state="done",  # always restore as done
                 is_orchestrator=ad.get("is_orchestrator", False),
-                listen_mode=ListenMode(ad.get("listen_mode", "all" if ad.get("is_orchestrator") else "mention")),
+                listen_mode=ListenMode(
+                    ad.get("listen_mode", "all" if ad.get("is_orchestrator") else "mention")
+                ),
             )
             ch.members[aid] = agent
         for md in data.get("messages", []):
@@ -530,7 +535,9 @@ class ChannelManager:
             try:
                 with open(path) as f:
                     data = json.load(f)
-                ch = Channel.deserialize(data, broadcast_fn=self._broadcast_fn, save_fn=self._save_channel)
+                ch = Channel.deserialize(
+                    data, broadcast_fn=self._broadcast_fn, save_fn=self._save_channel
+                )
                 ch._max_agents = self._max_agents
                 self._channels[ch.id] = ch
                 logger.info("Restored channel %s (%s)", ch.id, ch.topic)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3642,45 +3642,68 @@ async def api_chat_slot_reset_conversation(request: web.Request) -> web.Response
     return web.json_response({"slot": name, "reset": True, "replay": replay})
 
 
-async def api_chat_slot_delete(request: web.Request) -> web.Response:
-    """DELETE /api/chat/slots/{slot} — stop and remove a UI slot.
+class SlotCloseError(Exception):
+    """A close that could not complete, carrying the response the tab-✕ path
+    would have rendered.
 
-    Kills the per-tab kiro-cli session and saves history.  The session
-    will be recreated from the warm pool if the tab is resumed later.
+    Extracted alongside :func:`close_slot` so the DELETE endpoint and
+    session-control's ``close_target`` map the SAME three failures the same way.
+    ``code`` is the machine-readable contract; ``message`` is advisory prose;
+    ``status`` is 500 for every close failure (each leaves the tab open and
+    every partial step rolled back — a state the user can see and retry).
     """
-    state: DashboardState = request.app["state"]
-    name = request.match_info["slot"]
-    slot = state._slots.get(name)
-    if not slot:
-        return web.json_response({"error": "not found"}, status=404)
 
-    # App ownership check (App Kit §5.2): app can only delete slots it created.
-    # Unscoped slots (empty _app) cannot be deleted by app tokens.
-    # Dashboard users (empty request_app) can delete anything.
-    request_app = request.get("app", "")
-    if request_app and slot._app != request_app:
-        sel().log_api_access(
-            caller=request_app,
-            operation="slot_delete",
-            outcome="denied",
-            source="app_isolation",
-            resources=f"slot={name}",
-            error="app does not own this slot",
-        )
-        return web.json_response({"error": "not found"}, status=404)
-    if request_app and not slot._app:
-        sel().log_api_access(
-            caller=request_app,
-            operation="slot_delete",
-            outcome="denied",
-            source="app_isolation",
-            resources=f"slot={name}",
-            error="app cannot delete unscoped slots",
-        )
-        # 404 (not 403): a foreign/unscoped slot is indistinguishable from a
-        # missing one — anti-enumeration (CWE-204); true reason logged via SEL.
-        return web.json_response({"error": "not found"}, status=404)
+    def __init__(self, message: str, code: str, status: int = 500) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.status = status
 
+
+async def close_slot(
+    state: DashboardState,
+    slot: "_ChatSlot",
+    name: str,
+    *,
+    pre_pop_check: Callable[[], None] | None = None,
+) -> None:
+    """Close (archive) one live slot the way the tab ✕ does: tombstone it, retire
+    its auto-nudge loop, notify its owning app, persist it as closed, and tear
+    down the per-tab session.
+
+    Non-destructive: the conversation is saved to history (``closed=True``) and
+    recreated from the warm pool if the tab is resumed later — nothing is
+    permanently deleted here.
+
+    Shared by :func:`api_chat_slot_delete` and ``session_control.close_target``
+    so neither can diverge on the ordering invariants that keep a nudge or an
+    app watchdog from resurrecting the very tab being dismissed. The three
+    failure paths raise :class:`SlotCloseError`, leaving the slot open with every
+    partial step rolled back; the caller renders the refusal in its own idiom
+    (an HTTP response, or a ``SessionControlError``). The APP-OWNERSHIP check is
+    deliberately NOT here — it is DELETE-endpoint policy (App Kit isolation for
+    app tokens) and stays in that handler; session control scopes the caller
+    through ``authorize_target`` instead.
+
+    ``pre_pop_check`` runs SYNCHRONOUSLY at the point of no return — immediately
+    before the slot is popped, after the nudge-retirement and app-hook awaits. It
+    exists for a caller (``close_target``) that authorized the target BEFORE this
+    coroutine and must re-assert that authorization against state those awaits
+    could have changed: a target unmirrored/unlinked at admission can gain a
+    channel mirror or link while the AutoNudge lock and the app hook are awaited,
+    and archiving a now-channel-backed session it was never allowed to reach is
+    the boundary the target guards exist to hold. It is SYNCHRONOUS on purpose —
+    an awaited check would put a suspension back between the last retirement and
+    the pop (reopening the retired-loop window) and between the re-authorization
+    and the pop (reopening the mirror window); a synchronous check has neither, so
+    nothing can change between the final authorization and the archival. It must
+    therefore do no blocking I/O (``close_target`` passes ``skip_enabled_check=True``
+    so its ``authorize_target`` never reads config on the loop). It raises
+    :class:`SlotCloseError` to abort; the abort unwinds the teardown so far (the
+    retired nudge loop is restored, an app notification is taken back) and
+    re-raises, exactly like the persist-failure path. The human ✕ path passes
+    ``None`` — the person owns the tab and closes it unconditionally.
+    """
     # Synchronous tombstone, BEFORE any await: a channel-slot reconcile pass
     # whose snapshot predates this close reads these after its last await, so
     # it cannot re-surface the tab this handler is dismissing (see
@@ -3706,10 +3729,7 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
         logger.error("Failed to retire nudge loop for slot %s, close aborted", name)
         _sync_dashboard_slots(state)
         state.push_slots_update()
-        return web.json_response(
-            {"error": "failed to retire nudge loop", "code": "nudge_retire_failed"},
-            status=500,
-        )
+        raise SlotCloseError("failed to retire nudge loop", code="nudge_retire_failed")
     # Remove from the registry only AFTER the loop is retired, because the ORDER
     # is what decides whether a nudge landing in between is harmless or fatal.
     # Retiring takes the AutoNudge lock, so it awaits; a timer expiring inside
@@ -3751,10 +3771,7 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
             logger.error("Slot-close hook for app %r failed on %r, close aborted", slot._app, name)
             _sync_dashboard_slots(state)
             state.push_slots_update()
-            return web.json_response(
-                {"error": "failed to notify the app", "code": "app_close_hook_failed"},
-                status=500,
-            )
+            raise SlotCloseError("failed to notify the app", code="app_close_hook_failed")
         # The app hook awaits external work while the slot is still visible.
         # Re-arbitrate the nudge registry after it returns: an arm that committed
         # during that await must be retired before the synchronous pop below.
@@ -3778,12 +3795,37 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
             logger.error("Late nudge retirement failed for slot %s; close aborted", name)
             _sync_dashboard_slots(state)
             state.push_slots_update()
-            return web.json_response(
-                {"error": "failed to retire nudge loop", "code": "nudge_retire_failed"},
-                status=500,
-            )
+            raise SlotCloseError("failed to retire nudge loop", code="nudge_retire_failed")
         if late_retired_loop is not None:
             retired_loop = late_retired_loop
+    if pre_pop_check is not None:
+        # Point of no return: re-assert authorization that the awaits above could
+        # have staled (nudge retirement takes the AutoNudge lock; the app hook
+        # awaits external work). Called SYNCHRONOUSLY so there is NO suspension
+        # between the last retirement above, this re-check, and the pop below —
+        # nothing can change between the final authorization and the archival, and
+        # the retirement stays adjacent to the removal. A raised SlotCloseError
+        # unwinds the teardown so far — restore the retired nudge loop, take back
+        # an app notification — and re-raises, exactly like a failed persist.
+        try:
+            pre_pop_check()
+        except SlotCloseError:
+            await _restore_slot_nudge_loop(retired_loop, lambda: state.get_slot(name) is slot)
+            if slot._app:
+                from kiro_crew.apps.teardown import (
+                    notify_slot_close_undone,  # circular: apps.teardown -> apps.bridges
+                )
+
+                if not await notify_slot_close_undone(slot._app, name):
+                    logger.error(
+                        "Could not take back the dismissal for app %r on %r after a "
+                        "pre-pop re-check aborted the close",
+                        slot._app,
+                        name,
+                    )
+            _sync_dashboard_slots(state)
+            state.push_slots_update()
+            raise
     state._slots.pop(name, None)
     # Release any blocking wait before cancelling the task: a question pending on
     # the blocking POST /api/ask-question path holds an MCP worker on an open
@@ -3836,9 +3878,7 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
                 )
         _sync_dashboard_slots(state)
         state.push_slots_update()
-        return web.json_response(
-            {"error": "failed to save history", "code": "history_save_failed"}, status=500
-        )
+        raise SlotCloseError("failed to save history", code="history_save_failed")
     else:
         state._restricted_keys.discard(f"dashboard:{name}")
         # Durable, so no rollback can retract this frame — a client pruning its
@@ -3851,6 +3891,61 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
     _sync_dashboard_slots(state)
     state.push_slots_update()
     state.push_refresh("history")
+
+
+async def api_chat_slot_delete(request: web.Request) -> web.Response:
+    """DELETE /api/chat/slots/{slot} — stop and remove a UI slot.
+
+    Kills the per-tab kiro-cli session and saves history.  The session
+    will be recreated from the warm pool if the tab is resumed later.
+
+    The close sequence itself lives in :func:`close_slot`, shared with
+    session-control's ``close_target``; this handler adds only the
+    DELETE-endpoint's App Kit ownership check and maps the outcome to a
+    response.
+    """
+    state: DashboardState = request.app["state"]
+    name = request.match_info["slot"]
+    slot = state._slots.get(name)
+    if not slot:
+        return web.json_response({"error": "not found"}, status=404)
+
+    # App ownership check (App Kit §5.2): app can only delete slots it created.
+    # Unscoped slots (empty _app) cannot be deleted by app tokens.
+    # Dashboard users (empty request_app) can delete anything.
+    request_app = request.get("app", "")
+    if request_app and slot._app != request_app:
+        sel().log_api_access(
+            caller=request_app,
+            operation="slot_delete",
+            outcome="denied",
+            source="app_isolation",
+            resources=f"slot={name}",
+            error="app does not own this slot",
+        )
+        return web.json_response({"error": "not found"}, status=404)
+    if request_app and not slot._app:
+        sel().log_api_access(
+            caller=request_app,
+            operation="slot_delete",
+            outcome="denied",
+            source="app_isolation",
+            resources=f"slot={name}",
+            error="app cannot delete unscoped slots",
+        )
+        # 404 (not 403): a foreign/unscoped slot is indistinguishable from a
+        # missing one — anti-enumeration (CWE-204); true reason logged via SEL.
+        return web.json_response({"error": "not found"}, status=404)
+
+    try:
+        await close_slot(state, slot, name)
+    except SlotCloseError as exc:
+        # Every failure `close_slot` raises is a server-side 500 (nudge retire /
+        # app hook / history save); a literal status keeps the error-code contract
+        # gate able to verify the `code` statically (a `status=<expr>` would read
+        # as an un-verifiable dynamic-status response). The pre-pop re-check that
+        # raises other statuses is session-control's path, not this handler's.
+        return web.json_response({"error": exc.message, "code": exc.code}, status=500)
     return web.json_response({"ok": True})
 
 

--- a/src/kiro_crew/dashboard/handlers/session_control.py
+++ b/src/kiro_crew/dashboard/handlers/session_control.py
@@ -85,6 +85,12 @@ def _refusal(exc: sc.SessionControlError) -> web.Response:
         return web.json_response({"error": exc.message, "code": exc.code}, status=409)
     if exc.status == 429:
         return web.json_response({"error": exc.message, "code": exc.code}, status=429)
+    if exc.status == 500:
+        # A genuine server-side failure — `close_target` raises this for the three
+        # close-path failures (nudge retire / app hook / history save), each of
+        # which left the tab open with every partial step rolled back. It is not a
+        # client error, so it must not degrade to 400.
+        return web.json_response({"error": exc.message, "code": exc.code}, status=500)
     return web.json_response({"error": exc.message, "code": exc.code}, status=400)
 
 
@@ -141,6 +147,27 @@ async def api_session_control_stop(request: web.Request) -> web.Response:
     try:
         body = await _body(request)
         result = await sc.stop_target(
+            state,
+            caller_session_key=_read_session_key(request),
+            target=_target(body),
+        )
+    except sc.SessionControlError as exc:
+        return _refusal(exc)
+    return web.json_response(result)
+
+
+async def api_session_control_close(request: web.Request) -> web.Response:
+    """POST /api/session-control/close — archive another session (tab ✕)."""
+    refused = await _require_internal(request)
+    if refused is not None:
+        return refused
+    # No prewarm here: `close_target` warms the SEL logger and the config after
+    # its own SEL prewarm, the same ordering `stop_target`/`send_to_target` use
+    # and for the same reason — the body read above is a suspension point.
+    state: DashboardState = request.app["state"]
+    try:
+        body = await _body(request)
+        result = await sc.close_target(
             state,
             caller_session_key=_read_session_key(request),
             target=_target(body),

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -424,6 +424,7 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         # tool is unreachable in production while handler-level tests still pass.
         "/api/session-control/create",
         "/api/session-control/stop",
+        "/api/session-control/close",
         "/api/session-control/send",
         "/api/session-control/read",
     }
@@ -1289,6 +1290,9 @@ def _register_mcp_routes(app: web.Application) -> None:
     )
     app.router.add_post(
         "/api/session-control/stop", _deferred_session_control("api_session_control_stop")
+    )
+    app.router.add_post(
+        "/api/session-control/close", _deferred_session_control("api_session_control_close")
     )
     app.router.add_post(
         "/api/session-control/send", _deferred_session_control("api_session_control_send")

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -1,14 +1,16 @@
 """Session control: letting one chat session observe and interrupt another.
 
-Three operations — create a session, stop its turn, read its transcript — plus the
-authorization that decides whether a caller may address a target at all. The
-operations are deliberately thin: they reuse the same creation, stop and history
-paths the dashboard itself uses, so a controlled session behaves exactly like one
-a human is typing into.
+Four operations — create a session, stop its turn, close (archive) it, and read
+its transcript — plus the authorization that decides whether a caller may address
+a target at all. The operations are deliberately thin: they reuse the same
+creation, stop, close and history paths the dashboard itself uses, so a controlled
+session behaves exactly like one a human is typing into.
 
 **One verb here writes into another session's conversation: ``session_send``.**
 Reading returns a transcript tail; stopping cancels an in-flight turn the way the
-Stop button does; creating opens an empty session in the user's sidebar; sending
+Stop button does; closing archives the session the way the tab ✕ does (the
+conversation is saved to history and can be reopened — closing is not deletion);
+creating opens an empty session in the user's sidebar; sending
 delivers a message the target runs as its next turn, redacted through
 ``sanitize_outbound`` and prefixed with a ``[sent by session … via session_send]``
 envelope so it can never render as something the person typed. An IDLE target runs
@@ -21,9 +23,10 @@ that did not hold at admission. A human-typed queued message shares the same
 window and the same re-check.
 
 Authorization is deny-by-default and checked in one place
-(:func:`authorize_target`) for the two operations that take a target, so a guard
-cannot be present on one verb and missing on another. ``session_create`` has no
-target; it checks the caller's own eligibility with the same refusals.
+(:func:`authorize_target`) for the three operations that take a target — stop,
+close and read — so a guard cannot be present on one verb and missing on another.
+``session_create`` has no target; it checks the caller's own eligibility with the
+same refusals.
 """
 
 from __future__ import annotations
@@ -892,12 +895,21 @@ def authorize_target(
     caller_session_key: str,
     target: str,
     operation: str,
+    skip_enabled_check: bool = False,
 ) -> "_ChatSlot":
     """Resolve *target* and decide whether *caller* may act on it.
 
     Deny-by-default: every refusal raises :class:`SessionControlError` and is
     recorded in the SEL, so an attempt to reach a session that is out of bounds
     is visible after the fact even though nothing happened.
+
+    ``skip_enabled_check`` omits ONLY the ``session_control_enabled()`` config
+    read. It exists for a re-check that must run SYNCHRONOUSLY with no event-loop
+    suspension (``close_target``'s point-of-no-return callback): the feature was
+    already confirmed enabled when the operation was first authorized, whether
+    session control got switched off mid-operation is not a containment boundary,
+    and the config read is the one part of this function that can touch the disk
+    on a cache miss. Every containment and identity refusal still runs.
     """
 
     def deny(reason: str, code: str, status: int = 403) -> SessionControlError:
@@ -933,7 +945,7 @@ def authorize_target(
         )
         return SessionControlError(reason, status=status, code=code)
 
-    if not session_control_enabled():
+    if not skip_enabled_check and not session_control_enabled():
         raise deny(
             "session control is disabled in config (agent.session_control)",
             "session_control_disabled",
@@ -1215,6 +1227,114 @@ async def stop_target(
         },
     )
     return {"ok": True, "target": slot.key, **result}
+
+
+async def close_target(
+    state: "DashboardState",
+    *,
+    caller_session_key: str,
+    target: str,
+) -> dict[str, Any]:
+    """Close *target*, the same archival the tab ✕ performs.
+
+    Non-destructive: the conversation is saved to history and can be reopened
+    later — closing dismisses the LIVE tab, it does not delete the transcript.
+    An in-flight turn is cancelled first (its work is discarded), so this is a
+    strictly heavier act than :func:`stop_target`; the description tells the
+    caller to read the session before closing it.
+
+    Reuses the dashboard's own close path (:func:`chat_handlers.close_slot`), so
+    a controlled close and a human ✕ share the identical nudge-retirement and
+    app-notification ordering that keeps a dismissed tab from being resurrected.
+    Its three failure modes surface as their own ``SessionControlError`` codes
+    rather than a generic 500, so a caller can tell "the app refused the
+    dismissal" from "history could not be saved".
+    """
+    # Same prewarm ordering as `stop_target`, for the same reasons: the SEL write
+    # inside `authorize_target`'s deny path must be a cache hit, and the config
+    # warm must be the LAST suspension before the synchronous gate.
+    try:
+        await asyncio.to_thread(sel)
+    except Exception:  # noqa: BLE001 - a prewarm failure must not fail the close
+        logger.warning("session-control SEL prewarm failed", exc_info=True)
+    await prewarm_enabled_check()
+
+    slot = authorize_target(
+        state,
+        caller_session_key=caller_session_key,
+        target=target,
+        operation="close",
+    )
+    slot_key = slot.key
+    # Deferred for the same import cycle `stop_target` documents.
+    from kiro_crew.dashboard.chat_handlers import SlotCloseError, close_slot
+
+    def _reassert_closeable() -> None:
+        # Re-run the SAME target gate at close_slot's point of no return —
+        # SYNCHRONOUSLY, so there is NO event-loop suspension between it and the
+        # pop and nothing can change between the final authorization and the
+        # archival. The initial gate above ran before close_slot's awaits
+        # (nudge-loop retirement takes the AutoNudge lock; the app hook awaits
+        # external work), and a target that was unmirrored/unlinked then can gain
+        # a channel mirror or link in that window — archiving a now-channel-backed
+        # session the caller was never allowed to reach.
+        #
+        # `skip_enabled_check=True` omits the ONE part of authorize_target that
+        # can touch the disk (`session_control_enabled()`'s config read): the
+        # feature was already confirmed enabled above, whether it was switched off
+        # mid-close is not a containment boundary, and skipping it is what lets
+        # this run with no await — an async prewarm-then-check would put an await
+        # back before the pop and reopen the very window this closes. Every
+        # containment and identity refusal still runs.
+        try:
+            live = authorize_target(
+                state,
+                caller_session_key=caller_session_key,
+                target=slot_key,
+                operation="close",
+                skip_enabled_check=True,
+            )
+        except SessionControlError as exc:
+            # A stale-authorization refusal (mirrored/linked/workspace/caller-gone)
+            # becomes a SlotCloseError carrying that same status, so it round-trips
+            # to the caller as the specific 403 rather than a generic close failure.
+            raise SlotCloseError(exc.message, code=exc.code, status=exc.status) from exc
+        if live is not slot:
+            # The key was re-minted onto a DIFFERENT session while close_slot
+            # awaited (a concurrent close+reopen). authorize_target resolves by
+            # key, so it would authorize the replacement — but close_slot pops
+            # `name` and tears down / saves the ORIGINAL slot it holds. Comparing
+            # identity (not mere presence) is the same guard `create_session` uses
+            # for its re-minted-key window; abort so the replacement lives.
+            raise SlotCloseError(
+                "the target session was replaced during the close",
+                code="target_replaced",
+                status=409,
+            )
+
+    try:
+        await close_slot(state, slot, slot_key, pre_pop_check=_reassert_closeable)
+    except SlotCloseError as exc:
+        # The close path already rolled back every partial step and logged the
+        # cause; re-raise it as the surface's own error so the caller sees the
+        # specific reason (nudge/app/history) rather than a bare failure. Audited
+        # as a denied operation so the trail shows the close was attempted and did
+        # not take.
+        _audit(
+            caller_session_key=caller_session_key,
+            operation="close",
+            slot_key=slot_key,
+            outcome="denied",
+            detail={"code": exc.code},
+        )
+        raise SessionControlError(exc.message, status=exc.status, code=exc.code) from exc
+    _audit(
+        caller_session_key=caller_session_key,
+        operation="close",
+        slot_key=slot_key,
+        outcome="allowed",
+    )
+    return {"ok": True, "target": slot_key}
 
 
 #: Cap on one delivered message. Aliased to ``validation.MAX_LONG_STRING`` rather

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -87,6 +87,7 @@ from kiro_crew.validation import (
     CHAT_FOLDER_MOVE_SESSION_SCHEMA,
     CHAT_FOLDER_TREE_SCHEMA,
     MCP_DASHBOARD_SCHEMAS,
+    SESSION_CLOSE_SCHEMA,
     SESSION_CREATE_SCHEMA,
     SESSION_READ_MESSAGE_SCHEMA,
     SESSION_SEND_SCHEMA,
@@ -108,6 +109,7 @@ SERVER_VERSION = "1.0.0"
 SESSION_CONTROL_TOOLS: tuple[str, ...] = (
     "session_create",
     "session_stop",
+    "session_close",
     "session_send",
     "session_read_message",
 )
@@ -264,6 +266,30 @@ def _tool_definitions() -> list[dict[str, Any]]:
                 "target's transcript so the person reading it sees what happened. Stopping "
                 "discards the turn's work, so read the session first when you are not sure "
                 "what it is doing."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Session key from list_sessions, or its exact title.",
+                    },
+                },
+                "required": ["target"],
+            },
+        },
+        {
+            "name": "session_close",
+            "description": (
+                "Close another session — the same thing as pressing the ✕ on that tab. "
+                "The conversation is archived to history (it can be reopened later); "
+                "this is NOT a permanent delete, but it does dismiss the live tab and, "
+                "if the target is mid-turn, cancels that turn first and discards its "
+                "work. Use it to tidy up a peer session you created and are done with "
+                "(a finished watcher, a workstream you handed off), not to interrupt one "
+                "you might still need — for that, session_stop only cancels the turn and "
+                "leaves the tab open. Read the session first when you are unsure what it "
+                "is doing."
             ),
             "inputSchema": {
                 "type": "object",
@@ -472,9 +498,13 @@ def _resolve_chat_folder_ref(
     paths = _chat_folder_paths(folders)
     exact = sorted(fid for fid, p in paths.items() if p.strip().lower() == ref.lower())
     if len(exact) > 1:
-        return "", [], (
-            f"{len(exact)} folders render the same path {redact(ref)} "
-            f"({', '.join(exact)}) — pass the folder id instead of a path"
+        return (
+            "",
+            [],
+            (
+                f"{len(exact)} folders render the same path {redact(ref)} "
+                f"({', '.join(exact)}) — pass the folder id instead of a path"
+            ),
         )
 
     # Reading 3: walk the segments. When the exact reading already resolved, the
@@ -488,9 +518,13 @@ def _resolve_chat_folder_ref(
         return "", created, walk_err
 
     if exact and walked and walked != exact[0]:
-        return "", [], (
-            f"{redact(ref)} is ambiguous: it is both a folder's own name "
-            f"({exact[0]}) and a nested path ({walked}) — pass the folder id"
+        return (
+            "",
+            [],
+            (
+                f"{redact(ref)} is ambiguous: it is both a folder's own name "
+                f"({exact[0]}) and a nested path ({walked}) — pass the folder id"
+            ),
         )
     if exact:
         return exact[0], [], None
@@ -583,9 +617,7 @@ def _ensure_chat_folder_path(
     segments are real folders, and each must be created under the identity the
     caller's gate verified rather than one the write helper re-derives.
     """
-    return _resolve_chat_folder_ref(
-        ref, folders, create_missing=True, session_key=session_key
-    )
+    return _resolve_chat_folder_ref(ref, folders, create_missing=True, session_key=session_key)
 
 
 def _resolve_chat_slot_key(ref: str, slots: list[dict]) -> tuple[str, str | None]:
@@ -797,8 +829,7 @@ def _refuse_tree_shaping_if_unverifiable(verb: str) -> tuple[str, str | None]:
         return "", (
             f"Error: cannot verify which session is calling, so {verb} is "
             "refused — reshaping the shared folder tree requires a caller "
-            "identity the gateway can vouch for."
-            + strict_identity_diagnosis(SERVER_NAME)
+            "identity the gateway can vouch for." + strict_identity_diagnosis(SERVER_NAME)
         )
     rows, err = _get_rows("/api/chat/slots")
     if err:
@@ -896,6 +927,21 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
                 return f"\u2139\ufe0f `{target}`: {info} — the earlier stop still stands."
             return f"\u2139\ufe0f `{target}`: {info} — nothing to stop."
         return f"\U0001f6d1 Stop sent to `{target}`. Its transcript now shows the stop card."
+
+    if name == "session_close":
+        args = validate_tool_args(args, SESSION_CLOSE_SCHEMA)
+        resp = _post(
+            "/api/session-control/close",
+            {"target": args["target"]},
+            session_key=caller_key,
+        )
+        if resp.get("error"):
+            return f"Error: could not close that session: {resp['error']}"
+        target = resp.get("target", args["target"])
+        return (
+            f"\U0001f5d1\ufe0f Closed `{target}` — the tab is dismissed and the "
+            "conversation archived to history (it can be reopened later)."
+        )
 
     if name == "session_send":
         args = validate_tool_args(args, SESSION_SEND_SCHEMA)

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -1955,9 +1955,7 @@ ISSUE_RADAR_RECORD_INVESTIGATION_SCHEMA = ToolSchema(
     fields=[
         FieldSpec("owner", str, required=True, max_len=MAX_SHORT_STRING),
         FieldSpec("repo", str, required=True, max_len=MAX_SHORT_STRING),
-        FieldSpec(
-            "number", int, required=True, min_val=1, max_val=_ISSUE_RADAR_MAX_ITEM_NUMBER
-        ),
+        FieldSpec("number", int, required=True, min_val=1, max_val=_ISSUE_RADAR_MAX_ITEM_NUMBER),
         # provider/host/kind are REQUIRED, with no defaults, because together
         # with owner/repo they select the record's STORAGE NAMESPACE (see
         # ``store.provider_root``: public GitHub keeps the original
@@ -1969,9 +1967,7 @@ ISSUE_RADAR_RECORD_INVESTIGATION_SCHEMA = ToolSchema(
         # The caller always has this information to hand (`recordIdentityJson`
         # in ``website/src/apps/issue-radar/lib/links.ts`` emits all three), so
         # requiring them costs nothing and removes the ambiguity.
-        FieldSpec(
-            "provider", str, required=True, max_len=16, allowed=_ISSUE_RADAR_PROVIDERS
-        ),
+        FieldSpec("provider", str, required=True, max_len=16, allowed=_ISSUE_RADAR_PROVIDERS),
         FieldSpec("host", str, required=True, max_len=253),
         FieldSpec("kind", str, required=True, max_len=8, allowed=_ISSUE_RADAR_ITEM_KINDS),
         FieldSpec("status", str, max_len=16, allowed=_ISSUE_RADAR_STATUSES, default="resolved"),
@@ -2111,9 +2107,7 @@ ISSUE_RADAR_CREW_RECORD_SCHEMA = ToolSchema(
         # Bounds the number that becomes the work item's FILENAME
         # (``crews/<crew_id>/<n>.json``) — same ENAMETOOLONG rationale as the
         # investigation record, hence the same constant.
-        FieldSpec(
-            "number", int, required=True, min_val=1, max_val=_ISSUE_RADAR_MAX_ITEM_NUMBER
-        ),
+        FieldSpec("number", int, required=True, min_val=1, max_val=_ISSUE_RADAR_MAX_ITEM_NUMBER),
         FieldSpec("phase", str, max_len=32, allowed=_ISSUE_RADAR_CREW_PHASES),
         # Bounded but deliberately NOT ``allowed=``, unlike ``phase`` beside it.
         # An out-of-vocabulary phase has to be refused — it would corrupt the
@@ -2342,7 +2336,13 @@ HOOK_CREATE_SCHEMA = ToolSchema(
         FieldSpec("command", str, max_len=2000, default=""),
         FieldSpec("event", str, required=True, allowed=ALLOWED_HOOK_EVENTS),
         FieldSpec("matcher", str, max_len=500, default=""),  # optional: empty = match all
-        FieldSpec("matcher_mode", str, max_len=10, default="glob", allowed=frozenset({"glob", "regex", "contains"})),
+        FieldSpec(
+            "matcher_mode",
+            str,
+            max_len=10,
+            default="glob",
+            allowed=frozenset({"glob", "regex", "contains"}),
+        ),
         FieldSpec("skills", list, default=[], item_type=str, item_max_len=100),
         FieldSpec("timeout", int, min_val=1, max_val=300, default=30),
         FieldSpec("enabled", bool, default=True),
@@ -2357,7 +2357,9 @@ HOOK_UPDATE_SCHEMA = ToolSchema(
         FieldSpec("command", str, max_len=2000),  # optional on update
         FieldSpec("event", str, allowed=ALLOWED_HOOK_EVENTS),
         FieldSpec("matcher", str, max_len=500),  # optional: empty = match all
-        FieldSpec("matcher_mode", str, max_len=10, allowed=frozenset({"glob", "regex", "contains"})),
+        FieldSpec(
+            "matcher_mode", str, max_len=10, allowed=frozenset({"glob", "regex", "contains"})
+        ),
         FieldSpec("skills", list, item_type=str, item_max_len=100),
         FieldSpec("timeout", int, min_val=1, max_val=300),
         FieldSpec("enabled", bool),
@@ -2661,6 +2663,13 @@ SESSION_STOP_SCHEMA = ToolSchema(
     ],
 )
 
+SESSION_CLOSE_SCHEMA = ToolSchema(
+    tool_name="session_close",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+    ],
+)
+
 SESSION_SEND_SCHEMA = ToolSchema(
     tool_name="session_send",
     fields=[
@@ -2857,9 +2866,7 @@ _CU_DRAG_PATHS = frozenset(_cu_types.DRAG_PATHS)
 # accepted either would be "run an arbitrary program with attacker-chosen input"
 # rather than "open an application". The drivers narrow it much further (a resolved
 # executable must sit under a protected install root); this is only the outer bound.
-_CU_LAUNCH_APP_FIELD = FieldSpec(
-    "app", str, required=True, max_len=_cu_types.MAX_LAUNCH_QUERY_LEN
-)
+_CU_LAUNCH_APP_FIELD = FieldSpec("app", str, required=True, max_len=_cu_types.MAX_LAUNCH_QUERY_LEN)
 
 
 def _cu_coord_field(name: str, *, required: bool = False) -> FieldSpec:
@@ -2894,6 +2901,7 @@ def _cu_coord_field(name: str, *, required: bool = False) -> FieldSpec:
 MCP_DASHBOARD_SCHEMAS: dict[str, ToolSchema] = {
     "session_create": SESSION_CREATE_SCHEMA,
     "session_stop": SESSION_STOP_SCHEMA,
+    "session_close": SESSION_CLOSE_SCHEMA,
     "session_send": SESSION_SEND_SCHEMA,
     "session_read_message": SESSION_READ_MESSAGE_SCHEMA,
     "chat_folder_tree": CHAT_FOLDER_TREE_SCHEMA,

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1527,6 +1527,7 @@ class TestAdvertisedSet:
             "chat_folder_move_session",
             "session_create",
             "session_stop",
+            "session_close",
             "session_send",
             "session_read_message",
         }

--- a/test/test_mcp_dashboard_registration.py
+++ b/test/test_mcp_dashboard_registration.py
@@ -342,6 +342,7 @@ class TestWhatThisSetGrants:
     SESSION_TOOLS = {
         "session_create",
         "session_stop",
+        "session_close",
         "session_send",
         "session_read_message",
     }

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -810,6 +810,43 @@ class TestTheRoutesRequireTheInternalSecret:
         assert resp.status == 403
         assert self._body(resp)["code"] == "linked_session_target"
 
+    def test_close_without_the_secret_is_forbidden(self, tmp_path):
+        req = self._request(tmp_path, internal=False, path="/api/session-control/close")
+        resp = asyncio.run(handlers_sc.api_session_control_close(req))
+        assert resp.status == 403
+        assert self._body(resp)["code"] == "internal_secret_required"
+
+    def test_close_with_the_secret_reaches_the_operation(self, tmp_path, monkeypatch):
+        """The close ROUTE's success path, for the reason create's docstring gives:
+        a handler wired only at the business layer ships dead if the route itself
+        refuses or never reaches the operation."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/close")
+
+        async def _ok(*_a, **_kw):
+            return {"ok": True, "target": "chat-2"}
+
+        monkeypatch.setattr(sc, "close_target", _ok)
+        resp = asyncio.run(handlers_sc.api_session_control_close(req))
+
+        assert resp.status == 200
+        assert self._body(resp)["target"] == "chat-2"
+
+    def test_close_renders_a_refusal_as_its_status_not_a_500(self, tmp_path, monkeypatch):
+        """Same refusal contract the other routes hold — including the close-path
+        failure codes, which arrive as their own 500 rather than an unhandled crash."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/close")
+
+        async def _boom(*_a, **_kw):
+            raise sc.SessionControlError(
+                "failed to save history", status=500, code="history_save_failed"
+            )
+
+        monkeypatch.setattr(sc, "close_target", _boom)
+        resp = asyncio.run(handlers_sc.api_session_control_close(req))
+
+        assert resp.status == 500
+        assert self._body(resp)["code"] == "history_save_failed"
+
     def test_send_without_the_secret_is_forbidden(self, tmp_path):
         req = self._request(tmp_path, internal=False, path="/api/session-control/send")
         resp = asyncio.run(handlers_sc.api_session_control_send(req))
@@ -2916,3 +2953,230 @@ def test_slot_cap_has_one_owning_constant() -> None:
     assert sc_mod.MAX_LIVE_SLOTS is owning
     assert chat_fork.MAX_LIVE_SLOTS is owning
     assert session_transfer.MAX_LIVE_SLOTS is owning
+
+
+# ── Close (archive) ──────────────────────────────────────────────────────────
+
+
+def test_close_archives_a_peer_and_removes_the_slot(tmp_path):
+    """The happy path end to end: a peer in the caller's workspace is closed via
+    the real ``close_slot`` extraction, so the slot leaves ``_slots`` and the
+    per-tab session is torn down — exactly what the tab ✕ does."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+
+    result = asyncio.run(sc.close_target(state, caller_session_key=_key(caller), target=target.key))
+
+    assert result == {"ok": True, "target": target.key}
+    assert target.key not in state._slots
+    # The per-tab kiro-cli session is torn down through the shared close path.
+    state.sessions.remove.assert_awaited()
+
+
+def test_close_refuses_a_self_target(tmp_path):
+    """Close routes through ``authorize_target`` like stop and read, so a session
+    cannot close itself (the guard is operation-agnostic)."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.close_target(state, caller_session_key=_key(caller), target=caller.key))
+    assert exc.value.code == "self_target"
+    # The self-close was refused, so the caller's own slot survives.
+    assert caller.key in state._slots
+
+
+def test_close_maps_a_close_failure_to_its_code(tmp_path, monkeypatch):
+    """A ``SlotCloseError`` from the shared path surfaces as a
+    ``SessionControlError`` carrying the SAME code and status — so a caller can
+    tell "history could not be saved" from a generic failure — and the failed
+    close is audited as denied."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+
+    from kiro_crew.dashboard import chat_handlers
+
+    async def _boom(_state, _slot, _name, *, pre_pop_check=None):
+        raise chat_handlers.SlotCloseError("failed to notify the app", code="app_close_hook_failed")
+
+    audited: list[tuple[str, str]] = []
+    real_audit = sc._audit
+
+    def _audit(*, caller_session_key, operation, slot_key, outcome, detail=None):
+        audited.append((operation, outcome))
+        return real_audit(
+            caller_session_key=caller_session_key,
+            operation=operation,
+            slot_key=slot_key,
+            outcome=outcome,
+            detail=detail,
+        )
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.close_slot", _boom)
+    monkeypatch.setattr(sc, "_audit", _audit)
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.close_target(state, caller_session_key=_key(caller), target=target.key))
+    assert exc.value.code == "app_close_hook_failed"
+    assert exc.value.status == 500
+    # The target was NOT removed — the failing close rolled back, and the trail
+    # records the attempt as denied.
+    assert target.key in state._slots
+    assert ("close", "denied") in audited
+
+
+def test_close_authorizes_then_acts_with_nothing_in_between(tmp_path, monkeypatch):
+    """Same adjacency contract stop keeps: the SEL prewarm precedes authorization,
+    and no ``await`` separates the gate from the act it authorizes.
+
+    Mutation guard: moving the prewarm below the gate, or slipping an await
+    between ``authorize_target`` and ``close_slot``, reorders this list."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    order: list[str] = []
+
+    def _sel():
+        order.append("sel")
+        return MagicMock()
+
+    real_authorize = sc.authorize_target
+
+    def _authorize(*a, **kw):
+        order.append("authorize")
+        return real_authorize(*a, **kw)
+
+    async def _fake_close(_state, _slot, _name, *, pre_pop_check=None):
+        order.append("close")
+
+    monkeypatch.setattr(sc, "sel", _sel)
+    monkeypatch.setattr(sc, "authorize_target", _authorize)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.close_slot", _fake_close)
+
+    asyncio.run(sc.close_target(state, caller_session_key=_key(caller), target=target.key))
+
+    assert order[:1] == ["sel"], f"the prewarm must precede authorization; got {order}"
+    assert (
+        order.index("close") - order.index("authorize") == 1
+    ), f"something ran between the gate and the act it authorizes: {order}"
+
+
+def test_close_reauthorizes_at_the_point_of_no_return(tmp_path, monkeypatch):
+    """A target that gains a channel mirror DURING close_slot's awaits is refused
+    at the pre-pop re-check, so the now-channel-backed session is not archived.
+
+    This is the GPT-flagged race: `authorize_target` runs before `close_slot`,
+    whose nudge-retirement + app-hook awaits are a window in which the target can
+    gain a mirror link — the same class `create_session` re-gates for.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+
+    async def _fake_close(_state, _slot, _name, *, pre_pop_check=None):
+        # Simulate the race: the target gains an outbound channel mirror while
+        # close_slot is mid-await, then the point-of-no-return check runs.
+        state.sessions.set_mirror_link(slot_history_key(target), "C123", "T1")
+        assert pre_pop_check is not None, "close_target must arm a pre-pop re-check"
+        pre_pop_check()  # re-runs authorize_target -> raises for the new mirror
+        raise AssertionError("close must not reach the pop after a stale-auth abort")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.close_slot", _fake_close)
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.close_target(state, caller_session_key=_key(caller), target=target.key))
+    # The re-check's mirrored_target refusal round-trips with its own 403, not a
+    # generic close failure, and the session survives.
+    assert exc.value.code == "mirrored_target"
+    assert exc.value.status == 403
+    assert target.key in state._slots
+
+
+def test_close_slot_pre_pop_abort_rolls_back_and_does_not_pop(tmp_path):
+    """A `pre_pop_check` that raises `SlotCloseError` aborts the close at the point
+    of no return: the slot stays in `_slots` and the per-tab session is never torn
+    down. The human ✕ path (pre_pop_check=None) is unaffected."""
+    from kiro_crew.dashboard import chat_handlers
+
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+
+    def _abort():
+        raise chat_handlers.SlotCloseError(
+            "target became unreachable", code="mirrored_target", status=403
+        )
+
+    with pytest.raises(chat_handlers.SlotCloseError) as exc:
+        asyncio.run(chat_handlers.close_slot(state, slot, slot.key, pre_pop_check=_abort))
+
+    assert exc.value.code == "mirrored_target"
+    assert slot.key in state._slots  # not popped
+    state.sessions.remove.assert_not_awaited()  # teardown never ran
+
+
+def test_close_aborts_if_the_key_was_reminted_during_the_close(tmp_path, monkeypatch):
+    """A concurrent close+reopen re-mints the same key onto a DIFFERENT session
+    while close_slot awaits. The pre-pop re-check compares slot identity (not mere
+    presence) and aborts with `target_replaced`, so close_slot never pops the
+    replacement — the GPT-flagged data-corruption race."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    original_key = target.key
+
+    async def _fake_close(_state, _slot, _name, *, pre_pop_check=None):
+        # Simulate the re-mint: drop the original and put a fresh slot object
+        # under the SAME key, then run the point-of-no-return check.
+        state._slots.pop(original_key, None)
+        replacement = state.get_or_create_slot(original_key)
+        assert replacement is not target
+        assert pre_pop_check is not None
+        pre_pop_check()  # authorize_target resolves the replacement -> identity mismatch
+        raise AssertionError("close must not pop after a re-mint abort")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.close_slot", _fake_close)
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.close_target(state, caller_session_key=_key(caller), target=original_key))
+    assert exc.value.code == "target_replaced"
+    assert exc.value.status == 409
+    # The replacement survives.
+    assert original_key in state._slots
+
+
+def test_close_slot_runs_the_pre_pop_check_synchronously_after_retirement(tmp_path, monkeypatch):
+    """`pre_pop_check` runs SYNCHRONOUSLY after the (awaited) nudge retirement and
+    immediately before the pop, so there is no suspension between the last
+    retirement, the re-check, and the removal — a concurrent `monitor_start`
+    cannot arm a loop in a window that would leave a timer to rehydrate the
+    archived tab, and a mirror/link cannot land between the re-authorization and
+    the archival.
+
+    Asserted by the call order (retire is the last AWAIT; the sync check follows,
+    then the pop) and by the callback being a plain synchronous function."""
+    import inspect
+
+    from kiro_crew.dashboard import chat_handlers
+
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    order: list[str] = []
+
+    async def _retire(_name):
+        order.append("retire")
+        return None
+
+    def _check():  # synchronous by contract — no await before the pop
+        order.append("check")
+
+    assert not inspect.iscoroutinefunction(_check)
+    monkeypatch.setattr(chat_handlers, "_retire_slot_nudge_loop", _retire)
+
+    asyncio.run(chat_handlers.close_slot(state, slot, slot.key, pre_pop_check=_check))
+
+    # Retirement (the last await) then the synchronous check, then the pop. No
+    # second retirement is needed because the check itself suspends nothing.
+    assert order == ["retire", "check"], order
+    assert slot.key not in state._slots  # closed

--- a/test/test_session_control_boundaries.py
+++ b/test/test_session_control_boundaries.py
@@ -301,14 +301,18 @@ class TestRouteBodyValidation:
 class TestRefusalStatusMapping:
     """The renderer answers only from a closed set of statuses."""
 
-    @pytest.mark.parametrize("status", [403, 404, 409, 429])
+    @pytest.mark.parametrize("status", [403, 404, 409, 429, 500])
     def test_a_mapped_status_is_forwarded(self, status):
         exc = sc.SessionControlError("no", status=status, code="c")
         assert handlers_sc._refusal(exc).status == status
 
     def test_an_unmapped_status_degrades_to_400(self):
-        """A status outside the set must not be forwarded verbatim."""
-        exc = sc.SessionControlError("no", status=500, code="c")
+        """A status outside the set must not be forwarded verbatim.
+
+        500 is now in the set (``close_target`` raises it for the three close-path
+        failures), so the degrade case uses a genuinely unmapped status.
+        """
+        exc = sc.SessionControlError("no", status=418, code="c")
         assert handlers_sc._refusal(exc).status == 400
 
     def test_the_code_is_always_present(self):


### PR DESCRIPTION
## What is the problem?

The session-control MCP surface lets one chat session create, stop, send to, and read a peer session -- but there is **no way to close one**. An agent can stand up a workstream with `session_create` and drive it, but when that workstream is finished the only thing it can do is `session_stop` (cancel the turn), which leaves the tab open. Cleaning up is left entirely to the human clicking the X. The natural mirror of "open a session" was simply missing.

## Why this issue matters to the user

Session control exists so an agent can manage a fleet of sessions on the user's behalf (a watcher it spun up, a refactor it handed off). Without a close verb, every session the agent opens is a tab the **user** has to remember to dismiss -- the agent can make the mess but not tidy it. Over a long orchestration this accumulates dead tabs in the sidebar, which is exactly the friction the create/stop/send/read set was built to remove.

## How our fix solves it

Adds `session_close` -- the tool-side equivalent of pressing the tab X.

- **It reuses the dashboard's own close path, it does not reimplement it.** `api_chat_slot_delete` carried a large, invariant-heavy close sequence (synchronous tombstone, auto-nudge-loop retirement *before* the awaits so no nudge resurrects the tab, app close-hook notification with rollback, persist-as-closed, per-tab session teardown). That sequence is extracted verbatim into a shared `close_slot(state, slot, name)` coroutine that raises a typed `SlotCloseError` on its three failure paths; the DELETE endpoint and `session_close` now share it, so the two can never diverge on the ordering that keeps a dismissed tab from waking back up.
- **Symptom -> root cause:** the symptom is "agent can't clean up its own sessions"; the root cause is that closing lived only inside an HTTP handler bound to `request`, unreachable from the session-control layer. The fix makes the close sequence a callable the layer can authorize and invoke, rather than copying its logic.
- **Same authorization as the other target verbs.** `close_target` routes through the existing deny-by-default `authorize_target(operation="close")`, so every guard already covering stop/read applies unchanged (self-target, unattended, incognito/temporary, app-scoped, channel-linked, channel-mirrored, crew-mode, cross-workspace). It is added to `SESSION_CONTROL_TOOLS` (strict caller-identity gate) and to `CHANNEL_AGENT_BLOCKED_TOOLS`.
- **Non-destructive by design.** Closing **archives** the conversation to history (`closed=True`) -- it can be reopened later. It is not a permanent delete, matching the X button. An in-flight turn is cancelled first (its work discarded), so the tool description tells the caller this is heavier than `session_stop` and to read the session first.
- **Honest failure codes.** The three close-path failures surface as their own `SessionControlError` (`nudge_retire_failed` / `app_close_hook_failed` / `history_save_failed`) at HTTP 500, so a caller can tell "the app refused the dismissal" from "history could not be saved". This required adding a 500 branch to the handler's `_refusal` status map (a close failure is a server error, not a client 400).

## What tests we did

- New `close_target` unit tests: real end-to-end archive (slot leaves `_slots`, per-tab session torn down), self-target refusal through `authorize_target`, `SlotCloseError` -> `SessionControlError` code/status mapping with a denied audit line, and the prewarm-before-gate / gate-adjacent-to-act adjacency contract (mutation-guarded, mirroring the stop tests).
- New close **route** tests: forbidden without the internal secret, reaches the operation with it, and renders a close-path 500 as 500 (not a crash or a degraded 400).
- Updated the pinned ratchets that assert the tool set on purpose: the `kirocrew-dashboard` registration ratchet, the advertised-set test, and the refusal-status-mapping test (500 is now mapped; the degrade-to-400 case uses a genuinely unmapped status). The channel-containment ratchet derives from `SESSION_CONTROL_TOOLS`, so it covered `session_close` automatically.
- Ran the close-path invariant suite (`test_slot_close_nudge_race.py`, `test_autonudge_dashboard_fire.py`, `test_unattended_slot_guardrails.py`, `test_ephemeral_sessions.py`) to confirm the `close_slot` extraction preserved the DELETE endpoint's behavior -- all green (session-control + boundaries + folders + registration + channel: 277 passed; close-behavior suite: 198 passed).

## Any other suggestions on the work

- The `_refusal` status map is now `{403, 404, 409, 429, 500}`; if more server-side failure shapes appear it may be worth deriving the set from the errors that can actually be raised rather than listing statuses.
- A frontend affordance is out of scope here -- this is the tool/endpoint only; the human X path is unchanged.
