### PR TITLE
feat(desktop): add a copy-link block to the right-click menu in chat

### DIFF
--- a/website/electron/context-menu.js
+++ b/website/electron/context-menu.js
@@ -7,17 +7,153 @@
  * this module, right-clicking a misspelled word in the dashboard does
  * nothing — the gap this module closes.
  *
+ * It also owns the LINK block. Right-clicking a link rendered in chat used to
+ * yield only the text-selection menu, so extracting a clean URL meant an
+ * imprecise drag-selection over the visible label (issue #5920). Electron's
+ * `context-menu` params already carry `linkURL`, so the fix is a branch on the
+ * existing template — nothing is plumbed from the renderer.
+ *
+ * The block is clipboard-only, deliberately: left-click already reaches the OS
+ * browser for an external link, so the missing capability was the clipboard,
+ * not a second spelling of the hand-off.
+ *
  * Logic and wiring are split so the template builder is unit-testable without
  * stubbing Electron:
- *   - buildMenuTemplate(params, platform, webContents): pure. All branching
- *     (misspelled word / editable / selection / nothing) lives here. Takes
- *     webContents as an explicit dependency so tests can pass a plain mock.
- *   - attachContextMenu(webContents): side-effecting. Registers the
+ *   - buildMenuTemplate(params, platform, webContents, deps): pure. All
+ *     branching (link / misspelled word / editable / selection / nothing)
+ *     lives here. Takes webContents and `deps` as explicit dependencies so
+ *     tests can pass plain mocks.
+ *   - attachContextMenu(webContents, options): side-effecting. Registers the
  *     `context-menu` listener and pops the built menu on the owning
  *     BrowserWindow.
  */
-function buildMenuTemplate(params, platform, webContents) {
+
+/** A `C:\…` / `C:/…` drive-absolute path, mirroring the renderer's own rule
+ * (`WINDOWS_ABS_PATH_RE` in src/utils/urlTransform.ts). */
+const WINDOWS_ABS_PATH_RE = /^[A-Za-z]:[\\/]/;
+
+/** Longest string worth a filesystem probe. A pathname past this is not a real
+ * path on any supported platform, so it stays a URL without touching disk. */
+const MAX_PROBE_LENGTH = 4096;
+
+/** Two leading separators name a HOST, not a path — `//evil/share`, and the
+ * backslash spelling `\\evil\share` Windows treats identically.
+ *
+ * A chat message is untrusted, so a crafted link such as `/%2Fevil/share`
+ * decodes to `//evil/share`; probing that hands Windows an outbound SMB
+ * authentication attempt against the attacker's host, leaking the user's
+ * credentials with no click beyond the right-press itself. The renderer already
+ * refuses the same shape on both of its paths (`MdAnchor` drops a `//` href, and
+ * `urlTransform.ts` excludes backslash UNC from the local-file branch for this
+ * exact reason), so this is that boundary restated where the probe lives.
+ *
+ * Screened BEFORE the first filesystem call: a probe on a linked ancestor is
+ * already the outbound connection, so a check that runs after it is too late. */
+const UNC_PREFIX_RE = /^[/\\]{2}/;
+
+/**
+ * Read the on-disk path a dashboard-origin link stands for, or null.
+ *
+ * A file link rendered in chat is an anchor whose href is the bare absolute
+ * path, so the browser resolves it against the dashboard origin and `linkURL`
+ * arrives as `http://127.0.0.1:PORT/local/home/me/notes.md`. Copying THAT is
+ * useless — the user wants `/local/home/me/notes.md`. Two same-origin shapes
+ * carry a path:
+ *   - `/api/file-raw?path=<abs>` — the path is explicit in the query.
+ *   - `/<abs>` — the pathname IS the path.
+ * The second shape is indistinguishable from a dashboard route (`/schedule`,
+ * `/artifacts/foo`) by shape alone, and the route table has a catch-all, so it
+ * is settled by a single `pathExists` probe rather than a route list that would
+ * drift. A route that does not exist on disk stays a URL.
+ *
+ * Both shapes are screened for a host-naming UNC prefix (see `UNC_PREFIX_RE`)
+ * before anything touches the filesystem or the clipboard.
+ *
+ * @param {string} linkURL the raw `params.linkURL`
+ * @param {string} appOrigin any URL on the dashboard origin (absent = disabled)
+ * @param {(p: string) => boolean} pathExists filesystem probe
+ * @returns {string|null} the bare path, or null when this is not a file link
+ */
+function localPathForLink(linkURL, appOrigin, pathExists) {
+  if (!appOrigin || typeof pathExists !== "function") return null;
+  let url;
+  let origin;
+  try {
+    url = new URL(linkURL);
+    origin = new URL(appOrigin).origin;
+  } catch {
+    return null;
+  }
+  if (url.origin !== origin) return null;
+
+  // Explicit form first: /api/file-raw?path=<abs> addresses a file BY path, so
+  // no probe is needed — the query already says what it is.
+  const declared = url.pathname === "/api/file-raw" ? url.searchParams.get("path") : null;
+  if (declared) {
+    if (declared.includes("\u0000") || UNC_PREFIX_RE.test(declared)) return null;
+    return declared;
+  }
+
+  let pathname;
+  try {
+    pathname = decodeURIComponent(url.pathname);
+  } catch {
+    return null;
+  }
+  if (!pathname.startsWith("/") || pathname === "/") return null;
+  // A NUL would crash a realpath downstream; length past the cap is not a path.
+  if (pathname.includes("\u0000") || pathname.length > MAX_PROBE_LENGTH) return null;
+  // `/C:/Users/me/x.ts` is how a Windows drive path survives URL resolution.
+  const candidate = WINDOWS_ABS_PATH_RE.test(pathname.slice(1)) ? pathname.slice(1) : pathname;
+  // The screen tests the value handed to `pathExists`, so no later rewrite of
+  // `candidate` can slip a host past it.
+  if (UNC_PREFIX_RE.test(candidate)) return null;
+  try {
+    return pathExists(candidate) ? candidate : null;
+  } catch {
+    // An unreadable ancestor or an EACCES is not a reason to disturb the menu.
+    return null;
+  }
+}
+
+/** Items for the link block, or an empty array when there is no link. */
+function buildLinkItems(params, deps) {
+  const linkURL = params.linkURL;
+  if (!linkURL || typeof linkURL !== "string") return [];
   const items = [];
+  const write = (value) => {
+    const clipboard = deps.clipboard || require("electron").clipboard;
+    clipboard.writeText(value);
+  };
+
+  const localPath = localPathForLink(linkURL, deps.appOrigin, deps.pathExists);
+  if (localPath) {
+    items.push({ label: "Copy File Path", click: () => write(localPath) });
+    return items;
+  }
+
+  // Copy only. An "open in browser" item would re-spell what a plain left-click
+  // already does: chat renders external links `target="_blank"`, so activating
+  // one goes through `setWindowOpenHandler` -> `openExternalSafely` and reaches
+  // the same OS hand-off. #5920 asks for the clipboard, which left-click has no
+  // spelling for.
+  items.push({ label: "Copy Link Address", click: () => write(linkURL) });
+  return items;
+}
+
+function buildMenuTemplate(params, platform, webContents, deps = {}) {
+  const items = [];
+
+  // ── Link block ──
+  //
+  // First, mirroring every browser's own menu: when the click landed on a link
+  // the link is what the user meant. The selection block below still renders
+  // when a selection is also live, so the existing entries never disappear.
+  const linkItems = buildLinkItems(params, deps);
+  if (linkItems.length) {
+    items.push(...linkItems);
+    items.push({ type: "separator" });
+  }
 
   // ── Misspelled-word block ──
   if (params.misspelledWord) {
@@ -71,10 +207,32 @@ function buildMenuTemplate(params, platform, webContents) {
   return items;
 }
 
-function attachContextMenu(webContents) {
+/**
+ * Register the `context-menu` listener on a webContents.
+ *
+ * @param {object} webContents the target
+ * @param {object} [options]
+ * @param {() => string} [options.getAppOrigin] resolves the dashboard origin.
+ *   Supplying it enables the dashboard-origin file-path branch, so pass it ONLY
+ *   for webContents that actually render the dashboard — for arbitrary web
+ *   content a same-origin pathname that happens to exist on disk is not a file.
+ */
+function attachContextMenu(webContents, options = {}) {
   const { Menu, BrowserWindow } = require("electron");
+  const { existsSync } = require("node:fs");
   webContents.on("context-menu", (_event, params) => {
-    const template = buildMenuTemplate(params, process.platform, webContents);
+    let appOrigin = "";
+    if (typeof options.getAppOrigin === "function") {
+      try {
+        appOrigin = options.getAppOrigin() || "";
+      } catch {
+        /* a missing origin only disables the path branch */
+      }
+    }
+    const template = buildMenuTemplate(params, process.platform, webContents, {
+      appOrigin,
+      pathExists: existsSync,
+    });
     if (!template.length) return;
     const win = BrowserWindow.fromWebContents(webContents);
     if (!win) return;
@@ -82,4 +240,4 @@ function attachContextMenu(webContents) {
   });
 }
 
-module.exports = { buildMenuTemplate, attachContextMenu };
+module.exports = { buildMenuTemplate, attachContextMenu, localPathForLink };

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -1688,8 +1688,10 @@ function setupWindowContents(win, backendUrl) {
       removeView: (v) => win.contentView.removeChildView(v),
       // Chrome the embedded page needs but the module must not import Electron
       // for: the shared right-click menu (spelling suggestions, cut/copy/paste,
-      // Look Up). Safe for untrusted content — every item is a plain edit role,
-      // none reaches app state.
+      // Look Up, Copy Link Address). Safe for untrusted content — every item is
+      // a plain edit role or a clipboard write, none reaches app state. No
+      // origin is passed: an arbitrary site's same-origin pathname that happens
+      // to exist on disk is not a local file.
       onCreate: (v) => attachContextMenu(v.webContents),
       onEvent: (name, payload) => {
         // Page-driven window.open goes to the real browser, never a second
@@ -1911,7 +1913,11 @@ function setupWindowContents(win, backendUrl) {
   });
   win._mcAgentChannel.start();
 
-  attachContextMenu(view.webContents);
+  // The dashboard's own webContents, so the link block also gets the origin --
+  // which is what turns a `/abs/path` link into a bare-path copy instead of a
+  // useless localhost URL. The embedded browser panel below passes no origin:
+  // an arbitrary site's same-origin pathname is not a local file.
+  attachContextMenu(view.webContents, { getAppOrigin: () => backendUrl });
 
   // Keep native window controls centered in the zoom-scaled header row.
   // "zoom-changed" covers pinch / ctrl+wheel gestures; the View-menu zoom

--- a/website/electron/test/context-menu.test.js
+++ b/website/electron/test/context-menu.test.js
@@ -1,6 +1,27 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
-const { buildMenuTemplate } = require("../context-menu");
+const { buildMenuTemplate, localPathForLink } = require("../context-menu");
+
+const ORIGIN = "http://127.0.0.1:3210/";
+
+/** deps for the link block: a recording clipboard + a set-membership probe. */
+function mockDeps(overrides = {}) {
+  const written = [];
+  const probed = [];
+  return {
+    written,
+    probed,
+    deps: {
+      appOrigin: ORIGIN,
+      pathExists: (p) => {
+        probed.push(p);
+        return (overrides.existing || []).includes(p);
+      },
+      clipboard: { writeText: (t) => written.push(t) },
+      ...(overrides.deps || {}),
+    },
+  };
+}
 
 function mockParams(overrides = {}) {
   const calls = { replaceMisspelling: [], addWord: [] };
@@ -16,6 +37,7 @@ function mockParams(overrides = {}) {
       isEditable: false,
       editFlags: { canCut: true, canCopy: true, canPaste: true },
       selectionText: "",
+      linkURL: "",
       ...overrides,
     },
     webContents,
@@ -135,5 +157,263 @@ describe("buildMenuTemplate", () => {
     const t = buildMenuTemplate(params, "darwin", webContents);
     t[0].click();
     assert.deepEqual(calls.replaceMisspelling, ["the"]);
+  });
+});
+
+describe("localPathForLink", () => {
+  it("reads the bare path out of a dashboard-origin absolute-path link", () => {
+    const exists = (p) => p === "/local/home/me/notes.md";
+    assert.equal(
+      localPathForLink("http://127.0.0.1:3210/local/home/me/notes.md", ORIGIN, exists),
+      "/local/home/me/notes.md",
+    );
+  });
+
+  it("percent-decodes the pathname before probing", () => {
+    const seen = [];
+    const exists = (p) => { seen.push(p); return p === "/tmp/my file.md"; };
+    assert.equal(
+      localPathForLink("http://127.0.0.1:3210/tmp/my%20file.md", ORIGIN, exists),
+      "/tmp/my file.md",
+    );
+    assert.deepEqual(seen, ["/tmp/my file.md"]);
+  });
+
+  it("reads /api/file-raw?path= without probing the filesystem", () => {
+    let probed = false;
+    const exists = () => { probed = true; return false; };
+    assert.equal(
+      localPathForLink(
+        "http://127.0.0.1:3210/api/file-raw?path=%2Fsrv%2Freport.md&v=3",
+        ORIGIN,
+        exists,
+      ),
+      "/srv/report.md",
+    );
+    assert.equal(probed, false);
+  });
+
+  it("strips the resolution slash off a Windows drive path", () => {
+    const exists = (p) => p === "C:/Users/me/x.ts";
+    assert.equal(
+      localPathForLink("http://127.0.0.1:3210/C:/Users/me/x.ts", ORIGIN, exists),
+      "C:/Users/me/x.ts",
+    );
+  });
+
+  it("leaves a dashboard route alone (nothing on disk)", () => {
+    assert.equal(localPathForLink("http://127.0.0.1:3210/schedule", ORIGIN, () => false), null);
+    assert.equal(
+      localPathForLink("http://127.0.0.1:3210/artifacts/foo", ORIGIN, () => false),
+      null,
+    );
+  });
+
+  it("never treats a cross-origin link as a path, even when it exists on disk", () => {
+    assert.equal(localPathForLink("https://example.com/etc/passwd", ORIGIN, () => true), null);
+  });
+
+  it("is disabled without an origin or a probe", () => {
+    assert.equal(localPathForLink("http://127.0.0.1:3210/tmp/x", "", () => true), null);
+    assert.equal(localPathForLink("http://127.0.0.1:3210/tmp/x", ORIGIN, undefined), null);
+  });
+
+  it("refuses a host-naming UNC path WITHOUT probing (no outbound SMB auth)", () => {
+    // `/%2Fevil/share` decodes to `//evil/share`; probing it would hand Windows
+    // an outbound authentication attempt against the attacker's host.
+    for (const link of [
+      "http://127.0.0.1:3210/%2Fevil/share",
+      "http://127.0.0.1:3210//evil/share",
+      "http://127.0.0.1:3210/%5C%5Cevil%5Cshare",
+      "http://127.0.0.1:3210/%2F%5Cevil/share",
+    ]) {
+      let probed = false;
+      const exists = () => { probed = true; return true; };
+      assert.equal(localPathForLink(link, ORIGIN, exists), null, link);
+      assert.equal(probed, false, `${link} reached the filesystem`);
+    }
+  });
+
+  it("refuses a UNC path declared in /api/file-raw?path= too", () => {
+    let probed = false;
+    const exists = () => { probed = true; return true; };
+    for (const raw of ["%2F%2Fevil%2Fshare", "%5C%5Cevil%5Cshare"]) {
+      assert.equal(
+        localPathForLink(`http://127.0.0.1:3210/api/file-raw?path=${raw}`, ORIGIN, exists),
+        null,
+        raw,
+      );
+    }
+    assert.equal(probed, false);
+  });
+
+  it("a single leading separator is still a normal path", () => {
+    // The screen must not swallow the ordinary POSIX case it sits next to.
+    const exists = (p) => p === "/evil/share";
+    assert.equal(
+      localPathForLink("http://127.0.0.1:3210/evil/share", ORIGIN, exists),
+      "/evil/share",
+    );
+  });
+
+  it("refuses a NUL and an over-long pathname without probing", () => {
+    let probed = false;
+    const exists = () => { probed = true; return true; };
+    assert.equal(localPathForLink("http://127.0.0.1:3210/tmp/a%00b", ORIGIN, exists), null);
+    assert.equal(
+      localPathForLink(`http://127.0.0.1:3210/${"a".repeat(5000)}`, ORIGIN, exists),
+      null,
+    );
+    assert.equal(probed, false);
+  });
+
+  it("survives an unparseable link and a throwing probe", () => {
+    assert.equal(localPathForLink("not a url", ORIGIN, () => true), null);
+    assert.equal(
+      localPathForLink("http://127.0.0.1:3210/tmp/x", ORIGIN, () => { throw new Error("EACCES"); }),
+      null,
+    );
+  });
+});
+
+describe("buildMenuTemplate link block", () => {
+  it("L1: no linkURL leaves the template byte-identical to the pre-link build", () => {
+    // The regression guard for the plain-text right-click. Every non-link shape
+    // must produce exactly what it produced before the link block existed, so
+    // the shapes are compared against the 3-arg call that predates `deps`.
+    const shapes = [
+      {},
+      { selectionText: "hello world" },
+      { isEditable: true },
+      { isEditable: true, editFlags: { canCut: true, canCopy: true, canPaste: false } },
+      { misspelledWord: "teh", dictionarySuggestions: ["the", "tea"] },
+      { misspelledWord: "teh", dictionarySuggestions: [], isEditable: true },
+    ];
+    const shown = (t) => JSON.stringify(t.map((i) => ({
+      label: i.label, role: i.role, type: i.type, enabled: i.enabled, click: !!i.click,
+    })));
+    for (const platform of ["darwin", "linux", "win32"]) {
+      for (const overrides of shapes) {
+        const a = mockParams(overrides);
+        const b = mockParams(overrides);
+        const { deps } = mockDeps({ existing: ["/anything"] });
+        assert.equal(
+          shown(buildMenuTemplate(a.params, platform, a.webContents, deps)),
+          shown(buildMenuTemplate(b.params, platform, b.webContents)),
+          `shape ${JSON.stringify(overrides)} on ${platform} changed`,
+        );
+      }
+    }
+  });
+
+  it("L2: an http(s) link yields exactly one item, Copy Link Address", () => {
+    // Clipboard only: left-click already routes an external link to the OS
+    // browser via setWindowOpenHandler, so a menu hand-off would duplicate it.
+    const { params, webContents } = mockParams({ linkURL: "https://example.com/a?b=1#c" });
+    const { deps, written } = mockDeps();
+    const t = buildMenuTemplate(params, "darwin", webContents, deps);
+    assert.deepEqual(t.map((i) => i.label), ["Copy Link Address"]);
+    t[0].click();
+    assert.deepEqual(written, ["https://example.com/a?b=1#c"]);
+  });
+
+  it("L3: a dashboard-origin file link copies the bare path, NOT the localhost URL", () => {
+    const { params, webContents } = mockParams({
+      linkURL: "http://127.0.0.1:3210/local/home/me/notes.md",
+    });
+    const { deps, written, probed } = mockDeps({ existing: ["/local/home/me/notes.md"] });
+    const t = buildMenuTemplate(params, "darwin", webContents, deps);
+    assert.deepEqual(t.map((i) => i.label), ["Copy File Path"]);
+    t[0].click();
+    assert.deepEqual(written, ["/local/home/me/notes.md"]);
+    assert.ok(!written[0].includes("127.0.0.1"));
+    assert.deepEqual(probed, ["/local/home/me/notes.md"]);
+  });
+
+  it("L4: a link WITH a live selection keeps both blocks, link first", () => {
+    const { params, webContents } = mockParams({
+      linkURL: "https://example.com/x",
+      selectionText: "some highlighted words",
+    });
+    const { deps } = mockDeps();
+    const t = buildMenuTemplate(params, "darwin", webContents, deps);
+    assert.equal(t[0].label, "Copy Link Address");
+    assert.equal(t[1].type, "separator");
+    // The pre-existing selection entries survive, unchanged and in order.
+    assert.equal(t[2].role, "copy");
+    assert.ok(t[3].label.startsWith("Look Up '"));
+    assert.equal(t.length, 4);
+  });
+
+  it("L5: a link inside an editable field keeps cut/copy/paste/selectAll", () => {
+    const { params, webContents } = mockParams({
+      linkURL: "https://example.com/x",
+      isEditable: true,
+    });
+    const { deps } = mockDeps();
+    const t = buildMenuTemplate(params, "linux", webContents, deps);
+    assert.equal(t[0].label, "Copy Link Address");
+    assert.equal(t[1].type, "separator");
+    assert.deepEqual(t.slice(2).map((i) => i.role || i.type),
+      ["cut", "copy", "paste", "separator", "selectAll"]);
+  });
+
+  it("L6: a misspelled link label keeps its suggestions after the link block", () => {
+    const { params, webContents } = mockParams({
+      linkURL: "https://example.com/x",
+      misspelledWord: "exmaple",
+      dictionarySuggestions: ["example"],
+    });
+    const { deps } = mockDeps();
+    const t = buildMenuTemplate(params, "darwin", webContents, deps);
+    assert.equal(t[0].label, "Copy Link Address");
+    assert.equal(t[1].type, "separator");
+    assert.equal(t[2].label, "example");
+    assert.equal(t[4].label, "Add to Dictionary");
+  });
+
+  it("L7: the browser panel (no origin) copies the URL and never probes disk", () => {
+    const { params, webContents } = mockParams({
+      linkURL: "https://example.com/local/home/me/notes.md",
+    });
+    const { deps, written, probed } = mockDeps({
+      deps: { appOrigin: "" },
+      existing: ["/local/home/me/notes.md"],
+    });
+    const t = buildMenuTemplate(params, "darwin", webContents, deps);
+    assert.deepEqual(t.map((i) => i.label), ["Copy Link Address"]);
+    t[0].click();
+    assert.deepEqual(written, ["https://example.com/local/home/me/notes.md"]);
+    assert.deepEqual(probed, []);
+  });
+
+  it("L8: a same-origin non-file link copies the URL and offers no hand-off", () => {
+    const { params, webContents } = mockParams({ linkURL: "http://127.0.0.1:3210/schedule" });
+    const { deps, written } = mockDeps({ existing: [] });
+    const t = buildMenuTemplate(params, "darwin", webContents, deps);
+    assert.deepEqual(t.map((i) => i.label), ["Copy Link Address"]);
+    t[0].click();
+    assert.deepEqual(written, ["http://127.0.0.1:3210/schedule"]);
+  });
+
+  // The UX review noted a browser would spell this "Copy Email Address" and copy
+  // the bare address. Deliberately not done: the item's contract is "the
+  // clipboard gets the link", and one scheme-specific relabel invites the whole
+  // per-scheme table (tel:, sms:, magnet:) that #5920 never asked for.
+  it("L9: a non-web scheme copies the whole URL, scheme included", () => {
+    const { params, webContents } = mockParams({ linkURL: "mailto:someone@example.com" });
+    const { deps, written } = mockDeps();
+    const t = buildMenuTemplate(params, "darwin", webContents, deps);
+    assert.deepEqual(t.map((i) => i.label), ["Copy Link Address"]);
+    t[0].click();
+    assert.deepEqual(written, ["mailto:someone@example.com"]);
+  });
+
+  it("L10: a link with nothing else selected still yields a usable menu", () => {
+    const { params, webContents } = mockParams({ linkURL: "https://example.com/x" });
+    const { deps } = mockDeps();
+    const t = buildMenuTemplate(params, "linux", webContents, deps);
+    assert.notEqual(t[t.length - 1].type, "separator");
+    assert.deepEqual(t.map((i) => i.label), ["Copy Link Address"]);
   });
 });


### PR DESCRIPTION
## Problem / Motivation

Right-clicking a link rendered in chat in the desktop app gives only the OS
text-selection menu — `Copy` on whatever fragment happens to be highlighted,
and `Look Up`. There is no link-aware entry, so getting a clean URL out of a
link means an imprecise drag-selection over the visible label, and getting the
absolute path out of a file link is worse: the label is usually a truncated
display name, and the href resolves against the dashboard origin.

## Why it matters

Copying a link out of chat is a constant, low-level action — pasting a URL into
a browser, a ticket, or a terminal. Today every one of those costs a fiddly
drag-select that is easy to get wrong (one character short, one word long), and
on a file link there is no selection that yields the path at all.

## What changed (motivation → approach → change)

Electron's `context-menu` event params already carry `linkURL`, so the whole
feature is a branch on the existing template in
`website/electron/context-menu.js` — nothing is plumbed from the renderer, and
no new menu system is introduced.

**The block is clipboard-only, deliberately.** Chat renders external links
`target="_blank"`, so a plain left-click already goes through
`setWindowOpenHandler` → `openExternalSafely` and reaches the OS browser. An
"open in browser" menu item would be a second spelling of a hand-off the user
already has; the capability that had no spelling at all was the clipboard.

| Link | Item |
|---|---|
| Any link (external `http(s)`, same-origin route, `mailto:`, …) | `Copy Link Address` |
| Dashboard-origin file link | `Copy File Path` |

The link block renders **first**, mirroring every browser's own menu, and the
misspelled-word / editable / selection blocks below are untouched.

**The file-path case is the one worth reading.** A file link in chat is an
anchor whose href is the bare absolute path, so the browser resolves it against
the dashboard origin and `linkURL` arrives as
`http://127.0.0.1:PORT/local/home/me/notes.md`. Copying *that* is useless. Two
same-origin shapes carry a path, and they resolve differently on purpose:

- `/api/file-raw?path=<abs>` — the path is explicit in the query, so it is read
  straight out and **no filesystem probe happens**.
- `/<abs>` — the pathname *is* the path, but it is indistinguishable by shape
  from a dashboard route (`/schedule`, `/artifacts/foo`). The route table has a
  catch-all (`/:builtinApp`), so a hard-coded route list in the main process
  would drift silently the first time a route is added. It is settled instead by
  one `fs.existsSync` probe on right-click: a route that does not exist on disk
  stays a URL.

### The probe's rails

A chat message is untrusted, and the probe is the one thing in this diff that
reaches outside the process, so every screen runs **before** it:

- **A host-naming UNC prefix is refused.** `/%2Fevil/share` decodes to
  `//evil/share`, and probing that hands Windows an outbound SMB authentication
  attempt against the attacker's host. Both the decoded pathname and the
  `?path=` query value are screened, so nothing reaches the filesystem *or* the
  clipboard. The renderer already refuses this exact shape on both of its paths
  — `MdAnchor` drops a `//` href, and `urlTransform.ts` excludes backslash UNC
  from the local-file branch "because a UNC path names a HOST" — so this
  restates an existing boundary where the probe lives, rather than inventing one.
- A NUL or an over-length pathname is refused without touching disk.
- A throwing probe (EACCES, unreadable ancestor) degrades to "not a path"
  instead of disturbing the menu.
- A cross-origin link is never probed at all.

**The embedded browser panel deliberately gets less.** `attachContextMenu` takes
an options bag, and the panel's call site passes no `getAppOrigin` — so it never
probes disk and its menu is a plain copy. An arbitrary site's same-origin
pathname that happens to exist locally is not a local file.

### i18n

N/A. `website/electron/**` main-process menu labels are hardcoded English by
existing convention in this exact file (`Add to Dictionary`, `No suggestions`,
`Look Up '…'`), and the `lint:i18n` gate scopes itself to
`website/src/**/*.tsx?` — so there is no catalog to update and no locale file is
touched.

## Tests

22 new cases in `website/electron/test/context-menu.test.js` (34 in the file,
all passing), split between the pure path resolver and the template.

`localPathForLink`
- reads the bare path out of a dashboard-origin absolute-path link
- percent-decodes the pathname before probing (asserts the *decoded* form is
  what gets probed)
- reads `/api/file-raw?path=` **and asserts the filesystem was never touched**
- **refuses a host-naming UNC path WITHOUT probing** — four spellings
  (`/%2Fevil/share`, `//evil/share`, `/%5C%5Cevil%5Cshare`, the mixed
  `/%2F%5Cevil/share`), each asserting the probe was never called
- **refuses a UNC path declared in `/api/file-raw?path=`** (both slash spellings)
- **a single leading separator is still a normal path** — the screen must not
  swallow the ordinary POSIX case sitting next to it
- strips the resolution slash off a Windows drive path (`/C:/…` → `C:/…`)
- leaves a dashboard route alone when nothing is on disk (`/schedule`,
  `/artifacts/foo`)
- never treats a cross-origin link as a path *even when the probe says the
  pathname exists* (`https://example.com/etc/passwd`)
- is inert without an origin or without a probe
- refuses a NUL and an over-long pathname **without probing**
- survives an unparseable link and a throwing probe

`buildMenuTemplate`
- **L1 — no `linkURL` leaves the template byte-identical.** The regression guard
  for the plain-text right-click: six non-link param shapes × three platforms
  are built twice, once with the new `deps` and once through the 3-argument call
  that predates the link block, and the serialised templates must match. This is
  what proves nothing about today's menu moved.
- an http(s) link yields exactly one item, `Copy Link Address`, and the click is
  exercised against a recording clipboard
- **a dashboard-origin file link copies the bare path**, the assertion checks
  `127.0.0.1` is absent from what was written, and the probe is asserted to have
  seen the decoded path
- a link WITH a live selection keeps both blocks, link first, separator between,
  and the pre-existing `copy` + `Look Up '…'` entries intact and in order
- a link inside an editable field keeps cut/copy/paste/selectAll
- a misspelled link label keeps its suggestions after the link block
- the browser panel (no origin) copies the URL and **never probes disk**, proven
  with a path that does exist locally
- a same-origin non-file link copies the URL
- a non-web scheme (`mailto:`) copies the whole URL, scheme included
- no trailing separator is left behind

**Red-before proven** for the security fix: reverting just the two
`UNC_PREFIX_RE` screens turns both UNC tests red (32/34) and leaves the rest
green; restoring them returns 34/34.

Suites on this head:

- `website/electron`: **1480 tests, 1453 pass, 0 fail** (26 cancelled in
  `gateway-stop.test.js`, identical on the base commit — sandbox process-tree
  restrictions, not this diff).
- `tsc -b` clean; `eslint src` 0 errors; `lint:i18n` unchanged (no locale file
  touched); `node --check` clean on both changed main-process files.
- `website/src` vitest: this diff adds no file under `website/src` or
  `integration/`, which is vitest's entire scope. `MarkdownRenderer*`,
  `renderUserContent*` and `urlTransform*` (29 files) run green as a
  neighbouring sanity check; the full 4-shard suite is left to CI.

## Manual verification

Menu construction is fully covered by the unit suite above, including the
clipboard writes and the probe-call assertions. What unit tests cannot cover is
the native menu actually popping — see below.

## Screenshots / video

Not attached, and this is a deliberate statement rather than an omission: **the
surface is an Electron main-process native menu**, drawn by the OS window
manager and not by the page. Playwright cannot capture it, so the frames have to
be taken by hand on a desktop running this branch. `<!-- no-visual-delta -->`
would be the wrong claim — there *is* a visual delta.

Two frames are wanted, and I will commit them under
`temp-screenshots/copy-link-context-menu/` with SHA-pinned URLs as soon as they
exist:

1. the popped menu on an `https://` link in chat, showing `Copy Link Address`
   above the separator and the existing selection entries below;
2. the popped menu on a file-path link in chat, showing `Copy File Path`.

Repro for whoever captures them: build this branch's desktop app, open a chat
containing `[example](https://example.com/some/page)` and a link whose
destination is an absolute path that exists on the machine, then right-click
each.

## Related Issues

Fixes #5920

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the module header and both
      `attachContextMenu` call-site comments describe the link block, the UNC
      screen, and why the panel gets less
- [x] No secrets, credentials, or internal references in the diff
