### PR TITLE
fix(taskrunner): keep a run's lessons across a gateway restart

### DIFF
--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1882,6 +1882,15 @@ class TaskRunner:
                         "repo_root": run.repo_root,
                         "git_enabled": run.git_enabled,
                         "commit_hashes": run.commit_hashes,
+                        # Produced once by `_extract_lesson` during the run and
+                        # NOT recomputable: the lesson text is separately
+                        # durable in the lesson store, but that corpus is
+                        # global and keyed by category, so this per-run
+                        # attribution exists only here. Two consumers read it
+                        # after a restart -- the status payload
+                        # (task_reporter.build_status) and the to-chat
+                        # continuation prompt.
+                        "lessons_learned": run.lessons_learned,
                         "original_input": run.original_input,
                         "source": run.source,
                         "spec_content": run.spec_content,
@@ -2039,6 +2048,7 @@ class TaskRunner:
                     # no longer identified.
                     git_enabled=bool(item.get("git_enabled", bool(_worktree_path))),
                     commit_hashes=list(item.get("commit_hashes", [])),
+                    lessons_learned=list(item.get("lessons_learned", [])),
                     original_input=item.get("original_input", ""),
                     source=item.get("source", ""),
                     tasks=tasks,

--- a/test/test_taskrunner_atomic_persistence.py
+++ b/test/test_taskrunner_atomic_persistence.py
@@ -176,6 +176,93 @@ class TestGitWorkspaceIdentitySurvivesRestart:
         assert reloaded._runs["g2"].git_enabled is False
 
 
+class TestLessonsLearnedSurvivesRestart:
+    """`lessons_learned` is produced once and cannot be recomputed.
+
+    ``_extract_lesson`` appends a rule to ``run.lessons_learned`` after an LLM
+    call, once per lesson-yielding step, during execution. Nothing rebuilds it
+    on load: the lesson TEXT is separately durable in the lesson/vector store,
+    but that store is a global corpus keyed by category, so the per-run
+    attribution is the part that only ``runs.json`` holds.
+
+    Two consumers read it after a restart -- the dashboard status payload
+    (``task_reporter.build_status``, which ``handlers/taskrunner.py`` then
+    redacts element-wise) and the to-chat continuation prompt's "Lessons
+    Learned" section (``handlers/taskrunner.py:473``). Both go silently empty
+    for every run that outlived a gateway restart.
+    """
+
+    def _lessons_run(self, task_id: str = "l1") -> TaskRun:
+        run = _make_run(task_id)
+        run.lessons_learned = [
+            "Run the migration before seeding fixtures",
+            "The flake was a shared tmp dir, not a race",
+        ]
+        return run
+
+    def test_lessons_learned_round_trips(self, tmp_path: Path) -> None:
+        runner = _make_runner(tmp_path)
+        runner._runs["l1"] = self._lessons_run()
+        runner._persist_runs()
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+
+        assert reloaded._runs["l1"].lessons_learned == [
+            "Run the migration before seeding fixtures",
+            "The flake was a shared tmp dir, not a race",
+        ]
+
+    def test_the_status_payload_still_carries_the_lessons_after_a_restart(
+        self, tmp_path: Path
+    ) -> None:
+        """The consequence that matters: `build_status` publishes
+        `lessons_learned` for every run, and `api_taskrunner_status` redacts
+        each element before it reaches the dashboard. A restart turned that
+        into an empty list, so the section the UI renders disappeared with no
+        error anywhere."""
+        runner = _make_runner(tmp_path)
+        runner._runs["l1"] = self._lessons_run()
+        runner._persist_runs()
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+        payload = reloaded.status()
+        entry = next(r for r in payload["runs"] if r["task_id"] == "l1")
+
+        assert entry["lessons_learned"] == [
+            "Run the migration before seeding fixtures",
+            "The flake was a shared tmp dir, not a race",
+        ]
+
+    def test_a_legacy_entry_without_the_key_loads_as_no_lessons(self, tmp_path: Path) -> None:
+        """An entry written before this field was persisted carries no key.
+        The default is the empty list -- the same thing the reader saw before,
+        so no legacy entry changes meaning."""
+        runner = _make_runner(tmp_path)
+        runner._runs["l1"] = self._lessons_run()
+        runner._persist_runs()
+
+        runs_file = tmp_path / "runs.json"
+        data = json.loads(runs_file.read_text(encoding="utf-8"))
+        data[0].pop("lessons_learned", None)
+        runs_file.write_text(json.dumps(data), encoding="utf-8")
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+        assert reloaded._runs["l1"].lessons_learned == []
+
+    def test_a_run_that_learned_nothing_stays_empty(self, tmp_path: Path) -> None:
+        """Negative control: persisting the field must not manufacture one."""
+        runner = _make_runner(tmp_path)
+        runner._runs["l2"] = _make_run("l2")
+        runner._persist_runs()
+
+        reloaded = _make_runner(tmp_path)
+        reloaded._load_runs()
+        assert reloaded._runs["l2"].lessons_learned == []
+
+
 class TestLoadRunsResilience:
     def test_missing_file_seeds_fresh(self, tmp_path: Path) -> None:
         runner = _make_runner(tmp_path)


