### PR TITLE
fix(dashboard): sweep tranche 2 -- 18 more handlers onto the shared body guard

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1228,
+    "missing_code": 1217,
     "opaque_body": 18,
     "dynamic_status": 43
   },
@@ -144,7 +144,7 @@
       "missing_code": 20
     },
     "dashboard/handlers/taskrunner.py": {
-      "missing_code": 54
+      "missing_code": 43
     },
     "dashboard/handlers/themes.py": {
       "dynamic_status": 4,

--- a/src/kiro_crew/dashboard/chat_tags.py
+++ b/src/kiro_crew/dashboard/chat_tags.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, TypeVar
 from aiohttp import web
 
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -252,10 +253,10 @@ async def api_chat_tags(request: web.Request) -> web.Response:
 async def api_chat_tag_create(request: web.Request) -> web.Response:
     """POST /api/chat/tags — create a new tag."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     # Redact credential / exfiltration patterns from the user-supplied name
     # BEFORE truncation — truncating first can slice a credential that
     # straddles the length cut into a fragment the scanners no longer
@@ -298,10 +299,10 @@ async def api_chat_tag_update(request: web.Request) -> web.Response:
     # JSON parse + lock contention for non-existent tags).
     if not _tag_by_id(state, tid):
         return web.json_response({"error": "not found", "code": "not_found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     if "name" in body:
         new_name = str(body["name"]).strip()[:_NAME_MAX]
         if not new_name:
@@ -487,10 +488,10 @@ async def api_chat_slot_tags(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found", "code": "not_found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     raw_ids = body.get("tags")
     if not isinstance(raw_ids, list):
         return web.json_response(
@@ -623,10 +624,10 @@ def _state_lane_owner(
 async def api_chat_tag_column_create(request: web.Request) -> web.Response:
     """POST /api/chat/tag-columns — append a new sidebar column."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     async with _tags_write_lock(state):
         column = _normalize_column(state, {**body, "order": len(state._tag_boards)})
         if column is None:
@@ -678,10 +679,10 @@ async def api_chat_tag_column_update(request: web.Request) -> web.Response:
     column = next((c for c in state._tag_boards if c.get("id") == cid), None)
     if not column:
         return web.json_response({"error": "not found", "code": "not_found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     async with _tags_write_lock(state):
         # Re-check under lock (column may have been deleted concurrently).
         column = next((c for c in state._tag_boards if c.get("id") == cid), None)
@@ -765,10 +766,10 @@ async def api_chat_tag_column_delete(request: web.Request) -> web.Response:
 async def api_chat_tag_columns_reorder(request: web.Request) -> web.Response:
     """PUT /api/chat/tag-columns/order — reorder columns by id list."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     ids = body.get("ids")
     if not isinstance(ids, list):
         return web.json_response(
@@ -831,10 +832,10 @@ async def api_chat_slot_drop(request: web.Request) -> web.Response:
     slot = state._slots.get(name)
     if not slot:
         return web.json_response({"error": "not found", "code": "not_found"}, status=404)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    body, body_err = await read_bounded_json(request)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     column_id = str(body.get("column_id") or "")
     column = next((c for c in state._tag_boards if c.get("id") == column_id), None)
     if not column:

--- a/src/kiro_crew/dashboard/handlers/taskrunner.py
+++ b/src/kiro_crew/dashboard/handlers/taskrunner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from aiohttp import web
 
+from kiro_crew.dashboard.handlers._shared import read_bounded_json
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.task_planner import plan_to_yaml
@@ -135,10 +136,10 @@ async def api_taskrunner_start(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     if not state.task_runner:
         return web.json_response({"error": "task runner not available"}, status=400)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     spec_path = body.get("spec", "")
     if not spec_path:
         return web.json_response({"error": "spec path required"}, status=400)
@@ -212,10 +213,10 @@ async def api_taskrunner_cancel(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     if not state.task_runner:
         return web.json_response({"error": "task runner not available"}, status=400)
-    try:
-        body = await request.json() if request.content_length else {}
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     state.task_runner.cancel(body.get("task_id"))
     return web.json_response({"ok": True})
 
@@ -286,10 +287,10 @@ async def api_taskrunner_rename(request: web.Request) -> web.Response:
     run = state.task_runner._runs.get(task_id)
     if not run:
         return web.json_response({"error": "not found"}, status=404)
-    try:
-        data = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    data, data_err = await read_bounded_json(request)
+    if data_err is not None:
+        return data_err
+    assert data is not None  # read_bounded_json returns (dict, None) on success
     name = data.get("name", "").strip()
     if not name:
         return web.json_response({"error": "name required"}, status=400)
@@ -308,10 +309,10 @@ async def api_taskrunner_update_task(request: web.Request) -> web.Response:
         index = int(request.match_info["index"])
     except ValueError:
         return web.json_response({"error": "invalid index"}, status=400)
-    try:
-        data = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    data, data_err = await read_bounded_json(request, max_bytes=None)
+    if data_err is not None:
+        return data_err
+    assert data is not None  # read_bounded_json returns (dict, None) on success
     try:
         result = await state.task_runner.update_task(task_id, index, data)
         # SEL audit for all task field changes
@@ -344,10 +345,10 @@ async def api_taskrunner_retry(request: web.Request) -> web.Response:
     if not state.task_runner:
         return web.json_response({"error": "task runner not available"}, status=400)
     task_id = request.match_info["task_id"]
-    try:
-        body = await request.json() if request.content_length else {}
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     from_step = body.get("from_step", 1)
     try:
         await state.task_runner.retry_from_task(
@@ -519,10 +520,10 @@ async def api_taskrunner_plan(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     if not state.task_runner:
         return web.json_response({"error": "task runner not available"}, status=400)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     input_text = body.get("input", "")
     source = body.get("source", "text")
     spec_path = body.get("spec", "")
@@ -583,10 +584,10 @@ async def api_taskrunner_update_plan(request: web.Request) -> web.Response:
     if not state.task_runner:
         return web.json_response({"error": "task runner not available"}, status=400)
     task_id = request.match_info["task_id"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     steps = body.get("steps", [])
     try:
         run = await state.task_runner.update_plan(task_id, steps)
@@ -622,10 +623,10 @@ async def api_taskrunner_execute_plan(request: web.Request) -> web.Response:
     if not state.task_runner:
         return web.json_response({"error": "task runner not available"}, status=400)
     task_id = request.match_info["task_id"]
-    try:
-        body = await request.json() if request.content_length else {}
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, allow_absent=True)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     agent = body.get("agent", "")
     fresh = body.get("fresh", False)
     workspace_dir = body.get("workspace_dir", "")
@@ -658,10 +659,10 @@ async def api_taskrunner_from_chat(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     if not state.task_runner:
         return web.json_response({"error": "task runner not available"}, status=400)
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     steps = body.get("steps", [])
     task_id = body.get("task_id", "")
     if not steps or not isinstance(steps, list):
@@ -824,10 +825,10 @@ async def _run_refine(state: DashboardState, user_input: str) -> None:
 async def api_taskrunner_refine(request: web.Request) -> web.Response:
     """POST /api/taskrunner/refine — start background spec generation from user input."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     user_input = body.get("input", "").strip()
     if not user_input:
         return web.json_response({"error": "input is required"}, status=400)
@@ -872,10 +873,10 @@ async def api_taskrunner_refine_cancel(request: web.Request) -> web.Response:
 async def api_taskrunner_refine_answer(request: web.Request) -> web.Response:
     """POST /api/taskrunner/refine/answer — answer a clarifying question."""
     state: DashboardState = request.app["state"]
-    try:
-        body = await request.json()
-    except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+    body, body_err = await read_bounded_json(request, max_bytes=None)
+    if body_err is not None:
+        return body_err
+    assert body is not None  # read_bounded_json returns (dict, None) on success
     answer = body.get("answer", "").strip()
     if not answer:
         return web.json_response({"error": "answer required"}, status=400)

--- a/test/test_auto_approve.py
+++ b/test/test_auto_approve.py
@@ -103,6 +103,34 @@ def _plain_provider(text: str = "done"):
 # ══════════════════════════════════════════════════════════════════════
 
 
+class _Payload:
+    """Minimal stand-in for the request body stream.
+
+    ``api_taskrunner_start`` and ``api_taskrunner_execute_plan`` read their body
+    through ``_shared.read_bounded_json`` with the shared 64 KB cap, which
+    enforces the ceiling BEFORE decoding by draining ``request.content`` -- so a
+    mocked ``request.json`` alone no longer feeds them.
+    """
+
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    async def iter_chunked(self, n: int):
+        for i in range(0, len(self._raw), n):
+            yield self._raw[i : i + n]
+
+    async def read(self) -> bytes:
+        return self._raw
+
+    def set_read_chunk_size(self, size: int) -> None:
+        return None
+
+    def at_eof(self) -> bool:
+        # ``request.can_read_body`` is ``not payload.at_eof()``, and the
+        # allow_absent handlers branch on it.
+        return not self._raw
+
+
 class TestAutoApproveDefault:
     def test_project_auto_approve_defaults_false(self) -> None:
         run = Project(spec_path="s.md", spec_content="s")
@@ -456,15 +484,17 @@ class TestAutoApproveProvenanceGating:
         runner.start_background = MagicMock(return_value="tid")
         app = web.Application()
         app["state"] = SimpleNamespace(task_runner=runner)
-        req = make_mocked_request("POST", "/api/taskrunner", app=app)
-        req["app"] = request_app  # set by token_auth_middleware; "" == dashboard itself
-        req.json = AsyncMock(
-            return_value={
-                "spec": "__inline__:# t\n## Steps\n1. do",
-                "source": source,
-                "auto_approve": auto_approve,
-            }
+        start_body = {
+            "spec": "__inline__:# t\n## Steps\n1. do",
+            "source": source,
+            "auto_approve": auto_approve,
+        }
+        req = make_mocked_request(
+            "POST", "/api/taskrunner", app=app,
+            payload=_Payload(json.dumps(start_body).encode()),
         )
+        req["app"] = request_app  # set by token_auth_middleware; "" == dashboard itself
+        req.json = AsyncMock(return_value=start_body)
         await api_taskrunner_start(req)
         return runner.start_background.call_args.kwargs["auto_approve"]
 
@@ -490,12 +520,14 @@ class TestAutoApproveProvenanceGating:
         runner.execute_plan = AsyncMock(return_value=None)
         app = web.Application()
         app["state"] = SimpleNamespace(task_runner=runner)
+        exec_body = {"auto_approve": auto_approve}
+        raw = json.dumps(exec_body).encode()
         req = make_mocked_request(
             "POST", "/api/taskrunner/t1/execute", app=app, match_info={"task_id": "t1"},
-            headers={"Content-Length": "32"},
+            headers={"Content-Length": str(len(raw))}, payload=_Payload(raw),
         )
         req["app"] = request_app
-        req.json = AsyncMock(return_value={"auto_approve": auto_approve})
+        req.json = AsyncMock(return_value=exec_body)
         await api_taskrunner_execute_plan(req)
         return runner.execute_plan.call_args.kwargs["auto_approve"]
 
@@ -523,9 +555,10 @@ class TestAutoApproveProvenanceGating:
         runner.execute_plan = AsyncMock(return_value=None)
         app = web.Application()
         app["state"] = SimpleNamespace(task_runner=runner)
+        raw = json.dumps({"auto_approve": True}).encode()
         req = make_mocked_request(
             "POST", "/api/taskrunner/t1/execute", app=app, match_info={"task_id": "t1"},
-            headers={"Content-Length": "32"},
+            headers={"Content-Length": str(len(raw))}, payload=_Payload(raw),
         )
         req["app"] = ""  # dashboard context → requested trust is honored, so the gate audits
         req.json = AsyncMock(return_value={"auto_approve": True})
@@ -569,7 +602,10 @@ class TestInlineSpecCleanup:
             runner.start_background = AsyncMock(return_value="tid")
         app = web.Application()
         app["state"] = SimpleNamespace(task_runner=runner)
-        req = make_mocked_request("POST", "/api/taskrunner", app=app)
+        req = make_mocked_request(
+            "POST", "/api/taskrunner", app=app,
+            payload=_Payload(json.dumps(body).encode()),
+        )
         req["app"] = ""
         req.json = AsyncMock(return_value=body)
         return await api_taskrunner_start(req), runner

--- a/test/test_chat_tags.py
+++ b/test/test_chat_tags.py
@@ -1222,3 +1222,58 @@ class TestUpdateDeleteRace:
 
             # The tag must NOT be in state (no silent ghost mutation).
             assert not any(t["id"] == tid for t in state._tags)
+
+
+class TestNonObjectBodiesAcrossConvertedHandlers:
+    """Every converted handler answers 400, never 5xx, on a non-object body.
+
+    ``[]`` / ``"s"`` / ``5`` / ``true`` / ``null`` are all VALID JSON, so
+    ``request.json()`` returned them and the ``.get()`` (or ``in``) that each
+    handler performs next raised from OUTSIDE the parse ``try`` -- a 500 for
+    what is really malformed client input (issue #5587). Driven through a real
+    client so the shared guard's 64 KB pre-decode cap is exercised on the wire,
+    which is how these endpoints now read their body; the cap decision for each
+    site is recorded in ``_CAP_REGISTER`` in ``test_json_object_body_guard.py``.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [[], "a string", 5, 1.5, True, None], ids=repr)
+    async def test_non_object_body_is_400_not_500(self, payload, tmp_path) -> None:
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            # Seed a real tag and column: the {id} routes check existence BEFORE
+            # parsing, so a made-up id would 404 and never reach the guard --
+            # the test would pass for the wrong reason.
+            created = await client.post("/api/chat/tags", json={"name": "T"})
+            assert created.status in (200, 201), await created.text()
+            tag_id = (await created.json())["id"]
+            col = await client.post("/api/chat/tag-columns", json={"name": "C"})
+            assert col.status in (200, 201), await col.text()
+            col_id = (await col.json())["id"]
+
+            routes = [
+                ("post", "/api/chat/tags"),
+                ("patch", f"/api/chat/tags/{tag_id}"),
+                ("post", "/api/chat/tag-columns"),
+                ("put", "/api/chat/tag-columns/order"),
+                ("patch", f"/api/chat/tag-columns/{col_id}"),
+            ]
+            # api_chat_slot_tags and api_chat_slot_drop are converted too, but
+            # they resolve the slot BEFORE parsing, so reaching their guard
+            # needs a live slot rather than a seeded tag. Their call sites are
+            # pinned in _CAP_REGISTER, and their guard is the same shared call.
+            for method, path in routes:
+                # ``json=None`` makes the client send NO body, which is a
+                # different fact (invalid_json) from a body containing the JSON
+                # literal ``null`` -- send that one as raw bytes.
+                if payload is None:
+                    resp = await getattr(client, method)(
+                        path,
+                        data=b"null",
+                        headers={"Content-Type": "application/json"},
+                    )
+                else:
+                    resp = await getattr(client, method)(path, json=payload)
+                assert resp.status == 400, (path, payload, resp.status)
+                assert (await resp.json())["code"] == "body_not_object", path

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -99,6 +99,38 @@ def _state(runner: MagicMock | None) -> SimpleNamespace:
     return SimpleNamespace(task_runner=runner)
 
 
+class _Payload:
+    """Minimal stand-in for the request body stream.
+
+    Five of this module's handlers now read their body through
+    ``_shared.read_bounded_json`` with the shared 64 KB cap, which enforces the
+    ceiling BEFORE decoding by draining ``request.content`` incrementally --
+    so a mocked ``request.json`` alone no longer feeds them. Supplying a real
+    payload serves both paths: the capped handlers drain this stream, and the
+    uncapped ones still go through ``request.json()``.
+    """
+
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    async def iter_chunked(self, n: int):
+        for i in range(0, len(self._raw), n):
+            yield self._raw[i : i + n]
+
+    async def read(self) -> bytes:
+        return self._raw
+
+    def set_read_chunk_size(self, size: int) -> None:
+        # ``request.read()`` configures the stream before draining it.
+        return None
+
+    def at_eof(self) -> bool:
+        # ``request.can_read_body`` is ``not payload.at_eof()``, and the
+        # allow_absent handlers branch on it: reporting EOF while bytes are
+        # waiting would make every request look bodyless and silently default.
+        return not self._raw
+
+
 def _request(
     state: Any,
     method: str = "POST",
@@ -109,15 +141,33 @@ def _request(
     raw_json_error: bool = False,
     request_app: str = "",
     with_content_length: bool = True,
+    body_present: bool = False,
 ) -> web.Request:
     app = web.Application()
     app["state"] = state
-    headers = {"Content-Length": "32"} if (json_body is not None and with_content_length) else {}
-    req = make_mocked_request(method, path, app=app, match_info=match_info or {}, headers=headers)
+    if raw_json_error:
+        raw = b"{bad json"
+    elif json_body is not None or body_present:
+        # ``body_present`` distinguishes a body whose CONTENT is the JSON
+        # literal ``null`` from no body at all -- the allow_absent handlers
+        # branch on that difference, and conflating them hides a non-object
+        # body behind a silent default.
+        raw = json.dumps(json_body).encode()
+    else:
+        raw = b""
+    headers = {"Content-Length": str(len(raw))} if (raw and with_content_length) else {}
+    req = make_mocked_request(
+        method,
+        path,
+        app=app,
+        match_info=match_info or {},
+        headers=headers,
+        payload=_Payload(raw),
+    )
     req["app"] = request_app
     if raw_json_error:
         req.json = AsyncMock(side_effect=ValueError("bad json"))  # type: ignore[method-assign]
-    elif json_body is not None:
+    elif json_body is not None or body_present:
         req.json = AsyncMock(return_value=json_body)  # type: ignore[method-assign]
     return req
 
@@ -1353,3 +1403,45 @@ class TestRunRefine:
         state.sessions = sessions
         await _run_refine(state, "x")
         assert state._refine_status == "cancelled"
+
+
+class TestNonObjectBodiesAcrossConvertedHandlers:
+    """Every converted handler answers 400, never 5xx, on a non-object body.
+
+    ``[]`` / ``"s"`` / ``5`` / ``true`` / ``null`` are all VALID JSON, so
+    ``request.json()`` returned them and the ``.get()`` each handler performs
+    next raised ``AttributeError`` from OUTSIDE the parse ``try`` -- a 500 for
+    what is really malformed client input (issue #5587). Enumerated rather than
+    one test per handler so a handler that loses the guard fails by
+    construction; the cap decision for each of these sites is recorded in
+    ``_CAP_REGISTER`` in ``test_json_object_body_guard.py``.
+    """
+
+    _HANDLERS = [
+        (api_taskrunner_start, {}),
+        (api_taskrunner_cancel, {}),
+        (api_taskrunner_rename, {"task_id": "t1"}),
+        (api_taskrunner_update_task, {"task_id": "t1", "index": "0"}),
+        (api_taskrunner_retry, {"task_id": "t1"}),
+        (api_taskrunner_plan, {}),
+        (api_taskrunner_update_plan, {"task_id": "t1"}),
+        (api_taskrunner_execute_plan, {"task_id": "t1"}),
+        (api_taskrunner_from_chat, {}),
+        (api_taskrunner_refine, {}),
+        (api_taskrunner_refine_answer, {}),
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [[], "a string", 5, 1.5, True, None], ids=repr)
+    @pytest.mark.parametrize(
+        "handler,match_info", _HANDLERS, ids=lambda v: getattr(v, "__name__", "")
+    )
+    async def test_non_object_body_is_400_not_500(
+        self, handler: Any, match_info: dict[str, str], payload: Any, tmp_path: Path
+    ) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(spec_path="s.md", spec_content="s", task_id="t1")
+        req = _request(_state(runner), json_body=payload, match_info=match_info, body_present=True)
+        resp = await handler(req)
+        assert resp.status == 400, f"{handler.__name__} on {payload!r}: expected 400"
+        assert _body(resp)["code"] == "body_not_object", handler.__name__

--- a/test/test_json_object_body_guard.py
+++ b/test/test_json_object_body_guard.py
@@ -141,12 +141,17 @@ _CONTROL_FIELDS_CAP_PENDING = (
 )
 _BOUNDED_BY_DEFAULT = "small fixed-shape payload on a strict-internal route"
 _BOUNDED_EXPLICIT = "explicit per-route cap, larger than the shared default"
+_BOUNDED_CONTROL_FIELDS = (
+    "body is a fixed set of control fields (an identifier, a flag, a number, a "
+    "short name), so the shared 64 KB ceiling is right and is applied"
+)
 
 _CAP_REASONS = {
     _UNBOUNDED_USER_CONTENT,
     _CONTROL_FIELDS_CAP_PENDING,
     _BOUNDED_BY_DEFAULT,
     _BOUNDED_EXPLICIT,
+    _BOUNDED_CONTROL_FIELDS,
 }
 
 #: ``module::handler`` -> (declared cap, why). Declared cap is ``"None"`` for an
@@ -213,6 +218,41 @@ _CAP_REGISTER: dict[str, tuple[str, str]] = {
         "None",
         _UNBOUNDED_USER_CONTENT,
     ),
+    # ---- tranche 2 ----
+    # taskrunner.py: the control-field endpoints TAKE the cap rather than
+    # deferring it, which is what tranche 1 could not do without rewriting its
+    # handlers' mocked-json test harness. Its own harness is updated in this PR.
+    "handlers/taskrunner.py::api_taskrunner_cancel": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/taskrunner.py::api_taskrunner_rename": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/taskrunner.py::api_taskrunner_retry": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "handlers/taskrunner.py::api_taskrunner_execute_plan": (
+        "<default>",
+        _BOUNDED_CONTROL_FIELDS,
+    ),
+    # taskrunner.py: these carry a spec, a plan, or a free-text prompt.
+    # ``start`` looks like a path field, but its documented contract is
+    # ``{"spec": "path"}`` OR ``{"spec": "__inline__:<whole spec>"}`` -- the
+    # inline form puts an entire spec in the body, so capping it would 413 a
+    # large spec that works today.
+    "handlers/taskrunner.py::api_taskrunner_start": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/taskrunner.py::api_taskrunner_update_task": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/taskrunner.py::api_taskrunner_plan": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/taskrunner.py::api_taskrunner_update_plan": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/taskrunner.py::api_taskrunner_from_chat": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/taskrunner.py::api_taskrunner_refine": ("None", _UNBOUNDED_USER_CONTENT),
+    "handlers/taskrunner.py::api_taskrunner_refine_answer": (
+        "None",
+        _UNBOUNDED_USER_CONTENT,
+    ),
+    # chat_tags.py: every payload is a tag/column identifier, a short name
+    # (already truncated at _NAME_MAX), or an id array -- all capped.
+    "chat_tags.py::api_chat_tag_create": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_tags.py::api_chat_tag_update": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_tags.py::api_chat_slot_tags": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_tags.py::api_chat_tag_column_create": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_tags.py::api_chat_tag_column_update": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_tags.py::api_chat_tag_columns_reorder": ("<default>", _BOUNDED_CONTROL_FIELDS),
+    "chat_tags.py::api_chat_slot_drop": ("<default>", _BOUNDED_CONTROL_FIELDS),
 }
 
 _DASHBOARD_DIR = Path(shared.__file__).resolve().parent.parent


### PR DESCRIPTION
## Problem / Motivation

Second tranche of the #5587 sweep, on top of #7012 which consolidated the two
body-guard helpers and converted the first 14 handlers.

`[]`, `"s"`, `5`, `true` and `null` are all valid JSON, so `await
request.json()` returns them happily -- and the `.get()` (or `in`) that a
handler performs next raises from OUTSIDE the `try` that wrapped the parse. All
18 JSON-body sites in `handlers/taskrunner.py` (11) and `chat_tags.py` (7)
answered **500** for what is really malformed client input. Reverting either file
to `main` turns all 72 new test cases red, and the `chat_tags` ones report a
literal 500 rather than a 400.

After this tranche, 48 remain across 17 files.

## Why it matters

A client that posts a top-level array to `POST /api/chat/tags` or
`POST /api/taskrunner` is told the server broke. That is wrong three ways: the
payload was the client's mistake, the response carries no `code` to switch on,
and it lands in the logs as a server fault, so the real signal -- clients sending
the wrong shape -- stays invisible.

`taskrunner`'s 11 responses also had no `code` field at all, so a client could
not distinguish them programmatically from any other 400.

## What changed (motivation -> approach -> change)

Every site moves to the shape #7012 established:

```python
body, body_err = await read_bounded_json(request, max_bytes=...)
if body_err is not None:
    return body_err
assert body is not None  # read_bounded_json returns (dict, None) on success
```

**This tranche APPLIES the byte cap rather than deferring it, which is the
substantive difference from tranche 1.** #7012 converted 23 sites to
`max_bytes=None` uniformly to stay behaviour-preserving, and recorded in
`_CAP_REGISTER` that 13 of them SHOULD take the cap. Both review lanes pushed on
that. Here the decision is made per handler:

| cap | count | which |
|---|---|---|
| shared 64 KB default | 11 | all 7 `chat_tags` handlers (a tag/column id, a short name already truncated at `_NAME_MAX`, an id array) plus `taskrunner` cancel / rename / retry / execute_plan (a task id, a name, a step number, an agent name and two flags) |
| `max_bytes=None` | 7 | `taskrunner` start / update_task / plan / update_plan / from_chat / refine / refine_answer -- these carry a task's fields, a whole spec, a plan, or a free-text prompt, none of which has a defensible maximum size. `start` reads like a path field, but its documented contract is `{"spec": "path"}` OR `{"spec": "__inline__:<whole spec>"}`, so the inline form puts an entire spec in the body -- capping it would 413 a large spec that works today (caught by Design on `ccd002179`) |

That takes the bounded read from **5 live consumers to 16**, which is the
concern Design raised on #7012 ("bounded stays an opt-in nobody exercises")
answered with production sites rather than a promise. The deferred-cap ratchet
`_CAP_PENDING_CEILING` stays at 13 because this tranche defers nothing -- and it
is what forced the choice: adding a new deferral would have failed the build.

Three `taskrunner` handlers used the `await request.json() if
request.content_length else {}` idiom for a legitimately bodyless POST; those
became `allow_absent=True`, which keeps the bodyless case working while a
present-but-malformed body now answers 400 instead of silently running defaults.

**Test-harness consequence, stated because it is the real cost of capping.**
Taking the cap moves a site off `request.json()` onto the streaming read, so
`test_handlers_taskrunner_coverage.py`'s request helper now supplies a real
payload instead of only mocking `request.json`. `chat_tags` drives real HTTP
through `TestClient` and needed nothing. Both helpers also gained an explicit
body-present flag: "no body" and "a body whose content is the JSON literal
`null`" are different facts, and the `allow_absent` handlers branch on exactly
that difference -- conflating them made a non-object body pass as a silent
default, which is how the first version of these tests passed for the wrong
reason.

## Tests

- `TestNonObjectBodiesAcrossConvertedHandlers` in
  `test_handlers_taskrunner_coverage.py`: 11 handlers x 6 non-object payloads,
  each asserted 400 `body_not_object`.
- The same class in `test_chat_tags.py`, driven through a real client so the
  pre-decode cap is exercised on the wire. It seeds a real tag and column first,
  because the `{id}` routes check existence BEFORE parsing and a made-up id
  would 404 -- the test would have passed for the wrong reason. Two converted
  handlers (`api_chat_slot_tags`, `api_chat_slot_drop`) resolve a live slot
  before parsing, so they are not in this loop; a comment says so, and their
  call sites are pinned in `_CAP_REGISTER`.
- All 18 sites registered in `_CAP_REGISTER` with a reason from the documented
  set. A new reason, `_BOUNDED_CONTROL_FIELDS`, distinguishes "capped because the
  body is control fields" from tranche 1's "should be capped, deferred". The
  register's five existing tests hold every row against an AST scan: an
  unregistered conversion fails, a declared cap that disagrees with the code
  fails, an undocumented reason fails, a stale row fails, and the deferred count
  cannot grow.

**Red on base.** Reverting both handler files to `main` turns all 72 new cases
red -- `AttributeError: 'list' object has no attribute 'get'` on the taskrunner
side, HTTP 500 on the chat_tags side. That is the reported defect reproduced
mechanically, not asserted.

307 targeted tests pass across the touched modules plus the register and the
error-code contract gate. isort, flake8, black and mypy clean on every touched
file (mypy's 2 remaining errors are pre-existing in `transcribe.py`, untouched
here). `error-code-baseline.json` regenerated: `missing_code` 1228 -> 1217,
matching the 11 `taskrunner` responses that gained a `code`.

## Manual verification

N/A -- no user-visible surface changes. The behaviour is HTTP status and response
body on malformed input, asserted directly at the handler and route boundaries,
including the bodyless-POST case that must keep working.

## Other suggestions

- 48 unshaped sites remain, the largest clusters being `chat_handlers.py` (12),
  `handlers/messaging.py` (10) and `chat_folders.py` (5).
- The four surviving dashboard guard helpers recorded on #5587 are still
  unfixed, and `hooks._json_object(default_empty=True)` is the one worth doing
  first: it collapses a malformed body to defaults at 2 of its 5 call sites,
  the same defect #7012 fixed in `api_memory_promote`.
- The return-shape decision recorded on #5587 (tuple versus raising
  `HTTPBadRequest`) is still open, and every further tranche writes 4 lines per
  site until it is settled.

Refs #5587

