### PR TITLE
fix(dashboard): finalize streaming row at queue turn boundary (#7138)

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -715,6 +715,24 @@ A pending tool approval has **two** pieces of state that must stay in lockstep: 
 
 **Runner backstop totality**: `outcome` is pre-seeded to `"rejected"` before the approval `await`, because the `finally` runs on *every* exit including `CancelledError` (slot deletion and cleanup endpoints cancel `slot.task`). Assigning it only inside `try`/`except` would raise `UnboundLocalError` from the `finally`, replacing the cancellation with a spurious exception and skipping both the message marking and the Slack prompt cleanup.
 
+### Queue turn boundary finalize
+
+A successor turn dispatched WITHOUT a `chat_done` -- the tail-drain starting a
+queued turn (`_start_next_queued_turn`), and the synthesis dispatch in
+`_run_pending_synthesis` -- broadcasts `chat_segment` for the slot once the
+successor is certain to dispatch, before the successor's row and first chunk.
+The end-of-turn flush suppresses its own `chat_segment` (deferring the
+client-side streaming->assistant finalize to `_finish_queue_cycle`'s
+`chat_done`, which never comes on these paths), and the flush's
+`chat_message{role:assistant}` frame is conditional (suppressed while an HTTP
+SSE reader drains the slot, absent when the final segment is empty, droppable
+by the client's mid-keyed redelivery guard) -- without the unconditional
+boundary frame the successor's chunks append into the still-open `streaming`
+row and a line-final `[OPTIONS: ...]` marker degrades to prose. Non-fire
+condition: a boundary where no successor dispatches (empty queue, dropped
+entry, synthesis not eligible) emits nothing here -- `_finish_queue_cycle`'s
+`chat_done` stays that path's sole finalizer, so no path double-finalizes.
+
 ### Mid-Turn Steer (dashboard transcript contract)
 
 A steer (`POST /api/chat` with `steer: true` while the slot is running) injects

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4099,6 +4099,28 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     if next_msg is None:
         return False
 
+    # A successor turn is now certain to dispatch (every no-successor path above
+    # already returned False), so the predecessor turn's assistant bubble must be
+    # finalized on the clients NOW, before the successor's row and first chunk
+    # reach them. The end-of-turn flush suppresses ``chat_segment``
+    # (``broadcast=False``), deferring the finalize to the ``chat_done`` that
+    # ``_finish_queue_cycle`` emits -- but on this path no ``chat_done`` follows.
+    # The flush's ``slot.append`` does emit a ``chat_message{role:assistant}``
+    # frame whose reducer branch also finalizes, but that frame is CONDITIONAL:
+    # suppressed while an HTTP SSE reader drains the slot (``_has_reader``),
+    # absent when the turn's final segment is empty (text already flushed at a
+    # tool boundary), and droppable client-side by the mid-keyed redelivery
+    # guard. Without an unconditional finalize the successor's chunks append
+    # into the still-open ``streaming`` row: two turns render as one bubble,
+    # and a line-final ``[OPTIONS: ...]`` marker in the first turn loses its
+    # end-of-line anchor and degrades to prose. ``chat_segment`` is that
+    # unconditional finalize, and it is idempotent on the reducer (no live
+    # ``streaming`` row -> no-op), so clients that already finalized are
+    # unaffected. The queue-empty and dropped-entry paths keep
+    # ``_finish_queue_cycle``'s ``chat_done`` as their sole finalizer -- no
+    # double finalize on any path.
+    state.broadcast_ws("chat_segment", {"slot": slot.key})
+
     is_recovery = any(is_synthetic_recovery_item(item) for item in consumed)
     # Orthogonal to `is_recovery`, which decides how the row renders: this decides
     # whether the runner may mirror the text to a linked thread as user speech.
@@ -4345,6 +4367,13 @@ async def _run_pending_synthesis(state: DashboardState, slot: _ChatSlot) -> None
 
         # All delivery guards hold. Consume immediately before the turn begins.
         slot._pending_synthesis = False
+        # Same successor boundary as the queue drain (see the finalize comment in
+        # `_start_next_queued_turn`): this dispatch is reached from the previous
+        # turn's tail without a `chat_done`, so the predecessor's streaming row
+        # must be finalized before the synthesis turn's row and first chunk.
+        # Every not-eligible path above already returned into
+        # `_finish_queue_cycle`, whose `chat_done` stays the sole finalizer there.
+        state.broadcast_ws("chat_segment", {"slot": slot.key})
         # Append the row BEFORE dispatching, matching `_start_next_queued_turn`.
         # This site bypasses that function (it runs no queue entry), and it was
         # the only turn-dispatching path that appended nothing — so the prompt

--- a/test/test_queue_boundary_finalize.py
+++ b/test/test_queue_boundary_finalize.py
@@ -1,0 +1,366 @@
+"""The queue turn boundary finalizes the predecessor's assistant bubble.
+
+The end-of-turn flush suppresses the ``chat_segment`` broadcast
+(``broadcast=False``), deferring the client-side streaming->assistant finalize
+to the ``chat_done`` that ``_finish_queue_cycle`` emits. But when the
+tail-drain starts a SUCCESSOR turn from the queue -- or ``_run_pending_synthesis``
+dispatches a synthesis turn -- ``_finish_queue_cycle`` never runs for that
+boundary. The flush's ``slot.append`` does emit a
+``chat_message{role:assistant}`` frame whose reducer branch also finalizes, but
+that frame is CONDITIONAL (suppressed while an HTTP SSE reader drains the slot,
+absent when the final segment is empty because the text was already flushed at
+a tool boundary, droppable by the client's mid-keyed redelivery guard) -- so a
+client that misses it keeps its ``streaming`` row open, the successor's chunks
+append into it, two turns render as one bubble, and a line-final
+``[OPTIONS: ...]`` marker in the first turn loses its end-of-line anchor and
+degrades to literal prose.
+
+These tests pin the fix -- both successor-dispatch boundaries broadcast the
+unconditional, idempotent ``chat_segment`` finalize once a successor is certain
+to dispatch -- and its designed non-fires: a boundary where no successor
+dispatches (empty queue, dropped entry, synthesis not eligible) keeps
+``_finish_queue_cycle``'s ``chat_done`` as the sole finalizer, so there is no
+double finalize on the ordinary single-turn path.
+
+The full-turn test also confirms the persistence side: each turn lands as its
+own assistant row in ``slot.messages``, so a session reload renders the two
+turns correctly even without the live finalize frame -- the defect is
+live-render only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_TEXT_CHUNK
+from kiro_crew.dashboard import chat_runner as cr
+from kiro_crew.dashboard import session_control as sc
+from kiro_crew.dashboard.chat_utils import SUBAGENT_COMPLETION_KIND
+from kiro_crew.providers.base import LLMEvent
+
+
+@pytest.fixture(autouse=True)
+def _enabled(monkeypatch):
+    """Run in the shipped (enabled) session-control state without reading config."""
+    monkeypatch.setattr(sc, "session_control_enabled", lambda: True)
+
+
+@pytest.fixture(autouse=True)
+def _inline_audit(monkeypatch):
+    """Route SEL writes inline to a mock: no executor thread outlives the test."""
+    fake = MagicMock()
+    monkeypatch.setattr(sc, "sel", lambda: fake)
+    monkeypatch.setattr(sc, "_sel_off_loop", lambda write, what: write())
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _no_cycle_background_tasks(monkeypatch):
+    """Neutralize ``_finish_queue_cycle``'s detached tasks (title refresh,
+    session summary): both hop to executor threads (config load, transcript
+    flush) that would outlive the test and can re-create the per-test dir
+    after teardown."""
+    monkeypatch.setattr(cr, "maybe_refresh_title", AsyncMock())
+    monkeypatch.setattr(cr, "generate_session_summary", AsyncMock())
+
+
+def _busy(slot):
+    """``running`` is derived (``task is not None and not task.done()``)."""
+    task = MagicMock()
+    task.done.return_value = False
+    slot.task = task
+    return slot
+
+
+async def _never_runs(state, slot, prompt):  # pragma: no cover - queued, not run
+    raise AssertionError("a queued prompt must not start a turn at enqueue")
+
+
+def _recorded_state(tmp_path):
+    """A ``_make_state`` state whose WS broadcasts land in an ordered list."""
+    state = _make_state(tmp_path)
+    state.subagents = None
+    frames: list[tuple[str, object]] = []
+    state.broadcast_ws = MagicMock(side_effect=lambda t, d: frames.append((t, d)))
+    return state, frames
+
+
+def _stub_dispatch(monkeypatch, frames):
+    """Stub the successor dispatch, recording WHEN it happens relative to frames."""
+
+    async def _stub_run_chat(_state, _slot, _prompt, **_kwargs):
+        return None
+
+    def _fake_spawn(_state, _slot, coro):
+        coro.close()
+        frames.append(("spawned", None))
+        task = MagicMock()
+        task.done.return_value = True
+        return task
+
+    monkeypatch.setattr(cr, "_run_chat", _stub_run_chat)
+    monkeypatch.setattr(cr, "spawn_guarded_turn", _fake_spawn)
+
+
+# ── The boundary fires the finalize, before the successor ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_queued_user_message_boundary_emits_finalize_before_dispatch(tmp_path, monkeypatch):
+    """A queued USER message: the boundary broadcasts ``chat_segment`` for the
+    slot, and it precedes the successor's dispatch (so it precedes the
+    successor's first chunk, which can only be emitted by the spawned turn)."""
+    state, frames = _recorded_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("queued follow-up", _never_runs, state)
+    slot.task = None  # the turn ended; the tail-drain runs
+    _stub_dispatch(monkeypatch, frames)
+
+    started = await cr._start_next_queued_turn(state, slot)
+
+    assert started is True
+    kinds = [t for t, _ in frames]
+    assert "chat_segment" in kinds
+    seg = kinds.index("chat_segment")
+    assert frames[seg][1] == {"slot": slot.key}
+    assert "spawned" in kinds
+    assert seg < kinds.index("spawned")
+
+
+@pytest.mark.asyncio
+async def test_kind_tagged_continuation_boundary_emits_finalize(tmp_path, monkeypatch):
+    """A continuation-card (``kind``-tagged) entry -- the structural successor
+    every recovery/continuation producer enqueues -- gets the same finalize."""
+    state, frames = _recorded_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot.queue_append("[Subagent completion event] agent finished", kind=SUBAGENT_COMPLETION_KIND)
+    _stub_dispatch(monkeypatch, frames)
+
+    started = await cr._start_next_queued_turn(state, slot)
+
+    assert started is True
+    kinds = [t for t, _ in frames]
+    assert "chat_segment" in kinds
+    assert kinds.index("chat_segment") < kinds.index("spawned")
+
+
+@pytest.mark.asyncio
+async def test_synthesis_dispatch_emits_finalize_before_its_row(tmp_path, monkeypatch):
+    """``_run_pending_synthesis`` is the other successor-dispatch boundary with
+    no ``chat_done``: the synthesis turn's finalize fires once eligibility is
+    settled, before the synthesis ``inject`` row is appended."""
+    state, frames = _recorded_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot._titled = True
+    slot._pending_synthesis = True
+    state.subagents = MagicMock(running_agents_for=MagicMock(return_value=[]))
+    state._slots[slot.key] = slot
+
+    def _fake_spawn(_state, _slot, coro):
+        coro.close()
+        frames.append(("spawned", None))
+
+        async def _done():
+            return None
+
+        return asyncio.ensure_future(_done())
+
+    monkeypatch.setattr(cr, "spawn_guarded_turn", _fake_spawn)
+
+    await cr._run_pending_synthesis(state, slot)
+
+    kinds = [t for t, _ in frames]
+    assert "chat_segment" in kinds
+    seg = kinds.index("chat_segment")
+    assert frames[seg][1] == {"slot": slot.key}
+    assert seg < kinds.index("spawned")
+    # The finalize precedes the synthesis row's own broadcast-visible effects:
+    # the inject row lands in the transcript after the frame went out.
+    inject_rows = [m for m in slot.messages if m.get("role") == "inject"]
+    assert inject_rows and inject_rows[-1]["meta"]["injectKind"] == "synthesis"
+
+
+@pytest.mark.asyncio
+async def test_ineligible_synthesis_emits_no_finalize(tmp_path, monkeypatch):
+    """Synthesis NOT pending -> ``_run_pending_synthesis`` degrades to
+    ``_finish_queue_cycle``: no ``chat_segment``, one ``chat_done``."""
+    state, frames = _recorded_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot._titled = True
+    slot._pending_synthesis = False
+    state._slots[slot.key] = slot
+
+    await cr._run_pending_synthesis(state, slot)
+    await asyncio.sleep(0)
+
+    kinds = [t for t, _ in frames]
+    assert "chat_segment" not in kinds
+    assert kinds.count("chat_done") == 1
+
+
+# ── The designed non-fires: no successor, no finalize ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_queue_boundary_emits_no_finalize(tmp_path, monkeypatch):
+    """Queue empty -> no successor dispatches -> no ``chat_segment``; the
+    ordinary single-turn path keeps ``_finish_queue_cycle``'s ``chat_done`` as
+    the sole finalizer (no double finalize)."""
+    state, frames = _recorded_state(tmp_path)
+    slot = state.get_or_create_slot("chat-1")
+    slot._titled = True  # keep the cycle off the real auto-title path
+
+    started = await cr._start_next_queued_turn(state, slot)
+    assert started is False
+
+    cr._finish_queue_cycle(state, slot)
+    await asyncio.sleep(0)
+
+    kinds = [t for t, _ in frames]
+    assert "chat_segment" not in kinds
+    assert kinds.count("chat_done") == 1
+
+
+@pytest.mark.asyncio
+async def test_dropped_only_entry_emits_no_finalize(tmp_path, monkeypatch):
+    """The drain dropping the only entry (admission re-validation) is a
+    boundary where no successor dispatches: the finalize must not fire there
+    either -- ``_finish_queue_cycle`` still owns that path's ``chat_done``."""
+    state, frames = _recorded_state(tmp_path)
+    slot = _busy(state.get_or_create_slot("chat-1"))
+    slot.enqueue_or_run_prompt("admitted while unlinked", _never_runs, state)
+    slot.task = None
+    slot.linked_session_key = "C0LINKED|1700000000.000100"  # constraint newly holds
+
+    def _no_spawn(_state, _slot, coro):  # pragma: no cover - must not be reached
+        coro.close()
+        raise AssertionError("no successor may dispatch for a dropped entry")
+
+    monkeypatch.setattr(cr, "spawn_guarded_turn", _no_spawn)
+
+    started = await cr._start_next_queued_turn(state, slot)
+
+    assert started is False
+    assert slot._queue == []
+    assert "chat_segment" not in [t for t, _ in frames]
+
+
+# ── Full-turn frame sequence: finalize lands between the two turns' chunks ──
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_two_turn_frame_sequence_has_finalize_between_chunks(tmp_path):
+    """Through the real ``_run_chat`` tail: with a queued user message, the
+    client sees ``chat_segment`` after turn N's last chunk and before turn
+    N+1's first chunk, and exactly one ``chat_done`` (after the final turn).
+    Records BOTH egress channels -- ``broadcast_ws`` AND the ``_broadcast``
+    path that carries ``chat_message`` frames -- so the boundary's full frame
+    pair is pinned: the conditional ``chat_message{role:assistant}`` from the
+    flush AND the unconditional ``chat_segment``, both before the successor's
+    first chunk. Also confirms the reload prediction: each turn persists as
+    its OWN assistant row, so the merged bubble is a live-render defect only."""
+    state = _make_state(tmp_path)
+    state.subagents = None
+    frames: list[tuple[str, object]] = []
+    state.broadcast_ws = MagicMock(side_effect=lambda t, d: frames.append((t, d)))
+    real_broadcast = state._broadcast
+
+    def _recording_broadcast(note):
+        # `_broadcast` fans out to SSE queues + WS clients; record the frame
+        # type on the same ordered list so cross-channel ordering is asserted.
+        frames.append((f"bc:{note.get('_type')}", dict(note)))
+        return real_broadcast(note)
+
+    state._broadcast = _recording_broadcast  # type: ignore[method-assign]
+    state.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), False, False))
+    state.sessions.release = MagicMock()
+    state.sessions.reset = AsyncMock()
+    state.sessions.set_approval_policy = MagicMock()
+    state.sessions.check_context_usage = MagicMock()
+    state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+    state.sessions.record_failure = AsyncMock()
+    state.is_yolo_active = MagicMock(return_value=False)
+    slot = state.get_or_create_slot("chat-e2e")
+    slot._titled = True  # keep the end-of-turn cycle off the real auto-title path
+    slot.append("user", "first prompt", "msg msg-u")
+    slot.queue_append("queued follow-up")
+
+    client = state.sessions.get_or_create.return_value[0]
+    client.shutdown = AsyncMock()
+    client.context_usage_pct = MagicMock(return_value=0.0)
+    client._client = client
+    client.last_prompt_stats = None
+    turn1 = [
+        LLMEvent(kind=EVENT_TEXT_CHUNK, text="Pick a path.\n"),
+        LLMEvent(kind=EVENT_TEXT_CHUNK, text="[OPTIONS: Alpha | Bravo]"),
+        LLMEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+    ]
+    turn2 = [
+        LLMEvent(kind=EVENT_TEXT_CHUNK, text="Second turn reply."),
+        LLMEvent(kind=EVENT_COMPLETE, stop_reason="end_turn"),
+    ]
+    calls = {"n": 0}
+
+    def _stream(*_a, **_kw):
+        calls["n"] += 1
+        return _async_iter(turn1 if calls["n"] == 1 else turn2)
+
+    client.stream = MagicMock(side_effect=_stream)
+    client.stream_command = MagicMock(side_effect=_stream)
+
+    await cr._run_chat(state, slot, "first prompt")
+    successor = slot.task
+    assert successor is not None, "the tail-drain must have dispatched the queued turn"
+    await asyncio.wait_for(successor, timeout=10)
+
+    kinds = [t for t, _ in frames]
+    assert kinds.count("chat_segment") == 1, kinds
+    seg = kinds.index("chat_segment")
+    before = "".join(
+        d.get("content", "") for t, d in frames[:seg] if t == "chat_chunk" and isinstance(d, dict)
+    )
+    after = "".join(
+        d.get("content", "")
+        for t, d in frames[seg + 1 :]
+        if t == "chat_chunk" and isinstance(d, dict)
+    )
+    # Turn N's text (OPTIONS marker included) fully precedes the finalize;
+    # turn N+1's text fully follows it -- nothing glues onto the open bubble.
+    assert "[OPTIONS: Alpha | Bravo]" in before
+    assert "Second turn reply." not in before
+    assert "Second turn reply." in after
+
+    # The boundary's frame pair: the flush's conditional chat_message
+    # (role=assistant, turn N's text) precedes the unconditional chat_segment,
+    # and both precede the successor's chunks.
+    t1_assistant = [
+        i
+        for i, (t, d) in enumerate(frames)
+        if t == "bc:chat_message"
+        and isinstance(d, dict)
+        and d.get("role") == "assistant"
+        and "[OPTIONS: Alpha | Bravo]" in str(d.get("content", ""))
+    ]
+    assert t1_assistant and t1_assistant[0] < seg
+
+    # Exactly one chat_done for the two-turn cycle, and it follows the finalize:
+    # the boundary did not double-finalize the ordinary end-of-cycle path.
+    assert kinds.count("chat_done") == 1
+    assert kinds.index("chat_done") > seg
+
+    # Reload correctness (the reporter's prediction, confirmed): the backend
+    # persisted a SEPARATE assistant row per turn, first one ending line-final
+    # on its [OPTIONS: ...] marker.
+    assistants = [m for m in slot.messages if m.get("role") == "assistant"]
+    assert len(assistants) == 2
+    assert assistants[0]["content"].endswith("[OPTIONS: Alpha | Bravo]")
+    assert assistants[1]["content"] == "Second turn reply."

