### PR TITLE
fix(test): stop a leaked CLI log queue listener failing later tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1083,6 +1083,79 @@ def _restore_log_record_factory():
         logging.setLogRecordFactory(before)
 
 
+# ── the CLI log queue listener goes back after every test ────────────
+
+
+@pytest.fixture(autouse=True)
+def _restore_log_queue_listener():
+    """Stop the ``QueueListener`` a test leaves running, so no later test inherits it.
+
+    ``cli._LOG_QUEUE_LISTENER`` is ONE process-global slot, per worker, and the sibling of
+    the record factory above: ``_setup_cli_logging`` installs BOTH in the same
+    ``command in _LONG_LIVED_COMMANDS`` branch, so every test that drives the real
+    ``cli.main()`` for ``serve`` / ``gateway`` / ``chat`` leaks both. The factory half has
+    been floored since it was found; this half was not, and it is the one the SHORT-LIVED
+    branch then trips over. ``_setup_cli_logging("status", ...)`` takes the ``else`` path,
+    which correctly never touches the global -- the listener a long-lived command started
+    genuinely still exists -- so a test asserting "a short-lived verb starts no listener"
+    reads the PREVIOUS test's listener and fails at its own first line.
+
+    Measured: two tests in ``test_cli_logging.py`` assert that global is ``None`` after a
+    short-lived setup -- ``TestDrainBeforeHardExit::test_no_listener_is_a_silent_no_op``
+    and ``TestQueueOffLoop::test_short_lived_command_keeps_sync_handler`` -- and both go
+    red whenever ``test_cli.py`` or ``test_cpp_seam_failclosed.py`` precede them on the
+    worker, reading ``assert <QueueListener object ...> is None``. That file's own
+    ``_pristine_logging`` cannot absorb it: it clears the global in TEARDOWN only, which
+    makes the file self-clean but leaves it defenceless against a leak that is already
+    present at its SETUP. Under ``-n auto --dist loadgroup`` which worker an ordinary test
+    lands on varies run to run, so it surfaces as an intermittent failure rather than a
+    reproducible ordering bug -- it cost upstream PR #6798 a red ``Backend Tests (3.10, 1)``
+    shard while ``(3.12, 1)`` passed at the identical commit.
+
+    STOPPING rather than only reassigning, which is where this differs from the factory:
+    the leak is a live daemon thread holding the file handler's open descriptor on a
+    ``gateway.log`` under a ``tmp_path`` the next test deletes, so dropping the reference
+    alone would clear the assertion and keep the thread and the fd. ``cli`` is reached
+    through ``sys.modules`` rather than imported, as ``_no_leaked_telemetry_exporter``
+    does: a worker that never imported it cannot hold a listener, and importing it here
+    would charge every testpath ~0.5s and ~54MB for the ratchet in
+    ``test_cli_lazy_imports.py`` to then measure in a subprocess anyway.
+
+    Restoring rather than blaming, for the same reason as ``_restore_log_record_factory``
+    above: starting the listener is what the entry point under test is FOR, and production
+    starts it once per process and never undoes it. The damage is to OTHER tests, so
+    stopping it propagating is the whole job.
+
+    HANDLERS stay untouched, the boundary ``_restore_logger_levels`` below draws and for
+    its reasons. The ``_CliLogQueueHandler`` left on the ``kiro_crew`` logger therefore
+    outlives the listener it fed, holding an unattended queue; it is the same handler
+    accumulation that fixture already records as a separate defect, and
+    ``test_cli_logging.py``'s ``_pristine_logging`` is what absorbs it today by clearing
+    both handler lists at setup.
+
+    The restore target is what the test INHERITED, so a higher-scoped fixture that starts
+    a listener for a whole class or module is not torn out from under its second test --
+    and, as there, such a fixture has to stop its own listener, because every later test
+    then inherits it and so restores to it.
+    """
+    cli = sys.modules.get("kiro_crew.cli")
+    before = getattr(cli, "_LOG_QUEUE_LISTENER", None)
+    yield
+    cli = sys.modules.get("kiro_crew.cli")
+    if cli is None:
+        return
+    after = getattr(cli, "_LOG_QUEUE_LISTENER", None)
+    if after is before:
+        return
+    if after is not None:
+        # Drains and joins the listener thread, then closes the file handler. Suppressed
+        # because a floor must not fail a test for state it is only cleaning up, and the
+        # restore below has to happen either way.
+        with contextlib.suppress(Exception):
+            cli._stop_log_queue_listener()
+    cli._LOG_QUEUE_LISTENER = before
+
+
 # ── logger levels go back after every test ──────────────────────────
 
 

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -28,11 +28,14 @@ import importlib.util
 import logging
 import os
 import pathlib
