### PR TITLE
fix(service): write the systemd unit and env file as UTF-8

### DIFF
--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -343,7 +343,7 @@ def _write_unit_via_sudo(contents: str) -> subprocess.CompletedProcess[str]:
     """
     fd, tmp_path = tempfile.mkstemp(prefix="kirocrew-unit-", suffix=".service")
     try:
-        with os.fdopen(fd, "w") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(contents)
         return subprocess.run(
             [
@@ -377,7 +377,7 @@ def _install_file_via_sudo(contents: str, dest: Path, mode: str = "0644") -> Non
     """
     fd, tmp_path = tempfile.mkstemp(prefix="kirocrew-", suffix=".tmp")
     try:
-        with os.fdopen(fd, "w") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(contents)
         res = _sudo_run("install", "-m", mode, "-o", "root", "-g", "root", tmp_path, str(dest))
         if res.returncode != 0:

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -648,6 +648,170 @@ class TestLinuxEnvironmentFile:
         assert str(env_file) in removed
 
 
+def _text_writes_missing_encoding(source: str) -> list[str]:
+    """Return ``"<line>: <call>"`` for every TEXT-mode open in ``source`` that
+    does not name an explicit ``encoding=``.
+
+    Binary mode is skipped -- it has no encoding to name. A call whose mode is
+    not a literal is treated as text, which is the conservative direction: a
+    dynamic mode still needs an encoding on the text branch.
+    """
+    import ast
+
+    found: list[str] = []
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        else:
+            continue
+        if name not in ("open", "fdopen"):
+            continue
+        # Mode is the second positional arg for both builtins.open and
+        # os.fdopen, or the `mode=` keyword.
+        mode = None
+        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+            mode = node.args[1].value
+        for kw in node.keywords:
+            if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                mode = kw.value.value
+        if isinstance(mode, str) and "b" in mode:
+            continue
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        found.append(f"{node.lineno}: {name}(...)")
+    return found
+
+
+class TestLinuxServiceWritesUtf8:
+    """systemd reads unit and environment files as UTF-8. The writers here must
+    therefore EMIT UTF-8, not whatever ``locale.getpreferredencoding()`` happens
+    to return on the installing host.
+
+    Both staging writes went through ``os.fdopen(fd, "w")`` with no
+    ``encoding=``, so the bytes handed to ``sudo install`` were locale-dependent
+    while the consumer's contract is fixed. The same module already reads its
+    environment file back with ``encoding="utf-8"`` (``linux.py:448``), so the
+    round trip crossed two different encodings.
+
+    Reviewer-counted residual from merged #7164, which made the identical
+    argument for the drop-in it did fix.
+    """
+
+    def _capture_staged_bytes(self, call, contents: str) -> bytes:
+        """Run ``call(contents)`` with the privileged step stubbed, and return
+        the raw bytes of the temp file it staged.
+
+        The bytes must be read from inside the stub: both writers unlink the
+        temp file in a ``finally``, so by the time the call returns there is
+        nothing left to inspect.
+        """
+        import subprocess
+        from pathlib import Path
+
+        staged: dict[str, bytes] = {}
+
+        def _fake_run(argv, *a, **kw):
+            # The staged temp path is the second-to-last argv entry for both
+            # writers (`install -m MODE -o root -g root <tmp> <dest>`).
+            staged["raw"] = Path(argv[-2]).read_bytes()
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        with (
+            patch("kiro_crew.service.linux.subprocess.run", side_effect=_fake_run),
+            patch("kiro_crew.service.linux._privilege_prefix", return_value=["sudo"]),
+        ):
+            call(contents)
+        return staged["raw"]
+
+    def test_a_non_ascii_home_reaches_the_unit_writer(self, monkeypatch):
+        """Premise, not a regression pin: the unit is not ASCII by construction.
+
+        ``render_unit`` interpolates the account name and its home directory
+        into ``User=``, ``WorkingDirectory=`` and every ``Environment=`` line,
+        and both are ordinary UTF-8 filesystem values on Linux. So the string
+        handed to the writer can legitimately carry non-ASCII, which is what
+        makes the writer's encoding load-bearing rather than cosmetic.
+        """
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setenv("USER", "josé")
+        gid_result = MagicMock(returncode=0, stdout="josé\n", stderr="")
+        with (
+            patch("kiro_crew.service.common.shutil.which", return_value="/home/josé/bin/kirocrew"),
+            patch("kiro_crew.service.linux.subprocess.run", return_value=gid_result),
+            patch("kiro_crew.service.linux._home_for_user", return_value="/home/josé"),
+        ):
+            unit = svc_linux.render_unit()
+
+        assert not unit.isascii(), "expected the rendered unit to carry the non-ASCII home"
+        assert "/home/josé" in unit
+
+    def test_the_unit_write_stages_utf8_bytes(self):
+        """``_write_unit_via_sudo`` must hand ``install`` UTF-8 bytes."""
+        from kiro_crew.service import linux as svc_linux
+
+        contents = "[Service]\nWorkingDirectory=/home/josé\nEnvironment=USER=josé\n"
+        raw = self._capture_staged_bytes(svc_linux._write_unit_via_sudo, contents)
+
+        # Assert the ENCODING, not the line terminator: text mode translates
+        # newlines on Windows, which this Linux-only module never sees in
+        # production but a developer box does.
+        assert "josé".encode("utf-8") in raw
+        assert raw.decode("utf-8").replace("\r\n", "\n") == contents
+
+    def test_the_install_file_write_stages_utf8_bytes(self, tmp_path):
+        """``_install_file_via_sudo`` is the same staging shape and the same
+        contract. Its one current caller seeds an ASCII template, so this is a
+        contract pin rather than a live-harm test -- but the helper takes
+        arbitrary ``contents`` and publishes to a root-owned path, so the
+        encoding must not be left to the host."""
+        from kiro_crew.service import linux as svc_linux
+
+        contents = "# Kiro Crew — überschrift\nKIROCREW_PORT=5477\n"
+        raw = self._capture_staged_bytes(
+            lambda c: svc_linux._install_file_via_sudo(c, tmp_path / "env"), contents
+        )
+
+        assert "— überschrift".encode("utf-8") in raw
+        assert raw.decode("utf-8").replace("\r\n", "\n") == contents
+
+    def test_every_text_write_in_the_linux_service_names_its_encoding(self):
+        """Ratchet. This is the assertion that goes red on the unfixed tree, and
+        it is what stops the seam decaying again -- the two sites here were
+        themselves the residue of an earlier pass that fixed a sibling."""
+        from pathlib import Path
+
+        from kiro_crew.service import linux as svc_linux
+
+        source = Path(svc_linux.__file__).read_text(encoding="utf-8")
+        offenders = _text_writes_missing_encoding(source)
+
+        assert offenders == [], (
+            "text-mode open without encoding= in service/linux.py: "
+            + "; ".join(offenders)
+            + " — systemd reads these files as UTF-8, so the writer must not "
+            "depend on the installing host's locale"
+        )
+
+    def test_the_encoding_ratchet_can_actually_fail(self):
+        """A scan that matches nothing passes as green and proves nothing. Pin
+        that the detector fires on a violation and stays quiet on the fixed
+        form and on binary mode."""
+        offending = 'import os\nwith os.fdopen(fd, "w") as fh:\n    fh.write(x)\n'
+        fixed = 'import os\nwith os.fdopen(fd, "w", encoding="utf-8") as fh:\n    fh.write(x)\n'
+        binary = 'import os\nwith os.fdopen(fd, "wb") as fh:\n    fh.write(x)\n'
+
+        assert len(_text_writes_missing_encoding(offending)) == 1
+        assert _text_writes_missing_encoding(fixed) == []
+        assert _text_writes_missing_encoding(binary) == []
+
+
 class TestMacOSPlistRendering:
     def test_plist_and_unit_never_auto_open_a_browser(self, monkeypatch, tmp_path):
         """Both installers pass `--no-open`.

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -740,29 +740,31 @@ class TestLinuxServiceWritesUtf8:
         """
         from kiro_crew.service import linux as svc_linux
 
