### PR TITLE
refactor: promote fd_real_path to pinned_fs and document dev-mode grant

### DIFF
--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -760,19 +760,48 @@ Dev mode speeds up app-UI iteration: no manual copy-and-hard-refresh loop. When
 an installed app is in dev mode the gateway serves its UI files with
 `Cache-Control: no-store` and watches the app's `ui/` directory; on any file
 change it broadcasts an `app_reload` WebSocket event and the dashboard reloads
-the app so edits appear immediately. The recommended setup symlinks
-`~/.kiro/crew/apps/<name>/ui/` to your source tree so the watcher sees edits at
-the real files.
+the app so edits appear immediately.
+
+Link the whole `ui/` **directory**, never individual files inside it: since
+#6809 the UI route opens the final name with `O_NOFOLLOW`, so a per-file
+symlink like `ln -s ~/src/app/dist/index.mjs ui/index.mjs` answers 404 —
+indistinguishable from "not built yet". The directory link keeps working
+because the route resolves the ui root before validating against it. The
+recommended setup is `ln -s ~/src/my-app/dist ~/.kiro/crew/apps/<name>/ui`
+(a directory symlink to your source tree) so the watcher sees edits at the
+real files.
 
 **Contract surface:**
 
 - **`installed.json` field — `dev: bool`** (default `false`): persisted per-app
   flag. Tolerant on read (absent ⇒ `false`); reversible; no migration needed.
