### PR TITLE
test(cron): pin the env half of the post-#2602 resolver contract

### DIFF
--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -360,6 +360,37 @@ class TestResolveMcpServer:
         # no env block resolves to an empty dict, not None.
         assert _resolve_mcp_server("srv-hr") == (("c", "a"), {})
 
+    def test_a_declared_env_block_survives_the_hardened_read(self, agents_dir_resolver):
+        """The other half of the post-#2602 contract, on THIS module's read path.
+
+        The case above pins the empty-env shape, which a resolver that dropped the
+        block entirely would also satisfy. #2602 added ``env`` because a launcher
+        that shells out to a helper reachable only via the PATH the config supplies
+        dies at the JSON-RPC ``initialize`` handshake without it -- so the value has
+        to arrive, not just the tuple shape. Nothing here asserted that: this file's
+        other cases are refusals asserting ``is None``, and the accepted branch is
+        the size-capped hardened read, which is exactly where a future tightening
+        could drop the block with the argv assertion still green.
+        """
+        from kiro_crew.cron_script import _resolve_mcp_server
+
+        _plant(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {
+                "name": "kirocrew",
+                "mcpServers": {
+                    "srv-hr": {
+                        "command": "c",
+                        "args": ["a"],
+                        "env": {"PATH": "/opt/tools/bin"},
+                    }
+                },
+            },
+        )
+
+        assert _resolve_mcp_server("srv-hr") == (("c", "a"), {"PATH": "/opt/tools/bin"})
+
     def test_malformed_spec_no_longer_escapes_as_a_decode_error(self, agents_dir_resolver):
         """The differential case for THIS site.
 


### PR DESCRIPTION
## Problem / Motivation

#2602 widened `_resolve_mcp_server` to return `(argv, env)`. Two things followed from it, and only one has been fixed.

The stale assertion in this file — `assert _resolve_mcp_server("srv-hr") == ("c", "a")` — was repaired on `main` by **#7200**, so **this PR no longer carries that change**; it was rebased down to what #7200 did not cover.

What remains uncovered is the `env` half. On `main` today, `test/test_agent_spec_hardened_reads.py` contains **zero** occurrences of an `env` block. Every other case in `TestResolveMcpServer` is a refusal asserting `is None`, and the one positive control asserts:

```python
assert _resolve_mcp_server("srv-hr") == (("c", "a"), {})
```

That pins the tuple *shape*, and it is satisfied just as well by a resolver that drops the env block entirely — `{}` is what both a correct empty-env spec and a broken drop-everything resolver return.

## Why it matters

`env` is not decoration on this contract. #2602's own rationale is that a launcher shelling out to a helper reachable only through the PATH the config supplies dies at the JSON-RPC `initialize` handshake when the block is lost — a spawned MCP that simply never comes up, which reads to the user as a missing capability rather than a launch failure.

The path this file covers is the one where that is most likely to happen quietly. `TestResolveMcpServer` exercises the **hardened, size-capped** read, whose whole job is to refuse malformed or oversized specs. A future tightening of that refusal logic could drop or truncate the env block while every existing assertion in the file stays green, because none of them ever puts a value in it.

## What changed (motivation → approach → change)

**Symptom** → a contract field with no coverage on the path most able to lose it. **Root cause** → the positive control asserts an empty env, which cannot distinguish "no env declared" from "env discarded". **Change** → one test that declares an env and asserts the value arrives.

`test/test_agent_spec_hardened_reads.py`, one added test in the existing `TestResolveMcpServer` class, beside the control it complements:

```python
def test_a_declared_env_block_survives_the_hardened_read(self, agents_dir_resolver):
    _plant(agents_dir_resolver, AGENT_FILENAME, {
        "name": "kirocrew",
        "mcpServers": {"srv-hr": {"command": "c", "args": ["a"],
                                  "env": {"PATH": "/opt/tools/bin"}}},
    })
    assert _resolve_mcp_server("srv-hr") == (("c", "a"), {"PATH": "/opt/tools/bin"})
```

It uses the file's own `_plant` fixture, so it goes through the real hardened read rather than a mock.

**Scope.** Test-only, one file, one test. No production file is touched and no behaviour changes — `_resolve_mcp_server` and its single consumer (`cron_script.py:401`, which already unpacks `argv, spec_env`) are correct as they stand.

**On the rebase.** This PR previously also fixed the stale `("c", "a")` assertion and was approved on that basis. #7200 landed the same repair on `main` first, so that hunk is gone rather than resolved as a conflict — re-implementing it would have been a duplicate. The description is rewritten to what actually ships now, rather than left describing the superseded version.

## Tests

The change is the test. It asserts an exact `{"PATH": "/opt/tools/bin"}`, so it is discriminating by construction: a resolver returning `{}` — the pre-#2602 behaviour, and the shape a dropped block produces — fails it, while the neighbouring empty-env control would not notice.

**Verification** (Python 3.10.6, Windows): `test/test_agent_spec_hardened_reads.py` — **54 passed, 2 skipped, 0 failed** on this head, rebased onto `main` at `146a78b82`.

There is no red-before for the removed half: it is already green on `main` via #7200, which is precisely why it was dropped.

**Gates green:** flake8, isort.

## Manual verification

N/A — unit coverage sufficient: the assertion is about a value returned by a pure resolver call, which the test observes directly.

## Related Issues

Follows #2602 (introduced the `(argv, env)` return) and #7200 (repaired the stale assertion in this file, superseding this PR's original first half).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
