### PR TITLE
feat: pipeline-conductor agent, harness skill, and design doc

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,6 +7,7 @@ proposal lands.
 
 | Document | Covers |
 |---|---|
+| [pipeline-conductor.md](pipeline-conductor.md) | A dedicated fleet-orchestrator agent + harness skill for the issue→PR pipelines: probe/verify/intervene/adjudicate loop, resource-posture flow control, per-item credit budgets, and the PipelineSpec template seams for running the same conductor on any repository and campaign type. |
 | [playwright-cli-migration.md](playwright-cli-migration.md) | Moving browsing onto `playwright-cli`: the capability model, the install flow, snapshot retention, and the dashboard surface. |
 
 Indexed from [../README.md](../README.md).

--- a/docs/design/pipeline-conductor.md
+++ b/docs/design/pipeline-conductor.md
@@ -1,0 +1,170 @@
+# Pipeline Conductor: the issue pipelines as a conductor use case
+
+A dedicated `kirocrew-pipeline-conductor` agent and a `pipeline-conductor` builtin skill that run a
+repository pipeline as a supervised worker fleet. The skill is the operating procedure of record;
+this document carries the intent and the decisions.
+
+## What a conductor is
+
+A conductor is a long-lived supervisor agent that owns a body of work end to end without doing any
+of it itself: it picks up work items, stands up one worker session per item, patrols the fleet,
+verifies results independently, rules on exceptions, and reports upward. Every deterministic step
+(probing, verification arithmetic, budget sums) is delegated to bundled zero-token scripts; every
+judgment (adjudication, intervention, re-planning) stays in the agent. The shape is **agent +
+agent skills**: the skill carries the procedure, the scripts carry the bookkeeping, the agent
+carries the judgment.
+
+## Why
+
+Kiro Crew's issue-fixing automation today is three open-loop pipelines (issue → new PR, red PR →
+green, green PR → merge). They are **agentic workflows wrapped in deterministic scripts**: cron
+scanners and dispatchers own the control flow; agent sessions do the work inside it. The AI-native
+shape is the inversion — **deterministic scripts wrapped in an agentic control plane**, which is
+exactly agent + agent skills.
+
+The refactor is feasible now because most of the conductor architecture already exists in Kiro
+Crew (see the facts below). What is missing is a conductor **specialized to run a pipeline**, and
+the operating procedure that encodes how.
+
+Why invert at all? A pipeline's control plane needs **flexibility**, which the agentic layer has
+and a script does not:
+
+1. **Direction correction.** Issues routinely attract over-complicated implementations. A script
+   pipeline is only a dispatcher; a conductor detects the drift and corrects mid-flight — a
+   sharpened re-dispatch, a descope, an open-issue conversion.
+2. **Probes and live resource governance.** Worker sessions are noisy neighbours — one full-suite
+   test run can starve the host. A conductor reads live posture and intervenes; a cron cannot even
+   see the problem between ticks.
+3. **Judgment on whether the work should happen at all.** Wrong premise, superseded, or a real
+   design decision: a dispatcher cannot decline work; a conductor stands down with evidence or
+   converts it into a proposal. A decorative fix is worse than no fix.
+4. **Self-improvement.** A conductor summarizes as it operates and folds lessons back into its own
+   skill, briefs and probe rules. A cron script cannot get better at its job.
+5. **A node in the agent network.** A conductor is itself an agent, so other agents and crews can
+   invoke it. Every future multi-agent capability inherits the pipeline for free.
+
+The rigidity costs are concrete — the failure classes of the open-loop pipelines: duplicate
+dispatch ending in mutual-yield deadlocks; silent stalls noticed only by the 90-minute heartbeat
+reaper; every exception terminating in a human excavating logs; and hand-edited progress state
+drifting from the forge.
+
+With a conductor the human appears exactly twice: the merge click, and genuine design decisions.
+
+## Verified facts this plan rests on
+
+- The conductor pattern is already shipped: `kirocrew-conductor` is a generated agent spec, built
+  at gateway boot, with per-verb dashboard grants and installer tests.
+- The session-control surface exists: the `kirocrew-dashboard` MCP server (session
+  create/read/send/stop, chat folders), opt-in per agent.
+- The patrol loop exists (`monitor_start`, deadline-preserving, survives gateway restarts), as do
+  the durable session ledger and live host posture (`resource_status`: ample/tight/critical).
+- Per-session spend is measurable: usage shards record per-turn `credits` keyed by session slot.
+  Only dashboard-chat turns are instrumented today — subagent and non-chat sessions burn
+  invisibly, so budget verdicts must treat absent metering as unknown, never as zero.
+- The dispatch queues are already sharded per `owner__repo`, so per-repository pipeline identity
+  (#6221) has its storage seam half-built.
+- Worker transcripts are tailable on disk, which is what makes one batch probe per patrol cycle
+  cheap — the design that keeps a quiet cycle at one output line.
+
+## The agent
+
+`kirocrew-pipeline-conductor` follows the generated-agent pattern of `kirocrew-conductor` and its
+security invariants:
+
+- **No file-writing tool** (`fs_write`, `code` absent): never doing a work item's work itself is a
+  spec property, not a prompt request.
+- **Every auto-approval is a named verb**, dashboard and core alike: creates/reads, the patrol
+  loop's own lifecycle, and owner reporting are granted; anything that mutates a peer session or
+  starts new work from ingested content (`session_send`, `session_stop`, `spawn_run`, `task_run`,
+  `workflow_run`, `cron_add`, `execute_bash`) stays mounted but gated. The conductor ingests
+  untrusted content (issue text, PR bodies) on unattended cycles by design.
+- **Unattended operation is a session-level trust grant** by the operator ("trust before seed",
+  the same rule the worker sessions already follow) — not a standing spec-level bypass.
+
+## The harness
+
+The `pipeline-conductor` skill is the operating procedure: idempotent pickup, the work-order brief
+(one item / one worktree / one PR, six-word report protocol), the probe cycle and its action
+table, independent green verification, the intervention ladder, the adjudication and override
+protocol, the resource-posture table, the credit budget rules, steering-as-mode-change, and merge
+cleanup. Two subprocess-free scripts do the bookkeeping:
+
+- `scripts/fleet_probe.py` — one call per cycle: tail-classifies every worker session, computes
+  idle age, flags error tails, scans for banned processes, reads host load. Handled signals live
+  in a state file the script owns. All paths are derived, never configurable: transcripts only
+  from this gateway's own session store (keys are validated stems; a candidate resolving outside
+  the store — a symlink — reads as missing), state only beside the config file.
+- `scripts/credit_spend.py` — per-item credit rollup with budget verdicts `within` / `exhausted` /
+  `truncated` (a bounded scan never claims `within`) / `unmetered` (absent metering is unknown,
+  not zero).
+
+Decisions worth naming, in the skill's own sections:
+
+- **Verification**: a worker's GREEN is never trusted — check-runs collapsed per lane (newest run
+  wins), head SHA pinned, reviewer verdicts read from job logs and marker comments.
+- **Intervention**: nudge → a read-only inspector subagent (enforced via `allowed_tools`) →
+  ruling: sharpened re-dispatch, adjudicate, open-issue descope, or reclaim. Two sessions on one
+  item: decide ownership once.
+- **Adjudication**: overrides only when every lane is settled, the finding is the sole red, the
+  head SHA is pinned, the rationale is public, and the branch is push-frozen after. A base-owned
+  red is proven three ways and fixed once for the whole fleet.
+- **Governance**: posture ladder ample/tight/critical → dispatch / hold admission / stop the
+  expensive items; banned-operation response is stop + cooldown + directive re-injection, acting
+  only on fleet-owned processes.
+- **Budgets**: a per-item credit allowance (default 100). Exhaustion triggers a burn review —
+  progressing items get a recorded top-up, thrashing items get stopped, not refilled; past the
+  top-up ceiling the decision escalates to the human with the burn history.
+
+## The template: PipelineSpec
+
+The bigger vision: **one conductor engine, configured per (repository, campaign) pair** — any
+repo, any task. Every repo- or task-specific fact the conductor consumes is data:
+
+```yaml
+id: issue-fix                # queue/folder/audit names derive from it
+repo: <owner>/<repo>         # per-repo object key (#6221); one today, list later
+default_branch: main
+work_source: {kind: gh_issues, select_labels: [...], skip_signals: [...]}   # SEAM: adapter
+claim: {lock_label, marker_phrase, operator_tag}                            # lock protocol as data
+worker_contract: {branch_pattern, worktree_pattern, brief_template, heartbeat_sla}
+verifier: {gate_profile, reviewer_lanes: [...], readiness_context, acceptance}  # SEAM: adapter
+adjudication: {auto_action_categories, blast_radius_max, security_denylist}     # SEAM: policy as data
+governance: {max_in_flight, per_cycle, credit_budget_per_item, session_ceiling, posture}
+interface: {folder_name, worker_model, digest_language, notify_channel}
+```
+
+Five seams, each an interface with one implementation shipping: the work-source adapter (a docs or
+test-coverage campaign is a new work source + a new brief, not new engine code), the verifier
+adapter (reviewer lanes as a data list), protocol vocabulary as data (labels, markers, naming —
+the highest-leverage seam), adjudication policy as data, and per-repo identity (#6221). One
+invariant stays out of the template: the forge is the cross-operator lock (claim label + assignee
++ operator-tagged comments); local state is only a cache.
+
+## Phases
+
+- **M0** — the agent and the harness: the generated `kirocrew-pipeline-conductor` spec (installer,
+  filename constant, roster hiding, docs registry, installer tests mirroring the existing
+  conductor's) and the `pipeline-conductor` builtin skill with its two scripts, behavior pinned by
+  tests (probe classification, handled-set suppression, key containment, budget verdicts).
+- **M1** — `PipelineSpec` file consumed by the scripts; SQLite event store (append-only `events`,
+  `issues` as a fold, `decisions` first-class, `dispatch_id UNIQUE`); the board becomes a
+  generated view.
+- **M2** — adjudication queue, SLA timers, retry/catch matrix as data; budgets enforced, not just
+  observed; the self-improvement loop — per-run lessons folded back into the skill and briefs.
+- **M3** — `baking` stage on main CI (merged ≠ done); compensation sagas; per-repo pipeline
+  objects under Issue Radar (#6221); the conductor exposed as an invocable node for other agents
+  and crews.
+
+## Open decisions
+
+1. **Resident session vs deterministic spine.** A patrol loop is overwhelmingly no-signal
+   bookkeeping, which argues for a deterministic engine with the LLM demoted to stateless
+   judgment calls; a resident session's accumulated context makes some adjudications sharper. The
+   M1 event store is what makes the spine option real, so the call is deferred until it exists.
+2. **Unattended `session_send`/`session_stop`.** Session-level trust is the shipped answer; if
+   approval prompts prove to be the attended-mode bottleneck, a follow-up can argue a narrowed
+   server-side capability (e.g. send restricted to conductor-created sessions).
+3. **Credit metering coverage** for subagent and non-chat turns — folded into the planned
+   per-request token metrics work; budgets meanwhile bind what the shards see.
+4. **Digest surface**: chat today; a merge-queue/proposal-queue report page is an Auto Triage
+   Pipeline app extension once the event store exists.

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -48,6 +48,11 @@ from kiro_crew.agent_files import KNOWLEDGE_AGENT_FILENAME as _KNOWLEDGE_AGENT_F
 from kiro_crew.agent_files import LITE_AGENT_FILENAME as _LITE_AGENT_FILENAME
 from kiro_crew.agent_files import (
     OWNED_KIRO_AGENT_FILES,
+)
+from kiro_crew.agent_files import (
+    PIPELINE_CONDUCTOR_AGENT_FILENAME as _PIPELINE_CONDUCTOR_AGENT_FILENAME,
+)
+from kiro_crew.agent_files import (
     REQUIRED_KIRO_AGENT_FILES,
 )
 from kiro_crew.agent_files import RESEARCH_AGENT_FILENAME as _RESEARCH_AGENT_FILENAME
@@ -4543,6 +4548,12 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     except Exception:
         logger.debug("kirocrew-conductor agent install failed", exc_info=True)
 
+    # Install kirocrew-pipeline-conductor agent (repository pipeline fleet supervision)
+    try:
+        _install_pipeline_conductor_agent()
+    except Exception:
+        logger.debug("kirocrew-pipeline-conductor agent install failed", exc_info=True)
+
     # Bidirectional sync: ensure packages installed for one provider
     # are also available for the other (agents↔plugins, skills).
     sync_aim_packages()
@@ -5087,6 +5098,219 @@ def _install_conductor_agent() -> None:
     path = kiro_agents_dir_path() / _CONDUCTOR_AGENT_FILENAME
     _atomic_json_write(path, config)
     logger.info("Installed conductor agent config: %s", path)
+
+
+_PIPELINE_CONDUCTOR_SYSTEM_PROMPT = """# Kiro Crew Pipeline Conductor
+
+You are `kirocrew-pipeline-conductor`. You run ONE pipeline on ONE repository:
+you pick up queued work items, stand up one worker session per item in the
+pipeline's folder, patrol the fleet, verify claimed results independently,
+intervene when a worker loops or stalls, adjudicate blocked items, govern host
+resources and per-item credit budgets, and report verified greens to the
+person as plain-language digests.
+
+**You never do a work item's work yourself.** A file to write, a build to run,
+a fix to make — each one belongs to a worker session you dispatch, verify and
+report on. You have no dedicated file-writing tool (the shell tool stays
+mounted but gated behind operator approval), and a work item never goes to
+`spawn_run`, `spawn_sub_agents`, `workflow_run` or `task_run`. `spawn_run`
+exists here for ONE purpose: a bounded INSPECTOR subagent that reads a suspect
+worker's tail and its PR state and returns a verdict — spawn it with an
+`allowed_tools` list limited to reads so read-only is enforced by the spawn,
+not assumed of the prompt.
+
+**Scripts are the deterministic half of your loop.** Shell access exists to
+run the `pipeline-conductor` skill's two bundled scripts:
+`scripts/fleet_probe.py` (the ONE batch probe per patrol cycle — worker tails,
+idle age, error tails, banned-process scan, host load) and
+`scripts/credit_spend.py` (per-item credit rollups and budget verdicts). Read
+their output; never re-derive what they compute from transcripts.
+
+**Patrol with `monitor_start`, never with `wait`.** Arm it with the full cycle
+instructions AND the exit condition, then end the turn; call `autonudge_stop`
+when you stop. A reply saying *requested* is success — do not retry it. If
+arming is refused outright, say no loop is running and drive that one round
+with `wait`. A quiet cycle is one line, then end the turn.
+
+Your tools:
+
+- Worker sessions — `session_create`, `session_send`, `session_read_message`,
+  `session_stop`, `list_sessions`.
+- Keeping the pipeline's sessions together — `chat_folder_tree`,
+  `chat_folder_create`.
+- State that outlives a round — `session_ledger_read`, `session_ledger_record`.
+- Patrol — `monitor_start`, `monitor_update`, `autonudge_stop`, `wait`.
+- Capacity, before dispatching — `resource_status`.
+- Inspecting a suspect worker — `spawn_run`, bounded and read-only.
+- Talking to the person — `ask_question` puts a decision that is not yours to
+  make to them as a card, after which you END your turn and their answer
+  arrives as the next message; `send_message` / `send_notification` to report.
+- Naming the right skill in a seed message — `skill_search`, `skill_fetch`.
+- Reading — `fs_read`, `web_fetch`.
+- `tool_search` loads a tool that is not in your list yet.
+
+The `pipeline-conductor` skill carries the operating procedure — the pipeline
+spec, the work-order brief, the probe cycle and its action table, the
+intervention ladder, the adjudication and override protocol, the
+resource-posture table, the credit budget rules, and the cleanup steps. Read
+it before acting on a pipeline. The user can message you at any time: a
+steering message is a MODE CHANGE — fold it into the standing patrol
+instruction with `monitor_update` so every later cycle honors it.
+
+{{VERBOSITY_BLOCK}}
+"""
+
+
+#: The kirocrew-core verbs the pipeline conductor may call WITHOUT an approval
+#: prompt. Named one by one rather than as the whole ``@kirocrew-core`` server,
+#: extending the dashboard-grants invariant below to the core surface: the
+#: conductor ingests untrusted content (issue text, PR bodies) on unattended
+#: cycles, and a server-wide grant would let that content start persistent
+#: work (``task_run``, ``workflow_run``, ``cron_add``) or spawn arbitrary
+#: subagents with no human in the loop. What is granted is reads
+#: (``resource_status``, ``list_sessions``, skills), the conductor's OWN
+#: patrol-loop lifecycle (``monitor_*``, ``autonudge_stop``, ``wait``), its
+#: OWN durable ledger, and reporting to the owner (``send_message``,
+#: ``send_notification``, ``ask_question``). ``spawn_run`` — the intervention
+#: ladder's read-only inspector — is deliberately NOT here: it starts agent
+#: work from ingested context, so like ``session_send``/``session_stop`` it
+#: stays mounted-but-gated and unattended runs get it from the operator's
+#: session-level trust grant.
+_PIPELINE_CONDUCTOR_CORE_GRANTS: tuple[str, ...] = (
+    "@kirocrew-core/monitor_start",
+    "@kirocrew-core/monitor_update",
+    "@kirocrew-core/autonudge_stop",
+    "@kirocrew-core/wait",
+    "@kirocrew-core/resource_status",
+    "@kirocrew-core/list_sessions",
+    "@kirocrew-core/session_ledger_read",
+    "@kirocrew-core/session_ledger_record",
+    "@kirocrew-core/skill_search",
+    "@kirocrew-core/skill_fetch",
+    "@kirocrew-core/send_message",
+    "@kirocrew-core/send_notification",
+    "@kirocrew-core/ask_question",
+)
+
+
+#: The dashboard verbs the pipeline conductor may call WITHOUT an approval
+#: prompt. Same tuple, same reasoning, as ``_CONDUCTOR_DASHBOARD_GRANTS``
+#: above — the invariant (a granted verb may CREATE or READ, never MUTATE
+#: workspace state that already exists and is not the agent's own; its worst
+#: case in a loop must be bounded by the server) applies verbatim, because
+#: this agent too ingests untrusted content by design: issue text and PR
+#: bodies feed every granted verb on a nudge-driven cycle with nobody at the
+#: keyboard. ``session_send`` / ``session_stop`` — which the patrol's
+#: intervention ladder does use — stay mounted-but-gated for the same reason
+#: they are gated on the goal conductor; unattended operation gets them via
+#: the operator arming the conductor's own session in trust mode (the same
+#: explicit, session-scoped human grant the worker sessions already require),
+#: not via a standing spec-level bypass.
+_PIPELINE_CONDUCTOR_DASHBOARD_GRANTS: tuple[str, ...] = (
+    "@kirocrew-dashboard/chat_folder_tree",
+    "@kirocrew-dashboard/chat_folder_create",
+    "@kirocrew-dashboard/session_create",
+    "@kirocrew-dashboard/session_read_message",
+)
+
+
+def _install_pipeline_conductor_agent() -> None:
+    """Generate and install the kirocrew-pipeline-conductor agent config.
+
+    Follows ``_install_conductor_agent`` above deliberately — one standalone
+    installer per generated agent is the file's established pattern — and
+    keeps every property that installer's docstring argues for: derived from
+    the kirocrew agent, **no dedicated file-writing tool** (neither ``fs_write``
+    nor ``code``), ``@kirocrew-dashboard`` mounted whole but auto-approved only
+    verb by verb, ``execute_bash`` mounted but never auto-approved
+    (``allowedTools`` has no argument matching, so trusting the two bundled
+    skill scripts cannot be told apart from trusting arbitrary shell), and the
+    KAS policy derived from the FILTERED grant list. Where the two agents
+    differ is charter, not mechanics: this one supervises a repository
+    pipeline's worker fleet (probe / verify / intervene / adjudicate / govern)
+    per the ``pipeline-conductor`` builtin skill, rather than decomposing a
+    free-form goal.
+    """
+    config = build_agent_config()
+    config["name"] = "kirocrew-pipeline-conductor"
+    config["description"] = (
+        "Runs one repository pipeline as a supervised fleet: picks up queued "
+        "work items, dispatches one worker session per item, probes and "
+        "verifies them, intervenes on stalls, adjudicates blocked items, and "
+        "governs host resources and per-item credit budgets. Never does a "
+        "work item's work itself."
+    )
+    config["prompt"] = _PIPELINE_CONDUCTOR_SYSTEM_PROMPT
+    config["tools"] = [
+        "execute_bash",
+        "fs_read",
+        "web_fetch",
+        "session",
+        "report",
+        "tool_search",
+        "@kirocrew-core",
+        "@kirocrew-dashboard",
+    ]
+    granted: list[str] = []
+    withheld: list[str] = []
+    for ref in (
+        "session",
+        "report",
+        "tool_search",
+        *_PIPELINE_CONDUCTOR_CORE_GRANTS,
+        *_PIPELINE_CONDUCTOR_DASHBOARD_GRANTS,
+    ):
+        (granted if _may_auto_approve(ref) else withheld).append(ref)
+    config["allowedTools"] = granted
+    if withheld:
+        # Same audit contract as every other ``allowedTools`` writer: a
+        # withheld grant is a permission decision and must leave a record.
+        try:
+            sel().log_api_access(
+                caller="system",
+                operation="mcp_auto_approve_withheld",
+                outcome="ok",
+                source="_install_pipeline_conductor_agent",
+                resources=(
+                    f"{', '.join(withheld)} mounted without auto-approve "
+                    "(governance ceiling); calls go through the approval gate"
+                ),
+            )
+        except Exception:  # noqa: BLE001 — the audit must not break the install
+            logger.debug("SEL audit unavailable for withheld auto-approve", exc_info=True)
+    mcp = config.get("mcpServers", {}) or {}
+    core_entry = mcp.get("kirocrew-core")
+    narrowed: dict = {}
+    if core_entry:
+        narrowed["kirocrew-core"] = core_entry
+    dash_cmd, dash_args = _kirocrew_mcp_invocation("mcp-dashboard")
+    dash_entry: dict[str, Any] = {"command": dash_cmd, "args": dash_args}
+    # Same managed-server metadata as the conductor's hand-built entry, for the
+    # same two failure modes: a registry-mode client silently DROPS an entry
+    # with no ``type``, and without the data-home pin the shim reads the
+    # DEFAULT home while the gateway runs under an override.
+    if _mcp_registry_mode():
+        dash_entry["type"] = _MCP_REGISTRY_TYPE
+    dash_env = _managed_mcp_env()
+    if dash_env:
+        dash_entry["env"] = dash_env
+    narrowed["kirocrew-dashboard"] = dash_entry
+    config["mcpServers"] = narrowed
+    # Same derive-don't-restate rationale as the conductor above, but routed
+    # through the agent-sdk boundary: ``drivers.acp`` is the one layer permitted
+    # to import ``kiro_crew.acp``, and agent.py's direct-import count is a
+    # shrink-only baseline that must not grow.
+    from kiro_crew.agent_sdk.drivers.acp import (  # noqa: PLC0415 - boot path
+        derived_agent_permissions,
+    )
+
+    config["permissions"] = derived_agent_permissions(
+        config["allowedTools"], _PIPELINE_CONDUCTOR_AGENT_FILENAME
+    )
+    kiro_agents_dir_path().mkdir(parents=True, exist_ok=True)
+    path = kiro_agents_dir_path() / _PIPELINE_CONDUCTOR_AGENT_FILENAME
+    _atomic_json_write(path, config)
+    logger.info("Installed pipeline-conductor agent config: %s", path)
 
 
 _HEARTBEAT_SYSTEM_PROMPT = """# KiroCrew Heartbeat Worker

--- a/src/kiro_crew/agent_files.py
+++ b/src/kiro_crew/agent_files.py
@@ -22,6 +22,7 @@ AGENT_FILENAME = "kirocrew.json"
 # Background/auxiliary managed agent specs KiroCrew writes under ~/.kiro/agents/.
 LITE_AGENT_FILENAME = "kirocrew-lite.json"
 CONDUCTOR_AGENT_FILENAME = "kirocrew-conductor.json"
+PIPELINE_CONDUCTOR_AGENT_FILENAME = "kirocrew-pipeline-conductor.json"
 KNOWLEDGE_AGENT_FILENAME = "kirocrew-knowledge.json"
 RESEARCH_AGENT_FILENAME = "kirocrew-research.json"
 HEARTBEAT_AGENT_FILENAME = "kirocrew-heartbeat.json"
@@ -34,6 +35,7 @@ OWNED_KIRO_AGENT_FILES = (
     AGENT_FILENAME,
     LITE_AGENT_FILENAME,
     CONDUCTOR_AGENT_FILENAME,
+    PIPELINE_CONDUCTOR_AGENT_FILENAME,
     KNOWLEDGE_AGENT_FILENAME,
     RESEARCH_AGENT_FILENAME,
     HEARTBEAT_AGENT_FILENAME,

--- a/src/kiro_crew/agent_sdk/drivers/acp.py
+++ b/src/kiro_crew/agent_sdk/drivers/acp.py
@@ -39,8 +39,32 @@ __all__ = [
     "claude_adapter_cached_negative",
     "claude_adapter_install_command",
     "claude_components_resolve",
+    "derived_agent_permissions",
     "kiro_cli_resolves",
 ]
+
+
+def derived_agent_permissions(allowed_tools: list, agent_filename: str) -> dict:
+    """The KAS policy a generated agent spec should carry, from its grant list.
+
+    Deriving from the FILTERED ``allowedTools`` instead of restating a literal
+    means the rules come out byte-identical, a later edit to the grant list
+    carries through, and a ceiling that strips a grant strips its KAS rule with
+    it. ``{"rules": []}`` when nothing qualifies -- the key's mere PRESENCE is
+    what makes KAS load the spec at all, so the empty policy is still a policy.
+
+    Plain data in, plain data out: a list of grant refs and a spec filename
+    (the KAS ``agent_id`` is its stem), a JSON-ready dict back -- no ACP type
+    crosses the boundary. Function-local import for the same boot-path reason
+    as every other function here, though ``kas_permissions`` itself is a leaf
+    that depends on nothing else in the package.
+    """
+    from pathlib import Path
+
+    from kiro_crew.acp.kas_permissions import allowed_tools_to_permissions
+
+    derived = allowed_tools_to_permissions(allowed_tools, agent_id=Path(agent_filename).stem)
+    return derived if derived is not None else {"rules": []}
 
 
 def kiro_cli_resolves() -> bool:

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: pipeline-conductor
+description: Operating procedure for the kirocrew-pipeline-conductor agent - run one issue/PR pipeline on one repository as a supervised fleet. Auto-pick items, stand up one worker session per item in a dedicated folder, probe them each cycle with one script call, verify claimed greens independently, intervene when a worker loops or stalls, adjudicate blocked items under the override protocol, throttle admission on host posture, enforce per-item credit budgets, digest verified greens to the human, and clean up on merge. Use when a pipeline conductor session is being seeded, or when inspecting/debugging one.
+---
+
+# Pipeline Conductor
+
+You run ONE pipeline on ONE repository. You never do a work item's work — no
+file edits, no builds, no fixes in your own turns. Workers do the work; you
+pick up, dispatch, probe, verify, intervene, adjudicate, govern, report, and
+clean up. Every rule below closes a named failure mode.
+
+Your two bundled scripts are the deterministic half of the loop — run them via
+`execute_bash`, read their output, never re-derive what they compute:
+
+- `scripts/fleet_probe.py` — batch worker-tail classification + idle age +
+  error tails + banned-process scan + host load, in ONE call per cycle.
+- `scripts/credit_spend.py` — per-item credit rollup + budget verdict.
+
+## The pipeline spec
+
+The operator's seed message names a spec file (JSON). Fields you consume now:
+
+```json
+{
+  "id": "issue-fix",
+  "repo": "<owner>/<repo>",
+  "default_branch": "main",
+  "work_source": {"kind": "gh_issues", "select_labels": ["auto-fixable"],
+                   "skip_signals": ["claimed", "in-progress"]},
+  "worker_contract": {"branch_pattern": "fix/{slug}-{n}",
+                       "worktree_pattern": "../{repo_name}-fix-{n}"},
+  "governance": {"max_in_flight": 8, "max_per_cycle": 3,
+                  "idle_alert_secs": 900, "session_ceiling": 30,
+                  "credit_budget_per_item": 100, "topup_ceiling": 2},
+  "interface": {"folder_name": "pipeline-{id}", "digest_language": "auto"}
+}
+```
+
+Anything the spec does not set has the default shown above. Treat every value
+as data — never inline a repo name, label, or branch pattern from memory. The
+spec file's directory is your working state home: write the probe config as
+`<spec-dir>/probe-config.json` and let the probe own
+`<spec-dir>/probe-config.json.state.json` (the handled-set).
+
+## Startup (once per run)
+
+1. Read the spec. `chat_folder_create` the pipeline folder.
+2. Build the queue from the work source (or adopt the operator's seeded
+   backlog). Record every item in the session ledger:
+   `{item, state: queued, evidence}`.
+3. Arm the patrol: `monitor_start` (interval ~90s) with the standing
+   instruction below. **Patrol with `monitor_start`, never `wait`.** Call
+   `autonudge_stop` yourself when the exit condition fires — coasting into the
+   cycle cap is a failure, not a finish.
+
+Standing patrol instruction template (keep it CURRENT — steering edits go here
+via `monitor_update`, see "Live steering"):
+
+> PROBE FIRST: one `fleet_probe.py --config <path>` call. Act only on 🔔/BANNED
+> lines: ERR → batch resume; PR → record; GREEN → verify independently then
+> digest + backfill; STANDDOWN/PROPOSAL → disposition + backfill; BLOCKED →
+> adjudicate; IDLE → intervention ladder. Mark each acted signal handled.
+> Check budgets on items with open sessions every ~5 cycles. Admission per the
+> posture table. Quiet cycle = one line, end turn. EXIT when queue empty and
+> fleet drained: final tally, then `autonudge_stop`.
+
+## Pickup and dispatch
+
+Dispatch is **idempotent** — all four checks, every time (skipping them is how
+two sessions end up on one item and mutual-yield deadlock):
+
+1. Ledger state is `queued` — anything else, skip.
+2. The backlog/findings store (when the pipeline has one) still says the item
+   is open — a queue snapshot goes stale the moment it is built.
+3. No open PR, branch, or worktree already covers it (`gh pr list --search`,
+   branch glob from `branch_pattern`).
+4. In-flight count < `max_in_flight`, this cycle's dispatches <
+   `max_per_cycle`, and posture admits (see governance).
+
+Then: `session_create` (titled `{id}: {item}`, filed into the pipeline
+folder), seed it with the work-order brief, record
+`{state: dispatched, session, ts}` in the ledger. Worker sessions must be
+granted **trust mode before seeding** — an unattended session stuck on an
+approval prompt runs zero turns; if you cannot grant it, tell the operator
+instead of seeding sessions that will hang.
+
+### The work-order brief (seed message skeleton)
+
+Fill `{...}` from the spec; keep every clause — each one closes a failure mode:
+
+> You own exactly ONE item: {item} on {repo}. Work autonomously; do not wait
+> for a human; never ping the human directly — the conductor reports.
+> PREFLIGHT (mandatory): view the item; check open PRs and worktrees for
+> overlap — if anything already covers it, reply `STANDDOWN: <reason>` and
+> stop. Never adopt another session's WIP.
+> CONFIRM the mechanism before fixing: reproduce where cheap; wrong premise →
+> `STANDDOWN: premise disproven — <evidence>`. A design decision →
+> `PROPOSAL: <link>` (write the proposal on the item; do not build).
+> IMPLEMENT in your own worktree (`{worktree_pattern}`, branch
+> `{branch_pattern}` from `{default_branch}`): root-cause fix; regression test
+> red-on-base and mutation-verified; targeted tests ONLY — never the full
+> suite; `pytest` always with a bounded `-n`.
+> PR: English body (What/Why/How/Tests/Other), `Closes #{n}`, full URL in
+> your reply. Babysit to green (`monitor_start` ~300s). Fix every
+> Critical/High; disposition every advisory explicitly; read reviewer JOB
+> LOGS for the current head, not check conclusions; rebut with measurement,
+> never assertion; NEVER `/ai-review override` without the conductor's
+> sign-off — a blocking finding you dispute is `BLOCKED: <evidence + 2-4
+> options>`.
+> REPORT in exactly six words — `WORKING: / PR: / GREEN: / BLOCKED: /
+> STANDDOWN: / PROPOSAL:` — and RE-STATE the prefix on EVERY later turn while
+> this assignment is open (an unprefixed turn reads as "no status"). GREEN
+> must carry the PR URL, head SHA, and a 3-6 step plain-language summary.
+
+## The probe cycle
+
+One `fleet_probe.py` call. Keep `probe-config.json`'s `sessions` list synced
+with the ledger's open sessions (add on dispatch, drop on close). Fired lines
+carry **metadata only** (key, age, tag, digest) — the probe never emits
+transcript text; when a ruling needs content, read the session through the
+workspace-authorized session tools. Action
+table — act, then `--mark-handled KEY TAG DIGEST` (DIGEST is the `d=` field on
+the fired line), or the signal re-fires forever. A stale digest is refused
+(exit 3): the payload moved on since you read it — re-probe and act on what is
+there now, never mark blind:
+
+| Line | Action |
+| --- | --- |
+| `ERR` | Batch-resume the affected workers (`session_send`: "resume; re-state your protocol prefix"). |
+| `PR` | Record PR number + head in the ledger. |
+| `GREEN` | Verify independently (below). Pass → digest + mark item `green_verified`, backfill a queued item. Fail → send the worker the delta. |
+| `BLOCKED` | Adjudicate (below). Write the ruling back via `session_send`; record it. |
+| `STANDDOWN` / `PROPOSAL` | Verify the evidence is stated; record disposition; close or re-queue; backfill. |
+| `IDLE` | Intervention ladder (below). |
+| `GONE` | Transcript missing — treat as reclaim: re-queue the item with evidence. |
+| `BANNED pid=...` | Banned-ops response (below). |
+
+Never page through worker transcripts yourself, and never pull the whole
+fleet's state into context — the probe line is the interface. Quiet cycle:
+print nothing beyond the probe's own `OK` line, end the turn.
+
+## Independent green verification
+
+Never trust a worker's GREEN (workers believe their own summaries):
+
+1. Check-runs for the claimed head SHA, **collapsed per lane, newest run
+   wins** (a force-push leaves stale duplicates); zero red; PR MERGEABLE.
+2. The head SHA matches the claim — a green on yesterday's head is not green.
+3. Reviewer verdicts read from **job logs and marker comments**, never run
+   conclusions — they lie in both directions.
+
+Verified → ledger `green_verified` with the SHA + check snapshot, then the
+human digest: per-PR, plain language (`digest_language`, default: the
+operator's chat language), what/why/risk in 3-6 steps, full PR URL. The digest
+is what keeps a large merge queue reviewable at a glance — never skip it.
+
+## Intervention ladder (looping / self-doubt / wasted time)
+
+Signals: `IDLE` twice in a row; same tag across ~5 cycles with rising turn
+count; credit burn with no ledger transition; ERR recurring after resume.
+
+1. **Nudge** (`session_send`): restate the next step + protocol requirement.
+2. **Inspect** — `spawn_run` ONE bounded inspector with an ENFORCED read-only
+   toolset: pass `allowed_tools` limited to reads (`fs_read`, `web_fetch`,
+   `@kirocrew-dashboard/session_read_message`) so "read-only" is a property of
+   the spawn, not a hope in the prompt — never grant it `execute_bash` or any
+   write tool. Task: *"Read the tail of session {key}
+   (session_read_message) and the state of PR #{n} on {repo} (web_fetch the PR
+   page). Return one verdict — healthy-slow | looping | blocked-misclassified
+   | premise-wrong — plus two sentences of evidence. Do not modify anything."*
+3. **Rule** on the verdict:
+   - `healthy-slow` → extend; note the expected completion signal.
+   - `looping` → `session_stop`, re-dispatch a FRESH session with a sharpened
+     brief naming the loop (context poisoning rarely self-heals).
+   - `blocked-misclassified` → adjudicate it yourself as if BLOCKED.
+   - `premise-wrong` → **open-issue mode**: the worker files an issue with the
+     evidence and partial diff, descopes the PR to what is defensibly green,
+     dispositions the rest as deferred-with-cross-reference, drives the
+     narrowed PR green. A decorative fix is worse than no fix.
+4. **Reclaim** on SLA breach (no event for 3× `idle_alert_secs`): mark
+   reclaimed, re-queue or skip with evidence, close the session.
+
+Two sessions on one item: **decide ownership once** — adopt one, fully stand
+down the other. Two owners politely yielding to each other is a deadlock.
+
+## Adjudication (BLOCKED) and overrides
+
+A BLOCKED report must carry evidence + 2-4 options; if it does not, send it
+back for them. Verify the finding against the CURRENT head first. Rule by:
+
+- Finding real, remedy wrong (the classic: "revert") → look for the narrower
+  forward fix the finding's own wording points at.
+- Real but out of scope → route: fix now / own PR / backlog with
+  cross-reference. "Not applicable to THIS PR" is the honest disposition for a
+  zero-delta-vs-base finding — never "false positive".
+- Deterministic red inherited from {default_branch} → prove base-owned three
+  ways (base's own run red; gate postdates base; file absent from the diff) →
+  ONE minimal unblocking PR for the whole fleet.
+- **Override** only when ALL hold: every lane settled · sole red · head SHA
+  pinned in the override text · rationale public on the PR · branch
+  push-frozen afterwards except review responses. Record every ruling with its
+  rejected options. Genuine design/product decisions escalate to the human —
+  nothing else does.
+
+## Resource governance
+
+The probe's `OK` line carries load + memory + banned count; confirm with
+`resource_status` before batch dispatches.
+
+| Posture | Do |
+| --- | --- |
+| `ample` | Dispatch up to `max_in_flight`. |
+| `tight` | No new dispatches; ask heavy workers to defer gate runs; postpone items marked expensive. |
+| `critical` | Halt admission; `session_stop` the most expensive in-flight items (record as reclaim, not failure); handle violators; wait for recovery before resuming. |
+
+`BANNED` lines (full-suite runs): stop the owning worker session, wait out a
+~5min cooldown, restart it with the no-full-tests directive re-injected in the
+seed. Act ONLY on fleet-owned processes — platform processes and legitimate
+targeted runs are exempt. Standing constants: `session_ceiling` machine-wide,
+bounded `pytest -n`, targeted tests only, ≤2 subagents per worker.
+
+## Credit budgets
+
+Roughly every 5 cycles, for items with open sessions:
+`credit_spend.py --slots <current,previous...> --budget
+{credit_budget_per_item}`.
+
+- `within` → nothing to do.
+- `exhausted` → **burn review**, recorded like an adjudication:
+  - *Progressing* (PR open, review converging, ledger transitions happening) →
+    top-up with a stated size + rationale.
+  - *Thrashing* (no transitions, looping signals) → NO top-up — stop, then
+    sharpened re-dispatch, open-issue mode, or skip with evidence. Exhaustion
+    on a non-moving item is a defect signal, not a billing event.
+  - *Blocked on external* → park the item (parked time burns nothing).
+  - More than `topup_ceiling` top-ups → escalate to the human with the burn
+    history.
+- `unmetered` → treat spend as UNKNOWN, not zero — say so in the ledger and
+  lean on the time-based signals instead.
+- `truncated` (only if you passed `--max-shards`) → re-run without the bound;
+  an under-budget answer from a partial scan is not a verdict.
+
+## Live steering
+
+A human message mid-run is a MODE CHANGE, not a one-off reply: fold it into
+the standing patrol instruction via `monitor_update` so every later cycle
+honors it, and record the mode in the ledger. Canonical example — "stop taking
+new work": edit the instruction to `DRAIN MODE: no backfill, no new
+dispatches; patrol until in-flight items resolve; then final tally +
+autonudge_stop.`
+
+## Merge, cleanup, reconcile
+
+- On merge: worktree removed non-forced (a dirty tree is kept and flagged,
+  never `--force`), branch deleted safely (`-d`, not `-D`), `session_close`
+  the worker, ledger → `done`.
+- Merged is NOT done for the fleet: after a merge, watch the next
+  {default_branch} CI round — a merged gate change that reds every open PR is
+  base-owned (see adjudication) and yours to fix once, fleet-wide.
+- Every ~20 cycles, reconcile the ledger's `green_verified`/`merged` states
+  against the forge (`gh pr list`) — recorded state drifts from reality, and
+  the human WILL ask "where are the other N".
+
+## Exit
+
+Queue empty + fleet drained: final tally (dispatched / merged / open-green /
+proposals / standdowns / skips, with URLs), close remaining sessions,
+`autonudge_stop`.
+
+## Known limits (state them, don't hide them)
+
+- `session_send` / `session_stop` / `spawn_run` (the inspector) are mounted but
+  not auto-approved: unattended operation requires the operator to arm THIS
+  session in trust mode (same "trust before seed" rule as the workers).
+- Credit metering covers dashboard-session turns; `spawn_run` inspector turns
+  and non-chat sessions burn invisibly (`unmetered` verdict exists for a
+  reason).
+- One spec = one repo (M0). Multi-repo is a per-repo spec each, per the design
+  doc's template seams.
+- GitHub labels/assignees remain the cross-operator lock; your ledger is a
+  cache, never the authority, on anything another operator can also touch.

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/credit_spend.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/credit_spend.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Per-item credit spend — the deterministic half of the conductor's budget check.
+
+Sums the credits a work item's sessions have burned, from the gateway's usage
+shards, and answers "is this item inside its budget?" as data. The conductor
+never estimates spend from a transcript; it reads this script's verdict.
+
+Usage:
+    python3 credit_spend.py --slots KEY[,KEY...] [--budget 100]
+                            [--usage-dir PATH] [--max-shards N]
+
+    --slots      the item's session slot keys (the current session plus any
+                 retries), comma-separated
+    --budget     the item's allowance in credits; omit for a plain rollup
+    --usage-dir  default: <data home>/usage/tokens  (data home =
+                 $KIROCREW_HOME, else ~/.kiro/crew)
+    --max-shards newest daily shards scanned. Default: ALL retained shards —
+                 a cost bound is opt-in, and a bounded scan that skipped older
+                 shards never claims ``within`` (see verdicts)
+
+stdout (JSON):
+    {"slots": {"<key>": {"credits": 12.4, "turns": 9}},
+     "total_credits": 12.4, "shards_scanned": 3, "truncated": false,
+     "budget": 100.0, "remaining": 87.6, "verdict": "within"}
+
+``verdict``: ``exhausted`` (total >= budget — monotone: more shards or missing
+meters can only ADD spend, so it stands even on a partial view) | ``unmetered``
+(ANY watched slot had no shard row — the caller must treat spend as unknown,
+not as zero: today's shards are written by the dashboard chat runner, so a
+session outside it burns invisibly) | ``truncated`` (the under-budget scan is
+incomplete: older shards were skipped, a shard was unreadable, or a matched
+row was corrupt — spend outside the readable view could flip the answer) |
+``within`` (complete scan, every slot metered, under budget).
+
+Exit code: 0 when the rollup ran (verdict carries the outcome); 2 on malformed
+arguments. Reads only; writes nothing; no subprocess.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+
+def data_home() -> Path:
+    env = os.environ.get("KIROCREW_HOME")
+    return Path(env) if env else Path.home() / ".kiro" / "crew"
+
+
+def rollup(
+    slots: list[str], usage_dir: Path, max_shards: int | None
+) -> tuple[dict[str, dict[str, float]], int, bool]:
+    """Per-slot sums, shards scanned, and whether older shards were SKIPPED.
+
+    ``max_shards`` is a cost bound the caller opts into (None = scan every
+    retained shard, the default). Truncation is reported, never silent: spend
+    older than the window would otherwise vanish from the total and turn a
+    genuinely exhausted item back into ``within``.
+    """
+    per_slot: dict[str, dict[str, float]] = {key: {"credits": 0.0, "turns": 0.0} for key in slots}
+    wanted = set(slots)
+    seen_any = {key: False for key in slots}
+    all_shards = sorted(usage_dir.glob("*.jsonl"), reverse=True)
+    shards = all_shards if max_shards is None else all_shards[:max_shards]
+    truncated = len(shards) < len(all_shards)
+    for shard in shards:
+        try:
+            lines = shard.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            # An unreadable shard means the total is INCOMPLETE. Do not crash
+            # (the readable shards still inform the monotone `exhausted` case),
+            # but the scan may no longer claim completeness: flag it like a
+            # truncation so an under-budget answer is never reported `within`.
+            truncated = True
+            continue
+        for line in lines:
+            if not line.strip():
+                continue  # a blank line is not a torn row
+            try:
+                row = json.loads(line)
+            except ValueError:
+                # A torn row (append interrupted mid-write) means the total is
+                # INCOMPLETE: readable rows still inform the monotone
+                # `exhausted` case, but flag like a truncation so an
+                # under-budget answer is never reported `within`.
+                truncated = True
+                continue
+            if not isinstance(row, dict) or row.get("_type") != "tokens":
+                continue
+            slot = row.get("slot")
+            if slot not in wanted:
+                continue
+            seen_any[slot] = True
+            bucket = per_slot[slot]
+            # One accepted token row IS one turn: production rows are written
+            # per turn with a literal ``turns: 0`` field (measured on real
+            # shards), so summing the field would report zero turns for every
+            # active session. Count rows; sum only the spend.
+            bucket["turns"] += 1
+            value = row.get("credits")
+            if (
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and math.isfinite(value)
+                and value >= 0
+            ):
+                bucket["credits"] += float(value)
+            else:
+                # A matched tokens row whose credits are missing, non-finite,
+                # or negative is a CORRUPT row, not a free one: silently
+                # dropping it understates spend on a scan still claiming to be
+                # complete. Degrade like a truncation.
+                truncated = True
+    for key, seen in seen_any.items():
+        if not seen:
+            per_slot[key]["unmetered"] = 1.0
+    return per_slot, len(shards), truncated
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slots", required=True)
+    parser.add_argument("--budget", type=float, default=None)
+    parser.add_argument("--usage-dir", default=None)
+    parser.add_argument(
+        "--max-shards",
+        type=int,
+        default=None,
+        help="newest daily shards to scan (cost bound; default: ALL retained shards)",
+    )
+    args = parser.parse_args(argv)
+    slots = [item.strip() for item in args.slots.split(",") if item.strip()]
+    if not slots:
+        print("no slot keys given", file=sys.stderr)
+        return 2
+    if args.budget is not None and (not math.isfinite(args.budget) or args.budget <= 0):
+        # NaN compares false against everything, so a NaN budget would fall
+        # through every branch and print `within`. Malformed input is exit 2.
+        print(f"budget must be a finite positive number, got {args.budget}", file=sys.stderr)
+        return 2
+    usage_dir = Path(args.usage_dir) if args.usage_dir else data_home() / "usage" / "tokens"
+    max_shards = None if args.max_shards is None else max(args.max_shards, 1)
+    per_slot, scanned, truncated = rollup(slots, usage_dir, max_shards)
+    total = sum(bucket["credits"] for bucket in per_slot.values())
+    out: dict[str, object] = {
+        "slots": per_slot,
+        "total_credits": round(total, 4),
+        "shards_scanned": scanned,
+        "truncated": truncated,
+    }
+    if args.budget is not None:
+        out["budget"] = args.budget
+        out["remaining"] = round(args.budget - total, 4)
+        if total >= args.budget:
+            # Monotone: more shards (or the missing meters) can only ADD
+            # spend, so exhaustion stands even on a partial view.
+            out["verdict"] = "exhausted"
+        elif any("unmetered" in bucket for bucket in per_slot.values()):
+            # ANY unmetered slot makes an under-budget answer unknowable:
+            # the metered slots' spend is real, but the unmetered one could
+            # hold anything. `within` on mixed metering would skip the burn
+            # review exactly when spend is least visible.
+            out["verdict"] = "unmetered"
+        elif truncated:
+            # Under-budget on a partial view is NOT a verdict: spend older
+            # than the window could flip it. Say so instead of guessing.
+            out["verdict"] = "truncated"
+        else:
+            out["verdict"] = "within"
+    print(json.dumps(out, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/fleet_probe.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Batch fleet probe — the deterministic half of the pipeline conductor's patrol.
+
+One invocation answers, for every watched worker session, "does anything need
+judgment this cycle?" — plus host posture — so a quiet patrol cycle costs one
+script call and a couple of output lines instead of N transcript reads.
+
+Usage:
+    python3 fleet_probe.py --config <probe-config.json>
+    python3 fleet_probe.py --config <probe-config.json> --mark-handled KEY TAG DIGEST
+
+Config (JSON):
+    {
+      "sessions": ["dashboard_chat-601-1788099254", ...],   # slot keys to watch
+      "idle_alert_secs": 900,      # silent longer than this -> IDLE alert
+      "tail_bytes": 200000,        # per-session transcript read cap
+      "load_alert_per_cpu": 1.5,   # 1-min loadavg / cpu above this -> hot
+      "err_res": [...],            # extra error-tail regexes (optional)
+      "banned_process_res": [...]  # cmdline regexes for banned ops (optional)
+    }
+
+Paths are DERIVED, never configurable -- the same containment rule for every
+location this script touches, because its config is authored by a no-write
+agent and a config-chosen path would quietly widen what an approved run can
+reach:
+
+  * transcripts are read from ``<data home>/sessions`` only, where the data
+    home is ``$KIROCREW_HOME`` (else ``~/.kiro/crew``) -- the gateway this
+    conductor belongs to, not an arbitrary directory;
+  * the handled-set state file is ALWAYS ``<config path>.state.json``;
+  * the banned-process scan reads ``/proc`` (``$KIROCREW_PROBE_PROC_ROOT``
+    exists for the test harness).
+
+A session key that does not match a transcript stem directly is also tried as
+``dashboard_<key>`` (and with ``:`` as ``_``): ``session_create`` answers slot
+keys while the store prefixes the surface, and a raw key must not read as a
+missing session -- GONE triggers reclaim, and a false GONE is how an active
+item gets duplicate-dispatched.
+
+The data home is ``$KIROCREW_HOME`` when set, else ``~/.kiro/crew`` — the same
+resolution every pipeline script uses.
+
+Output (text, one line per FIRING signal; suppressed sessions print nothing):
+    🔔 <session-key> <age>s <TAG> d=<digest>
+
+Metadata only, by design: transcript-derived text never appears in the output,
+so no private session content crosses into the caller's context whatever keys
+the config watches. Content, when a ruling needs it, is read through the
+workspace-authorized session tools.
+    BANNED pid=<pid> <cmdline>
+    OK <n> watched, <m> fired | load/cpu <x> (<posture>) | mem <G>G | banned <k>
+
+Tags: the worker protocol words (``WORKING/PR/GREEN/BLOCKED/STANDDOWN/
+PROPOSAL``), ``ERR`` for an error/throttle tail, ``IDLE`` for silence past the
+threshold, ``-`` when a tail carries no tag (never fires on its own).
+
+THE HANDLED SET replaces the overnight run's hand-grown ``grep -vE`` exclusion
+pipe. Every fired line carries a ``d=<digest>`` field; ``--mark-handled KEY TAG
+DIGEST`` records exactly that digest into the state file (compare-and-set: if
+the tail moved on since the probe, the mark is REFUSED with exit 3 so the
+caller re-probes instead of suppressing a payload nobody read). A signal is
+then suppressed while (tag, digest) both still match. A new payload under the
+same tag re-fires (a second GREEN with a new PR number is a new signal).
+``IDLE`` marks expire after another ``idle_alert_secs``
+so a nudged-but-still-silent worker re-alerts instead of vanishing.
+
+Deliberately boring properties, do not weaken:
+  * No subprocess, ever. Reads transcripts, ``/proc`` and ``loadavg`` directly.
+  * The only write is the probe's own state file, atomically, and only on
+    ``--mark-handled``.
+  * A per-session problem (unreadable file, malformed line) degrades that one
+    row, never the cycle. Exit 0 when the probe ran; 2 on malformed config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+PROTO = re.compile(r"^(GREEN|PR|BLOCKED|STANDDOWN|PROPOSAL|WORKING)\b")
+
+#: Error shapes observed in real worker tails during the 2026-08-30 fleet run.
+DEFAULT_ERR_RES = (
+    r"Bedrock is throttling",
+    r"dispatch failure",
+    r"initialize timed out",
+)
+
+#: Banned-operation cmdline shapes: a pytest without an explicit bounded worker
+#: count (the repo's ``-n auto`` addopts means a bare pytest forks one worker
+#: per core; ``-n 4``, ``-n=4``, ``-n4`` and ``--numprocesses=4`` all count as
+#: bounded, ``-n auto`` does not), and a bare full-suite vitest with no file
+#: arguments.
+DEFAULT_BANNED_RES = (
+    r"\bpytest\b(?!.*(?:-n|--numprocesses)\s*=?\s*\d)",
+    r"\bvitest\b\s+run\s*$",
+)
+
+IDLE_TAG = "IDLE"
+_FIRING = {"GREEN", "PR", "BLOCKED", "STANDDOWN", "PROPOSAL", "ERR", IDLE_TAG}
+
+#: A session key is a filename STEM, never a path: one path-safe token. This is
+#: what keeps an agent-authored key (``../../etc/foo``, an absolute path) from
+#: steering the transcript read outside the sessions directory.
+_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+
+def data_home() -> Path:
+    env = os.environ.get("KIROCREW_HOME")
+    return Path(env) if env else Path.home() / ".kiro" / "crew"
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _text_of(entry: dict[str, Any]) -> str:
+    content = entry.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(part.get("text", "") for part in content if isinstance(part, dict))
+    return str(entry.get("text", ""))
+
+
+def _tail_entries(path: Path, max_bytes: int) -> list[dict[str, Any]]:
+    try:
+        raw = path.read_bytes()[-max_bytes:]
+    except OSError:
+        return []
+    entries: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        try:
+            parsed = json.loads(line)
+        except Exception:
+            continue  # a truncated first line is expected when tailing
+        if isinstance(parsed, dict):
+            entries.append(parsed)
+    return entries
+
+
+def _classify(entries: list[dict[str, Any]], err_res: list[re.Pattern[str]]) -> tuple[str, str]:
+    """Return (tag, tail_text) for one session's transcript tail."""
+    last_assistant = next(
+        (
+            _text_of(entry).strip()
+            for entry in reversed(entries)
+            if entry.get("role") == "assistant" and _text_of(entry).strip()
+        ),
+        "",
+    )
+    last_any = entries[-1] if entries else {}
+    last_any_text = _text_of(last_any)
+    if "error" in str(last_any.get("role", "")).lower() or any(
+        rx.search(last_any_text) for rx in err_res
+    ):
+        return "ERR", (last_any_text.strip() or last_assistant)
+    match = PROTO.match(last_assistant)
+    return (match.group(1) if match else "-"), last_assistant
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:12]
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _suppressed(handled: dict[str, Any], key: str, tag: str, digest: str, idle_secs: int) -> bool:
+    entry = handled.get(key)
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("tag") != tag or entry.get("digest") != digest:
+        return False
+    if tag == IDLE_TAG:
+        marked = entry.get("ts")
+        return isinstance(marked, (int, float)) and time.time() - marked < idle_secs
+    return True
+
+
+def _host_lines(cfg: dict[str, Any]) -> tuple[list[str], str]:
+    """Banned-process lines plus the host summary fragment."""
+    banned_res = [
+        re.compile(rx) for rx in cfg.get("banned_process_res") or list(DEFAULT_BANNED_RES)
+    ]
+    lines: list[str] = []
+    # /proc, with an env seam for the test harness only -- not a config key,
+    # for the same containment reason as the other paths.
+    proc_root = Path(os.environ.get("KIROCREW_PROBE_PROC_ROOT") or "/proc")
+    banned = 0
+    if proc_root.is_dir():
+        for entry in proc_root.iterdir():
+            if not entry.name.isdigit():
+                continue
+            try:
+                cmd = (
+                    (entry / "cmdline")
+                    .read_bytes()
+                    .replace(b"\0", b" ")
+                    .decode("utf-8", "replace")
+                    .strip()
+                )
+            except OSError:
+                continue
+            if cmd:
+                matched = next((rx.pattern for rx in banned_res if rx.search(cmd)), None)
+                if matched is not None:
+                    banned += 1
+                    # pid + WHICH RULE fired is everything the conductor needs
+                    # (stop the owner, re-seed with the directive). The argv is
+                    # deliberately not echoed: a command line can carry
+                    # credentials or presigned URLs, and this line lands in the
+                    # conductor's model context.
+                    lines.append(f"BANNED pid={entry.name} rule={matched}")
+    per_cpu = None
+    if hasattr(os, "getloadavg"):
+        try:
+            per_cpu = os.getloadavg()[0] / max(os.cpu_count() or 1, 1)
+        except OSError:
+            per_cpu = None
+    mem_gb = None
+    meminfo = proc_root / "meminfo"
+    try:
+        for line in meminfo.read_text(encoding="ascii").splitlines():
+            if line.startswith("MemAvailable:"):
+                mem_gb = int(line.split()[1]) / 1_048_576
+                break
+    except (OSError, ValueError, IndexError):
+        mem_gb = None
+    hot = per_cpu is not None and per_cpu > float(cfg.get("load_alert_per_cpu", 1.5))
+    load_part = (
+        f"load/cpu {per_cpu:.2f} ({'hot' if hot else 'ok'})"
+        if per_cpu is not None
+        else "load/cpu n/a"
+    )
+    mem_part = f"mem {mem_gb:.0f}G" if mem_gb is not None else "mem n/a"
+    return lines, f"{load_part} | {mem_part} | banned {banned}"
+
+
+def _sessions_dir() -> Path:
+    """DERIVED, never configurable: this gateway's own session store."""
+    return data_home() / "sessions"
+
+
+def _transcript_path(sessions_dir: Path, key: str) -> Path | None:
+    """The transcript file for ``key``, or None when no safe transcript exists.
+
+    ``session_create`` answers a slot key while the store prefixes the surface
+    (``dashboard_<slot>.jsonl``) and colon-form session keys use ``:`` where
+    the filename uses ``_``. A raw key must not read as a missing session:
+    GONE triggers reclaim, and a false GONE is how an active item gets
+    duplicate-dispatched. The first SAFE existing candidate wins.
+
+    Keys are validated against ``_KEY_RE`` before this is called, and an
+    existing candidate is returned only if it resolves to a file directly
+    under ``sessions_dir`` -- both halves of one rule: a key is a filename
+    stem, never a path. A candidate that exists but resolves elsewhere (a
+    symlink out of the store) is treated as MISSING, never returned: None is
+    the answer, and None reads as GONE.
+    """
+    candidates = (key, f"dashboard_{key}", key.replace(":", "_"))
+    root = sessions_dir.resolve()
+    for candidate in candidates:
+        path = sessions_dir / f"{candidate}.jsonl"
+        if path.exists() and path.resolve().parent == root:
+            return path
+    return None
+
+
+def _handled_of(state: dict[str, Any]) -> dict[str, Any]:
+    """The handled map, tolerating a corrupted state file: anything that is
+    not a dict reads as empty (worst case a handled signal re-fires once),
+    never as a crashed patrol."""
+    handled = state.get("handled")
+    return handled if isinstance(handled, dict) else {}
+
+
+def run_probe(cfg: dict[str, Any], state_path: Path) -> int:
+    sessions: list[str] = list(cfg.get("sessions") or [])
+    sessions_dir = _sessions_dir()
+    idle_secs = int(cfg.get("idle_alert_secs", 900))
+    tail_bytes = int(cfg.get("tail_bytes", 200_000))
+    err_res = [re.compile(rx) for rx in (list(DEFAULT_ERR_RES) + list(cfg.get("err_res") or []))]
+    handled = _handled_of(_load_state(state_path))
+
+    fired = 0
+    for key in sessions:
+        path = _transcript_path(sessions_dir, key)
+        age: int | None = None
+        if path is not None:
+            try:
+                age = int(time.time() - path.stat().st_mtime)
+            except OSError:
+                age = None
+        if path is None or age is None:
+            # GONE flows through the same suppression as every other tag: an
+            # acted-on GONE (item reclaimed, mark-handled) must not re-fire
+            # every cycle until the key is dropped from the watch list.
+            tag, tail, age_text = "GONE", "transcript missing", "?"
+        else:
+            tag, tail = _classify(_tail_entries(path, tail_bytes), err_res)
+            if tag not in _FIRING and age > idle_secs:
+                tag = IDLE_TAG
+            if tag not in _FIRING:
+                continue
+            age_text = str(age)
+        digest = _digest(f"{tag}:{tail}")
+        if _suppressed(handled, key, tag, digest, idle_secs):
+            continue
+        fired += 1
+        # Metadata ONLY: key, age, tag, digest. Transcript-derived text is
+        # deliberately never printed -- the conductor's action table is
+        # tag-keyed, and content, when a ruling needs it, is read through the
+        # workspace-authorized session tools, not through this script. That
+        # keeps the probe's output free of private session text no matter
+        # which keys an (agent-authored) config watches.
+        print(f"🔔 {key:<28} {age_text:>5}s {tag:<9} d={digest}")
+
+    banned_lines, host = _host_lines(cfg)
+    for line in banned_lines:
+        print(line)
+    print(f"OK {len(sessions)} watched, {fired} fired | {host}")
+    return 0
+
+
+def mark_handled(cfg: dict[str, Any], state_path: Path, key: str, tag: str, digest: str) -> int:
+    if not _KEY_RE.fullmatch(key):
+        print(f"malformed key {key!r}: keys are stems, never paths", file=sys.stderr)
+        return 2
+    tail_bytes = int(cfg.get("tail_bytes", 200_000))
+    err_res = [re.compile(rx) for rx in (list(DEFAULT_ERR_RES) + list(cfg.get("err_res") or []))]
+    path = _transcript_path(_sessions_dir(), key)
+    if path is not None and path.exists():
+        current_tag, tail = _classify(_tail_entries(path, tail_bytes), err_res)
+        del current_tag  # the digest is keyed on the CALLER's tag, like the probe's
+    else:
+        tail = "transcript missing"  # mirror run_probe's GONE payload exactly
+    current = _digest(f"{tag}:{tail}")
+    if current != digest:
+        # Compare-and-set: a new same-tag payload arrived between the probe
+        # and this mark. Digesting what is there NOW would suppress a signal
+        # nobody has read -- refuse, so the caller re-probes and acts on the
+        # payload that actually exists.
+        print(
+            f"refused: {key} payload changed since the probe (re-probe and act on it)",
+            file=sys.stderr,
+        )
+        return 3
+    state = _load_state(state_path)
+    handled = _handled_of(state)
+    state["handled"] = handled
+    handled[key] = {
+        "tag": tag,
+        "digest": current,
+        "ts": int(time.time()),
+    }
+    state["updated_at"] = int(time.time())
+    _atomic_write(state_path, json.dumps(state, indent=1, sort_keys=True) + "\n")
+    print(f"handled {key} {tag}")
+    return 0
+
+
+def _config_error(cfg: dict[str, Any]) -> str | None:
+    """The first problem with a parsed config, or None. Typed misconfiguration
+    is malformed config (exit 2 with a message), never an uncaught crash."""
+    for key in ("sessions", "err_res", "banned_process_res"):
+        value = cfg.get(key)
+        if value is not None and (
+            not isinstance(value, list) or any(not isinstance(item, str) for item in value)
+        ):
+            return f"{key} must be a list of strings"
+    for item in cfg.get("sessions") or []:
+        if not _KEY_RE.fullmatch(item):
+            return f"session key {item!r} is not a plain key (keys are stems, never paths)"
+    for key in ("idle_alert_secs", "tail_bytes", "load_alert_per_cpu"):
+        value = cfg.get(key)
+        if value is None:
+            continue
+        # bool is an int subclass, and JSON permits NaN/Infinity: neither is a
+        # usable threshold, and int(NaN) raises -- reject both up front.
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or value != value
+            or value in (float("inf"), float("-inf"))
+            or value < 0
+        ):
+            return f"{key} must be a finite non-negative number"
+    for rx in list(cfg.get("err_res") or []) + list(cfg.get("banned_process_res") or []):
+        try:
+            re.compile(rx)
+        except re.error as exc:
+            return f"bad regex {rx!r}: {exc}"
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument(
+        "--mark-handled",
+        nargs=3,
+        metavar=("KEY", "TAG", "DIGEST"),
+        help="record the fired signal as handled; DIGEST is the d= field of the"
+        " fired line, and a stale digest is refused (exit 3)",
+    )
+    args = parser.parse_args(argv)
+    config_path = Path(args.config)
+    try:
+        cfg = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(cfg, dict):
+            raise ValueError("config must be a JSON object")
+    except (OSError, ValueError) as exc:
+        print(f"malformed config: {exc}", file=sys.stderr)
+        return 2
+    problem = _config_error(cfg)
+    if problem is not None:
+        print(f"malformed config: {problem}", file=sys.stderr)
+        return 2
+    # Derived, never configurable -- see the module docstring: a config-chosen
+    # destination would make this no-write agent's one approved writer an
+    # arbitrary-path file replacer.
+    state_path = Path(f"{config_path}.state.json")
+    if args.mark_handled:
+        return mark_handled(cfg, state_path, *args.mark_handled)
+    return run_probe(cfg, state_path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kiro_crew/docs/agents.md
+++ b/src/kiro_crew/docs/agents.md
@@ -39,7 +39,7 @@ Cron jobs can specify an agent at creation time.
 
 ## Built-in Agent Specs
 
-Kiro Crew owns specs named `kirocrew`, `kirocrew-lite`, `kirocrew-conductor`, `kirocrew-knowledge`, `kirocrew-research`, and `kirocrew-heartbeat`. The primary and lite specs are required; the others support conductor, knowledge extraction, research, and heartbeat features.
+Kiro Crew owns specs named `kirocrew`, `kirocrew-lite`, `kirocrew-conductor`, `kirocrew-pipeline-conductor`, `kirocrew-knowledge`, `kirocrew-research`, and `kirocrew-heartbeat`. The primary and lite specs are required; the others support goal conducting, pipeline fleet supervision, knowledge extraction, research, and heartbeat features.
 
 ## Custom Agents
 

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -166,11 +166,11 @@ def _safe_fire(coro: Awaitable[None]) -> None:
 
 _MAX_CONCURRENT = 3
 
-#: Agent names a roster never suggests: the host default and the conductor are
+#: Agent names a roster never suggests: the host default and the conductors are
 #: reached by OMITTING ``agent``, not by naming one. Every roster inherits this
 #: as :func:`visible_agent_names`' default ``exclude``, so no other module names
-#: the pair and it cannot drift when a third reserved name appears.
-UNADVERTISED_AGENTS = frozenset({"kirocrew", "kirocrew-conductor"})
+#: the set and it cannot drift when a reserved name appears.
+UNADVERTISED_AGENTS = frozenset({"kirocrew", "kirocrew-conductor", "kirocrew-pipeline-conductor"})
 
 
 def visible_agent_names(

--- a/test/test_agent_roster_shared.py
+++ b/test/test_agent_roster_shared.py
@@ -224,8 +224,10 @@ class TestOrderingConverged:
 
 class TestExclusionIsInheritedNotRespelled:
     def test_the_helper_default_is_the_shared_constant(self) -> None:
-        """The spawn tools no longer name the reserved pair at all -- they inherit
+        """The spawn tools no longer name the reserved set at all -- they inherit
         it as this default -- so the default is what makes that omission safe."""
         default = inspect.signature(sa.visible_agent_names).parameters["exclude"].default
         assert default is sa.UNADVERTISED_AGENTS
-        assert sa.UNADVERTISED_AGENTS == frozenset({"kirocrew", "kirocrew-conductor"})
+        assert sa.UNADVERTISED_AGENTS == frozenset(
+            {"kirocrew", "kirocrew-conductor", "kirocrew-pipeline-conductor"}
+        )

--- a/test/test_pipeline_conductor_agent.py
+++ b/test/test_pipeline_conductor_agent.py
@@ -1,0 +1,661 @@
+"""Pipeline-conductor agent installer + bundled probe/budget scripts.
+
+The installer tests mirror ``test_conductor_agent.py``'s shape: stub the agents
+dir and ``build_agent_config``, run the installer, assert on the JSON it wrote.
+The script tests run the real files over fixtures — they are the deterministic
+half of the conductor's patrol, so their vocabulary (protocol tags, handled-set
+suppression, budget verdicts) is pinned here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+from skill_script_helpers import load_skill_script
+
+from kiro_crew import agent
+from kiro_crew.agent_files import (
+    OWNED_KIRO_AGENT_FILES,
+    PIPELINE_CONDUCTOR_AGENT_FILENAME,
+)
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "pipeline-conductor"
+)
+
+
+class TestPipelineConductorInstaller:
+    def _install(self, tmp_path, monkeypatch, *, may_auto_approve=None):
+        monkeypatch.setattr(agent, "kiro_agents_dir_path", lambda: tmp_path)
+        monkeypatch.setattr(
+            agent,
+            "build_agent_config",
+            lambda: {
+                "name": "kirocrew",
+                "prompt": "file://x",
+                "mcpServers": {
+                    "kirocrew-core": {"command": "/resolved/kirocrew", "args": ["mcp-core"]},
+                    "builder-mcp": {"command": "/x/builder", "args": []},
+                },
+                "tools": ["fs_write", "@kirocrew-core"],
+                "allowedTools": ["@kirocrew-core"],
+            },
+        )
+        monkeypatch.setattr(
+            agent,
+            "_kirocrew_mcp_invocation",
+            lambda sub: ("/resolved/kirocrew", [sub]),
+        )
+        monkeypatch.setattr(agent, "_may_auto_approve", may_auto_approve or (lambda ref: True))
+        agent._install_pipeline_conductor_agent()
+        return json.loads(
+            (tmp_path / PIPELINE_CONDUCTOR_AGENT_FILENAME).read_text(encoding="utf-8")
+        )
+
+    def test_identity_and_charter(self, tmp_path, monkeypatch):
+        data = self._install(tmp_path, monkeypatch)
+        assert data["name"] == "kirocrew-pipeline-conductor"
+        assert "work item" in data["prompt"]
+        assert "pipeline-conductor" in data["prompt"]  # the skill is the procedure
+
+    def test_filename_is_owned(self):
+        """The convergence sweep rewrites only OWNED files; a generated spec
+        missing from that allowlist silently rots when Playwright servers move."""
+        assert PIPELINE_CONDUCTOR_AGENT_FILENAME in OWNED_KIRO_AGENT_FILES
+
+    def test_prompt_carries_the_verbosity_placeholder(self, tmp_path, monkeypatch):
+        """Custom agents get their OWN prompt, so the token must appear here or
+        the user's verbosity setting silently never reaches this agent."""
+        data = self._install(tmp_path, monkeypatch)
+        assert "{{VERBOSITY_BLOCK}}" in data["prompt"]
+
+    def test_prompt_drives_patrol_with_monitor_start_not_wait(self, tmp_path, monkeypatch):
+        data = self._install(tmp_path, monkeypatch)
+        prompt = " ".join(data["prompt"].split())
+        assert "Patrol with `monitor_start`, never with `wait`" in prompt
+        assert "autonudge_stop" in prompt
+
+    def test_prompt_names_the_tools_and_scripts_it_runs_on(self, tmp_path, monkeypatch):
+        """The charter mounts whole servers; the prompt must name what each job
+        uses, and the two bundled scripts, or the agent re-derives fleet state
+        from transcripts — the context flood the probe exists to prevent."""
+        prompt = " ".join(self._install(tmp_path, monkeypatch)["prompt"].split())
+        for named in (
+            "session_create",
+            "session_ledger_record",
+            "monitor_update",
+            "resource_status",
+            "ask_question",
+            "fleet_probe.py",
+            "credit_spend.py",
+        ):
+            assert named in prompt, named
+
+    def test_no_file_writing_tool(self, tmp_path, monkeypatch):
+        """Never-does-the-work-itself is a spec property: neither ``fs_write``
+        nor ``code`` (governance classes it under filesystem.write) is mounted."""
+        data = self._install(tmp_path, monkeypatch)
+        assert "fs_write" not in data["tools"]
+        assert "code" not in data["tools"]
+
+    def test_dashboard_grants_are_create_and_read_only(self, tmp_path, monkeypatch):
+        """The grant invariant: create/read verbs auto-approved; the verbs that
+        mutate a peer session (send/stop/move) and ``execute_bash`` stay mounted
+        but gated."""
+        data = self._install(tmp_path, monkeypatch)
+        allowed = set(data["allowedTools"])
+        assert "@kirocrew-dashboard/session_create" in allowed
+        assert "@kirocrew-dashboard/session_read_message" in allowed
+        assert "@kirocrew-dashboard/chat_folder_tree" in allowed
+        assert "@kirocrew-dashboard/chat_folder_create" in allowed
+        for gated in (
+            "@kirocrew-dashboard/session_send",
+            "@kirocrew-dashboard/session_stop",
+            "@kirocrew-dashboard/chat_folder_move_session",
+            "@kirocrew-dashboard",
+            "execute_bash",
+        ):
+            assert gated not in allowed, gated
+        assert "@kirocrew-dashboard" in data["tools"]  # mounted, so gated verbs still work
+        assert "execute_bash" in data["tools"]
+
+    def test_core_grants_are_named_verbs_never_the_whole_server(self, tmp_path, monkeypatch):
+        """Untrusted content feeds every auto-approved call on an unattended
+        cycle, so the core surface is granted verb by verb: reads, the patrol
+        loop's own lifecycle, and owner reporting. The verbs that START work
+        from ingested context (task_run/workflow_run/cron_add/spawn_run) are
+        never auto-approved -- and the server stays mounted so they still work
+        under a session-level trust grant."""
+        data = self._install(tmp_path, monkeypatch)
+        allowed = set(data["allowedTools"])
+        assert "@kirocrew-core/monitor_start" in allowed
+        assert "@kirocrew-core/resource_status" in allowed
+        assert "@kirocrew-core/session_ledger_record" in allowed
+        for gated in (
+            "@kirocrew-core",
+            "@kirocrew-core/task_run",
+            "@kirocrew-core/workflow_run",
+            "@kirocrew-core/cron_add",
+            "@kirocrew-core/spawn_run",
+        ):
+            assert gated not in allowed, gated
+        assert "@kirocrew-core" in data["tools"]
+
+    def test_mcp_servers_are_narrowed(self, tmp_path, monkeypatch):
+        """Only kirocrew-core and the hand-built kirocrew-dashboard entry ship;
+        inherited third-party servers are dropped from this spec."""
+        data = self._install(tmp_path, monkeypatch)
+        assert set(data["mcpServers"]) == {"kirocrew-core", "kirocrew-dashboard"}
+        assert data["mcpServers"]["kirocrew-dashboard"]["args"] == ["mcp-dashboard"]
+
+    def test_governed_host_withholds_and_audits(self, tmp_path, monkeypatch):
+        """A ceiling that strips a grant must leave an audit record naming THIS
+        installer, or the operator has no record of why the agent now prompts."""
+        events: list[dict] = []
+
+        class _Sel:
+            def log_api_access(self, **kwargs):
+                events.append(kwargs)
+
+        monkeypatch.setattr(agent, "sel", lambda: _Sel())
+        data = self._install(
+            tmp_path,
+            monkeypatch,
+            may_auto_approve=lambda ref: ref != "@kirocrew-core/monitor_start",
+        )
+        assert "@kirocrew-core/monitor_start" not in data["allowedTools"]
+        withheld = [e for e in events if e.get("operation") == "mcp_auto_approve_withheld"]
+        assert withheld and withheld[0]["source"] == "_install_pipeline_conductor_agent"
+
+
+class TestFleetProbe:
+    def _mod(self):
+        return load_skill_script("fleet_probe", SKILL_DIR / "scripts" / "fleet_probe.py")
+
+    def _session(self, sessions_dir: Path, key: str, text: str, *, age_secs: int = 0) -> None:
+        path = sessions_dir / f"{key}.jsonl"
+        rows = [
+            {"role": "user", "content": "seed"},
+            {"role": "assistant", "content": text},
+        ]
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+        if age_secs:
+            stamp = time.time() - age_secs
+            os.utime(path, (stamp, stamp))
+
+    def _config(self, tmp_path: Path, monkeypatch, sessions: list[str], **extra) -> Path:
+        """Config file + the env the script derives its paths from: transcripts
+        under $KIROCREW_HOME/sessions, /proc behind the test-only env seam --
+        neither is a config key (containment: the config is agent-authored)."""
+        (tmp_path / "sessions").mkdir(exist_ok=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(tmp_path / "no-proc"))
+        cfg = {"sessions": sessions, **extra}
+        cfg_path = tmp_path / "probe-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+        return cfg_path
+
+    def _run(self, mod, cfg_path: Path, capsys, *extra_args: str) -> str:
+        rc = mod.main(["--config", str(cfg_path), *extra_args])
+        assert rc == 0
+        return capsys.readouterr().out
+
+    @staticmethod
+    def _digest_of(out: str, key: str) -> str:
+        """The d= field of KEY's fired line -- what mark-handled must echo back."""
+        line = next(ln for ln in out.splitlines() if key in ln and "d=" in ln)
+        match = re.search(r"d=(\S+)", line)
+        assert match is not None, line
+        return match.group(1)
+
+    def test_protocol_tag_fires_and_working_stays_quiet(self, tmp_path, capsys, monkeypatch):
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-green", "s-working"])
+        self._session(tmp_path / "sessions", "s-green", "GREEN: PR #5 https://x head abc123")
+        self._session(tmp_path / "sessions", "s-working", "WORKING: reproducing")
+        out = self._run(mod, cfg, capsys)
+        assert "s-green" in out and "GREEN" in out
+        assert "s-working" not in out  # WORKING is a heartbeat, not a signal
+        assert "OK 2 watched, 1 fired" in out
+
+    def test_idle_alert_fires_past_threshold(self, tmp_path, capsys, monkeypatch):
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-idle"], idle_alert_secs=100)
+        self._session(tmp_path / "sessions", "s-idle", "WORKING: still here", age_secs=500)
+        out = self._run(mod, cfg, capsys)
+        assert "IDLE" in out
+
+    def test_error_tail_flags_err(self, tmp_path, capsys, monkeypatch):
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-err"])
+        self._session(tmp_path / "sessions", "s-err", "Bedrock is throttling requests")
+        out = self._run(mod, cfg, capsys)
+        assert "ERR" in out
+
+    def test_missing_transcript_reports_gone(self, tmp_path, capsys, monkeypatch):
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-vanished"])
+        out = self._run(mod, cfg, capsys)
+        assert "GONE" in out and "s-vanished" in out
+
+    def test_fired_lines_carry_metadata_never_transcript_text(self, tmp_path, capsys, monkeypatch):
+        """The fired line is key/age/tag/digest ONLY: transcript-derived text
+        must never cross into the caller's context, whatever keys the
+        (agent-authored) config watches. Content goes through the
+        workspace-authorized session tools instead."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._session(
+            tmp_path / "sessions", "s-1", "GREEN: PR #5 private-payload-XYZZY https://x head abc"
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "GREEN" in out and "d=" in out
+        assert "private-payload-XYZZY" not in out
+        assert "PR #5" not in out
+
+    def test_mark_handled_suppresses_until_payload_changes(self, tmp_path, capsys, monkeypatch):
+        """The handled-set replaces the run's hand-grown grep exclusion: an acted
+        signal stays quiet, and a NEW payload under the same tag re-fires."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._session(tmp_path / "sessions", "s-1", "GREEN: PR #5 https://x head abc")
+        out = self._run(mod, cfg, capsys)
+        assert "GREEN" in out
+        self._run(mod, cfg, capsys, "--mark-handled", "s-1", "GREEN", self._digest_of(out, "s-1"))
+        out = self._run(mod, cfg, capsys)
+        assert "GREEN" not in out and "0 fired" in out
+        self._session(tmp_path / "sessions", "s-1", "GREEN: PR #9 https://y head def")
+        assert "GREEN" in self._run(mod, cfg, capsys)  # new payload = new signal
+
+    def test_mark_with_stale_digest_is_refused(self, tmp_path, capsys, monkeypatch):
+        """A new same-tag payload landing between probe and mark must NOT be
+        digested unseen: the mark is refused (exit 3), nothing is suppressed,
+        and the unseen payload still fires on the next probe."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._session(tmp_path / "sessions", "s-1", "GREEN: PR #5 https://x head abc")
+        stale = self._digest_of(self._run(mod, cfg, capsys), "s-1")
+        self._session(tmp_path / "sessions", "s-1", "GREEN: PR #9 https://y head def")
+        assert mod.main(["--config", str(cfg), "--mark-handled", "s-1", "GREEN", stale]) == 3
+        capsys.readouterr()
+        assert "GREEN" in self._run(mod, cfg, capsys)  # unseen payload still fires
+
+    def test_banned_process_scan_reports_matches(self, tmp_path, capsys, monkeypatch):
+        mod = self._mod()
+        proc = tmp_path / "proc"
+        (proc / "4242").mkdir(parents=True)
+        (proc / "4242" / "cmdline").write_bytes(
+            b"python\x00-m\x00pytest\x00--token\x00secret-token\x00test\x00"
+        )
+        (proc / "4343").mkdir(parents=True)
+        (proc / "4343" / "cmdline").write_bytes(b"pytest\x00-n\x004\x00test/x.py\x00")
+        cfg = self._config(tmp_path, monkeypatch, [])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        assert "BANNED pid=4242" in out  # unbounded pytest
+        assert "rule=" in out  # which rule fired is reported...
+        assert "secret-token" not in out  # ...the argv itself never is
+        assert "pid=4343" not in out  # bounded -n 4 run is legitimate
+
+    def test_every_bounded_pytest_spelling_is_legitimate(self, tmp_path, capsys, monkeypatch):
+        """`-n 4`, `-n=4`, `-n4` and `--numprocesses=4` are all bounded runs;
+        flagging any of them would make the conductor stop a healthy worker
+        and discard its active turn."""
+        mod = self._mod()
+        proc = tmp_path / "proc"
+        for pid, argv in (
+            ("11", b"pytest\x00-n=4\x00test/x.py\x00"),
+            ("12", b"pytest\x00-n4\x00test/x.py\x00"),
+            ("13", b"pytest\x00--numprocesses=4\x00test/x.py\x00"),
+            ("14", b"pytest\x00-n\x00auto\x00test/x.py\x00"),  # unbounded: fires
+        ):
+            (proc / pid).mkdir(parents=True)
+            (proc / pid / "cmdline").write_bytes(argv)
+        cfg = self._config(tmp_path, monkeypatch, [])
+        monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(proc))
+        out = self._run(mod, cfg, capsys)
+        for quiet in ("pid=11", "pid=12", "pid=13"):
+            assert quiet not in out, quiet
+        assert "pid=14" in out  # -n auto is the unbounded case
+
+    def test_raw_slot_key_matches_surface_prefixed_transcript(self, tmp_path, capsys, monkeypatch):
+        """session_create answers slot keys while the store writes
+        ``dashboard_<slot>.jsonl``; a raw key must classify, not read GONE --
+        a false GONE reclaims and duplicate-dispatches an active item."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["chat-9-1"])
+        self._session(
+            tmp_path / "sessions", "dashboard_chat-9-1", "GREEN: PR #7 https://x head abc"
+        )
+        out = self._run(mod, cfg, capsys)
+        assert "GREEN" in out and "GONE" not in out
+
+    def test_sessions_dir_config_key_is_ignored(self, tmp_path, capsys, monkeypatch):
+        """Transcripts are read from THIS gateway's own store only: a
+        config-chosen sessions dir would let the agent-authored config point
+        the probe at another trust domain's transcripts."""
+        mod = self._mod()
+        foreign = tmp_path / "foreign"
+        foreign.mkdir()
+        cfg = self._config(tmp_path, monkeypatch, ["s-x"], sessions_dir=str(foreign))
+        self._session(foreign, "s-x", "GREEN: PR #8 https://y head def")
+        out = self._run(mod, cfg, capsys)
+        assert "GONE" in out  # only the derived store is consulted
+
+    def test_typed_misconfiguration_is_malformed_config(self, tmp_path, capsys, monkeypatch):
+        """`{"err_res": 1}` is malformed config (exit 2), never an uncaught
+        TypeError mid-patrol."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, [], err_res=1)
+        assert mod.main(["--config", str(cfg)]) == 2
+
+    def test_traversal_session_keys_are_malformed_config(self, tmp_path, capsys, monkeypatch):
+        """A key is a filename stem, never a path: traversal/absolute spellings
+        are rejected as malformed config before any file is touched."""
+        mod = self._mod()
+        outside = tmp_path / "outside.jsonl"
+        outside.write_text(json.dumps({"role": "assistant", "content": "GREEN: leak"}) + "\n")
+        for bad in ("../outside", "/etc/hostname", "a/b"):
+            cfg = self._config(tmp_path, monkeypatch, [bad])
+            assert mod.main(["--config", str(cfg)]) == 2, bad
+        assert mod.main(["--config", str(cfg), "--mark-handled", "../outside", "GONE", "d0"]) == 2
+
+    def test_corrupt_handled_map_degrades_to_empty(self, tmp_path, capsys, monkeypatch):
+        """`{"handled": []}` in the state file must read as empty (a handled
+        signal re-fires once), never crash the patrol or the mark."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"])
+        self._session(tmp_path / "sessions", "s-1", "GREEN: PR #5 https://x head abc")
+        Path(f"{cfg}.state.json").write_text('{"handled": []}', encoding="utf-8")
+        out = self._run(mod, cfg, capsys)
+        assert "GREEN" in out  # probe survives
+        self._run(mod, cfg, capsys, "--mark-handled", "s-1", "GREEN", self._digest_of(out, "s-1"))
+        assert "GREEN" not in self._run(mod, cfg, capsys)  # and repairs the map
+
+    def test_gone_is_suppressible_via_mark_handled(self, tmp_path, capsys, monkeypatch):
+        """An acted-on GONE (item reclaimed) must not re-fire every cycle."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-vanished"])
+        out = self._run(mod, cfg, capsys)
+        assert "GONE" in out
+        self._run(
+            mod,
+            cfg,
+            capsys,
+            "--mark-handled",
+            "s-vanished",
+            "GONE",
+            self._digest_of(out, "s-vanished"),
+        )
+        assert "GONE" not in self._run(mod, cfg, capsys)
+
+    def test_symlink_out_of_the_store_reads_gone(self, tmp_path, capsys, monkeypatch):
+        """A transcript-shaped symlink resolving outside the session store is
+        MISSING, never read: the store is the containment boundary."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, ["s-link"])
+        outside = tmp_path / "outside.jsonl"
+        outside.write_text(
+            json.dumps({"role": "assistant", "content": "GREEN: leaked"}) + "\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "sessions" / "s-link.jsonl").symlink_to(outside)
+        out = self._run(mod, cfg, capsys)
+        assert "GONE" in out and "leaked" not in out
+
+    def test_nonfinite_numeric_config_is_malformed(self, tmp_path, capsys, monkeypatch):
+        """JSON permits NaN and bools are ints: neither is a usable threshold,
+        and int(NaN) would crash the patrol -- both are malformed config."""
+        mod = self._mod()
+        for bad in ("NaN", "true", "-5"):
+            cfg_path = tmp_path / "probe-config.json"
+            monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+            monkeypatch.setenv("KIROCREW_PROBE_PROC_ROOT", str(tmp_path / "no-proc"))
+            cfg_path.write_text('{"sessions": [], "tail_bytes": ' + bad + "}", encoding="utf-8")
+            assert mod.main(["--config", str(cfg_path)]) == 2, bad
+
+    def test_malformed_config_exits_2(self, tmp_path, capsys):
+        mod = self._mod()
+        bad = tmp_path / "bad.json"
+        bad.write_text("[]", encoding="utf-8")
+        assert mod.main(["--config", str(bad)]) == 2
+
+    def test_invalid_configured_regex_is_malformed_config(self, tmp_path, capsys, monkeypatch):
+        """A regex typo is malformed config (exit 2 with a message), never an
+        uncaught crash mid-patrol."""
+        mod = self._mod()
+        cfg = self._config(tmp_path, monkeypatch, [], banned_process_res=["(unclosed"])
+        assert mod.main(["--config", str(cfg)]) == 2
+
+    def test_state_path_config_key_is_ignored(self, tmp_path, capsys, monkeypatch):
+        """The handled-set destination is DERIVED from the config path, never
+        taken from the config: a config-chosen destination would let this
+        no-write agent's one approved writer replace an arbitrary file."""
+        mod = self._mod()
+        victim = tmp_path / "victim.json"
+        victim.write_text("precious", encoding="utf-8")
+        cfg = self._config(tmp_path, monkeypatch, ["s-1"], state_path=str(victim))
+        self._session(tmp_path / "sessions", "s-1", "GREEN: PR #5 https://x head abc")
+        out = self._run(mod, cfg, capsys)
+        self._run(mod, cfg, capsys, "--mark-handled", "s-1", "GREEN", self._digest_of(out, "s-1"))
+        assert victim.read_text(encoding="utf-8") == "precious"
+        assert Path(f"{cfg}.state.json").exists()
+
+
+class TestCreditSpend:
+    def _mod(self):
+        return load_skill_script("credit_spend", SKILL_DIR / "scripts" / "credit_spend.py")
+
+    def _shard(self, usage_dir: Path, name: str, rows: list[dict]) -> None:
+        usage_dir.mkdir(parents=True, exist_ok=True)
+        (usage_dir / name).write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8"
+        )
+
+    def _run(self, mod, capsys, *args: str) -> dict:
+        assert mod.main(list(args)) == 0
+        return json.loads(capsys.readouterr().out)
+
+    def test_sums_credits_and_counts_rows_as_turns(self, tmp_path, capsys):
+        """Production rows are per-turn with a literal ``turns: 0`` field
+        (measured on real shards), so turns are counted per accepted row --
+        summing the field would report zero for every active session."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(
+            usage,
+            "2026-08-30.jsonl",
+            [
+                {"_type": "tokens", "slot": "a", "credits": 2.5, "turns": 0},
+                {"_type": "tokens", "slot": "b", "credits": 99, "turns": 0},  # not ours
+                {"_type": "other", "slot": "a", "credits": 50},  # not a tokens row
+                {"_type": "tokens", "slot": "a", "credits": 1.5, "turns": 0},
+            ],
+        )
+        out = self._run(mod, capsys, "--slots", "a", "--usage-dir", str(usage))
+        assert out["slots"]["a"]["credits"] == 4.0
+        assert out["slots"]["a"]["turns"] == 2  # two accepted rows = two turns
+        assert out["total_credits"] == 4.0
+
+    def test_budget_verdicts(self, tmp_path, capsys):
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-30.jsonl", [{"_type": "tokens", "slot": "a", "credits": 40}])
+        within = self._run(
+            mod, capsys, "--slots", "a", "--budget", "100", "--usage-dir", str(usage)
+        )
+        assert within["verdict"] == "within" and within["remaining"] == 60.0
+        exhausted = self._run(
+            mod, capsys, "--slots", "a", "--budget", "40", "--usage-dir", str(usage)
+        )
+        assert exhausted["verdict"] == "exhausted"
+
+    def test_unmetered_when_no_shard_mentions_the_slots(self, tmp_path, capsys):
+        """Absent metering must read as UNKNOWN, never as zero spend: today's
+        shards only carry chat-runner turns, so a session outside them burns
+        invisibly and 'within budget' would be a false comfort."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-30.jsonl", [{"_type": "tokens", "slot": "other", "credits": 1}])
+        out = self._run(
+            mod, capsys, "--slots", "ghost", "--budget", "100", "--usage-dir", str(usage)
+        )
+        assert out["verdict"] == "unmetered"
+        assert out["slots"]["ghost"]["unmetered"] == 1.0
+
+    def test_missing_usage_dir_is_unmetered_not_a_crash(self, tmp_path, capsys):
+        mod = self._mod()
+        out = self._run(
+            mod,
+            capsys,
+            "--slots",
+            "a",
+            "--budget",
+            "5",
+            "--usage-dir",
+            str(tmp_path / "absent"),
+        )
+        assert out["verdict"] == "unmetered" and out["shards_scanned"] == 0
+
+    def test_max_shards_keeps_newest(self, tmp_path, capsys):
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-01.jsonl", [{"_type": "tokens", "slot": "a", "credits": 7}])
+        self._shard(usage, "2026-08-30.jsonl", [{"_type": "tokens", "slot": "a", "credits": 3}])
+        out = self._run(mod, capsys, "--slots", "a", "--usage-dir", str(usage), "--max-shards", "1")
+        assert out["total_credits"] == 3.0  # newest shard only
+        assert out["truncated"] is True  # and the omission is reported
+
+    def test_default_scan_is_all_shards(self, tmp_path, capsys):
+        """The cost bound is opt-in: with no --max-shards every retained shard
+        counts, so old spend can never silently vanish from the total."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-01.jsonl", [{"_type": "tokens", "slot": "a", "credits": 7}])
+        self._shard(usage, "2026-08-30.jsonl", [{"_type": "tokens", "slot": "a", "credits": 3}])
+        out = self._run(mod, capsys, "--slots", "a", "--usage-dir", str(usage))
+        assert out["total_credits"] == 10.0 and out["truncated"] is False
+
+    def test_truncated_scan_never_reports_within(self, tmp_path, capsys):
+        """Under budget on a partial view is not a verdict: spend older than
+        the window could flip it, so the answer is `truncated` — while
+        exhaustion is monotone and stands even when truncated."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-01.jsonl", [{"_type": "tokens", "slot": "a", "credits": 90}])
+        self._shard(usage, "2026-08-30.jsonl", [{"_type": "tokens", "slot": "a", "credits": 5}])
+        partial = self._run(
+            mod,
+            capsys,
+            "--slots",
+            "a",
+            "--budget",
+            "50",
+            "--usage-dir",
+            str(usage),
+            "--max-shards",
+            "1",
+        )
+        assert partial["verdict"] == "truncated"  # 5 < 50 but 90 was skipped
+        full = self._run(mod, capsys, "--slots", "a", "--budget", "50", "--usage-dir", str(usage))
+        assert full["verdict"] == "exhausted"  # the real answer
+        over = self._run(
+            mod,
+            capsys,
+            "--slots",
+            "a",
+            "--budget",
+            "4",
+            "--usage-dir",
+            str(usage),
+            "--max-shards",
+            "1",
+        )
+        assert over["verdict"] == "exhausted"  # monotone: valid even truncated
+
+    def test_unreadable_shard_never_yields_a_complete_within(self, tmp_path, capsys):
+        """A shard that cannot be read makes the total incomplete: readable
+        spend still counts (exhaustion is monotone), but an under-budget
+        answer degrades to `truncated`, never a false `within`."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-29.jsonl", [{"_type": "tokens", "slot": "a", "credits": 5}])
+        unreadable = usage / "2026-08-30.jsonl"
+        unreadable.mkdir()  # a directory named like a shard -> OSError on read
+        out = self._run(mod, capsys, "--slots", "a", "--budget", "50", "--usage-dir", str(usage))
+        assert out["verdict"] == "truncated"
+        assert out["total_credits"] == 5.0
+
+    def test_torn_row_never_yields_a_complete_within(self, tmp_path, capsys):
+        """An interrupted append leaves a torn row: readable spend still counts,
+        but the verdict degrades to `truncated` -- a blank line, by contrast,
+        is not corruption and costs nothing."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        usage.mkdir(parents=True)
+        (usage / "2026-08-29.jsonl").write_text(
+            json.dumps({"_type": "tokens", "slot": "a", "credits": 5})
+            + "\n\n"  # blank line: benign
+            + '{"_type": "tokens", "slot": "a", "cred',  # torn mid-write
+            encoding="utf-8",
+        )
+        out = self._run(mod, capsys, "--slots", "a", "--budget", "50", "--usage-dir", str(usage))
+        assert out["verdict"] == "truncated"
+        assert out["total_credits"] == 5.0
+
+    def test_mixed_metering_is_unmetered_not_within(self, tmp_path, capsys):
+        """One metered slot under budget + one slot with no rows at all: the
+        under-budget answer is unknowable, so the verdict is `unmetered` --
+        never `within`. Exhaustion still wins when the metered spend alone
+        crosses the budget (monotone)."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-29.jsonl", [{"_type": "tokens", "slot": "a", "credits": 5}])
+        out = self._run(
+            mod, capsys, "--slots", "a,ghost", "--budget", "50", "--usage-dir", str(usage)
+        )
+        assert out["verdict"] == "unmetered"
+        out = self._run(
+            mod, capsys, "--slots", "a,ghost", "--budget", "4", "--usage-dir", str(usage)
+        )
+        assert out["verdict"] == "exhausted"  # metered spend alone crosses it
+
+    def test_invalid_credits_on_matched_row_degrades_verdict(self, tmp_path, capsys):
+        """A matched tokens row with NaN/negative/boolean credits is corrupt:
+        its spend is unknown, so a complete `within` may not be claimed."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(
+            usage,
+            "2026-08-29.jsonl",
+            [
+                {"_type": "tokens", "slot": "a", "credits": 5},
+                {"_type": "tokens", "slot": "a", "credits": float("nan")},
+            ],
+        )
+        out = self._run(mod, capsys, "--slots", "a", "--budget", "50", "--usage-dir", str(usage))
+        assert out["verdict"] == "truncated"
+        assert out["total_credits"] == 5.0
+
+    def test_nonfinite_or_negative_budget_is_malformed(self, tmp_path, capsys):
+        """`--budget nan` would compare false against everything and print
+        `within`; non-finite and non-positive budgets are malformed input."""
+        mod = self._mod()
+        usage = tmp_path / "tokens"
+        self._shard(usage, "2026-08-29.jsonl", [{"_type": "tokens", "slot": "a", "credits": 5}])
+        for bad in ("nan", "inf", "-10", "0"):
+            rc = mod.main(["--slots", "a", "--budget", bad, "--usage-dir", str(usage)])
+            assert rc == 2, bad
+            capsys.readouterr()
+
+    def test_no_slots_exits_2(self, tmp_path):
+        mod = self._mod()
+        assert mod.main(["--slots", " , "]) == 2

