### PR TITLE
fix(build): split decoder authenticity from executability

### DIFF
--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -334,7 +334,10 @@ same way). Key details:
 - **Local dictation runtime bundled** — supported desktop builds include
   `pywhispercpp`, the platform `imageio-ffmpeg` executable used for compressed
   recordings, and all transitive runtime dependencies. The build imports the
-  recognizer and executes the exact packaged decoder before publishing. Model
+  recognizer and executes the exact packaged decoder before publishing — and
+  distinguishes a decoder that fails to AUTHENTICATE, which fails the build, from
+  one that authenticates but will not run on the build host, which warns and
+  ships (see [stt-streaming](../system-specs/features/stt-streaming.md)). Model
   weights are deliberately excluded from the installer: the user selects a
   model and clicks **Download now**, with no package manager or separate
   dependency step. Intel macOS is the unsupported recognizer exception.

--- a/docs/system-specs/features/stt-streaming.md
+++ b/docs/system-specs/features/stt-streaming.md
@@ -30,6 +30,19 @@ dependency metadata or an ambient PATH copy satisfying the check. Source
 environments use the fixed system-decoder search instead, because a project venv
 is agent-writable executable storage.
 
+That gate reports **two independent verdicts** and the build treats them
+differently (`transcribe.PackagedDecoderProbe`). Whether the resolved bytes
+**authenticate** is a property of the artifact, holds on every host, and failing
+it stops the build. Whether they then **execute** is a property of the build
+machine: an image lacking an OS library the executable load-time imports makes
+the loader refuse it before its entry point runs, while the identical bytes run
+correctly for a user. Windows Server Core is the case that forced the
+distinction — it carries no Video for Windows components, so it cannot load a
+Windows ffmpeg that imports `AVICAP32.dll`, and every CodeBuild Windows image is
+built on it. So an authenticated payload that will not run **warns and ships**;
+only an unauthenticated one fails. Collapsing the two reported a build-host
+limitation as a corrupt artifact and withheld a correct release over it.
+
 That executable ships **uncompressed** inside the macOS bundle, and must keep
 doing so: the Apple notary service decompresses archive members and scans what is
 inside them, so a decoder sealed as a compressed payload is rejected as an

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -155,23 +155,65 @@ is_macos_intel_backend() {
 # is not enough: an ABI mismatch or missing executable otherwise reaches every
 # user as an unusable Download button. Model weights are deliberately not involved
 # in this gate.
+#
+# THREE outcomes, not two, because the decoder answers two independent questions
+# (see transcribe.PackagedDecoderProbe):
+#
+#   exit 0  everything loaded and ran
+#   exit 1  the recogniser is broken, OR no decoder AUTHENTICATED -- a defect in
+#           what we are about to publish, so the build stops
+#   exit 2  the decoder authenticated but this HOST would not run it
+#
+# Exit 2 is a warning and not a failure, and that is the whole point of splitting
+# them. Authenticity is a property of the artifact and is gated everywhere;
+# executability is a property of the build machine. A build image missing an OS
+# library the pinned executable load-time imports refuses it before its entry
+# point runs -- Windows Server Core, which every CodeBuild Windows image is built
+# on, ships no Video for Windows components and so cannot load an ffmpeg that
+# imports AVICAP32.dll -- while the identical bytes run correctly on a user's
+# machine. Blocking a release on that withholds a correct artifact because the
+# machine that assembled it was not the machine that runs it.
 #   $1 = bundled interpreter
 local_voice_runtime_gate() {
-  local python="$1"
+  local python="$1" report status
   log "Verifying bundled local voice runtime…"
-  env PYTHONNOUSERSITE=1 PYTHONPATH= "$python" -s -c '
+  # `if` rather than a bare assignment: under `set -e` a command substitution that
+  # exits non-zero aborts the script, which would make exit 2 a hard failure again.
+  if report="$(env PYTHONNOUSERSITE=1 PYTHONPATH= "$python" -s -c '
+import sys
+
 from kiro_crew.stt.engine import probe
 from kiro_crew.transcribe import _packaged_ffmpeg_version_probe
 
 state = probe()
 if not state.ok:
-    raise SystemExit(f"{state.code}: {state.detail}")
-if not _packaged_ffmpeg_version_probe():
-    raise SystemExit("bundled ffmpeg executable is missing, modified, or cannot run")
-' || {
-    echo "ERROR: bundled local voice runtime cannot load" >&2
-    exit 1
-  }
+    sys.stderr.write(f"{state.code}: {state.detail}\n")
+    raise SystemExit(1)
+
+decoder = _packaged_ffmpeg_version_probe()
+if decoder.ok:
+    raise SystemExit(0)
+sys.stderr.write(f"{decoder.code}: {decoder.detail}\n")
+raise SystemExit(1 if not decoder.authentic else 2)
+' 2>&1)"; then
+    status=0
+  else
+    status=$?
+  fi
+  if [ -n "$report" ]; then
+    printf '    %s\n' "$report"
+  fi
+  case "$status" in
+    0) ;;
+    2)
+      echo "  ⚠ the bundled decoder authenticated but does not run on THIS host." >&2
+      echo "    Its bytes are the pinned payload, so the bundle is shipped as-is." >&2
+      ;;
+    *)
+      echo "ERROR: bundled local voice runtime cannot load" >&2
+      exit 1
+      ;;
+  esac
 }
 
 # Re-stamp every staged backend tree with <dist>, for the Linux multi-format

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -43,6 +43,7 @@ import sys
 import tempfile
 import threading
 import wave
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator
 
 from kiro_crew import aws_consent, platform_compat, stt
