### PR TITLE
refactor(core): fold the three remaining named atomic-write duplicates into the shared helper

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
@@ -71,11 +71,11 @@ from __future__ import annotations
 import os
 import re
 import subprocess
-import uuid
 from pathlib import Path
 from typing import IO, Awaitable, Callable, Protocol
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 
 # service.* is import-safe on every platform (it only touches launchctl/systemctl
@@ -146,17 +146,21 @@ def reject_unsafe(raw: str) -> str:
 
 
 def atomic_write_text(path: Path, content: str) -> None:
-    """Write *content* to *path* atomically (temp sibling + ``os.replace``).
+    """Write *content* to *path* atomically (unique temp sibling + rename).
 
-    ``os.replace`` is an atomic same-filesystem rename, so a crash or partial
-    write never leaves a half-written service definition behind.
+    Thin delegate to :func:`kiro_crew.atomic_write.atomic_write`, kept as a
+    named function because it is the seam Dev Fleet's tests drive the staging
+    failure path through. The shared helper carries the same
+    ``mkstemp``-plus-rename shape this used to hand-roll, plus the Windows
+    sharing-violation rename retry and the ``except BaseException`` temp
+    cleanup that the local ``finally`` provided.
+
+    ``fsync`` stays off and no explicit *mode* is passed, so the drop-in lands
+    at the umask default exactly as ``Path.write_text`` left it. Encoding is
+    now pinned to UTF-8 rather than following the locale, which is what the
+    generated unit text (systemd reads it as UTF-8) always needed.
     """
-    tmp = path.parent / f".{path.name}.tmp-{uuid.uuid4().hex}"
-    try:
-        tmp.write_text(content)
-        os.replace(tmp, path)
-    finally:
-        tmp.unlink(missing_ok=True)
+    atomic_write(path, content)
 
 
 class GatewayServiceBackend(Protocol):

--- a/src/kiro_crew/dashboard/handlers/themes.py
+++ b/src/kiro_crew/dashboard/handlers/themes.py
@@ -37,6 +37,7 @@ from typing import Any
 
 from aiohttp import web
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.dashboard.theme_validate import (
     _THEME_ASSET_CSP,
     _THEME_ASSET_CT,
@@ -398,20 +399,21 @@ def _atomic_write_theme_json(target: Path, text: str) -> None:
     reader ever sees either the old or the new complete file, never a partial
     one. Callers MUST hold ``_theme_install_lock(slug)`` so the exists-check and
     this write are one critical section (closes the create/update TOCTOU).
+
+    Delegates to :func:`kiro_crew.atomic_write.atomic_write`, which is the same
+    ``mkstemp``-plus-rename shape this used to hand-roll -- including the
+    ``except BaseException`` temp cleanup, so a Ctrl-C mid-write still leaves no
+    scratch file -- plus the Windows sharing-violation rename retry. ``fsync``
+    stays off, as before.
+
+    ``mode=0o600`` is not a tightening, it is what this site already published:
+    ``mkstemp`` creates its file owner-only and the hand-rolled form never
+    chmod'd it, so the theme JSON landed at ``0o600`` and the rename carried
+    that through. Passing it explicitly keeps that, because ``atomic_write``
+    without a *mode* applies the umask default instead and would widen a
+    previously owner-only file to ``0o644``.
     """
