### PR TITLE
test: fix both post-#2602 contract collisions breaking main CI

### DIFF
--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -356,7 +356,9 @@ class TestResolveMcpServer:
             {"name": "kirocrew", "mcpServers": {"srv-hr": {"command": "c", "args": ["a"]}}},
         )
 
-        assert _resolve_mcp_server("srv-hr") == ("c", "a")
+        # #2602 widened the resolver contract to ``(argv, env)`` -- a spec with
+        # no env block resolves to an empty dict, not None.
+        assert _resolve_mcp_server("srv-hr") == (("c", "a"), {})
 
     def test_malformed_spec_no_longer_escapes_as_a_decode_error(self, agents_dir_resolver):
         """The differential case for THIS site.

--- a/test/test_resource_limits_schema.py
+++ b/test/test_resource_limits_schema.py
@@ -275,6 +275,15 @@ class TestCgroupConsumerUnchanged:
                 unittest.mock.patch.object(sb, "_probe_cgroup_scope", return_value=(True, "")),
                 unittest.mock.patch.object(sb, "_reconcile_slice_memory_high_off_thread"),
                 unittest.mock.patch.object(sb, "_cpu_controller_delegated", return_value=True),
+                # #2602 pins the wrapper through ``trusted_system_bin`` before
+                # wrapping; an unresolvable systemd-run (e.g. Windows CI) now
+                # degrades to an unwrapped argv with no ceilings at all. Pin the
+                # resolution so this test keeps exercising the ceiling-emitting
+                # path on every platform, same as the probe mock above.
+                unittest.mock.patch(
+                    "kiro_crew.platform_compat.trusted_system_bin",
+                    return_value="/usr/bin/systemd-run",
+                ),
                 unittest.mock.patch(
                     "kiro_crew.config.loader._raw_config",
                     return_value={"resource_limits": raw},


### PR DESCRIPTION
## Problem / Motivation

`main` has been red since ~2026-08-31 02:40 UTC: every PR's CI inherits two test failures that belong to main itself.

- `test_agent_spec_hardened_reads.py::TestResolveMcpServer::test_valid_agent_spec_still_resolves_under_the_same_cap` fails on every platform with `assert (('c', 'a'), {}) == ('c', 'a')`.
- `test_resource_limits_schema.py::TestCgroupConsumerUnchanged::test_the_scope_argv_never_carries_a_zero_ceiling` fails on the Windows shards with `assert ([])` — no `TasksMax=` in the argv.

## Why it matters

Every open PR is tested against `refs/pull/N/merge` (branch merged with current main), so a red main blocks the whole queue: contributors chase failures their diffs cannot cause, and reruns cannot help.

## What changed (motivation → approach → change)

Two changes crossed mid-air with no textual conflict:

1. 533414c8d added `TestResolveMcpServer`, asserting `_resolve_mcp_server` returns bare argv (`("c", "a")`) — the contract at the time it was written.
2. #2602 (5fe1d64e4) then widened the resolver to return `(argv, env)` and, separately, pinned the cgroup scope wrapper through `trusted_system_bin("systemd-run")`, degrading to an **unwrapped argv** when the wrapper is unresolvable.

Each was green on its own pre-merge run; together they contradict. The second change also broke the zero-ceiling test on Windows only: Windows runners have no `systemd-run`, so the test's mock stack (which forces the probe to succeed) no longer reaches the ceiling-emitting path, and the argv legitimately carries no `TasksMax=`.

Both fixes are test-side — the production behavior is #2602's intended contract:

- Assert the resolver's full `(argv, env)` pair: `(("c", "a"), {})`.
- Add `trusted_system_bin` → `/usr/bin/systemd-run` to the zero-ceiling test's mock stack, the same strategy as its existing `_probe_cgroup_scope` mock, so it exercises the ceiling path on every platform. #2602's own suite (`test_sandbox_argv.py`) already covers the unresolvable-wrapper degradation, so no coverage is lost by pinning here.

Overlap note: #7176 and #7179 each fix the resolver-shape assertion only; neither touches the Windows failure. This PR is the complete heal — happy to rebase or close in favor of either if a maintainer prefers, but merging only a resolver fix leaves the Windows shards red.

## Tests

- `test_valid_agent_spec_still_resolves_under_the_same_cap` — now locks the full post-#2602 `(argv, env)` contract, including empty-env-is-`{}`.
- `test_the_scope_argv_never_carries_a_zero_ceiling` — unchanged assertions, now platform-independent again; keeps locking that hostile config values never emit a zero ceiling.
- Full runs of both files: 111 passed locally on the exact main head (527ea2776 + this commit).

## Manual verification

Verified the resolver-shape failure reproduces on a pristine `origin/main` probe worktree (fails without any branch changes), and read `cgroup_scope_argv` (sandbox.py:5865-5868) to confirm the unresolvable-wrapper early return is what starves the Windows test of `TasksMax=`.

## Screenshots / video

N/A — test-only change, no rendered surface.

no linked issue: this heals main's CI directly; no tracked issue exists for the breakage.
