### PR TITLE
fix(apps): confirm-gate out-of-install dev-mode grants (#6907)

### DIFF
--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -785,25 +785,121 @@ Dev mode speeds up app-UI iteration: no manual copy-and-hard-refresh loop. When
 an installed app is in dev mode the gateway serves its UI files with
 `Cache-Control: no-store` and watches the app's `ui/` directory; on any file
 change it broadcasts an `app_reload` WebSocket event and the dashboard reloads
-the app so edits appear immediately. The recommended setup symlinks
-`~/.kiro/crew/apps/<name>/ui/` to your source tree so the watcher sees edits at
-the real files.
+the app so edits appear immediately.
+
+The recommended setup symlinks the **whole `ui/` directory** —
+`~/.kiro/crew/apps/<name>/ui` → your source tree — so the watcher sees edits at
+the real files. Link the directory, **never individual files inside it**: the
+UI route opens the final path component with `O_NOFOLLOW` (a swap-resistant
+open), so a per-file symlink like `ln -s ~/src/app/dist/index.mjs ui/index.mjs`
+answers `404` — indistinguishable from "not built yet". The directory link
+works because the route resolves the ui root *through* the link before
+validating files against it.
 
 **Contract surface:**
 
 - **`installed.json` field — `dev: bool`** (default `false`): persisted per-app
   flag. Tolerant on read (absent ⇒ `false`); reversible; no migration needed.
-  Builtin apps cannot enter dev mode.
+  Builtin apps cannot enter dev mode. This field controls **watching and
+  `no-store` serving only** — it is app-writable metadata and never authorizes
+  anything by itself (see the grant record below).
 - **Endpoint — `POST /api/apps/{name}/dev`**, body `{"enabled": <bool>}`.
   Returns `{"name": <name>, "dev": <bool>}`. `400` for a non-boolean body,
-  a builtin app, or an unsafe app name; `404` if the app is not installed.
-  Behind the standard gateway auth; emits an `app_dev_mode` SEL audit event.
+  a builtin app, an unsafe app name, or a refused grant (see below); `404` if
+  the app is not installed. Behind the standard gateway auth; emits an
+  `app_dev_mode` SEL audit event. The endpoint deliberately has no field to
+  confirm an out-of-install root — that confirmation is CLI-only (below).
 - **WebSocket event — `app_reload`**, payload `{"app": <name>, "ts": <float>}`.
   Re-dispatched to the frontend as the `mc:app-reload` window CustomEvent; the
   AppHost triggers a full page reload for the matching app.
-- **CLI — `kirocrew app dev <name> [--off]`**: toggles the flag out-of-process;
-  the gateway watcher picks up the change within one poll interval, so no
-  gateway restart is needed.
+- **CLI — `kirocrew app dev <name> [--off] [--confirm-out-of-install-root]`**:
+  toggles the flag out-of-process; the gateway watcher picks up the change
+  within one poll interval, so no gateway restart is needed.
+
+### The operator grant record
+
+Enabling dev mode also records an **operator grant**: a file at the apps root
+(`~/.kiro/crew/apps/.dev-grants.json`) mapping the app name to the ui root's
+**resolved path at toggle time** (`realpath` of `<install>/ui`). It is written
+**only by the dev-mode toggle** (and revoked on disable/uninstall) — never by
+the gateway's startup reconcile, and never derived from `installed.json`. The
+UI route requires it before serving a ui root that resolves **outside the
+app's install directory**: without a grant that exactly matches the current
+resolved root, out-of-install files answer `400`.
+
+Two files, two jobs: `installed.json` `dev` (plus an internal sentinel cache,
+below) drives *watching and cache headers*; the grant record is the
+*authorization*. An app can write `dev: true` into its own metadata, but it
+cannot mint a grant — that separation is what stops an app from pointing `ui`
+at an arbitrary directory and having the UI route serve it.
+
+Because the grant binds one exact resolved root, it is **self-invalidating**:
+repointing `ui` after the toggle (an app update, a swapped link, a reinstall
+under the same name) yields a root that no longer equals the granted one, and
+the route answers `400` for those files until the operator re-toggles.
+**Re-toggle after re-pointing** is the workflow — run the toggle again (enable
+while already enabled is fine) to bind the grant to the new root. The same
+applies after upgrading from a gateway version that predates the grant record:
+an app already in dev mode on an out-of-install root has no grant, so its UI
+answers `400` until one re-toggle.
+
+### Refused and confirmed grants
+
+The toggle validates the resolved ui root **before writing anything** (a
+refusal never disturbs existing state):
+
+- **Sensitive roots are never grantable.** A root that resolves *into* a
+  sensitive location (credential stores, key material) or *contains* sensitive
+  leaves at toggle time is refused outright with `400` and an error naming the
+  resolved root — no confirmation can override this. The screen is
+  **point-in-time**: it inspects the tree as it exists when the toggle runs,
+  and serving afterwards re-checks only that the resolved root still equals
+  the granted one. Confirming a grant approves the *tree location*, not a
+  permanent screen of its future contents.
+- **Out-of-install roots are refused over HTTP; confirm from the host.**
+  App UI bundles run as same-origin modules with the dashboard's own
+  credentials, so a request-body flag can never prove operator intent — the
+  endpoint therefore has no confirmation field at all. Enabling dev mode on a
+  root outside the install directory always answers `400` with
+  `code: "dev_mode_out_of_install_confirmation_required"` and an error naming
+  the fix: run `kirocrew app dev <name> --confirm-out-of-install-root` on the
+  gateway host. The CLI is the confirmation boundary because running it
+  requires the operator's own process on the host — a boundary page code
+  cannot cross. This gate is a fail-closed default that blocks self-granting
+  and unwitting scripted callers; the load-bearing serving guarantees remain
+  the resolved-root equality binding and the sensitivity screen. Roots inside
+  the install directory need no confirmation.
+- **The flag is operator-only on the agent side too — three tiers.** First,
+  the builtin agent deny rule
+  `self-protection-dev-mode-out-of-root-confirm` refuses any agent shell
+  command carrying the flag — matched both as literal text and, via the
+  rule's argv floor, on the shell-de-escaped command, so quote-splitting the
+  token (`--confirm-out-of-install-'root'`) is denied the same as the plain
+  spelling; the `dev` subparser is built with `allow_abbrev=False`, so
+  argparse rejects abbreviated spellings (`--confirm`) that would otherwise
+  reach the flag without its literal text ever appearing. Second — because a
+  command can *synthesize* the flag at runtime (`$(printf ...)`) so that no
+  command-text scan sees it — the flag's consumption point performs a
+  runtime human-vs-agent check: a process showing evidence of agent-shell
+  confinement (the launcher-set sandbox marker, or on macOS the kernel's own
+  Seatbelt verdict) is refused with
+  `code: "dev_mode_operator_attestation_required"`. Third — because an
+  environment can be scrubbed — the grant record itself
+  (`~/.kiro/crew/apps/.dev-grants.json`) is sealed read-only inside the
+  agent OS sandbox (Seatbelt / mount namespaces, alongside the other
+  keystone ceilings), so a sandboxed process cannot mint, extend, or rewrite
+  a grant no matter how the toggle is spelled; the gateway materializes the
+  record at startup so the seal always has a target, and any grant-touching
+  toggle from a process that cannot write the record is refused up front
+  (`code: "dev_mode_grant_record_readonly"`, SEL-audited) rather than
+  half-applied — use the dashboard toggle from such a process. The
+  confirmation must come from the operator's own terminal, which none of
+  these tiers govern.
+- **Both outcomes are audited.** The unconfirmed refusal and the confirmed
+  grant each emit a security event log (SEL) entry
+  (`operation: dev_mode_out_of_install_grant`, outcome `denied`/`granted`,
+  naming the resolved root); the granted event is written only after the
+  grant record lands.
 
 **Cost model:** dev mode is off for essentially all gateways. The
 authoritative per-app state is the `installed.json` `dev` field above; to keep
@@ -817,4 +913,6 @@ UI-serving hot path decide the cache header with no per-request disk IO. This
 sentinel is a derived cache and **not** part of the App Kit contract: its path,
 name, and format are internal implementation details, may change without
 notice, and must not be read or written by app or third-party tooling — treat
-`installed.json` `dev` as the only supported source of truth.
+`installed.json` `dev` as the only supported source of truth for the flag, and
+the grant record as gateway-owned (written only through the toggle, never
+directly).

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -157,7 +157,7 @@ choice blob makes the usage line unreadable.
 | `kirocrew spawn run/list` | Manage background subagents |
 | `kirocrew app install/list/enable/disable/uninstall` | Manage App Kit apps. Uninstall preserves `apps/<name>/data/` by default. |
 | `kirocrew app uninstall NAME --purge-data` | Explicitly uninstall an app and permanently delete its app data. |
-| `kirocrew app dev <name> [--off]` | Toggle an installed app into/out of dev mode (no-store UI serving + live reload on file change). See [App Dev Mode](#app-dev-mode). |
+| `kirocrew app dev <name> [--off] [--confirm-out-of-install-root]` | Toggle an installed app into/out of dev mode (no-store UI serving + live reload on file change). See [App Dev Mode](#app-dev-mode). |
 | `kirocrew learn add/list/remove` | Manage learned corrections |
 | `kirocrew run TASK.md` | Run an autonomous task from a spec file |
 | `kirocrew token` | Print a dashboard access URL with auth token |
@@ -1242,24 +1242,47 @@ and prints uptime, sessions, messages, tool calls, subagents, crons, lessons.
 
 ## App Dev Mode
 
-`kirocrew app dev <name> [--off]` toggles an installed App Kit app into (or,
-with `--off`, out of) **dev mode**, which speeds the app-UI edit loop by serving
-UI files uncached and live-reloading the dashboard on file change. The command
-writes the flag out-of-process; the running gateway's watcher picks it up within
-one poll interval, so no gateway restart is needed. Full App Kit developer docs
-live in `docs/app-kit/api-reference.md`; the durable contract surfaces this
-feature introduces are:
+`kirocrew app dev <name> [--off] [--confirm-out-of-install-root]` toggles an
+installed App Kit app into (or, with `--off`, out of) **dev mode**, which speeds
+the app-UI edit loop by serving UI files uncached and live-reloading the
+dashboard on file change. The command writes the flag out-of-process; the
+running gateway's watcher picks it up within one poll interval, so no gateway
+restart is needed. Full App Kit developer docs live in
+`docs/app-kit/api-reference.md`; the durable contract surfaces this feature
+introduces are:
 
 - **Persisted schema — `installed.json` `dev: bool`** (default `false`): a
   per-app flag in each app's `~/.kiro/crew/apps/<name>/installed.json`. Tolerant
-  on read (absent ⇒ `false`), reversible, no migration. This field is the sole
-  authoritative source of truth for an app's dev-mode state. Builtin apps cannot
-  enter dev mode.
+  on read (absent ⇒ `false`), reversible, no migration. This field is the
+  authoritative source of truth for **watching and no-store serving**; enabling
+  also records a gateway-owned **operator grant** binding the ui root's resolved
+  path, which is what authorizes serving a ui root outside the install directory
+  (see api-reference.md). Builtin apps cannot enter dev mode.
 - **Endpoint — `POST /api/apps/{name}/dev`**, body `{"enabled": <bool>}`,
-  returns `{"name": <name>, "dev": <bool>}`. Behind standard gateway auth; emits
-  an `app_dev_mode` SEL audit event. `400` for a non-boolean body, a builtin
-  app, or an unsafe app name; `404` when the app is not installed. Equivalent to
-  the CLI toggle for in-dashboard control.
+  returns `{"name": <name>, "dev": <bool>}`. Behind standard gateway auth;
+  emits an `app_dev_mode` SEL audit event. `400` for a non-boolean body, a
+  builtin app, an unsafe app name, or a refused grant (a sensitive ui root is
+  never grantable; an out-of-install root always answers `400` over HTTP —
+  only the CLI flag, run on the gateway host, supplies the confirmation,
+  because a request-body flag from the dashboard origin is app-controllable);
+  `404` when the app is not installed. The flag is additionally operator-only
+  against agent shells through three tiers: the builtin rule
+  `self-protection-dev-mode-out-of-root-confirm` (literal text plus its argv
+  floor) refuses any agent shell command carrying it; the flag's consumption
+  point performs a runtime human-vs-agent check that refuses a process
+  showing evidence of agent-shell confinement
+  (`dev_mode_operator_attestation_required`) — closing runtime flag
+  synthesis, which no command-text scan can see; and the grant record
+  (`~/.kiro/crew/apps/.dev-grants.json`) is sealed read-only inside the agent
+  OS sandbox
+  (materialized at gateway startup so the seal always has a target), so a
+  sandboxed process cannot write a grant at all — any grant-touching toggle
+  from such a process is refused up front
+  (`dev_mode_grant_record_readonly`; use the dashboard toggle instead). Only
+  the operator's own terminal can supply the attestation — and both the
+  confirmed grant and each refusal emit a SEL event
+  (`dev_mode_out_of_install_grant` for the permission decision,
+  `dev_mode_grant_write` for the sealed-record refusal).
 - **WebSocket event — `app_reload`**, payload `{"app": <name>, "ts": <float>}`,
   broadcast when a dev-mode app's `ui/` tree changes; the dashboard reloads that
   app so edits appear immediately.

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/repository.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/repository.py
@@ -44,9 +44,10 @@ except Exception:  # pragma: no cover
     sel = None  # type: ignore[assignment]
 
 try:
-    from kiro_crew.hooks import _fd_real_path, safe_read_file_bytes_nolink
+    from kiro_crew.hooks import safe_read_file_bytes_nolink
+    from kiro_crew.pinned_fs import fd_real_path
 except Exception:  # pragma: no cover - hooks always present in prod
-    _fd_real_path = None  # type: ignore[assignment]
+    fd_real_path = None  # type: ignore[assignment]
     safe_read_file_bytes_nolink = None  # type: ignore[assignment]
 
 try:
@@ -1060,7 +1061,7 @@ def _open_verified_dir(spec_dir: Path) -> tuple[Path, int] | None:
     mutations use the same descriptor whose identity was authorized here.
     """
     real_dir = _verified_spec_dir(spec_dir)
-    if real_dir is None or not _CAN_PIN_DIR or _fd_real_path is None:
+    if real_dir is None or not _CAN_PIN_DIR or fd_real_path is None:
         return None
     try:
         dir_fd = os.open(
@@ -1070,7 +1071,7 @@ def _open_verified_dir(spec_dir: Path) -> tuple[Path, int] | None:
     except OSError:
         return None
     try:
-        opened_path = _fd_real_path(dir_fd)
+        opened_path = fd_real_path(dir_fd)
         expected = os.path.normcase(str(real_dir))
         if opened_path is None or os.path.normcase(os.path.normpath(opened_path)) != expected:
             os.close(dir_fd)
@@ -1097,7 +1098,7 @@ def _create_open_verified_dir(spec_dir: Path) -> tuple[Path, int, int] | None:
             os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
             dir_fd=parent_fd,
         )
-        opened_path = _fd_real_path(dir_fd) if _fd_real_path is not None else None
+        opened_path = fd_real_path(dir_fd) if fd_real_path is not None else None
         expected = os.path.normcase(str(spec_dir))
         if opened_path is None or os.path.normcase(os.path.normpath(opened_path)) != expected:
             os.close(dir_fd)

--- a/src/kiro_crew/apps/dev_mode.py
+++ b/src/kiro_crew/apps/dev_mode.py
@@ -52,6 +52,7 @@ from kiro_crew.apps.manager import (
 )
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.security import is_sensitive_path, path_contains_sensitive
+from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +195,54 @@ def _write_dev_grants(grants: dict[str, str]) -> None:
     atomic_write(path, json.dumps(grants, indent=2, sort_keys=True) + "\n")
 
 
+def _grant_record_unwritable() -> str | None:
+    """Reason the grant record cannot be written from THIS process, or ``None``.
+
+    The STRUCTURAL half of the operator-vs-agent runtime check (#6907): the
+    grant record is sealed read-only against agent-sandboxed processes at the
+    OS level (``sandbox._CREW_READONLY_LEAVES``), so opening it for write
+    succeeds only outside that confinement. Unlike the environment marker,
+    this cannot be evaded by scrubbing the environment or synthesizing command
+    text at runtime — the kernel answers, not the command's spelling.
+
+    The probe opens without ``O_TRUNC`` (never alters existing content) and
+    with ``O_CREAT`` (an operator's first-ever toggle creates the empty file,
+    which :func:`_read_dev_grants` already reads as "no grants").
+    """
+    path = _grants_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT, 0o600)
+        os.close(fd)
+    except OSError as exc:
+        return f"the dev-mode grant record is not writable from this process ({exc})"
+    return None
+
+
+def _operator_attestation_refusal() -> str | None:
+    """Reason this process cannot carry operator attestation, or ``None``.
+
+    The runtime human-vs-agent check for ``confirm_out_of_install_root``:
+    the flag is meaningful only when a HUMAN at a host terminal supplied it,
+    so a process showing any evidence of agent-shell confinement is refused
+    regardless of how the flag reached ``sys.argv``. Two independent tiers,
+    each unforgeable in the refusal direction:
+
+    * :func:`kiro_crew.sandbox.agent_confinement_evidence` — the launcher-set
+      marker plus (on macOS) the kernel's own Seatbelt verdict;
+    * :func:`_grant_record_unwritable` — the sealed-record write probe, which
+      holds even when the environment was scrubbed (``env -u``) or the flag
+      text was synthesized at runtime (``$(printf ...)``), because the OS
+      sandbox denies the write no matter what the command looked like.
+    """
+    from kiro_crew.sandbox import agent_confinement_evidence
+
+    evidence = agent_confinement_evidence()
+    if evidence is not None:
+        return evidence
+    return _grant_record_unwritable()
+
+
 def _scan_installed_dev_apps() -> set[str]:
     """Return the dev-app set derived authoritatively from every ``installed.json``.
 
@@ -276,6 +325,16 @@ def _reconcile_sentinel_from_installed() -> set[str]:
                 sorted(set(grants) - set(live)),
             )
             _write_dev_grants(live)
+        elif not _grants_path().exists():
+            # Materialize the (empty) record at gateway startup: the Linux
+            # sandbox launcher can only seal an EXISTING target read-only
+            # (bind-over-self + MS_RDONLY skips absent paths), so a host that
+            # never granted dev mode would otherwise leave the record
+            # creatable from inside an agent sandbox until the first operator
+            # toggle. Seatbelt denies by path pattern and does not need this,
+            # but the record's existence also keeps the operator-attestation
+            # write probe (#6907) exercising the same open() the seal governs.
+            _write_dev_grants(live)
         _set_dev_cache(installed)
     return installed
 
@@ -294,8 +353,18 @@ def _set_dev_cache(names: set[str]) -> None:
     _dev_apps_cache = set(names)
 
 
-def set_dev_mode(name: str, enabled: bool) -> dict[str, Any]:
+def set_dev_mode(
+    name: str, enabled: bool, *, confirm_out_of_install_root: bool = False
+) -> dict[str, Any]:
     """Toggle dev mode for an installed app. Returns a result dict.
+
+    ``confirm_out_of_install_root`` is the operator's explicit acknowledgement
+    for a grant whose ui root resolves OUTSIDE the app's install directory
+    (see the confirmation gate below). Only host-boundary callers (the CLI)
+    may pass it — the HTTP toggle route must not, because a request-body flag
+    from the dashboard origin is app-controllable, not operator attestation.
+    It never overrides the sensitive-path refusal, and an in-install root
+    does not need it.
 
     Blocking filesystem IO — callers on the event loop MUST offload this to a
     thread (``await asyncio.to_thread(set_dev_mode, ...)``).
@@ -323,6 +392,39 @@ def set_dev_mode(name: str, enabled: bool) -> dict[str, Any]:
         if meta is None:
             return {"error": f"app {name!r} is not installed"}
         granted_root: str | None = None
+        out_of_install_confirmed = False
+        # VALIDATE BEFORE ANY WRITE: every enable (and any disable of a granted
+        # app) mutates the grant record, and that record is sealed read-only
+        # against agent-sandboxed processes at the OS level (#6907 — see
+        # ``sandbox._CREW_READONLY_LEAVES``). Probing writability up front
+        # keeps the refusal atomic: without it, an enable would write
+        # installed.json and the sentinel and then fail at the (deliberately
+        # last) grant write, leaving dev metadata claiming a state the
+        # authorization record never granted. Dev-mode toggles from a
+        # sandboxed process go through the gateway (the dashboard toggle),
+        # which owns the record; the CLI path is for processes on the host
+        # outside agent confinement.
+        if enabled or name in _read_dev_grants():
+            unwritable = _grant_record_unwritable()
+            if unwritable is not None:
+                sel().log_api_access(
+                    caller=f"app:{name}",
+                    operation="dev_mode_grant_write",
+                    outcome="denied",
+                    source="apps",
+                    resources=str(_grants_path()),
+                    error=unwritable,
+                )
+                return {
+                    "error": (
+                        f"cannot toggle dev mode for app {name!r}: "
+                        f"{unwritable} — the grant record is operator-owned "
+                        "and sealed against agent-sandboxed processes; use "
+                        "the dashboard toggle, or run the CLI from a host "
+                        "terminal"
+                    ),
+                    "code": "dev_mode_grant_record_readonly",
+                }
         if enabled:
             # VALIDATE BEFORE ANY WRITE: a refusal must leave prior state
             # exactly as it was — an already-enabled app whose `ui` was
@@ -363,6 +465,87 @@ def set_dev_mode(name: str, enabled: bool) -> dict[str, Any]:
                             "dev-mode grant is refused"
                         )
                     }
+                # OUT-OF-INSTALL grants additionally require the operator's
+                # EXPLICIT confirmation, and only a caller on the gateway
+                # host can supply it. The toggle route carries no
+                # app-vs-operator identity — an app's UI bundle runs as a
+                # same-origin module with the dashboard's own credentials,
+                # so any request-body flag is data the app controls, never
+                # an attestation — which is why the HTTP endpoint NEVER
+                # passes this parameter and answers every out-of-install
+                # enable with the refusal below. The CLI flag
+                # (--confirm-out-of-install-root) is the one way to supply
+                # it, and it is operator-only through THREE independent
+                # tiers: running the CLI requires a process on the host
+                # (app page-code cannot cross that); an AGENT shell on
+                # the host is refused by the builtin deny rule
+                # ``self-protection-dev-mode-out-of-root-confirm`` plus its
+                # argv-structural floor (text tiers, evadable by runtime
+                # construction of the flag); and — decisive — the runtime
+                # human-vs-agent check below, whose kernel-enforced half
+                # (the sealed grant record) holds even against a command
+                # that synthesizes the flag at runtime or scrubs its own
+                # environment. Both outcomes of the decision are
+                # SEL-audited (see the emissions below). The load-bearing
+                # serving guarantees remain the resolved-root equality
+                # binding and the sensitivity screen above; this gate
+                # closes the self-grant path to them and makes the escape
+                # explicit at the call site.
+                # Validate-before-write: like the sensitivity refusal above,
+                # this must leave prior state untouched. Both the refusal and
+                # the confirmed grant are SEL-audited: the permission decision
+                # on an out-of-install root is exactly the kind of authority
+                # change the event log exists to record.
+                if not confirm_out_of_install_root:
+                    sel().log_api_access(
+                        caller=f"app:{name}",
+                        operation="dev_mode_out_of_install_grant",
+                        outcome="denied",
+                        source="apps",
+                        resources=granted_root,
+                        error="out-of-install ui root requires operator confirmation",
+                    )
+                    return {
+                        "error": (
+                            f"app {name!r} has a ui root resolving outside "
+                            f"its install directory ({granted_root}) — "
+                            "granting dev mode on it requires explicit "
+                            "operator confirmation: run `kirocrew app dev "
+                            f"{name} --confirm-out-of-install-root` on the "
+                            "gateway host"
+                        ),
+                        "code": "dev_mode_out_of_install_confirmation_required",
+                    }
+                # RUNTIME human-vs-agent check (#6907): the flag is operator
+                # ATTESTATION, so it is honoured only from a process showing
+                # no evidence of agent-shell confinement. The deny-list tiers
+                # above stop an agent SPELLING the flag; this stops an agent
+                # RUNNING it — including via runtime flag synthesis
+                # (``$(printf ...)``) and environment scrubbing, which no
+                # command-text scan can see.
+                attestation_refusal = _operator_attestation_refusal()
+                if attestation_refusal is not None:
+                    sel().log_api_access(
+                        caller=f"app:{name}",
+                        operation="dev_mode_out_of_install_grant",
+                        outcome="denied",
+                        source="apps",
+                        resources=granted_root,
+                        error=(
+                            "confirmation flag refused — not an operator "
+                            f"process: {attestation_refusal}"
+                        ),
+                    )
+                    return {
+                        "error": (
+                            f"app {name!r}: --confirm-out-of-install-root "
+                            "carries operator attestation and was refused "
+                            f"because {attestation_refusal}; run the command "
+                            "yourself from a host terminal"
+                        ),
+                        "code": "dev_mode_operator_attestation_required",
+                    }
+                out_of_install_confirmed = True
         else:
             # Revoke the AUTHORIZATION first: every write below narrows state,
             # so a crash after any prefix of them leaves the SAFER remainder
@@ -391,6 +574,17 @@ def set_dev_mode(name: str, enabled: bool) -> dict[str, Any]:
             grants = _read_dev_grants()
             grants[name] = granted_root
             _write_dev_grants(grants)
+            if out_of_install_confirmed:
+                # Audit AFTER the grant record lands, so the event asserts an
+                # authority change that actually happened (a decision-point
+                # event could record a grant a later write failure undid).
+                sel().log_api_access(
+                    caller=f"app:{name}",
+                    operation="dev_mode_out_of_install_grant",
+                    outcome="granted",
+                    source="apps",
+                    resources=granted_root,
+                )
         # Update the in-process cache immediately so a same-process POST toggle
         # takes effect on the very next UI request (no wait for a watcher tick).
         _set_dev_cache(names)
@@ -466,8 +660,9 @@ def dev_mode_granted_root(name: str) -> str | None:
     exact tree the operator approved, never whatever ``ui`` points at now.
     (The toggle endpoint itself carries no app-vs-operator identity — a
     same-origin caller reaches it too — which is why the binding, the
-    sensitive-path screen at grant time, and this equality check carry the
-    guarantee rather than the file's authorship alone.)
+    sensitive-path screen and the explicit out-of-install confirmation at
+    grant time, and this equality check carry the guarantee rather than the
+    file's authorship alone.)
 
     Blocking IO — do NOT call on the event loop; callers run it off-loop, and
     it sits on an exceptional path (an out-of-install ui root), never on

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -128,9 +128,9 @@ from kiro_crew.config.loader import (
 )
 from kiro_crew.cron import CronStoreBusy, CronStoreUnreadable
 from kiro_crew.executors import subprocess_executor
-from kiro_crew.hooks import _fd_real_path
 from kiro_crew.pinned_fs import (
     PinnedPathRefusal,
+    fd_real_path,
     is_reparse_point,
     open_in_pinned_parent,
     supports_pinned_walk,
@@ -2694,7 +2694,7 @@ def _open_ui_file(name: str, file_path: str) -> tuple[int, os.stat_result] | str
         # the POSIX hosts the tests run on) and require it to still sit under
         # the resolved root. Fail closed when it cannot be read — on this
         # branch the descriptor is the only trustworthy witness.
-        fd_real = _fd_real_path(fd)
+        fd_real = fd_real_path(fd)
         if fd_real is None:
             os.close(fd)
             return "not_found"
@@ -2846,6 +2846,17 @@ async def handle_app_dev_mode(request: web.Request) -> web.Response:
 
     Metadata-only change (installed.json); the dev-mode watcher picks it up
     within one poll interval, so no gateway restart is needed.
+
+    This route deliberately carries NO way to confirm an out-of-install ui
+    root: app UI bundles run as same-origin modules with the dashboard's own
+    credentials, so any request-body confirmation flag would be data the app
+    controls, not operator attestation — an app could self-grant serving an
+    arbitrary non-sensitive directory over the unauthenticated UI route by
+    POSTing to its own toggle. Enabling dev mode on such a root therefore
+    always answers 400 here (``code:
+    "dev_mode_out_of_install_confirmation_required"``, naming the CLI
+    command); confirmation is supplied only from the gateway host via
+    ``kirocrew app dev <name> --confirm-out-of-install-root``.
     """
     from kiro_crew.apps.dev_mode import set_dev_mode
 

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2434,10 +2434,25 @@ Examples:
     app_info = app_sub.add_parser("info", help="Show app details")
     app_info.add_argument("name", help="App name")
     app_dev = app_sub.add_parser(
-        "dev", help="Toggle dev mode (no-store UI serving + live reload on file change)"
+        "dev",
+        help="Toggle dev mode (no-store UI serving + live reload on file change)",
+        # No flag abbreviations: --confirm-out-of-install-root is the
+        # operator's out-of-install attestation and the builtin agent deny
+        # rule matches its LITERAL text, so an accepted abbreviation
+        # (`--confirm`, `--c`) would sail past the rule and let an agent
+        # shell self-supply the attestation. Only the exact flag parses.
+        allow_abbrev=False,
     )
     app_dev.add_argument("name", help="App name")
     app_dev.add_argument("--off", action="store_true", help="Turn dev mode off")
+    app_dev.add_argument(
+        "--confirm-out-of-install-root",
+        action="store_true",
+        help=(
+            "Confirm enabling dev mode on a ui root that resolves outside the "
+            "app's install directory (e.g. a ui/ symlinked to your source tree)"
+        ),
+    )
     app_init = app_sub.add_parser("init", help="Scaffold a new app")
     app_init.add_argument("name", help="App name (kebab-case)")
     app_init.add_argument("--dir", default=".", help="Output directory (default: current)")

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -799,7 +799,22 @@ def _handle_app(args: argparse.Namespace) -> None:
         from kiro_crew.apps.dev_mode import set_dev_mode
 
         enabled = not getattr(args, "off", False)
-        dev_result = set_dev_mode(args.name, enabled)
+        confirm_root = getattr(args, "confirm_out_of_install_root", False)
+        if confirm_root and not enabled:
+            # The confirmation only applies to enabling: a disable never
+            # grants. Say so rather than silently ignoring the flag — an
+            # operator who reaches for it on the wrong invocation would
+            # otherwise read the exit-0 as "confirmed".
+            print(
+                "⚠️  --confirm-out-of-install-root has no effect with --off "
+                "(disabling grants nothing)",
+                file=sys.stderr,
+            )
+        dev_result = set_dev_mode(
+            args.name,
+            enabled,
+            confirm_out_of_install_root=confirm_root,
+        )
         if "error" in dev_result:
             print(f"❌ {dev_result['error']}", file=sys.stderr)
             sys.exit(1)

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -774,7 +774,7 @@ _SCRIPT_SOURCE_MAX_BYTES = 256 * 1024
 
 # The read below traverses the O_NOFOLLOW + fd-real-path chokepoint in hooks
 # (safe_read_file_bytes_nolink), which has no Windows implementation
-# (_fd_real_path returns None there -> fail-closed on every read). Gate with an
+# (pinned_fs.fd_real_path returns None there -> fail-closed on every read). Gate with an
 # honest 501 rather than an opaque refusal, mirroring the theme-pack routes.
 _SCRIPT_SOURCE_WIN_UNSUPPORTED = os.name == "nt"
 

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -38,6 +38,12 @@ from kiro_crew.atomic_write import (
     _should_carry_xattr,
 )
 from kiro_crew.config import paths as _config_paths
+
+# Canonical home of the descriptor-path primitive (Windows fail-closed branch
+# included). The module-local alias is load-bearing: the gate helpers below
+# call it through this module's global, which the seam tests monkeypatch to
+# simulate a host where a descriptor's path cannot be read.
+from kiro_crew.pinned_fs import fd_real_path as _fd_real_path
 from kiro_crew.platform import current_context, redact_via_context
 from kiro_crew.platform.governance import (
     CU_CLASS_OBSERVE,
@@ -2180,59 +2186,6 @@ def stat_identity(raw: str) -> tuple[int, int] | None:
     except OSError:
         return None
     return (st.st_dev, st.st_ino)
-
-
-def _fd_real_path(fd: int) -> str | None:
-    """Real filesystem path of an OPEN descriptor."""
-    if os.name == "nt":
-        try:
-            import ctypes
-            import msvcrt
-
-            win_dll = getattr(ctypes, "WinDLL", None)
-            get_osfhandle = getattr(msvcrt, "get_osfhandle", None)
-            if not callable(win_dll) or not callable(get_osfhandle):
-                return None
-            kernel32 = win_dll("kernel32", use_last_error=True)
-            get_final_path = kernel32.GetFinalPathNameByHandleW
-            get_final_path.argtypes = [
-                ctypes.c_void_p,
-                ctypes.c_wchar_p,
-                ctypes.c_uint32,
-                ctypes.c_uint32,
-            ]
-            get_final_path.restype = ctypes.c_uint32
-            buffer = ctypes.create_unicode_buffer(32768)
-            length = get_final_path(
-                ctypes.c_void_p(get_osfhandle(fd)),
-                buffer,
-                len(buffer),
-                0,
-            )
-            if length == 0 or length >= len(buffer):
-                return None
-            path = buffer.value
-            if path.startswith("\\\\?\\UNC\\"):
-                return "\\\\" + path[8:]
-            if path.startswith("\\\\?\\"):
-                return path[4:]
-            return path
-        except (AttributeError, ImportError, OSError, ValueError):
-            return None
-
-    try:
-        return os.readlink(f"/proc/self/fd/{fd}")  # Linux
-    except OSError:
-        pass
-    try:
-        import fcntl
-
-        if hasattr(fcntl, "F_GETPATH"):  # macOS
-            buf = fcntl.fcntl(fd, fcntl.F_GETPATH, bytes(1024))
-            return buf.split(b"\x00", 1)[0].decode()
-    except (OSError, ValueError, ImportError):
-        pass
-    return None
 
 
 def safe_read_file_bytes_nolink(

--- a/src/kiro_crew/pinned_fs.py
+++ b/src/kiro_crew/pinned_fs.py
@@ -67,6 +67,7 @@ __all__ = [
     "dir_flags",
     "drain_verified_chain",
     "fatal_skip_reporter",
+    "fd_real_path",
     "is_reparse_point",
     "is_regular_at",
     "stat_at",
@@ -348,6 +349,73 @@ def refuse_hardlink_alias(
             "refused on the open descriptor instead. Remove the extra link or use a "
             "different path."
         )
+
+
+def fd_real_path(fd: int) -> str | None:
+    """Real filesystem path of an OPEN descriptor, or ``None`` when unreadable.
+
+    The descriptor-pinned twin of ``realpath``: the name it returns is the
+    kernel's own answer for the inode already held open, so it carries no
+    symlink component left to swap -- which is what makes it usable as the
+    containment witness after an ``O_NOFOLLOW`` open (validate the path the
+    descriptor REALLY refers to, not the path it was opened by).
+
+    Platform routes: ``/proc/self/fd`` on Linux, ``fcntl.F_GETPATH`` on macOS,
+    ``GetFinalPathNameByHandleW`` on Windows. Every route FAILS CLOSED --
+    ``None``, never a fallback to the mutable pathname -- including the whole
+    Windows branch: a host where the handle's final path cannot be read gives
+    callers nothing to validate, and each caller decides whether that refusal
+    aborts (a containment check) or degrades (an advisory diagnostic).
+    """
+    if os.name == "nt":
+        try:
+            import ctypes
+            import msvcrt
+
+            win_dll = getattr(ctypes, "WinDLL", None)
+            get_osfhandle = getattr(msvcrt, "get_osfhandle", None)
+            if not callable(win_dll) or not callable(get_osfhandle):
+                return None
+            kernel32 = win_dll("kernel32", use_last_error=True)
+            get_final_path = kernel32.GetFinalPathNameByHandleW
+            get_final_path.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_wchar_p,
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+            ]
+            get_final_path.restype = ctypes.c_uint32
+            buffer = ctypes.create_unicode_buffer(32768)
+            length = get_final_path(
+                ctypes.c_void_p(get_osfhandle(fd)),
+                buffer,
+                len(buffer),
+                0,
+            )
+            if length == 0 or length >= len(buffer):
+                return None
+            path = buffer.value
+            if path.startswith("\\\\?\\UNC\\"):
+                return "\\\\" + path[8:]
+            if path.startswith("\\\\?\\"):
+                return path[4:]
+            return path
+        except (AttributeError, ImportError, OSError, ValueError):
+            return None
+
+    try:
+        return os.readlink(f"/proc/self/fd/{fd}")  # Linux
+    except OSError:
+        pass
+    try:
+        import fcntl
+
+        if hasattr(fcntl, "F_GETPATH"):  # macOS
+            buf = fcntl.fcntl(fd, fcntl.F_GETPATH, bytes(1024))
+            return buf.split(b"\x00", 1)[0].decode()
+    except (OSError, ValueError, ImportError):
+        pass
+    return None
 
 
 def is_reparse_point(path: str | Path) -> bool:

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -45,6 +45,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.paths import config_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.identity_stores import AUTH_SQLITE_DB, AUTH_SQLITE_SIDECAR_SUFFIXES
+from kiro_crew.pinned_fs import fd_real_path
 from kiro_crew.platform import current_context
 
 try:
@@ -224,6 +225,15 @@ _CREW_READONLY_LEAVES: tuple[str, ...] = (
     "computer_use.json",
     "oauth_endpoints.json",
     "aws_service_consent.json",
+    # The app dev-mode AUTHORIZATION record (operator grants binding each dev
+    # app to its resolved ui root — see apps/dev_mode.py). Sealing it makes
+    # "operator, not agent" kernel-enforced: a sandboxed process cannot mint,
+    # extend, or rewrite a grant no matter how the toggle is spelled (the
+    # deny-list's text/argv tiers can be evaded by runtime construction —
+    # ``$(printf ...)`` — but a Seatbelt/namespace write denial cannot). The
+    # gateway ensures the file exists at startup (see apply_dev_mode's
+    # reconcile) because the Linux launcher can only seal an EXISTING target.
+    "apps/.dev-grants.json",
 )
 
 #: Crew-home leaves that MUST stay read-write for a sandboxed process. Every entry is
@@ -1290,13 +1300,7 @@ def bound_agent_workspace_target(descriptor: int, workspace: str | os.PathLike[s
     """
     if not _bound_agent_workspace_matches(descriptor, workspace):
         return None
-    # Local import: hooks imports sandbox at call time, so a module-level
-    # dependency would be circular. `_fd_real_path` is private but already
-    # borrowed this way by apps/builtins/spec_builder/backend/routes.py; issue
-    # #6907 tracks promoting it to a shared home.
-    from kiro_crew.hooks import _fd_real_path
-
-    resolved = _fd_real_path(descriptor)
+    resolved = fd_real_path(descriptor)
     if resolved is None:
         raise OSError(
             errno.ENOSYS,
@@ -4909,6 +4913,35 @@ def _inside_macos_sandbox() -> bool:
     The marker supplies that half; see :func:`wrap_argv`.
     """
     return _macos_sandbox_state() is True
+
+
+def agent_confinement_evidence() -> str | None:
+    """Evidence that THIS process runs under agent-shell confinement, or ``None``.
+
+    The runtime half of the operator-attestation check used by authorization
+    gates whose input must come from a human at a host terminal and never from
+    an agent-spawned process (the app dev-mode out-of-install confirmation,
+    #6907). Returns a short human-readable reason when there is ANY evidence of
+    confinement, ``None`` when there is none.
+
+    Deny-direction only, and deliberately so: each signal is unforgeable *in
+    the direction of refusal*. A present ``KIROCREW_SANDBOX_ACTIVE`` marker in
+    a genuinely unsandboxed process only over-refuses (and proves the marker
+    was forged or leaked — see :func:`_macos_sandbox_state`); a kernel verdict
+    of "Seatbelt-confined" for a non-KiroCrew sandbox (kiro-cli's internal
+    seatbelt, an operator-wrapped process) still means "not a bare operator
+    terminal", which is the question being asked. The converse is NOT
+    guaranteed: a ``None`` does not prove a human — an agent can strip the
+    marker with ``env -u``, and Linux offers no cheap kernel verdict — which
+    is why callers pair this with a structural probe of a sealed artifact
+    (``_CREW_READONLY_LEAVES``) that the OS sandbox denies regardless of the
+    environment. Never use this function to *grant* anything.
+    """
+    if os.environ.get(_IN_SANDBOX_MARKER):
+        return f"the {_IN_SANDBOX_MARKER} marker is set (agent-sandboxed process)"
+    if _macos_sandbox_state() is True:
+        return "the kernel reports this process is Seatbelt-confined"
+    return None
 
 
 def _warn_no_isolation(mode: str) -> None:

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -1545,6 +1545,34 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
             "a kill."
         ),
     ),
+    DeniedCommandRule(
+        id="self-protection-dev-mode-out-of-root-confirm",
+        # Two tiers, because neither alone closes the class.  The regex tier
+        # matches the flag as RAW TEXT, which covers the direct CLI form and
+        # nested shell payloads (``bash -c "kirocrew app dev x --confirm-…"``)
+        # — but raw text is exactly what quote-splitting defeats:
+        # ``--confirm-out-of-install-'root'`` reaches argparse as the accepted
+        # flag while the raw command never contains the literal.  The paired
+        # argv floor (``_is_dev_mode_out_of_root_confirm``, always run by
+        # ``is_denied`` while this rule is enabled) therefore re-checks the
+        # DE-ESCAPED text and every tokenized argv frame, so enforcement
+        # evaluates what the shell actually executes.  Deliberately broad
+        # (same posture as the printenv-AWS rule): the flag is the operator's
+        # out-of-install dev-mode attestation, and an agent command that
+        # merely *mentions* it is at best editing security-sensitive surface,
+        # which a human should drive.
+        pattern=".*--confirm-out-of-install-root.*",
+        category="self-protection",
+        description=(
+            "Blocks any agent command carrying the `--confirm-out-of-install-root` flag, "
+            "the operator's explicit attestation for granting app dev mode on a UI root "
+            "outside the app's install directory. The dev-mode grant relaxes the "
+            "unauthenticated UI route's root containment, so an agent able to pass the "
+            "flag itself would convert an auto-approved shell into a self-granted serving "
+            "grant on an arbitrary host directory. The confirmation must come from the "
+            "operator's own terminal, which these rules do not govern."
+        ),
+    ),
     # ── Legacy security.py deny globs (converted to regex) ──
     # These predate the agent-config ``deniedCommands`` list and were NOT part
     # of it, so they are not in the 130 ported patterns.  They cover explicit
@@ -1775,6 +1803,7 @@ _SELF_PROTECTION_FLOOR_RULE_IDS: frozenset[str] = frozenset(
         "self-protection-update",
         "self-protection-gateway-restart",
         "self-protection-cloud",
+        "self-protection-dev-mode-out-of-root-confirm",
     }
 )
 _SELF_PROTECTION_FLOOR_BY_ID: dict[str, str] = {
@@ -1824,6 +1853,12 @@ _SELF_PROTECTION_FLOOR_NOTES: dict[str, str] = {
     "self-protection-cloud": (
         "Matched structurally on the command's argv, not by the pattern text above: "
         "shell de-escaping resolves the command to a destructive cloud operation."
+    ),
+    "self-protection-dev-mode-out-of-root-confirm": (
+        "Matched structurally on the command's argv, not by the pattern text above: "
+        "shell de-escaping resolves an argument to the operator's "
+        "`--confirm-out-of-install-root` attestation flag, which agent commands "
+        "may never carry."
     ),
 }
 
@@ -5417,6 +5452,45 @@ def _is_self_gateway_restart(text_lower: str) -> bool:
 def _is_self_cloud_destructive(text_lower: str) -> bool:
     """``kirocrew cloud <destructive>`` behind any shell dressing of interposed flags."""
     return _matches_self_subcommand(text_lower, ("cloud", _SELF_CLOUD_DESTRUCTIVE_VERBS))
+
+
+_DEV_MODE_CONFIRM_FLAG = "--confirm-out-of-install-root"
+
+
+def _is_dev_mode_out_of_root_confirm(text_lower: str) -> bool:
+    """True if the operator's out-of-install confirm flag materializes after de-escaping.
+
+    The regex tier matches the flag in RAW text, so quote-splitting inside the
+    token (``--confirm-out-of-install-'root'``) reaches argparse as the accepted
+    flag while the raw command never contains the literal.  This floor closes
+    that class two ways: the whole string with quote/backslash glue removed
+    (covers every quoting spelling in one O(n) pass), and every tokenized argv
+    frame — the same descent the other floors use — whose payload walk also
+    decodes printf/``$'…'`` escapes the glue-strip cannot see.
+
+    Unlike the subcommand floors this predicate keys on the FLAG token, not on
+    the product CLI being the argv program: the rule is deliberately broad (see
+    its catalog comment), so a mention inside any command is a deny.  It matches
+    the flag only as a token PREFIX boundary — ``--confirm-out-of-install-root``
+    itself or with an attached ``=…``/wrapper — never as a substring of prose,
+    because the leading ``--`` and full spelling make accidental prose hits
+    implausible and the regex tier already denies them anyway.
+    """
+    # Cheap necessary condition: the flag cannot materialize from text that,
+    # after glue removal, carries neither of its distinctive words unless an
+    # escape encoding (backslash / ANSI-C quoting) could synthesize them.
+    stripped = _SELF_FLOOR_QUOTE_JUNK_RE.sub("", text_lower)
+    if _DEV_MODE_CONFIRM_FLAG in stripped:
+        return True
+    if "confirm" not in stripped and "install" not in stripped and "\\" not in text_lower:
+        return False
+    for tokens in _self_token_frames(text_lower):
+        for token in tokens:
+            if _DEV_MODE_CONFIRM_FLAG in _SELF_FLOOR_QUOTE_JUNK_RE.sub(
+                "", _normalize_operand(token)
+            ):
+                return True
+    return False
 
 
 def _is_git_publish(text_lower: str) -> bool:
@@ -13533,6 +13607,7 @@ def is_denied(
         ("self-protection-update", _is_self_update),
         ("self-protection-gateway-restart", _is_self_gateway_restart),
         ("self-protection-cloud", _is_self_cloud_destructive),
+        ("self-protection-dev-mode-out-of-root-confirm", _is_dev_mode_out_of_root_confirm),
     ):
         pattern = _SELF_PROTECTION_FLOOR_BY_ID.get(rule_id)
         if pattern is None or pattern not in floor_enabled:

--- a/test/fixtures/denied_commands_golden.json
+++ b/test/fixtures/denied_commands_golden.json
@@ -399,7 +399,7 @@
     "id": "iac-teardown-cdk-destroy",
     "pattern": "cdk destroy.*",
     "category": "iac-teardown",
-    "description": "Blocks `cdk destroy`, which tears down an entire AWS CDK stack and all its provisioned cloud resources — irreversible infrastructure and data loss."
+    "description": "Blocks `cdk destroy`, which tears down an entire AWS CDK stack and all its provisioned cloud resources \u2014 irreversible infrastructure and data loss."
   },
   {
     "id": "local-destructive-chmod-777",
@@ -579,7 +579,7 @@
     "id": "iac-teardown-kubectl-delete-namespace",
     "pattern": "kubectl delete namespace.*",
     "category": "iac-teardown",
-    "description": "Blocks `kubectl delete namespace`, which deletes a Kubernetes namespace and cascades to every workload, service, and volume inside it — irreversible cluster-wide teardown."
+    "description": "Blocks `kubectl delete namespace`, which deletes a Kubernetes namespace and cascades to every workload, service, and volume inside it \u2014 irreversible cluster-wide teardown."
   },
   {
     "id": "local-destructive-mkfs",
@@ -603,7 +603,7 @@
     "id": "iac-teardown-pulumi-destroy",
     "pattern": "pulumi destroy.*",
     "category": "iac-teardown",
-    "description": "Blocks `pulumi destroy`, which deletes all cloud resources managed by a Pulumi stack — irreversible infrastructure teardown."
+    "description": "Blocks `pulumi destroy`, which deletes all cloud resources managed by a Pulumi stack \u2014 irreversible infrastructure teardown."
   },
   {
     "id": "local-destructive-rm-rf-root",
@@ -621,7 +621,7 @@
     "id": "iac-teardown-terraform-destroy",
     "pattern": "terraform destroy.*",
     "category": "iac-teardown",
-    "description": "Blocks `terraform destroy`, which destroys every resource tracked in the Terraform state — irreversible infrastructure and data loss."
+    "description": "Blocks `terraform destroy`, which destroys every resource tracked in the Terraform state \u2014 irreversible infrastructure and data loss."
   },
   {
     "id": "sql-truncate-table",
@@ -832,6 +832,12 @@
     "pattern": ".*kiro.?crew\\b(?:(?!&&)[^;|])*?\\bcron\\b(?:(?!&&)[^;|])*?\\badopt\\b.*",
     "category": "self-protection",
     "description": "Blocks 'kirocrew cron adopt' so the agent cannot assign itself ownership of a scheduled job. A cron's owning session both manages the job and receives its output, and the MCP cron tools deliberately cannot write that field -- without this rule a session could reach the same power through bash and claim a job that belongs to another session. The gaps between the words tolerate anything that is not a command separator, rather than enumerating what may sit there: the CLI accepts '-v'/'--verbose' and '--no-jail' before a subcommand, a shell redirection is legal anywhere in a simple command, and $IFS is a word separator too, so an allow-list of interlopers would need extending on each new spelling. A single '&' is allowed through because '2>&1' is a redirection, while '&&' still ends the match: the three words have to belong to ONE simple command."
+  },
+  {
+    "id": "self-protection-dev-mode-out-of-root-confirm",
+    "pattern": ".*--confirm-out-of-install-root.*",
+    "category": "self-protection",
+    "description": "Blocks any agent command carrying the `--confirm-out-of-install-root` flag, the operator's explicit attestation for granting app dev mode on a UI root outside the app's install directory. The dev-mode grant relaxes the unauthenticated UI route's root containment, so an agent able to pass the flag itself would convert an auto-approved shell into a self-granted serving grant on an arbitrary host directory. The confirmation must come from the operator's own terminal, which these rules do not govern."
   },
   {
     "id": "legacy-get-secret",

--- a/test/test_app_dev_mode.py
+++ b/test/test_app_dev_mode.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 
 import pytest
@@ -65,6 +66,15 @@ def _setup_env(tmp_path, monkeypatch):
     kiro_agents.mkdir()
     import kiro_crew.apps.bridges as bridges_mod
     monkeypatch.setattr(bridges_mod, "KIRO_AGENTS_DIR", kiro_agents)
+    # Operator-process baseline for the runtime human-vs-agent check (#6907):
+    # the TEST process may itself run inside an agent sandbox (developer
+    # machines, agent-driven CI), which would otherwise make every
+    # confirmed-grant test refuse. Tests that exercise the agent-side refusal
+    # re-set the marker / re-patch the probe explicitly.
+    import kiro_crew.sandbox as sandbox_mod
+
+    monkeypatch.delenv("KIROCREW_SANDBOX_ACTIVE", raising=False)
+    monkeypatch.setattr(sandbox_mod, "_macos_sandbox_state", lambda: None)
     return home
 
 
@@ -996,3 +1006,367 @@ def test_enable_refuses_a_root_CONTAINING_sensitive_leaves(tmp_path, monkeypatch
     assert "error" in result and "sensitive location" in result["error"]
     assert dev_mode._read_dev_grants() == {}
     assert is_dev_mode("dev-mode-app") is False
+
+
+# ---------------------------------------------------------------------------
+# Out-of-install grants require explicit operator confirmation
+# ---------------------------------------------------------------------------
+
+
+def _repoint_ui_outside(tmp_path, dirname="external-src"):
+    """Replace the installed ui/ with a link to a benign out-of-install tree."""
+    import shutil
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    app_ui = dev_mode.apps_dir() / "dev-mode-app" / "ui"
+    shutil.rmtree(app_ui)
+    outside = tmp_path / dirname
+    outside.mkdir()
+    (outside / "index.mjs").write_text("export default () => null\n")
+    make_dir_link(app_ui, outside)
+    return outside
+
+
+def test_enable_out_of_install_root_requires_confirmation(tmp_path, monkeypatch):
+    """The remaining self-grant surface, closed.
+
+    An out-of-install (non-sensitive) root used to be granted unaided. Now the
+    toggle fails closed without the explicit host-boundary confirmation — the
+    refusal names the CLI command — and, like every validate-before-write
+    refusal, leaves no state behind. With the confirmation it binds the grant
+    to the escaped root as before.
+    """
+    import os
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    outside = _repoint_ui_outside(tmp_path)
+
+    result = set_dev_mode("dev-mode-app", True)
+
+    assert "error" in result and "operator confirmation" in result["error"]
+    assert "--confirm-out-of-install-root" in result["error"]
+    assert result["code"] == "dev_mode_out_of_install_confirmation_required"
+    assert dev_mode._read_dev_grants() == {}
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode("dev-mode-app") is False
+
+    confirmed = set_dev_mode("dev-mode-app", True, confirm_out_of_install_root=True)
+
+    assert confirmed == {"name": "dev-mode-app", "dev": True}
+    assert dev_mode._read_dev_grants() == {
+        "dev-mode-app": os.path.realpath(outside)
+    }
+    assert dev_mode.dev_mode_granted_root("dev-mode-app") == os.path.realpath(outside)
+
+
+def test_out_of_install_confirmation_decisions_are_SEL_audited(tmp_path, monkeypatch):
+    """Both outcomes of the out-of-install permission decision hit the SEL.
+
+    The grant relaxes the unauthenticated UI route's root containment, so the
+    decision is an authority change the security event log must record: the
+    unconfirmed refusal emits a denial, and a confirmed enable emits a granted
+    event only AFTER the grant record is written (the event asserts a change
+    that actually happened). An in-install enable emits nothing — no authority
+    beyond the normal dev-mode shape changed.
+    """
+    from types import SimpleNamespace
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+
+    sel_events: list = []
+    monkeypatch.setattr(
+        dev_mode,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kw: sel_events.append(kw)),
+    )
+
+    # In-install enable: no permission decision, no event.
+    assert set_dev_mode("dev-mode-app", True) == {"name": "dev-mode-app", "dev": True}
+    assert sel_events == []
+    set_dev_mode("dev-mode-app", False)
+    sel_events.clear()
+
+    outside = _repoint_ui_outside(tmp_path)
+
+    refused = set_dev_mode("dev-mode-app", True)
+    assert refused["code"] == "dev_mode_out_of_install_confirmation_required"
+    assert len(sel_events) == 1
+    denial = sel_events[0]
+    assert denial["operation"] == "dev_mode_out_of_install_grant"
+    assert denial["outcome"] == "denied"
+    assert denial["caller"] == "app:dev-mode-app"
+    import os
+
+    assert denial["resources"] == os.path.realpath(outside)
+
+    sel_events.clear()
+    confirmed = set_dev_mode("dev-mode-app", True, confirm_out_of_install_root=True)
+    assert confirmed == {"name": "dev-mode-app", "dev": True}
+    assert len(sel_events) == 1
+    grant = sel_events[0]
+    assert grant["operation"] == "dev_mode_out_of_install_grant"
+    assert grant["outcome"] == "granted"
+    assert grant["resources"] == os.path.realpath(outside)
+    # The event fired only after the grant record actually landed.
+    assert dev_mode._read_dev_grants() == {"dev-mode-app": os.path.realpath(outside)}
+
+
+def test_confirmation_cannot_override_the_sensitivity_screen(tmp_path, monkeypatch):
+    """The two gates are ordered: sensitivity is a hard refusal, confirmation
+    only answers the benign-escape case. An operator who confirms a sensitive
+    root is still refused — no dev workflow legitimately serves credential
+    stores over the unauthenticated UI route."""
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    _repoint_ui_outside(tmp_path, dirname="credential-store")
+    monkeypatch.setattr(dev_mode, "is_sensitive_path", lambda p: True)
+
+    result = set_dev_mode("dev-mode-app", True, confirm_out_of_install_root=True)
+
+    assert "error" in result and "sensitive location" in result["error"]
+    assert "confirmationRequired" not in result
+    assert dev_mode._read_dev_grants() == {}
+
+
+def test_an_unconfirmed_refusal_preserves_prior_dev_state(tmp_path, monkeypatch):
+    """Validate-before-write holds for the confirmation refusal too: an app
+    already in dev mode on its in-install root keeps its metadata, sentinel
+    entry, and OLD grant when an unconfirmed re-toggle over a repointed root
+    is refused."""
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    set_dev_mode("dev-mode-app", True)
+    prior_grants = dev_mode._read_dev_grants()
+    assert set(prior_grants) == {"dev-mode-app"}
+
+    _repoint_ui_outside(tmp_path)
+
+    result = set_dev_mode("dev-mode-app", True)
+
+    assert result.get("code") == "dev_mode_out_of_install_confirmation_required"
+    assert is_dev_mode("dev-mode-app") is True, "metadata dev flag preserved"
+    assert _read_dev_sentinel() == {"dev-mode-app"}, "watching preserved"
+    assert dev_mode._read_dev_grants() == prior_grants, "old grant untouched"
+
+
+@pytest.mark.asyncio
+async def test_dev_endpoint_never_confirms_out_of_install_roots(tmp_path, monkeypatch):
+    """The HTTP route is not a confirmation surface — pinned as a contract.
+
+    App UI bundles run as same-origin modules with the dashboard's own
+    credentials, so a request-body flag is app-controllable data, never
+    operator attestation. Enabling dev mode on an out-of-install root over
+    HTTP must answer 400 whether or not the caller supplies a
+    ``confirmOutOfInstallRoot`` flag — an app POSTing to its own toggle can
+    never mint the grant. (Confirmation is CLI-only: the host process
+    boundary is what proves the operator.)
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    _repoint_ui_outside(tmp_path)
+
+    async with TestClient(TestServer(_make_web_app())) as client:
+        resp = await client.post("/api/apps/dev-mode-app/dev", json={"enabled": True})
+        assert resp.status == 400
+        body = await resp.json()
+        assert body["code"] == "dev_mode_out_of_install_confirmation_required"
+        assert "--confirm-out-of-install-root" in body["error"]
+
+        # The self-grant vector: a same-origin caller supplying the flag
+        # itself. It must be inert — still 400, still no grant.
+        resp = await client.post(
+            "/api/apps/dev-mode-app/dev",
+            json={"enabled": True, "confirmOutOfInstallRoot": True},
+        )
+        assert resp.status == 400
+        assert (await resp.json())[
+            "code"
+        ] == "dev_mode_out_of_install_confirmation_required"
+        assert dev_mode._read_dev_grants() == {}
+        assert dev_mode.dev_mode_granted_root("dev-mode-app") is None
+
+
+# ---------------------------------------------------------------------------
+# Runtime human-vs-agent check on the confirmation flag (#6907)
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_flag_refused_from_agent_sandboxed_process(tmp_path, monkeypatch):
+    """The confirmation flag is operator ATTESTATION, refused at runtime from
+    a process carrying the agent-sandbox marker.
+
+    The deny-list tiers stop an agent SPELLING the flag; this check stops an
+    agent RUNNING it — the escalation the text tiers cannot close (a command
+    can synthesize the flag at runtime, ``$(printf ...)``, so no command-text
+    scan sees it). Like every validate-before-write refusal it leaves no
+    state behind, and the denial is SEL-audited naming the evidence.
+    """
+    from types import SimpleNamespace
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    outside = _repoint_ui_outside(tmp_path)
+
+    sel_events: list = []
+    monkeypatch.setattr(
+        dev_mode,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kw: sel_events.append(kw)),
+    )
+    monkeypatch.setenv("KIROCREW_SANDBOX_ACTIVE", "1")
+
+    result = set_dev_mode("dev-mode-app", True, confirm_out_of_install_root=True)
+
+    assert result.get("code") == "dev_mode_operator_attestation_required"
+    assert "operator attestation" in result["error"]
+    assert dev_mode._read_dev_grants() == {}
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode("dev-mode-app") is False
+    assert len(sel_events) == 1
+    denial = sel_events[0]
+    assert denial["operation"] == "dev_mode_out_of_install_grant"
+    assert denial["outcome"] == "denied"
+    assert "not an operator process" in denial["error"]
+    import os
+
+    assert denial["resources"] == os.path.realpath(outside)
+
+
+def test_confirm_flag_refused_when_kernel_reports_confinement(tmp_path, monkeypatch):
+    """The kernel's own sandbox verdict refuses the flag even with a scrubbed
+    environment — ``env -u KIROCREW_SANDBOX_ACTIVE`` does not launder an
+    agent shell into an operator terminal."""
+    import kiro_crew.apps.dev_mode as dev_mode
+    import kiro_crew.sandbox as sandbox_mod
+
+    _setup_env(tmp_path, monkeypatch)  # marker scrubbed by the baseline
+    install_app(str(_make_app_source(tmp_path)))
+    _repoint_ui_outside(tmp_path)
+    monkeypatch.setattr(sandbox_mod, "_macos_sandbox_state", lambda: True)
+
+    result = set_dev_mode("dev-mode-app", True, confirm_out_of_install_root=True)
+
+    assert result.get("code") == "dev_mode_operator_attestation_required"
+    assert "Seatbelt" in result["error"]
+    assert dev_mode._read_dev_grants() == {}
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or os.geteuid() == 0,
+    reason="write-denial probe needs a non-root POSIX process",
+)
+def test_confirm_flag_refused_when_grant_record_sealed(tmp_path, monkeypatch):
+    """The structural tier: a write-denied grant record refuses the flag even
+    when every environment signal was stripped.
+
+    In production the denial comes from the OS sandbox — the record is in
+    ``sandbox._CREW_READONLY_LEAVES``, so Seatbelt/namespace confinement
+    denies the open regardless of what the command looked like or what its
+    environment says. Simulated here with a permission-sealed file, which
+    exercises the identical ``open(O_WRONLY)`` failure path.
+    """
+    import os
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    _repoint_ui_outside(tmp_path)
+
+    dev_mode._write_dev_grants({})
+    os.chmod(dev_mode._grants_path(), 0o444)
+    try:
+        result = set_dev_mode("dev-mode-app", True, confirm_out_of_install_root=True)
+    finally:
+        os.chmod(dev_mode._grants_path(), 0o600)
+
+    # The upfront writability guard fires first (same structural signal): the
+    # refusal is clean either way — no grant, no sentinel, no metadata.
+    assert result.get("code") in (
+        "dev_mode_operator_attestation_required",
+        "dev_mode_grant_record_readonly",
+    )
+    assert dev_mode._read_dev_grants() == {}
+    assert _read_dev_sentinel() == set()
+    assert is_dev_mode("dev-mode-app") is False
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or os.geteuid() == 0,
+    reason="write-denial probe needs a non-root POSIX process",
+)
+def test_sealed_grant_record_refuses_every_toggle_atomically(tmp_path, monkeypatch):
+    """Validate-before-write for the seal itself: when the grant record is
+    not writable, ANY grant-touching toggle (an ordinary in-install enable
+    included) is refused up front — never half-applied.
+
+    Without the upfront probe, an enable would write ``installed.json`` and
+    the sentinel and then fail at the (deliberately last) grant write,
+    leaving dev metadata asserting a state the authorization record never
+    granted. The refusal is SEL-audited.
+    """
+    import os
+    from types import SimpleNamespace
+
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+
+    sel_events: list = []
+    monkeypatch.setattr(
+        dev_mode,
+        "sel",
+        lambda: SimpleNamespace(log_api_access=lambda **kw: sel_events.append(kw)),
+    )
+
+    dev_mode._write_dev_grants({})
+    os.chmod(dev_mode._grants_path(), 0o444)
+    try:
+        result = set_dev_mode("dev-mode-app", True)
+    finally:
+        os.chmod(dev_mode._grants_path(), 0o600)
+
+    assert result.get("code") == "dev_mode_grant_record_readonly"
+    assert "operator-owned" in result["error"]
+    assert is_dev_mode("dev-mode-app") is False, "metadata untouched"
+    assert _read_dev_sentinel() == set(), "sentinel untouched"
+    assert dev_mode._read_dev_grants() == {}
+    assert len(sel_events) == 1
+    assert sel_events[0]["operation"] == "dev_mode_grant_write"
+    assert sel_events[0]["outcome"] == "denied"
+
+
+def test_reconcile_materializes_the_grant_record(tmp_path, monkeypatch):
+    """Gateway startup creates the (empty) grant record when absent.
+
+    The Linux sandbox launcher can only seal an EXISTING target read-only
+    (bind-over-self skips absent paths), so a host that never granted dev
+    mode must not leave the record creatable from inside an agent sandbox.
+    An empty record reads as "no grants".
+    """
+    import kiro_crew.apps.dev_mode as dev_mode
+
+    _setup_env(tmp_path, monkeypatch)
+    install_app(str(_make_app_source(tmp_path)))
+    assert not dev_mode._grants_path().exists()
+
+    _reconcile_sentinel_from_installed()
+
+    assert dev_mode._grants_path().exists()
+    assert dev_mode._read_dev_grants() == {}

--- a/test/test_app_ui_file_route.py
+++ b/test/test_app_ui_file_route.py
@@ -336,7 +336,7 @@ async def test_the_windows_branch_validates_the_OPENED_descriptor_path(
     monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
     monkeypatch.setattr(app_routes, "supports_pinned_walk", lambda: False)
     monkeypatch.setattr(
-        app_routes, "_fd_real_path", lambda fd: str(tmp_path / "elsewhere" / "app.js")
+        app_routes, "fd_real_path", lambda fd: str(tmp_path / "elsewhere" / "app.js")
     )
     status, body = await _get(f"/apps/{APP}/ui/app.js")
     assert status == 404
@@ -355,7 +355,7 @@ async def test_the_windows_branch_fails_closed_when_the_fd_path_is_unreadable(
     (ui / "app.js").write_bytes(b"const x = 1\n")
     monkeypatch.setattr(app_routes, "apps_dir", lambda: root)
     monkeypatch.setattr(app_routes, "supports_pinned_walk", lambda: False)
-    monkeypatch.setattr(app_routes, "_fd_real_path", lambda fd: None)
+    monkeypatch.setattr(app_routes, "fd_real_path", lambda fd: None)
     status, _body = await _get(f"/apps/{APP}/ui/app.js")
     assert status == 404
 

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -462,8 +462,45 @@ class TestAppCli:
     def test_dev_off_restores_caching(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch("kiro_crew.apps.dev_mode.set_dev_mode", return_value={"ok": True}) as setter:
             cc._handle_app(_ns(app_action="dev", name="demo", off=True))
-        setter.assert_called_once_with("demo", False)
+        setter.assert_called_once_with("demo", False, confirm_out_of_install_root=False)
         assert "dev mode off" in capsys.readouterr().out
+
+    def test_dev_confirmation_refusal_reaches_stderr(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The refusal's own text (which names the CLI flag) is printed as-is."""
+        refusal = {
+            "error": "needs confirmation: run `kirocrew app dev demo --confirm-out-of-install-root`",
+            "code": "dev_mode_out_of_install_confirmation_required",
+        }
+        with (
+            patch("kiro_crew.apps.dev_mode.set_dev_mode", return_value=refusal) as setter,
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_app(
+                _ns(app_action="dev", name="demo", off=False, confirm_out_of_install_root=False)
+            )
+        assert exc.value.code == 1
+        assert "--confirm-out-of-install-root" in capsys.readouterr().err
+        setter.assert_called_once_with("demo", True, confirm_out_of_install_root=False)
+
+    def test_dev_confirm_flag_is_forwarded(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.apps.dev_mode.set_dev_mode", return_value={"ok": True}) as setter:
+            cc._handle_app(
+                _ns(app_action="dev", name="demo", off=False, confirm_out_of_install_root=True)
+            )
+        setter.assert_called_once_with("demo", True, confirm_out_of_install_root=True)
+
+    def test_dev_confirm_flag_with_off_warns(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The flag only applies to enabling — an ignored flag must say so,
+        not exit 0 looking like a confirmed grant."""
+        with patch("kiro_crew.apps.dev_mode.set_dev_mode", return_value={"ok": True}) as setter:
+            cc._handle_app(
+                _ns(app_action="dev", name="demo", off=True, confirm_out_of_install_root=True)
+            )
+        err = capsys.readouterr().err
+        assert "no effect with --off" in err
+        setter.assert_called_once_with("demo", False, confirm_out_of_install_root=True)
 
     def test_dev_error_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
@@ -2621,3 +2658,50 @@ class TestRunEval:
             await cc._run_eval(_ns(all_scenarios=False, scenarios=None, judge=True))
         h.judge.judge_turn.assert_not_awaited()
         assert turn.assertion_results[0][1] is False
+
+
+class TestDevConfirmFlagNoAbbreviation:
+    """The dev subparser must reject flag abbreviations (#7169 review).
+
+    The builtin agent deny rule for `--confirm-out-of-install-root` matches
+    the flag's LITERAL text, but argparse's default `allow_abbrev=True` would
+    accept `--confirm` (or `--c`) as the same flag — an agent shell could then
+    supply the operator attestation in a spelling the rule never sees. The
+    `dev` subparser is built with `allow_abbrev=False`, so only the exact
+    flag parses and the substring rule stays sufficient.
+    """
+
+    def test_abbreviated_confirm_flag_is_rejected(self, capsys) -> None:
+        import sys
+        from unittest.mock import patch
+
+        for abbrev in ("--confirm", "--confirm-out-of-install-roo", "--c"):
+            argv = ["kirocrew", "app", "dev", "demo", abbrev]
+            with (
+                patch.object(sys, "argv", argv),
+                patch("kiro_crew.cli_commands._handle_app") as handler,
+            ):
+                from kiro_crew.cli import main
+
+                with pytest.raises(SystemExit) as exc:
+                    main()
+                assert exc.value.code == 2, f"{abbrev} did not exit 2"
+                handler.assert_not_called()
+            err = capsys.readouterr().err
+            assert "unrecognized arguments" in err, f"{abbrev}: {err!r}"
+
+    def test_literal_confirm_flag_still_parses(self) -> None:
+        import sys
+        from unittest.mock import patch
+
+        argv = ["kirocrew", "app", "dev", "demo", "--confirm-out-of-install-root"]
+        with (
+            patch.object(sys, "argv", argv),
+            patch("kiro_crew.cli_commands._handle_app") as handler,
+        ):
+            from kiro_crew.cli import main
+
+            main()
+            ns = handler.call_args[0][0]
+            assert ns.confirm_out_of_install_root is True
+            assert ns.off is False

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -36,10 +36,12 @@ class TestCatalog:
     def test_catalog_ids_are_unique(self):
         # 130 patterns ported byte-exact from the retired agent-config
         # deniedCommands list + 7 legacy security.py globs (secret-fetch tool
-        # names + boto3 underscore destructive forms) restored as regexes.
-        assert len(BUILTIN_DENIED_RULES) == 148
+        # names + boto3 underscore destructive forms) restored as regexes,
+        # plus later additions (e.g. the dev-mode out-of-install confirmation
+        # flag, #6907).
+        assert len(BUILTIN_DENIED_RULES) == 149
         ids = [r.id for r in BUILTIN_DENIED_RULES]
-        assert len(set(ids)) == 148
+        assert len(set(ids)) == 149
 
     def test_token_mint_is_blocked_in_both_the_cli_and_module_forms(self):
         """`kirocrew token` mints a signed dashboard token that authenticates to EVERY gateway
@@ -178,7 +180,7 @@ class TestCatalog:
     def test_patterns_match_manifest_verbatim(self):
         golden = json.loads(_GOLDEN.read_text(encoding="utf-8"))
         golden_by_id = {g["id"]: g for g in golden}
-        assert len(golden_by_id) == 148
+        assert len(golden_by_id) == 149
         for rule in BUILTIN_DENIED_RULES:
             g = golden_by_id[rule.id]
             assert rule.pattern == g["pattern"]
@@ -192,7 +194,7 @@ class TestCatalog:
 
     def test_builtin_denied_rules_accessor_returns_dicts(self):
         rules = builtin_denied_rules()
-        assert len(rules) == 148
+        assert len(rules) == 149
         first = rules[0]
         assert set(first.keys()) == {"id", "pattern", "category", "description"}
         assert isinstance(first["id"], str)
@@ -229,6 +231,12 @@ class TestSelfProtectionFlagInterposition:
         # tempered-greedy pattern, so it needs no widening/floor from this PR -- it
         # is listed here only to satisfy the category-completeness invariant.
         "self-protection-cron-adopt": "kirocrew {flags} cron adopt",
+        # Keys on the flag LITERAL itself (plain substring), so interposed
+        # flags anywhere in the command cannot separate the anchor from the
+        # token the rule matches — the flag IS the token.
+        "self-protection-dev-mode-out-of-root-confirm": (
+            "kirocrew {flags} app dev my-app --confirm-out-of-install-root"
+        ),
         # The kill rules key on the kill TARGET, not a CLI subcommand; their gap
         # is between the kill verb and the product name.
         "self-protection-kill": "pkill {flags} kirocrew",
@@ -451,25 +459,39 @@ class TestSelfProtectionFlagInterposition:
         rule joining the floor cannot silently skip all three walks. The kill
         rules key on a kill target, not a CLI subcommand, and the credential
         mint rule is outside the self-protection category -- neither has a
-        ``kirocrew ...`` template, so the derivation excludes them.
+        ``kirocrew ...`` template, so the derivation excludes them. The
+        dev-mode confirm rule's template does start with ``kirocrew``, but its
+        floor keys on the FLAG literal, not the subcommand words -- the
+        subcommand walks would quote ``app dev`` alone, which must stay
+        allowed without the flag -- so it is carved out explicitly and gets
+        its own quoting cross in
+        ``test_dev_mode_confirm_flag_denied_under_quote_splitting``.
         """
         from kiro_crew import security
 
+        flag_keyed_floor_ids = {"self-protection-dev-mode-out-of-root-confirm"}
         floor_subcommand_ids = {
             rule_id
             for rule_id in security._SELF_PROTECTION_FLOOR_RULE_IDS
             if self._TEMPLATES.get(rule_id, "").startswith("kirocrew ")
+            and rule_id not in flag_keyed_floor_ids
         }
         assert set(self._SUBCOMMANDS) == floor_subcommand_ids, (
             "every floor-listed kirocrew-subcommand rule must register its "
             "words in _SUBCOMMANDS (and every _SUBCOMMANDS entry must be "
             "floor-listed), or the shell-dressing walks silently skip it"
         )
+        # every flag-keyed carve-out must still be floor-listed -- the carve-out
+        # exempts a rule from the SUBCOMMAND walks, never from the floor itself
+        assert flag_keyed_floor_ids <= set(security._SELF_PROTECTION_FLOOR_RULE_IDS)
         # the predicate for each is wired and fires on a de-escaped argv
         assert security._is_self_restart("kirocrew -\\v restart")
         assert security._is_self_update("kirocrew \\update")
         assert security._is_self_gateway_restart("kirocrew -\\v gateway restart")
         assert security._is_self_cloud_destructive("kirocrew -\\v cloud destroy")
+        assert security._is_dev_mode_out_of_root_confirm(
+            "kirocrew app dev x --confirm-out-of-install-'root'"
+        )
 
     def test_self_protection_denied_under_interposed_redirection(self):
         """A redirection is removed from argv by the shell and can sit anywhere in
@@ -3805,6 +3827,61 @@ class TestStdinProgramTextScoping:
             f"echo {rule.pattern!r} >> notes.txt",
         ):
             assert security.is_denied(cmd) is None, f"rule fires on its own text: {cmd!r}"
+
+
+class TestDevModeConfirmFlagIsAgentInaccessible:
+    """`--confirm-out-of-install-root` must be unreachable from an agent shell.
+
+    The flag is the operator's explicit attestation for granting app dev mode
+    on a UI root OUTSIDE the app's install directory (#6907), and the grant
+    relaxes the unauthenticated UI route's root containment. Without this rule
+    an auto-approved Bash tool could pass the flag itself and convert shell
+    access into a self-granted serving grant on an arbitrary host directory —
+    the exact self-grant path the confirmation gate exists to close. Two tiers
+    enforce it: the catalog rule matches the flag's literal text (direct form,
+    nested shell payloads, quoted interpreter argv), and the paired argv floor
+    (``_is_dev_mode_out_of_root_confirm``) re-checks the DE-ESCAPED text and
+    tokenized argv, because quote-splitting inside the token
+    (``--confirm-out-of-install-'root'``) reaches argparse as the accepted
+    flag while the raw text never carries the literal.
+    """
+
+    def test_the_flag_is_denied_in_direct_and_nested_forms(self):
+        from kiro_crew import security
+
+        for cmd in (
+            "kirocrew app dev my-app --confirm-out-of-install-root",
+            'bash -c "kirocrew app dev my-app --confirm-out-of-install-root"',
+            "python3 -c \"import subprocess; subprocess.run("
+            "['kirocrew','app','dev','x','--confirm-out-of-install-root'])\"",
+        ):
+            assert security.is_denied(cmd) is not None, f"not denied: {cmd!r}"
+
+    def test_dev_mode_confirm_flag_denied_under_quote_splitting(self):
+        """Quoting splits the flag in RAW text but the shell strips it, so the
+        de-quoted argv still carries the accepted flag -- the argv floor must
+        deny every spelling the raw-text regex cannot see."""
+        from kiro_crew import security
+
+        for cmd in (
+            "kirocrew app dev my-app --confirm-out-of-install-'root'",
+            'kirocrew app dev my-app --confirm-out-of-install-"root"',
+            'kirocrew app dev my-app "--confirm-out-of-install-root"',
+            "kirocrew app dev my-app '--confirm-out-of-install-root'",
+            'kirocrew app dev my-app --confirm-out-of-install-ro""ot',
+            "kirocrew app dev my-app --confirm\\-out-of-install-root",
+            "kirocrew app dev my-app --'confirm'-out-of-install-root",
+            "bash -c \"kirocrew app dev my-app --confirm-out-of-install-'root'\"",
+        ):
+            assert security.is_denied(cmd) is not None, f"not denied: {cmd!r}"
+
+    def test_ordinary_dev_toggles_stay_allowed(self):
+        """The rule targets the attestation flag, not the dev-mode verb —
+        in-install dev-mode toggles remain an ordinary agent operation."""
+        from kiro_crew import security
+
+        assert security.is_denied("kirocrew app dev my-app") is None
+        assert security.is_denied("kirocrew app dev my-app --off") is None
 
 
 class TestSelfModuleIndexIsLinear:

--- a/test/test_pinned_staging.py
+++ b/test/test_pinned_staging.py
@@ -1917,3 +1917,48 @@ def test_the_tree_walk_capability_probe_names_a_function_that_supports_dir_fd() 
     assert os.lstat not in os.supports_dir_fd
     if pinned_fs.supports_pinned_walk():
         assert pinned_fs.supports_pinned_tree_walk() is True
+
+
+class TestFdRealPathHome:
+    """``fd_real_path`` is defined in pinned_fs and every consumer binds THAT object.
+
+    The primitive has cross-module consumers (hooks, sandbox, the app UI route,
+    spec_builder), and its containment guarantees — including the Windows
+    fail-closed branch — belong with the other descriptor-pinned mechanisms.
+    Pinning the location keeps a refactor from quietly forking the
+    implementation into a consumer module.
+    """
+
+    def test_defined_in_pinned_fs_and_exported(self):
+        assert pinned_fs.fd_real_path.__module__ == "kiro_crew.pinned_fs"
+        assert "fd_real_path" in pinned_fs.__all__
+
+    def test_every_consumer_binds_the_pinned_fs_object(self):
+        from kiro_crew import hooks, sandbox
+        from kiro_crew.apps import routes as app_routes
+        from kiro_crew.apps.builtins.spec_builder.backend import repository as spec_repository
+
+        assert hooks._fd_real_path is pinned_fs.fd_real_path
+        assert sandbox.fd_real_path is pinned_fs.fd_real_path
+        assert app_routes.fd_real_path is pinned_fs.fd_real_path
+        # spec_builder's descriptor-pinned reads live in repository.py (the
+        # handlers refactor moved them out of routes.py).
+        assert spec_repository.fd_real_path is pinned_fs.fd_real_path
+
+    def test_resolves_an_open_descriptor_to_its_real_path(self, tmp_path: Path):
+        target = tmp_path / "witness.txt"
+        target.write_text("x")
+        fd = os.open(target, os.O_RDONLY)
+        try:
+            got = pinned_fs.fd_real_path(fd)
+        finally:
+            os.close(fd)
+        assert got is not None
+        assert os.path.normcase(os.path.normpath(got)) == os.path.normcase(os.path.realpath(target))
+
+    def test_fails_closed_on_a_dead_descriptor(self):
+        # A descriptor number that cannot be open (far above any real fd
+        # table): every platform route must answer None, never a guess. A
+        # freshly-closed real fd would race reuse by another thread in the
+        # test process, so the impossible number is the deterministic probe.
+        assert pinned_fs.fd_real_path(2**30) is None

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -681,7 +681,7 @@ class TestBuildSeatbeltProfile:
             sandbox_mod, "_bound_agent_workspace_matches", lambda *_args: True
         )
         monkeypatch.setattr(
-            "kiro_crew.hooks._fd_real_path", lambda _fd: "/canonical/workspace"
+            "kiro_crew.sandbox.fd_real_path", lambda _fd: "/canonical/workspace"
         )
 
         assert (
@@ -701,7 +701,7 @@ class TestBuildSeatbeltProfile:
         monkeypatch.setattr(
             sandbox_mod, "_bound_agent_workspace_matches", lambda *_args: True
         )
-        monkeypatch.setattr("kiro_crew.hooks._fd_real_path", lambda _fd: None)
+        monkeypatch.setattr("kiro_crew.sandbox.fd_real_path", lambda _fd: None)
 
         with pytest.raises(OSError):
             sandbox_mod.bound_agent_workspace_target(41, "/mutable/workspace")

--- a/test/test_sandbox_governance_mask.py
+++ b/test/test_sandbox_governance_mask.py
@@ -91,6 +91,11 @@ class TestKeystonesAreSealedInEveryMode:
         "computer_use.json",
         "oauth_endpoints.json",
         "aws_service_consent.json",
+        # The app dev-mode authorization record (#6907): sealing it is what
+        # makes the operator-attestation flag unforgeable from an agent shell
+        # — a sandboxed process cannot mint a grant however the toggle was
+        # spelled.
+        "apps/.dev-grants.json",
     )
 
     @_POSIX_ONLY


### PR DESCRIPTION
## Problem / Motivation

Three follow-ups deferred out of PR #6854 (the #6809 app UI-route TOCTOU fix) on its Design Review advisory:

1. **A residual self-grant surface.** The dev-mode toggle carries no app-vs-operator identity, and app UI bundles execute as same-origin ES modules with the dashboard's own credentials — so an app's page code could `POST /api/apps/{name}/dev` against its own name, grant itself dev mode on a `ui` link repointed at any non-sensitive external directory, and have the **unauthenticated** `/apps/{name}/ui/*` route serve files out of it.
2. **`_fd_real_path` outgrew its home.** The descriptor-to-real-path primitive lived private in `hooks.py` with three cross-module importers (`apps/routes.py`, spec_builder, and a lazy borrow in `sandbox.py` behind a circular-import workaround comment).
3. **Stale App Kit docs.** `docs/app-kit/api-reference.md` still presented `installed.json` `dev` as the only source of truth and recommended the symlinked-`ui/` setup unconditionally — predating the operator grant record, the sensitivity screen, and the `O_NOFOLLOW` per-file-symlink behavior that #6854 shipped.

## Why it matters

The self-grant path lets a malicious or compromised app widen the unauthenticated UI route onto directories the operator never approved (the sensitivity screen and root binding narrow the damage, but "any non-sensitive readable directory" is still a real exfiltration surface). The stale docs actively recommend a setup whose failure modes (`400` on escaped roots, `404` on per-file links) they do not explain, and the duplicated-primitive drift risk grows with each new `_fd_real_path` importer.

## What changed (motivation → approach → change)

**Hardening — out-of-install grants fail closed over HTTP; confirmation is CLI-only.** The root cause is that no HTTP-reachable signal can distinguish the operator from same-origin app code: the dashboard session is shared, so a request-body confirmation field would be app-controllable data, not attestation. `set_dev_mode` therefore gains a keyword-only `confirm_out_of_install_root` that only the CLI passes (`kirocrew app dev <name> --confirm-out-of-install-root` — the host process boundary is what proves the operator). The HTTP toggle deliberately has no confirmation field and never forwards the kwarg: enabling dev mode on a ui root resolving outside the install directory always answers `400` with `code: "dev_mode_out_of_install_confirmation_required"` and an error naming the CLI command. The sensitive-root refusal stays unconditional (confirmation cannot override it), in-install grants are unaffected, and a refusal is validate-before-write (prior dev state untouched). The CLI also warns when the flag is combined with `--off` (it grants nothing there). The load-bearing serving guarantees remain the resolved-root equality binding and the toggle-time sensitivity screen — this gate closes the self-grant path to them.

**Hardening (round 2, from review) — the flag is agent-denied and the decision is SEL-audited.** Review pointed out two gaps in the CLI boundary: an agent with an auto-approved shell could pass `--confirm-out-of-install-root` itself (the host-process boundary alone does not exclude agent shells), and the permission decision left no audit trail. Both are closed: a new builtin deny rule (`self-protection-dev-mode-out-of-root-confirm`) refuses any agent command carrying the flag, enforced in two tiers: the catalog regex matches the flag's literal text (direct form, nested shell payloads, quoted interpreter argv), and a paired argv floor (`_is_dev_mode_out_of_root_confirm`, round 4 from review) re-checks the shell-de-escaped text and every tokenized argv frame, so quote-splitting inside the token (`--confirm-out-of-install-'root'`) is denied the same as the plain spelling — making the confirmation supplied only from the operator's own terminal, which the agent deny rules do not govern. The floor is pinned by `test_dev_mode_confirm_flag_denied_under_quote_splitting`. And both outcomes of the decision now emit a SEL event (`dev_mode_out_of_install_grant`, outcome `denied`/`granted`, naming the resolved root); the granted event is written only after the grant record lands, so the log asserts an authority change that actually happened. The `dev` subparser is additionally built with `allow_abbrev=False`: argparse would otherwise accept `--confirm` as an unambiguous abbreviation, a spelling the literal-text deny rule never sees — abbreviations are now rejected at parse time, pinned by `TestDevConfirmFlagNoAbbreviation`.

**Hardening (round 5, per maintainer ruling) — runtime human-vs-agent enforcement at the flag's consumption point.** Review round 5 showed the text tiers' structural limit: a command can *synthesize* the flag at runtime (`$(printf ...)`), so no command-text scan — regex or argv floor — can ever see it. After a same-span stall escalation, the maintainer ruled: check human-vs-agent at run time. Two runtime tiers now decide at `set_dev_mode`, each unforgeable in the refusal direction: (1) `sandbox.agent_confinement_evidence()` (the launcher-set sandbox marker plus, on macOS, the kernel's own `sandbox_check` Seatbelt verdict) refuses the confirmation from any agent-confined process (`dev_mode_operator_attestation_required`, SEL-audited); and (2) the authorization record itself (`apps/.dev-grants.json`) is sealed read-only inside the agent OS sandbox via `_CREW_READONLY_LEAVES` — the same keystone-ceiling mechanism protecting `denied_commands.json` — so a sandboxed process cannot mint a grant even by writing the file directly; the gateway materializes the record at startup (the Linux bind-seal needs an existing target), a structural write-probe backs the runtime check under `env -u` scrubbing, and any grant-touching toggle from a process that cannot write the record is refused atomically up front (`dev_mode_grant_record_readonly`) rather than half-applied. The r3/r4 text tiers stay as defense in depth. Documented residual: `agent.sandbox='off'` hosts have no structural boundary for any control (existing logged opt-out, out of scope).

**Refactor.** `hooks._fd_real_path` is promoted to `pinned_fs.fd_real_path` — public, exported in `__all__`, behavior byte-identical including the Windows fail-closed branch. Importers repointed: `apps/routes.py` and spec_builder import the public name; `sandbox.py` imports it top-level (its circ
ular-import workaround is gone:
 pinned_fs is stdlib-only, so the import is cycle-free). hooks.py keeps a load-bearing module-local alias for its own call sites and their test monkeypatch seams. A location-pinning test asserts the definition site and that every consumer binds the pinned_fs object.

**Docs.** The App Dev Mode sections of docs/app-kit/api-reference.md and docs/system-specs/modules/cli.md are rewritten against merged behavior, each claim verified against code on current main: the operator grant record (.dev-grants.json at the apps root, written only by the toggle, bound to the resolved ui root), the point-in-time sensitivity screen, the 400-until-re-toggle contract for repointed or pre-upgrade escaped roots (re-toggle after re-pointing to re-bind), the directory-not-file symlink rule under the O_NOFOLLOW open, and the CLI-only confirmation contract.

## Tests

- test_enable_out_of_install_root_requires_confirmation: red-before proof (an unconfirmed out-of-install enable used to succeed); pins the refusal code, the no-state-left semantics, and the confirmed-grant binding to the escaped root.
- test_dev_endpoint_never_confirms_out_of_install_roots: pins the security property itself: a POST supplying confirmOutOfInstallRoot=true still answers 400 and mints no grant.
- test_confirmation_cannot_override_the_sensitivity_screen: gate ordering (sensitive refusal wins even with confirmation).
- test_an_unconfirmed_refusal_preserves_prior_dev_state: validate-before-write holds for the new refusal.
- CLI: flag forwarding, refusal-to-stderr, and the --off + flag warning.
- TestFdRealPathHome (test_pinned_staging.py): definition-site pin, consumer identity pin, descriptor-resolution smoke, dead-descriptor fail-closed.
- Existing descriptor-validation suites (test_hooks_coverage, test_app_ui_file_route, test_sandbox_argv) pass with monkeypatch targets updated to the new bindings.
- `test_denied_commands_security.py`: the flag is denied in direct, nested-shell, and interpreter-argv forms; ordinary dev-mode toggles stay allowed; golden fixture + catalog counts updated (141 rules); the new rule registers an interposed-flag template.
- `test_app_dev_mode.py::test_out_of_install_confirmation_decisions_are_SEL_audited`: the unconfirmed refusal emits a SEL denial, a confirmed enable emits `granted` only after the grant record is written, and an in-install enable emits nothing.

## Manual verification

N/A beyond unit coverage: the toggle, route, and CLI paths are all exercised end-to-end by the aiohttp TestClient and argparse-level tests above; no UI surface changed.

## Related Issues

Closes #6907






## Pattern harvest

Rule candidate: An "operator-only" input can never be enforced by scanning what the command *says* — regex deny rules and argv-structural floors are all evadable by runtime construction (`$(printf ...)`) because the guarded text only exists at execution time. Enforce operator-only-ness at the input's **consumption point** with signals about what the process **is**: evidence of agent-shell confinement (sandbox marker + kernel verdict), and — decisive — a kernel-sealed authorization artifact (`_CREW_READONLY_LEAVES`) the confined process cannot write regardless of spelling or environment. Text tiers remain useful as early, legible refusals (defense in depth), never as the load-bearing boundary. Corollary for the seal mechanism: the Linux bind-seal only applies to an existing target, so the owning process must materialize the file at startup or the seal silently doesn't exist on fresh installs.
