### PR TITLE
test: fix two broken-main tests red on every PR's merge ref

### DIFF
--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -356,7 +356,7 @@ class TestResolveMcpServer:
             {"name": "kirocrew", "mcpServers": {"srv-hr": {"command": "c", "args": ["a"]}}},
         )
 
-        assert _resolve_mcp_server("srv-hr") == ("c", "a")
+        assert _resolve_mcp_server("srv-hr") == (("c", "a"), {})
 
     def test_malformed_spec_no_longer_escapes_as_a_decode_error(self, agents_dir_resolver):
         """The differential case for THIS site.

--- a/test/test_resource_limits_schema.py
+++ b/test/test_resource_limits_schema.py
@@ -275,6 +275,14 @@ class TestCgroupConsumerUnchanged:
                 unittest.mock.patch.object(sb, "_probe_cgroup_scope", return_value=(True, "")),
                 unittest.mock.patch.object(sb, "_reconcile_slice_memory_high_off_thread"),
                 unittest.mock.patch.object(sb, "_cpu_controller_delegated", return_value=True),
+                # Pin the wrapper resolution too: on Windows/macOS there is no
+                # systemd-run, so the unmocked resolver returns None and the
+                # function degrades (argv unchanged) BY DESIGN — this test is
+                # about the argv the Linux path builds, so it must be hermetic
+                # on every OS the suite runs on.
+                unittest.mock.patch.object(
+                    sb.platform_compat, "trusted_system_bin", return_value="/usr/bin/systemd-run"
+                ),
                 unittest.mock.patch(
                     "kiro_crew.config.loader._raw_config",
                     return_value={"resource_limits": raw},


### PR DESCRIPTION
## Problem / Motivation

Two tests are red on `main` itself — both reproduced on a clean
`origin/main` worktree — redding their shards on **every open PR's**
merge ref:

1. `Backend Tests (*, 1)` (all OSes):
```
FAILED test/test_agent_spec_hardened_reads.py::TestResolveMcpServer::test_valid_agent_spec_still_resolves_under_the_same_cap
AssertionError: assert (('c', 'a'), {}) == ('c', 'a')
```
`_resolve_mcp_server` returns `(argv, env)` — the documented shape (the
per-server `env` block keeps PATH-dependent MCP launchers alive through
the JSON-RPC initialize handshake) — but this assertion still expects the
bare argv tuple.

2. `Backend Tests (Windows) (3)`:
```
FAILED test/test_resource_limits_schema.py::TestCgroupConsumerUnchanged::test_the_scope_argv_never_carries_a_zero_ceiling
```
The zero-ceiling test mocks the cgroup probe but not the `systemd-run`
resolver: on Windows/macOS `trusted_system_bin("systemd-run")` returns
`None` and `cgroup_scope_argv` degrades (argv unchanged) **by design** —
the "a ceiling is still present" assertions then fail on an empty list.
Confirmed identical on two independent branches' Windows shards.

## Change

Test-only, two files:
- Update the resolver expectation to `(("c", "a"), {})` (the planted spec
  declares no `env` block, which the docstring defines as the empty dict).
- Pin `trusted_system_bin` alongside the probe mock so the zero-ceiling
  test exercises the Linux argv-building path hermetically on every OS.

## Testing

- `test/test_agent_spec_hardened_reads.py` 55/55 (was 54+1F)
- `test/test_resource_limits_schema.py` 56/56 (was 55+1F on Windows;
  green on Linux before and after — the added mock only removes the
  OS dependency)

<!-- no-visual-delta -->
**Why no screenshot:** test-only change, no rendered surface.

no linked issue: broken-main hotfix found while babysitting PR #7189.
