### PR TITLE
fix(kiro-cli): derive the POSIX search dirs from the home that was asked for

### DIFF
--- a/src/kiro_crew/kiro_cli.py
+++ b/src/kiro_crew/kiro_cli.py
@@ -182,7 +182,16 @@ def known_kiro_cli_dirs(
     *,
     include_inherited_path: bool = True,
 ) -> list[str]:
-    """Return fixed and inherited directories where Kiro CLI may be installed."""
+    """Return fixed and inherited directories where Kiro CLI may be installed.
+
+    Every home-derived path comes from the ``home`` argument, never from a live
+    ``os.path.expanduser("~")``, so a caller that pins ``(platform_name, home,
+    environ)`` gets the same account's directories from this function and from
+    :func:`find_kiro_cli_candidates`, and may report them as the directories
+    that were searched. (:func:`~kiro_crew.env.mise_data_dir` still honours the
+    process-level ``MISE_DATA_DIR``/``XDG_DATA_HOME`` overrides, so the mise
+    shim entry is home-pinned only in their absence.)
+    """
 
     if platform_name == "win32":
         local_app_data = Path(environ.get("LOCALAPPDATA") or home / "AppData" / "Local")
@@ -211,8 +220,19 @@ def known_kiro_cli_dirs(
         # standard user tool directories and the venv Scripts fallback.
         dirs.extend(part for part in augmented_path("", home=str(home)).split(os.pathsep) if part)
     elif include_inherited_path:
+        # `home=` is forwarded for the same reason the win32 branch above does it:
+        # `augmented_path` falls back to a LIVE `os.path.expanduser("~")` when the
+        # keyword is omitted, so the `{home}`-templated extras and the Node/mise bin
+        # dirs would come from the process's account while the `.local/bin` and
+        # `.cargo/bin` entries above come from the caller's `home`. That makes this
+        # function's result depend on state outside its arguments, which is exactly
+        # what the ACP resolver's "the directories named in a not-found message are
+        # the directories that were actually searched" contract relies on it NOT
+        # doing (see acp/client.py's `_resolve_kiro_cli_for_spawn` docstring).
         dirs.extend(
-            part for part in augmented_path(environ.get("PATH", "")).split(os.pathsep) if part
+            part
+            for part in augmented_path(environ.get("PATH", ""), home=str(home)).split(os.pathsep)
+            if part
         )
     return _unique(dirs)
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1369,3 +1369,119 @@ class TestDeniedSpecEnvKeys:
         assert "KIROCREW_CLI" not in env_mod.sanitize_spec_env(
             [(k, v) for k, v in env.items()]
         )
+
+
+class TestKnownKiroCliDirsIsPureInItsHome:
+    """``known_kiro_cli_dirs`` must derive every home-relative entry from its ARGUMENT.
+
+    ``augmented_path`` falls back to a live ``os.path.expanduser("~")`` when its
+    ``home`` keyword is omitted. The win32 branch of ``known_kiro_cli_dirs``
+    forwards it; the POSIX branch did not, so one call returned a list mixing two
+    accounts -- ``.local/bin`` and ``.cargo/bin`` from the caller's ``home``, and
+    the ``{home}``-templated extras plus the Node/mise bin dirs from whichever
+    account owns the process.
+
+    That breaks the property ``acp/client.py``'s spawn resolver depends on: it
+    pins one ``(platform, home, environ)`` reading and passes it to BOTH the
+    resolve and the "kiro-cli not found (searched ...)" diagnostic, so that the
+    directories named are the directories walked. With a live re-read in the
+    middle, the two can disagree -- which is the split-read class #5048 and #6986
+    fixed at the call sites, surviving one level down.
+    """
+
+    @staticmethod
+    def _asked_home(tmp_path):
+        return tmp_path / "asked-home"
+
+    def test_posix_dirs_never_mention_the_process_home(self, tmp_path, monkeypatch):
+        from kiro_crew.kiro_cli import known_kiro_cli_dirs
+
+        process_home = tmp_path / "process-home"
+        asked = self._asked_home(tmp_path)
+        monkeypatch.setenv("HOME", str(process_home))
+        monkeypatch.setenv("USERPROFILE", str(process_home))
+        monkeypatch.setattr(env_mod.os.path, "expanduser", lambda _p: str(process_home))
+        env_mod._node_all_bin_dirs.cache_clear()
+
+        dirs = known_kiro_cli_dirs("linux", asked, {"PATH": "/usr/bin"})
+
+        leaked = [d for d in dirs if str(process_home) in d]
+        assert not leaked, (
+            "these entries came from the process home, not the home this call was "
+            f"given: {leaked}"
+        )
+        # The control: the asked-for home IS represented, so the assertion above
+        # cannot pass by the function returning nothing home-relative at all.
+        assert any(str(asked) in d for d in dirs)
+
+    def test_the_templated_extras_follow_the_asked_home(self, tmp_path, monkeypatch):
+        """Names the specific entries, so a partial fix cannot pass.
+
+        ``.local/bin`` alone is not evidence -- the POSIX branch builds that one
+        from ``home`` directly and it was always correct. The ``augmented_path``
+        extras are the ones that were being taken from the wrong account.
+        """
+        from kiro_crew.kiro_cli import known_kiro_cli_dirs
+
+        process_home = tmp_path / "process-home"
+        asked = self._asked_home(tmp_path)
+        monkeypatch.setattr(env_mod.os.path, "expanduser", lambda _p: str(process_home))
+        env_mod._node_all_bin_dirs.cache_clear()
+
+        dirs = known_kiro_cli_dirs("linux", asked, {"PATH": "/usr/bin"})
+        normalized = [d.replace("/", os.sep) for d in dirs]
+        for leaf in (".toolbox", ".npm-packages", ".volta"):
+            owning = [d for d in normalized if f"{os.sep}{leaf}{os.sep}" in d]
+            assert owning, f"no {leaf} entry was produced at all"
+            for entry in owning:
+                assert entry.startswith(str(asked)), (
+                    f"{leaf} was derived from {entry!r}, not from the home this "
+                    f"call was given ({str(asked)!r})"
+                )
+
+    def test_win32_branch_still_pins_its_home(self, tmp_path, monkeypatch):
+        """The branch that was already correct must stay correct.
+
+        This is the control that shows the fix mirrors an existing convention
+        rather than inventing one.
+        """
+        from kiro_crew.kiro_cli import known_kiro_cli_dirs
+
+        process_home = tmp_path / "process-home"
+        asked = self._asked_home(tmp_path)
+        monkeypatch.setattr(env_mod.os.path, "expanduser", lambda _p: str(process_home))
+        env_mod._node_all_bin_dirs.cache_clear()
+
+        dirs = known_kiro_cli_dirs(
+            "win32",
+            asked,
+            {"PATH": "C:/bin", "LOCALAPPDATA": "C:/la", "ProgramFiles": "C:/pf"},
+        )
+        assert not [d for d in dirs if str(process_home) in d]
+
+    def test_two_calls_with_the_same_arguments_agree_across_a_home_change(
+        self, tmp_path, monkeypatch
+    ):
+        """The property the ACP diagnostic actually needs, stated directly.
+
+        The resolver pins ``(platform, home, environ)`` once and uses it for both
+        the search and the message. If the process home moves between the two
+        calls, a live re-read makes them disagree and the message names
+        directories that were never walked.
+        """
+        from kiro_crew.kiro_cli import known_kiro_cli_dirs
+
+        asked = self._asked_home(tmp_path)
+        monkeypatch.setattr(env_mod.os.path, "expanduser", lambda _p: str(tmp_path / "home-a"))
+        env_mod._node_all_bin_dirs.cache_clear()
+        first = known_kiro_cli_dirs("linux", asked, {"PATH": "/usr/bin"})
+
+        monkeypatch.setattr(env_mod.os.path, "expanduser", lambda _p: str(tmp_path / "home-b"))
+        env_mod._node_all_bin_dirs.cache_clear()
+        second = known_kiro_cli_dirs("linux", asked, {"PATH": "/usr/bin"})
+
+        assert first == second, (
+            "the same arguments produced different search directories after the "
+            "process home moved, so a reported search path can disagree with the "
+            "search that ran"
+        )


### PR DESCRIPTION
## Problem / Motivation

`known_kiro_cli_dirs(platform_name, home, environ)` returns the directories where Kiro CLI may be installed. It builds the first entries from its `home` argument, then appends the augmented inherited PATH:

```python
# kiro_cli.py — POSIX branch
dirs = [str(home / ".local" / "bin"), str(home / ".cargo" / "bin")]
...
dirs.extend(part for part in augmented_path(environ.get("PATH", "")).split(os.pathsep) if part)
```

`augmented_path` resolves its own home when the keyword is omitted — `resolved_home = home or os.path.expanduser("~")` (`env.py:661`) — and uses it to format `_EXTRA_PATH_DIRS` (`{home}/.toolbox/bin`, `{home}/.npm-packages/bin`, `{home}/.volta/bin`, `{mise_data}/shims`) plus the Node bin dirs. So **one call returns a list mixing two accounts.** The win32 branch three lines above already forwards it: `augmented_path("", home=str(home))`.

Measured on current `main` (`5fe1d64e4`), asking for `/home/alice` while the process home is elsewhere:

```
entries derived from the ASKED home  : 2   (.local/bin, .cargo/bin)
entries derived from the PROCESS home: 5   (.toolbox/bin, .npm-packages/bin,
                                            .volta/bin, mise/shims, node bins)

win32 control (already forwards home=): 0 process-home entries
```

## Why it matters

This breaks the exact property the ACP spawn resolver was just built to rely on. `acp/client.py`'s `_resolve_kiro_cli_for_spawn` says so in its own docstring:

> `known_kiro_cli_dirs` is a pure function of `(platform, home, environ)`, so passing the same mapping here and to the diagnostic guarantees the directories named in a "not found" message are the directories that were actually searched.

On POSIX it is not a pure function of those arguments. A live `expanduser("~")` sits in the middle, so the resolve and the diagnostic are two readings again — which is precisely the split-read defect #5048 and #6986 fixed at the call sites, surviving one level down. #6986's First Principles review named it:

> the new docstring's claim that `known_kiro_cli_dirs` is "a pure function of (platform, home, environ)" is slightly overstated: its POSIX branch calls `augmented_path(environ.get("PATH",""))` without `home=` … mirroring that one argument would close the residual.

It is not only the message. `find_kiro_cli_candidates` walks this same list, so the directories actually searched for the binary are half-derived from the wrong account whenever the caller's `home` differs from the process's live `~`. Both production callers pin a `home` up front for exactly this reason — `PrerequisiteMonitor` captures `self._home` at construction and probes later on a worker thread (`kiro_prerequisite.py:1879`, `:2533`), and `_resolve_kiro_cli_for_spawn` snapshots per attempt — so the gap between capture and use is real by design, not hypothetical.

Being scoped to POSIX, this is invisible on the Windows branch that was already correct.

## What changed (motivation → approach → change)

**Symptom** → the search-dir list mixes two accounts, so a reported search path can disagree with the search that ran. **Root cause** → the POSIX branch drops the `home=` keyword that the win32 branch passes, and `augmented_path` then falls back to a live `expanduser("~")`. **Change** → forward it, mirroring the branch that was already right.

`src/kiro_crew/kiro_cli.py`, one argument:

```python
-        dirs.extend(
-            part for part in augmented_path(environ.get("PATH", "")).split(os.pathsep) if part
-        )
+        dirs.extend(
+            part
+            for part in augmented_path(environ.get("PATH", ""), home=str(home)).split(os.pathsep)
+            if part
+        )
```

`augmented_path`'s `home` keyword already exists and is already documented for this case ("pins user-relative candidates for callers already resolving a specific account instead of whichever account owns the current process"). Nothing is added; an existing seam is used on the branch that was missing it.

The function's docstring now states the purity contract rather than leaving it implied in a caller's docstring, so the next reader of `known_kiro_cli_dirs` sees the property that the ACP diagnostic depends on. The new code comment says why the keyword is there, naming the caller contract it serves.

**Scope.** One production line plus its comment and docstring. No behaviour change for win32 (already forwarding), and none for any caller whose `home` matches the process home — which is why this is a latent-correctness fix rather than a visible-symptom one, and the PR says so rather than claiming a user report.

## Tests

New in `test/test_env.py`, class `TestKnownKiroCliDirsIsPureInItsHome` — sited next to the existing `augmented_path` / `known_kiro_cli_dirs` boundary tests:

- `test_posix_dirs_never_mention_the_process_home` — patches `expanduser` to a distinct process home, asks for another, and asserts **no** returned entry is derived from the process home. Carries its own control (`the asked-for home IS represented`) so it cannot pass by the function returning nothing home-relative.
- `test_the_templated_extras_follow_the_asked_home` — names `.toolbox`, `.npm-packages`, `.volta` individually and requires each entry to start with the asked-for home. `.local/bin` alone would not discriminate: the POSIX branch always built that one correctly, so a partial fix would pass a looser assertion.
- `test_win32_branch_still_pins_its_home` — the control on the branch that was already correct, showing the fix mirrors an existing convention rather than inventing one.
- `test_two_calls_with_the_same_arguments_agree_across_a_home_change` — the property the ACP diagnostic needs, stated directly: same arguments, process home moved in between, same result.

**Red-before**, production change reverted with the tests in place: **3 failed, 1 passed** (the win32 control passes on both sides, as it must).

```
AssertionError: these entries came from the process home, not the home this call
                was given: [...process-home/.local/bin, ...process-home/.toolbox/bin,
                ...process-home/.npm-packages/bin, ...mise/shims, ...volta/bin]
AssertionError: .toolbox was derived from '...process-home\.toolbox\bin', not from
                the home this call was given
AssertionError: the same arguments produced different search directories after the
                process home moved, so a reported search path can disagree with the
                search that ran
```

**Green after**, `test_env.py` + `test_acp_client.py` + `test_kiro_prerequisite.py` (Python 3.10.6, Windows):

| | failed | passed |
| --- | --- | --- |
| pristine `origin/main`, twice | 18 | 785 |
| this branch | 18 | **789** |

Exactly the four new tests, no flips in either direction. The 18 are a stable Windows-only local baseline reproduced on pristine main — `TestResolveKrb5Ccname` (POSIX `os.getuid`) and two path-separator assertions in `TestAugmentedPath` / `TestExtraMcpPathDirs`. `test_acp_client.py` + `test_kiro_prerequisite.py` alone are **677 passed, 50 skipped, 0 failed** on this branch.

**Gates green:** flake8, isort, `scripts/check_black_formatting.py`, `mypy` on the changed module (no issues in it).

## Manual verification

N/A — unit coverage sufficient: the defect is which account a returned directory string is derived from, which the tests observe directly by pinning two different homes. Reproducing it by hand needs a gateway whose process home differs from the account being resolved, on POSIX.

## Related Issues

Residual named by the First Principles review on #6986 (merged). Same split-read class as #5048 (merged).

no linked issue: both prior issues in this defect class are already closed; this PR fixes the residual their reviews named, which was never filed as its own issue.

## Pattern harvest

Rule candidate: review-prompt — when a function takes an `environ`/`home` argument, flag any code path inside it (including helpers it calls, like `augmented_path` without `home=`) that falls back to live `os.environ` / `os.path.expanduser("~")` reads. This is the third instance of the split-read class (#5048, #6986, here), each one level deeper in the call chain.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

