### PR TITLE
docs: install dev extras and electron deps in first-time setup (#7209)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,13 @@ cd website
 npm install
 npm run build
 cp -r dist ../src/kiro_crew/static/dist
+cd electron && npm ci && cd ..       # desktop sub-package deps (npm test needs them)
 cd ..
 
-# 3. Editable backend install (with optional voice extras)
+# 3. Editable backend install (with dev/test tooling)
 python -m venv .venv && source .venv/bin/activate
-pip install -e ".[voice]"
+pip install -e ".[dev]"
+# Optional voice extras (local speech-to-text): pip install -e ".[dev,voice]"
 
 # 4. Configure and verify
 kirocrew setup               # data dir, agent backend (channels connect later)
@@ -70,9 +72,11 @@ kirocrew gateway             # start server (dashboard + messaging channels)
 The dashboard is at `http://localhost:5476`.
 
 On Windows, `.\make.ps1 build` does steps 2 and 3 in one command (the venv lands
-in `.venv\Scripts\`, and `Activate.ps1` replaces `source .venv/bin/activate`).
-Read the [Windows guide](docs/guides/windows-install.md) first — a few features
-need an explicit opt-in there.
+in `.venv\Scripts\`, and `Activate.ps1` replaces `source .venv/bin/activate`),
+except the `website/electron` sub-package — run
+`npm ci --prefix website/electron` separately before `npm test`. Read the
+[Windows guide](docs/guides/windows-install.md) first — a few features need an
+explicit opt-in there.
 
 **Messaging channels are optional**: the default `kirocrew setup` configures
 none, and the dashboard + CLI work without any channel credentials. Connect
@@ -103,7 +107,8 @@ truth (with `.github/workflows/ci.yml` canonical for the gate list).
 ### Backend
 
 ```bash
-pip install -e ".[voice]"    # installs deps + console scripts
+pip install -e ".[dev]"      # installs deps + console scripts + test tooling
+# Optional voice extras (local speech-to-text): pip install -e ".[dev,voice]"
 pytest                       # run the test suite
 ```
 
@@ -116,6 +121,7 @@ The React SPA lives in `website/`. Production builds are bundled into
 cd website
 npm install
 npm run build                # tsc + vite build → website/dist
+cd electron && npm ci && cd ..       # desktop sub-package deps (npm test needs them)
 ```
 
 After building, copy `website/dist` into `src/kiro_crew/static/dist/` so the


### PR DESCRIPTION
## Problem / Motivation

A reader who follows `CONTRIBUTING.md`'s First-Time Setup literally cannot run the checks the same document prescribes, in either half of the repo:

1. **Backend** — step 3 (`CONTRIBUTING.md:62`) and Building/Backend (`:106`) both say `pip install -e ".[voice]"`, but `setup.cfg`'s `voice` extra is only `kirocrew[voice-aws]` + `pywhispercpp>=1.5,<2` — zero test tooling. Everything the document then asks the reader to run (`pytest` at `:107`, `:389-391`, `:467`) lives in the `dev` extra, and `setup.cfg`'s own comment directly above that extra reads `# Development and test tooling:` / `#   pip install -e ".[dev]"` — the document contradicted its own build config. It does not even fail cleanly: `test/conftest.py:15` is an unconditional `from hypothesis import HealthCheck, settings`, so collection dies even for a reader who has pytest from elsewhere.
2. **Frontend** — step 2 (`:54-58`) and Building/Frontend (`:116-118`) run `npm install` in `website/` only, but `website/electron` is a separate npm package (`name: kirocrew-desktop`, its own `package.json`/`package-lock.json`, deps `electron-store` + `electron-updater`) reached via `"test:electron": "npm test --prefix electron"` with no `workspaces` key. `grep -c electron-updater website/package-lock.json` returns 0, so the outer install never reaches it, and `require("electron-store")` in `website/electron/test/store-rename-migration.test.js:33` cannot resolve. Because `"test"` joins the two halves with `&&`, the whole `npm test` (and `npm run check`, which inherits it) exits non-zero and reads as repository bugs.

## Why it matters

This is the first document every new contributor follows. As written, it strands them at their very first `pytest` / `npm test` with failures that look like broken code rather than a missing install — @swchoi0102 measured 17 `MODULE_NOT_FOUND` failures on a fresh clone before `npm ci` in `website/electron`, and 0 after. Worse, the `voice`-first install can fail outright at step 3: `pywhispercpp` compiles AVX2 intrinsics and (per `setup.cfg`'s own comment block) has no wheel on Intel macOS, so a first-time contributor can be blocked on an optional speech-to-text dependency before ever reaching the code.

## What changed (motivation → approach → change)

Docs-only. The build config is correct and the document is what is wrong, so the whole fix is editing `CONTRIBUTING.md` to match the config that already exists. No change to `setup.cfg`, `website/package.json`, `website/electron/package.json`, `test/conftest.py`, or any code.

- **Backend**: `pip install -e ".[dev]"` becomes the required install at both sites (step 3 and Building/Backend), with `voice` demoted to an explicitly optional, commented add-on line (`pip install -e ".[dev,voice]"`). Deliberately **not** `".[dev,voice]"` as the default: everything the document asks the reader to run needs `dev`, nothing it asks them to run needs `voice`, and `pywhispercpp` has no Intel-macOS wheel — making it mandatory blocks a first-time contributor at step 3 on an optional STT dependency. The optional line uses the `".[dev,voice]"` spelling (rather than incremental `".[voice]"`) so it is safe to run standalone in a fresh venv — a reader who copies only that line still gets the test tooling. Step 3's heading comment is adjusted to match ("with dev/test tooling").
- **Frontend**: the sub-package install is added as `cd electron && npm ci && cd ..` — the reporter's own suggested form — inside step 2 after the existing build/copy commands (before the block's final `cd ..`, so a reader copy-pasting the whole block still lands back at the repo root where step 3 expects them), and mirrored verbatim in the Building/Frontend block so the two copies cannot drift apart again.
- **Windows note** (pre-push review catch): step 2 now includes the electron install, but `make.ps1`'s `Invoke-Frontend` only runs `npm ci`/`npm run build` in `website/` — so the paragraph claiming `.\make.ps1 build` "does steps 2 and 3" would have gone stale. The note now says to run `npm ci --prefix website/electron` separately. (The backend half of that claim actually becomes *more* accurate with this PR: `make.ps1:332` and `Makefile:66` already install `-e ".[dev]"` — the build scripts agreed with `setup.cfg` all along; only the document disagreed.)

The four edited sites are the only `pip install -e` / `npm install` occurrences in the document (verified by grep over the whole file), so no third stale copy is left behind — duplication drift is exactly how this defect arose.

## Tests

N/A — docs-only change; no test harness covers `CONTRIBUTING.md`. The backend gates were still run to prove the diff is docs-only (see below).

## Manual verification

Walked the edited First-Time Setup as a literal reader on a fresh worktree at `main` (`ae457328e`):

- **Premises re-derived against the checkout** (not trusted from the issue): `setup.cfg`'s `voice` extra still carries zero test tooling; the `dev` extra carries `pytest>=8,<10` + `hypothesis>=6` (+ black/isort/flake8/mypy); `grep -c electron-updater website/package-lock.json` is still 0; `website/package.json` still declares no `workspaces` key.
- **Backend half**: a venv installed per the new instruction (`dev` extras) provides `pytest 8.4.2` and `hypothesis 6.165.2`, and `python -m pytest` collects. Control: a venv with pytest from elsewhere but no `hypothesis` (the old doc's outcome) dies at collection with `ImportError while loading conftest ... test/conftest.py:15 ... No module named 'hypothesis'` — the exact failure class the issue reports.
- **Frontend half**: on the fresh worktree, `require("electron-store")` does not resolve from `website/electron` (no `node_modules`). After running exactly the new doc line `cd electron && npm ci && cd ..`, it resolves, and `npm test --prefix electron` runs 1407 tests with **zero** `MODULE_NOT_FOUND` failures (the 2 remaining failures are pre-existing host-timing flakes in `gateway-stop.test.js`, unrelated to installs).
- Backend gates on the zero-`.py` diff: isort / flake8 (7.1.0) / mypy (1.14.1) all clean, plus the repo's black-ratchet, subprocess-encoding, brand-name, and docs-lint scripts. Full `python -m pytest` was run to prove the diff is docs-only: 63,575 passed with this host's known environment-failure baseline (123 failed + 7 errors, consistent with the failure band documented on this host across recent runs; the run ended in a known xdist worker-crash flake), zero failures referencing the changed file — the diff touches no `.py` files, so CI on clean runners is the authoritative suite signal.
- Pre-push dual model review: GPT lane (gpt-5.6-sol) raised one High — the Windows `make.ps1` note going stale — fixed in this diff. Claude lane (ran on the designated fallback claude-opus-4.8 after two infrastructure timeouts on the primary pin): PASS, two advisories — the same Windows note (fixed), and a pre-existing observation that the `dev` *extra* omits the PEP 735 `--group dev` set (`jsonschema`, `pytest-split`), so 11 config-validation guard tests skip silently on a local run. That skew predates this PR (the old `.[voice]` instruction omitted it equally), and folding `--group dev` into First-Time Setup would require pip ≥ 25.1 — a new first-contact failure mode of exactly the class this PR removes — so it is deliberately left out here and tracked in follow-up #7226 instead.

## Screenshots / video

N/A — not a UI change (deleted per template instruction).

## Related Issues

Follow-up (not closed by this PR): #7226 — the `make.ps1`/`Makefile` build targets themselves skipping the electron install, and the `dev`-extra vs `--group dev` skew, both surfaced by the pre-push review.

Credit: @swchoi0102 reported both defects with the measurements that made this verifiable — the 17→0 `MODULE_NOT_FOUND` count and the `setup.cfg` comment that turns "the doc is wrong" into "the doc contradicts its own build config" — and suggested the `cd electron && npm ci && cd ..` form used here.

Closes #7209

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality (docs-only; no new tests applicable)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
