### PR TITLE
refactor(aws-control): use CSS auto-fill for DrivePage grids

### DIFF
--- a/website/src/apps/aws-control/DrivePage.tsx
+++ b/website/src/apps/aws-control/DrivePage.tsx
@@ -41,7 +41,6 @@ import type { LibraryColumn } from '../../components/library/LibraryTable'
 import {
   WidgetThumb, ContentThumb, ImageThumb, WebAppThumb,
 } from '../../components/library/ArtifactThumbs'
-import { useColumnCount } from '../../hooks/useColumnCount'
 import { usePersistedString } from '../../hooks/usePersistedString'
 import { api } from '../../api/client'
 import type { Artifact } from '../../types'
@@ -275,7 +274,6 @@ function OrphanThumb() {
 function LibrarySection({ account, bucket }: { account: string; bucket: string }) {
   const [mode, setMode] = useViewMode('library', 'grid')
   const [picking, setPicking] = useState(false)
-  const [gridRef, cols] = useColumnCount(258)
 
   /* What is in the cloud, ACCUMULATED across pages. A plain query keyed by the
      continuation token replaced the visible page on every "Load more", which is
@@ -451,17 +449,15 @@ function LibrarySection({ account, bucket }: { account: string; bucket: string }
       )}
 
       {slugs.length > 0 && mode === 'grid' && (
-        <div ref={gridRef} className="-mr-3" data-testid="library-grid">
-          <div className="grid items-start" style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}>
-            {slugs.map((slug) => (
-              <LibraryCloudCard
-                key={slug}
-                slug={slug}
-                local={bySlug.get(slug)}
-                localAnswered={localAnswered}
-              />
-            ))}
-          </div>
+        <div className="grid items-start -mr-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(258px, 1fr))' }} data-testid="library-grid">
+          {slugs.map((slug) => (
+            <LibraryCloudCard
+              key={slug}
+              slug={slug}
+              local={bySlug.get(slug)}
+              localAnswered={localAnswered}
+            />
+          ))}
         </div>
       )}
 
@@ -695,7 +691,6 @@ function AddFromArtifactsDialog({ account, onClose }: { account: string; onClose
   const qc = useQueryClient()
   const [kind, setKind] = useState<ArtifactKind | 'all'>('all')
   const [q, setQ] = useState('')
-  const [gridRef, cols] = useColumnCount(258)
   const backdropDown = useRef(false)
 
   /**
@@ -892,18 +887,16 @@ function AddFromArtifactsDialog({ account, onClose }: { account: string; onClose
             </p>
           )}
           {shown.length > 0 && (
-            <div ref={gridRef} className="-mr-3">
-              <div className="grid items-start" style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}>
-                {shown.map((a) => (
-                  <PickerCard
-                    key={a.slug}
-                    artifact={a}
-                    onPush={() => { void addOne(a.slug) }}
-                    pushing={addingSlugs.has(a.slug)}
-                    failed={failedSlugs.has(a.slug)}
-                  />
-                ))}
-              </div>
+            <div className="grid items-start -mr-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(258px, 1fr))' }}>
+              {shown.map((a) => (
+                <PickerCard
+                  key={a.slug}
+                  artifact={a}
+                  onPush={() => { void addOne(a.slug) }}
+                  pushing={addingSlugs.has(a.slug)}
+                  failed={failedSlugs.has(a.slug)}
+                />
+              ))}
             </div>
           )}
         </div>
@@ -1061,7 +1054,6 @@ function DriveSectionView({ account, bucket }: { account: string; bucket: string
      what was removed rather than pretending to predict it. */
   const [deletedCount, setDeletedCount] = useState<number | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
-  const [filesGridRef, fileCols] = useColumnCount(258)
   /* The pinned Actions cell paints its seam only when the table actually
      overflows, so the edge is measured rather than assumed. */
   const [attachScroller, edges] = useScrollEdges<HTMLDivElement>()
@@ -1267,8 +1259,7 @@ function DriveSectionView({ account, bucket }: { account: string; bucket: string
           otherwise lose Share and Delete on every future visit with nothing to
           tell them the controls existed. */}
       {listQ.data && mode === 'grid' && (listQ.data.folders.length > 0 || listQ.data.files.length > 0) && (
-        <div ref={filesGridRef} className="-mr-3" data-testid="drive-grid">
-          <div className="grid items-start" style={{ gridTemplateColumns: `repeat(${fileCols}, minmax(0, 1fr))` }}>
+        <div className="grid items-start -mr-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(258px, 1fr))' }} data-testid="drive-grid">
             {listQ.data.folders.map((name) => {
               const open = () => { setPath(name); setToken(''); setDeletedCount(null) }
               return (
@@ -1397,7 +1388,6 @@ function DriveSectionView({ account, bucket }: { account: string; bucket: string
                 )}
               </div>
             ))}
-          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

`DrivePage.tsx` built four responsive card grids two different ways: the Drive root folder-card grid used pure CSS (`repeat(auto-fill, minmax(258px, 1fr))`), while the other three (Library grid, Files grid, Add-from-Artifacts picker) used `useColumnCount(258)` — a hook that attaches a ResizeObserver, measures the container in JS, computes a column count, and writes `repeat(${cols}, minmax(0, 1fr))`.

Both mechanisms produce the same layout. This PR replaces the three measured grids with the native CSS form the root grid already uses, removing the JS measurement, the observer subscription and the resize re-render for a result the browser computes natively — leaving one way to lay out a grid in this file.

Resolves the request in issue #7057.

## Changes

- Library grid (`data-testid="library-grid"`): dropped `useColumnCount(258)`, collapsed the `-mr-3` wrapper + measured inner grid into a single CSS `auto-fill` grid div.
- Add-from-Artifacts picker dialog: same collapse; dropped its `useColumnCount(258)`.
- Files grid (`data-testid="drive-grid"`): dropped `useColumnCount(258)`, collapsed the wrapper.
- Dropped the now-unused `useColumnCount` import from `DrivePage.tsx`.

Each collapsed grid keeps `items-start` and the `-mr-3` edge cancellation; the cards carry their own `mb-3 mr-3` spacing, so no `gap` change was needed and layout is preserved. `data-testid` attributes are retained on the grid divs.

## Scope preserved

- `website/src/hooks/useColumnCount.ts` is untouched and still exported.
- `website/src/pages/ArtifactsPage.tsx` is untouched (two `useColumnCount(300)` call sites intact), because its `VirtuosoMasonry` needs the column count as a number. So `src/test/ArtifactsPage.narrowSingleAxis.test.tsx` is unaffected.

Diff: 1 file changed, 20 insertions(+), 30 deletions(-).

## Testing

**Automated verification was NOT run in this environment.** The sandbox network mode is "Repository access only" (INTEGRATIONS_ONLY), which blocks the npm registry, and `node_modules` is absent from the checkout, so `npm ci` fails with `403 Forbidden`. As a result typecheck, lint, and the test suite could not be executed here.

Please run the following in an environment with npm registry access to complete verification:

```
cd website && npm ci && npm run typecheck && npm run lint \
  && npx vitest run src/test/widgetHeights.test.ts src/test/ArtifactsPage.narrowSingleAxis.test.tsx
```

Manual checks performed without dependencies:
- Reviewed the diff: JSX structure is balanced, changes scoped to the three grids only.
- `widgetHeights.test.ts` does not reference DrivePage, these grids, or `useColumnCount`.
- The 320px narrow-viewport frame should stay single-column: `auto-fill` + `minmax(258px, 1fr)` collapses to one column below ~258px, matching the root grid's existing behavior.

Two follow-ups called out in the issue that a reviewer with a running build should confirm: the 320px frame, and the widget-height ratchet in `src/test/widgetHeights.test.ts`.

Note: in the Files grid, the ~120 lines of child JSX were left at their original indentation to keep the diff minimal and the layout change attributable. If the project's formatter enforces indentation, a prettier/eslint pass may reflow those lines.