### PR TITLE
fix(dashboard): serialize the auto-update toggle against both config writers

### DIFF
--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -1199,19 +1199,31 @@ async def api_update_auto(request: web.Request) -> web.Response:
         return data
 
     # `update_config_locked` holds the advisory lock across the READ and the write, so no
-    # other process can land between them -- the whole point, since the in-process
-    # `_get_config_lock()` this endpoint used to rely on does not serialize against the CLI
-    # or a second gateway.
+    # other process can land between them -- that is what stopped the CLI and a second
+    # gateway interleaving here.
     #
-    # Offloaded because that lock is blocking: called inline from this coroutine it would
-    # stall every session and the liveness heartbeat while contended, which is what the
-    # repo's `no-blocking-call-on-event-loop` rule forbids.
+    # But the flock is only ONE of the two generations that guard config.json. The legacy
+    # dashboard writers -- the agents endpoint, core.py's theme/settings PUT, security.py,
+    # messaging.py, mcp.py, computer_use.py -- do a read-modify-write of this same file
+    # while holding ONLY the loop-side `_get_config_lock()`, which the sidecar flock does
+    # not exclude. So a theme save landing between this endpoint's read and its write
+    # commits from a snapshot taken before it, and silently reverts the auto-update flag
+    # the user just toggled -- or this write reverts their theme. Nothing errors and the
+    # response still reports success, because it is built from `enabled` rather than from
+    # a re-read of what actually landed.
+    #
+    # `run_config_write` is the one entry point that holds BOTH: it takes the loop-side
+    # lock on the event loop and then runs the blocking writer in a worker, so the flock
+    # wait still never stalls the loop -- the property the bare `to_thread` was there for,
+    # unchanged. Nothing here holds a config lock already, so this introduces no nesting;
+    # the handler is a flat coroutine and `run_config_write` is its only lock acquisition.
     #
     # The read still fails CLOSED (`on_corrupt` defaults to "fail"): treating an unreadable
     # config as {} would write back a single-key file and wipe every other setting the user
-    # has (see read_config_for_update).
+    # has (see read_config_for_update). `run_config_write` propagates the writer's
+    # exceptions unchanged, so that contract is untouched.
     try:
-        await asyncio.to_thread(update_config_locked, config_path(), mutate=_set_auto_update)
+        await run_config_write(update_config_locked, config_path(), mutate=_set_auto_update)
     except ConfigReadError:
         logger.exception("Refusing to toggle auto-update: config is unreadable")
         return web.json_response(

--- a/test/test_config_rmw_preserves_settings.py
+++ b/test/test_config_rmw_preserves_settings.py
@@ -9,8 +9,12 @@ existing config raises, and a genuinely absent one still starts from ``{}``.
 
 from __future__ import annotations
 
+import ast
 import asyncio
+import inspect
 import json
+import threading
+from pathlib import Path
 
 import pytest
 
@@ -784,3 +788,156 @@ class TestEveryConfigWriterIsLocked:
             "path -- the agent-spec write in agents.py is that shape -- and must "
             "not be flagged."
         )
