### PR TITLE
fix(dashboard): preserve concurrent same-key recreate during slot-close teardown (#7191)

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -484,6 +484,200 @@ compaction cooldown clears it too (`reset`, `remove`,
 `close_all`), because slot keys ARE reused and a leaked flag would starve the
 NEXT holder of that key of its re-anchor.
 
+Slot-key reuse is also why the dashboard close/teardown path re-checks identity
+after it pops the slot. Both `close_slot` (shared by `api_chat_slot_delete` and
+session-control's `close_target`) and `api_chat_slots_cleanup` pop `name` out of
+`state._slots` and then run several AWAITS — cancel the task,
+`save_slot_off_loop(..., closed=True)`, `sessions.remove(_history_key_for(name))`.
+Across that window a concurrent same-key recreate (a `POST /api/chat`, or the
+`session_close` MCP verb) can mint a REPLACEMENT slot under the same key, reusing
+the same history key and the same session. Because both sites still hold the
+popped object (`slot` / `removed`), a synchronous, race-free discriminator is
+available, and there are TWO of them because the destructive steps do not all
+answer to the same owner.
+
+`_slot_still_ours(state, name, <popped>)` is the KEY-scoped one. It asks whether a
+DIFFERENT object now owns the key — an absent key is the ordinary post-pop state of
+every close, so `None` counts as still ours; reading it as "our object owns the key"
+would make the guard fire on every close and skip the very teardown it guards. It
+governs the two steps whose resource IS the key: `sessions.remove` (whose argument
+is `_history_key_for(name)`, the session an unbound replacement runs on) and the
+failure arms' restores (`state._slots[name] = slot` / `= removed`), which run only
+when the key is still free or still the popped object and so never clobber a live
+replacement. Cleanup's `archived` report is key-scoped too, and stays key-scoped:
+it names slot keys, so a key with a live holder is never listed however its
+transcript ended up.
+
+`_replacement_shares_transcript(state, name, <popped>)` is the TRANSCRIPT-scoped
+one, and it is what governs the `closed=True` save — because that save's argument
+is not the key. It targets `slot_history_key(slot)`, so a slot carrying a
+`linked_session_key` (channel-, cron- or workflow-born) writes the LINKED
+transcript while a replacement minted by a plain `get_or_create_slot(name)` — what
+`POST /api/chat` and the `session_close` verb take — is unbound and writes
+`dashboard:{name}`. Same key, two files, so key identity cannot decide this step:
+yielding the archive to a replacement that shares nothing would leave the
+original's own transcript with no `closed` flag, and `channel_slots._close_stands`
+reads an absent flag as "the user never dismissed this", so the reconcile pass
+resurfaces the tab that was closed. The predicate therefore compares FILE identity
+(`transcript_stems` on both sides) rather than key strings: `history._safe_key`
+folds `slack:<ts>` and the `slack_<ts>` stem onto one `.jsonl` and a pre-migration
+thread still resolves to its bare `thread_ts` stem, and the two errors are not
+symmetric — over-reporting "shared" merely declines an archive the next close will
+make, while under-reporting stamps `closed` on a file a live slot is writing.
+
+When the replacement DOES share the transcript, the archive and the session
+teardown are both skipped. The original was already popped and cancelled, so the
+close is effectively complete for it: `close_slot` RETURNS rather than raising
+`SlotCloseError`, which is what makes both its callers report success, and cleanup
+takes its `continue` without counting the key archived. When it does NOT share the
+transcript the archive runs normally on the original's own file and only the
+key-scoped steps yield.
+
+The `note_slot_closed` tombstone (below) still fires before these awaits for the
+reconcile reader; it is NOT the vehicle for either guard, which are pure post-pop
+re-checks confined to the two teardown paths.
+
+What both guards cover is the WIDE window, not the durable write. `save_slot_off_loop`
+reaches its commit through the process-wide default executor, so a recreate can
+still land between the last synchronous check and the in-lock write, leaving
+`closed=True` on a key a live replacement holds. That residual is what an unguarded
+close carries as well, and the row is the same one a plain sequential
+close-then-reopen of a reused key produces: `closed`/`closed_at` are in
+`SLOT_OWNED_META_KEYS`, so the replacement's next full save drops them, and
+`api_chat_slot_resume` compensates a stale flag with an in-lock compare-and-clear
+(`clear_closed(..., only_if_closed_before=...)`). Closing it AT the commit needs an
+ownership predicate evaluated inside `_locked(history_key)` on the write AND on the
+resume's read-then-clear — a durable-metadata contract change rather than a
+loop-side ordering one, so it is deliberately not what these two teardown paths do.
+
+Yielding to a replacement carries four obligations, and they exist because the
+state a close compensates is not all scoped the same way.
+
+- **Key-scoped state moves with the key.** `state._restricted_keys` holds
+  `dashboard:{name}` — a SESSION KEY, not a slot identity — and
+  `_is_restricted_session` tests that set BEFORE it looks at the slot. So every exit
+  of either teardown owes one postcondition, which is what
+  `_resettle_restricted_key(state, name)` IS: the key is marked iff the slot
+  currently AT `name` is restricted, an absent key counting as unrestricted. All six
+  exits go through it rather than through a bare `discard` — the ordinary close
+  (where the key is gone, so the marker drops and the next holder is not starved),
+  and every exit that hands the key to a replacement (where it is re-derived from
+  the REPLACEMENT). Re-derived, never blindly discarded: a replacement that is
+  itself restricted keeps the marker, since dropping it is the fail-OPEN direction.
+  Skipping it on a hand-over gives a persistent replacement an incognito original's
+  403 on every memory, artifact and mcp-apps call for as long as that tab lives.
+- **Slot-scoped compensation is coupled to the restore.** The failure arms owe the
+  ORIGINAL two rollbacks, and both are conditional on the original getting its key
+  back — not on the original merely existing. The nudge loop already is, through
+  `_restore_slot_nudge_loop`'s own `state.get_slot(name) is slot` admission check.
+  `notify_slot_close_undone` is coupled the same way rather than gated on
+  `slot._app` alone: with a replacement on the key there is no tab to put back, so
+  the dismissal DID happen for the original, and resuming the app's worker re-arms
+  an autonomous crew whose `slot_key` its watchdog resolves with a bare
+  `state.get_slot(...)` and no ownership test — handing the auto-approve grant, and
+  then an unbounded nudge clock, to the user-owned replacement. Leaving the pause is
+  the same answer the pre-save guard gives from the identical state, and it is a
+  first-class visible one (a `paused_reason` row with a resume control). The bulk
+  archive has no sibling here: it deliberately never calls `notify_slot_closed`, so
+  it has no app dismissal to take back.
+- **The original's unpersisted content is owed to its transcript, not to the
+  original's slot object.** A hand-over exit stops referencing the popped
+  slot, and `_flush_dirty_slots` iterates exactly `state._slots`, so an
+  unreferenced slot has NO retry path: anything past its last commit —
+  `messages[_disk_window_len:]`, plus a note the bulk path is still holding in the
+  in-memory-only `_deferred_notes` — would simply cease to exist. The pre-save
+  exits need no store failure to reach it either; they return before the save is
+  attempted, in a window that opens while a turn is in flight. So every hand-over
+  exit routes through `_persist_handover_tail(state, name, slot)`, which flushes
+  held notes into the window and writes it with **`closed=False`**. Those rows
+  belong on the ORIGINAL's own transcript whether or not the replacement shares it;
+  what must not happen is the archive flag and the session teardown, not the write.
+  The
+  target is `slot_history_key(slot)` and never a derived `dashboard:<slot>` — the
+  forced save resolves its own target the same way and REFUSES a write whose
+  `expected_history_key` names a different transcript, so the derived form would
+  make the drain a silent no-op for every cron-, channel- or workflow-linked slot
+  and would name a row-less file in the failure log. The write is non-destructive
+  against the replacement's rows in both directions: `_save_slot_to_history`'s
+  foreign-append scan carries through every on-disk line the saved window does not
+  represent, so rows a replacement already committed survive. The METADATA line is
+  a different matter and is not the drain's to move, so the write is `rows_only`.
+  `_save_slot_to_history` is otherwise authoritative for `SLOT_OWNED_META_KEYS` and
+  REBUILDS that line from whichever slot it is handed, so a default save here would
+  revert a title, folder, tag set or pin the replacement had already published onto
+  the shared transcript (`POST /api/chat/slots` persists a folder and a pinned title
+  at birth) — silently undoing an acknowledged edit, and for a tab nobody types in
+  again undoing it for good, so the next restart resurrects the dismissed tab's name
+  and filing. `rows_only` keeps the on-disk value for every one of those fields and
+  narrows this write's ownership to `ROWS_ONLY_OWNED_META_KEYS`: the file's identity
+  and accounting, which every writer maintains and which the save carries forward
+  from disk anyway. The set it defers,
+  `ROWS_ONLY_DEFERRED_META_KEYS`, is named in full rather than derived as
+  `SLOT_OWNED_META_KEYS - ROWS_ONLY_OWNED_META_KEYS`, because that difference
+  under-approximates: the slot save also writes fields that DESCRIBE an owned one
+  without being owned themselves, and a title's provenance and refresh budget
+  (`title_origin`, `title_refresh_mark`) travel WITH the title rather than with the
+  writer. Deferring the title while keeping those commits a line matching neither
+  slot — read back beside another slot's title they either unlock the background
+  refresh on a name the user typed by hand or lock a generated name out of refresh
+  permanently — so they are deferred with it. `created_by` and `origin` are the same
+  shape with AUTHORIZATION rather than presentation behind them, so they are deferred
+  too: `created_by` is what session-control's member ownership boundary reads and is
+  meaningless without the `mode` deferred beside it, and `origin` must round-trip with
+  the deferred `app` because the pair decides `slots:user` visibility and the
+  unattended approval window. Both describe the SLOT, so on a transcript with a live
+  holder the holder's are the true ones — and deferring them fails CLOSED on a line
+  that carries neither, since an absent `created_by` denies and an absent `origin`
+  restores to the sentinel the rehydrate paths already treat as unattributed. The
+  conversation's own MONOTONE once-flags (`auto_tagged`, `human_seen`,
+  `channel_origin`, `channel_folder_filed`) are set and never cleared, so two writers
+  on one transcript cannot disagree about them in a way that outlives the pair; they
+  stay as written. Deferring to disk is deliberately not
+  the same as deriving the line from the replacement — a recreate that published
+  nothing has no metadata to protect, and re-deriving from it would ERASE a real
+  title and filing the two slots' shared conversation has; leaving the line alone is
+  what gets both directions right with one write. **The deferral is conditional on
+  there actually being another writer to defer to**, and the line's `tab_id` — minted
+  per slot object, stamped by every save — is the evidence: the flag holds fields
+  back only on a line ANOTHER slot published, and a line this slot published itself
+  (or no line at all) takes the ordinary rebuild. Without that test the flag would
+  cost the original its own uncommitted metadata: a rename, re-file, tag or pin is
+  acknowledged the instant it lands in memory and persists on a later `_dirty`
+  flush, and the drain runs past the pop, where no flush will ever visit that slot
+  again. The two errors are not symmetric, so unprovable ownership defers: a
+  deferred edit of this slot's was never committed, while a rebuild over a live
+  holder's line reverts what it already published and nothing rewrites that for a
+  replacement nobody types in again. `closed`/`closed_at` are deferred on the same
+  asymmetry, and the drain is open-shaped without being un-closing: on another
+  holder's line a `closed` flag is that holder's own DISMISSAL, so erasing it would
+  resurface a tab the user put away — permanently, since the holder that wrote it is
+  popped too — and re-arm the channel reconciler on it, while leaving a stale flag
+  costs nothing durable, because the live holder owns those keys on its next full
+  save. The only path that clears a stale flag from outside the holder is the resume
+  route, and it clears one only when it can prove the close predates its own
+  boundary (`clear_closed(..., only_if_closed_before=...)`, compared inside the
+  store's lock), for exactly this reason: an unconditional clear reopens a
+  replacement the user closed. A rows-only save carries no such boundary, so
+  clearing a stale flag is instead the job of the `tab_id` fallback above: on a line THIS slot
+  published there is no other holder's dismissal to lose, so the ordinary rebuild
+  runs and the open-shaped write erases it. The failure arms take the same route in place of the
+  restore they skip: a store that rejected the `closed=True` write can still
+  accept the next one, and a lock lost to the recreate is exactly that case.
+- **A drain that fails is reported, not swallowed.** `_persist_handover_tail`
+  returns whether rows were owed and reached disk, and every caller honours it —
+  because this frame is the last reference to those rows, so nothing will retry and
+  nothing else will ever report them. Both PRE-SAVE hand-over exits therefore turn
+  a False into their path's own failure: `close_slot` raises
+  `SlotCloseError(code="history_save_failed")` (the same code as an ordinary failed
+  archive — from the caller's side it is one thing, a close whose history write did
+  not land) and cleanup adds the key to `failed`. There is nothing to roll back on
+  either exit, so the report IS the whole remedy; a 200 there would claim durability
+  the close does not have. The two FAILURE-arm drains need no branch of their own:
+  those arms already end in `SlotCloseError` / `failed.append(name)`, so a lost tail
+  reaches the caller regardless, and the drain only decides whether the rows
+  survived. Every failure is also logged with the exact row count, which is the only
+  report anything in the process can still make about the rows themselves.
+
 Three properties the route holds, each of which fails silently if broken:
 
 - The key comes from `effective_session_key(slot)`, never a derived

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -106,7 +106,7 @@ from kiro_crew.dashboard.state import (
 )
 from kiro_crew.dashboard.system_notices import SESSION_RELOAD_KIND, is_system_notice
 from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
-from kiro_crew.history import carry_provenance, is_incognito_transcript
+from kiro_crew.history import carry_provenance, is_incognito_transcript, transcript_stems
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.providers.acp import AcpProvider
 from kiro_crew.providers.base import LLMProvider
@@ -2352,6 +2352,209 @@ def _reject_pending_approvals(slot: _ChatSlot) -> None:
             )
 
 
+def _slot_still_ours(state: DashboardState, name: str, slot: _ChatSlot) -> bool:
+    """Return True iff no OTHER slot object has taken over ``name`` in ``_slots``.
+
+    A close pops the slot, then awaits (task cancel, ``save_slot_off_loop``,
+    ``sessions.remove``). A concurrent same-key recreate (POST /api/chat, or the
+    session_close MCP verb) can mint a REPLACEMENT slot for the same key inside
+    that window, and only THAT is what the destructive teardown steps must yield
+    to. So the discriminator is "a DIFFERENT object owns the key", not "our object
+    owns the key": an absent key is the ORDINARY post-pop state of every close, so
+    ``None`` counts as still ours. Reading it the other way would make the guard
+    fire on every close and skip the teardown it guards.
+
+    Synchronous and purely read-only: no side effects, and it touches neither the
+    loop, the session map, nor history. Callers use it to decide whether the
+    KEY-SCOPED steps (``sessions.remove`` on ``dashboard:{name}``, the failure-arm
+    ``_slots`` restore) would clobber a live replacement, and skip them if so. The
+    archival history write is NOT key-scoped — see
+    :func:`_replacement_shares_transcript`.
+    """
+    current = state._slots.get(name)
+    return current is None or current is slot
+
+
+def _replacement_shares_transcript(state: DashboardState, name: str, slot: _ChatSlot) -> bool:
+    """True iff a DIFFERENT slot now holds ``name`` AND writes ``slot``'s transcript.
+
+    Slot identity is not transcript ownership, and the archival save is scoped to
+    the TRANSCRIPT: it targets ``slot_history_key(slot)``, not ``name``. A slot
+    carrying a ``linked_session_key`` — channel-, cron- or workflow-born — keeps its
+    conversation under that linked key, while a replacement minted by a plain
+    ``get_or_create_slot(name)`` (the shape POST /api/chat and the session_close
+    verb take) is unbound and keeps its own under ``dashboard:{name}``. Same key,
+    two files. So :func:`_slot_still_ours` cannot decide the save: yielding the
+    archive to a replacement that shares nothing leaves the ORIGINAL's transcript
+    with no ``closed`` flag, and an absent flag is exactly what
+    ``channel_slots._close_stands`` reads as "the user never dismissed this" — the
+    reconcile pass then resurfaces the tab the user closed.
+
+    Compared as FILE identity, not as key strings, because the file is what the
+    write touches and the mapping is not injective: ``history._safe_key`` folds
+    ``slack:<ts>`` and the ``slack_<ts>`` filename stem onto one ``.jsonl``, and a
+    Slack thread predating the canonical key still resolves to its bare
+    ``thread_ts`` stem (:func:`~kiro_crew.history.transcript_stems` carries both).
+    The two errors are not symmetric: over-reporting "shared" only declines an
+    archive the next close will make, while under-reporting stamps ``closed`` onto a
+    file a live slot is still writing, which is the whole harm being guarded.
+    """
+    current = state._slots.get(name)
+    if current is None or current is slot:
+        return False
+    return bool(
+        set(transcript_stems(slot_history_key(current)))
+        & set(transcript_stems(slot_history_key(slot)))
+    )
+
+
+def _resettle_restricted_key(state: DashboardState, name: str) -> None:
+    """Re-derive ``dashboard:{name}``'s restricted marker from whoever owns ``name`` NOW.
+
+    ``state._restricted_keys`` is keyed by SESSION KEY, not by slot identity, so the
+    marker describes whatever object holds the key — never the object a close happens
+    to be carrying. Every exit of a teardown therefore owes the one postcondition
+    this function IS: ``dashboard:{name}`` is in the set iff the slot currently at
+    ``name`` is restricted, an absent key counting as unrestricted.
+
+    Two shapes of exit need it, and they need opposite answers. An ordinary close
+    pops the slot for good, so the marker must be DROPPED — otherwise an incognito
+    tab's key stays blocked for every later holder of it. A close that yields the key
+    to a concurrent same-key replacement must re-derive from the REPLACEMENT:
+    ``_is_restricted_session`` tests the key BEFORE it looks at the slot, so an
+    incognito original's leftover marker makes every memory, artifact and mcp-apps
+    call on a PERSISTENT replacement answer 403 for as long as that tab lives.
+
+    Re-derived rather than blindly discarded, because a replacement that is itself
+    restricted has to KEEP the marker: dropping it is the fail-OPEN direction.
+    """
+    key = f"dashboard:{name}"
+    current = state._slots.get(name)
+    if current is not None and current.is_restricted:
+        state._restricted_keys.add(key)
+    else:
+        state._restricted_keys.discard(key)
+
+
+async def _persist_handover_tail(state: DashboardState, name: str, slot: _ChatSlot) -> bool:
+    """Write a handed-over original's still-unsaved rows before its object is dropped.
+
+    A teardown that yields ``name`` to a concurrent same-key recreate stops
+    referencing the original slot: it is out of ``state._slots``, and the periodic
+    flush iterates exactly that map, so nothing retries the write for it. Anything
+    the original held past its last commit — ``messages[_disk_window_len:]``, plus
+    any note the cleanup path is still carrying in ``_deferred_notes`` — would be
+    unreachable and never persist. Those rows belong to the ORIGINAL's own
+    transcript, whether or not the replacement happens to share it, and this frame
+    is the last moment anything can put them there.
+
+    The target is ``slot_history_key(slot)``, never ``_history_key_for(name)``. A
+    slot carrying a ``linked_session_key`` — cron-, channel- or workflow-injected —
+    stores its conversation under that key, and the forced save resolves its own
+    write target the same way and REFUSES the whole write when the caller's
+    ``expected_history_key`` names a different transcript. Authorizing
+    ``dashboard:{name}`` there would make this drain a silent no-op for exactly the
+    slots whose transcript is shared with something outside the dashboard, and would
+    name a row-less file in the report.
+
+    Deliberately NOT ``closed=True``. What this frame is finishing is the close of
+    the ORIGINAL; the KEY is open, because a live replacement holds it, so the
+    durable line has to say so. Stamping ``closed`` on a key someone is still using
+    is the harm the surrounding guard exists to prevent. Open-shaped is not the same
+    as un-closing, though: on a line the replacement published, ``closed`` is that
+    holder's own dismissal, so the save defers it rather than erasing it (see
+    ``ROWS_ONLY_OWNED_META_KEYS``). It is only on a line THIS slot published — where
+    there is no other holder's flag to lose — that the write clears a stale
+    ``closed`` an earlier close of the reused key left behind.
+
+    Non-destructive against the replacement's own rows in both directions. The save
+    re-serializes the ORIGINAL's window over the on-disk window region, and the
+    save's foreign-append scan classifies every on-disk line that window does not
+    represent as another writer's append and carries it through verbatim, so rows a
+    replacement already committed survive.
+
+    ``rows_only``, and that is the whole of what this frame claims. The rows are
+    owed to the transcript; the METADATA line may not be this slot's to move.
+    ``_save_slot_to_history`` is otherwise authoritative for every
+    ``SLOT_OWNED_META_KEYS`` field and REBUILDS the line from whichever slot it is
+    handed, so a default save here would revert a folder, pinned title, tag or pin
+    the replacement had already published (``POST /api/chat/slots`` persists both at
+    birth) — silently undoing an acknowledged edit, and for a tab nobody types in
+    again undoing it for good. ``rows_only`` keeps the on-disk value for each of
+    those — the close flags included — and leaves this write owning only the file's
+    identity and accounting, which it carries forward from disk anyway.
+
+    It rides with the write rather than being a caller's choice because the save
+    scopes the deferral itself, by the line's ``tab_id``: it holds back only fields
+    on a line ANOTHER slot published, and rebuilds normally from a line this slot
+    published or from no line at all. That distinction is what keeps the flag from
+    costing the original its own uncommitted metadata — a rename, re-file, tag or
+    pin is acknowledged the moment it lands in memory and persists on a later
+    flush, and this frame is past the pop, so no flush will ever visit this slot
+    again.
+
+    Returns True when nothing was owed or the write committed, False when rows were
+    owed and did not reach disk. Callers MUST honour it: nothing in the process can
+    reach these rows again, so a caller that discards the answer reports a close
+    that succeeded while the rows became unreachable. The log line names the exact
+    count for the same reason.
+    """
+    try:
+        slot.flush_deferred_notes()
+    except Exception:
+        # The flush puts the unwritten suffix back before raising, so this count is
+        # what is still held — and held notes are in-memory only, so they die with
+        # the popped object.
+        logger.error(
+            "Slot %s: %d held note(s) could not be flushed before the key was handed "
+            "to a concurrent recreate; they are lost with the original slot",
+            name,
+            len(slot._deferred_notes),
+            exc_info=True,
+        )
+    # ``_disk_window_len`` is how much of the current window the last committed save
+    # covered, so the difference is exactly what has never reached disk. ``_dirty``
+    # covers the other shape of unsaved state: an in-place edit to a row already
+    # persisted leaves the length unchanged.
+    unsaved = max(0, len(slot.messages) - slot._disk_window_len)
+    if not unsaved and not slot._dirty:
+        return True
+    history_key = slot_history_key(slot)
+    try:
+        committed = await save_slot_off_loop(
+            state,
+            slot,
+            closed=False,
+            best_effort=False,
+            expected_history_key=history_key,
+            rows_only=True,
+        )
+    except Exception:
+        logger.error(
+            "Slot %s: %d unpersisted row(s) could not be written to %s while handing "
+            "the key to a concurrent recreate; they are lost with the original slot",
+            name,
+            unsaved,
+            history_key,
+            exc_info=True,
+        )
+        return False
+    if not committed:
+        # The save declined without writing: the session was permanently deleted
+        # while this write awaited the lock, or the slot's routing moved off the
+        # transcript this frame authorized. Neither leaves anywhere for these rows
+        # to go, and the object holding them is about to be dropped.
+        logger.warning(
+            "Slot %s: %d unpersisted row(s) were not written to %s while handing the "
+            "key to a concurrent recreate; the save declined the write",
+            name,
+            unsaved,
+            history_key,
+        )
+        return False
+    return True
+
+
 def _unblock_pending_waits(state: DashboardState, slot: _ChatSlot) -> None:
     """Unblock EVERY thing a stop/interrupt could leave the runner waiting on.
 
@@ -4007,22 +4210,136 @@ async def close_slot(
             await asyncio.wait_for(asyncio.shield(slot.task), timeout=2.0)
         except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
             pass
+    # Post-pop teardown race: across the awaits above (and the app-notify awaits
+    # before the pop) a concurrent same-key recreate — a POST /api/chat or the
+    # session_close MCP verb — can mint a REPLACEMENT slot under `name`. When that
+    # replacement writes the SAME transcript, writing THIS (original) slot as
+    # closed=True would stamp the archive flag on a conversation the replacement is
+    # still using, and the sessions.remove below would tear down the session it now
+    # uses. The original was already popped and its task cancelled, so the close is
+    # effectively complete for it; leave the replacement's slot and session
+    # untouched and report success.
+    #
+    # The gate is TRANSCRIPT sharing, not key ownership, because those are two
+    # different questions and the save answers to the transcript: a linked slot
+    # (channel-, cron- or workflow-born) writes its `linked_session_key`, while an
+    # unbound same-name replacement writes `dashboard:{name}`. Yielding the archive
+    # on that pair would leave the ORIGINAL's transcript with no `closed` flag, and
+    # the channel reconcile reads an absent flag as "never dismissed" and resurfaces
+    # the tab. So a replacement that shares nothing takes nothing: the archive below
+    # runs normally on the original's own file, and only the KEY-SCOPED steps
+    # (`sessions.remove`, the failure-arm restore) still yield to it.
+    #
+    # Yielding the archive is NOT the same as discarding the original's content. Its
+    # own unsaved rows still belong on its own transcript — what must not happen is
+    # the `closed` stamp and the session teardown, not the write.
+    # `_persist_handover_tail` is that distinction made explicit: the same window
+    # this frame was about to save, saved OPEN instead of closed.
+    #
+    # Scope, precisely: this closes the WIDE window — the app-notify awaits before
+    # the pop and the up-to-2.0s task cancel above — and NOT the durable write
+    # itself. `save_slot_off_loop` reaches its commit through the process-wide
+    # default executor, so a recreate can still land between this synchronous
+    # check and the in-lock write. That residual is the one an unguarded close
+    # carries too, and the row it leaves is what a plain sequential
+    # close-then-reopen of a reused key already produces: `closed`/`closed_at` are
+    # slot-owned metadata, so the replacement's next full save drops them, and
+    # `api_chat_slot_resume` compensates a stale flag with an in-lock
+    # compare-and-clear. Closing it AT the commit needs an ownership predicate
+    # evaluated inside `_locked(history_key)` — on the write and on the resume's
+    # read-then-clear both — which is a durable-metadata contract change, not a
+    # loop-side ordering one.
+    if _replacement_shares_transcript(state, name, slot):
+        # Yielding the archive must not silently discard what this slot never got to
+        # disk. The original is out of `_slots` and about to be unreferenced, and
+        # the periodic flush only ever visits `_slots`, so this frame is the last
+        # thing that can persist its tail — as an OPEN-key write, which is the
+        # single difference from the archival save this exit declines.
+        drained = await _persist_handover_tail(state, name, slot)
+        # The key belongs to the replacement now, and so does every KEY-SCOPED
+        # marker sitting on it. Hand the restricted flag over before letting go:
+        # the discard below the save is the only thing that would have cleared the
+        # original's, and this exit skips it. After the drain above, so the marker
+        # is derived from the newest observation of who holds the key.
+        _resettle_restricted_key(state, name)
+        _sync_dashboard_slots(state)
+        state.push_slots_update()
+        if slot._app:
+            # Same decision the failure arm below takes, and it must be as visible:
+            # this is the MORE common hand-over, so a silent one would hide every
+            # ordinary occurrence of an app worker left paused.
+            logger.warning(
+                "Slot %s was recreated while its close was tearing down, so app %r "
+                "keeps the dismissal: the original tab is gone and resuming its "
+                "worker would target the replacement now holding this key",
+                name,
+                slot._app,
+            )
+        if not drained:
+            # The drain was this frame's last chance at those rows, so a close that
+            # reported success here would be reporting durability it does not have —
+            # and unlike the arm below there is nothing to roll back and nothing that
+            # will retry, so the report IS the whole remedy. Same code as the
+            # ordinary save failure: from the caller's side this is one thing, a
+            # close whose history write did not land.
+            raise SlotCloseError("failed to save history", code="history_save_failed")
+        # Otherwise return, do not raise: for the ORIGINAL the close is complete
+        # (popped, task cancelled, tail durable), so every caller — the DELETE
+        # handler and session-control's close_target — must read this as success.
+        return
     try:
         await save_slot_off_loop(state, slot, closed=True, closed_at=closed_at, best_effort=False)
     except Exception:
         # Save failed — restore slot so data isn't lost
         logger.error("Failed to save slot %s to history, restoring", name, exc_info=True)
-        state._slots[name] = slot
+        # ...but only if the key is still free or still ours. A recreate that
+        # landed while save_slot_off_loop was in flight now owns `name`; blindly
+        # writing `state._slots[name] = slot` would clobber that live replacement
+        # with the failed original. Restore only when the slot is genuinely still
+        # ours (or the key is now empty).
+        restored = _slot_still_ours(state, name, slot)
+        if restored:
+            state._slots[name] = slot
+        else:
+            # Not restored means not referenced: the periodic flush that would have
+            # retried this write only visits `_slots`, so without this the failure
+            # arm's own stated invariant — "restores the slot so data isn't lost" —
+            # is not met for the hand-over case. Re-attempt the write as the
+            # open-key save the state actually is, which also clears a failure that
+            # was only lock contention with the recreate instead of treating one as
+            # permanent, and reports the row count when it is not.
+            #
+            # Its answer needs no branch HERE — unlike the pre-save exit above, this
+            # arm already ends in `SlotCloseError`, so a lost tail is reported to the
+            # caller either way. The drain only decides whether the rows survived.
+            await _persist_handover_tail(state, name, slot)
+        # Whichever way that went, the key-scoped restricted marker has to describe
+        # whoever holds `name` when this frame ends — the restored original, or the
+        # replacement that kept the key. This arm never reaches the discard below
+        # the save, so it settles the marker itself.
+        _resettle_restricted_key(state, name)
         # The close did not happen, so the loop retired for it must come back —
         # a restored session with no clock is an abandoned unattended worker.
         await _restore_slot_nudge_loop(retired_loop, lambda: state.get_slot(name) is slot)
-        # ...and the app's record of the dismissal has to come back too. The
-        # notification above already SUCCEEDED, which for a crew means the worker is
-        # durably paused; without this the failed close would still have stopped it,
-        # so the user gets an error AND a silently disabled worker. Unwound in
-        # reverse order of commitment, which is the only arrangement that leaves no
-        # pair of the three stores disagreeing.
-        if slot._app:
+        # ...and the app's record of the dismissal has to come back too — but ONLY
+        # if the tab did. The notification above already SUCCEEDED, which for a crew
+        # means the worker is durably paused; a close that puts the tab back and
+        # leaves the worker stopped hands the user an error AND a silently disabled
+        # worker. Unwound in reverse order of commitment, which is the only
+        # arrangement that leaves no pair of the three stores disagreeing.
+        #
+        # The undo is COUPLED TO THE RESTORE, not to `_app` alone, because with a
+        # replacement on the key there is no tab to put back: the original is
+        # popped, cancelled, and not coming back, so the dismissal DID happen for it
+        # and taking it back would be a lie with teeth. Resuming a crew re-arms an
+        # autonomous worker whose `slot_key` its watchdog resolves straight through
+        # `state.get_slot(...)` with no ownership test — so the auto-approve grant,
+        # and then an unbounded nudge clock, would land on the USER-owned
+        # replacement now sitting on that key. Leaving the pause is the same answer
+        # the pre-save guard above gives from the identical state, and it is a
+        # first-class visible one (a paused_reason row with a resume control), not a
+        # silent stop.
+        if slot._app and restored:
             from kiro_crew.apps.teardown import (
                 notify_slot_close_undone,  # circular: apps.teardown -> apps.bridges
             )
@@ -4034,18 +4351,36 @@ async def close_slot(
                     slot._app,
                     name,
                 )
+        elif slot._app:
+            logger.warning(
+                "Slot %s was recreated while its close was persisting, so app %r keeps "
+                "the dismissal: the original tab is gone and resuming its worker would "
+                "target the replacement now holding this key",
+                name,
+                slot._app,
+            )
         _sync_dashboard_slots(state)
         state.push_slots_update()
         raise SlotCloseError("failed to save history", code="history_save_failed")
     else:
-        state._restricted_keys.discard(f"dashboard:{name}")
+        # Through the shared postcondition rather than a bare discard: on the
+        # ordinary close the key is gone and this drops the marker, and a recreate
+        # that landed during the save gets the marker re-derived from ITSELF instead
+        # of inheriting the original's.
+        _resettle_restricted_key(state, name)
         # Durable, so no rollback can retract this frame — a client pruning its
         # per-slot cards on it can never be pruning a slot that comes back.
         state.push_slots_update()
     # The app was already told, and compensated if the persist above failed — see
     # the notify block before the pop and the rollback in the except branch.
-    # Kill the per-tab session to free resources
-    await state.sessions.remove(_history_key_for(name))
+    # Kill the per-tab session to free resources. Re-check identity ONE more
+    # time, and KEY-scoped here rather than transcript-scoped: a recreate can land
+    # between the save above and this remove, and `_history_key_for(name)` is the
+    # session an unbound replacement runs on, so removing it would tear down a live
+    # replacement's session no matter which transcript that replacement writes. Skip
+    # it if the key is no longer ours.
+    if _slot_still_ours(state, name, slot):
+        await state.sessions.remove(_history_key_for(name))
     _sync_dashboard_slots(state)
     state.push_slots_update()
     state.push_refresh("history")
@@ -4246,6 +4581,39 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
                 await asyncio.wait_for(asyncio.shield(removed.task), timeout=2.0)
             except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
                 pass
+        # Post-pop teardown race (same as the single-tab close, same gate): across
+        # the cancel await above a concurrent same-key recreate can mint a
+        # REPLACEMENT slot under `name`. When that replacement writes the SAME
+        # transcript, saving THIS (original) slot as closed=True would stamp a
+        # conversation it is still using, and the sessions.remove below would tear
+        # down the session it now uses. Skip the ARCHIVE — the closed stamp, the
+        # session teardown, and the ``archived`` report, which must never claim a
+        # live replacement was archived over — while still persisting the original's
+        # own unsaved rows and held notes onto the transcript the two share.
+        #
+        # A replacement that writes a DIFFERENT transcript (an unbound recreate over
+        # a channel-, cron- or workflow-linked tab) takes none of that: leaving the
+        # linked transcript unarchived is what makes the reconcile pass resurface it,
+        # so the archive below runs on the original's own file and only the
+        # key-scoped steps yield.
+        if _replacement_shares_transcript(state, name, removed):
+            # Same obligation as the single-tab hand-over, and here it also covers
+            # the notes: this exit skips the ``flush_deferred_notes()`` below, and
+            # held notes live nowhere but this popped object. The drain flushes them
+            # into the window and writes the whole tail as an OPEN-key save.
+            drained = await _persist_handover_tail(state, name, removed)
+            # Hand the KEY-SCOPED restricted marker to the replacement on the way
+            # out: this exit skips the discard below the save, which is the only
+            # thing that would otherwise have cleared the original's.
+            _resettle_restricted_key(state, name)
+            if not drained:
+                # This frame was the last reference to those rows, so a pass that
+                # said nothing here would report a clean sweep over a slot whose
+                # tail it dropped. ``failed`` is the honest column: the key is not
+                # in ``archived`` either way, and the two together say "not
+                # archived, and something was lost" rather than "nothing to do".
+                failed.append(name)
+            continue
         try:
             # Order is unchanged and load-bearing: the cancel above, then the
             # flush, then the save. What the guard adds is failure handling, and
@@ -4266,7 +4634,33 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
             logger.error(
                 "Cleanup: failed to flush held notes or archive slot %s", name, exc_info=True
             )
-            state._slots[name] = removed
+            # Restore only if the key is still free or still ours: a recreate that
+            # landed while save_slot_off_loop was in flight now owns `name`, and
+            # blindly writing `state._slots[name] = removed` would clobber that
+            # live replacement with the failed original. Skip the restore in that
+            # case; the error-row / dead-task handling below still applies to the
+            # original object we hold.
+            if _slot_still_ours(state, name, removed):
+                state._slots[name] = removed
+            else:
+                # The restore is what this arm's own comment relies on to keep the
+                # flushed notes reachable ("restores the slot with its notes still
+                # held"). Skipping it for a live replacement removes that guarantee,
+                # so drain the tail — flushed notes included — onto the slot's own
+                # transcript instead of dropping the only object holding it.
+                #
+                # Deliberately BEFORE the error row appended below, and that row is
+                # deliberately left in memory on this branch: "the tab was kept" is
+                # false here (the replacement's tab is the one on screen), so
+                # persisting it would put a lie on a transcript a live slot may hold.
+                # The ``failed`` report is what carries the outcome instead — which
+                # is also why the drain's answer needs no branch here, unlike at the
+                # pre-save exit above: this key reaches ``failed`` regardless.
+                await _persist_handover_tail(state, name, removed)
+            # Either way the key-scoped restricted marker must describe whoever holds
+            # `name` now — the restored original, or the replacement that kept it.
+            # This arm never reaches the discard below, so it settles it here.
+            _resettle_restricted_key(state, name)
             # Restoring the slot does not undo the cancel above, and ``running`` is
             # derived from the task, so a cancel that already completed reads False:
             # the tab returns looking idle and dispatchable with that turn's output
@@ -4286,8 +4680,22 @@ async def api_chat_slots_cleanup(request: web.Request) -> web.Response:
             failed.append(name)
             continue
         else:
-            state._restricted_keys.discard(f"dashboard:{name}")
-        # Session cleanup is best-effort — history is already written
+            # Through the shared postcondition rather than a bare discard, for the
+            # same reason as the single-tab close: an archive that succeeded onto a
+            # key a recreate has since taken must leave the marker describing the
+            # REPLACEMENT, not the original it just wrote out.
+            _resettle_restricted_key(state, name)
+        # Re-check identity ONE more time, and KEY-scoped here rather than
+        # transcript-scoped: `_history_key_for(name)` is the session an unbound
+        # replacement runs on, so a recreate landing between the save above and here
+        # would have its session torn down. Skip the teardown, and do NOT report the
+        # key archived — ``archived`` names SLOT KEYS, and this one has a live holder
+        # whatever became of the transcript, so listing it would tell the UI a tab on
+        # screen was swept. Move on without touching the replacement's session or its
+        # running task.
+        if not _slot_still_ours(state, name, removed):
+            continue
+        # Session cleanup is best-effort — history is already written.
         try:
             await state.sessions.remove(_history_key_for(name))
         except Exception:

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -47,6 +47,8 @@ from kiro_crew.dashboard.state import (
 )
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
+    ROWS_ONLY_DEFERRED_META_KEYS,
+    ROWS_ONLY_OWNED_META_KEYS,
     SLOT_OWNED_META_KEYS,
     ConversationLog,
     _archive_lines,
@@ -2482,6 +2484,7 @@ def _save_slot_to_history(
     force: bool = False,
     rewrite: bool = False,
     expected_history_key: str | None = None,
+    rows_only: bool = False,
 ) -> bool:
     """Persist slot messages to JSONL history (append-safe).
 
@@ -2517,6 +2520,28 @@ def _save_slot_to_history(
     tab_id chaining is 1:1 (a slot's tab_id maps to exactly one file — fork makes
     a fresh slot with its own file), so this never reads/writes a sibling and
     legacy no-tab_id sessions stay isolated.
+
+    ``rows_only``: persist the window but leave the metadata line's slot-owned
+    fields as they are on disk, keeping authority over only
+    :data:`~kiro_crew.history.ROWS_ONLY_OWNED_META_KEYS`. It exists for the one
+    caller whose slot is not the transcript's only writer: the close/cleanup
+    hand-over drain, which writes a popped slot's unsaved rows onto a transcript a
+    concurrent same-key replacement now holds. The default rebuild would revert
+    whatever that replacement had already published (a folder or a pinned title
+    from ``POST /api/chat/slots``, a tag, a pin), so the rows move and the line does
+    not. The deferred set is
+    :data:`~kiro_crew.history.ROWS_ONLY_DEFERRED_META_KEYS`, which is wider than the
+    owned fields alone: a title's provenance and refresh budget describe the title
+    and travel with it. It includes ``closed``/``closed_at``, so an open-shaped
+    rows-only write does not erase a dismissal the replacement committed while this
+    one was in flight.
+
+    The deferral is conditional on there being another writer to defer to, decided
+    from the line's ``tab_id``: a line this slot published itself, or no line at
+    all, gets the ordinary rebuild. Otherwise the flag would cost the popped slot
+    its own uncommitted metadata — an edit is acknowledged when it lands in memory
+    and persists on a later flush, and after the pop no flush ever visits that slot
+    again.
 
     Returns ``False`` only when the delete-won guard aborted the save because
     the session was permanently deleted while this save awaited the lock — the
@@ -3083,7 +3108,45 @@ def _save_slot_to_history(
                 meta_line["rotation_generation"] = (
                     int(existing_meta.get("rotation_generation", 0) or 0) + 1
                 )
-            carry_unowned_metadata(meta_line, existing_meta, SLOT_OWNED_META_KEYS)
+            # ``rows_only`` DEFERS to the line on disk, so it owes evidence that the
+            # line is somebody ELSE's. ``tab_id`` is that evidence and the only
+            # per-writer mark the line carries: it is minted per slot OBJECT
+            # (``get_or_create_slot`` assigns a fresh uuid; a rehydrate adopts the
+            # file's), and every save stamps the writer's own onto the line. A line
+            # still carrying THIS slot's id was published by this slot and describes
+            # nothing that needs protecting, so the ordinary rebuild must run —
+            # metadata edits are acknowledged to the user the instant they land in
+            # memory (``_dirty``, persisted by a later flush), and the slot a
+            # rows-only write carries has been popped, so deferring here would drop
+            # a title, folder, tag set or pin the user already saw applied with
+            # nothing left to retry it.
+            #
+            # Unprovable ownership defers, because the two errors cost differently.
+            # Deferring this slot's own edit loses fields that were never committed;
+            # rebuilding over a live holder's committed line reverts fields it
+            # already published, and for a replacement nobody types in again nothing
+            # rewrites them, so that loss is permanent.
+            own_tab_id = getattr(slot, "_tab_id", "") or ""
+            line_is_this_slots = bool(own_tab_id) and existing_meta.get("tab_id") == own_tab_id
+            if rows_only and existing_meta and not line_is_this_slots:
+                # A rows-only write does not own the slot-owned fields: the line
+                # describes whichever OTHER live slot published it, and this one is
+                # only here to get its messages down. Drop the rebuild for every
+                # field outside the file-identity subset and let the carry below
+                # restore the on-disk value verbatim, so a title, folder, tag set or
+                # pin another holder acknowledged is not reverted by a write that was
+                # never about it. ``closed``/``closed_at`` are deferred with the
+                # rest: on this line they are the other holder's own dismissal, and
+                # an open-shaped write that erased them would resurface a tab the
+                # user put away with that holder already popped. Gated on an existing
+                # line because with none there is no other writer to defer to and
+                # the slot's own state is all there is — and that is the branch below,
+                # where the open-shaped write still clears a stale ``closed``.
+                for meta_key in ROWS_ONLY_DEFERRED_META_KEYS:
+                    meta_line.pop(meta_key, None)
+                carry_unowned_metadata(meta_line, existing_meta, ROWS_ONLY_OWNED_META_KEYS)
+            else:
+                carry_unowned_metadata(meta_line, existing_meta, SLOT_OWNED_META_KEYS)
             meta_str = json.dumps(meta_line) + "\n"
 
             # ── Frozen prefix (never rewritten) + freshly serialized window ──
@@ -3372,6 +3435,7 @@ async def save_slot_off_loop(
     rewrite: bool = False,
     best_effort: bool = True,
     expected_history_key: str | None = None,
+    rows_only: bool = False,
 ) -> bool:
     """Persist a slot from the event loop without blocking or dropping the save.
 
@@ -3406,6 +3470,12 @@ async def save_slot_off_loop(
     the worker's routing snapshot, and without this pin the durable write
     would target a transcript the caller never authorized.
 
+    ``rows_only``: write the window but leave the metadata line's slot-owned
+    fields as they stand on disk when the line was published by ANOTHER slot --
+    for a caller persisting a slot's rows onto a transcript another live slot now
+    holds. See :func:`_save_slot_to_history` for the full contract, including the
+    ``tab_id`` test that keeps the flag from deferring to the caller's own line.
+
     Returns ``False`` only when the save was skipped WITHOUT writing: the
     session was permanently deleted while the save awaited the lock (the
     delete-won guard in :func:`_save_slot_to_history`), or the routing moved
@@ -3426,6 +3496,7 @@ async def save_slot_off_loop(
             force=force,
             rewrite=rewrite,
             expected_history_key=expected_history_key,
+            rows_only=rows_only,
         )
 
     def _begin_guarded_metadata_write() -> None:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -193,6 +193,78 @@ SLOT_OWNED_META_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# The subset of :data:`SLOT_OWNED_META_KEYS` a ROWS-ONLY slot save still owns.
+#
+# A save that must persist a slot's messages onto a transcript whose metadata line
+# describes a DIFFERENT live slot cannot use the whole ownership claim above: the
+# rebuild would revert the other slot's title, folder, tags or pin. Such a save
+# preserves every slot-owned field the line already carries and keeps authority
+# over only these — the file's identity and accounting, which every writer
+# maintains and which the save carries forward from disk anyway.
+#
+# ``closed``/``closed_at`` are NOT here, even though the write is open-shaped and
+# the whole claim above would erase them. On a line another slot published, a
+# ``closed`` flag is that holder's own DISMISSAL, and the two mistakes cost
+# differently. Erasing a dismissal the holder just committed resurfaces a tab the
+# user put away and re-arms the channel reconciler on it, with the holder already
+# popped so nothing rewrites the flag. Leaving a stale flag in place instead costs
+# nothing durable: the live holder owns these keys on its own next full save.
+#
+# The one path that DOES clear a stale flag from outside the holder is the resume
+# route, and it only clears one it can prove predates its own boundary
+# (``clear_closed(..., only_if_closed_before=...)``, compared inside the store's
+# lock) — precisely because an unconditional clear "reopens a replacement the user
+# closed". A rows-only save carries no such boundary, so it defers, the same way
+# every other field on another writer's line does.
+#
+# Narrowing this far is only correct against ANOTHER slot's line, so the save
+# establishes that first (from the line's ``tab_id``) and falls back to the full
+# claim otherwise. Applied to a slot's own line it would strand that slot's
+# uncommitted metadata instead of protecting anyone's — and that fallback is where
+# an open-shaped write still clears a stale ``closed``, because a line this slot
+# published carries no other holder's dismissal to lose.
+ROWS_ONLY_OWNED_META_KEYS: frozenset[str] = frozenset({"_type", "created_at", "last_consolidated"})
+
+# The keys a ROWS-ONLY slot save must DROP from its rebuild so the on-disk values
+# are carried back verbatim.
+#
+# Named here in full rather than derived at the call site as
+# ``SLOT_OWNED_META_KEYS - ROWS_ONLY_OWNED_META_KEYS``, because that difference
+# under-approximates: the slot save also writes fields that DESCRIBE an owned one
+# without being owned themselves (absence must not erase them, so they are
+# deliberately outside the ownership claim and survive via
+# :func:`carry_unowned_metadata`). Deferring the described field while keeping the
+# describing one commits a line that matches NEITHER slot — worse than either,
+# because each half is separately valid and nothing downstream can detect the
+# mismatch. ``title_origin`` and ``title_refresh_mark`` are the title's provenance
+# and its background-refresh budget: read back beside another slot's title they
+# either unlock the refresh on a name a user typed by hand or lock a generated name
+# out of refresh permanently. They travel WITH the title, so they are deferred with
+# it.
+#
+# ``created_by`` and ``origin`` are the same shape and the highest-consequence
+# instance of it, because what they describe is AUTHORIZATION rather than
+# presentation. ``created_by`` is the attribution the member ownership boundary in
+# session-control reads, and it is meaningless without the ``mode`` that is deferred
+# beside it — a member ``mode`` from the live holder read next to a different
+# principal's ``created_by`` names an owner who never opened this session.
+# ``origin`` must round-trip with ``app``, also deferred: split, a tab reads back as
+# one holder's slot kind wearing the other's app binding, which is what decides
+# ``slots:user`` visibility and the unattended approval window. Both are attributes
+# of the SLOT, not facts about the conversation, so on a transcript with a live
+# holder the holder's are the true ones. Deferring them also fails CLOSED where the
+# line carries none: an absent ``created_by`` denies rather than grants, and an
+# absent ``origin`` restores to the empty sentinel the rehydrate paths already treat
+# that way.
+#
+# What is left out is left out deliberately: ``auto_tagged``, ``human_seen``,
+# ``channel_origin`` and ``channel_folder_filed`` are MONOTONE once-flags about the
+# CONVERSATION, set and never cleared, so a shared transcript's two writers cannot
+# disagree about them in a way that outlives the pair.
+ROWS_ONLY_DEFERRED_META_KEYS: frozenset[str] = (
+    SLOT_OWNED_META_KEYS - ROWS_ONLY_OWNED_META_KEYS
+) | frozenset({"title_origin", "title_refresh_mark", "created_by", "origin"})
+
 
 def carry_unowned_metadata(
     rebuilt: dict,

--- a/test/test_slot_close_recreation_race.py
+++ b/test/test_slot_close_recreation_race.py
@@ -1,0 +1,2079 @@
+"""Close-vs-recreate race on the shared dashboard slot-close teardown.
+
+The defect these pin (issue #7191): both ``api_chat_slot_delete`` and
+``api_chat_slots_cleanup`` pop ``name`` out of ``state._slots`` and then run a
+sequence of AWAITS — cancel the task, ``save_slot_off_loop(..., closed=True)``,
+``state.sessions.remove(_history_key_for(name))``. A concurrent same-key
+recreate (a POST /api/chat, or the session_close MCP verb) can mint a
+REPLACEMENT slot for the same key inside that window. The original, still in
+flight, then (a) writes ITS transcript over the shared history key as closed and
+(b) tears down the session the replacement now uses. The failure arms compound
+it: they blindly ``state._slots[name] = <original>`` over whatever now owns the
+key.
+
+The fix re-checks ownership after the pop, at BOTH sites, with TWO predicates
+because the destructive steps answer to two different owners. ``_slot_still_ours``
+(no DIFFERENT object owns ``name``) guards the KEY-scoped steps: ``sessions.remove``
+on ``dashboard:{name}``, the failure-arm restores, cleanup's ``archived`` report.
+``_replacement_shares_transcript`` (a different object owns ``name`` AND resolves the
+same file) guards the closed=True save, whose resource is the TRANSCRIPT rather than
+the key — a linked tab and an unbound same-name recreate hold one key and two files,
+and yielding the archive there would leave the original's transcript unarchived for
+the reconcile pass to resurface.
+
+These tests interleave a recreate across the teardown awaits (via an
+``asyncio.Event`` the monkeypatched ``save_slot_off_loop`` parks on) and assert the
+replacement's identity, history, and session survive, that the destructive step was
+skipped, that the original's own tail and archive were not paid for it, and that a
+tail that could NOT be persisted is reported rather than answered 200. Each would
+FAIL if its guard were reverted.
+
+Each predicate's polarity is pinned on its own, because getting either backwards is
+silent. For the key one, an absent key is the ORDINARY post-pop state, so a guard
+reading ``get(name) is <popped>`` would fire on EVERY close and skip the teardown it
+exists to protect — leaking the per-tab session, with a 200 either way. For the
+transcript one, both directions fail quietly: reading a divergent pair as shared
+loses an archive nothing else will make, and reading a folded pair as divergent
+stamps ``closed`` on a file a live slot is writing. The two ``ordinary`` tests below
+and the three predicate tests are that pin.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew import autonudge
+from kiro_crew import members as members_mod
+from kiro_crew.autonudge import AutoNudgeService
+from kiro_crew.dashboard import chat_handlers as handlers
+from kiro_crew.dashboard.state import SlotOrigin
+
+NAME = "chat-1-1785"
+
+
+@pytest.fixture(autouse=True)
+def _no_nudge_service(monkeypatch):
+    """No auto-nudge service: these tests isolate the teardown-race guard.
+
+    The nudge-loop retirement and its rollbacks are pinned by
+    test_slot_close_nudge_race.py; here the close path must find nothing to
+    retire so the only variable is the post-pop identity re-check.
+    """
+    monkeypatch.setattr(autonudge, "_INSTANCE", None)
+
+
+class _Req:
+    """Minimal stand-in for the aiohttp request the handlers read.
+
+    The race tests drive the handlers directly rather than through a client: the
+    interleaving of the concurrent recreate has to be scheduled deterministically
+    inside the teardown window, and a client's own awaits would let it run before
+    the handler even reached the pop.
+    """
+
+    def __init__(self, state, slot: str = NAME, body: dict | None = None) -> None:
+        self.app = {"state": state}
+        self.match_info = {"slot": slot}
+        self._body = body if body is not None else {}
+
+    def get(self, key: str, default: str = "") -> str:
+        del key
+        return default
+
+    async def json(self) -> dict:
+        return self._body
+
+
+def _state_with_slot(tmp_path, name: str = NAME):
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot(name)
+    slot.append("user", "watch the PR")
+    slot.append("assistant", "watching")
+    slot.drain()
+    return state
+
+
+def _arm_running_turn(slot, entered: asyncio.Event, release: asyncio.Event):
+    """Give ``slot`` a live, parkable turn so its task-cancel await blocks.
+
+    The close pops the slot and then, if ``slot.running``, cancels ``slot.task``
+    and waits on ``asyncio.wait_for(asyncio.shield(slot.task), 2.0)``. To land a
+    recreate in THAT await (the window the first pre-save guard protects) the
+    task has to still be pending when the recreate is minted. This turn swallows
+    the handler's cancel, signals ``entered`` so the test can mint the
+    replacement, then parks on ``release`` before returning — so the handler's
+    shielded wait is still blocked at the exact instant the key changes owner.
+    ``slot.running`` is ``self.task is not None and not self.task.done()``, so
+    assigning this task is all it takes to make the slot look busy.
+    """
+
+    async def _turn() -> None:
+        try:
+            await asyncio.Event().wait()  # block until cancelled
+        except asyncio.CancelledError:
+            entered.set()
+            await release.wait()
+
+    slot.task = asyncio.create_task(_turn())
+    return slot.task
+
+
+# --------------------------------------------------------------------------- #
+# the two predicates
+#
+# The teardown's destructive steps do not all answer to the same owner, so there
+# are two discriminators and each guards the step whose resource it describes:
+# ``_slot_still_ours`` for the KEY (``sessions.remove`` on ``dashboard:{name}``, the
+# failure-arm ``_slots`` restore, cleanup's ``archived`` report) and
+# ``_replacement_shares_transcript`` for the FILE (the closed=True save).
+# --------------------------------------------------------------------------- #
+
+
+def test_still_ours_treats_a_freed_key_as_ours(tmp_path) -> None:
+    """The predicate answers "has someone ELSE taken the key", not "is it ours".
+
+    A freed key (``None``) is the ordinary state at every guard site — the close
+    popped the slot before the awaits — so it MUST read as still ours. A predicate
+    written as ``get(name) is slot`` inverts every guard: the common path skips
+    ``sessions.remove`` while still answering 200.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots.pop(NAME)
+
+    assert handlers._slot_still_ours(state, NAME, original) is True
+
+    state._slots[NAME] = original
+    assert handlers._slot_still_ours(state, NAME, original) is True
+
+    replacement = state.get_or_create_slot("chat-2-1785")
+    state._slots[NAME] = replacement
+    assert handlers._slot_still_ours(state, NAME, original) is False
+
+
+def test_shares_transcript_needs_a_replacement_and_the_same_file(tmp_path) -> None:
+    """Only a DIFFERENT slot writing the SAME transcript makes the save yield.
+
+    Three answers, and each is a different guard site's decision. No replacement
+    (a freed key, or our own object still there) is the ordinary close, where the
+    archive must run. An unbound recreate over a LINKED tab is a replacement that
+    shares no file, where the archive must also run — on the original's own
+    transcript, which nothing else will ever archive. Only a replacement resolving
+    the same file may take the archive away.
+    """
+    state = _make_state(tmp_path)
+    original = state.get_or_create_slot(NAME)
+    state._slots.pop(NAME)
+
+    # The ordinary post-pop state, and the pre-pop state, are both "no hand-over".
+    assert handlers._replacement_shares_transcript(state, NAME, original) is False
+    state._slots[NAME] = original
+    assert handlers._replacement_shares_transcript(state, NAME, original) is False
+
+    # Two unbound slots on one key resolve one transcript: this is #7191's own case.
+    state._slots.pop(NAME)
+    unbound = state.get_or_create_slot(NAME)
+    assert unbound is not original
+    assert handlers._replacement_shares_transcript(state, NAME, original) is True
+
+    # A linked original vs an unbound replacement: same key, two files.
+    linked = state.get_or_create_slot("chat-9-1785", linked_session_key="cron:job7")
+    assert handlers._replacement_shares_transcript(state, NAME, linked) is False
+
+
+def test_shares_transcript_compares_files_not_key_strings(tmp_path) -> None:
+    """A channel stem and its canonical key are ONE file, and must read as shared.
+
+    ``history._safe_key`` folds ``slack:<ts>`` and the ``slack_<ts>`` filename stem
+    onto the same ``.jsonl``, so a bound original and a ``channel_origin``
+    replacement whose stem never resolved hold two DIFFERENT key strings for one
+    transcript. A string comparison would call that "not shared" and let the archive
+    stamp ``closed`` on the file the live replacement is writing — the exact harm the
+    guard exists for, and the asymmetric direction: over-reporting shared only
+    declines an archive the next close will make.
+    """
+    state = _make_state(tmp_path)
+    stem = "slack_1785370133.085469"
+    original = state.get_or_create_slot(stem, linked_session_key="slack:1785370133.085469")
+    state._slots.pop(stem)
+    replacement = state.get_or_create_slot(stem, channel_origin=True)
+
+    assert replacement is not original
+    assert not replacement.linked_session_key, "the stem must stay unresolved for this case"
+    assert handlers.slot_history_key(original) != handlers.slot_history_key(
+        replacement
+    ), "the two keys must differ, or this test is not about the fold"
+    assert handlers._replacement_shares_transcript(state, stem, original) is True
+
+
+# --------------------------------------------------------------------------- #
+# api_chat_slot_delete
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_delete_recreate_during_save_preserves_replacement(tmp_path, monkeypatch) -> None:
+    """(a) A recreate landing inside the closed=True save must survive intact.
+
+    While the close is parked inside ``save_slot_off_loop`` a concurrent
+    ``get_or_create_slot(NAME)`` mints a replacement. After the close returns the
+    replacement must still own the key, and ``sessions.remove`` must NOT have been
+    called for its key (the second identity re-check, before the remove, must see
+    the key is no longer ours and skip the destructive teardown). Without the
+    guard the close would run ``sessions.remove`` and tear down the session the
+    replacement now uses.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots[NAME]
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(*_a, **_kw) -> None:
+        # Park so the recreate can interleave INSIDE the teardown window.
+        entered.set()
+        await release.wait()
+
+    removed_keys: list[str] = []
+
+    async def _remove(key) -> None:
+        removed_keys.append(key)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+    state.sessions.remove = _remove  # type: ignore[assignment]
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()  # close is parked inside the persist
+    # The concurrent same-key recreate mints a fresh slot object under NAME.
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by the close"
+    assert removed_keys == [], "sessions.remove tore down the live replacement's session"
+
+
+@pytest.mark.asyncio
+async def test_delete_recreate_during_task_cancel_hits_first_guard(tmp_path, monkeypatch) -> None:
+    """(a2) A recreate landing in the task-cancel await hits the FIRST guard.
+
+    This is the ONLY window where the pre-save guard fires: the recreate is
+    minted while the close is parked in ``asyncio.wait_for(asyncio.shield(
+    slot.task), 2.0)`` — BEFORE ``save_slot_off_loop`` is reached — so the first
+    ``_slot_still_ours`` check (immediately after the cancel block) sees the key
+    is no longer ours and takes the early ``return {"ok": True}``. That means the
+    closed=True save is NEVER attempted for the original and ``sessions.remove``
+    is NEVER called: the replacement keeps its slot, its (unclosed) history, and
+    its session. Reverting ONLY the first guard would let the close fall through
+    to the save and the remove, so this case fails without it — the other cases
+    park inside the save and so exercise only the second/failure-arm guards.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots[NAME]
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+    assert original.running, "the turn must be live so the cancel-wait actually blocks"
+
+    saved: list[tuple[bool, bool]] = []
+    removed_keys: list[str] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> bool:
+        saved.append((bool(kw.get("closed")), bool(kw.get("rows_only"))))
+        return True
+
+    async def _remove(key) -> None:
+        removed_keys.append(key)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+    state.sessions.remove = _remove  # type: ignore[assignment]
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()  # close is parked in the shielded task-cancel wait
+    # The concurrent same-key recreate mints a fresh slot while the close is
+    # still short of the pre-save guard.
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()  # let the cancelled turn finish so the wait returns
+    resp = await close
+
+    assert resp.status == 200
+    assert state._slots.get(NAME) is replacement, "the first guard did not preserve the replacement"
+    # The guard stops the ARCHIVE, not the write: the hand-over drain still saves the
+    # original's own window, so its tail is not lost. Exactly one write, and it is
+    # the shape the hand-over is allowed — closed=False, so nothing stamps the
+    # archive flag on a key a live replacement holds, and rows_only, so it claims
+    # the rows without rebuilding a metadata line the replacement owns.
+    assert saved == [(False, True)], "the hand-over write was not the rows-only open save"
+    assert removed_keys == [], "sessions.remove ran past the first guard on the replacement's key"
+
+
+@pytest.mark.asyncio
+async def test_delete_first_guard_keeps_the_app_dismissal_and_says_so(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    """(a3) The pre-save guard keeps the app dismissal, and logs that it did.
+
+    This exit takes the same decision as the failure arm — the original is popped,
+    cancelled and not coming back, so its dismissal stands, and resuming the crew
+    would re-arm an autonomous worker onto the replacement's key. It is also the
+    MORE common of the two hand-overs, so the operator-visible record matters more
+    here than on the failure arm: without it the frequent case is the silent one and
+    a paused app worker has no trace explaining why.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots[NAME]
+    original._app = "issue-radar"
+
+    undone: list[str] = []
+
+    async def _told(_app: str, _slot_key: str) -> bool:
+        return True
+
+    async def _undo(_app: str, slot_key: str) -> bool:
+        undone.append(slot_key)
+        return True
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    saved: list[tuple[bool, bool]] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> bool:
+        saved.append((bool(kw.get("closed")), bool(kw.get("rows_only"))))
+        return True
+
+    monkeypatch.setattr("kiro_crew.apps.teardown.notify_slot_closed", _told)
+    monkeypatch.setattr("kiro_crew.apps.teardown.notify_slot_close_undone", _undo)
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    caplog.set_level(logging.WARNING, logger=handlers.__name__)
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert state._slots.get(NAME) is replacement
+    assert saved == [(False, True)], "the hand-over write was not the rows-only open save"
+    assert undone == [], "the dismissed app worker was resumed onto the replacement's key"
+    assert any(
+        "keeps the dismissal" in record.getMessage() for record in caplog.records
+    ), "the app-dismissal hand-over left no operator record"
+
+
+@pytest.mark.asyncio
+async def test_delete_recreate_between_save_and_remove_skips_remove(tmp_path, monkeypatch) -> None:
+    """(b) A recreate landing between the save and sessions.remove skips remove.
+
+    ``sessions.remove`` tears down the session backing the reused key, which the
+    replacement now uses; the second identity re-check must skip it.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots[NAME]
+
+    removed_keys: list[str] = []
+
+    async def _remove(key) -> None:
+        removed_keys.append(key)
+
+    # The recreate lands AFTER the save completes but BEFORE sessions.remove.
+    # The second identity re-check, immediately before the remove on the same
+    # frame, is what must catch it. Recreating as the save's final act reproduces
+    # exactly that interleaving deterministically.
+    async def _persist_then_recreate(*_a, **_kw) -> None:
+        state.get_or_create_slot(NAME)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist_then_recreate)
+    state.sessions.remove = _remove  # type: ignore[assignment]
+
+    resp = await handlers.api_chat_slot_delete(_Req(state, NAME))
+
+    assert resp.status == 200
+    replacement = state._slots.get(NAME)
+    assert replacement is not None and replacement is not original, "replacement lost"
+    assert removed_keys == [], "sessions.remove tore down the live replacement's session"
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_arm_does_not_clobber_replacement(tmp_path, monkeypatch) -> None:
+    """(c) A persist that raises WHILE a replacement owns the key must not restore.
+
+    The failure arm's ``state._slots[name] = slot`` would overwrite the live
+    replacement with the failed original; the guard must leave the replacement.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots[NAME]
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(*_a, **_kw) -> None:
+        entered.set()
+        await release.wait()
+        raise RuntimeError("disk wedged")
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    # The close still fails (its own persist raised), but the restore must NOT
+    # have clobbered the live replacement.
+    assert resp.status == 500
+    assert state._slots.get(NAME) is replacement, "the failure arm clobbered the replacement"
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_arm_skips_both_compensations_when_restore_skipped(
+    tmp_path, monkeypatch
+) -> None:
+    """(c2) A skipped restore skips BOTH compensations owed to the original.
+
+    The failed close owes the ORIGINAL two rollbacks, and both are conditional on
+    the original getting its key back:
+
+    - the retired auto-nudge loop goes through
+      ``_restore_slot_nudge_loop(retired_loop, lambda: state.get_slot(name) is
+      slot)``. With a replacement on ``name`` that admission check is False, so
+      ``AutoNudgeService._add_unserialized`` raises ``NudgeAdmissionRefused`` and
+      ``_restore_slot_nudge_loop`` swallows it — the loop stays retired.
+    - app-notify-undo (``notify_slot_close_undone``) is coupled to the ``_slots``
+      restore for the same reason. Resuming a crew re-arms an autonomous worker
+      whose ``slot_key`` its watchdog resolves with a bare
+      ``state.get_slot(slot_key)`` and no ownership test, so it would hand the
+      auto-approve grant — and then an unbounded nudge clock — to the user-owned
+      replacement now holding that key. The original is popped, cancelled and not
+      coming back, so the dismissal stands; the crew keeps its ``paused_reason``
+      row, which is the same state the pre-save guard leaves.
+
+    Gating on ``slot._app`` alone is what makes that escalation reachable, so this
+    pins the coupling in both directions: the undo must NOT fire here, and
+    ``test_delete_failure_arm_undoes_the_app_close_when_the_slot_is_restored``
+    pins that it still does on the ordinary restore.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots[NAME]
+    original._app = "issue-radar"
+
+    svc = AutoNudgeService(base_dir=tmp_path)
+    monkeypatch.setattr(autonudge, "_INSTANCE", svc)
+    await svc.add(NAME, "check the PR", idle_secs=300, max_cycles=24)
+
+    undone: list[str] = []
+
+    async def _told(_app: str, _slot_key: str) -> bool:
+        return True
+
+    async def _undo(_app: str, slot_key: str) -> bool:
+        undone.append(slot_key)
+        return True
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(*_a, **_kw) -> None:
+        entered.set()
+        await release.wait()
+        raise RuntimeError("disk wedged")
+
+    monkeypatch.setattr("kiro_crew.apps.teardown.notify_slot_closed", _told)
+    monkeypatch.setattr("kiro_crew.apps.teardown.notify_slot_close_undone", _undo)
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 500
+    # The _slots restore was skipped: the live replacement is untouched.
+    assert state._slots.get(NAME) is replacement, "the failure arm clobbered the replacement"
+    # The app-notify-undo was NOT taken back: resuming the crew would target the
+    # replacement's key, and its watchdog grants trust to whatever slot it finds.
+    assert undone == [], "the dismissed app worker was resumed onto the replacement's key"
+    # The nudge-loop restore is correctly REFUSED: its admission check
+    # (state.get_slot(name) is slot) is False while a replacement owns the key,
+    # so _add_unserialized raises NudgeAdmissionRefused and the loop stays retired.
+    assert (
+        svc.get_by_slot(NAME) is None
+    ), "the retired loop was revived onto a key the original no longer owns"
+    svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_arm_undoes_the_app_close_when_the_slot_is_restored(
+    tmp_path, monkeypatch
+) -> None:
+    """(c3) The other half of the coupling: a restored tab DOES resume its worker.
+
+    With no recreate the failed close puts the original back in ``_slots``, so the
+    dismissal genuinely did not happen and the durably-committed pause must be
+    taken back — otherwise the user gets an error AND a silently stopped worker.
+    Without this the coupling in (c2) could be satisfied by never undoing at all.
+    """
+    state = _state_with_slot(tmp_path)
+    original = state._slots[NAME]
+    original._app = "issue-radar"
+
+    undone: list[str] = []
+
+    async def _told(_app: str, _slot_key: str) -> bool:
+        return True
+
+    async def _undo(_app: str, slot_key: str) -> bool:
+        undone.append(slot_key)
+        return True
+
+    async def _persist(*_a, **_kw) -> None:
+        raise RuntimeError("disk wedged")
+
+    monkeypatch.setattr("kiro_crew.apps.teardown.notify_slot_closed", _told)
+    monkeypatch.setattr("kiro_crew.apps.teardown.notify_slot_close_undone", _undo)
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    resp = await handlers.api_chat_slot_delete(_Req(state, NAME))
+
+    assert resp.status == 500
+    assert state._slots.get(NAME) is original, "the failed close did not restore the slot"
+    assert undone == [NAME], "a restored tab left its app worker paused"
+
+
+@pytest.mark.asyncio
+async def test_delete_ordinary_close_still_saves_and_removes(tmp_path, monkeypatch) -> None:
+    """(f) With NO recreate, the guard is inert: pop, save closed=True, remove.
+
+    Proves the guard does not change the common path.
+    """
+    state = _state_with_slot(tmp_path)
+
+    saved_closed: list[bool] = []
+    removed_keys: list[str] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> None:
+        saved_closed.append(bool(kw.get("closed")))
+
+    async def _remove(key) -> None:
+        removed_keys.append(key)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+    state.sessions.remove = _remove  # type: ignore[assignment]
+
+    resp = await handlers.api_chat_slot_delete(_Req(state, NAME))
+
+    assert resp.status == 200
+    assert NAME not in state._slots, "ordinary close did not remove the slot"
+    assert saved_closed == [True], "ordinary close did not persist closed=True"
+    assert removed_keys == [f"dashboard:{NAME}"], "ordinary close did not tear down the session"
+
+
+# --------------------------------------------------------------------------- #
+# api_chat_slots_cleanup (bulk archive)
+# --------------------------------------------------------------------------- #
+
+
+def _make_stale(state, name: str = NAME):
+    """Age the slot's last activity past the 3-day cleanup cutoff."""
+    slot = state._slots[name]
+    slot.created_at = "2000-01-01T00:00:00+00:00"
+    for m in slot.messages:
+        m["ts"] = "2000-01-01T00:00:00+00:00"
+    return slot
+
+
+@pytest.mark.asyncio
+async def test_cleanup_recreate_during_save_preserves_replacement(tmp_path, monkeypatch) -> None:
+    """(d) The bulk path: a recreate inside the archive save must survive.
+
+    The replacement must not be archived-over, must remain in ``_slots``, and its
+    session must not be removed.
+    """
+    state = _state_with_slot(tmp_path)
+    original = _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(*_a, **_kw) -> None:
+        entered.set()
+        await release.wait()
+
+    removed_keys: list[str] = []
+
+    async def _remove(key) -> None:
+        removed_keys.append(key)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+    state.sessions.remove = _remove  # type: ignore[assignment]
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()  # parked inside the archive save for NAME
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert NAME not in payload["keys"], "a live replacement was reported archived-over"
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by cleanup"
+    assert removed_keys == [], "cleanup tore down the live replacement's session"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_recreate_during_task_cancel_hits_first_guard(tmp_path, monkeypatch) -> None:
+    """(d2) Bulk path: a recreate in the task-cancel await hits the FIRST guard.
+
+    The stale slot has a live turn, so the per-iteration cancel block awaits
+    ``asyncio.wait_for(asyncio.shield(removed.task), 2.0)``. A recreate minted in
+    THAT await lands before the flush+save, so the first ``_slot_still_ours``
+    check takes the early ``continue`` — the flush and closed=True save never run
+    for the original, ``sessions.remove`` is never called, and NAME is NOT
+    appended to the archived ``keys`` (a live replacement must never be reported
+    archived-over). Reverting only the first guard would let the pass flush, save
+    onto the replacement's key, remove its session, and report it archived.
+    """
+    state = _state_with_slot(tmp_path)
+    original = _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+    assert original.running, "the turn must be live so the cancel-wait actually blocks"
+
+    saved: list[tuple[bool, bool]] = []
+    removed_keys: list[str] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> bool:
+        saved.append((bool(kw.get("closed")), bool(kw.get("rows_only"))))
+        return True
+
+    async def _remove(key) -> None:
+        removed_keys.append(key)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+    state.sessions.remove = _remove  # type: ignore[assignment]
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()  # parked in the shielded task-cancel wait for NAME
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert NAME not in payload["keys"], "a live replacement was reported archived-over"
+    assert state._slots.get(NAME) is replacement, "the first guard did not preserve the replacement"
+    # The guard stops the ARCHIVE, not the write: the hand-over drain still saves the
+    # original's own window, so its tail is not lost. Exactly one write, and it is
+    # the shape the hand-over is allowed — closed=False, so nothing stamps the
+    # archive flag on a key a live replacement holds, and rows_only, so it claims
+    # the rows without rebuilding a metadata line the replacement owns.
+    assert saved == [(False, True)], "the hand-over write was not the rows-only open save"
+    assert removed_keys == [], "sessions.remove ran past the first guard on the replacement's key"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_arm_does_not_clobber_replacement(tmp_path, monkeypatch) -> None:
+    """(e) Bulk failure arm: a persist that raises while a replacement owns the key.
+
+    ``state._slots[name] = removed`` must not overwrite the live replacement.
+    """
+    state = _state_with_slot(tmp_path)
+    original = _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(*_a, **_kw) -> None:
+        entered.set()
+        await release.wait()
+        raise RuntimeError("disk wedged")
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert NAME in payload["failed"], "the failed original should be reported failed"
+    assert state._slots.get(NAME) is replacement, "the failure arm clobbered the replacement"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_ordinary_archive_still_saves_and_removes(tmp_path, monkeypatch) -> None:
+    """(g) With NO recreate, the bulk guards are inert too.
+
+    The delete-path sibling of this is (f). Both are needed: the two cleanup guards
+    are separate call sites, and an inverted predicate makes cleanup report
+    ``keys == []`` — an archive pass that silently archives nothing.
+    """
+    state = _state_with_slot(tmp_path)
+    _make_stale(state)
+
+    saved_closed: list[bool] = []
+    removed_keys: list[str] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> None:
+        saved_closed.append(bool(kw.get("closed")))
+
+    async def _remove(key) -> None:
+        removed_keys.append(key)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+    state.sessions.remove = _remove  # type: ignore[assignment]
+
+    resp = await handlers.api_chat_slots_cleanup(_Req(state, NAME))
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert payload["keys"] == [NAME], "ordinary cleanup archived nothing"
+    assert NAME not in state._slots, "ordinary cleanup did not remove the slot"
+    assert saved_closed == [True], "ordinary cleanup did not persist closed=True"
+    assert removed_keys == [f"dashboard:{NAME}"], "ordinary cleanup did not tear down the session"
+
+
+# --------------------------------------------------------------------------- #
+# the KEY-SCOPED restricted marker
+#
+# ``state._restricted_keys`` holds ``dashboard:{name}`` — a SESSION KEY, not a slot
+# identity — and ``_is_restricted_session`` tests that set BEFORE it looks at the
+# slot. So an incognito/guest original that yields its key to a persistent
+# replacement makes every memory, artifact and mcp-apps call on the replacement
+# answer 403 unless the marker is re-derived from the new owner. Each exit that
+# yields the key is pinned below, plus the fail-CLOSED direction (a restricted
+# replacement KEEPS the marker, so a blanket discard is not a legal fix).
+# --------------------------------------------------------------------------- #
+
+RKEY = f"dashboard:{NAME}"
+
+
+def _state_with_restricted_slot(tmp_path, mode: str = "temporary"):
+    """A state whose only slot is a guest/incognito tab, so its key is marked."""
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot(NAME, memory_mode=mode)
+    slot.append("user", "off the record")
+    slot.drain()
+    assert RKEY in state._restricted_keys, "the fixture did not mark the restricted key"
+    return state
+
+
+def test_resettle_reads_the_current_owner_not_the_popped_slot(tmp_path) -> None:
+    """The postcondition, directly: marked iff the slot AT the key is restricted."""
+    state = _state_with_restricted_slot(tmp_path)
+    restricted = state._slots[NAME]
+
+    # A live restricted owner keeps (and re-asserts) the marker.
+    state._restricted_keys.discard(RKEY)
+    handlers._resettle_restricted_key(state, NAME)
+    assert RKEY in state._restricted_keys, "a restricted owner lost its marker"
+
+    # An absent key is not restricted — the ordinary post-close state.
+    state._slots.pop(NAME)
+    handlers._resettle_restricted_key(state, NAME)
+    assert RKEY not in state._restricted_keys, "a freed key kept the marker"
+
+    # A persistent owner clears it, even though the popped slot was restricted.
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not restricted and not replacement.is_restricted
+    state._restricted_keys.add(RKEY)
+    handlers._resettle_restricted_key(state, NAME)
+    assert RKEY not in state._restricted_keys, "a persistent replacement inherited the marker"
+
+
+@pytest.mark.asyncio
+async def test_delete_first_guard_hands_the_marker_to_the_replacement(
+    tmp_path, monkeypatch
+) -> None:
+    """(h) The pre-save early return must not leave the original's marker behind.
+
+    It returns before the discard that follows the save, so without the hand-over
+    the persistent replacement inherits the guest tab's 403.
+    """
+    state = _state_with_restricted_slot(tmp_path)
+    original = state._slots[NAME]
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    # Records instead of raising: the drain the hand-over exit performs also goes
+    # through ``save_slot_off_loop``, and a stub that fails EVERY write would fail
+    # that one too and turn this exit into the drain-failure case. The pin is on the
+    # shape of the writes, asserted below — exactly one, open and rows-only.
+    saved: list[tuple[bool, bool]] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> bool:
+        saved.append((bool(kw.get("closed")), bool(kw.get("rows_only"))))
+        return True
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert state._slots.get(NAME) is replacement
+    assert saved == [(False, True)], "the closed=True save ran past the first guard"
+    assert RKEY not in state._restricted_keys, "the replacement inherited the guest tab's marker"
+
+
+@pytest.mark.asyncio
+async def test_delete_first_guard_keeps_the_marker_for_a_restricted_replacement(
+    tmp_path, monkeypatch
+) -> None:
+    """(h2) Fail CLOSED: a replacement that is itself restricted KEEPS the marker.
+
+    The hand-over re-derives from the new owner; a blanket discard would open
+    memory writes on a guest replacement, which is the direction that must never
+    happen. This test is what makes the discard in (h) a re-derivation.
+    """
+    state = _state_with_restricted_slot(tmp_path)
+    original = state._slots[NAME]
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    # Records instead of raising: the drain the hand-over exit performs also goes
+    # through ``save_slot_off_loop``, and a stub that fails EVERY write would fail
+    # that one too and turn this exit into the drain-failure case. The pin is on the
+    # shape of the writes, asserted below — exactly one, open and rows-only.
+    saved: list[tuple[bool, bool]] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> bool:
+        saved.append((bool(kw.get("closed")), bool(kw.get("rows_only"))))
+        return True
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME, memory_mode="incognito")
+    assert replacement is not original and replacement.is_restricted
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert saved == [(False, True)], "the closed=True save ran past the first guard"
+    assert RKEY in state._restricted_keys, "a restricted replacement lost its own marker"
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_arm_hands_the_marker_to_the_replacement(
+    tmp_path, monkeypatch
+) -> None:
+    """(h3) The save-failure arm skips the restore, so it must settle the marker."""
+    state = _state_with_restricted_slot(tmp_path)
+    original = state._slots[NAME]
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(*_a, **_kw) -> None:
+        entered.set()
+        await release.wait()
+        raise RuntimeError("disk wedged")
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 500
+    assert state._slots.get(NAME) is replacement
+    assert RKEY not in state._restricted_keys, "the replacement inherited the guest tab's marker"
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_arm_keeps_the_marker_when_the_original_returns(
+    tmp_path, monkeypatch
+) -> None:
+    """(h4) A restored guest tab keeps its marker — the restore is not a downgrade."""
+    state = _state_with_restricted_slot(tmp_path)
+    original = state._slots[NAME]
+
+    async def _persist(*_a, **_kw) -> None:
+        raise RuntimeError("disk wedged")
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    resp = await handlers.api_chat_slot_delete(_Req(state, NAME))
+
+    assert resp.status == 500
+    assert state._slots.get(NAME) is original
+    assert RKEY in state._restricted_keys, "a restored guest tab lost its marker"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_first_guard_hands_the_marker_to_the_replacement(
+    tmp_path, monkeypatch
+) -> None:
+    """(h5) The bulk path's pre-save ``continue`` has the same duty as (h)."""
+    state = _state_with_restricted_slot(tmp_path)
+    original = _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    # Records instead of raising: the drain the hand-over exit performs also goes
+    # through ``save_slot_off_loop``, and a stub that fails EVERY write would fail
+    # that one too and turn this exit into the drain-failure case. The pin is on the
+    # shape of the writes, asserted below — exactly one, open and rows-only.
+    saved: list[tuple[bool, bool]] = []
+
+    async def _persist(_state, _slot, *_a, **kw) -> bool:
+        saved.append((bool(kw.get("closed")), bool(kw.get("rows_only"))))
+        return True
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert NAME not in payload["keys"]
+    assert payload["failed"] == [], "the hand-over drain did not commit"
+    assert saved == [(False, True)], "the closed=True save ran past the first guard"
+    assert RKEY not in state._restricted_keys, "the replacement inherited the guest tab's marker"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_arm_hands_the_marker_to_the_replacement(
+    tmp_path, monkeypatch
+) -> None:
+    """(h6) The bulk failure arm skips the restore, so it must settle the marker."""
+    state = _state_with_restricted_slot(tmp_path)
+    original = _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(*_a, **_kw) -> None:
+        entered.set()
+        await release.wait()
+        raise RuntimeError("disk wedged")
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert NAME in _json(resp)["failed"]
+    assert state._slots.get(NAME) is replacement
+    assert RKEY not in state._restricted_keys, "the replacement inherited the guest tab's marker"
+
+
+def _json(resp) -> dict:
+    """Decode an aiohttp json_response body to a dict."""
+    import json
+
+    return json.loads(resp.body)
+
+
+# --------------------------------------------------------------------------- #
+# what the hand-over must NOT cost: the original's unpersisted tail
+# --------------------------------------------------------------------------- #
+#
+# Yielding the key preserves the replacement, and the object it yields from is the
+# only reference to whatever the original never committed: the periodic flush walks
+# ``state._slots``, so a popped, unreferenced slot has no retry path at all. These
+# drive the REAL ``save_slot_off_loop`` against a real ``ConversationLog`` and pin
+# BOTH halves at once — the replacement survives AND every row survives — because
+# either alone is satisfiable by a change that breaks the other: skipping the write
+# loses the tail, and doing the original write takes the replacement down with it.
+
+
+HKEY = f"dashboard:{NAME}"
+
+
+def _disk_contents(state) -> list[str]:
+    """The transcript's message contents, in file order, read back from disk."""
+    return [m.get("content", "") for m in state.conversation_log.read_messages(HKEY)]
+
+
+async def _slot_with_committed_and_uncommitted_rows(state, name: str = NAME):
+    """A slot with two rows on disk and two rows that have never been written.
+
+    ``_disk_window_len`` is what the last committed save covered, so this is the
+    shape that makes "the tail was lost" observable: a hand-over that writes
+    nothing leaves the file holding only the first two.
+    """
+    slot = state.get_or_create_slot(name)
+    slot.append("user", "PERSISTED-1")
+    slot.append("assistant", "PERSISTED-2")
+    slot.drain()
+    assert await handlers.save_slot_off_loop(state, slot, best_effort=False)
+    assert slot._disk_window_len == 2, "the seed save did not commit the first window"
+    slot.append("user", "TAIL-3")
+    slot.append("assistant", "TAIL-4")
+    slot.drain()
+    return slot
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_persists_the_tail_and_keeps_the_replacement(tmp_path) -> None:
+    """The pre-save hand-over exit must cost neither the replacement nor the tail.
+
+    This exit needs no store failure to reach: it returns BEFORE the save is
+    attempted, in a window that opens while a turn is in flight — so the rows at
+    risk are typically the reply the user was watching. The drain writes the same
+    window the close was about to write, with ``closed=False``, which is the one
+    difference that matters: the transcript gains the rows and does NOT gain the
+    archive flag on a key a live replacement holds.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+    assert original.running, "the turn must be live so the cancel-wait actually blocks"
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    # Half one: #7191 stays fixed.
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by the close"
+    assert state.sessions.remove.await_count == 0, "the replacement's session was torn down"
+    # Half two: nothing the original held was dropped on the way out.
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ], "the handed-over slot's unpersisted rows were lost"
+    assert not state.conversation_log.get_metadata(HKEY).get(
+        "closed"
+    ), "a key a live replacement holds was stamped closed"
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_writes_a_linked_slot_own_transcript(tmp_path) -> None:
+    """The drain must authorize the slot's OWN transcript, never a derived one.
+
+    A cron-, channel- or workflow-injected tab carries a ``linked_session_key``, and
+    that key — not ``dashboard:{name}`` — is where its conversation lives.
+    ``_save_slot_to_history`` resolves its write target through
+    ``slot_history_key(slot)`` and REFUSES the whole save when the caller's
+    ``expected_history_key`` names a different transcript, so a derived pin makes the
+    drain write nothing at all for exactly the slots whose transcript is shared with
+    something outside the dashboard — and names a row-less file in the report.
+
+    The recreate here is bound to the SAME linked key, which is what a cron
+    re-injecting the same job's tab produces. That is what puts both slots on one
+    transcript and so makes this the hand-over case at all; an UNBOUND recreate over
+    the same tab shares nothing and is
+    ``test_delete_divergent_transcript_still_archives_the_original``.
+    """
+    state = _make_state(tmp_path)
+    linked = "cron:job7"
+    original = state.get_or_create_slot(NAME, linked_session_key=linked)
+    original.append("user", "PERSISTED-1")
+    original.drain()
+    assert await handlers.save_slot_off_loop(state, original, best_effort=False)
+    assert original._disk_window_len == 1, "the seed save did not commit the first window"
+    original.append("assistant", "TAIL-2")
+    original.drain()
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME, linked_session_key=linked)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by the close"
+    assert [m.get("content", "") for m in state.conversation_log.read_messages(linked)] == [
+        "PERSISTED-1",
+        "TAIL-2",
+    ], "the linked slot's tail never reached its own transcript"
+    assert not state.conversation_log.get_metadata(linked).get("closed")
+    assert _disk_contents(state) == [], "rows landed on a transcript this slot never used"
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_write_failure_fails_the_close_and_names_the_rows(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    """A store that cannot take the tail owes the caller an error AND a row count.
+
+    The drain is the only path to durability on this exit, so when it fails the loss
+    is unrecoverable — and then the two things left that matter are that the caller
+    is not told the close succeeded, and that the loss is not silent. Returning 200
+    would claim durability this close does not have, with nothing left to retry it;
+    the ``history_save_failed`` code is the same one an ordinary failed archive
+    raises, because from the caller's side it is one thing. The count is derived the
+    way the drain derives it (``len(messages) - _disk_window_len``), so the log line
+    names the rows rather than just the slot.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    async def _persist(*_a, **_kw) -> bool:
+        raise OSError("disk wedged")
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+    caplog.set_level(logging.ERROR, logger=handlers.__name__)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    release.set()
+    resp = await close
+
+    assert resp.status == 500, "a lost hand-over tail was reported as a successful close"
+    assert _json(resp)["code"] == "history_save_failed"
+    # The replacement is still untouched: reporting the loss is not a licence to
+    # undo the hand-over, because there is no tab to put back.
+    assert state._slots.get(NAME) is replacement
+    assert state.sessions.remove.await_count == 0, "the replacement's session was torn down"
+    assert any(
+        "2 unpersisted row(s) could not be written" in record.getMessage()
+        for record in caplog.records
+    ), "an unrecoverable hand-over loss was not reported"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_handover_write_failure_is_reported_failed(tmp_path, monkeypatch) -> None:
+    """The bulk path owes the same report, in the column it has for it.
+
+    ``failed`` is the honest answer: the key is absent from ``keys`` either way, so
+    without this a pass that dropped a slot's tail is indistinguishable from a pass
+    that found nothing to do.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    async def _persist(*_a, **_kw) -> bool:
+        raise OSError("disk wedged")
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    release.set()
+    resp = await close
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert payload["failed"] == [NAME], "a dropped hand-over tail was reported as a clean pass"
+    assert NAME not in payload["keys"], "a live replacement was reported archived-over"
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by cleanup"
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_arm_handover_persists_the_tail(tmp_path, monkeypatch) -> None:
+    """The failure arm's "restore so data isn't lost" must hold for a hand-over too.
+
+    When the key went to a replacement the restore is skipped, and skipping it is
+    correct — but the reason the restore existed does not go away with it. The
+    original is unreferenced from that point, so the arm has to get its rows onto
+    the shared transcript itself. The seeded failure is the closed=True save only:
+    a real store that rejected one write can still take the next, and a lock lost
+    to the recreate is exactly that case.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+
+    real_save = handlers.save_slot_off_loop
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(_state, _slot, *a, **kw):
+        if kw.get("closed"):
+            # Park so the recreate lands INSIDE the archive save, then fail it.
+            entered.set()
+            await release.wait()
+            raise OSError("disk wedged")
+        return await real_save(_state, _slot, *a, **kw)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    # The close still reports its own failure; what must not happen is losing
+    # either the replacement or the rows.
+    assert resp.status == 500
+    assert state._slots.get(NAME) is replacement, "the failure arm clobbered the replacement"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ], "the failure arm dropped the handed-over slot's unpersisted rows"
+    assert not state.conversation_log.get_metadata(HKEY).get("closed")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_handover_persists_the_tail_and_the_held_notes(tmp_path) -> None:
+    """The bulk path's hand-over owes the tail AND the notes it is still holding.
+
+    ``_deferred_notes`` is in-memory only, and this exit is upstream of the
+    ``flush_deferred_notes()`` the ordinary archive runs — so the popped object is
+    the sole copy of a held note. The drain flushes them into the window first,
+    which is what makes the note durable instead of merely counted.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    original._deferred_notes.append(
+        {"content": "HELD-NOTE", "cls": "msg msg-note", "session": HKEY}
+    )
+    _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+    assert original.running, "the turn must be live so the cancel-wait actually blocks"
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert NAME not in payload["keys"], "a live replacement was reported archived-over"
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by cleanup"
+    assert state.sessions.remove.await_count == 0, "the replacement's session was torn down"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+        "HELD-NOTE",
+    ], "cleanup's hand-over dropped the original's unpersisted rows or its held note"
+    assert not state.conversation_log.get_metadata(HKEY).get("closed")
+    assert not original._deferred_notes, "the held note was left in memory on a dropped slot"
+
+
+# --------------------------------------------------------------------------- #
+# what the hand-over must NOT cost: the replacement's own metadata
+# --------------------------------------------------------------------------- #
+#
+# The rows and the metadata line have different owners on a shared transcript.
+# ``_save_slot_to_history`` is otherwise authoritative for SLOT_OWNED_META_KEYS and
+# REBUILDS that line from whichever slot it is handed, so a default save here would
+# revert a title, folder, tag set or pin the REPLACEMENT already published — and for
+# a tab nobody types in again, revert it for good, so the next restart resurrects the
+# dismissed tab's name and filing. The drain therefore writes ``rows_only``: it moves
+# the rows and keeps the on-disk value for every slot-owned field, retaining only the
+# close flags so the open-shaped erase still happens.
+#
+# The deferral is wider than the owned set, because the rebuild also writes fields
+# that DESCRIBE an owned one without being owned themselves. A title's provenance and
+# refresh budget travel WITH the title, so deferring the title while keeping those
+# commits a line matching neither slot — separately valid halves, undetectable
+# downstream — which is why the pairing is asserted below and not just the title.
+
+
+async def _publish_metadata(
+    state, slot, *, title: str, folder: str, origin: str = "auto", refresh_mark: int = 0
+) -> None:
+    """Commit ``slot``'s title and folder the way every metadata route does.
+
+    A forced save is what the tag / folder / pin / recreate-PATCH routes use, and
+    for a message-less slot it is the empty-window ``update_metadata_if`` merge —
+    the exact shape a replacement born from ``POST /api/chat/slots`` with a folder
+    or a pinned title takes.
+
+    ``origin`` sets the title's provenance the way the titling paths do — ``"auto"``
+    for a generated name, ``"user"`` for a manual rename — and ``refresh_mark`` the
+    background-refresh budget already spent, because the save persists BOTH
+    alongside the title. A pairing test that left these at their defaults would read
+    a consistent line no matter which slot each half came from.
+    """
+    slot.title = title
+    slot.folder_id = folder
+    slot._titled = True
+    slot._title_origin = origin
+    slot._title_refresh_mark = refresh_mark
+    assert await handlers.save_slot_off_loop(state, slot, force=True, best_effort=False)
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_keeps_the_replacement_published_metadata(tmp_path) -> None:
+    """A newborn replacement's published title and folder survive the drain.
+
+    The replacement here has no window of its own, which is the shape that
+    publishes at birth. Its line is on disk and nothing else will rewrite it until
+    the tab is used, so a rebuilding drain would leave the transcript filed and
+    named as the tab the user dismissed for as long as the replacement stays idle.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(
+        state,
+        original,
+        title="ORIGINAL TITLE",
+        folder="folder-original",
+        origin="auto",
+        refresh_mark=8,
+    )
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    await _publish_metadata(
+        state,
+        replacement,
+        title="REPLACEMENT TITLE",
+        folder="folder-replacement",
+        origin="user",
+        refresh_mark=24,
+    )
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by the close"
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "REPLACEMENT TITLE", "the drain reverted the replacement's title"
+    assert (
+        meta.get("folder_id") == "folder-replacement"
+    ), "the drain re-filed the transcript under the closed tab's folder"
+    # The provenance travels WITH the title. Committing the replacement's name beside
+    # the original's origin is a worse line than either slot's own: read back as
+    # "auto" it unlocks the background refresh on a name the user typed, and read
+    # back as "user" it locks a generated name out of refresh for good.
+    assert (
+        meta.get("title_origin") == "user"
+    ), "the drain kept the closed tab's title provenance beside the replacement's title"
+    # The spent-budget mark travels with the title too: rewinding it to the closed
+    # tab's would hand the replacement's title a refresh milestone it already spent.
+    assert (
+        meta.get("title_refresh_mark") == 24
+    ), "the drain rewound the replacement's spent refresh budget to the closed tab's"
+    # The close flags stay owned by the write, so the open-shaped erase still runs.
+    assert not meta.get("closed")
+    # ...and none of that cost the rows the drain existed for.
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ], "the rows-only write dropped the handed-over slot's rows"
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_keeps_the_original_metadata_when_nobody_replaced_it(
+    tmp_path,
+) -> None:
+    """Deferring to disk must not become erasing: a blank replacement inherits.
+
+    A recreate that has published nothing has no metadata to protect, and the line
+    on disk is the ORIGINAL's own — a real title and filing for the conversation
+    both slots now share. Re-deriving the line from the blank replacement would
+    clear them, which is the opposite failure and just as silent. Writing rows
+    while leaving the line alone is what gets both cases right at once.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(state, original, title="ORIGINAL TITLE", folder="folder-original")
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    assert not replacement.folder_id, "the replacement must be blank for this case"
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "ORIGINAL TITLE", "a blank replacement erased the shared title"
+    assert meta.get("folder_id") == "folder-original", "a blank replacement unfiled the transcript"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+def _leave_an_acknowledged_edit(slot, *, title: str, folder: str) -> None:
+    """Apply a metadata edit the way every mutation route leaves it: in memory only.
+
+    ``PATCH .../color``, the tag and pin routes and the auto-titler all mutate the
+    slot, mark it ``_dirty`` and answer the caller; the durable write is the next
+    periodic flush's. That flush iterates ``state._slots``, so this shape is exactly
+    what a pop makes unreachable — the user has been told the rename landed and the
+    only object that knows it is about to be dropped.
+    """
+    slot.title = title
+    slot._titled = True
+    slot.folder_id = folder
+    slot.pinned = True
+    slot._dirty = True
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_persists_the_original_uncommitted_metadata(tmp_path) -> None:
+    """Deferring to disk must not become discarding the drain's own pending edit.
+
+    The line on disk here is the ORIGINAL's own, so there is nobody else's state on
+    it to protect, and the edit the original is carrying has no other route to disk:
+    the periodic flush walks ``state._slots`` and this slot is out of it for good.
+    Deferring to disk on that line would answer 200 while silently discarding a
+    rename, re-file and pin the user watched land.
+
+    Metadata-only on purpose — the publish above commits the window, so ``_dirty``
+    is the sole reason the drain runs at all. That keeps this test about the
+    metadata half rather than riding on the row half's write.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(state, original, title="ORIGINAL TITLE", folder="folder-original")
+    assert original._disk_window_len == len(original.messages), "the publish left rows uncommitted"
+    _leave_an_acknowledged_edit(original, title="RENAMED BY HAND", folder="folder-renamed")
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    assert not replacement._titled, "the replacement must have published nothing for this case"
+    assert not replacement.folder_id
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "RENAMED BY HAND", "the drain discarded an acknowledged rename"
+    assert meta.get("folder_id") == "folder-renamed", "the drain discarded an acknowledged re-file"
+    assert meta.get("pinned") is True, "the drain discarded an acknowledged pin"
+    # Still an open-shaped write: the key has a live holder.
+    assert not meta.get("closed")
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_prefers_the_replacement_line_over_its_own_pending_edit(
+    tmp_path,
+) -> None:
+    """The polarity: a line ANOTHER slot published still outranks the drain's edit.
+
+    The two losses are not symmetric, so the tie is not broken in the drain's
+    favour. The original's edit was never committed; the replacement's WAS, and for
+    a tab nobody types in again nothing rewrites it — so rebuilding here would
+    revert a published title and filing for good, while deferring costs an
+    uncommitted one. Pinned beside the test above because a fix that simply stopped
+    deferring would satisfy that one and silently undo the restraint.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(state, original, title="ORIGINAL TITLE", folder="folder-original")
+    _leave_an_acknowledged_edit(original, title="RENAMED BY HAND", folder="folder-renamed")
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    await _publish_metadata(
+        state, replacement, title="REPLACEMENT TITLE", folder="folder-replacement"
+    )
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "REPLACEMENT TITLE", "the drain reverted a published title"
+    assert meta.get("folder_id") == "folder-replacement", "the drain re-filed a live transcript"
+    assert not meta.get("pinned"), "the drain pinned a live tab from the dismissed one's edit"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_keeps_the_replacement_authorization_attribution(
+    tmp_path,
+) -> None:
+    """The drain must not re-attribute a live holder's session to the dismissed tab.
+
+    ``created_by`` and ``origin`` are not facts about the conversation, they are
+    attributes of the SLOT, and each is meaningless apart from a field the drain
+    already defers: session-control's member ownership boundary reads ``created_by``
+    beside ``mode``, and ``origin`` decides ``slots:user`` visibility and the
+    unattended approval window beside ``app``. Carrying the original's forward would
+    commit a line naming an owner who never opened this session and a slot kind its
+    holder never had — and for a replacement nobody types in again, no later save
+    corrects it, so the next restart hands that pairing to the authorization checks.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    original.mode = members_mod.DM_SLOT_MODE
+    original._created_by = "member-alice"
+    original._origin = SlotOrigin.CRON
+    await _publish_metadata(state, original, title="ORIGINAL TITLE", folder="folder-original")
+    assert state.conversation_log.get_metadata(HKEY).get("created_by") == "member-alice"
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    replacement._created_by = "member-bob"
+    replacement._origin = SlotOrigin.USER
+    await _publish_metadata(
+        state, replacement, title="REPLACEMENT TITLE", folder="folder-replacement"
+    )
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert (
+        meta.get("created_by") == "member-bob"
+    ), "the drain re-attributed a live session to the dismissed tab's creator"
+    assert (
+        meta.get("origin") == SlotOrigin.USER
+    ), "the drain gave a live session the dismissed tab's slot kind"
+    # The field each describes is deferred, so the pair has to agree: a member
+    # ``mode`` beside the wrong ``created_by`` is the line matching neither slot.
+    assert meta.get("mode") != members_mod.DM_SLOT_MODE
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rows_only_defers_by_the_line_tab_id_not_by_the_flag_alone(tmp_path) -> None:
+    """``rows_only`` is scoped at the save, by the one per-writer mark the line has.
+
+    ``tab_id`` is minted per slot OBJECT and stamped by every save, so it is what
+    separates "this line is somebody else's" from "this line is mine". Driven
+    directly rather than through a race so the discriminator is the only variable:
+    the same call, the same slot and the same flag, answered two ways by the id on
+    the line. It is itself deferred, so a deferring write leaves the other writer's
+    id in place and the next drain defers again rather than flipping.
+    """
+    state = _make_state(tmp_path)
+    slot = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(state, slot, title="COMMITTED TITLE", folder="folder-committed")
+
+    # The line is this slot's own: nobody to defer to, so the pending edit commits.
+    _leave_an_acknowledged_edit(slot, title="MINE", folder="folder-mine")
+    assert await handlers.save_slot_off_loop(
+        state, slot, force=True, best_effort=False, rows_only=True
+    )
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "MINE", "a rows-only write deferred to the slot's own line"
+    assert meta.get("folder_id") == "folder-mine"
+    assert meta.get("tab_id") == slot._tab_id
+
+    # Re-stamp the line as another writer's and the identical call defers instead.
+    state.conversation_log.update_metadata(
+        HKEY, {"tab_id": "0123456789ab", "title": "THEIRS", "folder_id": "folder-theirs"}
+    )
+    _leave_an_acknowledged_edit(slot, title="MINE AGAIN", folder="folder-mine-again")
+    assert await handlers.save_slot_off_loop(
+        state, slot, force=True, best_effort=False, rows_only=True
+    )
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "THEIRS", "a rows-only write rebuilt over another writer's line"
+    assert meta.get("folder_id") == "folder-theirs"
+    assert meta.get("tab_id") == "0123456789ab", "the deferring write claimed the line's identity"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handover_rows_only_write_still_creates_a_first_metadata_line(tmp_path) -> None:
+    """With no line on disk yet there is nobody to defer to, so the slot's own wins.
+
+    ``rows_only`` protects ANOTHER writer's fields; a transcript with no metadata
+    line has none, and preserving an absent line would publish a row-bearing
+    transcript with no title, folder or memory mode at all. So the flag is ignored
+    in that case and the drain writes the original's own line — pinned because the
+    hand-over is reachable before a slot's first committed save.
+    """
+    state = _make_state(tmp_path)
+    original = state.get_or_create_slot(NAME)
+    original.title = "NEVER SAVED"
+    original.folder_id = "folder-original"
+    original.append("user", "TAIL-1")
+    original.drain()
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "NEVER SAVED", "the first line was written without the slot's state"
+    assert meta.get("folder_id") == "folder-original"
+    assert _disk_contents(state) == ["TAIL-1"]
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_rows_only_keeps_both_windows(tmp_path) -> None:
+    """A replacement that HAS a window keeps its rows, its line, and the drain's.
+
+    The two slots hold different windows over one file, so the drain re-serializes
+    the original's and the foreign-append scan carries the replacement's committed
+    rows through. Pinned alongside the metadata because a rows-only write that
+    protected the line by dropping rows would satisfy every other assertion here.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(state, original, title="ORIGINAL TITLE", folder="folder-original")
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    replacement.append("user", "REPLACEMENT-5")
+    replacement.drain()
+    await _publish_metadata(
+        state, replacement, title="REPLACEMENT TITLE", folder="folder-replacement"
+    )
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "REPLACEMENT TITLE", "the drain reverted the replacement's title"
+    assert meta.get("folder_id") == "folder-replacement"
+    # Sorted, not positional: two windows over one file interleave by ``ts``, and a
+    # position would pin a tiebreak this test is not about. Sorted still catches the
+    # two failures that matter — a dropped row and a duplicated one.
+    assert sorted(_disk_contents(state)) == sorted(
+        [
+            "PERSISTED-1",
+            "PERSISTED-2",
+            "TAIL-3",
+            "TAIL-4",
+            "REPLACEMENT-5",
+        ]
+    ), "the rows-only write dropped or duplicated a row from either window"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_handover_keeps_the_replacement_published_metadata(tmp_path) -> None:
+    """The bulk path's hand-over owes the same restraint as the single-tab close.
+
+    Both exits drain through ``_persist_handover_tail``, so ``rows_only`` rides with
+    the write rather than being restated per call site — this pins that the bulk
+    path really does inherit it.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(state, original, title="ORIGINAL TITLE", folder="folder-original")
+    _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    await _publish_metadata(
+        state, replacement, title="REPLACEMENT TITLE", folder="folder-replacement"
+    )
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    assert NAME not in _json(resp)["keys"], "a live replacement was reported archived-over"
+    assert state._slots.get(NAME) is replacement
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "REPLACEMENT TITLE", "cleanup's drain reverted the replacement"
+    assert meta.get("folder_id") == "folder-replacement"
+    assert not meta.get("closed")
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_arm_handover_keeps_the_replacement_metadata(
+    tmp_path, monkeypatch
+) -> None:
+    """The failure arm's drain carries the same restraint.
+
+    That arm reaches the drain after its archive save already failed, so the write
+    it performs is the one that would revert the replacement — and it is the arm
+    whose caller sees a 500, where a silently reverted title is the last thing
+    anyone would look for.
+    """
+    state = _make_state(tmp_path)
+    original = await _slot_with_committed_and_uncommitted_rows(state)
+    await _publish_metadata(state, original, title="ORIGINAL TITLE", folder="folder-original")
+
+    real_save = handlers.save_slot_off_loop
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _persist(_state, _slot, *a, **kw):
+        if kw.get("closed"):
+            entered.set()
+            await release.wait()
+            raise OSError("disk wedged")
+        return await real_save(_state, _slot, *a, **kw)
+
+    monkeypatch.setattr(handlers, "save_slot_off_loop", _persist)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    await _publish_metadata(
+        state, replacement, title="REPLACEMENT TITLE", folder="folder-replacement"
+    )
+    release.set()
+    resp = await close
+
+    assert resp.status == 500
+    assert state._slots.get(NAME) is replacement
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("title") == "REPLACEMENT TITLE", "the failure arm's drain reverted the title"
+    assert meta.get("folder_id") == "folder-replacement"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+async def _original_with_a_published_line_and_an_uncommitted_tail(state):
+    """The original, its metadata line on disk, and two rows that never reached it.
+
+    Ordering is the whole point: the tail is appended AFTER the last commit, so the
+    drain has both rows to write and a metadata line to decide about. Publishing
+    after the tail instead would commit it and reduce the drain to a no-op, which
+    every assertion about the line would then pass vacuously.
+    """
+    slot = state.get_or_create_slot(NAME)
+    slot.append("user", "PERSISTED-1")
+    slot.append("assistant", "PERSISTED-2")
+    slot.drain()
+    assert await handlers.save_slot_off_loop(state, slot, best_effort=False)
+    await _publish_metadata(state, slot, title="ORIGINAL TITLE", folder="folder-original")
+    slot.append("user", "TAIL-3")
+    slot.append("assistant", "TAIL-4")
+    slot.drain()
+    assert slot._disk_window_len == 2, "the tail was already committed, so no drain will run"
+    return slot
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_keeps_a_dismissal_the_replacement_committed(tmp_path) -> None:
+    """``closed`` on the replacement's line is ITS dismissal, so the drain defers it.
+
+    Open-shaped is not the same as un-closing. The drain and the replacement's own
+    close race for the transcript lock, so the dismissal can land first — and both
+    slots are popped by then, so erasing it resurfaces a tab the user put away with
+    nothing left to re-archive it. This is the mistake the resume route's
+    ``only_if_closed_before`` boundary exists to avoid one layer down, and a
+    rows-only save has no such boundary to reason with.
+    """
+    state = _make_state(tmp_path)
+    original = await _original_with_a_published_line_and_an_uncommitted_tail(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    await _publish_metadata(
+        state, replacement, title="REPLACEMENT TITLE", folder="folder-replacement"
+    )
+    # The user dismisses the REPLACEMENT while the original's drain is still owed, and
+    # its close reaches the lock first: the flag on the line is now the replacement's
+    # own, stamped at its own instant.
+    assert await handlers.save_slot_off_loop(
+        state, replacement, closed=True, closed_at=1234.0, force=True, best_effort=False
+    )
+    assert state.conversation_log.get_metadata(HKEY).get("closed") is True
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert meta.get("closed") is True, "the drain erased a dismissal the replacement committed"
+    assert meta.get("closed_at") == 1234.0, "the dismissal lost the instant it was stamped at"
+    assert meta.get("title") == "REPLACEMENT TITLE"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_handover_erases_a_stale_closed_flag_on_its_own_line(tmp_path) -> None:
+    """On a line THIS slot published, the open-shaped drain still clears ``closed``.
+
+    The deferral is scoped by the line's ``tab_id``, so a replacement that has
+    published nothing leaves the ORIGINAL's own line on disk — where there is no
+    other holder's dismissal to lose. The ordinary rebuild runs there, and a key that
+    now has a live holder reads open instead of staying archived under a tab the user
+    is looking at.
+    """
+    state = _make_state(tmp_path)
+    slot = state.get_or_create_slot(NAME)
+    slot.append("user", "PERSISTED-1")
+    slot.append("assistant", "PERSISTED-2")
+    slot.drain()
+    assert await handlers.save_slot_off_loop(state, slot, best_effort=False)
+    await _publish_metadata(state, slot, title="ORIGINAL TITLE", folder="folder-original")
+    # A prior close of this reused key left the archive flag on the original's line.
+    assert await handlers.save_slot_off_loop(
+        state, slot, closed=True, closed_at=1.0, force=True, best_effort=False
+    )
+    assert state.conversation_log.get_metadata(HKEY).get("closed") is True
+    slot.append("user", "TAIL-3")
+    slot.append("assistant", "TAIL-4")
+    slot.drain()
+    assert slot._disk_window_len == 2, "the tail was already committed, so no drain will run"
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(slot, entered, release)
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    # The replacement publishes NOTHING, so the line the drain meets is still the
+    # original's — the branch where the full ownership claim applies.
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not slot
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    meta = state.conversation_log.get_metadata(HKEY)
+    assert not meta.get("closed"), "a key with a live holder stayed stamped closed"
+    assert not meta.get("closed_at"), "closed_at outlived the flag it timestamps"
+    assert meta.get("title") == "ORIGINAL TITLE"
+    assert _disk_contents(state) == [
+        "PERSISTED-1",
+        "PERSISTED-2",
+        "TAIL-3",
+        "TAIL-4",
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# a replacement that shares NO transcript takes no archive
+# --------------------------------------------------------------------------- #
+#
+# Slot identity is not transcript ownership. A channel-, cron- or workflow-born tab
+# keeps its conversation under its ``linked_session_key``, while a replacement minted
+# by a plain ``get_or_create_slot(name)`` — the shape POST /api/chat and the
+# session_close verb take — is unbound and keeps its own under ``dashboard:{name}``.
+# Yielding the archive on that pair costs the user their dismissal: the linked
+# transcript keeps no ``closed`` flag, ``channel_slots._close_stands`` reads an absent
+# flag as "never dismissed", and the reconcile pass surfaces the tab again.
+#
+# So the archive is gated on the FILE and only the key-scoped steps yield: the save
+# runs on the original's own transcript, while the replacement keeps its slot and its
+# session.
+
+
+async def _linked_slot_with_a_tail(state, linked: str, name: str = NAME):
+    """A slot whose conversation lives on *linked*, with one row past its last save."""
+    slot = state.get_or_create_slot(name, linked_session_key=linked)
+    slot.append("user", "PERSISTED-1")
+    slot.drain()
+    assert await handlers.save_slot_off_loop(state, slot, best_effort=False)
+    assert slot._disk_window_len == 1, "the seed save did not commit the first window"
+    slot.append("assistant", "TAIL-2")
+    slot.drain()
+    return slot
+
+
+@pytest.mark.asyncio
+async def test_delete_divergent_transcript_still_archives_the_original(tmp_path) -> None:
+    """An unbound recreate over a linked tab must not carry off its archive."""
+    state = _make_state(tmp_path)
+    linked = "cron:job7"
+    original = await _linked_slot_with_a_tail(state, linked)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+    assert original.running, "the turn must be live so the cancel-wait actually blocks"
+
+    close = asyncio.create_task(handlers.api_chat_slot_delete(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    assert not replacement.linked_session_key, "the replacement must be unbound for this case"
+    release.set()
+    resp = await close
+
+    assert resp.status == 200
+    # The archive the user asked for happened, on the file only the original writes.
+    meta = state.conversation_log.get_metadata(linked)
+    assert meta.get("closed"), "the dismissed linked transcript was left open to resurface"
+    assert meta.get("closed_at"), "an archived transcript with no close instant keeps no close"
+    assert [m.get("content", "") for m in state.conversation_log.read_messages(linked)] == [
+        "PERSISTED-1",
+        "TAIL-2",
+    ], "archiving the original's own transcript dropped its tail"
+    # ...and the key-scoped steps still yielded: #7191 stays fixed.
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by the close"
+    assert state.sessions.remove.await_count == 0, "the replacement's session was torn down"
+    assert _disk_contents(state) == [], "rows landed on a transcript this slot never used"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_divergent_transcript_still_archives_the_original(tmp_path) -> None:
+    """The bulk path splits the same way: archive the file, yield the key.
+
+    ``keys`` stays key-scoped and so still omits ``NAME`` — it names slot keys, and
+    this one has a live holder — but the transcript is archived, which is what the
+    idle sweep was for.
+    """
+    state = _make_state(tmp_path)
+    linked = "cron:job7"
+    original = await _linked_slot_with_a_tail(state, linked)
+    _make_stale(state)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    _arm_running_turn(original, entered, release)
+    assert original.running, "the turn must be live so the cancel-wait actually blocks"
+
+    close = asyncio.create_task(handlers.api_chat_slots_cleanup(_Req(state, NAME)))
+    await entered.wait()
+    replacement = state.get_or_create_slot(NAME)
+    assert replacement is not original
+    release.set()
+    resp = await close
+
+    payload = _json(resp)
+    assert resp.status == 200
+    assert payload["failed"] == [], "the archive of the original's own transcript failed"
+    assert NAME not in payload["keys"], "a key with a live holder was reported swept"
+    meta = state.conversation_log.get_metadata(linked)
+    assert meta.get("closed"), "the stale linked transcript was left open to resurface"
+    assert [m.get("content", "") for m in state.conversation_log.read_messages(linked)] == [
+        "PERSISTED-1",
+        "TAIL-2",
+    ], "archiving the original's own transcript dropped its tail"
+    assert state._slots.get(NAME) is replacement, "the replacement was clobbered by cleanup"
+    assert state.sessions.remove.await_count == 0, "the replacement's session was torn down"


### PR DESCRIPTION
## Summary

Fixes #7191

This closes the post-pop teardown race in the shared dashboard slot-close sequence.

Both `api_chat_slot_delete` and `api_chat_slots_cleanup` pop `name` from `state._slots` and then run several awaits (task cancel, `save_slot_off_loop(..., closed=True)`, `sessions.remove(_history_key_for(name))`). A concurrent same-key recreate (a `POST /api/chat`, or the `session_close` MCP verb) can mint a **replacement** slot for the same key inside that window. The in-flight original then (a) writes its transcript over the replacement's shared history as `closed=True`, and (b) tears down the session the replacement now uses. The failure arms compounded this by blindly restoring the original (`state._slots[name] = slot`) over whatever now owned the key.

## Approach

Routing facts on the current base: the single-tab teardown lives in `close_slot`, shared by `api_chat_slot_delete` and session-control's `close_target`, while `api_chat_slots_cleanup` carries its own copy of the same shape; the `note_slot_closed` tombstone already fires pre-teardown but the creation path never reads it.

Chose **Option 2 (ownership re-check at teardown)** over Option 1 (consult-tombstone-at-creation): both destructive sites already hold the popped object, so a synchronous, mechanism-free discriminator is available that does not penalize a legitimate fast recreate. Option 1 would require inventing reservation semantics on the hot creation path.

There are **two** discriminators, because the destructive steps do not all answer to the same owner and one answer cannot gate resources with different owners:

- `_slot_still_ours(state, name, <popped>)` — "does a DIFFERENT object hold `name`". Governs the **key**-scoped steps: `sessions.remove(_history_key_for(name))` (the session an unbound replacement runs on), the failure-arm `_slots` restores, cleanup's `archived` report, and the app-dismissal decision coupled to the restore.
- `_replacement_shares_transcript(state, name, <popped>)` — "does that different object write MY transcript". Governs the `closed=True` save alone, whose resource is the transcript rather than the key. `_save_slot_to_history` targets `slot_history_key(slot)`, so a channel-, cron- or workflow-linked slot writes its `linked_session_key` while a replacement minted by a plain `get_or_create_slot(name)` (what `POST /api/chat` and the `session_close` verb do) is unbound and writes `dashboard:{name}`. Same key, two files. Yielding the archive on such a pair leaves the ORIGINAL's transcript with no `closed` flag, and `channel_slots._close_stands` reads an absent flag as "the user never dismissed this" — so the reconcile pass resurfaces the tab that was closed. It compares FILE identity (`transcript_stems` on both sides) rather than key strings, because `history._safe_key` folds `slack:<ts>` and the `slack_<ts>` stem onto one `.jsonl` and a pre-migration thread still resolves to its bare `thread_ts` stem; the two errors are not symmetric, since over-reporting "shared" only declines an archive the next close will make while under-reporting stamps `closed` on a file a live slot is writing.

The two paths were deliberately **not** merged further: they diverge past the shared shape (nudge retirement + app-notify in `close_slot`; `flush_deferred_notes` + batched task cancel + error-row append in cleanup). What they share is three pure helpers — the two predicates above and the `_resettle_restricted_key(state, name)` postcondition — plus the `_persist_handover_tail` drain.

The guards are applied at three points per path, each with the predicate its resource answers to:
- before the `closed=True` save — `_replacement_shares_transcript`, so the archive yields only to a replacement that actually holds the file,
- before `sessions.remove` — `_slot_still_ours`,
- around the failure-arm restore — `_slot_still_ours` (now only restores when the key is free or still the popped object).

Cleanup additionally skips `archived.append` under `_slot_still_ours`, so a key with a live holder is never reported swept — `archived` names slot keys, whatever became of the transcript.

Yielding to a replacement carries four obligations, because the state a close compensates is not all scoped the same way:

- **Key-scoped state moves with the key.** `state._restricted_keys` holds a session KEY (`dashboard:{name}`) and `_is_restricted_session` reads it before it looks at the slot, so every teardown exit now routes through one postcondition — `_resettle_restricted_key`: the key is marked iff the slot currently at it is restricted. A bare `discard` the hand-over exits skipped handed a persistent replacement an incognito original's 403; re-deriving rather than discarding keeps a restricted replacement's own marker, since dropping it is the fail-OPEN direction.
- **Slot-scoped compensation is coupled to the restore.** `notify_slot_close_undone` is now conditional on the original getting its key back, not on `slot._app` alone. With a replacement on the key there is no tab to put back, and resuming the crew would let its watchdog grant auto-approve — then an unbounded nudge clock — to the user-owned slot now holding that key.
- **The original's unpersisted content is owed to its own transcript, not to the original's slot object.** A hand-over exit stops referencing the popped slot, and `_flush_dirty_slots` iterates exactly `state._slots`, so an unreferenced slot has NO retry path: `messages[_disk_window_len:]`, plus any note the bulk path still holds in the in-memory-only `_deferred_notes`, would simply cease to exist. The pre-save exits need no store failure to reach that — they `return` before the save is attempted, in a window that opens while a turn is in flight, so the rows at risk are typically the reply the user was watching. Every hand-over exit therefore routes through `_persist_handover_tail(state, name, slot)`: it flushes held notes into the window and writes it with **`closed=False`**. Those rows belong on the ORIGINAL's transcript whether or not the replacement shares it; what must not happen is the archive stamp and the session teardown, not the write. The write target is `slot_history_key(slot)` and never a derived `dashboard:{name}` — `_save_slot_to_history` resolves its own target the same way and REFUSES a save whose `expected_history_key` names a different transcript, so the derived form would make the drain a silent no-op for every cron-, channel- or workflow-linked tab and would name a row-less file in the failure log. It is non-destructive against the replacement in both directions — `_save_slot_to_history`'s foreign-append scan carries through every on-disk line the saved window does not represent, so rows a replacement already committed survive. The METADATA line is not this slot's to move, so the write is `rows_only`: `_save_slot_to_history` is otherwise authoritative for `SLOT_OWNED_META_KEYS` and REBUILDS that line from whichever slot it is handed, so a default save here would revert a folder, pinned title, tag or pin the replacement had already published (`POST /api/chat/slots` persists both at birth) — silently undoing an acknowledged edit, and for a tab nobody types in again undoing it for good, so the next restart resurrects the dismissed tab's name and filing. `rows_only` keeps the on-disk value for each of those fields and narrows this write's ownership to `ROWS_ONLY_OWNED_META_KEYS` (the file's identity and accounting, which every writer maintains and which the rebuild reads out of the existing line anyway). The set it defers is named in full as `ROWS_ONLY_DEFERRED_META_KEYS` rather than derived as `SLOT_OWNED_META_KEYS - ROWS_ONLY_OWNED_META_KEYS`, because that difference under-approximates: the slot save also writes fields that DESCRIBE an owned one without being owned themselves, and a title's provenance and refresh budget (`title_origin`, `title_refresh_mark`) travel WITH the title rather than with the writer. Deferring the title while keeping those would commit a line matching NEITHER slot — read back beside another slot's title they either unlock the background title refresh on a name the user typed by hand or lock a generated name out of refresh permanently — so they are deferred with it, `created_by` and `origin` are the same shape with AUTHORIZATION rather than presentation behind them, so they are deferred too: `created_by` is what session-control's member ownership boundary reads and is meaningless without the `mode` deferred beside it, and `origin` must round-trip with the deferred `app` because that pair decides `slots:user` visibility and the unattended approval window. The conversation's own MONOTONE once-flags (`auto_tagged`, `human_seen`, `channel_origin`, `channel_folder_filed`) are set and never cleared, so two writers on one transcript cannot disagree about them in a way that outlives the pair; they stay as written. Deferring to disk is deliberately NOT the same as re-deriving the line from the replacement: a recreate that published nothing has no metadata to protect, and deriving from it would ERASE a real title and filing the shared conversation has — leaving the line alone is what gets both directions right with one write. The deferral is conditional on there BEING another writer to defer to, decided at the save from the line's `tab_id` — the one per-writer mark it carries, minted per slot object (`get_or_create_slot` assigns a fresh uuid, a rehydrate adopts the file's) and stamped by every save: fields are held back only on a line ANOTHER slot published, while a line this slot published itself, or no line at all, takes the ordinary rebuild. Unscoped it would cost the original its own uncommitted metadata, because a rename, re-file, tag or pin is acknowledged the instant it lands on the slot (`_dirty`) and persists on a later `_flush_dirty_slots` — which iterates `state._slots`, so no flush ever visits a popped slot again, and no failed save is needed to reach that state. Unprovable ownership defers, since the two errors cost differently: a deferred edit was never committed, while a rebuild over a live holder's line reverts what it published and nothing rewrites that for a replacement nobody types in again. `tab_id` is itself deferred, so a deferring write leaves the other writer's id in place rather than flipping the next drain's answer. `closed`/`closed_at` are deferred on that same asymmetry, so the drain is open-shaped without being un-closing. On a line the replacement published, a `closed` flag is that holder's own DISMISSAL, and the drain races its close for the transcript lock: erasing it would resurface a tab the user put away, permanently, since both slots are popped by then and nothing rewrites the flag. Leaving a stale one costs nothing durable, because the live holder owns those keys on its next full save. The only path that clears a stale flag from outside the holder is the resume route, and it clears one only when it can prove the close predates its own boundary (`clear_closed(..., only_if_closed_before=...)`, compared inside the store's lock) for exactly this reason. Clearing a stale flag is therefore the job of the `tab_id` fallback: on a line THIS slot published there is no other holder's dismissal to lose, so the ordinary rebuild runs and the open-shaped write erases it. The failure arms take the same route in place of the restore they skip: a store that rejected the `closed=True` write can still accept the next one, and a lock lost to the recreate is exactly that case. When even that write fails the loss is unrecoverable, so it is logged with the exact row count rather than left silent.
- **A drain that fails is reported, not swallowed.** `_persist_handover_tail` returns whether rows were owed and reached disk, and every caller honours it, because this frame is the last reference to those rows: nothing retries and nothing else can ever report them. Both PRE-SAVE hand-over exits therefore turn a `False` into their own path's failure — `close_slot` raises `SlotCloseError(code="history_save_failed")`, the same code an ordinary failed archive raises since from the caller's side it is one thing, and cleanup adds the key to `failed`. There is nothing to roll back on either exit (the original is popped, cancelled, and a live replacement holds the key), so the report IS the whole remedy; answering 200 there claims durability the close does not have. The two FAILURE-arm drains need no branch of their own — those arms already end in `SlotCloseError` / `failed.append(name)`, so a lost tail reaches the caller regardless.

### What this does NOT close

The guard covers the WIDE window (the app-notify awaits before the pop, the up-to-2.0s task cancel) and not the durable write: `save_slot_off_loop` reaches its commit through the process-wide default executor, so a recreate can still land between the last synchronous check and the in-lock write, leaving `closed=True` on a key a live replacement holds. That residual is what an unguarded close carries too — it is measurably identical on `main` — and the row it leaves is the one a plain sequential close-then-reopen of a reused key already produces: `closed`/`closed_at` are in `SLOT_OWNED_META_KEYS`, so the replacement's next full save drops them, and `api_chat_slot_resume` compensates a stale flag with an in-lock compare-and-clear. Closing it AT the commit needs an ownership predicate inside `_locked(history_key)` on the write AND on the resume's read-then-clear — a durable-metadata contract change across three modules, tracked as follow-up rather than folded in here. Both the code comment and `session.md` state this scope explicitly. Note the distinction from the row loss above: that residual is a stale `closed` FLAG that the replacement's next full save drops, not a lost message — the hand-over exits no longer discard content.

Also out of scope: `_remove_slot_for_history_key` in `src/kiro_crew/dashboard/handlers/sessions.py` has the same unguarded pop-then-await shape (it pops the slot key, awaits `crew.purge_slot`, pin cleanup and a 2.0s task cancel, then destroys the session) with no identity re-check. It is a permanent history DELETE rather than a close, so the recreate it would race is a different intent and the compensation differs; it is named here so the gap is on the record rather than folded into this diff.

## Files changed

- `src/kiro_crew/dashboard/chat_handlers.py`: the `_slot_still_ours` (key-scoped) and `_replacement_shares_transcript` (transcript-scoped) predicates, the `_resettle_restricted_key` postcondition, the `_persist_handover_tail` drain and the honouring of its result, and the guards at all six post-pop sites across both handlers.
- `src/kiro_crew/dashboard/chat_persistence.py`: the `rows_only` save mode — write the window, leave the metadata line's slot-owned fields as they stand on disk. Default `False`, threaded through `save_slot_off_loop`, and used by exactly one caller (the hand-over drain), so no existing save path changes shape.
- `src/kiro_crew/history.py`: `ROWS_ONLY_OWNED_META_KEYS`, the subset of `SLOT_OWNED_META_KEYS` a rows-only save still owns, and `ROWS_ONLY_DEFERRED_META_KEYS`, the set such a save must drop so the on-disk values are carried back — wider than the owned difference, because the rebuild also writes unowned fields that describe an owned one. Both defined next to the ownership vocabulary they partition.
- `docs/system-specs/modules/session.md`: documents the two post-pop predicates and which step each governs, the four obligations yielding to a replacement carries, and the residual the guards do NOT close.
- `test/test_slot_close_recreation_race.py` (new): concurrency tests driving both handlers directly with deterministic `asyncio.Event` interleaving — covering both predicates' polarity on their own, the first pre-save guard (via a parked running turn), the second guard, both failure arms, the failure-arm compensation asymmetry, the inert common path, the divergent-transcript case at both handlers (an unbound recreate over a linked tab: the original's own transcript IS archived with its tail, while the replacement keeps its slot and session), the drain-failure report at both handlers (a 500 with `history_save_failed`, a `failed` entry), five durability cases that run the REAL `save_slot_off_loop` against a real `ConversationLog` and pin BOTH halves at once (the replacement survives AND every row of the original reaches disk, unclosed — including a `linked_session_key` slot whose recreate is bound to the same key, which pins that the drain authorizes the slot's own transcript), and eleven metadata cases that pin `rows_only` from both sides (a published replacement keeps its title and folder AND its title's provenance and refresh budget, so the committed line matches one slot rather than half of each; a blank replacement does NOT erase the original's; a transcript with no line yet still gets the slot's own; a dismissal the replacement committed onto its own line survives the drain, while a stale `closed` on the ORIGINAL's own line is still erased; both windows' rows survive the write; the bulk path and the delete failure arm inherit the same restraint; the drain's OWN uncommitted rename, re-file and pin reach disk when the line is its own, with the save driven directly so the id on the line is the only variable; and a published replacement still outranks the drain's pending edit, which is the polarity guard a fix that merely stopped deferring would fail). Each destructive assertion fails if its corresponding guard is reverted, and each durability assertion fails if the drain is.

## Testing

`test/test_slot_close_recreation_race.py` drives both handlers directly (not through a client) so the concurrent recreate is scheduled deterministically inside the teardown window, via `asyncio.Event`s the monkeypatched `save_slot_off_loop` parks on. It covers each predicate's polarity on its own, the first pre-save guard (through a parked running turn), the second guard, both failure arms, the app-dismissal decision on both hand-over exits, the restricted-marker hand-over including a restricted replacement, and the inert ordinary path at both sites. Each destructive assertion fails if its corresponding guard is reverted.

Three groups pin what this round changed, and each was proved by reverting the change and watching exactly those tests red:

- **The transcript scope of the archive gate.** `test_delete_divergent_transcript_still_archives_the_original` and its cleanup sibling give the original a `linked_session_key` and let an unbound same-name recreate land in the cancel-await; they assert the linked transcript comes out `closed` WITH the original's tail, and that the replacement keeps its slot and its session. Reverting `_replacement_shares_transcript` to the key-only answer reds both with "the dismissed linked transcript was left open to resurface".
- **File identity rather than key strings.** `test_shares_transcript_compares_files_not_key_strings` pairs a bound channel slot with a `channel_origin` replacement whose stem never resolved — two key strings, one `.jsonl` — and asserts the pair reads as shared. Reverting the comparison to `slot_history_key(a) == slot_history_key(b)` reds it, which is the direction that would stamp `closed` on a file a live slot is writing.
- **The drain's result.** `test_delete_handover_write_failure_fails_the_close_and_names_the_rows` asserts the 500 and the `history_save_failed` code alongside the row-count log (and that the replacement is still untouched — reporting the loss is not a licence to undo the hand-over); `test_cleanup_handover_write_failure_is_reported_failed` asserts the `failed` entry. Dropping the two `if not drained:` branches reds both.

Three pre-existing tests moved with the behaviour rather than being loosened: the linked-slot drain test now binds its recreate to the same key (which is what a cron re-injecting the same job produces, and is what makes it a hand-over at all — the unbound pairing is the new divergent test), the drain-failure test now expects the 500 it always should have, and the three restricted-marker tests whose `save_slot_off_loop` stub raised on EVERY call now record instead, since raising also failed the drain and turned those exits into the drain-failure case. Each still pins what it pinned before: exactly one write, `closed=False` and `rows_only`.

The durability half runs the REAL `save_slot_off_loop` against a real `ConversationLog` rather than a stub, in five cases: the pre-save hand-over persists the tail and keeps the replacement; the same exit on a `linked_session_key` slot writes that slot's own transcript (and nothing onto `dashboard:{name}`); a store that cannot take the tail reports the exact row count; the delete failure arm's hand-over persists the tail; and cleanup's hand-over persists the tail plus the note it was still holding in `_deferred_notes`, leaving that list empty. Stubbing `_persist_handover_tail` to return early reds exactly those five plus the three guard assertions that changed from "no save" to "no `closed=True` save".

**The close flags' side of the deferral, proved by reverting.** `test_delete_handover_keeps_a_dismissal_the_replacement_committed` publishes the replacement's line, commits its dismissal at `closed_at=1234.0` while the original's drain is still owed, and asserts both flags survive with the instant intact; putting `closed`/`closed_at` back into `ROWS_ONLY_OWNED_META_KEYS` reds it with "the drain erased a dismissal the replacement committed". Its sibling `test_delete_handover_erases_a_stale_closed_flag_on_its_own_line` pins the other branch — the replacement publishes nothing, the drain meets the original's own line, and the erase still happens. Both assert `_disk_window_len == 2` before the close, because the earlier single test published AFTER the tail was appended, which committed the tail and reduced the drain to a no-op that satisfied every line assertion vacuously.

Local gate green: `isort`, `flake8 src/kiro_crew test`, `mypy --platform linux src/kiro_crew` (0 errors, 1,281 files), `scripts/check_black_formatting.py`, `scripts/check_subprocess_encoding.py`, `scripts/check_brand_name.py`, `scripts/check_harness_parity.py`, `scripts/docs-lint.sh`, plus every test module that touches a slot save, a metadata carry or the close flags — the 49 modules matching `save_slot_off_loop` / `_save_slot_to_history` / `carry_unowned_metadata` / `SLOT_OWNED_META_KEYS` / `clear_closed` / `update_metadata_if` (3,669 passed). `scripts/run_scoped_tests.py --surface backend` escalates this diff to the full suite, which was run once.

## Pattern harvest

Rule candidate: semgrep (new rule, `semgrep/popped-key-identity-guard.yaml`, alongside the existing `find-sentinel-truthiness.yaml` + its `semgrep-tests/` fixtures)

Pattern: within one function body, `$D.pop($K, ...)` assigned to `$V`, followed later by an identity guard on `$D.get($K) is $V` (or `$D.get($K) is not $V`). The comparison is structurally near-constant: the key was just removed, so on the ordinary path the lookup is `None` and the guard answers the opposite of what the author meant. Both directions are expressible as an ordered `pattern: | $V = $D.pop($K, ...) \n ... \n $D.get($K) is $V`, and the fix the rule should suggest is the three-way form that classifies the absent state explicitly (`current = $D.get($K); current is None or current is $V`).

Why this class and not a one-off: a post-mutation ownership re-check that fails toward "skip the work" is invisible in every direction a reviewer normally looks. This one type-checked, passed flake8/black/isort, read correctly in prose (the docstring faithfully described the wrong predicate, so prose and code agreed), and returned HTTP 200 on the broken path — the only observable was a leaked kiro-cli session per tab close, an unwritten transcript, and `archived=0` from bulk cleanup. It is the same shape as the repo's own `is_kiro_cli` fail-OPEN lesson in AGENTS.md (§ Harness parity) generalized off the harness axis: a guard whose default answer is the permissive one goes unnoticed until someone pays for it.

Secondary rule candidate: AUTOSDE.yaml `recurring-defect-patterns` — add a bullet for the reviewer-judgment half that semgrep cannot see. "A diff that answers the SAME ownership/liveness question with two DIFFERENT predicates is self-contradicting; one of them is wrong. Flag the disagreement, do not guess which side is intended." This PR contained both spellings: the shared `_slot_still_ours` used `get(name) is slot`, while the two failure arms it was written to serve hand-rolled `current is None or current is slot` inline. The correct answer was already present in the diff, four lines away from the defect, in the author's own hand — which is a mechanically detectable signal and stronger evidence than any single site read alone. This slots naturally next to the existing "docstring that CONTRADICTS the code below it" bullet, as the code-vs-code variant of it.

Not generalizable (the second half): the accompanying `mypy` failure — a `return web.json_response(...)` left inside `close_slot(...) -> None` — is not a defect class, it is an unrun gate. The change was authored against a base where that teardown was still inline in `api_chat_slot_delete`, and the sandbox had no `pytest-asyncio`, so the PR shipped on static checks with its own nine new tests never executed; seven of them fail or hang against the code as written. No lint rule retires that. The existing `python3 scripts/check_black_formatting.py && ... && mypy && python -m pytest` gate in AGENTS.md already covers it, and CI caught both within minutes.







