### PR TITLE
test(sandbox): pin the cgroup wrapper fail-open with an explicit negative control (#7183)

### DIFF
--- a/test/test_resource_limits_schema.py
+++ b/test/test_resource_limits_schema.py
@@ -299,6 +299,46 @@ class TestCgroupConsumerUnchanged:
             assert tasks and int(tasks[0].split("=")[1]) >= 1, raw
             assert memory and int(memory[0].split("=")[1].rstrip("M")) >= 1, raw
 
+    def test_an_unresolvable_wrapper_degrades_to_unwrapped_not_to_a_zero_ceiling(self):
+        """Negative control for the wrapper-pin mock above: when the
+        ``systemd-run`` pin cannot resolve (the reality on Windows, where #7183
+        turned this file red), ``cgroup_scope_argv`` returns argv UNCHANGED --
+        its documented fail-open, pinned in depth by
+        ``test_sandbox_argv.py::test_cgroup_wrapper_is_absolute_or_refused``.
+        Asserting it here too keeps the ceiling test above honest: the
+        "degrading must not mean unbounded" invariant is about the emitted
+        limit VALUES, and this is the shape degradation takes -- no properties
+        at all, never a zero ceiling."""
+        import kiro_crew.sandbox as sb
+
+        try:
+            with (
+                unittest.mock.patch.object(sb, "_probe_cgroup_scope", return_value=(True, "")),
+                unittest.mock.patch.object(sb, "_reconcile_slice_memory_high_off_thread"),
+                unittest.mock.patch.object(sb, "_cpu_controller_delegated", return_value=True),
+                unittest.mock.patch.object(
+                    sb.platform_compat, "trusted_system_bin", return_value=None
+                ),
+                # Deliberately never read on the healthy path -- the wrapper
+                # gate returns before ``_cgroup_limits_from_config`` runs. It
+                # stays mocked so a REGRESSION of the fail-open (proceeding
+                # past the gate) still cannot read the host's real config.
+                unittest.mock.patch(
+                    "kiro_crew.config.loader._raw_config",
+                    return_value={"resource_limits": {"max_processes": 0.5, "max_memory_mb": 0.5}},
+                ),
+            ):
+                argv = sb.cgroup_scope_argv(["/bin/true"])
+        finally:
+            # The degraded path arms the once-per-process warning latch; leaving
+            # it set would silence the SECURITY warning for later tests on this
+            # worker (same reset as test_sandbox_argv.py's _reset_probe).
+            sb._CGROUP_WARNED = False
+        assert argv == ["/bin/true"]
+        # Drift guard for the name's claim: degradation means NO properties,
+        # never a zero one.
+        assert not [a for a in argv if a.startswith(("TasksMax=", "MemoryMax=", "CPUQuota="))]
+
 
 class TestSliceConsumer:
     @staticmethod


### PR DESCRIPTION
## Problem / Motivation

Follow-up delta to #7200. That batch fixed the #7183 Windows red by mocking the `trusted_system_bin("systemd-run")` wrapper pin inside `test_the_scope_argv_never_carries_a_zero_ceiling` — but the documented fail-open the mock papers over (unresolvable pin ⇒ argv returned unchanged, no ceiling at all) is now only an implicit assumption in this file. That is exactly the shape that made #7183 a confusing red: the behaviour existed, was deliberate, and was invisible here.

## Why it matters

Without an explicit pin in this file, the next contributor who touches these mocks (or a future third gate in `cgroup_scope_argv`) can reintroduce a host-dependent assertion with no local test naming the degradation shape. The fail-open is security-relevant (it is the "lose the DoS ceiling rather than emit an unpinned argv[0]" tradeoff), so its shape deserves a test at every consumer that mocks around it.

## What changed (motivation → approach → change)

One new negative-control test in `TestCgroupConsumerUnchanged`: with the pin mocked to `None` (the real Windows condition), `cgroup_scope_argv` returns argv unchanged and emits no `TasksMax=`/`MemoryMax=`/`CPUQuota=` properties — never a zero ceiling. Depth ownership stays with `test_sandbox_argv.py::test_cgroup_wrapper_is_absolute_or_refused` (named in the docstring); this asserts the same fail-open at the consumer that #7183 bit. The test resets the once-per-process `_CGROUP_WARNED` latch in a `try/finally` (same hygiene as `test_sandbox_argv.py`'s `_reset_probe`) so the degraded path cannot mute the SECURITY warning for later tests on the worker, and keeps `loader._raw_config` mocked (deliberately unread on the healthy path, commented as such) so a regression of the fail-open still cannot read the host's real config.

## Tests

- New: `test_an_unresolvable_wrapper_degrades_to_unwrapped_not_to_a_zero_ceiling` (the change IS a test).
- File suite: 57/57 on a plain host AND under a simulated no-systemd-run host (trusted-dir tuple emptied) — the latter is the #7183 Windows condition, now green both because of #7200's mock and this explicit pin.
- Latch hygiene verified: `sb._CGROUP_WARNED` is `False` after the test runs.

## Manual verification

N/A — unit coverage sufficient: single test-file change, differential run above reproduces the Windows condition on Linux.

## Related Issues

Closes #7183

## Checklist

- [x] One commit, Conventional Commits title
- [x] Test-only; no `src/` changes

---
_History: this PR originally carried the wrapper-pin mock fix itself (approved by @buluoray, who folded it co-authored into #7202); #7200 landed the equivalent mock first, so this PR was rebased and slimmed to the additive delta above._
