### PR TITLE
fix(terminal): keep ime tab from accepting completions

### DIFF
--- a/website/src/components/TerminalCompletion.tsx
+++ b/website/src/components/TerminalCompletion.tsx
@@ -20,8 +20,8 @@ const ROW_H = 22
 /** Prompt-marker rows retained. Bounded so a long session cannot grow the map
  *  without limit; only the cursor's own row is ever read. */
 const MARKER_LIMIT = 64
-/** Grace window after `compositionend` in which Enter still belongs to the IME.
- *  Browsers disagree on whether the committing Enter is flagged as composing. */
+/** Grace window after `compositionend` in which a choose key still belongs to the IME.
+ *  Browsers disagree on whether the committing Enter or Tab is flagged as composing. */
 const IME_GRACE_MS = 60
 
 interface Entry {
@@ -499,12 +499,15 @@ export default function TerminalCompletion({ term, sessionId, active }: {
     term.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true
       // An IME candidate is committed with a keydown the browser marks as
-      // composing (Chrome reports keyCode 229 for it); swallowing that Enter
-      // would accept a path instead of the text the user just composed. Some
+      // composing (Chrome reports keyCode 229 for it); swallowing that Enter or
+      // Tab would accept a path instead of the text the user just composed. Some
       // browsers report the committing key as non-composing, hence the grace
       // window after `compositionend`.
       if (e.isComposing || e.keyCode === 229) return true
-      if (e.key === 'Enter' && Date.now() - imeEndAt.current < IME_GRACE_MS) return true
+      if (
+        (e.key === 'Enter' || e.key === 'Tab')
+        && Date.now() - imeEndAt.current < IME_GRACE_MS
+      ) return true
       const s = stateRef.current.sug
       if (!s) return true
       if (e.ctrlKey || e.metaKey || e.altKey) return true

--- a/website/src/components/TerminalCompletion.tsx
+++ b/website/src/components/TerminalCompletion.tsx
@@ -499,15 +499,16 @@ export default function TerminalCompletion({ term, sessionId, active }: {
     term.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true
       // An IME candidate is committed with a keydown the browser marks as
-      // composing (Chrome reports keyCode 229 for it); swallowing that Enter or
-      // Tab would accept a path instead of the text the user just composed. Some
-      // browsers report the committing key as non-composing, hence the grace
-      // window after `compositionend`.
+      // composing (Chrome reports keyCode 229 for it). Leave that native action
+      // alone. Some browsers clear both flags before the committing key arrives,
+      // hence the grace window after `compositionend`: Enter keeps its established
+      // pass-through behavior, while Tab must be consumed so it can neither accept
+      // the menu suggestion nor escape to xterm as shell completion.
       if (e.isComposing || e.keyCode === 229) return true
-      if (
-        (e.key === 'Enter' || e.key === 'Tab')
-        && Date.now() - imeEndAt.current < IME_GRACE_MS
-      ) return true
+      if (Date.now() - imeEndAt.current < IME_GRACE_MS) {
+        if (e.key === 'Enter') return true
+        if (e.key === 'Tab') return claim(e)
+      }
       const s = stateRef.current.sug
       if (!s) return true
       if (e.ctrlKey || e.metaKey || e.altKey) return true

--- a/website/src/test/TerminalCompletion.test.tsx
+++ b/website/src/test/TerminalCompletion.test.tsx
@@ -851,6 +851,15 @@ describe('TerminalCompletion', () => {
       expect(sent).toEqual([])
     })
 
+    it('passes through the Tab that ends composition', async () => {
+      const h = await open()
+      h.compositionEnd()
+      const r = h.key({ key: 'Tab' })
+      expect(r.passedThrough).toBe(true)
+      expect(r.prevented).toBe(false)
+      expect(sent).toEqual([])
+    })
+
     it('still accepts on a plain Enter once composition is over', async () => {
       const h = await open()
       h.compositionEnd()
@@ -858,6 +867,15 @@ describe('TerminalCompletion', () => {
       vi.setSystemTime(Date.now() + 1000)
       await act(async () => { expect(pick(h).passedThrough).toBe(false) })
       expect(sent).toEqual(['s/'])
+    })
+
+    it('still completes on a plain Tab once composition is over', async () => {
+      const h = await open()
+      h.compositionEnd()
+      // Past the grace window: this Tab belongs to the menu again.
+      vi.setSystemTime(Date.now() + 1000)
+      await act(async () => { expect(h.key({ key: 'Tab' }).passedThrough).toBe(false) })
+      expect(sent).toEqual(['s'])
     })
 
     // Regression: this child's effects run BEFORE the parent's `term.open()`, so

--- a/website/src/test/TerminalCompletion.test.tsx
+++ b/website/src/test/TerminalCompletion.test.tsx
@@ -851,12 +851,15 @@ describe('TerminalCompletion', () => {
       expect(sent).toEqual([])
     })
 
-    it('passes through the Tab that ends composition', async () => {
+    it('consumes the post-composition Tab without accepting the suggestion', async () => {
       const h = await open()
       h.compositionEnd()
       const r = h.key({ key: 'Tab' })
-      expect(r.passedThrough).toBe(true)
-      expect(r.prevented).toBe(false)
+      // Native composition flags are already clear, so the grace latch owns
+      // both halves: the menu must not accept Tab, and xterm/browser must not
+      // pass it on to the PTY as shell completion.
+      expect(r.passedThrough).toBe(false)
+      expect(r.prevented).toBe(true)
       expect(sent).toEqual([])
     })
 


### PR DESCRIPTION
## Problem / Motivation

Terminal completion already leaves Enter alone during the short window after an
IME composition ends, but Tab did not have the full choose-key contract. Accepting
Tab in that window rewrote the command with a menu suggestion; merely returning it
to xterm instead sent Tab to the PTY and triggered shell completion.

## Why it matters

People typing with a Chinese, Japanese, or Korean IME can have their terminal
command line rewritten by either UI completion layer when they are only committing
or navigating an IME candidate.

## What changed (motivation → approach → change)

The terminal tracks `compositionend` because browser native composition flags may
already be clear on the committing keydown. A Tab with live native composition
flags is still left to the browser/IME. During the post-composition grace window,
after those flags clear, Tab is now claimed and consumed: the completion menu does
not accept it, xterm does not pass it to the PTY, and the browser default is
prevented. Existing Enter behavior is unchanged, and ordinary Tab completion still
works after the grace window expires.

## Tests

- Added a decisive regression proving grace-window Tab is not accepted by the
  menu, is not passed to xterm/PTY, has its default action prevented, and sends no
  completion bytes.
- Kept the positive control proving Tab still completes after the grace window.
- `npm exec -- vitest run src/test/TerminalCompletion.test.tsx --coverage.enabled=false`
  — 65 passed.
- Directly relevant IME siblings (`useImeGuard.documentLatch` and
  `ImeEnterGuardSites`) — 37 passed.
- `npm exec -- tsc -b --pretty false` — passed.
- Exact-file ESLint — passed.

Red-before on PR head `22ca20622441ef84706b988303466d2ef903aaeb`:
1 failed / 64 passed; the regression observed that post-composition Tab returned
`true` to xterm. Green-after on current head: 65 / 65 passed.

## Manual verification

N/A — the focused component harness deterministically drives xterm's custom key
handler, composition-end event, fake clock, DOM cancellation state, and PTY-write
seam.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** This changes keyboard-event ownership during IME composition;
the rendered terminal completion UI is unchanged.

## Related Issues

no linked issue: this is the exact unfixed sibling named by merged PR #7000's
first-principles review.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


## Pattern harvest

Rule candidate: any `keydown` handler that routes committing keys (Enter/Tab) must honor the IME composition boundary — check `e.isComposing || e.keyCode === 229` AND the post-`compositionend` grace window before treating the key as a UI command; a handler reading `e.key` alone misroutes a just-committed IME candidate.