--- a/test/test_spawn_agent_roster.py
+++ b/test/test_spawn_agent_roster.py
@@ -186,8 +186,8 @@ class TestSpawnListUsesTheSameFilter:
         assert "Available agents: scout" in out
         assert "IGNORE" not in out
 
-    def test_the_reserved_pair_has_one_definition(self) -> None:
-        """Two rosters hid the same pair by respelling the literal. A behavioral test
+    def test_the_reserved_set_has_one_definition(self) -> None:
+        """Two rosters hid the same names by respelling the literal. A behavioral test
         cannot see a re-duplication (both spellings behave alike), so this is a
         source ratchet: the pair is spelled once, where the constant lives.
 
@@ -198,16 +198,19 @@ class TestSpawnListUsesTheSameFilter:
         import inspect
         import pathlib
 
-        assert sa.UNADVERTISED_AGENTS == frozenset({"kirocrew", "kirocrew-conductor"})
+        assert sa.UNADVERTISED_AGENTS == frozenset(
+            {"kirocrew", "kirocrew-conductor", "kirocrew-pipeline-conductor"}
+        )
         default = inspect.signature(sa.visible_agent_names).parameters["exclude"].default
         assert default is sa.UNADVERTISED_AGENTS
         for module in (sa, spawn_tools):
             src = pathlib.Path(module.__file__).read_text(encoding="utf-8")
             expected = 1 if module is sa else 0
