### PR TITLE
fix(sandbox): load libc via dlopen(NULL) in the namespace launcher

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2126,7 +2126,6 @@ import sys
 # from the filesystem.
 sys.path[:] = [p for p in sys.path if p not in ("", sys.path[0])]
 import ctypes
-import ctypes.util
 import os
 import stat
 import tempfile
@@ -2139,7 +2138,23 @@ _MS_BIND       = 4096
 _MS_REC        = 16384
 _MS_PRIVATE    = 1 << 18
 
-_libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+# dlopen(NULL): resolve mount()/unshare()/prctl() from the libc ALREADY loaded
+# into this interpreter. Never ctypes.util.find_library here -- on Linux it
+# EXECUTES helper processes to locate libc (ldconfig first, then a PATH-resolved
+# gcc/cc/objdump/ld once ldconfig yields no match, i.e. on musl hosts). This
+# module scope runs BEFORE the fork and before either unshare() below, under an
+# environment the SPAWNING CALLER supplies -- so on such a host a
+# caller-controlled `gcc` on PATH would be same-user code execution ahead of the
+# confinement this launcher exists to establish.
+#
+# Same rule, same reason, as the spawned userns probe in ``_PROBE_SHIM_CODE``,
+# which already resolves libc this way; the launcher was the one pre-confinement
+# script still violating it. Not a new code path either: ``find_library``
+# returning None made this call ``CDLL(None)`` anyway, so dlopen(NULL) was
+# already the implicit fallback here. ``ctypes.util`` is deliberately left
+# unimported above so a future reintroduction fails loudly instead of silently
+# reopening the PATH lookup.
+_libc = ctypes.CDLL(None, use_errno=True)
 _libc.mount.argtypes = [
     ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p,
     ctypes.c_ulong, ctypes.c_void_p,

--- a/test/test_sandbox_launcher_libc_load.py
+++ b/test/test_sandbox_launcher_libc_load.py
@@ -1,0 +1,149 @@
+"""The namespace launcher must resolve libc via ``dlopen(NULL)``, never PATH.
+
+The launcher's module scope runs BEFORE its ``fork()`` and before either
+``unshare()``, under an environment the SPAWNING CALLER supplies -- and a
+caller-declared ``PATH`` does reach it (``cron_script`` forwards a per-server
+``env`` block; ``mcp_discovery`` composes a declared ``PATH`` into the probe env).
+
+``ctypes.util.find_library("c")`` is therefore unsafe there. On Linux it
+EXECUTES helper processes to locate libc: ``_findSoname_ldconfig`` first
+(absolute ``/sbin/ldconfig``, env carrying no ``PATH``, so PATH-immune), and
+only when that yields no match -- musl/Alpine, or no ``ldconfig`` -- the
+PATH-resolving ``_findLib_gcc`` (``shutil.which('gcc')`` / ``'cc'``),
+``_get_soname`` (``objdump``) and ``_findLib_ld`` (bare ``ld``). On such a host a
+caller-controlled ``gcc`` on ``PATH`` would be same-user code execution ahead of
+the confinement the launcher exists to establish.
+
+The spawned userns probe already followed this rule; these tests pin the
+launcher to it too, so the two pre-confinement scripts cannot drift apart again.
+
+Two deliberate shapes here:
+
+* Assertions run over the parsed AST, not the source text. Every one of these
+  scripts *documents* the rule in a comment naming ``find_library``, so a
+  substring match would be satisfied by the prose and would pass on a script
+  that still calls it.
+* The scripts are built inside a fixture rather than at module scope, and the
+  module is Linux-marked. ``_build_launcher_script`` calls ``os.getuid()``,
+  which does not exist on Windows -- building at import time would crash
+  COLLECTION there rather than skipping, and macOS libc carries no ``unshare``
+  for the symbol check below. The launcher is Linux-only in production, so
+  there is nothing to assert elsewhere.
+"""
+
+from __future__ import annotations
+
+import ast
+import ctypes
+import sys
+
+import pytest
+
+from kiro_crew.sandbox import _PROBE_SHIM_CODE, _build_launcher_script
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="the namespace launcher is Linux-only: _build_launcher_script uses "
+    "os.getuid() (absent on Windows) and binds unshare() (absent on macOS libc)",
+)
+
+#: Labels for every pre-confinement script this module generates. Both kinds run
+#: with a caller-supplied environment before any namespace exists, so both are
+#: bound by the no-``find_library`` rule -- asserting over the pair is what stops
+#: a future change from fixing one and reopening the other.
+_PRECONFINEMENT_LABELS = ("launcher(standard)", "launcher(strict)", "probe shim")
+
+
+def _source_for(label: str) -> str:
+    if label == "probe shim":
+        return _PROBE_SHIM_CODE
+    mode = label[len("launcher(") : -1]
+    return _build_launcher_script(mode)
+
+
+def _dotted_name(node: ast.AST) -> str:
+    """Render an ``ast`` call target as its dotted source spelling."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _called_names(tree: ast.AST) -> list[str]:
+    return [_dotted_name(n.func) for n in ast.walk(tree) if isinstance(n, ast.Call)]
+
+
+@pytest.fixture(params=_PRECONFINEMENT_LABELS, ids=_PRECONFINEMENT_LABELS)
+def preconfinement(request: pytest.FixtureRequest) -> tuple[str, ast.Module]:
+    """A pre-confinement script's label and parsed tree.
+
+    Parsing here doubles as a syntax regression on the generated launcher: an
+    f-string template that produced invalid Python would fail every test in this
+    module rather than only surfacing at spawn time.
+    """
+    label = request.param
+    return label, ast.parse(_source_for(label))
+
+
+def test_never_resolves_libc_through_path(preconfinement: tuple[str, ast.Module]) -> None:
+    """No pre-confinement script may CALL a PATH-resolving libc lookup."""
+    label, tree = preconfinement
+    offenders = [n for n in _called_names(tree) if n.endswith("find_library")]
+    assert not offenders, (
+        f"{label} calls {offenders} to resolve libc, which execs a PATH-resolved "
+        "gcc/cc/objdump/ld on musl hosts -- before this script establishes "
+        "confinement, under a caller-supplied PATH"
+    )
+
+
+def test_loads_libc_via_dlopen_null(preconfinement: tuple[str, ast.Module]) -> None:
+    """libc comes from ``ctypes.CDLL(None)`` -- the already-mapped libc."""
+    label, tree = preconfinement
+    loads = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and _dotted_name(n.func).endswith("CDLL") and n.args
+    ]
+    assert loads, f"{label} never loads libc through ctypes.CDLL"
+    for call in loads:
+        first = call.args[0]
+        assert isinstance(first, ast.Constant) and first.value is None, (
+            f"{label} passes a computed path to CDLL; it must be the literal "
+            "None (dlopen(NULL)) so no lookup runs pre-confinement"
+        )
+
+
+def test_does_not_import_ctypes_util(preconfinement: tuple[str, ast.Module]) -> None:
+    """``ctypes.util`` stays unimported so a reintroduction fails loudly.
+
+    Without the import, a future ``find_library`` call in these scripts raises
+    ``AttributeError`` at spawn instead of silently reopening the PATH lookup --
+    the import's absence is the guard, not incidental tidiness.
+    """
+    label, tree = preconfinement
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            imported += [f"{node.module}.{a.name}" for a in node.names]
+    assert "ctypes.util" not in imported, f"{label} imports ctypes.util"
+
+
+def test_dlopen_null_exposes_the_syscalls_the_launcher_binds() -> None:
+    """``dlopen(NULL)`` really carries the symbols, not just the right spelling.
+
+    Guards the substitution rather than its source text: had ``CDLL(None)`` not
+    carried these, every assertion above would still pass while each namespace
+    spawn died at the launcher's module scope. ``prctl`` is excluded -- the
+    launcher already treats it as optional via ``hasattr``.
+    """
+    libc = ctypes.CDLL(None, use_errno=True)
+    for symbol in ("mount", "unshare"):
+        assert hasattr(libc, symbol), (
+            f"dlopen(NULL) does not expose {symbol}(); the launcher binds it at "
+            "module scope and would fail to start"
+        )


### PR DESCRIPTION
## Problem / Motivation

The namespace sandbox launcher resolved libc with `ctypes.util.find_library("c")` at **module scope** — before its own `fork()` and before either `unshare()` call, i.e. before it has established any confinement.

On Linux that call *executes helper processes* to locate libc. `_findSoname_ldconfig` runs first and is PATH-immune by construction (absolute `/sbin/ldconfig`, and an env carrying no `PATH` at all), but when it yields no libc match — musl/Alpine, or a host with no `ldconfig` — CPython falls through to the PATH-resolving branches: `_findLib_gcc` (`shutil.which('gcc')` / `which('cc')`), `_get_soname` (`objdump`), and `_findLib_ld` (bare `ld` via `execvp`).

That scope runs under an environment the **spawning caller** supplies, and a caller-declared `PATH` does reach it — `mcp_discovery` composes a declared `PATH` into the probe env it hands the launcher, and `cron_script` forwards a per-server `env` block. So on such a host a caller-controlled `gcc` on `PATH` would be same-user code execution ahead of the confinement the launcher exists to establish.

This repo already holds the rule, in the launcher's sibling script. The spawned userns probe resolves libc via `dlopen(NULL)` and says why:

> `dlopen(NULL)`: resolve `unshare()` from the libc ALREADY loaded into this interpreter. Never `ctypes.util.find_library` here -- on Linux it EXECUTES helper processes (ldconfig, then a PATH-resolved gcc/cc/objdump on musl hosts) to locate libc, and this probe runs before any confinement, so a workspace-controlled `gcc` on PATH would be same-user code execution.

The launcher was the one pre-confinement script still violating it.

## Why it matters

The launcher is the component that *creates* the sandbox. Any execution it performs beforehand is unconfined by definition, so a pre-confinement PATH lookup inverts the guarantee the rest of the file is built to provide. The window is narrow — it needs a host where `ldconfig` yields no libc match — but on such a host it is reachable from config text rather than from local access, and it precedes every mount-hiding and capability-dropping control the launcher installs.

Raised by the GPT 5.6 review lane on #2602. It is filed here rather than there because the call site is identical on `main` and affects **every** launcher caller, not just the cron path that PR touches — see the disposition on [#2602](https://github.com/kirodotdev/KiroCrew/pull/2602#issuecomment-5472679477).

## What changed (motivation → approach → change)

Symptom: a PATH-resolving libc lookup executes before confinement. Root cause: the launcher template asks `find_library` to *locate* libc, when the interpreter running the template already has libc mapped. Change: take it from there instead.

```python
_libc = ctypes.CDLL(None, use_errno=True)   # dlopen(NULL)
```

Three things make this a small change rather than a risky one:

- **It is not a new code path.** `find_library` returning `None` made the call `ctypes.CDLL(None)` anyway, so `dlopen(NULL)` was already this line's implicit fallback — the change promotes a path the launcher already relied on to the only path.
- **The symbols are there.** Verified `dlopen(NULL)` exposes `mount`, `unshare`, `prctl`, `umount2` and `pivot_root`. `prctl` was already treated as optional via `hasattr` and stays that way.
- **`ctypes.util` is left unimported** in the launcher template. That is a guard, not tidying: a future reintroduction of `find_library` there raises `AttributeError` at spawn instead of silently reopening the lookup.

Scope deliberately held to the launcher. `_probe_unshare_via_fork` (`sandbox.py`) also calls `find_library`, and is **not** changed here: it runs in the parent gateway process against the gateway's own `os.environ`, never a caller-supplied one, so it is not the same exposure and folding it in would widen this diff past the finding. The macOS `find_library("System")` call is likewise unrelated — it already carries an absolute fallback and is not on a pre-confinement path.

## Tests

`test/test_sandbox_launcher_libc_load.py`, asserting over the **parsed AST** of every pre-confinement script — both launcher modes and the probe shim — rather than its source text. That distinction is load-bearing: each of these scripts *documents* the rule in a comment that names `find_library`, so a substring assertion is satisfied by the prose and would pass on a script that still calls it.

- `test_never_resolves_libc_through_path` — no script *calls* anything named `find_library`.
- `test_loads_libc_via_dlopen_null` — every `CDLL` call passes a literal `None`, not a computed path.
- `test_does_not_import_ctypes_util` — the import stays absent, so a reintroduction fails loudly.
- `test_dlopen_null_exposes_the_syscalls_the_launcher_binds` — exercises `dlopen(NULL)` itself, so the substitution is proven and not merely spelled correctly. Without it the three static assertions would all pass on a host where `CDLL(None)` carried no `mount`, while every namespace spawn died at module scope.

Parsing the generated template also doubles as a syntax regression on it.

Mutation-verified: reverting `sandbox.py` alone fails all three launcher assertions (`calls ['ctypes.util.find_library']`, `passes a computed path to CDLL`, `imports ctypes.util`) while the probe-shim cases stay green — the probe was already compliant, so the tests distinguish the fixed site from the already-correct one.

Also run green: `test_sandbox_argv.py`, `test_sandbox_probe.py`, `test_sandbox_launcher_sweep.py`, `test_sandbox_mount_checked.py` (272 passed, 1 skipped). Gates: isort, flake8, mypy, black all clean.

Re-verified after rebasing onto `146a78b82` (14 commits, zero conflicts, diff byte-identical): the launcher's `CDLL(None)` load survived the rebase intact, and `_probe_unshare_via_fork` still carries its own `find_library` call — unchanged here on purpose, per the scope note above.

## Manual verification

N/A — unit coverage sufficient. The change is a libc-handle acquisition swap whose viability is asserted directly by exercising `dlopen(NULL)` for the bound symbols; the launcher's own namespace path is unreachable on this host (`unshare(CLONE_NEWUSER)` returns EPERM here, which the existing probe suite already covers).

## Related Issues

no linked issue: raised from a review finding on #2602, not a tracked bug.