-        monkeypatch.setenv("USER", "josé")
-        gid_result = MagicMock(returncode=0, stdout="josé\n", stderr="")
+        monkeypatch.setenv("USER", "usuário")
+        gid_result = MagicMock(returncode=0, stdout="usuário\n", stderr="")
         with (
-            patch("kiro_crew.service.common.shutil.which", return_value="/home/josé/bin/kirocrew"),
+            patch(
+                "kiro_crew.service.common.shutil.which", return_value="/home/usuario/bin/kirocrew"
+            ),
             patch("kiro_crew.service.linux.subprocess.run", return_value=gid_result),
-            patch("kiro_crew.service.linux._home_for_user", return_value="/home/josé"),
+            patch("kiro_crew.service.linux._home_for_user", return_value="/home/usuario"),
         ):
             unit = svc_linux.render_unit()
 
         assert not unit.isascii(), "expected the rendered unit to carry the non-ASCII home"
-        assert "/home/josé" in unit
+        assert "User=usuário" in unit
 
     def test_the_unit_write_stages_utf8_bytes(self):
         """``_write_unit_via_sudo`` must hand ``install`` UTF-8 bytes."""
         from kiro_crew.service import linux as svc_linux
 
-        contents = "[Service]\nWorkingDirectory=/home/josé\nEnvironment=USER=josé\n"
+        contents = "[Service]\nWorkingDirectory=/home/usuario\nEnvironment=USER=usuário\n"
         raw = self._capture_staged_bytes(svc_linux._write_unit_via_sudo, contents)
 
         # Assert the ENCODING, not the line terminator: text mode translates
         # newlines on Windows, which this Linux-only module never sees in
         # production but a developer box does.