-            assert src.count("kirocrew-conductor") == expected, (
-                f"{module.__name__} respells the reserved pair; call "
-                "subagent.visible_agent_names instead"
-            )
+            for reserved in ("kirocrew-conductor", "kirocrew-pipeline-conductor"):
+                assert src.count(reserved) == expected, (
+                    f"{module.__name__} respells the reserved set; call "
+                    "subagent.visible_agent_names instead"
+                )
 
 
 class TestRosterIsAdvertisedOnSpawnRun:


### PR DESCRIPTION
## What is the problem?

KiroCrew's issue-fixing automation is three open-loop pipelines (issue -> new PR, red PR -> green, green PR -> merge): scanners and dispatchers stand worker sessions up and then nothing watches them. Every failure class we have logged traces to that gap -- duplicate dispatch ending in mutual-yield deadlocks, silent stalls discovered only by the 90-minute heartbeat reaper, every exception (reviewer deadlock, main-owned CI red, wrong-premise issue) terminating in a human excavating logs, and hand-edited progress state drifting from GitHub reality.

The Pipeline Conductor closes that gap: a long-lived supervisor session per pipeline that picks up queued items, stands up one worker session per item, probes the fleet with one script call per cycle, independently verifies claimed greens, adjudicates blocked items under a published override protocol, intervenes on looping or stalled workers, governs host resources and per-item credit budgets, and digests each verified green for the human. Running this control plane ad hoc from a default-agent chat session works but does not repeat: the rules live in one session's context, the ledger is hand-edited markdown that drifts, and handled-signal tracking degenerates into hand-grown exclusion lists.

