### PR TITLE
fix(apps): drop an app's hook registrations when it is uninstalled

### DIFF
--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -113,7 +113,7 @@ from kiro_crew.apps.registry import (
     resolve_installed_trust_repository,
 )
 from kiro_crew.apps.spawn_sdk import build_spawn_impl
-from kiro_crew.apps.teardown import teardown_app_runtime
+from kiro_crew.apps.teardown import forget_app_hooks, teardown_app_runtime
 from kiro_crew.apps.version import check_min_version as _check_min_version_str
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import (
@@ -1363,6 +1363,12 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
         return web.json_response(result.to_dict(), status=400)
     invalidate_app_secret_cache(name)
     _unregister_notification_channels(request, name)
+    # Same reason as the line above, for the hook registries: uninstall is the
+    # terminal path, so an entry left behind is a closure over a store this
+    # handler is about to delete. A surviving slot-close hook makes the app's
+    # leftover tabs UNDISMISSABLE -- `notify_slot_closed` returns False when the
+    # hook raises and `api_chat_slot_delete` refuses the close on that.
+    forget_app_hooks(name)
 
     # Step 6: Clean up workspace (each registry app has its own workspace)
     if is_registry_source(info.get("source", "")):

--- a/src/kiro_crew/apps/teardown.py
+++ b/src/kiro_crew/apps/teardown.py
@@ -534,3 +534,33 @@ async def notify_slot_closed(app: str, slot_key: str) -> bool:
         )
         return False
     return True
+
+
+def forget_app_hooks(app: str) -> None:
+    """Drop every in-process hook *app* registered. For UNINSTALL, not disable.
+
+    The three registries above are process memory keyed by app name, and nothing
+    dropped an entry: ``unregister_app_disable_hook``,
+    ``unregister_slot_close_hook`` and ``unregister_slot_close_undo_hook`` existed
+    with no caller. Uninstall already drops the app's other per-app process state
+    (notification channels, the app-secret cache) and deletes its workspace, so a
+    surviving hook is a closure over a store whose files are gone.
+
+    That is not merely untidy, because :func:`notify_slot_closed` reports failure
+    rather than swallowing it and ``api_chat_slot_delete`` REFUSES the dismissal on
+    a false return. A slot belonging to an uninstalled app therefore becomes
+    undismissable: the stale hook raises, the close is refused with
+    ``app_close_hook_failed``, and the user is left with a tab they cannot get rid
+    of for an app that no longer exists. Dropping the entry restores the
+    no-hook-registered path, which returns True and lets the close proceed.
+
+    DISABLE deliberately does not call this. A disabled app can be switched back
+    on, and the registries are re-populated from each app's own watchdog rather
+    than at boot; clearing them on disable would rely on that watchdog having run
+    again before the next dismissal, which is a race this has no need to take.
+    Uninstall is terminal -- nothing re-registers behind it -- which is the same
+    reason the notification-channel unregistration sits on that path alone.
+    """
+    unregister_app_disable_hook(app)
+    unregister_slot_close_hook(app)
+    unregister_slot_close_undo_hook(app)

--- a/src/kiro_crew/apps/teardown.py
+++ b/src/kiro_crew/apps/teardown.py
@@ -554,12 +554,15 @@ def forget_app_hooks(app: str) -> None:
     of for an app that no longer exists. Dropping the entry restores the
     no-hook-registered path, which returns True and lets the close proceed.
 
