### PR TITLE
fix(test): assert the post-#2602 _resolve_mcp_server shape

### DIFF
--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -356,7 +356,11 @@ class TestResolveMcpServer:
             {"name": "kirocrew", "mcpServers": {"srv-hr": {"command": "c", "args": ["a"]}}},
         )
 
-        assert _resolve_mcp_server("srv-hr") == ("c", "a")
+        # #2602 made the resolver return the argv AND the server's own env block,
+        # so unpack the pair rather than comparing against the old bare argv.
+        argv, env = _resolve_mcp_server("srv-hr")
+        assert argv == ("c", "a")
+        assert env == {}, "a spec with no env block resolves to an empty env, not None"
 
     def test_malformed_spec_no_longer_escapes_as_a_decode_error(self, agents_dir_resolver):
         """The differential case for THIS site.


### PR DESCRIPTION
## What is the problem?

`test_agent_spec_hardened_reads.py::TestResolveMcpServer::test_valid_agent_spec_still_resolves_under_the_same_cap`
fails on `main` itself:

```
E   AssertionError: assert (('c', 'a'), {}) == ('c', 'a')
test/test_agent_spec_hardened_reads.py:359
```

#2602 ("fix(cron): forward per-server env, sanitized, and pin wrappers at their
source") changed `cron_script._resolve_mcp_server()` from returning the argv
tuple to returning `(argv, env)` -- the server's own env block alongside it. It
updated its own tests in `test_cron_script.py` and
`test_cron_script_more_coverage.py`, but this sibling file still asserted the
bare argv.

## Why this issue matters to the user

The user here is every contributor with an open PR. The test lands in Backend
Tests shard 1, so a single stale assertion reds **three** checks on any PR whose
merge ref includes it -- observed on PR #6997 as `Backend Tests (3.10, 1)`,
`Backend Tests (Windows) (1)` and `Backend Tests (Windows) (3)`, all with the
byte-identical assertion. Because it is deterministic rather than a flake, a
rerun cannot clear it, so every affected PR is stuck until this lands.

It also costs each of those authors the same investigation: the failure names a
file their diff never touched, which reads as "my change broke something far
away" until they prove otherwise.

## How our fix solves it

Symptom (three red shards on unrelated PRs) <- cause (an assertion comparing a
2-tuple against a 1-tuple) <- root cause (#2602 changed a return shape and one
sibling test file was not carried along). This fixes the last link.

The assertion now unpacks the pair and pins both halves:

```python
argv, env = _resolve_mcp_server("srv-hr")
assert argv == ("c", "a")
assert env == {}, "a spec with no env block resolves to an empty env, not None"
```

Unpacking rather than comparing against `(("c", "a"), {})` keeps the `argv`
assertion the test's name is about, and adds the empty-env case #2602 introduced
that this file never covered -- so the file now pins the new contract rather than
merely tolerating it.

Nothing else in the tree needed changing, which was checked rather than assumed:
every other `_resolve_mcp_server` assertion under `test/` is either `is None`
(shape-agnostic) or already the new `((argv...), {})` form. The production caller
at `cron_script.py:401` already unpacks the pair.

## What tests we did

`test/test_agent_spec_hardened_reads.py` passes in full (55 tests, `-n 4`) on
current `main`, whose tip IS #2602 (`5fe1d64e4`) -- so this is verified against
the exact commit that introduced the shape. flake8, isort and the repo's
baseline-aware black gate are clean. Per the repo's CPU rule no full suite was
run locally; CI runs it on the merge ref.

Ownership was established before writing anything, in this order:

1. Base drift ruled out first -- the branch that surfaced it was behind main, and
   a moved base had already produced one phantom failure earlier in that PR.
2. **A/B on a pristine detached `origin/main` worktree with the other PR's commit
   ABSENT: the test fails identically there.** That is what proves the break is
   main's, not the PR's.
3. That PR's diff contains zero `agent_spec` / `mcp` paths.

## Any other suggestions on the work

- This is deliberately a separate PR rather than folded into PR #6997, where it
  surfaced. Folding a foreign fix into an unrelated PR hides the breakage from
  #2602's owner and makes that PR's colour depend on it; a one-line fix on its own
  branch unblocks every affected PR at once instead of just the one that noticed.
- Worth a glance at whether a return-shape change like #2602's can be caught
  mechanically. `mypy` did not flag this because the test unpacked nothing -- it
  compared a tuple to a tuple, which is well-typed and merely false. A test that
  asserts a whole return value is exactly where a shape change hides.

Closes #7175
