### PR TITLE
fix(aws-control): recheck drive bucket after upload spool (#7060)

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -719,27 +719,20 @@ async def _handle_drive_upload(request: web.Request) -> web.Response:
         if received == 0:
             return _bad_request("empty upload", "empty_upload")
         # A 512 MB stream can take minutes: the authorization resolved before
-        # the transfer may no longer hold. Re-check the app gate, then RE-RESOLVE
-        # the identity, then consent -- in that order, because consent is asked
-        # ABOUT a profile and region, so verifying it against a stale pair proves
-        # nothing about where the bytes are going. A profile repointed A -> B
-        # during the spool would have had consent verified for B while `put_file`
-        # still wrote into A's bucket (reachable whenever B holds cross-account
-        # access), so the write must be refused unless the SAME triple the
-        # request was authorized for still resolves.
-        if not await asyncio.to_thread(is_app_enabled, APP_NAME):
-            _audit("drive_upload", request.path, "denied", error="app_disabled")
-            return _forbidden("aws-control is disabled", "app_disabled")
-        recheck = await _account_target(request)
-        if isinstance(recheck, web.Response):
-            return recheck
-        if recheck != (account, profile, region):
-            _audit("drive_upload", request.path, "denied", error="account_mismatch")
-            return _conflict(
-                "this connection changed while the file was uploading; nothing was written",
-                "account_mismatch",
-            )
-        denied = await _consent(aws_consent.SERVICE_S3, profile, region)
+        # the transfer may no longer hold. The spool is the same post-wait gap
+        # the Library operations cross under their lock, so the SAME helper
+        # re-runs the full re-authorization: app gate, live identity re-probe,
+        # consent, and the drive bucket itself -- the piece an identity check
+        # cannot cover, because tag discovery can move the drive to a different
+        # bucket while the identity is unchanged, and a name held across the
+        # spool is exactly the staleness the module's no-cache rule forbids. A
+        # pass means the pre-spool ``bucket`` still names the account's current
+        # drive, so the put below writes to the post-spool resolution; anything
+        # else is refused with nothing written. No publish gate: an upload does
+        # not consult it on the way in, so the re-check does not add it.
+        denied = await _reauthorize_in_lock(
+            request, "drive_upload", account, profile, region, bucket, publish=False
+        )
         if denied:
             return denied
         try:
@@ -972,21 +965,22 @@ async def _reauthorize_in_lock(
     *,
     publish: bool,
 ) -> web.Response | None:
-    """Re-run the authorization a queued caller may have outlived.
+    """Re-run the authorization a waiting caller may have outlived.
 
-    ``_library_lock`` makes a Library operation WAIT, and the wait sits between
-    the checks ``_require_drive`` ran and the AWS call they authorized. In that
-    gap the app can be disabled, the profile can be repointed at another account,
-    consent can be withdrawn, publish governance can start denying, or the drive
-    tags can move to a different bucket -- and the call would then run on an
+    Something makes a handler WAIT -- ``_library_lock`` queues the Library
+    operations, and the upload spool holds ``_handle_drive_upload`` for as long
+    as a 512 MB transfer takes -- and the wait sits between the checks
+    ``_require_drive`` ran and the AWS call they authorized. In that gap the app
+    can be disabled, the profile can be repointed at another account, consent
+    can be withdrawn, publish governance can start denying, or the drive tags
+    can move to a different bucket -- and the call would then run on an
     authorization that no longer holds.
 
-    Exactly the gap ``_handle_drive_upload`` already re-checks after its spool,
-    and in the same order and for the same reason: app, then IDENTITY, then
-    consent. Consent is asked ABOUT a profile and region, so verifying it against
-    a stale pair proves nothing about where the bytes are going -- the identity
-    has to be re-resolved first, and must still be the triple the request was
-    authorized for.
+    The order is deliberate: app, then IDENTITY, then consent. Consent is asked
+    ABOUT a profile and region, so verifying it against a stale pair proves
+    nothing about where the bytes are going -- the identity has to be
+    re-resolved first, and must still be the triple the request was authorized
+    for.
 
     The BUCKET is re-resolved too, which the identity check does not cover: tag
     discovery can return a different bucket while the identity is unchanged. This

--- a/test/test_aws_control_routes.py
+++ b/test/test_aws_control_routes.py
@@ -613,6 +613,112 @@ class TestDriveUpload:
         assert resp.status == 200
         put.assert_called_once()
 
+    def test_a_drive_retag_during_the_spool_refuses_the_write(self):
+        # The drive bucket is tag-discovered, and a 512 MB spool is long enough
+        # for the tags to move to a DIFFERENT bucket while the identity triple
+        # stays the same. A name resolved before the spool is exactly the
+        # staleness the module's no-cache rule forbids, so the post-spool
+        # re-authorization re-resolves the drive and refuses on a mismatch --
+        # otherwise put_file would land the object in the previously-discovered
+        # bucket.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        req = _request(
+            "POST",
+            f"/drive/{ACCOUNT}/upload?section=drive&key=f.bin",
+            match_info={"account": ACCOUNT},
+        )
+        req._fake_content = _FakeContent([b"hello"])  # type: ignore[attr-defined]
+        with (
+            mock.patch.object(type(req), "content", new=property(lambda s: s._fake_content)),
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            mock.patch.object(
+                routes_mod.storage_mod,
+                "find_drive",
+                side_effect=["drive-before", "drive-after"],
+            ),
+            mock.patch.object(routes_mod, "_audit") as audit,
+            mock.patch.object(routes_mod.storage_mod, "put_file") as put,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/drive/{account}/upload")](req)  # type: ignore[operator]
+            )
+        assert resp.status == 409
+        assert _payload(resp)["code"] == "drive_changed"
+        # The decisive assertions: nothing was written, and the denial is a
+        # permission DECISION so it must reach the audit trail.
+        put.assert_not_called()
+        audit.assert_any_call("drive_upload", mock.ANY, "denied", error="drive_changed")
+
+    def test_the_put_targets_the_bucket_the_post_spool_discovery_returned(self):
+        # A pass through the re-authorization means the pre-spool name and the
+        # post-spool resolution AGREE, so the put's target is the post-wait
+        # answer, never a name only the pre-spool lookup vouched for. The second
+        # find_drive call is that re-resolve; without it the equality was never
+        # checked and the write trusts a stale name.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        req = _request(
+            "POST",
+            f"/drive/{ACCOUNT}/upload?section=drive&key=f.bin",
+            match_info={"account": ACCOUNT},
+        )
+        req._fake_content = _FakeContent([b"hello"])  # type: ignore[attr-defined]
+        with (
+            mock.patch.object(type(req), "content", new=property(lambda s: s._fake_content)),
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            mock.patch.object(
+                routes_mod.storage_mod, "find_drive", return_value="drive-stable"
+            ) as find,
+            mock.patch.object(routes_mod.storage_mod, "put_file") as put,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/drive/{account}/upload")](req)  # type: ignore[operator]
+            )
+        assert resp.status == 200
+        assert find.call_count == 2
+        put.assert_called_once()
+        assert put.call_args.args[2] == "drive-stable"
+
+    def test_consent_withdrawn_during_the_spool_refuses_the_write(self):
+        # Way-in consent PASSES and the withdrawal lands during the spool, so
+        # the refusal can only come from the post-spool re-check. The blanket
+        # always-deny variant cannot tell the two gates apart: it refuses on
+        # the way in and never reaches the spool.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        req = _request(
+            "POST",
+            f"/drive/{ACCOUNT}/upload?section=drive&key=f.bin",
+            match_info={"account": ACCOUNT},
+        )
+        req._fake_content = _FakeContent([b"hello"])  # type: ignore[attr-defined]
+        with (
+            mock.patch.object(type(req), "content", new=property(lambda s: s._fake_content)),
+            p1,
+            p2,
+            p3,
+            mock.patch.object(
+                routes_mod.aws_consent,
+                "refuse_and_log",
+                AsyncMock(side_effect=[True, False]),
+            ),
+            _drive_found(),
+            mock.patch.object(routes_mod.storage_mod, "put_file") as put,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/drive/{account}/upload")](req)  # type: ignore[operator]
+            )
+        assert resp.status == 409
+        assert _payload(resp)["code"] == "aws_consent_required"
+        put.assert_not_called()
+
     def test_empty_upload_is_refused_and_never_put(self):
         resp, put = self._run([])
         assert resp.status == 400