-        assert "josé".encode("utf-8") in raw
+        assert "usuário".encode("utf-8") in raw
         assert raw.decode("utf-8").replace("\r\n", "\n") == contents
 
     def test_the_install_file_write_stages_utf8_bytes(self, tmp_path):


### PR DESCRIPTION
## Problem / Motivation

`kirocrew service install` stages the systemd unit and the environment-overrides
file through `os.fdopen(fd, "w")` with no `encoding=`
(`service/linux.py:346`, `:380`), then publishes each with
`sudo install`. With no explicit encoding, the bytes written are whatever
`locale.getpreferredencoding()` returns on the installing host.

systemd reads unit and environment files as **UTF-8**. So the producer's encoding
is host-dependent while the consumer's is fixed — and the same module already
reads its environment file back with `encoding="utf-8"`
(`service/linux.py:448`), so the round trip crosses two different encodings
inside one file.

## Why it matters

**The unit is not ASCII by construction.** `render_unit()` interpolates the
account name and its home directory into `User=`, `WorkingDirectory=` and every
`Environment=` line, and both are ordinary UTF-8 filesystem values on Linux. A
test in this PR pins that: with a `usuário` account, the rendered unit is
`not unit.isascii()`.

Scoped honestly, because the blast radius depends on the host locale:

- **`LC_ALL=C` / `POSIX` is mostly mitigated.** CPython coerces the C locale to
  a UTF-8 one (PEP 538) and enables UTF-8 mode (PEP 540), so this common case
  usually survives by accident rather than by contract.
- **A non-UTF-8, non-C locale is not mitigated** — `en_US.ISO-8859-1`,
  `zh_CN.GB18030`, `ja_JP.eucJP` and friends. There
  `getpreferredencoding()` returns a legacy codec, and the failure splits two
  ways: a name that codec *can* represent is written as mojibake bytes that
  systemd then misparses, and a name it cannot represent raises
  `UnicodeEncodeError` and the install fails outright.

The silent branch is the worse one — `install` succeeds, the unit lands, and
`daemon-reload` is where it goes wrong.

Reviewer-counted residual from the First Principles review of merged #7164,
which made the identical argument for the drop-in it *did* fix:

> The locale-encoding cause fixed for the drop-in has 2 unfixed siblings in the
> same subsystem: `service/linux.py:346` and `:380` write systemd unit content
> via `os.fdopen(fd, "w")` with no `encoding=`. They can't use `atomic_write`
> (root-owned publish via `sudo install`), but the PR's own
> systemd-reads-UTF-8 argument applies verbatim.

## What changed (motivation → approach → change)

**Symptom** → a unit staged on a legacy-locale host carries non-UTF-8 bytes.
**Root cause** → two text-mode writers leave the encoding to the host.
**Change** → name it: `os.fdopen(fd, "w", encoding="utf-8")` at both sites.

Deliberately *not* routed through `atomic_write`, for the reason the reviewer
already gave: the publish is a root-owned `sudo install`, not a rename performed
by this process, so the shared helper does not apply here. The atomicity these
functions rely on is `install`'s own rename, which the docstrings already
explain and which this change does not touch.

The two sites differ in how live they are, and the PR does not pretend otherwise:

- **`_write_unit_via_sudo`** is the live one — its input is `render_unit()`,
  which carries user-controlled paths.
