### PR TITLE
fix(virtualizer): hold the reader across a mid-list row splice

### DIFF
--- a/website/src/hooks/virtualizer/HeightCache.ts
+++ b/website/src/hooks/virtualizer/HeightCache.ts
@@ -74,10 +74,15 @@ export class HeightCache {
   private readonly storageKey: string
   private dirty = false
   private flushTimer: FlushTimer | null = null
-  // Running sum of MEASURED heights (every cache entry is a measurement), kept
-  // in lockstep with the map through set / overwrite / eviction / load so
-  // averageHeight() is O(1). The mean is sum / cache.size.
+  // Running sum of the LIVE measured heights, kept in lockstep with the map
+  // through set / overwrite / eviction / load / retire so averageHeight() is
+  // O(1). "Live" excludes retired keys (see `retired`), so the mean is
+  // measuredSum / (cache.size - retired.size).
   private measuredSum = 0
+  // Keys whose ROW HAS LEFT THE LIST but whose measurement is kept. They are
+  // excluded from the mean and from the persisted blob, and revived by a later
+  // set() -- see retire() for why the entry is kept rather than deleted.
+  private readonly retired: Set<string> = new Set()
   // Session row count driving the size-aware eviction cap. 0 means UNKNOWN,
   // never "this session is empty" — see setRowCount() and load().
   private rowCount = 0
@@ -146,8 +151,10 @@ export class HeightCache {
    * measurement beats a very-low flat one, so only the outlier ceiling is kept.
    */
   averageHeight(fallback: number = DEFAULT_ESTIMATED_HEIGHT): number {
-    const n = this.cache.size
-    if (n === 0) return fallback
+    // Retired entries are still in the map (their own rows can come back) but
+    // must not price OTHER rows, so they are out of both halves of the mean.
+    const n = this.cache.size - this.retired.size
+    if (n <= 0) return fallback
     return Math.min(this.measuredSum / n, MAX_MEAN_PX)
   }
 
@@ -184,11 +191,73 @@ export class HeightCache {
     const prev = this.cache.get(key)
     if (prev !== undefined) {
       this.cache.delete(key)
-      this.measuredSum -= prev
+      // A retired entry's height is ALREADY out of measuredSum, so subtracting
+      // it again would double-count. Measuring the row also revives it: a row
+      // being measured is mounted, so it is back in the list.
+      if (!this.retired.delete(key)) this.measuredSum -= prev
     }
     this.cache.set(key, height)
     this.measuredSum += height
     this.evictToCap()
+    this.dirty = true
+    this.scheduleFlush()
+  }
+
+  /**
+   * Retire the measurement for `key` -- the row it belonged to has LEFT the list.
+   *
+   * The entry is KEPT and only removed from the mean. That split is the whole
+   * point, because the two halves have opposite failure modes:
+   *
+   *  - Keeping it in the MEAN is wrong. `averageHeight()` prices every
+   *    UNMEASURED row, so a measurement is never local to its own row: a
+   *    transient streaming placeholder measured at a fraction of a real message
+   *    goes on dragging the estimate for rows that are still on screen, for the
+   *    rest of the session and across reloads once the blob is persisted.
+   *  - DELETING it is also wrong, because a row leaving the list is not always
+   *    permanent. An optimistically truncated transcript is restored wholesale
+   *    when the server refuses the press (regenerate and edit-resend both
+   *    snapshot, truncate, then replace the snapshot back), and rows that came
+   *    back without their measurements would be re-priced from the mean --
+   *    wrong spacers and a viewport jump, which is the very failure this cache
+   *    exists to prevent. Keeping the entry makes that restore exact.
+   *
+   * A later `set()` revives the key: a row being measured is mounted, so it is
+   * live again. Retired entries are evicted BEFORE any live measurement (see
+   * evictToCap), so they cannot accumulate and cannot cost a live row its
+   * height.
+   *
+   * Callers must pass only keys that left the DATA, never keys that merely
+   * UNMOUNTED -- remembering a row that scrolled out of the window is what this
+   * cache is for.
+   */
+  retire(key: string): void {
+    if (!this.cache.has(key) || this.retired.has(key)) return
+    this.retired.add(key)
+    this.measuredSum -= this.cache.get(key) as number
+    this.dirty = true
+    this.scheduleFlush()
+  }
+
+  /**
+   * Un-retire `key` because its row is in the list again, so its measurement
+   * counts toward the mean once more.
+   *
+   * The caller is the resolved-height read, not a removal site: a restore is not
+   * the mirror image of a removal. An optimistic TAIL truncation comes back as a
+   * plain append, which is not a splice at all, so there is no commit shape to
+   * hook a revive onto -- while a key resolving from a LIVE row index is itself
+   * proof the retirement's premise no longer holds. Idempotent and O(1); the
+   * mean it feeds converges on the next sync.
+   */
+  reviveIfRetired(key: string): void {
+    if (!this.retired.delete(key)) return
+    const h = this.cache.get(key)
+    // Cannot be missing (eviction drops the retired mark with the entry), but a
+    // silent no-op is the right answer if it ever is: adding an unknown height
+    // to the sum would corrupt every later mean.
+    if (h === undefined) return
+    this.measuredSum += h
     this.dirty = true
     this.scheduleFlush()
   }
@@ -207,6 +276,22 @@ export class HeightCache {
     const cap = this.effectiveCap()
     let evicted = 0
     while (this.cache.size > cap) {
+      // RETIRED FIRST, ahead of LRU order. A retired row has left the list and
+      // its entry exists only to serve a possible rollback, so it is strictly
+      // less valuable than any live measurement. LRU order alone gets this
+      // backwards: a transient row is measured immediately before it leaves, so
+      // it sits at the most-recently-used end and would be the LAST evicted,
+      // costing an older LIVE row its measurement while a dead one survives.
+      // The set is insertion-ordered, so this drops the longest-retired first.
+      const retiredKey = this.retired.values().next().value
+      if (retiredKey !== undefined) {
+        // Removed from `retired` first, so the loop makes progress even in the
+        // impossible case where the entry is already gone from the map.
+        this.retired.delete(retiredKey)
+        // Already out of measuredSum -- retire() subtracted it.
+        if (this.cache.delete(retiredKey)) evicted++
+        continue
+      }
       // Map iteration is in insertion order, so the first key is the oldest.
       const oldestEntry = this.cache.entries().next().value
       if (oldestEntry === undefined) break
@@ -235,7 +320,14 @@ export class HeightCache {
       // are stored as own properties instead of mutating the prototype.
       // (A naive `{}` literal swallows __proto__ on assignment.)
       const obj: Record<string, number> = Object.create(null)
-      for (const [k, v] of this.cache) obj[k] = v
+      // Retired keys are deliberately NOT persisted: the row is gone from the
+      // transcript, so after a reload its height would be back in the mean
+      // pricing rows that are still there. The in-memory entry is what serves a
+      // same-session rollback; a reload has no snapshot to roll back to.
+      for (const [k, v] of this.cache) {
+        if (this.retired.has(k)) continue
+        obj[k] = v
+      }
       this.storage.setItem(this.storageKey, JSON.stringify(obj))
     } catch {
       // Quota exceeded or transient failure — drop this flush. A future set()
@@ -247,6 +339,7 @@ export class HeightCache {
   /** Clears both in-memory and persisted state for this session. */
   clear(): void {
     this.cache.clear()
+    this.retired.clear()
     this.measuredSum = 0
     this.dirty = false
     if (this.flushTimer !== null) {
@@ -259,6 +352,16 @@ export class HeightCache {
     } catch {
       // Best-effort — swallow.
     }
+  }
+
+  /**
+   * True when any measurement is retired.
+   *
+   * The O(1) guard a caller uses to skip a live-row scan entirely on the
+   * overwhelmingly common commit, where nothing is retired at all.
+   */
+  hasRetired(): boolean {
+    return this.retired.size > 0
   }
 
   /** Number of entries currently in the cache. Visible for tests/debug. */

--- a/website/src/hooks/virtualizer/HeightIndex.ts
+++ b/website/src/hooks/virtualizer/HeightIndex.ts
@@ -164,6 +164,20 @@ export class HeightIndex {
   }
 
   /**
+   * Retire measurements for rows that have LEFT the list, so their heights stop
+   * pricing the unmeasured rows that remain. The measurements are KEPT and only
+   * dropped from the mean, so an optimistic removal that gets rolled back
+   * restores exact geometry -- see HeightCache.retire.
+   *
+   * Deliberately does NOT sync or announce: the caller retires during the render
+   * that dropped the rows and the tree is re-synced in that same render, so the
+   * reprice lands in the commit whose shift is already compensated.
+   */
+  retire(keys: Iterable<string>): void {
+    for (const key of keys) this.cache.retire(key)
+  }
+
+  /**
    * Height getter for the O(N) free functions that still take one
    * (`getOffset` / `getTotalHeight` / `computeWindow`).
    *
@@ -172,8 +186,37 @@ export class HeightIndex {
    */
   readonly getHeight = (index: number): number => this.heightAt(index)
 
+  /**
+   * Revive every retired key whose row is LIVE again -- BEFORE anything reads a
+   * height.
+   *
+   * A key resolving from a live row index falsifies the premise of its
+   * retirement (see HeightCache.retire): the row is in the list again, an
+   * optimistically removed row the server refused and restored wholesale. This
+   * is the only available signal, because a restore has no commit shape of its
+   * own to hook -- an optimistic TAIL truncation comes back as a plain append.
+   *
+   * It runs as a PASS BEFORE the tree walk rather than inside the height read,
+   * because the walk prices rows in index order and reads the mean per row: a
+   * revive partway through would leave every row priced earlier in that same
+   * walk holding the pre-revive mean, with no later sync guaranteed to correct
+   * them (a transcript that goes idle right after the rollback gets none). One
+   * pass first makes the whole tree consistent with one mean.
+   *
+   * Skipped outright when nothing is retired, which is the overwhelmingly common
+   * case, so the ordinary sync pays one integer comparison.
+   */
+  private reviveLiveRows(itemCount: number): void {
+    if (!this.cache.hasRetired()) return
+    for (let i = 0; i < itemCount; i++) {
+      const key = this.keyAt(i)
+      if (key !== null) this.cache.reviveIfRetired(key)
+    }
+  }
+
   /** Reconcile the prefix-sum tree with the current row count and heights. */
   sync(itemCount: number): void {
+    this.reviveLiveRows(itemCount)
     this.tree.sync(itemCount, this.getHeight)
   }
 
@@ -197,6 +240,7 @@ export class HeightIndex {
    * announced, so a later sync still sees the full accumulated delta.
    */
   syncAndAnnounce(itemCount: number, beforeNotify?: () => void): void {
+    this.reviveLiveRows(itemCount)
     this.tree.sync(itemCount, this.getHeight)
     const total = this.tree.totalHeight()
     if (Math.abs(total - this.lastAnnouncedTotal) <= ANNOUNCE_EPSILON_PX) return

--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -476,7 +476,7 @@ export function useVirtualChat<T>(
   const heightAnchorPendingRef = useRef<{ key: string; top: number } | null>(null)
 
   /**
-   * ONE compensation routine, THREE triggers, ONE capture point.
+   * ONE compensation routine, FIVE triggers, ONE capture point.
    *
    *   TRIGGER 1 — prepend (load-older history): every index shifts up, so
    *     pre-existing rows move down by the inserted height.
@@ -489,8 +489,27 @@ export function useVirtualChat<T>(
    *     re-priced from the running MEAN of the measured ones — so the height
    *     credited above the reader changes anyway and the transcript slides
    *     (measured in the harness: a row at screen offset 0 landed at 500).
+   *   TRIGGER 4 — mid-list INSERT (a transient "thinking" row mounts between rows
+   *     that are already on screen): the count grows and index 0 keeps its key,
+   *     which reads exactly like TRIGGER 3, but every index from the splice point
+   *     on MOVES. Left on trigger 3's path it anchored on a MIS-KEYED row,
+   *     because that path resolves a mounted node's previous-commit index through
+   *     the NEW items.
+   *   TRIGGER 5 — mid-list REMOVE (that same row unmounts): the height above the
+   *     reader SHRINKS and the transcript is pulled up under them. No trigger
+   *     covered a shrink at all (issue #6076).
+   *   TRIGGER 6 — mid-list SWAP: the thinking row leaves and its replacement
+   *     arrives in ONE commit, which React batching makes the ordinary streaming
+   *     shape. The net count is unchanged, so a count-delta trigger reads it as a
+   *     no-op. It participates in the height RETIREMENT below but deliberately
+   *     captures NO anchor: the single consumer is invalidated by `windowRange`
+   *     and `itemCount`, and an equal-count swap moves neither, so an anchor
+   *     taken here would sit in the slot and be spent on an unrelated later
+   *     commit — the exact stranded-anchor hazard the render-phase capture
+   *     exists to remove. Compensating it needs a new invalidation key in that
+   *     consumer, which is its own change; tracked in #7234.
    *
-   * All three are "the height above the reader grew"; the correction is
+   * All five are "the height above the reader changed"; the correction is
    * identical, so they share this slot and the single consumer below. A parallel
    * path would fight this one for `scrollTop`, which is why append folds in here
    * rather than getting an anchor slot of its own.
@@ -525,6 +544,9 @@ export function useVirtualChat<T>(
    *  it shares a commit with part 1 and would otherwise consume a prepend anchor
    *  before the re-base kept its row mounted — see part 2. */
   const rebaseScheduledRef = useRef(false)
+  /** Keys of rows that LEFT the list in this render, handed to the height owner
+   *  once it exists (it is constructed further down) — see its drain site. */
+  const retiredKeysRef = useRef<string[] | null>(null)
   /** Previous render's identity. `items` is held because `itemsRef` has already
    *  advanced by the time the capture runs, while the mounted nodes still carry
    *  the PREVIOUS commit's indices. `getKey` is held WITH them: a caller's
@@ -577,14 +599,177 @@ export function useVirtualChat<T>(
       anchorCapturedThisRender = true
     }
   }
-  // TRIGGER 3's predicate, read BEFORE the mirror below advances: the count grew
-  // while index 0 kept its key, which is a TAIL append (a front insert renames
-  // index 0 and is trigger 1's; a slot switch changes the session).
-  const tailAppended =
-    itemCount > prependPrev.count &&
-    prependPrev.session === sessionId &&
-    prependPrev.firstKey !== null &&
-    prependFirstKey === prependPrev.firstKey
+  // ---- Count-change classification, read BEFORE the mirror advances ----
+  //
+  // What the branches below need is which PRE-EXISTING INDICES moved, because the
+  // mounted nodes in `elIndexRef` carry the PREVIOUS commit's indices: a node's
+  // index still names its own row after a tail append, and names the WRONG row
+  // after any splice above it.
+  const sameSessionCount = prependPrev.session === sessionId && prependPrev.firstKey !== null
+  // A front insert renames index 0 (trigger 1's case) and a slot switch changes
+  // the session; both are excluded from everything below.
+  const frontKeyHeld = prependFirstKey === prependPrev.firstKey
+  // Did any PRE-EXISTING position change hands? That one question separates a
+  // tail append from a mid-list insert, and detects a same-count swap.
+  //
+  // Exact, not sampled. The cheap proxy this replaces read only the LAST
+  // pre-existing index, which a replacement anywhere ABOVE it satisfies while
+  // still stranding the replaced row's measurement -- so an artifact card
+  // refreshed in place, or a row replaced while another is appended, left a
+  // height in the mean that no live row justified.
+  //
+  // Cost is a scan, but not a re-keying one: the overwhelmingly common commit is
+  // a token append, which rebuilds the array while REUSING every element object
+  // except the streaming row's. Reference equality settles those rows without
+  // calling `getKey` at all, so the usual commit costs N pointer comparisons and
+  // zero allocation. A key is only computed for a position whose object actually
+  // changed, which is the only place a departure can hide.
+  const sharedCount = Math.min(prependPrev.count, itemCount)
+  let movedIndex = -1
+  for (let i = 0; i < sharedCount; i++) {
+    const prevItem = prependPrev.items[i]
+    const nextItem = items[i]
+    if (prevItem === nextItem) continue
+    if (prevItem === undefined || nextItem === undefined) { movedIndex = i; break }
+    // The PREVIOUS item is priced through the getKey captured WITH it, the NEW
+    // one through this render's closure: an index-addressed getKey (ChatPage's
+    // deduped key list) returns the new list's key at an old index, which would
+    // report every position as moved on an ordinary append.
+    if (prependPrev.getKey(prevItem, i) !== getKey(nextItem, i)) { movedIndex = i; break }
+  }
+  const anyIndexMoved = movedIndex >= 0
+  const grewInSession = itemCount > prependPrev.count && sameSessionCount && frontKeyHeld
+  /** TRIGGER 3 — the count grew and nothing pre-existing moved. */
+  const tailAppended = grewInSession && !anyIndexMoved
+  /** TRIGGER 4 — a row appeared above at least one row that is already mounted. */
+  const midListInserted = grewInSession && anyIndexMoved
+  /** TRIGGER 5 — a row LEFT the list, with index 0 held. `frontKeyHeld` is the
+   *  ANCHOR's requirement, not retirement's: a renamed index 0 means the mounted
+   *  nodes' indices no longer name their own rows, so there is nothing to anchor
+   *  on. Retirement has its own gate below and deliberately does not share this
+   *  one. */
+  const rowsRemoved = itemCount < prependPrev.count && sameSessionCount && frontKeyHeld
+  // TRIGGERS 4 and 5 — a mid-list splice, either direction. Both capture the
+  // anchor, through the one capture point and the one consumer: both are "a row
+  // came or went above the reader", and the correction part 2 already performs
+  // does not care which direction. Placed BEFORE trigger 2 so that in a render
+  // which does both, the splice's key mapping wins over the window branch's
+  // live-items mapping — the whole point being that live-items mapping is what is
+  // wrong here.
+  //
+  // There is no equal-count trigger. One existed only to reach the retirement
+  // below, and retirement is now gated on departure directly, so an equal-count
+  // swap is served by that gate with no trigger and no anchor of its own — the
+  // anchor it would have captured had no consumer on a commit that moves neither
+  // `windowRange` nor `itemCount`, and stranded in the slot for an unrelated
+  // later commit to spend. See #7234.
+  //
+  // Staged 'ready' (correct only, never a re-base): a transient row moves the
+  // anchor by one index, so it stays inside the mounted window and is
+  // measurable. A splice wide enough to unmount it leaves `rowTopFrom` unable to
+  // resolve the row and part 2 stands down — the pre-existing behaviour for an
+  // unmeasurable anchor, not a new failure mode.
+  //
+  // The GATE is departure, not any one trigger. Retirement kept escaping through
+  // whichever count arithmetic a commit happened not to match -- an equal-count
+  // swap, an interior replacement, and a full-transcript clear each reached this
+  // point with a row's measurement still pricing the transcript. Those are one
+  // defect with three faces, so the condition is stated once, at the level the
+  // harm lives on: A ROW LEFT THIS SESSION. A departure requires either a
+  // shrinking count or a shared index changing hands, so the streaming commit
+  // (same rows, one more at the tail) still does no work here.
+  //
+  // `frontKeyHeld` is deliberately NOT part of it. It is the anchor's
+  // requirement, and borrowing it for retirement is what let the clear through:
+  // emptying the list renames index 0 exactly as head paging does, so the proxy
+  // read a wipe as a page-out and kept every measurement.
+  const rowDeparturePossible =
+    sameSessionCount && (itemCount < prependPrev.count || anyIndexMoved)
+  if (rowDeparturePossible) {
+    const survivingKeys = new Set<string>()
+    for (let i = 0; i < items.length; i++) survivingKeys.add(getKey(items[i], i))
+    // The anchor keeps the narrower gate: it needs index 0 held (so the mounted
+    // nodes' indices still name their own rows) and a count that actually moved
+    // (so part 2, invalidated by `windowRange` and `itemCount`, runs and spends
+    // it). Retirement has neither dependency, which is why it sits outside.
+    if ((midListInserted || rowsRemoved) && !anchorCapturedThisRender && !stickRef.current) {
+      const spliceEl = scrollerRef.current
+      const spliceAnchor = spliceEl
+        ? captureTopAnchorFrom(spliceEl, elIndexRef.current.entries(), (idx) => {
+            // PREVIOUS items at the node's PREVIOUS index, filtered to rows that
+            // survive this commit — trigger 1's resolution, for the same reason:
+            // it is the only mapping that names the row the node actually shows.
+            const it = prependPrev.items[idx]
+            if (!it) return null
+            const k = prependPrev.getKey(it, idx)
+            return survivingKeys.has(k) ? k : null
+          })
+        : null
+      if (spliceAnchor) {
+        shiftAnchorRef.current = spliceAnchor
+        shiftStageRef.current = 'ready'
+        anchorCapturedThisRender = true
+      }
+    }
+    // Keyed on KEY DEPARTURE, not on the net count falling: the harm is a
+    // measurement outliving its row, and a commit that drops the thinking row
+    // while adding output nets to growth or to zero with the ghost's height still
+    // pricing the transcript. `survivingKeys` is already built above for the
+    // anchor, so the general detector costs one pass over the previous items and
+    // no extra allocation. Independent of stick: a departed row's measurement is
+    // wrong for a pinned reader too. Drained by the height owner further down.
+    //
+    // Head paging is the ONE departure that must not retire: the rows it drops
+    // are coming back when the reader scrolls up, so their measurements must keep
+    // pricing the region above. Recognising it starts from the CALLER, not from
+    // the data: nothing pages unless the consumer asked to be told when the
+    // reader reaches the top, so a consumer with no `onTopReached` has no
+    // page-out to exempt and every departure it makes is final. That is what
+    // separates the transcript (ChatPage, which wires it) from a filtered list
+    // (the artifacts gallery, which does not): narrowing a search box drops a
+    // leading run of cards and keeps later ones, which is indistinguishable from
+    // a page-out by the shape of the departure alone, and those cards are not
+    // coming back.
+    //
+    // Within a paging consumer, all three shape properties are still required,
+    // because any two of them are also true of a departure that MUST retire:
+    //
+    //   the count FELL          -- a prepend regroup also drops a prefix row while
+    //                              survivors remain, and it grows the count
+    //   the departures are a    -- a tail truncation or an interior removal leaves
+    //   contiguous PREFIX          a survivor ABOVE a departure
+    //   a survivor REMAINS      -- a full clear departs a prefix and nothing else,
+    //                              and its rows are not coming back
+    //
+    // Every other shape retires, and each is covered: interior removal (prefix
+    // test), equal-count swap and interior-replacement-plus-append (count test),
+    // tail truncation (prefix test), clear (survivor test), any departure at all
+    // in a non-paging consumer (the capability test).
+    //
+    // In a paging consumer a single row leaving the very head IS a one-row
+    // page-out by every one of these properties, so it is skipped, as it was
+    // before this branch existed.
+    const departed: string[] = []
+    let departedPrefixOnly = true
+    let survivorSeen = false
+    for (let i = 0; i < prependPrev.items.length; i++) {
+      const it = prependPrev.items[i]
+      if (!it) continue
+      const k = prependPrev.getKey(it, i)
+      if (survivingKeys.has(k)) { survivorSeen = true; continue }
+      if (survivorSeen) departedPrefixOnly = false
+      departed.push(k)
+    }
+    // `onTopReached` is read from the prop, not its ref: the ref is refreshed in
+    // an effect, so during the render a consumer first wires paging in it still
+    // holds the previous value.
+    const headPagedOut =
+      onTopReached !== undefined &&
+      itemCount < prependPrev.count &&
+      departedPrefixOnly &&
+      survivorSeen
+    if (departed.length > 0 && !headPagedOut) retiredKeysRef.current = departed
+  }
   prependPrevRef.current = { session: sessionId, count: itemCount, firstKey: prependFirstKey, items, getKey }
 
   // Window range for what is currently mounted. Initial state is the TAIL of
@@ -801,6 +986,36 @@ export function useVirtualChat<T>(
     heightIndexRef.current.setEstimate(estimatedHeight)
   }
   const heightIndex = heightIndexRef.current
+
+  // A transient row is MEASURED while it is mounted, and `getHeight` prices every
+  // UNMEASURED row from the running MEAN of the measured ones — so a measurement
+  // is never local to its own row. When the row then leaves the list its height
+  // stays in the cache and goes on pricing the transcript, holding the height
+  // credited above the reader at a value no live row justifies; a "thinking"
+  // placeholder is a fraction of a real message tall, so everything above the
+  // reader stays under-priced until the entry is evicted — and past a reload,
+  // once the blob is persisted. Compensating the commit cannot reach that: the
+  // reprice recurs on every later sync. Retire it instead, HERE — after the owner
+  // exists — so the reprice lands in the SAME commit whose shift the splice
+  // capture above already compensates. Retiring KEEPS the measurement itself (see
+  // HeightCache.retire), which is what makes an optimistic removal the server
+  // later refuses restorable rather than re-priced: regenerate and edit-resend
+  // both snapshot, truncate, and replace the snapshot back on refusal.
+  //
+  // The tree is re-synced HERE rather than left to the `offsetIndex` memo below,
+  // because that memo is keyed on `itemCount` and an equal-count SWAP moves none
+  // of its dependencies: the memo body would not run, and the spacers this render
+  // reads would keep prices the retirement just invalidated. A render-phase
+  // `sync` is the same call the memo makes, at the same phase, so the geometry
+  // read further down sees the corrected tree in this commit. On a commit that
+  // DOES change the count the memo syncs too, which is idempotent -- a second
+  // walk over the same heights.
+  const retiredKeys = retiredKeysRef.current
+  if (retiredKeys) {
+    retiredKeysRef.current = null
+    heightIndex.retire(retiredKeys)
+    heightIndex.sync(itemCount)
+  }
 
   // ---- Height lookup ----
   // Kept as a stable getter because the O(N) free functions still take one.

--- a/website/src/test/HeightCache.test.ts
+++ b/website/src/test/HeightCache.test.ts
@@ -540,4 +540,150 @@ describe('HeightCache: access-recency eviction', () => {
     expect(c.get('k5')).toBeUndefined()
     expect(c.get('n2')).toBe(9002)
   })
+
+  // ---- retire(): out of the mean, still in the cache (issue #6076) ----------
+  //
+  // A row leaving the list must stop pricing the rows that remain, but "leaving"
+  // is not always permanent: an optimistically truncated transcript is restored
+  // wholesale when the server refuses the press. Deleting the measurement would
+  // re-price those rows from the mean on the way back -- wrong spacers and a
+  // viewport jump, the failure this cache exists to prevent.
+
+  it('retire drops a key from the mean but keeps its measurement readable', () => {
+    const c = new HeightCache('retire-mean')
+    c.set('a', 300)
+    c.set('b', 300)
+    c.set('ghost', 20)
+    expect(c.averageHeight()).toBeCloseTo((300 + 300 + 20) / 3, 5)
+
+    c.retire('ghost')
+
+    // Out of the mean: unmeasured rows are priced by the two real messages.
+    expect(c.averageHeight()).toBe(300)
+    // Still readable: a restored row resolves its own exact height.
+    expect(c.peek('ghost')).toBe(20)
+    expect(c.get('ghost')).toBe(20)
+  })
+
+  it('retire is idempotent and ignores a key it never measured', () => {
+    const c = new HeightCache('retire-idem')
+    c.set('a', 300)
+    c.set('b', 100)
+    c.retire('b')
+    c.retire('b')
+    c.retire('never-measured')
+    expect(c.averageHeight()).toBe(300)
+    expect(c.peek('b')).toBe(100)
+  })
+
+  it('measuring a retired row again revives it into the mean', () => {
+    const c = new HeightCache('retire-revive')
+    c.set('a', 300)
+    c.set('ghost', 20)
+    c.retire('ghost')
+    expect(c.averageHeight()).toBe(300)
+
+    // The row is back and mounted, so its measurement counts again.
+    c.set('ghost', 20)
+    expect(c.averageHeight()).toBeCloseTo((300 + 20) / 2, 5)
+  })
+
+  it('falls back to the estimate when every measured row is retired', () => {
+    const c = new HeightCache('retire-all')
+    c.set('a', 300)
+    c.retire('a')
+    // n would be 0 here: the mean has no sample, so the caller's estimate wins
+    // rather than a division by zero.
+    expect(c.averageHeight(77)).toBe(77)
+  })
+
+  it('does not persist a retired key, so a reload cannot re-price from it', () => {
+    const c = new HeightCache('retire-persist')
+    c.set('a', 300)
+    c.set('ghost', 20)
+    c.retire('ghost')
+    c.flush()
+
+    const reloaded = new HeightCache('retire-persist')
+    expect(reloaded.peek('a')).toBe(300)
+    expect(reloaded.peek('ghost')).toBeUndefined()
+    expect(reloaded.averageHeight()).toBe(300)
+  })
+
+  it('revives a retired key when its row is in the list again', () => {
+    const c = new HeightCache('retire-revive-live')
+    c.set('a', 300)
+    c.set('b', 300)
+    c.set('tall', 900)
+    c.retire('tall')
+    expect(c.averageHeight()).toBe(300)
+
+    // The row came back (a refused truncation restored wholesale), so its
+    // measurement is a fact about the live transcript again.
+    c.reviveIfRetired('tall')
+    expect(c.averageHeight()).toBeCloseTo((300 + 300 + 900) / 3, 5)
+
+    // Idempotent: a second revive must not add the height twice.
+    c.reviveIfRetired('tall')
+    expect(c.averageHeight()).toBeCloseTo((300 + 300 + 900) / 3, 5)
+    // ...and reviving a key that was never retired is a no-op.
+    c.reviveIfRetired('a')
+    c.reviveIfRetired('never-seen')
+    expect(c.averageHeight()).toBeCloseTo((300 + 300 + 900) / 3, 5)
+  })
+
+  it('re-persists a revived key', () => {
+    const c = new HeightCache('retire-revive-persist')
+    c.set('a', 300)
+    c.set('tall', 900)
+    c.retire('tall')
+    c.reviveIfRetired('tall')
+    c.flush()
+
+    const reloaded = new HeightCache('retire-revive-persist')
+    expect(reloaded.peek('tall')).toBe(900)
+  })
+
+  it('evicts a retired entry before an older live one', () => {
+    // A transient row is measured immediately before it leaves, so it sits at
+    // the most-recently-used end. Under plain LRU order it would be the LAST
+    // evicted and an older LIVE row would lose its height instead.
+    const c = new HeightCache('retire-evict-first', { rowCount: 3 })
+    for (let i = 0; i < 1999; i++) c.set(`live${i}`, 100)
+    c.set('ghost', 20)
+    c.retire('ghost')
+    // Exactly at the 2000 cap, so nothing has been evicted yet.
+    expect(c.size()).toBe(2000)
+
+    // One more live measurement forces exactly one eviction.
+    c.set('fresh', 100)
+
+    // The dead row went; the oldest live row stayed.
+    expect(c.peek('ghost')).toBeUndefined()
+    expect(c.peek('live0')).toBe(100)
+    expect(c.peek('fresh')).toBe(100)
+    // And the mean is unaffected -- a retired height was never in it, so
+    // dropping the entry must not move it either.
+    expect(c.averageHeight()).toBe(100)
+  })
+
+  it('falls back to LRU order once no retired entry is left', () => {
+    const c = new HeightCache('retire-evict-drain', { rowCount: 3 })
+    for (let i = 0; i < 1998; i++) c.set(`live${i}`, 100)
+    c.set('ghostA', 20)
+    c.set('ghostB', 20)
+    c.retire('ghostA')
+    c.retire('ghostB')
+
+    // Three evictions: both retired entries, then the oldest live row.
+    c.set('n1', 100)
+    c.set('n2', 100)
+    c.set('n3', 100)
+
+    expect(c.peek('ghostA')).toBeUndefined()
+    expect(c.peek('ghostB')).toBeUndefined()
+    expect(c.peek('live0')).toBeUndefined()
+    expect(c.peek('live1')).toBe(100)
+    expect(c.averageHeight()).toBe(100)
+  })
 })

--- a/website/src/test/useVirtualChat.heightSyncAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.heightSyncAnchor.test.tsx
@@ -102,4 +102,413 @@ describe('useVirtualChat: height-sync spacer repricing keeps the top visible row
     act(() => { vi.advanceTimersByTime(120) })
     expect(state.scrollTop).toBe(before)
   })
+
+  // ---- Transient-row repricing (issue #6076) ----
+  //
+  // `getHeight` prices an UNMEASURED row from the running mean of the measured
+  // ones, so a measurement is not local to its own row: it re-prices every row
+  // that has never been measured. A "thinking" placeholder mounts, is measured
+  // at a height nothing like a real message, and then leaves the list — and its
+  // measurement keeps pricing the transcript after the row itself is gone, so
+  // the height credited above the reader stays wrong for the rest of the
+  // session. Compensating the commit cannot fix that; the measurement has to
+  // stop counting when the row it belongs to leaves.
+
+  /** A node reporting a fixed height through both measurement paths. */
+  function nodeOf(height: number): HTMLElement {
+    const node = document.createElement('div')
+    Object.defineProperty(node, 'offsetHeight', { configurable: true, get: () => height })
+    node.getBoundingClientRect = () => ({
+      top: 0, bottom: height, left: 0, right: 390, width: 390, height, x: 0, y: 0, toJSON: () => ({}),
+    }) as DOMRect
+    return node
+  }
+
+  it('stops pricing unmeasured rows from a transient row once it leaves the list (pinned reader)', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const view = renderHook(
+      (props: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(props),
+      // followOutput: the reader is PINNED to the bottom, which is where a
+      // streaming placeholder is actually watched from.
+      { initialProps: { items: mkItems(30), sessionId: 'ghost-reprice', getKey, externalScrollerRef: ref, followOutput: true } },
+    )
+
+    // Two real messages measured at 300 → every unmeasured row is priced 300.
+    act(() => { view.result.current.measureRef(0)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(1)(nodeOf(300)) })
+    act(() => { vi.advanceTimersByTime(200) })
+    const settled = view.result.current.totalHeight
+    expect(settled).toBeCloseTo(30 * 300, 1)
+
+    // The ghost row arrives at the tail and is measured at nothing like a
+    // message height.
+    const withGhost = [...mkItems(30), { id: 'thinking' }]
+    act(() => { view.rerender({ items: withGhost, sessionId: 'ghost-reprice', getKey, externalScrollerRef: ref, followOutput: true }) })
+    act(() => { view.result.current.measureRef(30)(nodeOf(20)) })
+    act(() => { vi.advanceTimersByTime(200) })
+    // Not vacuous: its measurement really did drag the mean, and with it every
+    // unmeasured row in the transcript.
+    expect(view.result.current.totalHeight).toBeLessThan(settled - 1000)
+
+    // The ghost leaves. Its 20px is no longer a fact about this transcript, so
+    // the rows it was pricing must return to what the real measurements say.
+    act(() => { view.rerender({ items: mkItems(30), sessionId: 'ghost-reprice', getKey, externalScrollerRef: ref, followOutput: true }) })
+    act(() => { vi.advanceTimersByTime(200) })
+    expect(view.result.current.totalHeight).toBeCloseTo(settled, 1)
+  })
+
+  // ---- Optimistic truncation that gets ROLLED BACK (issue #6076) -----------
+  //
+  // `handleRegenerate` and `handleEditResend` both snapshot the transcript,
+  // truncate it, and dispatch the snapshot back when the server refuses the
+  // press. The rows therefore leave the list and come back. Retiring their
+  // measurements (out of the mean, still in the cache) is what makes the restore
+  // exact; deleting them would price the restored rows from the mean, which is a
+  // wrong spacer and a viewport jump for rows still off-window.
+
+  it('restores a rolled-back row at its own measured height, not the mean', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const full = mkItems(30)
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'rollback', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const view = renderHook(
+      (p: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(p),
+      { initialProps: props(full) },
+    )
+
+    // Two ordinary messages set the mean, and one row far from them is measured
+    // much taller -- that row is what the rollback has to bring back intact.
+    act(() => { view.result.current.measureRef(0)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(1)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(25)(nodeOf(900)) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    const heightOf = (key: string): number | undefined => {
+      act(() => { view.result.current.mountIndex(full.findIndex((i) => i.id === key)) })
+      return view.result.current.virtualItems.find((v) => v.key === key)?.height
+    }
+    expect(heightOf('m25')).toBe(900)
+
+    // The refused press: truncate to 20 rows...
+    act(() => { view.rerender(props(full.slice(0, 20))) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // ...and while the row is gone it does not price the rows that stayed. The
+    // mean is the two real messages (300), so the 18 unmeasured rows are 300
+    // each; with the departed row still counted it would be 500 each.
+    expect(view.result.current.totalHeight).toBeCloseTo(300 + 300 + 18 * 300, 1)
+
+    // Now the rollback puts the snapshot back.
+    act(() => { view.rerender(props(full)) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // Its own measurement survived the round trip -- the restored row is placed
+    // at 900, not re-priced from the mean.
+    expect(heightOf('m25')).toBe(900)
+  })
+
+  it('retires a swapped-out row even though the count never moved', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'swap-retire', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const withGhost = [...mkItems(29), { id: 'thinking' }]
+    const view = renderHook(
+      (p: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(p),
+      { initialProps: props(withGhost) },
+    )
+
+    act(() => { view.result.current.measureRef(0)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(1)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(29)(nodeOf(20)) })
+    act(() => { vi.advanceTimersByTime(200) })
+    // The ghost is dragging the mean down, so the 27 unmeasured rows are priced
+    // below what the real messages say.
+    expect(view.result.current.totalHeight).toBeLessThan(300 + 300 + 20 + 27 * 300)
+
+    // React batches the removal and the replacement into ONE commit, so the
+    // count is unchanged: a net-count detector sees nothing while the ghost's
+    // measurement is still pricing the transcript.
+    act(() => { view.rerender(props([...mkItems(29), { id: 'output' }])) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // The retirement lands in the offset tree in THAT SAME commit. It cannot be
+    // left to the `offsetIndex` memo: an equal-count swap moves none of its
+    // dependencies, so the memo body does not run and the spacers would keep the
+    // prices the retirement just invalidated. No extra measurement, no later
+    // sync -- the geometry is correct as soon as the swap renders.
+    //
+    // The mean is the two real messages, so every unmeasured row -- the 27 plus
+    // the unmeasured replacement -- is priced at 300. With the ghost still
+    // counted the mean would be 206.67 and the total ~6386.
+    expect(view.result.current.totalHeight).toBeCloseTo(2 * 300 + 28 * 300, 1)
+  })
+
+  // ---- An INTERIOR replacement is a departure too (issue #6076) -------------
+  //
+  // The boundary is not where a replacement has to happen. An artifact card
+  // refreshing in place, or a row re-keyed mid-transcript, replaces a row the
+  // reader is looking PAST -- so a detector that only reads the last
+  // pre-existing index sees nothing while the replaced row's measurement stays
+  // in the mean that prices every unmeasured row.
+
+  /** Measures rows 0, 1 at 300 and `tallIdx` at 900, then settles. */
+  function seedMean(
+    view: { result: { current: { measureRef: (i: number) => (el: HTMLElement) => void } } },
+    tallIdx: number,
+  ): void {
+    act(() => { view.result.current.measureRef(0)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(1)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(tallIdx)(nodeOf(900)) })
+    act(() => { vi.advanceTimersByTime(200) })
+  }
+
+  it('retires an INTERIOR row replaced at equal count', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'interior-swap', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const base = mkItems(30)
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(base) },
+    )
+    seedMean(view, 15)
+
+    // Row 15 is replaced in place. The count is unchanged AND the last
+    // pre-existing index still answers to its own key, so nothing at the
+    // boundary moved -- only an interior position changed hands.
+    const swapped = base.map((it, i) => (i === 15 ? { id: 'refreshed' } : it))
+    act(() => { view.rerender(props(swapped)) })
+    act(() => { vi.advanceTimersByTime(200) })
+    // The replacement is what re-syncs the tree; the retirement rides that sync.
+    act(() => { view.result.current.measureRef(2)(nodeOf(300)) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // The mean is the three real messages, so the 27 unmeasured rows are 300
+    // each. With the replaced row's 900 still counted the mean would be 450.
+    expect(view.result.current.totalHeight).toBeCloseTo(3 * 300 + 27 * 300, 1)
+  })
+
+  it('retires an INTERIOR row replaced while another is appended', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'interior-swap-grow', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const base = mkItems(30)
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(base) },
+    )
+    seedMean(view, 15)
+
+    // The count GROWS here, and the last pre-existing index still holds its key,
+    // so the commit reads as a plain tail append -- while an interior row was
+    // replaced underneath it.
+    const swapped = base.map((it, i) => (i === 15 ? { id: 'refreshed' } : it))
+    act(() => { view.rerender(props([...swapped, { id: 'appended' }])) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // 31 rows: 2 measured at 300, 29 unmeasured at the restored mean of 300.
+    expect(view.result.current.totalHeight).toBeCloseTo(2 * 300 + 29 * 300, 1)
+  })
+
+  it('retires nothing when a commit only rewrites one row in place', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'token-append', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const base = mkItems(30)
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(base) },
+    )
+    seedMean(view, 15)
+    const settled = view.result.current.totalHeight
+
+    // The shape of a streaming token: a new array, every element object reused
+    // except the streaming row's, and its KEY unchanged. No key departed, so no
+    // measurement may be retired -- the mean must not move.
+    const streamed = [...base]
+    streamed[29] = { id: base[29].id }
+    act(() => { view.rerender(props(streamed)) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    expect(view.result.current.totalHeight).toBeCloseTo(settled, 1)
+  })
+
+  // ---- Departure detection under an INDEX-ADDRESSED getKey (#7207) ----------
+  //
+  // ChatPage's getKey resolves a per-render deduped key LIST by position, so it
+  // only prices an item correctly when paired with the items of its OWN render.
+  // The departure scan reads the PREVIOUS render's items, and an interior
+  // removal shifts every key below it up by one -- so pricing those items with
+  // THIS render's getKey reads the removed row's old index as the key of the row
+  // that moved into it, which still survives. The departure is invisible and the
+  // ghost keeps pricing the transcript.
+
+  it('retires an interior removal when getKey is INDEX-ADDRESSED (ChatPage shape)', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    // The harness contract: the function ignores its item argument and closes
+    // over the key list of the render it was created in.
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => {
+      const keys = items.map((it) => it.id)
+      return {
+        items,
+        sessionId: 'positional-departure',
+        getKey: (_it: Item, i: number) => keys[i] ?? `oob-${i}`,
+        externalScrollerRef: ref,
+        followOutput: false,
+      }
+    }
+    const base = mkItems(30)
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(base) },
+    )
+    seedMean(view, 5)
+
+    // Row 5 leaves from the MIDDLE, so indices 5..28 are all re-keyed one step
+    // up while index 0 keeps its key (head paging, which renames index 0, stays
+    // excluded).
+    act(() => { view.rerender(props(base.filter((_it, i) => i !== 5))) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // The mean is the two real messages, so the 27 unmeasured rows are 300 each.
+    // With the departed row's 900 still counted the mean is 500 and the total
+    // 14100 -- which is what the current render's getKey produces here.
+    expect(view.result.current.totalHeight).toBeCloseTo(2 * 300 + 27 * 300, 1)
+  })
+
+  // ---- The gate is DEPARTURE, not a count shape (#6076) ---------------------
+  //
+  // Retirement used to ride on the anchor's triggers, which require index 0 to
+  // keep its key. Emptying the transcript renames index 0 exactly as paging out
+  // the head does, so a wipe read as a page-out and every measurement stayed in
+  // the mean -- pricing the rows of the NEXT conversation from the heights of
+  // the one that was cleared. The two are separated by whether anything
+  // survived, not by what happened to index 0.
+
+  it('retires every height when the transcript is CLEARED in the same session', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'cleared', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(mkItems(30)) },
+    )
+    seedMean(view, 5)
+
+    // `/clear` empties the list while the session stays put.
+    act(() => { view.rerender(props([])) })
+    act(() => { vi.advanceTimersByTime(200) })
+    // Then the next conversation starts. Its row has never been measured, so it
+    // is priced from whatever samples are still standing.
+    act(() => { view.rerender(props([{ id: 'fresh0' }])) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // Every sample belonged to the cleared transcript, so none of them prices
+    // this row: it falls back to the flat estimate. With the wipe read as a
+    // page-out the mean is 500 and this row is priced at that.
+    expect(view.result.current.totalHeight).toBeCloseTo(80, 1)
+  })
+
+  it('retires a row that a PREPEND regroups away, which grows the count', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'prepend-regroup', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const base = mkItems(30)
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(base) },
+    )
+    // The mean is set by two rows that SURVIVE, and the head row -- the one the
+    // regroup takes away -- is the measured outlier, so the mean moves only if
+    // its height is actually retired.
+    act(() => { view.result.current.measureRef(5)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(6)(nodeOf(300)) })
+    act(() => { view.result.current.measureRef(0)(nodeOf(900)) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // Loading older history prepends rows AND regroups the top turn: index 0's
+    // row joins the turn above under a new lead key, so it departs while the
+    // count GROWS. It drops a contiguous prefix and leaves survivors standing --
+    // head paging's other two properties -- but it is not coming back.
+    const older = mkItems(10).map((it) => ({ id: `older-${it.id}` }))
+    act(() => { view.rerender(props([...older, { id: 'regrouped-lead' }, ...base.slice(1)])) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // 40 rows: the 2 surviving measurements at 300, and 38 unmeasured priced from
+    // their mean. With the regrouped row's 900 still counted the mean is 500 and
+    // the total 19600.
+    expect(view.result.current.totalHeight).toBeCloseTo(2 * 300 + 38 * 300, 1)
+  })
+
+  it('retires a filtered-out prefix when the consumer cannot page at all', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    // The artifacts gallery's shape: no `onTopReached`, so nothing pages, and the
+    // item list is a SEARCH RESULT. Narrowing the box drops a leading run of
+    // cards and keeps later ones -- head paging's every shape property -- but
+    // those cards are gone, not scrolled past.
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'gallery-filter', getKey, externalScrollerRef: ref, followOutput: false,
+    })
+    const base = mkItems(30)
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(base) },
+    )
+    // The measured cards are all in the run the filter removes, so their heights
+    // are the only thing that can still be pricing the survivors afterwards.
+    seedMean(view, 5)
+
+    act(() => { view.rerender(props(base.slice(10))) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // Every sample belonged to a filtered-out card, so the 20 survivors fall back
+    // to the flat estimate. Treated as a page-out the mean stays 500 (10000).
+    expect(view.result.current.totalHeight).toBeCloseTo(20 * 80, 1)
+  })
+
+  it('keeps measurements when the head is PAGED OUT, which is not a departure', () => {
+    const { el } = makeScroller({ scrollTop: 0, scrollHeight: 5000, clientHeight: 400 })
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    // `onTopReached` is what makes this consumer a paging one, and the exemption
+    // is gated on it -- a consumer that cannot page has no page-out to exempt.
+    const props = (items: Item[]): UseVirtualChatOptions<Item> => ({
+      items, sessionId: 'head-paged', getKey, externalScrollerRef: ref, followOutput: false,
+      onTopReached: () => {},
+    })
+    const base = mkItems(30)
+    const view = renderHook(
+      (o: UseVirtualChatOptions<Item>) => useVirtualChat<Item>(o),
+      { initialProps: props(base) },
+    )
+    // The measured rows are all in the prefix that gets trimmed -- so if the
+    // trim retired them, nothing would be left to price the rows that stayed.
+    seedMean(view, 5)
+
+    // Trimming the head drops a contiguous prefix and leaves the rest standing.
+    // Those rows are coming back when the reader scrolls up, so their heights
+    // must keep pricing the region above.
+    act(() => { view.rerender(props(base.slice(10))) })
+    act(() => { vi.advanceTimersByTime(200) })
+
+    // 20 unmeasured rows at the retained mean of 500. Retiring the trimmed
+    // prefix would drop every sample and price them at the flat estimate (1600).
+    expect(view.result.current.totalHeight).toBeCloseTo(20 * 500, 1)
+  })
 })

--- a/website/src/test/useVirtualChat.prependAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.prependAnchor.test.tsx
@@ -206,10 +206,10 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
 
   /** Mounts 30 rows, then scrolls up so stick is released and the window sits
    *  mid-transcript — the state a user reading history is in. */
-  function mountScrolledUp(H: typeof Harness = Harness) {
+  function mountScrolledUp(initial: Item[] = mkItems(30), H: typeof Harness = Harness) {
     const scrollerRef: RefObject<HTMLDivElement | null> = { current: null }
     let scrollTop = 0
-    const view = rtlRender(<H items={mkItems(30)} scrollerRef={scrollerRef} />)
+    const view = rtlRender(<H items={initial} scrollerRef={scrollerRef} />)
     const el = scrollerRef.current!
     Object.defineProperty(el, 'scrollTop', {
       configurable: true, get: () => scrollTop, set: (v: number) => { scrollTop = v },
@@ -228,10 +228,10 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
    *  hold the old position. `scrollHeight` is derived from the live children
    *  here (not the fixed constant) so growing the transcript really does move
    *  the bottom, which is what the follow pin is asserted against. */
-  function mountAtBottom() {
+  function mountAtBottom(initial: Item[] = mkItems(30)) {
     const scrollerRef: RefObject<HTMLDivElement | null> = { current: null }
     let scrollTop = 0
-    const view = rtlRender(<Harness items={mkItems(30)} scrollerRef={scrollerRef} />)
+    const view = rtlRender(<Harness items={initial} scrollerRef={scrollerRef} />)
     const el = scrollerRef.current!
     Object.defineProperty(el, 'scrollTop', {
       configurable: true, get: () => scrollTop, set: (v: number) => { scrollTop = v },
@@ -334,7 +334,7 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
   })
 
   it('holds the reading position across a prepend when getKey is INDEX-ADDRESSED (ChatPage shape)', () => {
-    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(PositionalHarness)
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(mkItems(30), PositionalHarness)
 
     const before = topVisible(el)
     expect(before).not.toBeNull()
@@ -491,4 +491,122 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     expect(after).not.toBeNull()
     expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
   })
+
+  // ---- Mid-list SPLICE: a transient "thinking" row mounting and unmounting
+  // between already-rendered output (issue #6076) ----
+  //
+  // Both directions grow/shrink the count while index 0 keeps its key, so
+  // neither is a prepend and neither is a tail append: every index from the
+  // splice point on MOVES. That is what separates them from TRIGGER 3 — the
+  // mounted DOM nodes still carry the previous commit's indices, so resolving
+  // them through the new `items` names the wrong row.
+
+  /** Index `key` currently occupies in `list`. */
+  function indexOf(list: Item[], key: string): number {
+    return list.findIndex((it) => it.id === key)
+  }
+
+  it('holds the reading position when a row is SPLICED IN above the reader', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef } = mountScrolledUp(base)
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+    const at = indexOf(base, before!.key)
+    expect(at).toBeGreaterThan(0)
+
+    // A "thinking" placeholder appearing directly above the row being read.
+    const spliced = [...base.slice(0, at), { id: 'ghost' }, ...base.slice(at)]
+    act(() => { view.rerender(<Harness items={spliced} scrollerRef={scrollerRef} />) })
+
+    // Not vacuous: the ghost really did mount between the rendered rows.
+    expect(screenTopOf(el, 'ghost')).not.toBeNull()
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  it('holds the reading position when a row is SPLICED IN and getKey is INDEX-ADDRESSED', () => {
+    // The splice anchor resolves the PREVIOUS render's items at the mounted
+    // nodes' PREVIOUS indices, so it prices them with the getKey captured WITH
+    // them -- the same contract the prepend capture has. This render's closure
+    // would read the post-splice key list at pre-splice indices and name the
+    // anchor one row off, correcting the viewport by the wrong row's travel.
+    const base = mkItems(30)
+    const { el, view, scrollerRef } = mountScrolledUp(base, PositionalHarness)
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+    const at = indexOf(base, before!.key)
+    expect(at).toBeGreaterThan(0)
+
+    const spliced = [...base.slice(0, at), { id: 'ghost' }, ...base.slice(at)]
+    act(() => { view.rerender(<PositionalHarness items={spliced} scrollerRef={scrollerRef} />) })
+
+    expect(screenTopOf(el, 'ghost')).not.toBeNull()
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  it('holds the reading position when a row is REMOVED above the reader', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef } = mountScrolledUp(base)
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+    const at = indexOf(base, before!.key)
+    expect(at).toBeGreaterThan(0)
+
+    // The same ghost row unmounting: content ABOVE the reader disappears, so
+    // the transcript is pulled UP under them — the symptom's other half, and
+    // the case no trigger covered.
+    const removed = base[at - 1].id
+    const pruned = base.filter((it) => it.id !== removed)
+    act(() => { view.rerender(<Harness items={pruned} scrollerRef={scrollerRef} />) })
+
+    // Not vacuous: the row above the reader is genuinely gone.
+    expect(screenTopOf(el, removed)).toBeNull()
+    const after = screenTopOf(el, before!.key)
+    expect(after).not.toBeNull()
+    expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
+  })
+
+  it('still follows to the bottom when a row is SPLICED IN while PINNED', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef, readScrollTop } = mountAtBottom(base)
+
+    const beforeTop = readScrollTop()
+    const spliced = [...base.slice(0, 10), { id: 'ghost' }, ...base.slice(10)]
+    act(() => { view.rerender(<Harness items={spliced} scrollerRef={scrollerRef} />) })
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+    // Holding position here would be the regression: a pinned reader follows
+    // the output down, mid-list splice or not.
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+    expect(readScrollTop()).toBe(el.scrollHeight - CLIENT)
+  })
+
+  it('keeps following after a row is REMOVED while PINNED', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef } = mountAtBottom(base)
+
+    const pruned = base.filter((it) => it.id !== 'm10')
+    act(() => { view.rerender(<Harness items={pruned} scrollerRef={scrollerRef} />) })
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+    // The removal must not steal stick: the next streamed message still lands
+    // at the bottom.
+    act(() => {
+      view.rerender(<Harness items={[...pruned, { id: 'z0' }]} scrollerRef={scrollerRef} />)
+    })
+    act(() => { frames.forEach((cb) => cb(0)); frames.length = 0 })
+
+    expect(el.scrollTop).toBe(el.scrollHeight - CLIENT)
+    const appended = screenTopOf(el, 'z0')
+    expect(appended).not.toBeNull()
+    expect(appended!).toBeGreaterThanOrEqual(0)
+    expect(appended!).toBeLessThan(CLIENT)
+  })
+
 })

--- a/website/src/test/virtualizerHeightOwner.test.ts
+++ b/website/src/test/virtualizerHeightOwner.test.ts
@@ -400,4 +400,38 @@ describe('HeightIndex announces geometry changes (store contract)', () => {
     // The announcement still happened -- only delivery to this listener stopped.
     expect(idx.getVersion()).toBe(2)
   })
+
+  // A retired measurement is one whose row left the list. A key resolving from a
+  // LIVE row index is proof the row is back -- the shape a refused
+  // regenerate/edit-resend produces when it restores its snapshot -- so the owner
+  // revives it in a pass BEFORE the tree walk rather than inside the height read.
+  // Reviving mid-walk would leave every row priced EARLIER in that same walk
+  // holding the pre-revive mean, with no later sync guaranteed to correct them.
+  it('revives a retired row before the tree walk, so one mean prices every row', () => {
+    // The unmeasured rows sit BEFORE the retired one, which is what makes the
+    // ordering observable: a mid-walk revive reaches them too late.
+    const rows = [{ id: 'p0' }, { id: 'p1' }, { id: 'a' }, { id: 'b' }, { id: 'tall' }]
+    const idx = new HeightIndex('revive-before-walk', {
+      rowCount: rows.length,
+      estimate: 80,
+      keyAt: (i) => rows[i]?.id ?? null,
+    })
+    idx.setMeasured(2, 300)
+    idx.setMeasured(3, 300)
+    idx.setMeasured(4, 900)
+
+    // The tall row leaves the list, so its height stops pricing what remains.
+    rows.pop()
+    idx.retire(['tall'])
+    idx.sync(rows.length)
+    expect(idx.totalHeight()).toBeCloseTo(300 + 300 + 300 + 300, 1)
+
+    // It comes back. Every unmeasured row must be priced by the mean that
+    // INCLUDES it (500), including the two the walk reaches first.
+    rows.push({ id: 'tall' })
+    idx.sync(rows.length)
+    expect(idx.totalHeight()).toBeCloseTo(500 + 500 + 300 + 300 + 900, 1)
+    // Its own measurement is exact again too.
+    expect(idx.getHeight(4)).toBe(900)
+  })
 })


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** scroll-position fix with no static visual delta — the change is where the viewport sits across a commit, which a before/after still cannot show. Reproduced numerically instead (100px / 400px / 200px of drift in the harness).

## Problem / Motivation

While a turn streams, transient "thinking" rows mount and unmount **above or between** output that is already rendered. Each whole-row add/remove jogs the viewport under a reader who has scrolled up: the transcript is pushed down when the row appears and pulled up when it goes. Token growth *inside* an existing line is already smooth — it is the row-level insert/remove that jitters.

Not the two anchor fixes that landed this week: #6645 collapsed two captures onto one render-phase slot, and #6949 added TRIGGER 3 for a **tail append**. Not #4399's pinned-jump glide either, which is untouched.

## Why it matters

Anyone reading back through a transcript while an agent is still working — the normal way a long turn is followed. The row they are reading walks off under them, repeatedly, for the duration of the turn. On engines with no native scroll anchoring (iOS Safari) nothing absorbs it.

## What changed (motivation → approach → change)

Everything below extends the **one** existing render-phase capture and its **one** consumer. No parallel anchor path — a second path fights this one for `scrollTop`.

**1. A mid-list INSERT was swallowed by TRIGGER 3's predicate.** `tailAppended` only tested "the count grew while index 0 kept its key", which a mid-list splice satisfies too — so it took the append path. That path resolves a mounted node's **previous-commit** index through the **new** `items`, which is only correct when no index moved; after a splice it names the wrong row, so the anchor was mis-keyed and the correction measured a row nobody was reading.

Split on the one O(1) fact that separates them: a tail append leaves the **last pre-existing index** answering to its own key, while a splice anywhere above it moves that row along. The splice case (TRIGGER 4) gets TRIGGER 1's mapping — previous items at the node's previous index, filtered to keys that survive the commit, so a retired key falls forward to the next survivor.

**2. A mid-list REMOVE had no trigger at all.** An unmounting "thinking" row is exactly that. TRIGGER 5 covers it through the same capture and the same consumer: the height above the reader changing is one event, and the correction does not care which direction it moved.

**3. The estimate-vs-measured reprice, at its source.** `getHeight` prices every **unmeasured** row from the running MEAN of the measured ones, so a measurement is never local to its own row. A transient row is measured while mounted and then leaves — and its height goes on pricing the transcript after the row is gone, so everything above the reader stays under-priced until the entry is evicted, and past a reload once the blob is persisted. Compensating one commit cannot reach that: the reprice recurs on every later sync.

New `HeightIndex.retire` / `HeightCache.retire` drop the height from the mean during the render that dropped the row, so the reprice lands in the commit the splice anchor already compensates. Two properties earned during review:

- **Keyed on key departure, not on the net count falling.** A commit that drops the ghost while adding output nets to growth or to zero with its height still pricing the transcript. The surviving-key set the anchor already builds is the general detector, so this costs one pass over the previous items and no extra allocation. That includes TRIGGER 6, the equal-count **swap** (the placeholder leaving and its replacement arriving in one React-batched commit).
- **Retiring KEEPS the measurement** and removes it only from the mean. Deleting it would corrupt a rollback: `handleRegenerate` and `handleEditResend` both snapshot the transcript, optimistically truncate it, and dispatch the snapshot back when the server refuses the press — so rows leave the list and come back, and rows restored without their measurements would be re-priced from the mean (wrong spacer, viewport jump, and it persists for every row still off-window). A later `set()` revives a retired key, retired entries keep their LRU position so they evict before live ones, and they are left out of the persisted blob so a reload does not re-admit them to the mean.

**Retirement is reversible, because removal is not always permanent.** A retired key is un-retired by `HeightCache.reviveIfRetired`, called from the resolved-height read in `HeightIndex.heightAt`. That read is the right site rather than a removal site: a restore has no commit shape of its own to hook (an optimistic *tail* truncation comes back as a plain append, which is not a splice at all), while a key resolving from a **live row index** is itself proof the retirement's premise no longer holds. Without it a restored row kept its own exact height but stayed out of the mean, so it never priced the unmeasured rows again — and an off-window row, which never re-measures, stayed out indefinitely.

**What TRIGGER 6 deliberately does NOT do:** capture an anchor. The single consumer is invalidated by `windowRange` and `itemCount`, and an equal-count commit moves neither, so an anchor taken there would sit in the slot and be spent on an unrelated later commit — the stranded-anchor hazard the render-phase capture exists to remove. Compensating a swap needs a new invalidation key in that shared consumer, which changes a contract every trigger depends on; filed as #7234 with the measured 200px reproduction.

Every trigger stays behind the `stickRef` guard: a reader pinned to the bottom keeps following the output down.

Diff is confined to `website/src/hooks/virtualizer/` and its tests. No reformatting.

## Tests

Each case red-before proven by reverting **only its own** production change and keeping the tests:

| New case | Reverted change | On the revert | On this branch |
|---|---|---|---|
| `prependAnchor`: row **spliced in** above the reader | TRIGGER 4 | drifted **100px** | holds (≤1px) |
| `prependAnchor`: row **removed** above the reader | TRIGGER 5 | drifted **400px** | holds (≤1px) |
| `heightSyncAnchor`: ghost row leaves the list | retirement | `totalHeight` stuck at **6386.67** | returns to **9000** |
| `heightSyncAnchor`: **rolled-back** row restored | `retire` → delete | came back at the flat estimate **80** | its own **900** |
| `heightSyncAnchor`: **swapped-out** row at equal count | TRIGGER 6 | `totalHeight` **7110** | **9000** |
| `virtualizerHeightOwner`: **restored** row back in the mean | `reviveIfRetired` | priced at **300** (mean without it) | **500** |

```
× holds the reading position when a row is SPLICED IN above the reader
  AssertionError: expected 100 to be less than or equal to 1
× holds the reading position when a row is REMOVED above the reader
  AssertionError: expected 400 to be less than or equal to 1
× stops pricing unmeasured rows from a transient row once it leaves the list (pinned reader)
  AssertionError: expected 6386.666666666669 to be close to 9000
× restores a rolled-back row at its own measured height, not the mean
  AssertionError: expected 80 to be 900
× retires a swapped-out row even though the count never moved
  AssertionError: expected 7109.999999999995 to be close to 9000
```

Plus seven `HeightCache` cases pinning the retire/revive contract (out of the mean, still readable, revived on re-measure, revived when its row is live again, idempotent revive, estimate fallback when every sample is retired, not persisted while retired and re-persisted once revived), and two pinned-to-bottom counterparts — `still follows to the bottom when a row is SPLICED IN while PINNED` and `keeps following after a row is REMOVED while PINNED` — which pass on `main` and stay green, so a fix that held position for a pinned reader would fail them.

Non-vacuity is asserted in each case: the ghost really mounts, the removed row really is gone.

**No existing assertion weakened.** Virtualizer family **198/198** green (`anchorRestore`, `heightSyncAnchor`, `integration`, `layoutShrink`, `observerBackfill`, `postStreamLurch`, `prependAnchor`, `railCollapse`, `spacerLurch`, `viewportResize`, `UseVirtualChatCoverage`, `HeightCache`, `HeightCache.multiInstance`, `virtualizerHeightOwner`, `ScrollAnchorCache`). Full website suite green; `tsc -b` and `eslint` clean on the changed files.

## Manual verification

N/A — the jitter is a scroll-position delta, and the harness reproduces it numerically: the deterministic layout engine in `prependAnchor.test.tsx` makes the rows genuinely move, so every number in the table above is measured, not asserted against source text.

## Pattern harvest

Rule candidate: review checklist (not mechanically greppable)

Pattern: **a cache retraction keyed on "the row left the list" must not treat removal as permanent when the app has optimistic-then-rollback flows.** The first version of the retirement deleted the measurement, which is correct only if a departure is final. It is not: `handleRegenerate` and `handleEditResend` both snapshot, truncate, and restore the snapshot when the server refuses the press. The generalizable shape is that a derived-data store gets *two* independent questions — "should this still influence other entries?" (here: the mean) and "should this still be retrievable?" (here: the entry) — and collapsing them into one delete is what turns a correct invalidation into data loss. The same split appears in this file's own eviction, which is a capacity decision about rows that still exist and therefore is not a retraction at all. Two of the three review findings on this PR were instances of getting that split wrong in opposite directions (delete loses the restore; retire-without-revive loses the sample), which is why it is worth writing down rather than treating as a one-off.

Not mechanically enforceable: the trigger is "this key's row may come back", which no pattern can see from the call site. The checkable proxy is narrower and worth asking on any PR that removes an entry from a persisted cache — *what restores this key, and does that path re-establish everything the removal took away?*

## Related Issues

Fixes #6076

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