## Why this issue matters to the user

The fleet pattern is how a maintainer turns a large backlog into merged PRs with the human appearing exactly twice -- the merge click and genuine design decisions. Without a productized conductor, every campaign re-improvises the harness, repeats the already-paid-for failures (double dispatch, ledger drift, host overload from full test suites), and burns the operator's attention on bookkeeping instead of decisions. And because today's pipelines are KiroCrew-shaped one-offs, none of this is reusable on another repository or another campaign type.

## How our fix solves it

Symptom -> root cause: fleet failures happen because no standing entity owns supervision, and supervision was unrepeatable because its rules lived in one session's context. So this PR makes the supervisor a first-class, regenerable artifact -- an agent spec plus a skill -- with the deterministic bookkeeping demoted to scripts:

- **`kirocrew-pipeline-conductor` generated agent** (`agent.py`, `agent_files.py`): follows the established one-installer-per-agent pattern and the `kirocrew-conductor` security invariants -- no file-writing tool (never does a work item's work itself), `@kirocrew-dashboard` mounted whole but auto-approved verb by verb (create/read granted; `session_send`/`session_stop`/move gated; unattended operation uses the same session-level trust grant the worker sessions already require), `execute_bash` mounted but never auto-approved, KAS policy derived from the filtered grant list, withheld grants audited. Hidden from the spawn roster (`subagent.py`) like the other conductor.
- **`pipeline-conductor` builtin skill**: the full operating procedure -- idempotent pickup (state check + store verdict + open-PR/worktree overlap), the work-order brief whose every clause closes an observed failure mode, the one-call-per-cycle probe with an action table, independent green verification (check-runs collapsed per lane, head SHA pinned, job logs not conclusions), an intervention ladder for looping/stalled workers (nudge -> bounded read-only inspector subagent -> rule: sharpened re-dispatch / adjudicate / open-issue descope / reclaim), the adjudication + override protocol, resource-posture flow control (ample/tight/critical -> dispatch/backoff/stop), per-item credit budgets with burn review, steering-as-mode-change, and merge cleanup + reconciliation.
- **Two subprocess-free scripts**: `fleet_probe.py` -- batch worker-tail classification, idle age, error tails, banned-process scan (e.g. an unbounded `pytest` with no `-n`), and host load in one call, with a handled-set state file replacing the run's hand-grown grep exclusions; `credit_spend.py` -- per-item credit rollups from the usage shards with `within`/`exhausted`/`unmetered` verdicts (absent metering reads as unknown, never as zero).
- **`docs/design/pipeline-conductor.md`**: the architecture, the lessons-to-rules table, and the bigger-picture template vision -- a `PipelineSpec` with five named seams (work-source adapter, verifier adapter, protocol vocabulary as data, adjudication policy as data, per-repo identity per #6221) so the same conductor can run any repository and campaign type; M1-M3 milestones (event store, adjudication queue/SLAs, baking stage + sagas) are specified there and deliberately not shipped here.

## What tests we did

- New `test/test_pipeline_conductor_agent.py` (installer + both scripts): agent identity/charter, verbosity placeholder, patrol-with-`monitor_start` contract, prompt names its tools and scripts, no `fs_write`/`code` mounted, dashboard grants pinned to the create/read set with mutating verbs and `execute_bash` excluded from `allowedTools`, MCP servers narrowed, governed-host withholds audited with this installer as source; probe protocol-tag firing vs quiet `WORKING`, idle alert, error tails, missing transcript, handled-set suppression + re-fire on new payload, banned-process scan (bounded `-n 4` run exempt), malformed config exit; credit rollup filtering, budget verdicts, unmetered-not-zero, missing dir tolerance, newest-shards bound.
- Updated `test/test_spawn_agent_roster.py` source ratchet for the third reserved name.
- Ran the adjacent suites green: `test_conductor_agent.py`, `test_agent_spec_preflight.py`, `test_builtin_skill_packaging.py`, `test_builtin_skill_scope.py` (which caught and forced repo-agnostic example config in the skill), `test_brand_name_gate.py`, `test_spawn_audit.py`, and the owned-files sweep tests in `test_agent.py` -- 200+ tests passing locally; `isort`/`flake8`/`black` clean on touched files.

## Any other suggestions on the work

- The design doc's open question 1 (resident LLM session vs deterministic engine spine) is deliberately deferred until the M1 event store exists; the cycle economics (a patrol loop is overwhelmingly no-signal bookkeeping) argue for the spine, and the event store is what makes it possible without losing adjudication context.
- Credit metering today covers dashboard-session turns only; inspector subagent turns burn invisibly. The `unmetered` verdict makes that honest, and closing the gap belongs to the planned per-request token metrics work.
- A `folder` argument on `session_create` (#6118) would remove the one remaining approval prompt in the attended dispatch path.