- **`_install_file_via_sudo`**'s only current caller seeds `_ENV_FILE_TEMPLATE`,
  which is pure ASCII, so today it is **latent**. It is fixed anyway because it
  is a general `(contents, dest)` helper publishing to a root-owned path — the
  next caller should not have to rediscover this.

## Tests

Five tests in `test/test_service.py`, in a new `TestLinuxServiceWritesUtf8`
class:

| Test | Locks in |
|---|---|
| `test_a_non_ascii_home_reaches_the_unit_writer` | the **premise**: a `usuário` account makes `render_unit()` non-ASCII, so the writer's encoding is load-bearing |
| `test_the_unit_write_stages_utf8_bytes` | the bytes `install` receives decode as UTF-8 and round-trip |
| `test_the_install_file_write_stages_utf8_bytes` | same contract for the general helper |
| `test_every_text_write_in_the_linux_service_names_its_encoding` | **ratchet** — an AST scan of the module; every text-mode `open`/`fdopen` must name `encoding=` |
| `test_the_encoding_ratchet_can_actually_fail` | the ratchet's own self-check: it fires on a violation, stays quiet on the fixed form and on binary mode |

The staged bytes are captured *inside* the stubbed `subprocess.run` — both
writers unlink the temp file in a `finally`, so after the call returns there is
nothing left to read. Assertions are on the encoding, not the line terminator,
because text mode translates newlines on a Windows developer box (a platform
this Linux-only module never runs on in production).

**Red-before — 3 failed, 2 passed**, tests written first and run against
unmodified `main` at `3df8ecc5c`:

```
FAILED TestLinuxServiceWritesUtf8::test_every_text_write_in_the_linux_service_names_its_encoding
    - AssertionError: text-mode open without encoding= in service/linux.py:
      346: fdopen(...); 380: fdopen(...)
FAILED TestLinuxServiceWritesUtf8::test_the_unit_write_stages_utf8_bytes
    - UnicodeEncodeError: 'cp950' codec can't encode character '\xe9'  (linux.py:347)
FAILED TestLinuxServiceWritesUtf8::test_the_install_file_write_stages_utf8_bytes
    - UnicodeEncodeError: 'cp950' codec can't encode character '\xfc'  (linux.py:381)
```

**Be precise about what that proves.** My host's preferred encoding is `cp950`,
which is exactly the legacy-locale case described above — so locally the two
behavioural tests reproduce the real mechanism, `UnicodeEncodeError` raised at
the two patched lines. **On a UTF-8 CI runner those two will pass on both sides
of this change**, and the **ratchet is the assertion that carries the red-before
there.** That is also why the ratchet is in the PR at all rather than being
treated as optional tidiness.

**Green after:** whole file, `248 passed, 56 skipped`.

**Second commit — `De-Amazon Scrub Lint` failed on the first, and it was mine.**
That gate's structural identity scan (`scripts/scrub-lint.sh`, check 3/5) greps
`/(local/home|home|Users)/[A-Za-z][A-Za-z0-9._-]+` across `test/` and refuses any
user segment outside its `GENERIC_USER` placeholder list. The interaction that
makes it non-obvious: the extractor's character class is **ASCII-only**, so
`/home/josé` is captured as the truncated stem `/home/jos`, which no placeholder
can ever match — *any* non-ASCII home path trips this, not just an
employee-shaped one.

The non-ASCII these tests actually need is on the **account name**, not the path.
The fixture now uses `usuário` for `User=` / `Environment=USER=` — still
non-ASCII, so the premise is unchanged — and `/home/usuario`, which is on the
gate's own list, for the path. Reproduced locally with
`./scripts/scrub-lint.sh --no-history`: **4 findings before, `All checks passed`
after**, and the suite is still `248 passed, 56 skipped`.

Also clean on the changed files: `flake8`, `isort --check-only`, `mypy`, and the
repo's baselined black gate. `test/test_service.py` is a pre-existing baseline
entry; the new code is written in the form black wants, and the file's existing
unformatted lines were deliberately left untouched rather than swept into this
diff.

## Manual verification

N/A — unit coverage sufficient: the change is the encoding of a staged temp
file, and the tests assert the actual bytes handed to `install` rather than the
`str` passed in, which is the only place the defect was observable.

## Related Issues

Residual named by the First Principles review of #7164 (merged). No open issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing doc describes the staging encoding
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

