### PR TITLE
fix(pierre): bound runaway highlight tokenization with the WASM regex engine

### DIFF
--- a/website/src/pierre/PierreImpl.tsx
+++ b/website/src/pierre/PierreImpl.tsx
@@ -14,6 +14,7 @@ import { useIsDark } from '../hooks/useIsDark'
 import { PlainCodeFallback } from './PlainCodeFallback'
 import {
   PIERRE_EXTENSION_OVERRIDES,
+  PIERRE_REGEX_ENGINE,
   PIERRE_THEMES,
   PIERRE_VIRTUALIZER_CONFIG,
   PIERRE_WORKER_POOL_SIZE,
@@ -249,7 +250,7 @@ const workerPool = typeof window === 'undefined' || typeof Worker === 'undefined
             type: 'module',
           }),
       },
-      highlighterOptions: { theme: PIERRE_THEMES },
+      highlighterOptions: { theme: PIERRE_THEMES, preferredHighlighter: PIERRE_REGEX_ENGINE },
     })
 
 /** Hands every descendant the shared pool. Exported because the editor surface

--- a/website/src/pierre/config.ts
+++ b/website/src/pierre/config.ts
@@ -101,6 +101,37 @@ export const PIERRE_EDIT_CARET_ALIGN_CSS = `
  *  how many files tokenize concurrently — four covers a chat message or PR
  *  with several diffs open at once without spawning the library's default 8. */
 export const PIERRE_WORKER_POOL_SIZE = 4