@@ -654,11 +655,86 @@ def _packaged_ffmpeg_resource() -> str | None:
         authenticated.close()
 
 
-def _packaged_ffmpeg_version_probe() -> bool:
-    """Run ``-version`` from authenticated bytes for the desktop build gate."""
+#: Outcome codes for :func:`_packaged_ffmpeg_version_probe`.
+DECODER_OK = "decoder_ok"
+DECODER_UNAUTHENTIC = "decoder_unauthentic"
+DECODER_NOT_EXECUTABLE = "decoder_not_executable"
+
+#: Windows loader refusals worth naming in the build gate's report. Both mean the
+#: image was rejected BEFORE its entry point ran -- a missing or wrong-version
+#: import -- which is a property of the host, never of the bytes. Spelled as the
+#: signed values ``subprocess`` reports, because CPython surfaces the Windows exit
+#: DWORD through a signed C int.
+_WINDOWS_LOADER_STATUS: dict[int, str] = {
+    -1073741515: "STATUS_DLL_NOT_FOUND",
+    -1073741511: "STATUS_ENTRYPOINT_NOT_FOUND",
+}
+
+#: Cap on child output quoted into a probe's ``detail``. Enough for a loader or
+#: dynamic-linker complaint, short enough to stay one readable log line.
+_DECODER_DETAIL_MAX_CHARS = 400
+
+
+@dataclass(frozen=True)
+class PackagedDecoderProbe:
+    """Whether the packaged decoder authenticated, and whether it then ran.
+
+    Two INDEPENDENT questions, and collapsing them is what made this unreadable.
+    ``authentic`` is a property of the ARTIFACT: the bytes matched the pinned
+    upstream digest or an accepted signature, and it must hold on every host.
+    ``ok`` additionally requires that they EXECUTED, which is a property of the
+    BUILD HOST -- a container image can lack an OS library the executable
+    load-time imports, and the loader then refuses it before its entry point runs
+    even though the identical bytes run correctly for a user.
+
+    A caller that treats a host limitation as a corrupt payload sends the reader
+    to the wrong half of the problem, so the release gate reads these separately:
+    ``authentic`` false fails the build, ``ok`` false alone only warns.
+    """
+
+    ok: bool
+    authentic: bool
+    code: str = DECODER_OK
+    detail: str = ""
+
+
+def _decoder_exit_detail(source_path: str, result: subprocess.CompletedProcess[bytes]) -> str:
+    """Describe a decoder that authenticated but would not run."""
+    code = result.returncode
+    named = _WINDOWS_LOADER_STATUS.get(code)
+    # The unsigned spelling is what a reader can look up; the signed one is what
+    # the log of a failing build will actually have shown them.
+    status = f"exit {code} (0x{code & 0xFFFFFFFF:08X}{f', {named}' if named else ''})"
+    # Decoded here rather than by asking subprocess for text mode: a loader or
+    # dynamic-linker complaint arrives in the host's console encoding, not
+    # necessarily UTF-8, and a probe must not raise while explaining a failure.
+    streams = b"\n".join(part for part in (result.stderr, result.stdout) if part)
+    noise = streams.decode("utf-8", "replace").strip()
+    if len(noise) > _DECODER_DETAIL_MAX_CHARS:
+        noise = f"{noise[:_DECODER_DETAIL_MAX_CHARS]}…"
+    return f"{source_path} authenticated but did not run: {status}{f'; {noise}' if noise else ''}"
+
+
+def _packaged_ffmpeg_version_probe() -> PackagedDecoderProbe:
+    """Authenticate the packaged decoder, then try to run it, for the build gate.
+
+    Both halves are reported because they fail for unrelated reasons and demand
+    unrelated fixes; see :class:`PackagedDecoderProbe`. Streams are captured
+    rather than discarded so that a refusal explains itself in the build log
+    instead of arriving as one unattributable line.
+    """
     authenticated = _open_packaged_ffmpeg_resource()
     if authenticated is None:
