### PR TITLE
test(agents): assert the current _resolve_mcp_server shape

### DIFF
--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -356,7 +356,9 @@ class TestResolveMcpServer:
             {"name": "kirocrew", "mcpServers": {"srv-hr": {"command": "c", "args": ["a"]}}},
         )
 
-        assert _resolve_mcp_server("srv-hr") == ("c", "a")
+        # `_resolve_mcp_server` returns `(argv, env)`; the env block is load-bearing (see
+        # its docstring) and empty when the spec declares none.
+        assert _resolve_mcp_server("srv-hr") == (("c", "a"), {})
 
     def test_malformed_spec_no_longer_escapes_as_a_decode_error(self, agents_dir_resolver):
         """The differential case for THIS site.


### PR DESCRIPTION
## What

One stale assertion in `test/test_agent_spec_hardened_reads.py`, updated to the return
shape `_resolve_mcp_server` has had since the env block was added.

## Why

`TestResolveMcpServer::test_valid_agent_spec_still_resolves_under_the_same_cap` fails on
`main` right now:

```
AssertionError: assert (('c', 'a'), {}) == ('c', 'a')
```

The implementation is the deliberate side, not the test. `_resolve_mcp_server` is annotated
`-> tuple[tuple[str, ...], dict[str, str]] | None`, and its docstring says why the
per-server env block is load-bearing: a launcher that shells out to a helper binary
reachable only via the PATH the config supplies dies at the JSON-RPC `initialize` handshake
without it.

The sibling test file was already updated for that change --
`test/test_cron_script.py::test_returns_argv_and_env_for_valid_config` asserts
`(("node", "server.js", "--port", "3000"), {})` and carries the comment
`# New shape: (argv, env)`. This one assertion in the other file was simply missed.

Pull-request CI tests the MERGE commit, so every open PR inherits this in `Backend Tests`
shard 1 regardless of what it changes, and a re-run cannot clear it because the check is
deterministic rather than flaky. I hit it from that side, on
https://github.com/kirodotdev/KiroCrew/pull/7187, whose diff contains no Python at all.

## How

Updated the assertion to `(("c", "a"), {})`, with a comment pointing at the docstring so the
empty dict does not read as an accident.

## Testing

- `test/test_agent_spec_hardened_reads.py` on a clean `origin/main` worktree: **1 failed, 54
  passed** before, **55 passed** after.
- `test/test_cron_script.py`: 124 passed, unchanged -- it already asserted the new shape.
- `ruff check` clean.

## Blocked features

None. This unblocks `Backend Tests` shard 1 for every open PR.

<!-- no-visual-delta -->

**Why no screenshot:** test-only change, no user-visible surface.
