### PR TITLE
fix(dashboard): claim IME Escape before the command bar consumes it (#5481)

### DIFF
--- a/website/src/apps/command-bar/CommandBarOverlay.imeEscape.test.tsx
+++ b/website/src/apps/command-bar/CommandBarOverlay.imeEscape.test.tsx
@@ -1,0 +1,174 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import CommandBarOverlay from './CommandBarOverlay'
+
+/**
+ * IME guard on the dialog's Escape branch (#5481). The overlay is one of the two
+ * `handleEscape: false` consumers (the other, Modal, is guarded upstream): its
+ * dialog `onKeyDown` used to `preventDefault()` every Escape before the
+ * scope-pop-or-close decision, so an Escape pressed to cancel an in-flight IME
+ * candidate list was consumed by the overlay instead of the IME. The branch now
+ * claims the key through the shared latch (`ime.claimKey`) first — a declined
+ * composing Escape keeps its default action for the IME and neither pops the
+ * scope nor closes the bar. Coverage mirrors
+ * `useImeGuard.documentLatch.test.tsx` (PR #5505 lineage): live composition,
+ * the WebKit post-compositionend grace window, and recovery.
+ */
+
+const dispatch = vi.fn()
+const navigate = vi.fn()
+const newSessionWithToken = vi.fn()
+const enterInsertOrNewSession = vi.fn()
+
+const storeState = {
+  dashboard: { slots: [] as Record<string, unknown>[], unreadSlots: [] as string[] },
+  chat: { slotStatusDetail: {} as Record<string, unknown>, activeSlot: null as string | null },
+}
+
+vi.mock('../../store', () => ({
+  useAppDispatch: () => dispatch,
+  useAppSelector: (fn: (s: unknown) => unknown) => fn(storeState),
+}))
+vi.mock('../../store/chatSlice', () => ({
+  createSlot: (arg: unknown) => ({ type: 'createSlot', arg }),
+  setPendingInput: (text: string) => ({ type: 'setPendingInput', text }),
+  switchSlot: (key: string) => ({ type: 'switchSlot', key }),
+}))
+vi.mock('../../components/commandPalette/paletteActions', () => ({
+  usePaletteActions: () => ({ navigate, enterInsertOrNewSession, newSessionWithToken }),
+}))
+vi.mock('../../components/commandPalette/providers/sessionsProvider', () => ({
+  useSessionsProvider: () => ({ search: vi.fn(async () => []) }),
+}))
+vi.mock('../../components/commandPalette/providers/recentsProvider', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../components/commandPalette/providers/recentsProvider')>()),
+  useRecentsProvider: () => ({ search: vi.fn(async () => []) }),
+}))
+vi.mock('../../hooks/useVisualViewport', () => ({ useVisualViewport: () => ({ height: 800 }) }))
+vi.mock('../../hooks/useDialogFocusTrap', () => ({ useDialogFocusTrap: () => {} }))
+vi.mock('../../hooks/useTheme', () => ({ useTheme: () => ({ cycle: vi.fn() }) }))
+
+function mount(onClose = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <CommandBarOverlay open onClose={onClose} />
+    </QueryClientProvider>,
+  )
+  return onClose
+}
+
+const rowByText = (text: string) =>
+  screen.getByText(text).closest('[role="option"]') as HTMLElement
+
+/** Enter the sessions scope the same way the row tests do. */
+async function enterScope() {
+  fireEvent.mouseDown(rowByText('Search Sessions'))
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Back to all commands' })).toBeTruthy(),
+  )
+}
+
+const inScope = () =>
+  screen.queryByRole('button', { name: 'Back to all commands' }) !== null
+
+describe('CommandBarOverlay IME Escape guard', () => {
+  beforeEach(() => {
+    dispatch.mockReset()
+    storeState.dashboard = { slots: [], unreadSlots: [] }
+    storeState.chat = { slotStatusDetail: {}, activeSlot: null }
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('declines an Escape during live composition: default kept, bar stays open', () => {
+    const onClose = mount()
+    const input = screen.getByRole('combobox')
+    fireEvent.compositionStart(input)
+    // The decline contract has two halves and this repo's drift history is of
+    // one being dropped: the default is KEPT (the IME needs it to cancel the
+    // candidate list) while propagation is STOPPED (a declined Escape must not
+    // leak to outer layers' own Escape handling). The bubble listener pins the
+    // second half, as useDialogFocusTrap.imeGuard.test.tsx does.
+    const bubbleListener = vi.fn()
+    window.addEventListener('keydown', bubbleListener)
+    try {
+      // A live composition's keydown carries the native `isComposing` flag —
+      // fireEvent returns false when preventDefault was called.
+      const defaultKept = fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
+      expect(defaultKept).toBe(true)
+      expect(bubbleListener).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', bubbleListener)
+    }
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not pop the scope on a composing Escape', async () => {
+    const onClose = mount()
+    const input = screen.getByRole('combobox')
+    await enterScope()
+    fireEvent.compositionStart(input)
+    fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
+    // The scope chip is still there: the Escape belonged to the IME, not the
+    // scope-pop-before-close chain.
+    expect(inScope()).toBe(true)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('still declines inside the WebKit post-compositionend grace window', () => {
+    // On WebKit the keydown that cancels a candidate can arrive AFTER
+    // compositionend with `isComposing` already false — only the tracked latch
+    // window identifies it. Inside that window both native signals read clear,
+    // so the claim consumes the key it declines (preventDefault) to stop the
+    // browser acting on a key the overlay decided was not its own. Fake timers
+    // hold the 50ms window open: on a loaded runner real timers could let it
+    // lapse between the two fireEvent calls and fail the assertion.
+    vi.useFakeTimers()
+    const onClose = mount()
+    const input = screen.getByRole('combobox')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    const defaultKept = fireEvent.keyDown(input, { key: 'Escape' })
+    expect(defaultKept).toBe(false)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('recovers: a non-composing Escape after the window closes the bar', () => {
+    vi.useFakeTimers()
+    const onClose = mount()
+    const input = screen.getByRole('combobox')
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+    // Past the post-composition window the latch releases and Escape is the
+    // dialog's again.
+    vi.advanceTimersByTime(60)
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('recovers inside a scope too: scope-pop-then-close ordering is untouched', async () => {
+    const onClose = mount()
+    const input = screen.getByRole('combobox')
+    // Enter the scope on real timers (the scope entry awaits a render), then
+    // switch to fake ones for the latch window.
+    await enterScope()
+    vi.useFakeTimers()
+    fireEvent.compositionStart(input)
+    fireEvent.compositionEnd(input)
+    vi.advanceTimersByTime(60)
+    // First clear Escape pops the scope, the second closes — the deliberate
+    // ordering the guard must not change.
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(inScope()).toBe(false)
+    expect(onClose).not.toHaveBeenCalled()
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/website/src/apps/command-bar/CommandBarOverlay.tsx
+++ b/website/src/apps/command-bar/CommandBarOverlay.tsx
@@ -316,8 +316,9 @@ export default function CommandBarOverlay({
   const slotStatusDetail = useAppSelector(s => s.chat.slotStatusDetail ?? {})
   const simplifiedToolNames = useSimplifiedToolNames()
   // `aria-modal` is a promise that Tab cannot reach the page behind the dialog, so
-  // the trap has to be real. Escape is left to the input's own handler, which needs
-  // it to pop a scope before it closes the bar.
+  // the trap has to be real. Escape is owned by the dialog panel's own keydown
+  // handler below, which needs it to pop a scope before it closes the bar (and
+  // claims it through the IME latch first).
   useDialogFocusTrap(dialogRef, onClose, { handleEscape: false })
   // Constructing the sessions engine is just memoized closures — it issues no
   // request until `search()` is called, and only the sessions VIEW calls it. That
@@ -971,6 +972,12 @@ export default function CommandBarOverlay({
         // one owner rather than two.
         onKeyDown={e => {
           if (e.key !== 'Escape') return
+          // An Escape mid-composition belongs to the IME — it cancels the candidate
+          // list, not the search scope or the bar. The claim owns the whole decline
+          // contract (a declined key keeps its default for the IME and is stopped
+          // from leaking to outer layers), so it must run BEFORE the unconditional
+          // preventDefault below takes the key for the dialog.
+          if (!ime.claimKey(e)) return
           e.preventDefault()
           // Inside a scope, Escape steps OUT of it rather than discarding the whole
           // search: the query the user typed is the expensive part, and Backspace on


### PR DESCRIPTION
## Summary

The command bar overlay is one of the two `handleEscape: false` Escape consumers (issue #5481). Its dialog `onKeyDown` Escape branch called `e.preventDefault()` unconditionally before the scope-pop-or-close decision, so an Escape pressed to cancel an in-flight IME candidate list (Chinese/Japanese/Korean input) was consumed by the overlay — popping the search scope or closing the bar — instead of letting the IME cancel its candidates. Modal, the other consumer, was already guarded on main (#7006).

The fix is the one-branch edit the guard was designed for: `if (!ime.claimKey(e)) return` before the `preventDefault()`. The overlay already had `const ime = useImeGuard()` in scope with `bindComposition()` wired on the input; `ime.claimKey` owns the full decline contract (a declined composing Escape keeps its default action for the IME and is stopped from leaking to outer layers; an accepted Escape proceeds normally). The scope-pop-before-close ordering is untouched, as is `useDialogFocusTrap` and the deliberate `handleEscape: false` opt-out.

Also updates the stale comment at the `useDialogFocusTrap` call site, which still said Escape was left to the input's own handler — the dialog panel handler has owned it since Tab could reach the scope chip.

## Tests

New `CommandBarOverlay.imeEscape.test.tsx` (5 tests), mirroring the coverage pattern of `useImeGuard.documentLatch.test.tsx` (#5505 lineage):
- Escape during live composition is declined: default kept for the IME, propagation stopped (window bubble-listener assertion), bar stays open
- A composing Escape does not pop the search scope
- The WebKit post-`compositionend` grace window still declines (fake timers hold the 50ms window open, so the test cannot flake on a loaded runner)
- Recovery: a non-composing Escape after the window closes the bar
- Recovery inside a scope: the scope-pop-then-close ordering is unchanged

Mutation-verified: with the claim line removed, 4 of 5 tests fail.

Gates: `npx tsc -b` clean, full frontend vitest suite green (26,876 tests / 1,694 files), eslint 0 errors (the file's 2 warnings pre-exist on main verbatim), backend isort/flake8/mypy clean, black + brand gates pass. The new test file trips none of the `ImeEnterClaimRatchet` source-scan predicates.

## Accepted residual (documented, not changed)

A composition abandoned with neither `compositionend` nor a blur leaves the latch set, and since the claim consumes what it declines, Escape would silently stop closing the bar until the latch recovers. `bindComposition()`'s blur reset is the recovery, but this input holds focus for the dialog's whole life, so blur may never fire on this surface; the backdrop click and the open/close chord remain as exits. This is the same cross-tree residual `useImeGuard` documents — called out here rather than papered over.

<!-- no-visual-delta -->
**Why no screenshot:** behavior-only keyboard fix — the Escape key's IME claim changes event handling, not any rendered pixel; there is no visual state to photograph.

## Pattern harvest

The defect shape (a key branch that consumes-and-acts with no composition signal) is already ratcheted for Enter and Tab by `website/src/test/ImeEnterClaimRatchet.test.ts`, but none of its eleven predicates covers an **Escape** branch — this bug sat in a file that already imported the guard and wired `bindComposition()`, invisible to every scan.

Rule candidate: an Escape twin of the ratchet's Tab rules — flag an `e.key === 'Escape'` branch that calls `preventDefault()` and then acts (close/dismiss/scope change) with no `claim(Synthetic)?Key(` between the key check and the consumption. The issue enumerated exactly two `handleEscape: false` consumers and both are now guarded, so the ratchet rule is what keeps a third copy from growing unseen.

Closes #5481