--- a/website/src/store/chatSlice.queueBoundaryFinalize.test.ts
+++ b/website/src/store/chatSlice.queueBoundaryFinalize.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import reducer, { sseChatMessage } from './chatSlice'
+import { parseOptions } from '../app-sdk/protocol/options'
+import '../test/mockApiClient'
+
+/**
+ * Reducer contract behind the queue-boundary finalize fix (backend
+ * `_start_next_queued_turn` / `_run_pending_synthesis` broadcasting
+ * `chat_segment` before dispatching a successor turn).
+ *
+ * The chunk reducer deliberately appends into the LAST live `streaming` row,
+ * so the frame between two turns is what separates them. Two frames can
+ * finalize that row: the flush's `chat_message{role:'assistant'}` (which is
+ * CONDITIONAL server-side -- suppressed while an HTTP SSE reader drains the
+ * slot, absent when the final segment is empty, droppable by the mid-keyed
+ * redelivery guard) and `chat_segment` (unconditional, idempotent -- what the
+ * backend fix emits at the boundary). These tests drive the REAL reducer and
+ * the REAL `OPTION_MARKER_RE` (via `parseOptions`) and pin:
+ *
+ *  - the fixed frame sequence yields TWO rows with a parseable first-row
+ *    `[OPTIONS: ...]` marker;
+ *  - either finalizing frame alone separates the turns, and applying both is
+ *    idempotent (the fix cannot double-finalize a client that also got the
+ *    assistant frame);
+ *  - WITHOUT any finalizing frame the turns merge and the marker degrades --
+ *    the defect mechanism the unconditional frame exists to close.
+ */
+
+const SLOT = 'chat-boundary'
+const init = () => ({ ...reducer(undefined, { type: '@@INIT' }), activeSlot: SLOT })
+
+const TURN1_CHUNKS = ['Pick a path.\n', '[OPTIONS: Alpha | Bravo]']
+const TURN1_TEXT = TURN1_CHUNKS.join('')
+const TURN2_CHUNK = 'Second turn reply.'
+
+const apply = (frames: Array<Parameters<typeof sseChatMessage>[0]>) => {
+  let state = init()
+  for (const f of frames) state = reducer(state, sseChatMessage(f))
+  return state
+}
+
+const textRows = (state: ReturnType<typeof apply>) =>
+  state.messages.filter(m => m.role === 'assistant' || m.role === 'streaming')
+
+describe('queue-boundary finalize frame (defect mechanism + fixed contract)', () => {
+  it('with the chat_segment finalize: two rows, and the first row\'s [OPTIONS:] parses', () => {
+    const state = apply([
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[0], seq: 1 },
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[1], seq: 2 },
+      { slot: SLOT, role: '_segment', content: '' },
+      { slot: SLOT, role: 'chunk', content: TURN2_CHUNK, seq: 3 },
+      { slot: SLOT, role: '_done', content: '' },
+    ])
+
+    const rows = textRows(state)
+    expect(rows.map(m => ({ role: m.role, content: m.content }))).toEqual([
+      { role: 'assistant', content: TURN1_TEXT },
+      { role: 'assistant', content: TURN2_CHUNK },
+    ])
+    expect(parseOptions(rows[0].content).options).toEqual(['Alpha', 'Bravo'])
+  })
+
+  it('the assistant chat_message frame alone also separates the turns (when it arrives)', () => {
+    // The end-of-turn flush's `slot.append` emits this frame on paths where it
+    // is not suppressed; a client that receives it never merges. It is the
+    // conditional half of the boundary's frame pair.
+    const state = apply([
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[0], seq: 1 },
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[1], seq: 2 },
+      { slot: SLOT, role: 'assistant', content: TURN1_TEXT, meta: { mid: 'm-t1' } },
+      { slot: SLOT, role: 'chunk', content: TURN2_CHUNK, seq: 3 },
+      { slot: SLOT, role: '_done', content: '' },
+    ])
+
+    const rows = textRows(state)
+    expect(rows.map(m => ({ role: m.role, content: m.content }))).toEqual([
+      { role: 'assistant', content: TURN1_TEXT },
+      { role: 'assistant', content: TURN2_CHUNK },
+    ])
+    expect(parseOptions(rows[0].content).options).toEqual(['Alpha', 'Bravo'])
+  })
+
+  it('both frames together (the fixed backend boundary) do not double-finalize', () => {
+    // The fixed backend emits chat_segment right after the flush already sent
+    // the assistant frame: the second finalize must find no streaming row and
+    // be a no-op, never mint an extra row or clobber the finalized one.
+    const state = apply([
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[0], seq: 1 },
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[1], seq: 2 },
+      { slot: SLOT, role: 'assistant', content: TURN1_TEXT, meta: { mid: 'm-t1' } },
+      { slot: SLOT, role: '_segment', content: '' },
+      { slot: SLOT, role: 'chunk', content: TURN2_CHUNK, seq: 3 },
+      { slot: SLOT, role: '_done', content: '' },
+    ])
+
+    const rows = textRows(state)
+    expect(rows.map(m => ({ role: m.role, content: m.content }))).toEqual([
+      { role: 'assistant', content: TURN1_TEXT },
+      { role: 'assistant', content: TURN2_CHUNK },
+    ])
+  })
+
+  it('without any finalizing frame the turns merge and the marker degrades (the defect)', () => {
+    const state = apply([
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[0], seq: 1 },
+      { slot: SLOT, role: 'chunk', content: TURN1_CHUNKS[1], seq: 2 },
+      // Neither `_segment` nor an assistant frame between the turns -- the
+      // shape a client sees when the conditional assistant frame is suppressed
+      // and no boundary finalize is emitted (the pre-fix backend).
+      { slot: SLOT, role: 'chunk', content: TURN2_CHUNK, seq: 3 },
+      { slot: SLOT, role: '_done', content: '' },
+    ])
+
+    const rows = textRows(state)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].content).toBe(TURN1_TEXT + TURN2_CHUNK)
+
+    // The marker no longer ends its line, so the real regex declines it:
+    // the pills degrade to literal prose. This is what makes the backend's
+    // unconditional boundary finalize load-bearing rather than cosmetic.
+    expect(parseOptions(rows[0].content).options).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