### PR DESCRIPTION
## Problem / Motivation

A task run that outlives a gateway restart comes back with **no lessons**. Its
"Lessons Learned" section is simply gone — from the dashboard row and from the
prompt you get when you send the run to chat — with nothing logged and no error
anywhere.

`TaskRunner._serialize_runs` and `TaskRunner._load_runs` are two hand-maintained
allow-lists, and `lessons_learned` appears in neither.

## Why it matters

The field is **produced once and cannot be recomputed**. `_extract_lesson`
(`taskrunner.py:1725`) appends a rule to `run.lessons_learned` after an LLM call,
once per lesson-yielding step, during execution. Nothing rebuilds it on load.

The lesson *text* is separately durable — `_extract_lesson` also writes it to the
lesson/vector store — but that corpus is **global and keyed by category**. The
per-run attribution ("this run learned these things") exists only in `runs.json`,
so a restart destroys it permanently.

Two consumers read it after a restart and both go silently empty:

- `task_reporter.build_status` publishes `lessons_learned` for every run
  (`task_reporter.py:252`), and `api_taskrunner_status` redacts each element
  before it reaches the dashboard (`dashboard/handlers/taskrunner.py:113-119`) —
  code that only exists because the field is expected to be there;
- `api_taskrunner_to_chat` renders a `## Lessons Learned` section into the
  continuation prompt (`dashboard/handlers/taskrunner.py:473-476`), so a resumed
  run hands the model a review context that is missing what the run already
  discovered.

This is a reviewer-counted residual, not a self-chosen one. The First Principles
review of #7088 — which persisted the six git-identity fields on these same two
allow-lists — named it exactly:

> Same allow-list cause has one unfixed sibling with a real post-restart
> consumer: `lessons_learned` is dropped by both allow-lists yet rendered after
> restart at `dashboard/handlers/taskrunner.py:473` (grepped `run\.lessons_learned`:
> 2 consumer sites). One line per side fixes it; the other 6 unpersisted fields
> are recomputed at runtime.

**One correction to that quote, since this PR leans on it.** I enumerated the
unpersisted set rather than taking "recomputed at runtime" on trust, and it does
**not** hold for all six. Diffing `dataclasses.fields(Project)` against
`_serialize_runs`' allow-list leaves `current_task`, `memory`, `last_task_time`,
`mode`, `source_spec`, `skip_planning` (`tasks` is persisted, as `task_details`).
Of those, **`run.memory` is neither persisted nor recomputed**:

- `WorkingMemory.update_from_result` has **zero** production callers — it was
  removed in V2 and `TestScenarioNonGitMemoryNotUpdated` pins the resulting
  emptiness on purpose ("git is the coordination surface"), so `files_changed`
  and `decisions` stay empty by design;
- `blockers` does have one live writer, `task_executor.py:938`, on a failed
  self-review;