+import queue
 import sys
 import tempfile
+from logging.handlers import QueueListener
 
 import pytest
 
+from kiro_crew import cli
 from kiro_crew.log_redaction import install_log_redaction
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -787,6 +790,18 @@ def _autouse_floor_generator(name: str):
     return getattr(definition, "__wrapped__", definition)
 
 
+def _listener_thread_alive(listener: QueueListener) -> bool:
+    """Whether the listener's drain thread is still running.
+
+    ``QueueListener.stop`` joins the thread and then drops the handle, so a stopped
+    listener reports ``None`` here. Checked rather than trusting the cleared slot: the
+    leak this floor absorbs is the live thread and the descriptor it holds, and dropping
+    the reference alone would satisfy every assertion about the slot while leaking both.
+    """
+    thread = getattr(listener, "_thread", None)
+    return thread is not None and thread.is_alive()
+
+
 class TestDynamicCredentialEnvironmentIsRestored:
     """A dynamic per-host Jira token must not leak to the next test.
 
@@ -971,6 +986,124 @@ class TestLoggerLevelsAreRestored:
         with caplog.at_level("DEBUG"):
             logging.getLogger("kiro_crew.slack.gateway").debug("floor canary")
         assert "floor canary" in caplog.text
+
+
+# ── the CLI log queue listener ─────────────────────────────────────────────
+
+
+class TestTheLogQueueListenerIsRestored:
+    """``cli._LOG_QUEUE_LISTENER`` is ONE process-global slot, per worker.
+
+    ``_setup_cli_logging`` starts a ``QueueListener`` for a LONG-LIVED command and never
+    stops it -- correct in production, which does it once per process -- so every test
+    that drives the real ``cli.main()`` for ``serve`` / ``gateway`` / ``chat`` leaves one
+    running. The SHORT-LIVED branch then reads it: it takes the ``else`` path and does not
+    touch the global, so a test asserting a short-lived verb starts no listener sees the
+    PREVIOUS test's and fails on its own first line, in a file that cleans up after itself
+    correctly. Two tests in ``test_cli_logging.py`` assert exactly that, and under
+    ``-n auto --dist loadgroup`` whether a leaker precedes them on the worker varies run
+    to run, so it surfaces as an intermittent failure rather than an ordering bug.
+
+    ``conftest._restore_log_queue_listener`` is what removes the class; without a test, an
+    edit to it reverts silently and the failures reappear as a flake. Its teardown is
+    driven directly (see ``_autouse_floor_generator``), so the proof needs no adjacent
+    observer test.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_cli_logging(self, monkeypatch):
+        """Foreground mode, and remove the handlers these tests' real setup calls attach.
+
+        Driving the real ``_setup_cli_logging`` is the point -- a test that assigned the
+        global instead would pass even if the production install site moved -- but it also
+        attaches a handler holding an open descriptor, and the floor under test
+        deliberately does not restore handlers. Removing only what this test ADDED is what
+        ``_pristine_logging`` does; the snapshotted list is never written back, because
+        ``caplog`` swaps a handler on the root logger at every phase boundary and writing
+        a setup-phase list back during teardown would drop the one it is capturing
+        through.
+        """
+        monkeypatch.setattr("kiro_crew.cli._fd_targets_file", lambda fd, path: False)
+        loggers = (logging.getLogger(), logging.getLogger("kiro_crew"))
+        saved = [(lgr, lgr.handlers[:]) for lgr in loggers]
+        yield
+        for lgr, handlers in saved:
+            for handler in lgr.handlers[:]:
+                if handler not in handlers:
+                    lgr.removeHandler(handler)
+                    handler.close()
+
+    def test_this_test_starts_with_no_listener(self) -> None:
+        """Which is only true if no earlier test on this worker left one running."""
+        assert cli._LOG_QUEUE_LISTENER is None
+
+    def test_a_leaked_listener_is_removed_by_the_floors_own_teardown(self) -> None:
+        """One full cycle of the real fixture: snapshot, leak a listener, restore.
+
+        The leak is produced by the real ``_setup_cli_logging`` on the real long-lived
+        branch, which is exactly how it happens in the wild, so the test still fails if
+        the production install site moves. A failure part-way cannot leak the listener
+        past this test: the live autouse instance of the same fixture wraps this test too,
+        and its snapshot predates the install.
+        """
+        cycle = _autouse_floor_generator("_restore_log_queue_listener")()
+        next(cycle)  # the floor's setup: snapshot, taken while the slot is empty
+
+        cli._setup_cli_logging("gateway", 1)
+        leaked = cli._LOG_QUEUE_LISTENER
+        assert leaked is not None, "the long-lived branch no longer starts a listener"
+
+        with pytest.raises(StopIteration):
+            next(cycle)  # the floor's teardown: the restore under test
+        assert cli._LOG_QUEUE_LISTENER is None, (
+            f"the slot still holds {cli._LOG_QUEUE_LISTENER!r} -- the next test to run "
+            "_setup_cli_logging for a SHORT-LIVED command would read this listener and "
+            "fail asserting it started none"
+        )
+        assert not _listener_thread_alive(leaked), (
+            "the listener object was dropped but its thread is still running -- it holds "
+            "the file handler's descriptor open on a gateway.log under a tmp_path the "
+            "next test deletes"
+        )
+
+    def test_the_restore_target_is_what_the_test_inherited(self, monkeypatch) -> None:
+        """The floor restores the INHERITED listener, so a higher-scoped installer survives.
+
+        Same reason the record-factory floor restores to its snapshot: a class- or
+        module-scoped fixture that starts a listener for its whole scope must not have it
+        torn out after the first test.
+        """
+        sentinel = QueueListener(queue.SimpleQueue())
+        monkeypatch.setattr(cli, "_LOG_QUEUE_LISTENER", sentinel)
+
+        cycle = _autouse_floor_generator("_restore_log_queue_listener")()
+        next(cycle)  # snapshot taken while the sentinel holds the slot
+
+        cli._setup_cli_logging("gateway", 1)
+        assert cli._LOG_QUEUE_LISTENER is not sentinel
+
+        with pytest.raises(StopIteration):
+            next(cycle)
+        assert cli._LOG_QUEUE_LISTENER is sentinel, (
+            "the floor restored past the listener this cycle inherited, so a "
+            "higher-scoped installer would be torn out after its first test"
+        )
+
+    def test_a_short_lived_command_leaves_the_slot_alone(self, monkeypatch) -> None:
+        """The production behaviour the floor exists to accommodate, pinned at source.
+
+        ``_setup_cli_logging`` deliberately does not clear the global on the short-lived
+        branch -- a listener a long-lived command started genuinely still exists -- which
+        is why the leak is absorbed in the test seam rather than by clearing it there. If
+        this ever changes, the floor becomes redundant rather than wrong, and this test is
+        what says so.
+        """
+        sentinel = QueueListener(queue.SimpleQueue())
+        monkeypatch.setattr(cli, "_LOG_QUEUE_LISTENER", sentinel)
+
+        cli._setup_cli_logging("status", 1)
+
+        assert cli._LOG_QUEUE_LISTENER is sentinel
 
 
 # ── the worker budget ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem / Motivation

