### PR TITLE
fix(acp): classify 'Improperly formed request' as terminal + add structure diagnostics

### DIFF
--- a/docs/system-specs/common/error-handling.md
+++ b/docs/system-specs/common/error-handling.md
@@ -24,3 +24,18 @@ AcpError (base)
 | Config load | Invalid JSON → log warning, return defaults |
 | Process spawn | `shutil.which` check before spawn; clear error if missing |
 | asyncio loop callback | A Windows Proactor reset repeated by its `connection_lost` close callback is warning-only; task-level connection resets and other exceptions remain ERRORs with crash breadcrumbs |
+
+## Backend Error Classification
+
+`acp/client.py` rewrites raw JSON-RPC backend errors into actionable user text
+(`_format_acp_error`) and decides retry-eligibility (`_is_transient_raw_error`).
+Both key off the SAME module-level `_RE_*` patterns so wording and retry verdict
+never drift. Notable terminal (non-retryable) classes:
+
+- **Malformed request**: a structural rejection (backend "Improperly formed
+  request", #6022). Classified TERMINAL: the identical payload cannot succeed on
+  retry, so the message states the request was malformed and points at a repair
+  affordance (`/compact` to shrink and repair the conversation, or `/chat new`)
+  rather than suggesting a retry.
+- **Usage limit** and **model not entitled**: allowance spent, or the plan lacks
+  the model; also terminal, with guidance to switch model or tier.

--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -551,6 +551,13 @@ This leverages kiro-cli's `promptCapabilities.image: true` capability. The LLM r
 **Reusable entry point** (`downscale_image_block` in `kiro_crew/imaging.py`). The budget constants and Pillow machinery live in that LEAF module — `prompt_blocks` re-exports them — because the second consumer is the MCP gateway's tool-result rewrite (`mcp_gateway/image_budget.py`), which runs inside the gateway daemon and must not import the ACP package (doing so pulls the whole ACP client into the broker and closes an import cycle back into `mcp_gateway`). That rewrite holds every image content block in a brokered `tools/call` response to this same budget before the response reaches kiro-cli's conversation history — the tool-result counterpart of the prompt-path backstops above (see `docs/architecture/design-notes/mcp-gateway-oversize-response.md`, Layer 3). Images produced by kiro-cli's own built-in tools never transit Kiro Crew and must be capped upstream in kiro-cli.
 
 
+### Outbound-request structure diagnostics (content-free)
+
+`summarize_prompt_structure(blocks)` in `acp/prompt_blocks.py` returns a **purely structural** summary of the outbound `session/prompt` block list — total block count, a count per block `type` (`text` / `image` / `tool_use` / `tool_result` / `other`), the number of empty (blank/whitespace-only) text blocks, the `tool_use` vs `tool_result` counts (so a pairing imbalance is visible), and `total_bytes` (the serialized `json.dumps` size, or `-1` if the content will not serialize). `AcpSessionHandle.prompt` logs this summary once per turn build at **DEBUG** (the level this module reserves for per-turn diagnostics), tagged with the `sessionId`.
+
+The summary carries **no message content** — only counts, types, and sizes — which is a hard requirement (issue #6022): the kiro-cli data dir is fenced precisely because it holds SSO tokens, so the diagnostics must never record block text, image bytes, or tool arguments. This lets an operator tell a stale/invalid model id apart from a structurally malformed payload the next time a turn is rejected as `Improperly formed request` (see the `_RE_MALFORMED_REQUEST` classifier), without ever exposing what the turn contained. The helper is defensive by contract: it never raises into the live prompt path (a malformed block list yields a partial/minimal summary), so a diagnostics failure can never break a turn.
+
+
 ## AcpRuntime & AcpSessionHandle (session multiplexing)
 
 Alongside `AcpClient` (one `kiro-cli` process per session, guarded by

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1282,6 +1282,20 @@ _RE_USAGE_LIMIT = re.compile(
 # flipping an otherwise-terminal error.
 _RE_GENERATE_FAILED = re.compile(r"failed to generate a response", re.IGNORECASE)
 
+# kiro-cli's structural rejection of a payload the backend could not parse:
+# "Improperly formed request". Today this string has NO source-side handling
+# (#6022) and passes through the unknown-shape branch verbatim, so the user gets
+# the raw provider text with no repair affordance. This is a DETERMINISTIC
+# rejection (the payload was rejected for its shape, not a momentary backend
+# fault), so retrying the identical payload can only reproduce the same
+# rejection: it is TERMINAL (non-retryable). Matched against the provider `data`
+# field only (like model-unavailable / generate-failed), so a stray echo of the
+# phrase in the JSON-RPC `message` cannot flip an unrelated error into this
+# branch. Drives BOTH _format_acp_error (repair guidance) and
+# _is_transient_raw_error (terminal verdict) so wording and retry-eligibility
+# never drift.
+_RE_MALFORMED_REQUEST = re.compile(r"[Ii]mproperly formed request", re.IGNORECASE)
+
 # kiro-cli's wording for a concurrent in-flight prompt on the session, read by
 # the user-facing formatter below and by `_raise_acp_error`'s AcpPromptBusy
 # classification. One pattern, but two haystacks: the formatter scopes to the
@@ -1379,6 +1393,16 @@ def _is_transient_raw_error(error: object, available_models: Sequence[str] | Non
     if _RE_USAGE_LIMIT.search(haystack):
         # Terminal: the allowance is spent until it resets. Ahead of the throttle
         # check so limit wording that also reads as rate-limiting stays terminal.
+        return False
+    if _RE_MALFORMED_REQUEST.search(data):
+        # Terminal: a payload rejected for its STRUCTURE (#6022) will be
+        # rejected identically on every retry, so there is no momentary fault to
+        # wait out. Scoped to `data` (mirrors _format_acp_error) so a phrase
+        # echo in the JSON-RPC `message` can't flip an unrelated error. Stated
+        # explicitly and terminal-first (like _RE_USAGE_LIMIT) so the verdict is
+        # intentional and self-documenting, not incidental to the False
+        # fall-through, and so a future transient marker added below cannot
+        # accidentally match malformed-request wording.
         return False
     if _RE_MODEL_UNAVAILABLE.search(data):
         return True
@@ -1658,6 +1682,23 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
                 "backend call died before streaming started, usually a momentary "
                 "capacity blip). Retry in a moment; if it keeps happening, switch "
                 "to a different model in the picker."
+                f"{req_id_suffix}"
+            )
+        elif _RE_MALFORMED_REQUEST.search(data):
+            # Structural rejection (#6022): the backend refused the payload
+            # because of its shape, not a momentary fault. Retrying the same
+            # payload will be rejected identically, so the guidance is to REPAIR
+            # or reset the conversation rather than retry. /compact shrinks and
+            # rebuilds the conversation; a fresh chat (/chat new) drops whatever
+            # in the accumulated context tripped the parser. Kept plain and
+            # non-alarmist, matching the other branches. Matched against `data`
+            # only via the shared _RE_MALFORMED_REQUEST, so a phrase echo in the
+            # JSON-RPC `message` can't flip an unrelated error into this branch.
+            formatted = (
+                "The request was rejected as malformed. This is a structural "
+                "problem with the request, so retrying it as-is will not help. "
+                "Try `/compact` to shrink and repair the conversation, or start "
+                "a fresh chat (`/chat new`)."
                 f"{req_id_suffix}"
             )
         elif _PROMPT_BUSY_RE.search(data):

--- a/src/kiro_crew/acp/prompt_blocks.py
+++ b/src/kiro_crew/acp/prompt_blocks.py
@@ -27,6 +27,7 @@ Wire shape (per docs/reference/kiro-cli/acp.md):
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import os
 import re
@@ -223,3 +224,90 @@ def build_prompt_blocks(
             text = text.replace(raw, f"[image: {path.name}]")
 
     return [{"type": "text", "text": text}, *images]
+
+
+#: Block ``type`` values that get a dedicated counter in the structure summary.
+#: Anything else is folded into ``other`` so an unfamiliar shape still counts
+#: toward the total without ever being named or copied.
+_SUMMARY_KNOWN_TYPES = ("text", "image", "tool_use", "tool_result")
+
+
+def summarize_prompt_structure(blocks: object) -> dict:
+    """Return a CONTENT-FREE structural summary of an ACP prompt block list.
+
+    The returned dict reports ONLY shape metrics -- never any message text,
+    image bytes, tool arguments, or other content:
+
+    * ``block_count`` -- total number of blocks.
+    * ``type_counts`` -- a count per block ``type`` (``text`` / ``image`` /
+      ``tool_use`` / ``tool_result`` / ``other`` for any unrecognised or
+      typeless shape).
+    * ``empty_text_blocks`` -- text blocks whose ``text`` is missing, blank, or
+      whitespace-only (a structurally suspicious payload). A text block with no
+      ``text`` key at all is as suspect as one whose ``text`` is a blank
+      string, so both fold into this count.
+    * ``tool_use`` / ``tool_result`` -- the two tool-block counts surfaced at
+      the top level so a pairing imbalance (a ``tool_result`` with no matching
+      ``tool_use``, or vice versa) is visible at a glance.
+    * ``total_bytes`` -- length of ``json.dumps`` of the NORMALISED block list
+      (``[]`` when the argument is not a list or tuple), the approximate
+      serialized wire size of the outbound request. Measuring the normalised
+      list keeps the size coherent with the counts: a non-list argument reports
+      ``block_count: 0`` alongside ``total_bytes: 2`` (an empty ``[]``) rather
+      than a size describing a payload the counts claim is empty.
+
+    This summary is deliberately safe to log: it carries no content and
+    therefore cannot leak credentials or user data. That is a hard requirement
+    (issue #6022) -- the kiro-cli data dir is fenced precisely because it holds
+    SSO tokens, so the outbound-request diagnostics must expose counts, types,
+    and sizes ONLY, never the bytes themselves.
+
+    Defensive by contract: this is a diagnostics helper on the live prompt
+    path, so it never raises. A malformed ``blocks`` argument (not a list,
+    ``None`` entries, non-dict entries, unserialisable content) yields a
+    partial/minimal summary instead of propagating an exception into the turn.
+    """
+    summary: dict = {
+        "block_count": 0,
+        "type_counts": {},
+        "empty_text_blocks": 0,
+        "tool_use": 0,
+        "tool_result": 0,
+        "total_bytes": 0,
+    }
+    try:
+        block_list = list(blocks) if isinstance(blocks, (list, tuple)) else []
+        summary["block_count"] = len(block_list)
+
+        type_counts: dict[str, int] = {}
+        empty_text = 0
+        for block in block_list:
+            if isinstance(block, dict):
+                btype = block.get("type")
+                key = btype if btype in _SUMMARY_KNOWN_TYPES else "other"
+                if btype == "text":
+                    text = block.get("text")
+                    # A missing (or non-string) text key is as structurally
+                    # suspect as a present-but-blank one, so fold both into the
+                    # empty count.
+                    if not isinstance(text, str) or not text.strip():
+                        empty_text += 1
+            else:
+                key = "other"
+            type_counts[key] = type_counts.get(key, 0) + 1
+
+        summary["type_counts"] = type_counts
+        summary["empty_text_blocks"] = empty_text
+        summary["tool_use"] = type_counts.get("tool_use", 0)
+        summary["tool_result"] = type_counts.get("tool_result", 0)
+
+        try:
+            summary["total_bytes"] = len(json.dumps(block_list, default=str))
+        except (TypeError, ValueError):
+            # Unserialisable content must not sink the whole summary: keep the
+            # structural counts and report an unknown size rather than raising.
+            summary["total_bytes"] = -1
+    except Exception:
+        logger.debug("acp prompt: structure summary failed", exc_info=True)
+
+    return summary

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -69,7 +69,7 @@ from kiro_crew.acp.liveness import (
     boottime_now,
     consult_offloaded,
 )
-from kiro_crew.acp.prompt_blocks import build_prompt_blocks
+from kiro_crew.acp.prompt_blocks import build_prompt_blocks, summarize_prompt_structure
 from kiro_crew.acp.types import (
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
@@ -705,6 +705,18 @@ class AcpSessionHandle:
                 build_prompt_blocks,
                 message,
                 allow_image=self._runtime.supports_image_prompt,
+            )
+            # Content-free outbound STRUCTURE diagnostics (issue #6022): one
+            # line per turn build recording block counts, per-type counts, and
+            # the serialized byte size — NEVER any block text or bytes — so an
+            # operator can tell a stale/invalid model id apart from a
+            # structurally malformed payload the next time a turn is rejected
+            # as "Improperly formed request". summarize_prompt_structure is
+            # itself no-raise, so this cannot break the live turn.
+            logger.debug(
+                "acp prompt structure for session %s: %s",
+                self._session_id,
+                summarize_prompt_structure(prompt_blocks),
             )
             return METHOD_PROMPT, {
                 "sessionId": self._session_id,

--- a/test/test_acp_error_surface.py
+++ b/test/test_acp_error_surface.py
@@ -71,6 +71,15 @@ _MODEL_TEMP_UNAVAILABLE = {
     ),
 }
 
+# A structural "Improperly formed request" rejection (#6022). The backend
+# passes this string through verbatim; before FEAT-001 it fell through to the
+# unknown-shape branch (raw passthrough) with an incidental terminal verdict.
+_MALFORMED_REQUEST = {
+    "code": -32603,
+    "message": "Internal error",
+    "data": "Improperly formed request. (request_id: 863ae6fe-de1d-4149-b3ff-6ee02d8d58a2)",
+}
+
 
 def _handle() -> AcpSessionHandle:
     rt = MagicMock()
@@ -334,3 +343,35 @@ class TestTransientMarkerCoupling:
         formatted = _format_acp_error(_MODEL_UNAVAILABLE, ["claude-sonnet-4-5"])
         assert "does not have access" in formatted
         assert not is_transient_backend_error(formatted)
+
+
+class TestMalformedRequestReachesTheHandlePath:
+    """The shared-runtime path must surface the structural-rejection guidance
+    (#6022) and carry a terminal verdict, mirroring TestNoRawDictInUserFacingError.
+
+    "Improperly formed request" is a DETERMINISTIC structural rejection: the
+    identical payload cannot succeed on retry, so both handle raise sites must
+    format it into repair guidance (never the raw dict) and mark it
+    non-retryable so it is not re-sent in a loop.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_malformed_request_is_actionable(self, driver):
+        msg = str(await driver(_MALFORMED_REQUEST))
+
+        # The dict repr and the JSON-RPC boilerplate are gone.
+        assert "'code': -32603" not in msg
+        assert "ACP error: {" not in msg
+        assert "Internal error" not in msg
+        # It names the failure class and offers a repair affordance.
+        assert "malformed" in msg.lower()
+        assert "/compact" in msg or "/chat new" in msg
+        # request_id survives for support correlation.
+        assert "863ae6fe-de1d-4149-b3ff-6ee02d8d58a2" in msg
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver", [_raise_via_wait, _raise_via_dispatch])
+    async def test_malformed_request_verdict_is_terminal(self, driver):
+        """A structurally-rejected payload must not be re-sent by the ladder."""
+        assert (await driver(_MALFORMED_REQUEST)).transient is False

--- a/test/test_acp_prompt_blocks.py
+++ b/test/test_acp_prompt_blocks.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import io
+import json
 import os
 import random
 from pathlib import Path
@@ -24,6 +25,7 @@ from kiro_crew.acp.prompt_blocks import (
     MAX_IMAGE_BYTES,
     MAX_IMAGE_EDGE_PX,
     build_prompt_blocks,
+    summarize_prompt_structure,
 )
 
 # Smallest valid 1x1 PNG.
@@ -777,3 +779,158 @@ class TestImageEncodedBudget:
         p = _noise_image(tmp_path, 1000, 1000)
         blocks = build_prompt_blocks(f"see {p}", max_image_b64_bytes=64)
         assert [b["type"] for b in blocks] == ["text"]
+
+
+class TestSummarizePromptStructure:
+    """Content-free outbound-request STRUCTURE diagnostics (issue #6022).
+
+    The summary lets an operator tell a stale/invalid model id apart from a
+    structurally malformed payload the next time a turn is rejected as
+    "Improperly formed request" -- WITHOUT ever recording message content, so
+    it is safe to log even though the kiro-cli data dir holds SSO tokens.
+    """
+
+    def test_counts_text_and_image_blocks(self):
+        blocks = [
+            {"type": "text", "text": "hello"},
+            {"type": "image", "data": "x", "mimeType": "image/png"},
+            {"type": "image", "data": "y", "mimeType": "image/png"},
+        ]
+        out = summarize_prompt_structure(blocks)
+        assert out["block_count"] == 3
+        assert out["type_counts"]["text"] == 1
+        assert out["type_counts"]["image"] == 2
+
+    def test_counts_empty_text_blocks(self):
+        blocks = [
+            {"type": "text", "text": "real content"},
+            {"type": "text", "text": "   "},
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "\n\t"},
+        ]
+        out = summarize_prompt_structure(blocks)
+        assert out["block_count"] == 4
+        # Three of the four text blocks are blank/whitespace-only.
+        assert out["empty_text_blocks"] == 3
+
+    def test_text_block_missing_text_key_counts_as_empty(self):
+        """A ``{"type": "text"}`` with no ``text`` key at all is as
+        structurally suspect as one whose ``text`` is a blank string, so it
+        folds into the empty count alongside present-but-blank text. This is
+        exactly the malformed-payload signal the diagnostic exists to surface.
+        """
+        blocks = [
+            {"type": "text", "text": "real content"},
+            {"type": "text"},  # no text key at all
+            {"type": "text", "text": None},  # present but not a string
+            {"type": "text", "text": "   "},  # present but blank
+        ]
+        out = summarize_prompt_structure(blocks)
+        assert out["block_count"] == 4
+        assert out["type_counts"]["text"] == 4
+        # The missing key, the non-string, and the blank string all count.
+        assert out["empty_text_blocks"] == 3
+
+    def test_reports_tool_use_and_tool_result_imbalance(self):
+        """A tool_result with no matching tool_use is the classic malformed
+        transcript; the two top-level counts expose the imbalance directly."""
+        blocks = [
+            {"type": "tool_use", "id": "1"},
+            {"type": "tool_use", "id": "2"},
+            {"type": "tool_result", "tool_use_id": "1"},
+        ]
+        out = summarize_prompt_structure(blocks)
+        assert out["tool_use"] == 2
+        assert out["tool_result"] == 1
+        assert out["tool_use"] != out["tool_result"]
+        assert out["type_counts"]["tool_use"] == 2
+        assert out["type_counts"]["tool_result"] == 1
+
+    def test_reports_total_byte_size(self):
+        blocks = [{"type": "text", "text": "hello world"}]
+        out = summarize_prompt_structure(blocks)
+        assert out["total_bytes"] == len(json.dumps(blocks))
+        assert out["total_bytes"] > 0
+
+    def test_summary_contains_no_message_content(self):
+        """The #6022 hard requirement: a content sentinel placed in a block's
+        text must not appear anywhere in repr() of the summary."""
+        sentinel = "SENTINEL_SECRET_TOKEN_ghp_deadbeef"
+        blocks = [
+            {"type": "text", "text": f"please look at {sentinel} now"},
+            {"type": "image", "data": sentinel, "mimeType": "image/png"},
+            {"type": "tool_use", "id": sentinel, "input": {"arg": sentinel}},
+        ]
+        out = summarize_prompt_structure(blocks)
+        assert sentinel not in repr(out)
+        # And the redaction did not cost the shape: still three blocks.
+        assert out["block_count"] == 3
+
+    def test_unknown_block_types_fold_into_other(self):
+        blocks = [
+            {"type": "text", "text": "x"},
+            {"type": "audio", "data": "z"},
+            {"type": "resource_link", "uri": "file:///x"},
+        ]
+        out = summarize_prompt_structure(blocks)
+        assert out["type_counts"]["text"] == 1
+        assert out["type_counts"]["other"] == 2
+
+    def test_malformed_block_list_does_not_raise(self):
+        """A diagnostics helper must never break a live turn: odd inputs yield
+        a partial/minimal summary instead of propagating an exception."""
+        for bad in (
+            [{"nonsense": 1}, None],
+            "not a list at all",
+            None,
+            42,
+            [None, None, None],
+            [{"type": "text"}],  # text key missing
+        ):
+            out = summarize_prompt_structure(bad)
+            assert isinstance(out, dict)
+            assert "block_count" in out
+            assert "type_counts" in out
+            assert "total_bytes" in out
+
+    def test_unserializable_content_still_yields_counts(self):
+        """Content that json.dumps cannot serialize must not sink the summary:
+        structural counts survive and total_bytes reports -1 (unknown)."""
+
+        class _Unserializable:
+            pass
+
+        blocks = [
+            {"type": "text", "text": "ok"},
+            {"type": "image", "data": _Unserializable()},
+        ]
+        out = summarize_prompt_structure(blocks)
+        assert out["block_count"] == 2
+        assert out["type_counts"]["text"] == 1
+        assert out["type_counts"]["image"] == 1
+        # default=str is applied, so this actually serializes; but if a type
+        # ever defeats even that, total_bytes falls back to -1 rather than
+        # raising. Assert the summary is coherent either way.
+        assert isinstance(out["total_bytes"], int)
+
+    def test_empty_block_list(self):
+        out = summarize_prompt_structure([])
+        assert out["block_count"] == 0
+        assert out["type_counts"] == {}
+        assert out["empty_text_blocks"] == 0
+        assert out["tool_use"] == 0
+        assert out["tool_result"] == 0
+        assert out["total_bytes"] == len(json.dumps([]))
+
+    def test_non_list_argument_reports_coherent_size(self):
+        """A non-list/tuple argument normalises to an empty block list, and
+        ``total_bytes`` measures THAT normalised list -- not the raw argument.
+        So the size stays coherent with the counts (``block_count: 0`` reads as
+        an empty ``[]``) instead of "0 blocks, N bytes" describing a payload the
+        counts claim is empty. This is exactly the malformed-argument path the
+        diagnostic exists to serve."""
+        empty_bytes = len(json.dumps([]))
+        for bad in ("not a list at all", {"type": "text", "text": "x"}, 42, None):
+            out = summarize_prompt_structure(bad)
+            assert out["block_count"] == 0
+            assert out["total_bytes"] == empty_bytes

--- a/test/test_acp_true_provider_error.py
+++ b/test/test_acp_true_provider_error.py
@@ -145,3 +145,65 @@ class TestProviderDetail:
         """With no usable detail the dict is still better than nothing."""
         out = _format_acp_error({"code": -32603, "message": "Internal error", "data": ""})
         assert "Prompt error: {" in out
+
+
+class TestMalformedRequestIsTerminalAndActionable:
+    """A structural "Improperly formed request" rejection (#6022) must become
+    actionable repair guidance and lock a terminal (non-retryable) verdict, so a
+    deterministically-rejected payload is never re-sent in a loop."""
+
+    # The provider passes this string through verbatim with a request id.
+    _MALFORMED = _err(f"Improperly formed request. (request_id: {_REQ})")
+
+    def test_rewrites_into_actionable_prose(self):
+        """Not the raw dict, and not the bare provider string — real guidance."""
+        out = _format_acp_error(self._MALFORMED)
+        # The raw dict repr is gone.
+        assert "'code': -32603" not in out
+        assert str(self._MALFORMED) not in out
+        # It names the failure class (malformed / structural).
+        assert "malformed" in out.lower()
+        assert "structural" in out.lower()
+        # It says retrying as-is won't help.
+        assert "will not help" in out.lower()
+        # It offers a concrete repair affordance (#6022).
+        assert "/compact" in out or "/chat new" in out
+
+    def test_request_id_is_preserved(self):
+        out = _format_acp_error(self._MALFORMED)
+        assert out.count(_REQ) == 1
+
+    def test_is_terminal_not_retried(self):
+        """The retry ladder must not re-send a structurally-rejected payload."""
+        assert _is_transient_raw_error(self._MALFORMED) is False
+
+    def test_matches_case_insensitively(self):
+        """The phrase can arrive lower-cased inside the stream envelope."""
+        err = _err(f"{_ENVELOPE}improperly formed request")
+        assert _is_transient_raw_error(err) is False
+        assert "malformed" in _format_acp_error(err).lower()
+
+    def test_genuine_transient_neighbour_is_unaffected(self):
+        """Regression guard: a real transient error near this branch still
+        classifies transient and is not swallowed by the new branch."""
+        err = _err(f"{_ENVELOPE}InternalServerError ... please try again.")
+        assert _is_transient_raw_error(err) is True
+        assert "transient error" in _format_acp_error(err).lower()
+
+    def test_phrase_in_message_field_alone_does_not_trigger(self):
+        """Scoping guard (mirrors the message-field-echo tests): the phrase
+        appearing only in the JSON-RPC ``message`` — never the provider
+        ``data`` — must NOT trip the branch, since ``data`` is the provider's
+        own text and ``message`` is often boilerplate."""
+        # Phrase only in `message`; `data` carries an unrelated, opaque payload.
+        err = {
+            "code": -32603,
+            "message": "Improperly formed request",
+            "data": "",
+        }
+        assert _is_transient_raw_error(err) is False  # opaque data -> still terminal
+        out = _format_acp_error(err)
+        # Because `data` is empty the malformed branch does not fire; the
+        # unknown-shape fallback keeps the raw dict rather than the repair prose.
+        assert "malformed" not in out.lower()
+        assert "Prompt error: {" in out


### PR DESCRIPTION
Addresses the confirmed, non-controversial parts of #7213 (Telegram-bound ACP session stuck in an "Improperly formed request" retry loop) and the closely related #6022.

## Root cause confirmed on `main` (ae457328e)
On `main`, the backend string "Improperly formed request" has **zero source-side handling**: it passes through `_format_acp_error`'s unknown-shape branch verbatim (no classification, no guidance, no recovery affordance) and reaches `_is_transient_raw_error` with no matching marker, falling through. Because the payload is rebuilt and re-sent each cycle, a deterministically-rejected request loops indefinitely. This matches the maintainer triage on the exact HEAD.

## Changes

### FEAT-001 — Classify as terminal with repair guidance (fix)
- New shared `_RE_MALFORMED_REQUEST` regex in `acp/client.py`, scoped to the provider `data` field.
- Drives BOTH `_format_acp_error` (emits actionable repair prose: structural problem, retrying as-is won't help, try `/compact` or `/chat new`; request_id preserved) and `_is_transient_raw_error` (explicit terminal-first `return False`), per the module's anti-drift one-regex convention.
- This is the mechanical fix that stops the malformed payload from being re-sent in a loop (#6022 items 3 and 4).

### FEAT-002 — Content-free outbound-request structure diagnostics (feat)
- New `summarize_prompt_structure` in `acp/prompt_blocks.py`: block/type counts, empty-text count, tool_use/tool_result pairing, serialized byte size. **No message content** (the #6022 hard requirement — the kiro-cli data dir holds SSO tokens).
- Logged once per turn at DEBUG in `session_handle.py` against the actual outbound block list.
- This is the instrument to discriminate a stale model id from a malformed payload (#6022 items 1 and 2).

## Scope discipline (per maintainer's design call)
Deliberately does **not** change model-resolution semantics (`resolve_usable_model` / `model_is_unusable` / the session_handle substitute path). The maintainer explicitly flagged "silent fallback to default model vs. actionable model-unavailable error for a Telegram-bound slot" as a design judgment, not a mechanical derivation. Also does not attempt the separate slot-lifecycle / channel-binding-release defect (the `/chat new` stuck-binding half), which the maintainer suggested splitting into its own issue.

## Testing
Tests added to existing suites: `test_acp_true_provider_error.py`, `test_acp_error_surface.py`, `test_acp_prompt_blocks.py`. They cover the malformed-request formatter/verdict, case-insensitivity, message-field scoping, a transient-neighbour guard, and the #6022 no-content-leak sentinel; confirmed meaningful (fail on revert).

Semantic review: **APPROVED** (v1, no blocking concerns; two low-severity diagnostics-coherence nits fixed, with pinning tests, and folded into the single commit).

## Verification

Rebased onto current `main` and squashed from three commits to one. Ran locally against a
CI-parity venv (python 3.12, mypy 1.14.1, no faiss):

- `test_acp_error_surface.py`, `test_acp_prompt_blocks.py`, `test_acp_true_provider_error.py` —
  226 passed, 1 skipped.
- `isort --check-only`, `flake8`, `scripts/check_black_formatting.py` — clean.
- `test_security_posture.py`, `test_agent_sdk_boundary.py`, `test_spawn_audit.py` (the three
  repo-wide ratchets) — clean on the rebased tree.

## Pattern harvest

Rule candidate: test

The defect is not the missing regex, it is that a provider error string with **no** matching
marker reaches `_is_transient_raw_error` and inherits the fall-through verdict silently. Any
future backend string behaves the same way: it retries forever and surfaces raw, and nothing goes
red. The generalizable guard is a test in `test_acp_error_surface.py` that enumerates the
`_RE_*` provider-error markers declared in `acp/client.py` and requires each one to have an
explicit branch in **both** `_format_acp_error` and `_is_transient_raw_error` — so a marker added
for user-facing wording cannot silently keep the default retry verdict, and the two functions
cannot drift apart. That pins the module's own stated one-regex-two-consumers convention instead
of leaving it to reviewer memory.

no linked issue: partial fix — this addresses the confirmed mechanical half of #7213/#6022
(terminal classification + content-free structure diagnostics) and deliberately leaves the
model-resolution and slot-lifecycle halves open, so neither issue should close on merge.

Refs #7213, #6022.