+/** Which regex engine the highlight workers tokenize with.
+ *
+ *  Pierre defaults to `shiki-js`, which runs TextMate grammar patterns through
+ *  `oniguruma-to-es` on V8's own RegExp. That engine has no ceiling on a single
+ *  match: a grammar pattern that backtracks catastrophically grows V8's
+ *  backtracking stack until the renderer is killed, and because that stack is
+ *  an external allocation inside the sandbox reservation the fatal reads as a
+ *  CAGE OOM with an almost empty JS heap — which is why it never looked like a
+ *  highlighter problem:
+ *
+ *      <--- Near heap limit --->
+ *      Heap: used=10.1MB limit=4192.0MB
+ *      Near V8 cage limit; stack trace capture may not succeed
+ *      V8 javascript OOM (CALL_AND_RETRY_LAST).
+ *
+ *      #1 exec              (worker-portable-*.js)   <- EmulatedRegExp.exec
+ *      #2 findNextMatchSync
+ *      #8 _tokenize
+ *      #9 tokenizeLine2
+ *
+ *  `shiki-wasm` is the reference oniguruma build, and it is compiled with
+ *  `DEFAULT_RETRY_LIMIT_IN_MATCH 10000000`, so a pathological match aborts
+ *  instead of running unbounded. The two guards that would otherwise cap this
+ *  are both unavailable to us: the 1000-char `tokenizeMaxLineLength` does not
+ *  apply (exponential backtracking needs only tens of characters), and
+ *  `tokenizeTimeLimit` is hardcoded to `0` — no limit — inside `@pierre/diffs`,
+ *  reachable through no option this module can pass.
+ *
+ *  Cost is a one-time WASM instantiation per worker; both engines are already
+ *  in the worker bundle, so nothing new is fetched. */
+export const PIERRE_REGEX_ENGINE = 'shiki-wasm'
 /** Row windowing for whole-file surfaces.
  *
  *  Pierre only windows rows when a `<Virtualizer>` is an ancestor; without one

--- a/website/src/test/PierreImpl.workerPool.test.tsx
+++ b/website/src/test/PierreImpl.workerPool.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * The highlight worker pool's ENGINE choice, pinned.
+ *
+ * `PierreImpl` builds the one worker pool the whole tab shares, and the engine
+ * it asks for is the difference between a runaway grammar match being bounded
+ * and killing the renderer process. Pierre's own default (`shiki-js`) runs
+ * TextMate patterns on V8's RegExp with no per-match ceiling; six renderer
+ * deaths on 2026-08-30 were V8 cage OOMs raised from `tokenizeLine2` ->
+ * `findNextMatchSync` -> `EmulatedRegExp.exec` with a JS heap of 8-32 MB out of
+ * 4192 MB. `shiki-wasm` is the reference oniguruma build and aborts a
+ * pathological match at its compiled-in retry limit instead.
+ *
+ * The option is easy to lose and impossible to notice losing: it lands in
+ * `highlighterOptions`, NOT `poolOptions`, and Pierre silently defaults an
+ * absent value back to `shiki-js`. Nothing else in the suite reads it, so this
+ * file is the guard. Deleting the option from `PierreImpl` fails the first
+ * assertion; moving it to `poolOptions` fails the second.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+
+const pool = vi.hoisted(() => ({
+  calls: [] as { poolOptions: Record<string, unknown>; highlighterOptions: Record<string, unknown> }[],
+}))
+
+vi.mock('@pierre/diffs/worker', () => ({
+  getOrCreateWorkerPoolSingleton: (args: {
+    poolOptions: Record<string, unknown>
+    highlighterOptions: Record<string, unknown>
+  }) => {
+    pool.calls.push(args)
+    return { isWorkingPool: () => true }
+  },
+}))
+
+// The library itself is never exercised here — only the options the wrapper
+// hands its pool — so these doubles carry just enough shape to let the module
+// evaluate under happy-dom.
+vi.mock('@pierre/diffs', () => ({
+  EXTENSION_TO_FILE_FORMAT: {},
+  parsePatchFiles: () => [],
+  setCustomExtension: () => {},
+}))
+
+vi.mock('@pierre/diffs/react', async () => {
+  const { createContext } = await import('react')
+  return {
+    File: () => null,
+    FileDiff: () => null,
+    MultiFileDiff: () => null,
+    Virtualizer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    WorkerPoolContext: createContext<unknown>(undefined),
+  }
+})
+
+describe('Pierre highlight worker pool engine', () => {
+  beforeEach(() => {
+    pool.calls.length = 0
+    vi.resetModules()
+    // The pool is only constructed when a Worker constructor exists — without
+    // this the module takes its SSR branch and makes no call to assert on.
+    vi.stubGlobal('Worker', class {})
+  })
+
+  it('asks for the WASM oniguruma engine, whose pathological matches are bounded', async () => {
+    await import('../pierre/PierreImpl')
+
+    expect(pool.calls).toHaveLength(1)
+    expect(pool.calls[0].highlighterOptions.preferredHighlighter).toBe('shiki-wasm')
+  })
+
+  it('passes the engine in highlighterOptions, the only argument Pierre reads it from', async () => {
+    await import('../pierre/PierreImpl')
+
+    // WorkerPoolManager takes the engine off its SECOND argument; a value on
+    // poolOptions is silently ignored and the default `shiki-js` stands.
+    expect(pool.calls[0].poolOptions).not.toHaveProperty('preferredHighlighter')
+    expect(Object.keys(pool.calls[0].highlighterOptions)).toContain('preferredHighlighter')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

The dashboard renderer process died **six times on 2026-08-30** (13:53, 16:39, 17:05, 18:40, 21:32, 21:57 local), each time taking the window black until the recovery reload. Every crash is the same fatal, from `~/Library/Logs/Kiro Crew/chromium.log`:

```
[78368:0830/215703:ERROR:electron/shell/renderer/oom_stack_trace.cc:151]
<--- Near heap limit --->
Heap: used=10.1MB limit=4192.0MB
[78368:0830/215703:INFO:...:233] Near V8 cage limit; stack trace capture may not succeed
[78368:0830/215703:ERROR:...v8_initializer.cc:947] V8 javascript OOM (CALL_AND_RETRY_LAST).
```

The JS heap was **0.2% full** at death (8–32 MB of 4192 MB across the six), so this is not a JS-object leak — it is the V8 pointer-compression **cage** filling with external allocations. One crash (17:05) captured a JS stack, which names the culprit:

```
#0 #a                (worker-portable-ogdEFvyx.js:152:15653)   <- EmulatedRegExp.#execCore
#1 exec              (worker-portable-ogdEFvyx.js:152:15593)   <- EmulatedRegExp.exec
#2 findNextMatchSync
#3 findNextMatchSync
#4 ct / st / f / at
#8 _tokenize
#9 tokenizeLine2
```

That is the TextMate tokenizer inside Pierre's highlight worker, dying in a regex match.

## Why it matters

Any chat message, diff, or file view can carry the content that triggers it, so this is a whole-window crash reachable from ordinary use — not an edge case behind a setting. It fires on remote-crew panes too (the 17:05 worker bundle was served from a tunnelled pane), so it is not specific to one machine's content.

## What changed (motivation → approach → change)

**Symptom → root cause.** Pierre defaults to the `shiki-js` engine, which compiles TextMate grammar patterns through `oniguruma-to-es` and runs them on V8's own `RegExp` (confirmed in the shipped bytes: `function Mu(e=\`shiki-js\`)`, and the captured `exec` frame is `EmulatedRegExp.exec`, not native `RegExp.prototype.exec`). That path has **no ceiling on a single match**. A grammar pattern that backtracks catastrophically grows V8's backtracking stack — an external allocation that must live inside the sandbox reservation — until the process is killed. That is exactly why the fatal reads as a cage OOM with a near-empty GC heap, and why this never looked like a highlighter problem.

**Why the two obvious guards do not apply.** Both were checked against the real bytes, not assumed:

- A line-length guard already exists and is already active — `@pierre/diffs` sets `tokenizeMaxLineLength = 1e3` in its pool defaults and shiki emits any line ≥1000 chars as one uncoloured token without invoking the grammar. It cannot help here: exponential backtracking needs only tens of characters.
- A per-line time limit is the guard that *would* stop this, and `@pierre/diffs` hardcodes `tokenizeTimeLimit: 0` — which vscode-textmate reads as *no limit* — in both its file and diff render paths. It is unreachable through any option this repo can pass. Shiki's own default is 500 ms; VS Code passes 500 ms at every call site.

**The change.** Ask for `shiki-wasm` instead. That is the reference oniguruma build, compiled with `DEFAULT_RETRY_LIMIT_IN_MATCH 10000000`, so a pathological match aborts at its retry ceiling rather than running unbounded. Both engines are already inside the worker bundle (`worker/wasm-B9ZqxnKj.js`), so nothing new is fetched at runtime and no dependency is added.

Three files:

- `website/src/pierre/config.ts` — new `PIERRE_REGEX_ENGINE = 'shiki-wasm'` constant, carrying the crash evidence and the reasoning above as its doc comment so the next reader does not have to re-derive it.
- `website/src/pierre/PierreImpl.tsx` — passes it as `preferredHighlighter` in **`highlighterOptions`**. Position is load-bearing: `WorkerPoolManager` destructures `preferredHighlighter` off its *second* constructor argument, and a value placed on `poolOptions` is silently ignored with `shiki-js` still in force.
- `website/src/test/PierreImpl.workerPool.test.tsx` — new, pins both the value and its position.

## Tests

`website/src/test/PierreImpl.workerPool.test.tsx`, 2 tests, mocking `@pierre/diffs/worker` and asserting on the arguments the pool is constructed with:

1. *asks for the WASM oniguruma engine* — locks `highlighterOptions.preferredHighlighter === 'shiki-wasm'`.
2. *passes the engine in highlighterOptions, the only argument Pierre reads it from* — locks the position, because the wrong-argument mistake is a silent no-op that no other test would catch.

Both proven RED against the defect they guard, then GREEN restored:

| mutation | result |
|---|---|
| option deleted (Pierre silently defaults to `shiki-js`) | 2 failed |
| option moved to `poolOptions` (silently ignored) | 2 failed |
| unmodified | 2 passed |

Full frontend suite on this diff: **1689/1690 files, 26796 tests passed**, 1 expected fail, 3 skipped. The single failure is `AutoNudgePopover.test.tsx > lists a script cron this slot owns` — a pre-existing flake: it passes on 2 of 3 standalone re-runs, and neither the component nor its test references anything under `src/pierre/`.

Also green: `npx tsc -b`, `eslint src/ --max-warnings 659`, `i18n:check`, `lint:phantom-classes`, `npm run build`.

## Manual verification

**1. Engine equivalence and cost, measured.** A Node harness ran both engines head-to-head over real files in this repo, using the exact `shiki` / `@shikijs/*` / `oniguruma-to-es` versions the dashboard ships, `tokenizeMaxLineLength: 1000` as in production, median of 7 runs:

| file | lines | tokens | `shiki-js` | `shiki-wasm` | delta |
|---|---|---|---|---|---|
| `website/src/pages/ChatSidebar.tsx` | 6630 | 37242 | 1452.6 ms | 299.3 ms | **−79%** |
| `website/src/pierre/PierreImpl.tsx` | 406 | 2311 | 72.3 ms | 17.7 ms | **−76%** |
| `src/kiro_crew/dashboard/chat_runner.py` | 9996 | 30081 | 183.7 ms | 211.4 ms | +15% |
| `website/package.json` | 205 | 961 | 0.7 ms | 1.0 ms | +0.3 ms |

Output is **token-for-token and colour-for-colour identical** on all four (token counts equal; the first 400 token colours compare byte-identical), which is why this carries a no-visual-delta marker rather than screenshots. Highlighter construction — paid once per worker, 4 per realm — goes from 2.5 ms to 18.7 ms.

**2. The engine actually loads and paints, in a real browser.** Ran the built `website/dist` behind the repo's own loopback static server with the dashboard API stubbed, opened a note holding a Python and a TSX fence, and asserted on the *painted* result rather than on the option: **5 distinct computed token colours** on each fence (an engine that failed to instantiate would collapse the block to a single inherited colour), and **0 page errors** after filtering the known KaTeX/favicon noise. Screenshot reviewed by hand — both fences fully coloured, indistinguishable from before.

**3. Scope of effect.** All four connected remote crews plus this machine serve a byte-identical Pierre worker bundle (`worker-portable-ogdEFvyx.js`, 834682 bytes, md5 `1970f0feda9113ae11f815df1b72224d`), so no host is on a different `@pierre/diffs` with different defaults. Being a desktop-layer change, it reaches an installed app only after `make desktop`, and reaches a remote pane only when that host is rebuilt.

**What this does not claim.** The retry ceiling bounds a runaway match; it does not make tokenization unconditionally safe, and the crash is rare enough (six in one day, none reproducible on demand) that absence of recurrence will take days to be meaningful. The durable fix is upstream — `@pierre/diffs` should stop passing `tokenizeTimeLimit: 0` and inherit shiki's 500 ms — and no change in this repo can substitute for it.

<!-- no-visual-delta -->
**Why no screenshot:** the two engines produce identical tokens and identical colours (measured above), so there is no rendered delta to show.

## Related Issues

no linked issue: found by log analysis of a local crash, not filed as an issue first.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the reasoning lives in the `PIERRE_REGEX_ENGINE` doc comment; no user-facing docs describe the engine choice
- [x] No secrets, credentials, or internal references in the diff