When a turn is followed by a successor turn taken from the queue (a queued user message, a subagent-completion continuation, refusal recovery, or a Stop-hook continuation), the dashboard can be left with no finalize frame for the first turn's assistant bubble. The successor's tokens then append into the still-open `streaming` row: two turns render as one run-together message, and a line-final `[OPTIONS: ...]` marker in the first turn stops rendering as buttons and degrades to literal prose (the marker's `]` is no longer line-final, so `OPTION_MARKER_RE` declines it).

## Why it matters

Every next-turn-from-queue path is affected, and the most reachable trigger — a Stop hook returning `{"decision":"block"}` — involves no user timing at all. The user loses turn separation in the transcript and loses working option pills exactly on the turns that end with a question.

## What changed (motivation → approach → change)

Symptom → root cause: the end-of-turn flush persists the final segment with `broadcast=False` (no `chat_segment`), deferring the client-side streaming→assistant finalize to the `chat_done` that `_finish_queue_cycle` emits — but when the tail-drain starts a queued successor (or `_run_pending_synthesis` dispatches a synthesis turn), `_finish_queue_cycle` never runs for that boundary, so no `chat_done` comes.

One refinement over the issue's stated mechanism, found in review and verified with an instrumented full-turn probe: the flush's `slot.append` does emit a `chat_message{role:assistant}` frame, and the reducer's assistant branch also finalizes on it — but that frame is **conditional**: suppressed while an HTTP SSE reader drains the slot (`_has_reader`), absent when the turn's final segment is empty (text already flushed at a tool boundary), and droppable client-side by the mid-keyed redelivery guard. A client that misses it merges the turns. `chat_segment` is the **unconditional, reducer-idempotent** finalizer, and these two successor boundaries were the only ones without it.

Fix (backend seam (a) of the issue, smallest blast radius — fires only on the paths that are broken):

- `_start_next_queued_turn` broadcasts `chat_segment` for the slot once a successor is certain to dispatch — after the dequeue, where every no-successor path (empty queue, purged continuation, dropped stale admission) has already returned `False` — and before the successor's row and first chunk.
- `_run_pending_synthesis` does the same after synthesis eligibility settles (`_pending_synthesis` consumed), before the synthesis `inject` row. This is the sibling boundary with the same missing-`chat_done` shape, found by the GPT review lane.

Invariants preserved: the queue-empty, dropped-entry, and synthesis-ineligible paths keep `_finish_queue_cycle`'s `chat_done` as their sole finalizer (no double finalize anywhere); the held-note flush ordering in the drain is untouched (the new frame appends no row); the steer / requeued-steer paths and the plan `_stage_loop` keep their current behaviour. The dashboard spec (`docs/system-specs/modules/learn-cron-dashboard.md`) documents the new boundary frame and its non-fire condition in the same commit.

## Tests

Backend (`test/test_queue_boundary_finalize.py`, 7 tests — red-before proven on base for all four finalize-emitting tests):

- Queued USER message and kind-tagged continuation-card entry: `chat_segment` for the slot is emitted and precedes the successor dispatch.
- Synthesis dispatch: same finalize before the synthesis `inject` row (red-before proven against the queue-boundary-only fix).
- No finalize on the empty-queue, dropped-entry (admission re-validation), and synthesis-ineligible boundaries — `chat_done` stays the sole finalizer, exactly once.
- Full two-turn `_run_chat` frame sequence, recording **both** egress channels (`broadcast_ws` and the `_broadcast` `chat_message` path): turn N's chunks (OPTIONS marker included) fully precede the finalize, turn N+1's chunks fully follow it, the conditional `chat_message{role:assistant}` precedes the unconditional `chat_segment`, and exactly one `chat_done` ends the cycle. Also confirms the issue's reload prediction: each turn persists as its own assistant row, so the defect was live-render only.

Frontend (`website/src/store/chatSlice.queueBoundaryFinalize.test.ts`, 4 tests driving the real reducer and the real `OPTION_MARKER_RE` via `parseOptions`): the fixed frame sequence yields two rows with parseable first-row options; the assistant frame alone also separates the turns when it arrives; both frames together do not double-finalize; and with neither frame the turns merge and the marker degrades — the defect mechanism the unconditional frame closes. These pin the reducer contract the backend fix relies on (the reducer already handled `_segment`, so their red-before counterpart is the backend suite).

Full gates: backend 75,661 passed with a failure set byte-identical to pristine base (all environmental: sandbox EPERM, AF_UNix path length); frontend `tsc -b` clean and 26,593 vitest tests passed; isort/flake8/mypy/black-gate/brand/changelog/harness/docs-lint all green.

## Manual verification

N/A — the full-turn backend test drives the real `_run_chat` tail through a scripted provider and asserts the exact wire frame sequence, and the reducer tests drive the real store; there is no visual surface change to inspect beyond what those pin.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** frame-sequence fix in the backend runner plus tests; no CSS/layout/component change, no new visual surface — the rendered pixels for a correctly-separated pair of turns are the ones the dashboard already draws.

## Related Issues

Fixes #7138

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