### PR DESCRIPTION
## Problem / Motivation

`routes.py` in the aws-control app carries three hand-written spellings of the same post-wait re-authorization: the shared `_reauthorize_in_lock` helper plus inlined copies in `_handle_drive_upload` and `_handle_drive_bootstrap`. Only the helper re-resolves the drive bucket. The upload handler re-verified app/identity/consent after its 512 MB spool but then wrote to the bucket name it resolved BEFORE the spool — so a drive re-tagged during a long upload lands the object in the previously-discovered bucket. The module deliberately keeps no bucket-name cache ("numbers can be stale; the identity of the bucket we write to cannot"), and a name held across a multi-minute spool is exactly that staleness.

## Why it matters

This is a live security defect at a re-authorization boundary, not just duplication: bytes can be written to a bucket that tag discovery no longer vouches for. And with three drifting copies, each future check lands in one spelling and not the others (the helper had already gained the bucket check the inlined copies lack).

## What changed (motivation → approach → change)

Symptom: upload writes to a stale, pre-spool bucket name. Root cause: the inlined post-spool recheck omits the drive-bucket re-resolve+compare the shared helper performs. Change: `_handle_drive_upload` now calls `_reauthorize_in_lock(request, "drive_upload", account, profile, region, bucket, publish=False)` in place of the inlined block. The helper runs app-enabled → live identity re-probe → triple comparison → S3 consent → drive-bucket re-resolve+compare, in the same order the inline copy used, plus the missing bucket check. A pass proves the pre-spool `bucket` still names the account's current drive, so the `put_file` that follows writes to the post-wait resolution; any change refuses 409 `drive_changed` with nothing written. `publish=False` because an upload does not consult the publish gate on the way in, so the recheck does not add it.