-    DISABLE deliberately does not call this. A disabled app can be switched back
-    on, and the registries are re-populated from each app's own watchdog rather
-    than at boot; clearing them on disable would rely on that watchdog having run
-    again before the next dismissal, which is a race this has no need to take.
-    Uninstall is terminal -- nothing re-registers behind it -- which is the same
-    reason the notification-channel unregistration sits on that path alone.
+    DISABLE deliberately does not call this, and the asymmetry with the
+    notification channels next to it is the reason rather than an oversight:
+    those ARE unregistered on both paths, because the gateway's own enable
+    pipeline puts them back. These registries are not gateway-owned. They are
+    repopulated only from each app's own watchdog -- ``register_app_disable_hook``
+    says so -- so clearing them on disable would leave a window after a re-enable,
+    before that watchdog next runs, in which a dismissal quietly fails to reach a
+    worker that is live again. Uninstall has no such window: nothing re-registers
+    behind it.
     """
     unregister_app_disable_hook(app)
     unregister_slot_close_hook(app)

--- a/test/test_apps_uninstall_hook_registries.py
+++ b/test/test_apps_uninstall_hook_registries.py
@@ -1,0 +1,176 @@
+"""Uninstall must drop the app's in-process hook registrations.
+
+``apps/teardown.py`` keeps three per-app registries in process memory —
+``_APP_DISABLE_HOOKS``, ``_SLOT_CLOSE_HOOKS``, ``_SLOT_CLOSE_UNDO_HOOKS`` — and
+ships an ``unregister_*`` primitive for each. Nothing called any of them, so an
+uninstall left the removed app's closures installed over a store the same handler
+had just deleted.
+
+That is load-bearing rather than untidy. ``notify_slot_closed`` reports a hook
+failure instead of swallowing it, and ``api_chat_slot_delete`` REFUSES the
+dismissal on a false return — deliberately, so a dismissed tab can never outlive
+a still-running worker. Applied to a stale hook the same rule inverts: a slot
+belonging to an uninstalled app can no longer be closed at all, because the hook
+that must approve the close belongs to an app that is gone.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import kiro_crew.apps.teardown as teardown
+
+APP = "test-app"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    """The registries are module globals; never leak one into another test."""
+    teardown.forget_app_hooks(APP)
+    yield
+    teardown.forget_app_hooks(APP)
+
+
+def _install_hooks(record: list[str]):
+    """Register one hook of each kind for APP, all recording that they ran."""
+
+    async def _disable(app: str) -> None:
+        record.append("disable")
+
+    async def _closed(slot_key: str) -> None:
+        record.append("closed")
+
+    async def _undone(slot_key: str) -> None:
+        record.append("undone")
+
+    teardown.register_app_disable_hook(APP, _disable)
+    teardown.register_slot_close_hook(APP, _closed)
+    teardown.register_slot_close_undo_hook(APP, _undone)
+
+
+def _registered() -> dict[str, bool]:
+    return {
+        "disable": APP in teardown._APP_DISABLE_HOOKS,
+        "close": APP in teardown._SLOT_CLOSE_HOOKS,
+        "undo": APP in teardown._SLOT_CLOSE_UNDO_HOOKS,
+    }
+
+
+class TestForgetAppHooks:
+    """The primitive itself, before anything wires it into a handler."""
+
+    def test_it_drops_all_three_registries(self):
+        _install_hooks([])
+        assert all(_registered().values()), "fixture must actually register"
+
+        teardown.forget_app_hooks(APP)
+
+        assert _registered() == {"disable": False, "close": False, "undo": False}
+
+    def test_it_leaves_other_apps_alone(self):
+        """Keyed by app name — uninstalling one app must not disarm another."""
+        other_ran: list[str] = []
+
+        async def _other(slot_key: str) -> None:
+            other_ran.append(slot_key)
+
+        _install_hooks([])
+        teardown.register_slot_close_hook("other-app", _other)
+        try:
+            teardown.forget_app_hooks(APP)
+            assert "other-app" in teardown._SLOT_CLOSE_HOOKS
+        finally:
+            teardown.unregister_slot_close_hook("other-app")
+
+    def test_it_is_safe_when_nothing_is_registered(self):
+        """Uninstall runs for apps that never registered anything."""
+        teardown.forget_app_hooks("never-registered-app")
+
+
+@pytest.mark.asyncio
+class TestUninstallDropsTheHooks:
+    async def _uninstall(self) -> None:
+        """Drive handle_uninstall_app for APP with the surrounding I/O stubbed."""
+        fake_app = {
+            "name": APP,
+            "manifest": {},
+            "resources": "gateway",
+            "lifecycle": "normal",
+            "enabled": False,
+        }
+        request = MagicMock()
+        request.match_info = {"name": APP}
+        request.app = {"state": MagicMock()}
+        request.json = AsyncMock(return_value={})
+
+        with (
+            patch("kiro_crew.apps.routes.get_app", return_value=fake_app),
+            patch(
+                "kiro_crew.apps.routes.uninstall_app",
+                return_value=MagicMock(ok=True, to_dict=lambda: {"ok": True}),
+            ),
+            patch("kiro_crew.apps.routes.stop_app_backend", return_value=None),
+            patch("kiro_crew.apps.routes.deregister_app", return_value=None),
+            patch(
+                "kiro_crew.apps.teardown.on_app_disable",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("kiro_crew.apps.routes.sel", return_value=MagicMock()),
+            patch(
+                "kiro_crew.apps.routes.classify_and_clean_for_uninstall",
+                return_value={"removable": [], "shared": [], "userInstalled": []},
+            ),
+            patch(
+                "kiro_crew.apps.routes.clean_dependencies",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            from kiro_crew.apps.routes import handle_uninstall_app
+
+            resp = await handle_uninstall_app(request)
+        assert resp.status < 400, f"uninstall failed with {resp.status}"
+
+    async def test_uninstall_leaves_no_hook_behind(self):
+        """Red before the fix: all three survive the uninstall."""
+        _install_hooks([])
+        await self._uninstall()
+        assert _registered() == {"disable": False, "close": False, "undo": False}
+
+    async def test_a_leftover_slot_can_still_be_dismissed_after_uninstall(self):
+        """The user-visible consequence, stated as the property that matters.
+
+        A hook whose app was uninstalled raises — its store is gone — and
+        ``notify_slot_closed`` turns that into ``False``, which
+        ``api_chat_slot_delete`` treats as "refuse the close". Asserting the
+        registry is empty would pass on a fix that merely swapped one registry;
+        asserting the ANSWER is what pins the behaviour the user feels.
+        """
+
+        async def _hook_over_deleted_store(slot_key: str) -> None:
+            raise FileNotFoundError("app store was removed by uninstall")
+
+        teardown.register_slot_close_hook(APP, _hook_over_deleted_store)
+
+        # Before the uninstall the stale hook is what refuses the dismissal.
+        assert await teardown.notify_slot_closed(APP, "slot-1") is False
+
+        await self._uninstall()
+
+        # After it, no hook is registered, so the close is allowed to proceed.
+        assert await teardown.notify_slot_closed(APP, "slot-1") is True
+
+    async def test_the_disable_hook_is_not_dropped_by_a_plain_disable(self):
+        """Scope control: only uninstall is terminal.
+
+        A disabled app can be switched back on and the registries are repopulated
+        by each app's own watchdog, so clearing them on disable would depend on
+        that watchdog having run again before the next dismissal. This asserts the
+        narrower scope rather than leaving it to the description.
+        """
+        _install_hooks([])
+        await teardown.notify_app_disabled(APP)
+        assert _registered() == {"disable": True, "close": True, "undo": True}


### PR DESCRIPTION
## Problem / Motivation

`apps/teardown.py` keeps three per-app hook registries in process memory and ships an `unregister_*` primitive for each:

```
_APP_DISABLE_HOOKS      unregister_app_disable_hook
_SLOT_CLOSE_HOOKS       unregister_slot_close_hook
_SLOT_CLOSE_UNDO_HOOKS  unregister_slot_close_undo_hook
```

**All three primitives have zero callers.** Grepped across `src/`: 3 `register_*` call sites, 0 `unregister_*`. So uninstalling an app leaves its closures installed over a store the same handler has just deleted — `handle_uninstall_app` runs `uninstall_app`, then `shutil.rmtree`s the app's workspace.

That is not merely untidy, because a slot-close hook is not advisory. `notify_slot_closed` reports a hook failure rather than swallowing it, and `api_chat_slot_delete` **refuses the dismissal** on a false return:

```python
# teardown.py — the hook raised
logger.warning("slot-close hook for app %r failed on %r", app, slot_key, ...)
return False

# chat_handlers.py:3740 — the caller
if not await notify_slot_closed(slot._app, name):
    # "Refuse the close rather than leave a worker running behind a tab
    #  the user believes is gone."
    ...
    return web.json_response({"error": ..., "code": "app_close_hook_failed"}, ...)
```

That rule is right for a live app and inverts for a dead one. A slot belonging to an **uninstalled** app can no longer be closed at all: the stale hook raises (its store is gone), `notify_slot_closed` returns `False`, and the close is refused — a tab the user cannot get rid of, for an app that no longer exists, reporting `app_close_hook_failed`.

## Why it matters

The failure is terminal from the user's side rather than transient. Uninstalling was the action that was supposed to remove the app; the leftover tab is the one piece of it still on screen, and the uninstall itself is what made that tab permanently un-dismissable. Retrying does not help — the hook raises every time — and there is no UI affordance to clear a registry that lives in gateway process memory, so the only escape is a gateway restart.

It is also a live-code-after-removal issue in its own right. `teardown.py`'s own ordering comment states the invariant — hooks, then the process, then registrations, *"so nothing re-registers behind us"* — and uninstall already drops the app's other per-app process state on exactly that reasoning (`invalidate_app_secret_cache`, `_unregister_notification_channels`). The hook registries were simply missed.

## What changed (motivation → approach → change)

**Symptom** → an uninstalled app's leftover tab cannot be dismissed. **Root cause** → uninstall drops every other per-app process registration but not the three hook registries, whose `unregister_*` primitives exist unused. **Change** → call them, on the uninstall path only.

`src/kiro_crew/apps/teardown.py` — one function, built from the three primitives that already exist:

```python
def forget_app_hooks(app: str) -> None:
    unregister_app_disable_hook(app)
    unregister_slot_close_hook(app)
    unregister_slot_close_undo_hook(app)
```

`src/kiro_crew/apps/routes.py` — one call in `handle_uninstall_app`, immediately after the notification-channel unregistration it mirrors:

```python
 invalidate_app_secret_cache(name)
 _unregister_notification_channels(request, name)
+forget_app_hooks(name)
```

**Scope: uninstall only, and the asymmetry with the line above it is the reason rather than an oversight.** `_unregister_notification_channels` runs on **both** paths (`routes.py:1365` uninstall, `routes.py:1703` disable) — it can, because those channels are gateway-owned and the enable pipeline puts them back. The hook registries are not gateway-owned: they are repopulated only from each app's own watchdog, which `register_app_disable_hook`'s docstring states outright ("apps re-register from their own watchdog rather than once at boot because this registry is process memory"). Clearing them on disable would therefore leave a window after a re-enable, before that watchdog next runs, in which a dismissal quietly fails to reach a worker that is live again. Uninstall has no such window. A test asserts the disable path does **not** clear them, so the boundary cannot erode silently.

No new mechanism is introduced: this is three existing, documented, currently-unused primitives being called from the one place whose semantics require them.

## Tests

New file `test/test_apps_uninstall_hook_registries.py`, six tests. The uninstall harness mirrors the one in `test_apps_uninstall_keep_specific.py`, so `handle_uninstall_app` runs for real with only its I/O stubbed.

`TestForgetAppHooks` — the primitive:

- `test_it_drops_all_three_registries` — with a fixture assertion first, so it cannot pass by nothing having been registered.
- `test_it_leaves_other_apps_alone` — the registries are keyed by app name; uninstalling one app must not disarm another's hooks.
- `test_it_is_safe_when_nothing_is_registered` — uninstall runs for apps that never registered anything.

`TestUninstallDropsTheHooks` — the handler:

- `test_uninstall_leaves_no_hook_behind` — all three registries are empty after a real `handle_uninstall_app` call.
- `test_a_leftover_slot_can_still_be_dismissed_after_uninstall` — **the user-visible property, not the registry state.** Registers a hook that raises `FileNotFoundError("app store was removed by uninstall")`, asserts `notify_slot_closed(...) is False` *before* the uninstall (the refusal, reproduced), then asserts it is `True` after. Asserting only that a dict is empty would pass on a fix that merely moved the registry; asserting the answer pins what the user feels.
- `test_the_disable_hook_is_not_dropped_by_a_plain_disable` — the scope boundary above, asserted rather than described.

An autouse fixture clears the registries before and after each test — they are module globals, and a leaked entry is exactly the failure mode under test.

**Red-before**, production changes reverted with the tests in place: **2 failed, 4 passed** (Python 3.10.6, Windows).

```
AssertionError: assert {'close': True, 'disable': True, 'undo': True}
                    == {'close': False, 'disable': False, 'undo': False}
WARNING kiro_crew.apps.teardown: slot-close hook for app 'test-app' failed on 'slot-1'
AssertionError  (notify_slot_closed still False after uninstall)
```

The four unit tests of `forget_app_hooks` pass in the red run only because the function itself is the new code; the two that exercise `handle_uninstall_app` are the ones that discriminate, and both fail.

**Green after**: `test_apps_uninstall_hook_registries.py` + `test_apps_uninstall_keep_specific.py` + `test_slot_close_nudge_race.py` — **29 passed, 0 failed**. The two sibling suites are the existing coverage of the uninstall handler and of the slot-close refusal path this change interacts with.

**Gates green:** flake8, isort, `scripts/check_black_formatting.py` (both changed source files are pre-existing entries in its baseline, so nothing was reformatted into this diff), `mypy` on the changed module.

**Second commit is comment-only.** The first draft of the docstring justified the uninstall-only scope by claiming the notification-channel unregistration "sits on the uninstall path alone". It does not — it runs on both. The scope decision was unchanged by that correction, but its stated reason was wrong, so it is corrected in the tree rather than only here.

## Manual verification

N/A — unit coverage sufficient: the defect is which entries survive in a process-memory dict across a handler call, and the decisive test observes the resulting `notify_slot_closed` answer directly. Reproducing it by hand needs an installed app that registers a slot-close hook, a leftover slot, and an uninstall in between.

## Related Issues

None filed. Found while auditing the app-lifecycle cleanup primitives: `unregister_app_disable_hook`, `unregister_slot_close_hook` and `unregister_slot_close_undo_hook` are public, documented, and had no caller.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
