### PR TITLE
fix: stop chat transcript blanking content above the viewport

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -520,9 +520,19 @@ export function useVirtualChat<T>(
   const rebaseScheduledRef = useRef(false)
   /** Previous render's identity. `items` is held because `itemsRef` has already
    *  advanced by the time the capture runs, while the mounted nodes still carry
-   *  the PREVIOUS commit's indices. */
-  const prependPrevRef = useRef<{ session: string; count: number; firstKey: string | null; items: T[] }>({
-    session: sessionId, count: itemCount, firstKey: null, items,
+   *  the PREVIOUS commit's indices. `getKey` is held WITH them: a caller's
+   *  getKey may be index-addressed (ChatPage resolves a per-render deduped key
+   *  LIST), so only the getKey of the same render prices these items correctly —
+   *  the current render's closure would return the NEW list's key at the old
+   *  index, misnaming the anchor by the inserted count. */
+  const prependPrevRef = useRef<{
+    session: string
+    count: number
+    firstKey: string | null
+    items: T[]
+    getKey: (it: T, i: number) => string
+  }>({
+    session: sessionId, count: itemCount, firstKey: null, items, getKey,
   })
   const prependPrev = prependPrevRef.current
   const prependFirstKey = itemCount > 0 ? getKey(items[0], 0) : null
@@ -547,7 +557,9 @@ export function useVirtualChat<T>(
       ? captureTopAnchorFrom(prependEl, elIndexRef.current.entries(), (idx) => {
           const it = prependPrev.items[idx]
           if (!it) return null
-          const k = getKey(it, idx)
+          // Previous items resolve through the getKey captured WITH them — see
+          // prependPrevRef's doc for why the current closure misnames them.
+          const k = prependPrev.getKey(it, idx)
           return survivingKeys.has(k) ? k : null
         })
       : null
@@ -566,7 +578,7 @@ export function useVirtualChat<T>(
     prependPrev.session === sessionId &&
     prependPrev.firstKey !== null &&
     prependFirstKey === prependPrev.firstKey
-  prependPrevRef.current = { session: sessionId, count: itemCount, firstKey: prependFirstKey, items }
+  prependPrevRef.current = { session: sessionId, count: itemCount, firstKey: prependFirstKey, items, getKey }
 
   // Window range for what is currently mounted. Initial state is the TAIL of
   // the list (last ~overscan+1 items) — chat sessions always open at the
@@ -1308,6 +1320,15 @@ export function useVirtualChat<T>(
         const it = itemsRef.current[idx]
         if (!it) continue
         const newH = measureBorderBoxHeight(entry.target as HTMLElement)
+        // A 0 here is a hidden ancestor (display:none tab/panel makes the
+        // observer report an empty content box), not a row height. Writing it
+        // would poison the cache — persisted per session — pricing the whole
+        // region at ~1px/row (heightAt's floor) until every row remounts, and
+        // collapsing offsetBefore into the blank-above symptom. The measureRef
+        // seed path applies the same h > 0 floor; skipping loses nothing
+        // because re-showing the ancestor fires the observer again with the
+        // real size.
+        if (newH <= 0) continue
         // Resolved at call time, never captured: a callback that closed over the
         // owner would keep writing into the PREVIOUS session's heights after a
         // slot switch -- the same wrong-transcript class this owner exists to

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -463,6 +463,64 @@ export function virtualKeyFor(
   return turnLeadKey(it, msgKey)
 }
 
+/** Virtualizer keys for the WHOLE display list, with a collision tie-break.
+ *
+ *  `virtualKeyFor` is not unique across the list: a `single` keys on
+ *  `msgKey` alone (`row-<ts>`), and a coarse OS clock can stamp two rows
+ *  appended in one tick with the same `ts` — the exact hazard `msgIdentityKey`
+ *  closes for group leads. Two rows sharing one key reach React as duplicate
+ *  siblings (one is silently dropped from the DOM — content visibly missing)
+ *  and share one HeightCache slot (each re-measure of either row reprices the
+ *  other, oscillating the spacers). Same failure from an overlapping older
+ *  page whose rows lack the `meta.mid` the prepend dedup keys on.
+ *
+ *  The tie-break is positional among COLLIDERS ONLY: the first occurrence
+ *  keeps the bare key — so the common case is byte-identical to
+ *  `virtualKeyFor` and every cached height, DOM node, and scroll anchor keyed
+ *  before this pass survives — and each later duplicate gets an occurrence
+ *  suffix. Deterministic for a given list order, so keys are stable across
+ *  re-renders. An insert BEFORE a collider shifts which physical row holds
+ *  the bare key: those rows remount (a `~#N` height or scroll anchor
+ *  persisted under the old occupant can also go stale until re-measured) —
+ *  bounded to rows that previously rendered broken (dropped sibling), and
+ *  strictly better than that render.
+ *
+ *  NOT folded into `virtualKeyFor`: uniqueness is a property of the list, not
+ *  of one row, and a per-row `~mid` suffix instead would rename every
+ *  streamed/optimistic row (which lacks `mid`) at the post-turn `refreshSlot`
+ *  rebuild (which carries it) — a mass remount per turn end. */
+/** Tie-break suffix for colliding virtualizer keys. Key plumbing only — the
+ *  string never renders as user-visible text. */
+const DUP_KEY_SUFFIX = '~#'
+
+export function uniqueRowKeys(
+  items: readonly DisplayItem[],
+  msgKey: (m: ChatMessage) => string,
+): string[] {
+  const seen = new Map<string, number>()
+  return items.map((it, i) => {
+    const base = virtualKeyFor(it, i, msgKey)
+    const n = seen.get(base)
+    if (n === undefined) {
+      seen.set(base, 1)
+      return base
+    }
+    // The suffixed candidate is re-checked against `seen` too: a NATURAL key
+    // can spell `<base>~#1` (msgKey passes through arbitrary meta), so
+    // emitting the suffix unchecked would reintroduce the duplicate this
+    // function exists to remove.
+    let count = n
+    let candidate = `${base}${DUP_KEY_SUFFIX}${count}`
+    while (seen.has(candidate)) {
+      count++
+      candidate = `${base}${DUP_KEY_SUFFIX}${count}`
+    }
+    seen.set(base, count + 1)
+    seen.set(candidate, 1)
+    return candidate
+  })
+}
+
 /** React key for a message row's INNER bubble (the virtualizer row key is
  *  virtualKeyFor). Prefer the optimistic client ts (stashed by the steer-echo
  *  reconcile, and stamped at birth on streaming/thinking messages) over the
@@ -5821,9 +5879,22 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     if (!id) { id = `mid-${msgIdSeq.current++}`; msgIds.current.set(m, id) }
     return id
   }, [])
+  const rowKeys = useMemo(
+    () => uniqueRowKeys(displayItems, stableMsgKey),
+    [displayItems, stableMsgKey],
+  )
+  // Index lookup into the deduped list, so this getKey prices an item
+  // correctly ONLY against the displayItems of its own render. Live consumers
+  // pair getKeyRef with itemsRef from the same tick; the one stale-ITEMS
+  // consumer — the prepend anchor capture — snapshots getKey ALONGSIDE the
+  // previous items (see prependPrevRef in useVirtualChat). The window-shift /
+  // tail-append captures read previous-commit DOM indices through the current
+  // render, which stays correct in the shapes they fire on (indices before
+  // the change point keep both item and bare key). The fallback covers only
+  // an out-of-range probe.
   const virtualKey = useCallback(
-    (it: DisplayItem, i: number) => virtualKeyFor(it, i, stableMsgKey),
-    [stableMsgKey],
+    (it: DisplayItem, i: number) => rowKeys[i] ?? virtualKeyFor(it, i, stableMsgKey),
+    [rowKeys, stableMsgKey],
   )
 
   // (Sticky widget detection removed — widgets now unmount with the

--- a/website/src/test/ChatPage.steerKeyIdentity.test.tsx
+++ b/website/src/test/ChatPage.steerKeyIdentity.test.tsx
@@ -42,6 +42,9 @@ vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
 // this a test of production behaviour rather than of the stub.
 vi.mock('../hooks/virtualizer/useVirtualChat', () => ({
   useVirtualChat: (opts: { items?: unknown[]; getKey?: (it: unknown, i: number) => string }) => {
+    // Stashed for the duplicate-key wiring test below: the REAL getKey ChatPage
+    // hands the virtualizer, paired with the items of the same render.
+    ;(globalThis as Record<string, unknown>).__vcOpts = opts
     const items = opts.items ?? []
     return {
       virtualItems: items.map((data, index) => ({
@@ -172,7 +175,10 @@ const rowNode = (container: HTMLElement) =>
   container.querySelector('[data-display-index="0"]') as HTMLElement | null
 
 describe('ChatPage — the virtualizer row survives steer reconciliation without remounting', () => {
-  beforeEach(() => { Object.keys(apiMocks).forEach(k => delete apiMocks[k]) })
+  beforeEach(() => {
+    Object.keys(apiMocks).forEach(k => delete apiMocks[k])
+    delete (globalThis as Record<string, unknown>).__vcOpts
+  })
 
   it('keeps the SAME row DOM node when the server ts replaces the optimistic one', () => {
     const { store, container } = renderChatPage([OPTIMISTIC])
@@ -206,5 +212,26 @@ describe('ChatPage — the virtualizer row survives steer reconciliation without
     const after = rowNode(container)
     expect(after).toBeTruthy()
     expect((after as HTMLElement & { __probe?: string }).__probe).toBeUndefined()
+  })
+
+  it('derives DISTINCT virtualizer keys for two rows stamped in the same tick', () => {
+    // A coarse OS clock can stamp two rows appended in one tick with the same
+    // `ts`; a `single` keys on `msgKey` alone, so without the list-level
+    // dedupe (uniqueRowKeys) both rows reach React AND the HeightCache under
+    // ONE key — a dropped sibling and a shared height slot. This asserts
+    // through the REAL getKey ChatPage hands the virtualizer (captured by the
+    // mock above), so it pins the WIRING, not just the helper.
+    const SAME_TS = '2026-06-23T20:00:00.000Z'
+    renderChatPage([
+      { role: 'user', content: 'first', cls: '', ts: SAME_TS },
+      { role: 'assistant', content: 'second', cls: '', ts: SAME_TS },
+    ])
+    const opts = (globalThis as Record<string, unknown>).__vcOpts as {
+      items: unknown[]
+      getKey: (it: unknown, i: number) => string
+    }
+    const keys = opts.items.map((it, i) => opts.getKey(it, i))
+    expect(keys.length).toBeGreaterThanOrEqual(2)
+    expect(new Set(keys).size).toBe(keys.length)
   })
 })

--- a/website/src/test/ChatPage.uniqueRowKeys.test.ts
+++ b/website/src/test/ChatPage.uniqueRowKeys.test.ts
@@ -1,0 +1,80 @@
+// Feature: chat-virtualizer — row keys are unique across the display list.
+//
+// `virtualKeyFor` keys a `single` on `msgKey` alone (`row-<ts>`), and a coarse
+// OS clock can stamp two rows appended in one tick with the same `ts` — the
+// hazard `msgIdentityKey` closes for group leads but singles were exposed to.
+// Duplicate keys reach React as duplicate siblings (one row is silently
+// dropped from the DOM — the "content disappears" symptom) and share one
+// HeightCache slot (each re-measure of either row reprices the other). The
+// same collision arrives via an overlapping older page whose rows lack the
+// `meta.mid` the prepend dedup keys on.
+//
+// `uniqueRowKeys` closes this at the list level: the FIRST occurrence keeps
+// the bare `virtualKeyFor` key — so the non-colliding common case is
+// byte-identical and every persisted height / scroll anchor keyed before this
+// pass survives — and each later duplicate gets an occurrence suffix.
+
+import { describe, it, expect } from 'vitest'
+import { uniqueRowKeys, virtualKeyFor } from '../pages/ChatPage'
+import type { DisplayItem } from '../pages/chat/types'
+import type { ChatMessage } from '../types'
+
+const msgKey = (m: ChatMessage): string => (m.meta?.clientTs as string | undefined) || m.ts || ''
+
+function single(ts: string, idx: number, role = 'user'): DisplayItem {
+  return { kind: 'single', msg: { role, content: `c${idx}`, ts } as ChatMessage, idx }
+}
+
+describe('uniqueRowKeys', () => {
+  it('is byte-identical to virtualKeyFor when there is no collision', () => {
+    const items = [single('100', 0), single('200', 1), single('300', 2)]
+    const keys = uniqueRowKeys(items, msgKey)
+    expect(keys).toEqual(items.map((it, i) => virtualKeyFor(it, i, msgKey)))
+  })
+
+  it('tie-breaks same-tick ts collisions; the first occurrence keeps the bare key', () => {
+    const items = [single('100', 0), single('100', 1, 'assistant'), single('200', 2)]
+    const keys = uniqueRowKeys(items, msgKey)
+    expect(keys[0]).toBe(virtualKeyFor(items[0], 0, msgKey))
+    expect(keys[1]).not.toBe(keys[0])
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('suffixes every later duplicate distinctly in a multi-way collision', () => {
+    const items = [single('100', 0), single('100', 1), single('100', 2)]
+    const keys = uniqueRowKeys(items, msgKey)
+    expect(new Set(keys).size).toBe(3)
+    expect(keys[0]).toBe(virtualKeyFor(items[0], 0, msgKey))
+  })
+
+  it('dedupes a turn against a loose single sharing the lead message ts', () => {
+    // A turn inherits its LEAD single's key (deliberate — regroup stability),
+    // so a loose single with the same ts elsewhere in the list collides with
+    // the turn row. Both must still reach React distinct.
+    const lead = single('100', 0)
+    const turn: DisplayItem = { kind: 'turn', items: [lead], complete: true }
+    const items: DisplayItem[] = [turn, single('100', 1)]
+    const keys = uniqueRowKeys(items, msgKey)
+    expect(new Set(keys).size).toBe(2)
+    expect(keys[0]).toBe(virtualKeyFor(turn, 0, msgKey))
+  })
+
+  it('does not let the ~#N suffix collide with a NATURAL key spelling the same string', () => {
+    // msgKey passes through arbitrary meta (clientTs), so a natural key can
+    // literally spell `row-100~#1` — the string the tie-break would mint for
+    // the second `row-100`. All three must still reach React distinct.
+    const natural: DisplayItem = {
+      kind: 'single',
+      msg: { role: 'user', content: 'n', ts: '999', meta: { clientTs: '100~#1' } } as ChatMessage,
+      idx: 0,
+    }
+    const items = [natural, single('100', 1), single('100', 2)]
+    const keys = uniqueRowKeys(items, msgKey)
+    expect(new Set(keys).size).toBe(3)
+  })
+
+  it('is deterministic for a given list order', () => {
+    const items = [single('100', 0), single('100', 1), single('200', 2), single('200', 3)]
+    expect(uniqueRowKeys(items, msgKey)).toEqual(uniqueRowKeys(items, msgKey))
+  })
+})

--- a/website/src/test/useVirtualChat.prependAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.prependAnchor.test.tsx
@@ -61,6 +61,36 @@ function Harness({ items, scrollerRef }: {
   )
 }
 
+/** Same transcript, but getKey is INDEX-ADDRESSED the way ChatPage's is: a
+ *  per-render key LIST looked up by position (ChatPage builds a deduped
+ *  `rowKeys` array and its getKey returns `rowKeys[i]`). The function ignores
+ *  the item argument and changes identity every render — so it only prices an
+ *  item correctly when paired with the items of its OWN render. The prepend
+ *  capture resolves the PREVIOUS render's items and must therefore use the
+ *  getKey snapshotted with them; this harness is what gives that contract a
+ *  failing shape. */
+function PositionalHarness({ items, scrollerRef }: {
+  items: Item[]
+  scrollerRef: RefObject<HTMLDivElement | null>
+}) {
+  const keys = items.map((it) => it.id)
+  const positionalGetKey = (_it: Item, i: number) => keys[i] ?? `oob-${i}`
+  const v = useVirtualChat<Item>({
+    items, sessionId: 'prepend-pos', getKey: positionalGetKey, overscan: 2, externalScrollerRef: scrollerRef,
+  })
+  return (
+    <div ref={scrollerRef as RefObject<HTMLDivElement>} data-scroller>
+      <div ref={v.topSentinelRef} data-sentinel="top" />
+      <div data-spacer="before" style={{ height: v.offsetBefore }} />
+      {v.virtualItems.map((it) => (
+        <div key={it.key} data-index={it.index} data-key={it.key} ref={v.measureRef(it.index)} />
+      ))}
+      <div data-spacer="after" style={{ height: v.offsetAfter }} />
+      <div ref={v.bottomSentinelRef} data-sentinel="bottom" />
+    </div>
+  )
+}
+
 /** Topmost row still visible (bottom edge below the viewport top), by virtual
  *  key — the identity that survives the index shift a prepend causes. */
 function topVisible(el: HTMLElement): { key: string; idx: number; top: number } | null {
@@ -176,10 +206,10 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
 
   /** Mounts 30 rows, then scrolls up so stick is released and the window sits
    *  mid-transcript — the state a user reading history is in. */
-  function mountScrolledUp() {
+  function mountScrolledUp(H: typeof Harness = Harness) {
     const scrollerRef: RefObject<HTMLDivElement | null> = { current: null }
     let scrollTop = 0
-    const view = rtlRender(<Harness items={mkItems(30)} scrollerRef={scrollerRef} />)
+    const view = rtlRender(<H items={mkItems(30)} scrollerRef={scrollerRef} />)
     const el = scrollerRef.current!
     Object.defineProperty(el, 'scrollTop', {
       configurable: true, get: () => scrollTop, set: (v: number) => { scrollTop = v },
@@ -269,6 +299,62 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     const survivorAfter = screenTopOf(el, survivor.key)
     expect(survivorAfter).not.toBeNull()
     expect(Math.abs(survivorAfter! - survivor.top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
+  it('shows no blank band when a prepend retires EVERY visible key (no anchor to bind)', () => {
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp()
+
+    const visible = visibleByIndex(el)
+    expect(visible.length).toBeGreaterThan(0)
+    const scrollBefore = readScrollTop()
+
+    // A prepend whose commit ALSO retires every previously-visible key (a
+    // wholesale refresh regrouping the transcript). No anchor survives, so the
+    // capture stands down entirely: no stage is set, part 1 never shifts the
+    // window, and the reading position is (acceptably) lost — but the window
+    // must still resolve to a range that covers the viewport, not strand it in
+    // spacer. Pins the deliberate no-anchor design so a future change to the
+    // capture cannot introduce a shift-without-correction path unnoticed.
+    act(() => {
+      view.rerender(
+        <Harness items={[...mkItems(10, 'p'), ...mkItems(30, 'r')]} scrollerRef={scrollerRef} />,
+      )
+    })
+
+    // Not vacuous: the old keys are genuinely gone (the anchor had nothing to
+    // bind to) and no correction moved the viewport.
+    for (const v of visible) expect(screenTopOf(el, v.key)).toBeNull()
+    expect(readScrollTop()).toBe(scrollBefore)
+
+    // No blank band: a mounted row still covers the viewport top.
+    const after = visibleByIndex(el)
+    expect(after.length).toBeGreaterThan(0)
+    expect(after[0].top).toBeLessThanOrEqual(1)
+  })
+
+  it('holds the reading position across a prepend when getKey is INDEX-ADDRESSED (ChatPage shape)', () => {
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(PositionalHarness)
+
+    const before = topVisible(el)
+    expect(before).not.toBeNull()
+    const beforeTop = readScrollTop()
+
+    // The capture resolves the PREVIOUS render's items at their OLD indices.
+    // A positional getKey answers that correctly only through the snapshot
+    // taken with those items — resolving them through the CURRENT render's
+    // closure returns the new list's key at the old index (a row 10 positions
+    // earlier), misnaming the anchor: the correction then either no-ops or
+    // yanks the viewport to the wrong row.
+    act(() => {
+      view.rerender(
+        <PositionalHarness items={[...mkItems(10, 'p'), ...mkItems(30)]} scrollerRef={scrollerRef} />,
+      )
+    })
+
+    const afterTop = screenTopOf(el, before!.key)
+    expect(afterTop).not.toBeNull()
+    expect(Math.abs(afterTop! - before!.top)).toBeLessThanOrEqual(1)
     expect(readScrollTop()).toBeGreaterThan(beforeTop)
   })
 

--- a/website/src/test/useVirtualChat.zeroHeightGuard.test.tsx
+++ b/website/src/test/useVirtualChat.zeroHeightGuard.test.tsx
@@ -1,0 +1,122 @@
+// Feature: chat-virtualizer — hidden-ancestor resize reports must not poison
+// the height cache.
+//
+// ResizeObserver delivers a 0×0 content box for every observed row the moment
+// an ancestor goes display:none (hidden tab, collapsed panel) — that is the
+// observer reporting visibility, not a row height. The RO write path must skip
+// those entries: writing them caches 0 for every mounted row (and HeightCache
+// persists per session), so on return the offset tree prices the region at
+// heightAt's 1px floor, offsetBefore collapses, and the transcript shows the
+// "blank area above" symptom until every row remounts and re-measures. The
+// measureRef seed path already applies an h > 0 floor; this suite pins the
+// same floor on the ResizeObserver path.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type RefObject } from 'react'
+import { useVirtualChat } from '../hooks/virtualizer/useVirtualChat'
+
+interface Item { id: string }
+const getKey = (it: Item) => it.id
+
+class FakeRO {
+  static instances: FakeRO[] = []
+  constructor(readonly cb: ResizeObserverCallback) { FakeRO.instances.push(this) }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  fire(entries: Partial<ResizeObserverEntry>[]) {
+    this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+  }
+}
+
+/** A row node whose measured height the test controls after registration. */
+function mkRowNode(initialH: number): { node: HTMLDivElement; setH: (h: number) => void } {
+  const node = document.createElement('div')
+  let h = initialH
+  Object.defineProperty(node, 'offsetHeight', { configurable: true, get: () => h })
+  return { node, setH: (v: number) => { h = v } }
+}
+
+describe('useVirtualChat: ResizeObserver zero-height guard', () => {
+  let origRO: typeof ResizeObserver | undefined
+  let origRaf: typeof requestAnimationFrame
+
+  beforeEach(() => {
+    localStorage.clear()
+    FakeRO.instances = []
+    origRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeRO as unknown as typeof ResizeObserver
+    origRaf = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => { cb(0); return 0 }) as typeof requestAnimationFrame
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.ResizeObserver = origRO as typeof ResizeObserver
+    globalThis.requestAnimationFrame = origRaf
+  })
+
+  function mount(sessionId: string, rowCount: number) {
+    const el = document.createElement('div')
+    Object.defineProperty(el, 'scrollTop', { configurable: true, value: 0, writable: true })
+    Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => 3000 })
+    Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => 400 })
+    ;(el as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = () => {}
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    const items = Array.from({ length: rowCount }, (_, i) => ({ id: `m${i}` }))
+    const view = renderHook(() =>
+      useVirtualChat<Item>({ items, sessionId, getKey, externalScrollerRef: ref }),
+    )
+    const rows = items.map((_, i) => {
+      const row = mkRowNode(100)
+      act(() => { view.result.current.measureRef(i)(row.node) })
+      return row
+    })
+    // Settle the seed measurements' debounced sync so the baseline is the
+    // committed post-mount tree, not a mid-debounce snapshot.
+    act(() => { vi.advanceTimersByTime(150) })
+    return { view, rows }
+  }
+
+  it('ignores 0-height entries (hidden ancestor) instead of caching them', () => {
+    const { view, rows } = mount('zero-h-guard', 5)
+    const ro = FakeRO.instances[FakeRO.instances.length - 1]
+    const baseline = view.result.current.totalHeight
+    expect(baseline).toBeGreaterThan(0)
+
+    // The transcript's ancestor goes display:none: the observer reports every
+    // mounted row at 0 in one tick.
+    act(() => {
+      rows.forEach((r) => r.setH(0))
+      ro.fire(rows.map((r) => ({ target: r.node })))
+    })
+    act(() => { vi.advanceTimersByTime(300) })
+
+    // Nothing was written: the tree still prices every row at its real height.
+    expect(view.result.current.totalHeight).toBe(baseline)
+  })
+
+  it('still applies a genuine resize after the hidden interval ends', () => {
+    const { view, rows } = mount('zero-h-recover', 5)
+    const ro = FakeRO.instances[FakeRO.instances.length - 1]
+    const baseline = view.result.current.totalHeight
+
+    // Hidden tick (skipped), then the ancestor is shown again and row 0 comes
+    // back GROWN — the guard must not swallow the real follow-up measurement.
+    act(() => {
+      rows.forEach((r) => r.setH(0))
+      ro.fire(rows.map((r) => ({ target: r.node })))
+    })
+    act(() => { vi.advanceTimersByTime(300) })
+    act(() => {
+      rows.forEach((r) => r.setH(100))
+      rows[0].setH(140)
+      ro.fire(rows.map((r) => ({ target: r.node })))
+    })
+    act(() => { vi.advanceTimersByTime(300) })
+
+    expect(view.result.current.totalHeight).toBe(baseline + 40)
+  })
+})


### PR DESCRIPTION
## Summary

Users intermittently see the chat transcript lose content above the viewport — a large blank region where earlier messages should be (reported with a session full of repeated `Request initialize timed out` / recovery-card rows). The blank region is the top spacer mispriced against real content. This PR fixes the two deterministic mechanisms behind it:

**1. Duplicate row keys (content genuinely dropped).** A `single` display row keys on `msgKey` alone (`row-<ts>`); a coarse OS clock stamps two rows appended in one tick with the same `ts`, and an overlapping older page whose rows lack `meta.mid` prepends duplicates. Duplicate keys make React silently drop a sibling row and make two rows share one `HeightCache` slot (spacer oscillation). ChatPage now derives a **list-level deduped key array** (`uniqueRowKeys`): the first occurrence keeps the bare key — the non-colliding common case is byte-identical, so persisted heights and scroll anchors survive — and later duplicates get an occurrence suffix, itself re-checked so it cannot collide with a natural key.

**2. Zero-height cache poisoning (spacer collapse).** The ResizeObserver write path cached the 0-height entries the observer reports when an ancestor goes `display:none` (hidden tab/panel). `HeightCache` persists per session, so every row above the viewport got priced at the 1px floor, collapsing `offsetBefore`. The RO path now applies the same `h > 0` floor the `measureRef` seed path already had. Previously-persisted zeros are fix-forward: they self-heal on remount.

Because ChatPage's `getKey` is now index-addressed (a per-render key list), the prepend anchor capture — the one consumer that deliberately resolves the **previous** render's items at old indices — now snapshots `getKey` alongside those items (`prependPrevRef`) and resolves through the snapshot. Without this, load-older would misname the reading anchor by the inserted count.

Investigated but deliberately **not** changed here (architectural, separate work): stale key→height bindings across regroup (`refreshSlot` wholesale rebuild) and the 120 ms height-sync debounce starving under continuous re-measures.

## Testing

- `ChatPage.uniqueRowKeys.test.ts` — 6 unit cases incl. natural-key `~dupN` collision and turn-vs-single dedupe
- `ChatPage.steerKeyIdentity.test.tsx` — wiring test through the REAL getKey ChatPage hands the virtualizer
- `useVirtualChat.zeroHeightGuard.test.tsx` — hidden-ancestor 0 reports skipped; genuine post-hide resize still applies
- `useVirtualChat.prependAnchor.test.tsx` — new positional-getKey prepend test (ChatPage wiring shape) + a no-surviving-anchor regression pin
- Every fix is **mutation-verified** (reverting each fix reds exactly its test)
- Full gates: `tsc -b` clean, eslint 0 errors (no new warnings), vitest 26,803 passed

## Adversarial review

2 rounds, blind reviewers. Round 1: dual reviewers, both independently flagged a Critical — the index-addressed getKey broke the prepend capture's stale-items contract — fixed via the `prependPrevRef` getKey snapshot and covered by the positional test. Round 2 (fresh reviewer): PASS; both Optional findings adopted (suffix/natural-key re-check, comment precision).

No UI appearance change — no screenshots (behavioral fix pinned by tests).