-        return False
+        return PackagedDecoderProbe(
+            ok=False,
+            authentic=False,
+            code=DECODER_UNAUTHENTIC,
+            detail=(
+                "no packaged decoder authenticated against the pinned upstream "
+                "digest or an accepted signature"
+            ),
+        )
+    source_path = authenticated.source_path
     try:
         kwargs: dict[str, Any] = {}
         if not platform_compat.IS_WINDOWS:
@@ -666,15 +742,26 @@ def _packaged_ffmpeg_version_probe() -> bool:
         result = subprocess.run(
             [authenticated.execution_path, "-version"],
             check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            capture_output=True,
             **kwargs,
         )
-        return result.returncode == 0
-    except OSError:
-        return False
+    except OSError as exc:
+        return PackagedDecoderProbe(
+            ok=False,
+            authentic=True,
+            code=DECODER_NOT_EXECUTABLE,
+            detail=f"{source_path} authenticated but could not be spawned: {exc}",
+        )
     finally:
         authenticated.close()
+    if result.returncode == 0:
+        return PackagedDecoderProbe(ok=True, authentic=True)
+    return PackagedDecoderProbe(
+        ok=False,
+        authentic=True,
+        code=DECODER_NOT_EXECUTABLE,
+        detail=_decoder_exit_detail(source_path, result),
+    )
 
 
 def _bundled_ffmpeg() -> str | None:

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -1227,8 +1227,10 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "transcribe.py::_pcm_via_ffmpeg",
         "transcribe.py::_transcribe_aws",
         # The build probe executes the same authenticated image with the single
-        # fixed `-version` argument and discards both streams; it accepts no external
-        # input at all.
+        # fixed `-version` argument; it accepts no external input at all. Both
+        # streams are CAPTURED rather than discarded, so a refusal can name itself
+        # in the build log, and are decoded with errors="replace" because a loader
+        # complaint arrives in the host's console encoding.
         "transcribe.py::_packaged_ffmpeg_version_probe",
         # JSON-Schema ``pattern`` validation for MCP app→gateway tool-call args
         # (validate_mcp_tool_arguments). The spawn's command surface is FULLY

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -1299,6 +1299,116 @@ class TestBundledFfmpeg:
 
         assert transcribe._bundled_ffmpeg() is None
 