Observable differences at this security boundary, called out explicitly:

- The `account_mismatch` refusal body text changes from "this connection changed while the file was uploading; nothing was written" to the helper's "this connection changed while the request was queued; nothing was written". Status (409) and machine-readable `code` (`account_mismatch`) are unchanged — the frontend (`website/src/apps/aws-control/api.ts`) matches on `code` only. Accepted as the price of convergence on the helper's canonical wording.
- Net audit gain: the old inline block returned `_account_target`'s error response with no SEL event; the helper audits that arm as `account_unavailable` denied. New refusal surface: 409 `drive_changed` (and `_aws_failed` if the re-resolve itself errors), both fail-closed.
- No check runs later than before; no refusal is weakened. The stricter behaviour (bucket re-resolve) is added.

`_handle_drive_bootstrap` is deliberately NOT converted. The helper's pre-bucket portion carries an `is_app_enabled` gate and point-of-decision SEL audits that bootstrap's inline copy lacks, and bootstrap has no bucket yet — so extracting a split helper is not plainly behaviour-preserving, and splitting a shared security helper on speculation is worse than leaving one call site for a follow-up (tracked separately; see linked follow-up issue).

## Tests

All in `test/test_aws_control_routes.py::TestDriveUpload` (12 tests, class fully green):

- **`test_a_drive_retag_during_the_spool_refuses_the_write`** (headline, fails on base with 200-vs-409): drive bucket changes during the spool → 409 `drive_changed`, `put_file` never called, denial audited.
- **`test_the_put_targets_the_bucket_the_post_spool_discovery_returned`** (fails on base with find_drive call-count 1-vs-2): pins that the write target is vouched for by the post-spool re-resolve, not only the pre-spool lookup.
- **`test_consent_withdrawn_during_the_spool_refuses_the_write`**: way-in consent passes, withdrawal lands during the spool → 409 (the pre-existing consent recheck test uses a blanket deny that the way-in gate absorbs, so it never reaches the spool; this one is genuinely spool-scoped). Passes on base too — it guards the conversion, since base already refused this case inline.
- Pre-existing spool-scoped coverage retained and green: app disabled during spool (`test_upload_rechecks_app_enabled_after_the_transfer`), profile repointed during spool (`test_a_connection_change_during_the_spool_refuses_the_write`), and the success path (`test_an_unchanged_connection_still_uploads`, `test_upload_streams_to_a_spool_and_puts_the_file`).

Mutation verification: the two bucket tests were run against the base source (fix stashed) and failed exactly as designed; the rest of the class passed unchanged.

Local gates: isort / flake8 (byte-identical to a pristine-main control) / mypy (`Success`, identical to main) / full `python -m pytest` — failure set byte-identical to a clean-main control run in the same environment (98 known host-env failures both sides, zero regressions, aws_control fully green) / black ratchet / subprocess-encoding / brand / harness-parity gates all pass.

## Manual verification

N/A — unit coverage sufficient: the changed behaviour is request-handler control flow fully exercised by the route-level tests above; no UI surface changed (verified `website/` matches only on the unchanged `code` fields).

## Related Issues

Closes #7060

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