-  Builtin apps cannot enter dev mode.
+  Builtin apps cannot enter dev mode. This field drives the watcher and the
+  `no-store` header, but for an out-of-install `ui` root it is **not**
+  sufficient for serving — see the grant below.
+- **Operator grant — `.dev-grants.json` under `~/.kiro/crew/apps/`** (JSON
+  object `app -> resolved ui root` as `os.path.realpath(<install>/ui)` at
+  toggle time), written **only** by `POST /api/apps/{name}/dev` (and pruned by
+  `remove_dev_app` on uninstall) — never by the startup reconcile. A grant
+  is bound to the **specific resolved directory** the operator approved, so it
+  is self-invalidating: repointing `ui/` after the toggle (swap, update,
+  reinstall under the same name) yields a root that no longer equals the
+  granted one, and the UI route answers `400` with `code: dev_grant_mismatch`
+  until you re-toggle dev mode once after repointing to re-bind it. A
+  pre-existing escaped root from before #6809 behaves the same — `400` until
+  that one re-toggle after upgrade. Grants for a missing app are pruned on
+  next reconcile (remove-only, never add — deriving a grant from
+  app-writable `installed.json` is the laundering path #6809 closes).
+- **Safety gate — sensitive roots are refused.** Toggling dev mode on while
+  `ui` resolves into **or contains** a sensitive location
+  (`is_sensitive_path` / `path_contains_sensitive`, e.g. `~/.ssh`,
+  `~/.aws`) is refused with `400` and no state is changed — no dev workflow
+  legitimately serves those, and the unauthenticated `/apps/{name}/ui/`
+  route must never be grantable onto them.
 - **Endpoint — `POST /api/apps/{name}/dev`**, body `{"enabled": <bool>}`.
   Returns `{"name": <name>, "dev": <bool>}`. `400` for a non-boolean body,
-  a builtin app, or an unsafe app name; `404` if the app is not installed.
-  Behind the standard gateway auth; emits an `app_dev_mode` SEL audit event.
+  a builtin app, an unsafe app name, or a sensitive `ui` root; `404` if the
+  app is not installed. Behind the standard gateway auth; emits an
+  `app_dev_mode` SEL audit event.
 - **WebSocket event — `app_reload`**, payload `{"app": <name>, "ts": <float>}`.
   Re-dispatched to the frontend as the `mc:app-reload` window CustomEvent; the
   AppHost triggers a full page reload for the matching app.
@@ -783,13 +812,16 @@ the real files.
 **Cost model:** dev mode is off for essentially all gateways. The
 authoritative per-app state is the `installed.json` `dev` field above; to keep
 the steady-state cost negligible the gateway also maintains an **internal,
-unstable cache** (a small sentinel file under `~/.kiro/crew/apps/`, plus an
-in-memory mirror) listing the app names currently in dev mode. The watcher
-`stat()`s only that one file each second and walks a `ui/` tree solely for apps
-in the set — so a gateway with no dev apps pays one `stat()` per second and
-never invokes the heavier `list_apps()` walk; the in-memory mirror lets the
-UI-serving hot path decide the cache header with no per-request disk IO. This
-sentinel is a derived cache and **not** part of the App Kit contract: its path,
-name, and format are internal implementation details, may change without
-notice, and must not be read or written by app or third-party tooling — treat
-`installed.json` `dev` as the only supported source of truth.
+unstable cache** (a small sentinel file `.dev-apps.json` under
+`~/.kiro/crew/apps/`, plus an in-memory mirror) listing the app names currently
+in dev mode. The watcher `stat()`s only that one file each second and walks a
+`ui/` tree solely for apps in the set — so a gateway with no dev apps pays one
+`stat()` per second and never invokes the heavier `list_apps()` walk; the
+in-memory mirror lets the UI-serving hot path decide the cache header with no
+per-request disk IO. This sentinel is a derived cache and **not** part of the
+App Kit contract: its path, name, and format are internal implementation
+details, may change without notice, and must not be read or written by app or
+third-party tooling — treat `installed.json` `dev` as the only supported source
+of truth for watching. The `.dev-grants.json` record above **is** part of the
+contract for out-of-install roots, but its path is still an internal detail —
+do not read or write it by hand; use the toggle endpoint.

--- a/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/spec_builder/backend/routes.py
@@ -84,9 +84,13 @@ except Exception:  # pragma: no cover - constant always present in prod
     CHAT_TURN_TIMEOUT = 1800  # type: ignore[assignment]
 
 try:
-    from kiro_crew.hooks import _fd_real_path, safe_read_file_bytes_nolink
-except Exception:  # pragma: no cover - hooks always present in prod
+    from kiro_crew.pinned_fs import fd_real_path as _fd_real_path
+except Exception:  # pragma: no cover - pinned_fs always present in prod
     _fd_real_path = None  # type: ignore[assignment]
+
+try:
+    from kiro_crew.hooks import safe_read_file_bytes_nolink
+except Exception:  # pragma: no cover - hooks always present in prod
     safe_read_file_bytes_nolink = None  # type: ignore[assignment]
 
 try:

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from kiro_crew import platform_compat, security, webhooks
 from kiro_crew.config import paths as _config_paths
+from kiro_crew.pinned_fs import fd_real_path as _fd_real_path  # noqa: F401  (re-exported)
 from kiro_crew.platform import current_context, redact_via_context
 from kiro_crew.platform.governance import (
     CU_CLASS_OBSERVE,
@@ -2092,59 +2093,6 @@ def stat_identity(raw: str) -> tuple[int, int] | None:
     except OSError:
         return None
     return (st.st_dev, st.st_ino)
-
-
-def _fd_real_path(fd: int) -> str | None:
-    """Real filesystem path of an OPEN descriptor."""
-    if os.name == "nt":
-        try:
-            import ctypes
-            import msvcrt
-
-            win_dll = getattr(ctypes, "WinDLL", None)
-            get_osfhandle = getattr(msvcrt, "get_osfhandle", None)
-            if not callable(win_dll) or not callable(get_osfhandle):
-                return None
-            kernel32 = win_dll("kernel32", use_last_error=True)
-            get_final_path = kernel32.GetFinalPathNameByHandleW
-            get_final_path.argtypes = [
-                ctypes.c_void_p,
-                ctypes.c_wchar_p,
-                ctypes.c_uint32,
-                ctypes.c_uint32,
-            ]
-            get_final_path.restype = ctypes.c_uint32
-            buffer = ctypes.create_unicode_buffer(32768)
-            length = get_final_path(
-                ctypes.c_void_p(get_osfhandle(fd)),
-                buffer,
-                len(buffer),
-                0,
-            )
-            if length == 0 or length >= len(buffer):
-                return None
-            path = buffer.value
-            if path.startswith("\\\\?\\UNC\\"):
-                return "\\\\" + path[8:]
-            if path.startswith("\\\\?\\"):
-                return path[4:]
-            return path
-        except (AttributeError, ImportError, OSError, ValueError):
-            return None
-
-    try:
-        return os.readlink(f"/proc/self/fd/{fd}")  # Linux
-    except OSError:
-        pass
-    try:
-        import fcntl
-
-        if hasattr(fcntl, "F_GETPATH"):  # macOS
-            buf = fcntl.fcntl(fd, fcntl.F_GETPATH, bytes(1024))
-            return buf.split(b"\x00", 1)[0].decode()
-    except (OSError, ValueError, ImportError):
-        pass
-    return None
 
 
 def safe_read_file_bytes_nolink(

--- a/src/kiro_crew/pinned_fs.py
+++ b/src/kiro_crew/pinned_fs.py
@@ -36,12 +36,23 @@ Two things this module deliberately does NOT do:
 
 from __future__ import annotations
 
+import ctypes
 import errno
 import os
 import shutil
 import stat as _stat
 from pathlib import Path, PurePath
 from typing import Callable
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None  # type: ignore[assignment]
 
 __all__ = [
     "PinnedPathRefusal",
@@ -52,6 +63,7 @@ __all__ = [
     "copy_file_pinned",
     "create_and_open_dir_pinned",
     "fatal_skip_reporter",
+    "fd_real_path",
     "is_reparse_point",
     "is_regular_at",
     "stat_at",
@@ -336,6 +348,61 @@ def is_reparse_point(path: str | Path) -> bool:
         return bool(getattr(os.lstat(path), "st_reparse_tag", 0))
     except OSError:  # pragma: no cover - a component that vanished mid-walk
         return False
+
+
+def fd_real_path(fd: int) -> str | None:
+    """Real filesystem path of an OPEN descriptor.
+
+    Windows fail-closed descriptor-path containment lives here, not in
+    ``hooks`` — the descriptor is pinned, so a component that is open is
+    fixed and the path it reports is the inode actually opened. Used by the
+    staging helpers and by the safe-read path that pins the open before
+    validating containment.
+    """
+    if os.name == "nt":
+        try:
+            win_dll = getattr(ctypes, "WinDLL", None)
+            get_osfhandle = getattr(msvcrt, "get_osfhandle", None)
+            if not callable(win_dll) or not callable(get_osfhandle):
+                return None
+            kernel32 = win_dll("kernel32", use_last_error=True)
+            get_final_path = kernel32.GetFinalPathNameByHandleW
+            get_final_path.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_wchar_p,
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+            ]
+            get_final_path.restype = ctypes.c_uint32
+            buffer = ctypes.create_unicode_buffer(32768)
+            length = get_final_path(
+                ctypes.c_void_p(get_osfhandle(fd)),
+                buffer,
+                len(buffer),
+                0,
+            )
+            if length == 0 or length >= len(buffer):
+                return None
+            path = buffer.value
+            if path.startswith("\\\\?\\UNC\\"):
+                return "\\\\" + path[8:]
+            if path.startswith("\\\\?\\"):
+                return path[4:]
+            return path
+        except (AttributeError, ImportError, OSError, ValueError):
+            return None
+
+    try:
+        return os.readlink(f"/proc/self/fd/{fd}")  # Linux
+    except OSError:
+        pass
+    try:
+        if fcntl is not None and hasattr(fcntl, "F_GETPATH"):  # macOS
+            buf = fcntl.fcntl(fd, fcntl.F_GETPATH, bytes(1024))  # type: ignore[union-attr]
+            return buf.split(b"\x00", 1)[0].decode()
+    except (OSError, ValueError, ImportError):
+        pass
+    return None
 
 
 def copy_file_pinned(


### PR DESCRIPTION
## Problem / Motivation

PR #6854 landed the dev-mode operator grant (`.dev-grants.json`, sensitive-root
refusal, re-toggle workflow) but deferred three follow-ups: the
`docs/app-kit/api-reference.md` contract still described `installed.json:dev`
as the only source of truth and recommended a per-file symlink, and the
private helper `_fd_real_path` had a third cross-module import.

## Why it matters

- Operators reading `api-reference.md` would still treat `installed.json:dev`
  as sufficient for an out-of-install `ui/` and would try a per-file symlink
  that now answers `404` (pinned `O_NOFOLLOW` open). A sensitive `ui` root
  would look grantable.
- `_fd_real_path`'s Windows fail-closed containment belongs with the pinning
  helpers, not in `hooks.py`; three importers reaching into a private symbol
  is the drift the issue flags.

## What changed (motivation → approach → change)

- **Docs — `docs/app-kit/api-reference.md`:** replace the "symlink your source
  tree" paragraph and the four-bullet contract with a directory-symlink
  recommendation and six bullets: `installed.json:dev`, the new **operator
  grant** (`.dev-grants.json` mapping `app -> realpath(ui)` written only by
  the toggle, bound to the specific resolved directory, self-invalidating on
  repoint, `400 dev_grant_mismatch` until re-toggle, prune-only reconcile),
  the **sensitive-root refusal**, plus endpoint / websocket / CLI. Clarify that
  `.dev-apps.json` remains an internal cache while `.dev-grants.json` is the
  authorization half for out-of-install roots (re-toggle after repointing
  workflow included).
- **Refactor — `src/kiro_crew/pinned_fs.py`:** add public `fd_real_path(fd)`
  (same Windows `GetFinalPathNameByHandleW` / Linux `/proc/self/fd` / macOS
  `F_GETPATH` implementation) and export it in `__all__`.
- **Repoint — `src/kiro_crew/hooks.py`:** delete the private definition,
  re-export `from kiro_crew.pinned_fs import fd_real_path as _fd_real_path`
  at top (keeps `hooks._fd_real_path` importable for existing callers/tests).
- **Repoint — `src/kiro_crew/apps/builtins/spec_builder/backend/routes.py`:**
  import `_fd_real_path` from `pinned_fs` (split from the `safe_read_file`
  import) with the same `None` fallback.

No new behavior for in-install `ui/` roots; no change to the toggle's
gateway-auth model (explicit operator confirmation for escaping grants is the
remaining item from #6907 and is left for a follow-up).

## Tests

- `pytest test/test_app_dev_mode.py` — 31 passed
- `pytest test/test_app_ui_file_route.py` — 40 passed, 4 skipped
- `isort` / `flake8` on the three touched Python files — PASS
- `fd_real_path` re-export: `pinned_fs.fd_real_path is hooks._fd_real_path`
  and `spec_builder.routes._fd_real_path is pinned_fs.fd_real_path`

## Manual verification

- Verified the new `api-reference.md` section renders the grant, sensitive
  refusal, and re-toggle workflow as described in #6907.
- Verified `mypy` on the moved helper still has the same platform branches
  (Windows / Linux / macOS) and that the two repointed importers still
  guard `None` the same way.

## Screenshots / video

N/A — docs + internal refactor, no UI.

## Related Issues

Part of #6907 (docs + `_fd_real_path` promotion; operator-confirmation
hardening remains as a follow-up).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