+    def _probe_with_exit(self, monkeypatch, tmp_path, script: bytes):
+        """Install *script* as the packaged decoder and probe it for real.
+
+        The decoder is EXECUTED rather than stubbed, because the split this covers
+        is about what a real spawn reports back.
+        """
+        package_dir = tmp_path / "imageio_ffmpeg"
+        binaries = package_dir / "binaries"
+        binaries.mkdir(parents=True)
+        filename = "ffmpeg-test.exe" if _pc.IS_WINDOWS else "ffmpeg-test"
+        binary = binaries / filename
+        binary.write_bytes(script)
+        binary.chmod(0o755)
+        monkeypatch.setattr(transcribe, "_trusted_site_package_roots", lambda: (str(tmp_path),))
+        monkeypatch.setattr(
+            transcribe,
+            "_PACKAGED_FFMPEG_ARTIFACTS",
+            {filename: (len(script), transcribe.hashlib.sha256(script).hexdigest())},
+        )
+        monkeypatch.setattr(transcribe, "_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS", frozenset())
+        return binary, transcribe._packaged_ffmpeg_version_probe()
+
+    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="needs a POSIX shell for the fake decoder")
+    def test_probe_reports_ok_when_the_authenticated_decoder_runs(self, monkeypatch, tmp_path):
+        _, probe = self._probe_with_exit(
+            monkeypatch, tmp_path, b"#!/bin/sh\necho 'ffmpeg version 7'\nexit 0\n"
+        )
+
+        assert probe.ok is True
+        assert probe.authentic is True
+        assert probe.code == transcribe.DECODER_OK
+
+    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="needs a POSIX shell for the fake decoder")
+    def test_a_host_that_cannot_run_an_authentic_decoder_is_not_reported_as_tampering(
+        self, monkeypatch, tmp_path
+    ):
+        """This is the WHOLE point of the split, so it is pinned explicitly.
+
+        A build image missing a library the decoder needs makes the loader refuse
+        an executable whose bytes are exactly the pinned payload. Reporting that as
+        an unauthentic artifact fails the release over a property of the build
+        machine, and sends whoever reads the log hunting a supply-chain problem
+        that is not there.
+        """
+        _, probe = self._probe_with_exit(
+            monkeypatch,
+            tmp_path,
+            b"#!/bin/sh\necho 'libavcodec.so.61: cannot open shared object' >&2\nexit 127\n",
+        )
+
+        assert probe.ok is False
+        # Authentic: the release gate must NOT fail the build on this.
+        assert probe.authentic is True
+        assert probe.code == transcribe.DECODER_NOT_EXECUTABLE
+        # The child's own complaint reaches the caller, rather than DEVNULL.
+        assert "libavcodec.so.61" in probe.detail
+
+    @pytest.mark.skipif(_pc.IS_WINDOWS, reason="needs a POSIX shell for the fake decoder")
+    def test_a_decoder_that_cannot_be_spawned_at_all_still_counts_as_authentic(
+        self, monkeypatch, tmp_path
+    ):
+        """The OSError arm is a DISTINCT path from a non-zero exit and must reach
+        the same verdict: the bytes authenticated, the host would not run them."""
+        _, probe = self._probe_with_exit(
+            monkeypatch, tmp_path, b"#!/nonexistent/interpreter\nbody\n"
+        )
+
+        assert probe.ok is False
+        assert probe.authentic is True
+        assert probe.code == transcribe.DECODER_NOT_EXECUTABLE
+
+    def test_a_payload_that_fails_authentication_is_still_refused(self, monkeypatch, tmp_path):
+        """Splitting the outcomes must not have weakened the half that matters:
+        bytes that are not the pinned payload stay a hard failure."""
+        binary = self._fake_package(monkeypatch, tmp_path)
+        binary.write_bytes(b"attacker decoder")
+
+        probe = transcribe._packaged_ffmpeg_version_probe()
+
+        assert probe.ok is False
+        assert probe.authentic is False
+        assert probe.code == transcribe.DECODER_UNAUTHENTIC
+
+    def test_windows_loader_statuses_are_named_in_the_detail(self):
+        """0xC0000135 is the observed Server Core refusal, and a bare signed
+        integer in a build log is not something a reader can act on."""
+
+        class _Refused:
+            returncode = -1073741515
+            stdout = b""
+            stderr = b""
+
+        detail = transcribe._decoder_exit_detail("/x/ffmpeg", _Refused())
+
+        assert "0xC0000135" in detail
+        assert "STATUS_DLL_NOT_FOUND" in detail
+
+    def test_probe_detail_is_bounded(self):
+        """A decoder can emit unbounded output; the report stays log-sized."""
+
+        class _Noisy:
+            returncode = 1
+            stdout = b""
+            stderr = b"x" * 5000
+
+        detail = transcribe._decoder_exit_detail("/x/ffmpeg", _Noisy())
+
+        assert len(detail) < transcribe._DECODER_DETAIL_MAX_CHARS + 200
+        assert detail.endswith("…")
+
     def test_payload_chunks_yield_the_file_bytes(self, tmp_path):
         raw = tmp_path / "ffmpeg"
         raw.write_bytes(b"bundled decoder")

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -340,7 +340,18 @@ describe("first-download installer design contract", () => {
     assert.doesNotMatch(buildScript, /bundling without it/);
     assert.match(buildScript, /from kiro_crew\.stt\.engine import probe/);
     assert.match(buildScript, /from kiro_crew\.transcribe import _packaged_ffmpeg_version_probe/);
-    assert.match(buildScript, /if not _packaged_ffmpeg_version_probe\(\)/);
+    assert.match(buildScript, /decoder = _packaged_ffmpeg_version_probe\(\)/);
+    // Both halves of the decoder verdict are pinned, because collapsing them back
+    // into one boolean is the regression this shape exists to prevent.
+    // AUTHENTICITY gates the release everywhere (exit 1 -> the build stops), so
+    // pip metadata or a swapped payload still cannot publish. EXECUTABILITY does
+    // not, because it is a property of the build host rather than the artifact:
+    // an image lacking an OS library the executable load-time imports refuses it
+    // before its entry point runs, while the same bytes run for a user, so that
+    // case warns and ships (exit 2).
+    assert.match(buildScript, /raise SystemExit\(1 if not decoder\.authentic else 2\)/);
+    assert.match(buildScript, /ERROR: bundled local voice runtime cannot load/);
+    assert.match(buildScript, /authenticated but does not run on THIS host/);
     // The Apple-Silicon decoder must ship as a PLAIN Mach-O so the app signer
     // signs it. Sealing it as a compressed payload (#6746) made Apple's notary
     // service decompress the member, find an unsigned executable inside, and


### PR DESCRIPTION
## Problem / Motivation

The desktop release gate reports one line for three unrelated causes:

```
bundled ffmpeg executable is missing, modified, or cannot run
```

and it runs the probe with **both** streams on `DEVNULL`
(`transcribe._packaged_ffmpeg_version_probe`), so the child's exit code never
reaches the log either. There is nothing in a failing build's output that says
which of the three it was.

It is also wrong about the case that actually happens. A downstream Windows
packaging lane failed **eight consecutive builds** here on a payload that was
never at fault: its bytes are the pinned upstream wheel's to the digest, and the
same bytes print a version banner and exit 0 on any desktop Windows install.
Windows Server Core ships no Video for Windows components, so it cannot load a
Windows ffmpeg that load-time imports `AVICAP32.dll`, and the loader refuses the
image before its entry point runs.

## Why it matters

The gate withholds a **correct** artifact because the machine that assembled it
is not the machine that runs it — and it reports that as if the payload were
tampered with, which sends whoever reads the log hunting a supply-chain problem
that does not exist. Reconstructing the real cause took a PyPI wheel download and
a container-image inspection, entirely outside the build.

There is no build-environment escape either: every Windows image AWS CodeBuild
publishes is built on Server Core, for container *and* EC2 compute, so no
environment type or fleet setting changes it.

## What changed (motivation → approach → change)

The two questions the gate was conflating are independent, and they fail for
unrelated reasons:

| verdict | property of | on failure |
| --- | --- | --- |
| `authentic` | the **artifact** — bytes match the pinned digest or an accepted signature | stop the build |
| `ok` | additionally the **build host** — the bytes actually executed | warn and ship |

- `_packaged_ffmpeg_version_probe` now returns a `PackagedDecoderProbe`
  (`ok`, `authentic`, `code`, `detail`), mirroring the shape of
  `stt.engine.Availability` that the same gate already consumes.
- It **captures** the child's streams instead of discarding them, decoding with
  `errors="replace"` because a loader complaint arrives in the host's console
  encoding, not necessarily UTF-8. `detail` is length-bounded so it stays one
  readable log line.
- Windows loader statuses render as `0xC0000135 (STATUS_DLL_NOT_FOUND)` rather
  than a bare signed int — the difference between a log a reader can act on and
  one they cannot.
- `local_voice_runtime_gate` reads the verdicts separately: exit 1 for a broken
  recogniser or an unauthenticated decoder, exit 2 (a warning that ships) for an
  authenticated decoder this host will not run. The `if`-wrapped command
  substitution is deliberate: under `set -euo pipefail` a bare assignment from a
  non-zero substitution aborts the script, which would silently turn exit 2 back
  into a hard failure.

**Not weakened.** Bytes that fail authentication are still refused, and the
runtime path `_open_ffmpeg_for_execution` still fails closed on a bundled
interpreter. Only the *build* gate's treatment of an execution failure changes.

## Tests

New, in `test/test_transcribe.py`:

- `test_probe_reports_ok_when_the_authenticated_decoder_runs`
- `test_a_host_that_cannot_run_an_authentic_decoder_is_not_reported_as_tampering` —
  the point of the split: `authentic` stays true, so the release is not failed,
  and the child's own stderr reaches `detail`.
- `test_a_decoder_that_cannot_be_spawned_at_all_still_counts_as_authentic` —
  the `OSError` arm is a distinct path to the same verdict.
- `test_a_payload_that_fails_authentication_is_still_refused` — pins the half
  that must not have moved.
- `test_windows_loader_statuses_are_named_in_the_detail`
- `test_probe_detail_is_bounded`

The decoder is really spawned in these rather than stubbed, since the split is
about what a real spawn reports back. `test_spawn_audit.py`'s note on this call
site is updated: the streams are captured now, not discarded.

## Manual verification

- All four probe arms driven against a real spawn: runs/exit 0, authentic +
  exit 127 with stderr surfaced, authentic + unspawnable (`OSError`), and
  digest mismatch.
- All four gate exit paths driven end to end against a stubbed `kiro_crew`,
  confirming exit 2 warns and lets the script continue while exit 1 still stops
  it.
- The pinned Windows payload was confirmed byte-identical to the PyPI wheel
  (`87638016`, `2ce797a0…`) and confirmed to run and exit 0 on a desktop
  Windows host; `avicap32.dll` is absent from both layers of
  `mcr.microsoft.com/windows/servercore:ltsc2022`.
- `black` / `flake8` / `isort` clean; `mypy --platform linux src/kiro_crew` →
  no issues in 1210 files; `scripts/docs-lint.sh` and the working-tree half of
  `scripts/scrub-lint.sh` pass.

## Screenshots / video

N/A — no user-visible UI change; this is a build-time gate.

## Related Issues

N/A — found while triaging a downstream packaging lane rather than from a filed
issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] New tests added for the new behaviour (see **Tests**); the full suite is
      running on this PR's checks rather than asserted from a local run
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated — `docs/system-specs/features/stt-streaming.md`
      (which documented the old single-verdict contract) and
      `docs/build/desktop-app.md`
- [x] No secrets, credentials, or internal references in the diff