### PR TITLE
fix: discriminate Sage no-result failures and preflight the runtime

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -457,12 +457,24 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
             # the subprocess (and its memory) lives exactly as long as the batch. The
             # holder is reference-counted, so overlapping runs share one runtime and the
             # last one out tears it down.
-            await pool.begin_batch()
+            #
+            # Runtime preflight, read ONCE and reused: when the host cannot spawn a
+            # reviewer (no kiro-cli, ACP runtime unimportable) the batch is never
+            # opened — begin_batch would raise inside the spawn with a generic
+            # message — and the same verdict is handed to run_review, which fails
+            # every change fast with a reason naming the missing runtime. One
+            # reading keeps the bracket and the driver's verdict consistent.
+            # Offloaded: the executable resolution stats candidates across every
+            # PATH entry, and one stale network mount there would stall the loop.
+            runtime_error = await asyncio.to_thread(review_pool.runtime_preflight)
+            if not runtime_error:
+                await pool.begin_batch()
             try:
                 summary = await asyncio.to_thread(
                     review_driver.run_review, changes,  # type: ignore[attr-defined]
                     dispatch=dispatch, progress=_make_progress(run),
                     run_id=run_id, cancelled=lambda: run_id in _CANCELLED,
+                    preflight=lambda: runtime_error,
                     # One reviewer at a time. Workers share the staging directory and
                     # each has shell and file tools, so two running at once means one
                     # can write another change's record between that change's slot
@@ -474,7 +486,8 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
                     concurrency=1,
                 )
             finally:
-                await pool.end_batch()
+                if not runtime_error:
+                    await pool.end_batch()
             run["summary"] = summary
             _collect_delivered(run, summary)
             run["report_slug"] = summary.get("report_slug") or run.get("report_slug")
@@ -533,6 +546,17 @@ def _first_change_error(summary: dict) -> str:
                 return {
                     "no_review_recorded": "the reviewer finished but wrote no "
                                           "findings record",
+                    "review_record_incomplete": "the reviewer wrote a findings "
+                                                "record but never completed the "
+                                                "review",
+                    # Reason-level fallback only: a preflight-failed record
+                    # carries the specific runtime message in its error fields,
+                    # which the key order above prefers, and the run-level error
+                    # for that case comes from the summary's own error. Kept so
+                    # the reason itself always renders as a cause, never as a
+                    # bare enum value.
+                    "runtime_unavailable": "the reviewer never ran: its agent "
+                                           "runtime is unavailable on this host",
                     "review_failed": "the review turn failed",
                 }.get(val, val)
     return ""

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -1037,7 +1037,7 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
                concurrency: int = 0, timeout: int = DEFAULT_TASK_TIMEOUT,
                generate_report: bool = True, root: Path | None = None,
                progress=None, run_id: str | None = None, cancelled=None,