+
+
+class TestAutoUpdateToggleHoldsBothConfigLocks:
+    """The auto-update toggle must exclude the LEGACY config writers too.
+
+    ``config.json`` has two writer generations that do not exclude each other.
+    ``update_config_locked`` takes the sidecar advisory flock, covering the CLI,
+    the boot refresh and a second gateway process. The legacy dashboard handlers
+    -- ``core.py``'s theme/settings PUT, the agents endpoint, ``security.py``,
+    ``messaging.py``, ``mcp.py``, ``computer_use.py`` -- do their own
+    read-modify-write of the same file while holding ONLY the loop-side
+    ``_get_config_lock`` asyncio lock, which the flock does not exclude.
+
+    So a bare ``asyncio.to_thread(update_config_locked, ...)`` here is right about
+    the event loop and wrong about exclusion: a theme save landing between this
+    endpoint's read and its write commits from a snapshot taken before it and
+    silently reverts the flag the user just toggled. ``run_config_write`` is the
+    one entry point that holds both.
+
+    Probing the lock from INSIDE the worker is what makes this behavioural rather
+    than a shape assertion: it fails on the defect, not on the spelling of the
+    dispatch.
+    """
+
+    class _Req:
+        async def json(self):
+            return {"enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_the_loop_side_lock_is_held_across_the_write(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.dashboard.handlers import updates
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(_REAL_SETTINGS, indent=2), encoding="utf-8")
+        monkeypatch.setattr(updates, "config_path", lambda: path)
+
+        seen: dict = {}
+        real = updates.update_config_locked
+
+        def _spy(*args, **kwargs):
+            seen["locked"] = _get_config_lock().locked()
+            seen["thread"] = threading.current_thread()
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(updates, "update_config_locked", _spy)
+
+        resp = await updates.api_update_auto(self._Req())
+        assert resp.status == 200
+        assert seen, "the config write never ran"
+        # Red-before with the bare `asyncio.to_thread` dispatch: False is not True.
+        assert seen["locked"] is True, (
+            "config.json was rewritten without the loop-side lock, so a legacy "
+            "dashboard writer could interleave and revert the toggle"
+        )
+        # And the reason the old dispatch existed is preserved: the blocking
+        # flock wait still happens off the event loop.
+        assert seen["thread"] is not threading.current_thread(), (
+            "the blocking write must stay off the event loop"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_loop_side_lock_is_released_afterwards(
+        self, tmp_path, monkeypatch
+    ):
+        """Holding it is only correct if the handler also gives it back."""
+        from kiro_crew.dashboard.handlers import updates
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(_REAL_SETTINGS, indent=2), encoding="utf-8")
+        monkeypatch.setattr(updates, "config_path", lambda: path)
+
+        resp = await updates.api_update_auto(self._Req())
+        assert resp.status == 200
+        assert not _get_config_lock().locked()
+        assert json.loads(path.read_text(encoding="utf-8"))["auto_update"] is False
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_config_still_fails_closed_and_releases(
+        self, tmp_path, monkeypatch
+    ):
+        """The fail-closed contract must survive the new dispatch.
+
+        ``run_config_write`` awaits the worker through ``asyncio.shield``, so a
+        writer exception has to propagate unchanged for the 500 arm to stay
+        reachable -- and the lock must not be stranded on that path.
+        """
+        from kiro_crew.dashboard.handlers import updates
+        from kiro_crew.dashboard.handlers.agents import _get_config_lock
+
+        path = tmp_path / "config.json"
+        torn = json.dumps(_REAL_SETTINGS, indent=2)[:-20]
+        path.write_text(torn, encoding="utf-8")
+        monkeypatch.setattr(updates, "config_path", lambda: path)
+
+        resp = await updates.api_update_auto(self._Req())
+        assert resp.status == 500
+        assert path.read_text(encoding="utf-8") == torn
+        assert not _get_config_lock().locked()
+
+    def test_the_dispatch_cannot_regress_to_a_one_lock_offload(self):
+        """Static guard so nobody reintroduces the bare offload silently.
+
+        The behavioural tests above prove the lock is held today. This names the
+        site if the dispatch is ever changed back, and it is written as an AST
+        walk rather than a substring search so a reformat cannot defeat it.
+        """
+        from kiro_crew.dashboard.handlers import updates
+
+        source = Path(inspect.getsourcefile(updates)).read_text(encoding="utf-8")
+        offenders = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr == "to_thread"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "asyncio"
+            ):
+                continue
+            for arg in node.args:
+                if isinstance(arg, ast.Name) and arg.id == "update_config_locked":
+                    offenders.append(func.lineno)
+        assert not offenders, (
+            "update_config_locked dispatched with a bare asyncio.to_thread at "
+            f"updates.py:{offenders} -- that holds only the sidecar flock; use "
+            "run_config_write, which holds both config locks"
+        )
+
+    def test_the_ratchet_can_actually_fail(self):
+        """A scan that matches nothing passes vacuously; prove it does not."""
+        tree = ast.parse(
+            "import asyncio\n"
+            "async def f():\n"
+            "    await asyncio.to_thread(update_config_locked, p, mutate=m)\n"
+        )
+        found = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "to_thread"
+            and any(
+                isinstance(a, ast.Name) and a.id == "update_config_locked"
+                for a in n.args
+            )
+        ]
+        assert len(found) == 1


### PR DESCRIPTION
## Problem / Motivation

`POST /api/update/auto` — the auto-update toggle in dashboard settings — persists the flag with a bare offload:

```python
# handlers/updates.py:1204
await asyncio.to_thread(update_config_locked, config_path(), mutate=_set_auto_update)
```

That is correct about the event loop and wrong about **exclusion**. `config.json` has two writer generations that do not exclude each other:

- `update_config_locked` takes the **sidecar advisory flock** — covering the CLI, the boot refresh, and a second gateway process.
- The legacy dashboard handlers — `core.py`'s theme/settings PUT, the agents endpoint, `security.py`, `messaging.py`, `mcp.py`, `computer_use.py` — do their own read-modify-write of the same file while holding **only** the loop-side `_get_config_lock` asyncio lock.

Holding just the flock excludes nothing that second family respects. `core.py:424` is the plainest counterpart: `async with _get_config_lock():` → `KiroCrewConfig.load` → mutate → save, with no flock anywhere. A theme save landing between this endpoint's read and its write commits from a snapshot taken before it, and silently reverts the auto-update flag the user just toggled — or this write reverts their theme.

`config/loader.py` states the rule directly: a caller running while the dashboard serves requests must **also** hold the in-process asyncio lock.

## Why it matters

The lost update is silent and bidirectional, and it is reachable by ordinary use rather than by a race a user has to provoke — toggling auto-update and saving a setting are both routine dashboard actions. Nothing errors and nothing is logged; the endpoint reports success in both directions because the response is built from `enabled` rather than from a re-read of what landed on disk. The write window is not narrow either: it includes a filesystem lock wait plus, on Windows, an owner-only DACL application that can cost an unbounded SMB round-trip on a network-homed data home.