-    fd, tmp = tempfile.mkstemp(
-        dir=str(target.parent), prefix=f".{target.stem}-", suffix=".tmp"
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(text)
-        os.replace(tmp, target)
-    except BaseException:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+    atomic_write(target, text, mode=0o600)
 
 
 def _read_theme_bytes_nolink(slug: str, target: Path) -> bytes | None:

--- a/src/kiro_crew/service/macos.py
+++ b/src/kiro_crew/service/macos.py
@@ -13,9 +13,9 @@ import os
 import plistlib
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.gateway_shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
 from kiro_crew.service.common import (
     LAUNCHD_LABEL,
@@ -166,20 +166,22 @@ def _write_plist_atomic(contents: str) -> None:
     when source and destination are on the same filesystem, so a SIGINT
     or crash mid-write leaves either the old plist or no plist at all —
     never a partial XML document that ``launchctl load`` would reject.
+
+    Delegates to :func:`kiro_crew.atomic_write.atomic_write`, which is that
+    exact shape. Two deliberate strengthenings come with it: the temp cleanup
+    moves from ``except Exception`` to ``except BaseException``, so the SIGINT
+    this docstring already promised to survive also stops leaving a scratch
+    file behind, and the shared helper adds the Windows sharing-violation
+    rename retry. ``fsync`` stays off, as before.
+
+    ``mode=0o600`` preserves rather than tightens: ``mkstemp`` creates its file
+    owner-only and the hand-rolled form never chmod'd it, so the plist has
+    always landed at ``0o600``. It has to be explicit, because ``atomic_write``
+    with no *mode* applies the umask default and would publish the plist
+    world-readable instead. launchd loads the agent as the owning user, so
+    nothing else needs to read it.
     """
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=PLIST_PATH.name + ".", suffix=".tmp", dir=str(PLIST_DIR)
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(contents)
-        os.replace(tmp_path, PLIST_PATH)
-    except Exception:
-        try:
-            os.unlink(tmp_path)
-        except FileNotFoundError:
-            pass
-        raise
+    atomic_write(PLIST_PATH, contents, mode=0o600)
 
 
 def _launchctl(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -232,9 +234,12 @@ def write_live_program(contents: str, path: Path | None = None) -> None:
     disagree about which file is authoritative.
 
     Atomic because the agent may be kickstarted at any moment: a partially
-    written launcher would exec a truncated script. The temp file is chmod'd
-    BEFORE the rename so the file is never visible at the final path without its
-    exec bit.
+    written launcher would exec a truncated script. The mode is applied to the
+    temp file BEFORE the rename so the file is never visible at the final path
+    without its exec bit -- :func:`kiro_crew.atomic_write.atomic_write` applies
+    *mode* to the descriptor before any content reaches it, which is if anything
+    tighter than the ``os.chmod``-after-write this used to hand-roll. The temp
+    cleanup also widens from ``except Exception`` to ``except BaseException``.
 
     ``0o700``, not ``0o755``: launchd runs the agent as the owning user, so
     nobody else needs to read or execute it, and it lives in that user's own
@@ -242,21 +247,8 @@ def write_live_program(contents: str, path: Path | None = None) -> None:
     """
     dest = path or LIVE_PROGRAM
     dest.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=dest.name + ".", suffix=".tmp", dir=str(dest.parent)
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(contents)
-        # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- launchd EXECUTES this file as the ProgramArguments entry, so the exec bit is required and the rule's suggested 0o644 would stop the agent from spawning at all. 0o700 is the tightest mode that still works: owner-only, in the owner's own application-support directory, and the agent runs as that same user.  # noqa: E501
-        os.chmod(tmp_path, 0o700)  # fmt: skip
-        os.replace(tmp_path, dest)
-    except Exception:
-        try:
-            os.unlink(tmp_path)
-        except FileNotFoundError:
-            pass
-        raise
+    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- launchd EXECUTES this file as the ProgramArguments entry, so the exec bit is required and the rule's suggested 0o644 would stop the agent from spawning at all. 0o700 is the tightest mode that still works: owner-only, in the owner's own application-support directory, and the agent runs as that same user.  # noqa: E501
+    atomic_write(dest, contents, mode=0o700)
 
 
 def _repairer_bin() -> str:

--- a/test/test_atomic_write_named_duplicates.py
+++ b/test/test_atomic_write_named_duplicates.py
@@ -1,0 +1,396 @@
+"""Regression tests for the three named atomic-write duplicates now folded into
+the shared helper.
+
+The sites are ``dev_fleet.gateway_service.atomic_write_text``,
+``dashboard.handlers.themes._atomic_write_theme_json``, and BOTH writers in
+``service.macos`` (``_write_plist_atomic`` and ``write_live_program``). Each had
+its own hand-rolled temp-write-and-rename, so each independently missed the
+Windows sharing-violation rename retry that ``atomic_write`` applies, and the two
+macOS writers cleaned up their temp file under ``except Exception`` — which does
+not catch a ``KeyboardInterrupt``, so a Ctrl-C at the rename left a scratch file
+in the directory launchd scans.
+
+Every assertion here is chosen to FAIL if its site is reverted to the
+hand-rolled write, which is what stops the file from passing by accident:
+
+* the routing assertions record calls through the module-level ``atomic_write``
+  seam, so a reverted site never records one;
+* the missing-parent assertions exercise the ``mkdir(parents=True)`` the shared
+  helper owns — the hand-rolled ``Path.write_text`` and ``mkstemp(dir=...)``
+  both raise on an absent parent;
+* the Ctrl-C assertions raise ``KeyboardInterrupt`` from ``os.replace``, the one
+  seam every form of this write reaches, so the reverted site is interrupted at
+  the same point and its ``except Exception`` demonstrably fails to reclaim the
+  temp file.
+
+The mode assertions are the ones that caught a real defect while this migration
+was being written, so they are load-bearing in BOTH directions. ``mkstemp``
+creates its file owner-only, and neither ``_atomic_write_theme_json`` nor
+``_write_plist_atomic`` chmod'd it afterwards, so both published at ``0o600``
+— while ``atomic_write`` with no *mode* applies the umask default. Migrating
+them without an explicit ``mode=0o600`` silently widened two previously
+owner-only files to ``0o644``. ``write_live_program`` keeps its explicit
+``0o700`` (drop it and launchd cannot exec the agent), and the Dev Fleet drop-in
+keeps the umask default its ``Path.write_text`` always produced. No site ever
+asked for ``fsync``, so none may acquire one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.apps.builtins.dev_fleet import gateway_service
+from kiro_crew.dashboard.handlers import themes as themes_mod
+from kiro_crew.service import macos as svc_macos
+
+POSIX_ONLY = pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits only")
+
+
+def _umask_default_mode() -> int:
+    """The mode ``open(path, "w")`` would have produced under this umask."""
+    current = os.umask(0)
+    os.umask(current)
+    return 0o666 & ~current
+
+
+def _mode_of(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def _recorder(monkeypatch: pytest.MonkeyPatch, module: object) -> list[tuple[str, dict]]:
+    """Record every ``atomic_write`` call *module* makes, still performing it."""
+    calls: list[tuple[str, dict]] = []
+    original = module.atomic_write  # type: ignore[attr-defined]
+
+    def recording(path, content, **kwargs):
+        calls.append((str(path), dict(kwargs)))
+        original(path, content, **kwargs)
+
+    monkeypatch.setattr(module, "atomic_write", recording)
+    return calls
+
+
+def _interrupt_the_rename_of(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+    """Raise ``KeyboardInterrupt`` when the write renames its temp onto *target*.
+
+    ``os.replace`` is the seam EVERY form of this write reaches — the shared
+    helper through ``replace_with_retry``, each hand-rolled site directly — so a
+    reverted site is interrupted at exactly the same point rather than at a
+    different one, which is what makes the cleanup assertion a real comparison.
+    Interrupting there also means the content is already fully in the temp file,
+    so what the assertion measures is purely whether the temp is reclaimed.
+
+    Keyed on the destination path, so pytest's own renames and the ``tmp_path``
+    teardown that runs after the exception are untouched.
+    """
+    real_replace = os.replace
+    needle = str(target)
+
+    def guarded(src, dst, **kwargs):  # noqa: ANN001 - mirrors os.replace
+        if str(dst) == needle:
+            raise KeyboardInterrupt("simulated Ctrl-C at the atomic rename")
+        return real_replace(src, dst, **kwargs)
+
+    monkeypatch.setattr(os, "replace", guarded)
+
+
+class TestDevFleetDropInWrite:
+    """``gateway_service.atomic_write_text`` stages and rolls back the systemd
+    drop-in a Dev Fleet make-live rewrites under the operator."""
+
+    def test_routes_through_the_shared_helper_with_no_fsync_or_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        calls = _recorder(monkeypatch, gateway_service)
+        target = tmp_path / "make-live.conf"
+
+        gateway_service.atomic_write_text(target, "[Service]\n")
+
+        assert calls, "the drop-in write did not go through atomic_write"
+        assert calls[0][0] == str(target)
+        # This site wrote through ``Path.write_text``, so it had neither: an
+        # fsync would add a disk barrier to a staging write, and an explicit
+        # mode would stop honouring the operator's umask.
+        assert calls[0][1] == {}
+        assert target.read_text(encoding="utf-8") == "[Service]\n"
+
+    def test_creates_a_missing_parent_directory(self, tmp_path: Path) -> None:
+        """``rollback`` never mkdir'd, so the helper owning it is the fix.
+
+        ``SystemdBackend.stage`` mkdirs the drop-in directory itself, but
+        ``rollback`` calls straight into this writer — on a host where that
+        directory went away between the two, the hand-rolled
+        ``Path.write_text`` raised ``FileNotFoundError`` and the rollback
+        reported failure to the dashboard.
+        """
+        target = tmp_path / "kirocrew.service.d" / "make-live.conf"
+        assert not target.parent.exists()
+
+        gateway_service.atomic_write_text(target, "prior\n")
+
+        assert target.read_text(encoding="utf-8") == "prior\n"
+
+    def test_writes_utf8_and_leaves_no_temp_sibling(self, tmp_path: Path) -> None:
+        """Encoding is pinned rather than locale-derived, and nothing residual.
+
+        systemd reads unit files as UTF-8. ``Path.write_text`` with no encoding
+        follows the locale, so a non-UTF-8 locale wrote a drop-in with a
+        non-ASCII ``WorkingDirectory`` that systemd could not parse.
+        ``atomic_write`` encodes UTF-8 unconditionally.
+
+        The line terminator is ``os.linesep``, not a hard-coded ``\n``: both this
+        writer's old ``Path.write_text`` and ``atomic_write`` default to
+        ``newline=None``, which translates. Pinning ``\n`` would assert a
+        BEHAVIOUR CHANGE on Windows rather than the preservation this test is
+        for — so the expectation is built from the same translation the replaced
+        ``open()`` applied.
+        """
+        target = tmp_path / "make-live.conf"
+
+        gateway_service.atomic_write_text(target, "WorkingDirectory=/home/tést\n")
+
+        expected = f"WorkingDirectory=/home/tést{os.linesep}".encode("utf-8")
+        assert target.read_bytes() == expected
+        assert b"t\xc3\xa9st" in expected, "the fixture must exercise a non-ASCII byte"
+        assert [p.name for p in tmp_path.iterdir()] == ["make-live.conf"]
+
+    @POSIX_ONLY
+    def test_keeps_the_umask_default_mode(self, tmp_path: Path) -> None:
+        """Unlike the two mkstemp sites, this one published at the umask default
+        (``Path.write_text`` goes through ``open``), so it must NOT gain a mode."""
+        target = tmp_path / "make-live.conf"
+
+        gateway_service.atomic_write_text(target, "[Service]\n")
+
+        assert _mode_of(target) == _umask_default_mode()
+
+    def test_a_ctrl_c_at_the_rename_leaves_no_temp_sibling(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A preservation assertion, not a gap being closed.
+
+        This site is the one of the three that already reclaimed its temp file
+        on a ``KeyboardInterrupt``, because it cleaned up in a ``finally`` rather
+        than an ``except Exception``. It therefore passes on revert by design;
+        it is here so the migration cannot LOSE that behaviour, which the two
+        macOS writers' versions of this test do catch.
+        """
+        target = tmp_path / "make-live.conf"
+        _interrupt_the_rename_of(monkeypatch, target)
+
+        with pytest.raises(KeyboardInterrupt):
+            gateway_service.atomic_write_text(target, "[Service]\n")
+
+        assert not target.exists(), "no partial drop-in may be published"
+        assert list(tmp_path.iterdir()) == [], "the temp sibling must be reclaimed"
+
+    def test_rollback_still_restores_prior_content_through_the_helper(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The migration must not change what the rollback path publishes."""
+        from unittest.mock import AsyncMock
+
+        calls = _recorder(monkeypatch, gateway_service)
+        dropin = tmp_path / "make-live.conf"
+        dropin.write_text("staged\n", encoding="utf-8")
+        backend = gateway_service.SystemdBackend(
+            AsyncMock(return_value=(0, "", "")),
+            lambda: "kirocrew.service",
+            platform="linux",
+            which=lambda _name: "/usr/bin/systemctl",
+            dropin_path=lambda: dropin,
+            dropin_content=lambda _wt, _kcbin: "",
+        )
+
+        assert backend.rollback("prior\n") is True
+
+        assert dropin.read_text(encoding="utf-8") == "prior\n"
+        assert calls and calls[0][0] == str(dropin)
+
+
+class TestThemeJsonWrite:
+    """``themes._atomic_write_theme_json`` publishes editor-authored theme packs
+    the dashboard reads back immediately."""
+
+    def test_routes_through_the_shared_helper_carrying_mode_0o600(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        calls = _recorder(monkeypatch, themes_mod)
+        target = tmp_path / "sunset.json"
+
+        themes_mod._atomic_write_theme_json(target, json.dumps({"slug": "sunset"}) + "\n")
+
+        assert calls, "the theme write did not go through atomic_write"
+        assert calls[0][0] == str(target)
+        assert calls[0][1] == {"mode": 0o600}, (
+            "mkstemp already published this file owner-only, so the mode must be "
+            "passed explicitly or the helper's umask default widens it; and no "
+            "fsync may be introduced"
+        )
+        assert json.loads(target.read_text(encoding="utf-8")) == {"slug": "sunset"}
+
+    def test_creates_a_missing_parent_directory(self, tmp_path: Path) -> None:
+        """The hand-rolled ``mkstemp(dir=target.parent)`` raised on an absent
+        parent; the helper's ``mkdir(parents=True)`` now owns it."""
+        target = tmp_path / "themes" / "sunset.json"
+        assert not target.parent.exists()
+
+        themes_mod._atomic_write_theme_json(target, json.dumps({"v": 1}) + "\n")
+
+        assert json.loads(target.read_text(encoding="utf-8")) == {"v": 1}
+
+    def test_leaves_the_directory_holding_only_the_target(self, tmp_path: Path) -> None:
+        """Stronger than globbing the old ``.<stem>-*.tmp`` shape.
+
+        The temp name is now ``mkstemp``'s own, so a glob for the previous
+        prefix would pass vacuously. Assert the directory's exact contents
+        instead, so a leaked temp under ANY name fails.
+        """
+        target = tmp_path / "sunset.json"
+
+        themes_mod._atomic_write_theme_json(target, json.dumps({"v": 1}) + "\n")
+        themes_mod._atomic_write_theme_json(target, json.dumps({"v": 2}) + "\n")
+
+        assert json.loads(target.read_text(encoding="utf-8")) == {"v": 2}
+        assert [p.name for p in tmp_path.iterdir()] == ["sunset.json"]
+
+    @POSIX_ONLY
+    def test_publishes_the_theme_owner_only(self, tmp_path: Path) -> None:
+        """``0o600``, matching what mkstemp-without-chmod always produced."""
+        target = tmp_path / "sunset.json"
+
+        themes_mod._atomic_write_theme_json(target, json.dumps({"v": 1}) + "\n")
+
+        assert _mode_of(target) == 0o600
+
+    def test_a_non_text_payload_still_raises_typeerror_and_publishes_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """The failure contract the install route relies on is unchanged."""
+        target = tmp_path / "sunset.json"
+
+        with pytest.raises(TypeError):
+            themes_mod._atomic_write_theme_json(target, 123)  # type: ignore[arg-type]
+
+        assert not target.exists()
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestLaunchdPlistWrite:
+    """``macos._write_plist_atomic`` rewrites the LaunchAgent plist launchctl
+    loads. Its own docstring promises a SIGINT mid-write leaves no partial
+    file — under ``except Exception`` it still left the temp one."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_plist(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._dir = tmp_path / "LaunchAgents"
+        self._dir.mkdir()
+        self._path = self._dir / "dev.kirocrew.gateway.plist"
+        monkeypatch.setattr(svc_macos, "PLIST_DIR", self._dir)
+        monkeypatch.setattr(svc_macos, "PLIST_PATH", self._path)
+
+    def test_routes_through_the_shared_helper_carrying_mode_0o600(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = _recorder(monkeypatch, svc_macos)
+
+        svc_macos._write_plist_atomic("<plist/>\n")
+
+        assert calls, "the plist write did not go through atomic_write"
+        assert calls[0][0] == str(self._path)
+        assert calls[0][1] == {"mode": 0o600}, (
+            "mkstemp already published the plist owner-only, so the mode must be "
+            "passed explicitly or the helper's umask default widens it; and no "
+            "fsync may be introduced"
+        )
+        assert self._path.read_text(encoding="utf-8") == "<plist/>\n"
+
+    def test_a_ctrl_c_at_the_rename_leaves_no_temp_sibling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``except BaseException``, not ``except Exception``.
+
+        The hand-rolled clause did not catch ``KeyboardInterrupt``, so an
+        operator pressing Ctrl-C during ``service install`` left a
+        ``dev.kirocrew.gateway.plist.*.tmp`` file directly in the directory
+        launchd scans.
+        """
+        _interrupt_the_rename_of(monkeypatch, self._path)
+
+        with pytest.raises(KeyboardInterrupt):
+            svc_macos._write_plist_atomic("<plist/>\n")
+
+        assert not self._path.exists(), "no partial plist may be published"
+        assert list(self._dir.iterdir()) == [], "the temp sibling must be reclaimed"
+
+    @POSIX_ONLY
+    def test_publishes_the_plist_owner_only(self) -> None:
+        """``0o600``, matching what mkstemp-without-chmod always produced."""
+        svc_macos._write_plist_atomic("<plist/>\n")
+
+        assert _mode_of(self._path) == 0o600
+
+
+class TestLaunchdLiveProgramWrite:
+    """``macos.write_live_program`` rewrites the shell launcher the LaunchAgent
+    EXECUTES, so its explicit ``0o700`` is load-bearing in both directions:
+    drop it and launchd cannot exec the agent, widen it and an owner-only
+    directory starts publishing a world-readable executable."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_launcher(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._dir = tmp_path / "support"
+        self._path = self._dir / "live-gateway"
+        monkeypatch.setattr(svc_macos, "LIVE_PROGRAM", self._path)
+
+    def test_routes_through_the_shared_helper_carrying_mode_0o700(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = _recorder(monkeypatch, svc_macos)
+
+        svc_macos.write_live_program("#!/bin/sh\nexec /bin/true\n")
+
+        assert calls, "the launcher write did not go through atomic_write"
+        assert calls[0][0] == str(self._path)
+        assert calls[0][1] == {"mode": 0o700}, (
+            "the launcher's explicit owner-only exec mode must survive the "
+            "migration, and no fsync may be introduced"
+        )
+
+    @POSIX_ONLY
+    def test_publishes_the_launcher_owner_only_and_executable(self) -> None:
+        svc_macos.write_live_program("#!/bin/sh\nexec /bin/true\n")
+
+        assert _mode_of(self._path) == 0o700
+        assert os.access(self._path, os.X_OK), "launchd must be able to exec it"
+
+    def test_a_ctrl_c_at_the_rename_leaves_no_temp_sibling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same ``except Exception`` gap as the plist writer, on the file the
+        agent execs: a leftover ``live-gateway.*.tmp`` is an orphaned
+        owner-executable script in the user's application-support directory."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        _interrupt_the_rename_of(monkeypatch, self._path)
+
+        with pytest.raises(KeyboardInterrupt):
+            svc_macos.write_live_program("#!/bin/sh\nexec /bin/true\n")
+
+        assert not self._path.exists(), "no partial launcher may be published"
+        assert list(self._dir.iterdir()) == [], "the temp sibling must be reclaimed"
+
+    def test_an_explicit_path_argument_still_wins_over_the_module_default(
+        self, tmp_path: Path
+    ) -> None:
+        """Dev Fleet passes the path it reports as live; the writer must use it."""
+        explicit = tmp_path / "elsewhere" / "live-gateway"
+
+        svc_macos.write_live_program("#!/bin/sh\nexec /bin/true\n", explicit)
+
+        assert explicit.is_file()
+        assert not self._path.exists()


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/atomic_write.py` is meant to be the one place that knows how to
publish a file atomically. Three named writers still hand-rolled the same
sequence, and each one independently missed a property the shared helper has:

| Site | What it hand-rolled | What it therefore missed |
|---|---|---|
| `apps/builtins/dev_fleet/gateway_service.atomic_write_text` | `Path.write_text` into a uuid-named sibling, `os.replace`, `finally: unlink` | UTF-8 encoding (it followed the process locale); parent-directory creation; the Windows rename retry |
| `dashboard/handlers/themes._atomic_write_theme_json` | `mkstemp` + `fdopen` + `os.replace`, `except BaseException` cleanup | parent-directory creation; the Windows rename retry |
| `service/macos._write_plist_atomic` | `mkstemp` + `fdopen` + `os.replace`, **`except Exception`** cleanup | `KeyboardInterrupt` temp cleanup; the Windows rename retry |
| `service/macos.write_live_program` | `mkstemp` + `fdopen` + `os.chmod(0o700)` + `os.replace`, **`except Exception`** cleanup | `KeyboardInterrupt` temp cleanup; the Windows rename retry |

Two of those gaps are user-visible rather than theoretical:

- **The two macOS writers leaked a temp file on Ctrl-C.** `except Exception` does
  not catch `KeyboardInterrupt`, so an operator interrupting `service install`
  left a `dev.kirocrew.gateway.plist.<random>.tmp` — or a `live-gateway.<random>.tmp`
  — sitting in `~/Library/LaunchAgents` and the application-support directory.
  `_write_plist_atomic`'s own docstring already promised that "a SIGINT or crash
  mid-write leaves either the old plist or no plist at all"; the temp sibling was
  the part it did not deliver.
- **The Dev Fleet drop-in was written in the process locale.** systemd reads unit
  files as UTF-8. `Path.write_text` with no `encoding=` follows
  `locale.getpreferredencoding()`, so on a non-UTF-8 locale a drop-in carrying a
  non-ASCII `WorkingDirectory` was written in an encoding systemd could not parse.
  It also never created a missing parent, so `SystemdBackend.rollback` — which,
  unlike `stage`, does not mkdir — reported failure on a host where the drop-in
  directory had gone away.

## Why it matters

These are all writes to files another program loads and acts on: launchd loads
the plist and execs the launcher, systemd parses the drop-in. A torn or
mis-encoded file there is a gateway that does not come back, and the leaked
`.tmp` files accumulate in a directory launchd scans. Folding them into the one
helper also means the next fix to atomic publishing — the Windows rename retry
was exactly such a fix — lands everywhere instead of at one of five sites.

## What changed (motivation → approach → change)

Each of the four bodies becomes a delegate to `atomic_write`. **The function
names all stay**, because they are the seams the existing tests drive
(`test_dev_fleet_server_coverage` monkeypatches `atomic_write_text` to force the
staging-failure path; `test_theme_install` and `test_dashboard_themes_coverage`
call `_atomic_write_theme_json` directly), so keeping them means no call site or
existing test has to move.

**Modes are preserved per site rather than uniformly, and this is the part worth
reading.** `mkstemp` creates its file **owner-only**, and neither
`_atomic_write_theme_json` nor `_write_plist_atomic` chmod'd it afterwards — so
both have always published at `0o600`, while `atomic_write` with no `mode=`
applies the umask default. Migrating them without an explicit `mode=0o600` would
therefore have silently widened two previously owner-only files to `0o644`. Both
now pass it explicitly. The other two sites keep what they had:
`write_live_program` its explicit `0o700` (drop it and launchd cannot exec the
agent), and `atomic_write_text` the umask default, because it wrote through
`open()` and never had a mode of its own. No site ever asked for `fsync` and none
acquires one.

The only behaviour changes are the four gaps closed above, plus two deliberate
strengthenings that come with the shared helper: the two macOS writers' temp
cleanup widens from `except Exception` to `except BaseException`, and
`write_live_program`'s mode is now applied to the descriptor before any content
reaches it rather than by an `os.chmod` after the write — if anything tighter,
and the file is still never visible at its final path without the exec bit. The
`nosemgrep` waiver explaining why `0o700` is required moves with the mode; it is
not dropped.

**Two of #2155's five original targets are deliberately NOT migrated here**, and
both exclusions are main's own settled position rather than an omission:

- `agent.py:_atomic_json_write` keeps its own `mkstemp` plus `except BaseException`
  orphan-temp cleanup, importing only `replace_with_retry` from the helper.
  Migrating it was #2155's original blocking review finding, precisely because it
  would drop that Ctrl-C cleanup — main then resolved it in the opposite
  direction and kept the hand-rolled form on purpose. Re-migrating it would
  reintroduce the exact defect that review caught.
- `apps/builtins/mochi/queue_file.py` documents in its own docstring why it does
  not use `atomic_write` (`0600` mode and a pid-suffixed temp name).

## Tests

`test/test_atomic_write_named_duplicates.py` — 18 cases, one class per writer.
Per site: that the write routes through the module-level `atomic_write` seam with
exactly the expected kwargs, that a missing parent directory is created, the
mode actually published, that no temp file survives, and what a Ctrl-C at the
rename leaves behind.

**Every assertion was mutation-verified** by reverting that one file to main's
hand-rolled body and confirming the failure — so no assertion here can pass by
accident:

| Reverted site | Assertions that fail |
|---|---|
| `gateway_service.py` | routing (×2), missing-parent creation |
| `themes.py` | routing, missing-parent creation |
| `service/macos.py` | routing (×2), **Ctrl-C temp residue (×2)** |

Two notes on reading that table honestly. The Ctrl-C assertions inject
`KeyboardInterrupt` at **`os.replace`**, which is the one seam every form of this
write reaches, so the reverted site is interrupted at the same point and the
comparison is real; on revert they fail with `the temp sibling must be
reclaimed`, which is the `except Exception` gap itself. And the drop-in writer's
Ctrl-C test passes on revert **by design** — that site cleaned up in a `finally`
and so never had the gap; its test is there so the migration cannot lose that,
and its own docstring says so.

The mode assertions earned their place: they are what caught the `0o600`
widening described above, during the first mutation round, before this PR was
opened.

Existing coverage for these sites is unchanged and still passes
(`test_theme_install`, `test_dashboard_themes_coverage`,
`test_dev_fleet_server_coverage`, `test_service` — 614 cases together).

## Manual verification

N/A — unit coverage sufficient. All four writers are exercised directly by the
tests above, including their failure and interrupt paths, and the two macOS sites
are platform-gated code whose behaviour is asserted at the module seam rather
than against a live launchd.

Local gates run green on this head: `isort`, `flake8`, `mypy` (1210 files), the
black gate, subprocess-encoding, lockdown-before-publish, brand, harness-parity,
loop-bound-locks, testpaths-coverage, changelog-history, focus-cue, docs-lint,
per-file-coverage, vendor-manifest and scrub-lint. The scoped suite over every
file this diff touches is green: 906 passed across
`test_atomic_write_named_duplicates`, `test_theme_install`,
`test_dashboard_themes_coverage`, `test_dev_fleet_server_coverage` and
`test_service`.

The full backend suite additionally shows failures in `test_file_explorer_app`,
`test_design_tweak_backend`, `test_host_isolation_floor`, `test_artifact_source`,
`test_dashboard_peer_auth`, `test_service` (the four uid-trust classes) and a few
others — all host-environment artifacts on the machine this was verified on
(`/local/home` owned by uid 65534, `AF_UNIX path too long`), reproduced with this
diff reverted to confirm they are not from this change.

## Related Issues

No linked issue: this is the carried-forward remainder of PR #2155, whose branch
had drifted 2173 commits behind main. That PR is now closed in favour of this one.

Co-authored with @smeyffret, who did the original work in #2155.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the four docstrings now state what they delegate to and which semantics are pinned deliberately
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — four file-writing helpers keep their
signatures and published bytes; nothing rendered changes.