`test/test_cli_logging.py::TestDrainBeforeHardExit::test_no_listener_is_a_silent_no_op`
fails intermittently in CI:

```
FAILED test/test_cli_logging.py::TestDrainBeforeHardExit::test_no_listener_is_a_silent_no_op
  - assert <logging.handlers.QueueListener object at 0x...> is None
```

It cost PR #6798 a red `Backend Tests (3.10, 1)` shard while `(3.12, 1)` passed on the
identical tree — the tell that the trigger is scheduling, not content.

The cause is a cross-module leak of one process-global, read at source:

- `cli._setup_cli_logging` starts a `QueueListener` and stores it in the module global
  `_LOG_QUEUE_LISTENER` only when `command in _LONG_LIVED_COMMANDS = {"serve", "gateway",
  "chat", None}`. Nothing but `_stop_log_queue_listener()` clears it, and production never
  calls that outside `atexit` — correct, because the listener genuinely still exists.
- The victim calls `_setup_cli_logging("status", 1)`. That is short-lived, so it takes the
  `else` branch, which correctly does not touch the global — and then asserts the global is
  `None`. It is reading whatever a *previous* test left there.
- `test_cli_logging.py`'s own autouse `_pristine_logging` fixture does clear the global, but
  only **after its `yield`**. That makes the file self-clean, so it passes serially, and
  leaves it defenceless against a leak already present at its **setup**, which is when it
  asserts.