- its single reader, `taskrunner.py:1221`, is a **fallback**: `memory_ctx` is
  taken from `git_coord.get_state_summary(run)` first and `run.memory.summary()`
  is consulted only when `run.branch_name` is empty or that call returned
  nothing, so a git-coordinated run never reaches it.

So `run.memory` is a genuine unpersisted sibling, not a recomputed field — but it
is a much narrower one (one component, one writer, a reader that git runs bypass),
and it is **out of scope here**. This PR does not touch it. Naming it is the
point: `lessons_learned` is not "the only field that isn't recomputed", it is the
one whose loss reaches two unconditional post-restart readers.

## What changed (motivation → approach → change)

**Symptom** → a restarted run's lessons are blank. **Root cause** → `lessons_learned`
is absent from both persistence allow-lists, and nothing rebuilds it on load.
**Change** → add it to both, in exactly the shape the field beside it already
uses.

- `_serialize_runs`: `"lessons_learned": run.lessons_learned` — placed next to
  `commit_hashes`, the other list-valued field on that list, with a comment
  recording why it cannot be recomputed and which two consumers read it.
- `_load_runs`: `lessons_learned=list(item.get("lessons_learned", []))` —
  mirrors the `commit_hashes` line directly above it: a defensive `list(...)`
  copy and an empty-list default.

**No migration and no legacy branch.** This is deliberately unlike #7088, whose
`git_enabled` needed a fallback because its `True` default was actively unsafe on
a pre-upgrade entry. Here the dataclass default is `field(default_factory=list)`
and the readers already guard with `if run.lessons_learned:` — so an entry written
before this change carries no key, loads as no lessons, and means exactly what it
meant before. A test pins that.

**No cap on the stored list.** Lessons are one short rule per lesson-yielding
step, so the growth is bounded by step count, and the serializer's existing caps
(`result[:2000]`) are on per-step free text, not on this. Capping would be a
product decision this fix does not need to make.

## Tests

Four tests in `test/test_taskrunner_atomic_persistence.py`, in a new
`TestLessonsLearnedSurvivesRestart` class alongside #7088's git-identity class:

| Test | Locks in |
|---|---|
| `test_lessons_learned_round_trips` | the field survives persist → load |
| `test_the_status_payload_still_carries_the_lessons_after_a_restart` | the **consequence**: `build_status()`'s payload — what the dashboard actually receives — still carries them after a reload |
| `test_a_legacy_entry_without_the_key_loads_as_no_lessons` | an entry written before this change is unchanged in meaning |
| `test_a_run_that_learned_nothing_stays_empty` | negative control: persisting the field does not manufacture one |

**Red-before** — tests written first and run before the two source lines were
added, against `main` at `ae457328e`; the two consequence tests fail and the two
controls pass, as they must:

```
2 failed, 17 passed
FAILED TestLessonsLearnedSurvivesRestart::test_lessons_learned_round_trips
    - AssertionError: assert [] == ['Run the mig..., not a race']
FAILED TestLessonsLearnedSurvivesRestart::test_the_status_payload_still_carries_the_lessons_after_a_restart
    - AssertionError: assert [] == ['Run the mig..., not a race']
```

**Green after:** `19 passed`.

Neighbouring suites, same run: `test_taskrunner.py`,
`test_taskrunner_atomic_persistence.py`, `test_taskrunner_coverage.py`,
`test_handlers_taskrunner_coverage.py` → **390 passed, 1 skipped**.

Also clean on the changed files: `flake8`, `isort --check-only`, `mypy`, and the
repo's baselined black gate (`scripts/check_black_formatting.py`). The two
pre-existing black complaints elsewhere in this test file are on `main` and are
covered by the baseline; they are deliberately left alone rather than swept into
this diff.

## Manual verification

N/A — unit coverage sufficient: the defect is a JSON round-trip through
`_serialize_runs`/`_load_runs`, and the consequence test exercises the real
`build_status()` payload rather than only the dataclass field, so the whole path
a reader depends on is covered in-process.

## Related Issues

Residual named by the First Principles review of #7088 (merged). No open issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe this allow-list
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

