### PR TITLE
feat(artifacts): expose --slug on the artifact save CLI verb

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -124,7 +124,7 @@ middleware live in one place.
 ```
 kirocrew artifact list [--tag T] [--kind K] [--q SUBSTR]
 kirocrew artifact show <slug> [--version N] [--meta]
-kirocrew artifact save --name N [--kind K] [--content C | --content-file F] [--tags A,B] [--description D]
+kirocrew artifact save --name N [--slug S] [--kind K] [--content C | --content-file F] [--tags A,B] [--description D]
 kirocrew artifact update <slug> [--content C | --content-file F] [--name N] [--description D] [--tags A,B]
 kirocrew artifact versions <slug>
 kirocrew artifact delete <slug>

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2242,6 +2242,15 @@ Examples:
     art_save = art_sub.add_parser("save", help="Save a new artifact")
     art_save.add_argument("--name", required=True, help="Human-readable name")
     art_save.add_argument(
+        "--slug",
+        help=(
+            "Explicit slug instead of one derived from --name. A taken or "
+            "malformed slug is REFUSED, never renamed: use 'artifact update "
+            "<slug>' to version one in place. Omit to let a collision resolve "
+            "by suffixing (-2, -3, ...)"
+        ),
+    )
+    art_save.add_argument(
         "--kind",
         choices=["widget", "html", "markdown", "svg", "json", "text", "image"],
         default=None,

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -2329,6 +2329,13 @@ def _artifact(args: argparse.Namespace) -> None:
             "content": _read_content(args),
             "tags": _parse_tags(getattr(args, "tags", None)),
         }
+        # An explicit --slug is forwarded whenever it is not None, INCLUDING the
+        # empty string. "" is a slug the caller named, not a request to derive
+        # one, and the store refuses it; truthy filtering would swallow it and
+        # silently take the derive-and-suffix branch instead.
+        slug_arg = getattr(args, "slug", None)
+        if slug_arg is not None:
+            body["slug"] = slug_arg
         for k in ("kind", "description"):
             v = getattr(args, k, None)
             if v:
@@ -2339,12 +2346,14 @@ def _artifact(args: argparse.Namespace) -> None:
             sys.exit(1)
         slug = d.get("slug", "?")
         print(f"Saved: slug={slug} version={d.get('version', 1)}")
-        # `save` has no --slug, so the slug is always derived from --name and a
-        # name collision can only ever be resolved by suffixing. That reads as
-        # success (exit 0, "version=1"), which is how a re-save of corrected
-        # content ends up published at a slug nobody looks at while the
-        # original keeps serving the old text. Name the slug that was taken and
-        # the verb that versions in place.
+        # Present only when the slug was derived from --name, because that is the
+        # branch where a taken slug resolves by suffixing. That reads as success
+        # (exit 0, "version=1"), which is how a re-save of corrected content ends
+        # up published at a slug nobody looks at while the original keeps serving
+        # the old text. Name the slug that was taken and the verb that versions in
+        # place. An explicit --slug cannot land here: the store refuses it rather
+        # than renaming — 409 when the slug is taken, 400 when it is malformed
+        # (the empty string included) — so both surface on the error path above.
         taken = d.get("slug_collided_with")
         if taken:
             print(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4729,6 +4729,35 @@ class TestArtifactCli:
     `--content-file`).
     """
 
+    def test_save_parses_an_explicit_slug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A subparser that never declared the flag exits at parse time, so this
+        # pins the whole argv -> namespace -> command hop rather than the
+        # forwarding alone.
+        seen: dict[str, object] = {}
+        from kiro_crew import cli
+
+        monkeypatch.setattr(
+            "kiro_crew.cli_commands._artifact",
+            lambda args: seen.update(slug=args.slug, name=args.name),
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "kirocrew",
+                "artifact",
+                "save",
+                "--name",
+                "Run Summary",
+                "--slug",
+                "chosen-by-hand",
+                "--content",
+                "body",
+            ],
+        )
+        cli.main()
+        assert seen == {"slug": "chosen-by-hand", "name": "Run Summary"}
+
     def test_save_refuses_sensitive_content_file(
         self, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -1863,6 +1863,145 @@ class TestArtifactCli:
         assert "Saved: slug=fresh version=1" in captured.out
         assert captured.err == ""
 
+    def test_save_forwards_an_explicit_slug(self) -> None:
+        with _ArtifactHarness([_FakeResponse({"slug": "chosen", "version": 1})]) as h:
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Chosen",
+                    slug="chosen-by-hand",
+                    content="body",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        body = json.loads(h.urlopen.call_args[0][0].data.decode())
+        assert body["slug"] == "chosen-by-hand"
+
+    def test_save_forwards_an_empty_explicit_slug(self) -> None:
+        # "" is a slug the caller named, not a request to derive one. Filtering it
+        # out would silently route an explicit save into the derive-and-suffix
+        # branch — the exact asymmetry this flag exists to close.
+        with _ArtifactHarness([_FakeResponse({"slug": "x", "version": 1})]) as h:
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Empty Slug",
+                    slug="",
+                    content="body",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        body = json.loads(h.urlopen.call_args[0][0].data.decode())
+        assert "slug" in body
+        assert body["slug"] == ""
+
+    def test_save_with_an_empty_slug_surfaces_the_refusal(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Forwarding "" is only worth anything if the refusal reaches the caller.
+        # The store rejects it via _validate_slug and the handler answers 400, so
+        # it arrives on the CLI's existing error path — no new error surface.
+        err = _http_error(
+            400,
+            json.dumps({"error": "invalid slug '': must match ^[a-z0-9]..."}).encode(),
+        )
+        with _ArtifactHarness([err]), pytest.raises(SystemExit) as exc:
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Empty Slug",
+                    slug="",
+                    content="body",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "invalid slug" in captured.err
+        assert captured.out == ""
+
+    def test_save_omits_the_slug_key_when_none_was_given(self) -> None:
+        # An ABSENT flag must send no key at all. Forwarding it as "" would hand
+        # the store a slug it refuses, so every plain `save` would start failing;
+        # only an explicitly-passed value may reach the request body.
+        with _ArtifactHarness([_FakeResponse({"slug": "derived", "version": 1})]) as h:
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Derived",
+                    slug=None,
+                    content="body",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        body = json.loads(h.urlopen.call_args[0][0].data.decode())
+        # Positive control: this is the save request body, so the absence below
+        # is a fact about the field and not about a request that never went out.
+        assert body["name"] == "Derived"
+        assert "slug" not in body
+
+    def test_save_with_a_taken_slug_reports_the_conflict(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The store refuses an explicit slug rather than suffixing it, so the
+        # handler answers 409. It has to reach the caller as the named condition
+        # and a non-zero exit, never a traceback.
+        err = _http_error(409, json.dumps({"error": "artifact already exists: taken"}).encode())
+        with _ArtifactHarness([err]), pytest.raises(SystemExit) as exc:
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Taken",
+                    slug="taken",
+                    content="body",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "artifact already exists: taken" in captured.err
+        assert captured.out == ""
+
+    def test_save_with_an_explicit_slug_emits_no_suffix_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The warning advises `artifact update`, which is wrong guidance for a
+        # caller who named the slug: they get a 409, never a rename. The CLI must
+        # therefore key it on the server's field alone and not on the flag being
+        # set. The server half — an explicit slug reporting no collision — is
+        # pinned in test_artifacts_handlers.py.
+        with _ArtifactHarness([_FakeResponse({"slug": "chosen-by-hand", "version": 1})]):
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="Run Summary",
+                    slug="chosen-by-hand",
+                    content="body",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        captured = capsys.readouterr()
+        assert "Saved: slug=chosen-by-hand version=1" in captured.out
+        assert captured.err == ""
+
     def test_save_reads_content_file(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Problem / Motivation

`ArtifactStore.create()` resolves one condition — *the target slug is taken* — two opposite
ways, about ten lines apart: a **name-derived** slug is silently suffixed (`-2`, `-3`, …),
while an **explicit** `slug=` is refused with `ArtifactAlreadyExistsError`.

#6798 made the suffixing loud rather than changing it: the CLI now warns on stderr naming
the taken slug and the `update` verb, and `POST /api/artifacts` reports `slug_collided_with`
on its 201. What it deliberately left out is the other half, and it named that half in its
own description:

> Exposing `--slug` on `kirocrew artifact save` would give CLI callers access to the loud
> branch at all. It is a small addition, but it is a new capability rather than a fix to
> this asymmetry, and it brings its own surface (a 409 path the CLI would need to report
> well). Worth doing separately.

This is that follow-up, kept to the size that description implies.

## Why it matters

Every other client of the store can already pick the branch it wants; `artifact save` is the
only one that cannot.

- MCP `artifact_save` takes a `slug` parameter — *"Optional explicit slug … auto-derived
  from name when omitted."*
- `POST /api/artifacts` passes `body.get("slug")` straight to the store and already answers
  **409** on `ArtifactAlreadyExistsError`.
- `kirocrew artifact save` has no `--slug`, so the slug is always `slugify(--name)`. A CLI
  caller reaches the suffixing branch and nothing else.

The gap is not only a missing convenience, because the two branches fail differently.
Refusal is loud and stops you. Suffixing is *silent success* — exit 0, `Saved: … version=1`
— which is exactly the incident #6798 documented: corrected content published at a suffixed
slug while the canonical one kept serving text known to be wrong. A CLI caller who knows
which slug they mean currently has no way to say "this one, or fail". The loud branch is
already implemented in the store; the CLI simply has no door to it.

## What changed — and what it deliberately does not

Two production edits, and **no change to the store or the handler**.

- **`cli.py`** — `artifact save` gains `--slug`. Its help states the contract the store
  actually implements: a taken slug is REFUSED, never renamed, and `artifact update <slug>`
  is the verb that versions in place.
- **`cli_commands.py`** — `slug` joins `kind`/`description` among the optional fields
  forwarded into the POST body only when non-empty. An absent flag sends **no** `slug` key,
  which matters rather than being incidental: the handler computes `slug_collided_with` only
  for a request that carried no slug, so forwarding an empty string would suppress the
  suffix warning on every plain save.

**The 409 needs no new code** — checked before writing any. `_request` already maps an
`HTTPError` to `{"error": <the error from the JSON body>}`, so a taken slug surfaces as
`Error: artifact already exists: <slug>` on stderr with exit 1: the named condition, no
traceback, and a non-zero exit a script can branch on. The remedy guidance lives in the
flag's help, where the choice is actually made, rather than in a status-code branch that
would require `_request` to start returning codes for every artifact verb.

Unchanged on purpose: the store's collision behaviour, and no store-level `logger.warning`
— a First Principles review on #6798 removed exactly that.

One comment is corrected because this PR falsifies it. The note above the CLI's suffix
warning opened *"`save` has no --slug, so the slug is always derived from --name"* — true
until now. It states the current condition instead: the report is present only when the slug
was derived, and an explicit one goes to the 409 path.

## Tests

Five CLI cases, plus a parser case:

- `--slug` reaches the request body.
- argv → namespace → command, so the flag is genuinely declared on the subparser rather than
  only read defensively downstream.
- A save with no `--slug` sends no `slug` key, with a positive control on the same body so
  the absence is a fact about the field and not about a request that never went out.
- A 409 arrives as the named condition on stderr, exit 1, stdout empty.
- An explicit slug emits **no** suffix warning. This is the interaction most likely to
  regress: that warning advises `artifact update`, which is wrong guidance for a caller who
  will get a 409 rather than a rename. The CLI half — keyed on the server's field, not on the
  flag being set — is pinned here; the server half (an explicit slug reports `""`) and the
  409 itself are already pinned in `test_artifacts_handlers.py`, so no handler test is added
  for a handler this PR does not touch.

Negative controls run against unmodified `upstream/main`: the two meaningful ones fail there
— `kirocrew: error: unrecognized arguments: --slug` at the parser, and `KeyError: 'slug'` on
the request body. The other three pass on both sides, as regression guards must.

## Gates

`pytest` (full backend), `isort`, `flake8` (both over `src/kiro_crew test conftest.py
xdist_budget.py`), `mypy` (1.14.1, the pinned version, in a venv without `faiss` so it does
not run stricter than CI), `tsc -b`, `vitest` — plus the brand-name, builtin-skill-scope,
loop-bound-locks, testpaths-coverage, black-baseline, lockdown-before-publish,
harness-parity, subprocess-encoding, agent-SDK-boundary, de-Amazon-scrub and docs-lint
gates. Frontend is green at 1689 files / 26690 tests, and this change touches no frontend
file.

The backend suite carries pre-existing failures in this environment (a checkout outside
`$HOME`, which trips the source-root classification and host-isolation tests). Verified
rather than assumed, at two scopes against a clean `upstream/main` worktree at the same
commit: the 22 files containing every non-passing test, and then the **full** suite. Both
failure **sets** diffed identical — 142 entries each (119 failed + 23 errors), zero new
failures — which also covers the one test that fails only in whole-suite context and so
escapes a per-file comparison.
