### PR TITLE
test: repair the two base breaks that block every PR's CI

### DIFF
--- a/test/test_agent_spec_hardened_reads.py
+++ b/test/test_agent_spec_hardened_reads.py
@@ -348,6 +348,13 @@ class TestResolveMcpServer:
         assert _resolve_mcp_server("srv-hr") is None
 
     def test_valid_agent_spec_still_resolves_under_the_same_cap(self, agents_dir_resolver):
+        """The positive control for the refusal cases above.
+
+        The resolver returns ``(argv, env)``; this asserts the whole tuple rather
+        than only ``argv`` so the control cannot drift out of step with the
+        contract again -- an env block the caller never receives is how a spawned
+        MCP dies at the ``initialize`` handshake.
+        """
         from kiro_crew.cron_script import _resolve_mcp_server
 
         _plant(
@@ -356,7 +363,34 @@ class TestResolveMcpServer:
             {"name": "kirocrew", "mcpServers": {"srv-hr": {"command": "c", "args": ["a"]}}},
         )
 
-        assert _resolve_mcp_server("srv-hr") == ("c", "a")
+        assert _resolve_mcp_server("srv-hr") == (("c", "a"), {})
+
+    def test_a_declared_env_block_survives_the_hardened_read(self, agents_dir_resolver):
+        """The env half of the contract, on THIS module's read path.
+
+        The refusal cases above prove a capped/oversized spec yields no server.
+        This proves the accepted path still carries the per-server ``env`` the
+        launcher needs, so a future tightening of the hardened read cannot
+        quietly drop it while the argv assertion stays green.
+        """
+        from kiro_crew.cron_script import _resolve_mcp_server
+
+        _plant(
+            agents_dir_resolver,
+            AGENT_FILENAME,
+            {
+                "name": "kirocrew",
+                "mcpServers": {
+                    "srv-hr": {
+                        "command": "c",
+                        "args": ["a"],
+                        "env": {"PATH": "/opt/tools/bin"},
+                    }
+                },
+            },
+        )
+
+        assert _resolve_mcp_server("srv-hr") == (("c", "a"), {"PATH": "/opt/tools/bin"})
 
     def test_malformed_spec_no_longer_escapes_as_a_decode_error(self, agents_dir_resolver):
         """The differential case for THIS site.

--- a/test/test_resource_limits_schema.py
+++ b/test/test_resource_limits_schema.py
@@ -275,6 +275,17 @@ class TestCgroupConsumerUnchanged:
                 unittest.mock.patch.object(sb, "_probe_cgroup_scope", return_value=(True, "")),
                 unittest.mock.patch.object(sb, "_reconcile_slice_memory_high_off_thread"),
                 unittest.mock.patch.object(sb, "_cpu_controller_delegated", return_value=True),
+                # ``cgroup_scope_argv`` has a SECOND fail-open gate after the
+                # probe: it pins the wrapper via
+                # ``platform_compat.trusted_system_bin("systemd-run")`` and
+                # returns argv UNCHANGED when that cannot resolve (every
+                # Windows host, any Linux host without systemd-run). Without
+                # this mock the ceiling assertions below never reach the
+                # property-emitting path there, making the test
+                # platform-dependent instead of a statement about limit values.
+                unittest.mock.patch.object(
+                    sb.platform_compat, "trusted_system_bin", return_value="/usr/bin/systemd-run"
+                ),
                 unittest.mock.patch(
                     "kiro_crew.config.loader._raw_config",
                     return_value={"resource_limits": raw},
@@ -289,6 +300,46 @@ class TestCgroupConsumerUnchanged:
             memory = [a for a in argv if a.startswith("MemoryMax=")]
             assert tasks and int(tasks[0].split("=")[1]) >= 1, raw
             assert memory and int(memory[0].split("=")[1].rstrip("M")) >= 1, raw
+
+    def test_an_unresolvable_wrapper_degrades_to_unwrapped_not_to_a_zero_ceiling(self):
+        """Negative control for the mock above: when the ``systemd-run`` pin
+        cannot resolve (the reality on Windows, where #7183 turned this file
+        red), ``cgroup_scope_argv`` returns argv UNCHANGED -- its documented
+        fail-open, pinned in depth by
+        ``test_sandbox_argv.py::test_cgroup_wrapper_is_absolute_or_refused``.
+        Asserting it here too keeps the ceiling test above honest: the
+        "degrading must not mean unbounded" invariant is about the emitted
+        limit VALUES, and this is the shape degradation takes -- no properties
+        at all, never a zero ceiling."""
+        import kiro_crew.sandbox as sb
+
+        try:
+            with (
+                unittest.mock.patch.object(sb, "_probe_cgroup_scope", return_value=(True, "")),
+                unittest.mock.patch.object(sb, "_reconcile_slice_memory_high_off_thread"),
+                unittest.mock.patch.object(sb, "_cpu_controller_delegated", return_value=True),
+                unittest.mock.patch.object(
+                    sb.platform_compat, "trusted_system_bin", return_value=None
+                ),
+                # Deliberately never read on the healthy path -- the wrapper
+                # gate returns before ``_cgroup_limits_from_config`` runs. It
+                # stays mocked so a REGRESSION of the fail-open (proceeding
+                # past the gate) still cannot read the host's real config.
+                unittest.mock.patch(
+                    "kiro_crew.config.loader._raw_config",
+                    return_value={"resource_limits": {"max_processes": 0.5, "max_memory_mb": 0.5}},
+                ),
+            ):
+                argv = sb.cgroup_scope_argv(["/bin/true"])
+        finally:
+            # The degraded path arms the once-per-process warning latch; leaving
+            # it set would silence the SECURITY warning for later tests on this
+            # worker (same reset as test_sandbox_argv.py's _reset_probe).
+            sb._CGROUP_WARNED = False
+        assert argv == ["/bin/true"]
+        # Drift guard for the name's claim: degradation means NO properties,
+        # never a zero one.
+        assert not [a for a in argv if a.startswith(("TasksMax=", "MemoryMax=", "CPUQuota="))]
 
 
 class TestSliceConsumer:


### PR DESCRIPTION
## Problem

`main` carries two failing backend tests, and **neither can be fixed alone**.

The `protected-branches` ruleset requires exactly one context — the `PR Readiness` **commit status** — and its evaluator monitors `ci.yml|CI` as a *whole workflow* (`.github/workflows/pr-readiness.yml`, the `workflow_specs` list). So any single failing shard fails the aggregate, and every open PR is blocked, including each PR that fixes one of the two breaks:

| PR | fixes | still carries | CI |
|---|---|---|---|
| #7176 (+ #7179, #7192, #7197) | the resolver shape | the ceiling break | fail |
| #7201 | the ceiling break | the resolver shape | fail |

Five people opened a fix within 80 minutes, which is the usual signature of a base break that each PR's own stale-green checks hide — a PR's checks are not re-run when `main` advances, so PRs whose lanes finished before the break landed still show green.

This PR lands both halves so CI can reach green again. Both fixes are the contributors' own work, taken from #7176 (@leonlaiyc) and #7201 (@bolichen97) and squashed into one commit because the repo requires a single commit per PR. Once this merges, both of those can close and every other open PR goes green on a rerun.

## What changed

**1. The resolver returns `(argv, env)`, not a flat argv.** `test_agent_spec_hardened_reads.py` pinned the pre-#2602 shape. `cron_script._resolve_mcp_server` is now declared `-> tuple[tuple[str, ...], dict[str, str]] | None` and ends in `return argv, env`. The env block is load-bearing — a launcher that shells out to a helper binary only reachable through the config's `PATH` dies at the JSON-RPC `initialize` handshake without it — so the assertion compares the whole pair, and a second case proves a *declared* `env` survives the hardened read rather than only checking that an absent one yields `{}`.

**2. The ceiling test depended on the host having `systemd-run`.** `cgroup_scope_argv` has a *second* fail-open gate after the probe:

```python
systemd_run = platform_compat.trusted_system_bin("systemd-run")
if not systemd_run:
    _warn_cgroup_unavailable("systemd-run is not in a trusted system directory")
    return argv
```

On Windows that pin never resolves, so argv came back **unchanged, carrying no properties at all** — which is why the failure read `AssertionError: {'max_memory_mb': 0.5, 'max_processes': 0.5}` (the raw config, as the assertion's message) rather than reporting a zero ceiling. A test named for limit *values* was silently asserting host configuration. The pin is now mocked so the ceiling assertions reach the property-emitting path, and a negative control pins the shape the degradation actually takes: no properties, never a zero one.

Both `>= 1` ceiling assertions are unchanged. Mocking a fail-open gate away is exactly the move that can delete coverage silently, which is what the negative control is for.

## Verification

Run against `main`'s own source, with the host condition simulated both ways by forcing `trusted_system_bin("systemd-run")` to return `None`:

| condition | `main`'s tests | this PR's tests |
|---|---|---|
| Linux (as-is) | resolver break reproduces: `AssertionError: assert (('c', 'a'), {}) == ('c', 'a')` | 113 passed |
| Windows simulated | ceiling break reproduces: `AssertionError: {'max_memory_mb': 0.5, 'max_processes': 0.5}` — CI's exact message | 113 passed |

Both reproductions match the CI failures verbatim, so the two fixes are confirmed against the real breaks rather than against a plausible story about them. The first attempt at the Windows simulation was invalid — a `git stash` in the same command reverted the mutation before pytest ran, and the test "passed" for that reason; the numbers above are from the re-run with the mutation verified present in the file.

**Why no screenshot:** test-only change, no user-visible surface.

**Why no linked issue:** a base break found while diagnosing CI on an unrelated frontend PR.