- Several modules drive the real `cli.main()` without stubbing `_setup_cli_logging`, so any
  of them can install and leak the listener. Under `-n auto --dist loadgroup` an ordinary
  test's worker placement varies run to run, so whether a leaker lands ahead of the victim
  is a coin flip — hence intermittent rather than a reproducible ordering bug.

A second test has the same exposure and the same cause:
`TestQueueOffLoop::test_short_lived_command_keeps_sync_handler`.

## Why it matters

`docs/system-specs/common/testing-conventions.md` § Determinism class 4 (order dependence
and shared state) already names this class and why sharding hides it: a leaker only damages
tests in the **same process**, so PR CI's duration-balanced shards often cannot observe it
at all, and the unsharded release run is otherwise the first place it appears — as failures
in files unrelated to the cause, long after the diff merged. Here it is already escaping
into PR CI as a flake on an unrelated PR's shard.

The leak is also a real resource leak, not just a stale reference: the listener is a live
daemon thread holding the file handler's descriptor open on a `gateway.log` under a
`tmp_path` the next test deletes.

## What changed — a floor fixture for the process-global, not a production change

`_setup_cli_logging` leaving the global set on the short-lived branch is correct production
behaviour, so the fix is in the test seam.

**Shared `conftest.py`, not the file's own fixture.** The rootdir `conftest.py` already has
a logging-floor section covering the *other* process-globals this same function installs —
`_restore_log_record_factory` for the record factory (installed by `install_log_redaction`
in the very same `if command in _LONG_LIVED_COMMANDS:` block) and `_restore_logger_levels`
for logger levels. `_LOG_QUEUE_LISTENER` is the third global that branch installs and the
only one with no floor entry. Adding `_restore_log_queue_listener` beside its siblings
completes an existing floor rather than inventing a pattern, and it fixes the leak at the
**leaker's** teardown, so it protects both victims and any future one in any module —
whereas clearing at the victim file's setup would fix only that file and leave the thread
and descriptor leaking.

Following the two siblings exactly:

- **Restores to what the test inherited**, not to a pristine `None`, so a leak is not
  re-reported against every later test and a higher-scoped installer is not torn out from
  under its second test.
- **Restores silently rather than failing.** Starting the listener is what the entry point
  under test is *for*, and production does it once per process and never undoes it; the
  damage is to *other* tests, so stopping it propagating is the whole job. Same reasoning
  `_restore_log_record_factory` documents.
- **Stops the listener** rather than only reassigning the slot — the difference from the
  record-factory case, since dropping the reference alone would satisfy every assertion
  about the slot while leaving the thread and its descriptor live.
- **Reaches `cli` through `sys.modules`** rather than importing it, as
  `_no_leaked_telemetry_exporter` does: a worker that never imported it cannot hold a
  listener, and importing it in the rootdir conftest would charge every testpath the
  module-scope import weight that `test_cli_lazy_imports.py` exists to keep down.
