### PR TITLE
refactor(aws-control): unify drive-upload post-wait re-auth via _reauthorize_in_lock

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -719,27 +719,27 @@ async def _handle_drive_upload(request: web.Request) -> web.Response:
         if received == 0:
             return _bad_request("empty upload", "empty_upload")
         # A 512 MB stream can take minutes: the authorization resolved before
-        # the transfer may no longer hold. Re-check the app gate, then RE-RESOLVE
-        # the identity, then consent -- in that order, because consent is asked
-        # ABOUT a profile and region, so verifying it against a stale pair proves
-        # nothing about where the bytes are going. A profile repointed A -> B
-        # during the spool would have had consent verified for B while `put_file`
-        # still wrote into A's bucket (reachable whenever B holds cross-account
-        # access), so the write must be refused unless the SAME triple the
-        # request was authorized for still resolves.
-        if not await asyncio.to_thread(is_app_enabled, APP_NAME):
-            _audit("drive_upload", request.path, "denied", error="app_disabled")
-            return _forbidden("aws-control is disabled", "app_disabled")
-        recheck = await _account_target(request)
-        if isinstance(recheck, web.Response):
-            return recheck
-        if recheck != (account, profile, region):
-            _audit("drive_upload", request.path, "denied", error="account_mismatch")
-            return _conflict(
-                "this connection changed while the file was uploading; nothing was written",
-                "account_mismatch",
-            )
-        denied = await _consent(aws_consent.SERVICE_S3, profile, region)
+        # the transfer may no longer hold. Re-run the SAME post-wait re-auth the
+        # Library operations use -- app gate, then RE-RESOLVE the identity, then
+        # consent, then RE-RESOLVE the bucket -- in that order, because consent is
+        # asked ABOUT a profile and region, so verifying it against a stale pair
+        # proves nothing about where the bytes are going. A profile repointed
+        # A -> B during the spool would have had consent verified for B while
+        # `put_file` still wrote into A's bucket (reachable whenever B holds
+        # cross-account access), so the write must be refused unless the SAME
+        # triple the request was authorized for still resolves. The helper also
+        # re-resolves the bucket, which the old inlined copy did NOT: a drive
+        # re-tagged mid-spool would otherwise land the object in the bucket name
+        # discovered before the wait. Must stay AFTER the spool loop and BEFORE
+        # `put_file`; do not move it relative to either.
+        #
+        # The account_mismatch/drive_changed message is now the shared helper's
+        # generic wording ("...while the request was queued..."), accepted
+        # deliberately in place of the old upload-specific text so all post-wait
+        # re-auth callers speak with one voice; tests assert the code, not text.
+        denied = await _reauthorize_in_lock(
+            request, "drive_upload", account, profile, region, bucket, publish=False
+        )
         if denied:
             return denied
         try:


### PR DESCRIPTION
Closes #7060.

## What changed

`_handle_drive_upload` in `src/kiro_crew/apps/builtins/aws_control/backend/routes.py` had its own inlined post-spool re-authorization block (`is_app_enabled` / `_account_target` recheck / triple compare / `_consent`) that was missing the drive-bucket re-resolve the shared `_reauthorize_in_lock` helper performs. That block is now replaced with a single call:

```python
denied = await _reauthorize_in_lock(request, "drive_upload", account, profile, region, bucket, publish=False)
if denied:
    return denied
```

placed exactly where the old block was: AFTER the spool loop and empty-upload check, BEFORE `storage_mod.put_file`. This closes the core bug: a drive re-tagged during a multi-minute 512 MB spool now yields `drive_changed` instead of silently writing the object to the stale bucket name resolved before the wait. The load-bearing order (app, then identity, then consent, then bucket) is preserved by the helper.

### Error message
The upload-specific `account_mismatch` text ("...while the file was uploading...") is dropped in favor of the shared helper's generic wording. This was accepted **deliberately** and documented with a call-site comment so all post-wait re-auth callers speak with one voice. The shared helper was NOT forked or parameterized, so no other caller's behavior changed. Response codes are unchanged and no test asserts the old text.

### `_handle_drive_bootstrap` deliberately left unchanged
Per the triage scope decision, bootstrap is reported rather than reshaped on a guess. Its in-lock re-check does `_account_target` + `_consent` with NO `is_app_enabled` gate and NO existing bucket (create_drive creates one), whereas `_reauthorize_in_lock` always performs the app check and requires an existing bucket to re-resolve. A behavior-preserving pre-bucket extraction is impossible without either adding a check bootstrap lacks or speculatively splitting a shared security helper that guards a billable create inside its own lock. `_reauthorize_in_lock` was not split or modified. The three Library call sites are untouched.

## Testing

Network mode in the build sandbox is INTEGRATIONS_ONLY (Repository access only): PyPI is blocked and `aiohttp`/`kiro_crew` cannot be installed, so the aiohttp-based pytest suite could not run here and **must run in CI**.

Static verification passed:
- `py_compile` OK
- `black --check --line-length 100` reports already-formatted
- `ruff check` findings are all pre-existing and unrelated to the edited region (verified against base state)

Test integrity verified by inspection: `_drive_found()` patches `find_drive` to a stable name, so the helper's added bucket re-resolve returns `current == bucket` and the happy-path upload test still calls `put_file` once; the connection-change test trips the identity check first and still asserts 409 + `account_mismatch`.

Diff: 1 file, a clean logic-for-helper swap in `_handle_drive_upload` only.