-               post: bool | None = None, confirm=None) -> dict:
+               post: bool | None = None, confirm=None, preflight=None) -> dict:
     """Two-stage per change (bounded concurrency): a Phase-1 gate task, then a
     Phase-2 deep-review task for every usable verdict (PASS / CONCERNS / BLOCK).
     Each task is dispatched to the reusable worker pool (``dispatch``) and the
@@ -1065,7 +1065,16 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
     published back to the pull request as a PENDING (draft) review only when it is
     enabled. It defaults to OFF, because the review is meant to be READ in the
     app, and writing to a pull request is a side effect the user asks for rather
-    than a consequence of running a review."""
+    than a consequence of running a review.
+
+    ``preflight`` is an optional zero-arg callable returning ``""`` when the
+    runtime the dispatched sessions need is available, else a message naming
+    what is missing (the app backend wires ``review_pool.runtime_preflight``).
+    A non-empty answer fails the run fast — every change is recorded as
+    ``runtime_unavailable`` with that message, and nothing is dispatched — so a
+    host that cannot spawn a reviewer reports the cause instead of completing
+    with nothing written. ``None`` (tests, callers owning their own dispatch)
+    skips the check."""
     if run_id:
         store.ensure_run_layout(run_id, root)
     store.ensure_layout(root)
@@ -1075,6 +1084,34 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
     dispatch = dispatch or _unconfigured_dispatch
     progress = progress or (lambda *a, **k: None)   # (change_id, phase, extra) sink
     is_cancelled = cancelled or (lambda: False)
+
+    # Fail-fast runtime preflight. Runs BEFORE the clean-slate resets below, so a
+    # host that cannot spawn a reviewer keeps its previous report and staged
+    # records intact, and every change carries a reason that names the missing
+    # runtime instead of the untriageable "produced no result record".
+    runtime_error = str(preflight() or "") if preflight is not None else ""
+    if runtime_error:
+        failed_records: list[dict] = []
+        for link in changes:
+            change_id = _cid(link)
+            progress(change_id, "failed", {"error": runtime_error})
+            failed_records.append({
+                "change": link, "change_id": change_id,
+                "gate_spawn_ok": False, "gate_error": runtime_error,
+                "gate_verdict": "UNKNOWN", "phase2_ran": False,
+                "deep_spawn_ok": False, "deep_error": runtime_error,
+                "deep_reviewed": False, "result_recorded": False,
+                "design_block": False, "deep_rounds": 0,
+                "skipped_reason": "runtime_unavailable",
+            })
+        return {
+            "ok": False, "error": runtime_error,
+            "changes": len(failed_records), "gate_spawns": 0, "deep_spawns": 0,
+            "design_blocked": 0, "phase2_skipped_on_block": 0, "cancelled": 0,
+            "deep_reviewed": 0, "deep_rounds": 0, "design_comments_posted": 0,
+            "result_records": 0, "failures": failed_records,
+            "per_change": failed_records,
+        }
 
     # Whether to publish findings back to the pull request. Read ONCE per run so a
     # mid-run config edit cannot post some PRs and not others. Explicit `is True`
@@ -1230,8 +1267,21 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
             progress(change_id, "failed", {"error": review_spawn.get("error", "review failed")})
             return rec
         if not rec["deep_reviewed"]:
-            rec["skipped_reason"] = "no_review_recorded"  # turn completed but wrote no review
-            progress(change_id, "failed", {"error": "review produced no result record"})
+            if rev_rec is None:
+                # Turn completed but wrote no record at all — the residual case
+                # (a genuinely empty review, or a worker whose commands ran no
+                # Python). Kept as the ``no_review_recorded`` value existing
+                # consumers key on; environment failures are discriminated by
+                # the preflight before any dispatch.
+                rec["skipped_reason"] = "no_review_recorded"
+                progress(change_id, "failed", {"error": "review produced no result record"})
+            else:
+                # A record landed but never marked the review complete: the
+                # worker got far enough to write, then stopped short. Distinct
+                # from "wrote nothing" so the two can be triaged apart.
+                rec["skipped_reason"] = "review_record_incomplete"
+                progress(change_id, "failed", {
+                    "error": "review wrote a result record but never completed the review"})
             return rec
 
         # --- Bounded coverage backstop: AT MOST ONE targeted follow-up, and only

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
@@ -77,9 +77,42 @@ try:  # SEL audit — the runtime layer has no audit_source, so the pool emits i
 except Exception:  # pragma: no cover - standalone / test fallback
     _sel = None  # type: ignore[assignment]
 
+try:  # same resolver the AcpRuntime spawn path uses to locate the agent CLI
+    from kiro_crew.kiro_cli import resolve_kiro_cli
+except Exception:  # pragma: no cover - standalone / test fallback
+    resolve_kiro_cli = None  # type: ignore[assignment]
+
 from sage_lib import followup, store  # noqa: E402
 
 logger = logging.getLogger(__name__)
+
+
+def runtime_preflight() -> str:
+    """Cheap, read-only check that a reviewer session could actually be spawned.
+
+    Returns ``""`` when the runtime looks usable, else a message naming exactly
+    what is missing. Mirrors what ``_ensure_runtime_locked`` needs to spawn the
+    shared runtime — an importable ``AcpRuntime`` driving a ``kiro-cli``
+    subprocess — using the same resolver (``resolve_kiro_cli``) the runtime's
+    own spawn path goes through, so the answer here matches what a real spawn
+    would find. Without this check a review on a host with no usable agent CLI
+    completes with nothing written and reports an undiscriminated "no result
+    record", which cannot be triaged.
+
+    Deliberately does NOT spawn anything or touch the filesystem beyond the
+    executable lookup. That lookup still stats candidates under every ``PATH``
+    entry, so callers on the gateway event loop MUST offload this to a thread
+    (``asyncio.to_thread``) — one stale network mount in ``PATH`` would
+    otherwise stall the whole loop.
+    """
+    if AcpRuntime is None:
+        return ("the reviewer cannot run: the ACP runtime "
+                "(kiro_crew.acp.runtime) is not importable in this install")
+    if resolve_kiro_cli is not None and resolve_kiro_cli() is None:
+        return ("the reviewer cannot run: no kiro-cli executable was found on "
+                "this host (the reviewer session is driven by kiro-cli — "
+                "install it or add it to PATH)")
+    return ""
 
 
 def _is_abnormal_stop(reason: str) -> bool:

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
@@ -2939,3 +2939,128 @@ class TestFollowupRunLiveAndReentry(unittest.IsolatedAsyncioTestCase):
         data = json.loads((await self.mod._handle_chat_get(
             _Req(query={"run_id": "run1", "change_id": "GH-o-r-42"}))).body)
         self.assertTrue(data["resumable"])
+
+
+class TestFailureStringMapping(unittest.TestCase):
+    """Each skipped_reason renders a DISTINCT, cause-naming sentence.
+
+    "The reviewer found nothing" and "the reviewer never ran" collapsing into one
+    message is the ambiguity that made these failures untriageable — a reader
+    must be able to tell the causes apart from the run-level error alone.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self._old_home = os.environ.get("KIROCREW_HOME")
+        self.addCleanup(self._restore_home)
+        os.environ["KIROCREW_HOME"] = self.tmp
+        self.mod = _load_routes_module()
+
+    def _restore_home(self):
+        if self._old_home is None:
+            os.environ.pop("KIROCREW_HOME", None)
+        else:
+            os.environ["KIROCREW_HOME"] = self._old_home
+
+    def _mapped(self, reason: str) -> str:
+        return self.mod._first_change_error(
+            {"per_change": [{"skipped_reason": reason}]})
+
+    def test_every_reason_maps_to_its_own_sentence(self):
+        reasons = ("no_review_recorded", "review_record_incomplete",
+                   "runtime_unavailable", "review_failed")
+        rendered = {reason: self._mapped(reason) for reason in reasons}
+        for reason, text in rendered.items():
+            self.assertNotEqual(text, reason,
+                                f"{reason} passed through unmapped")
+            self.assertTrue(text, f"{reason} rendered empty")
+        self.assertEqual(len(set(rendered.values())), len(reasons),
+                         f"reasons share a sentence: {rendered}")
+
+    def test_never_ran_and_found_nothing_read_apart(self):
+        never_ran = self._mapped("runtime_unavailable")
+        found_nothing = self._mapped("no_review_recorded")
+        self.assertIn("never ran", never_ran)
+        self.assertNotIn("never ran", found_nothing)
+
+    def test_specific_error_text_outranks_the_reason_mapping(self):
+        # A record carrying the preflight's own message (which names the missing
+        # runtime) surfaces that message verbatim rather than the generic map.
+        out = self.mod._first_change_error({"per_change": [{
+            "deep_error": "the reviewer cannot run: no kiro-cli executable was "
+                          "found on this host",
+            "skipped_reason": "runtime_unavailable",
+        }]})
+        self.assertIn("kiro-cli", out)
+
+
+class TestRuntimePreflightWiring(unittest.IsolatedAsyncioTestCase):
+    """The review path checks the runtime BEFORE spawning anything.
+
+    On a host that cannot spawn a reviewer, the run must fail fast with an error
+    naming the missing runtime — the batch is never opened, no session is
+    dispatched, and every change's progress carries the discriminated reason —
+    instead of "completing" and reporting an untriageable "no result record".
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self._old_home = os.environ.get("KIROCREW_HOME")
+        self.addCleanup(self._restore_home)
+        os.environ["KIROCREW_HOME"] = self.tmp
+        self.mod = _load_routes_module()
+        self.mod._RUNS = []
+
+    def _restore_home(self):
+        if self._old_home is None:
+            os.environ.pop("KIROCREW_HOME", None)
+        else:
+            os.environ["KIROCREW_HOME"] = self._old_home
+
+    async def test_failing_preflight_fails_the_run_without_spawning(self):
+        batch_calls: list[str] = []
+
+        class _FakePool:
+            async def begin_batch(self):
+                batch_calls.append("begin")
+
+            async def end_batch(self):
+                batch_calls.append("end")
+
+        def _refuse_dispatch(loop, pool, **kw):
+            def dispatch(task, timeout=0, **kwargs):
+                raise AssertionError("a session was dispatched despite a "
+                                     "failed runtime preflight")
+            return dispatch
+
+        async def _noop_async(*a, **k):
+            return None
+
+        url = "https://github.com/kirodotdev/KiroCrew/pull/33"
+        run: dict = {"run_id": "rp1", "status": "running", "changes": [url],
+                     "change_ids": [_rd.change_id_for(url)], "progress": {}}
+        self.mod._RUNS = [run]
+        with unittest.mock.patch.object(
+                self.mod.review_pool, "runtime_preflight",
+                lambda: "the reviewer cannot run: no kiro-cli executable was "
+                        "found on this host"), \
+                unittest.mock.patch.object(
+                    self.mod.review_pool, "get_pool", lambda: _FakePool()), \
+                unittest.mock.patch.object(
+                    self.mod.review_pool, "make_sync_dispatch",
+                    _refuse_dispatch), \
+                unittest.mock.patch.object(self.mod, "_save_runs", _noop_async), \
+                unittest.mock.patch.object(
+                    self.mod, "_notify_finished", _noop_async):
+            await self.mod._run_review_bg(run, [url])
+
+        self.assertEqual(batch_calls, [])            # runtime never spawned
+        self.assertEqual(run["status"], "error")
+        self.assertIn("kiro-cli", run["error"])
+        entry = run["progress"][_rd.change_id_for(url)]
+        self.assertEqual(entry["phase"], "failed")
+        self.assertIn("kiro-cli", entry["error"])
+        recs = run["summary"]["per_change"]
+        self.assertEqual(recs[0]["skipped_reason"], "runtime_unavailable")

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
@@ -167,7 +167,11 @@ class TestDriverAdopts(_Base):
                            root=self.root, run_id="run-a", progress=prog)
         self.assertEqual(seen["CR-1"], "failed")
         self.assertEqual(out["result_records"], 0)
+        # The residual "turn completed, nothing written" case keeps this value —
+        # discriminated causes (runtime preflight, incomplete record) carry
+        # their own reasons and must never collapse back into it.
         self.assertEqual(out["per_change"][0]["skipped_reason"], "no_review_recorded")
+        self.assertFalse(out["per_change"][0]["result_recorded"])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -220,7 +220,75 @@ class TestReviewDriver(unittest.TestCase):
             return {"ok": True, "output": "", "error": ""}
         out = D.run_review(["CR-7"], dispatch=no_record, generate_report=False, root=self.root, post=True)
         self.assertEqual(out["deep_reviewed"], 0)
+        # The residual "turn completed, nothing written" case keeps this value;
+        # environment failures carry their own discriminated reasons instead.
         self.assertEqual(out["per_change"][0]["skipped_reason"], "no_review_recorded")
+        self.assertFalse(out["per_change"][0]["result_recorded"])
+
+    def test_incomplete_record_is_discriminated_from_no_record(self):
+        # A worker that writes a record but never marks the review complete is a
+        # DIFFERENT detectable cause than one that writes nothing — the two must
+        # not collapse into one reason (that ambiguity is what made the failure
+        # untriageable).
+        errors: dict = {}
+
+        def prog(cid, phase, extra=None):
+            if phase == "failed":
+                errors[cid] = (extra or {}).get("error", "")
+
+        def partial(task, timeout=0):
+            results.write_result({
+                "schema": "code-review-sage-result", "version": 1, "change_id": "CR-8",
+                "platform": "github", "repo_identity": "github.com/o/r", "revision": "1",
+                "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
+                "blast_radius": {"rating": "SMALL", "signals": {}},
+                "counts": {"red": 0, "yellow": 0}, "findings": [],
+                "deep_reviewed": False, "title": "CR-8",
+                "files_covered": [], "coverage_complete": True,
+            }, self.root)
+            return {"ok": True, "output": "", "error": ""}
+
+        out = D.run_review(["CR-8"], dispatch=partial, generate_report=False,
+                           root=self.root, post=True, progress=prog)
+        rec = out["per_change"][0]
+        self.assertEqual(rec["skipped_reason"], "review_record_incomplete")
+        self.assertTrue(rec["result_recorded"])
+        self.assertIn("never completed", errors["CR-8"])
+        self.assertNotIn("no result record", errors["CR-8"])
+
+    def test_preflight_failure_fails_fast_and_never_dispatches(self):
+        # A failed runtime preflight must produce its own discriminated reason,
+        # name the missing runtime in the progress error, and return BEFORE any
+        # reviewer session is dispatched.
+        errors: dict = {}
+
+        def prog(cid, phase, extra=None):
+            errors[cid] = (phase, (extra or {}).get("error", ""))
+
+        out = D.run_review(
+            ["CR-1", "CR-2"], dispatch=self._fake_dispatch(),
+            generate_report=False, root=self.root, post=True, progress=prog,
+            preflight=lambda: "the reviewer cannot run: no kiro-cli executable "
+                              "was found on this host")
+        self.assertEqual(self.calls, [])            # nothing was dispatched
+        self.assertFalse(out["ok"])
+        self.assertIn("kiro-cli", out["error"])
+        self.assertEqual(out["changes"], 2)
+        self.assertEqual(out["result_records"], 0)
+        for rec in out["per_change"]:
+            self.assertEqual(rec["skipped_reason"], "runtime_unavailable")
+            self.assertIn("kiro-cli", rec["deep_error"])
+        self.assertEqual(errors["CR-1"][0], "failed")
+        self.assertIn("kiro-cli", errors["CR-1"][1])
+
+    def test_passing_preflight_runs_the_review(self):
+        # "" means the runtime is available — the run proceeds normally.
+        out = D.run_review(["CR-1"], dispatch=self._fake_dispatch(),
+                           generate_report=False, root=self.root, post=True,
+                           preflight=lambda: "")
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["deep_reviewed"], 1)
+        self.assertGreater(len(self.calls), 0)
 
     def test_each_task_is_single_change(self):
         D.run_review(["CR-1", "CR-2"], dispatch=self._fake_dispatch(), archiver=self._archiver,

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_pool.py
@@ -9,6 +9,7 @@ import json
 import tempfile
 import threading
 import unittest
+import unittest.mock
 from pathlib import Path
 
 from sage_lib import review_pool as rp
@@ -474,3 +475,44 @@ class TestReviewEffort(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRuntimePreflight(unittest.TestCase):
+    """runtime_preflight answers "could a reviewer session actually spawn?"
+
+    "" means yes; anything else names what is missing, so the driver can fail
+    the run fast with a triagable reason instead of completing with nothing
+    written and reporting an undiscriminated "no result record".
+    """
+
+    def test_available_runtime_returns_empty(self):
+        with unittest.mock.patch.object(rp, "AcpRuntime", object()), \
+                unittest.mock.patch.object(rp, "resolve_kiro_cli",
+                                           lambda: "/usr/local/bin/kiro-cli"):
+            self.assertEqual(rp.runtime_preflight(), "")
+
+    def test_missing_cli_names_the_runtime(self):
+        with unittest.mock.patch.object(rp, "AcpRuntime", object()), \
+                unittest.mock.patch.object(rp, "resolve_kiro_cli", lambda: None):
+            msg = rp.runtime_preflight()
+            self.assertIn("kiro-cli", msg)
+
+    def test_unimportable_acp_runtime_is_reported(self):
+        with unittest.mock.patch.object(rp, "AcpRuntime", None):
+            msg = rp.runtime_preflight()
+            self.assertTrue(msg)
+            self.assertIn("runtime", msg.lower())
+
+    def test_check_is_read_only(self):
+        # The preflight runs (off the event loop) before every review run — it
+        # must only LOOK for the executable, never spawn or write anything.
+        calls: list[str] = []
+
+        def _resolver() -> str:
+            calls.append("resolve")
+            return "/bin/kiro-cli"
+
+        with unittest.mock.patch.object(rp, "AcpRuntime", object()), \
+                unittest.mock.patch.object(rp, "resolve_kiro_cli", _resolver):
+            rp.runtime_preflight()
+        self.assertEqual(calls, ["resolve"])


### PR DESCRIPTION
<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

The Code Review Sage app emits one undiscriminated failure — "review produced no result record" — for at least two unrelated causes. The single emit site (`sage_lib/review_driver.py`, the `no_review_recorded` terminal) fires whenever a turn completes without a usable review record, whether the reviewer runtime never existed on the host, the worker wrote a partial record, or the review was genuinely empty. There is no runtime availability preflight anywhere in the review path: `kiro-cli` appears nowhere in `review_driver.py`, so a host with no usable runtime "completes" a review with nothing written.

## Why it matters

The failure is silent-by-construction ("looks like it ran") and the one sentence cannot be triaged — issue #3084 sat unresolved because of exactly this ambiguity. Anyone hitting the message has no way to tell "the reviewer found nothing" apart from "the reviewer never ran", and support/triage has to reproduce the environment to find out.

## What changed (motivation → approach → change)

Symptom: one message for several causes → root cause: no preflight plus one collapsed terminal emit → change, three mechanically-derived pieces with minimal surface:

1. **Runtime preflight, fail-fast** — new `review_pool.runtime_preflight()`: a cheap, read-only check that a reviewer session could actually spawn (importable `AcpRuntime` + `kiro-cli` found by the same `resolve_kiro_cli` resolver the runtime's own spawn path uses). `_run_review_bg` evaluates it once **off the event loop** (`asyncio.to_thread` — the resolver stats candidates across every `PATH` entry) before `pool.begin_batch()`; on failure the batch is never opened, nothing is dispatched, and `run_review` fails every change fast with `skipped_reason: "runtime_unavailable"` and an error naming the missing `kiro-cli`. The check runs before the driver's clean-slate resets, so a host that cannot review keeps its previous report intact.
2. **Discriminated terminal record** — the single `no_review_recorded` emit is split: a record that landed but never marked the review complete is now `review_record_incomplete` with its own error string; `no_review_recorded` stays the value for the residual "turn completed, nothing written" case so existing consumers stay coherent.
3. **Surface mapping** — `backend/routes.py`'s `_first_change_error` reason→sentence map gains distinct, cause-naming sentences for the new reasons, so "the reviewer found nothing" and "the reviewer never ran" can never render as one message.

Pre-push adversarial review (2 rounds: GPT + Opus blind reviewers, then a fresh verifier on the fix delta) found and fixed two blocking issues before this PR was opened: the preflight originally ran synchronously on the gateway event loop (now offloaded per the `no-blocking-call-on-event-loop` rule), and the two new test classes used bare `mkdtemp` with tearDown-only cleanup (now `addCleanup` per `no-test-side-effects`).

One advisory is deliberately deferred: the frontend `failureReason` cause translator (`website/src/apps/code-review-sage/lib/format.ts`) passes the new backend strings through verbatim (its documented behavior for unrecognized causes — the strings are cause-naming and self-describing in English). Localizing them needs two new i18n keys across 12 locales plus screenshot evidence, which widens this backend-scoped fix; it is filed as a follow-up issue rather than folded in here.

## Tests

- `test_preflight_failure_fails_fast_and_never_dispatches` — a failed preflight yields `runtime_unavailable`, names `kiro-cli` in the progress error, and dispatches **nothing** (the review never starts).
- `test_passing_preflight_runs_the_review` — `""` from the preflight means the run proceeds normally.
- `test_incomplete_record_is_discriminated_from_no_record` — a record with `deep_reviewed: false` yields `review_record_incomplete`, not `no_review_recorded`.
- `test_no_record_marks_failed` / `test_a_worker_that_writes_nothing_is_reported_failed` (updated) — the residual empty-review path still yields `no_review_recorded` with `result_recorded` false.
- `TestFailureStringMapping` — every reason maps to its own non-empty sentence; "never ran" and "found nothing" read apart; a record's specific error text outranks the generic map.
- `TestRuntimePreflightWiring` — end-to-end through `_run_review_bg`: a failing preflight marks the run `error` with `kiro-cli` named, writes per-change failed progress with the discriminated reason, and **never opens the pool batch**.
- `TestRuntimePreflight` (review_pool) — available runtime → `""`; missing CLI names `kiro-cli`; unimportable ACP runtime is reported; the check is read-only.

## Manual verification

N/A — unit coverage sufficient: the wiring test exercises the real `_run_review_bg` path end-to-end with only the pool faked, and the full backend suite's failures were proven byte-identical on unmodified `main` (host-environment, unrelated).

## Related Issues

Refs #3084

Closes #7233

## Pattern harvest

Rule candidate: agentic (review-lane rule, not regex-decidable)
Pattern: a subsystem that spawns worker sessions with no availability preflight on the runtime they need, collapsing "the environment cannot run this" and "this ran and produced nothing" into one terminal error. Detection: a dispatch/spawn call site whose failure terminal sets a single reason for both a falsy spawn result and an empty result readback. The fix shape is always the same — a cheap read-only preflight using the same resolver the spawn path uses, plus a discriminated reason per detectable cause.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc documents these reason values
- [x] No secrets, credentials, or internal references in the diff