Auto-update is also the wrong setting to lose silently. A user who turned it **off** and finds it back on has an install that will update itself against their explicit decision.

## What changed (motivation → approach → change)

**Symptom** → a config write that can be silently reverted, in either direction. **Root cause** → the dispatch holds one of the two locks that guard `config.json`. **Change** → route it through the entry point that holds both.

`src/kiro_crew/dashboard/handlers/updates.py`:

```python
-    await asyncio.to_thread(update_config_locked, config_path(), mutate=_set_auto_update)
+    await run_config_write(update_config_locked, config_path(), mutate=_set_auto_update)
```

`run_config_write` (`dashboard/chat_utils.py`) acquires `_get_config_lock` **on the event loop**, then runs the blocking writer in a worker — so the flock wait still never stalls the loop, which is the property the bare `to_thread` was there for, unchanged. It also shields and drains that worker across cancellation, so a client disconnecting mid-toggle cannot unwind the lock while the write is still in flight.

Three properties checked before making the swap rather than assumed, because a canonical-helper swap on a persistence path is not mechanical:

- **The file is the same one.** `config_path()` here is the main `config.json` the legacy family mutates, not a sidecar.
- **No outer config lock is already held.** `api_update_auto` is a flat coroutine with no `async with` of its own, so `run_config_write` is its only lock acquisition and this introduces no nesting. (This is what distinguishes the site from `apps/routes.py`, where the same swap in #6984 sat inside `app_lifecycle_lock` and needed an explicit lock-ordering argument. There is no second lock here to order against.)
- **The fail-closed contract survives.** `run_config_write` awaits the worker through `asyncio.shield` and re-raises, so `ConfigReadError` still reaches the handler's 500 arm and an unreadable config is still never overwritten with a one-key file. Pinned by a test rather than asserted.

The import is module-level, unlike #6984's call-time one: `updates.py` already lives inside `kiro_crew.dashboard`, so there is no layering inversion to avoid and no import cycle (verified by importing both modules in either order).

The comment block above the call is rewritten. The old one explained why the flock replaced `_get_config_lock` and read as though that were the end of the story; it now says why both are needed.

**Scope.** This is the one `update_config_locked` site in `updates.py`. It is the sibling the First Principles review on #6984 counted as the remaining same-class one-lock config writer, and #6984 (merged) names `updates.py` in its own problem statement. No other handler is touched.

## Tests

New in `test/test_config_rmw_preserves_settings.py`, class `TestAutoUpdateToggleHoldsBothConfigLocks` — the file that already owns this endpoint's config-write contract:

- `test_the_loop_side_lock_is_held_across_the_write` — **the defect, pinned behaviourally.** Spies `update_config_locked` and, from **inside the worker**, records `_get_config_lock().locked()` and the thread identity. Probing from inside is what makes this a test of the property rather than of the spelling of the dispatch. It also asserts the write is still off the loop, so the fix cannot pass by moving the blocking call back onto it.
- `test_the_loop_side_lock_is_released_afterwards` — holding it is only correct if the handler gives it back; also asserts the toggle actually landed on disk.
- `test_an_unreadable_config_still_fails_closed_and_releases` — the 500 arm survives the new dispatch, the torn file is byte-identical afterwards, and the lock is not stranded on the exception path.
- `test_the_dispatch_cannot_regress_to_a_one_lock_offload` — an **AST** ratchet (not a substring search, so a reformat cannot defeat it) that names the offending `updates.py:<line>` if `update_config_locked` is ever dispatched with a bare `asyncio.to_thread` again.
- `test_the_ratchet_can_actually_fail` — a scan that matches nothing passes vacuously; this plants a violating source and asserts the scan finds exactly one.

**Red-before**, production change reverted with the tests in place: **2 failed, 3 passed**.

```
AssertionError: config.json was rewritten without the loop-side lock, so a legacy
                dashboard writer could interleave and revert the toggle
AssertionError: update_config_locked dispatched with a bare asyncio.to_thread at
                updates.py:[1204] -- that holds only the sidecar flock; use
                run_config_write, which holds both config locks
```

**Green after**: `test_config_rmw_preserves_settings.py` + `test_dashboard_updates_coverage.py` — **99 passed, 3 skipped, 0 failed** (Python 3.10.6, Windows).

**Gates green:** flake8, isort, `scripts/check_black_formatting.py`, `mypy` on the changed handler (no issues in it), and `scripts/check_loop_bound_locks.py` including its own `--test` self-check (21/21 probes).

## Manual verification

N/A — unit coverage sufficient: the defect is which lock is held around a write, and the test observes that lock's state from inside the worker doing the write, which is the exact moment a manual toggle could not show. Reproducing it by hand would require winning a millisecond-scale interleaving between two dashboard requests.

## Related Issues

Sibling of #6984 (merged), which made the same correction at the two `apps/routes.py` call sites and whose First Principles review counted this one as the remaining member of the class.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