- **Leaves handlers untouched**, the boundary `_restore_logger_levels` documents and for its
  reasons.

## Tests

`test/test_host_isolation_floor.py` gains `TestTheLogQueueListenerIsRestored`, mirroring the
two existing logging-floor classes. It drives one setup → teardown cycle of the real fixture
via the file's `_autouse_floor_generator`, which is the established shape here precisely
because an injector/observer pair is unprovable in a sharded run: `pytest-split` partitions
the collected suite before xdist runs and can place the two halves in different shards
regardless of any `xdist_group` mark. The leak is produced by the real `_setup_cli_logging`
on the real long-lived branch, so the test still fails if the production install site moves.

Four tests: the ambient check the CI victim makes, the leaked-listener restore (slot cleared
**and** thread stopped), the restore-to-inherited semantics, and a pin that the short-lived
branch deliberately leaves the slot alone — so if production ever changes, the floor is
shown redundant rather than silently wrong.

**Reproduction, on a clean `upstream/main` tree with no other changes:**

```bash
# FAILS on main -- polluter before victim, one process
python -m pytest -q --no-cov --override-ini="addopts=-n0" \
  test/test_cli.py \
  "test/test_cli_logging.py::TestDrainBeforeHardExit::test_no_listener_is_a_silent_no_op"
# -> 1 failed, 366 passed   assert <QueueListener object ...> is None

# PASSES -- victim alone (negative control: the assertion can discriminate)
python -m pytest -q --no-cov --override-ini="addopts=-n0" \
  "test/test_cli_logging.py::TestDrainBeforeHardExit::test_no_listener_is_a_silent_no_op"
# -> 1 passed
```

With this change the first command is `367 passed, 2 skipped`. The same pairing against
`TestQueueOffLoop::test_short_lived_command_keeps_sync_handler` goes red → green identically,
and `test_cli_logging.py` still passes whole and serially (33 passed).

**Fail-first, then mutation-controlled.** Reverting only the `conftest.py` change makes the
new tests fail; because that failure is an `AttributeError` for the missing fixture, it only
proves they notice a missing *name*. So the fixture was also kept in place and its teardown
broken three ways, one behaviour at a time — each caught by the assertion that should catch
it, and no mutation survived:

| mutation | caught by |
| --- | --- |
| teardown does nothing | leaked-listener restore + restore-to-inherited |
| restores to a pristine `None` instead of the inherited value | restore-to-inherited |
| clears the slot but never stops the thread | leaked-listener restore (thread-liveness assertion) |

**Gates.** `pytest` (full, `-n 8 --dist loadgroup`), `isort` and `flake8` at CI's exact
paths (`src/kiro_crew test conftest.py xdist_budget.py`), `mypy src/kiro_crew/` on a
faiss-free venv at the pinned version, the baselined `black` gate, `npx tsc -b`, and
`npx vitest run` (1690 files, 26694 passed).

This checkout sits outside `$HOME`, which trips the host-isolation and source-root
classification tests, so the backend suite carries pre-existing failures here. They are
proven pre-existing by failure **set**, not count: the full suite was run again on clean
`upstream/main` in the same worktree, holding the venv and host constant.

**No failure is unique to the branch** — the set difference in that direction is empty, which
is the direction that matters. The reverse direction holds one entry,
`test_pod_e2e_harness_paths.py::test_health_accepts_the_pods_own_serving_codes`, which failed
on main and passed on the branch. That is host-load variance, not something this change fixed:
the file contains no reference to logging or to the listener, and it failed on a
`POD_E2E_HEALTH_TIMEOUT=1` health poll — a one-second wall-clock budget on a loaded host, which
is § Determinism class 2. Collected totals reconcile exactly to the four added tests
(76753 → 76757).

Note that neither full run reproduced the flake: the two victims passed on main as well,
because in those particular runs no leaker happened to land ahead of them on their worker.
That is the intermittency itself, and it is why the targeted reproduction above — not the
full-suite result — is the evidence that the defect is real and fixed.
